### PR TITLE
[codex] Add file-backed prompt attachments

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/events.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/events.rs
@@ -297,6 +297,8 @@ pub enum ContentPart {
         uri: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<super::PromptAttachmentSource>,
     },
     Resource {
         #[serde(rename = "attachmentId")]
@@ -318,6 +320,8 @@ pub enum ContentPart {
         #[serde(rename = "previewOriginalBytes")]
         #[serde(skip_serializing_if = "Option::is_none")]
         preview_original_bytes: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<super::PromptAttachmentSource>,
     },
     ResourceLink {
         uri: String,

--- a/anyharness/crates/anyharness-contract/src/v1/mobility.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/mobility.rs
@@ -289,6 +289,8 @@ pub struct MobilityPromptAttachmentRecord {
     pub session_id: String,
     pub state: String,
     pub kind: String,
+    #[serde(default = "default_prompt_attachment_source")]
+    pub source: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -301,6 +303,10 @@ pub struct MobilityPromptAttachmentRecord {
     pub content_base64: String,
     pub created_at: String,
     pub updated_at: String,
+}
+
+fn default_prompt_attachment_source() -> String {
+    "upload".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-contract/src/v1/sessions.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/sessions.rs
@@ -374,6 +374,8 @@ pub enum PromptInputBlock {
         name: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<PromptAttachmentSource>,
     },
     #[serde(rename = "resource")]
     Resource {
@@ -390,6 +392,8 @@ pub enum PromptInputBlock {
         mime_type: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<PromptAttachmentSource>,
     },
     #[serde(rename = "resource_link")]
     ResourceLink {
@@ -412,6 +416,13 @@ pub enum PromptInputBlock {
         #[serde(rename = "snapshotHash")]
         snapshot_hash: String,
     },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptAttachmentSource {
+    Upload,
+    Paste,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-lib/src/acp/manager.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/manager.rs
@@ -15,6 +15,7 @@ use crate::agents::model::ResolvedAgent;
 use crate::api::http::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::plans::service::PlanService;
 use crate::reviews::service::ReviewService;
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::mcp::SessionMcpServer;
 use crate::sessions::model::SessionRecord;
 use crate::sessions::runtime_event::{
@@ -63,6 +64,7 @@ impl AcpManager {
         workspace_env: std::collections::BTreeMap<String, String>,
         session_launch_env: std::collections::BTreeMap<String, String>,
         session_store: SessionStore,
+        attachment_storage: PromptAttachmentStorage,
         mcp_servers: Vec<SessionMcpServer>,
         startup_strategy: SessionStartupStrategy,
         system_prompt_append: Option<String>,
@@ -157,6 +159,7 @@ impl AcpManager {
                 .and_then(|guard| guard.clone()),
             event_tx,
             session_store,
+            attachment_storage,
             mcp_servers,
             startup_strategy,
             last_seq,
@@ -418,7 +421,7 @@ mod tests {
     use tokio::sync::{broadcast, mpsc, watch};
     use tokio::time::{sleep, Duration};
 
-    use super::AcpManager;
+    use super::{AcpManager, PromptAttachmentStorage};
     use crate::acp::session_actor::{LiveSessionHandle, SessionStartupStrategy};
     use crate::agents::model::{
         AgentKind, ArtifactRole, CredentialState, ResolvedAgent, ResolvedAgentStatus,
@@ -510,6 +513,12 @@ mod tests {
         store
     }
 
+    fn test_attachment_storage() -> PromptAttachmentStorage {
+        PromptAttachmentStorage::new(
+            std::env::temp_dir().join(format!("anyharness-test-{}", uuid::Uuid::new_v4())),
+        )
+    }
+
     fn subagent_turn_completed_event() -> RuntimeInjectedSessionEvent {
         RuntimeInjectedSessionEvent::SubagentTurnCompleted(SubagentTurnCompletedPayload {
             completion_id: "completion-1".to_string(),
@@ -550,6 +559,7 @@ mod tests {
                 Default::default(),
                 Default::default(),
                 SessionStore::new(Db::open_in_memory().expect("open db")),
+                test_attachment_storage(),
                 vec![],
                 SessionStartupStrategy::ResumeSeqFreshNative,
                 None,
@@ -599,6 +609,7 @@ mod tests {
                     Default::default(),
                     Default::default(),
                     SessionStore::new(Db::open_in_memory().expect("open db")),
+                    test_attachment_storage(),
                     vec![],
                     SessionStartupStrategy::ResumeSeqFreshNative,
                     None,

--- a/anyharness/crates/anyharness-lib/src/acp/session_actor.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/session_actor.rs
@@ -26,6 +26,7 @@ use crate::api::http::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::plans::model::{NewPlan, PlanRecord};
 use crate::plans::service::{PlanCreateError, PlanDecisionError, PlanService};
 use crate::reviews::service::ReviewService;
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::extensions::SessionTurnOutcome;
 use crate::sessions::live_config::{
     build_live_config_snapshot, normalized_key_rank, option_matches_key, snapshot_from_record,
@@ -34,7 +35,8 @@ use crate::sessions::live_config::{
 };
 use crate::sessions::mcp::{to_acp_servers, SessionMcpServer};
 use crate::sessions::model::{
-    serialize_action_capabilities, PendingConfigChangeRecord, SessionRecord,
+    serialize_action_capabilities, PendingConfigChangeRecord, PromptAttachmentRecord,
+    PromptAttachmentState, SessionRecord,
 };
 use crate::sessions::prompt::{capabilities_from_acp, PromptPayload};
 use crate::sessions::runtime_event::{RuntimeEventInjectionResult, RuntimeInjectedSessionEvent};
@@ -645,6 +647,7 @@ pub struct SessionActorConfig {
     pub review_service: Option<Arc<ReviewService>>,
     pub event_tx: broadcast::Sender<SessionEventEnvelope>,
     pub session_store: SessionStore,
+    pub attachment_storage: PromptAttachmentStorage,
     pub mcp_servers: Vec<SessionMcpServer>,
     pub startup_strategy: SessionStartupStrategy,
     pub last_seq: i64,
@@ -1188,6 +1191,7 @@ async fn run_actor(
     let (notification_tx, mut notification_rx) =
         mpsc::unbounded_channel::<acp::SessionNotification>();
     let store = config.session_store.clone();
+    let attachment_storage = config.attachment_storage.clone();
 
     let event_sink = Arc::new(Mutex::new(if startup_strategy.resumes_durable_history() {
         SessionEventSink::resume_from_seq(
@@ -1731,7 +1735,7 @@ async fn run_actor(
                                     prompt_id = latency_fields.prompt_id,
                                     "[workspace-latency] session.actor.prompt.received"
                                 );
-                                let mut acp_blocks = match current_payload.to_acp_blocks(&store, &session_id) {
+                                let mut acp_blocks = match current_payload.to_acp_blocks(&store, &attachment_storage, &session_id) {
                                     Ok(blocks) => blocks,
                                     Err(error) => {
                                         let detail = error.detail.clone();
@@ -2084,10 +2088,10 @@ async fn run_actor(
                                                 }
                                             }
                                             Some(SessionCommand::EditPendingPrompt { seq, payload, respond_to }) => {
-                                                let _ = respond_to.send(handle_edit_pending_prompt(&store, &event_sink, &session_id, seq, payload).await);
+                                                let _ = respond_to.send(handle_edit_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq, payload).await);
                                             }
                                             Some(SessionCommand::DeletePendingPrompt { seq, respond_to }) => {
-                                                let _ = respond_to.send(handle_delete_pending_prompt(&store, &event_sink, &session_id, seq).await);
+                                                let _ = respond_to.send(handle_delete_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq).await);
                                             }
                                             Some(SessionCommand::ReplayAdvance { respond_to }) => {
                                                 let _ = respond_to.send(Err(anyhow::anyhow!("session is not a replay session")));
@@ -2335,10 +2339,10 @@ async fn run_actor(
                         }
                     }
                     Some(SessionCommand::EditPendingPrompt { seq, payload, respond_to }) => {
-                        let _ = respond_to.send(handle_edit_pending_prompt(&store, &event_sink, &session_id, seq, payload).await);
+                        let _ = respond_to.send(handle_edit_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq, payload).await);
                     }
                     Some(SessionCommand::DeletePendingPrompt { seq, respond_to }) => {
-                        let _ = respond_to.send(handle_delete_pending_prompt(&store, &event_sink, &session_id, seq).await);
+                        let _ = respond_to.send(handle_delete_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq).await);
                     }
                     Some(SessionCommand::ResolveInteraction { request_id, resolution, respond_to }) => {
                         let result = handle_resolve_interaction(
@@ -4511,6 +4515,7 @@ fn config_request_matches_current_state(
 
 async fn handle_edit_pending_prompt(
     store: &SessionStore,
+    attachment_storage: &PromptAttachmentStorage,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     seq: i64,
@@ -4528,6 +4533,7 @@ async fn handle_edit_pending_prompt(
                 .filter(|old_id| !new_attachment_ids.contains(old_id))
                 .map(String::as_str)
                 .collect::<Vec<_>>();
+            let removed_records = pending_attachment_records(store, session_id, &removed);
             if let Err(error) = store.delete_prompt_attachments(session_id, &removed) {
                 tracing::warn!(
                     session_id = %session_id,
@@ -4536,6 +4542,7 @@ async fn handle_edit_pending_prompt(
                     "failed to delete removed pending prompt attachments",
                 );
             }
+            delete_pending_attachment_files(attachment_storage, &removed_records);
             let mut sink = event_sink.lock().await;
             let content_parts = payload.content_parts();
             sink.pending_prompt_updated(PendingPromptUpdatedPayload {
@@ -4565,6 +4572,7 @@ async fn handle_edit_pending_prompt(
 
 async fn handle_delete_pending_prompt(
     store: &SessionStore,
+    attachment_storage: &PromptAttachmentStorage,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     seq: i64,
@@ -4576,6 +4584,7 @@ async fn handle_delete_pending_prompt(
                 .iter()
                 .map(String::as_str)
                 .collect::<Vec<_>>();
+            let removed_records = pending_attachment_records(store, session_id, &attachment_refs);
             if let Err(error) = store.delete_prompt_attachments(session_id, &attachment_refs) {
                 tracing::warn!(
                     session_id = %session_id,
@@ -4584,6 +4593,7 @@ async fn handle_delete_pending_prompt(
                     "failed to delete pending prompt attachments",
                 );
             }
+            delete_pending_attachment_files(attachment_storage, &removed_records);
             let mut sink = event_sink.lock().await;
             sink.pending_prompt_removed(PendingPromptRemovedPayload {
                 seq,
@@ -4600,6 +4610,39 @@ async fn handle_delete_pending_prompt(
                 "failed to delete pending prompt",
             );
             Err(QueueMutationError::NotFound)
+        }
+    }
+}
+
+fn pending_attachment_records(
+    store: &SessionStore,
+    session_id: &str,
+    attachment_ids: &[&str],
+) -> Vec<PromptAttachmentRecord> {
+    attachment_ids
+        .iter()
+        .filter_map(|attachment_id| {
+            store
+                .find_prompt_attachment(session_id, attachment_id)
+                .ok()
+                .flatten()
+                .filter(|record| record.state == PromptAttachmentState::Pending)
+        })
+        .collect()
+}
+
+fn delete_pending_attachment_files(
+    attachment_storage: &PromptAttachmentStorage,
+    records: &[PromptAttachmentRecord],
+) {
+    for record in records {
+        if let Err(error) = attachment_storage.delete_record(record) {
+            tracing::warn!(
+                session_id = %record.session_id,
+                attachment_id = %record.attachment_id,
+                error = %error,
+                "failed to delete pending prompt attachment file"
+            );
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -17,6 +17,7 @@ use axum::{
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use sha2::{Digest, Sha256};
 use std::time::Instant;
 
 use super::access::assert_workspace_not_retired;
@@ -25,11 +26,12 @@ use super::error::ApiError;
 use super::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::app::AppState;
 use crate::mobility::model::{
-    ImportedWorkspaceArchiveSummary, MobilityBlocker, MobilityFileData, MobilitySessionCandidate,
-    WorkspaceMobilityArchiveData, WorkspaceMobilityPreflightResult,
-    WorkspaceMobilitySessionBundleData, MAX_MOBILITY_FILE_BYTES,
+    ImportedWorkspaceArchiveSummary, MobilityBlocker, MobilityFileData,
+    MobilityPromptAttachmentData, MobilitySessionCandidate, WorkspaceMobilityArchiveData,
+    WorkspaceMobilityPreflightResult, WorkspaceMobilitySessionBundleData, MAX_MOBILITY_FILE_BYTES,
 };
 use crate::mobility::service::MobilityError;
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::extensions::SessionTurnOutcome;
 use crate::sessions::links::model::{
     SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
@@ -191,7 +193,11 @@ pub async fn install_workspace_mobility_archive(
         .map_err(map_access_error)?;
     let mobility_service = state.mobility_service.clone();
     let operation_id = req.operation_id;
-    let archive = from_contract_archive(req.archive, &workspace_id)?;
+    let archive = from_contract_archive(
+        req.archive,
+        &workspace_id,
+        state.session_service.attachment_storage(),
+    )?;
     let summary = run_blocking("mobility_install", move || {
         mobility_service.install_workspace_archive(&workspace_id, &archive, operation_id.as_deref())
     })
@@ -558,18 +564,22 @@ fn to_contract_pending_prompt(record: PendingPromptRecord) -> MobilityPendingPro
     }
 }
 
-fn to_contract_prompt_attachment(record: PromptAttachmentRecord) -> MobilityPromptAttachmentRecord {
+fn to_contract_prompt_attachment(
+    data: MobilityPromptAttachmentData,
+) -> MobilityPromptAttachmentRecord {
+    let record = data.record;
     MobilityPromptAttachmentRecord {
         attachment_id: record.attachment_id,
         session_id: record.session_id,
         state: record.state.as_str().to_string(),
         kind: record.kind.as_str().to_string(),
+        source: record.source.as_str().to_string(),
         mime_type: record.mime_type,
         display_name: record.display_name,
         source_uri: record.source_uri,
         size_bytes: record.size_bytes.max(0) as u64,
         sha256: record.sha256,
-        content_base64: STANDARD.encode(record.content),
+        content_base64: STANDARD.encode(data.content),
         created_at: record.created_at,
         updated_at: record.updated_at,
     }
@@ -602,6 +612,7 @@ fn to_contract_raw_notification(
 fn from_contract_archive(
     archive: WorkspaceMobilityArchive,
     workspace_id: &str,
+    attachment_storage: &PromptAttachmentStorage,
 ) -> Result<WorkspaceMobilityArchiveData, ApiError> {
     Ok(WorkspaceMobilityArchiveData {
         source_workspace_path: archive.source_workspace_path,
@@ -617,7 +628,7 @@ fn from_contract_archive(
         sessions: archive
             .sessions
             .into_iter()
-            .map(|bundle| from_contract_session_bundle(bundle, workspace_id))
+            .map(|bundle| from_contract_session_bundle(bundle, workspace_id, attachment_storage))
             .collect::<Result<Vec<_>, _>>()?,
         session_links: archive
             .session_links
@@ -666,9 +677,12 @@ fn from_contract_file(file: WorkspaceMobilityFileEntry) -> Result<MobilityFileDa
 fn from_contract_session_bundle(
     bundle: WorkspaceMobilitySessionBundle,
     workspace_id: &str,
+    attachment_storage: &PromptAttachmentStorage,
 ) -> Result<WorkspaceMobilitySessionBundleData, ApiError> {
+    let session = from_contract_session_record(bundle.session, workspace_id);
+    let session_id = session.id.clone();
     Ok(WorkspaceMobilitySessionBundleData {
-        session: from_contract_session_record(bundle.session, workspace_id),
+        session,
         live_config_snapshot: bundle
             .live_config_snapshot
             .map(from_contract_live_config_snapshot),
@@ -685,7 +699,7 @@ fn from_contract_session_bundle(
         prompt_attachments: bundle
             .prompt_attachments
             .into_iter()
-            .map(from_contract_prompt_attachment)
+            .map(|record| from_contract_prompt_attachment(record, &session_id, attachment_storage))
             .collect::<Result<Vec<_>, _>>()?,
         events: bundle.events.into_iter().map(from_contract_event).collect(),
         raw_notifications: bundle
@@ -843,7 +857,15 @@ fn from_contract_pending_prompt(record: MobilityPendingPromptRecord) -> PendingP
 
 fn from_contract_prompt_attachment(
     record: MobilityPromptAttachmentRecord,
-) -> Result<PromptAttachmentRecord, ApiError> {
+    expected_session_id: &str,
+    attachment_storage: &PromptAttachmentStorage,
+) -> Result<MobilityPromptAttachmentData, ApiError> {
+    if record.session_id != expected_session_id {
+        return Err(ApiError::bad_request(
+            "Prompt attachment sessionId does not match containing session",
+            "INVALID_ARCHIVE",
+        ));
+    }
     let content = STANDARD.decode(record.content_base64).map_err(|_| {
         ApiError::bad_request("Invalid prompt attachment content", "INVALID_ARCHIVE")
     })?;
@@ -853,19 +875,33 @@ fn from_contract_prompt_attachment(
             "INVALID_ARCHIVE",
         ));
     }
-    Ok(PromptAttachmentRecord {
-        attachment_id: record.attachment_id,
-        session_id: record.session_id,
-        state: PromptAttachmentState::parse(&record.state),
-        kind: PromptAttachmentKind::parse(&record.kind),
-        mime_type: record.mime_type,
-        display_name: record.display_name,
-        source_uri: record.source_uri,
-        size_bytes: record.size_bytes.try_into().unwrap_or(i64::MAX),
-        sha256: record.sha256,
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+    let digest = format!("{:x}", hasher.finalize());
+    if digest != record.sha256 {
+        return Err(ApiError::bad_request(
+            "Prompt attachment sha256 does not match decoded content",
+            "INVALID_ARCHIVE",
+        ));
+    }
+    let storage_path = attachment_storage.storage_path(&record.session_id, &record.attachment_id);
+    Ok(MobilityPromptAttachmentData {
+        record: PromptAttachmentRecord {
+            attachment_id: record.attachment_id,
+            session_id: record.session_id,
+            state: PromptAttachmentState::parse(&record.state),
+            kind: PromptAttachmentKind::parse(&record.kind),
+            source: crate::sessions::model::PromptAttachmentSource::parse(&record.source),
+            mime_type: record.mime_type,
+            display_name: record.display_name,
+            source_uri: record.source_uri,
+            storage_path,
+            size_bytes: record.size_bytes.try_into().unwrap_or(i64::MAX),
+            sha256: record.sha256,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+        },
         content,
-        created_at: record.created_at,
-        updated_at: record.updated_at,
     })
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
@@ -498,7 +498,11 @@ pub async fn get_prompt_attachment(
             headers.insert("content-type", value);
         }
     }
-    Ok((headers, attachment.content))
+    let content = state
+        .session_service
+        .read_prompt_attachment_content(&attachment)
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    Ok((headers, content))
 }
 
 // ---------------------------------------------------------------------------

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -27,6 +27,7 @@ use crate::reviews::mcp_auth::ReviewMcpAuth;
 use crate::reviews::runtime::ReviewRuntime;
 use crate::reviews::service::ReviewService;
 use crate::reviews::store::ReviewStore;
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::links::completions::LinkCompletionStore;
 use crate::sessions::links::service::SessionLinkService;
 use crate::sessions::links::store::SessionLinkStore;
@@ -255,6 +256,7 @@ impl AppState {
             workspace_runtime.clone(),
             WorkspaceStore::new(db.clone()),
             SessionStore::new(db.clone()),
+            PromptAttachmentStorage::new(runtime_home.clone()),
             workspace_operation_gate.clone(),
             checkout_deletion_gate.clone(),
             retire_preflight_checker.clone(),

--- a/anyharness/crates/anyharness-lib/src/mobility/model.rs
+++ b/anyharness/crates/anyharness-lib/src/mobility/model.rs
@@ -36,10 +36,16 @@ pub struct WorkspaceMobilitySessionBundleData {
     pub live_config_snapshot: Option<SessionLiveConfigSnapshotRecord>,
     pub pending_config_changes: Vec<PendingConfigChangeRecord>,
     pub pending_prompts: Vec<PendingPromptRecord>,
-    pub prompt_attachments: Vec<PromptAttachmentRecord>,
+    pub prompt_attachments: Vec<MobilityPromptAttachmentData>,
     pub events: Vec<SessionEventRecord>,
     pub raw_notifications: Vec<SessionRawNotificationRecord>,
     pub agent_artifacts: Vec<MobilityFileData>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MobilityPromptAttachmentData {
+    pub record: PromptAttachmentRecord,
+    pub content: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]

--- a/anyharness/crates/anyharness-lib/src/mobility/service.rs
+++ b/anyharness/crates/anyharness-lib/src/mobility/service.rs
@@ -636,7 +636,15 @@ impl MobilityService {
             let prompt_attachments = self
                 .session_service
                 .store()
-                .list_prompt_attachments(&session.id)?;
+                .list_prompt_attachments(&session.id)?
+                .into_iter()
+                .map(|record| {
+                    let content = self
+                        .session_service
+                        .read_prompt_attachment_content(&record)?;
+                    Ok(crate::mobility::model::MobilityPromptAttachmentData { record, content })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
             let events = self.session_service.store().list_events(&session.id)?;
             let raw_notifications = self
                 .session_service
@@ -840,7 +848,7 @@ fn validate_archive_size(archive: &WorkspaceMobilityArchiveData) -> Result<(), M
         if attachment.content.len() > MAX_MOBILITY_FILE_BYTES {
             return Err(MobilityError::SizeLimitExceeded(format!(
                 "prompt attachment {} exceeded the {} byte limit",
-                attachment.attachment_id, MAX_MOBILITY_FILE_BYTES
+                attachment.record.attachment_id, MAX_MOBILITY_FILE_BYTES
             )));
         }
     }
@@ -907,15 +915,17 @@ fn session_bundle_size_bytes(bundle: &WorkspaceMobilitySessionBundleData) -> u64
             bundle
                 .prompt_attachments
                 .iter()
-                .map(|record| {
+                .map(|attachment| {
+                    let record = &attachment.record;
                     string_size(&record.attachment_id)
                         + string_size(&record.session_id)
                         + str_size(record.state.as_str())
                         + str_size(record.kind.as_str())
+                        + str_size(record.source.as_str())
                         + option_string_size(&record.mime_type)
                         + option_string_size(&record.display_name)
                         + option_string_size(&record.source_uri)
-                        + base64_size(record.content.len())
+                        + base64_size(attachment.content.len())
                         + string_size(&record.sha256)
                         + string_size(&record.created_at)
                         + string_size(&record.updated_at)

--- a/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
@@ -157,6 +157,10 @@ pub(super) const MIGRATIONS: &[(&str, &str)] = &[
         "0042_fork_link_child_unique",
         include_str!("sql/0042_fork_link_child_unique.sql"),
     ),
+    (
+        "0043_prompt_attachment_file_storage",
+        include_str!("sql/0043_prompt_attachment_file_storage.sql"),
+    ),
 ];
 
 pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0043_prompt_attachment_file_storage.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0043_prompt_attachment_file_storage.sql
@@ -1,0 +1,5 @@
+ALTER TABLE session_prompt_attachments
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'upload';
+
+ALTER TABLE session_prompt_attachments
+    ADD COLUMN storage_path TEXT NOT NULL DEFAULT '';

--- a/anyharness/crates/anyharness-lib/src/sessions/attachment_storage.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/attachment_storage.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Context;
+
+use crate::sessions::model::PromptAttachmentRecord;
+
+#[derive(Debug, Clone)]
+pub struct PromptAttachmentStorage {
+    root: PathBuf,
+}
+
+impl PromptAttachmentStorage {
+    pub fn new(runtime_home: impl Into<PathBuf>) -> Self {
+        Self {
+            root: runtime_home.into().join("attachments").join("sessions"),
+        }
+    }
+
+    pub fn storage_path(&self, session_id: &str, attachment_id: &str) -> String {
+        format!("attachments/sessions/{session_id}/{attachment_id}/content")
+    }
+
+    pub fn write_new(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+        content: &[u8],
+    ) -> anyhow::Result<String> {
+        let relative_path = self.storage_path(session_id, attachment_id);
+        let final_path = self.resolve_storage_path(&relative_path)?;
+        let parent = final_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("attachment storage path has no parent"))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating attachment directory {}", parent.display()))?;
+        let tmp_path = parent.join(format!(".{attachment_id}.tmp"));
+        {
+            let mut file = fs::File::create(&tmp_path)
+                .with_context(|| format!("creating attachment temp file {}", tmp_path.display()))?;
+            file.write_all(content)
+                .with_context(|| format!("writing attachment temp file {}", tmp_path.display()))?;
+            file.sync_all()
+                .with_context(|| format!("syncing attachment temp file {}", tmp_path.display()))?;
+        }
+        fs::rename(&tmp_path, &final_path).with_context(|| {
+            format!(
+                "moving attachment temp file {} to {}",
+                tmp_path.display(),
+                final_path.display()
+            )
+        })?;
+        Ok(relative_path)
+    }
+
+    pub fn read(&self, record: &PromptAttachmentRecord) -> anyhow::Result<Vec<u8>> {
+        let path = self.resolve_storage_path(&record.storage_path)?;
+        fs::read(&path).with_context(|| {
+            format!(
+                "reading prompt attachment {} from {}",
+                record.attachment_id,
+                path.display()
+            )
+        })
+    }
+
+    pub fn delete_record(&self, record: &PromptAttachmentRecord) -> anyhow::Result<()> {
+        let path = self.resolve_storage_path(&record.storage_path)?;
+        if path.exists() {
+            fs::remove_file(&path)
+                .with_context(|| format!("deleting prompt attachment {}", path.display()))?;
+        }
+        if let Some(parent) = path.parent() {
+            let _ = fs::remove_dir(parent);
+        }
+        Ok(())
+    }
+
+    pub fn delete_session_dir(&self, session_id: &str) -> anyhow::Result<()> {
+        let path = self.resolve_relative_components(Path::new(session_id))?;
+        if path.exists() {
+            fs::remove_dir_all(&path)
+                .with_context(|| format!("deleting session attachment dir {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    fn resolve_storage_path(&self, relative_path: &str) -> anyhow::Result<PathBuf> {
+        let prefix = Path::new("attachments").join("sessions");
+        let path = Path::new(relative_path);
+        let suffix = path.strip_prefix(&prefix).with_context(|| {
+            format!("attachment storage path must be under {}", prefix.display())
+        })?;
+        self.resolve_relative_components(suffix)
+    }
+
+    fn resolve_relative_components(&self, suffix: &Path) -> anyhow::Result<PathBuf> {
+        let mut resolved = self.root.clone();
+        for component in suffix.components() {
+            match component {
+                Component::Normal(part) => resolved.push(part),
+                _ => anyhow::bail!("invalid prompt attachment storage path"),
+            }
+        }
+        Ok(resolved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PromptAttachmentStorage;
+    use crate::sessions::model::{
+        PromptAttachmentKind, PromptAttachmentRecord, PromptAttachmentSource, PromptAttachmentState,
+    };
+
+    #[test]
+    fn writes_reads_and_deletes_attachment_bytes() {
+        let storage = test_storage();
+        let storage_path = storage
+            .write_new("session-1", "attachment-1", b"hello")
+            .expect("write attachment");
+        let record = record(storage_path);
+
+        assert_eq!(storage.read(&record).expect("read attachment"), b"hello");
+        storage.delete_record(&record).expect("delete attachment");
+        assert!(storage.read(&record).is_err());
+    }
+
+    #[test]
+    fn rejects_storage_paths_outside_attachment_root() {
+        let storage = test_storage();
+        let mut record = record("../escape".to_string());
+        assert!(storage.read(&record).is_err());
+        record.storage_path = "attachments/sessions/session-1/../escape/content".to_string();
+        assert!(storage.read(&record).is_err());
+    }
+
+    fn test_storage() -> PromptAttachmentStorage {
+        PromptAttachmentStorage::new(
+            std::env::temp_dir().join(format!("anyharness-test-{}", uuid::Uuid::new_v4())),
+        )
+    }
+
+    fn record(storage_path: String) -> PromptAttachmentRecord {
+        PromptAttachmentRecord {
+            attachment_id: "attachment-1".to_string(),
+            session_id: "session-1".to_string(),
+            state: PromptAttachmentState::Pending,
+            kind: PromptAttachmentKind::TextResource,
+            source: PromptAttachmentSource::Upload,
+            mime_type: Some("text/plain".to_string()),
+            display_name: Some("hello.txt".to_string()),
+            source_uri: None,
+            storage_path,
+            size_bytes: 5,
+            sha256: String::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mod.rs
@@ -1,3 +1,4 @@
+pub mod attachment_storage;
 pub mod delegation;
 pub mod execution_summary;
 pub mod extensions;

--- a/anyharness/crates/anyharness-lib/src/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/model.rs
@@ -1,7 +1,7 @@
 use anyharness_contract::v1;
 
 use crate::origin::OriginContext;
-use crate::sessions::prompt::{PromptPayload, StoredPromptBlock};
+use crate::sessions::prompt::PromptPayload;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionMcpBindingPolicy {
@@ -198,66 +198,15 @@ pub struct PromptAttachmentRecord {
     pub session_id: String,
     pub state: PromptAttachmentState,
     pub kind: PromptAttachmentKind,
+    pub source: PromptAttachmentSource,
     pub mime_type: Option<String>,
     pub display_name: Option<String>,
     pub source_uri: Option<String>,
+    pub storage_path: String,
     pub size_bytes: i64,
     pub sha256: String,
-    pub content: Vec<u8>,
     pub created_at: String,
     pub updated_at: String,
-}
-
-impl PromptAttachmentRecord {
-    pub fn from_stored_block(
-        session_id: &str,
-        block: &StoredPromptBlock,
-    ) -> Option<PromptAttachmentRecord> {
-        match block {
-            StoredPromptBlock::Image {
-                attachment_id,
-                mime_type,
-                name,
-                uri,
-                size,
-            } => Some(PromptAttachmentRecord {
-                attachment_id: attachment_id.clone(),
-                session_id: session_id.to_string(),
-                state: PromptAttachmentState::Pending,
-                kind: PromptAttachmentKind::Image,
-                mime_type: Some(mime_type.clone()),
-                display_name: name.clone(),
-                source_uri: uri.clone(),
-                size_bytes: (*size).try_into().unwrap_or(i64::MAX),
-                sha256: String::new(),
-                content: Vec::new(),
-                created_at: String::new(),
-                updated_at: String::new(),
-            }),
-            StoredPromptBlock::Resource {
-                attachment_id: Some(attachment_id),
-                uri,
-                name,
-                mime_type,
-                size,
-                ..
-            } => Some(PromptAttachmentRecord {
-                attachment_id: attachment_id.clone(),
-                session_id: session_id.to_string(),
-                state: PromptAttachmentState::Pending,
-                kind: PromptAttachmentKind::TextResource,
-                mime_type: mime_type.clone(),
-                display_name: name.clone(),
-                source_uri: Some(uri.clone()),
-                size_bytes: (*size).try_into().unwrap_or(i64::MAX),
-                sha256: String::new(),
-                content: Vec::new(),
-                created_at: String::new(),
-                updated_at: String::new(),
-            }),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,6 +239,35 @@ impl PromptAttachmentState {
                     "unknown prompt attachment state; defaulting to orphaned"
                 );
                 Self::Orphaned
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptAttachmentSource {
+    Upload,
+    Paste,
+}
+
+impl PromptAttachmentSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Upload => "upload",
+            Self::Paste => "paste",
+        }
+    }
+
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "upload" => Self::Upload,
+            "paste" => Self::Paste,
+            other => {
+                tracing::warn!(
+                    attachment_source = %other,
+                    "unknown prompt attachment source; defaulting to upload"
+                );
+                Self::Upload
             }
         }
     }

--- a/anyharness/crates/anyharness-lib/src/sessions/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/prompt.rs
@@ -2,15 +2,19 @@ use std::collections::HashSet;
 
 use agent_client_protocol as acp;
 use anyharness_contract::v1::{
-    ContentPart, PromptCapabilities, PromptInputBlock, PromptProvenance as PublicPromptProvenance,
-    SessionLiveConfigSnapshot,
+    ContentPart, PromptAttachmentSource as ContractPromptAttachmentSource, PromptCapabilities,
+    PromptInputBlock, PromptProvenance as PublicPromptProvenance, SessionLiveConfigSnapshot,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::plans::{document, model::PlanRecord};
-use crate::sessions::model::{PromptAttachmentKind, PromptAttachmentRecord, PromptAttachmentState};
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::sessions::model::{
+    PromptAttachmentKind, PromptAttachmentRecord, PromptAttachmentSource, PromptAttachmentState,
+};
+use crate::sessions::service::read_prompt_attachment_content_with_legacy_fallback;
 use crate::sessions::store::SessionStore;
 
 pub const MAX_PROMPT_BLOCKS: usize = 32;
@@ -30,6 +34,7 @@ pub trait PlanReferenceResolver {
 
 pub struct PromptPrepareContext<'a> {
     pub store: &'a SessionStore,
+    pub attachment_storage: &'a PromptAttachmentStorage,
     pub session_id: &'a str,
     pub workspace_id: &'a str,
     pub capabilities: PromptCapabilities,
@@ -138,6 +143,7 @@ impl PromptPayload {
     pub fn to_acp_blocks(
         &self,
         store: &SessionStore,
+        attachment_storage: &PromptAttachmentStorage,
         session_id: &str,
     ) -> Result<Vec<acp::ContentBlock>, PromptValidationError> {
         let mut blocks = Vec::with_capacity(self.blocks.len());
@@ -165,11 +171,19 @@ impl PromptPayload {
                                 "image attachment not found",
                             )
                         })?;
-                    let image = acp::ImageContent::new(
-                        BASE64_STANDARD.encode(&attachment.content),
-                        mime_type.clone(),
+                    let content = read_prompt_attachment_content_with_legacy_fallback(
+                        store,
+                        attachment_storage,
+                        &attachment,
                     )
-                    .uri(uri.clone());
+                    .map_err(|error| {
+                        PromptValidationError::internal(format!(
+                            "failed to read image attachment: {error}"
+                        ))
+                    })?;
+                    let image =
+                        acp::ImageContent::new(BASE64_STANDARD.encode(content), mime_type.clone())
+                            .uri(uri.clone());
                     blocks.push(acp::ContentBlock::Image(image));
                 }
                 StoredPromptBlock::Resource {
@@ -191,7 +205,17 @@ impl PromptPayload {
                                 "resource attachment not found",
                             )
                         })?;
-                    let text = String::from_utf8(attachment.content).map_err(|_| {
+                    let content = read_prompt_attachment_content_with_legacy_fallback(
+                        store,
+                        attachment_storage,
+                        &attachment,
+                    )
+                    .map_err(|error| {
+                        PromptValidationError::internal(format!(
+                            "failed to read resource attachment: {error}"
+                        ))
+                    })?;
+                    let text = String::from_utf8(content).map_err(|_| {
                         PromptValidationError::new(
                             "PROMPT_UNSUPPORTED_BINARY_RESOURCE",
                             "embedded resources must be UTF-8 text",
@@ -377,6 +401,8 @@ pub enum StoredPromptBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         uri: Option<String>,
         size: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<ContractPromptAttachmentSource>,
     },
     #[serde(rename = "resource")]
     Resource {
@@ -392,6 +418,8 @@ pub enum StoredPromptBlock {
         size: u64,
         #[serde(skip_serializing_if = "Option::is_none")]
         preview: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<ContractPromptAttachmentSource>,
     },
     #[serde(rename = "resource_link")]
     ResourceLink {
@@ -455,12 +483,14 @@ impl StoredPromptBlock {
                 name,
                 uri,
                 size,
+                source,
             } => ContentPart::Image {
                 attachment_id: attachment_id.clone(),
                 mime_type: mime_type.clone(),
                 name: name.clone(),
                 uri: uri.clone(),
                 size: Some(*size),
+                source: *source,
             },
             Self::Resource {
                 attachment_id,
@@ -469,6 +499,7 @@ impl StoredPromptBlock {
                 mime_type,
                 size,
                 preview,
+                source,
             } => ContentPart::Resource {
                 attachment_id: attachment_id.clone(),
                 uri: uri.clone(),
@@ -478,6 +509,7 @@ impl StoredPromptBlock {
                 preview: preview.clone(),
                 preview_truncated: None,
                 preview_original_bytes: None,
+                source: *source,
             },
             Self::ResourceLink {
                 uri,
@@ -523,13 +555,50 @@ impl StoredPromptBlock {
 #[derive(Debug, Clone)]
 pub struct PreparedPrompt {
     pub payload: PromptPayload,
-    pub attachments: Vec<PromptAttachmentRecord>,
+    pub attachments: Vec<PreparedPromptAttachment>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedPromptAttachment {
+    pub record: PromptAttachmentRecord,
+    pub content: Vec<u8>,
 }
 
 impl PreparedPrompt {
-    pub fn persist_attachments(&self, store: &SessionStore) -> anyhow::Result<()> {
+    pub fn persist_attachments(
+        &self,
+        store: &SessionStore,
+        attachment_storage: &PromptAttachmentStorage,
+    ) -> anyhow::Result<()> {
+        let mut written = Vec::new();
         for attachment in &self.attachments {
-            store.insert_prompt_attachment(attachment)?;
+            if let Err(error) = attachment_storage.write_new(
+                &attachment.record.session_id,
+                &attachment.record.attachment_id,
+                &attachment.content,
+            ) {
+                let ids = written
+                    .iter()
+                    .map(|record: &PromptAttachmentRecord| record.attachment_id.as_str())
+                    .collect::<Vec<_>>();
+                let _ = store.delete_prompt_attachments(&attachment.record.session_id, &ids);
+                for record in &written {
+                    let _ = attachment_storage.delete_record(record);
+                }
+                return Err(error);
+            }
+            written.push(attachment.record.clone());
+            if let Err(error) = store.insert_prompt_attachment(&attachment.record) {
+                let ids = written
+                    .iter()
+                    .map(|record| record.attachment_id.as_str())
+                    .collect::<Vec<_>>();
+                let _ = store.delete_prompt_attachments(&attachment.record.session_id, &ids);
+                for record in &written {
+                    let _ = attachment_storage.delete_record(record);
+                }
+                return Err(error);
+            }
         }
         Ok(())
     }
@@ -537,14 +606,19 @@ impl PreparedPrompt {
     pub fn cleanup_attachments(
         &self,
         store: &SessionStore,
+        attachment_storage: &PromptAttachmentStorage,
         session_id: &str,
     ) -> anyhow::Result<()> {
         let ids = self
             .attachments
             .iter()
-            .map(|attachment| attachment.attachment_id.as_str())
+            .map(|attachment| attachment.record.attachment_id.as_str())
             .collect::<Vec<_>>();
-        store.delete_prompt_attachments(session_id, &ids)
+        store.delete_prompt_attachments(session_id, &ids)?;
+        for attachment in &self.attachments {
+            let _ = attachment_storage.delete_record(&attachment.record);
+        }
+        Ok(())
     }
 }
 
@@ -603,6 +677,7 @@ pub fn prepare_prompt(
     }
 
     let store = context.store;
+    let attachment_storage = context.attachment_storage;
     let session_id = context.session_id;
     let workspace_id = context.workspace_id;
     let capabilities = context.capabilities;
@@ -629,7 +704,9 @@ pub fn prepare_prompt(
                 mime_type,
                 name,
                 uri,
+                source,
             } => {
+                let source = prompt_attachment_source(source);
                 if !capabilities.image {
                     return Err(PromptValidationError::new(
                         "PROMPT_CAPABILITY_DENIED",
@@ -667,21 +744,24 @@ pub fn prepare_prompt(
                         let attachment_id = uuid::Uuid::new_v4().to_string();
                         let size = bytes.len() as u64;
                         attachments.push(new_attachment(
+                            attachment_storage,
                             session_id,
                             attachment_id.clone(),
                             state,
                             PromptAttachmentKind::Image,
+                            source,
                             Some(mime_type.clone()),
                             name.clone(),
                             uri.clone(),
                             bytes,
                         ));
                         stored_blocks.push(StoredPromptBlock::Image {
+                            uri: Some(managed_attachment_uri(session_id, &attachment_id)),
                             attachment_id,
                             mime_type,
                             name,
-                            uri,
                             size,
+                            source: Some(source.into_contract()),
                         });
                     }
                     (None, Some(attachment_id)) => {
@@ -697,7 +777,7 @@ pub fn prepare_prompt(
                                 "image attachment MIME type does not match the prompt block",
                             ));
                         }
-                        let byte_len = attachment.content.len();
+                        let byte_len = attachment.size_bytes.max(0) as usize;
                         if byte_len > MAX_IMAGE_BYTES {
                             return Err(PromptValidationError::new(
                                 "PROMPT_IMAGE_TOO_LARGE",
@@ -713,11 +793,12 @@ pub fn prepare_prompt(
                         )?;
                         attachment_count = checked_attachment_count(attachment_count + 1)?;
                         stored_blocks.push(StoredPromptBlock::Image {
+                            uri: Some(managed_attachment_uri(session_id, &attachment_id)),
                             attachment_id,
                             mime_type,
                             name,
-                            uri,
                             size: byte_len as u64,
+                            source: Some(attachment.source.into_contract()),
                         });
                     }
                     (Some(_), Some(_)) => {
@@ -741,7 +822,9 @@ pub fn prepare_prompt(
                 name,
                 mime_type,
                 size: declared_size,
+                source,
             } => {
+                let source = prompt_attachment_source(source);
                 if !capabilities.embedded_context {
                     return Err(PromptValidationError::new(
                         "PROMPT_CAPABILITY_DENIED",
@@ -775,22 +858,25 @@ pub fn prepare_prompt(
                         let size = bytes.len() as u64;
                         let preview = bounded_preview(&text);
                         attachments.push(new_attachment(
+                            attachment_storage,
                             session_id,
                             attachment_id.clone(),
                             state,
                             PromptAttachmentKind::TextResource,
+                            source,
                             mime_type.clone(),
                             name.clone(),
                             Some(uri.clone()),
                             bytes,
                         ));
                         stored_blocks.push(StoredPromptBlock::Resource {
+                            uri: managed_attachment_uri(session_id, &attachment_id),
                             attachment_id: Some(attachment_id),
-                            uri,
                             name,
                             mime_type,
                             size,
                             preview,
+                            source: Some(source.into_contract()),
                         });
                     }
                     (None, Some(attachment_id)) => {
@@ -800,7 +886,7 @@ pub fn prepare_prompt(
                             &attachment_id,
                             PromptAttachmentKind::TextResource,
                         )?;
-                        let byte_len = attachment.content.len();
+                        let byte_len = attachment.size_bytes.max(0) as usize;
                         if byte_len > MAX_TEXT_RESOURCE_BYTES {
                             return Err(PromptValidationError::new(
                                 "PROMPT_RESOURCE_TOO_LARGE",
@@ -816,12 +902,13 @@ pub fn prepare_prompt(
                         )?;
                         attachment_count = checked_attachment_count(attachment_count + 1)?;
                         stored_blocks.push(StoredPromptBlock::Resource {
+                            uri: managed_attachment_uri(session_id, &attachment_id),
                             attachment_id: Some(attachment_id),
-                            uri,
                             name,
                             mime_type: mime_type.or_else(|| attachment.mime_type.clone()),
                             size: declared_size.unwrap_or(byte_len as u64),
                             preview: None,
+                            source: Some(attachment.source.into_contract()),
                         });
                     }
                     (Some(_), Some(_)) => {
@@ -1029,32 +1116,59 @@ fn validate_referenced_attachment(
 }
 
 fn new_attachment(
+    attachment_storage: &PromptAttachmentStorage,
     session_id: &str,
     attachment_id: String,
     state: PromptAttachmentState,
     kind: PromptAttachmentKind,
+    source: PromptAttachmentSource,
     mime_type: Option<String>,
     display_name: Option<String>,
     source_uri: Option<String>,
     content: Vec<u8>,
-) -> PromptAttachmentRecord {
+) -> PreparedPromptAttachment {
     let now = chrono::Utc::now().to_rfc3339();
     let mut hasher = Sha256::new();
     hasher.update(&content);
     let sha256 = format!("{:x}", hasher.finalize());
-    PromptAttachmentRecord {
-        attachment_id,
+    let storage_path = attachment_storage.storage_path(session_id, &attachment_id);
+    let record = PromptAttachmentRecord {
+        attachment_id: attachment_id.clone(),
         session_id: session_id.to_string(),
         state,
         kind,
+        source,
         mime_type,
         display_name,
         source_uri,
+        storage_path,
         size_bytes: content.len().try_into().unwrap_or(i64::MAX),
         sha256,
-        content,
         created_at: now.clone(),
         updated_at: now,
+    };
+    PreparedPromptAttachment { record, content }
+}
+
+fn prompt_attachment_source(
+    source: Option<ContractPromptAttachmentSource>,
+) -> PromptAttachmentSource {
+    match source {
+        Some(ContractPromptAttachmentSource::Paste) => PromptAttachmentSource::Paste,
+        _ => PromptAttachmentSource::Upload,
+    }
+}
+
+fn managed_attachment_uri(session_id: &str, attachment_id: &str) -> String {
+    format!("anyharness-attachment://sessions/{session_id}/attachments/{attachment_id}")
+}
+
+impl PromptAttachmentSource {
+    fn into_contract(self) -> ContractPromptAttachmentSource {
+        match self {
+            PromptAttachmentSource::Upload => ContractPromptAttachmentSource::Upload,
+            PromptAttachmentSource::Paste => ContractPromptAttachmentSource::Paste,
+        }
     }
 }
 
@@ -1218,7 +1332,7 @@ mod tests {
         .expect("prepare resource")
         .payload;
         let resource_blocks = resource_payload
-            .to_acp_blocks(&store, "session-1")
+            .to_acp_blocks(&store, test_attachment_storage(), "session-1")
             .expect("to acp");
         assert!(matches!(
             resource_blocks.as_slice(),
@@ -1235,7 +1349,7 @@ mod tests {
         .expect("prepare text")
         .payload;
         let text_blocks = text_payload
-            .to_acp_blocks(&store, "session-1")
+            .to_acp_blocks(&store, test_attachment_storage(), "session-1")
             .expect("to acp");
         assert!(matches!(
             text_blocks.as_slice(),
@@ -1270,6 +1384,7 @@ mod tests {
     ) -> PromptPrepareContext<'a> {
         PromptPrepareContext {
             store,
+            attachment_storage: test_attachment_storage(),
             session_id: "session-1",
             workspace_id,
             capabilities: PromptCapabilities {
@@ -1279,6 +1394,12 @@ mod tests {
             attachment_state: PromptAttachmentState::Pending,
             plan_resolver: resolver,
         }
+    }
+
+    fn test_attachment_storage() -> &'static PromptAttachmentStorage {
+        Box::leak(Box::new(PromptAttachmentStorage::new(
+            std::env::temp_dir().join(format!("anyharness-test-{}", uuid::Uuid::new_v4())),
+        )))
     }
 
     fn fixture(workspace_id: &str, body_markdown: &str) -> (SessionStore, TestPlanResolver) {

--- a/anyharness/crates/anyharness-lib/src/sessions/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/runtime.rs
@@ -1128,6 +1128,7 @@ impl SessionRuntime {
         let prepared = prepare_prompt(
             PromptPrepareContext {
                 store: self.session_service.store(),
+                attachment_storage: self.session_service.attachment_storage(),
                 session_id,
                 workspace_id: &record.workspace_id,
                 capabilities: capabilities_from_live_config(live_config.as_ref()),
@@ -1138,7 +1139,10 @@ impl SessionRuntime {
         )
         .map_err(SendPromptError::InvalidPrompt)?;
         prepared
-            .persist_attachments(self.session_service.store())
+            .persist_attachments(
+                self.session_service.store(),
+                self.session_service.attachment_storage(),
+            )
             .map_err(SendPromptError::Internal)?;
         tracing::info!(
             session_id = %session_id,
@@ -1191,7 +1195,11 @@ impl SessionRuntime {
                     SendPromptError::Internal(anyhow::anyhow!("session actor is not responding"))
                 }
                 PromptAcceptError::EnqueueFailed(detail) => {
-                    let _ = prepared.cleanup_attachments(self.session_service.store(), session_id);
+                    let _ = prepared.cleanup_attachments(
+                        self.session_service.store(),
+                        self.session_service.attachment_storage(),
+                        session_id,
+                    );
                     SendPromptError::Internal(anyhow::anyhow!("failed to enqueue prompt: {detail}"))
                 }
             })?;
@@ -1360,6 +1368,7 @@ impl SessionRuntime {
         let prepared = prepare_prompt(
             PromptPrepareContext {
                 store: self.session_service.store(),
+                attachment_storage: self.session_service.attachment_storage(),
                 session_id,
                 workspace_id: &record.workspace_id,
                 capabilities: capabilities_from_live_config(live_config.as_ref()),
@@ -1370,7 +1379,10 @@ impl SessionRuntime {
         )
         .map_err(PendingPromptMutationError::InvalidPrompt)?;
         prepared
-            .persist_attachments(self.session_service.store())
+            .persist_attachments(
+                self.session_service.store(),
+                self.session_service.attachment_storage(),
+            )
             .map_err(PendingPromptMutationError::Internal)?;
 
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -1384,7 +1396,11 @@ impl SessionRuntime {
             .await
             .is_err()
         {
-            let _ = prepared.cleanup_attachments(self.session_service.store(), session_id);
+            let _ = prepared.cleanup_attachments(
+                self.session_service.store(),
+                self.session_service.attachment_storage(),
+                session_id,
+            );
             return Err(PendingPromptMutationError::Internal(anyhow::anyhow!(
                 "session actor channel closed"
             )));
@@ -1397,7 +1413,11 @@ impl SessionRuntime {
             })?
             .map_err(|error| match error {
                 QueueMutationError::NotFound => {
-                    let _ = prepared.cleanup_attachments(self.session_service.store(), session_id);
+                    let _ = prepared.cleanup_attachments(
+                        self.session_service.store(),
+                        self.session_service.attachment_storage(),
+                        session_id,
+                    );
                     PendingPromptMutationError::NotFound
                 }
                 QueueMutationError::ActorDead => PendingPromptMutationError::Internal(
@@ -1971,6 +1991,7 @@ impl SessionRuntime {
         );
         let session_launch_env = build_session_launch_env(&resolved_agent);
         let session_store = self.session_service.store().clone();
+        let attachment_storage = self.session_service.attachment_storage().clone();
         let workspace_path = PathBuf::from(&workspace.path);
         let workspace_env = self
             .workspace_runtime
@@ -2006,6 +2027,7 @@ impl SessionRuntime {
                 workspace_env,
                 session_launch_env,
                 session_store,
+                attachment_storage,
                 mcp_servers,
                 startup_strategy,
                 system_prompt_append,

--- a/anyharness/crates/anyharness-lib/src/sessions/service.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/service.rs
@@ -3,9 +3,10 @@ use std::time::Instant;
 
 use uuid::Uuid;
 
+use super::attachment_storage::PromptAttachmentStorage;
 use super::live_config::snapshot_from_record;
 use super::model::{
-    PendingConfigChangeRecord, PendingPromptRecord, PromptAttachmentRecord, SessionEventRecord,
+    PendingConfigChangeRecord, PendingPromptRecord, SessionEventRecord,
     SessionLiveConfigSnapshotRecord, SessionMcpBindingPolicy, SessionRawNotificationRecord,
     SessionRecord,
 };
@@ -14,11 +15,13 @@ use crate::agents::catalog::ModelCatalogService;
 use crate::agents::model::{ModelRegistryMetadata, ResolvedAgentStatus};
 use crate::agents::registry::built_in_registry;
 use crate::agents::resolver::resolve_agent;
+use crate::mobility::model::MobilityPromptAttachmentData;
 use crate::origin::OriginContext;
 use crate::workspaces::store::WorkspaceStore;
 
 pub struct SessionService {
     session_store: SessionStore,
+    attachment_storage: PromptAttachmentStorage,
     workspace_store: WorkspaceStore,
     runtime_home: std::path::PathBuf,
     model_catalog_service: Arc<ModelCatalogService>,
@@ -79,6 +82,7 @@ impl SessionService {
     ) -> Self {
         Self {
             session_store,
+            attachment_storage: PromptAttachmentStorage::new(runtime_home.clone()),
             workspace_store,
             runtime_home,
             model_catalog_service,
@@ -333,6 +337,21 @@ impl SessionService {
         &self.session_store
     }
 
+    pub fn attachment_storage(&self) -> &PromptAttachmentStorage {
+        &self.attachment_storage
+    }
+
+    pub fn read_prompt_attachment_content(
+        &self,
+        record: &super::model::PromptAttachmentRecord,
+    ) -> anyhow::Result<Vec<u8>> {
+        read_prompt_attachment_content_with_legacy_fallback(
+            &self.session_store,
+            &self.attachment_storage,
+            record,
+        )
+    }
+
     pub fn import_session_bundle(
         &self,
         workspace_id: &str,
@@ -340,26 +359,54 @@ impl SessionService {
         live_config_snapshot: Option<&SessionLiveConfigSnapshotRecord>,
         pending_config_changes: &[PendingConfigChangeRecord],
         pending_prompts: &[PendingPromptRecord],
-        prompt_attachments: &[PromptAttachmentRecord],
+        prompt_attachments: &[MobilityPromptAttachmentData],
         events: &[SessionEventRecord],
         raw_notifications: &[SessionRawNotificationRecord],
     ) -> anyhow::Result<()> {
         self.workspace_store
             .find_by_id(workspace_id)?
             .ok_or_else(|| anyhow::anyhow!("workspace not found: {workspace_id}"))?;
-        self.session_store.import_bundle(
+        let mut records = Vec::with_capacity(prompt_attachments.len());
+        for attachment in prompt_attachments {
+            if let Err(error) = self.attachment_storage.write_new(
+                &attachment.record.session_id,
+                &attachment.record.attachment_id,
+                &attachment.content,
+            ) {
+                for record in &records {
+                    let _ = self.attachment_storage.delete_record(record);
+                }
+                return Err(error);
+            }
+            records.push(attachment.record.clone());
+        }
+        let result = self.session_store.import_bundle(
             session,
             live_config_snapshot,
             pending_config_changes,
             pending_prompts,
-            prompt_attachments,
+            &records,
             events,
             raw_notifications,
-        )
+        );
+        if result.is_err() {
+            for record in &records {
+                let _ = self.attachment_storage.delete_record(record);
+            }
+        }
+        result
     }
 
     pub fn delete_session(&self, session_id: &str) -> anyhow::Result<()> {
-        self.session_store.delete_session(session_id)
+        self.session_store.delete_session(session_id)?;
+        if let Err(error) = self.attachment_storage.delete_session_dir(session_id) {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "failed to delete session prompt attachment directory"
+            );
+        }
+        Ok(())
     }
 
     pub fn update_session_title(
@@ -470,6 +517,47 @@ impl SessionService {
         })
     }
 }
+
+pub fn read_prompt_attachment_content_with_legacy_fallback(
+    store: &SessionStore,
+    attachment_storage: &PromptAttachmentStorage,
+    record: &super::model::PromptAttachmentRecord,
+) -> anyhow::Result<Vec<u8>> {
+    let has_storage_path = !record.storage_path.trim().is_empty();
+    if has_storage_path {
+        match attachment_storage.read(record) {
+            Ok(content) => return Ok(content),
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %record.session_id,
+                    attachment_id = %record.attachment_id,
+                    error = %error,
+                    "failed to read file-backed prompt attachment; trying legacy content"
+                );
+            }
+        }
+    }
+
+    let content = store
+        .read_legacy_prompt_attachment_content(&record.session_id, &record.attachment_id)?
+        .ok_or_else(|| anyhow::anyhow!("prompt attachment bytes missing"))?;
+    if content.is_empty()
+        && has_storage_path
+        && !(record.size_bytes == 0 && record.sha256 == EMPTY_SHA256)
+    {
+        anyhow::bail!("prompt attachment file is missing and legacy placeholder is empty");
+    }
+    let storage_path =
+        attachment_storage.write_new(&record.session_id, &record.attachment_id, &content)?;
+    store.update_prompt_attachment_storage_path(
+        &record.session_id,
+        &record.attachment_id,
+        &storage_path,
+    )?;
+    Ok(content)
+}
+
+const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
 fn find_model_registry<'a>(
     configs: &'a [ModelRegistryMetadata],

--- a/anyharness/crates/anyharness-lib/src/sessions/store.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store.rs
@@ -2,9 +2,10 @@ use rusqlite::{params, OptionalExtension};
 
 use super::model::{
     PendingConfigChangeRecord, PendingPromptRecord, PromptAttachmentKind, PromptAttachmentRecord,
-    PromptAttachmentState, SessionBackgroundWorkRecord, SessionBackgroundWorkState,
-    SessionBackgroundWorkTrackerKind, SessionEventRecord, SessionLiveConfigSnapshotRecord,
-    SessionMcpBindingPolicy, SessionRawNotificationRecord, SessionRecord,
+    PromptAttachmentSource, PromptAttachmentState, SessionBackgroundWorkRecord,
+    SessionBackgroundWorkState, SessionBackgroundWorkTrackerKind, SessionEventRecord,
+    SessionLiveConfigSnapshotRecord, SessionMcpBindingPolicy, SessionRawNotificationRecord,
+    SessionRecord,
 };
 use crate::acp::persistence_sanitizer::{
     sanitize_raw_notification_json_for_sqlite, sanitize_session_event_for_sqlite,
@@ -750,6 +751,40 @@ impl SessionStore {
             )?;
             let rows = stmt.query_map([session_id], map_prompt_attachment)?;
             rows.collect()
+        })
+    }
+
+    pub fn read_legacy_prompt_attachment_content(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        self.db.with_conn(|conn| {
+            conn.query_row(
+                "SELECT content FROM session_prompt_attachments
+                 WHERE session_id = ?1 AND attachment_id = ?2",
+                params![session_id, attachment_id],
+                |row| row.get(0),
+            )
+            .optional()
+        })
+    }
+
+    pub fn update_prompt_attachment_storage_path(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+        storage_path: &str,
+    ) -> anyhow::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE session_prompt_attachments
+                 SET storage_path = ?3, updated_at = ?4
+                 WHERE session_id = ?1 AND attachment_id = ?2",
+                params![session_id, attachment_id, storage_path, now],
+            )?;
+            Ok(())
         })
     }
 
@@ -1587,17 +1622,19 @@ fn map_pending_prompt(row: &rusqlite::Row) -> rusqlite::Result<PendingPromptReco
 fn map_prompt_attachment(row: &rusqlite::Row) -> rusqlite::Result<PromptAttachmentRecord> {
     let state: String = row.get("state")?;
     let kind: String = row.get("kind")?;
+    let source: String = row.get("source")?;
     Ok(PromptAttachmentRecord {
         attachment_id: row.get("attachment_id")?,
         session_id: row.get("session_id")?,
         state: PromptAttachmentState::parse(&state),
         kind: PromptAttachmentKind::parse(&kind),
+        source: PromptAttachmentSource::parse(&source),
         mime_type: row.get("mime_type")?,
         display_name: row.get("display_name")?,
         source_uri: row.get("source_uri")?,
+        storage_path: row.get("storage_path")?,
         size_bytes: row.get("size_bytes")?,
         sha256: row.get("sha256")?,
-        content: row.get("content")?,
         created_at: row.get("created_at")?,
         updated_at: row.get("updated_at")?,
     })
@@ -1741,16 +1778,18 @@ fn insert_prompt_attachment_row(
 ) -> rusqlite::Result<()> {
     conn.execute(
         "INSERT INTO session_prompt_attachments (
-            attachment_id, session_id, state, kind, mime_type, display_name, source_uri,
-            size_bytes, sha256, content, created_at, updated_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            attachment_id, session_id, state, kind, source, mime_type, display_name, source_uri,
+            storage_path, size_bytes, sha256, content, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
          ON CONFLICT(attachment_id) DO UPDATE SET
             session_id = excluded.session_id,
             state = excluded.state,
             kind = excluded.kind,
+            source = excluded.source,
             mime_type = excluded.mime_type,
             display_name = excluded.display_name,
             source_uri = excluded.source_uri,
+            storage_path = excluded.storage_path,
             size_bytes = excluded.size_bytes,
             sha256 = excluded.sha256,
             content = excluded.content,
@@ -1760,12 +1799,14 @@ fn insert_prompt_attachment_row(
             record.session_id,
             record.state.as_str(),
             record.kind.as_str(),
+            record.source.as_str(),
             record.mime_type,
             record.display_name,
             record.source_uri,
+            record.storage_path,
             record.size_bytes,
             record.sha256,
-            record.content,
+            Vec::<u8>::new(),
             record.created_at,
             record.updated_at,
         ],

--- a/anyharness/crates/anyharness-lib/src/workspaces/purge.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/purge.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::agents::portability::delete_session_agent_artifacts;
+use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::store::SessionStore;
 use crate::workspaces::checkout_gate::{CheckoutDeletionGate, CheckoutPathLockKey};
 use crate::workspaces::model::WorkspaceRecord;
@@ -31,6 +32,7 @@ pub struct WorkspacePurgeService {
     workspace_runtime: Arc<WorkspaceRuntime>,
     workspace_store: WorkspaceStore,
     session_store: SessionStore,
+    attachment_storage: PromptAttachmentStorage,
     operation_gate: Arc<WorkspaceOperationGate>,
     checkout_gate: Arc<CheckoutDeletionGate>,
     preflight_checker: Arc<RetirePreflightChecker>,
@@ -41,6 +43,7 @@ impl WorkspacePurgeService {
         workspace_runtime: Arc<WorkspaceRuntime>,
         workspace_store: WorkspaceStore,
         session_store: SessionStore,
+        attachment_storage: PromptAttachmentStorage,
         operation_gate: Arc<WorkspaceOperationGate>,
         checkout_gate: Arc<CheckoutDeletionGate>,
         preflight_checker: Arc<RetirePreflightChecker>,
@@ -49,6 +52,7 @@ impl WorkspacePurgeService {
             workspace_runtime,
             workspace_store,
             session_store,
+            attachment_storage,
             operation_gate,
             checkout_gate,
             preflight_checker,
@@ -121,8 +125,12 @@ impl WorkspacePurgeService {
             return self.cleanup_failed(workspace_id, &pending, &attempted_at, error);
         }
 
+        let sessions = self.session_store.list_by_workspace(workspace_id)?;
+        let session_ids = sessions
+            .iter()
+            .map(|session| session.id.clone())
+            .collect::<Vec<_>>();
         let artifact_cleanup = {
-            let sessions = self.session_store.list_by_workspace(workspace_id)?;
             let workspace_path = pending.path.clone();
             tokio::task::spawn_blocking(move || {
                 for session in sessions {
@@ -142,6 +150,15 @@ impl WorkspacePurgeService {
             .purge_workspace_with_sessions(workspace_id)
         {
             return self.cleanup_failed(workspace_id, &pending, &attempted_at, error);
+        }
+        for session_id in session_ids {
+            if let Err(error) = self.attachment_storage.delete_session_dir(&session_id) {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %error,
+                    "failed to delete session prompt attachment directory during workspace purge"
+                );
+            }
         }
 
         Ok(WorkspacePurgeServiceOutcome::Deleted {

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -5779,6 +5779,16 @@
                 "format": "int64",
                 "minimum": 0
               },
+              "source": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PromptAttachmentSource"
+                  }
+                ]
+              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -5845,6 +5855,16 @@
                 ],
                 "format": "int64",
                 "minimum": 0
+              },
+              "source": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PromptAttachmentSource"
+                  }
+                ]
               },
               "type": {
                 "type": "string",
@@ -9298,6 +9318,9 @@
             "format": "int64",
             "minimum": 0
           },
+          "source": {
+            "type": "string"
+          },
           "sourceUri": {
             "type": [
               "string",
@@ -10549,6 +10572,13 @@
           }
         }
       },
+      "PromptAttachmentSource": {
+        "type": "string",
+        "enum": [
+          "upload",
+          "paste"
+        ]
+      },
       "PromptCapabilities": {
         "type": "object",
         "properties": {
@@ -10611,6 +10641,16 @@
                   "null"
                 ]
               },
+              "source": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PromptAttachmentSource"
+                  }
+                ]
+              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -10657,6 +10697,16 @@
                 ],
                 "format": "int64",
                 "minimum": 0
+              },
+              "source": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PromptAttachmentSource"
+                  }
+                ]
               },
               "text": {
                 "type": [

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -1756,6 +1756,7 @@ export interface components {
             name?: string | null;
             /** Format: int64 */
             size?: number | null;
+            source?: null | components["schemas"]["PromptAttachmentSource"];
             /** @enum {string} */
             type: "image";
             uri?: string | null;
@@ -1769,6 +1770,7 @@ export interface components {
             previewTruncated?: boolean | null;
             /** Format: int64 */
             size?: number | null;
+            source?: null | components["schemas"]["PromptAttachmentSource"];
             /** @enum {string} */
             type: "resource";
             uri: string;
@@ -2528,6 +2530,7 @@ export interface components {
             sha256: string;
             /** Format: int64 */
             sizeBytes: number;
+            source?: string;
             sourceUri?: string | null;
             state: string;
             updatedAt: string;
@@ -2864,6 +2867,8 @@ export interface components {
             title: string;
             type: string;
         };
+        /** @enum {string} */
+        PromptAttachmentSource: "upload" | "paste";
         PromptCapabilities: {
             audio?: boolean;
             embeddedContext?: boolean;
@@ -2878,6 +2883,7 @@ export interface components {
             data?: string | null;
             mimeType: string;
             name?: string | null;
+            source?: null | components["schemas"]["PromptAttachmentSource"];
             /** @enum {string} */
             type: "image";
             uri?: string | null;
@@ -2887,6 +2893,7 @@ export interface components {
             name?: string | null;
             /** Format: int64 */
             size?: number | null;
+            source?: null | components["schemas"]["PromptAttachmentSource"];
             text?: string | null;
             /** @enum {string} */
             type: "resource";

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -170,6 +170,7 @@ describe("transcript reducer", () => {
         mimeType: "image/png",
         name: "screenshot.png",
         size: 2048,
+        source: "upload",
       },
       {
         type: "resource",
@@ -179,6 +180,7 @@ describe("transcript reducer", () => {
         mimeType: "text/markdown",
         size: 1024,
         preview: "# Readme",
+        source: "paste",
       },
       {
         type: "resource_link",

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -917,6 +917,7 @@ function normalizeContentPart(part: ContentPart): ContentPart {
         name: coerceNullableString(raw.name),
         uri: coerceNullableString(raw.uri),
         size: coerceNullableNumber(raw.size),
+        source: coercePromptAttachmentSource(raw.source),
       };
 
     case "resource":
@@ -930,6 +931,7 @@ function normalizeContentPart(part: ContentPart): ContentPart {
         preview: coerceNullableString(raw.preview),
         previewTruncated: coerceNullableBoolean(raw.previewTruncated ?? raw.preview_truncated),
         previewOriginalBytes: coerceNullableNumber(raw.previewOriginalBytes ?? raw.preview_original_bytes),
+        source: coercePromptAttachmentSource(raw.source),
       };
 
     case "resource_link":
@@ -1237,6 +1239,10 @@ function coerceNullableNumber(value: unknown): number | null {
 
 function coerceNullableBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
+}
+
+function coercePromptAttachmentSource(value: unknown): "upload" | "paste" {
+  return value === "paste" ? "paste" : "upload";
 }
 
 function coerceTerminalEvent(value: unknown): "start" | "output" | "exit" {

--- a/desktop/src/components/settings/panes/GeneralPane.tsx
+++ b/desktop/src/components/settings/panes/GeneralPane.tsx
@@ -46,6 +46,7 @@ export function GeneralPane() {
     pluginsInCodingSessionsEnabled: state.pluginsInCodingSessionsEnabled,
     subagentsEnabled: state.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: state.coworkWorkspaceDelegationEnabled,
+    pasteAttachmentsEnabled: state.pasteAttachmentsEnabled,
     set: state.set,
   })));
 
@@ -111,6 +112,16 @@ export function GeneralPane() {
                   onSelect: () => preferences.set("branchPrefixType", option.id),
                 })),
               }]}
+            />
+          </SettingsCardRow>
+
+          <SettingsCardRow
+            label="Turn long pastes into attachments"
+            description="Large text pastes in chat become text-resource attachments instead of inline draft text."
+          >
+            <Switch
+              checked={preferences.pasteAttachmentsEnabled}
+              onChange={(value) => preferences.set("pasteAttachmentsEnabled", value)}
             />
           </SettingsCardRow>
         </SettingsCard>

--- a/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -303,7 +303,7 @@ function attachmentKindLabel(part: PromptDisplayAttachmentPart): string {
     case "image":
       return "Image";
     case "file":
-      return "File";
+      return part.source === "paste" ? "Paste" : "File";
     case "link":
       return "Link";
     case "plan_reference":

--- a/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -227,10 +227,18 @@ export function ChatInput({
   }, [attachments, planAttachments]);
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
-    if (!canAttach || event.clipboardData.files.length === 0) {
+    if (!canAttach) {
       return;
     }
-    attachments.addFiles(event.clipboardData.files);
+    if (event.clipboardData.files.length > 0) {
+      attachments.addFiles(event.clipboardData.files);
+      event.preventDefault();
+      return;
+    }
+    const text = event.clipboardData.getData("text/plain");
+    if (text && attachments.addTextPaste(text)) {
+      event.preventDefault();
+    }
   }, [attachments, canAttach]);
 
   useEffect(() => {

--- a/desktop/src/hooks/chat/use-chat-prompt-attachments.ts
+++ b/desktop/src/hooks/chat/use-chat-prompt-attachments.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { PromptCapabilities } from "@anyharness/sdk";
 import { canAttachPromptContent } from "@/lib/domain/chat/prompt-content";
 import { usePromptAttachments } from "@/hooks/chat/use-prompt-attachments";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 export type PromptAttachmentController = ReturnType<typeof usePromptAttachments> & {
   canAttachFiles: boolean;
@@ -19,16 +20,24 @@ export function useChatPromptAttachments({
 }): PromptAttachmentController {
   const attachments = usePromptAttachments(activeSessionId, promptCapabilities);
   const supportsAttachments = canAttachPromptContent(promptCapabilities);
+  const pasteAttachmentsEnabled = useUserPreferencesStore((state) => state.pasteAttachmentsEnabled);
   const addFiles = useCallback((files: Iterable<File>) => {
     if (!canAttachFiles) {
       return;
     }
     attachments.addFiles(files);
   }, [attachments.addFiles, canAttachFiles]);
+  const addTextPaste = useCallback((text: string): boolean => {
+    if (!canAttachFiles || !pasteAttachmentsEnabled) {
+      return false;
+    }
+    return attachments.addTextPaste(text);
+  }, [attachments.addTextPaste, canAttachFiles, pasteAttachmentsEnabled]);
 
   return {
     ...attachments,
     addFiles,
+    addTextPaste,
     canAttachFiles,
     supportsAttachments,
   };

--- a/desktop/src/hooks/chat/use-prompt-attachments.ts
+++ b/desktop/src/hooks/chat/use-prompt-attachments.ts
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PromptCapabilities, PromptInputBlock } from "@anyharness/sdk";
 import {
   isTextFileCandidate,
+  pasteAttachmentName,
   PROMPT_IMAGE_MAX_BYTES,
   PROMPT_TEXT_RESOURCE_MAX_BYTES,
+  shouldCreatePasteAttachment,
   type PromptAttachmentDescriptor,
 } from "@/lib/domain/chat/prompt-content";
 
@@ -96,6 +98,7 @@ export function usePromptAttachments(
             mimeType: file.type || "image/png",
             size: file.size,
             kind: "image",
+            source: "upload",
             objectUrl: URL.createObjectURL(file),
           },
         });
@@ -115,6 +118,7 @@ export function usePromptAttachments(
             mimeType: file.type || "text/plain",
             size: file.size,
             kind: "text_resource",
+            source: "upload",
             objectUrl: null,
           },
         });
@@ -128,6 +132,33 @@ export function usePromptAttachments(
 
     setEntries((current) => [...current, ...next].slice(0, MAX_PROMPT_ATTACHMENTS));
   }, [capabilities?.embeddedContext, capabilities?.image]);
+
+  const addTextPaste = useCallback((text: string): boolean => {
+    if (!capabilities?.embeddedContext || !shouldCreatePasteAttachment(text)) {
+      return false;
+    }
+    if (entriesRef.current.length >= MAX_PROMPT_ATTACHMENTS) {
+      return false;
+    }
+    const file = new File([text], pasteAttachmentName(), { type: "text/plain" });
+    if (file.size > PROMPT_TEXT_RESOURCE_MAX_BYTES) {
+      return false;
+    }
+    const entry: AttachmentEntry = {
+      file,
+      descriptor: {
+        id: createAttachmentId(),
+        name: file.name,
+        mimeType: "text/plain",
+        size: file.size,
+        kind: "text_resource",
+        source: "paste",
+        objectUrl: null,
+      },
+    };
+    setEntries((current) => [...current, entry].slice(0, MAX_PROMPT_ATTACHMENTS));
+    return true;
+  }, [capabilities?.embeddedContext]);
 
   const removeAttachment = useCallback((id: string) => {
     setEntries((current) => {
@@ -161,6 +192,7 @@ export function usePromptAttachments(
           data: await readAsBase64(entry.file),
           mimeType: entry.descriptor.mimeType,
           name: entry.descriptor.name,
+          source: entry.descriptor.source,
         });
         continue;
       }
@@ -172,6 +204,7 @@ export function usePromptAttachments(
         name: entry.descriptor.name,
         mimeType: entry.descriptor.mimeType,
         size: entry.descriptor.size,
+        source: entry.descriptor.source,
       });
     }
 
@@ -181,6 +214,7 @@ export function usePromptAttachments(
   return {
     attachments: descriptors,
     addFiles,
+    addTextPaste,
     removeAttachment,
     clearAttachments,
     buildBlocks,

--- a/desktop/src/lib/domain/chat/prompt-content.test.ts
+++ b/desktop/src/lib/domain/chat/prompt-content.test.ts
@@ -17,6 +17,7 @@ describe("prompt content normalization", () => {
       mimeType: "image/png",
       name: "screenshot.png",
       size: 2048,
+      source: "upload",
     }];
 
     const [part] = normalizeContentParts(parts);
@@ -42,6 +43,7 @@ describe("prompt content normalization", () => {
       mimeType: "text/markdown",
       size: 1536,
       preview: "# Hello",
+      source: "paste",
     }];
 
     const [part] = normalizeContentParts(parts);
@@ -56,8 +58,9 @@ describe("prompt content normalization", () => {
       sizeLabel: "1.5 KB",
       preview: "# Hello",
       uri: "file:///README.md",
+      source: "paste",
     });
-    expect(part && promptPartSummary(part)).toBe("[file: README.md]");
+    expect(part && promptPartSummary(part)).toBe("[paste: README.md]");
   });
 
   it("normalizes resource links as link display parts", () => {
@@ -133,6 +136,7 @@ describe("prompt content normalization", () => {
         mimeType: "image/png",
         size: 512,
         kind: "image",
+        source: "upload",
         objectUrl: "blob:image",
       },
       {
@@ -141,6 +145,7 @@ describe("prompt content normalization", () => {
         mimeType: "text/plain",
         size: 42,
         kind: "text_resource",
+        source: "paste",
         objectUrl: null,
       },
       {
@@ -164,6 +169,7 @@ describe("prompt content normalization", () => {
         size: 512,
         sizeLabel: "512 B",
         objectUrl: "blob:image",
+        source: "upload",
       },
       {
         type: "file",
@@ -173,6 +179,7 @@ describe("prompt content normalization", () => {
         size: 42,
         sizeLabel: "42 B",
         objectUrl: null,
+        source: "paste",
       },
       {
         type: "plan_reference",

--- a/desktop/src/lib/domain/chat/prompt-content.ts
+++ b/desktop/src/lib/domain/chat/prompt-content.ts
@@ -2,6 +2,10 @@ import type { ContentPart, PromptCapabilities, ProposedPlanDetail } from "@anyha
 
 export const PROMPT_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 export const PROMPT_TEXT_RESOURCE_MAX_BYTES = 256 * 1024;
+export const PROMPT_PASTE_ATTACHMENT_MIN_CHARS = 2_000;
+export const PROMPT_PASTE_ATTACHMENT_MIN_LINES = 25;
+
+export type PromptAttachmentSource = "upload" | "paste";
 
 export interface PromptAttachmentDescriptor {
   id: string;
@@ -9,6 +13,7 @@ export interface PromptAttachmentDescriptor {
   mimeType: string;
   size: number;
   kind: "image" | "text_resource";
+  source: PromptAttachmentSource;
   objectUrl: string | null;
 }
 
@@ -62,6 +67,7 @@ export interface PromptDisplayPartBase {
   attachmentId?: string;
   objectUrl?: string | null;
   uri?: string;
+  source?: PromptAttachmentSource;
 }
 
 export interface PromptDisplayTextPart extends PromptDisplayPartBase {
@@ -121,6 +127,24 @@ export function isTextFileCandidate(file: File): boolean {
     .test(file.name);
 }
 
+export function shouldCreatePasteAttachment(text: string): boolean {
+  return text.length >= PROMPT_PASTE_ATTACHMENT_MIN_CHARS
+    || text.split(/\r\n|\r|\n/u).length >= PROMPT_PASTE_ATTACHMENT_MIN_LINES;
+}
+
+export function pasteAttachmentName(): string {
+  const now = new Date();
+  const stamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("-");
+  return `paste-${stamp}.txt`;
+}
+
 export function normalizeContentParts(
   parts: readonly ContentPart[],
   fallbackText = "",
@@ -159,6 +183,7 @@ export function normalizeContentParts(
           size: part.size ?? undefined,
           sizeLabel: formatPromptFileSize(part.size),
           uri: part.uri ?? undefined,
+          source: part.source ?? "upload",
         }];
       }
 
@@ -174,6 +199,7 @@ export function normalizeContentParts(
           sizeLabel: formatPromptFileSize(part.size),
           preview: part.preview ?? undefined,
           uri: part.uri,
+          source: part.source ?? "upload",
         }];
       }
 
@@ -245,6 +271,7 @@ export function normalizeDraftAttachments(
       size: attachment.size,
       sizeLabel: formatPromptFileSize(attachment.size),
       objectUrl: attachment.objectUrl,
+      source: attachment.source,
     };
 
     if (attachment.kind === "image") {
@@ -291,7 +318,7 @@ export function promptPartSummary(part: PromptDisplayPart): string {
     case "image":
       return `[image: ${part.name}]`;
     case "file":
-      return `[file: ${part.name}]`;
+      return part.source === "paste" ? `[paste: ${part.name}]` : `[file: ${part.name}]`;
     case "link":
       return `[link: ${part.name}]`;
     case "plan_reference":

--- a/desktop/src/lib/domain/preferences/user-preferences.ts
+++ b/desktop/src/lib/domain/preferences/user-preferences.ts
@@ -56,6 +56,7 @@ export interface UserPreferences {
   subagentsEnabled: boolean;
   coworkWorkspaceDelegationEnabled: boolean;
   cloudRuntimeInputSyncEnabled: boolean;
+  pasteAttachmentsEnabled: boolean;
   reviewDefaultsByKind: ReviewDefaultsByKind;
   reviewPersonalitiesByKind: ReviewPersonalitiesByKind;
 }
@@ -78,6 +79,7 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   subagentsEnabled: true,
   coworkWorkspaceDelegationEnabled: true,
   cloudRuntimeInputSyncEnabled: false,
+  pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
 };
@@ -102,6 +104,7 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   subagentsEnabled: true,
   coworkWorkspaceDelegationEnabled: true,
   cloudRuntimeInputSyncEnabled: false,
+  pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
 };
@@ -126,6 +129,7 @@ const USER_PREFERENCE_KEYS = [
   "subagentsEnabled",
   "coworkWorkspaceDelegationEnabled",
   "cloudRuntimeInputSyncEnabled",
+  "pasteAttachmentsEnabled",
   "reviewDefaultsByKind",
   "reviewPersonalitiesByKind",
 ] as const satisfies readonly (keyof UserPreferences)[];
@@ -498,6 +502,11 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
 
   if (typeof next.cloudRuntimeInputSyncEnabled !== "boolean") {
     next.cloudRuntimeInputSyncEnabled = PERSISTED_RECORD_BACKFILL.cloudRuntimeInputSyncEnabled;
+    changed = true;
+  }
+
+  if (typeof next.pasteAttachmentsEnabled !== "boolean") {
+    next.pasteAttachmentsEnabled = PERSISTED_RECORD_BACKFILL.pasteAttachmentsEnabled;
     changed = true;
   }
 

--- a/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -56,6 +56,7 @@ describe("user preference migration", () => {
     expect(preferences.uiFontSizeId).toBe("default");
     expect(preferences.readableCodeFontSizeId).toBe("default");
     expect(preferences.transparentChromeEnabled).toBe(false);
+    expect(preferences.pasteAttachmentsEnabled).toBe(true);
   });
 
   it("backfills legacy per-key users with old appearance defaults", async () => {
@@ -360,6 +361,10 @@ describe("user preference migration", () => {
     expect(USER_PREFERENCE_DEFAULTS.cloudRuntimeInputSyncEnabled).toBe(false);
   });
 
+  it("defaults long-paste attachments on", () => {
+    expect(USER_PREFERENCE_DEFAULTS.pasteAttachmentsEnabled).toBe(true);
+  });
+
   it("defaults appearance font preferences to default", () => {
     expect(USER_PREFERENCE_DEFAULTS.uiFontSizeId).toBe("default");
     expect(USER_PREFERENCE_DEFAULTS.readableCodeFontSizeId).toBe("default");
@@ -377,6 +382,18 @@ describe("user preference migration", () => {
 
     expect(result.changed).toBe(true);
     expect(result.preferences.cloudRuntimeInputSyncEnabled).toBe(false);
+  });
+
+  it("migrates missing long-paste attachment preference to on", () => {
+    const legacy = {
+      ...USER_PREFERENCE_DEFAULTS,
+      pasteAttachmentsEnabled: undefined,
+    } as unknown as UserPreferences;
+
+    const result = migrateUserPreferences(legacy);
+
+    expect(result.changed).toBe(true);
+    expect(result.preferences.pasteAttachmentsEnabled).toBe(true);
   });
 
   it("migrates missing transparent chrome through existing-record backfill", () => {

--- a/desktop/src/stores/preferences/user-preferences-store.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.ts
@@ -104,6 +104,7 @@ async function readLegacyUserPreferences(): Promise<LegacyUserPreferencesInput> 
     subagentsEnabled: defaults.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: defaults.coworkWorkspaceDelegationEnabled,
     cloudRuntimeInputSyncEnabled: defaults.cloudRuntimeInputSyncEnabled,
+    pasteAttachmentsEnabled: defaults.pasteAttachmentsEnabled,
     reviewDefaultsByKind: defaults.reviewDefaultsByKind,
     reviewPersonalitiesByKind: defaults.reviewPersonalitiesByKind,
   };
@@ -156,6 +157,7 @@ function selectPersistedSlice(state: UserPreferencesState): UserPreferences {
     subagentsEnabled: state.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: state.coworkWorkspaceDelegationEnabled,
     cloudRuntimeInputSyncEnabled: state.cloudRuntimeInputSyncEnabled,
+    pasteAttachmentsEnabled: state.pasteAttachmentsEnabled,
     reviewDefaultsByKind: state.reviewDefaultsByKind,
     reviewPersonalitiesByKind: state.reviewPersonalitiesByKind,
   };

--- a/docs/anyharness/contract.md
+++ b/docs/anyharness/contract.md
@@ -114,6 +114,9 @@ Owns session-facing transport types:
 `PromptInputBlock::PlanReference` with only `planId` and `snapshotHash`; the
 runtime must resolve the trusted plan snapshot from its own store before any
 agent input is produced. Clients must not send plan markdown as authority.
+Image and embedded resource prompt blocks may carry optional attachment
+`source` metadata (`upload` or `paste`). Source is display metadata only and
+must not be used as an authorization, trust, or storage boundary.
 
 Prompt provenance is a read-only display model on transcript user-message
 payloads and pending-prompt summaries/events. Public prompt request bodies must
@@ -201,6 +204,9 @@ represent different workflows even though they carry the same immutable plan
 snapshot fields. `ProposedPlan` is agent-emitted transcript content with
 decision UI. `PlanReference` is a user-prompt echo showing that a stored plan
 snapshot was attached to a prompt.
+`ContentPart::Image` and `ContentPart::Resource` may echo attachment `source`
+metadata so clients can render uploaded and pasted resources differently
+without inferring behavior from names or URIs.
 
 ## Transport-Only Rule
 

--- a/docs/anyharness/src/sessions.md
+++ b/docs/anyharness/src/sessions.md
@@ -148,6 +148,23 @@ projection for product UI:
 Internal automation provenance is not exposed directly; it must be converted to
 generic display-safe system provenance or omitted.
 
+### Prompt Attachments
+
+Prompt attachments are durable session state split across SQLite metadata and
+runtime-home files. `session_prompt_attachments` owns lifecycle state, kind,
+source, MIME/display metadata, size/hash, and the relative storage path. The
+attachment bytes live under the AnyHarness runtime home at
+`attachments/sessions/<session-id>/<attachment-id>/content` and are read or
+deleted only through `PromptAttachmentStorage`.
+
+`kind` describes the content class (`image` or `text_resource`). `source`
+describes how the attachment entered the prompt (`upload` or `paste`) and is
+display metadata only. Pasted text is still a text resource; it is not a
+separate prompt block type. Runtime dispatch embeds image and text-resource
+bytes into ACP prompt content after reading them from storage. Managed
+`anyharness-attachment://sessions/<session-id>/attachments/<attachment-id>`
+URIs identify transcript resources but are not an agent dereference mechanism.
+
 ## Same-Workspace Subagents
 
 Same-workspace subagents are the first product use of `SessionLinkRecord`.


### PR DESCRIPTION
## Summary
- Move AnyHarness prompt attachment bytes out of SQLite BLOB storage and into runtime-home files with SQLite metadata/index rows.
- Preserve image/text dispatch semantics, HTTP fetch, mobility export/import, transcript source metadata, and lazy legacy BLOB fallback.
- Add paste-as-text-resource attachments, including a General setting to turn long chat paste attachment conversion on or off.

## Validation
- cargo check -p anyharness-lib -p anyharness-contract
- pnpm --dir desktop exec tsc --noEmit
- pnpm --dir desktop exec vitest run src/stores/preferences/user-preferences-store.test.ts src/lib/domain/chat/prompt-content.test.ts
- pnpm --dir anyharness/sdk test -- transcript.test.ts
- git diff --check HEAD~1..HEAD
