### PR TITLE
Clean up workspace shortcuts

### DIFF
--- a/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
@@ -60,6 +60,7 @@ export function StandardWorkspaceShell() {
     rightPanelOpen,
     rightPanelState,
     rightPanelWidth,
+    rightPanelFocusRequestToken,
     terminalActivationRequest,
     publishDialog,
     commandPaletteOpen,
@@ -277,6 +278,7 @@ export function StandardWorkspaceShell() {
                       })}
                       onStateChange={layout.setRightPanelState}
                       terminalActivationRequest={terminalActivationRequest}
+                      focusRequestToken={rightPanelFocusRequestToken}
                       nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
                       onTerminalActivationRequestHandled={(request) => {
                         layout.setTerminalActivationRequest((current) =>

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -319,10 +319,41 @@ describe("RightPanel tab shortcuts", () => {
   });
 });
 
+describe("RightPanel root focus requests", () => {
+  it("focuses the root when an open panel receives a root focus token", async () => {
+    const rendered = render(<RightPanelHarness isWorkspaceReady focusRequestToken={0} />);
+    const root = rendered.container.querySelector("[data-right-panel-root='true']");
+    if (!(root instanceof HTMLElement)) {
+      throw new Error("Expected right panel root");
+    }
+
+    expect(document.activeElement).not.toBe(root);
+
+    rendered.rerender(<RightPanelHarness isWorkspaceReady focusRequestToken={1} />);
+
+    await waitFor(() => expect(document.activeElement).toBe(root));
+  });
+
+  it("does not focus the root while the panel is closed", async () => {
+    const rendered = render(
+      <RightPanelHarness isWorkspaceReady isOpen={false} focusRequestToken={1} />,
+    );
+    const root = rendered.container.querySelector("[data-right-panel-root='true']");
+    if (!(root instanceof HTMLElement)) {
+      throw new Error("Expected right panel root");
+    }
+
+    await Promise.resolve();
+
+    expect(document.activeElement).not.toBe(root);
+  });
+});
+
 function RightPanelHarness({
   initialState = DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
   isOpen = true,
   isWorkspaceReady,
+  focusRequestToken = 0,
   nativeOverlaysHidden = false,
   terminalActivationRequestToken,
   terminalActivationRequestWorkspaceId,
@@ -331,6 +362,7 @@ function RightPanelHarness({
   initialState?: RightPanelWorkspaceState;
   isOpen?: boolean;
   isWorkspaceReady: boolean;
+  focusRequestToken?: number;
   nativeOverlaysHidden?: boolean;
   terminalActivationRequestToken?: number;
   terminalActivationRequestWorkspaceId?: string;
@@ -346,6 +378,7 @@ function RightPanelHarness({
       state={state}
       repoSettingsHref="/settings"
       onStateChange={setState as Dispatch<SetStateAction<RightPanelWorkspaceState>>}
+      focusRequestToken={focusRequestToken}
       nativeOverlaysHidden={nativeOverlaysHidden}
       terminalActivationRequest={terminalActivationRequestToken
         ? {

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -94,6 +94,7 @@ interface RightPanelProps {
   repoSettingsHref: string;
   onStateChange: Dispatch<SetStateAction<RightPanelWorkspaceState>>;
   terminalActivationRequest: TerminalActivationRequest | null;
+  focusRequestToken?: number;
   nativeOverlaysHidden?: boolean;
   onTerminalActivationRequestHandled: (request: TerminalActivationRequest) => void;
 }
@@ -108,6 +109,7 @@ export function RightPanel({
   repoSettingsHref,
   onStateChange,
   terminalActivationRequest,
+  focusRequestToken = 0,
   nativeOverlaysHidden = false,
   onTerminalActivationRequestHandled,
 }: RightPanelProps) {
@@ -125,6 +127,7 @@ export function RightPanel({
   }>({ token: 0, defaultKind: "terminal" });
   const rootRef = useRef<HTMLDivElement>(null);
   const handledActivationRequestRef = useRef<string | null>(null);
+  const handledFocusRequestRef = useRef(0);
   // One-shot per mounted shell: users who close the starter terminal should not
   // get a replacement every time they revisit the workspace in the same session.
   const autoTerminalWorkspaceIdsRef = useRef(new Set<string>());
@@ -437,6 +440,19 @@ export function RightPanel({
 
     rootRef.current?.focus({ preventScroll: true });
   }, []);
+
+  useEffect(() => {
+    if (
+      !isOpen
+      || focusRequestToken <= 0
+      || handledFocusRequestRef.current === focusRequestToken
+    ) {
+      return;
+    }
+
+    handledFocusRequestRef.current = focusRequestToken;
+    rootRef.current?.focus({ preventScroll: true });
+  }, [focusRequestToken, isOpen]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -76,8 +76,18 @@ export function MainSidebar() {
     isPending: isCloudRepoConfigsPending,
   } = useCloudRepoConfigs(cloudActive);
   const [supportOpen, setSupportOpen] = useState(false);
-  const [showArchived, setShowArchived] = useState(false);
   const pendingWorkspaceEntry = useHarnessStore((state) => state.pendingWorkspaceEntry);
+  const {
+    showArchived,
+    setShowArchived,
+    workspaceTypes,
+    toggleSidebarWorkspaceType,
+  } = useWorkspaceUiStore(useShallow((state) => ({
+    showArchived: state.showArchived,
+    setShowArchived: state.setShowArchived,
+    workspaceTypes: state.workspaceTypes,
+    toggleSidebarWorkspaceType: state.toggleSidebarWorkspaceType,
+  })));
   const {
     groups,
     selectedWorkspaceId,
@@ -96,13 +106,6 @@ export function MainSidebar() {
   const hideRepoRoot = useWorkspaceUiStore((s) => s.hideRepoRoot);
   const unarchiveWorkspace = useWorkspaceUiStore((s) => s.unarchiveWorkspace);
   const unarchiveWorkspaces = useWorkspaceUiStore((s) => s.unarchiveWorkspaces);
-  const {
-    workspaceTypes,
-    toggleSidebarWorkspaceType,
-  } = useWorkspaceUiStore(useShallow((state) => ({
-    workspaceTypes: state.workspaceTypes,
-    toggleSidebarWorkspaceType: state.toggleSidebarWorkspaceType,
-  })));
   const { updateWorkspaceDisplayName } = useWorkspaceDisplayNameActions();
   const handleRenameWorkspace = useCallback(
     (workspaceId: string, displayName: string | null) =>
@@ -277,7 +280,7 @@ export function MainSidebar() {
                       <>
                         <PopoverMenuItem
                           onClick={() => {
-                            setShowArchived((value) => !value);
+                            setShowArchived(!showArchived);
                           }}
                           variant="sidebar"
                           icon={<Archive className="size-3.5 text-muted-foreground" />}

--- a/desktop/src/config/shortcuts.ts
+++ b/desktop/src/config/shortcuts.ts
@@ -13,6 +13,10 @@ export type ShortcutMatch =
     key: string;
   } & ShortcutModifierMatch)
   | ({
+    kind: "fixed-code";
+    code: string;
+  } & ShortcutModifierMatch)
+  | ({
     kind: "digit-key";
   } & ShortcutModifierMatch)
   | ({
@@ -44,6 +48,15 @@ export const SHORTCUTS = {
     description: "Open settings",
     owner: "native-menu",
     match: { kind: "fixed", key: ",", meta: true, shift: false, alt: false },
+    allowInInputs: true,
+  },
+  goHome: {
+    id: "app.go-home",
+    label: "⌘⇧,",
+    nonMacLabel: "Ctrl+Shift+,",
+    description: "Go home",
+    owner: "js",
+    match: { kind: "fixed-code", code: "Comma", meta: true, shift: true, alt: false },
     allowInInputs: true,
   },
   selectAll: {
@@ -203,8 +216,8 @@ export const SHORTCUTS = {
     nonMacLabel: "Ctrl+B",
     description: "Toggle left sidebar",
     owner: "js",
-    match: { kind: "fixed", key: "b", meta: true, shift: false, alt: false },
-    allowInInputs: false,
+    match: { kind: "fixed-code", code: "KeyB", meta: true, shift: false, alt: false },
+    allowInInputs: true,
   },
   toggleRightPanel: {
     id: "workspace.toggle-right-panel",
@@ -212,8 +225,8 @@ export const SHORTCUTS = {
     nonMacLabel: "Ctrl+Alt+B",
     description: "Toggle right panel",
     owner: "js",
-    match: { kind: "fixed", key: "b", meta: true, shift: false, alt: true },
-    allowInInputs: false,
+    match: { kind: "fixed-code", code: "KeyB", meta: true, shift: false, alt: true },
+    allowInInputs: true,
   },
   openCommandPalette: {
     id: "workspace.open-command-palette",
@@ -272,6 +285,7 @@ export const SHORTCUT_GROUPS = [
     title: "App",
     shortcutKeys: [
       "openSettings",
+      "goHome",
     ],
   },
   {

--- a/desktop/src/hooks/app/use-app-command-actions.ts
+++ b/desktop/src/hooks/app/use-app-command-actions.ts
@@ -8,6 +8,8 @@ import { useCreateCloudWorkspace } from "@/hooks/cloud/use-create-cloud-workspac
 import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-projection";
 import { useWorkspaceEntryActions } from "@/hooks/workspaces/use-workspace-entry-actions";
 import { useAddRepo } from "@/hooks/workspaces/use-add-repo";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/use-workspace-navigation-workflow";
+import { APP_ROUTES } from "@/config/app-routes";
 import { buildCloudRepoSettingsHref } from "@/lib/domain/settings/navigation";
 import {
   buildConfiguredCloudRepoKeys,
@@ -36,6 +38,7 @@ export interface AppCommandAction {
 
 export interface AppCommandActions {
   openSettings: AppCommandAction;
+  goHome: AppCommandAction;
   addRepository: AppCommandAction;
   newLocalWorkspace: AppCommandAction;
   newWorktreeWorkspace: AppCommandAction;
@@ -46,6 +49,7 @@ export function useAppCommandActions(): AppCommandActions {
   const navigate = useNavigate();
   const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
   const showToast = useToastStore((state) => state.show);
+  const { goToTopLevelRoute } = useWorkspaceNavigationWorkflow();
   const { cloudActive } = useCloudAvailabilityState();
   const { data: billingPlan } = useCloudBilling();
   const {
@@ -107,6 +111,9 @@ export function useAppCommandActions(): AppCommandActions {
   const openSettings = useCallback(() => {
     navigate("/settings");
   }, [navigate]);
+  const goHome = useCallback(() => {
+    goToTopLevelRoute(APP_ROUTES.home);
+  }, [goToTopLevelRoute]);
 
   const addRepositoryDisabledReason = isAddingRepo
     ? "Action already in progress."
@@ -234,6 +241,10 @@ export function useAppCommandActions(): AppCommandActions {
       execute: openSettings,
       disabledReason: null,
     },
+    goHome: {
+      execute: goHome,
+      disabledReason: null,
+    },
     addRepository: {
       execute: addRepository,
       disabledReason: addRepositoryDisabledReason,
@@ -259,6 +270,7 @@ export function useAppCommandActions(): AppCommandActions {
     newLocalWorkspace,
     newWorktreeDisabledReason,
     newWorktreeWorkspace,
+    goHome,
     openSettings,
   ]);
 }

--- a/desktop/src/hooks/app/use-app-shortcuts.ts
+++ b/desktop/src/hooks/app/use-app-shortcuts.ts
@@ -1,46 +1,24 @@
-import { useMemo } from "react";
-import type { Workspace } from "@anyharness/sdk";
 import { useShortcutHandler } from "@/hooks/shortcuts/use-shortcut-handler";
-import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-projection";
-import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
-import {
-  buildSidebarWorkspaceEntries,
-  groupSidebarEntries,
-} from "@/lib/domain/workspaces/sidebar";
-import { isUsableWorkspace } from "@/lib/domain/workspaces/usability";
 import type { AppCommandActions } from "@/hooks/app/use-app-command-actions";
-import {
-  failLatencyFlow,
-  startLatencyFlow,
-} from "@/lib/infra/latency-flow";
+import { useSidebarShortcutTargets } from "@/hooks/workspaces/use-sidebar-shortcut-targets";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/use-workspace-navigation-workflow";
+import { resolveSidebarShortcutDigitTarget } from "@/lib/domain/workspaces/sidebar-shortcut-targets";
 import {
   runRedoCommand,
   runSelectAllCommand,
   runUndoCommand,
 } from "@/lib/infra/dom-select-all";
 
-const EMPTY_WORKSPACES: Workspace[] = [];
-
 export function useAppShortcuts(actions: AppCommandActions): void {
-  const {
-    localWorkspaces,
-    cloudWorkspaces,
-  } = useStandardRepoProjection();
-  const workspaces = localWorkspaces ?? EMPTY_WORKSPACES;
-  const { selectWorkspace } = useWorkspaceSelection();
-
-  const orderedWorkspaceIds = useMemo(() => {
-    const entries = buildSidebarWorkspaceEntries(workspaces, cloudWorkspaces);
-    const groups = groupSidebarEntries(entries);
-    return groups.flatMap((group) =>
-      group.entries
-        .filter((entry) => entry.source === "cloud" || isUsableWorkspace(entry.workspace))
-        .map((entry) => entry.id)
-    );
-  }, [cloudWorkspaces, workspaces]);
+  const sidebarShortcutTargetIds = useSidebarShortcutTargets();
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
 
   useShortcutHandler("app.open-settings", () => {
     actions.openSettings.execute("shortcut");
+  });
+
+  useShortcutHandler("app.go-home", () => {
+    actions.goHome.execute("shortcut");
   });
 
   useShortcutHandler("app.select-all", () => {
@@ -60,17 +38,9 @@ export function useAppShortcuts(actions: AppCommandActions): void {
       return false;
     }
 
-    const idx = digit === 9 ? orderedWorkspaceIds.length - 1 : digit - 1;
-    const targetId = orderedWorkspaceIds[idx];
+    const targetId = resolveSidebarShortcutDigitTarget(sidebarShortcutTargetIds, digit);
     if (targetId) {
-      const latencyFlowId = startLatencyFlow({
-        flowKind: "workspace_switch",
-        source: "shortcut",
-        targetWorkspaceId: targetId,
-      });
-      void selectWorkspace(targetId, { latencyFlowId }).catch(() => {
-        failLatencyFlow(latencyFlowId, "workspace_switch_failed");
-      });
+      selectWorkspaceFromSurface(targetId, "shortcut");
     }
   });
 

--- a/desktop/src/hooks/main/use-main-screen-actions.test.tsx
+++ b/desktop/src/hooks/main/use-main-screen-actions.test.tsx
@@ -78,6 +78,7 @@ describe("useMainScreenActions publish actions", () => {
 
     expect(spies.setRightPanelState).not.toHaveBeenCalled();
     expect(spies.setRightPanelOpen).not.toHaveBeenCalled();
+    expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 
   it("opens PRs from the publish dialog without opening the right panel", () => {
@@ -88,6 +89,7 @@ describe("useMainScreenActions publish actions", () => {
     expect(openExternal).toHaveBeenCalledWith("https://github.test/pull/1");
     expect(spies.setRightPanelState).not.toHaveBeenCalled();
     expect(spies.setRightPanelOpen).not.toHaveBeenCalled();
+    expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 
 });
@@ -104,6 +106,7 @@ describe("useMainScreenActions right panel actions", () => {
       lastCallArg(spies.setRightPanelState),
     );
     expect(nextState.activeEntryKey).toBe("tool:files");
+    expect(spies.requestRightPanelFocus).toHaveBeenCalledTimes(1);
   });
 
   it("opens a concrete terminal by adding and selecting its header entry", () => {
@@ -125,6 +128,7 @@ describe("useMainScreenActions right panel actions", () => {
         spies.setTerminalActivationRequest,
       ),
     )).toEqual({ token: 1, workspaceId: "workspace-1" });
+    expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 
   it("opens terminal panel without an id by preserving state and bumping activation", () => {
@@ -141,6 +145,7 @@ describe("useMainScreenActions right panel actions", () => {
       ),
     )).toEqual({ token: 1, workspaceId: "workspace-1" });
     expect(spies.setRightPanelState).not.toHaveBeenCalled();
+    expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 
   it("toggles a closed right panel to files when a singleton tool is active", () => {
@@ -160,6 +165,7 @@ describe("useMainScreenActions right panel actions", () => {
     );
     expect(nextState.activeEntryKey).toBe("tool:files");
     expect(spies.setRightPanelOpen).toHaveBeenCalledWith(true);
+    expect(spies.requestRightPanelFocus).toHaveBeenCalledTimes(1);
   });
 
   it("toggles a closed right panel from a live entry without rewriting selection", () => {
@@ -179,6 +185,18 @@ describe("useMainScreenActions right panel actions", () => {
 
     expect(spies.setRightPanelOpen).toHaveBeenCalledWith(true);
     expect(spies.setRightPanelState).not.toHaveBeenCalled();
+    expect(spies.requestRightPanelFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes an open right panel without requesting root focus", () => {
+    const { result, spies } = renderActions({
+      rightPanelOpen: true,
+    });
+
+    act(() => result.current.toggleRightPanel());
+
+    expect(spies.setRightPanelOpen).toHaveBeenCalledWith(false);
+    expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 });
 
@@ -207,12 +225,14 @@ function mainScreenLayout(overrides: Partial<MainScreenLayoutState> = {}): {
   layout: MainScreenLayoutState;
   spies: {
     setPublishDialog: ReturnType<typeof vi.fn>;
+    requestRightPanelFocus: ReturnType<typeof vi.fn>;
     setRightPanelOpen: ReturnType<typeof vi.fn>;
     setRightPanelState: ReturnType<typeof vi.fn>;
     setTerminalActivationRequest: ReturnType<typeof vi.fn>;
   };
 } {
   const setPublishDialog = vi.fn();
+  const requestRightPanelFocus = vi.fn();
   const setRightPanelOpen = vi.fn();
   const setRightPanelState = vi.fn();
   const setTerminalActivationRequest = vi.fn();
@@ -227,6 +247,8 @@ function mainScreenLayout(overrides: Partial<MainScreenLayoutState> = {}): {
       setSidebarWidth: vi.fn(),
       rightPanelOpen: false,
       setRightPanelOpen,
+      rightPanelFocusRequestToken: 0,
+      requestRightPanelFocus,
       terminalActivationRequest: null,
       setTerminalActivationRequest,
       publishDialog: {
@@ -245,6 +267,7 @@ function mainScreenLayout(overrides: Partial<MainScreenLayoutState> = {}): {
     },
     spies: {
       setPublishDialog,
+      requestRightPanelFocus,
       setRightPanelOpen,
       setRightPanelState,
       setTerminalActivationRequest,

--- a/desktop/src/hooks/main/use-main-screen-actions.ts
+++ b/desktop/src/hooks/main/use-main-screen-actions.ts
@@ -45,6 +45,7 @@ export function useMainScreenActions({
     setRightPanelState,
     setSidebarOpen,
     setRightPanelOpen,
+    requestRightPanelFocus,
     setTerminalActivationRequest,
     setCommandPaletteOpen,
     setPublishDialog,
@@ -56,7 +57,8 @@ export function useMainScreenActions({
       activeEntryKey: rightPanelToolHeaderKey(tool),
     }));
     setRightPanelOpen(true);
-  }, [setRightPanelOpen, setRightPanelState]);
+    requestRightPanelFocus();
+  }, [requestRightPanelFocus, setRightPanelOpen, setRightPanelState]);
 
   const openTerminalPanel = useCallback((terminalId?: string) => {
     if (!selectedWorkspaceId) {
@@ -100,11 +102,18 @@ export function useMainScreenActions({
       const activeEntry = parseRightPanelHeaderEntryKey(rightPanelState.activeEntryKey);
       if (activeEntry?.kind === "browser" || activeEntry?.kind === "terminal") {
         setRightPanelOpen(true);
+        requestRightPanelFocus();
         return;
       }
       openRightPanelTool("files");
     }
-  }, [openRightPanelTool, rightPanelOpen, rightPanelState.activeEntryKey, setRightPanelOpen]);
+  }, [
+    openRightPanelTool,
+    requestRightPanelFocus,
+    rightPanelOpen,
+    rightPanelState.activeEntryKey,
+    setRightPanelOpen,
+  ]);
 
   const openPrInBrowser = useCallback((pullRequest?: MainScreenDataState["existingPr"]) => {
     const url = pullRequest?.url ?? existingPr?.url;

--- a/desktop/src/hooks/main/use-main-screen-shortcuts.test.tsx
+++ b/desktop/src/hooks/main/use-main-screen-shortcuts.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearShortcutHandlerRegistryForTests,
+  runShortcutHandler,
+} from "@/lib/domain/shortcuts/registry";
+import { useMainScreenShortcuts } from "./use-main-screen-shortcuts";
+
+const harnessState = vi.hoisted(() => ({
+  selectedWorkspaceId: null as string | null,
+}));
+
+vi.mock("@/stores/sessions/harness-store", () => ({
+  useHarnessStore: (selector: (state: { selectedWorkspaceId: string | null }) => unknown) =>
+    selector(harnessState),
+}));
+
+vi.mock("@/lib/domain/focus-zone", () => ({
+  focusChatInput: vi.fn(() => true),
+}));
+
+describe("useMainScreenShortcuts", () => {
+  beforeEach(() => {
+    harnessState.selectedWorkspaceId = null;
+    clearShortcutHandlerRegistryForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearShortcutHandlerRegistryForTests();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the left-sidebar toggle shell-scoped when no workspace is selected", () => {
+    const onToggleLeftSidebar = vi.fn();
+    const onToggleRightPanel = vi.fn();
+
+    renderHook(() => useMainScreenShortcuts({
+      canOpenCommandPalette: false,
+      onOpenCommandPalette: vi.fn(),
+      onOpenTerminal: vi.fn(),
+      onToggleLeftSidebar,
+      onToggleRightPanel,
+    }));
+
+    expect(runShortcutHandler("workspace.toggle-left-sidebar", { source: "keyboard" })).toBe(true);
+    expect(onToggleLeftSidebar).toHaveBeenCalledTimes(1);
+
+    expect(runShortcutHandler("workspace.toggle-right-panel", { source: "keyboard" })).toBe(false);
+    expect(onToggleRightPanel).not.toHaveBeenCalled();
+  });
+
+  it("registers workspace-scoped shortcuts when a workspace is selected", () => {
+    harnessState.selectedWorkspaceId = "workspace-1";
+    const onOpenTerminal = vi.fn(() => true);
+    const onToggleRightPanel = vi.fn();
+
+    renderHook(() => useMainScreenShortcuts({
+      canOpenCommandPalette: true,
+      onOpenCommandPalette: vi.fn(),
+      onOpenTerminal,
+      onToggleLeftSidebar: vi.fn(),
+      onToggleRightPanel,
+    }));
+
+    expect(runShortcutHandler("workspace.open-terminal", { source: "keyboard" })).toBe(true);
+    expect(onOpenTerminal).toHaveBeenCalledTimes(1);
+
+    expect(runShortcutHandler("workspace.toggle-right-panel", { source: "keyboard" })).toBe(true);
+    expect(onToggleRightPanel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/hooks/main/use-main-screen-shortcuts.ts
+++ b/desktop/src/hooks/main/use-main-screen-shortcuts.ts
@@ -30,7 +30,7 @@ export function useMainScreenShortcuts({
 
   useShortcutHandler("workspace.toggle-left-sidebar", () => {
     onToggleLeftSidebar();
-  }, { enabled: canUseWorkspaceShortcuts });
+  });
 
   useShortcutHandler("workspace.toggle-right-panel", () => {
     onToggleRightPanel();

--- a/desktop/src/hooks/main/use-main-screen-state.ts
+++ b/desktop/src/hooks/main/use-main-screen-state.ts
@@ -61,6 +61,8 @@ export interface MainScreenLayoutState {
   setSidebarWidth: Dispatch<SetStateAction<number>>;
   rightPanelOpen: boolean;
   setRightPanelOpen: Dispatch<SetStateAction<boolean>>;
+  rightPanelFocusRequestToken: number;
+  requestRightPanelFocus: () => void;
   terminalActivationRequest: TerminalActivationRequest | null;
   setTerminalActivationRequest: Dispatch<SetStateAction<TerminalActivationRequest | null>>;
   publishDialog: PublishDialogState;
@@ -105,6 +107,7 @@ export function useMainScreenState(): MainScreenState {
     useState<RightPanelDurableState | null>(null);
   const [terminalActivationRequest, setTerminalActivationRequest] =
     useState<TerminalActivationRequest | null>(null);
+  const [rightPanelFocusRequestToken, setRightPanelFocusRequestToken] = useState(0);
   const [publishDialog, setPublishDialog] = useState<PublishDialogState>(
     CLOSED_PUBLISH_DIALOG_STATE,
   );
@@ -250,6 +253,9 @@ export function useMainScreenState(): MainScreenState {
       workspaceUiKey,
     ],
   );
+  const requestRightPanelFocus = useCallback(() => {
+    setRightPanelFocusRequestToken((token) => token + 1);
+  }, []);
 
   const onLeftSeparatorDown = useResize({
     direction: "horizontal",
@@ -342,6 +348,8 @@ export function useMainScreenState(): MainScreenState {
       setSidebarWidth,
       rightPanelOpen,
       setRightPanelOpen,
+      rightPanelFocusRequestToken,
+      requestRightPanelFocus,
       terminalActivationRequest,
       setTerminalActivationRequest,
       publishDialog,

--- a/desktop/src/hooks/shortcuts/use-shortcut-dispatcher.test.ts
+++ b/desktop/src/hooks/shortcuts/use-shortcut-dispatcher.test.ts
@@ -70,6 +70,39 @@ describe("resolveKeyboardShortcut", () => {
     } as KeyboardEvent)).toBeNull();
   });
 
+  it("keeps command-comma settings distinct from command-shift-comma home on mac", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: ",",
+      code: "Comma",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "app.open-settings",
+      shortcut: expect.objectContaining({ id: "app.open-settings" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "<",
+      code: "Comma",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "app.go-home",
+      shortcut: expect.objectContaining({ id: "app.go-home" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+  });
+
   it("resolves directional chat and terminal shortcuts on mac", () => {
     vi.stubGlobal("navigator", {
       platform: "MacIntel",
@@ -116,7 +149,33 @@ describe("resolveKeyboardShortcut", () => {
     });
 
     expect(resolveKeyboardShortcut({
+      key: "∫",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.toggle-left-sidebar",
+      shortcut: expect.objectContaining({ id: "workspace.toggle-left-sidebar" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
       key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.toggle-right-panel",
+      shortcut: expect.objectContaining({ id: "workspace.toggle-right-panel" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "∫",
       code: "KeyB",
       metaKey: true,
       ctrlKey: false,

--- a/desktop/src/hooks/workspaces/use-sidebar-shortcut-targets.ts
+++ b/desktop/src/hooks/workspaces/use-sidebar-shortcut-targets.ts
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces";
+import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-projection";
+import {
+  buildSidebarGroupStates,
+  SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+} from "@/lib/domain/workspaces/sidebar";
+import { visibleSidebarShortcutTargetIds } from "@/lib/domain/workspaces/sidebar-shortcut-targets";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
+import { useWorkspaceSidebarShowMoreStore } from "@/stores/workspaces/workspace-sidebar-show-more-store";
+
+const EMPTY_WORKSPACE_ACTIVITIES = {};
+const EMPTY_PENDING_PROMPT_COUNTS = {};
+const EMPTY_LAST_VIEWED_AT = {};
+const EMPTY_FINISH_SUGGESTIONS = {};
+
+export function useSidebarShortcutTargets(): string[] {
+  const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
+  const selectedLogicalWorkspaceId = useLogicalWorkspaceStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const { logicalWorkspaces } = useLogicalWorkspaces();
+  const { repoRoots } = useStandardRepoProjection();
+  const {
+    archivedWorkspaceIds,
+    hiddenRepoRootIds,
+    collapsedRepoGroups,
+    showArchived,
+    workspaceTypes,
+    workspaceLastInteracted,
+  } = useWorkspaceUiStore(useShallow((state) => ({
+    archivedWorkspaceIds: state.archivedWorkspaceIds,
+    hiddenRepoRootIds: state.hiddenRepoRootIds,
+    collapsedRepoGroups: state.collapsedRepoGroups,
+    showArchived: state.showArchived,
+    workspaceTypes: state.workspaceTypes,
+    workspaceLastInteracted: state.workspaceLastInteracted,
+  })));
+  const repoGroupsShownMore = useWorkspaceSidebarShowMoreStore(
+    (state) => state.repoGroupsShownMore,
+  );
+
+  const archivedSet = useMemo(
+    () => new Set(archivedWorkspaceIds),
+    [archivedWorkspaceIds],
+  );
+  const hiddenRepoRootSet = useMemo(
+    () => new Set(hiddenRepoRootIds),
+    [hiddenRepoRootIds],
+  );
+  const collapsedRepoGroupKeys = useMemo(
+    () => new Set(collapsedRepoGroups),
+    [collapsedRepoGroups],
+  );
+  const repoGroupsShownMoreKeys = useMemo(
+    () => new Set(repoGroupsShownMore),
+    [repoGroupsShownMore],
+  );
+
+  const groups = useMemo(() => buildSidebarGroupStates({
+    repoRoots,
+    logicalWorkspaces,
+    showArchived,
+    workspaceTypes,
+    archivedSet,
+    hiddenRepoRootIds: hiddenRepoRootSet,
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+    workspaceActivities: EMPTY_WORKSPACE_ACTIVITIES,
+    pendingPromptCounts: EMPTY_PENDING_PROMPT_COUNTS,
+    gitStatus: undefined,
+    activeSessionTitle: null,
+    lastViewedAt: EMPTY_LAST_VIEWED_AT,
+    workspaceLastInteracted,
+    finishSuggestionsByWorkspaceId: EMPTY_FINISH_SUGGESTIONS,
+  }), [
+    archivedSet,
+    hiddenRepoRootSet,
+    logicalWorkspaces,
+    repoRoots,
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+    showArchived,
+    workspaceLastInteracted,
+    workspaceTypes,
+  ]);
+
+  return useMemo(() => visibleSidebarShortcutTargetIds({
+    groups,
+    collapsedRepoGroupKeys,
+    repoGroupsShownMore: repoGroupsShownMoreKeys,
+    itemLimit: SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+  }), [
+    collapsedRepoGroupKeys,
+    groups,
+    repoGroupsShownMoreKeys,
+  ]);
+}

--- a/desktop/src/hooks/workspaces/use-workspace-command-palette.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-command-palette.ts
@@ -258,6 +258,16 @@ export function useWorkspaceCommandPalette({
       execute: () => appActions.openSettings.execute("palette"),
     },
     {
+      id: "app.go-home",
+      value: commandPaletteCommandValue("app.go-home"),
+      group: "app",
+      label: "Go Home",
+      icon: "arrow-left",
+      shortcut: getShortcutDisplayLabel(SHORTCUTS.goHome),
+      disabledReason: appActions.goHome.disabledReason,
+      execute: () => appActions.goHome.execute("palette"),
+    },
+    {
       id: "workspace.add-repository",
       value: commandPaletteCommandValue("workspace.add-repository"),
       group: "app",

--- a/desktop/src/hooks/workspaces/use-workspace-navigation-workflow.test.tsx
+++ b/desktop/src/hooks/workspaces/use-workspace-navigation-workflow.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/use-workspace-navigation-workflow";
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  location: { pathname: "/" },
+}));
+
+const harnessMocks = vi.hoisted(() => ({
+  state: {
+    pendingWorkspaceEntry: null as unknown,
+    selectedWorkspaceId: null as string | null,
+    setPendingWorkspaceEntry: vi.fn(),
+    deselectWorkspacePreservingSlots: vi.fn(),
+  },
+}));
+
+const mobilityMocks = vi.hoisted(() => ({
+  state: {
+    selectionLocked: false,
+    selectedLogicalWorkspaceId: null as string | null,
+  },
+}));
+
+const selectionMocks = vi.hoisted(() => ({
+  selectWorkspace: vi.fn(async () => undefined),
+}));
+
+const toastMocks = vi.hoisted(() => ({
+  show: vi.fn(),
+}));
+
+const editorMocks = vi.hoisted(() => ({
+  resetWorkspaceEditorState: vi.fn(),
+}));
+
+const workspaceUiMocks = vi.hoisted(() => ({
+  markWorkspaceViewed: vi.fn(),
+}));
+
+const latencyMocks = vi.hoisted(() => ({
+  failLatencyFlow: vi.fn(),
+  startLatencyFlow: vi.fn(() => "flow-1"),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useLocation: () => routerMocks.location,
+  useNavigate: () => routerMocks.navigate,
+}));
+
+vi.mock("@/stores/sessions/harness-store", () => ({
+  useHarnessStore: (selector: (state: typeof harnessMocks.state) => unknown) =>
+    selector(harnessMocks.state),
+}));
+
+vi.mock("@/hooks/workspaces/mobility/use-workspace-mobility-state", () => ({
+  useWorkspaceMobilityState: () => mobilityMocks.state,
+}));
+
+vi.mock("@/hooks/workspaces/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({
+    selectWorkspace: selectionMocks.selectWorkspace,
+  }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof toastMocks.show }) => unknown) =>
+    selector({ show: toastMocks.show }),
+}));
+
+vi.mock("@/stores/editor/workspace-editor-state", () => ({
+  resetWorkspaceEditorState: editorMocks.resetWorkspaceEditorState,
+}));
+
+vi.mock("@/stores/preferences/workspace-ui-store", () => ({
+  markWorkspaceViewed: workspaceUiMocks.markWorkspaceViewed,
+}));
+
+vi.mock("@/lib/infra/latency-flow", () => ({
+  failLatencyFlow: latencyMocks.failLatencyFlow,
+  startLatencyFlow: latencyMocks.startLatencyFlow,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  routerMocks.location.pathname = "/";
+  harnessMocks.state.pendingWorkspaceEntry = null;
+  harnessMocks.state.selectedWorkspaceId = null;
+  mobilityMocks.state.selectionLocked = false;
+  mobilityMocks.state.selectedLogicalWorkspaceId = null;
+  selectionMocks.selectWorkspace.mockResolvedValue(undefined);
+});
+
+describe("useWorkspaceNavigationWorkflow", () => {
+  it("leaves a selected workspace with slot-preserving deselection before top-level navigation", () => {
+    harnessMocks.state.selectedWorkspaceId = "materialized-1";
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.goToTopLevelRoute("/"));
+
+    expect(harnessMocks.state.deselectWorkspacePreservingSlots).toHaveBeenCalledTimes(1);
+    expect(harnessMocks.state.setPendingWorkspaceEntry).not.toHaveBeenCalled();
+    expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("clears pending workspace state before top-level navigation", () => {
+    harnessMocks.state.pendingWorkspaceEntry = { id: "pending-1" };
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.goToTopLevelRoute("/"));
+
+    expect(harnessMocks.state.setPendingWorkspaceEntry).toHaveBeenCalledWith(null);
+    expect(harnessMocks.state.deselectWorkspacePreservingSlots).not.toHaveBeenCalled();
+    expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("blocks top-level navigation while workspace mobility locks selection", () => {
+    mobilityMocks.state.selectionLocked = true;
+    harnessMocks.state.selectedWorkspaceId = "materialized-1";
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.goToTopLevelRoute("/"));
+
+    expect(toastMocks.show).toHaveBeenCalledWith(
+      "Finish the current workspace move before leaving this workspace.",
+    );
+    expect(harnessMocks.state.deselectWorkspacePreservingSlots).not.toHaveBeenCalled();
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("blocks workspace switching while mobility is locked to another logical workspace", () => {
+    mobilityMocks.state.selectionLocked = true;
+    mobilityMocks.state.selectedLogicalWorkspaceId = "logical-current";
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.selectWorkspaceFromSurface("logical-target", "shortcut"));
+
+    expect(toastMocks.show).toHaveBeenCalledWith(
+      "Finish the current workspace move before switching workspaces.",
+    );
+    expect(selectionMocks.selectWorkspace).not.toHaveBeenCalled();
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("selects workspaces through the shared latency and viewed-state workflow", () => {
+    routerMocks.location.pathname = "/settings";
+    mobilityMocks.state.selectedLogicalWorkspaceId = "logical-current";
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.selectWorkspaceFromSurface("logical-current", "shortcut"));
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+    expect(workspaceUiMocks.markWorkspaceViewed).toHaveBeenCalledWith("logical-current");
+    expect(latencyMocks.startLatencyFlow).toHaveBeenCalledWith({
+      flowKind: "workspace_switch",
+      source: "shortcut",
+      targetWorkspaceId: "logical-current",
+    });
+    expect(selectionMocks.selectWorkspace).toHaveBeenCalledWith("logical-current", {
+      latencyFlowId: "flow-1",
+    });
+  });
+});

--- a/desktop/src/hooks/workspaces/use-workspace-navigation-workflow.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-navigation-workflow.ts
@@ -1,0 +1,90 @@
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useWorkspaceMobilityState } from "@/hooks/workspaces/mobility/use-workspace-mobility-state";
+import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
+import {
+  failLatencyFlow,
+  startLatencyFlow,
+} from "@/lib/infra/latency-flow";
+import { resetWorkspaceEditorState } from "@/stores/editor/workspace-editor-state";
+import { markWorkspaceViewed } from "@/stores/preferences/workspace-ui-store";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+export function useWorkspaceNavigationWorkflow() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const setPendingWorkspaceEntry = useHarnessStore((state) => state.setPendingWorkspaceEntry);
+  const deselectWorkspacePreservingSlots = useHarnessStore(
+    (state) => state.deselectWorkspacePreservingSlots,
+  );
+  const pendingWorkspaceEntry = useHarnessStore((state) => state.pendingWorkspaceEntry);
+  const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
+  const mobility = useWorkspaceMobilityState();
+  const { selectWorkspace } = useWorkspaceSelection();
+  const showToast = useToastStore((state) => state.show);
+
+  const navigateToWorkspaceShell = useCallback(() => {
+    if (location.pathname !== "/") {
+      navigate("/");
+    }
+  }, [location.pathname, navigate]);
+
+  const goToTopLevelRoute = useCallback((path: string) => {
+    if (mobility.selectionLocked) {
+      showToast("Finish the current workspace move before leaving this workspace.");
+      return;
+    }
+
+    if (selectedWorkspaceId) {
+      deselectWorkspacePreservingSlots();
+      resetWorkspaceEditorState();
+    } else if (pendingWorkspaceEntry) {
+      setPendingWorkspaceEntry(null);
+      resetWorkspaceEditorState();
+    }
+    navigate(path);
+  }, [
+    deselectWorkspacePreservingSlots,
+    mobility.selectionLocked,
+    navigate,
+    pendingWorkspaceEntry,
+    selectedWorkspaceId,
+    setPendingWorkspaceEntry,
+    showToast,
+  ]);
+
+  const selectWorkspaceFromSurface = useCallback((workspaceId: string, source: string) => {
+    if (mobility.selectionLocked && workspaceId !== mobility.selectedLogicalWorkspaceId) {
+      showToast("Finish the current workspace move before switching workspaces.");
+      return;
+    }
+
+    navigateToWorkspaceShell();
+    if (workspaceId === mobility.selectedLogicalWorkspaceId) {
+      markWorkspaceViewed(workspaceId);
+    }
+    const latencyFlowId = startLatencyFlow({
+      flowKind: "workspace_switch",
+      source,
+      targetWorkspaceId: workspaceId,
+    });
+    void selectWorkspace(workspaceId, { latencyFlowId }).catch((error) => {
+      failLatencyFlow(latencyFlowId, "workspace_switch_failed");
+      const message = error instanceof Error ? error.message : String(error);
+      showToast(`Failed to select workspace: ${message}`);
+    });
+  }, [
+    mobility.selectedLogicalWorkspaceId,
+    mobility.selectionLocked,
+    navigateToWorkspaceShell,
+    selectWorkspace,
+    showToast,
+  ]);
+
+  return {
+    goToTopLevelRoute,
+    navigateToWorkspaceShell,
+    selectWorkspaceFromSurface,
+  };
+}

--- a/desktop/src/hooks/workspaces/use-workspace-sidebar-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-sidebar-actions.ts
@@ -1,38 +1,32 @@
 import { useCallback } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
 import type { WorkspacePurgeResponse, WorkspaceRetireResponse } from "@anyharness/sdk";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { APP_ROUTES } from "@/config/app-routes";
-import { resetWorkspaceEditorState } from "@/stores/editor/workspace-editor-state";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useWorkspaceMobilityState } from "@/hooks/workspaces/mobility/use-workspace-mobility-state";
 import { useCreateCloudWorkspace } from "@/hooks/cloud/use-create-cloud-workspace";
 import type { CloudWorkspaceRepoTarget } from "@/lib/domain/workspaces/cloud-workspace-creation";
 import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar";
 import { useWorkspaceEntryActions } from "./use-workspace-entry-actions";
-import { useWorkspaceSelection } from "./selection/use-workspace-selection";
 import { useWorkspaceActivationWorkflow } from "./use-workspace-activation-workflow";
 import { useAddRepo } from "./use-add-repo";
 import {
   failLatencyFlow,
   startLatencyFlow,
 } from "@/lib/infra/latency-flow";
-import { markWorkspaceViewed } from "@/stores/preferences/workspace-ui-store";
 import { useWorkspaceRetireActions } from "./use-workspace-retire-actions";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useWorkspaceNavigationWorkflow } from "./use-workspace-navigation-workflow";
 
 export function useWorkspaceSidebarActions() {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const setPendingWorkspaceEntry = useHarnessStore((state) => state.setPendingWorkspaceEntry);
-  const deselectWorkspacePreservingSlots = useHarnessStore(
-    (state) => state.deselectWorkspacePreservingSlots,
-  );
-  const pendingWorkspaceEntry = useHarnessStore((state) => state.pendingWorkspaceEntry);
   const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
   const mobility = useWorkspaceMobilityState();
-  const { selectWorkspace } = useWorkspaceSelection();
   const { openWorkspaceSession } = useWorkspaceActivationWorkflow();
+  const {
+    goToTopLevelRoute,
+    navigateToWorkspaceShell,
+    selectWorkspaceFromSurface,
+  } = useWorkspaceNavigationWorkflow();
   const {
     createLocalWorkspaceAndEnter,
     createWorktreeAndEnter,
@@ -51,36 +45,6 @@ export function useWorkspaceSidebarActions() {
     void addRepoFromPicker();
   }, [addRepoFromPicker]);
 
-  const navigateToWorkspaceShell = useCallback(() => {
-    if (location.pathname !== "/") {
-      navigate("/");
-    }
-  }, [location.pathname, navigate]);
-
-  const goToTopLevelRoute = useCallback((path: string) => {
-    if (mobility.selectionLocked) {
-      showToast("Finish the current workspace move before leaving this workspace.");
-      return;
-    }
-
-    if (selectedWorkspaceId) {
-      deselectWorkspacePreservingSlots();
-      resetWorkspaceEditorState();
-    } else if (pendingWorkspaceEntry) {
-      setPendingWorkspaceEntry(null);
-      resetWorkspaceEditorState();
-    }
-    navigate(path);
-  }, [
-    deselectWorkspacePreservingSlots,
-    mobility.selectionLocked,
-    navigate,
-    pendingWorkspaceEntry,
-    setPendingWorkspaceEntry,
-    selectedWorkspaceId,
-    showToast,
-  ]);
-
   const handleGoHome = useCallback(() => {
     goToTopLevelRoute(APP_ROUTES.home);
   }, [goToTopLevelRoute]);
@@ -94,32 +58,8 @@ export function useWorkspaceSidebarActions() {
   }, [goToTopLevelRoute]);
 
   const handleSelectWorkspace = useCallback((workspaceId: string) => {
-    if (mobility.selectionLocked && workspaceId !== mobility.selectedLogicalWorkspaceId) {
-      showToast("Finish the current workspace move before switching workspaces.");
-      return;
-    }
-
-    navigateToWorkspaceShell();
-    if (workspaceId === mobility.selectedLogicalWorkspaceId) {
-      markWorkspaceViewed(workspaceId);
-    }
-    const latencyFlowId = startLatencyFlow({
-      flowKind: "workspace_switch",
-      source: "sidebar",
-      targetWorkspaceId: workspaceId,
-    });
-    void selectWorkspace(workspaceId, { latencyFlowId }).catch((error) => {
-      failLatencyFlow(latencyFlowId, "workspace_switch_failed");
-      const message = error instanceof Error ? error.message : String(error);
-      showToast(`Failed to select workspace: ${message}`);
-    });
-  }, [
-    mobility.selectedLogicalWorkspaceId,
-    mobility.selectionLocked,
-    navigateToWorkspaceShell,
-    selectWorkspace,
-    showToast,
-  ]);
+    selectWorkspaceFromSurface(workspaceId, "sidebar");
+  }, [selectWorkspaceFromSurface]);
 
   const handleSidebarIndicatorAction = useCallback((action: SidebarIndicatorAction) => {
     switch (action.kind) {
@@ -175,7 +115,6 @@ export function useWorkspaceSidebarActions() {
     mobility.selectionLocked,
     navigateToWorkspaceShell,
     openWorkspaceSession,
-    selectWorkspace,
     showToast,
   ]);
 

--- a/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -8,8 +8,9 @@ describe("shortcut dispatch policy", () => {
   });
 
   it("respects defaultPrevented for non-rename shortcuts", () => {
-    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
-      key: "b",
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.openTerminal, {
+      key: "j",
+      code: "KeyJ",
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
@@ -82,13 +83,132 @@ describe("shortcut dispatch policy", () => {
       },
     });
 
-    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
-      key: "b",
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.addRepository, {
+      key: "i",
+      code: "KeyI",
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
       altKey: false,
       defaultPrevented: false,
+      target: null,
+    } as KeyboardEvent)).toBe(false);
+  });
+
+  it("allows left-sidebar toggle from text-entry and terminal focus targets", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: false,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+
+    vi.stubGlobal("document", {
+      activeElement: {
+        closest: () => ({
+          getAttribute: () => "terminal",
+        }),
+      },
+    });
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: false,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+  });
+
+  it("allows right-panel toggle from text-entry and terminal focus targets", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleRightPanel, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+      defaultPrevented: false,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+
+    vi.stubGlobal("document", {
+      activeElement: {
+        closest: () => ({
+          getAttribute: () => "terminal",
+        }),
+      },
+    });
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleRightPanel, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+      defaultPrevented: false,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+  });
+
+  it("allows only the exact left-sidebar toggle through when defaultPrevented", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: true,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleLeftSidebar, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: false,
+      defaultPrevented: true,
+      target: null,
+    } as KeyboardEvent)).toBe(false);
+  });
+
+  it("allows only the exact right-panel toggle through when defaultPrevented", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleRightPanel, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+      defaultPrevented: true,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.toggleRightPanel, {
+      key: "b",
+      code: "KeyB",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: true,
+      defaultPrevented: true,
       target: null,
     } as KeyboardEvent)).toBe(false);
   });

--- a/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
+++ b/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
@@ -11,7 +11,9 @@ type KeyboardShortcutEventLike = Pick<
   | "metaKey"
   | "shiftKey"
   | "target"
->;
+> & {
+  code?: string;
+};
 
 function isReloadBlockedRShortcut(
   shortcut: Pick<ShortcutDef, "id">,
@@ -47,11 +49,37 @@ function canBypassDefaultPrevented(
     return true;
   }
 
-  return shortcut.id === SHORTCUTS.openSettings.id
+  if (
+    shortcut.id === SHORTCUTS.openSettings.id
     && (event.metaKey || event.ctrlKey)
     && !event.altKey
     && !event.shiftKey
-    && event.key === ",";
+    && event.key === ","
+  ) {
+    return true;
+  }
+
+  if (
+    shortcut.id === SHORTCUTS.toggleLeftSidebar.id
+    && (event.metaKey || event.ctrlKey)
+    && !event.altKey
+    && !event.shiftKey
+    && (event.key.toLowerCase() === "b" || event.code === "KeyB")
+  ) {
+    return true;
+  }
+
+  if (
+    shortcut.id === SHORTCUTS.toggleRightPanel.id
+    && (event.metaKey || event.ctrlKey)
+    && event.altKey
+    && !event.shiftKey
+    && (event.key.toLowerCase() === "b" || event.code === "KeyB")
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function isTabCyclingShortcut(

--- a/desktop/src/lib/domain/shortcuts/matching.test.ts
+++ b/desktop/src/lib/domain/shortcuts/matching.test.ts
@@ -61,6 +61,25 @@ describe("shortcut matching", () => {
     )).toEqual({ digit: 7 });
   });
 
+  it("matches fixed physical-key shortcuts by code", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    expect(matchShortcutDef(
+      SHORTCUTS.goHome,
+      {
+        key: "<",
+        code: "Comma",
+        metaKey: true,
+        ctrlKey: false,
+        shiftKey: true,
+        altKey: false,
+      } as KeyboardEvent,
+    )).toEqual({});
+  });
+
   it("requires exact shift and alt modifiers", () => {
     expect(matchShortcut(
       { kind: "fixed", key: "p", meta: true, shift: false, alt: false },

--- a/desktop/src/lib/domain/shortcuts/matching.ts
+++ b/desktop/src/lib/domain/shortcuts/matching.ts
@@ -86,6 +86,8 @@ export function matchShortcut(
   switch (match.kind) {
     case "fixed":
       return normalizeKey(event.key) === normalizeKey(match.key) ? {} : null;
+    case "fixed-code":
+      return event.code === match.code ? {} : null;
     case "digit-key": {
       const digit = getShortcutDigitByKey(event.key);
       return digit ? { digit } : null;

--- a/desktop/src/lib/domain/shortcuts/native-accelerators.test.ts
+++ b/desktop/src/lib/domain/shortcuts/native-accelerators.test.ts
@@ -17,6 +17,7 @@ describe("getShortcutNativeAccelerator", () => {
 
   it("does not invent accelerators for shortcut ranges or platform-specific matches", () => {
     expect(getShortcutNativeAccelerator(SHORTCUTS.tabByIndex)).toBeNull();
+    expect(getShortcutNativeAccelerator(SHORTCUTS.goHome)).toBeNull();
     expect(getShortcutNativeAccelerator(SHORTCUTS.newCloud)).toBeNull();
   });
 });

--- a/desktop/src/lib/domain/workspaces/sidebar-shortcut-targets.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar-shortcut-targets.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import { SIDEBAR_REPO_GROUP_ITEM_LIMIT } from "@/lib/domain/workspaces/sidebar";
+import {
+  resolveSidebarShortcutDigitTarget,
+  visibleSidebarShortcutTargetIds,
+} from "@/lib/domain/workspaces/sidebar-shortcut-targets";
+import {
+  buildGroups,
+  makeCloudLogicalWorkspace,
+  makeLocalLogicalWorkspace,
+} from "@/lib/domain/workspaces/sidebar-test-fixtures";
+
+describe("visibleSidebarShortcutTargetIds", () => {
+  it("returns visible repository rows in sidebar group and item order", () => {
+    const logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "repo-a-older-record-newer-work",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+        kind: "worktree",
+        updatedAt: "2026-04-13T11:00:00.000Z",
+      }),
+      makeLocalLogicalWorkspace({
+        id: "repo-a-newer-record-older-work",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+        kind: "worktree",
+        updatedAt: "2026-04-13T12:00:00.000Z",
+      }),
+      makeLocalLogicalWorkspace({
+        id: "repo-b-latest",
+        repoKey: "/tmp/repo-b",
+        repoName: "repo-b",
+        updatedAt: "2026-04-13T09:00:00.000Z",
+      }),
+    ];
+    const groups = buildGroups({
+      logicalWorkspaces,
+      workspaceLastInteracted: {
+        "repo-a-older-record-newer-work": "2026-04-13T11:30:00.000Z",
+        "repo-a-newer-record-older-work": "2026-04-13T10:00:00.000Z",
+        "repo-b-latest": "2026-04-13T12:00:00.000Z",
+      },
+    });
+
+    expect(visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(),
+      repoGroupsShownMore: new Set(),
+      itemLimit: SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+    })).toEqual([
+      "repo-b-latest",
+      "repo-a-older-record-newer-work",
+      "repo-a-newer-record-older-work",
+    ]);
+  });
+
+  it("keeps selected type-filtered rows targetable when the sidebar kept them visible", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "local-visible",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+        }),
+        makeCloudLogicalWorkspace({
+          id: "cloud-selected",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+        }),
+      ],
+      workspaceTypes: ["local"],
+      selectedLogicalWorkspaceId: "cloud-selected",
+    });
+
+    expect(visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(),
+      repoGroupsShownMore: new Set(),
+      itemLimit: SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+    })).toEqual(["local-visible", "cloud-selected"]);
+  });
+
+  it("keeps selected archived rows targetable when the sidebar kept them visible", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "local-visible",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "archived-selected",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+        }),
+      ],
+      archivedIds: ["archived-selected"],
+      selectedLogicalWorkspaceId: "archived-selected",
+    });
+
+    expect(visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(),
+      repoGroupsShownMore: new Set(),
+      itemLimit: SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+    })).toEqual(["local-visible", "archived-selected"]);
+  });
+
+  it("omits collapsed repository groups and truncates groups that have not shown more", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        ...Array.from({ length: 8 }, (_, index) =>
+          makeLocalLogicalWorkspace({
+            id: `repo-a-${index + 1}`,
+            repoKey: "/tmp/repo-a",
+            repoName: "repo-a",
+            kind: "worktree",
+            updatedAt: `2026-04-13T10:0${index}:00.000Z`,
+          })),
+        makeLocalLogicalWorkspace({
+          id: "repo-b-hidden",
+          repoKey: "/tmp/repo-b",
+          repoName: "repo-b",
+        }),
+      ],
+    });
+
+    expect(visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(["/tmp/repo-b"]),
+      repoGroupsShownMore: new Set(),
+      itemLimit: 6,
+    })).toEqual([
+      "repo-a-1",
+      "repo-a-2",
+      "repo-a-3",
+      "repo-a-4",
+      "repo-a-5",
+      "repo-a-6",
+    ]);
+
+    expect(visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(["/tmp/repo-b"]),
+      repoGroupsShownMore: new Set(["/tmp/repo-a"]),
+      itemLimit: 6,
+    })).toEqual([
+      "repo-a-1",
+      "repo-a-2",
+      "repo-a-3",
+      "repo-a-4",
+      "repo-a-5",
+      "repo-a-6",
+      "repo-a-7",
+      "repo-a-8",
+    ]);
+  });
+
+  it("does not change target ids when visual-only sidebar inputs change", () => {
+    const logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "workspace-a",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+      makeLocalLogicalWorkspace({
+        id: "workspace-b",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+        kind: "worktree",
+      }),
+    ];
+    const baseGroups = buildGroups({ logicalWorkspaces });
+    const visualGroups = buildGroups({
+      logicalWorkspaces,
+      workspaceActivities: {
+        "workspace-a": "error",
+      },
+      pendingPromptCounts: {
+        "workspace-a": 2,
+      },
+      lastViewedAt: {
+        "workspace-a": "2026-04-13T10:00:00.000Z",
+      },
+      finishSuggestionsByWorkspaceId: {
+        "workspace-a-materialization": {
+          workspaceId: "workspace-a-materialization",
+          readinessFingerprint: "fingerprint-1",
+        },
+      },
+    });
+
+    const readTargets = (groups: typeof baseGroups) => visibleSidebarShortcutTargetIds({
+      groups,
+      collapsedRepoGroupKeys: new Set(),
+      repoGroupsShownMore: new Set(),
+      itemLimit: SIDEBAR_REPO_GROUP_ITEM_LIMIT,
+    });
+
+    expect(readTargets(visualGroups)).toEqual(readTargets(baseGroups));
+  });
+});
+
+describe("resolveSidebarShortcutDigitTarget", () => {
+  it("resolves digits one through eight by index and digit nine as the last target", () => {
+    const targetIds = ["a", "b", "c", "d"];
+
+    expect(resolveSidebarShortcutDigitTarget(targetIds, 1)).toBe("a");
+    expect(resolveSidebarShortcutDigitTarget(targetIds, 4)).toBe("d");
+    expect(resolveSidebarShortcutDigitTarget(targetIds, 9)).toBe("d");
+  });
+
+  it("returns null for missing targets", () => {
+    expect(resolveSidebarShortcutDigitTarget([], 9)).toBeNull();
+    expect(resolveSidebarShortcutDigitTarget(["a"], 2)).toBeNull();
+  });
+});

--- a/desktop/src/lib/domain/workspaces/sidebar-shortcut-targets.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar-shortcut-targets.ts
@@ -1,0 +1,34 @@
+import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
+import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar";
+
+export function visibleSidebarShortcutTargetIds(args: {
+  groups: readonly SidebarGroupState[];
+  collapsedRepoGroupKeys: ReadonlySet<string>;
+  repoGroupsShownMore: ReadonlySet<string>;
+  itemLimit: number;
+}): string[] {
+  const ids: string[] = [];
+
+  for (const group of args.groups) {
+    if (args.collapsedRepoGroupKeys.has(group.sourceRoot)) {
+      continue;
+    }
+
+    const visibleItems = args.repoGroupsShownMore.has(group.sourceRoot)
+      ? group.items
+      : group.items.slice(0, args.itemLimit);
+    for (const item of visibleItems) {
+      ids.push(item.id);
+    }
+  }
+
+  return ids;
+}
+
+export function resolveSidebarShortcutDigitTarget(
+  targetIds: readonly string[],
+  digit: ShortcutDigit,
+): string | null {
+  const index = digit === 9 ? targetIds.length - 1 : digit - 1;
+  return targetIds[index] ?? null;
+}

--- a/desktop/src/stores/preferences/workspace-ui-store.test.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.test.ts
@@ -41,6 +41,28 @@ describe("workspace ui tab persistence", () => {
     expect(state.manualChatGroupsByWorkspace).toEqual({});
   });
 
+  it("defaults and sanitizes persisted archived visibility", () => {
+    const missingState = {
+      ...WORKSPACE_UI_DEFAULTS,
+      migrationVersion: 8,
+    } as Partial<typeof WORKSPACE_UI_DEFAULTS> & { migrationVersion: number };
+    delete missingState.showArchived;
+
+    const missing = migrateWorkspaceUiState(
+      missingState as typeof WORKSPACE_UI_DEFAULTS,
+    );
+    const invalid = migrateWorkspaceUiState({
+      ...WORKSPACE_UI_DEFAULTS,
+      migrationVersion: 8,
+      showArchived: "yes" as never,
+    });
+
+    expect(missing.didMigrate).toBe(false);
+    expect(missing.state.showArchived).toBe(false);
+    expect(invalid.didMigrate).toBe(true);
+    expect(invalid.state.showArchived).toBe(false);
+  });
+
   it("defaults missing session error views without bumping migration", () => {
     const legacyState = {
       ...WORKSPACE_UI_DEFAULTS,
@@ -252,6 +274,17 @@ describe("workspace ui tab persistence", () => {
     store.markWorkspaceViewed("w2");
     expect(useWorkspaceUiStore.getState().lastViewedAt.w2)
       .toBe("2026-04-04T00:00:30.000Z");
+  });
+
+  it("stores archived workspace visibility", () => {
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+    });
+
+    useWorkspaceUiStore.getState().setShowArchived(true);
+
+    expect(useWorkspaceUiStore.getState().showArchived).toBe(true);
   });
 
   it("stores right panel preferences per workspace", () => {

--- a/desktop/src/stores/preferences/workspace-ui-store.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.ts
@@ -47,6 +47,7 @@ export interface WorkspaceUiState {
   archivedWorkspaceIds: string[];
   hiddenRepoRootIds: string[];
   collapsedRepoGroups: string[];
+  showArchived: boolean;
   threadsCollapsed: boolean;
   sidebarOpen: boolean;
   sidebarWidth: number;
@@ -76,6 +77,7 @@ export interface WorkspaceUiState {
   toggleRepoGroupCollapsed: (repoKey: string) => void;
   ensureRepoGroupExpanded: (repoKey: string) => void;
   setCollapsedRepoGroups: (keys: string[]) => void;
+  setShowArchived: (value: boolean) => void;
   setThreadsCollapsed: (value: boolean) => void;
   setSidebarOpen: (value: SetStateAction<boolean>) => void;
   setSidebarWidth: (value: SetStateAction<number>) => void;
@@ -187,6 +189,7 @@ export interface PersistedWorkspaceUiState {
   archivedWorkspaceIds: string[];
   hiddenRepoRootIds: string[];
   collapsedRepoGroups: string[];
+  showArchived: boolean;
   threadsCollapsed: boolean;
   sidebarOpen: boolean;
   sidebarWidth: number;
@@ -219,6 +222,7 @@ export const WORKSPACE_UI_DEFAULTS: PersistedWorkspaceUiState = {
   archivedWorkspaceIds: [],
   hiddenRepoRootIds: [],
   collapsedRepoGroups: [],
+  showArchived: false,
   threadsCollapsed: false,
   sidebarOpen: false,
   sidebarWidth: WORKSPACE_SIDEBAR_DEFAULT_WIDTH,
@@ -283,6 +287,7 @@ async function readAll(): Promise<{ state: PersistedWorkspaceUiState; didMigrate
         (await readPersistedValue<Record<string, string>>("workspaceLastInteracted"))
         ?? WORKSPACE_UI_DEFAULTS.workspaceLastInteracted,
       collapsedRepoGroups: WORKSPACE_UI_DEFAULTS.collapsedRepoGroups,
+      showArchived: WORKSPACE_UI_DEFAULTS.showArchived,
       threadsCollapsed: WORKSPACE_UI_DEFAULTS.threadsCollapsed,
       dismissedSetupFailures: WORKSPACE_UI_DEFAULTS.dismissedSetupFailures,
       finishSuggestionDismissalsByWorkspaceId:
@@ -350,6 +355,11 @@ export function migrateWorkspaceUiState(
 
   if (typeof state.sidebarOpen !== "boolean") {
     state.sidebarOpen = WORKSPACE_UI_DEFAULTS.sidebarOpen;
+    didMigrate = true;
+  }
+
+  if (typeof state.showArchived !== "boolean") {
+    state.showArchived = WORKSPACE_UI_DEFAULTS.showArchived;
     didMigrate = true;
   }
 
@@ -453,6 +463,7 @@ function selectPersistedSlice(state: WorkspaceUiState): PersistedWorkspaceUiStat
     archivedWorkspaceIds: state.archivedWorkspaceIds,
     hiddenRepoRootIds: state.hiddenRepoRootIds,
     collapsedRepoGroups: state.collapsedRepoGroups,
+    showArchived: state.showArchived,
     threadsCollapsed: state.threadsCollapsed,
     sidebarOpen: state.sidebarOpen,
     sidebarWidth: state.sidebarWidth,
@@ -689,6 +700,10 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
 
   setCollapsedRepoGroups: (keys) => {
     set({ collapsedRepoGroups: keys });
+  },
+
+  setShowArchived: (value) => {
+    set({ showArchived: value });
   },
 
   setThreadsCollapsed: (value) => {


### PR DESCRIPTION
## Summary
- align workspace index shortcuts with sidebar-visible repo row ordering
- add Cmd+Shift+Comma home navigation and physical-key matching for shifted shortcuts
- make left/right panel B shortcuts consistent across input and terminal focus, including shell-scoped Cmd+B
- extract shared workspace navigation workflow and right-panel focus token behavior

## Validation
- pnpm --dir desktop exec vitest run src/hooks/workspaces/use-workspace-navigation-workflow.test.tsx src/lib/domain/workspaces/sidebar-shortcut-targets.test.ts src/hooks/main/use-main-screen-shortcuts.test.tsx src/hooks/shortcuts/use-shortcut-dispatcher.test.ts src/lib/domain/shortcuts/dispatch-policy.test.ts src/lib/domain/shortcuts/matching.test.ts src/lib/domain/shortcuts/native-accelerators.test.ts src/components/workspace/shell/right-panel/RightPanel.test.tsx src/hooks/main/use-main-screen-actions.test.tsx src/stores/preferences/workspace-ui-store.test.ts
- pnpm --dir desktop exec tsc --noEmit --pretty false
- git diff --check