### PR TITLE
[codex] Fix duplicate local workspace creation

### DIFF
--- a/desktop/src/hooks/workspaces/use-workspace-actions.test.tsx
+++ b/desktop/src/hooks/workspaces/use-workspace-actions.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnyHarnessError, type Workspace } from "@anyharness/sdk";
+import { useWorkspaceActions } from "./use-workspace-actions";
+
+const mocks = vi.hoisted(() => {
+  const create = vi.fn();
+  const resolveFromPath = vi.fn();
+  const createWorktree = vi.fn();
+  const getAnyHarnessClient = vi.fn(() => ({
+    workspaces: {
+      create,
+      resolveFromPath,
+      createWorktree,
+    },
+  }));
+
+  return {
+    create,
+    resolveFromPath,
+    createWorktree,
+    getAnyHarnessClient,
+    ensureRuntimeReady: vi.fn(async () => "http://localhost:7007"),
+    trackProductEvent: vi.fn(),
+    captureTelemetryException: vi.fn(),
+  };
+});
+
+vi.mock("@anyharness/sdk-react", () => ({
+  getAnyHarnessClient: mocks.getAnyHarnessClient,
+}));
+
+vi.mock("./runtime-ready", () => ({
+  ensureRuntimeReady: mocks.ensureRuntimeReady,
+}));
+
+vi.mock("./use-workspaces", () => ({
+  useWorkspaces: () => ({
+    data: {
+      localWorkspaces: [],
+      retiredLocalWorkspaces: [],
+      repoRoots: [],
+      cloudWorkspaces: [],
+      workspaces: [],
+      allWorkspaces: [],
+      cleanupAttentionWorkspaces: [],
+    },
+  }),
+}));
+
+vi.mock("@/stores/sessions/harness-store", () => {
+  const useHarnessStore = Object.assign(
+    vi.fn((selector: (state: { runtimeUrl: string }) => unknown) =>
+      selector({ runtimeUrl: "http://localhost:7007" })),
+    {
+      getState: vi.fn(() => ({ runtimeUrl: "http://localhost:7007" })),
+    },
+  );
+  return { useHarnessStore };
+});
+
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  captureTelemetryException: mocks.captureTelemetryException,
+  trackProductEvent: mocks.trackProductEvent,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useWorkspaceActions local workspace creation", () => {
+  it("creates a workspace through the strict create endpoint", async () => {
+    const workspace = localWorkspace("workspace-new");
+    mocks.create.mockResolvedValueOnce({ workspace });
+
+    const { result } = renderActions();
+    let created: Workspace | null = null;
+    await act(async () => {
+      created = await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+    });
+
+    expect(created).toBe(workspace);
+    expect(mocks.create).toHaveBeenCalledWith({
+      path: "/Users/pablo/proliferate",
+      origin: { kind: "human", entrypoint: "desktop" },
+    });
+    expect(mocks.resolveFromPath).not.toHaveBeenCalled();
+    expect(mocks.trackProductEvent).toHaveBeenCalledWith("workspace_created", {
+      workspace_kind: "local",
+      creation_kind: "local",
+    });
+  });
+
+  it("opens an existing workspace when create reports the path is already registered", async () => {
+    const workspace = localWorkspace("workspace-existing");
+    mocks.create.mockRejectedValueOnce(new AnyHarnessError({
+      type: "about:blank",
+      title: "Bad request",
+      status: 400,
+      detail: "a workspace record already exists for path: /Users/pablo/proliferate",
+      code: "WORKSPACE_CREATE_FAILED",
+    }));
+    mocks.resolveFromPath.mockResolvedValueOnce({ workspace });
+
+    const { result } = renderActions();
+    let resolved: Workspace | null = null;
+    await act(async () => {
+      resolved = await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+    });
+
+    expect(resolved).toBe(workspace);
+    expect(mocks.resolveFromPath).toHaveBeenCalledWith({
+      path: "/Users/pablo/proliferate",
+      origin: { kind: "human", entrypoint: "desktop" },
+    });
+    expect(mocks.trackProductEvent).not.toHaveBeenCalled();
+    expect(mocks.captureTelemetryException).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-conflict create errors", async () => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Bad request",
+      status: 400,
+      detail: "path is not a git repository",
+      code: "WORKSPACE_CREATE_FAILED",
+    });
+    mocks.create.mockRejectedValueOnce(error);
+
+    const { result } = renderActions();
+    let thrown: unknown = null;
+    await act(async () => {
+      try {
+        await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+      } catch (caught) {
+        thrown = caught;
+      }
+    });
+
+    expect(thrown).toBe(error);
+    expect(mocks.resolveFromPath).not.toHaveBeenCalled();
+    expect(mocks.trackProductEvent).not.toHaveBeenCalled();
+    expect(mocks.captureTelemetryException).toHaveBeenCalledWith(error, {
+      tags: {
+        action: "create_local_workspace",
+        domain: "workspace",
+        workspace_kind: "local",
+      },
+    });
+  });
+
+  it("propagates resolve failures after a duplicate-path create error", async () => {
+    const resolveError = new Error("runtime connection lost");
+    mocks.create.mockRejectedValueOnce(new AnyHarnessError({
+      type: "about:blank",
+      title: "Bad request",
+      status: 400,
+      detail: "a workspace record already exists for path: /Users/pablo/proliferate",
+      code: "WORKSPACE_CREATE_FAILED",
+    }));
+    mocks.resolveFromPath.mockRejectedValueOnce(resolveError);
+
+    const { result } = renderActions();
+    let thrown: unknown = null;
+    await act(async () => {
+      try {
+        await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+      } catch (caught) {
+        thrown = caught;
+      }
+    });
+
+    expect(thrown).toBe(resolveError);
+    expect(mocks.resolveFromPath).toHaveBeenCalledWith({
+      path: "/Users/pablo/proliferate",
+      origin: { kind: "human", entrypoint: "desktop" },
+    });
+    expect(mocks.trackProductEvent).not.toHaveBeenCalled();
+    expect(mocks.captureTelemetryException).toHaveBeenCalledWith(resolveError, {
+      tags: {
+        action: "create_local_workspace",
+        domain: "workspace",
+        workspace_kind: "local",
+      },
+    });
+  });
+});
+
+function renderActions() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return renderHook(() => useWorkspaceActions(), { wrapper });
+}
+
+function localWorkspace(id: string): Workspace {
+  return {
+    id,
+    kind: "local",
+    repoRootId: "repo-1",
+    path: "/Users/pablo/proliferate",
+    surface: "standard",
+    sourceRepoRootPath: "/Users/pablo/proliferate",
+    sourceWorkspaceId: id,
+    gitProvider: null,
+    gitOwner: null,
+    gitRepoName: null,
+    originalBranch: "main",
+    currentBranch: "main",
+    displayName: null,
+    origin: null,
+    creatorContext: null,
+    lifecycleState: "active",
+    cleanupState: "none",
+    cleanupOperation: null,
+    cleanupErrorMessage: null,
+    cleanupFailedAt: null,
+    cleanupAttemptedAt: null,
+    executionSummary: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  } as Workspace;
+}

--- a/desktop/src/hooks/workspaces/use-workspace-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-actions.ts
@@ -1,6 +1,10 @@
 import { getAnyHarnessClient } from "@anyharness/sdk-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { CreateWorktreeWorkspaceResponse, Workspace } from "@anyharness/sdk";
+import {
+  AnyHarnessError,
+  type CreateWorktreeWorkspaceResponse,
+  type Workspace,
+} from "@anyharness/sdk";
 import { workspaceCollectionsScopeKey } from "./query-keys";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
@@ -40,6 +44,21 @@ import { getLatencyFlowRequestHeaders } from "@/lib/infra/latency-flow";
 interface CreateWorktreeMutationInput {
   params: WorktreeCreationParams;
   latencyFlowId?: string | null;
+}
+
+interface CreateLocalWorkspaceResult {
+  workspace: Workspace;
+  created: boolean;
+}
+
+function isExistingWorkspacePathError(error: unknown): boolean {
+  if (error instanceof AnyHarnessError) {
+    return error.problem.code === "WORKSPACE_CREATE_FAILED"
+      && error.problem.detail?.includes("a workspace record already exists for path") === true;
+  }
+
+  return error instanceof Error
+    && error.message.includes("a workspace record already exists for path");
 }
 
 export function useWorkspaceActions() {
@@ -102,25 +121,45 @@ export function useWorkspaceActions() {
     });
   };
 
-  const createLocalWorkspaceMutation = useMutation<Workspace, Error, string>({
+  const createLocalWorkspaceMutation = useMutation<CreateLocalWorkspaceResult, Error, string>({
     meta: {
       telemetryHandled: true,
     },
     mutationFn: async (sourceRoot) => {
       const readyRuntimeUrl = await ensureRuntimeReady();
-      const response = await getAnyHarnessClient({ runtimeUrl: readyRuntimeUrl }).workspaces.create({
+      const client = getAnyHarnessClient({ runtimeUrl: readyRuntimeUrl });
+      const request = {
         path: sourceRoot,
         origin: DESKTOP_ORIGIN,
-      });
-      return response.workspace;
+      };
+
+      try {
+        const response = await client.workspaces.create(request);
+        return {
+          workspace: response.workspace,
+          created: true,
+        };
+      } catch (error) {
+        if (!isExistingWorkspacePathError(error)) {
+          throw error;
+        }
+
+        const response = await client.workspaces.resolveFromPath(request);
+        return {
+          workspace: response.workspace,
+          created: false,
+        };
+      }
     },
-    onSuccess: (workspace) => {
+    onSuccess: ({ workspace, created }) => {
       primeWorkspaceCollections(workspace, "local_create");
       refreshWorkspaceCollections("local_create", workspace.id);
-      trackProductEvent("workspace_created", {
-        workspace_kind: "local",
-        creation_kind: "local",
-      });
+      if (created) {
+        trackProductEvent("workspace_created", {
+          workspace_kind: "local",
+          creation_kind: "local",
+        });
+      }
     },
     onError: (error) => {
       captureTelemetryException(error, {
@@ -237,7 +276,8 @@ export function useWorkspaceActions() {
         repoConfig: repoPreferences.repoConfigs[repoRoot.path] ?? null,
       });
     },
-    createLocalWorkspace: createLocalWorkspaceMutation.mutateAsync,
+    createLocalWorkspace: async (sourceRoot: string) =>
+      (await createLocalWorkspaceMutation.mutateAsync(sourceRoot)).workspace,
     isCreatingLocalWorkspace: createLocalWorkspaceMutation.isPending,
     createWorktreeWorkspace: (
       params: WorktreeCreationParams,


### PR DESCRIPTION
## Summary

Fixes local workspace creation when the selected path already has an AnyHarness workspace record. The desktop create flow still calls the strict create endpoint first, but now treats the duplicate-path response as an idempotent open-existing case by falling back to `resolveFromPath`.

## Why

Users could no longer open/create a local workspace for an already-registered path such as `/Users/pablo/proliferate`; the strict create endpoint correctly rejected the duplicate record and the UI surfaced that backend error as a toast.

## Impact

- Existing callers still receive a `Workspace` from `createLocalWorkspace`.
- Duplicate-path recovery updates the workspace cache and opens the existing workspace.
- `workspace_created` telemetry only fires for true new workspace records.
- Non-conflict create failures and resolve failures still propagate and are captured as telemetry exceptions.

## Validation

- `pnpm --dir desktop exec vitest run src/hooks/workspaces/use-workspace-actions.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop test`
- `git diff --check`
