### PR TITLE
[codex] Improve worktree cleanup feedback

### DIFF
--- a/desktop/src/components/settings/panes/WorktreesPane.test.tsx
+++ b/desktop/src/components/settings/panes/WorktreesPane.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { RunWorktreeRetentionResponse } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorktreesPane } from "./WorktreesPane";
+
+const worktreeSettingsMocks = vi.hoisted(() => ({
+  pruneOrphan: vi.fn(),
+  pruneWorkspaceCheckout: vi.fn(),
+  purgeWorkspace: vi.fn(),
+  retryPurge: vi.fn(),
+  runRetention: vi.fn(),
+  updatePolicy: vi.fn(),
+}));
+
+const toastStoreMocks = vi.hoisted(() => ({
+  show: vi.fn(),
+}));
+
+vi.mock("@/hooks/workspaces/use-worktree-settings-targets", () => ({
+  useWorktreeSettingsTargets: () => ({
+    isDiscovering: false,
+    targets: [{
+      error: null,
+      inventory: { rows: [] },
+      isLoading: false,
+      policy: {
+        maxMaterializedWorktreesPerRepo: 20,
+        updatedAt: "2026-05-03T00:00:00Z",
+      },
+      target: {
+        key: "local:http://localhost:4444:generation:0",
+        label: "Local runtime",
+        location: "local",
+        runtimeGeneration: 0,
+        runtimeUrl: "http://localhost:4444",
+      },
+    }],
+    ...worktreeSettingsMocks,
+  }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof toastStoreMocks.show }) => unknown) =>
+    selector({ show: toastStoreMocks.show }),
+}));
+
+beforeEach(() => {
+  worktreeSettingsMocks.runRetention.mockResolvedValue(retentionResponse({
+    attemptedCount: 2,
+    consideredCount: 2,
+    moreEligibleRemaining: true,
+    retiredCount: 2,
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("WorktreesPane cleanup feedback", () => {
+  it("uses the retention run result instead of the static success message", async () => {
+    render(<WorktreesPane />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Run cleanup" }));
+
+    await waitFor(() => {
+      expect(toastStoreMocks.show).toHaveBeenCalledWith(
+        "Retired 2 checkouts. Run cleanup again to continue.",
+      );
+    });
+    expect(toastStoreMocks.show).not.toHaveBeenCalledWith("Worktree cleanup finished.");
+  });
+});
+
+function retentionResponse(
+  overrides: Partial<RunWorktreeRetentionResponse>,
+): RunWorktreeRetentionResponse {
+  return {
+    alreadyRunning: false,
+    attemptedCount: 0,
+    blockedCount: 0,
+    consideredCount: 0,
+    failedCount: 0,
+    moreEligibleRemaining: false,
+    policy: {
+      maxMaterializedWorktreesPerRepo: 20,
+      updatedAt: "2026-05-03T00:00:00Z",
+    },
+    retiredCount: 0,
+    rows: [],
+    skippedCount: 0,
+    ...overrides,
+  };
+}

--- a/desktop/src/components/settings/panes/WorktreesPane.tsx
+++ b/desktop/src/components/settings/panes/WorktreesPane.tsx
@@ -16,7 +16,10 @@ import {
   useWorktreeSettingsTargets,
   type WorktreeSettingsTargetState,
 } from "@/hooks/workspaces/use-worktree-settings-targets";
-import { worktreeSettingsActionFailureMessage } from "@/lib/domain/workspaces/worktree-settings-actions";
+import {
+  worktreeRetentionRunMessage,
+  worktreeSettingsActionFailureMessage,
+} from "@/lib/domain/workspaces/worktree-settings-actions";
 import { useToastStore } from "@/stores/toast/toast-store";
 
 const EMPTY_ROWS: WorktreeInventoryRow[] = [];
@@ -29,23 +32,18 @@ export function WorktreesPane() {
     workspaceId: string;
   } | null>(null);
 
-  const runAction = (operation: () => Promise<unknown>, success: string) => {
+  const runAction = <TResult,>(
+    operation: () => Promise<TResult>,
+    success: string | ((result: TResult) => string),
+  ) => {
     void operation().then((result) => {
-      if (
-        result
-        && typeof result === "object"
-        && "alreadyRunning" in result
-        && result.alreadyRunning === true
-      ) {
-        showToast("Cleanup is already running.");
-        return;
-      }
       const failureMessage = worktreeSettingsActionFailureMessage(result);
       if (failureMessage) {
         showToast(failureMessage);
         return;
       }
-      showToast(success);
+      const successMessage = typeof success === "function" ? success(result) : success;
+      showToast(successMessage);
     }).catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
       showToast(message);
@@ -79,7 +77,7 @@ export function WorktreesPane() {
           )}
           onRunCleanup={() => runAction(
             () => settings.runRetention(targetState.target),
-            "Worktree cleanup finished.",
+            worktreeRetentionRunMessage,
           )}
           onPruneOrphan={(path) => runAction(
             () => settings.pruneOrphan(targetState.target, { path }),

--- a/desktop/src/lib/domain/workspaces/worktree-settings-actions.test.ts
+++ b/desktop/src/lib/domain/workspaces/worktree-settings-actions.test.ts
@@ -1,0 +1,136 @@
+import type {
+  RunWorktreeRetentionResponse,
+  WorktreeRetentionRowOutcome,
+  WorktreeRetentionRunRow,
+} from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import { worktreeRetentionRunMessage } from "./worktree-settings-actions";
+
+describe("worktreeRetentionRunMessage", () => {
+  it("reports already-running cleanup", () => {
+    expect(worktreeRetentionRunMessage(response({ alreadyRunning: true })))
+      .toBe("Cleanup is already running.");
+  });
+
+  it("reports a run with no candidates", () => {
+    expect(worktreeRetentionRunMessage(response()))
+      .toBe("No checkouts are over the retention limit.");
+  });
+
+  it("reports retired checkouts and remaining eligible work", () => {
+    expect(worktreeRetentionRunMessage(response({
+      attemptedCount: 2,
+      consideredCount: 2,
+      moreEligibleRemaining: true,
+      retiredCount: 2,
+      rows: [
+        row("retired", "checkout retired", "workspace-1"),
+        row("retired", "checkout retired", "workspace-2"),
+      ],
+    }))).toBe("Retired 2 checkouts. Run cleanup again to continue.");
+  });
+
+  it("reports blocked candidates with the first row message", () => {
+    expect(worktreeRetentionRunMessage(response({
+      blockedCount: 1,
+      consideredCount: 1,
+      rows: [row("blocked", "workspace operation is in progress")],
+    }))).toBe(
+      "Cleanup found 1 candidate blocked by safety checks or active operations: workspace operation is in progress.",
+    );
+  });
+
+  it("reports skipped rows before treating zero considered rows as no candidates", () => {
+    expect(worktreeRetentionRunMessage(response({
+      skippedCount: 1,
+      rows: [row("skipped", "checkout is outside managed worktrees root")],
+    }))).toBe(
+      "Cleanup skipped 1 row that was not eligible for retention: checkout is outside managed worktrees root.",
+    );
+  });
+
+  it("does not imply checkout deletion failed when no cleanup was attempted", () => {
+    expect(worktreeRetentionRunMessage(response({
+      consideredCount: 1,
+      failedCount: 1,
+      rows: [row("failed", "workspace eligibility check failed")],
+    }))).toBe(
+      "Cleanup could not evaluate 1 candidate: workspace eligibility check failed.",
+    );
+  });
+
+  it("mentions attempted checkout cleanup for failures after attempts", () => {
+    expect(worktreeRetentionRunMessage(response({
+      attemptedCount: 1,
+      consideredCount: 1,
+      failedCount: 1,
+      rows: [row("failed", "checkout cleanup failed")],
+    }))).toBe(
+      "Cleanup hit 1 failure after attempting checkout cleanup: checkout cleanup failed.",
+    );
+  });
+
+  it("does not surface path-like row messages", () => {
+    expect(worktreeRetentionRunMessage(response({
+      consideredCount: 1,
+      failedCount: 1,
+      rows: [row("failed", "failed at /Users/example/private-checkout")],
+    }))).toBe("Cleanup could not evaluate 1 candidate.");
+  });
+
+  it("summarizes mixed outcomes without hiding partial success", () => {
+    expect(worktreeRetentionRunMessage(response({
+      attemptedCount: 3,
+      blockedCount: 1,
+      consideredCount: 5,
+      failedCount: 1,
+      moreEligibleRemaining: true,
+      retiredCount: 2,
+      skippedCount: 1,
+      rows: [
+        row("retired", "checkout retired", "workspace-1"),
+        row("retired", "checkout retired", "workspace-2"),
+        row("blocked", "workspace operation is in progress", "workspace-3"),
+        row("skipped", "checkout is outside managed worktrees root", "workspace-4"),
+        row("failed", "workspace eligibility check failed", "workspace-5"),
+      ],
+    }))).toBe(
+      "Cleanup hit 1 failure after attempting checkout cleanup: workspace eligibility check failed. 2 retired; 1 blocked; 1 skipped. Run cleanup again to continue.",
+    );
+  });
+});
+
+function response(
+  overrides: Partial<RunWorktreeRetentionResponse> = {},
+): RunWorktreeRetentionResponse {
+  return {
+    alreadyRunning: false,
+    attemptedCount: 0,
+    blockedCount: 0,
+    consideredCount: 0,
+    failedCount: 0,
+    moreEligibleRemaining: false,
+    policy: {
+      maxMaterializedWorktreesPerRepo: 20,
+      updatedAt: "2026-05-03T00:00:00Z",
+    },
+    retiredCount: 0,
+    rows: [],
+    skippedCount: 0,
+    ...overrides,
+  };
+}
+
+function row(
+  outcome: WorktreeRetentionRowOutcome,
+  message: string,
+  workspaceId = "workspace-1",
+): WorktreeRetentionRunRow {
+  return {
+    message,
+    outcome,
+    path: `/Users/example/worktrees/${workspaceId}`,
+    repoRootId: "repo-root-1",
+    workspaceId,
+  };
+}

--- a/desktop/src/lib/domain/workspaces/worktree-settings-actions.ts
+++ b/desktop/src/lib/domain/workspaces/worktree-settings-actions.ts
@@ -1,4 +1,6 @@
 import type {
+  RunWorktreeRetentionResponse,
+  WorktreeRetentionRowOutcome,
   WorkspacePurgeResponse,
   WorkspaceRetireResponse,
 } from "@anyharness/sdk";
@@ -41,4 +43,129 @@ export function worktreeSettingsActionFailureMessage(
     return cleanupMessage;
   }
   return outcome === "blocked" ? "Workspace action was blocked." : "Workspace cleanup failed.";
+}
+
+export function worktreeRetentionRunMessage(
+  response: RunWorktreeRetentionResponse,
+): string {
+  if (response.alreadyRunning) {
+    return "Cleanup is already running.";
+  }
+
+  if (response.failedCount > 0) {
+    const detail = firstSafeRowMessage(response, "failed");
+    const base = response.attemptedCount > 0
+      ? `Cleanup hit ${formatCount(response.failedCount, "failure")} after attempting checkout cleanup`
+      : `Cleanup could not evaluate ${formatCount(response.failedCount, "candidate")}`;
+    return finishRetentionMessage(
+      withOptionalDetail(base, detail),
+      response,
+      "failed",
+    );
+  }
+
+  if (response.retiredCount > 0) {
+    return finishRetentionMessage(
+      `Retired ${formatCount(response.retiredCount, "checkout")}.`,
+      response,
+      "retired",
+    );
+  }
+
+  if (response.blockedCount > 0) {
+    const detail = firstSafeRowMessage(response, "blocked");
+    return finishRetentionMessage(
+      withOptionalDetail(
+        `Cleanup found ${formatCount(response.blockedCount, "candidate")} blocked by safety checks or active operations`,
+        detail,
+      ),
+      response,
+      "blocked",
+    );
+  }
+
+  if (response.skippedCount > 0) {
+    const detail = firstSafeRowMessage(response, "skipped");
+    return finishRetentionMessage(
+      withOptionalDetail(
+        `Cleanup skipped ${formatCount(response.skippedCount, "row")} that ${response.skippedCount === 1 ? "was" : "were"} not eligible for retention`,
+        detail,
+      ),
+      response,
+      "skipped",
+    );
+  }
+
+  if (response.consideredCount === 0 && response.rows.length === 0) {
+    return finishRetentionMessage(
+      "No checkouts are over the retention limit.",
+      response,
+      null,
+    );
+  }
+
+  return finishRetentionMessage(
+    "Worktree cleanup finished.",
+    response,
+    null,
+  );
+}
+
+function finishRetentionMessage(
+  base: string,
+  response: RunWorktreeRetentionResponse,
+  primaryOutcome: WorktreeRetentionRowOutcome | null,
+): string {
+  const details = retentionOutcomeDetails(response, primaryOutcome);
+  const remaining = response.moreEligibleRemaining
+    ? ["Run cleanup again to continue."]
+    : [];
+  return [base, ...details, ...remaining].join(" ");
+}
+
+function retentionOutcomeDetails(
+  response: RunWorktreeRetentionResponse,
+  primaryOutcome: WorktreeRetentionRowOutcome | null,
+): string[] {
+  const details: string[] = [];
+  const outcomes: Array<[WorktreeRetentionRowOutcome, number, string]> = [
+    ["retired", response.retiredCount, "retired"],
+    ["blocked", response.blockedCount, "blocked"],
+    ["skipped", response.skippedCount, "skipped"],
+    ["failed", response.failedCount, "failed"],
+  ];
+  for (const [outcome, count, label] of outcomes) {
+    if (outcome === primaryOutcome || count === 0) {
+      continue;
+    }
+    details.push(`${count} ${label}`);
+  }
+  return details.length > 0 ? [`${details.join("; ")}.`] : [];
+}
+
+function firstSafeRowMessage(
+  response: RunWorktreeRetentionResponse,
+  outcome: WorktreeRetentionRowOutcome,
+): string | null {
+  const row = response.rows.find((candidate) => candidate.outcome === outcome);
+  return safeRowMessage(row?.message);
+}
+
+function safeRowMessage(message: string | undefined): string | null {
+  const trimmed = message?.trim() ?? "";
+  if (trimmed.length === 0 || trimmed.length > 140) {
+    return null;
+  }
+  if (/[\\/]/.test(trimmed) || /(^|\s)~($|\s|\/)/.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function withOptionalDetail(base: string, detail: string | null): string {
+  return detail ? `${base}: ${detail}.` : `${base}.`;
+}
+
+function formatCount(count: number, singular: string): string {
+  return `${count} ${count === 1 ? singular : `${singular}s`}`;
 }


### PR DESCRIPTION
## Summary

- Add typed retention-run toast messaging for Worktree settings cleanup runs.
- Wire `Run cleanup` to use the retention response instead of the static success message.
- Add focused domain and component coverage for retention cleanup feedback.

## Root Cause

`Run cleanup` returned `RunWorktreeRetentionResponse`, but `WorktreesPane` passed it through the generic action path that only understood retire/purge responses with a top-level `outcome`. Retention responses do not have `outcome`, so the UI always fell back to `Worktree cleanup finished.` even for no-op, blocked, skipped, failed, or bounded cleanup runs.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/workspaces/worktree-settings-actions.test.ts src/components/settings/panes/WorktreesPane.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check`
