### PR TITLE
ci(release): standardize desktop release process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+-
+
+## PR Metadata
+
+- Title format: `<type>(<scope>): <plain-English change>`
+- Required: exactly one `release:*` label
+- Required: at least one `area:*` label
+
+Release labels:
+`release:large-feature`, `release:minor-feature`, `release:performance`,
+`release:fix`, `release:docs`, `release:maintenance`, `release:skip`
+
+Area labels:
+`area:desktop`, `area:anyharness`, `area:sdk`, `area:server`, `area:cloud`,
+`area:docs`, `area:website`, `area:release`, `area:product`
+
+## Verification
+
+-

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - release:skip
+  categories:
+    - title: Large Features
+      labels:
+        - release:large-feature
+    - title: Minor Features
+      labels:
+        - release:minor-feature
+    - title: Performance
+      labels:
+        - release:performance
+    - title: Fixes
+      labels:
+        - release:fix
+    - title: Docs
+      labels:
+        - release:docs
+    - title: Maintenance
+      labels:
+        - release:maintenance
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,111 @@
+name: PR Metadata
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-pr-metadata:
+    name: Validate PR title and labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate metadata
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This workflow must run on a pull request event.");
+              return;
+            }
+
+            if (pr.draft) {
+              core.notice("Draft PR: metadata enforcement starts when the PR is ready for review.");
+              return;
+            }
+
+            const allowedTitleTypes = [
+              "feat",
+              "fix",
+              "perf",
+              "docs",
+              "refactor",
+              "chore",
+              "ci",
+              "test",
+              "build",
+              "release",
+            ];
+            const titlePattern = new RegExp(
+              `^(${allowedTitleTypes.join("|")})\\([a-z0-9][a-z0-9/-]*\\): .+`,
+            );
+
+            const allowedReleaseLabels = new Set([
+              "release:large-feature",
+              "release:minor-feature",
+              "release:performance",
+              "release:fix",
+              "release:docs",
+              "release:maintenance",
+              "release:skip",
+            ]);
+            const allowedAreaLabels = new Set([
+              "area:desktop",
+              "area:anyharness",
+              "area:sdk",
+              "area:server",
+              "area:cloud",
+              "area:docs",
+              "area:website",
+              "area:release",
+              "area:product",
+            ]);
+
+            const labels = pr.labels.map((label) => label.name);
+            const releaseLabels = labels.filter((label) => label.startsWith("release:"));
+            const areaLabels = labels.filter((label) => label.startsWith("area:"));
+            const invalidReleaseLabels = releaseLabels.filter(
+              (label) => !allowedReleaseLabels.has(label),
+            );
+            const invalidAreaLabels = areaLabels.filter(
+              (label) => !allowedAreaLabels.has(label),
+            );
+
+            const errors = [];
+            if (!titlePattern.test(pr.title)) {
+              errors.push(
+                `PR title must match <type>(<scope>): <change>. Allowed types: ${allowedTitleTypes.join(", ")}.`,
+              );
+            }
+            if (releaseLabels.length !== 1) {
+              errors.push(
+                `PR must have exactly one release:* label. Found ${releaseLabels.length}: ${releaseLabels.join(", ") || "none"}.`,
+              );
+            }
+            if (areaLabels.length < 1) {
+              errors.push("PR must have at least one area:* label.");
+            }
+            if (invalidReleaseLabels.length > 0) {
+              errors.push(`Unknown release label(s): ${invalidReleaseLabels.join(", ")}.`);
+            }
+            if (invalidAreaLabels.length > 0) {
+              errors.push(`Unknown area label(s): ${invalidAreaLabels.join(", ")}.`);
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.join("\n"));
+              return;
+            }
+
+            core.notice("PR metadata looks good.");

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -7,7 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run (skip GitHub release creation)"
+        description: "Dry run (skip GitHub release creation and updater publish)"
+        type: boolean
+        default: false
+      publish_updater:
+        description: "Publish updater/download assets to S3 and CloudFront on manual runs"
         type: boolean
         default: false
       target_os:
@@ -394,6 +398,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     steps:
+      - name: Validate release ref
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != desktop-v* ]]; then
+            echo "::error::Manual non-dry-run desktop releases must run from a desktop-v* tag ref, not ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -408,8 +421,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: Proliferate ${{ github.ref_name }}
+          name: Proliferate Desktop ${{ github.ref_name }}
           draft: true
+          generate_release_notes: true
           files: all-artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -417,7 +431,7 @@ jobs:
   publish-updater:
     needs: [build-desktop, create-release]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.publish_updater)
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -70,12 +70,21 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate release ref
+        if: steps.filter.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && !inputs.dry_run
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != desktop-v* ]]; then
+            echo "::error::Manual non-dry-run desktop releases must run from a desktop-v* tag ref, not ${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Validate version consistency
-        if: steps.filter.outputs.skip != 'true' && github.event_name == 'push'
+        if: steps.filter.outputs.skip != 'true' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
         shell: bash
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#desktop-v}"
@@ -402,8 +411,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_NAME}" != desktop-v* ]]; then
-            echo "::error::Manual non-dry-run desktop releases must run from a desktop-v* tag ref, not ${GITHUB_REF_NAME}."
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != desktop-v* ]]; then
+            echo "::error::Manual non-dry-run desktop releases must run from a desktop-v* tag ref, not ${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ AnyHarness code, read the relevant area doc too.
 
 - Read the relevant area doc as early as possible before editing code in that
   area.
+- PR titles and labels must follow the metadata rules in
+  `docs/ci-cd/README.md`. Use exactly one `release:*` label and at least one
+  `area:*` label before marking a PR ready for review.
 - Preserve current behavior unless an explicit behavior change is requested.
 - Prefer ownership-correct extractions over cosmetic churn.
 - Do not leave duplicate old and new code paths behind after a migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,21 +109,10 @@ AnyHarness code, read the relevant area doc too.
 
 ## Desktop Release Procedure
 
-**NEVER trigger `Release Desktop` via `workflow_dispatch` on `main`.** The
-updater manifest version is derived from `${GITHUB_REF_NAME#desktop-v}`. When
-triggered on `main`, the manifest gets `version: "main"` instead of valid
-semver, and the Tauri updater silently ignores it — users never see the update.
-
-Correct procedure:
-
-1. Bump the version in all three files (must match):
-   - `desktop/package.json`
-   - `desktop/src-tauri/tauri.conf.json`
-   - `desktop/src-tauri/Cargo.toml`
-2. Commit and push to `main`.
-3. Create and push a tag: `git tag desktop-v<VERSION> && git push origin desktop-v<VERSION>`
-4. The workflow triggers automatically on the tag push, or run manually
-   **from the tag ref**: `gh workflow run "Release Desktop" --ref desktop-v<VERSION>`
+If you are releasing a new version of the product, read
+`docs/ci-cd/README.md` first. That document is the source of truth for desktop
+version bumps, `desktop-v*` tags, draft GitHub releases, updater publishing,
+release dry runs, and PR release-note metadata.
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ PROD_DB_SECRET ?= proliferate/prod/database
 PROD_DB_INSTANCE ?= proliferate-prod
 SQL ?= select version_num from alembic_version;
 LOCAL_CODEX_ACP ?= $(HOME)/codex-acp/target/debug/codex-acp
+DESKTOP_RELEASE_WORKFLOW ?= Release Desktop
+DESKTOP_RELEASE_REF ?= $(shell git branch --show-current 2>/dev/null)
+DESKTOP_RELEASE_TARGET_OS ?= macos
+DESKTOP_RELEASE_TAG ?= desktop-v$(shell node -p "require('./desktop/package.json').version" 2>/dev/null)
 SERVER_ENV_SOURCE = set -a; \
 	[ ! -f server/.env ] || . server/.env; \
 	[ ! -f server/.env.local ] || . server/.env.local; \
@@ -51,6 +55,7 @@ endif
         check check-max-lines check-server-boundaries test test-server fmt clippy \
         dev-automation-worker \
         sdk-generate sdk-build sdk-react-build runtime-build desktop-build rebuild \
+        release-desktop-dry-run release-desktop-draft \
         test-agent-spec test-agent-runtime-local test-agent-local-fast test-agent-local \
         test-agent-runtime-cloud-e2b test-agent-runtime-cloud-daytona \
         cloud-runtime-build publish-cloud-template-env-local \
@@ -242,6 +247,49 @@ db-local:
 
 db-ah:
 	@sqlite3 -cmd ".headers on" -cmd ".mode column" $(HOME)/.proliferate-local/anyharness/db.sqlite
+
+# --- Release helpers ---
+
+release-desktop-dry-run:
+	@set -e; \
+	command -v gh >/dev/null 2>&1 || { echo "GitHub CLI is required: brew install gh"; exit 1; }; \
+	ref="$(DESKTOP_RELEASE_REF)"; \
+	if [ -z "$$ref" ]; then \
+		echo "DESKTOP_RELEASE_REF is required. Example: make release-desktop-dry-run DESKTOP_RELEASE_REF=feat/my-branch"; \
+		exit 1; \
+	fi; \
+	echo "Triggering $(DESKTOP_RELEASE_WORKFLOW) build dry run on $$ref..."; \
+	gh workflow run "$(DESKTOP_RELEASE_WORKFLOW)" \
+		--ref "$$ref" \
+		-f dry_run=true \
+		-f target_os="$(DESKTOP_RELEASE_TARGET_OS)"; \
+	echo ""; \
+	echo "Next:"; \
+	echo "  gh run list --workflow \"$(DESKTOP_RELEASE_WORKFLOW)\" --limit 5"; \
+	echo "  gh run watch <RUN_ID>"
+
+release-desktop-draft:
+	@set -e; \
+	command -v gh >/dev/null 2>&1 || { echo "GitHub CLI is required: brew install gh"; exit 1; }; \
+	tag="$(DESKTOP_RELEASE_TAG)"; \
+	if [ -z "$$tag" ] || [ "$$tag" = "desktop-v" ]; then \
+		echo "DESKTOP_RELEASE_TAG is required. Example: make release-desktop-draft DESKTOP_RELEASE_TAG=desktop-v0.1.28"; \
+		exit 1; \
+	fi; \
+	git ls-remote --exit-code --tags origin "$$tag" >/dev/null || { \
+		echo "Tag $$tag does not exist on origin. Create and push the tag before draft-release preview."; \
+		exit 1; \
+	}; \
+	echo "Triggering $(DESKTOP_RELEASE_WORKFLOW) draft release preview on $$tag with updater publish disabled..."; \
+	gh workflow run "$(DESKTOP_RELEASE_WORKFLOW)" \
+		--ref "$$tag" \
+		-f dry_run=false \
+		-f publish_updater=false \
+		-f target_os="$(DESKTOP_RELEASE_TARGET_OS)"; \
+	echo ""; \
+	echo "Next:"; \
+	echo "  gh run list --workflow \"$(DESKTOP_RELEASE_WORKFLOW)\" --limit 5"; \
+	echo "  gh run watch <RUN_ID>"
 
 # --- Production ops shortcuts ---
 

--- a/anyharness/crates/anyharness-lib/src/mobility/service.rs
+++ b/anyharness/crates/anyharness-lib/src/mobility/service.rs
@@ -30,6 +30,8 @@ use crate::workspaces::runtime::WorkspaceRuntime;
 use crate::workspaces::service::WorkspaceService;
 use crate::{files::safety::resolve_safe_path, git::GitService};
 
+const INCLUDE_RAW_NOTIFICATIONS_ENV: &str = "ANYHARNESS_MOBILITY_INCLUDE_RAW_NOTIFICATIONS";
+
 #[derive(Debug, thiserror::Error)]
 pub enum MobilityError {
     #[error("workspace not found: {0}")]
@@ -646,10 +648,13 @@ impl MobilityService {
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
             let events = self.session_service.store().list_events(&session.id)?;
-            let raw_notifications = self
-                .session_service
-                .store()
-                .list_raw_notifications(&session.id)?;
+            let raw_notifications = if include_raw_notifications_in_mobility_archive() {
+                self.session_service
+                    .store()
+                    .list_raw_notifications(&session.id)?
+            } else {
+                Vec::new()
+            };
             let agent_artifacts = collect_agent_artifacts(&session, &workspace_path)?;
 
             bundles.push(WorkspaceMobilitySessionBundleData {
@@ -776,6 +781,19 @@ fn write_workspace_file(repo_root: &Path, file: &MobilityFileData) -> Result<(),
 
 fn is_supported_agent_kind(agent_kind: &str) -> bool {
     matches!(agent_kind, "claude" | "codex")
+}
+
+fn include_raw_notifications_in_mobility_archive() -> bool {
+    env_flag_enabled(INCLUDE_RAW_NOTIFICATIONS_ENV)
+}
+
+fn env_flag_enabled(key: &str) -> bool {
+    let Some(value) = std::env::var_os(key) else {
+        return false;
+    };
+    let value = value.to_string_lossy();
+    let normalized = value.trim().to_ascii_lowercase();
+    !normalized.is_empty() && !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
 }
 
 fn is_active_terminal(terminal: &TerminalRecord) -> bool {

--- a/desktop/src/hooks/workspaces/mobility/use-cloud-to-local-handoff.ts
+++ b/desktop/src/hooks/workspaces/mobility/use-cloud-to-local-handoff.ts
@@ -23,6 +23,7 @@ import { useWorkspaceMobilityUiStore } from "@/stores/workspaces/workspace-mobil
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/logical-workspaces";
+import { describeMobilityPreflightLoadFailure } from "@/lib/domain/workspaces/mobility-preflight-error";
 import { elapsedMs, logLatency, startLatencyTimer } from "@/lib/infra/debug-latency";
 import { deriveHandoffFailureRecovery } from "./handoff-failure-recovery";
 
@@ -143,7 +144,11 @@ export function useCloudToLocalHandoff(args: {
       const sourcePreflightResult = await sourcePreflightQuery.refetch();
       const sourcePreflightData = sourcePreflightResult.data;
       if (!sourcePreflightData) {
-        throw new Error("Failed to load workspace mobility preflight.");
+        throw new Error(describeMobilityPreflightLoadFailure({
+          error: sourcePreflightResult.error,
+          status: sourcePreflightResult.status,
+          fetchStatus: sourcePreflightResult.fetchStatus,
+        }));
       }
       const sourcePreflight = withRequiredSourceMetadata(
         sourcePreflightData,

--- a/desktop/src/hooks/workspaces/mobility/use-local-to-cloud-handoff.ts
+++ b/desktop/src/hooks/workspaces/mobility/use-local-to-cloud-handoff.ts
@@ -25,6 +25,7 @@ import { useWorkspaceMobilityUiStore } from "@/stores/workspaces/workspace-mobil
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useHarnessStore } from "@/stores/sessions/harness-store";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/logical-workspaces";
+import { describeMobilityPreflightLoadFailure } from "@/lib/domain/workspaces/mobility-preflight-error";
 import { elapsedMs, logLatency, startLatencyTimer } from "@/lib/infra/debug-latency";
 import { deriveHandoffFailureRecovery } from "./handoff-failure-recovery";
 
@@ -143,7 +144,11 @@ export function useLocalToCloudHandoff(args: {
       const sourcePreflightResult = await sourcePreflightQuery.refetch();
       const sourcePreflightData = sourcePreflightResult.data;
       if (!sourcePreflightData) {
-        throw new Error("Failed to load workspace mobility preflight.");
+        throw new Error(describeMobilityPreflightLoadFailure({
+          error: sourcePreflightResult.error,
+          status: sourcePreflightResult.status,
+          fetchStatus: sourcePreflightResult.fetchStatus,
+        }));
       }
       const sourcePreflight = withRequiredSourceMetadata(
         sourcePreflightData,

--- a/desktop/src/lib/domain/workspaces/mobility-preflight-error.ts
+++ b/desktop/src/lib/domain/workspaces/mobility-preflight-error.ts
@@ -1,0 +1,48 @@
+import { AnyHarnessError } from "@anyharness/sdk";
+
+export function describeMobilityPreflightLoadFailure(args: {
+  error: unknown;
+  status?: string;
+  fetchStatus?: string;
+}): string {
+  const diagnostic = describeUnknownError(args.error)
+    ?? describeQueryState(args.status, args.fetchStatus)
+    ?? "No preflight data returned.";
+
+  return `Failed to load workspace mobility preflight: ${diagnostic}`;
+}
+
+function describeUnknownError(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof AnyHarnessError) {
+    const problem = error.problem;
+    const code = problem.code?.trim();
+    const detail = problem.detail?.trim() || problem.title?.trim();
+    const status = Number.isFinite(problem.status) ? `HTTP ${problem.status}` : null;
+    return [code, status, detail].filter(Boolean).join(" - ") || error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function describeQueryState(status?: string, fetchStatus?: string): string | null {
+  if (!status && !fetchStatus) {
+    return null;
+  }
+  return `query status=${status ?? "unknown"}, fetchStatus=${fetchStatus ?? "unknown"}`;
+}

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -206,11 +206,20 @@ Flow:
    - `desktop/package.json`
    - `desktop/src-tauri/tauri.conf.json`
    - `desktop/src-tauri/Cargo.toml`
-2. Push a tag like `desktop-v0.1.0`. The workflow triggers automatically.
-   If you must trigger manually, use `--ref desktop-v<VERSION>` — **never
+2. Commit and merge the version bump to `main`.
+3. From updated `main`, create and push a tag like `desktop-v0.1.0`. The
+   workflow triggers automatically.
+4. Treat pushing the `desktop-v*` tag as the shipping action. The tag-push
+   workflow publishes updater/download assets after the build succeeds, even
+   though the GitHub Release remains a draft.
+5. After the workflow succeeds, manually review the draft GitHub Release:
+   - add a short highlights section at the top
+   - clean up generated release notes if needed
+   - publish the GitHub Release as the human-facing release page
+6. If you must trigger manually, use `--ref desktop-v<VERSION>` — **never
    trigger on `main`**, because the updater manifest version is derived from
    `GITHUB_REF_NAME` and will resolve to `"main"` instead of valid semver.
-3. The workflow:
+7. The workflow:
    - validates version consistency on tag pushes
    - builds the AnyHarness sidecar for each desktop target
    - builds exactly one bundled agent seed for that target from
@@ -224,7 +233,7 @@ Flow:
    - normalizes macOS DMG names to stable arch-specific filenames
    - normalizes macOS updater archive names to stable arch-specific filenames
    - creates a draft GitHub release with generated release notes
-4. The updater publish job then:
+8. The updater publish job then:
    - generates `latest.json`
    - generates `installers.json`
    - uploads signed updater artifacts and public DMG installers to
@@ -279,6 +288,9 @@ Note:
   to S3 or invalidating CloudFront.
 - Real `desktop-v*` tag pushes still publish updater and download assets
   automatically after the draft GitHub release is created.
+- Publishing the GitHub Release does not make the updater live. The updater is
+  made live by the tag-push workflow's S3/CloudFront publish step. The GitHub
+  Release is the public release-notes and artifact archive surface.
 - The release workflow is intentionally fail-closed now: manifest generation
   happens before S3 upload so a broken manifest does not leave a partial updater
   publish behind.

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -283,6 +283,17 @@ Note:
   happens before S3 upload so a broken manifest does not leave a partial updater
   publish behind.
 
+Useful local wrappers:
+
+```bash
+# Safe build-only workflow dry run. Creates no GitHub release and publishes no updater assets.
+make release-desktop-dry-run DESKTOP_RELEASE_REF=feat/my-branch
+
+# Draft GitHub release preview from an already-pushed desktop tag.
+# Creates a draft release with generated notes, but does not publish updater assets.
+make release-desktop-draft DESKTOP_RELEASE_TAG=desktop-v0.1.28
+```
+
 ### Desktop In-App Update Flow
 
 Source of truth:

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -12,9 +12,13 @@ publishing, or the desktop in-app update flow.
   cloud-live-webhook.yml     # manual/nightly live E2B webhook delivery smoke
   release-cloud-template.yml # public E2B cloud template build + publish + staging promote
   promote-cloud-template.yml # manual production promote for public E2B templates
+  pr-metadata.yml            # PR title and release/area label validation
   release-desktop.yml        # desktop packaging, draft release, updater publish
   release-runtime.yml        # AnyHarness binary release + npm publish for @anyharness/sdk
   server-ci.yml              # server lint/test/build-and-push image pipeline
+.github/
+  release.yml                # generated GitHub release-note grouping
+  pull_request_template.md   # PR title, label, and verification checklist
 desktop/
   infra/main.tf              # updater bucket, CloudFront, GitHub OIDC release role
   src-tauri/tauri.conf.json  # updater endpoint, public key, bundle config
@@ -66,8 +70,91 @@ scripts/
   from those files.
 - Preserve public artifact names, release channels, and updater URLs unless an
   explicit product change is requested.
+- PRs must use the repository release metadata standard before they are marked
+  ready for review. Draft PRs are exempt until ready.
 
-## 3. Delivery Flows
+## 3. PR Metadata and Release Notes
+
+Generated GitHub release notes are driven by PR titles and labels. Keep PR
+titles readable for humans and labels precise for automation.
+
+PR titles must use:
+
+```text
+<type>(<scope>): <plain-English change>
+```
+
+Allowed types:
+
+```text
+feat, fix, perf, docs, refactor, chore, ci, test, build, release
+```
+
+Examples:
+
+```text
+feat(desktop): open new chat tabs optimistically
+fix(anyharness): use materialized session IDs for runtime calls
+perf(desktop): avoid header tab rerenders during stream updates
+docs(cloud): clarify local and cloud workspace flows
+ci(release): generate desktop release notes
+```
+
+Every non-draft PR must have exactly one release label:
+
+```text
+release:large-feature
+release:minor-feature
+release:performance
+release:fix
+release:docs
+release:maintenance
+release:skip
+```
+
+Every non-draft PR must have at least one area label:
+
+```text
+area:desktop
+area:anyharness
+area:sdk
+area:server
+area:cloud
+area:docs
+area:website
+area:release
+area:product
+```
+
+Use `release:maintenance` for non-user-facing work such as refactors, tests,
+CI, release infra, dependency bumps, codegen, logging, dev tooling, and cleanup.
+Use `release:skip` only when the PR should not appear in generated release
+notes.
+
+Before making `.github/workflows/pr-metadata.yml` required in branch
+protection, create the full `release:*` and `area:*` label set in GitHub.
+Example:
+
+```bash
+gh label create "release:large-feature" --color "5319e7" --description "Major user-visible product surface"
+gh label create "release:minor-feature" --color "1d76db" --description "Small user-visible improvement"
+gh label create "release:performance" --color "fbca04" --description "Speed, latency, memory, render, or request improvement"
+gh label create "release:fix" --color "d73a4a" --description "Bug fix, crash fix, or correctness fix"
+gh label create "release:docs" --color "0075ca" --description "Documentation, changelog, install guide, or troubleshooting"
+gh label create "release:maintenance" --color "cfd3d7" --description "Refactor, test, CI, dependency, codegen, or tooling work"
+gh label create "release:skip" --color "eeeeee" --description "Exclude from generated release notes"
+gh label create "area:desktop" --color "bfd4f2" --description "Desktop app, Tauri shell, updater, or local app behavior"
+gh label create "area:anyharness" --color "bfdadc" --description "AnyHarness runtime, sessions, workspaces, agents, or contract"
+gh label create "area:sdk" --color "bfdadc" --description "AnyHarness SDK or SDK React package"
+gh label create "area:server" --color "c2e0c6" --description "API server, auth, billing, orgs, or control plane"
+gh label create "area:cloud" --color "c2e0c6" --description "Cloud workspaces, providers, or cloud runtime flows"
+gh label create "area:docs" --color "d4c5f9" --description "Docs site or documentation content"
+gh label create "area:website" --color "d4c5f9" --description "Marketing site or public changelog pages"
+gh label create "area:release" --color "fef2c0" --description "Release workflows, packaging, updater manifests, or publishing"
+gh label create "area:product" --color "fef2c0" --description "Cross-cutting product behavior spanning multiple areas"
+```
+
+## 4. Delivery Flows
 
 ### Continuous Integration
 
@@ -136,7 +223,7 @@ Flow:
    - verifies updater artifacts before release creation
    - normalizes macOS DMG names to stable arch-specific filenames
    - normalizes macOS updater archive names to stable arch-specific filenames
-   - creates a draft GitHub release
+   - creates a draft GitHub release with generated release notes
 4. The updater publish job then:
    - generates `latest.json`
    - generates `installers.json`
@@ -186,6 +273,12 @@ Note:
   release pipeline has a self-hosted clean macOS runner or VM lane.
 - `dry_run: true` exercises the build matrix but skips `create-release` and
   `publish-updater`.
+- Manual non-dry-run desktop releases must run from a `desktop-v*` tag ref.
+- Manual runs default `publish_updater` to false. Use this to test draft
+  GitHub release creation and generated notes without uploading updater assets
+  to S3 or invalidating CloudFront.
+- Real `desktop-v*` tag pushes still publish updater and download assets
+  automatically after the draft GitHub release is created.
 - The release workflow is intentionally fail-closed now: manifest generation
   happens before S3 upload so a broken manifest does not leave a partial updater
   publish behind.
@@ -312,11 +405,14 @@ Current boundary:
 - If you add that rollout later, update this doc, `server/infra/**`, and the
   GitHub workflow together.
 
-## 4. Source of Truth
+## 5. Source of Truth
 
 | Concern | Canonical files |
 | --- | --- |
 | Shared CI for Rust, SDK, and desktop frontend | `.github/workflows/ci.yml` |
+| PR title and release/area label validation | `.github/workflows/pr-metadata.yml` |
+| Generated GitHub release-note grouping | `.github/release.yml` |
+| PR metadata checklist | `.github/pull_request_template.md` |
 | Real-provider cloud lifecycle and cloud-backed runtime CI | `.github/workflows/cloud-tests.yml` |
 | Live ngrok-backed E2B webhook smoke | `.github/workflows/cloud-live-webhook.yml` |
 | Public E2B cloud template build + publish + staging | `.github/workflows/release-cloud-template.yml` |


### PR DESCRIPTION
## Summary

- standardize PR title and release/area label metadata
- generate grouped draft GitHub release notes for desktop releases
- add safer manual desktop release dry-run and draft-release helpers
- clarify desktop release procedure in CI/CD docs

## Verification

- actionlint .github/workflows/release-desktop.yml .github/workflows/pr-metadata.yml
- YAML parse for release workflow/config files
- git diff --check for release/docs files
- make -n release-desktop-dry-run DESKTOP_RELEASE_REF=feat/new-release-process
- make -n release-desktop-draft DESKTOP_RELEASE_TAG=desktop-v0.1.28

Note: CI repo-shape failure is known and being handled in a separate concurrent PR/worktree.