### PR TITLE
Clean chat completion state and composer geometry

### DIFF
--- a/desktop/src/components/feedback/TurnEndCelebration.tsx
+++ b/desktop/src/components/feedback/TurnEndCelebration.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { ProliferateIcon } from "@/components/ui/icons";
-import { offTurnEnd, onTurnEnd } from "@/lib/integrations/anyharness/turn-end-events";
+import {
+  offUserFacingTurnEnd,
+  onUserFacingTurnEnd,
+} from "@/lib/integrations/anyharness/turn-end-events";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 export function TurnEndCelebration() {
@@ -15,9 +18,9 @@ export function TurnEndCelebration() {
   }, []);
 
   useEffect(() => {
-    onTurnEnd(handleTurnEnd);
+    onUserFacingTurnEnd(handleTurnEnd);
     return () => {
-      offTurnEnd(handleTurnEnd);
+      offUserFacingTurnEnd(handleTurnEnd);
     };
   }, [handleTurnEnd]);
 

--- a/desktop/src/components/playground/PlaygroundComposer.tsx
+++ b/desktop/src/components/playground/PlaygroundComposer.tsx
@@ -111,6 +111,7 @@ const PLAYGROUND_COWORK_ROWS: CoworkComposerWorkspaceRow[] = [
   {
     ownershipId: "workspace-frontend-polish",
     workspaceId: "workspace-frontend-polish",
+    parentSessionId: "playground-root-session",
     label: "frontend-polish",
     sessionCount: 2,
     active: true,
@@ -118,6 +119,7 @@ const PLAYGROUND_COWORK_ROWS: CoworkComposerWorkspaceRow[] = [
       {
         sessionLinkId: "coding-link-composer-layout",
         codingSessionId: "coding-session-composer-layout",
+        parentSessionId: "playground-root-session",
         label: "composer layout cleanup",
         agentKind: "codex",
         statusLabel: "Working",
@@ -130,6 +132,7 @@ const PLAYGROUND_COWORK_ROWS: CoworkComposerWorkspaceRow[] = [
       {
         sessionLinkId: "coding-link-visual-regression",
         codingSessionId: "coding-session-visual-regression",
+        parentSessionId: "playground-root-session",
         label: "visual regression pass",
         agentKind: "claude",
         statusLabel: "Idle",

--- a/desktop/src/components/workspace/chat/input/ChatComposerDock.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatComposerDock.tsx
@@ -103,7 +103,7 @@ export const ChatComposerDock = forwardRef<HTMLDivElement, ChatComposerDockProps
             ))}
             {children}
             {footerSlot ? (
-              <div className="mt-2">{footerSlot}</div>
+              <div className="mt-2" data-chat-composer-footer="true">{footerSlot}</div>
             ) : null}
           </div>
         </div>

--- a/desktop/src/components/workspace/chat/input/ComposerReviewRunPanel.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerReviewRunPanel.tsx
@@ -26,6 +26,7 @@ import {
   reviewRoundProgress,
   reviewRunReplacesStartingReview,
 } from "@/lib/domain/reviews/review-runs";
+import { collectReviewSessionRelationshipHints } from "@/lib/domain/reviews/session-relationship-hints";
 import {
   type StartingReviewState,
   useReviewUiStore,
@@ -46,6 +47,9 @@ function ConnectedComposerReviewRunSurface({ panel = false }: { panel?: boolean 
   const actions = useReviewActions();
   const { activateChatTab } = useWorkspaceShellActivation();
   const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
+  const recordSessionRelationshipHint = useHarnessStore(
+    (state) => state.recordSessionRelationshipHint,
+  );
   const openCritique = useReviewUiStore((state) => state.openCritique);
   const dismissTerminalNotice = useReviewUiStore((state) => state.dismissTerminalNotice);
   const clearStartingReview = useReviewUiStore((state) => state.clearStartingReview);
@@ -60,6 +64,21 @@ function ConnectedComposerReviewRunSurface({ panel = false }: { panel?: boolean 
     }
   }, [clearStartingReview, runReplacesStartingReview]);
 
+  useEffect(() => {
+    if (!run) {
+      return;
+    }
+    for (const hint of collectReviewSessionRelationshipHints([run])) {
+      recordSessionRelationshipHint(hint.sessionId, {
+        kind: "review_child",
+        parentSessionId: hint.parentSessionId,
+        sessionLinkId: hint.sessionLinkId,
+        relation: "review",
+        workspaceId: selectedWorkspaceId,
+      });
+    }
+  }, [recordSessionRelationshipHint, run, selectedWorkspaceId]);
+
   const handleOpenCritique = (assignment: ReviewAssignmentDetail) => {
     if (!run) {
       return;
@@ -72,6 +91,17 @@ function ConnectedComposerReviewRunSurface({ panel = false }: { panel?: boolean 
   };
   const handleOpenReviewerSession = (sessionId: string) => {
     if (!selectedWorkspaceId) return;
+    const hint = collectReviewSessionRelationshipHints(run ? [run] : [])
+      .find((candidate) => candidate.sessionId === sessionId);
+    if (hint) {
+      recordSessionRelationshipHint(sessionId, {
+        kind: "review_child",
+        parentSessionId: hint.parentSessionId,
+        sessionLinkId: hint.sessionLinkId,
+        relation: "review",
+        workspaceId: selectedWorkspaceId,
+      });
+    }
     void activateChatTab({
       workspaceId: selectedWorkspaceId,
       sessionId,

--- a/desktop/src/components/workspace/chat/input/CoworkComposerStrip.tsx
+++ b/desktop/src/components/workspace/chat/input/CoworkComposerStrip.tsx
@@ -18,7 +18,12 @@ interface CoworkComposerStripProps {
   rows: CoworkComposerWorkspaceRow[];
   summary: CoworkComposerStripSummary;
   onOpenWorkspace: (workspaceId: string) => void;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }
 
 export function CoworkComposerStrip({
@@ -99,7 +104,12 @@ function CoworkWorkspaceGroup({
 }: {
   workspace: CoworkComposerWorkspaceRow;
   onOpenWorkspace: (workspaceId: string) => void;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }) {
   return (
     <div className="min-w-0">
@@ -149,7 +159,12 @@ function CoworkSessionRow({
 }: {
   session: CoworkComposerSessionRow;
   workspaceId: string;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }) {
   return (
     <Button
@@ -161,6 +176,8 @@ function CoworkSessionRow({
       onClick={() => onOpenSession({
         workspaceId,
         sessionId: session.codingSessionId,
+        parentSessionId: session.parentSessionId,
+        sessionLinkId: session.sessionLinkId,
       })}
     >
       <AgentGlyph

--- a/desktop/src/components/workspace/chat/input/McpElicitationCard.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationCard.tsx
@@ -72,23 +72,28 @@ export function McpElicitationCard({
 
     return (
       <ComposerAttachedPanel header={header}>
-        <div className="flex flex-col gap-3 p-3">
-          <div className="space-y-1 text-sm">
-            <div className="text-muted-foreground">{payload.mode.message}</div>
-            <div className="text-xs text-muted-foreground">
-              Destination: {payload.mode.urlDisplay}
+        <div className="flex max-h-[min(40vh,360px)] flex-col">
+          <div className="min-h-0 overflow-y-auto p-3 pb-2">
+            <div className="flex flex-col gap-3">
+              <div className="space-y-1 text-sm">
+                <div className="text-muted-foreground">{payload.mode.message}</div>
+                <div className="text-xs text-muted-foreground">
+                  Destination: {payload.mode.urlDisplay}
+                </div>
+              </div>
+              {revealedUrl && (
+                <Input
+                  value={revealedUrl}
+                  readOnly
+                  data-telemetry-mask="true"
+                  className="font-mono text-xs"
+                />
+              )}
+              {error && <InlineError message={error} />}
             </div>
           </div>
-          {revealedUrl && (
-            <Input
-              value={revealedUrl}
-              readOnly
-              data-telemetry-mask="true"
-              className="font-mono text-xs"
-            />
-          )}
-          {error && <InlineError message={error} />}
-          <div className="flex flex-wrap items-center gap-2">
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2 px-3 pb-3 pt-2">
             <Button
               type="button"
               variant="secondary"
@@ -153,22 +158,27 @@ export function McpElicitationCard({
 
   return (
     <ComposerAttachedPanel header={header}>
-      <div className="flex flex-col gap-3 p-3">
-        <div className="text-sm text-muted-foreground">
-          {formMode.message}
+      <div className="flex max-h-[min(40vh,360px)] flex-col">
+        <div className="min-h-0 overflow-y-auto p-3 pb-2">
+          <div className="flex flex-col gap-3">
+            <div className="text-sm text-muted-foreground">
+              {formMode.message}
+            </div>
+            <div className="flex flex-col gap-3">
+              {formFields.map((field) => (
+                <McpFieldControl
+                  key={field.fieldId}
+                  field={field}
+                  value={drafts[field.fieldId]}
+                  onChange={(value) => updateDraft(field.fieldId, value)}
+                />
+              ))}
+            </div>
+            {error && <InlineError message={error} />}
+          </div>
         </div>
-        <div className="flex flex-col gap-3">
-          {formFields.map((field) => (
-            <McpFieldControl
-              key={field.fieldId}
-              field={field}
-              value={drafts[field.fieldId]}
-              onChange={(value) => updateDraft(field.fieldId, value)}
-            />
-          ))}
-        </div>
-        {error && <InlineError message={error} />}
-        <div className="flex flex-wrap items-center justify-end gap-2">
+
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 px-3 pb-3 pt-2">
           <Button
             type="button"
             variant="secondary"

--- a/desktop/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/desktop/src/components/workspace/chat/input/UserInputCard.tsx
@@ -136,73 +136,85 @@ export function UserInputCard({
 
   return (
     <ComposerAttachedPanel header={header}>
-      <div className="flex flex-col gap-3 p-3">
-        <div className="space-y-1">
-          {currentQuestion.header && currentQuestion.header !== title && (
-            <div className="text-sm font-medium text-foreground">
-              {currentQuestion.header}
+      <div className="flex max-h-[min(40vh,360px)] flex-col">
+        <div className="min-h-0 overflow-y-auto p-3 pb-2">
+          <div className="flex flex-col gap-3">
+            <div className="space-y-1">
+              {currentQuestion.header && currentQuestion.header !== title && (
+                <div className="text-sm font-medium text-foreground">
+                  {currentQuestion.header}
+                </div>
+              )}
+              <div className="text-sm text-muted-foreground">
+                {currentQuestion.question}
+              </div>
             </div>
-          )}
-          <div className="text-sm text-muted-foreground">
-            {currentQuestion.question}
+
+            {options.length > 0 && (
+              <div className="flex flex-col gap-2">
+                {options.map((option) => {
+                  const selected = draft.selectedOptionLabel === option.label;
+                  return (
+                    <Button
+                      key={option.label}
+                      type="button"
+                      variant={selected ? "primary" : "secondary"}
+                      size="sm"
+                      className="h-auto justify-start rounded-xl px-3 py-2 text-left"
+                      onClick={() =>
+                        updateDraft({
+                          selectedOptionLabel: option.label,
+                          text: option.label === OTHER_OPTION_LABEL ? draft.text : "",
+                        })}
+                    >
+                      <span className="flex flex-col gap-0.5">
+                        <span>{option.label}</span>
+                        {option.description && (
+                          <span
+                            className={
+                              selected
+                                ? "text-primary-foreground/75"
+                                : "text-muted-foreground"
+                            }
+                          >
+                            {option.description}
+                          </span>
+                        )}
+                      </span>
+                    </Button>
+                  );
+                })}
+              </div>
+            )}
+
+            {showTextInput && (
+              currentQuestion.isSecret ? (
+                <Input
+                  type="password"
+                  value={draft.text}
+                  onChange={(event) =>
+                    updateDraft({ text: event.currentTarget.value })}
+                  placeholder="Enter your answer"
+                  autoComplete="off"
+                  data-telemetry-mask="true"
+                />
+              ) : (
+                <Textarea
+                  value={draft.text}
+                  onChange={(event) =>
+                    updateDraft({ text: event.currentTarget.value })}
+                  placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
+                    ? "Write a custom answer"
+                    : "Enter your answer"}
+                  rows={3}
+                  data-telemetry-mask="true"
+                />
+              )
+            )}
           </div>
         </div>
 
-        {options.length > 0 && (
-          <div className="flex flex-col gap-2">
-            {options.map((option) => {
-              const selected = draft.selectedOptionLabel === option.label;
-              return (
-                <Button
-                  key={option.label}
-                  type="button"
-                  variant={selected ? "primary" : "secondary"}
-                  size="sm"
-                  className="h-auto justify-start rounded-xl px-3 py-2 text-left"
-                  onClick={() =>
-                    updateDraft({
-                      selectedOptionLabel: option.label,
-                      text: option.label === OTHER_OPTION_LABEL ? draft.text : "",
-                    })}
-                >
-                  <span className="flex flex-col gap-0.5">
-                    <span>{option.label}</span>
-                    {option.description && (
-                      <span className={selected ? "text-primary-foreground/75" : "text-muted-foreground"}>
-                        {option.description}
-                      </span>
-                    )}
-                  </span>
-                </Button>
-              );
-            })}
-          </div>
-        )}
-
-        {showTextInput && (
-          currentQuestion.isSecret ? (
-            <Input
-              type="password"
-              value={draft.text}
-              onChange={(event) => updateDraft({ text: event.currentTarget.value })}
-              placeholder="Enter your answer"
-              autoComplete="off"
-              data-telemetry-mask="true"
-            />
-          ) : (
-            <Textarea
-              value={draft.text}
-              onChange={(event) => updateDraft({ text: event.currentTarget.value })}
-              placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
-                ? "Write a custom answer"
-                : "Enter your answer"}
-              rows={3}
-              data-telemetry-mask="true"
-            />
-          )
-        )}
-
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-3 pt-2">
           <Button
             type="button"
             variant="secondary"
@@ -219,7 +231,8 @@ export function UserInputCard({
                 variant="secondary"
                 size="sm"
                 className={BUTTON_CLASSNAME}
-                onClick={() => setQuestionIndex((index) => Math.max(0, index - 1))}
+                onClick={() =>
+                  setQuestionIndex((index) => Math.max(0, index - 1))}
               >
                 Back
               </Button>
@@ -240,7 +253,9 @@ export function UserInputCard({
                 variant="primary"
                 size="sm"
                 className={BUTTON_CLASSNAME}
-                onClick={() => setQuestionIndex((index) => Math.min(questions.length - 1, index + 1))}
+                onClick={() =>
+                  setQuestionIndex((index) =>
+                    Math.min(questions.length - 1, index + 1))}
               >
                 Next
               </Button>

--- a/desktop/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx
@@ -83,23 +83,25 @@ export function CloudRuntimeAttachedPanelView({
       expanded={expanded}
       onToggleExpanded={() => setExpanded((value) => !value)}
     >
-      <SectionRow label="Status">
-        <span className="text-base text-muted-foreground">
-          {state.actionBlockReason}
-        </span>
-      </SectionRow>
-      {state.showRetry && retry && (
-        <SectionRow label="Actions">
-          <Button
-            size="sm"
-            onClick={() => {
-              retry?.();
-            }}
-          >
-            Retry
-          </Button>
+      <div className="max-h-[min(32vh,280px)] overflow-y-auto">
+        <SectionRow label="Status">
+          <span className="text-base text-muted-foreground">
+            {state.actionBlockReason}
+          </span>
         </SectionRow>
-      )}
+        {state.showRetry && retry && (
+          <SectionRow label="Actions">
+            <Button
+              size="sm"
+              onClick={() => {
+                retry?.();
+              }}
+            >
+              Retry
+            </Button>
+          </SectionRow>
+        )}
+      </div>
     </ComposerAttachedPanel>
   );
 }

--- a/desktop/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx
@@ -77,33 +77,35 @@ export function WorkspaceArrivalAttachedPanelView({
       expanded={expanded}
       onToggleExpanded={onToggleExpanded}
     >
-      <SectionRow label="Setup">
-        <div className="flex items-center gap-2 text-base">
-          {isSetupRunning && (
-            <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground" />
-          )}
-          <span className={`shrink-0 whitespace-nowrap ${setupToneColor}`}>{viewModel.setupStatusLabel}</span>
-          <span className="text-muted-foreground/40">·</span>
-          <span className="group/setup-error relative min-w-0 truncate text-muted-foreground">
-            {viewModel.setupSummary}
-            {viewModel.setupDetail && (
-              <span className="pointer-events-none absolute bottom-full left-0 z-50 mb-1.5 hidden max-w-md whitespace-pre-wrap rounded-lg border border-border/60 bg-popover px-3 py-2 font-mono text-xs text-popover-foreground shadow-floating group-hover/setup-error:block">
-                {viewModel.setupDetail}
-              </span>
+      <div className="max-h-[min(32vh,280px)] overflow-y-auto">
+        <SectionRow label="Setup">
+          <div className="flex items-center gap-2 text-base">
+            {isSetupRunning && (
+              <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground" />
             )}
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onSetupAction}
-            className="ml-auto h-6 shrink-0 px-1.5"
-          >
-            {viewModel.setupActionLabel}
-            {viewModel.setupTone !== "destructive" && <ArrowUpRight className="size-3" />}
-          </Button>
-        </div>
-      </SectionRow>
+            <span className={`shrink-0 whitespace-nowrap ${setupToneColor}`}>{viewModel.setupStatusLabel}</span>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="group/setup-error relative min-w-0 truncate text-muted-foreground">
+              {viewModel.setupSummary}
+              {viewModel.setupDetail && (
+                <span className="pointer-events-none absolute bottom-full left-0 z-50 mb-1.5 hidden max-w-md whitespace-pre-wrap rounded-lg border border-border/60 bg-popover px-3 py-2 font-mono text-xs text-popover-foreground shadow-floating group-hover/setup-error:block">
+                  {viewModel.setupDetail}
+                </span>
+              )}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onSetupAction}
+              className="ml-auto h-6 shrink-0 px-1.5"
+            >
+              {viewModel.setupActionLabel}
+              {viewModel.setupTone !== "destructive" && <ArrowUpRight className="size-3" />}
+            </Button>
+          </div>
+        </SectionRow>
+      </div>
     </ComposerAttachedPanel>
   );
 }
@@ -246,45 +248,47 @@ export function WorkspaceArrivalAttachedPanel() {
         expanded={expanded}
         onToggleExpanded={() => setExpanded((v) => !v)}
       >
-        {panelState.detail && (
-          <SectionRow label="Details">
-            <span className="truncate text-base text-muted-foreground">
-              {panelState.detail}
-            </span>
-          </SectionRow>
-        )}
+        <div className="max-h-[min(32vh,280px)] overflow-y-auto">
+          {panelState.detail && (
+            <SectionRow label="Details">
+              <span className="truncate text-base text-muted-foreground">
+                {panelState.detail}
+              </span>
+            </SectionRow>
+          )}
 
-        {deferredPromptCount > 0 ? (
-          <SectionRow label="Prompt">
-            <span className="truncate text-base text-muted-foreground">
-              Queued prompt will send when this cloud workspace is ready.
-            </span>
-          </SectionRow>
-        ) : null}
+          {deferredPromptCount > 0 ? (
+            <SectionRow label="Prompt">
+              <span className="truncate text-base text-muted-foreground">
+                Queued prompt will send when this cloud workspace is ready.
+              </span>
+            </SectionRow>
+          ) : null}
 
-        {panelState.isFailed && (
-          <SectionRow label="Actions">
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  void handleBack(panelState.entry);
-                }}
-              >
-                Back
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => {
-                  void handleRetry(panelState.entry);
-                }}
-              >
-                Retry
-              </Button>
-            </div>
-          </SectionRow>
-        )}
+          {panelState.isFailed && (
+            <SectionRow label="Actions">
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    void handleBack(panelState.entry);
+                  }}
+                >
+                  Back
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    void handleRetry(panelState.entry);
+                  }}
+                >
+                  Retry
+                </Button>
+              </div>
+            </SectionRow>
+          )}
+        </div>
       </ComposerAttachedPanel>
     );
   }

--- a/desktop/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx
@@ -85,39 +85,41 @@ export function WorkspaceArrivalCloudPanel({
       expanded={expanded}
       onToggleExpanded={() => setExpanded((value) => !value)}
     >
-      <SectionRow label="Repository">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base text-muted-foreground">
-          <span className="text-foreground">{model.repoLabel}</span>
-          <span>{model.branchLabel}</span>
-        </div>
-      </SectionRow>
-
-      {model.footer.kind === "action" ? (
-        <SectionRow label="Actions">
-          <div className="flex items-center gap-3">
-            <Button
-              size="sm"
-              loading={isPrimaryActionPending}
-              onClick={onPrimaryAction ?? undefined}
-            >
-              {model.footer.label}
-            </Button>
-            <span className="text-sm text-muted-foreground">{model.footer.helperText}</span>
+      <div className="max-h-[min(32vh,280px)] overflow-y-auto">
+        <SectionRow label="Repository">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base text-muted-foreground">
+            <span className="text-foreground">{model.repoLabel}</span>
+            <span>{model.branchLabel}</span>
           </div>
         </SectionRow>
-      ) : (
-        <SectionRow label="Status">
-          <span className="text-sm text-muted-foreground">{model.footer.message}</span>
-        </SectionRow>
-      )}
 
-      {pendingPromptCount > 0 ? (
-        <SectionRow label="Prompt">
-          <span className="text-sm text-muted-foreground">
-            Queued prompt will send when this cloud workspace is ready.
-          </span>
-        </SectionRow>
-      ) : null}
+        {model.footer.kind === "action" ? (
+          <SectionRow label="Actions">
+            <div className="flex items-center gap-3">
+              <Button
+                size="sm"
+                loading={isPrimaryActionPending}
+                onClick={onPrimaryAction ?? undefined}
+              >
+                {model.footer.label}
+              </Button>
+              <span className="text-sm text-muted-foreground">{model.footer.helperText}</span>
+            </div>
+          </SectionRow>
+        ) : (
+          <SectionRow label="Status">
+            <span className="text-sm text-muted-foreground">{model.footer.message}</span>
+          </SectionRow>
+        )}
+
+        {pendingPromptCount > 0 ? (
+          <SectionRow label="Prompt">
+            <span className="text-sm text-muted-foreground">
+              Queued prompt will send when this cloud workspace is ready.
+            </span>
+          </SectionRow>
+        ) : null}
+      </div>
     </ComposerAttachedPanel>
   );
 }

--- a/desktop/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolActionRow.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolActionRow.tsx
@@ -21,7 +21,12 @@ import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "@/lib/domain/chat/tool-call-lay
 
 interface CoworkCodingToolActionRowProps {
   item: ToolCallItem;
-  onOpenCodingSession?: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenCodingSession?: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
   onOpenWorkspace?: (workspaceId: string) => void;
 }
 
@@ -48,6 +53,8 @@ export function CoworkCodingToolActionRow({
     ? () => onOpenCodingSession?.({
       workspaceId: presentation.workspaceId!,
       sessionId: presentation.codingSessionId!,
+      parentSessionId: presentation.parentSessionId,
+      sessionLinkId: presentation.sessionLinkId,
     })
     : undefined;
   const openWorkspace = presentation.action === "create_workspace"

--- a/desktop/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/desktop/src/components/workspace/chat/transcript/MessageList.tsx
@@ -129,6 +129,7 @@ import type {
   TurnRecord,
   TerminalOutputContentPart,
 } from "@anyharness/sdk";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
 import type { SessionViewState } from "@/lib/domain/sessions/activity";
 import { VirtualTranscriptRowList } from "@/components/workspace/chat/transcript/VirtualTranscriptRowList";
 import {
@@ -891,11 +892,12 @@ function TranscriptItemBlock({
   switch (item.kind) {
     case "user_message": {
       if (isSubagentWakeProvenance(item.promptProvenance)) {
+        const wakeProvenance = item.promptProvenance;
         const completion =
-          transcript.linkCompletionsByCompletionId[item.promptProvenance.completionId] ?? null;
+          transcript.linkCompletionsByCompletionId[wakeProvenance.completionId] ?? null;
         const childRole: TranscriptOpenSessionRole =
-          item.promptProvenance.type === "linkWake"
-          && item.promptProvenance.relation === "cowork_coding_session"
+          wakeProvenance.type === "linkWake"
+          && wakeProvenance.relation === "cowork_coding_session"
             ? "cowork-coding-child"
             : "linked-child";
         const childSessionId = completion?.childSessionId ?? null;
@@ -905,17 +907,32 @@ function TranscriptItemBlock({
         return (
           <div className="flex justify-end">
             <SubagentWakeBadge
-              label={item.promptProvenance.label ?? completion?.label ?? null}
+              label={wakeProvenance.label ?? completion?.label ?? null}
               childSessionId={childSessionId}
               outcome={completion?.outcome ?? null}
               titleFallback={
-                item.promptProvenance.type === "linkWake"
-                && item.promptProvenance.relation === "cowork_coding_session"
+                wakeProvenance.type === "linkWake"
+                && wakeProvenance.relation === "cowork_coding_session"
                   ? "Coding session"
                   : "Subagent"
               }
               onOpenChild={canOpenChild
-                ? (targetSessionId) => openSession(targetSessionId, childRole)
+                ? (targetSessionId) => {
+                  useHarnessStore.getState().recordSessionRelationshipHint(targetSessionId, {
+                    kind: wakeProvenance.type === "subagentWake"
+                      ? "subagent_child"
+                      : childRole === "cowork-coding-child"
+                        ? "cowork_child"
+                        : "linked_child",
+                    parentSessionId: sessionId,
+                    sessionLinkId: wakeProvenance.sessionLinkId,
+                    relation: wakeProvenance.type === "linkWake"
+                      ? wakeProvenance.relation
+                      : "subagent",
+                    workspaceId,
+                  });
+                  openSession(targetSessionId, childRole);
+                }
                 : undefined}
             />
           </div>

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkManagedWorkspaceList.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkManagedWorkspaceList.tsx
@@ -53,21 +53,33 @@ function completionOutcomeLabel(outcome: string): string {
 function CoworkCodingSessionRowSurface({
   session,
   workspaceId,
+  parentSessionId,
   index,
   active,
   onOpenSession,
 }: {
   session: CoworkCodingSessionSummary;
   workspaceId: string;
+  parentSessionId: string;
   index: number;
   active: boolean;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }) {
   const color = resolveSubagentColor(session.sessionLinkId);
   return (
     <SidebarRowSurface
       active={active}
-      onPress={() => onOpenSession({ workspaceId, sessionId: session.codingSessionId })}
+      onPress={() => onOpenSession({
+        workspaceId,
+        sessionId: session.codingSessionId,
+        parentSessionId,
+        sessionLinkId: session.sessionLinkId,
+      })}
       className="h-[30px] pl-2 pr-1 py-1 focus-visible:outline-offset-[-2px]"
       data-telemetry-mask="true"
     >
@@ -104,7 +116,12 @@ function CoworkCodingSessionRow({
   parentSessionId: string;
   index: number;
   active: boolean;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }) {
   const [renaming, setRenaming] = useState(false);
   const { renameCodingSession, archiveCodingSession } = useCoworkSessionActions();
@@ -125,6 +142,7 @@ function CoworkCodingSessionRow({
     <CoworkCodingSessionRowSurface
       session={session}
       workspaceId={workspaceId}
+      parentSessionId={parentSessionId}
       index={index}
       active={active}
       onOpenSession={onOpenSession}
@@ -188,7 +206,12 @@ function CoworkManagedWorkspaceBlock({
   expanded: boolean;
   onToggleExpanded: () => void;
   onOpenWorkspace: (workspaceId: string) => void;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }) {
   const sessionCount = workspace.sessions.length;
   const hasSessions = sessionCount > 0;
@@ -265,7 +288,12 @@ interface CoworkManagedWorkspaceListProps {
   expandedWorkspaces: Set<string>;
   onToggleWorkspace: (ownershipId: string) => void;
   onOpenWorkspace: (workspaceId: string) => void;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }
 
 export function CoworkManagedWorkspaceList({

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadItem.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadItem.tsx
@@ -23,7 +23,12 @@ interface CoworkThreadItemProps {
   expandedWorkspaceIds: Set<string>;
   onToggleWorkspaceExpanded: (ownershipId: string) => void;
   onOpenWorkspace: (workspaceId: string) => void;
-  onOpenSession: (input: { workspaceId: string; sessionId: string }) => void;
+  onOpenSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }
 
 export function CoworkThreadItem({

--- a/desktop/src/components/workspace/shell/HeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/HeaderTabs.tsx
@@ -427,6 +427,7 @@ export function HeaderTabs() {
         >
           {(close) => (
             <ChatTabsMenu
+              workspaceId={viewModel.selectedWorkspaceId}
               rows={viewModel.menuChatTabs}
               childrenByParentSessionId={viewModel.childrenByParentSessionId}
               renderIcon={renderChatTabIcon}

--- a/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
@@ -22,6 +22,7 @@ import { useNativeOverlayOpen } from "@/hooks/ui/use-native-overlay-presence";
 import { useUpdater } from "@/hooks/updater/use-updater";
 import { useRunWorkspaceCommand } from "@/hooks/workspaces/use-run-workspace-command";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/use-workspace-runtime-block";
+import { useWorkspaceActivityAcknowledgement } from "@/hooks/workspaces/use-workspace-activity-acknowledgement";
 import { resolveStandardWorkspaceChromeClasses } from "@/lib/domain/preferences/workspace-chrome";
 import { WorkspacePathProvider } from "@/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
@@ -32,6 +33,11 @@ import {
 
 export function StandardWorkspaceShell() {
   useDebugRenderCount("workspace-shell");
+  // Workspace activity is a shell-level read receipt: if the selected workspace
+  // is visible, activity in any shell tab is considered consumed. Session error
+  // acknowledgement intentionally stays in ChatView because errors are
+  // transcript-scoped and need the chat surface for context.
+  useWorkspaceActivityAcknowledgement();
   const { layout, data } = useMainScreenState();
   const actions = useMainScreenActions({
     layout,

--- a/desktop/src/components/workspace/shell/tabs/ChatTabsMenu.tsx
+++ b/desktop/src/components/workspace/shell/tabs/ChatTabsMenu.tsx
@@ -8,6 +8,7 @@ import {
 import { createPortal } from "react-dom";
 import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
 import { ChevronRight } from "@/components/ui/icons";
+import { recordSubagentChildRelationshipHint } from "@/hooks/sessions/session-relationship-hints";
 import type { HeaderChatMenuEntry } from "@/hooks/workspaces/tabs/use-workspace-header-tabs-view-model";
 import type { HeaderSubagentChildRow } from "@/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy";
 
@@ -25,12 +26,14 @@ interface FlyoutState {
 }
 
 export function ChatTabsMenu({
+  workspaceId,
   rows,
   childrenByParentSessionId,
   renderIcon,
   renderStatus,
   onOpenSession,
 }: {
+  workspaceId: string | null;
   rows: HeaderChatMenuEntry[];
   childrenByParentSessionId: Map<string, HeaderSubagentChildRow[]>;
   renderIcon: (row: Pick<HeaderChatMenuEntry, "agentKind" | "viewState">) => ReactNode;
@@ -159,6 +162,7 @@ export function ChatTabsMenu({
       </div>
       {flyout && createPortal(
         <SubagentFlyout
+          workspaceId={workspaceId}
           children={childrenByParentSessionId.get(flyout.parentId) ?? []}
           position={flyout.position}
           onMouseEnter={clearCloseTimer}
@@ -172,12 +176,14 @@ export function ChatTabsMenu({
 }
 
 function SubagentFlyout({
+  workspaceId,
   children,
   position,
   onMouseEnter,
   onMouseLeave,
   onOpenSession,
 }: {
+  workspaceId: string | null;
   children: HeaderSubagentChildRow[];
   position: FlyoutState["position"];
   onMouseEnter: () => void;
@@ -208,6 +214,12 @@ function SubagentFlyout({
             if (child.source === "review") {
               return;
             }
+            recordSubagentChildRelationshipHint({
+              sessionId: child.sessionId,
+              parentSessionId: child.parentSessionId,
+              sessionLinkId: child.sessionLinkId,
+              workspaceId,
+            });
             onOpenSession(child.sessionId);
           }}
         >

--- a/desktop/src/config/chat-layout.test.ts
+++ b/desktop/src/config/chat-layout.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHAT_SCROLL_BASE_BOTTOM_PADDING_PX,
   computeChatDockLowerBackdropTopPx,
-  computeChatStickyBottomInsetPx,
+  computeChatStableBottomInsetPx,
   computeChatSurfaceBottomInsetPx,
 } from "./chat-layout";
 
@@ -45,7 +45,10 @@ describe("chat layout", () => {
     })).toBeNull();
   });
 
-  it("keeps sticky transcript scrolling above the full dock", () => {
-    expect(computeChatStickyBottomInsetPx(220)).toBe(260);
+  it("keeps sticky transcript scrolling above the stable composer reserve", () => {
+    expect(computeChatStableBottomInsetPx({
+      composerSurfaceHeightPx: 120,
+      composerFooterHeightPx: 24,
+    })).toBe(184);
   });
 });

--- a/desktop/src/config/chat-layout.ts
+++ b/desktop/src/config/chat-layout.ts
@@ -10,6 +10,7 @@ interface ChatSurfaceBottomInsetArgs {
   dockHeightPx: number;
   composerSurfaceHeightPx: number;
   composerSurfaceOffsetTopPx: number;
+  composerFooterHeightPx?: number;
 }
 
 export function computeChatSurfaceBottomInsetPx({
@@ -28,10 +29,14 @@ export function computeChatSurfaceBottomInsetPx({
   );
 }
 
-export function computeChatStickyBottomInsetPx(dockHeightPx: number): number {
-  const dockHeight = Math.max(0, Math.ceil(dockHeightPx));
+export function computeChatStableBottomInsetPx({
+  composerSurfaceHeightPx,
+  composerFooterHeightPx = 0,
+}: Pick<ChatSurfaceBottomInsetArgs, "composerSurfaceHeightPx" | "composerFooterHeightPx">): number {
+  const surfaceHeight = Math.max(0, Math.ceil(composerSurfaceHeightPx));
+  const footerHeight = Math.max(0, Math.ceil(composerFooterHeightPx));
 
-  return dockHeight + CHAT_SCROLL_BASE_BOTTOM_PADDING_PX;
+  return surfaceHeight + footerHeight + CHAT_SCROLL_BASE_BOTTOM_PADDING_PX;
 }
 
 export function computeChatDockLowerBackdropTopPx({

--- a/desktop/src/hooks/chat/subagents/use-linked-session-mounting.ts
+++ b/desktop/src/hooks/chat/subagents/use-linked-session-mounting.ts
@@ -5,12 +5,13 @@ import {
   createSessionSlotFromSummary,
   getWorkspaceClientAndId,
 } from "@/lib/integrations/anyharness/session-runtime";
-import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { type SessionRelationship, useHarnessStore } from "@/stores/sessions/harness-store";
 
 interface MountLinkedSessionInput {
   sessionId: string;
   label?: string | null;
   workspaceId: string | null;
+  sessionRelationship?: SessionRelationship;
   requestHeaders?: HeadersInit;
 }
 
@@ -18,6 +19,8 @@ interface MountSubagentChildInput {
   childSessionId: string;
   label?: string | null;
   workspaceId: string | null;
+  parentSessionId: string | null;
+  sessionLinkId?: string | null;
   requestHeaders?: HeadersInit;
 }
 
@@ -51,6 +54,7 @@ export function useLinkedSessionMounting() {
         createSessionSlotFromSummary(session, input.workspaceId, {
           titleFallback: input.label ?? null,
           transcriptHydrated: false,
+          sessionRelationship: input.sessionRelationship,
         }),
       );
     } catch {
@@ -65,6 +69,13 @@ export function useLinkedSessionMounting() {
     sessionId: input.childSessionId,
     label: input.label,
     workspaceId: input.workspaceId,
+    sessionRelationship: {
+      kind: "subagent_child",
+      parentSessionId: input.parentSessionId,
+      sessionLinkId: input.sessionLinkId,
+      relation: "subagent",
+      workspaceId: input.workspaceId,
+    },
     requestHeaders: input.requestHeaders,
   }), [mountLinkedSessionSlot]);
 
@@ -91,6 +102,8 @@ export function useLinkedSessionMounting() {
         childSessionId: event.childSessionId,
         label: event.label ?? null,
         workspaceId: parentWorkspaceId,
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
         requestHeaders,
       });
     }

--- a/desktop/src/hooks/chat/subagents/use-subagent-composer-strip.ts
+++ b/desktop/src/hooks/chat/subagents/use-subagent-composer-strip.ts
@@ -5,6 +5,7 @@ import {
   useActiveSessionId,
   useActiveSessionWorkspaceId,
 } from "@/hooks/chat/use-active-chat-session-selectors";
+import { recordSubagentChildRelationshipHint } from "@/hooks/sessions/session-relationship-hints";
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
 import { formatSubagentLabel } from "@/lib/domain/chat/subagents/provenance";
 
@@ -59,6 +60,11 @@ export function useSubagentComposerStrip(): SubagentComposerStripViewModel | nul
   const children = parentSubagentsQuery.data?.children
     ?? subagentsQuery.data?.children
     ?? EMPTY_CHILDREN;
+  const childParentSessionId = parentSessionId ?? activeSessionId;
+  const childBySessionId = useMemo(
+    () => new Map(children.map((child) => [child.childSessionId, child])),
+    [children],
+  );
 
   const rows = useMemo(
     () => children.map((child, index) => (
@@ -76,13 +82,20 @@ export function useSubagentComposerStrip(): SubagentComposerStripViewModel | nul
   );
 
   const openSubagent = useCallback((childSessionId: string) => {
-    if (!activeWorkspaceId) return;
+    if (!activeWorkspaceId || !childParentSessionId) return;
+    const child = childBySessionId.get(childSessionId);
+    recordSubagentChildRelationshipHint({
+      sessionId: childSessionId,
+      parentSessionId: childParentSessionId,
+      sessionLinkId: child?.sessionLinkId ?? null,
+      workspaceId: activeWorkspaceId,
+    });
     void activateChatTab({
       workspaceId: activeWorkspaceId,
       sessionId: childSessionId,
       source: "subagent-composer-strip",
     });
-  }, [activateChatTab, activeWorkspaceId]);
+  }, [activateChatTab, activeWorkspaceId, childBySessionId, childParentSessionId]);
   const openParent = useCallback((parentSessionId: string) => {
     if (!activeWorkspaceId) return;
     void activateChatTab({

--- a/desktop/src/hooks/chat/use-chat-dock-inset.ts
+++ b/desktop/src/hooks/chat/use-chat-dock-inset.ts
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import {
   computeChatDockLowerBackdropTopPx,
-  computeChatStickyBottomInsetPx,
+  computeChatStableBottomInsetPx,
   computeChatSurfaceBottomInsetPx,
 } from "@/config/chat-layout";
 
@@ -10,6 +10,7 @@ export function useChatDockInset() {
   const [metrics, setMetrics] = useState({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
+    composerFooterHeightPx: 0,
     dockHeightPx: 0,
   });
 
@@ -24,17 +25,21 @@ export function useChatDockInset() {
     const measure = () => {
       const dockRect = dock.getBoundingClientRect();
       const composerSurface = dock.querySelector<HTMLElement>("[data-chat-composer-surface]");
+      const composerFooter = dock.querySelector<HTMLElement>("[data-chat-composer-footer]");
       const surfaceRect = composerSurface?.getBoundingClientRect() ?? null;
+      const footerRect = composerFooter?.getBoundingClientRect() ?? null;
       const nextMetrics = {
         composerSurfaceHeightPx: surfaceRect ? Math.max(0, surfaceRect.height) : 0,
         composerSurfaceOffsetTopPx: surfaceRect
           ? Math.max(0, surfaceRect.top - dockRect.top)
           : 0,
+        composerFooterHeightPx: footerRect ? Math.max(0, footerRect.height) : 0,
         dockHeightPx: Math.max(0, dockRect.height),
       };
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
+        && current.composerFooterHeightPx === nextMetrics.composerFooterHeightPx
         && current.dockHeightPx === nextMetrics.dockHeightPx
           ? current
           : nextMetrics
@@ -62,6 +67,10 @@ export function useChatDockInset() {
     if (composerSurface) {
       observer.observe(composerSurface);
     }
+    const composerFooter = dock.querySelector<HTMLElement>("[data-chat-composer-footer]");
+    if (composerFooter) {
+      observer.observe(composerFooter);
+    }
 
     return () => {
       observer.disconnect();
@@ -76,7 +85,7 @@ export function useChatDockInset() {
     dockHeightPx: metrics.dockHeightPx,
     lowerBackdropTopPx: computeChatDockLowerBackdropTopPx(metrics),
     scrollBottomInsetPx: computeChatSurfaceBottomInsetPx(metrics),
-    stickyBottomInsetPx: computeChatStickyBottomInsetPx(metrics.dockHeightPx),
-    dockSafeAreaPx: Math.max(0, Math.ceil(metrics.dockHeightPx)),
+    stickyBottomInsetPx: computeChatStableBottomInsetPx(metrics),
+    dockSafeAreaPx: computeChatStableBottomInsetPx(metrics),
   };
 }

--- a/desktop/src/hooks/cowork/use-cowork-composer-strip.ts
+++ b/desktop/src/hooks/cowork/use-cowork-composer-strip.ts
@@ -15,6 +15,7 @@ import { useOpenCoworkCodingSession } from "./use-open-cowork-coding-session";
 export interface CoworkComposerSessionRow {
   sessionLinkId: string;
   codingSessionId: string;
+  parentSessionId: string;
   label: string;
   agentKind: string;
   statusLabel: string;
@@ -28,6 +29,7 @@ export interface CoworkComposerSessionRow {
 export interface CoworkComposerWorkspaceRow {
   ownershipId: string;
   workspaceId: string;
+  parentSessionId: string;
   label: string;
   sessionCount: number;
   active: boolean;
@@ -44,7 +46,12 @@ export interface CoworkComposerStripViewModel {
   rows: CoworkComposerWorkspaceRow[];
   summary: CoworkComposerStripSummary;
   openWorkspace: (workspaceId: string) => void;
-  openSession: (input: { workspaceId: string; sessionId: string }) => void;
+  openSession: (input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => void;
 }
 
 export function useCoworkComposerStrip(): CoworkComposerStripViewModel | null {
@@ -69,16 +76,22 @@ export function useCoworkComposerStrip(): CoworkComposerStripViewModel | null {
     buildWorkspaceRow({
       workspace,
       index,
+      parentSessionId: activeThread?.sessionId ?? activeSessionId ?? "",
       selectedWorkspaceId,
       activeCodingSessionId,
     })
-  )), [activeCodingSessionId, selectedWorkspaceId, workspaces]);
+  )), [activeCodingSessionId, activeSessionId, activeThread?.sessionId, selectedWorkspaceId, workspaces]);
   const summary = useMemo(() => buildSummary(rows), [rows]);
 
   const openWorkspace = useCallback((workspaceId: string) => {
     void selectWorkspace(workspaceId, { force: true });
   }, [selectWorkspace]);
-  const openSession = useCallback((input: { workspaceId: string; sessionId: string }) => {
+  const openSession = useCallback((input: {
+    workspaceId: string;
+    sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
+  }) => {
     void openCodingSession(input);
   }, [openCodingSession]);
 
@@ -97,18 +110,20 @@ export function useCoworkComposerStrip(): CoworkComposerStripViewModel | null {
 function buildWorkspaceRow(args: {
   workspace: CoworkManagedWorkspaceSummary;
   index: number;
+  parentSessionId: string;
   selectedWorkspaceId: string | null;
   activeCodingSessionId: string | null;
 }): CoworkComposerWorkspaceRow {
-  const { workspace, index, selectedWorkspaceId, activeCodingSessionId } = args;
+  const { workspace, index, parentSessionId, selectedWorkspaceId, activeCodingSessionId } = args;
   return {
     ownershipId: workspace.ownershipId,
     workspaceId: workspace.workspaceId,
+    parentSessionId,
     label: workspaceLabel(workspace, index),
     sessionCount: workspace.sessions.length,
     active: selectedWorkspaceId === workspace.workspaceId,
     sessions: workspace.sessions.map((session, sessionIndex) => (
-      buildSessionRow(session, sessionIndex, activeCodingSessionId)
+      buildSessionRow(session, sessionIndex, parentSessionId, activeCodingSessionId)
     )),
   };
 }
@@ -116,11 +131,13 @@ function buildWorkspaceRow(args: {
 function buildSessionRow(
   session: CoworkCodingSessionSummary,
   index: number,
+  parentSessionId: string,
   activeCodingSessionId: string | null,
 ): CoworkComposerSessionRow {
   return {
     sessionLinkId: session.sessionLinkId,
     codingSessionId: session.codingSessionId,
+    parentSessionId,
     label: sessionLabel(session, index),
     agentKind: session.agentKind,
     statusLabel: sessionStatusLabel(session),

--- a/desktop/src/hooks/cowork/use-cowork-thread-workflow.ts
+++ b/desktop/src/hooks/cowork/use-cowork-thread-workflow.ts
@@ -229,6 +229,7 @@ export function useCoworkThreadWorkflow() {
         launchedSession.id,
         createSessionSlotFromSummary(launchedSession, result.workspace.id, {
           transcriptHydrated: true,
+          sessionRelationship: { kind: "root" },
         }),
       );
       if (input.draftText?.length) {

--- a/desktop/src/hooks/cowork/use-open-cowork-coding-session.ts
+++ b/desktop/src/hooks/cowork/use-open-cowork-coding-session.ts
@@ -1,23 +1,36 @@
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useWorkspaceActivationWorkflow } from "@/hooks/workspaces/use-workspace-activation-workflow";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
 
 export function useOpenCoworkCodingSession() {
   const location = useLocation();
   const navigate = useNavigate();
   const { openWorkspaceSession } = useWorkspaceActivationWorkflow();
+  const recordSessionRelationshipHint = useHarnessStore(
+    (state) => state.recordSessionRelationshipHint,
+  );
 
   return useCallback(async (input: {
     workspaceId: string;
     sessionId: string;
+    parentSessionId?: string | null;
+    sessionLinkId?: string | null;
   }) => {
     if (location.pathname !== "/") {
       navigate("/");
     }
+    recordSessionRelationshipHint(input.sessionId, {
+      kind: "cowork_child",
+      parentSessionId: input.parentSessionId ?? null,
+      sessionLinkId: input.sessionLinkId ?? null,
+      relation: "cowork_coding_session",
+      workspaceId: input.workspaceId,
+    });
     await openWorkspaceSession({
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
       forceWorkspaceSelection: true,
     });
-  }, [location.pathname, navigate, openWorkspaceSession]);
+  }, [location.pathname, navigate, openWorkspaceSession, recordSessionRelationshipHint]);
 }

--- a/desktop/src/hooks/reviews/use-active-review-run.ts
+++ b/desktop/src/hooks/reviews/use-active-review-run.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useSessionReviewsQuery } from "@anyharness/sdk-react";
 import type { ReviewRunDetail } from "@anyharness/sdk";
 import {
@@ -6,6 +6,7 @@ import {
   isReviewRunBusy,
   selectComposerReviewRun,
 } from "@/lib/domain/reviews/review-runs";
+import { collectReviewSessionRelationshipHints } from "@/lib/domain/reviews/session-relationship-hints";
 import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
 import type { StartingReviewState } from "@/stores/reviews/review-ui-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
@@ -23,6 +24,9 @@ export function useActiveReviewRun(): {
     (state) => state.dismissedTerminalNoticeRunIds,
   );
   const startingReview = useReviewUiStore((state) => state.startingReview);
+  const recordSessionRelationshipHint = useHarnessStore(
+    (state) => state.recordSessionRelationshipHint,
+  );
   const activeStartingReview = startingReview?.parentSessionId === activeSessionId
     ? startingReview
     : null;
@@ -32,6 +36,18 @@ export function useActiveReviewRun(): {
     refetchInterval: 5000,
   });
   const reviews = reviewsQuery.data?.reviews ?? null;
+
+  useEffect(() => {
+    for (const hint of collectReviewSessionRelationshipHints(reviews)) {
+      recordSessionRelationshipHint(hint.sessionId, {
+        kind: "review_child",
+        parentSessionId: hint.parentSessionId,
+        sessionLinkId: hint.sessionLinkId,
+        relation: "review",
+        workspaceId: selectedWorkspaceId,
+      });
+    }
+  }, [recordSessionRelationshipHint, reviews, selectedWorkspaceId]);
 
   const run = useMemo(() => {
     return selectComposerReviewRun(reviews, dismissedTerminalNoticeRunIds);

--- a/desktop/src/hooks/sessions/session-relationship-hints.test.ts
+++ b/desktop/src/hooks/sessions/session-relationship-hints.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createEmptySessionSlot } from "@/lib/integrations/anyharness/session-runtime";
+import {
+  recordLinkedChildRelationshipHint,
+  recordSubagentChildRelationshipHint,
+} from "@/hooks/sessions/session-relationship-hints";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+
+describe("session relationship hint helpers", () => {
+  beforeEach(() => {
+    useHarnessStore.setState({
+      selectedWorkspaceId: "workspace-1",
+      activeSessionId: null,
+      sessionSlots: {},
+      sessionRelationshipHints: {},
+    });
+  });
+
+  it("records subagent child hints before a slot exists", () => {
+    recordSubagentChildRelationshipHint({
+      sessionId: "child-session",
+      parentSessionId: "parent-session",
+      sessionLinkId: "link-1",
+      workspaceId: "workspace-1",
+    });
+
+    expect(useHarnessStore.getState().sessionRelationshipHints["child-session"])
+      .toEqual({
+        kind: "subagent_child",
+        parentSessionId: "parent-session",
+        sessionLinkId: "link-1",
+        relation: "subagent",
+        workspaceId: "workspace-1",
+      });
+  });
+
+  it("applies linked child hints to existing pending slots", () => {
+    useHarnessStore.getState().putSessionSlot(
+      "child-session",
+      createEmptySessionSlot("child-session", "codex", {
+        workspaceId: "workspace-1",
+      }),
+    );
+
+    recordLinkedChildRelationshipHint({
+      sessionId: "child-session",
+      parentSessionId: "parent-session",
+      relation: "header_child",
+      workspaceId: "workspace-1",
+    });
+
+    expect(useHarnessStore.getState().sessionSlots["child-session"].sessionRelationship)
+      .toEqual({
+        kind: "linked_child",
+        parentSessionId: "parent-session",
+        sessionLinkId: null,
+        relation: "header_child",
+        workspaceId: "workspace-1",
+      });
+  });
+});

--- a/desktop/src/hooks/sessions/session-relationship-hints.ts
+++ b/desktop/src/hooks/sessions/session-relationship-hints.ts
@@ -1,0 +1,35 @@
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+
+export interface RecordChildRelationshipHintInput {
+  sessionId: string;
+  parentSessionId: string | null;
+  sessionLinkId?: string | null;
+  workspaceId?: string | null;
+}
+
+export function recordSubagentChildRelationshipHint(
+  input: RecordChildRelationshipHintInput,
+) {
+  useHarnessStore.getState().recordSessionRelationshipHint(input.sessionId, {
+    kind: "subagent_child",
+    parentSessionId: input.parentSessionId,
+    sessionLinkId: input.sessionLinkId ?? null,
+    relation: "subagent",
+    workspaceId: input.workspaceId ?? null,
+  });
+}
+
+export function recordLinkedChildRelationshipHint(
+  input: RecordChildRelationshipHintInput & { relation?: string | null },
+) {
+  if (!input.parentSessionId) {
+    return;
+  }
+  useHarnessStore.getState().recordSessionRelationshipHint(input.sessionId, {
+    kind: "linked_child",
+    parentSessionId: input.parentSessionId,
+    sessionLinkId: input.sessionLinkId ?? null,
+    relation: input.relation ?? "linked_child",
+    workspaceId: input.workspaceId ?? null,
+  });
+}

--- a/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
@@ -12,11 +12,13 @@ import {
 } from "@anyharness/sdk";
 import { applyBatchedStreamSideEffects } from "@/hooks/sessions/session-stream-side-effects";
 import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import type { SessionRelationship } from "@/stores/sessions/harness-store";
 
 const mocks = vi.hoisted(() => ({
   effectOrder: [] as string[],
   trackWorkspaceInteraction: vi.fn(),
   notifyTurnEnd: vi.fn(),
+  notifyUserFacingTurnEnd: vi.fn(),
   clearPendingConfigRollbackCheck: vi.fn(),
   schedulePendingConfigRollbackCheck: vi.fn(),
 }));
@@ -27,6 +29,7 @@ vi.mock("@/stores/preferences/workspace-ui-store", () => ({
 
 vi.mock("@/lib/integrations/anyharness/turn-end-events", () => ({
   notifyTurnEnd: mocks.notifyTurnEnd,
+  notifyUserFacingTurnEnd: mocks.notifyUserFacingTurnEnd,
 }));
 
 vi.mock("@/hooks/sessions/session-runtime-pending-config", () => ({
@@ -43,6 +46,9 @@ describe("applyBatchedStreamSideEffects", () => {
     });
     mocks.notifyTurnEnd.mockImplementation((sessionId: string, eventType: string) => {
       mocks.effectOrder.push(`notify:${sessionId}:${eventType}`);
+    });
+    mocks.notifyUserFacingTurnEnd.mockImplementation((sessionId: string, eventType: string) => {
+      mocks.effectOrder.push(`notify-user:${sessionId}:${eventType}`);
     });
     mocks.clearPendingConfigRollbackCheck.mockImplementation((sessionId: string) => {
       mocks.effectOrder.push(`clear-rollback:${sessionId}`);
@@ -94,6 +100,27 @@ describe("applyBatchedStreamSideEffects", () => {
     );
   });
 
+  it("acknowledges selected activity in the same side-effect pass", () => {
+    const acknowledgeWorkspaceActivity = vi.fn((workspaceId: string, timestamp: string) => {
+      mocks.effectOrder.push(`ack:${workspaceId}:${timestamp}`);
+    });
+
+    applyBatchedStreamSideEffects({
+      ...baseInput(),
+      acknowledgeWorkspaceActivity,
+      envelopes: [
+        turnStarted(2),
+      ],
+    });
+
+    expect(mocks.effectOrder).toEqual([
+      "activity:workspace-1:2026-04-04T00:00:02Z",
+      "ack:workspace-1:2026-04-04T00:00:02Z",
+      "clear-rollback:session-1",
+      "clear-rollback:session-1",
+    ]);
+  });
+
   it("notifies once for every terminal event in a batch", () => {
     applyBatchedStreamSideEffects({
       ...baseInput(),
@@ -106,12 +133,33 @@ describe("applyBatchedStreamSideEffects", () => {
     expect(mocks.notifyTurnEnd).toHaveBeenCalledTimes(2);
     expect(mocks.notifyTurnEnd).toHaveBeenNthCalledWith(1, "session-1", "turn_ended");
     expect(mocks.notifyTurnEnd).toHaveBeenNthCalledWith(2, "session-1", "error");
+    expect(mocks.notifyUserFacingTurnEnd).not.toHaveBeenCalled();
+  });
+
+  it("emits user-facing completion only for explicitly root sessions", () => {
+    applyBatchedStreamSideEffects({
+      ...baseInput({
+        sessionRelationship: { kind: "root" },
+      }),
+      envelopes: [
+        turnEnded(2),
+        errorEvent(3),
+      ],
+    });
+
+    expect(mocks.notifyTurnEnd).toHaveBeenCalledTimes(2);
+    expect(mocks.notifyUserFacingTurnEnd).toHaveBeenCalledTimes(2);
+    expect(mocks.notifyUserFacingTurnEnd).toHaveBeenNthCalledWith(1, "session-1", "turn_ended");
+    expect(mocks.notifyUserFacingTurnEnd).toHaveBeenNthCalledWith(2, "session-1", "error");
   });
 });
 
 function baseInput(overrides?: {
   pendingConfigChanges?: PendingSessionConfigChanges;
+  sessionRelationship?: SessionRelationship | null;
 }) {
+  const sessionRelationship: SessionRelationship | null =
+    overrides?.sessionRelationship ?? { kind: "pending" };
   return {
     queryClient: new QueryClient(),
     sessionId: "session-1",
@@ -123,6 +171,9 @@ function baseInput(overrides?: {
     pendingConfigChanges: overrides?.pendingConfigChanges ?? {},
     reconciledIntents: [],
     mountSubagentChildSession: vi.fn(),
+    recordSessionRelationshipHint: vi.fn(),
+    getSessionRelationship: vi.fn((sessionId: string) =>
+      sessionId === "session-1" ? sessionRelationship : null),
     persistReconciledModePreferences: vi.fn(),
     refreshSessionSlotMeta: vi.fn(),
     showToast: vi.fn(),

--- a/desktop/src/hooks/sessions/session-stream-side-effects.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.ts
@@ -23,7 +23,14 @@ import {
   resolveSubagentLaunchDisplay,
 } from "@/lib/domain/chat/subagent-launch";
 import { trackWorkspaceInteraction } from "@/stores/preferences/workspace-ui-store";
-import { notifyTurnEnd } from "@/lib/integrations/anyharness/turn-end-events";
+import {
+  notifyTurnEnd,
+  notifyUserFacingTurnEnd,
+} from "@/lib/integrations/anyharness/turn-end-events";
+import type {
+  SessionChildRelationship,
+  SessionRelationship,
+} from "@/stores/sessions/harness-store";
 import {
   clearPendingConfigRollbackCheck,
   schedulePendingConfigRollbackCheck,
@@ -60,8 +67,16 @@ export function applyBatchedStreamSideEffects(input: {
     childSessionId: string;
     label: string | null;
     workspaceId: string | null;
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
     requestHeaders?: HeadersInit;
   }) => Promise<void> | void;
+  recordSessionRelationshipHint: (
+    sessionId: string,
+    relationship: SessionChildRelationship,
+  ) => void;
+  getSessionRelationship: (sessionId: string) => SessionRelationship | null;
+  acknowledgeWorkspaceActivity?: (workspaceId: string, timestamp: string) => void;
   persistReconciledModePreferences: (
     workspaceId: string | null | undefined,
     agentKind: string | null | undefined,
@@ -136,10 +151,19 @@ export function applyBatchedStreamSideEffects(input: {
       });
     }
     if (event.type === "subagent_turn_completed") {
+      input.recordSessionRelationshipHint(event.childSessionId, {
+        kind: "subagent_child",
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
+        relation: "subagent",
+        workspaceId: input.workspaceId,
+      });
       void input.mountSubagentChildSession({
         childSessionId: event.childSessionId,
         label: event.label ?? null,
         workspaceId: input.workspaceId,
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
         requestHeaders: input.requestHeaders,
       });
       shouldInvalidateSessionSubagents = true;
@@ -148,7 +172,22 @@ export function applyBatchedStreamSideEffects(input: {
       event.type === "session_link_turn_completed"
       && event.relation === "cowork_coding_session"
     ) {
+      input.recordSessionRelationshipHint(event.childSessionId, {
+        kind: "cowork_child",
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
+        relation: event.relation,
+        workspaceId: input.workspaceId,
+      });
       shouldInvalidateCowork = true;
+    } else if (event.type === "session_link_turn_completed") {
+      input.recordSessionRelationshipHint(event.childSessionId, {
+        kind: "linked_child",
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
+        relation: event.relation,
+        workspaceId: input.workspaceId,
+      });
     }
     if (event.type === "review_run_updated") {
       reviewParentSessionIds.add(event.parentSessionId);
@@ -159,10 +198,19 @@ export function applyBatchedStreamSideEffects(input: {
         const launchResult = parseSubagentLaunchResult(item);
         const display = resolveSubagentLaunchDisplay(item);
         if (launchResult?.childSessionId) {
+          input.recordSessionRelationshipHint(launchResult.childSessionId, {
+            kind: "subagent_child",
+            parentSessionId: input.sessionId,
+            sessionLinkId: launchResult.sessionLinkId,
+            relation: "subagent",
+            workspaceId: input.workspaceId,
+          });
           void input.mountSubagentChildSession({
             childSessionId: launchResult.childSessionId,
             label: display.title,
             workspaceId: input.workspaceId,
+            parentSessionId: input.sessionId,
+            sessionLinkId: launchResult.sessionLinkId,
             requestHeaders: input.requestHeaders,
           });
         }
@@ -196,6 +244,7 @@ export function applyBatchedStreamSideEffects(input: {
   }
   if (lastActivityTimestamp && input.workspaceId) {
     trackWorkspaceInteraction(input.workspaceId, lastActivityTimestamp);
+    input.acknowledgeWorkspaceActivity?.(input.workspaceId, lastActivityTimestamp);
   }
   if (shouldInvalidateSessionSubagents) {
     void input.queryClient.invalidateQueries({
@@ -255,6 +304,9 @@ export function applyBatchedStreamSideEffects(input: {
         break;
       case "notify_turn_end":
         notifyTurnEnd(input.sessionId, effect.eventType);
+        if (input.getSessionRelationship(input.sessionId)?.kind === "root") {
+          notifyUserFacingTurnEnd(input.sessionId, effect.eventType);
+        }
         break;
     }
   }

--- a/desktop/src/hooks/sessions/use-session-creation-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-creation-actions.ts
@@ -226,6 +226,7 @@ export function useSessionCreationActions() {
         modelId: options.modelId,
         modeId: resolvedModeId ?? null,
         optimisticPrompt: null,
+        sessionRelationship: { kind: "root" },
       }),
       status: "starting",
       transcriptHydrated: true,
@@ -466,6 +467,7 @@ export function useSessionCreationActions() {
           mcpBindingSummaries: launchedSession.mcpBindingSummaries ?? null,
           lastPromptAt: launchedSession.lastPromptAt ?? null,
           optimisticPrompt: null,
+          sessionRelationship: { kind: "root" },
         }),
         status: resolveStatusFromExecutionSummary(
           launchedSession.executionSummary,

--- a/desktop/src/hooks/sessions/use-session-error-acknowledgement.ts
+++ b/desktop/src/hooks/sessions/use-session-error-acknowledgement.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { resolveSessionErrorAttentionKey } from "@/lib/domain/sessions/activity";
 import { parseWorkspaceShellTabKey } from "@/lib/domain/workspaces/tabs/shell-tabs";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
@@ -6,13 +6,10 @@ import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
 import { resolveSelectedWorkspaceIdentity } from "@/lib/domain/workspaces/workspace-ui-key";
 import { resolveWithWorkspaceFallback } from "@/lib/domain/workspaces/workspace-keyed-preferences";
-
-function isDocumentVisibleAndFocused(): boolean {
-  if (typeof document === "undefined" || typeof window === "undefined") {
-    return false;
-  }
-  return document.visibilityState === "visible" && document.hasFocus();
-}
+import {
+  isDocumentVisibleAndFocused,
+  useDocumentFocusVisibilityNonce,
+} from "@/hooks/ui/use-document-focus-visibility";
 
 export function useSessionErrorAcknowledgement(): void {
   const activeSessionId = useHarnessStore((state) => state.activeSessionId);
@@ -44,27 +41,7 @@ export function useSessionErrorAcknowledgement(): void {
   const markSessionErrorViewed = useWorkspaceUiStore(
     (state) => state.markSessionErrorViewed,
   );
-  const [focusVisibilityNonce, setFocusVisibilityNonce] = useState(0);
-
-  useEffect(() => {
-    if (typeof document === "undefined" || typeof window === "undefined") {
-      return;
-    }
-
-    const bumpFocusVisibilityNonce = () => {
-      setFocusVisibilityNonce((value) => value + 1);
-    };
-
-    document.addEventListener("visibilitychange", bumpFocusVisibilityNonce);
-    window.addEventListener("focus", bumpFocusVisibilityNonce);
-    window.addEventListener("blur", bumpFocusVisibilityNonce);
-
-    return () => {
-      document.removeEventListener("visibilitychange", bumpFocusVisibilityNonce);
-      window.removeEventListener("focus", bumpFocusVisibilityNonce);
-      window.removeEventListener("blur", bumpFocusVisibilityNonce);
-    };
-  }, []);
+  const focusVisibilityNonce = useDocumentFocusVisibilityNonce();
 
   useEffect(() => {
     if (!activeSessionId || !isChatActiveShellTab || !errorAttentionKey) {

--- a/desktop/src/hooks/sessions/use-session-selection-actions.test.ts
+++ b/desktop/src/hooks/sessions/use-session-selection-actions.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createEmptySessionSlot } from "@/lib/integrations/anyharness/session-runtime";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { classifyTrustedSessionSelection } from "@/hooks/sessions/use-session-selection-actions";
+
+describe("classifyTrustedSessionSelection", () => {
+  beforeEach(() => {
+    useHarnessStore.setState({
+      selectedWorkspaceId: "workspace-1",
+      activeSessionId: null,
+      sessionSlots: {},
+      sessionRelationshipHints: {},
+    });
+  });
+
+  it("promotes a pending mounted session to root when no child hint exists", () => {
+    useHarnessStore.getState().putSessionSlot(
+      "root-session",
+      createEmptySessionSlot("root-session", "codex", {
+        workspaceId: "workspace-1",
+      }),
+    );
+
+    const relationship = classifyTrustedSessionSelection("root-session");
+
+    expect(relationship).toEqual({ kind: "root" });
+    expect(useHarnessStore.getState().sessionSlots["root-session"].sessionRelationship)
+      .toEqual({ kind: "root" });
+  });
+
+  it("applies and prunes a known child hint instead of promoting to root", () => {
+    useHarnessStore.setState({
+      sessionSlots: {
+        "child-session": createEmptySessionSlot("child-session", "codex", {
+          workspaceId: "workspace-1",
+        }),
+      },
+      sessionRelationshipHints: {
+        "child-session": {
+          kind: "subagent_child",
+          parentSessionId: "parent-session",
+          sessionLinkId: "link-1",
+          relation: "subagent",
+          workspaceId: "workspace-1",
+        },
+      },
+    });
+
+    const relationship = classifyTrustedSessionSelection("child-session");
+
+    expect(relationship).toEqual({
+      kind: "subagent_child",
+      parentSessionId: "parent-session",
+      sessionLinkId: "link-1",
+      relation: "subagent",
+      workspaceId: "workspace-1",
+    });
+    expect(useHarnessStore.getState().sessionSlots["child-session"].sessionRelationship)
+      .toEqual(relationship);
+    expect(useHarnessStore.getState().sessionRelationshipHints["child-session"])
+      .toBeUndefined();
+  });
+});

--- a/desktop/src/hooks/sessions/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-selection-actions.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/domain/sessions/activity";
 import {
   useHarnessStore,
+  type SessionChildRelationship,
+  type SessionRelationship,
 } from "@/stores/sessions/harness-store";
 import {
   createEmptySessionSlot,
@@ -67,6 +69,23 @@ export interface SelectSessionOptionsWithoutGuard {
 type SessionLatencyFlowOptions = SelectSessionOptionsWithoutGuard & {
   guard?: SessionActivationGuard;
 };
+
+export function classifyTrustedSessionSelection(sessionId: string): SessionRelationship {
+  const state = useHarnessStore.getState();
+  const slot = state.sessionSlots[sessionId] ?? null;
+  if (slot && slot.sessionRelationship.kind !== "pending") {
+    return slot.sessionRelationship;
+  }
+  const relationshipHint =
+    state.sessionRelationshipHints[sessionId] as SessionChildRelationship | undefined;
+  const relationship = relationshipHint ?? { kind: "root" as const };
+  if (relationship.kind === "root") {
+    state.setSessionRelationship(sessionId, relationship);
+  } else {
+    state.recordSessionRelationshipHint(sessionId, relationship);
+  }
+  return relationship;
+}
 
 export async function fetchWorkspaceSessions(
   runtimeUrl: string,
@@ -208,7 +227,7 @@ export function useSessionSelectionActions() {
       maxDurationMs: 30_000,
     });
     const current = useHarnessStore.getState();
-    const existingSlot = current.sessionSlots[sessionId] ?? null;
+    let existingSlot = current.sessionSlots[sessionId] ?? null;
     const requestHeaders = getLatencyFlowRequestHeaders(options?.latencyFlowId);
     logLatency("session.select.start", {
       sessionId,
@@ -218,6 +237,14 @@ export function useSessionSelectionActions() {
     });
     if (guard && !isSessionActivationCurrent(guard)) {
       return staleSelection("intent-replaced");
+    }
+
+    const sessionSelectionRelationship = classifyTrustedSessionSelection(sessionId);
+    if (existingSlot?.sessionRelationship.kind === "pending") {
+      existingSlot = {
+        ...existingSlot,
+        sessionRelationship: sessionSelectionRelationship,
+      };
     }
 
     if (existingSlot) {
@@ -252,7 +279,7 @@ export function useSessionSelectionActions() {
         }
         const nonce = useHarnessStore.getState().workspaceSelectionNonce;
         useHarnessStore.getState().setHotPaintGate({
-          workspaceId: existingSlot.workspaceId,
+          workspaceId: existingSlot.workspaceId!,
           sessionId,
           nonce,
           operationId: hotOperationId,
@@ -391,6 +418,7 @@ export function useSessionSelectionActions() {
           executionSummary: sessionMeta?.executionSummary ?? null,
           mcpBindingSummaries: sessionMeta?.mcpBindingSummaries ?? null,
           lastPromptAt: sessionMeta?.lastPromptAt ?? null,
+          sessionRelationship: sessionSelectionRelationship,
         }),
         status: resolveStatusFromExecutionSummary(
           sessionMeta?.executionSummary ?? null,

--- a/desktop/src/hooks/sessions/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.ts
@@ -15,6 +15,13 @@ import {
   type MeasurementSurface,
 } from "@/lib/infra/debug-measurement";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
+import type {
+  SessionChildRelationship,
+  SessionRelationship,
+} from "@/stores/sessions/harness-store";
+import { markWorkspaceViewedAt } from "@/stores/preferences/workspace-ui-store";
+import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
+import { isDocumentVisibleAndFocused } from "@/hooks/ui/use-document-focus-visibility";
 import {
   reconcilePendingConfigChanges,
   type PendingSessionConfigChange,
@@ -56,6 +63,8 @@ interface SessionStreamFlushFactoryDeps {
     childSessionId: string;
     label: string | null;
     workspaceId: string | null;
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
     requestHeaders?: HeadersInit;
   }) => Promise<void> | void;
   persistReconciledModePreferences: (
@@ -315,6 +324,26 @@ export function createSessionStreamFlushController(
       transcript: result.state.transcript,
       pendingConfigChanges: configReconcileResult.pendingConfigChanges,
       reconciledIntents: configReconcileResult.reconciledIntents,
+      recordSessionRelationshipHint: (
+        sessionId: string,
+        relationship: SessionChildRelationship,
+      ) => {
+        useHarnessStore.getState().recordSessionRelationshipHint(sessionId, relationship);
+      },
+      getSessionRelationship: (sessionId: string): SessionRelationship | null =>
+        useHarnessStore.getState().sessionSlots[sessionId]?.sessionRelationship ?? null,
+      acknowledgeWorkspaceActivity: (workspaceId: string, timestamp: string) => {
+        if (!isDocumentVisibleAndFocused()) {
+          return;
+        }
+        const selectedWorkspaceId = useHarnessStore.getState().selectedWorkspaceId;
+        if (workspaceId !== selectedWorkspaceId) {
+          return;
+        }
+        const selectedLogicalWorkspaceId =
+          useLogicalWorkspaceStore.getState().selectedLogicalWorkspaceId;
+        markWorkspaceViewedAt(selectedLogicalWorkspaceId ?? workspaceId, timestamp);
+      },
     });
 
     finishOrCancelMeasurementOperation(streamEventBatchOperationId, "completed");

--- a/desktop/src/hooks/sessions/use-turn-end-sound.ts
+++ b/desktop/src/hooks/sessions/use-turn-end-sound.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-import { offTurnEnd, onTurnEnd } from "@/lib/integrations/anyharness/turn-end-events";
+import {
+  offUserFacingTurnEnd,
+  onUserFacingTurnEnd,
+} from "@/lib/integrations/anyharness/turn-end-events";
 import dingSrc from "@/assets/sounds/ding.mp3";
 import gongSrc from "@/assets/sounds/gong.mp3";
 
@@ -37,9 +40,9 @@ export function useTurnEndSound(): void {
       }
     };
 
-    onTurnEnd(handler);
+    onUserFacingTurnEnd(handler);
     return () => {
-      offTurnEnd(handler);
+      offUserFacingTurnEnd(handler);
     };
   }, []);
 }

--- a/desktop/src/hooks/ui/use-document-focus-visibility.ts
+++ b/desktop/src/hooks/ui/use-document-focus-visibility.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+export function isDocumentVisibleAndFocused(): boolean {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return false;
+  }
+  return document.visibilityState === "visible" && document.hasFocus();
+}
+
+export function useDocumentFocusVisibilityNonce(): number {
+  const [focusVisibilityNonce, setFocusVisibilityNonce] = useState(0);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    const bumpFocusVisibilityNonce = () => {
+      setFocusVisibilityNonce((value) => value + 1);
+    };
+
+    document.addEventListener("visibilitychange", bumpFocusVisibilityNonce);
+    window.addEventListener("focus", bumpFocusVisibilityNonce);
+    window.addEventListener("blur", bumpFocusVisibilityNonce);
+
+    return () => {
+      document.removeEventListener("visibilitychange", bumpFocusVisibilityNonce);
+      window.removeEventListener("focus", bumpFocusVisibilityNonce);
+      window.removeEventListener("blur", bumpFocusVisibilityNonce);
+    };
+  }, []);
+
+  return focusVisibilityNonce;
+}

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
@@ -2,6 +2,7 @@ import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { findLogicalWorkspace, resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/logical-workspaces";
 import {
   markWorkspaceViewed,
+  markWorkspaceViewedAt,
   trackWorkspaceInteraction,
   useWorkspaceUiStore,
 } from "@/stores/preferences/workspace-ui-store";
@@ -145,8 +146,10 @@ export async function runWorkspaceSelection(
       const latestSessionTimestamp = getLatestWorkspaceInteractionTimestamp(bootstrapResult.sessions);
       if (latestSessionTimestamp) {
         trackWorkspaceInteraction(context.logicalWorkspaceId, latestSessionTimestamp);
+        markWorkspaceViewedAt(context.logicalWorkspaceId, latestSessionTimestamp);
+      } else {
+        markWorkspaceViewed(context.logicalWorkspaceId);
       }
-      markWorkspaceViewed(context.logicalWorkspaceId);
       return;
     }
 
@@ -253,6 +256,8 @@ export async function runWorkspaceSelection(
   const latestSessionTimestamp = getLatestWorkspaceInteractionTimestamp(bootstrapResult.sessions);
   if (latestSessionTimestamp) {
     trackWorkspaceInteraction(context.logicalWorkspaceId, latestSessionTimestamp);
+    markWorkspaceViewedAt(context.logicalWorkspaceId, latestSessionTimestamp);
+  } else {
+    markWorkspaceViewed(context.logicalWorkspaceId);
   }
-  markWorkspaceViewed(context.logicalWorkspaceId);
 }

--- a/desktop/src/hooks/workspaces/tabs/use-chat-tab-visibility-actions.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-chat-tab-visibility-actions.ts
@@ -15,6 +15,7 @@ import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
+import { recordLinkedChildRelationshipHint } from "@/hooks/sessions/session-relationship-hints";
 
 interface ChatTabVisibilityContext {
   workspaceUiKey?: string | null;
@@ -63,6 +64,13 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
     if (!materializedWorkspaceId) {
       return;
     }
+    const parentSessionId = childToParent.get(sessionId) ?? null;
+    recordLinkedChildRelationshipHint({
+      sessionId,
+      parentSessionId,
+      relation: "header_child",
+      workspaceId: materializedWorkspaceId,
+    });
     const latencyFlowId = startLatencyFlow({
       flowKind: "session_switch",
       source,
@@ -80,7 +88,7 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
       const message = error instanceof Error ? error.message : String(error);
       showToast(message);
     });
-  }, [activateChatTab, materializedWorkspaceId, showToast, workspaceUiKey]);
+  }, [activateChatTab, childToParent, materializedWorkspaceId, showToast, workspaceUiKey]);
 
   const markErroredSessionsViewedBeforeHide = useCallback((idsToHide: string[]) => {
     if (idsToHide.length === 0) {

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import {
   anyHarnessSessionReviewsKey,
@@ -19,6 +19,14 @@ import {
   reviewAssignmentHeaderStatusLabel,
   reviewKindLabel,
 } from "@/lib/domain/reviews/review-runs";
+import {
+  collectReviewSessionRelationshipHints,
+  type ReviewSessionRelationshipHint,
+} from "@/lib/domain/reviews/session-relationship-hints";
+import {
+  collectSubagentSessionRelationshipHints,
+  type SubagentSessionRelationshipHint,
+} from "@/lib/domain/chat/subagents/session-relationship-hints";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 
 export interface HeaderSubagentParentRow {
@@ -31,6 +39,7 @@ export interface HeaderSubagentParentRow {
 export interface HeaderSubagentChildRow {
   sessionLinkId: string;
   sessionId: string;
+  parentSessionId: string;
   title: string;
   agentKind: string;
   source: "subagent" | "review";
@@ -54,6 +63,9 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
 }): WorkspaceHeaderSubagentHierarchy {
   const workspace = useAnyHarnessWorkspaceContext();
   const runtimeUrl = useHarnessStore((state) => state.runtimeUrl);
+  const recordSessionRelationshipHint = useHarnessStore(
+    (state) => state.recordSessionRelationshipHint,
+  );
   const uniqueSessionIds = useMemo(
     () => [...new Set(args.sessionIds)].filter(Boolean),
     [args.sessionIds],
@@ -89,6 +101,59 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       staleTime: 2_500,
     })),
   });
+  const subagentRelationshipHintRows = subagentQueries.flatMap((query, index) => {
+    const sessionId = uniqueSessionIds[index];
+    return sessionId
+      ? collectSubagentSessionRelationshipHints(sessionId, query.data)
+      : [];
+  });
+  const subagentRelationshipHintSignature =
+    buildSubagentRelationshipHintSignature(subagentRelationshipHintRows);
+  const subagentRelationshipHints = useMemo(
+    () => subagentRelationshipHintRows,
+    // The query result array is intentionally not a dependency: useQueries returns
+    // a new array each render, while this signature only changes when the
+    // relationship hints we record into the store actually change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [subagentRelationshipHintSignature],
+  );
+  const reviewRelationshipHintRows = reviewQueries.flatMap((query) =>
+    collectReviewSessionRelationshipHints(query.data?.reviews)
+  );
+  const reviewRelationshipHintSignature =
+    buildReviewRelationshipHintSignature(reviewRelationshipHintRows);
+  const reviewRelationshipHints = useMemo(
+    () => reviewRelationshipHintRows,
+    // The query result array is intentionally not a dependency: useQueries returns
+    // a new array each render, while this signature only changes when the
+    // relationship hints we record into the store actually change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [reviewRelationshipHintSignature],
+  );
+
+  useEffect(() => {
+    for (const hint of subagentRelationshipHints) {
+      recordSessionRelationshipHint(hint.sessionId, {
+        kind: "subagent_child",
+        parentSessionId: hint.parentSessionId,
+        sessionLinkId: hint.sessionLinkId,
+        relation: "subagent",
+        workspaceId: args.workspaceId,
+      });
+    }
+  }, [args.workspaceId, recordSessionRelationshipHint, subagentRelationshipHints]);
+
+  useEffect(() => {
+    for (const hint of reviewRelationshipHints) {
+      recordSessionRelationshipHint(hint.sessionId, {
+        kind: "review_child",
+        parentSessionId: hint.parentSessionId,
+        sessionLinkId: hint.sessionLinkId,
+        relation: "review",
+        workspaceId: args.workspaceId,
+      });
+    }
+  }, [args.workspaceId, recordSessionRelationshipHint, reviewRelationshipHints]);
 
   return useMemo(() => {
     const childToParent = new Map<string, string>();
@@ -119,7 +184,7 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
         childrenByParentSessionId.set(
           sessionId,
           data.children.map((child, childIndex) =>
-            buildChildRow(child, childIndex + 1, args.activeSessionId)
+            buildChildRow(child, sessionId, childIndex + 1, args.activeSessionId)
           ),
         );
         for (const child of data.children) {
@@ -166,12 +231,14 @@ function buildParentRow(parent: ParentSubagentLinkSummary): HeaderSubagentParent
 
 function buildChildRow(
   child: ChildSubagentSummary,
+  parentSessionId: string,
   ordinal: number,
   activeSessionId: string | null,
 ): HeaderSubagentChildRow {
   return {
     sessionLinkId: child.sessionLinkId,
     sessionId: child.childSessionId,
+    parentSessionId,
     title: formatSubagentLabel(child.label ?? child.title, ordinal),
     agentKind: child.agentKind,
     source: "subagent",
@@ -195,6 +262,7 @@ function buildReviewChildRows(
         rowsBySessionId.set(sessionId, {
           sessionLinkId: assignment.sessionLinkId ?? assignment.id,
           sessionId,
+          parentSessionId: run.parentSessionId,
           title: assignment.personaLabel || reviewKindLabel(run.kind),
           agentKind: assignment.agentKind,
           source: "review",
@@ -207,6 +275,32 @@ function buildReviewChildRows(
     }
   }
   return [...rowsBySessionId.values()];
+}
+
+function buildReviewRelationshipHintSignature(
+  hints: readonly ReviewSessionRelationshipHint[],
+): string {
+  return hints
+    .map((hint) => [
+      hint.sessionId,
+      hint.parentSessionId,
+      hint.sessionLinkId ?? "",
+    ].join(":"))
+    .sort()
+    .join("|");
+}
+
+function buildSubagentRelationshipHintSignature(
+  hints: readonly SubagentSessionRelationshipHint[],
+): string {
+  return hints
+    .map((hint) => [
+      hint.sessionId,
+      hint.parentSessionId,
+      hint.sessionLinkId ?? "",
+    ].join(":"))
+    .sort()
+    .join("|");
 }
 
 function formatSessionStatus(status: ChildSubagentSummary["status"]): string {

--- a/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.test.tsx
+++ b/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/logical-workspaces";
+import { makeLocalLogicalWorkspace } from "@/lib/domain/workspaces/sidebar-test-fixtures";
+import {
+  WORKSPACE_UI_DEFAULTS,
+  useWorkspaceUiStore,
+} from "@/stores/preferences/workspace-ui-store";
+import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
+import { useWorkspaceActivityAcknowledgement } from "./use-workspace-activity-acknowledgement";
+
+const mocks = vi.hoisted(() => ({
+  focused: true,
+  focusVisibilityNonce: 0,
+  logicalWorkspaces: [] as LogicalWorkspace[],
+}));
+
+vi.mock("@/hooks/ui/use-document-focus-visibility", () => ({
+  isDocumentVisibleAndFocused: () => mocks.focused,
+  useDocumentFocusVisibilityNonce: () => mocks.focusVisibilityNonce,
+}));
+
+vi.mock("@/hooks/workspaces/use-logical-workspaces", () => ({
+  useLogicalWorkspaces: () => ({
+    logicalWorkspaces: mocks.logicalWorkspaces,
+    isLoading: false,
+  }),
+}));
+
+describe("useWorkspaceActivityAcknowledgement", () => {
+  beforeEach(() => {
+    mocks.focused = true;
+    mocks.focusVisibilityNonce = 0;
+    mocks.logicalWorkspaces = [];
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+    });
+    useLogicalWorkspaceStore.setState({
+      _hydrated: true,
+      selectedLogicalWorkspaceId: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("acknowledges selected focused logical workspace activity with the related timestamp", async () => {
+    const logicalWorkspace = makeLocalLogicalWorkspace({
+      id: "logical-workspace-1",
+      repoKey: "/repo",
+      repoName: "repo",
+    });
+    const materializedWorkspaceId = logicalWorkspace.localWorkspace?.id ?? "";
+    mocks.logicalWorkspaces = [logicalWorkspace];
+    useLogicalWorkspaceStore.setState({
+      selectedLogicalWorkspaceId: logicalWorkspace.id,
+    });
+    useWorkspaceUiStore.setState({
+      lastViewedAt: {
+        [logicalWorkspace.id]: "2026-04-04T00:00:01.000Z",
+      },
+      workspaceLastInteracted: {
+        [materializedWorkspaceId]: "2026-04-04T00:00:05.000Z",
+      },
+    });
+
+    renderHook(() => useWorkspaceActivityAcknowledgement());
+
+    await waitFor(() => {
+      expect(useWorkspaceUiStore.getState().lastViewedAt[logicalWorkspace.id])
+        .toBe("2026-04-04T00:00:05.000Z");
+    });
+  });
+
+  it("does not acknowledge hidden or unfocused activity", () => {
+    const logicalWorkspace = makeLocalLogicalWorkspace({
+      id: "logical-workspace-1",
+      repoKey: "/repo",
+      repoName: "repo",
+    });
+    const materializedWorkspaceId = logicalWorkspace.localWorkspace?.id ?? "";
+    mocks.focused = false;
+    mocks.logicalWorkspaces = [logicalWorkspace];
+    useLogicalWorkspaceStore.setState({
+      selectedLogicalWorkspaceId: logicalWorkspace.id,
+    });
+    useWorkspaceUiStore.setState({
+      lastViewedAt: {
+        [logicalWorkspace.id]: "2026-04-04T00:00:01.000Z",
+      },
+      workspaceLastInteracted: {
+        [materializedWorkspaceId]: "2026-04-04T00:00:05.000Z",
+      },
+    });
+
+    renderHook(() => useWorkspaceActivityAcknowledgement());
+
+    expect(useWorkspaceUiStore.getState().lastViewedAt[logicalWorkspace.id])
+      .toBe("2026-04-04T00:00:01.000Z");
+  });
+});

--- a/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import {
+  findLogicalWorkspace,
+  latestLogicalWorkspaceTimestamp,
+} from "@/lib/domain/workspaces/logical-workspaces";
+import {
+  isDocumentVisibleAndFocused,
+  useDocumentFocusVisibilityNonce,
+} from "@/hooks/ui/use-document-focus-visibility";
+import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
+
+export function useWorkspaceActivityAcknowledgement(): void {
+  const focusVisibilityNonce = useDocumentFocusVisibilityNonce();
+  const selectedLogicalWorkspaceId = useLogicalWorkspaceStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const { logicalWorkspaces } = useLogicalWorkspaces();
+  const {
+    lastViewedAt,
+    markWorkspaceViewedAt,
+    workspaceLastInteracted,
+  } = useWorkspaceUiStore(useShallow((state) => ({
+    lastViewedAt: state.lastViewedAt,
+    markWorkspaceViewedAt: state.markWorkspaceViewedAt,
+    workspaceLastInteracted: state.workspaceLastInteracted,
+  })));
+  const selectedLogicalWorkspace = useMemo(() => (
+    findLogicalWorkspace(logicalWorkspaces, selectedLogicalWorkspaceId)
+  ), [logicalWorkspaces, selectedLogicalWorkspaceId]);
+  const latestActivityAt = selectedLogicalWorkspace
+    ? latestLogicalWorkspaceTimestamp(workspaceLastInteracted, selectedLogicalWorkspace)
+    : null;
+  const latestViewedAt = selectedLogicalWorkspace
+    ? latestLogicalWorkspaceTimestamp(lastViewedAt, selectedLogicalWorkspace)
+    : null;
+
+  useEffect(() => {
+    if (!selectedLogicalWorkspace || !latestActivityAt || !isDocumentVisibleAndFocused()) {
+      return;
+    }
+    if (
+      latestViewedAt
+      && new Date(latestViewedAt).getTime() >= new Date(latestActivityAt).getTime()
+    ) {
+      return;
+    }
+
+    markWorkspaceViewedAt(selectedLogicalWorkspace.id, latestActivityAt);
+  }, [
+    focusVisibilityNonce,
+    latestActivityAt,
+    latestViewedAt,
+    markWorkspaceViewedAt,
+    selectedLogicalWorkspace,
+  ]);
+}

--- a/desktop/src/lib/domain/chat/cowork-coding-tool-presentation.ts
+++ b/desktop/src/lib/domain/chat/cowork-coding-tool-presentation.ts
@@ -25,6 +25,8 @@ export interface CoworkCodingToolPresentation {
   sourceWorkspaceId: string | null;
   workspaceId: string | null;
   codingSessionId: string | null;
+  sessionLinkId: string | null;
+  parentSessionId: string | null;
   eventCount: number | null;
   truncated: boolean | null;
   wakeScheduled: boolean | null;
@@ -83,6 +85,8 @@ export function deriveCoworkCodingToolPresentation(
     workspaceId: readString(output, "workspaceId") ?? readString(input, "workspaceId"),
     codingSessionId:
       readString(output, "codingSessionId") ?? readString(input, "codingSessionId"),
+    sessionLinkId: readString(output, "sessionLinkId") ?? readString(input, "sessionLinkId"),
+    parentSessionId: readString(output, "parentSessionId") ?? readString(input, "parentSessionId"),
     eventCount,
     truncated,
     wakeScheduled: readBoolean(output, "wakeScheduled"),

--- a/desktop/src/lib/domain/chat/subagents/session-relationship-hints.test.ts
+++ b/desktop/src/lib/domain/chat/subagents/session-relationship-hints.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { SessionSubagentsResponse } from "@anyharness/sdk";
+import { collectSubagentSessionRelationshipHints } from "@/lib/domain/chat/subagents/session-relationship-hints";
+
+describe("collectSubagentSessionRelationshipHints", () => {
+  it("records the queried session as a child when parent metadata exists", () => {
+    const hints = collectSubagentSessionRelationshipHints("child-session", {
+      parent: {
+        parentSessionId: "parent-session",
+        parentAgentKind: "codex",
+        parentModelId: null,
+        parentTitle: "Parent",
+        label: null,
+        linkCreatedAt: "2026-04-04T00:00:00Z",
+        sessionLinkId: "parent-link",
+      },
+      children: [],
+    });
+
+    expect(hints).toEqual([{
+      sessionId: "child-session",
+      parentSessionId: "parent-session",
+      sessionLinkId: "parent-link",
+    }]);
+  });
+
+  it("records each returned child under the queried parent session", () => {
+    const hints = collectSubagentSessionRelationshipHints("parent-session", {
+      parent: null,
+      children: [
+        child("child-a", "link-a"),
+        child("child-b", "link-b"),
+      ],
+    });
+
+    expect(hints).toEqual([
+      {
+        sessionId: "child-a",
+        parentSessionId: "parent-session",
+        sessionLinkId: "link-a",
+      },
+      {
+        sessionId: "child-b",
+        parentSessionId: "parent-session",
+        sessionLinkId: "link-b",
+      },
+    ]);
+  });
+});
+
+function child(childSessionId: string, sessionLinkId: string): SessionSubagentsResponse["children"][number] {
+  return {
+    childSessionId,
+    sessionLinkId,
+    agentKind: "codex",
+    childCreatedAt: "2026-04-04T00:00:00Z",
+    modelId: null,
+    title: childSessionId,
+    label: null,
+    status: "idle",
+    wakeScheduled: false,
+    latestCompletion: null,
+    linkCreatedAt: "2026-04-04T00:00:00Z",
+  };
+}

--- a/desktop/src/lib/domain/chat/subagents/session-relationship-hints.ts
+++ b/desktop/src/lib/domain/chat/subagents/session-relationship-hints.ts
@@ -1,0 +1,31 @@
+import type { SessionSubagentsResponse } from "@anyharness/sdk";
+
+export interface SubagentSessionRelationshipHint {
+  sessionId: string;
+  parentSessionId: string;
+  sessionLinkId: string | null;
+}
+
+export function collectSubagentSessionRelationshipHints(
+  sessionId: string,
+  subagents: SessionSubagentsResponse | null | undefined,
+): SubagentSessionRelationshipHint[] {
+  const hintsBySessionId = new Map<string, SubagentSessionRelationshipHint>();
+  if (subagents?.parent) {
+    hintsBySessionId.set(sessionId, {
+      sessionId,
+      parentSessionId: subagents.parent.parentSessionId,
+      sessionLinkId: subagents.parent.sessionLinkId ?? null,
+    });
+  }
+
+  for (const child of subagents?.children ?? []) {
+    hintsBySessionId.set(child.childSessionId, {
+      sessionId: child.childSessionId,
+      parentSessionId: sessionId,
+      sessionLinkId: child.sessionLinkId ?? null,
+    });
+  }
+
+  return [...hintsBySessionId.values()];
+}

--- a/desktop/src/lib/domain/reviews/session-relationship-hints.ts
+++ b/desktop/src/lib/domain/reviews/session-relationship-hints.ts
@@ -1,0 +1,29 @@
+import type { ReviewRunDetail } from "@anyharness/sdk";
+
+export interface ReviewSessionRelationshipHint {
+  sessionId: string;
+  parentSessionId: string;
+  sessionLinkId: string | null;
+}
+
+export function collectReviewSessionRelationshipHints(
+  reviews: readonly ReviewRunDetail[] | null | undefined,
+): ReviewSessionRelationshipHint[] {
+  const hintsBySessionId = new Map<string, ReviewSessionRelationshipHint>();
+  for (const run of reviews ?? []) {
+    for (const round of run.rounds) {
+      for (const assignment of round.assignments) {
+        const sessionId = assignment.reviewerSessionId?.trim();
+        if (!sessionId) {
+          continue;
+        }
+        hintsBySessionId.set(sessionId, {
+          sessionId,
+          parentSessionId: run.parentSessionId,
+          sessionLinkId: assignment.sessionLinkId?.trim() || null,
+        });
+      }
+    }
+  }
+  return [...hintsBySessionId.values()];
+}

--- a/desktop/src/lib/integrations/anyharness/session-runtime.test.ts
+++ b/desktop/src/lib/integrations/anyharness/session-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   resumeSession,
 } from "./session-runtime";
 import type { Session, SessionStreamHandle } from "@anyharness/sdk";
+import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
 
 const mocks = vi.hoisted(() => ({
   listEvents: vi.fn(),
@@ -48,6 +49,7 @@ beforeEach(() => {
   useHarnessStore.setState({
     runtimeUrl: "http://localhost:5173",
     selectedWorkspaceId: "workspace-1",
+    sessionRelationshipHints: {},
     sessionSlots: {
       "session-1": createEmptySessionSlot("session-1", "codex", {
         workspaceId: "workspace-1",
@@ -111,6 +113,39 @@ describe("fetchSessionHistory", () => {
 describe("collectInactiveSessionStreamIds", () => {
   it("initializes empty pending config changes on new slots", () => {
     expect(createEmptySessionSlot("session-1", "codex").pendingConfigChanges).toEqual({});
+  });
+
+  it("defaults generic slots to pending relationships", () => {
+    expect(createEmptySessionSlot("session-1", "codex").sessionRelationship)
+      .toEqual({ kind: "pending" });
+  });
+
+  it("applies and prunes relationship hints when slots mount later", () => {
+    useHarnessStore.getState().recordSessionRelationshipHint("child-session", {
+      kind: "subagent_child",
+      parentSessionId: "parent-session",
+      sessionLinkId: "link-1",
+      relation: "subagent",
+      workspaceId: "workspace-1",
+    });
+
+    useHarnessStore.getState().putSessionSlot(
+      "child-session",
+      createEmptySessionSlot("child-session", "codex", {
+        workspaceId: "workspace-1",
+      }),
+    );
+
+    expect(useHarnessStore.getState().sessionSlots["child-session"].sessionRelationship)
+      .toEqual({
+        kind: "subagent_child",
+        parentSessionId: "parent-session",
+        sessionLinkId: "link-1",
+        relation: "subagent",
+        workspaceId: "workspace-1",
+      });
+    expect(useHarnessStore.getState().sessionRelationshipHints["child-session"])
+      .toBeUndefined();
   });
 
   it("prunes only idle, non-pending sessions with open stream handles", () => {
@@ -228,6 +263,42 @@ describe("createSessionSlotFromSummary", () => {
     expect(slot.transcript.sessionMeta.title).toBe("haiku-test");
     expect(slot.transcriptHydrated).toBe(false);
     expect(slot.status).toBe("idle");
+  });
+
+  it("preserves existing relationship metadata across summary patches", () => {
+    const relationship = {
+      kind: "review_child" as const,
+      parentSessionId: "parent-session",
+      sessionLinkId: "review-link-1",
+      relation: "review",
+      workspaceId: "workspace-1",
+    };
+    const slot = createEmptySessionSlot("review-session", "codex", {
+      workspaceId: "workspace-1",
+      sessionRelationship: relationship,
+    });
+    useHarnessStore.getState().putSessionSlot("review-session", slot);
+
+    const patch = buildSessionSlotPatchFromSummary(
+      {
+        id: "review-session",
+        agentKind: "codex",
+        modelId: "gpt-5.4",
+        modeId: "default",
+        title: "Reviewer",
+        status: "idle",
+        liveConfig: null,
+        executionSummary: null,
+        mcpBindingSummaries: null,
+        lastPromptAt: null,
+      } as Session,
+      "workspace-1",
+      slot.transcript,
+    );
+    useHarnessStore.getState().patchSessionSlot("review-session", patch);
+
+    expect(useHarnessStore.getState().sessionSlots["review-session"].sessionRelationship)
+      .toEqual(relationship);
   });
 });
 

--- a/desktop/src/lib/integrations/anyharness/session-runtime.ts
+++ b/desktop/src/lib/integrations/anyharness/session-runtime.ts
@@ -31,7 +31,7 @@ import {
   type RuntimeTarget,
 } from "@/lib/integrations/anyharness/runtime-target";
 import { resolveSessionMcpServersForLaunch } from "@/lib/integrations/anyharness/mcp_launch";
-import type { SessionSlot } from "@/stores/sessions/harness-store";
+import type { SessionRelationship, SessionSlot } from "@/stores/sessions/harness-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 
 interface SessionStreamCallbacks {
@@ -108,6 +108,7 @@ export function createEmptySessionSlot(
     mcpBindingSummaries?: SessionMcpBindingSummary[] | null;
     lastPromptAt?: string | null;
     optimisticPrompt?: PendingPromptEntry | null;
+    sessionRelationship?: SessionRelationship;
   },
 ): SessionSlot {
   const resolvedModeId =
@@ -142,6 +143,7 @@ export function createEmptySessionSlot(
     sseHandle: null,
     streamConnectionState: "disconnected",
     transcriptHydrated: false,
+    sessionRelationship: config?.sessionRelationship ?? { kind: "pending" },
   };
 }
 
@@ -151,6 +153,7 @@ export function createSessionSlotFromSummary(
   options?: {
     titleFallback?: string | null;
     transcriptHydrated?: boolean;
+    sessionRelationship?: SessionRelationship;
   },
 ): SessionSlot {
   const modeId =
@@ -170,6 +173,7 @@ export function createSessionSlotFromSummary(
       executionSummary: session.executionSummary ?? null,
       mcpBindingSummaries: session.mcpBindingSummaries ?? null,
       lastPromptAt: session.lastPromptAt ?? null,
+      sessionRelationship: options?.sessionRelationship ?? { kind: "pending" },
     }),
     status: resolveStatusFromExecutionSummary(
       session.executionSummary,

--- a/desktop/src/lib/integrations/anyharness/turn-end-events.ts
+++ b/desktop/src/lib/integrations/anyharness/turn-end-events.ts
@@ -1,6 +1,7 @@
 export type TurnEndCallback = (sessionId: string, eventType: "turn_ended" | "error") => void;
 
 const turnEndListeners = new Set<TurnEndCallback>();
+const userFacingTurnEndListeners = new Set<TurnEndCallback>();
 
 export function onTurnEnd(callback: TurnEndCallback): void {
   turnEndListeners.add(callback);
@@ -8,6 +9,14 @@ export function onTurnEnd(callback: TurnEndCallback): void {
 
 export function offTurnEnd(callback: TurnEndCallback): void {
   turnEndListeners.delete(callback);
+}
+
+export function onUserFacingTurnEnd(callback: TurnEndCallback): void {
+  userFacingTurnEndListeners.add(callback);
+}
+
+export function offUserFacingTurnEnd(callback: TurnEndCallback): void {
+  userFacingTurnEndListeners.delete(callback);
 }
 
 export function notifyTurnEnd(
@@ -23,6 +32,19 @@ export function notifyTurnEnd(
   }
 }
 
+export function notifyUserFacingTurnEnd(
+  sessionId: string,
+  eventType: "turn_ended" | "error",
+): void {
+  for (const listener of userFacingTurnEndListeners) {
+    try {
+      listener(sessionId, eventType);
+    } catch {
+      // Listener errors must not break session updates.
+    }
+  }
+}
+
 export function emitTurnEnd(): void {
-  notifyTurnEnd("__test__", "turn_ended");
+  notifyUserFacingTurnEnd("__test__", "turn_ended");
 }

--- a/desktop/src/stores/preferences/workspace-ui-store.test.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   migrateWorkspaceUiState,
   WORKSPACE_UI_DEFAULTS,
   useWorkspaceUiStore,
 } from "./workspace-ui-store";
 import { createManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("workspace ui tab persistence", () => {
   it("migrates archived workspaces from v7 preference blobs", () => {
@@ -219,6 +223,35 @@ describe("workspace ui tab persistence", () => {
 
     expect(useWorkspaceUiStore.getState().visibleChatSessionIdsByWorkspace.w1).toEqual(["a", "b"]);
     expect(useWorkspaceUiStore.getState().recentlyHiddenChatSessionIdsByWorkspace.w1).toEqual(["b"]);
+  });
+
+  it("marks workspace viewed at exact monotonic timestamps", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-04T00:00:30.000Z"));
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      lastViewedAt: {
+        w1: "2026-04-04T00:00:10.000Z",
+      },
+    });
+
+    const store = useWorkspaceUiStore.getState();
+    store.markWorkspaceViewedAt("w1", "2026-04-04T00:00:09.000Z");
+    expect(useWorkspaceUiStore.getState().lastViewedAt.w1)
+      .toBe("2026-04-04T00:00:10.000Z");
+
+    store.markWorkspaceViewedAt("w1", "2026-04-04T00:00:10.000Z");
+    expect(useWorkspaceUiStore.getState().lastViewedAt.w1)
+      .toBe("2026-04-04T00:00:10.000Z");
+
+    store.markWorkspaceViewedAt("w1", "2026-04-04T00:00:11.000Z");
+    expect(useWorkspaceUiStore.getState().lastViewedAt.w1)
+      .toBe("2026-04-04T00:00:11.000Z");
+
+    store.markWorkspaceViewed("w2");
+    expect(useWorkspaceUiStore.getState().lastViewedAt.w2)
+      .toBe("2026-04-04T00:00:30.000Z");
   });
 
   it("stores right panel preferences per workspace", () => {

--- a/desktop/src/stores/preferences/workspace-ui-store.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.ts
@@ -133,6 +133,7 @@ export interface WorkspaceUiState {
   resetWorkspaceShellTabs: (workspaceId: string) => void;
   toggleSidebarWorkspaceType: (type: SidebarWorkspaceVariant) => void;
   markWorkspaceViewed: (workspaceId: string) => void;
+  markWorkspaceViewedAt: (workspaceId: string, timestamp: string) => void;
   setLastViewedSessionForWorkspace: (workspaceId: string, sessionId: string) => void;
   clearLastViewedSessionForWorkspace: (workspaceId: string, sessionId?: string) => void;
   markSessionErrorViewed: (sessionId: string, errorAt: string) => void;
@@ -973,6 +974,21 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
     });
   },
 
+  markWorkspaceViewedAt: (workspaceId, timestamp) => {
+    set((state) => {
+      const current = state.lastViewedAt[workspaceId];
+      if (current && new Date(current).getTime() >= new Date(timestamp).getTime()) {
+        return state;
+      }
+      return {
+        lastViewedAt: {
+          ...state.lastViewedAt,
+          [workspaceId]: timestamp,
+        },
+      };
+    });
+  },
+
   setLastViewedSessionForWorkspace: (workspaceId, sessionId) => {
     set({
       lastViewedSessionByWorkspace: {
@@ -1252,6 +1268,10 @@ export function trackWorkspaceInteraction(workspaceId: string, timestamp: string
 
 export function markWorkspaceViewed(workspaceId: string) {
   useWorkspaceUiStore.getState().markWorkspaceViewed(workspaceId);
+}
+
+export function markWorkspaceViewedAt(workspaceId: string, timestamp: string) {
+  useWorkspaceUiStore.getState().markWorkspaceViewedAt(workspaceId, timestamp);
 }
 
 export function rememberLastViewedSession(workspaceId: string, sessionId: string) {

--- a/desktop/src/stores/sessions/harness-store.ts
+++ b/desktop/src/stores/sessions/harness-store.ts
@@ -27,6 +27,41 @@ export type SessionStreamConnectionState =
   | "open"
   | "ended";
 
+export type SessionRelationship =
+  | { kind: "root" }
+  | { kind: "pending" }
+  | SessionChildRelationship;
+
+export type SessionChildRelationship =
+  | {
+    kind: "subagent_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "cowork_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "review_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "linked_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  };
+
 export interface HotPaintGate {
   workspaceId: string;
   sessionId: string;
@@ -55,6 +90,7 @@ export interface SessionSlot {
   sseHandle: SessionStreamHandle | null;
   streamConnectionState: SessionStreamConnectionState;
   transcriptHydrated: boolean;
+  sessionRelationship: SessionRelationship;
 }
 
 interface HarnessState {
@@ -90,7 +126,17 @@ interface HarnessState {
   activeSessionVersion: number;
   sessionActivationIntentEpochByWorkspace: Record<string, number>;
   sessionSlots: Record<string, SessionSlot>;
+  sessionRelationshipHints: Record<string, SessionChildRelationship>;
   hotPaintGate: HotPaintGate | null;
+
+  recordSessionRelationshipHint: (
+    sessionId: string,
+    relationship: SessionChildRelationship,
+  ) => void;
+  setSessionRelationship: (
+    sessionId: string,
+    relationship: SessionRelationship,
+  ) => void;
 }
 
 export const useHarnessStore = create<HarnessState>((set, get) => ({
@@ -143,13 +189,27 @@ export const useHarnessStore = create<HarnessState>((set, get) => ({
   })),
 
   removeWorkspaceSlots: (workspaceId) => set((s) => {
+    const removedSessionIds = new Set<string>();
+    const sessionSlots = Object.fromEntries(
+      Object.entries(s.sessionSlots).filter(([sessionId, slot]) => {
+        const keep = slot.workspaceId !== workspaceId;
+        if (!keep) {
+          removedSessionIds.add(sessionId);
+        }
+        return keep;
+      }),
+    );
+    const sessionRelationshipHints = Object.fromEntries(
+      Object.entries(s.sessionRelationshipHints).filter(([sessionId, hint]) =>
+        !removedSessionIds.has(sessionId) && hint.workspaceId !== workspaceId
+      ),
+    );
     const nextActiveSessionId = s.activeSessionId && s.sessionSlots[s.activeSessionId]?.workspaceId !== workspaceId
       ? s.activeSessionId
       : null;
     return {
-      sessionSlots: Object.fromEntries(
-        Object.entries(s.sessionSlots).filter(([, slot]) => slot.workspaceId !== workspaceId),
-      ),
+      sessionSlots,
+      sessionRelationshipHints,
       activeSessionId: nextActiveSessionId,
       activeSessionVersion: bumpVersionIfChanged(
         s.activeSessionVersion,
@@ -168,15 +228,21 @@ export const useHarnessStore = create<HarnessState>((set, get) => ({
     activeSessionId: null,
     activeSessionVersion: bumpVersionIfChanged(s.activeSessionVersion, s.activeSessionId, null),
     sessionSlots: {},
+    sessionRelationshipHints: {},
     hotPaintGate: null,
   })),
 
-  putSessionSlot: (sessionId, slot) => set((state) => ({
-    sessionSlots: {
-      ...state.sessionSlots,
-      [sessionId]: slot,
-    },
-  })),
+  putSessionSlot: (sessionId, slot) => set((state) => {
+    const hint = state.sessionRelationshipHints[sessionId];
+    const { [sessionId]: _consumedHint, ...remainingHints } = state.sessionRelationshipHints;
+    return {
+      sessionSlots: {
+        ...state.sessionSlots,
+        [sessionId]: hint ? { ...slot, sessionRelationship: hint } : slot,
+      },
+      sessionRelationshipHints: hint ? remainingHints : state.sessionRelationshipHints,
+    };
+  }),
 
   patchSessionSlot: (sessionId, patch) => set((state) => {
     const slot = state.sessionSlots[sessionId];
@@ -197,9 +263,12 @@ export const useHarnessStore = create<HarnessState>((set, get) => ({
       return state;
     }
     const { [sessionId]: _removed, ...sessionSlots } = state.sessionSlots;
+    const { [sessionId]: _removedHint, ...sessionRelationshipHints } =
+      state.sessionRelationshipHints;
     const nextActiveSessionId = state.activeSessionId === sessionId ? null : state.activeSessionId;
     return {
       sessionSlots,
+      sessionRelationshipHints,
       activeSessionId: nextActiveSessionId,
       activeSessionVersion: bumpVersionIfChanged(
         state.activeSessionVersion,
@@ -238,6 +307,62 @@ export const useHarnessStore = create<HarnessState>((set, get) => ({
       : state
   )),
 
+  recordSessionRelationshipHint: (sessionId, relationship) => set((state) => {
+    const slot = state.sessionSlots[sessionId];
+    if (slot) {
+      const sessionRelationshipHints = removeRecordKey(
+        state.sessionRelationshipHints,
+        sessionId,
+      );
+      if (sessionRelationshipEqual(slot.sessionRelationship, relationship)) {
+        return sessionRelationshipHints === state.sessionRelationshipHints
+          ? state
+          : { sessionRelationshipHints };
+      }
+      return {
+        sessionSlots: {
+          ...state.sessionSlots,
+          [sessionId]: {
+            ...slot,
+            sessionRelationship: relationship,
+          },
+        },
+        sessionRelationshipHints,
+      };
+    }
+
+    const existing = state.sessionRelationshipHints[sessionId];
+    if (sessionChildRelationshipEqual(existing, relationship)) {
+      return state;
+    }
+
+    return {
+      sessionRelationshipHints: {
+        ...state.sessionRelationshipHints,
+        [sessionId]: relationship,
+      },
+    };
+  }),
+
+  setSessionRelationship: (sessionId, relationship) => set((state) => {
+    const slot = state.sessionSlots[sessionId];
+    if (!slot) {
+      return state;
+    }
+    if (sessionRelationshipEqual(slot.sessionRelationship, relationship)) {
+      return state;
+    }
+    return {
+      sessionSlots: {
+        ...state.sessionSlots,
+        [sessionId]: {
+          ...slot,
+          sessionRelationship: relationship,
+        },
+      },
+    };
+  }),
+
   pendingWorkspaceEntry: null,
   selectedWorkspaceId: null,
   workspaceSelectionNonce: 0,
@@ -247,6 +372,7 @@ export const useHarnessStore = create<HarnessState>((set, get) => ({
   activeSessionVersion: 0,
   sessionActivationIntentEpochByWorkspace: {},
   sessionSlots: {},
+  sessionRelationshipHints: {},
   hotPaintGate: null,
 }));
 
@@ -256,6 +382,40 @@ function bumpVersionIfChanged(
   nextSessionId: string | null,
 ): number {
   return previousSessionId === nextSessionId ? version : version + 1;
+}
+
+function removeRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in record)) {
+    return record;
+  }
+  const { [key]: _removed, ...rest } = record;
+  return rest;
+}
+
+function sessionRelationshipEqual(
+  a: SessionRelationship | undefined,
+  b: SessionRelationship | undefined,
+): boolean {
+  if (!a || !b || a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "root" || a.kind === "pending") {
+    return true;
+  }
+  return sessionChildRelationshipEqual(a, b as SessionChildRelationship);
+}
+
+function sessionChildRelationshipEqual(
+  a: SessionChildRelationship | undefined,
+  b: SessionChildRelationship | undefined,
+): boolean {
+  return !!a
+    && !!b
+    && a.kind === b.kind
+    && a.parentSessionId === b.parentSessionId
+    && (a.sessionLinkId ?? null) === (b.sessionLinkId ?? null)
+    && (a.relation ?? null) === (b.relation ?? null)
+    && (a.workspaceId ?? null) === (b.workspaceId ?? null);
 }
 
 const RETAINED_SESSION_SLOT_WARNING_THRESHOLD = 50;


### PR DESCRIPTION
## Summary
- split broad AnyHarness turn completion from root-only user-facing sound/celebration
- add session relationship metadata and hint propagation for subagents, cowork, reviews, and linked children
- add timestamp-correct logical-workspace read acknowledgement
- stabilize composer/transcript bottom geometry and cap tall composer panels

## Validation
- pnpm --dir desktop exec vitest run src/hooks/sessions/session-stream-side-effects.test.ts src/lib/integrations/anyharness/session-runtime.test.ts src/hooks/sessions/use-session-selection-actions.test.ts src/hooks/sessions/session-relationship-hints.test.ts src/lib/domain/chat/subagents/session-relationship-hints.test.ts src/stores/preferences/workspace-ui-store.test.ts src/hooks/workspaces/use-workspace-activity-acknowledgement.test.tsx src/config/chat-layout.test.ts
- pnpm --dir desktop exec tsc --noEmit
- git diff --check