### PR TITLE
Add global worktree cleanup policy

### DIFF
--- a/anyharness/crates/anyharness-lib/src/workspaces/retention.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/retention.rs
@@ -21,6 +21,7 @@ const RETENTION_MAX_REMOVALS_PER_PASS: usize = 20;
 const RETENTION_MAX_CONSIDERED_PER_PASS: usize = 200;
 const RETENTION_MAX_ATTEMPTS_PER_PASS: usize = 50;
 const RETENTION_OPERATION_GATE_TIMEOUT: Duration = Duration::from_millis(150);
+pub const ANYHARNESS_DEFER_STARTUP_RETENTION_ENV: &str = "ANYHARNESS_DEFER_STARTUP_RETENTION";
 
 #[derive(Clone)]
 pub struct WorkspaceRetentionService {
@@ -33,6 +34,7 @@ pub struct WorkspaceRetentionService {
     runtime_home: std::path::PathBuf,
     running: Arc<AtomicBool>,
     enabled: bool,
+    defer_startup_pass: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +71,8 @@ impl WorkspaceRetentionService {
         runtime_home: std::path::PathBuf,
     ) -> Self {
         let enabled = std::env::var_os("ANYHARNESS_DISABLE_WORKTREE_RETENTION").is_none();
+        let defer_startup_pass =
+            std::env::var_os(ANYHARNESS_DEFER_STARTUP_RETENTION_ENV).is_some();
         Self {
             workspace_runtime,
             workspace_store,
@@ -79,11 +83,12 @@ impl WorkspaceRetentionService {
             runtime_home,
             running: Arc::new(AtomicBool::new(false)),
             enabled,
+            defer_startup_pass,
         }
     }
 
     pub fn spawn_startup_pass(self: Arc<Self>) {
-        if !self.enabled {
+        if !should_spawn_startup_pass(self.enabled, self.defer_startup_pass) {
             return;
         }
         tokio::spawn(async move {
@@ -453,10 +458,27 @@ fn display_safe_error(message: &str, error: &anyhow::Error) -> String {
     message.to_string()
 }
 
+fn should_spawn_startup_pass(enabled: bool, defer_startup_pass: bool) -> bool {
+    enabled && !defer_startup_pass
+}
+
 struct RunningGuard<'a>(&'a AtomicBool);
 
 impl Drop for RunningGuard<'_> {
     fn drop(&mut self) {
         self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_spawn_startup_pass;
+
+    #[test]
+    fn startup_deferral_is_startup_only_gate() {
+        assert!(should_spawn_startup_pass(true, false));
+        assert!(!should_spawn_startup_pass(true, true));
+        assert!(!should_spawn_startup_pass(false, false));
+        assert!(!should_spawn_startup_pass(false, true));
     }
 }

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -12,6 +12,7 @@ use crate::desktop_telemetry_mode::{resolve_desktop_telemetry_mode, DesktopTelem
 const DEFAULT_HOST: &str = "127.0.0.1";
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const HEALTH_POLL_TIMEOUT: Duration = Duration::from_secs(60);
+const ANYHARNESS_DEFER_STARTUP_RETENTION_ENV: &str = "ANYHARNESS_DEFER_STARTUP_RETENTION";
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -334,6 +335,10 @@ mod tests {
 fn build_spawn_command(binary: &str, port: u16, launch_env: &HashMap<String, String>) -> Command {
     let mut cmd = Command::new(binary);
     let mut runtime_env = default_anyharness_launch_env();
+    runtime_env.insert(
+        ANYHARNESS_DEFER_STARTUP_RETENTION_ENV.to_string(),
+        "1".to_string(),
+    );
     runtime_env.extend(launch_env.clone());
 
     if let Some(shell_path) = resolve_shell_path() {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -20,6 +20,8 @@ import { useRuntimeInputSyncRuntime } from "@/hooks/cloud/use-runtime-input-sync
 import { useHomeDeferredLaunchRunner } from "@/hooks/home/use-home-deferred-launch-runner"
 import { useShortcutDispatcher } from "@/hooks/shortcuts/use-shortcut-dispatcher"
 import { useTurnEndSound } from "@/hooks/sessions/use-turn-end-sound"
+import { useLocalWorktreeSettingsTarget } from "@/hooks/workspaces/use-local-worktree-settings-target"
+import { useWorktreeCleanupPolicy } from "@/hooks/workspaces/use-worktree-cleanup-policy"
 import {
   elapsedStartupMs,
   logStartupDebug,
@@ -243,6 +245,7 @@ function AppRuntime() {
         <UpdateRestartDialog />
         <SessionModelAvailabilityDialog />
         <RuntimeInputSyncGate />
+        <WorktreeCleanupPolicySyncGate />
         <InstrumentedRoutes>
           <Route path="/index.html" element={<Navigate to="/" replace />} />
           <Route path="/settings/cloud" element={<SettingsCloudRedirect />} />
@@ -310,6 +313,22 @@ function RuntimeInputSyncGate() {
 
 function RuntimeInputSyncRuntimeMount() {
   useRuntimeInputSyncRuntime()
+  return null
+}
+
+function WorktreeCleanupPolicySyncGate() {
+  const preferencesHydrated = useUserPreferencesStore((s) => s._hydrated)
+
+  if (!preferencesHydrated) {
+    return null
+  }
+
+  return <WorktreeCleanupPolicySyncMount />
+}
+
+function WorktreeCleanupPolicySyncMount() {
+  const settings = useLocalWorktreeSettingsTarget()
+  useWorktreeCleanupPolicy(settings.targets, settings.syncPolicyToTarget)
   return null
 }
 

--- a/desktop/src/components/settings/panes/WorktreesPane.test.tsx
+++ b/desktop/src/components/settings/panes/WorktreesPane.test.tsx
@@ -11,7 +11,12 @@ const worktreeSettingsMocks = vi.hoisted(() => ({
   purgeWorkspace: vi.fn(),
   retryPurge: vi.fn(),
   runRetention: vi.fn(),
-  updatePolicy: vi.fn(),
+  syncPolicyToTarget: vi.fn(),
+}));
+
+const cleanupPolicyMocks = vi.hoisted(() => ({
+  apply: vi.fn(),
+  setDraftValue: vi.fn(),
 }));
 
 const toastStoreMocks = vi.hoisted(() => ({
@@ -25,10 +30,6 @@ vi.mock("@/hooks/workspaces/use-worktree-settings-targets", () => ({
       error: null,
       inventory: { rows: [] },
       isLoading: false,
-      policy: {
-        maxMaterializedWorktreesPerRepo: 20,
-        updatedAt: "2026-05-03T00:00:00Z",
-      },
       target: {
         key: "local:http://localhost:4444:generation:0",
         label: "Local runtime",
@@ -38,6 +39,20 @@ vi.mock("@/hooks/workspaces/use-worktree-settings-targets", () => ({
       },
     }],
     ...worktreeSettingsMocks,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/use-worktree-cleanup-policy", () => ({
+  useWorktreeCleanupPolicy: () => ({
+    apply: cleanupPolicyMocks.apply,
+    applyDisabledReason: null,
+    canApply: true,
+    draftValue: "20",
+    isApplying: false,
+    parsedDraft: 20,
+    setDraftValue: cleanupPolicyMocks.setDraftValue,
+    statusMessage: null,
+    value: 20,
   }),
 }));
 

--- a/desktop/src/components/settings/panes/WorktreesPane.tsx
+++ b/desktop/src/components/settings/panes/WorktreesPane.tsx
@@ -12,6 +12,7 @@ import {
   EnvironmentSection,
 } from "@/components/ui/EnvironmentLayout";
 import { SettingsPageHeader } from "@/components/settings/SettingsPageHeader";
+import { useWorktreeCleanupPolicy } from "@/hooks/workspaces/use-worktree-cleanup-policy";
 import {
   useWorktreeSettingsTargets,
   type WorktreeSettingsTargetState,
@@ -26,6 +27,10 @@ const EMPTY_ROWS: WorktreeInventoryRow[] = [];
 
 export function WorktreesPane() {
   const settings = useWorktreeSettingsTargets();
+  const cleanupPolicy = useWorktreeCleanupPolicy(
+    settings.targets,
+    settings.syncPolicyToTarget,
+  );
   const showToast = useToastStore((state) => state.show);
   const [confirmDelete, setConfirmDelete] = useState<{
     target: WorktreeSettingsTargetState["target"];
@@ -57,8 +62,20 @@ export function WorktreesPane() {
         description="Recommended for most users. Automatic cleanup only removes clean Proliferate-managed checkouts; it does not snapshot, push, or back up work before deleting a checkout."
       />
 
+      <AutomaticCleanupSection
+        draftValue={cleanupPolicy.draftValue}
+        onDraftValueChange={cleanupPolicy.setDraftValue}
+        canApply={cleanupPolicy.canApply && !cleanupPolicy.isApplying}
+        applyDisabledReason={cleanupPolicy.applyDisabledReason}
+        statusMessage={cleanupPolicy.statusMessage}
+        onApply={() => runAction(
+          cleanupPolicy.apply,
+          "Worktree cleanup policy updated.",
+        )}
+      />
+
       {settings.targets.length === 0 ? (
-        <EnvironmentSection title="Runtime roots">
+        <EnvironmentSection title="Current worktrees">
           <EnvironmentPanel>
             <EnvironmentPanelRow>
               <p className="text-sm text-muted-foreground">No runtime roots found.</p>
@@ -69,14 +86,8 @@ export function WorktreesPane() {
         <RuntimeWorktreesSection
           key={targetState.target.key}
           targetState={targetState}
-          onUpdatePolicy={(value) => runAction(
-            () => settings.updatePolicy(targetState.target, {
-              maxMaterializedWorktreesPerRepo: value,
-            }),
-            "Worktree cleanup policy updated.",
-          )}
           onRunCleanup={() => runAction(
-            () => settings.runRetention(targetState.target),
+            () => settings.runRetention(targetState.target, cleanupPolicy.value),
             worktreeRetentionRunMessage,
           )}
           onPruneOrphan={(path) => runAction(
@@ -120,58 +131,55 @@ export function WorktreesPane() {
   );
 }
 
-function RuntimeWorktreesSection({
-  targetState,
-  onUpdatePolicy,
-  onRunCleanup,
-  onPruneOrphan,
-  onPruneWorkspace,
-  onPurgeWorkspace,
-  onRetryPurge,
+function AutomaticCleanupSection({
+  draftValue,
+  onDraftValueChange,
+  canApply,
+  applyDisabledReason,
+  statusMessage,
+  onApply,
 }: {
-  targetState: WorktreeSettingsTargetState;
-  onUpdatePolicy: (value: number) => void;
-  onRunCleanup: () => void;
-  onPruneOrphan: (path: string) => void;
-  onPruneWorkspace: (workspaceId: string) => void;
-  onPurgeWorkspace: (workspaceId: string) => void;
-  onRetryPurge: (workspaceId: string) => void;
+  draftValue: string;
+  onDraftValueChange: (value: string) => void;
+  canApply: boolean;
+  applyDisabledReason: string | null;
+  statusMessage: string | null;
+  onApply: () => void;
 }) {
-  const policy = targetState.policy;
-  const rows = targetState.inventory?.rows ?? EMPTY_ROWS;
-  const [draftValue, setDraftValue] = useState<string | null>(null);
-  const currentValue = policy?.maxMaterializedWorktreesPerRepo ?? 20;
-  const effectiveValue = draftValue ?? String(currentValue);
-  const parsedDraft = Number.parseInt(effectiveValue, 10);
-  const canApply = Number.isInteger(parsedDraft) && parsedDraft >= 10 && parsedDraft <= 100;
-
   return (
     <EnvironmentSection
-      title={targetState.target.label}
-      description={targetState.target.location === "cloud" ? "Cloud runtime" : "Local runtime"}
+      title="Automatic cleanup"
+      description="This policy is global. Inventories and manual actions below remain runtime-specific."
     >
       <EnvironmentPanel>
         <EnvironmentPanelRow>
           <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <EnvironmentField
-              label="Automatic cleanup"
-              description="When a repo has more managed checkouts than the limit below, Proliferate retires the oldest clean checkouts first. Workspace and session history stay available unless you explicitly delete the workspace."
+              label="Keep up to N materialized managed checkouts per repo"
+              description="When a repo exceeds this limit, Proliferate retires the oldest clean managed checkouts first. Workspace and session history stay available unless you explicitly delete the workspace."
             >
               <div className="w-full max-w-64 space-y-1.5">
-                <Label htmlFor={`worktree-policy-${targetState.target.key}`}>Auto-delete limit</Label>
+                <Label htmlFor="worktree-policy-global">Auto-delete limit</Label>
                 <Input
-                  id={`worktree-policy-${targetState.target.key}`}
+                  id="worktree-policy-global"
                   type="number"
                   min={10}
                   max={100}
-                  value={effectiveValue}
-                  onChange={(event) => setDraftValue(event.target.value)}
+                  value={draftValue}
+                  onChange={(event) => onDraftValueChange(event.target.value)}
                 />
                 <p className="text-xs leading-4 text-muted-foreground">
-                  Default is 20 active checkouts per repo; minimum is 10. Commits, branches, and
-                  pull requests are preserved by Git; uncommitted work is not saved, so dirty
-                  worktrees are skipped.
+                  Default is 20; minimum is 10. Commits, branches, and pull requests are
+                  preserved by Git; dirty worktrees are skipped.
                 </p>
+                {statusMessage ? (
+                  <p className="text-xs leading-4 text-muted-foreground">{statusMessage}</p>
+                ) : null}
+                {applyDisabledReason ? (
+                  <p className="text-xs leading-4 text-muted-foreground">
+                    {applyDisabledReason}
+                  </p>
+                ) : null}
               </div>
             </EnvironmentField>
             <div className="flex shrink-0 gap-2">
@@ -180,32 +188,53 @@ function RuntimeWorktreesSection({
                 variant="outline"
                 size="sm"
                 disabled={!canApply}
-                onClick={() => {
-                  if (!canApply) {
-                    return;
-                  }
-                  onUpdatePolicy(parsedDraft);
-                  setDraftValue(null);
-                }}
+                onClick={onApply}
               >
                 Apply
-              </Button>
-              <Button type="button" variant="outline" size="sm" onClick={onRunCleanup}>
-                <RefreshCw className="size-4" />
-                Run cleanup
               </Button>
             </div>
           </div>
         </EnvironmentPanelRow>
       </EnvironmentPanel>
+    </EnvironmentSection>
+  );
+}
 
+function RuntimeWorktreesSection({
+  targetState,
+  onRunCleanup,
+  onPruneOrphan,
+  onPruneWorkspace,
+  onPurgeWorkspace,
+  onRetryPurge,
+}: {
+  targetState: WorktreeSettingsTargetState;
+  onRunCleanup: () => void;
+  onPruneOrphan: (path: string) => void;
+  onPruneWorkspace: (workspaceId: string) => void;
+  onPurgeWorkspace: (workspaceId: string) => void;
+  onRetryPurge: (workspaceId: string) => void;
+}) {
+  const rows = targetState.inventory?.rows ?? EMPTY_ROWS;
+
+  return (
+    <EnvironmentSection
+      title={targetState.target.label}
+      description={targetState.target.location === "cloud" ? "Cloud runtime" : "Local runtime"}
+    >
       <EnvironmentPanel>
         <EnvironmentPanelRow>
-          <div className="space-y-1">
-            <h3 className="text-sm font-medium text-foreground">Current worktrees</h3>
-            <p className="text-sm text-muted-foreground">
-              Review managed checkouts, orphaned paths, and workspace history in this runtime.
-            </p>
+          <div className="flex w-full items-center justify-between gap-3">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-foreground">Current worktrees</h3>
+              <p className="text-sm text-muted-foreground">
+                Review managed checkouts, orphaned paths, and workspace history in this runtime.
+              </p>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={onRunCleanup}>
+              <RefreshCw className="size-4" />
+              Run cleanup
+            </Button>
           </div>
         </EnvironmentPanelRow>
         {targetState.isLoading ? (

--- a/desktop/src/hooks/cloud/query-keys.test.ts
+++ b/desktop/src/hooks/cloud/query-keys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   cloudBillingKey,
+  cloudWorktreeRetentionPolicyKey,
   cloudWorkspaceConnectionKey,
   cloudWorkspaceRepoConfigStatusKey,
   isCloudWorkspaceConnectionQueryKey,
@@ -14,6 +15,19 @@ describe("cloud query keys", () => {
       ownerScope: "organization",
       organizationId: "org-1",
     })).toEqual(["cloud", "billing", "organization", "org-1"]);
+  });
+
+  it("scopes account policy keys by user", () => {
+    expect(cloudWorktreeRetentionPolicyKey("user-1")).toEqual([
+      "cloud",
+      "worktree-retention-policy",
+      "user-1",
+    ]);
+    expect(cloudWorktreeRetentionPolicyKey("user-2")).toEqual([
+      "cloud",
+      "worktree-retention-policy",
+      "user-2",
+    ]);
   });
 
   it("scopes workspace connection and repo config keys by owner", () => {

--- a/desktop/src/hooks/cloud/query-keys.ts
+++ b/desktop/src/hooks/cloud/query-keys.ts
@@ -35,6 +35,10 @@ export function cloudRepoConfigsKey() {
   return [...cloudRootKey(), "repo-configs"] as const;
 }
 
+export function cloudWorktreeRetentionPolicyKey(userId: string | null) {
+  return [...cloudRootKey(), "worktree-retention-policy", userId] as const;
+}
+
 export function cloudMobilityRootKey() {
   return [...cloudRootKey(), "mobility"] as const;
 }

--- a/desktop/src/hooks/cloud/use-cloud-worktree-retention-policy.ts
+++ b/desktop/src/hooks/cloud/use-cloud-worktree-retention-policy.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  CloudWorktreeRetentionPolicyRequest,
+  CloudWorktreeRetentionPolicyResponse,
+} from "@/lib/integrations/cloud/client";
+import {
+  getCloudWorktreeRetentionPolicy,
+  putCloudWorktreeRetentionPolicy,
+} from "@/lib/integrations/cloud/worktree-policy";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { cloudWorktreeRetentionPolicyKey } from "./query-keys";
+
+export function useCloudWorktreeRetentionPolicy() {
+  const authStatus = useAuthStore((state) => state.status);
+  const userId = useAuthStore((state) => state.user?.id ?? null);
+  return useQuery<CloudWorktreeRetentionPolicyResponse>({
+    queryKey: cloudWorktreeRetentionPolicyKey(userId),
+    queryFn: getCloudWorktreeRetentionPolicy,
+    enabled: authStatus === "authenticated" && userId !== null,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function usePutCloudWorktreeRetentionPolicy() {
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((state) => state.user?.id ?? null);
+  return useMutation({
+    mutationFn: (input: CloudWorktreeRetentionPolicyRequest) =>
+      putCloudWorktreeRetentionPolicy(input),
+    onSuccess: (policy) => {
+      queryClient.setQueryData(cloudWorktreeRetentionPolicyKey(userId), policy);
+    },
+  });
+}

--- a/desktop/src/hooks/workspaces/use-local-worktree-settings-target.ts
+++ b/desktop/src/hooks/workspaces/use-local-worktree-settings-target.ts
@@ -1,0 +1,80 @@
+import {
+  anyHarnessRuntimeWorkspacesKey,
+  anyHarnessWorktreesInventoryKey,
+  anyHarnessWorktreesRetentionPolicyKey,
+  getAnyHarnessClient,
+} from "@anyharness/sdk-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+import { useHarnessStore } from "@/stores/sessions/harness-store";
+import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
+import type {
+  WorktreeSettingsTarget,
+  WorktreeSettingsTargetState,
+} from "@/hooks/workspaces/use-worktree-settings-targets";
+
+const EMPTY_TARGETS: WorktreeSettingsTargetState[] = [];
+
+export function useLocalWorktreeSettingsTarget() {
+  const runtimeUrl = useHarnessStore((state) => state.runtimeUrl);
+  const connectionState = useHarnessStore((state) => state.connectionState);
+  const queryClient = useQueryClient();
+
+  const targets = useMemo<WorktreeSettingsTargetState[]>(() => {
+    const trimmedRuntimeUrl = runtimeUrl.trim();
+    if (connectionState !== "healthy" || trimmedRuntimeUrl.length === 0) {
+      return EMPTY_TARGETS;
+    }
+
+    const target: WorktreeSettingsTarget = {
+      key: `local:${trimmedRuntimeUrl}:generation:0`,
+      label: "Local runtime",
+      location: "local",
+      runtimeUrl: trimmedRuntimeUrl,
+      runtimeGeneration: 0,
+      environmentId: null,
+    };
+
+    return [{
+      target,
+      inventory: null,
+      isLoading: false,
+      error: null,
+    }];
+  }, [connectionState, runtimeUrl]);
+
+  const refreshTarget = useCallback(async (target: WorktreeSettingsTarget) => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessWorktreesInventoryKey(target.runtimeUrl),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessWorktreesRetentionPolicyKey(target.runtimeUrl),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessRuntimeWorkspacesKey(target.runtimeUrl),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: workspaceCollectionsScopeKey(target.runtimeUrl),
+      }),
+    ]);
+  }, [queryClient]);
+
+  const syncPolicyToTarget = useCallback(async (
+    target: WorktreeSettingsTarget,
+    maxMaterializedWorktreesPerRepo: number,
+    options: { runDeferredCleanup?: boolean } = {},
+  ) => {
+    const client = getAnyHarnessClient({ runtimeUrl: target.runtimeUrl });
+    await client.worktrees.updateRetentionPolicy({ maxMaterializedWorktreesPerRepo });
+    if (options.runDeferredCleanup) {
+      await client.worktrees.runRetention();
+    }
+    await refreshTarget(target);
+  }, [refreshTarget]);
+
+  return {
+    targets,
+    syncPolicyToTarget,
+  };
+}

--- a/desktop/src/hooks/workspaces/use-worktree-cleanup-policy.ts
+++ b/desktop/src/hooks/workspaces/use-worktree-cleanup-policy.ts
@@ -1,0 +1,272 @@
+import { getAnyHarnessClient } from "@anyharness/sdk-react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCloudWorktreeRetentionPolicy, usePutCloudWorktreeRetentionPolicy } from "@/hooks/cloud/use-cloud-worktree-retention-policy";
+import {
+  hasPendingWorktreeAutoDeleteLimitAdoption,
+  markWorktreeAutoDeleteLimitAdopted,
+  useUserPreferencesStore,
+  WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,
+  WORKTREE_AUTO_DELETE_LIMIT_MAX,
+  WORKTREE_AUTO_DELETE_LIMIT_MIN,
+} from "@/stores/preferences/user-preferences-store";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import type {
+  WorktreeSettingsTarget,
+  WorktreeSettingsTargetState,
+} from "./use-worktree-settings-targets";
+
+const seededCloudPolicyRuntimeKeys = new Set<string>();
+const syncedPolicyKeys = new Set<string>();
+const deferredRunKeys = new Set<string>();
+
+type SyncPolicyToTarget = (
+  target: WorktreeSettingsTarget,
+  maxMaterializedWorktreesPerRepo: number,
+  options?: { runDeferredCleanup?: boolean },
+) => Promise<void>;
+
+export interface WorktreeCleanupPolicyState {
+  value: number;
+  draftValue: string;
+  setDraftValue: (value: string) => void;
+  parsedDraft: number;
+  canApply: boolean;
+  applyDisabledReason: string | null;
+  statusMessage: string | null;
+  isApplying: boolean;
+  apply: () => Promise<void>;
+}
+
+function parseLimit(value: string): number {
+  return Number.parseInt(value, 10);
+}
+
+function validLimit(value: number): boolean {
+  return Number.isInteger(value)
+    && value >= WORKTREE_AUTO_DELETE_LIMIT_MIN
+    && value <= WORKTREE_AUTO_DELETE_LIMIT_MAX;
+}
+
+export function useWorktreeCleanupPolicy(
+  targets: WorktreeSettingsTargetState[],
+  syncPolicyToTarget: SyncPolicyToTarget,
+): WorktreeCleanupPolicyState {
+  const authStatus = useAuthStore((state) => state.status);
+  const preferenceValue = useUserPreferencesStore((state) => state.worktreeAutoDeleteLimit);
+  const setPreference = useUserPreferencesStore((state) => state.set);
+  const preferencesHydrated = useUserPreferencesStore((state) => state._hydrated);
+  const [adoptionPending, setAdoptionPending] = useState(
+    () => hasPendingWorktreeAutoDeleteLimitAdoption(),
+  );
+  const [draftValue, setDraftValue] = useState("");
+  const [localErrorMessage, setLocalErrorMessage] = useState<string | null>(null);
+  const cloudPolicy = useCloudWorktreeRetentionPolicy();
+  const putCloudPolicy = usePutCloudWorktreeRetentionPolicy();
+  const putCloudPolicyAsync = putCloudPolicy.mutateAsync;
+
+  const localTarget = targets.find((targetState) => targetState.target.location === "local")
+    ?.target ?? null;
+  const localPolicyQuery = useQuery({
+    queryKey: [
+      "worktree-settings",
+      "local-retention-policy",
+      localTarget?.runtimeUrl ?? "",
+    ] as const,
+    queryFn: async () => {
+      if (!localTarget) {
+        throw new Error("Local runtime is unavailable.");
+      }
+      return getAnyHarnessClient({ runtimeUrl: localTarget.runtimeUrl })
+        .worktrees.retentionPolicy();
+    },
+    enabled: preferencesHydrated && adoptionPending && localTarget !== null,
+    retry: 1,
+  });
+
+  const resolvedValue = useMemo(() => {
+    if (authStatus === "bootstrapping") {
+      return null;
+    }
+    if (
+      authStatus === "authenticated"
+      && cloudPolicy.data === undefined
+      && !cloudPolicy.isError
+    ) {
+      return null;
+    }
+    if (authStatus === "authenticated" && cloudPolicy.data?.source === "persisted") {
+      return cloudPolicy.data.maxMaterializedWorktreesPerRepo;
+    }
+    if (
+      authStatus === "authenticated"
+      && cloudPolicy.data?.source === "default"
+      && adoptionPending
+      && !localPolicyQuery.isError
+      && localPolicyQuery.data === undefined
+    ) {
+      return null;
+    }
+    return preferenceValue;
+  }, [
+    adoptionPending,
+    authStatus,
+    cloudPolicy.data,
+    cloudPolicy.isError,
+    localPolicyQuery.data,
+    localPolicyQuery.isError,
+    preferenceValue,
+  ]);
+
+  const effectiveValue = resolvedValue ?? preferenceValue;
+
+  useEffect(() => {
+    if (!preferencesHydrated || !adoptionPending) {
+      return;
+    }
+
+    if (authStatus === "authenticated" && cloudPolicy.data?.source === "persisted") {
+      setPreference("worktreeAutoDeleteLimit", cloudPolicy.data.maxMaterializedWorktreesPerRepo);
+      void markWorktreeAutoDeleteLimitAdopted().then(() => setAdoptionPending(false));
+      return;
+    }
+
+    const localPolicyValue = localPolicyQuery.data?.maxMaterializedWorktreesPerRepo;
+    if (localPolicyValue === undefined) {
+      return;
+    }
+
+    if (
+      authStatus === "authenticated"
+      && cloudPolicy.data?.source === "default"
+      && localPolicyValue !== WORKTREE_AUTO_DELETE_LIMIT_DEFAULT
+    ) {
+      if (!localTarget || seededCloudPolicyRuntimeKeys.has(localTarget.key)) {
+        return;
+      }
+      seededCloudPolicyRuntimeKeys.add(localTarget.key);
+      void putCloudPolicyAsync({
+        maxMaterializedWorktreesPerRepo: localPolicyValue,
+      }).then(() => {
+        setPreference("worktreeAutoDeleteLimit", localPolicyValue);
+        return markWorktreeAutoDeleteLimitAdopted();
+      }).then(() => {
+        setAdoptionPending(false);
+      }).catch((error) => {
+        seededCloudPolicyRuntimeKeys.delete(localTarget.key);
+        setLocalErrorMessage(error instanceof Error ? error.message : String(error));
+      });
+      return;
+    }
+
+    if (authStatus !== "authenticated" || cloudPolicy.data?.source === "default") {
+      setPreference("worktreeAutoDeleteLimit", localPolicyValue);
+      void markWorktreeAutoDeleteLimitAdopted().then(() => setAdoptionPending(false));
+    }
+  }, [
+    adoptionPending,
+    authStatus,
+    cloudPolicy.data,
+    localTarget,
+    localPolicyQuery.data,
+    preferencesHydrated,
+    putCloudPolicyAsync,
+    setPreference,
+  ]);
+
+  useEffect(() => {
+    if (
+      !preferencesHydrated
+      || authStatus === "bootstrapping"
+      || resolvedValue === null
+      || adoptionPending
+    ) {
+      return;
+    }
+    for (const targetState of targets) {
+      const key = `${targetState.target.key}:${resolvedValue}`;
+      if (syncedPolicyKeys.has(key)) {
+        continue;
+      }
+      syncedPolicyKeys.add(key);
+      const runKey = targetState.target.key;
+      const runDeferredCleanup = !deferredRunKeys.has(runKey);
+      if (runDeferredCleanup) {
+        deferredRunKeys.add(runKey);
+      }
+      void syncPolicyToTarget(targetState.target, resolvedValue, {
+        runDeferredCleanup,
+      }).catch((error) => {
+        syncedPolicyKeys.delete(key);
+        if (runDeferredCleanup) {
+          deferredRunKeys.delete(runKey);
+        }
+        setLocalErrorMessage(error instanceof Error ? error.message : String(error));
+      });
+    }
+  }, [
+    adoptionPending,
+    authStatus,
+    preferencesHydrated,
+    resolvedValue,
+    syncPolicyToTarget,
+    targets,
+  ]);
+
+  const parsedDraft = parseLimit(draftValue || String(effectiveValue));
+  const cloudLoading = authStatus === "authenticated"
+    && cloudPolicy.isLoading
+    && cloudPolicy.data === undefined;
+  const canApply = !cloudLoading && validLimit(parsedDraft);
+  const applyDisabledReason = cloudLoading
+    ? "Loading cloud policy."
+    : validLimit(parsedDraft)
+      ? null
+      : `Enter a value from ${WORKTREE_AUTO_DELETE_LIMIT_MIN} to ${WORKTREE_AUTO_DELETE_LIMIT_MAX}.`;
+
+  const apply = useCallback(async () => {
+    if (!validLimit(parsedDraft)) {
+      throw new Error(
+        `Enter a value from ${WORKTREE_AUTO_DELETE_LIMIT_MIN} to ${WORKTREE_AUTO_DELETE_LIMIT_MAX}.`,
+      );
+    }
+    if (authStatus === "authenticated" && !cloudPolicy.isError) {
+      if (cloudLoading) {
+        throw new Error("Cloud policy is still loading.");
+      }
+      await putCloudPolicyAsync({
+        maxMaterializedWorktreesPerRepo: parsedDraft,
+      });
+    }
+    setPreference("worktreeAutoDeleteLimit", parsedDraft);
+    await markWorktreeAutoDeleteLimitAdopted();
+    setAdoptionPending(false);
+    setDraftValue("");
+    setLocalErrorMessage(null);
+  }, [
+    authStatus,
+    cloudLoading,
+    cloudPolicy.isError,
+    parsedDraft,
+    putCloudPolicyAsync,
+    setPreference,
+  ]);
+
+  const statusMessage = localErrorMessage
+    ?? (adoptionPending ? "Waiting for existing runtime policy." : null)
+    ?? (authStatus === "authenticated" && cloudPolicy.isError
+      ? "Cloud policy is unavailable; using local fallback."
+      : null);
+
+  return {
+    value: effectiveValue,
+    draftValue: draftValue || String(effectiveValue),
+    setDraftValue,
+    parsedDraft,
+    canApply,
+    applyDisabledReason,
+    statusMessage,
+    isApplying: putCloudPolicy.isPending,
+    apply,
+  };
+}

--- a/desktop/src/hooks/workspaces/use-worktree-settings-targets.ts
+++ b/desktop/src/hooks/workspaces/use-worktree-settings-targets.ts
@@ -7,15 +7,13 @@ import {
 import type {
   PruneOrphanWorktreeRequest,
   RunWorktreeRetentionResponse,
-  UpdateWorktreeRetentionPolicyRequest,
   WorktreeInventoryResponse,
-  WorktreeRetentionPolicy,
   WorkspacePurgeResponse,
   WorkspaceRetireResponse,
 } from "@anyharness/sdk";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
-import { getCloudWorkspaceConnection } from "@/lib/integrations/cloud/workspaces";
+import { useCallback, useMemo } from "react";
+import { cloudWorkspaceConnectionQueryOptions } from "@/hooks/cloud/use-cloud-workspace-connection";
 import type { CloudConnectionInfo } from "@/lib/integrations/cloud/client";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
@@ -29,18 +27,13 @@ export interface WorktreeSettingsTarget {
   location: "local" | "cloud";
   runtimeUrl: string;
   runtimeGeneration: number | null;
+  environmentId: string | null;
   authToken?: string | null;
-}
-
-interface WorktreeSettingsTargetData {
-  inventory: WorktreeInventoryResponse;
-  policy: WorktreeRetentionPolicy;
 }
 
 export interface WorktreeSettingsTargetState {
   target: WorktreeSettingsTarget;
   inventory: WorktreeInventoryResponse | null;
-  policy: WorktreeRetentionPolicy | null;
   isLoading: boolean;
   error: Error | null;
 }
@@ -59,10 +52,8 @@ export function useWorktreeSettingsTargets() {
 
   const cloudConnectionQueries = useQueries({
     queries: readyCloudWorkspaces.map((workspace) => ({
-      queryKey: ["worktree-settings", "cloud-connection", workspace.id] as const,
-      queryFn: () => getCloudWorkspaceConnection(workspace.id),
-      staleTime: Number.POSITIVE_INFINITY,
-      retry: 1,
+      ...cloudWorkspaceConnectionQueryOptions(workspace.id),
+      enabled: true,
     })),
   });
 
@@ -71,7 +62,7 @@ export function useWorktreeSettingsTargets() {
     const seen = new Set<string>();
     const trimmedRuntimeUrl = runtimeUrl.trim();
     if (trimmedRuntimeUrl.length > 0) {
-      const key = targetIdentity("local", trimmedRuntimeUrl, 0);
+      const key = targetIdentity("local", trimmedRuntimeUrl, 0, null);
       seen.add(key);
       next.push({
         key,
@@ -79,6 +70,7 @@ export function useWorktreeSettingsTargets() {
         location: "local",
         runtimeUrl: trimmedRuntimeUrl,
         runtimeGeneration: 0,
+        environmentId: null,
       });
     }
 
@@ -91,17 +83,21 @@ export function useWorktreeSettingsTargets() {
       const generation = typeof connection.runtimeGeneration === "number"
         ? connection.runtimeGeneration
         : null;
-      const key = targetIdentity("cloud", connection.runtimeUrl, generation);
+      const environmentId = workspace.runtime?.environmentId ?? null;
+      const key = targetIdentity("cloud", connection.runtimeUrl, generation, environmentId);
       if (seen.has(key)) {
         return;
       }
       seen.add(key);
       next.push({
         key,
-        label: workspace.displayName ?? `${workspace.repo.owner}/${workspace.repo.name}`,
+        label: environmentId
+          ? `Cloud runtime ${environmentId.slice(0, 8)}`
+          : workspace.displayName ?? `${workspace.repo.owner}/${workspace.repo.name}`,
         location: "cloud",
         runtimeUrl: connection.runtimeUrl,
         runtimeGeneration: generation,
+        environmentId,
         authToken: connection.accessToken,
       });
     });
@@ -112,16 +108,12 @@ export function useWorktreeSettingsTargets() {
   const targetDataQueries = useQueries({
     queries: targets.map((target) => ({
       queryKey: targetDataKey(target),
-      queryFn: async (): Promise<WorktreeSettingsTargetData> => {
+      queryFn: async (): Promise<WorktreeInventoryResponse> => {
         const client = getAnyHarnessClient({
           runtimeUrl: target.runtimeUrl,
           authToken: target.authToken,
         });
-        const [inventory, policy] = await Promise.all([
-          client.worktrees.inventory(),
-          client.worktrees.retentionPolicy(),
-        ]);
-        return { inventory, policy };
+        return client.worktrees.inventory();
       },
       enabled: target.runtimeUrl.trim().length > 0,
     })),
@@ -131,14 +123,13 @@ export function useWorktreeSettingsTargets() {
     const query = targetDataQueries[index];
     return {
       target,
-      inventory: query?.data?.inventory ?? null,
-      policy: query?.data?.policy ?? null,
+      inventory: query?.data ?? null,
       isLoading: query?.isLoading ?? false,
       error: query?.error instanceof Error ? query.error : null,
     };
   }), [targetDataQueries, targets]);
 
-  const refreshTarget = async (target: WorktreeSettingsTarget) => {
+  const refreshTarget = useCallback(async (target: WorktreeSettingsTarget) => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: targetDataKey(target) }),
       queryClient.invalidateQueries({
@@ -154,25 +145,37 @@ export function useWorktreeSettingsTargets() {
         queryKey: workspaceCollectionsScopeKey(runtimeUrl),
       }),
     ]);
-  };
+  }, [queryClient, runtimeUrl]);
 
-  const clientForTarget = (target: WorktreeSettingsTarget) => getAnyHarnessClient({
+  const clientForTarget = useCallback((target: WorktreeSettingsTarget) => getAnyHarnessClient({
     runtimeUrl: target.runtimeUrl,
     authToken: target.authToken,
-  });
+  }), []);
+
+  const syncPolicyToTarget = useCallback(async (
+    target: WorktreeSettingsTarget,
+    maxMaterializedWorktreesPerRepo: number,
+    options: { runDeferredCleanup?: boolean } = {},
+  ) => {
+    const client = clientForTarget(target);
+    await client.worktrees.updateRetentionPolicy({ maxMaterializedWorktreesPerRepo });
+    if (options.runDeferredCleanup) {
+      await client.worktrees.runRetention();
+    }
+    await refreshTarget(target);
+  }, [clientForTarget, refreshTarget]);
 
   return {
     targets: targetStates,
     isDiscovering: cloudConnectionQueries.some((query) => query.isLoading),
-    updatePolicy: async (
+    syncPolicyToTarget,
+    runRetention: async (
       target: WorktreeSettingsTarget,
-      input: UpdateWorktreeRetentionPolicyRequest,
-    ) => {
-      await clientForTarget(target).worktrees.updateRetentionPolicy(input);
-      await refreshTarget(target);
-    },
-    runRetention: async (target: WorktreeSettingsTarget): Promise<RunWorktreeRetentionResponse> => {
-      const result = await clientForTarget(target).worktrees.runRetention();
+      maxMaterializedWorktreesPerRepo: number,
+    ): Promise<RunWorktreeRetentionResponse> => {
+      const client = clientForTarget(target);
+      await client.worktrees.updateRetentionPolicy({ maxMaterializedWorktreesPerRepo });
+      const result = await client.worktrees.runRetention();
       await refreshTarget(target);
       return result;
     },
@@ -211,10 +214,12 @@ function targetIdentity(
   location: "local" | "cloud",
   runtimeUrl: string,
   runtimeGeneration: number | null,
+  environmentId: string | null,
 ) {
+  const runtimeIdentity = environmentId ?? runtimeUrl.trim();
   return runtimeGeneration === null
-    ? `${location}:${runtimeUrl.trim()}`
-    : `${location}:${runtimeUrl.trim()}:generation:${runtimeGeneration}`;
+    ? `${location}:${runtimeIdentity}`
+    : `${location}:${runtimeIdentity}:generation:${runtimeGeneration}`;
 }
 
 function targetDataKey(target: WorktreeSettingsTarget) {
@@ -222,7 +227,7 @@ function targetDataKey(target: WorktreeSettingsTarget) {
     "worktree-settings",
     "target",
     target.location,
-    target.runtimeUrl,
+    target.environmentId ?? target.runtimeUrl,
     target.runtimeGeneration,
   ] as const;
 }

--- a/desktop/src/lib/domain/preferences/user-preferences.ts
+++ b/desktop/src/lib/domain/preferences/user-preferences.ts
@@ -36,6 +36,10 @@ export type ReviewKindPreference = StoredReviewKindDefaults;
 export type ReviewDefaultsByKind = Record<ReviewDefaultKind, StoredReviewKindDefaults | null>;
 export type ReviewPersonalitiesByKind = StoredReviewPersonalitiesByKind;
 
+export const WORKTREE_AUTO_DELETE_LIMIT_DEFAULT = 20;
+export const WORKTREE_AUTO_DELETE_LIMIT_MIN = 10;
+export const WORKTREE_AUTO_DELETE_LIMIT_MAX = 100;
+
 export interface UserPreferences {
   themePreset: ThemePreset;
   colorMode: ColorMode;
@@ -54,6 +58,7 @@ export interface UserPreferences {
   subagentsEnabled: boolean;
   coworkWorkspaceDelegationEnabled: boolean;
   cloudRuntimeInputSyncEnabled: boolean;
+  worktreeAutoDeleteLimit: number;
   pasteAttachmentsEnabled: boolean;
   reviewDefaultsByKind: ReviewDefaultsByKind;
   reviewPersonalitiesByKind: ReviewPersonalitiesByKind;
@@ -77,6 +82,7 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   subagentsEnabled: true,
   coworkWorkspaceDelegationEnabled: true,
   cloudRuntimeInputSyncEnabled: false,
+  worktreeAutoDeleteLimit: WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,
   pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
@@ -102,6 +108,7 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   subagentsEnabled: true,
   coworkWorkspaceDelegationEnabled: true,
   cloudRuntimeInputSyncEnabled: false,
+  worktreeAutoDeleteLimit: WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,
   pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
@@ -127,6 +134,7 @@ const USER_PREFERENCE_KEYS = [
   "subagentsEnabled",
   "coworkWorkspaceDelegationEnabled",
   "cloudRuntimeInputSyncEnabled",
+  "worktreeAutoDeleteLimit",
   "pasteAttachmentsEnabled",
   "reviewDefaultsByKind",
   "reviewPersonalitiesByKind",
@@ -168,6 +176,13 @@ export type LegacyUserPreferencesInput =
     defaultChatModelIdByAgentKind?: unknown;
     powersInCodingSessionsEnabled?: unknown;
   };
+
+export function isValidWorktreeAutoDeleteLimit(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= WORKTREE_AUTO_DELETE_LIMIT_MIN
+    && value <= WORKTREE_AUTO_DELETE_LIMIT_MAX;
+}
 
 export function pickLegacyUserPreferencesInput(
   value: Record<string, unknown>,
@@ -530,6 +545,11 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
 
   if (typeof next.cloudRuntimeInputSyncEnabled !== "boolean") {
     next.cloudRuntimeInputSyncEnabled = PERSISTED_RECORD_BACKFILL.cloudRuntimeInputSyncEnabled;
+    changed = true;
+  }
+
+  if (!isValidWorktreeAutoDeleteLimit(next.worktreeAutoDeleteLimit)) {
+    next.worktreeAutoDeleteLimit = PERSISTED_RECORD_BACKFILL.worktreeAutoDeleteLimit;
     changed = true;
   }
 

--- a/desktop/src/lib/integrations/cloud/client.ts
+++ b/desktop/src/lib/integrations/cloud/client.ts
@@ -153,6 +153,10 @@ export type PutCloudRepoFileRequest   = components["schemas"]["PutCloudRepoFileR
 export type CloudWorkspaceRepoConfigStatusResponse = components["schemas"]["CloudWorkspaceRepoConfigStatusResponse"];
 export type ResyncCloudWorkspaceFilesResponse = components["schemas"]["ResyncCloudWorkspaceFilesResponse"];
 export type RunCloudWorkspaceSetupResponse = components["schemas"]["RunCloudWorkspaceSetupResponse"];
+export type CloudWorktreeRetentionPolicyRequest =
+  components["schemas"]["CloudWorktreeRetentionPolicyRequest"];
+export type CloudWorktreeRetentionPolicyResponse =
+  components["schemas"]["CloudWorktreeRetentionPolicyResponse"];
 export type CreateCloudWorkspaceRequest = components["schemas"]["CreateCloudWorkspaceRequest"];
 export type GenerateSessionTitleRequest = components["schemas"]["GenerateSessionTitleRequest"];
 export type GenerateSessionTitleResponse = components["schemas"]["GenerateSessionTitleResponse"];

--- a/desktop/src/lib/integrations/cloud/generated/openapi.ts
+++ b/desktop/src/lib/integrations/cloud/generated/openapi.ts
@@ -369,6 +369,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/worktree-retention-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cloud Worktree Retention Policy Endpoint */
+        get: operations["get_cloud_worktree_retention_policy_endpoint_v1_cloud_worktree_retention_policy_get"];
+        /** Put Cloud Worktree Retention Policy Endpoint */
+        put: operations["put_cloud_worktree_retention_policy_endpoint_v1_cloud_worktree_retention_policy_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workspaces": {
         parameters: {
             query?: never;
@@ -2027,6 +2045,23 @@ export interface components {
             lastApplyFailedPath: string | null;
             /** Lastapplyerror */
             lastApplyError: string | null;
+        };
+        /** CloudWorktreeRetentionPolicyRequest */
+        CloudWorktreeRetentionPolicyRequest: {
+            /** Maxmaterializedworktreesperrepo */
+            maxMaterializedWorktreesPerRepo: number;
+        };
+        /** CloudWorktreeRetentionPolicyResponse */
+        CloudWorktreeRetentionPolicyResponse: {
+            /** Maxmaterializedworktreesperrepo */
+            maxMaterializedWorktreesPerRepo: number;
+            /** Updatedat */
+            updatedAt: string;
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "persisted" | "default";
         };
         /** ConnectorArgTemplateModel */
         ConnectorArgTemplateModel: {
@@ -4474,6 +4509,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RunCloudWorkspaceSetupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cloud_worktree_retention_policy_endpoint_v1_cloud_worktree_retention_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudWorktreeRetentionPolicyResponse"];
+                };
+            };
+        };
+    };
+    put_cloud_worktree_retention_policy_endpoint_v1_cloud_worktree_retention_policy_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CloudWorktreeRetentionPolicyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudWorktreeRetentionPolicyResponse"];
                 };
             };
             /** @description Validation Error */

--- a/desktop/src/lib/integrations/cloud/worktree-policy.ts
+++ b/desktop/src/lib/integrations/cloud/worktree-policy.ts
@@ -1,0 +1,21 @@
+import {
+  getProliferateClient,
+  type CloudWorktreeRetentionPolicyRequest,
+  type CloudWorktreeRetentionPolicyResponse,
+} from "./client";
+
+export async function getCloudWorktreeRetentionPolicy(): Promise<CloudWorktreeRetentionPolicyResponse> {
+  return (
+    await getProliferateClient().GET("/v1/cloud/worktree-retention-policy")
+  ).data!;
+}
+
+export async function putCloudWorktreeRetentionPolicy(
+  input: CloudWorktreeRetentionPolicyRequest,
+): Promise<CloudWorktreeRetentionPolicyResponse> {
+  return (
+    await getProliferateClient().PUT("/v1/cloud/worktree-retention-policy", {
+      body: input,
+    })
+  ).data!;
+}

--- a/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { THEME_PRESETS } from "@/config/theme";
 import {
   bootstrapUserPreferences,
+  hasPendingWorktreeAutoDeleteLimitAdoption,
+  markWorktreeAutoDeleteLimitAdopted,
   migrateUserPreferences,
   PERSISTED_RECORD_BACKFILL,
   USER_PREFERENCE_DEFAULTS,
@@ -57,6 +59,7 @@ describe("user preference migration", () => {
     expect(preferences.readableCodeFontSizeId).toBe("default");
     expect(preferences.transparentChromeEnabled).toBe(false);
     expect(preferences.pasteAttachmentsEnabled).toBe(true);
+    expect(preferences.worktreeAutoDeleteLimit).toBe(20);
   });
 
   it("backfills legacy per-key users with old appearance defaults", async () => {
@@ -99,6 +102,47 @@ describe("user preference migration", () => {
     const preferences = useUserPreferencesStore.getState();
     expect(preferences.themePreset).toBe("ship");
     expect(preferences.transparentChromeEnabled).toBe(true);
+  });
+
+  it("marks missing worktree cleanup policy for adoption without persisting immediately", async () => {
+    const persisted = { ...USER_PREFERENCE_DEFAULTS } as Record<string, unknown>;
+    delete persisted.worktreeAutoDeleteLimit;
+    storeMocks.values.set("user_preferences", persisted);
+
+    await bootstrapUserPreferences();
+    await flushPersist();
+
+    const preferences = useUserPreferencesStore.getState();
+    expect(preferences.worktreeAutoDeleteLimit).toBe(20);
+    expect(hasPendingWorktreeAutoDeleteLimitAdoption()).toBe(true);
+    const nextPersisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
+    expect(nextPersisted.worktreeAutoDeleteLimit).toBeUndefined();
+    expect(nextPersisted.worktreeAutoDeleteLimitBackfilled).toBe(true);
+  });
+
+  it("consumes worktree cleanup adoption metadata after adoption", async () => {
+    const persisted = { ...USER_PREFERENCE_DEFAULTS } as Record<string, unknown>;
+    delete persisted.worktreeAutoDeleteLimit;
+    storeMocks.values.set("user_preferences", persisted);
+
+    await bootstrapUserPreferences();
+    useUserPreferencesStore.getState().set("worktreeAutoDeleteLimit", 50);
+    await markWorktreeAutoDeleteLimitAdopted();
+    await flushPersist();
+
+    const nextPersisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
+    expect(nextPersisted.worktreeAutoDeleteLimit).toBe(50);
+    expect(nextPersisted.worktreeAutoDeleteLimitBackfilled).toBeUndefined();
+  });
+
+  it("sanitizes invalid worktree cleanup policy values to the default", () => {
+    const result = migrateUserPreferences({
+      ...USER_PREFERENCE_DEFAULTS,
+      worktreeAutoDeleteLimit: 101,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.preferences.worktreeAutoDeleteLimit).toBe(20);
   });
 
   it("preserves explicit persisted Ship preferences", async () => {

--- a/desktop/src/stores/preferences/user-preferences-store.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import {
   getForwardCompatibleUserPreferenceExtras,
   hasDeprecatedUserPreferenceKeys,
+  isValidWorktreeAutoDeleteLimit,
   migrateUserPreferences,
   NEW_USER_DEFAULTS,
   PERSISTED_RECORD_BACKFILL,
@@ -18,6 +19,9 @@ export {
   NEW_USER_DEFAULTS,
   PERSISTED_RECORD_BACKFILL,
   USER_PREFERENCE_DEFAULTS,
+  WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,
+  WORKTREE_AUTO_DELETE_LIMIT_MAX,
+  WORKTREE_AUTO_DELETE_LIMIT_MIN,
 } from "@/lib/domain/preferences/user-preferences";
 export type {
   BranchPrefixType,
@@ -35,6 +39,7 @@ export type {
 const USER_PREFERENCES_KEY = "user_preferences";
 const LEGACY_THEME_KEY = "proliferate-theme";
 const LEGACY_MODE_KEY = "proliferate-mode";
+const WORKTREE_AUTO_DELETE_LIMIT_ADOPTION_PENDING_KEY = "worktreeAutoDeleteLimitBackfilled";
 
 let persistedPreferenceExtras: Record<string, unknown> = {};
 
@@ -104,6 +109,7 @@ async function readLegacyUserPreferences(): Promise<LegacyUserPreferencesInput> 
     subagentsEnabled: defaults.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: defaults.coworkWorkspaceDelegationEnabled,
     cloudRuntimeInputSyncEnabled: defaults.cloudRuntimeInputSyncEnabled,
+    worktreeAutoDeleteLimit: defaults.worktreeAutoDeleteLimit,
     pasteAttachmentsEnabled: defaults.pasteAttachmentsEnabled,
     reviewDefaultsByKind: defaults.reviewDefaultsByKind,
     reviewPersonalitiesByKind: defaults.reviewPersonalitiesByKind,
@@ -114,13 +120,22 @@ async function readAll(): Promise<{
   preferences: LegacyUserPreferencesInput;
   shouldPersist: boolean;
   extras: Record<string, unknown>;
+  deferWorktreeAutoDeleteLimitPersist: boolean;
 }> {
   const persisted = await readPersistedValue<Record<string, unknown>>(USER_PREFERENCES_KEY);
   if (persisted && typeof persisted === "object" && !Array.isArray(persisted)) {
+    const needsWorktreeAdoption = !isValidWorktreeAutoDeleteLimit(
+      persisted.worktreeAutoDeleteLimit,
+    );
+    const extras = getForwardCompatibleUserPreferenceExtras(persisted);
+    if (needsWorktreeAdoption) {
+      extras[WORKTREE_AUTO_DELETE_LIMIT_ADOPTION_PENDING_KEY] = true;
+    }
     return {
       preferences: pickLegacyUserPreferencesInput(persisted),
       shouldPersist: hasDeprecatedUserPreferenceKeys(persisted),
-      extras: getForwardCompatibleUserPreferenceExtras(persisted),
+      extras,
+      deferWorktreeAutoDeleteLimitPersist: needsWorktreeAdoption,
     };
   }
 
@@ -128,6 +143,7 @@ async function readAll(): Promise<{
     preferences: await readLegacyUserPreferences(),
     shouldPersist: false,
     extras: {},
+    deferWorktreeAutoDeleteLimitPersist: false,
   };
 }
 
@@ -157,6 +173,7 @@ function selectPersistedSlice(state: UserPreferencesState): UserPreferences {
     subagentsEnabled: state.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: state.coworkWorkspaceDelegationEnabled,
     cloudRuntimeInputSyncEnabled: state.cloudRuntimeInputSyncEnabled,
+    worktreeAutoDeleteLimit: state.worktreeAutoDeleteLimit,
     pasteAttachmentsEnabled: state.pasteAttachmentsEnabled,
     reviewDefaultsByKind: state.reviewDefaultsByKind,
     reviewPersonalitiesByKind: state.reviewPersonalitiesByKind,
@@ -166,9 +183,15 @@ function selectPersistedSlice(state: UserPreferencesState): UserPreferences {
 function buildPersistedPreferencesRecord(
   preferences: UserPreferences,
 ): Record<string, unknown> {
+  const {
+    worktreeAutoDeleteLimit,
+    ...preferencesWithoutWorktreeAutoDeleteLimit
+  } = preferences;
   return {
     ...persistedPreferenceExtras,
-    ...preferences,
+    ...(hasPendingWorktreeAutoDeleteLimitAdoption()
+      ? preferencesWithoutWorktreeAutoDeleteLimit
+      : { ...preferencesWithoutWorktreeAutoDeleteLimit, worktreeAutoDeleteLimit }),
   };
 }
 
@@ -200,7 +223,24 @@ export async function bootstrapUserPreferences(): Promise<void> {
     ...migrated.preferences,
     _hydrated: true,
   });
-  if (migrated.changed || persisted.shouldPersist) {
+  if (persisted.deferWorktreeAutoDeleteLimitPersist || migrated.changed || persisted.shouldPersist) {
     void persistValue(USER_PREFERENCES_KEY, buildPersistedPreferencesRecord(migrated.preferences));
   }
+}
+
+export function hasPendingWorktreeAutoDeleteLimitAdoption(): boolean {
+  return persistedPreferenceExtras[WORKTREE_AUTO_DELETE_LIMIT_ADOPTION_PENDING_KEY] === true;
+}
+
+export async function markWorktreeAutoDeleteLimitAdopted(): Promise<void> {
+  if (!hasPendingWorktreeAutoDeleteLimitAdoption()) {
+    return;
+  }
+  const { [WORKTREE_AUTO_DELETE_LIMIT_ADOPTION_PENDING_KEY]: _removed, ...nextExtras } =
+    persistedPreferenceExtras;
+  persistedPreferenceExtras = nextExtras;
+  await persistValue(
+    USER_PREFERENCES_KEY,
+    buildPersistedPreferencesRecord(selectPersistedSlice(useUserPreferencesStore.getState())),
+  );
 }

--- a/docs/anyharness/src/workspaces.md
+++ b/docs/anyharness/src/workspaces.md
@@ -172,6 +172,14 @@ The durable workspace rows are loaded and stored through:
 - Workspace paths should be canonicalized before identity decisions.
 - Workspace env should be derived from durable workspace + repo-root records,
   not reconstructed ad hoc by callers.
+- Worktree retention policy is enforced only by AnyHarness. Desktop and cloud
+  control planes may store desired policy, but they must sync it through the
+  runtime retention policy API before triggering cleanup.
+- Managed launchers may set `ANYHARNESS_DEFER_STARTUP_RETENTION=1` to skip only
+  the automatic startup retention pass until the desired policy is applied.
+  This is distinct from `ANYHARNESS_DISABLE_WORKTREE_RETENTION`, which disables
+  retention more broadly. Post-create and manual retention runs stay enabled
+  when startup retention is deferred.
 
 ## Extension Points
 

--- a/server/alembic/versions/c3d4e5f6a7b8_cloud_worktree_retention_policy.py
+++ b/server/alembic/versions/c3d4e5f6a7b8_cloud_worktree_retention_policy.py
@@ -1,0 +1,81 @@
+"""cloud worktree retention policy
+
+Revision ID: c3d4e5f6a7b8
+Revises: b1c2d3e4f5a6
+Create Date: 2026-05-04 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | Sequence[str] | None = "b1c2d3e4f5a6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = current_schema() AND table_name = :table_name)"
+            ),
+            {"table_name": table_name},
+        ).scalar()
+    )
+
+
+def _has_index(index_name: str) -> bool:
+    bind = op.get_bind()
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM pg_indexes "
+                "WHERE schemaname = current_schema() AND indexname = :index_name)"
+            ),
+            {"index_name": index_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if not _has_table("cloud_worktree_retention_policy"):
+        op.create_table(
+            "cloud_worktree_retention_policy",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("max_materialized_worktrees_per_repo", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "max_materialized_worktrees_per_repo >= 10 "
+                "AND max_materialized_worktrees_per_repo <= 100",
+                name="ck_cloud_worktree_retention_policy_limit",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id", name="uq_cloud_worktree_retention_policy_user_id"),
+        )
+    if not _has_index(op.f("ix_cloud_worktree_retention_policy_user_id")):
+        op.create_index(
+            op.f("ix_cloud_worktree_retention_policy_user_id"),
+            "cloud_worktree_retention_policy",
+            ["user_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_cloud_worktree_retention_policy_user_id"),
+        table_name="cloud_worktree_retention_policy",
+    )
+    op.drop_table("cloud_worktree_retention_policy")

--- a/server/proliferate/db/models/cloud.py
+++ b/server/proliferate/db/models/cloud.py
@@ -396,6 +396,28 @@ class CloudCredential(Base):
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
+class CloudWorktreeRetentionPolicy(Base):
+    __tablename__ = "cloud_worktree_retention_policy"
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uq_cloud_worktree_retention_policy_user_id"),
+        CheckConstraint(
+            "max_materialized_worktrees_per_repo >= 10 "
+            "AND max_materialized_worktrees_per_repo <= 100",
+            name="ck_cloud_worktree_retention_policy_limit",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    max_materialized_worktrees_per_repo: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
 class CloudMcpConnection(Base):
     __tablename__ = "cloud_mcp_connection"
     __table_args__ = (

--- a/server/proliferate/db/store/cloud_worktree_policy.py
+++ b/server/proliferate/db/store/cloud_worktree_policy.py
@@ -1,0 +1,100 @@
+"""Persistence helpers for account-scoped cloud worktree cleanup policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import engine as db_engine
+from proliferate.db.models.cloud import CloudWorktreeRetentionPolicy
+from proliferate.utils.time import utcnow
+
+DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO = 20
+MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO = 10
+MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO = 100
+
+
+@dataclass(frozen=True)
+class CloudWorktreePolicyValue:
+    user_id: UUID
+    max_materialized_worktrees_per_repo: int
+    created_at: datetime
+    updated_at: datetime
+
+
+def _policy_value(record: CloudWorktreeRetentionPolicy) -> CloudWorktreePolicyValue:
+    return CloudWorktreePolicyValue(
+        user_id=record.user_id,
+        max_materialized_worktrees_per_repo=record.max_materialized_worktrees_per_repo,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+async def get_cloud_worktree_policy(
+    db: AsyncSession,
+    user_id: UUID,
+) -> CloudWorktreePolicyValue | None:
+    record = (
+        await db.execute(
+            select(CloudWorktreeRetentionPolicy).where(
+                CloudWorktreeRetentionPolicy.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    return None if record is None else _policy_value(record)
+
+
+async def save_cloud_worktree_policy(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    max_materialized_worktrees_per_repo: int,
+) -> CloudWorktreePolicyValue:
+    now = utcnow()
+    await db.execute(
+        pg_insert(CloudWorktreeRetentionPolicy)
+        .values(
+            user_id=user_id,
+            max_materialized_worktrees_per_repo=max_materialized_worktrees_per_repo,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=[CloudWorktreeRetentionPolicy.user_id],
+            set_={
+                "max_materialized_worktrees_per_repo": max_materialized_worktrees_per_repo,
+                "updated_at": now,
+            },
+        )
+    )
+    await db.commit()
+    value = await get_cloud_worktree_policy(db, user_id)
+    if value is None:
+        raise RuntimeError("Cloud worktree retention policy was not persisted.")
+    return value
+
+
+async def load_cloud_worktree_policy_for_user(
+    user_id: UUID,
+) -> CloudWorktreePolicyValue | None:
+    async with db_engine.async_session_factory() as db:
+        return await get_cloud_worktree_policy(db, user_id)
+
+
+async def persist_cloud_worktree_policy_for_user(
+    *,
+    user_id: UUID,
+    max_materialized_worktrees_per_repo: int,
+) -> CloudWorktreePolicyValue:
+    async with db_engine.async_session_factory() as db:
+        return await save_cloud_worktree_policy(
+            db,
+            user_id=user_id,
+            max_materialized_worktrees_per_repo=max_materialized_worktrees_per_repo,
+        )

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -12,10 +12,12 @@ from proliferate.server.cloud.repo_config.api import router as repo_config_route
 from proliferate.server.cloud.repos.api import router as repos_router
 from proliferate.server.cloud.webhooks.api import router as webhooks_router
 from proliferate.server.cloud.workspaces.api import router as workspaces_router
+from proliferate.server.cloud.worktree_policy.api import router as worktree_policy_router
 
 router = APIRouter(prefix="/cloud", tags=["cloud"])
 router.include_router(repos_router)
 router.include_router(repo_config_router)
+router.include_router(worktree_policy_router)
 router.include_router(workspaces_router)
 router.include_router(mobility_router)
 router.include_router(credentials_router)

--- a/server/proliferate/server/cloud/runtime/anyharness_api.py
+++ b/server/proliferate/server/cloud/runtime/anyharness_api.py
@@ -237,6 +237,75 @@ async def verify_runtime_auth_enforced(
     )
 
 
+async def update_runtime_worktree_retention_policy(
+    runtime_url: str,
+    access_token: str,
+    *,
+    max_materialized_worktrees_per_repo: int,
+    workspace_id: UUID | None = None,
+) -> None:
+    sync_started = time.perf_counter()
+    log_cloud_event(
+        "cloud runtime worktree policy sync started",
+        workspace_id=workspace_id,
+        runtime_url=runtime_url,
+        max_materialized_worktrees_per_repo=max_materialized_worktrees_per_repo,
+    )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.put(
+                f"{runtime_url}/v1/worktrees/retention-policy",
+                headers=_auth_headers(access_token),
+                json={
+                    "maxMaterializedWorktreesPerRepo": max_materialized_worktrees_per_repo,
+                },
+            )
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise CloudRuntimeReconnectError(
+            "Failed to sync cloud worktree retention policy to the runtime."
+        ) from exc
+    log_cloud_event(
+        "cloud runtime worktree policy sync finished",
+        workspace_id=workspace_id,
+        runtime_url=runtime_url,
+        max_materialized_worktrees_per_repo=max_materialized_worktrees_per_repo,
+        elapsed_ms=duration_ms(sync_started),
+    )
+
+
+async def run_runtime_worktree_retention(
+    runtime_url: str,
+    access_token: str,
+    *,
+    workspace_id: UUID | None = None,
+) -> None:
+    run_started = time.perf_counter()
+    log_cloud_event(
+        "cloud runtime deferred worktree retention run started",
+        workspace_id=workspace_id,
+        runtime_url=runtime_url,
+    )
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{runtime_url}/v1/worktrees/retention/run",
+                headers=_auth_headers(access_token),
+                json={},
+            )
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise CloudRuntimeReconnectError(
+            "Failed to run deferred cloud worktree retention cleanup."
+        ) from exc
+    log_cloud_event(
+        "cloud runtime deferred worktree retention run finished",
+        workspace_id=workspace_id,
+        runtime_url=runtime_url,
+        elapsed_ms=duration_ms(run_started),
+    )
+
+
 async def _list_remote_agents(
     runtime_url: str,
     access_token: str,

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -26,6 +26,7 @@ _CLAUDE_MIN_NODE_MAJOR = 20
 _CLAUDE_MIN_NODE_MINOR = 10
 _RUST_INSTALL_TIMEOUT_SECONDS = 900
 _BUILD_DEPS_INSTALL_TIMEOUT_SECONDS = 300
+_ANYHARNESS_DEFER_STARTUP_RETENTION_ENV = "ANYHARNESS_DEFER_STARTUP_RETENTION"
 
 
 def _sha256_file(path: Path) -> str:
@@ -59,7 +60,10 @@ def build_runtime_env(
     anyharness_data_key: str,
     repo_env_vars: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    env: dict[str, str] = {"ANYHARNESS_DEV_CORS": "1"}
+    env: dict[str, str] = {
+        "ANYHARNESS_DEV_CORS": "1",
+        _ANYHARNESS_DEFER_STARTUP_RETENTION_ENV: "1",
+    }
     if is_vendor_telemetry_enabled() and _runtime_sentry_dsn():
         env["ANYHARNESS_SENTRY_DSN"] = _runtime_sentry_dsn()
     if is_vendor_telemetry_enabled() and _runtime_sentry_environment():

--- a/server/proliferate/server/cloud/runtime/ensure_running.py
+++ b/server/proliferate/server/cloud/runtime/ensure_running.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from uuid import UUID
 
 from proliferate.db.models.cloud import CloudRuntimeEnvironment, CloudWorkspace
@@ -29,6 +30,7 @@ from proliferate.server.cloud.runtime.sandbox_exec import (
     result_stderr,
     result_stdout,
     run_sandbox_command_logged,
+    runtime_launcher_path,
 )
 
 _DEFAULT_ENDPOINT_HEALTH_ATTEMPTS = 4
@@ -41,6 +43,62 @@ _DAYTONA_RESTART_HEALTH_ATTEMPTS = 45
 _DAYTONA_RESTART_HEALTH_DELAY_SECONDS = 1.0
 _RUNNING_SANDBOX_STATES = frozenset({"running", "started"})
 _RESUMABLE_SANDBOX_STATES = frozenset({"paused", "stopped"})
+_ANYHARNESS_DEFER_STARTUP_RETENTION_ENV = "ANYHARNESS_DEFER_STARTUP_RETENTION"
+
+
+async def _ensure_launcher_defers_startup_retention(
+    provider: SandboxProvider,
+    sandbox: object,
+    runtime_context: SandboxRuntimeContext,
+    workspace_id: UUID,
+) -> None:
+    launcher = shlex.quote(runtime_launcher_path(runtime_context))
+    sentinel = "# Managed by Proliferate: defer startup worktree retention"
+    env_line = f"export {_ANYHARNESS_DEFER_STARTUP_RETENTION_ENV}=1"
+    command = "sh -lc " + shlex.quote(
+        "\n".join(
+            [
+                f"launcher={launcher}",
+                'test -f "$launcher" || exit 1',
+                (
+                    f"if ! grep -q '^export {_ANYHARNESS_DEFER_STARTUP_RETENTION_ENV}=' "
+                    '"$launcher"; then'
+                ),
+                '  tmp="${launcher}.tmp.$$"',
+                (
+                    f"  awk -v sentinel={shlex.quote(sentinel)} "
+                    f"-v line={shlex.quote(env_line)} "
+                    "'BEGIN { inserted=0 } "
+                    "/^exec / && !inserted { print sentinel; print line; inserted=1 } "
+                    "{ print } "
+                    "END { if (!inserted) { print sentinel; print line } }' "
+                    '"$launcher" > "$tmp"'
+                ),
+                '  chmod +x "$tmp"',
+                '  mv "$tmp" "$launcher"',
+                "fi",
+                f"grep -q '^export {_ANYHARNESS_DEFER_STARTUP_RETENTION_ENV}=1$' "
+                '"$launcher"',
+            ]
+        )
+    )
+    patch_result = await run_sandbox_command_logged(
+        provider,
+        sandbox,
+        workspace_id=workspace_id,
+        label="ensure_runtime_launcher_startup_retention_deferral",
+        command=command,
+        runtime_context=runtime_context,
+        cwd=runtime_context.runtime_workdir,
+        timeout_seconds=15,
+        log_output_on_success=True,
+    )
+    if result_exit_code(patch_result) != 0:
+        stderr = result_stderr(patch_result) or result_stdout(patch_result)
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime launcher could not be patched for startup retention deferral: "
+            f"{stderr.strip()[:400]}"
+        )
 
 
 async def _relaunch_runtime(
@@ -201,6 +259,12 @@ async def ensure_workspace_runtime_ready(
     # sandbox. We do this after both the cached URL and the fresh provider URL
     # failed health checks.
     runtime_context = await provider.resolve_runtime_context(sandbox)
+    await _ensure_launcher_defers_startup_retention(
+        provider,
+        sandbox,
+        runtime_context,
+        workspace.id,
+    )
     await _relaunch_runtime(provider, sandbox, runtime_context, workspace.id)
     restart_probe_attempts, restart_probe_delay_seconds = _restart_health_wait_config(
         sandbox_record.provider,
@@ -300,6 +364,12 @@ async def ensure_environment_runtime_ready(
         raise CloudRuntimeReconnectError("Cloud runtime is unavailable in the existing sandbox.")
 
     runtime_context = await provider.resolve_runtime_context(sandbox)
+    await _ensure_launcher_defers_startup_retention(
+        provider,
+        sandbox,
+        runtime_context,
+        workspace_id,
+    )
     await _relaunch_runtime(provider, sandbox, runtime_context, workspace_id)
     restart_probe_attempts, restart_probe_delay_seconds = _restart_health_wait_config(
         sandbox_record.provider,

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -100,6 +100,9 @@ from proliferate.server.cloud.runtime.sandbox_exec import (
     run_sandbox_command_logged,
     runtime_launcher_path,
 )
+from proliferate.server.cloud.runtime.worktree_policy_sync import (
+    sync_cloud_worktree_policy_to_runtime,
+)
 from proliferate.utils.crypto import decrypt_text, encrypt_text
 from proliferate.utils.time import duration_ms, utcnow
 
@@ -618,6 +621,14 @@ async def _launch_and_connect_runtime(
         runtime_token,
         workspace_id=ctx.workspace_id,
     )
+    await sync_cloud_worktree_policy_to_runtime(
+        user_id=ctx.user_id,
+        runtime_url=connected.endpoint.runtime_url,
+        access_token=runtime_token,
+        workspace_id=ctx.workspace_id,
+        run_deferred_startup_cleanup=True,
+        await_deferred_startup_cleanup=False,
+    )
 
     handshake = await _prepare_workspace_in_runtime(
         tracker,
@@ -660,6 +671,14 @@ async def _attach_workspace_to_running_runtime(
         connected.endpoint.runtime_url,
         runtime_token,
         workspace_id=ctx.workspace_id,
+    )
+    await sync_cloud_worktree_policy_to_runtime(
+        user_id=ctx.user_id,
+        runtime_url=connected.endpoint.runtime_url,
+        access_token=runtime_token,
+        workspace_id=ctx.workspace_id,
+        run_deferred_startup_cleanup=True,
+        await_deferred_startup_cleanup=False,
     )
     return await _prepare_workspace_in_runtime(
         tracker,

--- a/server/proliferate/server/cloud/runtime/service.py
+++ b/server/proliferate/server/cloud/runtime/service.py
@@ -19,6 +19,9 @@ from proliferate.server.cloud.runtime.ensure_running import (
 )
 from proliferate.server.cloud.runtime.models import RuntimeConnectionTarget
 from proliferate.server.cloud.runtime.provision import provision_workspace as _provision_workspace
+from proliferate.server.cloud.runtime.worktree_policy_sync import (
+    sync_cloud_worktree_policy_to_runtime,
+)
 from proliferate.utils.crypto import decrypt_text
 
 provision_workspace = _provision_workspace
@@ -123,6 +126,14 @@ async def get_workspace_connection(workspace: CloudWorkspace) -> RuntimeConnecti
             status_code=409,
         )
     access_token = decrypt_text(reloaded_environment.runtime_token_ciphertext)
+    await sync_cloud_worktree_policy_to_runtime(
+        user_id=reloaded_workspace.user_id,
+        runtime_url=runtime_url,
+        access_token=access_token,
+        workspace_id=workspace.id,
+        run_deferred_startup_cleanup=True,
+        await_deferred_startup_cleanup=False,
+    )
     ready_agent_kinds = await get_runtime_ready_agent_kinds(
         runtime_url,
         access_token,

--- a/server/proliferate/server/cloud/runtime/worktree_policy_sync.py
+++ b/server/proliferate/server/cloud/runtime/worktree_policy_sync.py
@@ -1,0 +1,73 @@
+"""Sync account worktree cleanup policy into managed AnyHarness runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
+from proliferate.server.cloud.runtime.anyharness_api import (
+    run_runtime_worktree_retention,
+    update_runtime_worktree_retention_policy,
+)
+from proliferate.server.cloud.worktree_policy.service import get_worktree_retention_policy
+
+
+async def _run_deferred_cleanup_background(
+    *,
+    runtime_url: str,
+    access_token: str,
+    workspace_id: UUID | None,
+) -> None:
+    try:
+        await run_runtime_worktree_retention(
+            runtime_url,
+            access_token,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:
+        log_cloud_event(
+            "cloud runtime deferred worktree retention run failed",
+            level=logging.WARNING,
+            workspace_id=workspace_id,
+            runtime_url=runtime_url,
+            error=format_exception_message(exc),
+            error_type=exc.__class__.__name__,
+        )
+
+
+async def sync_cloud_worktree_policy_to_runtime(
+    *,
+    user_id: UUID,
+    runtime_url: str,
+    access_token: str,
+    workspace_id: UUID | None,
+    run_deferred_startup_cleanup: bool,
+    await_deferred_startup_cleanup: bool = True,
+) -> int:
+    policy = await get_worktree_retention_policy(user_id)
+    limit = policy.max_materialized_worktrees_per_repo
+    await update_runtime_worktree_retention_policy(
+        runtime_url,
+        access_token,
+        max_materialized_worktrees_per_repo=limit,
+        workspace_id=workspace_id,
+    )
+    if run_deferred_startup_cleanup:
+        if await_deferred_startup_cleanup:
+            await run_runtime_worktree_retention(
+                runtime_url,
+                access_token,
+                workspace_id=workspace_id,
+            )
+        else:
+            asyncio.create_task(
+                _run_deferred_cleanup_background(
+                    runtime_url=runtime_url,
+                    access_token=access_token,
+                    workspace_id=workspace_id,
+                ),
+                name=f"cloud-worktree-retention-{workspace_id or 'runtime'}",
+            )
+    return limit

--- a/server/proliferate/server/cloud/worktree_policy/__init__.py
+++ b/server/proliferate/server/cloud/worktree_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud worktree cleanup policy domain."""

--- a/server/proliferate/server/cloud/worktree_policy/api.py
+++ b/server/proliferate/server/cloud/worktree_policy/api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.worktree_policy.models import (
+    CloudWorktreeRetentionPolicyRequest,
+    CloudWorktreeRetentionPolicyResponse,
+)
+from proliferate.server.cloud.worktree_policy.service import (
+    get_worktree_retention_policy,
+    set_worktree_retention_policy,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    "/worktree-retention-policy",
+    response_model=CloudWorktreeRetentionPolicyResponse,
+)
+async def get_cloud_worktree_retention_policy_endpoint(
+    user: User = Depends(current_active_user),
+) -> CloudWorktreeRetentionPolicyResponse:
+    return await get_worktree_retention_policy(user.id)
+
+
+@router.put(
+    "/worktree-retention-policy",
+    response_model=CloudWorktreeRetentionPolicyResponse,
+)
+async def put_cloud_worktree_retention_policy_endpoint(
+    body: CloudWorktreeRetentionPolicyRequest,
+    user: User = Depends(current_active_user),
+) -> CloudWorktreeRetentionPolicyResponse:
+    try:
+        return await set_worktree_retention_policy(
+            user.id,
+            max_materialized_worktrees_per_repo=body.max_materialized_worktrees_per_repo,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/worktree_policy/models.py
+++ b/server/proliferate/server/cloud/worktree_policy/models.py
@@ -1,0 +1,33 @@
+"""Request and response models for cloud worktree cleanup policy APIs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.cloud_worktree_policy import CloudWorktreePolicyValue
+
+CloudWorktreePolicySource = Literal["persisted", "default"]
+
+
+class CloudWorktreeRetentionPolicyRequest(BaseModel):
+    max_materialized_worktrees_per_repo: int = Field(alias="maxMaterializedWorktreesPerRepo")
+
+
+class CloudWorktreeRetentionPolicyResponse(BaseModel):
+    max_materialized_worktrees_per_repo: int = Field(
+        serialization_alias="maxMaterializedWorktreesPerRepo",
+    )
+    updated_at: str = Field(serialization_alias="updatedAt")
+    source: CloudWorktreePolicySource
+
+
+def cloud_worktree_policy_payload(
+    value: CloudWorktreePolicyValue,
+) -> CloudWorktreeRetentionPolicyResponse:
+    return CloudWorktreeRetentionPolicyResponse(
+        max_materialized_worktrees_per_repo=value.max_materialized_worktrees_per_repo,
+        updated_at=value.updated_at.isoformat(),
+        source="persisted",
+    )

--- a/server/proliferate/server/cloud/worktree_policy/service.py
+++ b/server/proliferate/server/cloud/worktree_policy/service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from proliferate.db.store.cloud_worktree_policy import (
+    DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+    MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+    MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+    load_cloud_worktree_policy_for_user,
+    persist_cloud_worktree_policy_for_user,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.worktree_policy.models import (
+    CloudWorktreeRetentionPolicyResponse,
+    cloud_worktree_policy_payload,
+)
+
+DEFAULT_POLICY_UPDATED_AT = "1970-01-01T00:00:00+00:00"
+
+
+def validate_worktree_policy_limit(value: int) -> int:
+    if (
+        value < MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO
+        or value > MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO
+    ):
+        raise CloudApiError(
+            "invalid_worktree_retention_policy",
+            (
+                "Worktree cleanup policy must keep between "
+                f"{MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO} and "
+                f"{MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO} materialized managed checkouts "
+                "per repo."
+            ),
+            status_code=400,
+        )
+    return value
+
+
+async def get_worktree_retention_policy(
+    user_id: UUID,
+) -> CloudWorktreeRetentionPolicyResponse:
+    value = await load_cloud_worktree_policy_for_user(user_id)
+    if value is None:
+        return CloudWorktreeRetentionPolicyResponse(
+            max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+            updated_at=DEFAULT_POLICY_UPDATED_AT,
+            source="default",
+        )
+    return cloud_worktree_policy_payload(value)
+
+
+async def set_worktree_retention_policy(
+    user_id: UUID,
+    *,
+    max_materialized_worktrees_per_repo: int,
+) -> CloudWorktreeRetentionPolicyResponse:
+    value = await persist_cloud_worktree_policy_for_user(
+        user_id=user_id,
+        max_materialized_worktrees_per_repo=validate_worktree_policy_limit(
+            max_materialized_worktrees_per_repo,
+        ),
+    )
+    return cloud_worktree_policy_payload(value)

--- a/server/tests/integration/schema_migration_assertions.py
+++ b/server/tests/integration/schema_migration_assertions.py
@@ -22,6 +22,7 @@ async def assert_current_schema(
         "cloud_workspace_handoff_op",
         "cloud_workspace_mobility",
         "cloud_sandbox",
+        "cloud_worktree_retention_policy",
         "cloud_workspace",
         "desktop_auth_code",
         "oauth_account",
@@ -124,6 +125,16 @@ async def assert_current_schema(
         }
     )
     assert "uq_cloud_runtime_environment_org_repo_policy" in runtime_indexes
+
+    worktree_policy_checks = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_check_constraints(
+                "cloud_worktree_retention_policy"
+            )
+        }
+    )
+    assert "ck_cloud_worktree_retention_policy_limit" in worktree_policy_checks
 
     billing_grant_columns = await conn.run_sync(
         lambda sync_conn: {

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -21,6 +21,7 @@ from proliferate.db.models.cloud import (
     CloudRuntimeEnvironment,
     CloudSandbox,
     CloudWorkspace,
+    CloudWorktreeRetentionPolicy,
 )
 from proliferate.db.store.cloud_mcp.auth import (
     update_connection_auth_if_version,
@@ -210,6 +211,81 @@ def _patch_repo_branches_lookup(
     monkeypatch.setattr(repos_service, "get_github_repo_branches", resolver)
     monkeypatch.setattr(cloud_service, "get_github_repo_branches", resolver)
     monkeypatch.setattr(repo_config_service, "get_repo_branches_for_user", resolver)
+
+
+class TestCloudWorktreeRetentionPolicy:
+    @pytest.mark.asyncio
+    async def test_default_policy_does_not_create_row(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+        first = await client.get("/v1/cloud/worktree-retention-policy", headers=headers)
+        second = await client.get("/v1/cloud/worktree-retention-policy", headers=headers)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == {
+            "maxMaterializedWorktreesPerRepo": 20,
+            "updatedAt": "1970-01-01T00:00:00+00:00",
+            "source": "default",
+        }
+        assert second.json() == first.json()
+        rows = (
+            await db_session.execute(
+                select(CloudWorktreeRetentionPolicy).where(
+                    CloudWorktreeRetentionPolicy.user_id == uuid.UUID(tokens["user_id"])
+                )
+            )
+        ).scalars().all()
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_put_persists_policy(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+        response = await client.put(
+            "/v1/cloud/worktree-retention-policy",
+            headers=headers,
+            json={"maxMaterializedWorktreesPerRepo": 50},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["maxMaterializedWorktreesPerRepo"] == 50
+        assert payload["source"] == "persisted"
+        assert payload["updatedAt"] != "1970-01-01T00:00:00+00:00"
+        row = (
+            await db_session.execute(
+                select(CloudWorktreeRetentionPolicy).where(
+                    CloudWorktreeRetentionPolicy.user_id == uuid.UUID(tokens["user_id"])
+                )
+            )
+        ).scalar_one()
+        assert row.max_materialized_worktrees_per_repo == 50
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_out_of_range_policy(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        response = await client.put(
+            "/v1/cloud/worktree-retention-policy",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+            json={"maxMaterializedWorktreesPerRepo": 9},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "invalid_worktree_retention_policy"
 
 
 class TestCloudCredentials:

--- a/server/tests/integration/test_desktop_auth_gate.py
+++ b/server/tests/integration/test_desktop_auth_gate.py
@@ -13,6 +13,7 @@ from httpx import AsyncClient
 
 PROTECTED_ENDPOINTS = [
     ("GET", "/v1/cloud/workspaces"),
+    ("GET", "/v1/cloud/worktree-retention-policy"),
     ("GET", "/v1/billing/plan"),
     ("GET", "/v1/billing/cloud-plan"),
     ("GET", "/users/me"),

--- a/server/tests/unit/test_cloud_runtime_ensure_running.py
+++ b/server/tests/unit/test_cloud_runtime_ensure_running.py
@@ -311,6 +311,14 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
     ) -> None:
         events.append("relaunch")
 
+    async def _ensure_launcher_defers_startup_retention(
+        _provider: object,
+        _sandbox: object,
+        _runtime_context: object,
+        _workspace: object,
+    ) -> None:
+        events.append("patch_launcher")
+
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
     monkeypatch.setattr(ensure_running, "verify_runtime_auth_enforced", _verify)
     monkeypatch.setattr(ensure_running, "load_active_sandbox_for_workspace", _load_active_sandbox)
@@ -321,6 +329,11 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
         _persist,
     )
     monkeypatch.setattr(ensure_running, "_relaunch_runtime", _relaunch)
+    monkeypatch.setattr(
+        ensure_running,
+        "_ensure_launcher_defers_startup_retention",
+        _ensure_launcher_defers_startup_retention,
+    )
 
     runtime_url = await ensure_running.ensure_workspace_runtime_ready(
         workspace,
@@ -329,7 +342,7 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
     )
 
     assert runtime_url == "https://fresh.invalid"
-    assert events == ["connect", "endpoint", "context", "relaunch", "verify"]
+    assert events == ["connect", "endpoint", "context", "patch_launcher", "relaunch", "verify"]
     assert persisted == [(True, "https://fresh.invalid")]
 
 

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -678,6 +678,12 @@ class TestLaunchAndConnectRuntime:
         async def _set_workspace_status(*_args, **_kwargs) -> None:
             return None
 
+        async def _sync_cloud_worktree_policy_to_runtime(*_args, **_kwargs) -> int:
+            calls.append("sync_cloud_worktree_policy_to_runtime")
+            assert _kwargs["run_deferred_startup_cleanup"] is True
+            assert _kwargs["await_deferred_startup_cleanup"] is False
+            return 20
+
         provider.write_file = _write_file
         provider.resolve_runtime_endpoint = _resolve_runtime_endpoint
 
@@ -708,6 +714,11 @@ class TestLaunchAndConnectRuntime:
             "prepare_remote_mobility_destination",
             _prepare_remote_mobility_destination,
         )
+        monkeypatch.setattr(
+            runtime_provision,
+            "sync_cloud_worktree_policy_to_runtime",
+            _sync_cloud_worktree_policy_to_runtime,
+        )
 
         await runtime_provision._launch_and_connect_runtime(
             tracker,
@@ -723,6 +734,7 @@ class TestLaunchAndConnectRuntime:
             "resolve_runtime_endpoint",
             "wait_for_runtime_health",
             "verify_runtime_auth_enforced",
+            "sync_cloud_worktree_policy_to_runtime",
             "reconcile_remote_agents",
             "resolve_remote_workspace",
             "resolve_runtime_root_head_sha",

--- a/server/tests/unit/test_cloud_worktree_policy_sync.py
+++ b/server/tests/unit/test_cloud_worktree_policy_sync.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from proliferate.server.cloud.runtime import worktree_policy_sync
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_can_trigger_deferred_cleanup_without_awaiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid4()
+    calls: list[str] = []
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def _get_policy(_user_id):
+        return SimpleNamespace(max_materialized_worktrees_per_repo=42)
+
+    async def _update_policy(*_args, **_kwargs) -> None:
+        calls.append("update_policy")
+
+    async def _run_retention(*_args, **_kwargs) -> None:
+        calls.append("run_retention_started")
+        cleanup_started.set()
+        await cleanup_release.wait()
+        calls.append("run_retention_finished")
+        cleanup_finished.set()
+
+    monkeypatch.setattr(worktree_policy_sync, "get_worktree_retention_policy", _get_policy)
+    monkeypatch.setattr(
+        worktree_policy_sync,
+        "update_runtime_worktree_retention_policy",
+        _update_policy,
+    )
+    monkeypatch.setattr(
+        worktree_policy_sync,
+        "run_runtime_worktree_retention",
+        _run_retention,
+    )
+
+    limit = await worktree_policy_sync.sync_cloud_worktree_policy_to_runtime(
+        user_id=uuid4(),
+        runtime_url="https://runtime.invalid",
+        access_token="token",
+        workspace_id=workspace_id,
+        run_deferred_startup_cleanup=True,
+        await_deferred_startup_cleanup=False,
+    )
+
+    assert limit == 42
+    assert calls[0] == "update_policy"
+    assert not cleanup_finished.is_set()
+
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    assert calls == ["update_policy", "run_retention_started"]
+
+    cleanup_release.set()
+    await asyncio.wait_for(cleanup_finished.wait(), timeout=1)
+    assert calls == ["update_policy", "run_retention_started", "run_retention_finished"]


### PR DESCRIPTION
## Summary
- add account-scoped cloud worktree retention policy API and persistence
- refactor desktop Worktree storage to one global cleanup policy with local fallback/adoption
- defer managed AnyHarness startup retention until policy sync, including cloud provision/reconnect launch paths

## Verification
- pnpm --dir desktop exec tsc --noEmit
- pnpm --dir desktop exec vitest run src/hooks/cloud/query-keys.test.ts src/components/settings/panes/WorktreesPane.test.tsx src/stores/preferences/user-preferences-store.test.ts
- uv run --extra dev python -m pytest tests/unit/test_cloud_runtime_provision.py tests/unit/test_cloud_worktree_policy_sync.py -q
- uv run --extra dev python -m pytest tests/unit/test_cloud_runtime_ensure_running.py tests/unit/test_cloud_runtime_service.py -q
- uv run --extra dev python -m pytest tests/integration/test_cloud_api.py::TestCloudWorktreeRetentionPolicy tests/integration/test_desktop_auth_gate.py tests/integration/test_schema_migrations.py -q
- uv run --extra dev ruff check touched server files/tests
- cargo test -q -p anyharness-lib workspaces::retention::tests::startup_deferral_is_startup_only_gate
- cargo test -q -p proliferate sidecar::tests
- git diff --check