### PR TITLE
[codex] fix duplicate composer submits

### DIFF
--- a/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -22,6 +22,7 @@ import { useChatDraftState } from "@/hooks/chat/use-chat-draft-state";
 import { useChatModelSelectorState } from "@/hooks/chat/use-chat-model-selector-state";
 import { useChatPromptActions } from "@/hooks/chat/use-chat-prompt-actions";
 import type { PromptAttachmentController } from "@/hooks/chat/use-chat-prompt-attachments";
+import { useComposerSubmitGate } from "@/hooks/chat/use-composer-submit-gate";
 import { usePlanDraftAttachments } from "@/hooks/plans/use-plan-draft-attachments";
 import { useChatSessionControls } from "@/hooks/chat/use-chat-session-controls";
 import { useQueuedPromptEdit } from "@/hooks/chat/use-queued-prompt-edit";
@@ -83,6 +84,7 @@ export function ChatInput({
   const { handleSubmit, handleCancel } = useChatPromptActions({
     forceNewSession: suppressActiveSessionState,
   });
+  const { isSubmitting, run: runSubmit } = useComposerSubmitGate();
   const reviewActions = useReviewActions();
   const activeReview = useActiveReviewRun();
   const {
@@ -98,7 +100,7 @@ export function ChatInput({
     sdkWorkspaceId: materializedWorkspaceId,
   });
   const canUseUtilityActions =
-    !effectiveIsEditingQueuedPrompt && !isDisabled && !areRuntimeControlsDisabled;
+    !effectiveIsEditingQueuedPrompt && !isDisabled && !areRuntimeControlsDisabled && !isSubmitting;
   const canAttach = canUseUtilityActions && attachments.canAttachFiles;
   // Plan references are resolved to markdown text by the runtime, so they do
   // not depend on file/image attachment capabilities.
@@ -141,7 +143,8 @@ export function ChatInput({
   const effectiveIsEmpty = effectiveIsEditingQueuedPrompt
     ? editDraft.trim().length === 0
     : isEmpty && !hasDraftAttachments;
-  const canSubmit = !effectiveIsEmpty && !isDisabled && !planAttachments.hasUnresolvedPlans;
+  const canSubmit =
+    !effectiveIsEmpty && !isDisabled && !planAttachments.hasUnresolvedPlans && !isSubmitting;
   useComposerTextareaAutosize({
     textareaRef,
     value: editDraft,
@@ -152,25 +155,35 @@ export function ChatInput({
   });
 
   const onSubmit = useCallback(async () => {
-    if (effectiveIsEditingQueuedPrompt) {
-      await commitEdit();
-      return;
-    }
-    if (planAttachments.hasUnresolvedPlans) {
-      return;
-    }
-    const blocks = [
-      ...await attachments.buildBlocks(promptText.trim()),
-      ...planAttachments.blocks,
-    ];
-    const optimisticContentParts = [
-      ...(promptText.trim() ? [{ type: "text" as const, text: promptText.trim() }] : []),
-      ...planAttachments.contentParts,
-    ];
-    await handleSubmit({ text: promptText, blocks, optimisticContentParts });
-    attachments.clearAttachments();
-    planAttachments.clearPlans();
-  }, [attachments, commitEdit, effectiveIsEditingQueuedPrompt, handleSubmit, planAttachments, promptText]);
+    await runSubmit(async () => {
+      if (effectiveIsEditingQueuedPrompt) {
+        await commitEdit();
+        return;
+      }
+      if (planAttachments.hasUnresolvedPlans) {
+        return;
+      }
+      const blocks = [
+        ...await attachments.buildBlocks(promptText.trim()),
+        ...planAttachments.blocks,
+      ];
+      const optimisticContentParts = [
+        ...(promptText.trim() ? [{ type: "text" as const, text: promptText.trim() }] : []),
+        ...planAttachments.contentParts,
+      ];
+      await handleSubmit({ text: promptText, blocks, optimisticContentParts });
+      attachments.clearAttachments();
+      planAttachments.clearPlans();
+    });
+  }, [
+    attachments,
+    commitEdit,
+    effectiveIsEditingQueuedPrompt,
+    handleSubmit,
+    planAttachments,
+    promptText,
+    runSubmit,
+  ]);
 
   const onCancel = useCallback(() => {
     if (effectiveIsEditingQueuedPrompt) {
@@ -371,7 +384,7 @@ export function ChatInput({
               <ChatComposerActions
                 isRunning={isRunningForUi}
                 isEmpty={effectiveIsEmpty}
-                isDisabled={isDisabled || planAttachments.hasUnresolvedPlans}
+                isDisabled={isDisabled || planAttachments.hasUnresolvedPlans || isSubmitting}
                 isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
                 onSubmit={onSubmit}
                 onCancel={onCancel}

--- a/desktop/src/components/workspace/chat/input/ComposerMentionEditor.test.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerMentionEditor.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import type { SearchWorkspaceFilesResponse } from "@anyharness/sdk";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTextDraft,
+  serializeChatDraftToPrompt,
+  type ChatComposerDraft,
+} from "@/lib/domain/chat/file-mentions";
+import { ComposerMentionEditor } from "./ComposerMentionEditor";
+
+type FileSearchResult = SearchWorkspaceFilesResponse["results"][number];
+
+const mentionSearchMock = vi.hoisted(() => ({
+  results: [] as FileSearchResult[],
+  moveHighlight: vi.fn(),
+  selectedCount: 0,
+}));
+
+vi.mock("@/hooks/chat/use-chat-file-mention-search", () => ({
+  useChatFileMentionSearch: ({ onSelect }: { onSelect: (result: FileSearchResult) => void }) => ({
+    results: mentionSearchMock.results,
+    highlightedIndex: 0,
+    isLoading: false,
+    errorMessage: null,
+    listRef: { current: null },
+    moveHighlight: mentionSearchMock.moveHighlight,
+    selectHighlighted: () => {
+      mentionSearchMock.selectedCount += 1;
+      const first = mentionSearchMock.results[0];
+      if (first) {
+        onSelect(first);
+      }
+    },
+    setRowRef: vi.fn(),
+    handleRowMouseEnter: vi.fn(),
+  }),
+}));
+
+function renderEditor({
+  draft = createTextDraft("hello"),
+  canSubmit = true,
+  onSubmit = vi.fn(),
+  onDraftChange = vi.fn(),
+}: {
+  draft?: ChatComposerDraft;
+  canSubmit?: boolean;
+  onSubmit?: () => void;
+  onDraftChange?: (draft: ChatComposerDraft) => void;
+} = {}) {
+  render(
+    <ComposerMentionEditor
+      draft={draft}
+      onDraftChange={onDraftChange}
+      placeholder="Message"
+      canSubmit={canSubmit}
+      disabled={false}
+      onSubmit={onSubmit}
+      topInset="standard"
+    />,
+  );
+  return {
+    onSubmit,
+    onDraftChange,
+    textarea: screen.getByPlaceholderText("Message"),
+  };
+}
+
+describe("ComposerMentionEditor", () => {
+  beforeEach(() => {
+    mentionSearchMock.results = [];
+    mentionSearchMock.moveHighlight.mockClear();
+    mentionSearchMock.selectedCount = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("prevents repeated raw Enter fallback without submitting", () => {
+    const { textarea, onSubmit } = renderEditor();
+
+    expect(fireEvent.keyDown(textarea, { key: "Enter", repeat: true })).toBe(false);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on a non-repeated raw Enter fallback", () => {
+    const { textarea, onSubmit } = renderEditor();
+
+    expect(fireEvent.keyDown(textarea, { key: "Enter", repeat: false })).toBe(false);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Enter as mention selection when a mention trigger is active", () => {
+    mentionSearchMock.results = [{
+      name: "file.ts",
+      path: "src/file.ts",
+    } as FileSearchResult];
+    const onSubmit = vi.fn();
+    const onDraftChange = vi.fn();
+    const { textarea } = renderEditor({
+      draft: createTextDraft("Open @fi"),
+      onSubmit,
+      onDraftChange,
+    });
+
+    expect(fireEvent.keyDown(textarea, { key: "Enter", repeat: true })).toBe(false);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(mentionSearchMock.selectedCount).toBe(1);
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+    expect(serializeChatDraftToPrompt(onDraftChange.mock.calls[0]?.[0])).toBe(
+      "Open [file.ts](src/file.ts) ",
+    );
+  });
+});

--- a/desktop/src/components/workspace/chat/input/ComposerMentionEditor.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerMentionEditor.tsx
@@ -18,6 +18,7 @@ import { useComposerTextareaAutosize } from "@/hooks/chat/use-composer-textarea-
 import {
   isComposerMentionSelectKey,
   isRawComposerSubmitKey,
+  isRepeatedComposerSubmitKey,
 } from "@/lib/domain/chat/composer-keyboard";
 import {
   createTextDraft,
@@ -202,6 +203,11 @@ export function ComposerMentionEditor({
 
     onKeyDown?.(event);
     if (event.defaultPrevented) {
+      return;
+    }
+
+    if (isRepeatedComposerSubmitKey(event)) {
+      event.preventDefault();
       return;
     }
 

--- a/desktop/src/hooks/chat/use-chat-composer-keyboard.test.ts
+++ b/desktop/src/hooks/chat/use-chat-composer-keyboard.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useChatComposerKeyboard } from "./use-chat-composer-keyboard";
+
+function keyboardEvent(overrides: Partial<{
+  key: string;
+  code: string;
+  repeat: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  defaultPrevented: boolean;
+  nativeEvent: { isComposing?: boolean };
+}> = {}) {
+  const event = {
+    key: "Enter",
+    code: "Enter",
+    repeat: false,
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    defaultPrevented: false,
+    nativeEvent: {
+      isComposing: false,
+      ...overrides.nativeEvent,
+    },
+    preventDefault: vi.fn(() => {
+      event.defaultPrevented = true;
+    }),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  };
+  return event;
+}
+
+describe("useChatComposerKeyboard", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("prevents repeated submit keys without submitting", () => {
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+    const handleSubmit = vi.fn();
+    const { result } = renderHook(() => useChatComposerKeyboard({
+      handleSubmit,
+      handleCancel: vi.fn(),
+      isRunning: false,
+      canSubmit: true,
+      modeControl: null,
+    }));
+    const event = keyboardEvent({ repeat: true });
+
+    result.current.handleKeyDown(event as never);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("prevents repeated submit keys even when submit is currently unavailable", () => {
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+    const handleSubmit = vi.fn();
+    const { result } = renderHook(() => useChatComposerKeyboard({
+      handleSubmit,
+      handleCancel: vi.fn(),
+      isRunning: false,
+      canSubmit: false,
+      modeControl: null,
+    }));
+    const event = keyboardEvent({ repeat: true });
+
+    result.current.handleKeyDown(event as never);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on a non-repeated submit key", () => {
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+    const handleSubmit = vi.fn();
+    const { result } = renderHook(() => useChatComposerKeyboard({
+      handleSubmit,
+      handleCancel: vi.fn(),
+      isRunning: false,
+      canSubmit: true,
+      modeControl: null,
+    }));
+    const event = keyboardEvent();
+
+    result.current.handleKeyDown(event as never);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/hooks/chat/use-chat-composer-keyboard.ts
+++ b/desktop/src/hooks/chat/use-chat-composer-keyboard.ts
@@ -2,7 +2,10 @@ import { useCallback, type KeyboardEvent } from "react";
 import { getPreviousSessionModeValue } from "@/lib/domain/chat/session-mode-control";
 import { COMPOSER_SHORTCUTS } from "@/config/shortcuts";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls";
-import { isComposerSubmitKey } from "@/lib/domain/chat/composer-keyboard";
+import {
+  isComposerSubmitKey,
+  isRepeatedComposerSubmitKey,
+} from "@/lib/domain/chat/composer-keyboard";
 import { runShortcutHandler } from "@/lib/domain/shortcuts/registry";
 
 interface UseChatComposerKeyboardArgs {
@@ -81,10 +84,12 @@ export function useChatComposerKeyboard({
       }
     }
 
-    if (
-      isComposerSubmitKey(event)
-      && canSubmit
-    ) {
+    if (isRepeatedComposerSubmitKey(event)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (isComposerSubmitKey(event) && canSubmit) {
       event.preventDefault();
       void handleSubmit();
     }

--- a/desktop/src/hooks/chat/use-composer-submit-gate.test.ts
+++ b/desktop/src/hooks/chat/use-composer-submit-gate.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useComposerSubmitGate } from "./use-composer-submit-gate";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useComposerSubmitGate", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("blocks synchronous duplicate runs while an action is pending", async () => {
+    const gate = deferred();
+    const action = vi.fn(() => gate.promise);
+    const { result } = renderHook(() => useComposerSubmitGate());
+
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    act(() => {
+      first = result.current.run(action);
+      second = result.current.run(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    await expect(second).resolves.toBe(false);
+
+    await act(async () => {
+      gate.resolve();
+      await expect(first).resolves.toBe(true);
+    });
+  });
+
+  it("reports submitting while the action is pending", async () => {
+    const gate = deferred();
+    const { result } = renderHook(() => useComposerSubmitGate());
+
+    let run!: Promise<boolean>;
+    act(() => {
+      run = result.current.run(() => gate.promise);
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    await act(async () => {
+      gate.resolve();
+      await run;
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it("allows another run after settlement", async () => {
+    const { result } = renderHook(() => useComposerSubmitGate());
+    const action = vi.fn();
+
+    await act(async () => {
+      await expect(result.current.run(action)).resolves.toBe(true);
+    });
+    await act(async () => {
+      await expect(result.current.run(action)).resolves.toBe(true);
+    });
+
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it("unlocks and propagates action failures", async () => {
+    const { result } = renderHook(() => useComposerSubmitGate());
+    const error = new Error("submit failed");
+    const failingAction = vi.fn(() => {
+      throw error;
+    });
+    const nextAction = vi.fn();
+
+    await act(async () => {
+      await expect(result.current.run(failingAction)).rejects.toThrow("submit failed");
+    });
+    await act(async () => {
+      await expect(result.current.run(nextAction)).resolves.toBe(true);
+    });
+
+    expect(failingAction).toHaveBeenCalledTimes(1);
+    expect(nextAction).toHaveBeenCalledTimes(1);
+    expect(result.current.isSubmitting).toBe(false);
+  });
+});

--- a/desktop/src/hooks/chat/use-composer-submit-gate.ts
+++ b/desktop/src/hooks/chat/use-composer-submit-gate.ts
@@ -1,0 +1,27 @@
+import { useCallback, useRef, useState } from "react";
+
+export function useComposerSubmitGate(): {
+  isSubmitting: boolean;
+  run: (action: () => Promise<void> | void) => Promise<boolean>;
+} {
+  const submittingRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const run = useCallback(async (action: () => Promise<void> | void): Promise<boolean> => {
+    if (submittingRef.current) {
+      return false;
+    }
+
+    submittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await action();
+      return true;
+    } finally {
+      submittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }, []);
+
+  return { isSubmitting, run };
+}

--- a/desktop/src/lib/domain/chat/composer-keyboard.test.ts
+++ b/desktop/src/lib/domain/chat/composer-keyboard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isComposerMentionSelectKey,
+  isRepeatedComposerSubmitKey,
   isComposerSubmitKey,
   isRawComposerSubmitKey,
   type ComposerKeyboardEventLike,
@@ -10,6 +11,7 @@ function event(overrides: Partial<ComposerKeyboardEventLike> = {}): ComposerKeyb
   return {
     ...{
       key: "Enter",
+      repeat: false,
       shiftKey: false,
       altKey: false,
       ctrlKey: false,
@@ -62,6 +64,44 @@ describe("composer keyboard predicates", () => {
     expect(isComposerSubmitKey(event({ ctrlKey: true }))).toBe(true);
     expect(isComposerSubmitKey(event({ metaKey: true }))).toBe(false);
     expect(isComposerSubmitKey(event({ ctrlKey: true, altKey: true }))).toBe(false);
+  });
+
+  it("classifies repeated raw Enter as repeated submit", () => {
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true }))).toBe(true);
+    expect(isRepeatedComposerSubmitKey(event({ repeat: false }))).toBe(false);
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true, shiftKey: true }))).toBe(false);
+  });
+
+  it("classifies repeated platform submit shortcuts", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true, metaKey: true }))).toBe(true);
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true, ctrlKey: true }))).toBe(false);
+
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true, ctrlKey: true }))).toBe(true);
+    expect(isRepeatedComposerSubmitKey(event({ repeat: true, metaKey: true }))).toBe(false);
+  });
+
+  it("does not classify composing events as submit repeats", () => {
+    expect(isComposerSubmitKey(event({
+      repeat: true,
+      nativeEvent: { isComposing: true },
+    }))).toBe(false);
+    expect(isRepeatedComposerSubmitKey(event({
+      repeat: true,
+      nativeEvent: { isComposing: true },
+    }))).toBe(false);
   });
 
   it("uses raw Enter or unshifted Tab for mention selection only", () => {

--- a/desktop/src/lib/domain/chat/composer-keyboard.ts
+++ b/desktop/src/lib/domain/chat/composer-keyboard.ts
@@ -2,6 +2,7 @@ import { isApplePlatform } from "@/lib/domain/shortcuts/matching";
 
 export interface ComposerKeyboardEventLike {
   key: string;
+  repeat?: boolean;
   shiftKey: boolean;
   altKey: boolean;
   ctrlKey: boolean;
@@ -39,6 +40,10 @@ export function isModifiedComposerSubmitKey(event: ComposerKeyboardEventLike): b
 
 export function isComposerSubmitKey(event: ComposerKeyboardEventLike): boolean {
   return isRawComposerSubmitKey(event) || isModifiedComposerSubmitKey(event);
+}
+
+export function isRepeatedComposerSubmitKey(event: ComposerKeyboardEventLike): boolean {
+  return event.repeat === true && isComposerSubmitKey(event);
 }
 
 export function isComposerMentionSelectKey(event: ComposerKeyboardEventLike): boolean {


### PR DESCRIPTION
## Summary
- Add a ref-backed submit gate around the chat composer primary submit flow.
- Suppress repeated Enter/Cmd+Enter/Ctrl+Enter submit key events while preserving mention selection.
- Disable composer submit and utility actions while submit serialization/cleanup is in flight.

## Root Cause
The desktop composer could re-enter its async submit workflow before React reflected the cleared draft or disabled state, so a held Enter or rapid follow-up action could enqueue the same follow-up twice.

## Validation
- `pnpm --dir desktop test -- use-composer-submit-gate.test.ts composer-keyboard.test.ts use-chat-composer-keyboard.test.ts ComposerMentionEditor.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check`
