### PR TITLE
[codex] Fix workspace mark-done context menu

### DIFF
--- a/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -4,12 +4,39 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { WorkspaceItem } from "./WorkspaceItem";
 
+vi.mock("@/platform/tauri/context-menu", () => ({
+  canShowNativeContextMenu: () => false,
+  showNativeContextMenu: vi.fn(),
+}));
+
 describe("WorkspaceItem", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("does not select the workspace when confirming mark done from the context menu", () => {
+  it("keeps the mark-done context menu open after right-clicking", async () => {
+    const onSelect = vi.fn();
+
+    render(
+      <WorkspaceItem
+        name="Feature worktree"
+        variant="worktree"
+        onSelect={onSelect}
+        onMarkDone={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByText("Feature worktree").closest('[role="button"]');
+    expect(row).not.toBeNull();
+
+    fireEvent.contextMenu(row!, { clientX: 12, clientY: 12 });
+
+    expect(await screen.findByRole("button", { name: "Mark done..." })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Confirm done" })).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not select the workspace when confirming mark done from the context menu", async () => {
     const onSelect = vi.fn();
     const onMarkDone = vi.fn();
 
@@ -25,8 +52,8 @@ describe("WorkspaceItem", () => {
     const row = screen.getByText("Feature worktree").closest('[role="button"]');
     expect(row).not.toBeNull();
 
-    fireEvent.contextMenu(row!);
-    fireEvent.click(screen.getByRole("button", { name: "Mark done..." }));
+    fireEvent.contextMenu(row!, { clientX: 12, clientY: 12 });
+    fireEvent.click(await screen.findByRole("button", { name: "Mark done..." }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm done" }));
 
     expect(onMarkDone).toHaveBeenCalledTimes(1);

--- a/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -184,12 +184,16 @@ export function WorkspaceItem({
     </SidebarRowSurface>
   );
 
+  // Leave PopoverButton uncontrolled until the confirmation step is active.
+  // Passing false would force-close the internally opened right-click menu.
+  const forcedContextMenuOpen = doneConfirmOpen ? true : undefined;
+
   const contextMenu = (
     <PopoverButton
       trigger={row}
       triggerMode="contextMenu"
       stopPropagation
-      externalOpen={doneConfirmOpen}
+      externalOpen={forcedContextMenuOpen}
       onOpenChange={(isOpen) => {
         if (!isOpen) setDoneConfirmOpen(false);
       }}
@@ -247,7 +251,7 @@ export function WorkspaceItem({
               label="Mark done..."
               variant="sidebar"
               onClick={() => {
-                setDoneConfirmOpen(true);
+                handleMarkDoneCommand();
               }}
             />
           )}


### PR DESCRIPTION
## Summary

Fixes the workspace sidebar mark-done context menu so right-clicking a worktree keeps the popover open instead of immediately force-closing it.

## Root Cause

`WorkspaceItem` passed `externalOpen={doneConfirmOpen}` into `PopoverButton`. When `doneConfirmOpen` was `false`, `PopoverButton` treated the defined `false` value as a force-close command, so a right-click-opened menu was closed on the next render.

## Changes

- Leave the context-menu popover uncontrolled until the mark-done confirmation step is active.
- Route the DOM fallback mark-done action through the same handler as the native menu path.
- Add regression coverage for the right-click menu staying open and for confirming mark done without selecting the workspace.

## Validation

- `pnpm --dir desktop exec vitest run src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check`