### PR TITLE
Add latency diagnostics instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 .venv/
 
+reference/
+
 # Build output
 dist/
 out/

--- a/anyharness/crates/anyharness-lib/src/api/http/git.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/git.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use anyharness_contract::v1::{
     CommitRequest, CommitResponse, GitActionAvailability as ContractGitActionAvailability,
     GitBranchDiffFilesResponse, GitBranchRef, GitChangedFile as ContractGitChangedFile,
@@ -9,12 +11,14 @@ use anyharness_contract::v1::{
 };
 use axum::{
     extract::{Path, Query, State},
+    http::HeaderMap,
     Json,
 };
 use serde::Deserialize;
 
 use super::access::{assert_workspace_mutable, assert_workspace_not_retired};
 use super::error::ApiError;
+use super::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::app::AppState;
 use crate::git::types::{
     CommitError, GitActionAvailability as InternalGitActionAvailability,
@@ -40,7 +44,7 @@ fn resolve_workspace_path(
     Ok(std::path::PathBuf::from(workspace.path))
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum GitTaskAccess {
     Read,
     Write,
@@ -57,24 +61,62 @@ where
     T: Send + 'static,
     F: FnOnce(String, std::path::PathBuf) -> Result<T, ApiError> + Send + 'static,
 {
+    let started = Instant::now();
     // Acquire exactly one operation lease per request. Nested read leases can
     // deadlock behind a queued exclusive retire lease.
     let operation_kind = match access {
         GitTaskAccess::Read => WorkspaceOperationKind::MaterializationRead,
         GitTaskAccess::Write => WorkspaceOperationKind::GitWrite,
     };
+    let lease_started = Instant::now();
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, operation_kind)
         .await;
+    tracing::info!(
+        workspace_id = %workspace_id,
+        task_label = task_label,
+        access = ?access,
+        elapsed_ms = lease_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        "[anyharness-latency] git.http.task.lease_acquired"
+    );
+    let access_started = Instant::now();
     match access {
         GitTaskAccess::Read => assert_workspace_not_retired(state, &workspace_id)?,
         GitTaskAccess::Write => assert_workspace_mutable(state, &workspace_id)?,
     }
+    tracing::info!(
+        workspace_id = %workspace_id,
+        task_label = task_label,
+        access = ?access,
+        elapsed_ms = access_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        "[anyharness-latency] git.http.task.access_checked"
+    );
     let workspace_runtime = state.workspace_runtime.clone();
     tokio::task::spawn_blocking(move || {
+        let blocking_started = Instant::now();
+        let resolve_started = Instant::now();
         let workspace_path = resolve_workspace_path(&workspace_runtime, &workspace_id)?;
-        task(workspace_id, workspace_path)
+        tracing::info!(
+            workspace_id = %workspace_id,
+            task_label = task_label,
+            elapsed_ms = resolve_started.elapsed().as_millis(),
+            blocking_elapsed_ms = blocking_started.elapsed().as_millis(),
+            "[anyharness-latency] git.http.task.workspace_path_resolved"
+        );
+        let task_started = Instant::now();
+        let result = task(workspace_id.clone(), workspace_path);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            task_label = task_label,
+            success = result.is_ok(),
+            elapsed_ms = task_started.elapsed().as_millis(),
+            blocking_elapsed_ms = blocking_started.elapsed().as_millis(),
+            "[anyharness-latency] git.http.task.completed"
+        );
+        result
     })
     .await
     .map_err(|e| ApiError::internal(format!("{task_label} task failed: {e}")))?
@@ -96,11 +138,24 @@ where
 )]
 pub async fn get_git_status(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<GitStatusSnapshot>, ApiError> {
+    let latency = LatencyRequestContext::from_headers(&headers);
+    let latency_fields = latency_trace_fields(latency.as_ref());
+    let started = Instant::now();
+    tracing::info!(
+        workspace_id = %workspace_id,
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] git.http.status.request_received"
+    );
     let snapshot = run_git_task(
         &state,
-        workspace_id,
+        workspace_id.clone(),
         GitTaskAccess::Read,
         "git status",
         |workspace_id, ws_path| {
@@ -111,6 +166,18 @@ pub async fn get_git_status(
     )
     .await?;
 
+    tracing::info!(
+        workspace_id = %workspace_id,
+        changed_files = snapshot.summary.changed_files,
+        included_files = snapshot.summary.included_files,
+        elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] git.http.status.response_ready"
+    );
     Ok(Json(snapshot))
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/latency.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/latency.rs
@@ -4,6 +4,7 @@ const FLOW_ID_HEADER: &str = "x-anyharness-flow-id";
 const FLOW_KIND_HEADER: &str = "x-anyharness-flow-kind";
 const FLOW_SOURCE_HEADER: &str = "x-anyharness-flow-source";
 const PROMPT_ID_HEADER: &str = "x-anyharness-prompt-id";
+const MEASUREMENT_OPERATION_ID_HEADER: &str = "x-proliferate-measurement-operation-id";
 
 #[derive(Debug, Clone, Default)]
 pub struct LatencyRequestContext {
@@ -11,6 +12,7 @@ pub struct LatencyRequestContext {
     flow_kind: Option<String>,
     flow_source: Option<String>,
     prompt_id: Option<String>,
+    measurement_operation_id: Option<String>,
 }
 
 impl LatencyRequestContext {
@@ -20,12 +22,14 @@ impl LatencyRequestContext {
             flow_kind: header_value(headers, FLOW_KIND_HEADER),
             flow_source: header_value(headers, FLOW_SOURCE_HEADER),
             prompt_id: header_value(headers, PROMPT_ID_HEADER),
+            measurement_operation_id: header_value(headers, MEASUREMENT_OPERATION_ID_HEADER),
         };
 
         if context.flow_id.is_none()
             && context.flow_kind.is_none()
             && context.flow_source.is_none()
             && context.prompt_id.is_none()
+            && context.measurement_operation_id.is_none()
         {
             return None;
         }
@@ -48,6 +52,10 @@ impl LatencyRequestContext {
     pub fn prompt_id(&self) -> Option<&str> {
         self.prompt_id.as_deref()
     }
+
+    pub fn measurement_operation_id(&self) -> Option<&str> {
+        self.measurement_operation_id.as_deref()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -56,6 +64,7 @@ pub struct LatencyTraceFields<'a> {
     pub flow_kind: Option<&'a str>,
     pub flow_source: Option<&'a str>,
     pub prompt_id: Option<&'a str>,
+    pub measurement_operation_id: Option<&'a str>,
 }
 
 pub fn latency_trace_fields(latency: Option<&LatencyRequestContext>) -> LatencyTraceFields<'_> {
@@ -64,6 +73,7 @@ pub fn latency_trace_fields(latency: Option<&LatencyRequestContext>) -> LatencyT
         flow_kind: latency.and_then(LatencyRequestContext::flow_kind),
         flow_source: latency.and_then(LatencyRequestContext::flow_source),
         prompt_id: latency.and_then(LatencyRequestContext::prompt_id),
+        measurement_operation_id: latency.and_then(LatencyRequestContext::measurement_operation_id),
     }
 }
 
@@ -99,6 +109,10 @@ mod tests {
             "x-anyharness-prompt-id",
             HeaderValue::from_static("prompt-456"),
         );
+        headers.insert(
+            "x-proliferate-measurement-operation-id",
+            HeaderValue::from_static("mop_123"),
+        );
 
         let context = LatencyRequestContext::from_headers(&headers)
             .expect("expected latency request context");
@@ -107,6 +121,7 @@ mod tests {
         assert_eq!(context.flow_kind(), Some("prompt_submit"));
         assert_eq!(context.flow_source(), Some("composer_submit"));
         assert_eq!(context.prompt_id(), Some("prompt-456"));
+        assert_eq!(context.measurement_operation_id(), Some("mop_123"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use anyharness_contract::v1::{
     DetectProjectSetupResponse, GitBranchRef, PrepareRepoRootMobilityDestinationRequest,
     PrepareRepoRootMobilityDestinationResponse, ReadWorkspaceFileResponse, RepoRoot, RepoRootKind,
@@ -5,6 +7,7 @@ use anyharness_contract::v1::{
 };
 use axum::{
     extract::{Path, Query, State},
+    http::HeaderMap,
     Json,
 };
 
@@ -12,6 +15,7 @@ use super::access::map_access_error;
 use super::blocking::run_blocking;
 use super::error::ApiError;
 use super::files::{map_service_error, read_response_to_contract, run_files_task, FilePathQuery};
+use super::latency::{latency_trace_fields, LatencyRequestContext};
 use super::workspaces::workspace_to_contract;
 use super::workspaces_contract::detection_result_to_contract;
 use crate::app::AppState;
@@ -28,16 +32,54 @@ use crate::workspaces::types::ResolveRepoRootError;
 )]
 pub async fn list_repo_roots(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<RepoRoot>>, ApiError> {
+    let latency = LatencyRequestContext::from_headers(&headers);
+    let latency_fields = latency_trace_fields(latency.as_ref());
+    let started = Instant::now();
+    tracing::info!(
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] repo_root.http.list.request_received"
+    );
     let repo_root_service = state.repo_root_service.clone();
+    let records_started = Instant::now();
     let repo_roots = run_blocking("list repo roots", move || {
         repo_root_service.list_repo_roots()
     })
     .await?
     .map_err(|error| ApiError::internal(error.to_string()))?;
-    Ok(Json(
-        repo_roots.into_iter().map(repo_root_to_contract).collect(),
-    ))
+    tracing::info!(
+        repo_root_count = repo_roots.len(),
+        elapsed_ms = records_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] repo_root.http.list.records_loaded"
+    );
+    let response_started = Instant::now();
+    let response = repo_roots
+        .into_iter()
+        .map(repo_root_to_contract)
+        .collect::<Vec<_>>();
+    tracing::info!(
+        repo_root_count = response.len(),
+        elapsed_ms = response_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] repo_root.http.list.response_built"
+    );
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
@@ -237,31 +237,78 @@ pub async fn create_worktree(
 )]
 pub async fn list_workspaces(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<Workspace>>, ApiError> {
+    let latency = LatencyRequestContext::from_headers(&headers);
+    let latency_fields = latency_trace_fields(latency.as_ref());
+    let started = Instant::now();
+    tracing::info!(
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] workspace.http.list.request_received"
+    );
     let workspace_runtime = state.workspace_runtime.clone();
+    let records_started = Instant::now();
     let records = run_blocking("list", move || workspace_runtime.list_workspaces())
         .await?
         .map_err(|e| ApiError::internal(e.to_string()))?;
+    tracing::info!(
+        workspace_count = records.len(),
+        elapsed_ms = records_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] workspace.http.list.records_loaded"
+    );
+    let summaries_started = Instant::now();
     let summaries = state
         .session_runtime
         .workspace_execution_summaries()
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
-    Ok(Json(
-        records
-            .into_iter()
-            .map(|record| {
-                let workspace_id = record.id.clone();
-                workspace_to_contract_with_summary(
-                    record,
-                    summaries
-                        .get(&workspace_id)
-                        .cloned()
-                        .unwrap_or_else(idle_workspace_execution_summary),
-                )
-            })
-            .collect(),
-    ))
+    tracing::info!(
+        summary_count = summaries.len(),
+        elapsed_ms = summaries_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] workspace.http.list.execution_summaries_loaded"
+    );
+    let response_started = Instant::now();
+    let response = records
+        .into_iter()
+        .map(|record| {
+            let workspace_id = record.id.clone();
+            workspace_to_contract_with_summary(
+                record,
+                summaries
+                    .get(&workspace_id)
+                    .cloned()
+                    .unwrap_or_else(idle_workspace_execution_summary),
+            )
+        })
+        .collect::<Vec<_>>();
+    tracing::info!(
+        workspace_count = response.len(),
+        elapsed_ms = response_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] workspace.http.list.response_built"
+    );
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/sse/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/sse/sessions.rs
@@ -48,15 +48,30 @@ pub async fn stream_session(
         session_id = %session_id,
         after_seq,
         flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
         "[workspace-latency] session.sse.request_received"
     );
     let acp_manager = state.acp_manager.clone();
+    let live_handle_started = Instant::now();
     let live_handle = acp_manager.get_handle(&session_id).await;
     let live_rx = live_handle.as_ref().map(|handle| handle.subscribe());
+    tracing::info!(
+        session_id = %session_id,
+        has_live_handle = live_handle.is_some(),
+        elapsed_ms = live_handle_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] session.sse.live_handle_checked"
+    );
 
+    let backlog_query_started = Instant::now();
     let backlog_records = state
         .session_service
         .list_session_event_records(&session_id, Some(after_seq), None, None, None)
@@ -67,11 +82,38 @@ pub async fn stream_session(
                 "SESSION_NOT_FOUND",
             )
         })?;
+    tracing::info!(
+        session_id = %session_id,
+        after_seq,
+        backlog_record_count = backlog_records.len(),
+        elapsed_ms = backlog_query_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] session.sse.backlog_records_loaded"
+    );
 
+    let backlog_map_started = Instant::now();
     let backlog = backlog_records
         .into_iter()
         .filter_map(event_record_to_envelope)
         .collect::<Vec<_>>();
+    tracing::info!(
+        session_id = %session_id,
+        after_seq,
+        backlog_count = backlog.len(),
+        elapsed_ms = backlog_map_started.elapsed().as_millis(),
+        total_elapsed_ms = started.elapsed().as_millis(),
+        flow_id = latency_fields.flow_id,
+        flow_kind = latency_fields.flow_kind,
+        flow_source = latency_fields.flow_source,
+        prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
+        "[anyharness-latency] session.sse.backlog_mapped"
+    );
     tracing::info!(
         session_id = %session_id,
         after_seq,
@@ -82,6 +124,7 @@ pub async fn stream_session(
         flow_kind = latency_fields.flow_kind,
         flow_source = latency_fields.flow_source,
         prompt_id = latency_fields.prompt_id,
+        measurement_operation_id = latency_fields.measurement_operation_id,
         "[workspace-latency] session.sse.open"
     );
     let max_sent_seq = Arc::new(AtomicI64::new(
@@ -105,6 +148,7 @@ pub async fn stream_session(
                     return stream::empty().boxed();
                 };
                 let after_seq = max_sent_seq.load(Ordering::Acquire);
+                let replay_started = Instant::now();
                 let replay = match session_service.list_session_event_records(
                     &session_id,
                     Some(after_seq),
@@ -130,6 +174,7 @@ pub async fn stream_session(
                     session_id = %session_id,
                     after_seq,
                     replay_count = replay.len(),
+                    elapsed_ms = replay_started.elapsed().as_millis(),
                     "[workspace-latency] session.sse.await_live_handle.replay"
                 );
                 let replay_stream = stream::iter(replay.into_iter().filter_map({

--- a/anyharness/crates/anyharness-lib/src/git/service.rs
+++ b/anyharness/crates/anyharness-lib/src/git/service.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::default_branch::detect_default_branch;
 use super::diff;
@@ -21,21 +21,61 @@ impl GitService {
     }
 
     pub fn status(workspace_id: &str, workspace_path: &Path) -> anyhow::Result<GitStatusSnapshot> {
+        let started = Instant::now();
+        let repo_root_started = Instant::now();
         let repo_root = run_git_ok(workspace_path, &["rev-parse", "--show-toplevel"])?
             .trim()
             .to_string();
         let repo_root_path = PathBuf::from(&repo_root);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            elapsed_ms = repo_root_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.repo_root_resolved"
+        );
 
+        let porcelain_started = Instant::now();
         let raw = run_git_ok(
             &repo_root_path,
             &["status", "--porcelain=v2", "--branch", "-z"],
         )?;
+        tracing::info!(
+            workspace_id = %workspace_id,
+            output_bytes = raw.len(),
+            elapsed_ms = porcelain_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.porcelain_loaded"
+        );
 
+        let parse_started = Instant::now();
         let mut parsed = parse_porcelain_v2(&raw);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            changed_files = parsed.files.len(),
+            elapsed_ms = parse_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.porcelain_parsed"
+        );
 
+        let operation_started = Instant::now();
         parsed.operation = detect_operation(&repo_root_path);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            operation = ?parsed.operation,
+            elapsed_ms = operation_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.operation_detected"
+        );
 
-        enrich_file_stats(&repo_root_path, &mut parsed.files);
+        let enrich_started = Instant::now();
+        enrich_file_stats(workspace_id, &repo_root_path, &mut parsed.files);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            changed_files = parsed.files.len(),
+            elapsed_ms = enrich_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.file_stats_enriched"
+        );
 
         let detached = parsed.branch_head.is_none();
 
@@ -67,9 +107,17 @@ impl GitService {
         .to_string();
         let can_create_pr = !detached && has_upstream && parsed.ahead == 0 && clean;
 
+        let default_branch_started = Instant::now();
         let suggested_base = detect_default_branch(&repo_root_path);
+        tracing::info!(
+            workspace_id = %workspace_id,
+            has_suggested_base = suggested_base.is_some(),
+            elapsed_ms = default_branch_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.default_branch_detected"
+        );
 
-        Ok(GitStatusSnapshot {
+        let snapshot = GitStatusSnapshot {
             workspace_id: workspace_id.to_string(),
             workspace_path: workspace_path.display().to_string(),
             repo_root_path: repo_root,
@@ -104,7 +152,16 @@ impl GitService {
                 },
             },
             files: parsed.files,
-        })
+        };
+        tracing::info!(
+            workspace_id = %workspace_id,
+            changed_files = snapshot.summary.changed_files,
+            additions = snapshot.summary.additions,
+            deletions = snapshot.summary.deletions,
+            elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.status.completed"
+        );
+        Ok(snapshot)
     }
 
     pub fn diff_for_path(workspace_path: &Path, file_path: &str) -> anyhow::Result<GitDiffResult> {
@@ -435,9 +492,22 @@ fn detect_operation(repo_root: &Path) -> GitOperation {
     }
 }
 
-fn enrich_file_stats(repo_root: &Path, files: &mut [GitChangedFile]) {
+fn enrich_file_stats(workspace_id: &str, repo_root: &Path, files: &mut [GitChangedFile]) {
+    let unstaged_started = Instant::now();
     let numstat = run_git(repo_root, &["diff", "--numstat", "-z"]);
+    let unstaged_elapsed_ms = unstaged_started.elapsed().as_millis();
+    let unstaged_success = numstat
+        .as_ref()
+        .map(|output| output.success)
+        .unwrap_or(false);
+
+    let staged_started = Instant::now();
     let staged_numstat = run_git(repo_root, &["diff", "--cached", "--numstat", "-z"]);
+    let staged_elapsed_ms = staged_started.elapsed().as_millis();
+    let staged_success = staged_numstat
+        .as_ref()
+        .map(|output| output.success)
+        .unwrap_or(false);
 
     fn apply_numstats(raw: &str, files: &mut [GitChangedFile]) {
         for chunk in raw.split('\0') {
@@ -472,6 +542,15 @@ fn enrich_file_stats(repo_root: &Path, files: &mut [GitChangedFile]) {
             apply_numstats(&o.stdout, files);
         }
     }
+    tracing::info!(
+        workspace_id = %workspace_id,
+        file_count = files.len(),
+        unstaged_elapsed_ms,
+        unstaged_success,
+        staged_elapsed_ms,
+        staged_success,
+        "[anyharness-latency] git.status.numstat_loaded"
+    );
 }
 
 fn git_command_message(stderr: &str, fallback: &str) -> String {

--- a/anyharness/crates/anyharness-lib/src/repo_roots/service.rs
+++ b/anyharness/crates/anyharness-lib/src/repo_roots/service.rs
@@ -1,3 +1,4 @@
+use std::time::Instant;
 use uuid::Uuid;
 
 use super::model::{CreateRepoRootInput, RepoRootRecord};
@@ -22,7 +23,14 @@ impl RepoRootService {
     }
 
     pub fn list_repo_roots(&self) -> anyhow::Result<Vec<RepoRootRecord>> {
-        self.store.list_all()
+        let started = Instant::now();
+        let records = self.store.list_all()?;
+        tracing::info!(
+            repo_root_count = records.len(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] repo_root.service.list.store_loaded"
+        );
+        Ok(records)
     }
 
     pub fn ensure_repo_root(&self, input: CreateRepoRootInput) -> anyhow::Result<RepoRootRecord> {

--- a/anyharness/crates/anyharness-lib/src/workspaces/resolver.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/resolver.rs
@@ -4,14 +4,48 @@ use std::time::Instant;
 
 use super::model::{ParsedRemote, ResolvedGitContext};
 
+const GIT_CONTEXT_SLOW_STEP_MS: u128 = 25;
+
 pub fn resolve_git_context(path: &str) -> anyhow::Result<ResolvedGitContext> {
+    let started = Instant::now();
+    let canonicalize_started = Instant::now();
     let canon = std::fs::canonicalize(path)
         .map_err(|e| anyhow::anyhow!("cannot resolve path '{}': {}", path, e))?;
+    log_git_context_step_if_slow(
+        path,
+        "canonicalize",
+        canonicalize_started.elapsed().as_millis(),
+        true,
+    );
 
+    let repo_root_started = Instant::now();
     let repo_root = git_rev_parse(&canon, "--show-toplevel")?;
+    log_git_context_step_if_slow(
+        path,
+        "rev_parse_show_toplevel",
+        repo_root_started.elapsed().as_millis(),
+        true,
+    );
 
-    let common_dir = git_rev_parse(&canon, "--git-common-dir").ok();
-    let git_dir = git_rev_parse(&canon, "--git-dir").ok();
+    let common_dir_started = Instant::now();
+    let common_dir_result = git_rev_parse(&canon, "--git-common-dir");
+    log_git_context_step_if_slow(
+        path,
+        "rev_parse_git_common_dir",
+        common_dir_started.elapsed().as_millis(),
+        common_dir_result.is_ok(),
+    );
+    let common_dir = common_dir_result.ok();
+
+    let git_dir_started = Instant::now();
+    let git_dir_result = git_rev_parse(&canon, "--git-dir");
+    log_git_context_step_if_slow(
+        path,
+        "rev_parse_git_dir",
+        git_dir_started.elapsed().as_millis(),
+        git_dir_result.is_ok(),
+    );
+    let git_dir = git_dir_result.ok();
 
     let is_worktree = match (&common_dir, &git_dir) {
         (Some(common), Some(git)) => {
@@ -34,8 +68,35 @@ pub fn resolve_git_context(path: &str) -> anyhow::Result<ResolvedGitContext> {
         None
     };
 
-    let current_branch = git_rev_parse(&canon, "--abbrev-ref HEAD").ok();
-    let remote_url = git_config_get(&canon, "remote.origin.url").ok();
+    let branch_started = Instant::now();
+    let current_branch_result = git_rev_parse(&canon, "--abbrev-ref HEAD");
+    log_git_context_step_if_slow(
+        path,
+        "rev_parse_current_branch",
+        branch_started.elapsed().as_millis(),
+        current_branch_result.is_ok(),
+    );
+    let current_branch = current_branch_result.ok();
+
+    let remote_started = Instant::now();
+    let remote_url_result = git_config_get(&canon, "remote.origin.url");
+    log_git_context_step_if_slow(
+        path,
+        "config_remote_origin_url",
+        remote_started.elapsed().as_millis(),
+        remote_url_result.is_ok(),
+    );
+    let remote_url = remote_url_result.ok();
+
+    let total_elapsed_ms = started.elapsed().as_millis();
+    if total_elapsed_ms >= GIT_CONTEXT_SLOW_STEP_MS {
+        tracing::info!(
+            path = %path,
+            is_worktree,
+            elapsed_ms = total_elapsed_ms,
+            "[anyharness-latency] git_context.resolve_slow"
+        );
+    }
 
     Ok(ResolvedGitContext {
         repo_root,
@@ -44,6 +105,19 @@ pub fn resolve_git_context(path: &str) -> anyhow::Result<ResolvedGitContext> {
         current_branch,
         remote_url,
     })
+}
+
+fn log_git_context_step_if_slow(path: &str, step: &str, elapsed_ms: u128, success: bool) {
+    if elapsed_ms < GIT_CONTEXT_SLOW_STEP_MS {
+        return;
+    }
+    tracing::info!(
+        path = %path,
+        step = step,
+        success,
+        elapsed_ms,
+        "[anyharness-latency] git_context.step_slow"
+    );
 }
 
 pub fn parse_remote_url(url: &str) -> Option<ParsedRemote> {

--- a/anyharness/crates/anyharness-lib/src/workspaces/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/runtime.rs
@@ -419,11 +419,44 @@ impl WorkspaceRuntime {
     }
 
     pub fn list_workspaces(&self) -> anyhow::Result<Vec<WorkspaceRecord>> {
-        self.store
-            .list_execution_surfaces()?
-            .into_iter()
-            .map(reconcile_current_branch)
-            .collect()
+        let started = Instant::now();
+        let store_started = Instant::now();
+        let records = self.store.list_execution_surfaces()?;
+        tracing::info!(
+            workspace_count = records.len(),
+            elapsed_ms = store_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] workspace.runtime.list.store_loaded"
+        );
+
+        let reconcile_started = Instant::now();
+        let mut reconciled = Vec::with_capacity(records.len());
+        let mut slow_reconcile_count = 0_u32;
+        for record in records {
+            let workspace_id = record.id.clone();
+            let kind = record.kind.clone();
+            let item_started = Instant::now();
+            let reconciled_record = reconcile_current_branch(record)?;
+            let item_elapsed_ms = item_started.elapsed().as_millis();
+            if item_elapsed_ms >= 25 {
+                slow_reconcile_count = slow_reconcile_count.saturating_add(1);
+                tracing::info!(
+                    workspace_id = %workspace_id,
+                    kind = %kind,
+                    elapsed_ms = item_elapsed_ms,
+                    "[anyharness-latency] workspace.runtime.list.reconcile_slow"
+                );
+            }
+            reconciled.push(reconciled_record);
+        }
+        tracing::info!(
+            workspace_count = reconciled.len(),
+            slow_reconcile_count,
+            elapsed_ms = reconcile_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] workspace.runtime.list.reconciled"
+        );
+        Ok(reconciled)
     }
 
     pub fn set_lifecycle_cleanup_state(

--- a/desktop/src/components/cloud/repo-settings/RepoTrackedFilesCard.tsx
+++ b/desktop/src/components/cloud/repo-settings/RepoTrackedFilesCard.tsx
@@ -64,7 +64,7 @@ export function RepoTrackedFilesCard({
       >
         <div className="space-y-3">
           <PopoverButton
-            align="start"
+            align="end"
             trigger={(
               <Button
                 type="button"

--- a/desktop/src/components/settings/panes/GeneralPane.tsx
+++ b/desktop/src/components/settings/panes/GeneralPane.tsx
@@ -185,7 +185,7 @@ export function GeneralPane() {
           </SettingsCardRow>
           <SettingsCardRow
             label="Plugins setup"
-            description="Connector setup, auth, and enablement stay on the Plugins page."
+            description="Configure your plugins."
           >
             <Button
               type="button"

--- a/desktop/src/components/ui/PopoverButton.tsx
+++ b/desktop/src/components/ui/PopoverButton.tsx
@@ -52,7 +52,7 @@ export function PopoverButton({
   trigger,
   children,
   align = "start",
-  side = "bottom",
+  side = "auto",
   offset = 4,
   className = "w-56 rounded-xl border border-border bg-popover p-1 shadow-floating",
   stopPropagation = false,

--- a/desktop/src/components/ui/icons.tsx
+++ b/desktop/src/components/ui/icons.tsx
@@ -1,5 +1,4 @@
 import { useId, type ComponentType, type SVGProps } from "react";
-import { useBrailleSweep } from "@/hooks/ui/use-braille-sweep";
 
 export type IconProps = SVGProps<SVGSVGElement>;
 
@@ -977,17 +976,15 @@ export function Spinner({ className }: { className?: string }) {
 /**
  * Animated braille-sweep badge — the diagonal-fill loading vocabulary used
  * across the app (transcript indicator, chat tab badges, sidebar workspace
- * rows). Driven by the shared useBrailleSweep ticker so every instance
- * animates in lockstep. Pass `className` for size and color.
+ * rows). The frames are CSS-driven so loaders do not force React commits while
+ * they are visible. Pass `className` for size and color.
  */
 export function BrailleSweepBadge({ className }: { className?: string }) {
-  const frame = useBrailleSweep();
   return (
     <span
-      className={`inline-block w-[1em] shrink-0 font-mono leading-none tracking-[-0.18em] ${className ?? ""}`}
-    >
-      {frame}
-    </span>
+      aria-hidden="true"
+      className={`braille-sweep-frame inline-block w-[1em] shrink-0 font-mono leading-none tracking-[-0.18em] ${className ?? ""}`}
+    />
   );
 }
 
@@ -1125,7 +1122,7 @@ export function ProliferateIcon({ className, ...props }: IconProps) {
 
 
 /**
- * Proliferate loading mark — uses the shared braille sweep so the loading
+ * Proliferate loading mark — uses the shared CSS braille sweep so the loading
  * vocabulary stays consistent across the app. Sized via `className` with a
  * `text-Xl` token (the braille is a glyph, not an SVG).
  */

--- a/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/desktop/src/components/workspace/chat/ChatView.tsx
@@ -22,6 +22,7 @@ import { useCloudWorkspacePolling } from "@/hooks/chat/use-cloud-workspace-polli
 import { useComposerDockSlots } from "@/hooks/chat/use-composer-dock-slots";
 import { useQueuedPromptEditStatus } from "@/hooks/chat/use-queued-prompt-edit";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { useSessionErrorAcknowledgement } from "@/hooks/sessions/use-session-error-acknowledgement";
 import { useSelectedCloudRuntimeRehydration } from "@/hooks/workspaces/use-selected-cloud-runtime-rehydration";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
@@ -139,6 +140,22 @@ export function ChatView({
   useSelectedCloudRuntimeRehydration(selectedCloudRuntime);
   useSessionErrorAcknowledgement();
   useWorkspaceMobilityLifecycle();
+
+  useDebugValueChange("chat_surface.inputs", "chat_view_refs", {
+    modeKind: mode.kind,
+    activeSessionId,
+    activePromptCapabilities,
+    availability,
+    queuedPromptEditStatus,
+    selectedCloudRuntimeState: selectedCloudRuntime.state,
+    composerDockSlots,
+    promptAttachments,
+    canAcceptFileDrop,
+    dockSafeAreaPx,
+    lowerBackdropTopPx,
+    scrollBottomInsetPx,
+    stickyBottomInsetPx,
+  });
 
   const handleFileDrag = useCallback((event: DragEvent<HTMLDivElement>) => {
     const dragInput = readFileDragInput(event.dataTransfer);

--- a/desktop/src/components/workspace/chat/surface/ChatLoadingHero.tsx
+++ b/desktop/src/components/workspace/chat/surface/ChatLoadingHero.tsx
@@ -1,6 +1,6 @@
-import { useBrailleSweep } from "@/hooks/ui/use-braille-sweep";
 import { useChatLoadingSubstep } from "@/hooks/chat/use-chat-loading-substep";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
+import { BrailleSweepBadge } from "@/components/ui/icons";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
 
 /**
@@ -15,18 +15,12 @@ import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
  */
 export function ChatLoadingHero() {
   useDebugRenderCount("loading-braille");
-  const frame = useBrailleSweep();
   const { caption, workspaceName } = useChatLoadingSubstep();
 
   return (
     <DebugProfiler id="loading-braille">
       <div className="flex flex-col items-center text-center">
-      <span
-        aria-hidden
-        className="font-mono text-6xl leading-none tracking-[-0.18em] text-foreground"
-      >
-        {frame}
-      </span>
+      <BrailleSweepBadge className="text-6xl text-foreground" />
       <p className="mt-6 text-sm font-medium text-muted-foreground">{caption}</p>
       {workspaceName && (
         <p className="mt-1 text-xs text-muted-foreground/70">{workspaceName}</p>

--- a/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import { useActiveTranscriptPaneState } from "@/hooks/chat/use-active-chat-session-selectors";
@@ -35,13 +35,25 @@ export function SessionTranscriptPane({ bottomInsetPx }: SessionTranscriptPanePr
   const { rehydrateSessionSlotFromHistory } = useSessionRuntimeActions();
   const { data: workspaceCollections } = useWorkspaces();
   const [olderHistoryLoadingSessionId, setOlderHistoryLoadingSessionId] = useState<string | null>(null);
-  const {
-    activeSessionId,
-    optimisticPrompt,
-    transcript,
-    sessionViewState,
-    oldestLoadedEventSeq,
-  } = useActiveTranscriptPaneState();
+  const immediatePaneState = useActiveTranscriptPaneState();
+  const deferredPaneState = useDeferredValue(immediatePaneState);
+  const transcriptDeferred =
+    deferredPaneState.activeSessionId !== immediatePaneState.activeSessionId;
+  const activeSessionId = transcriptDeferred
+    ? null
+    : deferredPaneState.activeSessionId;
+  const optimisticPrompt = transcriptDeferred
+    ? null
+    : deferredPaneState.optimisticPrompt;
+  const transcript = transcriptDeferred
+    ? null
+    : deferredPaneState.transcript;
+  const sessionViewState = transcriptDeferred
+    ? "idle"
+    : deferredPaneState.sessionViewState;
+  const oldestLoadedEventSeq = transcriptDeferred
+    ? null
+    : deferredPaneState.oldestLoadedEventSeq;
   const selectedWorkspace = useMemo(
     () => selectedWorkspaceId
       ? workspaceCollections?.allWorkspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null
@@ -171,6 +183,14 @@ export function SessionTranscriptPane({ bottomInsetPx }: SessionTranscriptPanePr
     openWorkspaceSession,
     resolveOpenSessionWorkspaceId,
   ]);
+
+  if (transcriptDeferred) {
+    return (
+      <DebugProfiler id="session-transcript-pane">
+        <div className="h-full min-h-0" />
+      </DebugProfiler>
+    );
+  }
 
   if (!activeSessionId || !transcript) {
     return null;

--- a/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -3,6 +3,7 @@ import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import { useActiveTranscriptPaneState } from "@/hooks/chat/use-active-chat-session-selectors";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { MessageList } from "@/components/workspace/chat/transcript/MessageList";
 import { ConnectedPlanHandoffDialog } from "@/components/workspace/chat/plans/ConnectedPlanHandoffDialog";
 import { usePlanHandoffDialogState } from "@/hooks/plans/use-plan-handoff-dialog-state";
@@ -84,6 +85,21 @@ export function SessionTranscriptPane({ bottomInsetPx }: SessionTranscriptPanePr
     );
     return Object.fromEntries(entries);
   }, [coworkManagedWorkspaces]);
+  useDebugValueChange("transcript_pane.inputs", "active_transcript_refs", {
+    selectedWorkspaceId,
+    immediateActiveSessionId: immediatePaneState.activeSessionId,
+    deferredActiveSessionId: deferredPaneState.activeSessionId,
+    transcriptDeferred,
+    transcript,
+    optimisticPrompt,
+    sessionViewState,
+    oldestLoadedEventSeq,
+    workspaceCollections,
+    selectedWorkspace,
+    selectedCloudWorkspace,
+    coworkManagedWorkspaces,
+    linkedSessionWorkspaces,
+  });
   const hasOlderHistory = oldestLoadedEventSeq !== null && oldestLoadedEventSeq > 1;
   const isLoadingOlderHistory = olderHistoryLoadingSessionId === activeSessionId;
   const loadOlderHistory = useCallback(() => {

--- a/desktop/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/desktop/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -2,7 +2,9 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  memo,
   useRef,
+  type ReactNode,
 } from "react";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
 import {
@@ -24,6 +26,12 @@ import {
   type HistoryPrependScrollAnchor,
   type TranscriptRowListBaseProps,
 } from "@/components/workspace/chat/transcript/TranscriptRowListShared";
+import type { TranscriptVirtualRow } from "@/lib/domain/chat/transcript-virtual-rows";
+
+type TranscriptRowRenderer = (
+  row: TranscriptVirtualRow,
+  rowIndex: number,
+) => ReactNode;
 
 interface FullTranscriptRowListProps extends TranscriptRowListBaseProps {
   fallbackReason: string | null;
@@ -236,14 +244,12 @@ export function FullTranscriptRowList({
           )}
           {isLoadingOlderHistory && <TranscriptHistoryLoadingRow />}
           {rows.map((row, rowIndex) => (
-            <div
+            <MemoizedFullTranscriptRow
               key={row.key}
-              data-transcript-virtual-row="true"
-              data-index={rowIndex}
-              className="w-full"
-            >
-              {renderRow(row, rowIndex)}
-            </div>
+              row={row}
+              rowIndex={rowIndex}
+              renderRow={renderRow}
+            />
           ))}
           {bottomInsetPx > 0 && (
             <div aria-hidden="true" style={{ height: bottomInsetPx }} />
@@ -253,3 +259,27 @@ export function FullTranscriptRowList({
     </AutoHideScrollArea>
   );
 }
+
+const MemoizedFullTranscriptRow = memo(function MemoizedFullTranscriptRow({
+  row,
+  rowIndex,
+  renderRow,
+}: {
+  row: TranscriptVirtualRow;
+  rowIndex: number;
+  renderRow: TranscriptRowRenderer;
+}) {
+  return (
+    <div
+      data-transcript-virtual-row="true"
+      data-index={rowIndex}
+      className="w-full"
+    >
+      {renderRow(row, rowIndex)}
+    </div>
+  );
+}, (prev, next) =>
+  prev.row === next.row
+  && prev.rowIndex === next.rowIndex
+  && prev.renderRow === next.renderRow
+);

--- a/desktop/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/desktop/src/components/workspace/chat/transcript/MessageList.tsx
@@ -216,14 +216,25 @@ export function MessageList({
     )
     : null;
   const virtualRows = useTranscriptRowModel({
-      activeSessionId,
-      transcript,
-      visibleOptimisticPrompt,
-      latestTurnId,
-      latestTurnHasAssistantRenderableContent,
-    });
+    activeSessionId,
+    transcript,
+    visibleOptimisticPrompt,
+    latestTurnId,
+    latestTurnHasAssistantRenderableContent,
+  });
   const visibleTurnIds = useMemo(
-    () => virtualRows.flatMap((row) => row.kind === "turn" ? [row.turnId] : []),
+    () => {
+      const ids: string[] = [];
+      const seen = new Set<string>();
+      for (const row of virtualRows) {
+        if (row.kind !== "turn" || seen.has(row.turnId)) {
+          continue;
+        }
+        seen.add(row.turnId);
+        ids.push(row.turnId);
+      }
+      return ids;
+    },
     [virtualRows],
   );
   const latestTurnInProgress = !!latestTurn && !latestTurn.completedAt;
@@ -398,6 +409,7 @@ export function MessageList({
     const isLatestTurnInProgress = isLatestTurn && !turn.completedAt;
     const hasFileBadges = turn.fileBadges.length > 0;
     const presentation = row.presentation;
+    const renderPresentation = row.renderPresentation;
     const liveExplorationBlock = isLatestTurn ? latestLiveExplorationBlock : null;
     const tailAssistantProseRootId = findTailAssistantProseRootId(
       presentation,
@@ -417,7 +429,9 @@ export function MessageList({
     // Hide the trailing indicator only while the assistant prose item
     // itself is actively streaming. If Codex closes the prose item but
     // keeps working internally, the trailing indicator should return.
-    const trailingStatus = isLatestTurn
+    const trailingStatus = !row.isLastTurnRow
+      ? null
+      : isLatestTurn
       ? latestLiveStatus
       : shouldAllowTurnTrailingStatus({
           turn,
@@ -446,14 +460,15 @@ export function MessageList({
             turn={turn}
             transcript={transcript}
             isTurnComplete={!!turn.completedAt}
-            presentation={presentation}
+            presentation={renderPresentation}
             forceExpandedCollapsedActionBlockId={liveExplorationBlock?.blockId ?? null}
             tailAssistantProseRootId={tailAssistantProseRootId}
+            showCompletedArtifactFallback={row.isLastTurnRow}
             workspaceId={selectedWorkspaceId}
             onOpenArtifact={openArtifact}
             onHandOffPlanToNewSession={onHandOffPlanToNewSession}
           />
-          {turn.completedAt && hasFileBadges && (
+          {row.isLastTurnRow && turn.completedAt && hasFileBadges && (
             <TurnDiffPanel
               turn={turn}
               transcript={transcript}
@@ -462,8 +477,8 @@ export function MessageList({
           )}
           <TurnAssistantActionRow
             content={tailAssistantCopyContent}
-            showCopyButton={!!turn.completedAt}
-            reserveSlot={shouldReserveTurnAssistantActionSlot}
+            showCopyButton={row.isLastTurnRow && !!turn.completedAt}
+            reserveSlot={row.isLastTurnRow && shouldReserveTurnAssistantActionSlot}
             timestampLabel={tailAssistantActionTime}
           />
           {trailingStatus && (
@@ -621,6 +636,7 @@ function TurnItemSequence({
   presentation,
   forceExpandedCollapsedActionBlockId,
   tailAssistantProseRootId,
+  showCompletedArtifactFallback,
   workspaceId,
   onOpenArtifact,
   onHandOffPlanToNewSession,
@@ -631,6 +647,7 @@ function TurnItemSequence({
   presentation: ReturnType<typeof buildTurnPresentation>;
   forceExpandedCollapsedActionBlockId?: string | null;
   tailAssistantProseRootId: string | null;
+  showCompletedArtifactFallback: boolean;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
@@ -719,7 +736,7 @@ function TurnItemSequence({
           />
         );
       })}
-      {tailAssistantProseRootId === null && completedArtifactToolCalls.length > 0 && (
+      {showCompletedArtifactFallback && tailAssistantProseRootId === null && completedArtifactToolCalls.length > 0 && (
         <div className="space-y-1.5">
           {completedArtifactToolCalls.map((item) => (
             <CoworkArtifactTurnCard

--- a/desktop/src/components/workspace/chat/transcript/StreamingIndicator.tsx
+++ b/desktop/src/components/workspace/chat/transcript/StreamingIndicator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { useBrailleSweep } from "@/hooks/ui/use-braille-sweep";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
+import { BrailleSweepBadge } from "@/components/ui/icons";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
 
 interface StreamingIndicatorProps {
@@ -10,7 +10,6 @@ interface StreamingIndicatorProps {
 export function StreamingIndicator({ startedAt }: StreamingIndicatorProps) {
   useDebugRenderCount("loading-braille");
   const [elapsed, setElapsed] = useState(() => computeElapsed(startedAt));
-  const frame = useBrailleSweep();
 
   useEffect(() => {
     setElapsed(computeElapsed(startedAt));
@@ -23,9 +22,7 @@ export function StreamingIndicator({ startedAt }: StreamingIndicatorProps) {
   return (
     <DebugProfiler id="loading-braille">
       <div className="flex items-end gap-1 py-1 text-muted-foreground">
-      <span className="scale-[.8] inline-block w-[1.25em] font-mono text-[1.125rem] leading-none tracking-[-0.18em] text-foreground">
-        {frame}
-      </span>
+      <BrailleSweepBadge className="scale-[.8] w-[1.25em] text-[1.125rem] text-foreground" />
       <span className="text-[0.5rem] leading-none tabular-nums">{elapsed}s</span>
       </div>
     </DebugProfiler>

--- a/desktop/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
+++ b/desktop/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
@@ -2,9 +2,11 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  memo,
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
@@ -14,6 +16,7 @@ import {
 } from "@/config/chat-layout";
 import {
   shouldStickToVirtualBottom,
+  type TranscriptVirtualRow,
 } from "@/lib/domain/chat/transcript-virtual-rows";
 import {
   parseTranscriptVirtualizationMode,
@@ -48,6 +51,11 @@ const LEGACY_ENABLE_VIRTUALIZATION_STORAGE_KEY =
   "proliferate:enableTranscriptVirtualization";
 const LEGACY_DISABLE_VIRTUALIZATION_STORAGE_KEY =
   "proliferate:disableTranscriptVirtualization";
+
+type TranscriptVirtualRowRenderer = (
+  row: TranscriptVirtualRow,
+  rowIndex: number,
+) => ReactNode;
 
 interface VirtualScrollAnchor {
   key: TranscriptRenderableRow["key"];
@@ -534,15 +542,14 @@ function VirtualizedTranscriptRowList({
             }
 
             return (
-              <div
+              <MemoizedVirtualTranscriptRow
                 key={row.key}
-                ref={virtualizer.measureElement}
-                data-transcript-virtual-row="true"
-                data-index={virtualRow.index}
-                className="w-full"
-              >
-                {renderRow(row, renderableRow.rowIndex)}
-              </div>
+                row={row}
+                rowIndex={renderableRow.rowIndex}
+                virtualIndex={virtualRow.index}
+                renderRow={renderRow}
+                measureElement={virtualizer.measureElement}
+              />
             );
           })}
           {bottomSpacerHeight > 0 && (
@@ -553,6 +560,37 @@ function VirtualizedTranscriptRowList({
     </AutoHideScrollArea>
   );
 }
+
+const MemoizedVirtualTranscriptRow = memo(function MemoizedVirtualTranscriptRow({
+  row,
+  rowIndex,
+  virtualIndex,
+  renderRow,
+  measureElement,
+}: {
+  row: TranscriptVirtualRow;
+  rowIndex: number;
+  virtualIndex: number;
+  renderRow: TranscriptVirtualRowRenderer;
+  measureElement: (element: Element | null) => void;
+}) {
+  return (
+    <div
+      ref={measureElement}
+      data-transcript-virtual-row="true"
+      data-index={virtualIndex}
+      className="w-full"
+    >
+      {renderRow(row, rowIndex)}
+    </div>
+  );
+}, (prev, next) =>
+  prev.row === next.row
+  && prev.rowIndex === next.rowIndex
+  && prev.virtualIndex === next.virtualIndex
+  && prev.renderRow === next.renderRow
+  && prev.measureElement === next.measureElement
+);
 
 function readTranscriptVirtualizationMode(): TranscriptVirtualizationMode {
   if (typeof window === "undefined") {

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 import { BrailleSweepBadge, CollapseAll, ExpandAll, Plus } from "@/components/ui/icons";
 import { SidebarShowToggleRow } from "@/components/workspace/shell/sidebar/SidebarShowToggleRow";
 import { useCoworkStatus } from "@/hooks/cowork/use-cowork-status";
 import { useCoworkThreadWorkflow } from "@/hooks/cowork/use-cowork-thread-workflow";
 import { useCoworkThreads } from "@/hooks/cowork/use-cowork-threads";
 import { useOpenCoworkCodingSession } from "@/hooks/cowork/use-open-cowork-coding-session";
-import { collectWorkspaceSidebarActivityStates } from "@/lib/domain/sessions/activity";
+import { useWorkspaceSidebarActivityStates } from "@/hooks/workspaces/use-workspace-sidebar-activities";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { SidebarActionButton } from "@/components/workspace/shell/sidebar/SidebarActionButton";
@@ -17,9 +16,7 @@ const DEFAULT_VISIBLE_THREAD_COUNT = 5;
 export function CoworkThreadsSection() {
   const selectedWorkspaceId = useHarnessStore((state) => state.selectedWorkspaceId);
   const activeSessionId = useHarnessStore((state) => state.activeSessionId);
-  const workspaceActivities = useHarnessStore(useShallow((state) =>
-    collectWorkspaceSidebarActivityStates(state.sessionSlots)
-  ));
+  const workspaceActivities = useWorkspaceSidebarActivityStates();
   const { status, isLoading: statusLoading } = useCoworkStatus();
   const { threads, isLoading: threadsLoading } = useCoworkThreads(status?.enabled ?? false);
   const { createThread, openThread, isCreatingThread } = useCoworkThreadWorkflow();

--- a/desktop/src/components/workspace/files/panel/FileTreeNode.tsx
+++ b/desktop/src/components/workspace/files/panel/FileTreeNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { WorkspaceFileEntry } from "@anyharness/sdk";
 import { Button } from "@/components/ui/Button";
 import { useWorkspaceFileTreeUiStore } from "@/stores/editor/workspace-file-tree-ui-store";
@@ -37,7 +38,7 @@ interface FileTreeNodeProps {
   targets: OpenTarget[];
 }
 
-export function FileTreeNode({ entry, level, targets }: FileTreeNodeProps) {
+function FileTreeNodeInner({ entry, level, targets }: FileTreeNodeProps) {
   const treeStateKey = useWorkspaceViewerTabsStore((s) => s.treeStateKey);
   const workspaceUiKey = useWorkspaceViewerTabsStore((s) => s.workspaceUiKey);
   const activeTargetKey = useWorkspaceViewerTabsStore((s) => s.activeTargetKey);
@@ -388,6 +389,9 @@ export function FileTreeNode({ entry, level, targets }: FileTreeNodeProps) {
     </div>
   );
 }
+
+export const FileTreeNode = memo(FileTreeNodeInner);
+FileTreeNode.displayName = "FileTreeNode";
 
 function parentDirectoryPath(path: string): string {
   return path.split("/").slice(0, -1).join("/");

--- a/desktop/src/components/workspace/files/panel/FileTreePane.tsx
+++ b/desktop/src/components/workspace/files/panel/FileTreePane.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useState,
   useEffect,
   useCallback,
@@ -18,6 +19,7 @@ import { FilePlus, FolderPlus } from "@/components/ui/icons";
 import { listOpenTargets, type OpenTarget } from "@/platform/tauri/shell";
 import { FileTreeNode } from "./FileTreeNode";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { useNativeContextMenu } from "@/hooks/ui/use-native-context-menu";
 import {
   finishOrCancelMeasurementOperation,
@@ -26,7 +28,7 @@ import {
   type MeasurementOperationId,
 } from "@/lib/infra/debug-measurement";
 
-export function FileTreePane() {
+function FileTreePaneInner() {
   useDebugRenderCount("file-tree");
   const scrollSampleOperationRef = useRef<MeasurementOperationId | null>(null);
   const workspaceUiKey = useWorkspaceViewerTabsStore((s) => s.workspaceUiKey);
@@ -134,6 +136,18 @@ export function FileTreePane() {
   );
 
   const rootEntries = rootQuery.data?.entries;
+  useDebugValueChange("file_tree.inputs", "pane_refs", {
+    anyharnessWorkspaceId,
+    authToken,
+    materializedWorkspaceId,
+    rootEntries,
+    rootQueryStatus: rootQuery.status,
+    runtimeUrl,
+    selectedDirectory,
+    targets,
+    treeStateKey,
+    workspaceUiKey,
+  });
 
   if (rootQuery.isLoading) {
     return withBackgroundContextMenu(
@@ -199,6 +213,9 @@ export function FileTreePane() {
     </DebugProfiler>
   );
 }
+
+export const FileTreePane = memo(FileTreePaneInner);
+FileTreePane.displayName = "FileTreePane";
 
 function FileTreeCreateMenu({
   onNewFile,

--- a/desktop/src/components/workspace/shell/HeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/HeaderTabs.tsx
@@ -40,7 +40,7 @@ import { useChatTabVisibilityActions } from "@/hooks/workspaces/tabs/use-chat-ta
 import { useTabGroupActions } from "@/hooks/workspaces/tabs/use-tab-group-actions";
 import { useShellTabOrderActions } from "@/hooks/workspaces/tabs/use-shell-tab-order-actions";
 import { useShellTabDrag } from "@/hooks/workspaces/tabs/use-tab-drag";
-import { useWorkspaceHeaderTabsViewModel } from "@/hooks/workspaces/tabs/use-workspace-header-tabs-view-model";
+import { useWorkspaceHeaderTabsViewModelContext } from "@/components/workspace/shell/WorkspaceHeaderTabsViewModelContext";
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
 import { useWorkspaceTabActions } from "@/hooks/workspaces/use-workspace-tab-actions";
 import {
@@ -58,7 +58,7 @@ import { startMeasurementOperation } from "@/lib/infra/debug-measurement";
 
 export function HeaderTabs() {
   useDebugRenderCount("header-tabs");
-  const viewModel = useWorkspaceHeaderTabsViewModel();
+  const viewModel = useWorkspaceHeaderTabsViewModelContext();
   const chatVisibilityActions = useChatTabVisibilityActions({
     workspaceUiKey: viewModel.workspaceUiKey,
     materializedWorkspaceId: viewModel.materializedWorkspaceId,

--- a/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/StandardWorkspaceShell.tsx
@@ -1,10 +1,13 @@
 import { HomeNextScreen } from "@/components/home/HomeNextScreen";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { PublishDialog } from "@/components/workspace/git/PublishDialog";
 import { ConnectedReviewCritiqueDialog } from "@/components/workspace/reviews/ConnectedReviewCritiqueDialog";
 import { ConnectedReviewSetupDialog } from "@/components/workspace/reviews/ConnectedReviewSetupDialog";
 import { GlobalHeader } from "@/components/workspace/shell/GlobalHeader";
 import { WorkspaceContentView } from "@/components/workspace/shell/WorkspaceContentView";
+import {
+  WorkspaceHeaderTabsViewModelProvider,
+} from "@/components/workspace/shell/WorkspaceHeaderTabsViewModelContext";
 import { WorkspaceShellActionsProvider } from "@/components/workspace/shell/WorkspaceShellActionsContext";
 import { WorkspaceCommandPalette } from "@/components/workspace/shell/command-palette/WorkspaceCommandPalette";
 import { RightPanel } from "@/components/workspace/shell/right-panel/RightPanel";
@@ -124,6 +127,17 @@ export function StandardWorkspaceShell() {
   const nativeWorkspaceOverlaysHidden = commandPaletteOpen
     || publishDialog.open
     || nativePortalOverlayOpen;
+  const handleTerminalActivationRequestHandled = useCallback(
+    (request: NonNullable<typeof terminalActivationRequest>) => {
+      layout.setTerminalActivationRequest((current) =>
+        current?.workspaceId === request.workspaceId
+        && current.token === request.token
+          ? null
+          : current
+      );
+    },
+    [layout.setTerminalActivationRequest],
+  );
 
   useMainScreenShortcuts({
     canOpenCommandPalette: hasWorkspaceShell,
@@ -156,6 +170,7 @@ export function StandardWorkspaceShell() {
     <DebugProfiler id="workspace-shell">
       <WorkspaceShellActionsProvider value={shellActions}>
         <WorkspacePathProvider workspacePath={selectedWorkspace?.path ?? null}>
+          <WorkspaceHeaderTabsViewModelProvider>
           <div
         className={`h-screen flex overflow-hidden ${chromeClasses.root}`}
         data-telemetry-block
@@ -280,14 +295,7 @@ export function StandardWorkspaceShell() {
                       terminalActivationRequest={terminalActivationRequest}
                       focusRequestToken={rightPanelFocusRequestToken}
                       nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
-                      onTerminalActivationRequestHandled={(request) => {
-                        layout.setTerminalActivationRequest((current) =>
-                          current?.workspaceId === request.workspaceId
-                          && current.token === request.token
-                            ? null
-                            : current
-                        );
-                      }}
+                      onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
                     />
                   </div>
                 </div>
@@ -330,6 +338,7 @@ export function StandardWorkspaceShell() {
           </div>
         </div>
           </div>
+          </WorkspaceHeaderTabsViewModelProvider>
         </WorkspacePathProvider>
       </WorkspaceShellActionsProvider>
     </DebugProfiler>

--- a/desktop/src/components/workspace/shell/WorkspaceContentView.tsx
+++ b/desktop/src/components/workspace/shell/WorkspaceContentView.tsx
@@ -1,14 +1,15 @@
+import { memo } from "react";
 import { ChatView } from "@/components/workspace/chat/ChatView";
 import { useWorkspaceContentShortcuts } from "@/hooks/workspaces/use-workspace-content-shortcuts";
 import { useWorkspaceTabActions } from "@/hooks/workspaces/use-workspace-tab-actions";
-import { useWorkspaceHeaderTabsViewModel } from "@/hooks/workspaces/tabs/use-workspace-header-tabs-view-model";
+import { useWorkspaceHeaderTabsViewModelContext } from "@/components/workspace/shell/WorkspaceHeaderTabsViewModelContext";
 import { FileEditorView } from "@/components/workspace/files/FileEditorView";
 import { AllChangesFrame } from "@/components/workspace/changes/AllChangesFrame";
 import { viewerTargetKey } from "@/lib/domain/workspaces/viewer-target";
 
-export function WorkspaceContentView() {
+export const WorkspaceContentView = memo(function WorkspaceContentView() {
   const tabActions = useWorkspaceTabActions();
-  const headerTabs = useWorkspaceHeaderTabsViewModel();
+  const headerTabs = useWorkspaceHeaderTabsViewModelContext();
   useWorkspaceContentShortcuts(tabActions);
 
   return (
@@ -33,4 +34,4 @@ export function WorkspaceContentView() {
       </div>
     </div>
   );
-}
+});

--- a/desktop/src/components/workspace/shell/WorkspaceHeaderTabsViewModelContext.tsx
+++ b/desktop/src/components/workspace/shell/WorkspaceHeaderTabsViewModelContext.tsx
@@ -1,0 +1,37 @@
+import {
+  createContext,
+  useContext,
+  type ReactNode,
+} from "react";
+import { useWorkspaceHeaderTabsViewModel } from "@/hooks/workspaces/tabs/use-workspace-header-tabs-view-model";
+
+type WorkspaceHeaderTabsViewModel = ReturnType<typeof useWorkspaceHeaderTabsViewModel>;
+
+const WorkspaceHeaderTabsViewModelContext =
+  createContext<WorkspaceHeaderTabsViewModel | null>(null);
+
+interface WorkspaceHeaderTabsViewModelProviderProps {
+  children: ReactNode;
+}
+
+export function WorkspaceHeaderTabsViewModelProvider({
+  children,
+}: WorkspaceHeaderTabsViewModelProviderProps) {
+  const viewModel = useWorkspaceHeaderTabsViewModel();
+
+  return (
+    <WorkspaceHeaderTabsViewModelContext.Provider value={viewModel}>
+      {children}
+    </WorkspaceHeaderTabsViewModelContext.Provider>
+  );
+}
+
+export function useWorkspaceHeaderTabsViewModelContext(): WorkspaceHeaderTabsViewModel {
+  const viewModel = useContext(WorkspaceHeaderTabsViewModelContext);
+  if (!viewModel) {
+    throw new Error(
+      "useWorkspaceHeaderTabsViewModelContext must be used inside WorkspaceHeaderTabsViewModelProvider",
+    );
+  }
+  return viewModel;
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -99,7 +100,7 @@ interface RightPanelProps {
   onTerminalActivationRequestHandled: (request: TerminalActivationRequest) => void;
 }
 
-export function RightPanel({
+export const RightPanel = memo(function RightPanel({
   workspaceId,
   isWorkspaceReady,
   isOpen,
@@ -668,4 +669,4 @@ export function RightPanel({
       </div>
     </div>
   );
-}
+});

--- a/desktop/src/hooks/chat/use-composer-dock-slots.tsx
+++ b/desktop/src/hooks/chat/use-composer-dock-slots.tsx
@@ -12,6 +12,7 @@ import {
   useActivePendingInteractionState,
   useActivePendingPrompts,
 } from "@/hooks/chat/use-active-chat-session-selectors";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { useDelegatedWorkComposer } from "@/hooks/chat/use-delegated-work-composer";
 import { useActiveTodoTracker } from "@/hooks/chat/use-active-todo-tracker";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
@@ -33,6 +34,16 @@ export function useComposerDockSlots(options?: {
   const delegatedWorkComposer = useDelegatedWorkComposer();
   const workspaceStatusPanel = useWorkspaceStatusPanelState();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
+
+  useDebugValueChange("composer_slots.inputs", "active_session_refs", {
+    suppressSessionSlots,
+    primaryPendingInteraction,
+    pendingPrompts,
+    activeTodoTracker,
+    delegatedWorkComposer,
+    workspaceStatusPanel,
+    selectedCloudRuntimeState: selectedCloudRuntime.state,
+  });
 
   const interactionPanel: ReactNode | null = primaryPendingInteraction?.kind === "permission"
     ? <ConnectedApprovalCard />

--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -331,7 +331,13 @@ export function useSessionRuntimeActions() {
 
         if (!nextState.applied) {
           finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed");
-          return false;
+          logLatency("session.history.rehydrate.noop", {
+            sessionId,
+            eventCount: events.length,
+            afterSeq,
+            elapsedMs: Math.round(performance.now() - startedAt),
+          });
+          return true;
         }
 
         const storeStartedAt = performance.now();

--- a/desktop/src/hooks/sessions/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-selection-actions.ts
@@ -37,6 +37,7 @@ import {
   getLatencyFlowRequestHeaders,
 } from "@/lib/infra/latency-flow";
 import {
+  finishOrCancelMeasurementOperation,
   finishMeasurementOperation,
   getMeasurementRequestOptions,
   markOperationForNextCommit,
@@ -57,7 +58,6 @@ import {
 export type WorkspaceSession = Session & { workspaceId: string };
 
 const INITIAL_SESSION_HISTORY_EVENT_BUDGET = 3_000;
-const INITIAL_SESSION_HISTORY_TURN_LIMIT = 40;
 
 export interface SelectSessionOptionsWithoutGuard {
   latencyFlowId?: string | null;
@@ -306,6 +306,7 @@ export function useSessionSelectionActions() {
             currentState.hotPaintGate?.nonce !== nonce
             || currentState.activeSessionId !== sessionId
           ) {
+            finishOrCancelMeasurementOperation(hotOperationId, "aborted");
             return;
           }
           currentState.clearHotPaintGate(nonce);
@@ -477,9 +478,43 @@ export function useSessionSelectionActions() {
     }
 
     const currentSlot = useHarnessStore.getState().sessionSlots[sessionId] ?? null;
+    let streamConnectDeferredUntilHydrate = false;
+    const scheduleStreamConnect = () => {
+      const streamStartedAt = performance.now();
+      recordMeasurementWorkflowStep({
+        operationId: measurementOperationId,
+        step: "session.select.stream_connect_scheduled",
+        startedAt: streamStartedAt,
+        outcome: "completed",
+      });
+      void ensureSessionStreamConnected(sessionId, {
+        allowColdIdleNoStream: options?.allowColdIdleNoStream,
+        resumeIfActive: true,
+        requestHeaders,
+        skipInitialRefresh: true,
+        refreshOnStartupReady: true,
+        isCurrent: () => {
+          if (guard && !isSessionActivationCurrent(guard)) {
+            return false;
+          }
+          const state = useHarnessStore.getState();
+          return state.activeSessionId === sessionId
+            && state.selectedWorkspaceId === workspaceId;
+        },
+      });
+      logLatency("session.select.stream_connected", {
+        sessionId,
+        workspaceId,
+        flowId: options?.latencyFlowId ?? null,
+        scheduled: true,
+        elapsedMs: Math.round(performance.now() - streamStartedAt),
+        totalElapsedMs: elapsedMs(startedAt),
+      });
+    };
     if (!currentSlot?.transcriptHydrated) {
       const hydrateStartedAt = startLatencyTimer();
       const selectionNonce = useHarnessStore.getState().workspaceSelectionNonce;
+      const afterSeq = currentSlot?.transcript.lastSeq ?? 0;
       const isStillSelected = () => {
         if (guard && !isSessionActivationCurrent(guard)) {
           return false;
@@ -489,75 +524,57 @@ export function useSessionSelectionActions() {
           && state.activeSessionId === sessionId
           && state.selectedWorkspaceId === workspaceId;
       };
-      const hydrated = await rehydrateSessionSlotFromHistory(sessionId, {
-        limit: INITIAL_SESSION_HISTORY_EVENT_BUDGET,
-        turnLimit: INITIAL_SESSION_HISTORY_TURN_LIMIT,
-        requestHeaders,
-        measurementOperationId,
-        isCurrent: isStillSelected,
-      });
-      if (!isStillSelected()) {
-        if (measurementOperationId) {
-          finishMeasurementOperation(measurementOperationId, "aborted");
-        }
-        return guard
-          ? { result: "stale", sessionId, guard, reason: "selection-replaced" }
-          : undefined;
-      }
+      streamConnectDeferredUntilHydrate = true;
       useHarnessStore.getState().patchSessionSlot(sessionId, { transcriptHydrated: true });
       recordMeasurementWorkflowStep({
         operationId: measurementOperationId,
         step: "session.select.history_hydrate",
         startedAt: hydrateStartedAt,
-        outcome: hydrated ? "completed" : "error_sanitized",
+        outcome: "completed",
       });
-      logLatency("session.select.history_hydrated", {
+      logLatency("session.select.history_hydrate_deferred", {
         sessionId,
         workspaceId,
-        hydrated,
+        afterSeq,
         flowId: options?.latencyFlowId ?? null,
-        elapsedMs: elapsedMs(hydrateStartedAt),
         totalElapsedMs: elapsedMs(startedAt),
+      });
+      scheduleAfterNextPaint(() => {
+        if (!isStillSelected()) {
+          return;
+        }
+        void rehydrateSessionSlotFromHistory(sessionId, {
+          afterSeq,
+          limit: INITIAL_SESSION_HISTORY_EVENT_BUDGET,
+          requestHeaders,
+          isCurrent: isStillSelected,
+        }).then((hydrated) => {
+          logLatency("session.select.history_hydrated", {
+            sessionId,
+            workspaceId,
+            hydrated,
+            flowId: options?.latencyFlowId ?? null,
+            elapsedMs: elapsedMs(hydrateStartedAt),
+            totalElapsedMs: elapsedMs(startedAt),
+          });
+        }).finally(() => {
+          if (isStillSelected()) {
+            scheduleStreamConnect();
+          }
+        });
       });
       logLatency("session.select.full_history_backfill_skipped", {
         sessionId,
         workspaceId,
-        hydrated,
+        hydrated: true,
         reason: "protect_interactivity",
         flowId: options?.latencyFlowId ?? null,
       });
     }
 
-    const streamStartedAt = performance.now();
-    recordMeasurementWorkflowStep({
-      operationId: measurementOperationId,
-      step: "session.select.stream_connect_scheduled",
-      startedAt: streamStartedAt,
-      outcome: "completed",
-    });
-    void ensureSessionStreamConnected(sessionId, {
-      allowColdIdleNoStream: options?.allowColdIdleNoStream,
-      resumeIfActive: true,
-      requestHeaders,
-      skipInitialRefresh: true,
-      refreshOnStartupReady: true,
-      isCurrent: () => {
-        if (guard && !isSessionActivationCurrent(guard)) {
-          return false;
-        }
-        const state = useHarnessStore.getState();
-        return state.activeSessionId === sessionId
-          && state.selectedWorkspaceId === workspaceId;
-      },
-    });
-    logLatency("session.select.stream_connected", {
-      sessionId,
-      workspaceId,
-      flowId: options?.latencyFlowId ?? null,
-      scheduled: true,
-      elapsedMs: Math.round(performance.now() - streamStartedAt),
-      totalElapsedMs: elapsedMs(startedAt),
-    });
+    if (!streamConnectDeferredUntilHydrate) {
+      scheduleStreamConnect();
+    }
     logLatency("session.select.completed", {
       sessionId,
       workspaceId,

--- a/desktop/src/hooks/sessions/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-selection-actions.ts
@@ -217,6 +217,7 @@ export function useSessionSelectionActions() {
     const measurementOperationId = startMeasurementOperation({
       kind: "session_switch",
       surfaces: [
+        "workspace-shell",
         "chat-surface",
         "session-transcript-pane",
         "transcript-list",
@@ -264,6 +265,7 @@ export function useSessionSelectionActions() {
         const hotOperationId = startMeasurementOperation({
           kind: "session_hot_switch",
           surfaces: [
+            "workspace-shell",
             "chat-surface",
             "session-transcript-pane",
             "transcript-list",
@@ -277,8 +279,13 @@ export function useSessionSelectionActions() {
         if (commitOutcome?.result === "stale") {
           return commitOutcome;
         }
-        const nonce = useHarnessStore.getState().workspaceSelectionNonce;
-        useHarnessStore.getState().setHotPaintGate({
+        const gateState = useHarnessStore.getState();
+        const previousHotOperationId = gateState.hotPaintGate?.operationId ?? null;
+        if (previousHotOperationId && previousHotOperationId !== hotOperationId) {
+          finishOrCancelMeasurementOperation(previousHotOperationId, "aborted");
+        }
+        const nonce = gateState.workspaceSelectionNonce;
+        gateState.setHotPaintGate({
           workspaceId: existingSlot.workspaceId!,
           sessionId,
           nonce,
@@ -293,6 +300,7 @@ export function useSessionSelectionActions() {
         });
         if (hotOperationId) {
           markOperationForNextCommit(hotOperationId, [
+            "workspace-shell",
             "chat-surface",
             "session-transcript-pane",
             "transcript-list",
@@ -583,6 +591,7 @@ export function useSessionSelectionActions() {
     });
     if (measurementOperationId) {
       markOperationForNextCommit(measurementOperationId, [
+        "workspace-shell",
         "chat-surface",
         "session-transcript-pane",
         "transcript-list",

--- a/desktop/src/hooks/ui/use-debug-value-change.ts
+++ b/desktop/src/hooks/ui/use-debug-value-change.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import {
+  isDebugMeasurementEnabled,
+  recordMeasurementDiagnostic,
+} from "@/lib/infra/debug-measurement";
+
+type DebugValueMap = Record<string, unknown>;
+
+export function useDebugValueChange(
+  category: string,
+  label: string,
+  values: DebugValueMap,
+): void {
+  const previousRef = useRef<DebugValueMap | null>(null);
+
+  // Intentionally no dependency array: this debug hook exists to compare
+  // references across every render and only records when measurement is on.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!isDebugMeasurementEnabled()) {
+      previousRef.current = values;
+      return;
+    }
+
+    const previous = previousRef.current;
+    previousRef.current = values;
+    const changedKeys = previous
+      ? Object.keys(values).filter((key) => !Object.is(previous[key], values[key]))
+      : Object.keys(values);
+
+    if (changedKeys.length === 0) {
+      return;
+    }
+
+    recordMeasurementDiagnostic({
+      category,
+      label,
+      keys: changedKeys,
+      count: changedKeys.length,
+    });
+  });
+}

--- a/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
+++ b/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
@@ -11,6 +11,7 @@ import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { isPendingSessionId } from "@/lib/integrations/anyharness/session-runtime";
 import {
   finishMeasurementOperation,
+  finishOrCancelMeasurementOperation,
   markOperationForNextCommit,
   recordMeasurementWorkflowStep,
   startMeasurementOperation,
@@ -126,6 +127,7 @@ export function runHotWorkspaceReopen(
   scheduleAfterNextPaint(() => {
     const current = useHarnessStore.getState();
     if (current.hotPaintGate?.nonce !== nonce) {
+      finishOrCancelMeasurementOperation(operationId, "aborted");
       return;
     }
     recordMeasurementWorkflowStep({

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
@@ -185,4 +185,66 @@ describe("runWorkspaceSelection", () => {
     expect(bootstrapWorkspace).not.toHaveBeenCalled();
     expect(listActiveLatencyFlows()).toEqual([]);
   });
+
+  it("does not activate a remembered session unless its slot is already retained", async () => {
+    vi.mocked(resolveCloudWorkspaceReadiness).mockResolvedValueOnce({ kind: "local" });
+    vi.mocked(resolveSelectionConnection).mockResolvedValueOnce({
+      runtimeUrl: "http://runtime.test",
+      workspaceConnection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "ah-workspace-1",
+      },
+    });
+    useWorkspaceUiStore.setState({
+      lastViewedSessionByWorkspace: {
+        "logical:workspace-1": "session-forgotten",
+      },
+    });
+
+    await runWorkspaceSelection({
+      queryClient: {} as never,
+      logicalWorkspaces,
+      rawWorkspaces: [],
+      setSelectedLogicalWorkspaceId: vi.fn(),
+      setSelectedWorkspace: useHarnessStore.getState().setSelectedWorkspace,
+      removeWorkspaceSlots: vi.fn(),
+      clearSelection: vi.fn(),
+      bootstrapWorkspace: vi.fn().mockResolvedValue({ sessions: [] }),
+      reconcileHotWorkspace: vi.fn(),
+    }, {
+      workspaceId: "workspace-1",
+    });
+
+    expect(useHarnessStore.getState().selectedWorkspaceId).toBe("workspace-1");
+    expect(useHarnessStore.getState().activeSessionId).toBeNull();
+  });
+
+  it("preserves an explicit initial active session even when the slot is not retained", async () => {
+    vi.mocked(resolveCloudWorkspaceReadiness).mockResolvedValueOnce({ kind: "local" });
+    vi.mocked(resolveSelectionConnection).mockResolvedValueOnce({
+      runtimeUrl: "http://runtime.test",
+      workspaceConnection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "ah-workspace-1",
+      },
+    });
+
+    await runWorkspaceSelection({
+      queryClient: {} as never,
+      logicalWorkspaces,
+      rawWorkspaces: [],
+      setSelectedLogicalWorkspaceId: vi.fn(),
+      setSelectedWorkspace: useHarnessStore.getState().setSelectedWorkspace,
+      removeWorkspaceSlots: vi.fn(),
+      clearSelection: vi.fn(),
+      bootstrapWorkspace: vi.fn().mockResolvedValue({ sessions: [] }),
+      reconcileHotWorkspace: vi.fn(),
+    }, {
+      workspaceId: "workspace-1",
+      options: { initialActiveSessionId: "session-explicit" },
+    });
+
+    expect(useHarnessStore.getState().selectedWorkspaceId).toBe("workspace-1");
+    expect(useHarnessStore.getState().activeSessionId).toBe("session-explicit");
+  });
 });

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
@@ -21,11 +21,28 @@ import { resolveSelectionConnection } from "./connection";
 import { isWorkspaceSelectionCurrent } from "./guards";
 import type {
   ReadyCloudReadinessResult,
+  WorkspaceSelectionOptions,
   WorkspaceConnectionResult,
   WorkspaceSelectionContext,
   WorkspaceSelectionDeps,
   WorkspaceSelectionRequest,
 } from "./types";
+
+function resolveInitialActiveSessionId(
+  workspaceId: string,
+  options: WorkspaceSelectionOptions | undefined,
+  cachedSessionId: string | null,
+): string | null {
+  if (options && "initialActiveSessionId" in options) {
+    return options.initialActiveSessionId ?? null;
+  }
+  if (!cachedSessionId) {
+    return null;
+  }
+
+  const cachedSlot = useHarnessStore.getState().sessionSlots[cachedSessionId] ?? null;
+  return cachedSlot?.workspaceId === workspaceId ? cachedSessionId : null;
+}
 
 async function invalidateCloudWorkspaceStartState(
   deps: WorkspaceSelectionDeps,
@@ -104,7 +121,11 @@ export async function runWorkspaceSelection(
 
       const cachedSessionId =
         useWorkspaceUiStore.getState().lastViewedSessionByWorkspace[directWorkspace.id] ?? null;
-      const initialActiveSessionId = request.options?.initialActiveSessionId ?? cachedSessionId;
+      const initialActiveSessionId = resolveInitialActiveSessionId(
+        directWorkspace.id,
+        request.options,
+        cachedSessionId,
+      );
       deps.setSelectedLogicalWorkspaceId(null);
       deps.setSelectedWorkspace(directWorkspace.id, {
         clearPending: !request.options?.preservePending,
@@ -181,7 +202,11 @@ export async function runWorkspaceSelection(
 
   const cachedSessionId =
     useWorkspaceUiStore.getState().lastViewedSessionByWorkspace[logicalWorkspace.id] ?? null;
-  const initialActiveSessionId = request.options?.initialActiveSessionId ?? cachedSessionId;
+  const initialActiveSessionId = resolveInitialActiveSessionId(
+    resolvedWorkspaceId,
+    request.options,
+    cachedSessionId,
+  );
   deps.setSelectedLogicalWorkspaceId(logicalWorkspace.id);
   deps.setSelectedWorkspace(resolvedWorkspaceId, {
     clearPending: !request.options?.preservePending,

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -28,6 +28,8 @@ import {
   type SubagentSessionRelationshipHint,
 } from "@/lib/domain/chat/subagents/session-relationship-hints";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
+import { measureDebugComputation } from "@/lib/infra/debug-measurement";
 
 export interface HeaderSubagentParentRow {
   sessionId: string;
@@ -155,7 +157,20 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     }
   }, [args.workspaceId, recordSessionRelationshipHint, reviewRelationshipHints]);
 
-  return useMemo(() => {
+  useDebugValueChange("header_subagent_hierarchy.inputs", "query_refs", {
+    workspaceId: args.workspaceId,
+    activeSessionId: args.activeSessionId,
+    uniqueSessionIds,
+    subagentQueries,
+    reviewQueries,
+  });
+
+  return useMemo(() => measureDebugComputation({
+    category: "header_subagent_hierarchy.derive",
+    label: "build_hierarchy",
+    keys: ["activeSessionId", "subagentQueries", "reviewQueries", "uniqueSessionIds"],
+    count: (hierarchy) => hierarchy.resolvedSessionIds.size,
+  }, () => {
     const childToParent = new Map<string, string>();
     const parentRowsBySessionId = new Map<string, HeaderSubagentParentRow>();
     const childrenByParentSessionId = new Map<string, HeaderSubagentChildRow[]>();
@@ -215,7 +230,7 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       childrenByParentSessionId,
       resolvedSessionIds,
     };
-  }, [args.activeSessionId, reviewQueries, subagentQueries, uniqueSessionIds]);
+  }), [args.activeSessionId, reviewQueries, subagentQueries, uniqueSessionIds]);
 }
 
 function buildParentRow(parent: ParentSubagentLinkSummary): HeaderSubagentParentRow {

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
@@ -45,7 +45,7 @@ import {
 } from "@/stores/editor/workspace-file-buffers-store";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
-import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { useHarnessStore, type SessionSlot } from "@/stores/sessions/harness-store";
 import { useIsHotPaintGatePendingForWorkspace } from "@/hooks/workspaces/use-hot-paint-gate";
 import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
 import { resolveSelectedWorkspaceIdentity } from "@/lib/domain/workspaces/workspace-ui-key";
@@ -84,6 +84,7 @@ const EMPTY_OPEN_TARGETS: ViewerTarget[] = [];
 
 const EMPTY_BUFFERS_BY_PATH: Record<string, WorkspaceFileBuffer> = {};
 const EMPTY_TAB_MODES: Record<string, FileViewerMode> = {};
+const EMPTY_LIVE_SLOTS: SessionSlot[] = [];
 
 export function useWorkspaceHeaderTabsViewModel() {
   const rawOpenTargets = useWorkspaceViewerTabsStore((s) => s.openTargets);
@@ -111,7 +112,11 @@ export function useWorkspaceHeaderTabsViewModel() {
   const tabModes = isViewerStoreCurrent ? rawTabModes : EMPTY_TAB_MODES;
   const hotPaintPending = useIsHotPaintGatePendingForWorkspace(selectedWorkspaceId);
   const activeSessionId = useHarnessStore((s) => s.activeSessionId);
-  const sessionSlots = useHarnessStore((s) => s.sessionSlots);
+  const liveSlotsSelector = useMemo(
+    () => createWorkspaceHeaderLiveSlotsSelector(selectedWorkspaceId),
+    [selectedWorkspaceId],
+  );
+  const liveSlots = useHarnessStore(liveSlotsSelector);
 
   const visibleByWorkspace = useWorkspaceUiStore((s) => s.visibleChatSessionIdsByWorkspace);
   const hiddenByWorkspace = useWorkspaceUiStore((s) => s.recentlyHiddenChatSessionIdsByWorkspace);
@@ -135,11 +140,6 @@ export function useWorkspaceHeaderTabsViewModel() {
     enabled: !!selectedWorkspaceId && !hotPaintPending,
   });
 
-  const liveSlots = useMemo(
-    () => Object.values(sessionSlots)
-      .filter((slot) => sessionSlotBelongsToWorkspace(slot, selectedWorkspaceId)),
-    [selectedWorkspaceId, sessionSlots],
-  );
   const knownSessions = useMemo<Map<string, KnownHeaderSession>>(() => {
     const map = new Map<string, KnownHeaderSession>();
     for (const session of workspaceSessionsQuery.data ?? []) {
@@ -573,7 +573,7 @@ export function useWorkspaceHeaderTabsViewModel() {
     ],
   );
 
-  return {
+  return useMemo(() => ({
     activeSessionId,
     activeShellTab,
     activeShellTabKey,
@@ -597,5 +597,114 @@ export function useWorkspaceHeaderTabsViewModel() {
     childrenByParentSessionId: hierarchy.childrenByParentSessionId,
     hierarchyResolvedSessionIds: hierarchy.resolvedSessionIds,
     displayManualGroups,
+  }), [
+    activeSessionId,
+    activeShellTab,
+    activeShellTabKey,
+    activation,
+    buffersByPath,
+    chatTabs,
+    displayManualGroups,
+    hierarchy.childToParent,
+    hierarchy.childrenByParentSessionId,
+    hierarchy.resolvedSessionIds,
+    liveChatSessionIds,
+    materializedWorkspaceId,
+    menuChatTabs,
+    openTargets,
+    orderedShellTabKeys,
+    orderedTabs,
+    selectedWorkspaceId,
+    displayShellRows,
+    stripChatSessionIds,
+    stripRows,
+    tabModes,
+    visibleChatSessionIds,
+    workspaceUiKey,
+  ]);
+}
+
+type HarnessStoreSnapshot = ReturnType<typeof useHarnessStore.getState>;
+
+function createWorkspaceHeaderLiveSlotsSelector(
+  workspaceId: string | null,
+): (state: HarnessStoreSnapshot) => SessionSlot[] {
+  let previousSignature = "";
+  let previousSlots = EMPTY_LIVE_SLOTS;
+
+  return (state) => {
+    if (!workspaceId) {
+      previousSignature = "";
+      previousSlots = EMPTY_LIVE_SLOTS;
+      return EMPTY_LIVE_SLOTS;
+    }
+
+    const signature = buildWorkspaceHeaderLiveSlotsSignature(
+      state.sessionSlots,
+      workspaceId,
+    );
+    if (signature === previousSignature) {
+      return previousSlots;
+    }
+
+    previousSignature = signature;
+    previousSlots = Object.values(state.sessionSlots)
+      .filter((slot) => sessionSlotBelongsToWorkspace(slot, workspaceId));
+    return previousSlots;
   };
+}
+
+function buildWorkspaceHeaderLiveSlotsSignature(
+  sessionSlots: Record<string, SessionSlot>,
+  workspaceId: string,
+): string {
+  let signature = "";
+  for (const slot of Object.values(sessionSlots)) {
+    if (!sessionSlotBelongsToWorkspace(slot, workspaceId)) {
+      continue;
+    }
+    signature += buildHeaderSlotSignature(slot);
+    signature += "\u001e";
+  }
+  return signature;
+}
+
+function buildHeaderSlotSignature(slot: SessionSlot): string {
+  return [
+    slot.sessionId,
+    slot.workspaceId ?? "",
+    slot.agentKind,
+    slot.title ?? "",
+    slot.status ?? "",
+    slot.executionSummary?.phase ?? "",
+    pendingInteractionSignature(slot.executionSummary?.pendingInteractions),
+    slot.streamConnectionState,
+    slot.transcript.isStreaming ? "streaming" : "idle",
+    slot.transcript.sessionMeta.title ?? "",
+    pendingInteractionSignature(slot.transcript.pendingInteractions),
+    slot.actionCapabilities.fork ? "fork" : "no-fork",
+  ].join("\u001f");
+}
+
+function pendingInteractionSignature(
+  interactions: readonly HeaderPendingInteraction[] | null | undefined,
+): string {
+  if (!interactions || interactions.length === 0) {
+    return "";
+  }
+  return interactions
+    .map((interaction) => [
+      interaction.requestId ?? "",
+      interaction.linkedPlanId ?? "",
+      interaction.source?.linkedPlanId ?? "",
+    ].join(":"))
+    .join(",");
+}
+
+interface HeaderPendingInteraction {
+  requestId?: string;
+  linkedPlanId?: string | null;
+  source?: {
+    linkedPlanId?: string | null;
+  } | null;
 }

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
@@ -53,6 +53,8 @@ import {
   resolveWithWorkspaceFallback,
   sameStringArray,
 } from "@/lib/domain/workspaces/workspace-keyed-preferences";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
+import { measureDebugComputation } from "@/lib/infra/debug-measurement";
 
 export interface HeaderChatTabEntry extends GroupedChatTab {
   id: string;
@@ -140,23 +142,29 @@ export function useWorkspaceHeaderTabsViewModel() {
     enabled: !!selectedWorkspaceId && !hotPaintPending,
   });
 
-  const knownSessions = useMemo<Map<string, KnownHeaderSession>>(() => {
-    const map = new Map<string, KnownHeaderSession>();
-    for (const session of workspaceSessionsQuery.data ?? []) {
-      if (session.dismissedAt) continue;
-      if (!selectedWorkspaceId || session.workspaceId !== selectedWorkspaceId) continue;
-      map.set(session.id, { kind: "session", session });
-    }
-    for (const slot of liveSlots) {
-      const existing = map.get(slot.sessionId);
-      map.set(slot.sessionId, {
-        kind: "slot",
-        slot,
-        session: existing?.kind === "session" ? existing.session : existing?.session,
-      });
-    }
-    return map;
-  }, [liveSlots, selectedWorkspaceId, workspaceSessionsQuery.data]);
+  const knownSessions = useMemo<Map<string, KnownHeaderSession>>(() =>
+    measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "known_sessions",
+      keys: ["liveSlots", "workspaceSessionsQuery.data", "selectedWorkspaceId"],
+      count: (map) => map.size,
+    }, () => {
+      const map = new Map<string, KnownHeaderSession>();
+      for (const session of workspaceSessionsQuery.data ?? []) {
+        if (session.dismissedAt) continue;
+        if (!selectedWorkspaceId || session.workspaceId !== selectedWorkspaceId) continue;
+        map.set(session.id, { kind: "session", session });
+      }
+      for (const slot of liveSlots) {
+        const existing = map.get(slot.sessionId);
+        map.set(slot.sessionId, {
+          kind: "slot",
+          slot,
+          session: existing?.kind === "session" ? existing.session : existing?.session,
+        });
+      }
+      return map;
+    }), [liveSlots, selectedWorkspaceId, workspaceSessionsQuery.data]);
   const knownSessionIds = useMemo(() => Array.from(knownSessions.keys()), [knownSessions]);
   const hierarchy = useWorkspaceHeaderSubagentHierarchy({
     workspaceId: selectedWorkspaceId,
@@ -164,12 +172,22 @@ export function useWorkspaceHeaderTabsViewModel() {
     activeSessionId,
   });
   const hierarchyChildren = useMemo(
-    () => collectHierarchyChildren(hierarchy.childrenByParentSessionId),
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "hierarchy_children",
+      keys: ["hierarchy.childrenByParentSessionId"],
+      count: (children) => children.visibilityCandidates.length,
+    }, () => collectHierarchyChildren(hierarchy.childrenByParentSessionId)),
     [hierarchy.childrenByParentSessionId],
   );
 
   const liveVisibilityCandidates = useMemo<ChatVisibilityCandidate[]>(
-    () => {
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "live_visibility_candidates",
+      keys: ["knownSessionIds", "hierarchy.childToParent", "hierarchyChildren.visibilityCandidates"],
+      count: (candidates) => candidates.length,
+    }, () => {
       const candidatesBySessionId = new Map<string, ChatVisibilityCandidate>();
       for (const sessionId of knownSessionIds) {
         candidatesBySessionId.set(sessionId, {
@@ -181,7 +199,7 @@ export function useWorkspaceHeaderTabsViewModel() {
         candidatesBySessionId.set(candidate.sessionId, candidate);
       }
       return Array.from(candidatesBySessionId.values());
-    },
+    }),
     [hierarchy.childToParent, hierarchyChildren.visibilityCandidates, knownSessionIds],
   );
   const liveChatSessionIds = useMemo(
@@ -268,36 +286,67 @@ export function useWorkspaceHeaderTabsViewModel() {
       return;
     }
 
-    useWorkspaceUiStore.setState((state) => ({
-      visibleChatSessionIdsByWorkspace:
-        persistedVisibleFallback.shouldWriteBack && persistedVisibleFallback.value !== undefined
-          ? {
-              ...state.visibleChatSessionIdsByWorkspace,
-              [workspaceUiKey]: persistedVisibleFallback.value,
-            }
-          : state.visibleChatSessionIdsByWorkspace,
-      recentlyHiddenChatSessionIdsByWorkspace:
-        recentlyHiddenFallback.shouldWriteBack && recentlyHiddenFallback.value !== undefined
-          ? {
-              ...state.recentlyHiddenChatSessionIdsByWorkspace,
-              [workspaceUiKey]: recentlyHiddenFallback.value,
-            }
-          : state.recentlyHiddenChatSessionIdsByWorkspace,
-      collapsedChatGroupsByWorkspace:
-        collapsedParentFallback.shouldWriteBack && collapsedParentFallback.value !== undefined
-          ? {
-              ...state.collapsedChatGroupsByWorkspace,
-              [workspaceUiKey]: collapsedParentFallback.value,
-            }
-          : state.collapsedChatGroupsByWorkspace,
-      manualChatGroupsByWorkspace:
-        manualGroupsFallback.shouldWriteBack && manualGroupsFallback.value !== undefined
-          ? {
-              ...state.manualChatGroupsByWorkspace,
-              [workspaceUiKey]: manualGroupsFallback.value,
-            }
-          : state.manualChatGroupsByWorkspace,
-    }));
+    const state = useWorkspaceUiStore.getState();
+    const patch: Partial<ReturnType<typeof useWorkspaceUiStore.getState>> = {};
+    if (
+      persistedVisibleFallback.shouldWriteBack
+      && persistedVisibleFallback.value !== undefined
+      && shouldWriteStringArrayPreference(
+        state.visibleChatSessionIdsByWorkspace,
+        workspaceUiKey,
+        persistedVisibleFallback.value,
+      )
+    ) {
+      patch.visibleChatSessionIdsByWorkspace = {
+        ...state.visibleChatSessionIdsByWorkspace,
+        [workspaceUiKey]: persistedVisibleFallback.value,
+      };
+    }
+    if (
+      recentlyHiddenFallback.shouldWriteBack
+      && recentlyHiddenFallback.value !== undefined
+      && shouldWriteStringArrayPreference(
+        state.recentlyHiddenChatSessionIdsByWorkspace,
+        workspaceUiKey,
+        recentlyHiddenFallback.value,
+      )
+    ) {
+      patch.recentlyHiddenChatSessionIdsByWorkspace = {
+        ...state.recentlyHiddenChatSessionIdsByWorkspace,
+        [workspaceUiKey]: recentlyHiddenFallback.value,
+      };
+    }
+    if (
+      collapsedParentFallback.shouldWriteBack
+      && collapsedParentFallback.value !== undefined
+      && shouldWriteStringArrayPreference(
+        state.collapsedChatGroupsByWorkspace,
+        workspaceUiKey,
+        collapsedParentFallback.value,
+      )
+    ) {
+      patch.collapsedChatGroupsByWorkspace = {
+        ...state.collapsedChatGroupsByWorkspace,
+        [workspaceUiKey]: collapsedParentFallback.value,
+      };
+    }
+    if (
+      manualGroupsFallback.shouldWriteBack
+      && manualGroupsFallback.value !== undefined
+      && shouldWriteReferencePreference(
+        state.manualChatGroupsByWorkspace,
+        workspaceUiKey,
+        manualGroupsFallback.value,
+      )
+    ) {
+      patch.manualChatGroupsByWorkspace = {
+        ...state.manualChatGroupsByWorkspace,
+        [workspaceUiKey]: manualGroupsFallback.value,
+      };
+    }
+    if (Object.keys(patch).length > 0) {
+      useWorkspaceUiStore.setState(patch);
+    }
   }, [
     collapsedParentFallback.shouldWriteBack,
     collapsedParentFallback.value,
@@ -380,7 +429,18 @@ export function useWorkspaceHeaderTabsViewModel() {
     return map;
   }, [displayManualGroups]);
   const chatTabs = useMemo<HeaderChatTabEntry[]>(
-    () => groupedTabs
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "chat_tabs",
+      keys: [
+        "activeChatSessionIdForTabs",
+        "groupedTabs",
+        "hierarchy",
+        "knownSessions",
+        "manualGroupByTopLevelSessionId",
+      ],
+      count: (tabs) => tabs.length,
+    }, () => groupedTabs
       .map((grouped) => {
         const known = knownSessions.get(grouped.sessionId);
         const hierarchyChild = hierarchyChildren.rowsBySessionId.get(grouped.sessionId);
@@ -412,7 +472,7 @@ export function useWorkspaceHeaderTabsViewModel() {
           isHierarchyResolved: hierarchy.resolvedSessionIds.has(grouped.sessionId),
         } satisfies HeaderChatTabEntry;
       })
-      .filter((tab): tab is HeaderChatTabEntry => !!tab),
+      .filter((tab): tab is HeaderChatTabEntry => !!tab)),
     [
       activeChatSessionIdForTabs,
       groupedTabs,
@@ -425,7 +485,12 @@ export function useWorkspaceHeaderTabsViewModel() {
   );
 
   const stripRows = useMemo(
-    () => buildHeaderStripRows({
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "strip_rows",
+      keys: ["activeSessionId", "chatTabs", "collapsedParentIds", "displayManualGroups"],
+      count: (rows) => rows.length,
+    }, () => buildHeaderStripRows({
       groupedTabs: chatTabs,
       childrenByParentSessionId: hierarchy.childrenByParentSessionId,
       collapsedGroupIds: collapsedParentIds,
@@ -433,7 +498,7 @@ export function useWorkspaceHeaderTabsViewModel() {
       manualGroups: displayManualGroups,
       activeSessionId,
       subagentLabel: "Agents",
-    }),
+    })),
     [
       activeSessionId,
       chatTabs,
@@ -471,7 +536,12 @@ export function useWorkspaceHeaderTabsViewModel() {
     return highlighted?.kind === "chat" ? highlighted.sessionId : null;
   }, [activation.highlightedTabKey]);
   const displayShellRows = useMemo<HeaderWorkspaceShellStripRow[]>(
-    () => shellRows.map((shellRow) => {
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "display_shell_rows",
+      keys: ["highlightedChatSessionId", "shellRows"],
+      count: (rows) => rows.length,
+    }, () => shellRows.map((shellRow) => {
       if (shellRow.kind !== "chat" || shellRow.row.kind !== "tab") {
         return shellRow;
       }
@@ -485,7 +555,7 @@ export function useWorkspaceHeaderTabsViewModel() {
           },
         },
       };
-    }),
+    })),
     [highlightedChatSessionId, shellRows],
   );
 
@@ -552,7 +622,12 @@ export function useWorkspaceHeaderTabsViewModel() {
   ]);
 
   const menuChatTabs = useMemo<HeaderChatMenuEntry[]>(
-    () => Array.from(knownSessions.values())
+    () => measureDebugComputation({
+      category: "header_tabs.derive",
+      label: "menu_chat_tabs",
+      keys: ["highlightedChatSessionId", "hierarchy.childToParent", "knownSessions", "visibleChatSessionIds"],
+      count: (tabs) => tabs.length,
+    }, () => Array.from(knownSessions.values())
       .filter((known) => !hierarchy.childToParent.has(getKnownSessionId(known)))
       .map((known) => {
         const id = getKnownSessionId(known);
@@ -564,7 +639,7 @@ export function useWorkspaceHeaderTabsViewModel() {
           isActive: id === highlightedChatSessionId,
           isVisible: visibleChatSessionIds.includes(id),
         };
-      }),
+      })),
     [
       highlightedChatSessionId,
       hierarchy.childToParent,
@@ -572,6 +647,21 @@ export function useWorkspaceHeaderTabsViewModel() {
       visibleChatSessionIds,
     ],
   );
+
+  useDebugValueChange("header_tabs.model", "view_model_refs", {
+    selectedWorkspaceId,
+    activeSessionId,
+    hotPaintPending,
+    liveSlots,
+    knownSessions,
+    hierarchyChildToParent: hierarchy.childToParent,
+    hierarchyChildrenByParent: hierarchy.childrenByParentSessionId,
+    chatTabs,
+    stripRows,
+    displayShellRows,
+    menuChatTabs,
+    activation,
+  });
 
   return useMemo(() => ({
     activeSessionId,
@@ -684,6 +774,23 @@ function buildHeaderSlotSignature(slot: SessionSlot): string {
     pendingInteractionSignature(slot.transcript.pendingInteractions),
     slot.actionCapabilities.fork ? "fork" : "no-fork",
   ].join("\u001f");
+}
+
+function shouldWriteStringArrayPreference(
+  record: Record<string, string[]>,
+  key: string,
+  value: readonly string[],
+): boolean {
+  const hasCurrent = Object.prototype.hasOwnProperty.call(record, key);
+  return !hasCurrent || !sameStringArray(record[key] ?? [], value);
+}
+
+function shouldWriteReferencePreference<T>(
+  record: Record<string, T>,
+  key: string,
+  value: T,
+): boolean {
+  return !Object.prototype.hasOwnProperty.call(record, key) || record[key] !== value;
 }
 
 function pendingInteractionSignature(

--- a/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
@@ -72,6 +72,45 @@ interface ReconcileHotWorkspaceInput {
 
 const EMPTY_WORKSPACES = [] as const;
 const EMPTY_MODEL_REGISTRIES: ModelRegistry[] = [];
+const WORKSPACE_BOOTSTRAP_SESSION_LIST_TIMEOUT_MS = 8_000;
+const WORKSPACE_RECONCILE_SESSION_LIST_TIMEOUT_MS = 3_000;
+
+function requestOptionsWithSignal(
+  requestOptions: AnyHarnessRequestOptions | undefined,
+  signal: AbortSignal,
+): AnyHarnessRequestOptions {
+  return {
+    ...requestOptions,
+    signal: requestOptions?.signal ?? signal,
+  };
+}
+
+async function withAbortTimeout<T>(
+  timeoutMs: number | undefined,
+  run: (signal: AbortSignal | null) => Promise<T>,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return await run(null);
+  }
+
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      reject(new Error(`Timed out after ${timeoutMs}ms`));
+      controller.abort();
+    }, timeoutMs);
+  });
+  const runPromise = run(controller.signal);
+  runPromise.catch(() => undefined);
+  try {
+    return await Promise.race([runPromise, timeoutPromise]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}
 
 async function fetchWorkspaceSessionsWithConnection(
   workspaceConnection: AnyHarnessResolvedConnection,
@@ -79,14 +118,23 @@ async function fetchWorkspaceSessionsWithConnection(
   options?: {
     includeDismissed?: boolean;
     requestOptions?: AnyHarnessRequestOptions;
+    timeoutMs?: number;
   },
 ): Promise<WorkspaceSession[]> {
-  const requestOptions = options?.includeDismissed
-    ? { ...options?.requestOptions, includeDismissed: true }
-    : options?.requestOptions;
-  const sessions = await getAnyHarnessClient(workspaceConnection).sessions.list(
-    workspaceConnection.anyharnessWorkspaceId,
-    requestOptions,
+  const sessions = await withAbortTimeout(
+    options?.timeoutMs,
+    async (signal) => {
+      const timedRequestOptions = signal
+        ? requestOptionsWithSignal(options?.requestOptions, signal)
+        : options?.requestOptions;
+      const requestOptions = options?.includeDismissed
+        ? { ...timedRequestOptions, includeDismissed: true }
+        : timedRequestOptions;
+      return await getAnyHarnessClient(workspaceConnection).sessions.list(
+        workspaceConnection.anyharnessWorkspaceId,
+        requestOptions,
+      );
+    },
   );
   return sessions.map((session) => ({
     ...session,
@@ -113,6 +161,7 @@ async function loadWorkflowWorkspaceSessions(input: {
   workspaceId: string;
   requestOptions?: AnyHarnessRequestOptions;
   forceRefresh?: boolean;
+  timeoutMs?: number;
 }): Promise<WorkspaceSession[]> {
   const cacheState = input.queryClient.getQueryState(input.queryKey);
   const cachedSessions = input.queryClient.getQueryData<WorkspaceSession[]>(input.queryKey);
@@ -131,7 +180,10 @@ async function loadWorkflowWorkspaceSessions(input: {
   const sessions = await fetchWorkspaceSessionsWithConnection(
     input.workspaceConnection,
     input.workspaceId,
-    input.requestOptions ? { requestOptions: input.requestOptions } : undefined,
+    {
+      requestOptions: input.requestOptions,
+      timeoutMs: input.timeoutMs,
+    },
   );
   input.queryClient.setQueryData(input.queryKey, sessions);
   return sessions;
@@ -233,6 +285,7 @@ export function useWorkspaceBootstrapActions() {
         workspaceConnection,
         workspaceId,
         requestOptions: sessionRequestOptions ?? undefined,
+        timeoutMs: WORKSPACE_BOOTSTRAP_SESSION_LIST_TIMEOUT_MS,
       }).then((result) => {
         recordMeasurementWorkflowStep({
           operationId: measurementOperationId,
@@ -299,6 +352,7 @@ export function useWorkspaceBootstrapActions() {
         {
           includeDismissed: true,
           requestOptions: sessionRequestOptions,
+          timeoutMs: WORKSPACE_BOOTSTRAP_SESSION_LIST_TIMEOUT_MS,
         },
       ).catch(() => sessions);
       const hasDismissedSessions = hasHiddenDismissedWorkspaceSessions(
@@ -424,6 +478,20 @@ export function useWorkspaceBootstrapActions() {
       }
 
       if (targetSession && isCurrent()) {
+        const currentActiveSessionId = useHarnessStore.getState().activeSessionId;
+        if (currentActiveSessionId && currentActiveSessionId !== targetSession.id) {
+          logLatency("workspace.select.session_select.skipped", {
+            workspaceId,
+            sessionId: targetSession.id,
+            currentActiveSessionId,
+            reason: "active_session_changed",
+            totalElapsedMs: elapsedMs(startedAt),
+          });
+          if (isCurrent()) {
+            markWorkspaceBootstrappedInSession(workspaceId);
+          }
+          return { sessions };
+        }
         logLatency("workspace.select.session_select.start", {
           workspaceId,
           sessionId: targetSession.id,
@@ -552,6 +620,7 @@ export function useWorkspaceBootstrapActions() {
           workspaceId,
           requestOptions: sessionRequestOptions ?? undefined,
           forceRefresh: true,
+          timeoutMs: WORKSPACE_RECONCILE_SESSION_LIST_TIMEOUT_MS,
         });
         recordMeasurementWorkflowStep({
           operationId: measurementOperationId,

--- a/desktop/src/hooks/workspaces/use-workspace-sidebar-activities.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-sidebar-activities.ts
@@ -1,0 +1,153 @@
+import { useMemo } from "react";
+import {
+  collectWorkspaceSidebarActivityStates,
+  collectWorkspaceSidebarActivityStatesWithErrorAttention,
+  resolveSessionErrorAttentionKey,
+  type SidebarSessionActivityState,
+} from "@/lib/domain/sessions/activity";
+import { useHarnessStore, type SessionSlot } from "@/stores/sessions/harness-store";
+
+const EMPTY_ACTIVITY_STATES: Record<string, SidebarSessionActivityState> = {};
+const EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION: Record<string, string> = {};
+
+export function useWorkspaceSidebarActivityStates(): Record<string, SidebarSessionActivityState> {
+  const selector = useMemo(
+    () => createWorkspaceSidebarActivitySelector({
+      includeErrorAttention: false,
+      lastViewedSessionErrorAtBySession: EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION,
+    }),
+    [],
+  );
+  return useHarnessStore(selector);
+}
+
+export function useWorkspaceSidebarActivityStatesWithErrorAttention(
+  lastViewedSessionErrorAtBySession:
+    Record<string, string> | null | undefined,
+): Record<string, SidebarSessionActivityState> {
+  const lastViewed =
+    lastViewedSessionErrorAtBySession ?? EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION;
+  const selector = useMemo(
+    () => createWorkspaceSidebarActivitySelector({
+      includeErrorAttention: true,
+      lastViewedSessionErrorAtBySession: lastViewed,
+    }),
+    [lastViewed],
+  );
+  return useHarnessStore(selector);
+}
+
+type HarnessStoreSnapshot = ReturnType<typeof useHarnessStore.getState>;
+
+function createWorkspaceSidebarActivitySelector({
+  includeErrorAttention,
+  lastViewedSessionErrorAtBySession,
+}: {
+  includeErrorAttention: boolean;
+  lastViewedSessionErrorAtBySession: Record<string, string>;
+}): (state: HarnessStoreSnapshot) => Record<string, SidebarSessionActivityState> {
+  let previousSignature = "";
+  let previousStates = EMPTY_ACTIVITY_STATES;
+
+  return (state) => {
+    const signature = buildWorkspaceSidebarActivitySignature(
+      state.sessionSlots,
+      includeErrorAttention,
+    );
+    if (signature === previousSignature) {
+      return previousStates;
+    }
+
+    previousSignature = signature;
+    previousStates = includeErrorAttention
+      ? collectWorkspaceSidebarActivityStatesWithErrorAttention(
+          toSidebarAttentionSnapshots(state.sessionSlots),
+          lastViewedSessionErrorAtBySession,
+        )
+      : collectWorkspaceSidebarActivityStates(toSidebarActivitySnapshots(state.sessionSlots));
+    return previousStates;
+  };
+}
+
+function buildWorkspaceSidebarActivitySignature(
+  sessionSlots: Record<string, SessionSlot>,
+  includeErrorAttention: boolean,
+): string {
+  let signature = "";
+  for (const slot of Object.values(sessionSlots)) {
+    signature += [
+      slot.sessionId,
+      slot.workspaceId ?? "",
+      slot.status ?? "",
+      slot.executionSummary?.phase ?? "",
+      pendingInteractionSignature(slot.executionSummary?.pendingInteractions),
+      slot.streamConnectionState,
+      slot.transcript.isStreaming ? "streaming" : "idle",
+      pendingInteractionSignature(slot.transcript.pendingInteractions),
+      includeErrorAttention ? resolveSessionErrorAttentionKey(slot) ?? "" : "",
+    ].join("\u001f");
+    signature += "\u001e";
+  }
+  return signature;
+}
+
+function toSidebarActivitySnapshots(sessionSlots: Record<string, SessionSlot>) {
+  return Object.fromEntries(
+    Object.entries(sessionSlots).map(([sessionId, slot]) => [
+      sessionId,
+      {
+        workspaceId: slot.workspaceId,
+        status: slot.status,
+        executionSummary: slot.executionSummary,
+        streamConnectionState: slot.streamConnectionState,
+        transcript: {
+          isStreaming: slot.transcript.isStreaming,
+          pendingInteractions: slot.transcript.pendingInteractions,
+        },
+      },
+    ]),
+  );
+}
+
+function toSidebarAttentionSnapshots(sessionSlots: Record<string, SessionSlot>) {
+  return Object.fromEntries(
+    Object.entries(sessionSlots).map(([sessionId, slot]) => [
+      sessionId,
+      {
+        sessionId: slot.sessionId,
+        workspaceId: slot.workspaceId,
+        status: slot.status,
+        executionSummary: slot.executionSummary,
+        streamConnectionState: slot.streamConnectionState,
+        transcript: {
+          isStreaming: slot.transcript.isStreaming,
+          pendingInteractions: slot.transcript.pendingInteractions,
+        },
+        errorAttentionKey: resolveSessionErrorAttentionKey(slot),
+      },
+    ]),
+  );
+}
+
+function pendingInteractionSignature(
+  interactions: readonly SidebarPendingInteraction[] | null | undefined,
+): string {
+  if (!interactions || interactions.length === 0) {
+    return "";
+  }
+  return interactions
+    .map((interaction) => [
+      interaction.requestId ?? "",
+      interaction.linkedPlanId ?? "",
+      interaction.source?.linkedPlanId ?? "",
+    ].join(":"))
+    .join(",");
+}
+
+interface SidebarPendingInteraction {
+  requestId?: string;
+  linkedPlanId?: string | null;
+  source?: {
+    linkedPlanId?: string | null;
+  } | null;
+}

--- a/desktop/src/hooks/workspaces/use-workspace-sidebar-state.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-sidebar-state.ts
@@ -3,8 +3,6 @@ import type { Workspace } from "@anyharness/sdk";
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import {
-  collectWorkspaceSidebarActivityStatesWithErrorAttention,
-  resolveSessionErrorAttentionKey,
   type SidebarSessionActivityState,
 } from "@/lib/domain/sessions/activity";
 import {
@@ -19,6 +17,7 @@ import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-
 import { useWorkspaceMetadataSync } from "@/hooks/workspaces/use-workspace-metadata-sync";
 import { useWorkspaceFinishSuggestions } from "@/hooks/workspaces/use-workspace-finish-suggestions";
 import { useWorkspaces } from "@/hooks/workspaces/use-workspaces";
+import { useWorkspaceSidebarActivityStatesWithErrorAttention } from "@/hooks/workspaces/use-workspace-sidebar-activities";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { useLogicalWorkspaceStore } from "@/stores/workspaces/logical-workspace-store";
@@ -54,28 +53,9 @@ export function useWorkspaceSidebarState({
     state.lastViewedSessionErrorAtBySession
     ?? EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION
   );
-  const workspaceActivities = useHarnessStore(useShallow((state) =>
-    collectWorkspaceSidebarActivityStatesWithErrorAttention(
-      Object.fromEntries(
-        Object.entries(state.sessionSlots).map(([sessionId, slot]) => [
-          sessionId,
-          {
-            sessionId: slot.sessionId,
-            workspaceId: slot.workspaceId,
-            status: slot.status,
-            executionSummary: slot.executionSummary,
-            streamConnectionState: slot.streamConnectionState,
-            transcript: {
-              isStreaming: slot.transcript.isStreaming,
-              pendingInteractions: slot.transcript.pendingInteractions,
-            },
-            errorAttentionKey: resolveSessionErrorAttentionKey(slot),
-          },
-        ]),
-      ),
-      lastViewedSessionErrorAtBySession,
-    )
-  ));
+  const workspaceActivities = useWorkspaceSidebarActivityStatesWithErrorAttention(
+    lastViewedSessionErrorAtBySession,
+  );
   const deferredLaunchesById = useDeferredHomeLaunchStore((state) => state.launches);
   const activeSessionTitle = useHarnessStore((state) => {
     const sessionId = state.activeSessionId;

--- a/desktop/src/hooks/workspaces/use-workspaces.ts
+++ b/desktop/src/hooks/workspaces/use-workspaces.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/infra/debug-measurement";
 
 const WORKSPACE_ACTIVITY_REFRESH_INTERVAL_MS = 5_000;
+const WORKSPACE_COLLECTIONS_STALE_MS = 30_000;
 
 export function useWorkspaces() {
   const queryClient = useQueryClient();
@@ -38,7 +39,7 @@ export function useWorkspaces() {
     queryFn: async () => {
       const startedAt = startLatencyTimer();
       const operationId = startMeasurementOperation({
-        kind: "workspace_open",
+        kind: "workspace_collections_refresh",
         surfaces: [
           "workspace-shell",
           "workspace-sidebar",
@@ -125,6 +126,10 @@ export function useWorkspaces() {
       }
     },
     enabled: canQuery,
+    staleTime: WORKSPACE_COLLECTIONS_STALE_MS,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     refetchInterval: (query) =>
       workspaceCollectionsNeedActivityRefresh(query.state.data)
         ? WORKSPACE_ACTIVITY_REFRESH_INTERVAL_MS

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -1586,6 +1586,52 @@ body {
   animation: brand-mark-fade-out 0.22s ease-out forwards;
 }
 
+/* ---- Braille sweep loading text ----
+   This must stay CSS-driven. The previous React ticker updated every 60ms and
+   forced the chat shell to commit continuously while a loader was visible. */
+@keyframes braille-sweep-content {
+  0%,
+  6.249% { content: "⠁⠀"; }
+  6.25%,
+  12.499% { content: "⠋⠀"; }
+  12.5%,
+  18.749% { content: "⠟⠁"; }
+  18.75%,
+  24.999% { content: "⡿⠋"; }
+  25%,
+  31.249% { content: "⣿⠟"; }
+  31.25%,
+  37.499% { content: "⣿⡿"; }
+  37.5%,
+  49.999% { content: "⣿⣿"; }
+  50%,
+  56.249% { content: "⣾⣿"; }
+  56.25%,
+  62.499% { content: "⣴⣿"; }
+  62.5%,
+  68.749% { content: "⣠⣾"; }
+  68.75%,
+  74.999% { content: "⢀⣴"; }
+  75%,
+  81.249% { content: "⠀⣠"; }
+  81.25%,
+  87.499% { content: "⠀⢀"; }
+  87.5%,
+  100% { content: "⠀⠀"; }
+}
+
+.braille-sweep-frame::before {
+  content: "⠁⠀";
+  animation: braille-sweep-content 960ms step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .braille-sweep-frame::before {
+    animation: none;
+    content: "⣿⣿";
+  }
+}
+
 /* ---- Toast slide-in ---- */
 @keyframes toast-in {
   from {

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -1087,7 +1087,7 @@
   --color-faint: rgba(13, 13, 13, 0.5);
   --color-helper: rgba(13, 13, 13, 0.7);
 
-  --color-card: rgba(255, 255, 255, 0.96);
+  --color-card: rgba(13, 13, 13, 0.035);
   --color-card-foreground: #0d0d0d;
 
   --color-popover: #ffffff;

--- a/desktop/src/lib/domain/chat/transcript-row-model.test.ts
+++ b/desktop/src/lib/domain/chat/transcript-row-model.test.ts
@@ -89,6 +89,38 @@ describe("buildTranscriptRowModel", () => {
     ]);
   });
 
+  it("splits large turns into stable display-block rows", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-large", false);
+    addAssistantItems(transcript, "turn-large", 30);
+
+    const rows = buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: "turn-large",
+      latestTurnHasAssistantRenderableContent: true,
+    });
+
+    expect(rows).toHaveLength(30);
+    expect(rows[0]).toEqual(expect.objectContaining({
+      kind: "turn",
+      key: "turn:turn-large:block:item-0",
+      turnId: "turn-large",
+      blockKey: "item-0",
+      isFirstTurnRow: true,
+      isLastTurnRow: false,
+    }));
+    expect(rows[29]).toEqual(expect.objectContaining({
+      kind: "turn",
+      key: "turn:turn-large:block:item-29",
+      turnId: "turn-large",
+      blockKey: "item-29",
+      isFirstTurnRow: false,
+      isLastTurnRow: true,
+    }));
+  });
+
   it("reuses unchanged turn rows from the presentation cache", () => {
     const transcript = createTranscriptState("session-1");
     addTurn(transcript, "turn-1", true);
@@ -198,6 +230,29 @@ function addTurn(
     stopReason: completed ? "stop" : null,
     fileBadges: [],
   };
+}
+
+function addAssistantItems(
+  transcript: TranscriptState,
+  turnId: string,
+  count: number,
+) {
+  const turn = transcript.turnsById[turnId];
+  if (!turn) {
+    throw new Error(`missing test turn ${turnId}`);
+  }
+  for (let index = 0; index < count; index += 1) {
+    const itemId = `item-${index}`;
+    turn.itemOrder.push(itemId);
+    transcript.itemsById[itemId] = {
+      kind: "assistant_prose",
+      itemId,
+      turnId,
+      text: `message ${index}`,
+      isStreaming: false,
+      startedSeq: index + 1,
+    } as TranscriptState["itemsById"][string];
+  }
 }
 
 function pendingPrompt(): PendingPromptEntry {

--- a/desktop/src/lib/domain/chat/transcript-row-model.ts
+++ b/desktop/src/lib/domain/chat/transcript-row-model.ts
@@ -6,18 +6,25 @@ import type {
 } from "@anyharness/sdk";
 import {
   buildTurnPresentation,
+  type TurnDisplayBlock,
   type TurnPresentation,
 } from "@/lib/domain/chat/transcript-presentation";
 
 export const TURN_CONTENT_BLOCK_KEY = "content";
+export const TURN_COMPLETED_HISTORY_BLOCK_KEY = "completed-history";
+
+const SPLIT_TURN_MIN_ITEM_COUNT = 24;
 
 export type TranscriptRow =
   | {
     kind: "turn";
     key: `turn:${string}:block:${string}`;
     turnId: string;
-    blockKey: typeof TURN_CONTENT_BLOCK_KEY;
+    blockKey: string;
     presentation: TurnPresentation;
+    renderPresentation: TurnPresentation;
+    isFirstTurnRow: boolean;
+    isLastTurnRow: boolean;
   }
   | {
     kind: "pending_prompt";
@@ -39,7 +46,7 @@ export interface TranscriptRowModelCache {
 interface CachedTurnRow {
   turn: TurnRecord;
   itemRefs: readonly (TranscriptItem | null)[];
-  row: Extract<TranscriptRow, { kind: "turn" }>;
+  rows: readonly Extract<TranscriptRow, { kind: "turn" }>[];
 }
 
 export function createTranscriptRowModelCache(): TranscriptRowModelCache {
@@ -75,7 +82,7 @@ export function buildTranscriptRowModel({
     }
 
     seenTurnIds.add(turnId);
-    rows.push(buildTurnRow(turn, transcript, cache));
+    rows.push(...buildTurnRows(turn, transcript, cache));
   }
 
   if (visibleOptimisticPrompt) {
@@ -102,17 +109,24 @@ export function buildTurnContentRowKey(
   return `turn:${turnId}:block:${TURN_CONTENT_BLOCK_KEY}`;
 }
 
+function buildTurnBlockRowKey(
+  turnId: string,
+  blockKey: string,
+): `turn:${string}:block:${string}` {
+  return `turn:${turnId}:block:${blockKey}`;
+}
+
 export function buildPendingPromptRowKey(
   activeSessionId: string,
 ): `pending-prompt:${string}` {
   return `pending-prompt:${activeSessionId}`;
 }
 
-function buildTurnRow(
+function buildTurnRows(
   turn: TurnRecord,
   transcript: TranscriptState,
   cache?: TranscriptRowModelCache,
-): Extract<TranscriptRow, { kind: "turn" }> {
+): readonly Extract<TranscriptRow, { kind: "turn" }>[] {
   const itemRefs = collectTurnItemRefs(turn, transcript);
   const cached = cache?.turnRowsById.get(turn.turnId) ?? null;
   if (
@@ -120,22 +134,141 @@ function buildTurnRow(
     && cached.turn === turn
     && areItemRefsEqual(cached.itemRefs, itemRefs)
   ) {
-    return cached.row;
+    return cached.rows;
   }
 
-  const row: Extract<TranscriptRow, { kind: "turn" }> = {
-    kind: "turn",
-    key: buildTurnContentRowKey(turn.turnId),
-    turnId: turn.turnId,
-    blockKey: TURN_CONTENT_BLOCK_KEY,
-    presentation: buildTurnPresentation(turn, transcript),
-  };
+  const presentation = buildTurnPresentation(turn, transcript);
+  const rows = buildRowsForTurnPresentation(turn, presentation);
   cache?.turnRowsById.set(turn.turnId, {
     turn,
     itemRefs,
-    row,
+    rows,
   });
-  return row;
+  return rows;
+}
+
+function buildRowsForTurnPresentation(
+  turn: TurnRecord,
+  presentation: TurnPresentation,
+): readonly Extract<TranscriptRow, { kind: "turn" }>[] {
+  const chunks = shouldSplitTurnIntoRows(turn, presentation)
+    ? chunkTurnDisplayBlocks(presentation)
+    : [];
+  if (chunks.length <= 1) {
+    return [buildTurnRow({
+      turnId: turn.turnId,
+      blockKey: TURN_CONTENT_BLOCK_KEY,
+      presentation,
+      renderPresentation: presentation,
+      isFirstTurnRow: true,
+      isLastTurnRow: true,
+    })];
+  }
+
+  return chunks.map((chunk, index) => {
+    const renderPresentation: TurnPresentation = {
+      ...presentation,
+      displayBlocks: chunk.blocks,
+    };
+    return buildTurnRow({
+      turnId: turn.turnId,
+      blockKey: chunk.blockKey,
+      presentation,
+      renderPresentation,
+      isFirstTurnRow: index === 0,
+      isLastTurnRow: index === chunks.length - 1,
+    });
+  });
+}
+
+function buildTurnRow(input: {
+  turnId: string;
+  blockKey: string;
+  presentation: TurnPresentation;
+  renderPresentation: TurnPresentation;
+  isFirstTurnRow: boolean;
+  isLastTurnRow: boolean;
+}): Extract<TranscriptRow, { kind: "turn" }> {
+  return {
+    kind: "turn",
+    key: input.blockKey === TURN_CONTENT_BLOCK_KEY
+      ? buildTurnContentRowKey(input.turnId)
+      : buildTurnBlockRowKey(input.turnId, input.blockKey),
+    turnId: input.turnId,
+    blockKey: input.blockKey,
+    presentation: input.presentation,
+    renderPresentation: input.renderPresentation,
+    isFirstTurnRow: input.isFirstTurnRow,
+    isLastTurnRow: input.isLastTurnRow,
+  };
+}
+
+function shouldSplitTurnIntoRows(
+  turn: TurnRecord,
+  presentation: TurnPresentation,
+): boolean {
+  return turn.itemOrder.length >= SPLIT_TURN_MIN_ITEM_COUNT
+    && presentation.displayBlocks.length > 1;
+}
+
+interface TurnDisplayBlockChunk {
+  blockKey: string;
+  blocks: TurnDisplayBlock[];
+}
+
+function chunkTurnDisplayBlocks(
+  presentation: TurnPresentation,
+): TurnDisplayBlockChunk[] {
+  const completedHistoryRootIds = new Set(presentation.completedHistoryRootIds);
+  const chunks: TurnDisplayBlockChunk[] = [];
+  let completedHistoryBlocks: TurnDisplayBlock[] = [];
+
+  const flushCompletedHistory = () => {
+    if (completedHistoryBlocks.length === 0) {
+      return;
+    }
+    chunks.push({
+      blockKey: TURN_COMPLETED_HISTORY_BLOCK_KEY,
+      blocks: completedHistoryBlocks,
+    });
+    completedHistoryBlocks = [];
+  };
+
+  for (const block of presentation.displayBlocks) {
+    if (
+      presentation.completedHistorySummary
+      && blockBelongsToCompletedHistory(block, completedHistoryRootIds)
+    ) {
+      completedHistoryBlocks.push(block);
+      continue;
+    }
+
+    flushCompletedHistory();
+    chunks.push({
+      blockKey: getTurnDisplayBlockKey(block),
+      blocks: [block],
+    });
+  }
+
+  flushCompletedHistory();
+  return chunks;
+}
+
+function blockBelongsToCompletedHistory(
+  block: TurnDisplayBlock,
+  completedHistoryRootIds: ReadonlySet<string>,
+): boolean {
+  if (block.kind === "collapsed_actions" || block.kind === "inline_tools") {
+    return block.itemIds.every((itemId) => completedHistoryRootIds.has(itemId));
+  }
+  return completedHistoryRootIds.has(block.itemId);
+}
+
+function getTurnDisplayBlockKey(block: TurnDisplayBlock): string {
+  if (block.kind === "collapsed_actions" || block.kind === "inline_tools") {
+    return block.blockId;
+  }
+  return block.itemId;
 }
 
 function collectTurnItemRefs(

--- a/desktop/src/lib/domain/chat/transcript-virtualization-config.ts
+++ b/desktop/src/lib/domain/chat/transcript-virtualization-config.ts
@@ -1,7 +1,7 @@
 export const TRANSCRIPT_VIRTUALIZATION_STORAGE_KEY =
   "proliferate:transcriptVirtualization";
 
-export const TRANSCRIPT_VIRTUALIZATION_AUTO_ROW_THRESHOLD = 80;
+export const TRANSCRIPT_VIRTUALIZATION_AUTO_ROW_THRESHOLD = 16;
 
 export type TranscriptVirtualizationMode = "auto" | "on" | "off";
 

--- a/desktop/src/lib/infra/debug-measurement.ts
+++ b/desktop/src/lib/infra/debug-measurement.ts
@@ -14,6 +14,7 @@ export type MeasurementOperationId = AnyHarnessMeasurementOperationId;
 
 export type MeasurementOperationKind =
   | "workspace_open"
+  | "workspace_collections_refresh"
   | "workspace_hot_reopen"
   | "session_switch"
   | "session_hot_switch"

--- a/desktop/src/lib/infra/debug-measurement.ts
+++ b/desktop/src/lib/infra/debug-measurement.ts
@@ -203,6 +203,16 @@ export type MeasurementMetricInput =
       metric: "react_commit" | "render_count" | "long_task" | "frame_gap";
       durationMs?: number;
       count?: number;
+    }
+  | {
+      type: "diagnostic";
+      category: string;
+      label: string;
+      operationId?: MeasurementOperationId;
+      durationMs?: number;
+      count?: number;
+      keys?: readonly string[];
+      detail?: string | null;
     };
 
 type MeasurementSummaryValue = string | number | boolean | null;
@@ -289,6 +299,15 @@ type MeasurementMetricSnapshot =
       metric: "react_commit" | "render_count" | "long_task" | "frame_gap";
       durationMs: number | null;
       count: number | null;
+    }
+  | {
+      type: "diagnostic";
+      category: string;
+      label: string;
+      durationMs: number | null;
+      count: number | null;
+      keys: string[];
+      detail: string | null;
     };
 
 interface MeasurementOperationSnapshot {
@@ -328,6 +347,9 @@ interface MeasurementAggregateSnapshot {
   maxLongTaskMs: number;
   frameGapCount: number;
   maxFrameGapMs: number;
+  diagnosticCount: number;
+  totalDiagnosticMs: number;
+  maxDiagnosticMs: number;
 }
 
 interface MeasurementMemorySnapshot {
@@ -449,6 +471,13 @@ interface MeasurementStateCountBreakdown {
   maxCount: number;
 }
 
+interface MeasurementDiagnosticBreakdown extends DurationAggregate {
+  category: string;
+  label: string;
+  latestKeys: string;
+  latestDetail: string | null;
+}
+
 export interface MeasurementCategoryBindingInput {
   operationId: MeasurementOperationId;
   categories: readonly MeasurementTimingCategory[];
@@ -486,6 +515,9 @@ interface MeasurementOperationAggregate {
   maxLongTaskMs: number;
   frameGapCount: number;
   maxFrameGapMs: number;
+  diagnosticCount: number;
+  totalDiagnosticMs: number;
+  maxDiagnosticMs: number;
   requestBreakdowns: Map<string, MeasurementRequestBreakdown>;
   streamBreakdowns: Map<string, MeasurementStreamBreakdown>;
   cacheBreakdowns: Map<string, MeasurementCacheBreakdown>;
@@ -494,6 +526,7 @@ interface MeasurementOperationAggregate {
   workflowBreakdowns: Map<string, MeasurementWorkflowBreakdown>;
   stateCountBreakdowns: Map<MeasurementStateCountTarget, MeasurementStateCountBreakdown>;
   surfaceBreakdowns: Map<MeasurementSurface, MeasurementSurfaceBreakdown>;
+  diagnosticBreakdowns: Map<string, MeasurementDiagnosticBreakdown>;
 }
 
 interface MeasurementOperationRecord {
@@ -524,7 +557,9 @@ interface MeasurementCategoryBinding {
 }
 
 const MEASUREMENT_HEADER = "x-proliferate-measurement-operation-id";
-const RECENT_METRIC_LIMIT = 5_000;
+// Diagnostic sessions can generate many short-lived events; this buffer is
+// still dev-only because recordMeasurementMetric exits when measurement is off.
+const RECENT_METRIC_LIMIT = 50_000;
 const RECENT_OPERATION_EVENT_LIMIT = 1_000;
 const RECENT_MEMORY_SAMPLE_LIMIT = 1_000;
 const RECENT_SUMMARY_LIMIT = 500;
@@ -800,6 +835,51 @@ export function recordMeasurementWorkflowStep(input: {
   });
 }
 
+export function recordMeasurementDiagnostic(input: {
+  category: string;
+  label: string;
+  operationId?: MeasurementOperationId | null;
+  startedAt?: number;
+  durationMs?: number;
+  count?: number;
+  keys?: readonly string[];
+  detail?: string | null;
+}): void {
+  recordMeasurementMetric({
+    type: "diagnostic",
+    category: input.category,
+    label: input.label,
+    operationId: input.operationId ?? undefined,
+    durationMs: input.startedAt === undefined
+      ? input.durationMs
+      : now() - input.startedAt,
+    count: input.count,
+    keys: input.keys,
+    detail: input.detail,
+  });
+}
+
+export function measureDebugComputation<T>(input: {
+  category: string;
+  label: string;
+  keys?: readonly string[];
+  count?: (value: T) => number | undefined;
+}, compute: () => T): T {
+  if (!isDebugMeasurementEnabled()) {
+    return compute();
+  }
+  const startedAt = now();
+  const value = compute();
+  recordMeasurementDiagnostic({
+    category: input.category,
+    label: input.label,
+    startedAt,
+    count: input.count?.(value),
+    keys: input.keys,
+  });
+  return value;
+}
+
 export function resetDebugMeasurementForTest(): void {
   for (const operation of operations.values()) {
     clearOperationTimers(operation);
@@ -1027,6 +1107,16 @@ function metricSnapshot(input: MeasurementMetricInput): MeasurementMetricSnapsho
         durationMs: input.durationMs === undefined ? null : round(input.durationMs),
         count: input.count ?? null,
       };
+    case "diagnostic":
+      return {
+        type: "diagnostic",
+        category: input.category,
+        label: input.label,
+        durationMs: input.durationMs === undefined ? null : round(input.durationMs),
+        count: input.count ?? null,
+        keys: [...(input.keys ?? [])],
+        detail: input.detail ?? null,
+      };
   }
 }
 
@@ -1070,6 +1160,9 @@ function aggregateSnapshot(a: MeasurementOperationAggregate): MeasurementAggrega
     maxLongTaskMs: round(a.maxLongTaskMs),
     frameGapCount: a.frameGapCount,
     maxFrameGapMs: round(a.maxFrameGapMs),
+    diagnosticCount: a.diagnosticCount,
+    totalDiagnosticMs: round(a.totalDiagnosticMs),
+    maxDiagnosticMs: round(a.maxDiagnosticMs),
   };
 }
 
@@ -1115,6 +1208,12 @@ function resolveMetricOperationIds(input: MeasurementMetricInput): MeasurementOp
 
   if (input.type === "main_thread") {
     return resolveMainThreadOperationIds(input);
+  }
+
+  if (input.type === "diagnostic") {
+    // Diagnostics describe ambient render/store work, so attach them to every
+    // active operation unless the caller provided a specific operation id.
+    return [...operations.keys()];
   }
 
   if ("category" in input) {
@@ -1276,6 +1375,12 @@ function applyMetric(
         aggregate.maxFrameGapMs = Math.max(aggregate.maxFrameGapMs, input.durationMs ?? 0);
       }
       break;
+    case "diagnostic":
+      aggregate.diagnosticCount += input.count ?? 1;
+      aggregate.totalDiagnosticMs += input.durationMs ?? 0;
+      aggregate.maxDiagnosticMs = Math.max(aggregate.maxDiagnosticMs, input.durationMs ?? 0);
+      applyDiagnosticBreakdown(aggregate, input);
+      break;
   }
 }
 
@@ -1426,6 +1531,25 @@ function applySurfaceBreakdown(
   }
 }
 
+function applyDiagnosticBreakdown(
+  aggregate: MeasurementOperationAggregate,
+  input: Extract<MeasurementMetricInput, { type: "diagnostic" }>,
+): void {
+  const key = `${input.category}:${input.label}`;
+  const breakdown = getOrCreate(aggregate.diagnosticBreakdowns, key, () => ({
+    category: input.category,
+    label: input.label,
+    count: 0,
+    totalMs: 0,
+    maxMs: 0,
+    latestKeys: "",
+    latestDetail: null,
+  }));
+  applyDurationAggregate(breakdown, input.durationMs ?? 0, input.count);
+  breakdown.latestKeys = (input.keys ?? []).join(",");
+  breakdown.latestDetail = input.detail ?? null;
+}
+
 function applyDurationBreakdown(
   map: Map<string, DurationAggregate>,
   key: string,
@@ -1505,6 +1629,9 @@ function printSummaryRow(
     maxLongTaskMs: round(a.maxLongTaskMs),
     frameGapCount: a.frameGapCount,
     maxFrameGapMs: round(a.maxFrameGapMs),
+    diagnosticCount: a.diagnosticCount,
+    totalDiagnosticMs: round(a.totalDiagnosticMs),
+    maxDiagnosticMs: round(a.maxDiagnosticMs),
   }];
 
   for (const breakdown of a.requestBreakdowns.values()) {
@@ -1621,6 +1748,20 @@ function printSummaryRow(
     });
   }
 
+  for (const breakdown of a.diagnosticBreakdowns.values()) {
+    rows.push({
+      ...base,
+      rowKind: "diagnostic",
+      target: `${breakdown.category}:${breakdown.label}`,
+      durationMs: null,
+      count: breakdown.count,
+      totalMs: round(breakdown.totalMs),
+      maxMs: round(breakdown.maxMs),
+      keys: breakdown.latestKeys,
+      detail: breakdown.latestDetail,
+    });
+  }
+
   const payload: MeasurementSummaryPayload = {
     tag: "measurement_summary_json",
     operationId: operation.id,
@@ -1718,6 +1859,9 @@ function createEmptyAggregate(): MeasurementOperationAggregate {
     maxLongTaskMs: 0,
     frameGapCount: 0,
     maxFrameGapMs: 0,
+    diagnosticCount: 0,
+    totalDiagnosticMs: 0,
+    maxDiagnosticMs: 0,
     requestBreakdowns: new Map(),
     streamBreakdowns: new Map(),
     cacheBreakdowns: new Map(),
@@ -1726,6 +1870,7 @@ function createEmptyAggregate(): MeasurementOperationAggregate {
     workflowBreakdowns: new Map(),
     stateCountBreakdowns: new Map(),
     surfaceBreakdowns: new Map(),
+    diagnosticBreakdowns: new Map(),
   };
 }
 

--- a/desktop/src/lib/integrations/anyharness/session-stream-state.test.ts
+++ b/desktop/src/lib/integrations/anyharness/session-stream-state.test.ts
@@ -46,6 +46,35 @@ describe("session-stream-state", () => {
     );
   });
 
+  it("treats empty tail history as a no-op", () => {
+    const state = replaySessionHistory("session-1", [
+      turnStarted(1),
+      assistantStarted(2, "assistant-1", "Hello"),
+    ]);
+
+    const result = appendHistoryTail(state, []);
+
+    expect(result.applied).toBe(false);
+    expect(result.state).toBe(state);
+    expect(result.state.events).toBe(state.events);
+    expect(result.state.transcript).toBe(state.transcript);
+  });
+
+  it("treats duplicate tail history as a no-op", () => {
+    const events = [
+      turnStarted(1),
+      assistantStarted(2, "assistant-1", "Hello"),
+    ];
+    const state = replaySessionHistory("session-1", events);
+
+    const result = appendHistoryTail(state, events);
+
+    expect(result.applied).toBe(false);
+    expect(result.state).toBe(state);
+    expect(result.state.events).toBe(state.events);
+    expect(result.state.transcript).toBe(state.transcript);
+  });
+
   it("applies a contiguous stream batch with one events array copy", () => {
     const state = replaySessionHistory("session-1", [turnStarted(1)]);
 

--- a/desktop/src/stores/preferences/workspace-ui-store.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.ts
@@ -41,6 +41,10 @@ import {
 } from "@/lib/domain/workspaces/tabs/shell-file-seed";
 import { sameStringArray } from "@/lib/domain/workspaces/workspace-keyed-preferences";
 import { readPersistedValue, persistValue } from "@/lib/infra/preferences-persistence";
+import {
+  isDebugMeasurementEnabled,
+  recordMeasurementDiagnostic,
+} from "@/lib/infra/debug-measurement";
 
 export interface WorkspaceUiState {
   _hydrated: boolean;
@@ -1005,11 +1009,16 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   },
 
   setLastViewedSessionForWorkspace: (workspaceId, sessionId) => {
-    set({
-      lastViewedSessionByWorkspace: {
-        ...get().lastViewedSessionByWorkspace,
-        [workspaceId]: sessionId,
-      },
+    set((state) => {
+      if (state.lastViewedSessionByWorkspace[workspaceId] === sessionId) {
+        return state;
+      }
+      return {
+        lastViewedSessionByWorkspace: {
+          ...state.lastViewedSessionByWorkspace,
+          [workspaceId]: sessionId,
+        },
+      };
     });
   },
 
@@ -1104,11 +1113,22 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   },
 
   setVisibleChatSessionIdsForWorkspace: (workspaceId, sessionIds) => {
-    set({
-      visibleChatSessionIdsByWorkspace: {
-        ...get().visibleChatSessionIdsByWorkspace,
-        [workspaceId]: uniqueIds(sessionIds),
-      },
+    const nextSessionIds = uniqueIds(sessionIds);
+    set((state) => {
+      const hasCurrent = Object.prototype.hasOwnProperty.call(
+        state.visibleChatSessionIdsByWorkspace,
+        workspaceId,
+      );
+      const current = state.visibleChatSessionIdsByWorkspace[workspaceId] ?? [];
+      if (hasCurrent && sameStringArray(current, nextSessionIds)) {
+        return state;
+      }
+      return {
+        visibleChatSessionIdsByWorkspace: {
+          ...state.visibleChatSessionIdsByWorkspace,
+          [workspaceId]: nextSessionIds,
+        },
+      };
     });
   },
 
@@ -1253,6 +1273,18 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
 }));
 
 useWorkspaceUiStore.subscribe((state, prev) => {
+  if (isDebugMeasurementEnabled()) {
+    const changedKeys = getChangedWorkspaceUiStateKeys(prev, state);
+    if (changedKeys.length > 0) {
+      recordMeasurementDiagnostic({
+        category: "workspace_ui_store.write",
+        label: "top_level_keys",
+        keys: changedKeys,
+        count: changedKeys.length,
+      });
+    }
+  }
+
   if (!state._hydrated) {
     return;
   }
@@ -1307,4 +1339,41 @@ export function clearViewedSessionErrors(sessionIds: string[]) {
 
 export function ensureRepoGroupExpanded(repoKey: string) {
   useWorkspaceUiStore.getState().ensureRepoGroupExpanded(repoKey);
+}
+
+function getChangedWorkspaceUiStateKeys(
+  previous: WorkspaceUiState,
+  next: WorkspaceUiState,
+): string[] {
+  // Manual top-level allowlist for debug diagnostics. Keep this in sync when
+  // adding workspace UI state that should show up in store-write traces.
+  return [
+    "archivedWorkspaceIds",
+    "hiddenRepoRootIds",
+    "collapsedRepoGroups",
+    "showArchived",
+    "threadsCollapsed",
+    "sidebarOpen",
+    "sidebarWidth",
+    "rightPanelDurableByWorkspace",
+    "rightPanelMaterializedByWorkspace",
+    "activeShellTabKeyByWorkspace",
+    "shellTabOrderByWorkspace",
+    "shellActivationEpochByWorkspace",
+    "pendingChatActivationByWorkspace",
+    "workspaceTypes",
+    "lastViewedAt",
+    "lastViewedSessionByWorkspace",
+    "lastViewedSessionErrorAtBySession",
+    "workspaceLastInteracted",
+    "dismissedSetupFailures",
+    "finishSuggestionDismissalsByWorkspaceId",
+    "visibleChatSessionIdsByWorkspace",
+    "recentlyHiddenChatSessionIdsByWorkspace",
+    "collapsedChatGroupsByWorkspace",
+    "manualChatGroupsByWorkspace",
+  ].filter((key) => !Object.is(
+    previous[key as keyof WorkspaceUiState],
+    next[key as keyof WorkspaceUiState],
+  ));
 }

--- a/desktop/src/stores/sessions/harness-store.ts
+++ b/desktop/src/stores/sessions/harness-store.ts
@@ -16,6 +16,7 @@ import type { PendingWorkspaceEntry } from "@/lib/domain/workspaces/pending-entr
 import { DEFAULT_RUNTIME_URL } from "@/config/runtime";
 import {
   isDebugMeasurementEnabled,
+  recordMeasurementDiagnostic,
   type MeasurementOperationId,
 } from "@/lib/infra/debug-measurement";
 
@@ -422,6 +423,30 @@ const RETAINED_SESSION_SLOT_WARNING_THRESHOLD = 50;
 const retainedSessionSlotWarningEnabled = isDebugMeasurementEnabled();
 let lastRetainedSlotWarningBucket = 0;
 
+if (isDebugMeasurementEnabled()) {
+  let previousHarnessState = useHarnessStore.getState();
+  const unsubscribeHarnessStoreDiagnostics = useHarnessStore.subscribe((state) => {
+    const changedKeys = getChangedHarnessStateKeys(previousHarnessState, state);
+    previousHarnessState = state;
+    if (changedKeys.length === 0) {
+      return;
+    }
+    recordMeasurementDiagnostic({
+      category: "harness_store.write",
+      label: "top_level_keys",
+      keys: changedKeys,
+      count: changedKeys.length,
+      detail: buildHarnessStateWriteDetail(state),
+    });
+  });
+
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      unsubscribeHarnessStoreDiagnostics();
+    });
+  }
+}
+
 if (retainedSessionSlotWarningEnabled) {
   const unsubscribeRetainedSlotWarning = useHarnessStore.subscribe((state) => {
     const retainedSlotCount = Object.keys(state.sessionSlots).length;
@@ -451,4 +476,39 @@ export function isHotPaintGatePendingForWorkspace(
   workspaceId: string | null | undefined,
 ): boolean {
   return !!workspaceId && gate?.workspaceId === workspaceId;
+}
+
+function getChangedHarnessStateKeys(
+  previous: HarnessState,
+  next: HarnessState,
+): string[] {
+  // Manual top-level allowlist for debug diagnostics. Keep this in sync when
+  // adding harness state that should show up in store-write traces.
+  return [
+    "runtimeUrl",
+    "connectionState",
+    "error",
+    "pendingWorkspaceEntry",
+    "selectedWorkspaceId",
+    "workspaceSelectionNonce",
+    "workspaceArrivalEvent",
+    "activeSessionId",
+    "activeSessionVersion",
+    "sessionActivationIntentEpochByWorkspace",
+    "sessionSlots",
+    "sessionRelationshipHints",
+    "hotPaintGate",
+  ].filter((key) => !Object.is(
+    previous[key as keyof HarnessState],
+    next[key as keyof HarnessState],
+  ));
+}
+
+function buildHarnessStateWriteDetail(state: HarnessState): string {
+  return [
+    `slots=${Object.keys(state.sessionSlots).length}`,
+    `workspace=${state.selectedWorkspaceId ?? "none"}`,
+    `active=${state.activeSessionId ?? "none"}`,
+    `hotGate=${state.hotPaintGate?.kind ?? "none"}`,
+  ].join(" ");
 }


### PR DESCRIPTION
## Summary
- add AnyHarness latency tracing across workspace, repo-root, session SSE, and git status paths
- add debug-only frontend diagnostic measurements for render/reference churn and store writes
- reduce redundant workspace UI store writes and abort superseded hot-paint measurements

## Validation
- git diff --check
- pnpm --dir desktop exec tsc --noEmit
- cargo check -p anyharness-lib
- env VITE_PROLIFERATE_DEBUG_ANYHARNESS_TIMING=0 VITE_PROLIFERATE_DEBUG_MAIN_THREAD=0 pnpm --dir desktop exec vitest run src/lib/infra/debug-measurement.test.ts