### PR TITLE
Clean up support dialog

### DIFF
--- a/desktop/src/components/settings/SettingsSidebar.test.tsx
+++ b/desktop/src/components/settings/SettingsSidebar.test.tsx
@@ -1,0 +1,77 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
+import type { SupportMessageContext } from "@/lib/integrations/cloud/support";
+
+const supportDialogRender = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/support/SupportDialog", () => ({
+  SupportDialog: (props: {
+    onClose: () => void;
+    context: SupportMessageContext;
+  }) => {
+    supportDialogRender(props);
+    return (
+      <div data-testid="support-dialog">
+        <button type="button" onClick={props.onClose}>
+          Close support
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/hooks/settings/use-app-version", () => ({
+  useAppVersion: () => ({ data: "0.0.0" }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderSettingsSidebar() {
+  return render(
+    <MemoryRouter initialEntries={["/settings?section=general"]}>
+      <SettingsSidebar
+        activeSection="general"
+        onNavigateHome={vi.fn()}
+        onSelectSection={vi.fn()}
+        onCheckForUpdates={vi.fn()}
+        onDownloadUpdate={vi.fn()}
+        onOpenRestartPrompt={vi.fn()}
+        updateActionState={{
+          availableVersion: null,
+          downloadProgress: null,
+          isChecking: false,
+          hasAvailableUpdate: false,
+          phase: "idle",
+          updatesSupported: true,
+        }}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("SettingsSidebar support mount boundary", () => {
+  it("does not mount SupportDialog until Support is opened", async () => {
+    renderSettingsSidebar();
+
+    expect(supportDialogRender).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("support-dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    expect(supportDialogRender).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("support-dialog")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close support" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("support-dialog")).toBeNull();
+    });
+  });
+});

--- a/desktop/src/components/settings/SettingsSidebar.tsx
+++ b/desktop/src/components/settings/SettingsSidebar.tsx
@@ -126,15 +126,16 @@ export function SettingsSidebar({
 
   return (
     <div className="flex w-64 flex-col border-r border-sidebar-border bg-sidebar">
-      <SupportDialog
-        open={supportOpen}
-        onClose={() => setSupportOpen(false)}
-        context={{
-          source: "settings",
-          intent: "general",
-          pathname: `${location.pathname}${location.search}`,
-        }}
-      />
+      {supportOpen && (
+        <SupportDialog
+          onClose={() => setSupportOpen(false)}
+          context={{
+            source: "settings",
+            intent: "general",
+            pathname: `${location.pathname}${location.search}`,
+          }}
+        />
+      )}
       <div className="h-10 pl-[82px]" data-tauri-drag-region="true" />
 
       <Button

--- a/desktop/src/components/support/SupportDialog.test.tsx
+++ b/desktop/src/components/support/SupportDialog.test.tsx
@@ -1,0 +1,159 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SupportDialog } from "@/components/support/SupportDialog";
+import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
+import type { SupportMessageContext } from "@/lib/integrations/cloud/support";
+
+const supportState = vi.hoisted(() => ({
+  current: null as SupportDialogStateMock | null,
+}));
+
+vi.mock("@/hooks/support/use-support-dialog-state", () => ({
+  useSupportDialogState: () => supportState.current,
+}));
+
+interface SupportDialogStateMock {
+  canExportDebugBundle: boolean;
+  canCopyInvestigationJson: boolean;
+  canExportActiveSessionJson: boolean;
+  canExportReplayRecording: boolean;
+  canExportWorkspaceJson: boolean;
+  contextLabel: string | null;
+  fallbackEmail: string;
+  handleCopyInvestigationJson: () => Promise<void>;
+  handleExportActiveSessionJson: () => Promise<void>;
+  handleExportReplayRecording: () => Promise<void>;
+  handleExportDebugBundle: () => Promise<void>;
+  handleExportWorkspaceJson: () => Promise<void>;
+  handleCopyEmail: () => Promise<void>;
+  handleEmail: () => Promise<void>;
+  handleGmail: () => Promise<void>;
+  handleOutlook: () => Promise<void>;
+  handleSend: () => Promise<void>;
+  inAppSupportEnabled: boolean;
+  isCopyingInvestigationJson: boolean;
+  isExportingDebugBundle: boolean;
+  isExportingReplayRecording: boolean;
+  isExportingSessionDebugJson: boolean;
+  isExportingWorkspaceDebugJson: boolean;
+  isSendingSupportMessage: boolean;
+  message: string;
+  setMessage: (message: string) => void;
+}
+
+const context: SupportMessageContext = {
+  source: "sidebar",
+  intent: "general",
+  workspaceName: "hedgehog",
+  workspaceLocation: "local",
+};
+
+function createSupportState(
+  overrides: Partial<SupportDialogStateMock> = {},
+): SupportDialogStateMock {
+  return {
+    canExportDebugBundle: true,
+    canCopyInvestigationJson: true,
+    canExportActiveSessionJson: true,
+    canExportReplayRecording: true,
+    canExportWorkspaceJson: true,
+    contextLabel: "local · hedgehog",
+    fallbackEmail: "support@example.com",
+    handleCopyInvestigationJson: vi.fn(async () => {}),
+    handleExportActiveSessionJson: vi.fn(async () => {}),
+    handleExportReplayRecording: vi.fn(async () => {}),
+    handleExportDebugBundle: vi.fn(async () => {}),
+    handleExportWorkspaceJson: vi.fn(async () => {}),
+    handleCopyEmail: vi.fn(async () => {}),
+    handleEmail: vi.fn(async () => {}),
+    handleGmail: vi.fn(async () => {}),
+    handleOutlook: vi.fn(async () => {}),
+    handleSend: vi.fn(async () => {}),
+    inAppSupportEnabled: true,
+    isCopyingInvestigationJson: false,
+    isExportingDebugBundle: false,
+    isExportingReplayRecording: false,
+    isExportingSessionDebugJson: false,
+    isExportingWorkspaceDebugJson: false,
+    isSendingSupportMessage: false,
+    message: "",
+    setMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderSupportDialog(overrides: Partial<SupportDialogStateMock> = {}) {
+  supportState.current = createSupportState(overrides);
+
+  return render(
+    <SupportDialog
+      onClose={vi.fn()}
+      context={context}
+    />,
+  );
+}
+
+beforeEach(() => {
+  supportState.current = createSupportState();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SupportDialog", () => {
+  it("blocks telemetry on the portaled panel and shows the support message count", () => {
+    renderSupportDialog({ message: "Need help" });
+
+    const dialog = screen.getByRole("dialog", { name: "Support" });
+    const textarea = screen.getByPlaceholderText("What do you need help with?") as HTMLTextAreaElement;
+
+    expect(dialog.getAttribute("data-telemetry-block")).toBe("true");
+    expect(textarea.maxLength).toBe(SUPPORT_MESSAGE_MAX_LENGTH);
+    expect(screen.getByText(`${"Need help".length} / ${SUPPORT_MESSAGE_MAX_LENGTH}`)).toBeTruthy();
+  });
+
+  it("clamps pasted support messages before storing them", () => {
+    const setMessage = vi.fn();
+    renderSupportDialog({ setMessage });
+
+    fireEvent.change(screen.getByPlaceholderText("What do you need help with?"), {
+      target: { value: "a".repeat(SUPPORT_MESSAGE_MAX_LENGTH + 1) },
+    });
+
+    expect(setMessage).toHaveBeenCalledWith("a".repeat(SUPPORT_MESSAGE_MAX_LENGTH));
+  });
+
+  it("keeps diagnostics collapsed until the disclosure opens", () => {
+    renderSupportDialog();
+
+    const disclosure = screen.getByRole("button", { name: /Session debugging/i });
+    const region = document.getElementById(disclosure.getAttribute("aria-controls") ?? "");
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(region?.hidden).toBe(true);
+    expect(screen.queryByRole("button", { name: "Copy investigation JSON" })).toBeNull();
+
+    fireEvent.click(disclosure);
+
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(region?.hidden).toBe(false);
+    expect(screen.getByText("Copy investigation JSON")).toBeTruthy();
+    expect(screen.getByText(/Event exports include prompts/)).toBeTruthy();
+  });
+
+  it("keeps Gmail first without a white fallback background", () => {
+    renderSupportDialog({ inAppSupportEnabled: false });
+
+    const buttons = screen.getAllByRole("button");
+    const gmail = screen.getByRole("button", { name: /Gmail/i });
+    const outlook = screen.getByRole("button", { name: /Outlook/i });
+
+    expect(buttons.indexOf(gmail)).toBeLessThan(buttons.indexOf(outlook));
+    expect(gmail.className).toContain("bg-foreground/5");
+    expect(gmail.className).not.toContain("bg-primary");
+    expect(outlook.className).toContain("border");
+  });
+});

--- a/desktop/src/components/support/SupportDialog.tsx
+++ b/desktop/src/components/support/SupportDialog.tsx
@@ -1,30 +1,34 @@
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import {
   Archive,
+  ChevronDown,
   Copy,
   FileText,
   FolderList,
   GmailBrandIcon,
-  Mail,
+  MailAppIcon,
   OutlookBrandIcon,
 } from "@/components/ui/icons";
 import { ModalShell } from "@/components/ui/ModalShell";
 import { Textarea } from "@/components/ui/Textarea";
 import { CAPABILITY_COPY } from "@/config/capabilities";
 import { useSupportDialogState } from "@/hooks/support/use-support-dialog-state";
+import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
+import { clampSupportMessage } from "@/lib/domain/support/formatting";
 import type { SupportMessageContext } from "@/lib/integrations/cloud/support";
 
 interface SupportDialogProps {
-  open: boolean;
   onClose: () => void;
   context: SupportMessageContext;
 }
 
 export function SupportDialog({
-  open,
   onClose,
   context,
 }: SupportDialogProps) {
+  const [debugExpanded, setDebugExpanded] = useState(false);
+  const debugSectionId = useId();
   const {
     canExportDebugBundle,
     canCopyInvestigationJson,
@@ -52,22 +56,24 @@ export function SupportDialog({
     isSendingSupportMessage,
     message,
     setMessage,
-    textareaRef,
   } = useSupportDialogState({
-    open,
     onClose,
     context,
   });
 
   return (
     <ModalShell
-      open={open}
+      open
       onClose={onClose}
       title="Support"
       description={inAppSupportEnabled
         ? "Questions, bugs, or setup issues. Send a note and we'll follow up directly."
         : undefined}
       sizeClassName="max-w-lg"
+      overlayClassName="bg-background/65 backdrop-blur-[3px]"
+      panelClassName="border-border/70 bg-background/95 shadow-floating"
+      bodyClassName="px-5 pb-5 pt-0"
+      telemetryBlocked
       footer={inAppSupportEnabled ? (
         <>
           <Button variant="ghost" size="sm" onClick={onClose}>
@@ -84,105 +90,105 @@ export function SupportDialog({
         </>
       ) : undefined}
     >
-      {inAppSupportEnabled ? (
-        <div className="space-y-3">
-          {contextLabel && (
-            <div className="rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-              {contextLabel}
+      <div className="space-y-4">
+        {inAppSupportEnabled ? (
+          <div className="space-y-3">
+            {contextLabel && (
+              <div className="rounded-md border border-border bg-foreground/5 px-3 py-2 text-xs text-muted-foreground">
+                {contextLabel}
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Textarea
+                autoFocus
+                rows={6}
+                maxLength={SUPPORT_MESSAGE_MAX_LENGTH}
+                value={message}
+                onChange={(event) => setMessage(clampSupportMessage(event.target.value))}
+                placeholder="What do you need help with?"
+                className="min-h-[132px]"
+              />
+              <div className="flex justify-end">
+                <span className="text-xs text-muted-foreground">
+                  {message.length} / {SUPPORT_MESSAGE_MAX_LENGTH}
+                </span>
+              </div>
             </div>
-          )}
-          <Textarea
-            ref={textareaRef}
-            rows={6}
-            value={message}
-            onChange={(event) => setMessage(event.target.value)}
-            placeholder="What do you need help with?"
-            className="min-h-[132px] border-border bg-background text-[13px]"
-          />
-          {canExportDebugBundle && (
-            <SupportDebugSection
-              canCopyInvestigationJson={canCopyInvestigationJson}
-              canExportActiveSessionJson={canExportActiveSessionJson}
-              canExportReplayRecording={canExportReplayRecording}
-              canExportWorkspaceJson={canExportWorkspaceJson}
-              handleCopyInvestigationJson={handleCopyInvestigationJson}
-              handleExportActiveSessionJson={handleExportActiveSessionJson}
-              handleExportReplayRecording={handleExportReplayRecording}
-              handleExportDebugBundle={handleExportDebugBundle}
-              handleExportWorkspaceJson={handleExportWorkspaceJson}
-              isCopyingInvestigationJson={isCopyingInvestigationJson}
-              isExportingDebugBundle={isExportingDebugBundle}
-              isExportingReplayRecording={isExportingReplayRecording}
-              isExportingSessionDebugJson={isExportingSessionDebugJson}
-              isExportingWorkspaceDebugJson={isExportingWorkspaceDebugJson}
-            />
-          )}
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <p className="max-w-md text-sm leading-6 text-foreground">
-            Help is a message away. Send us a note at {fallbackEmail}, and
-            we&apos;ll reply within a day.
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => { void handleGmail(); }}
-            >
-              <GmailBrandIcon className="size-3.5 shrink-0" />
-              {CAPABILITY_COPY.supportGmailLabel}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => { void handleOutlook(); }}
-            >
-              <OutlookBrandIcon className="size-3.5 shrink-0" />
-              {CAPABILITY_COPY.supportOutlookLabel}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => { void handleEmail(); }}
-            >
-              <Mail className="size-3.5 shrink-0" />
-              {CAPABILITY_COPY.supportMailAppLabel}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => { void handleCopyEmail(); }}
-            >
-              <Copy className="size-3.5 shrink-0" />
-              {CAPABILITY_COPY.supportCopyLabel}
-            </Button>
           </div>
-          {canExportDebugBundle && (
-            <SupportDebugSection
-              canCopyInvestigationJson={canCopyInvestigationJson}
-              canExportActiveSessionJson={canExportActiveSessionJson}
-              canExportReplayRecording={canExportReplayRecording}
-              canExportWorkspaceJson={canExportWorkspaceJson}
-              handleCopyInvestigationJson={handleCopyInvestigationJson}
-              handleExportActiveSessionJson={handleExportActiveSessionJson}
-              handleExportReplayRecording={handleExportReplayRecording}
-              handleExportDebugBundle={handleExportDebugBundle}
-              handleExportWorkspaceJson={handleExportWorkspaceJson}
-              isCopyingInvestigationJson={isCopyingInvestigationJson}
-              isExportingDebugBundle={isExportingDebugBundle}
-              isExportingReplayRecording={isExportingReplayRecording}
-              isExportingSessionDebugJson={isExportingSessionDebugJson}
-              isExportingWorkspaceDebugJson={isExportingWorkspaceDebugJson}
-            />
-          )}
-        </div>
-      )}
+        ) : (
+          <div className="space-y-4">
+            <p className="max-w-md text-sm leading-6 text-foreground">
+              Help is a message away. Send us a note at {fallbackEmail}, and
+              we&apos;ll reply within a day.
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                className="border border-foreground/20 bg-foreground/5 text-foreground shadow-none hover:bg-foreground/10"
+                onClick={() => { void handleGmail(); }}
+              >
+                <GmailBrandIcon className="size-3.5 shrink-0" />
+                {CAPABILITY_COPY.supportGmailLabel}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { void handleOutlook(); }}
+              >
+                <OutlookBrandIcon className="size-3.5 shrink-0" />
+                {CAPABILITY_COPY.supportOutlookLabel}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { void handleEmail(); }}
+              >
+                <MailAppIcon className="size-4 shrink-0" />
+                {CAPABILITY_COPY.supportMailAppLabel}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { void handleCopyEmail(); }}
+              >
+                <Copy className="size-3.5 shrink-0" />
+                {CAPABILITY_COPY.supportCopyLabel}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {canExportDebugBundle && (
+          <SupportDebugSection
+            expanded={debugExpanded}
+            contentId={debugSectionId}
+            onToggle={() => setDebugExpanded((expanded) => !expanded)}
+            canCopyInvestigationJson={canCopyInvestigationJson}
+            canExportActiveSessionJson={canExportActiveSessionJson}
+            canExportReplayRecording={canExportReplayRecording}
+            canExportWorkspaceJson={canExportWorkspaceJson}
+            handleCopyInvestigationJson={handleCopyInvestigationJson}
+            handleExportActiveSessionJson={handleExportActiveSessionJson}
+            handleExportReplayRecording={handleExportReplayRecording}
+            handleExportDebugBundle={handleExportDebugBundle}
+            handleExportWorkspaceJson={handleExportWorkspaceJson}
+            isCopyingInvestigationJson={isCopyingInvestigationJson}
+            isExportingDebugBundle={isExportingDebugBundle}
+            isExportingReplayRecording={isExportingReplayRecording}
+            isExportingSessionDebugJson={isExportingSessionDebugJson}
+            isExportingWorkspaceDebugJson={isExportingWorkspaceDebugJson}
+          />
+        )}
+      </div>
     </ModalShell>
   );
 }
 
 interface SupportDebugSectionProps {
+  expanded: boolean;
+  contentId: string;
+  onToggle: () => void;
   canCopyInvestigationJson: boolean;
   canExportActiveSessionJson: boolean;
   canExportReplayRecording: boolean;
@@ -200,6 +206,9 @@ interface SupportDebugSectionProps {
 }
 
 function SupportDebugSection({
+  expanded,
+  contentId,
+  onToggle,
   canCopyInvestigationJson,
   canExportActiveSessionJson,
   canExportReplayRecording,
@@ -216,71 +225,98 @@ function SupportDebugSection({
   isExportingWorkspaceDebugJson,
 }: SupportDebugSectionProps) {
   return (
-    <div className="rounded-lg border border-border bg-muted/30 px-3 py-2">
-      <div className="space-y-2">
-        <div>
-          <p className="text-xs font-medium text-foreground">Session debugging</p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={onToggle}
+        className="flex w-full whitespace-normal rounded-md border border-border bg-foreground/5 px-3 py-2 text-left transition-colors hover:bg-foreground/10"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-medium text-foreground">
+            Session debugging
+          </span>
+          <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+            Export diagnostic details only when support asks for them.
+          </span>
+        </span>
+        <ChevronDown
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            expanded ? "rotate-180" : ""
+          }`}
+        />
+      </Button>
+
+      <div
+        id={contentId}
+        hidden={!expanded}
+        className="rounded-md border border-border bg-foreground/5 px-3 py-2"
+      >
+        <div className="space-y-2">
+          <p className="text-xs leading-5 text-muted-foreground">
             Copy a compact investigation locator or export full raw and normalized event JSON.
           </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            loading={isCopyingInvestigationJson}
-            disabled={!canCopyInvestigationJson}
-            onClick={() => { void handleCopyInvestigationJson(); }}
-          >
-            <Copy className="size-3.5 shrink-0" />
-            Copy investigation JSON
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            loading={isExportingSessionDebugJson}
-            disabled={!canExportActiveSessionJson}
-            onClick={() => { void handleExportActiveSessionJson(); }}
-          >
-            <FileText className="size-3.5 shrink-0" />
-            Export active session JSON
-          </Button>
-          {canExportReplayRecording && (
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               variant="outline"
               size="sm"
-              loading={isExportingReplayRecording}
-              onClick={() => { void handleExportReplayRecording(); }}
+              loading={isCopyingInvestigationJson}
+              disabled={!canCopyInvestigationJson}
+              onClick={() => { void handleCopyInvestigationJson(); }}
+            >
+              <Copy className="size-3.5 shrink-0" />
+              Copy investigation JSON
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              loading={isExportingSessionDebugJson}
+              disabled={!canExportActiveSessionJson}
+              onClick={() => { void handleExportActiveSessionJson(); }}
             >
               <FileText className="size-3.5 shrink-0" />
-              Export replay recording
+              Export active session JSON
             </Button>
-          )}
-          <Button
-            variant="outline"
-            size="sm"
-            loading={isExportingWorkspaceDebugJson}
-            disabled={!canExportWorkspaceJson}
-            onClick={() => { void handleExportWorkspaceJson(); }}
-          >
-            <FolderList className="size-3.5 shrink-0" />
-            Export workspace JSON
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            loading={isExportingDebugBundle}
-            onClick={() => { void handleExportDebugBundle(); }}
-          >
-            <Archive className="size-3.5 shrink-0" />
-            Export debug bundle
-          </Button>
+            {canExportReplayRecording && (
+              <Button
+                variant="outline"
+                size="sm"
+                loading={isExportingReplayRecording}
+                onClick={() => { void handleExportReplayRecording(); }}
+              >
+                <FileText className="size-3.5 shrink-0" />
+                Export replay recording
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              loading={isExportingWorkspaceDebugJson}
+              disabled={!canExportWorkspaceJson}
+              onClick={() => { void handleExportWorkspaceJson(); }}
+            >
+              <FolderList className="size-3.5 shrink-0" />
+              Export workspace JSON
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              loading={isExportingDebugBundle}
+              onClick={() => { void handleExportDebugBundle(); }}
+            >
+              <Archive className="size-3.5 shrink-0" />
+              Export debug bundle
+            </Button>
+          </div>
         </div>
+        <p className="mt-2 text-[11px] leading-5 text-muted-foreground/80">
+          Event exports include prompts, raw notifications, tool output, file paths, and
+          runtime metadata. Nothing is sent automatically.
+        </p>
       </div>
-      <p className="mt-2 text-[11px] leading-5 text-muted-foreground/80">
-        Event exports include prompts, raw notifications, tool output, file paths, and
-        runtime metadata. Nothing is sent automatically.
-      </p>
     </div>
   );
 }

--- a/desktop/src/components/ui/ModalShell.test.tsx
+++ b/desktop/src/components/ui/ModalShell.test.tsx
@@ -44,4 +44,14 @@ describe("ModalShell", () => {
       expect(screen.getByTestId("native-overlay-state").dataset.open).toBe("false");
     });
   });
+
+  it("can mark the portaled dialog panel as telemetry blocked", () => {
+    render(
+      <ModalShell open title="Support" onClose={vi.fn()} telemetryBlocked>
+        Content
+      </ModalShell>,
+    );
+
+    expect(screen.getByRole("dialog").getAttribute("data-telemetry-block")).toBe("true");
+  });
 });

--- a/desktop/src/components/ui/ModalShell.tsx
+++ b/desktop/src/components/ui/ModalShell.tsx
@@ -16,6 +16,7 @@ export interface ModalShellProps {
   bodyClassName?: string;
   overlayClassName?: string;
   panelClassName?: string;
+  telemetryBlocked?: boolean;
 }
 
 export function ModalShell({
@@ -31,6 +32,7 @@ export function ModalShell({
   bodyClassName = "px-5 pb-5 pt-4",
   overlayClassName = "bg-black/70 backdrop-blur-sm",
   panelClassName = "border-border bg-background shadow-lg",
+  telemetryBlocked = false,
 }: ModalShellProps) {
   const titleId = useId();
   const descriptionId = useId();
@@ -74,6 +76,7 @@ export function ModalShell({
           aria-modal="true"
           aria-labelledby={titleId}
           aria-describedby={description ? descriptionId : undefined}
+          data-telemetry-block={telemetryBlocked ? true : undefined}
           className={`relative flex w-full flex-col overflow-hidden rounded-2xl border ${panelClassName} ${sizeClassName}`}
           onClick={(event) => event.stopPropagation()}
         >

--- a/desktop/src/components/ui/icons.tsx
+++ b/desktop/src/components/ui/icons.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, SVGProps } from "react";
+import { useId, type ComponentType, type SVGProps } from "react";
 import { useBrailleSweep } from "@/hooks/ui/use-braille-sweep";
 
 export type IconProps = SVGProps<SVGSVGElement>;
@@ -77,6 +77,29 @@ export function Mail({ className, ...props }: IconProps) {
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="m4 7 8 6 8-6" />
+    </svg>
+  );
+}
+
+export function MailAppIcon({ className, ...props }: IconProps) {
+  const gradientId = useId();
+
+  return (
+    <svg className={className} viewBox="0 0 90 90" fill="none" {...props}>
+      <defs>
+        <linearGradient id={gradientId} x1="45" y1="90" x2="45" y2="0" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#70efff" />
+          <stop offset="1" stopColor="#5770ff" />
+        </linearGradient>
+      </defs>
+      <path
+        fill={`url(#${gradientId})`}
+        d="M20.653 0h48.694C80.789 0 90 9.211 90 20.653v48.694C90 80.789 80.789 90 69.347 90H20.653C9.211 90 0 80.789 0 69.347V20.653C0 9.211 9.211 0 20.653 0Z"
+      />
+      <path
+        fill="#fff"
+        d="M19.719 25.594c-.474 0-.921.082-1.344.25l8.469 8.719 8.562 8.875.156.187.25.25.25.25.5.531 7.344 7.532c.122.076.477.404.753.542.357.179.743.343 1.142.357.43.015.869-.108 1.256-.296.29-.141.419-.343.755-.604l8.5-8.781 8.594-8.844 8.281-8.53c-.532-.289-1.12-.438-1.75-.438H19.719Zm-2.594 1.062c-.903.856-1.469 2.142-1.469 3.594v28.625c0 1.175.378 2.243 1 3.063l1.188-1.126 8.843-8.593 7.844-7.594-.156-.187-8.594-8.844-8.594-8.875-.062-.063Zm57.187.282-8.375 8.656-8.562 8.844-.156.156 8.156 7.906 8.844 8.594.531.5c.476-.764.75-1.705.75-2.719V30.25c0-1.294-.449-2.468-1.188-3.312ZM35.531 45.656l-7.812 7.594-8.875 8.594-1.125 1.094c.593.381 1.268.624 2 .624h51.719c.88 0 1.678-.338 2.343-.874l-.562-.563-8.875-8.594-8.156-7.875-7.344 7.563c-.397.263-.663.555-1.051.735-.625.289-1.309.533-1.997.523-.69-.011-1.366-.281-1.986-.586-.31-.153-.476-.305-.84-.61l-7.439-7.625Z"
+      />
     </svg>
   );
 }

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -1,0 +1,254 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MainSidebar } from "@/components/workspace/shell/sidebar/MainSidebar";
+import type { SupportMessageContext } from "@/lib/integrations/cloud/support";
+
+const supportDialogRender = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/support/SupportDialog", () => ({
+  SupportDialog: (props: {
+    onClose: () => void;
+    context: SupportMessageContext;
+  }) => {
+    supportDialogRender(props);
+    return (
+      <div data-testid="support-dialog">
+        <button type="button" onClick={props.onClose}>
+          Close support
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/ui/DebugProfiler", () => ({
+  DebugProfiler: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("./SidebarFooter", () => ({
+  SidebarFooter: () => <div data-testid="sidebar-footer" />,
+}));
+
+vi.mock("./SidebarRowSurface", () => ({
+  SidebarRowSurface: ({
+    active,
+    children,
+    onPress,
+  }: {
+    active?: boolean;
+    children: ReactNode;
+    onPress?: () => void;
+  }) => (
+    <button type="button" data-active={String(!!active)} onClick={onPress}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("./SidebarActionButton", () => ({
+  SidebarActionButton: ({
+    children,
+    onClick,
+    title,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    title: string;
+  }) => (
+    <button type="button" aria-label={title} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("./SidebarWorkspaceVariantIcon", () => ({
+  SidebarWorkspaceVariantIcon: () => <span data-testid="workspace-variant-icon" />,
+}));
+
+vi.mock("./SidebarWorkspaceContent", () => ({
+  SidebarWorkspaceContent: () => <div data-testid="sidebar-workspace-content" />,
+}));
+
+vi.mock("./WorkspaceCleanupAttentionSection", () => ({
+  WorkspaceCleanupAttentionSection: () => <div data-testid="cleanup-attention" />,
+}));
+
+vi.mock("@/components/workspace/cowork/sidebar/CoworkThreadsSection", () => ({
+  CoworkThreadsSection: () => <div data-testid="cowork-threads" />,
+}));
+
+vi.mock("@/components/ui/PopoverMenuItem", () => ({
+  PopoverMenuItem: ({
+    label,
+    onClick,
+  }: {
+    label: string;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/layout/AutoHideScrollArea", () => ({
+  AutoHideScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/PopoverButton", () => ({
+  PopoverButton: ({
+    children,
+    trigger,
+  }: {
+    children: () => ReactNode;
+    trigger: ReactNode;
+  }) => (
+    <div>
+      {trigger}
+      {children()}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/workspace/repo-setup/RepoSetupModal", () => ({
+  RepoSetupModal: () => <div data-testid="repo-setup-modal" />,
+}));
+
+vi.mock("@/hooks/cloud/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: false, cloudUnavailable: false }),
+}));
+
+vi.mock("@/hooks/cloud/use-cloud-billing", () => ({
+  useCloudBilling: () => ({ data: null }),
+}));
+
+vi.mock("@/hooks/cloud/use-cloud-repo-configs", () => ({
+  useCloudRepoConfigs: () => ({ data: { configs: [] }, isPending: false }),
+}));
+
+vi.mock("@/hooks/ui/use-debug-render-count", () => ({
+  useDebugRenderCount: () => {},
+}));
+
+vi.mock("@/hooks/support/use-sidebar-support-context", () => ({
+  useSidebarSupportContext: () => ({
+    source: "sidebar",
+    intent: "general",
+    workspaceName: "hedgehog",
+    workspaceLocation: "local",
+  }),
+}));
+
+vi.mock("@/stores/sessions/harness-store", () => ({
+  useHarnessStore: (selector: (state: { pendingWorkspaceEntry: null }) => unknown) =>
+    selector({ pendingWorkspaceEntry: null }),
+}));
+
+const workspaceUiState = vi.hoisted(() => ({
+  archiveWorkspace: vi.fn(),
+  hideRepoRoot: vi.fn(),
+  unarchiveWorkspace: vi.fn(),
+  unarchiveWorkspaces: vi.fn(),
+  workspaceTypes: ["local", "worktree", "cloud"],
+  toggleSidebarWorkspaceType: vi.fn(),
+}));
+
+vi.mock("@/stores/preferences/workspace-ui-store", () => ({
+  useWorkspaceUiStore: (selector: (state: typeof workspaceUiState) => unknown) =>
+    selector(workspaceUiState),
+}));
+
+vi.mock("@/hooks/workspaces/use-workspace-display-name-actions", () => ({
+  useWorkspaceDisplayNameActions: () => ({ updateWorkspaceDisplayName: vi.fn() }),
+}));
+
+vi.mock("@/hooks/workspaces/use-workspace-sidebar-actions", () => ({
+  useWorkspaceSidebarActions: () => ({
+    handleAddRepo: vi.fn(),
+    handleCreateCloudWorkspace: vi.fn(),
+    handleCreateLocalWorkspace: vi.fn(),
+    handleCreateWorktreeWorkspace: vi.fn(),
+    handleGoAutomations: vi.fn(),
+    handleGoHome: vi.fn(),
+    handleGoPlugins: vi.fn(),
+    handleMarkWorkspaceDone: vi.fn(),
+    handleRetryWorkspaceCleanup: vi.fn(),
+    handleSelectWorkspace: vi.fn(),
+    handleSidebarIndicatorAction: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/use-sidebar-repo-group-state", () => ({
+  useSidebarRepoGroupState: () => ({
+    allRepoKeys: [],
+    allRepoGroupsCollapsed: false,
+    collapsedRepoGroupKeys: new Set<string>(),
+    repoGroupsShownMoreKeys: new Set<string>(),
+    handleToggleRepoShowMore: vi.fn(),
+    handleToggleRepoCollapsed: vi.fn(),
+    handleToggleAllRepoGroups: vi.fn(),
+    clearRepoGroupShowMore: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/use-workspace-sidebar-state", () => ({
+  useWorkspaceSidebarState: () => ({
+    groups: [],
+    selectedWorkspaceId: null,
+    selectedLogicalWorkspaceId: null,
+    cleanupAttentionWorkspaces: [],
+    emptyState: null,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/use-session-activity-reconciler", () => ({
+  useSessionActivityReconciler: () => {},
+}));
+
+const repoSetupModalState = vi.hoisted(() => ({
+  modal: null,
+  close: vi.fn(),
+}));
+
+vi.mock("@/stores/ui/repo-setup-modal-store", () => ({
+  useRepoSetupModalStore: (selector: (state: typeof repoSetupModalState) => unknown) =>
+    selector(repoSetupModalState),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderMainSidebar() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <MainSidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe("MainSidebar support mount boundary", () => {
+  it("does not mount SupportDialog until Support is opened", async () => {
+    renderMainSidebar();
+
+    expect(supportDialogRender).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("support-dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    expect(supportDialogRender).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("support-dialog")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close support" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("support-dialog")).toBeNull();
+    });
+  });
+});

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -176,11 +176,12 @@ export function MainSidebar() {
   return (
     <DebugProfiler id="workspace-sidebar">
       <div className="h-full bg-sidebar select-none flex flex-col gap-2 pb-2">
-      <SupportDialog
-        open={supportOpen}
-        onClose={() => setSupportOpen(false)}
-        context={supportContext}
-      />
+      {supportOpen && (
+        <SupportDialog
+          onClose={() => setSupportOpen(false)}
+          context={supportContext}
+        />
+      )}
       <div className="flex flex-col flex-1 min-h-0 w-full min-w-0">
         {/* Top actions */}
         <div className="px-2">

--- a/desktop/src/hooks/support/use-support-dialog-state.test.tsx
+++ b/desktop/src/hooks/support/use-support-dialog-state.test.tsx
@@ -1,0 +1,91 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSupportDialogState } from "@/hooks/support/use-support-dialog-state";
+import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
+import type { SupportMessageContext } from "@/lib/integrations/cloud/client";
+
+const sendSupportMessage = vi.hoisted(() => vi.fn(async () => {}));
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/capabilities/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({ supportEnabled: true }),
+}));
+
+vi.mock("@/hooks/cloud/use-send-support-message", () => ({
+  useSendSupportMessage: () => ({
+    sendSupportMessage,
+    isSendingSupportMessage: false,
+  }),
+}));
+
+vi.mock("@/hooks/support/use-session-debug-actions", () => ({
+  useSessionDebugActions: () => ({
+    canCopyInvestigationJson: false,
+    canExportActiveSessionJson: false,
+    canExportReplayRecording: false,
+    canExportWorkspaceJson: false,
+    handleCopyInvestigationJson: vi.fn(async () => {}),
+    handleExportActiveSessionJson: vi.fn(async () => {}),
+    handleExportReplayRecording: vi.fn(async () => {}),
+    handleExportWorkspaceJson: vi.fn(async () => {}),
+    isCopyingInvestigationJson: false,
+    isExportingReplayRecording: false,
+    isExportingSessionDebugJson: false,
+    isExportingWorkspaceDebugJson: false,
+  }),
+}));
+
+vi.mock("@/platform/tauri/diagnostics", () => ({
+  exportDebugBundle: vi.fn(async () => null),
+  isTauriDesktop: () => false,
+}));
+
+vi.mock("@/platform/tauri/shell", () => ({
+  copyText: vi.fn(async () => {}),
+  openEmailCompose: vi.fn(async () => {}),
+  openGmailCompose: vi.fn(async () => {}),
+  openOutlookCompose: vi.fn(async () => {}),
+}));
+
+vi.mock("@/stores/auth/auth-store", () => ({
+  useAuthStore: (selector: (state: { status: string }) => unknown) =>
+    selector({ status: "authenticated" }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof showToast }) => unknown) =>
+    selector({ show: showToast }),
+}));
+
+const context: SupportMessageContext = {
+  source: "sidebar",
+  intent: "general",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useSupportDialogState", () => {
+  it("does not send support payloads beyond the server message limit", async () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() => useSupportDialogState({ onClose, context }));
+
+    act(() => {
+      result.current.setMessage(`  ${"a".repeat(SUPPORT_MESSAGE_MAX_LENGTH + 5)}  `);
+    });
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    expect(sendSupportMessage).toHaveBeenCalledWith({
+      message: "a".repeat(SUPPORT_MESSAGE_MAX_LENGTH),
+      context,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/hooks/support/use-support-dialog-state.ts
+++ b/desktop/src/hooks/support/use-support-dialog-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { CAPABILITY_COPY } from "@/config/capabilities";
 import { useAppCapabilities } from "@/hooks/capabilities/use-app-capabilities";
 import { useSendSupportMessage } from "@/hooks/cloud/use-send-support-message";
@@ -6,6 +6,7 @@ import { useSessionDebugActions } from "@/hooks/support/use-session-debug-action
 import {
   buildSupportEmailBody,
   formatSupportContextLabel,
+  normalizeSupportMessageForSend,
 } from "@/lib/domain/support/formatting";
 import type { SupportMessageContext } from "@/lib/integrations/cloud/client";
 import {
@@ -19,13 +20,11 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 
 interface UseSupportDialogStateOptions {
-  open: boolean;
   onClose: () => void;
   context: SupportMessageContext;
 }
 
 export function useSupportDialogState({
-  open,
   onClose,
   context,
 }: UseSupportDialogStateOptions) {
@@ -34,7 +33,6 @@ export function useSupportDialogState({
   const showToast = useToastStore((state) => state.show);
   const { sendSupportMessage, isSendingSupportMessage } = useSendSupportMessage();
   const sessionDebugActions = useSessionDebugActions();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [message, setMessage] = useState("");
   const [isExportingDebugBundle, setIsExportingDebugBundle] = useState(false);
   const inAppSupportEnabled = supportEnabled && authStatus === "authenticated";
@@ -42,31 +40,15 @@ export function useSupportDialogState({
   const contextLabel = useMemo(() => formatSupportContextLabel(context), [context]);
   const fallbackBody = useMemo(() => buildSupportEmailBody(context), [context]);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    setMessage("");
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || !inAppSupportEnabled) {
-      return;
-    }
-
-    textareaRef.current?.focus();
-  }, [inAppSupportEnabled, open]);
-
   async function handleSend() {
-    const trimmed = message.trim();
-    if (!trimmed) {
+    const normalizedMessage = normalizeSupportMessageForSend(message);
+    if (!normalizedMessage) {
       return;
     }
 
     try {
       await sendSupportMessage({
-        message: trimmed,
+        message: normalizedMessage,
         context,
       });
       showToast("Support note sent.", "info");
@@ -168,7 +150,6 @@ export function useSupportDialogState({
     isSendingSupportMessage,
     message,
     setMessage,
-    textareaRef,
     handleSend,
     handleCopyEmail,
     handleEmail,

--- a/desktop/src/lib/domain/support/constants.ts
+++ b/desktop/src/lib/domain/support/constants.ts
@@ -1,0 +1,1 @@
+export const SUPPORT_MESSAGE_MAX_LENGTH = 2000;

--- a/desktop/src/lib/domain/support/formatting.test.ts
+++ b/desktop/src/lib/domain/support/formatting.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
 import {
   buildSupportEmailBody,
+  clampSupportMessage,
   formatSupportContextLabel,
+  normalizeSupportMessageForSend,
 } from "@/lib/domain/support/formatting";
 
 describe("formatSupportContextLabel", () => {
@@ -31,5 +34,27 @@ describe("buildSupportEmailBody", () => {
       workspaceName: "repo-a",
       workspaceLocation: "local",
     })).toBe("");
+  });
+});
+
+describe("clampSupportMessage", () => {
+  it("keeps a message at the support limit intact", () => {
+    const message = "a".repeat(SUPPORT_MESSAGE_MAX_LENGTH);
+
+    expect(clampSupportMessage(message)).toHaveLength(SUPPORT_MESSAGE_MAX_LENGTH);
+  });
+
+  it("clamps messages beyond the support limit", () => {
+    const message = "a".repeat(SUPPORT_MESSAGE_MAX_LENGTH + 1);
+
+    expect(clampSupportMessage(message)).toHaveLength(SUPPORT_MESSAGE_MAX_LENGTH);
+  });
+});
+
+describe("normalizeSupportMessageForSend", () => {
+  it("trims and clamps the payload sent to support", () => {
+    const message = `  ${"a".repeat(SUPPORT_MESSAGE_MAX_LENGTH + 5)}  `;
+
+    expect(normalizeSupportMessageForSend(message)).toHaveLength(SUPPORT_MESSAGE_MAX_LENGTH);
   });
 });

--- a/desktop/src/lib/domain/support/formatting.ts
+++ b/desktop/src/lib/domain/support/formatting.ts
@@ -1,4 +1,5 @@
 import type { SupportMessageContext } from "@/lib/integrations/cloud/client";
+import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
 
 export function formatSupportContextLabel(
   context: SupportMessageContext,
@@ -17,4 +18,12 @@ export function buildSupportEmailBody(_context: SupportMessageContext): string {
   // the product, and the user should start with a clean textarea rather
   // than the default robotic "Context: / Intent: general" template.
   return "";
+}
+
+export function clampSupportMessage(message: string): string {
+  return message.slice(0, SUPPORT_MESSAGE_MAX_LENGTH);
+}
+
+export function normalizeSupportMessageForSend(message: string): string {
+  return clampSupportMessage(message.trim());
 }


### PR DESCRIPTION
## Summary
- clean up the Support dialog UI and fallback contact actions
- add a real mount boundary so support/debug hooks only run while the dialog is open
- enforce the 2000-character support message cap in UI and send path
- block the portaled support modal from telemetry replay

## Verification
- pnpm --dir desktop exec vitest run src/components/support/SupportDialog.test.tsx src/components/ui/ModalShell.test.tsx src/hooks/support/use-support-dialog-state.test.tsx src/lib/domain/support/formatting.test.ts src/components/settings/SettingsSidebar.test.tsx src/components/workspace/shell/sidebar/MainSidebar.test.tsx
- pnpm --dir desktop exec tsc --noEmit
- git diff --check
