### PR TITLE
refactor(frontend): purify workspace cloud domain models

### DIFF
--- a/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-state.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-state.ts
@@ -1,7 +1,7 @@
 import type {
   CloudCredentialFreshness,
   CloudWorkspaceStatus,
-} from "@/lib/access/cloud/client";
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 export type SelectedCloudRuntimePhase = "ready" | "resuming" | "failed";
 export type SelectedCloudRuntimeVariant = "initial" | "warm";

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
@@ -3,7 +3,7 @@ import {
   type CloudRepoConfigSummary,
   type CloudWorkspaceSummary,
   type CreateCloudWorkspaceRequest,
-} from "@/lib/access/cloud/client";
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import type { AuthUser } from "@/lib/domain/auth/auth-user";
 import type { BranchPrefixType } from "@/lib/domain/preferences/user-preferences";
 import { generateWorkspaceSlug } from "@/lib/domain/workspaces/creation/arrival";

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
@@ -1,0 +1,148 @@
+export type CloudWorkspaceStatus =
+  | "pending"
+  | "materializing"
+  | "ready"
+  | "archived"
+  | "error";
+
+export type CloudRuntimeStatus =
+  | "pending"
+  | "provisioning"
+  | "running"
+  | "paused"
+  | "error"
+  | "disabled";
+
+export type CloudCredentialFreshnessStatus =
+  | "current"
+  | "stale"
+  | "restart_required"
+  | "apply_failed"
+  | "missing_credentials";
+
+export interface CloudCredentialFreshness {
+  status: CloudCredentialFreshnessStatus;
+  filesCurrent: boolean;
+  processCurrent: boolean;
+  requiresRestart: boolean;
+  lastError?: string | null;
+  lastErrorAt?: string | null;
+  filesAppliedAt?: string | null;
+  processAppliedAt?: string | null;
+}
+
+export interface CloudWorkspaceRuntimeSummary {
+  environmentId: string | null;
+  status: CloudRuntimeStatus;
+  generation: number;
+  credentialFreshness?: CloudCredentialFreshness | null;
+  actionBlockKind?: string | null;
+  actionBlockReason?: string | null;
+}
+
+export interface CloudWorkspaceRepoRef {
+  provider: string;
+  owner: string;
+  name: string;
+  branch: string;
+  baseBranch: string;
+}
+
+export interface CloudWorkspaceOriginContext {
+  kind: "human" | "cowork" | "api" | "system";
+  entrypoint: "desktop" | "cloud" | "local_runtime" | "cowork";
+}
+
+export interface CloudWorkspaceCreatorContext {
+  kind: "human" | "automation" | "agent";
+  automationId?: string | null;
+  automationRunId?: string | null;
+  sourceSessionId?: string | null;
+  sourceSessionWorkspaceId?: string | null;
+  sessionLinkId?: string | null;
+  sourceWorkspaceId?: string | null;
+  label?: string | null;
+}
+
+export interface CloudWorkspaceSummary {
+  id: string;
+  displayName: string | null;
+  repo: CloudWorkspaceRepoRef;
+  status: CloudWorkspaceStatus;
+  workspaceStatus: CloudWorkspaceStatus;
+  runtime?: CloudWorkspaceRuntimeSummary;
+  statusDetail: string | null;
+  lastError: string | null;
+  templateVersion: string | null;
+  updatedAt: string | null;
+  createdAt: string | null;
+  actionBlockKind?: string | null;
+  actionBlockReason?: string | null;
+  postReadyPhase: string;
+  postReadyFilesTotal: number;
+  postReadyFilesApplied: number;
+  postReadyStartedAt: string | null;
+  postReadyCompletedAt: string | null;
+  repoFilesLastFailedPath?: string | null;
+  origin?: CloudWorkspaceOriginContext | null;
+  creatorContext?: CloudWorkspaceCreatorContext | null;
+}
+
+export interface CloudRepoConfigSummary {
+  gitOwner: string;
+  gitRepoName: string;
+  configured: boolean;
+  configuredAt: string | null;
+  filesVersion: number;
+}
+
+export interface CreateCloudWorkspaceRequest {
+  gitProvider: "github";
+  gitOwner: string;
+  gitRepoName: string;
+  baseBranch?: string | null;
+  branchName: string;
+  displayName?: string | null;
+  ownerScope: "personal" | "organization";
+  organizationId?: string | null;
+}
+
+export interface CloudMobilityRepoRef {
+  provider: string;
+  owner: string;
+  name: string;
+  branch: string;
+}
+
+export interface CloudMobilityHandoffSummary {
+  id: string;
+  direction: string;
+  sourceOwner: string;
+  targetOwner: string;
+  phase: string;
+  requestedBranch: string;
+  requestedBaseSha?: string | null;
+  excludePaths: string[];
+  failureCode?: string | null;
+  failureDetail?: string | null;
+  startedAt: string;
+  heartbeatAt: string;
+  finalizedAt?: string | null;
+  cleanupCompletedAt?: string | null;
+}
+
+export interface CloudMobilityWorkspaceSummary {
+  id: string;
+  displayName?: string | null;
+  repo: CloudMobilityRepoRef;
+  owner: string;
+  lifecycleState: string;
+  statusDetail?: string | null;
+  lastError?: string | null;
+  cloudWorkspaceId?: string | null;
+  cloudLostAt?: string | null;
+  cloudLostReason?: string | null;
+  activeHandoff?: CloudMobilityHandoffSummary | null;
+  updatedAt: string | null;
+  createdAt: string | null;
+}

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts
@@ -1,5 +1,7 @@
-import type { CloudWorkspaceStatus } from "@/lib/access/cloud/client";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type {
+  CloudWorkspaceStatus,
+  CloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
   CLOUD_STATUS_ACTION_COPY,
   CLOUD_STATUS_COMPACT_COPY,

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.test.ts
@@ -7,7 +7,10 @@ import {
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
 import { shouldShowCloudWorkspaceStatusScreen } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
 import { CLOUD_STATUS_COMPACT_COPY } from "@/copy/cloud/cloud-status-copy";
-import type { CloudWorkspaceStatus, CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type {
+  CloudWorkspaceStatus,
+  CloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 function makeCloudWorkspace(
   overrides: Partial<CloudWorkspaceSummary> = {},

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts
@@ -1,7 +1,7 @@
 import type {
   CloudWorkspaceStatus,
   CloudWorkspaceSummary,
-} from "@/lib/access/cloud/client";
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 const PENDING_STATUSES = new Set<CloudWorkspaceStatus>([
   "pending",

--- a/desktop/src/lib/domain/workspaces/cloud/collections.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/collections.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
   buildWorkspaceCollections,
   cloudWorkspaceGroupKey,

--- a/desktop/src/lib/domain/workspaces/cloud/collections.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/collections.ts
@@ -1,5 +1,5 @@
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { shouldPollCloudWorkspaceForUpdates } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
 
 function sortWorkspacesByUpdatedAtDesc<T extends Pick<Workspace, "updatedAt">>(workspaces: T[]): T[] {

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { CloudMobilityWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudMobilityWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import {
   buildLogicalWorkspaces,

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -2,7 +2,7 @@ import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import type {
   CloudMobilityWorkspaceSummary,
   CloudWorkspaceSummary,
-} from "@/lib/access/cloud/client";
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
   humanizeBranchName,
   workspaceCurrentBranchName,

--- a/desktop/src/lib/domain/workspaces/cloud/selected-repo-target.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/selected-repo-target.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "@anyharness/sdk";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { localWorkspaceGroupKey } from "@/lib/domain/workspaces/cloud/collections";
 import { isCloudWorkspaceId, parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import type { CloudWorkspaceRepoTarget } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";

--- a/desktop/src/lib/domain/workspaces/cloud/standard-projection.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/standard-projection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { buildStandardRepoProjection } from "@/lib/domain/workspaces/cloud/standard-projection";
 
 function makeRepoRoot(overrides: Partial<RepoRoot> = {}): RepoRoot {

--- a/desktop/src/lib/domain/workspaces/cloud/standard-projection.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/standard-projection.ts
@@ -1,5 +1,5 @@
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 export interface StandardRepoProjection {
   repoRoots: RepoRoot[];

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -36,14 +36,6 @@ DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/files/file-visuals.ts 2 domain im
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/mcp/local-stdio-finalizer.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/support/formatting.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/telemetry/events.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/cloud-runtime-state.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts 2 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/collections.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/selected-repo-target.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/cloud/standard-projection.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/creation/pending-entry.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/mobility/mobility-blockers.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts 1 domain imports transport or UI types before lib cleanup


### PR DESCRIPTION
## Summary

- add domain-owned workspace cloud models so `lib/domain/workspaces/cloud/**` no longer imports cloud access transport types
- switch workspace-cloud domain helpers and adjacent tests to the domain model types
- remove the eight workspace-cloud `DOMAIN_FORBIDDEN_IMPORT` allowlist entries

## Why

Wave 2 is making `lib/domain/**` pure product logic. The workspace-cloud domain files were only coupled to `lib/access/cloud/client` for type aliases, but that still violated the documented boundary and CI ratchet.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts src/lib/domain/workspaces/cloud/cloud-workspace-status.test.ts src/lib/domain/workspaces/cloud/collections.test.ts src/lib/domain/workspaces/cloud/logical-workspaces.test.ts src/lib/domain/workspaces/cloud/standard-projection.test.ts`
