### PR TITLE
docs(frontend): codify ownership rules

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -9,6 +9,23 @@ Scope:
 Use this doc first to understand the frontend ownership model. Then read the
 layer doc and any surface spec that applies to the code you are changing.
 
+## North Star
+
+The frontend is organized for legibility by file path. When a developer sees a
+file location, they should know what kind of logic is allowed there before
+opening the file. When something breaks or needs to change, they should know
+where to look first.
+
+Structural rules are not aesthetic. They prevent mixed-ownership files from
+becoming god modules that nobody can change confidently.
+
+The single rule behind this guide:
+
+> A file should be readable cold. A contributor should be able to open the top
+> file in a feature and understand what it owns, what it exposes, and where the
+> real work lives. If understanding the file requires following imports through
+> unrelated layers, the structure is wrong.
+
 ## Read Order
 
 Always start here.
@@ -65,18 +82,21 @@ desktop/src/
     access/
       anyharness/
       cloud/
-      tauri/
+      mcp/
       tauri/
     ui/
     <domain>/
       derived/
       workflows/
       lifecycle/
+      ui/
+      cache/
       facade/
   lib/
     access/
       anyharness/
       cloud/
+      tauri/
     domain/
       <domain>/
         <subdomain>/
@@ -107,9 +127,15 @@ focused doc that owns the layer.
 - Hooks are not the default extraction unit. Use hooks for React behavior; use
   plain functions for pure logic, product workflows, access helpers, and infra
   utilities.
+- Product hook domains are organized by responsibility folders. New
+  non-migration hook files should not sit directly under `hooks/<domain>/`.
 - Preserve current UI and behavior unless an explicit behavior change is
   requested.
 - Delete dead code when replacing an implementation.
+- Move toward the target architecture incrementally. Do not create empty
+  folder trees or speculative abstractions.
+- Cleanup PRs should state whether they are behavior-preserving extractions or
+  behavior changes. Do not mix both unless the task explicitly requires it.
 - Avoid god modules and god stores. Prefer splitting before roughly 400 lines.
   Files at 600+ lines need a strong reason to stay whole. Mixed ownership
   should be split even below those thresholds.
@@ -131,6 +157,8 @@ Use the lowest layer that can own the logic cleanly.
 | Product derived hooks | `hooks/<domain>/derived/**` | It computes UI-ready state from stores, providers, and queries. | Writes, effects, raw access, navigation, or telemetry. | [guides/hooks.md](guides/hooks.md) |
 | Product workflow hooks | `hooks/<domain>/workflows/**` | It exposes user-action callbacks and coordinates React dependencies. | Large business algorithms or raw clients. | [guides/hooks.md](guides/hooks.md) |
 | Product lifecycle hooks | `hooks/<domain>/lifecycle/**` | It owns mounted effects, streams, dispatchers, polling, or reconciliation. | Render logic or user-click workflow branching. | [guides/hooks.md](guides/hooks.md) |
+| Product UI-mechanic hooks | `hooks/<domain>/ui/**` | It wraps UI mechanics that are specific to one product domain. | Generic browser mechanics or product workflows. | [guides/hooks.md](guides/hooks.md) |
+| Product cache hooks | `hooks/<domain>/cache/**` | It owns a product-composed cache that combines multiple external/local sources. | One-resource external query wrappers or raw access. | [guides/hooks.md](guides/hooks.md), [guides/access.md](guides/access.md), [guides/state.md](guides/state.md) |
 | Shared client state | `stores/<domain>/<concern>-store.ts` | It is client-only state such as selected ids, drafts, panels, or active UI. | Server/runtime caches, API calls, navigation, telemetry, or multi-store orchestration. | [guides/state.md](guides/state.md) |
 | Scoped dependencies | `providers/**` | It defines an app/subtree context boundary. | General mutable UI state. | [guides/state.md](guides/state.md) |
 | Pure product rules | `lib/domain/<domain>/<subdomain>/**` | It is deterministic product logic with no React or external access. | Hooks, stores, clients, query invalidation, platform APIs. | [guides/lib.md](guides/lib.md) |
@@ -146,6 +174,9 @@ Use the lowest layer that can own the logic cleanly.
 - Components may call hooks and render UI primitives.
 - Product hooks may read stores/providers, call access hooks, and call
   `lib/domain` or `lib/workflows` functions.
+- Product hooks do not own React Query key definitions or query cache shape.
+  They call access hooks/cache callbacks when a workflow needs remote state
+  invalidated or updated.
 - Stores do not call hooks, clients, query invalidation, navigation, telemetry,
   or other stores.
 - `lib/domain` does not import React, stores, query clients, access helpers, or
@@ -153,3 +184,25 @@ Use the lowest layer that can own the logic cleanly.
 - `lib/workflows` may coordinate multiple dependencies, but those dependencies
   are passed in. It does not import React hooks.
 - Raw cloud, AnyHarness, and Tauri access stays behind the access boundary.
+
+Dependency direction is one-way:
+
+```text
+components -> hooks -> lib/workflows -> lib/domain/lib/infra -> lib/access
+```
+
+Stores are read by hooks. `lib/**` files do not read stores directly unless a
+focused area doc explicitly marks the file as a transitional state adapter.
+
+## Cleanup Discipline
+
+- Move ownership violations before introducing new abstractions.
+- Do not leave duplicate old and new paths behind after a migration.
+- Do not create one-file folders or empty target trees to satisfy a diagram.
+- Prefer one bounded product area per PR.
+- Keep public hook/component APIs stable unless the cleanup explicitly changes
+  callsites.
+- When splitting a file, preserve behavior first; improve behavior in a
+  separate PR.
+- Use focused tests around moved domain/workflow logic when the logic is
+  meaningful or risky.

--- a/docs/frontend/guides/access.md
+++ b/docs/frontend/guides/access.md
@@ -14,22 +14,176 @@ lib/access/
   anyharness/
     runtime-target.ts
     runtime-bootstrap.ts
+    workspace-connection.ts
+    session-stream-transport.ts
   tauri/
     <capability>.ts
 hooks/access/
   cloud/
-    query-keys.ts
-    use-<resource>.ts
-    use-<action>-mutation.ts
+    <resource>/
+      query-keys.ts
+      use-<resource>.ts
+      use-<action>-mutation.ts
   anyharness/
-    use-<resource>.ts
+    <desktop-runtime-concern>/
+      use-<concern>.ts
   tauri/
-    use-<capability>-actions.ts
+    <capability>/
+      query-keys.ts
+      use-<capability>-actions.ts
+  mcp/
+    connectors/
+      query-keys.ts
+      use-connectors.ts
+      use-connector-mutations.ts
 ```
 
 Existing code may still live under older transitional paths such as
 `lib/integrations/**` or domain hook folders. New code and cleanup work should
 move toward the access shape above.
+
+## Query Key Ownership
+
+Query keys are part of the React-facing access contract. They should live next
+to the access hook that owns the same external resource cache:
+
+```text
+hooks/access/cloud/automations/query-keys.ts
+hooks/access/cloud/automations/use-automations.ts
+hooks/access/cloud/automations/use-automation-mutations.ts
+```
+
+Do not put React Query key factories in `lib/access/**`; that layer owns raw
+transport, not React cache identity. Do not define remote-resource query keys
+inside product hook folders such as `hooks/automations/**`,
+`hooks/workspaces/**`, or `hooks/sessions/**`.
+
+Product hook folders may keep a key helper only when the cache is genuinely
+product-composed state rather than one external resource. If that exception is
+used, the file should make the product ownership obvious and should not call
+raw endpoint helpers.
+
+Cleanup audits should start with:
+
+```bash
+rg "query-keys" desktop/src/hooks --glob '!access/**'
+```
+
+Every hit should be either migration debt or a documented product-composed
+cache.
+
+## Desktop Access Folder Shape
+
+Use resource folders under `hooks/access/**`. The folder name should describe
+the external boundary or access capability being cached, not the product screen
+that happens to use it. Most folders map directly to an external system
+(`cloud`, `anyharness`, `tauri`). A capability folder such as `mcp` is allowed
+when one React-facing access API intentionally coordinates more than one
+external boundary, such as cloud connector records plus local OAuth/native
+setup.
+
+```text
+hooks/access/
+  cloud/
+    auth/
+      query-keys.ts
+      use-github-auth-availability.ts
+    automations/
+      query-keys.ts
+      use-automations.ts
+      use-automation-mutations.ts
+    billing/
+      query-keys.ts
+      use-cloud-billing.ts
+      use-cloud-billing-mutations.ts
+    credentials/
+      query-keys.ts
+      use-cloud-credentials.ts
+      use-cloud-credential-mutations.ts
+    mobility/
+      query-keys.ts
+      use-cloud-mobility-workspaces.ts
+      use-cloud-mobility-workspace.ts
+      use-cloud-mobility-mutations.ts
+      cache.ts
+    organizations/
+      query-keys.ts
+      use-organizations.ts
+      use-organization-members.ts
+      use-organization-invitations.ts
+      use-organization-mutations.ts
+    repo-configs/
+      query-keys.ts
+      use-cloud-repo-config.ts
+      use-cloud-repo-configs.ts
+      use-cloud-repo-config-mutations.ts
+    repos/
+      query-keys.ts
+      use-cloud-repo-branches.ts
+    runtime/
+      query-keys.ts
+      use-control-plane-health.ts
+      use-cloud-workspace-connection.ts
+    workspaces/
+      query-keys.ts
+      use-cloud-workspace-repo-config-status.ts
+      use-cloud-workspace-mutations.ts
+    worktree-policy/
+      query-keys.ts
+      use-cloud-worktree-retention-policy.ts
+      use-cloud-worktree-retention-policy-mutation.ts
+  anyharness/
+    runtime/
+      use-runtime-health.ts
+    sessions/
+      use-prompt-attachment-url.ts
+    worktrees/
+      use-dynamic-worktree-inventory.ts
+      use-dynamic-worktree-policy.ts
+  tauri/
+    app/
+      query-keys.ts
+      use-app-version.ts
+    credentials/
+      query-keys.ts
+      use-local-agent-credentials.ts
+    shell/
+      query-keys.ts
+      use-available-editors.ts
+      use-shell-actions.ts
+    updater/
+      query-keys.ts
+      use-updater.ts
+    window/
+      use-window-actions.ts
+    diagnostics/
+      use-diagnostics-actions.ts
+  mcp/
+    connectors/
+      query-keys.ts
+      use-connectors.ts
+      use-connector-mutations.ts
+```
+
+`hooks/access/anyharness/**` should stay rare. Prefer importing
+`@anyharness/sdk-react` hooks directly for normal AnyHarness resources. Do not
+wrap SDK React hooks just for symmetry with cloud or Tauri access. Add a
+desktop AnyHarness access hook only when the hook needs selected-runtime
+resolution, desktop connection state, or a local/cloud runtime target that SDK
+React cannot know.
+
+Product-composed caches do not move here just because they use React Query. For
+example, workspace collections combine local runtime workspaces, cloud
+workspaces, repository roots, cleanup state, and product latency diagnostics.
+That cache should live under a product-owned cache folder such as:
+
+```text
+hooks/workspaces/cache/workspace-collections-query.ts
+hooks/workspaces/cache/workspace-collections-cache.ts
+```
+
+Access hooks own one external resource cache. Product cache folders own
+cross-boundary product projections.
 
 ## Cloud
 
@@ -60,7 +214,7 @@ File naming:
 
 File naming:
 
-- `query-keys.ts` for cloud query key factories
+- `<resource>/query-keys.ts` for cloud query key factories
 - `use-<resource>.ts` for list or summary queries
 - `use-<resource>-detail.ts` for single-entity queries
 - `use-<action>-mutation.ts` for one mutation
@@ -69,6 +223,18 @@ File naming:
 New cloud query/mutation wrappers belong in `hooks/access/cloud/**`. Existing
 `hooks/cloud/**` is transitional; product workflow hooks should migrate to
 their owning product hook domain.
+
+If a hook wraps a cloud endpoint with `useQuery` or `useMutation`, it belongs
+here even when the resource is product-specific. For example:
+
+```text
+hooks/access/cloud/mobility/query-keys.ts
+hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
+```
+
+Product hooks should consume this access hook and derive product state in their
+own domain folder. They should not define cloud query keys or call cloud raw
+helpers directly.
 
 Do not create ad hoc `openapi-fetch` clients outside the cloud access layer.
 Do not call raw `client.GET`, `client.POST`, `client.PUT`, or `client.DELETE`
@@ -80,6 +246,15 @@ Generic AnyHarness React access goes through `@anyharness/sdk-react`.
 Product hooks should not call `getAnyHarnessClient` directly except in
 transitional code. Put normal AnyHarness resource operations behind
 `@anyharness/sdk-react` or `hooks/access/anyharness/**`.
+
+Prefer direct SDK React imports for generic resources:
+
+```ts
+import { useAnyHarnessRuntimeWorkspaces } from "@anyharness/sdk-react";
+```
+
+Create a desktop access hook only when desktop adds connection/runtime
+selection, local/cloud bridging, or cache behavior the SDK cannot provide.
 
 Low-level framework-agnostic primitives, such as streams, transcript reducers,
 and terminal connections, belong in `@anyharness/sdk`.
@@ -141,3 +316,9 @@ Component
 Keep business rules in `lib/domain` or `lib/workflows`. Keep transport details
 in access. Keep rendering in components. Do not call React hooks from
 `lib/workflows`.
+
+Query cache ownership follows the same boundary. Access hooks own query keys,
+cache object shape, invalidation, and `setQueryData` for remote resources.
+Product workflow hooks may decide that a resource should be refreshed or
+updated, but they should do that through access-owned callbacks rather than
+constructing query keys or writing cache objects inline.

--- a/docs/frontend/guides/components.md
+++ b/docs/frontend/guides/components.md
@@ -9,6 +9,10 @@ state/actions, tiny local UI callbacks, JSX out.
   product logic.
 - Components may call hooks. Hooks should provide the data, callbacks, and
   state needed for rendering.
+- Components may import small pure domain/presentation helpers directly when
+  the helper only builds local render metadata, such as a row label, tone, or
+  icon choice. If the composition reads multiple stores/queries or combines
+  several product concerns, put it behind a derived hook instead.
 - Components may own local presentational state that only their subtree needs.
 - If a component has real computation in `useMemo`, move the computation into a
   derived hook or `lib/domain` helper.
@@ -25,6 +29,7 @@ Allowed component logic:
   prop callback
 - local-only measurement, hover, drag, focus, and menu state
 - simple formatting that is truly local and not a repeated product rule
+- small calls to pure presentation/domain helpers for local render metadata
 
 Red flags:
 
@@ -35,6 +40,8 @@ Red flags:
 - non-trivial `useMemo` or `useEffect`
 - inline status-to-label/tone/icon maps
 - callbacks that read like workflows
+- async mutations, file parsing, sorting/filtering product models, or
+  multi-step state transitions
 
 ## Folder Shape
 
@@ -81,6 +88,21 @@ Avoid new root buckets like `modals`, `panels`, `sidebar`, or `topbar`.
 Domain-aware dialogs, panels, sidebars, and toolbars stay inside their owning
 product area.
 
+Folder hygiene:
+
+- A top-level `components/<domain>/` folder should represent a real product
+  area, not a UI shape or transport boundary.
+- Single-file folders are usually not worth it. Keep the file in its parent
+  unless the folder is clearly about to hold a cohesive surface/role.
+- Pick one shape per parent. A folder should not mix many direct component
+  files with some nested role folders unless the direct files are the surface
+  entrypoints.
+- Avoid `shared/` and `common/` inside surfaces. Reuse moves up to
+  `components/ui/**` for generic primitives or to a domain root when it remains
+  product-aware.
+- When a flat component folder grows past roughly ten files, introduce
+  surface/role folders before adding more unrelated components.
+
 ## UI Primitives
 
 - Put foundational primitives and shells in `components/ui/**`.
@@ -102,9 +124,20 @@ product area.
 - Use `React.memo` only when props are reference-stable and the component
   demonstrably re-renders due to parent state churn.
 - Component files use `PascalCase.tsx`.
+- Do not put `.ts` files under `components/**`. Static metadata, copy,
+  config, and pure presentation helpers belong in `config/**`, `copy/**`, or
+  `lib/domain/**`.
 - Component names should describe the product surface or UI primitive they own.
 - Avoid generic names like `Panel`, `Modal`, `Content`, or `Row` unless the
   folder path already makes the ownership unambiguous.
+
+File size guidance:
+
+- Prefer splitting product component files before roughly 300 lines.
+- Component files around 500 lines need a strong reason to stay whole.
+- Size alone is not the only signal. Split earlier when a component mixes
+  rendering with workflows, product-model construction, repeated presentation
+  maps, or non-trivial effects.
 
 ## Settings
 

--- a/docs/frontend/guides/hooks.md
+++ b/docs/frontend/guides/hooks.md
@@ -28,14 +28,46 @@ React Query or mutation wrappers around external systems.
 Path:
 
 ```text
-hooks/access/cloud/use-cloud-billing.ts
-hooks/access/anyharness/use-runtime-workspaces.ts
-hooks/access/tauri/use-updater-actions.ts
+hooks/access/cloud/billing/use-cloud-billing.ts
+hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
+hooks/access/anyharness/runtime/use-runtime-workspaces.ts
+hooks/access/tauri/updater/use-updater-actions.ts
 ```
 
 Access hooks own query keys, `useQuery`, `useMutation`, retries, invalidation,
 and request telemetry. Product hooks should use access hooks instead of
 constructing clients or calling raw endpoint helpers directly.
+
+If a hook directly wraps an external request with `useQuery` or `useMutation`,
+it belongs under `hooks/access/<boundary>/**`. Do not put query/mutation hooks
+inside product-domain folders such as `hooks/workspaces/**`, `hooks/agents/**`,
+or `hooks/sessions/**`.
+
+Query keys live with the access hooks for the same external boundary and
+resource:
+
+```text
+hooks/access/cloud/mobility/query-keys.ts
+hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
+```
+
+The concrete access folder map lives in `docs/frontend/guides/access.md`.
+Follow that map before inventing a new access folder or leaving query keys in a
+product hook directory.
+
+For example, automation list/detail/run keys belong with the cloud automation
+access hooks, not in `hooks/automations/query-keys.ts`:
+
+```text
+hooks/access/cloud/automations/query-keys.ts
+hooks/access/cloud/automations/use-automations.ts
+hooks/access/cloud/automations/use-automation-mutations.ts
+```
+
+Do not create `hooks/<domain>/access/**` by default. Product domains consume
+access hooks; they do not own raw external access. If a product domain needs a
+local cache adapter over remote data, name that folder by the product
+responsibility, such as `derived/`, `workflows/`, or `cache/`, not `access/`.
 
 Access hook naming:
 
@@ -47,6 +79,30 @@ Access hook naming:
 
 Access hooks may call `lib/access/**`, `@anyharness/sdk-react`, or
 `@anyharness/sdk`. They should not contain product workflow branching.
+
+Query cache writes belong here too. Access hooks own query cache shape,
+`queryClient.invalidateQueries`, and `queryClient.setQueryData` for their
+resource. Product workflow hooks may call access-provided callbacks such as
+`invalidateWorkspaceSessions` or `upsertSession`, but should not hand-edit
+query cache keys or cache object shapes directly.
+
+### Product Cache Hooks
+
+Product cache hooks are rare React Query caches that combine multiple
+external/local sources into one product-owned data model. They are not raw
+access wrappers.
+
+Path:
+
+```text
+hooks/<domain>/cache/<cache-name>-query.ts
+hooks/<domain>/cache/<cache-name>-cache.ts
+```
+
+Use this only when the cache is genuinely product-composed rather than one
+external resource. For example, a workspace collection cache may combine local
+runtime workspaces, cloud workspaces, repository roots, cleanup state, and
+diagnostics. A simple cloud endpoint query still belongs in `hooks/access/**`.
 
 ### Derived Hooks
 
@@ -66,6 +122,12 @@ hooks/<domain>/derived/use-<thing>-model.ts
 Derived hooks may call other derived hooks and read access hooks. They must not
 call mutation hooks except to read stable status that is already exposed as
 state.
+
+Derived hooks are read-only. A hook named `use-*-state`, `use-*-model`, or
+living under `derived/` must not return mutating callbacks such as `save`,
+`submit`, `update`, `set`, `dismiss`, or `retry`. Split actions into a workflow
+hook and compose them with a facade only when a component genuinely benefits
+from one combined interface.
 
 ### Workflow Hooks
 
@@ -103,13 +165,15 @@ Workflow hooks may:
 - call `lib/workflows` for multi-step product sequences
 - pass access-hook callbacks, store setters, and other side-effect functions
   into `lib/workflows`
-- perform query invalidation and store updates at the React boundary
+- call access-owned invalidation/cache callbacks and store setters at the
+  React boundary
 
 Workflow hooks must not:
 
 - construct raw clients
 - call raw endpoint paths or raw Tauri invoke wrappers
 - contain large reusable algorithms inline
+- define query keys or hand-edit React Query cache object shapes
 - become a grab bag of unrelated actions
 
 The workflow hook is the React boundary. It is allowed to call hooks. Plain
@@ -135,6 +199,74 @@ Component
        })
 ```
 
+### Actions vs. Workflows
+
+Most exposed callbacks are actions, not workflows.
+
+An action is one user intent with a short, mostly linear body: validate a
+snapshot, call one access function or mutation, update local state/cache through
+owned callbacks, and return. Keep actions inline in the workflow hook when they
+are easy to scan.
+
+A workflow earns `lib/workflows/<domain>/**` only when it has sequencing worth
+testing: ordering invariants, branching on fetched data, rollback, retries,
+multi-step error recovery, or a body that keeps growing past the point where
+the hook remains readable.
+
+Before extracting to `lib/workflows`, check:
+
+1. It is a sequence, not a single action.
+2. The dependency object is narrow, usually five capabilities or fewer.
+3. The sequence is reused, likely to be reused, or naturally unit-testable with
+   fake deps.
+
+If any answer is no, leave it in the hook and instead extract pure decisions to
+`lib/domain/**` or repeated access/cache details to access hooks.
+
+Do not extract actions just to make files look layered. Thin wrappers with no
+information value make the code harder to read.
+
+Workflow shape:
+
+```ts
+export interface DoThingInput {
+  workspaceId: string;
+  promptText: string;
+}
+
+export interface DoThingDeps {
+  createSession(input: CreateSessionInput): Promise<Session>;
+  promptSession(sessionId: string, prompt: PromptInput): Promise<void>;
+  rollbackSession(sessionId: string): Promise<void>;
+}
+
+export type DoThingResult =
+  | { kind: "completed" }
+  | { kind: "interrupted" }
+  | { kind: "failed"; message: string };
+
+export async function doThing(
+  input: DoThingInput,
+  deps: DoThingDeps,
+): Promise<DoThingResult> {
+  // Ordered product sequence.
+}
+```
+
+State values that change per call belong in `input`. Stable capabilities belong
+in `deps`. Do not pass state snapshots, pure helpers, constants, or formatting
+functions as deps.
+
+If a workflow appears to need many deps, investigate before accepting it:
+
+- State values may belong in `input`.
+- Several setters for one store may be one writer capability.
+- One function may really be two workflows.
+- Heavy branching may want a pure `plan(input) -> Command[]` domain planner
+  plus a small executor.
+- Some callbacks should return tagged results so the hook can decide whether
+  to toast, navigate, or call `onCompleted`.
+
 ### Lifecycle Hooks
 
 Mounted background behavior: streams, dispatchers, subscriptions, polling,
@@ -154,6 +286,16 @@ hooks/<domain>/lifecycle/use-<thing>-reconciler.ts
 
 Use lifecycle hooks for background behavior triggered by mounting or external
 events, not direct user clicks.
+
+Lifecycle hooks may manage imperative controllers, not only passive
+`useEffect` blocks. Streams, reconnect loops, background dispatchers, hot
+session ingest, and long-lived subscriptions are lifecycle concerns when their
+main trigger is mounting or external events. The hook should make the owned
+system obvious and keep timers, handles, and cleanup in one readable place.
+
+If extracting lifecycle logic creates one giant dependency interface, the
+extraction boundary is too large. Keep the lifecycle hook as the readable
+orchestrator and extract smaller substeps instead.
 
 ### Facade Hooks
 
@@ -188,17 +330,88 @@ hooks/
     derived/
     workflows/
     lifecycle/
+    ui/
+    cache/
     facade/
 ```
 
 Existing domain folders may still be transitional. New hooks and cleanup work
 should move toward the taxonomy above.
 
+For product domains, responsibility folders are mandatory for new
+non-migration files. A tiny domain does not need every folder, but it should
+still use the folder for the kind it has:
+
+```text
+hooks/automations/workflows/use-automation-actions.ts
+hooks/chat/derived/use-chat-surface-state.ts
+hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
+hooks/workspaces/cache/workspace-collections-query.ts
+```
+
+Do not add new flat files directly under `hooks/<domain>/`. During migrations,
+flat files should be treated as transitional and moved into the appropriate
+responsibility folder as the area is touched.
+
+Do not create empty or speculative folder trees. Add the folders needed for the
+files being moved now, and let later cleanup passes add more responsibility
+folders as real files need them.
+
+## Hook Cleanup Playbook
+
+Use this sequence when cleaning an existing hook:
+
+1. Classify the hook as access, UI, derived, workflow, lifecycle, or facade.
+2. Write the ownership boundary first: "Owns X. Does not own Y."
+3. Preserve the public hook API unless the task explicitly changes callsites.
+4. Extract non-React code before creating more hooks.
+5. Move pure product decisions to `lib/domain/**`.
+6. Move multi-step product sequences to `lib/workflows/**`.
+7. Move raw external calls to `lib/access/**` or `hooks/access/**`.
+8. Create another hook only when the extracted code owns React behavior.
+9. Keep dependency objects narrow; giant `EverythingDeps` types usually mean
+   the workflow boundary is too broad.
+10. Add or adjust focused tests around moved domain/workflow logic.
+
+Prefer modest cleanup passes over idealized rewrites. The target architecture
+guides direction; it is not a request to introduce every possible future file
+or split a stable hook only to match a diagram. Preserve behavior, move the
+obvious ownership violations first, and leave invasive rewrites explicit for a
+separate plan.
+
+When reading a hook, separate three regions:
+
+```text
+1. React reads: stores, queries, context, access hooks
+2. Pure logic: inline if tiny, otherwise `lib/domain/**`
+3. Async glue: inline if linear, `lib/workflows/**` if sequenced/branchy
+```
+
+Most god hooks are not solved by immediately creating workflows. First look for
+pure decisions trapped in hooks, repeated selector boilerplate, and raw access
+or cache code in the wrong layer.
+
+Example: terminal actions should usually stay as one public
+`useTerminalActions` hook. The hook gathers React dependencies and returns
+`createTab`, `closeTab`, `renameTab`, and related callbacks. Record actions
+move to `lib/workflows/terminals/terminal-record-workflows.ts`, stream
+connection behavior moves to `terminal-stream-workflows.ts`, and normal
+terminal resource calls should use `@anyharness/sdk-react` hooks. Desktop
+access should keep only runtime/transport wiring that SDK React cannot own.
+
+Example: prompt outbox dispatch should stay as one app-mounted lifecycle hook.
+The hook owns singleton mount behavior, store subscription, and in-flight loop
+coordination. It should extract focused substeps such as block preparation,
+failure classification, runtime prompt access, and history reconciliation. Do
+not replace it with one mega-workflow that needs every outbox, session,
+latency, title, and access dependency in the app.
+
 ## Rules
 
 - Product hooks should not construct raw cloud clients, AnyHarness clients, or
   Tauri invocations directly.
 - Components should not call `queryClient.invalidateQueries` directly.
+- Product hooks should not define query keys or own cache object shape.
 - Components should not call multiple store setters in sequence; put that in a
   workflow hook.
 - Product workflow hooks should read like route handlers. If the middle of the
@@ -206,6 +419,10 @@ should move toward the taxonomy above.
   `lib/workflows`.
 - Hooks may call hooks. Plain functions in `lib/**` must not call hooks.
 - Query key helpers live alongside their access/query hooks.
+- Product-domain `query-keys.ts` files are migration debt unless they cache
+  product-composed state rather than one external resource.
+- Query/mutation wrappers for external systems live in `hooks/access/**`, not
+  product-domain hook folders.
 - Reducers are pure functions, not hooks. Do not use a `use-` prefix for pure
   reducers.
 - Non-trivial hooks should start with a short ownership comment when the name

--- a/docs/frontend/guides/lib.md
+++ b/docs/frontend/guides/lib.md
@@ -24,6 +24,9 @@ Rules:
 - Keep functions deterministic when possible.
 - Organize large domains by subdomain and product purpose, not by generic file
   types like `utils` or `helpers`.
+- Pure side-effect planners belong here when the decision is product logic.
+  They inspect state/events and return an explicit plan; they do not execute
+  the effects.
 
 Target shape:
 
@@ -57,11 +60,45 @@ File naming:
 - `<specific-rule>.ts` for pure decisions and computations
 - `<thing>-model.ts` for model construction
 - `<thing>-reducer.ts` for pure reducers
+- `<thing>-effect-plan.ts` for pure side-effect planning
 - `<thing>-presentation.ts` or `presentation.ts` for state-to-display metadata
 - `<thing>.test.ts` next to meaningful pure logic when coverage is useful
 
 Avoid names like `utils.ts`, `helpers.ts`, or `types.ts` unless the file is
 truly tiny and local to one subdomain. Prefer names that state the product rule.
+
+### Side-Effect Planners
+
+Use this pattern when product logic needs to decide what effects should happen
+but should not execute those effects directly.
+
+Domain planner:
+
+```ts
+export function planSessionStreamEffects(input): SessionStreamEffectPlan {
+  return {
+    refreshSummary: true,
+    playTurnEndSound: false,
+    mountLinkedSessionIds: [],
+  };
+}
+```
+
+Workflow or lifecycle hook executor:
+
+```ts
+const plan = planSessionStreamEffects(snapshot);
+if (plan.refreshSummary) {
+  await deps.refreshSummary();
+}
+if (plan.playTurnEndSound) {
+  deps.playTurnEndSound();
+}
+```
+
+The planner belongs in `lib/domain/**` because it is pure product decision
+logic. The executor belongs in a workflow hook, lifecycle hook, or
+`lib/workflows/**` because it performs side effects.
 
 ## `lib/workflows/**`
 
@@ -103,6 +140,65 @@ Workflow functions should accept a small dependency object instead of importing
 singletons. That keeps the sequence testable and makes side effects visible.
 Use an `(input, deps)` shape by default. The dependency object should expose
 side effects as named callbacks, not hidden imports.
+
+### Workflow Dependency Interfaces
+
+Dependencies are for live side effects and runtime collaborators: access
+calls, store setters, cache invalidation, navigation, toasts, telemetry,
+runtime connection resolution, clocks, and id generation when testability
+requires it.
+
+Do not pass pure helpers, constants, or simple formatting functions as
+dependencies. Import pure domain helpers and static config directly.
+
+Prefer small capability interfaces and compose narrow workflow deps:
+
+```ts
+interface TerminalRuntimeDeps {
+  getWorkspaceRuntimeBlockReason(workspaceId: string): string | null;
+  resolveWorkspaceConnection(workspaceId: string): Promise<TerminalConnection>;
+}
+
+interface TerminalCacheDeps {
+  invalidateWorkspaceTerminals(workspaceId: string): Promise<void>;
+}
+
+interface TerminalRecordAccessDeps {
+  createTerminal(
+    connection: TerminalConnection,
+    input: CreateTerminalRequest,
+  ): Promise<TerminalRecord>;
+  closeTerminal(connection: TerminalConnection, terminalId: string): Promise<void>;
+  isMissingTerminalError(error: unknown): boolean;
+}
+
+type CreateTerminalDeps =
+  TerminalRuntimeDeps
+  & Pick<TerminalRecordAccessDeps, "createTerminal">
+  & TerminalCacheDeps;
+```
+
+Each workflow should receive only the capabilities it uses. Avoid one giant
+`TerminalEverythingDeps` or `PromptOutboxEverythingDeps` object. If a workflow
+needs a very large dependency type, split the workflow into smaller substeps or
+keep the owning hook as the readable orchestrator.
+
+Use one workflow file per cohesive family at first:
+
+```text
+lib/workflows/terminals/
+  terminal-record-workflows.ts
+  terminal-stream-workflows.ts
+```
+
+Split into per-action files only when a family file becomes too large or mixes
+unrelated ownership:
+
+```text
+lib/workflows/terminals/
+  create-terminal-workflow.ts
+  close-terminal-workflow.ts
+```
 
 Example shape:
 

--- a/docs/frontend/guides/state.md
+++ b/docs/frontend/guides/state.md
@@ -37,6 +37,32 @@ Stores should expose simple verbs such as `setActiveSessionId`, `patchDraft`,
 or `clearSelection`. Avoid verbs that imply orchestration, such as `submit`,
 `sync`, `load`, `refresh`, or `bootstrap`.
 
+### Store Facades
+
+Cross-store facades are allowed only as local state adapters. Use them when a
+domain has split stores but callers need one narrow way to read or patch the
+local state model.
+
+Allowed:
+
+- read from multiple stores
+- write to multiple stores with simple local setters
+- hide storage layout during a store split
+- expose local state helpers with no remote side effects
+
+Not allowed:
+
+- API calls
+- React Query invalidation or cache writes
+- navigation
+- telemetry
+- toasts
+- timers, streams, or subscriptions
+- raw client construction
+
+If a facade starts coordinating external work or product sequences, move that
+logic to a workflow hook or `lib/workflows/**`.
+
 ## Remote State
 
 TanStack Query owns authoritative remote state from cloud, AnyHarness, and
@@ -54,8 +80,10 @@ hooks/access/<system>/**       # app-owned query and mutation hooks
   policy.
 - Use generated response types or SDK types as the source of truth for remote
   transport shapes.
-- Product workflow hooks may coordinate invalidation, but the query/mutation
-  primitive belongs in an access hook.
+- Product workflow hooks may decide that remote state needs refreshing or
+  updating, but access hooks own the query keys and cache shape. Product
+  workflow hooks should call access-owned callbacks instead of constructing
+  query keys or writing cache objects directly.
 
 ## Providers
 


### PR DESCRIPTION
## Summary

- tighten frontend ownership rules for hooks, access, state, lib, and components
- document access hook query-key/cache ownership and product-composed cache exceptions
- clarify workflow hook boundaries, side-effect planner patterns, store facade constraints, and component/domain helper usage

## Verification

- `git diff --check -- docs/frontend/README.md docs/frontend/guides/access.md docs/frontend/guides/components.md docs/frontend/guides/hooks.md docs/frontend/guides/lib.md docs/frontend/guides/state.md`
