### PR TITLE
refactor(frontend): clean cloud settings card boundaries

### DIFF
--- a/desktop/src/components/cloud/repo-settings/RepoTrackedFilesCard.tsx
+++ b/desktop/src/components/cloud/repo-settings/RepoTrackedFilesCard.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import type { CloudRepoFileMetadata } from "@/lib/access/cloud/client";
 import {
   EnvironmentAdvancedDisclosure,
   EnvironmentField,
@@ -12,9 +11,13 @@ import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
 import { Check, ChevronUpDown, RefreshCw, X } from "@/components/ui/icons";
 import { matchesPickerSearch } from "@/lib/infra/search/search";
 
+interface RepoTrackedFileMetadata {
+  relativePath: string;
+}
+
 interface RepoTrackedFilesCardProps {
   trackedFilePaths: string[];
-  trackedFiles: CloudRepoFileMetadata[];
+  trackedFiles: RepoTrackedFileMetadata[];
   suggestedPaths: string[];
   canSyncTrackedFiles: boolean;
   syncPathInFlight: string | null;

--- a/desktop/src/components/cloud/workspace-settings/CloudWorkspaceTrackedFilesCard.tsx
+++ b/desktop/src/components/cloud/workspace-settings/CloudWorkspaceTrackedFilesCard.tsx
@@ -1,9 +1,13 @@
-import type { CloudRepoFileMetadata } from "@/lib/access/cloud/client";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { Badge } from "@/components/ui/Badge";
 
+interface CloudWorkspaceTrackedFileMetadata {
+  relativePath: string;
+  updatedAt: string;
+}
+
 interface CloudWorkspaceTrackedFilesCardProps {
-  trackedFiles: CloudRepoFileMetadata[];
+  trackedFiles: CloudWorkspaceTrackedFileMetadata[];
 }
 
 export function CloudWorkspaceTrackedFilesCard({

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -13,8 +13,6 @@ COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/list/AutomationLis
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/list/AutomationRow.tsx 1 component owns access/cache before component cleanup
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/screen/AutomationsScreen.tsx 1 component owns access/cache before component cleanup
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/timeline/AutomationRunTimeline.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/cloud/repo-settings/RepoTrackedFilesCard.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/cloud/workspace-settings/CloudWorkspaceTrackedFilesCard.tsx 1 component owns access/cache before component cleanup
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/settings/panes/BillingPane.tsx 1 component owns access/cache before component cleanup
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/settings/panes/CloudBillingSummary.tsx 1 component owns access/cache before component cleanup
 COMPONENT_FORBIDDEN_ACCESS desktop/src/components/settings/panes/CloudPane.tsx 2 component owns access/cache before component cleanup


### PR DESCRIPTION
## Summary

- Remove generated cloud access type imports from cloud tracked-files card components.
- Narrow component prop types to the render fields each card actually uses.
- Remove the two matching component boundary allowlist entries.

## Validation

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec tsc --noEmit`

## Notes

This is a behavior-preserving Wave 2 component boundary cleanup. It is stacked on the Wave 1 access/store foundation branch so the PR diff stays focused.
