### PR TITLE
refactor(frontend): clean workspace file component boundaries

### DIFF
--- a/desktop/src/components/automations/editor/AutomationEditorModal.tsx
+++ b/desktop/src/components/automations/editor/AutomationEditorModal.tsx
@@ -17,10 +17,10 @@ import type {
 import type { AutomationModeOverride } from "@/lib/domain/automations/mode-selection";
 import type { AutomationTargetSelection } from "@/lib/domain/automations/target-selection";
 import type {
-  AutomationResponse,
-  CreateAutomationRequest,
-  UpdateAutomationRequest,
-} from "@/lib/access/cloud/client";
+  AutomationRecord,
+  CreateAutomationInput,
+  UpdateAutomationInput,
+} from "@/lib/domain/automations/automation-ui-records";
 import {
   defaultAutomationTimezone,
   presetForRrule,
@@ -43,12 +43,12 @@ type SchedulePresetValue = AutomationSchedulePresetOrCustom;
 
 interface AutomationEditorModalProps {
   open: boolean;
-  automation: AutomationResponse | null;
+  automation: AutomationRecord | null;
   busy: boolean;
   onClose: () => void;
   onConfigureCloudTarget: (target: { gitOwner: string; gitRepoName: string }) => void;
-  onCreate: (body: CreateAutomationRequest) => Promise<void>;
-  onUpdate: (automationId: string, body: UpdateAutomationRequest) => Promise<void>;
+  onCreate: (body: CreateAutomationInput) => Promise<void>;
+  onUpdate: (automationId: string, body: UpdateAutomationInput) => Promise<void>;
 }
 
 export function AutomationEditorModal({

--- a/desktop/src/components/automations/list/AutomationDetailContent.tsx
+++ b/desktop/src/components/automations/list/AutomationDetailContent.tsx
@@ -1,22 +1,22 @@
 import { Button } from "@/components/ui/Button";
 import { ArrowLeft } from "@/components/ui/icons";
 import type {
-  AutomationResponse,
-  AutomationRunResponse,
-} from "@/lib/access/cloud/client";
+  AutomationRecord,
+  AutomationRunRecord,
+} from "@/lib/domain/automations/automation-ui-records";
 import { AutomationRunTimeline } from "@/components/automations/timeline/AutomationRunTimeline";
 import { AutomationSectionHeader } from "./AutomationSectionHeader";
 
 interface AutomationDetailContentProps {
-  automation: AutomationResponse | null;
+  automation: AutomationRecord | null;
   loading: boolean;
   error: boolean;
-  runs: AutomationRunResponse[];
+  runs: AutomationRunRecord[];
   runsLoading: boolean;
   pendingCloudWorkspaceId?: string | null;
   onBack: () => void;
   onOpenCloudWorkspace: (cloudWorkspaceId: string) => void;
-  onOpenLocalWorkspace: (run: AutomationRunResponse) => void;
+  onOpenLocalWorkspace: (run: AutomationRunRecord) => void;
 }
 
 export function AutomationDetailContent({

--- a/desktop/src/components/automations/list/AutomationListContent.tsx
+++ b/desktop/src/components/automations/list/AutomationListContent.tsx
@@ -1,14 +1,14 @@
 import { AUTOMATION_PREEXECUTOR_COPY } from "@/copy/automations/automation-copy";
-import type { AutomationResponse } from "@/lib/access/cloud/client";
+import type { AutomationRecord } from "@/lib/domain/automations/automation-ui-records";
 import { AutomationRow } from "./AutomationRow";
 import { AutomationSectionHeader } from "./AutomationSectionHeader";
 
 interface AutomationListContentProps {
-  automations: AutomationResponse[];
+  automations: AutomationRecord[];
   loading: boolean;
   busy: boolean;
   onSelect: (automationId: string) => void;
-  onEdit: (automation: AutomationResponse) => void;
+  onEdit: (automation: AutomationRecord) => void;
   onPause: (automationId: string) => void;
   onResume: (automationId: string) => void;
   onRunNow: (automationId: string) => void;

--- a/desktop/src/components/automations/list/AutomationRow.tsx
+++ b/desktop/src/components/automations/list/AutomationRow.tsx
@@ -3,11 +3,11 @@ import { Button } from "@/components/ui/Button";
 import { PopoverButton } from "@/components/ui/PopoverButton";
 import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
 import { MoreHorizontal, Pause, Pencil, Play, Zap } from "@/components/ui/icons";
-import type { AutomationResponse } from "@/lib/access/cloud/client";
+import type { AutomationRecord } from "@/lib/domain/automations/automation-ui-records";
 import { buildAutomationRowViewModel } from "@/lib/domain/automations/view-model";
 
 interface AutomationRowProps {
-  automation: AutomationResponse;
+  automation: AutomationRecord;
   selected: boolean;
   busy: boolean;
   onSelect: () => void;

--- a/desktop/src/components/automations/screen/AutomationsScreen.tsx
+++ b/desktop/src/components/automations/screen/AutomationsScreen.tsx
@@ -21,17 +21,17 @@ import { buildAutomationRowViewModel } from "@/lib/domain/automations/view-model
 import { buildCloudRepoSettingsHref } from "@/lib/domain/settings/navigation";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import type {
-  AutomationResponse,
-  AutomationRunResponse,
-  CreateAutomationRequest,
-  UpdateAutomationRequest,
-} from "@/lib/access/cloud/client";
+  AutomationRecord,
+  AutomationRunRecord,
+  CreateAutomationInput,
+  UpdateAutomationInput,
+} from "@/lib/domain/automations/automation-ui-records";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import { useWorkspaceActivationWorkflow } from "@/hooks/workspaces/use-workspace-activation-workflow";
 
-const EMPTY_AUTOMATIONS: AutomationResponse[] = [];
-const EMPTY_AUTOMATION_RUNS: AutomationRunResponse[] = [];
+const EMPTY_AUTOMATIONS: AutomationRecord[] = [];
+const EMPTY_AUTOMATION_RUNS: AutomationRunRecord[] = [];
 
 interface AutomationsScreenProps {
   selectedAutomationId?: string | null;
@@ -44,7 +44,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
   const { openWorkspaceSession } = useWorkspaceActivationWorkflow();
   const { refreshCloudWorkspace } = useCloudWorkspaceActions();
   const { refetch: refetchWorkspaces } = useWorkspaces();
-  const [editingAutomation, setEditingAutomation] = useState<AutomationResponse | null>(null);
+  const [editingAutomation, setEditingAutomation] = useState<AutomationRecord | null>(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [pendingCloudWorkspaceId, setPendingCloudWorkspaceId] = useState<string | null>(null);
 
@@ -76,7 +76,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     setEditorOpen(true);
   };
 
-  const openEdit = (automation: AutomationResponse) => {
+  const openEdit = (automation: AutomationRecord) => {
     setEditingAutomation(automation);
     setEditorOpen(true);
   };
@@ -88,12 +88,12 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     navigate(buildCloudRepoSettingsHref(target.gitOwner, target.gitRepoName));
   };
 
-  const handleCreate = async (body: CreateAutomationRequest) => {
+  const handleCreate = async (body: CreateAutomationInput) => {
     const created = await actions.createAutomation(body);
     navigate(`/automations/${created.id}`);
   };
 
-  const handleUpdate = async (automationId: string, body: UpdateAutomationRequest) => {
+  const handleUpdate = async (automationId: string, body: UpdateAutomationInput) => {
     await actions.updateAutomation({ automationId, body });
   };
 
@@ -111,7 +111,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     }
   }, [navigate, refreshCloudWorkspace, selectWorkspace, showToast]);
 
-  const handleOpenLocalWorkspace = async (run: AutomationRunResponse) => {
+  const handleOpenLocalWorkspace = async (run: AutomationRunRecord) => {
     if (!run.anyharnessWorkspaceId) {
       return;
     }

--- a/desktop/src/components/automations/timeline/AutomationRunTimeline.tsx
+++ b/desktop/src/components/automations/timeline/AutomationRunTimeline.tsx
@@ -1,30 +1,30 @@
 import { memo, type KeyboardEvent } from "react";
-import type { AutomationRunResponse } from "@/lib/access/cloud/client";
+import type { AutomationRunRecord } from "@/lib/domain/automations/automation-ui-records";
 import {
   automationRunStatusLabel,
   automationRunTimestampLabel,
 } from "@/lib/domain/automations/view-model";
 
 interface AutomationRunTimelineProps {
-  runs: AutomationRunResponse[];
+  runs: AutomationRunRecord[];
   loading: boolean;
   pendingCloudWorkspaceId?: string | null;
   openableLocalWorkspaceIds?: ReadonlySet<string>;
   onOpenCloudWorkspace?: (cloudWorkspaceId: string) => void;
-  onOpenLocalWorkspace?: (run: AutomationRunResponse) => void;
+  onOpenLocalWorkspace?: (run: AutomationRunRecord) => void;
 }
 
 interface AutomationRunTimelineRowProps {
-  run: AutomationRunResponse;
+  run: AutomationRunRecord;
   pendingCloudWorkspaceId?: string | null;
   openableLocalWorkspaceIds: ReadonlySet<string>;
   onOpenCloudWorkspace?: (cloudWorkspaceId: string) => void;
-  onOpenLocalWorkspace?: (run: AutomationRunResponse) => void;
+  onOpenLocalWorkspace?: (run: AutomationRunRecord) => void;
 }
 
 const EMPTY_LOCAL_WORKSPACE_IDS = new Set<string>();
 
-function triggerKindLabel(kind: AutomationRunResponse["triggerKind"]): string {
+function triggerKindLabel(kind: AutomationRunRecord["triggerKind"]): string {
   return kind === "manual" ? "Manual" : "Scheduled";
 }
 

--- a/desktop/src/components/support/SupportDialog.test.tsx
+++ b/desktop/src/components/support/SupportDialog.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SupportDialog } from "@/components/support/SupportDialog";
 import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
-import type { SupportMessageContext } from "@/lib/access/cloud/support";
+import type { SupportMessageContext } from "@/lib/domain/support/types";
 
 const supportState = vi.hoisted(() => ({
   current: null as SupportDialogStateMock | null,

--- a/desktop/src/components/support/SupportDialog.tsx
+++ b/desktop/src/components/support/SupportDialog.tsx
@@ -16,7 +16,7 @@ import { CAPABILITY_COPY } from "@/copy/capabilities/capability-copy";
 import { useSupportDialogState } from "@/hooks/support/use-support-dialog-state";
 import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
 import { clampSupportMessage } from "@/lib/domain/support/formatting";
-import type { SupportMessageContext } from "@/lib/access/cloud/support";
+import type { SupportMessageContext } from "@/lib/domain/support/types";
 
 interface SupportDialogProps {
   onClose: () => void;

--- a/desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx
+++ b/desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx
@@ -1,10 +1,5 @@
 import { useMemo, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  anyHarnessWorkspaceFileSearchScopeKey,
-  anyHarnessWorkspaceFilesScopeKey,
-  useSearchWorkspaceFilesQuery,
-} from "@anyharness/sdk-react";
+import { useSearchWorkspaceFilesQuery } from "@anyharness/sdk-react";
 import { FileTreePane } from "./FileTreePane";
 import { FileBrowserToolbar, type FileBrowserScopeFilter } from "./FileBrowserToolbar";
 import { FileCreateDraftRow } from "./FileCreateDraftRow";
@@ -14,6 +9,7 @@ import { FileTreeEntryIcon } from "@/components/ui/file-icons";
 import { ArrowUpRight, ChevronRight } from "@/components/ui/icons";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
+import { useWorkspaceFilesRefresh } from "@/hooks/workspaces/files/workflows/use-workspace-files-refresh";
 import { useGitPanelState } from "@/hooks/workspaces/use-git-panel-state";
 import {
   buildChangedFileTree,
@@ -33,9 +29,7 @@ interface WorkspaceFilesPanelProps {
 export function WorkspaceFilesPanel({ showHeader = true }: WorkspaceFilesPanelProps) {
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<FileBrowserScopeFilter>("all");
-  const queryClient = useQueryClient();
   const materializedWorkspaceId = useWorkspaceViewerTabsStore((s) => s.materializedWorkspaceId);
-  const runtimeUrl = useWorkspaceViewerTabsStore((s) => s.runtimeUrl);
   const changesMode = scopeFilter === "all" ? "working_tree_composite" : scopeFilter;
   const changesState = useGitPanelState(changesMode);
   const searchQuery = useSearchWorkspaceFilesQuery({
@@ -45,17 +39,9 @@ export function WorkspaceFilesPanel({ showHeader = true }: WorkspaceFilesPanelPr
     enabled: scopeFilter === "all" && search.trim().length > 0,
   });
   const { openFile, openFileDiff } = useWorkspaceFileActions();
-  const refreshFiles = () => {
-    void Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceFilesScopeKey(runtimeUrl, materializedWorkspaceId),
-      }),
-      queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, materializedWorkspaceId),
-      }),
-      changesState.refetch(),
-    ]);
-  };
+  const { refreshFiles } = useWorkspaceFilesRefresh({
+    refetchChanges: changesState.refetch,
+  });
   const changedSections = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
     return changesState.sections

--- a/desktop/src/components/workspace/open-target/OpenTargetIcon.tsx
+++ b/desktop/src/components/workspace/open-target/OpenTargetIcon.tsx
@@ -3,7 +3,7 @@ import {
   OPEN_TARGET_FALLBACK_ICON,
   OPEN_TARGET_ICON_DEFINITIONS,
 } from "@/config/open-targets";
-import type { OpenTargetIconId } from "@/lib/access/tauri/shell";
+import type { OpenTargetIconId } from "@/hooks/access/tauri/use-shell-actions";
 
 type OpenTargetIconVariant = "inline" | "menu";
 

--- a/desktop/src/components/workspace/open-target/OpenTargetMenu.tsx
+++ b/desktop/src/components/workspace/open-target/OpenTargetMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, type ReactNode } from "react";
 import { Copy } from "@/components/ui/icons";
 import { OpenTargetIcon } from "./OpenTargetIcon";
-import type { OpenTarget } from "@/lib/access/tauri/shell";
+import type { OpenTarget } from "@/hooks/access/tauri/use-shell-actions";
 
 export function TargetIcon({ target, size = "size-3.5" }: { target: OpenTarget; size?: string }) {
   if (target.kind === "copy") {

--- a/desktop/src/components/workspace/open-target/SplitButton.tsx
+++ b/desktop/src/components/workspace/open-target/SplitButton.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from "react";
 import { ChevronDown } from "@/components/ui/icons";
 import { OpenTargetMenu, TargetIcon } from "./OpenTargetMenu";
 import { OpenTargetIcon } from "./OpenTargetIcon";
-import type { OpenTarget } from "@/lib/access/tauri/shell";
+import type { OpenTarget } from "@/hooks/access/tauri/use-shell-actions";
 
 interface SplitButtonProps {
   icon?: ReactNode;

--- a/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
+++ b/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
@@ -1,0 +1,31 @@
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  anyHarnessWorkspaceFileSearchScopeKey,
+  anyHarnessWorkspaceFilesScopeKey,
+} from "@anyharness/sdk-react";
+import { useCallback } from "react";
+
+export function useWorkspaceFilesCache() {
+  const queryClient = useQueryClient();
+
+  const invalidateWorkspaceFiles = useCallback(async ({
+    runtimeUrl,
+    workspaceId,
+  }: {
+    runtimeUrl: string;
+    workspaceId: string;
+  }) => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessWorkspaceFilesScopeKey(runtimeUrl, workspaceId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+      }),
+    ]);
+  }, [queryClient]);
+
+  return {
+    invalidateWorkspaceFiles,
+  };
+}

--- a/desktop/src/hooks/support/use-support-dialog-state.test.tsx
+++ b/desktop/src/hooks/support/use-support-dialog-state.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useSupportDialogState } from "@/hooks/support/use-support-dialog-state";
 import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
-import type { SupportMessageContext } from "@/lib/access/cloud/client";
+import type { SupportMessageContext } from "@/lib/domain/support/types";
 
 const sendSupportMessage = vi.hoisted(() => vi.fn(async () => {}));
 const showToast = vi.hoisted(() => vi.fn());

--- a/desktop/src/hooks/support/use-support-dialog-state.ts
+++ b/desktop/src/hooks/support/use-support-dialog-state.ts
@@ -9,7 +9,7 @@ import {
   formatSupportContextLabel,
   normalizeSupportMessageForSend,
 } from "@/lib/domain/support/formatting";
-import type { SupportMessageContext } from "@/lib/access/cloud/client";
+import type { SupportMessageContext } from "@/lib/domain/support/types";
 import { useTauriDiagnosticsActions } from "@/hooks/access/tauri/use-diagnostics-actions";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useAuthStore } from "@/stores/auth/auth-store";

--- a/desktop/src/hooks/workspaces/files/workflows/use-workspace-files-refresh.ts
+++ b/desktop/src/hooks/workspaces/files/workflows/use-workspace-files-refresh.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useWorkspaceFilesCache } from "@/hooks/access/anyharness/files/use-workspace-files-cache";
+import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
+
+export function useWorkspaceFilesRefresh(args: {
+  refetchChanges: () => Promise<unknown>;
+}) {
+  const { refetchChanges } = args;
+  const materializedWorkspaceId = useWorkspaceViewerTabsStore((s) => s.materializedWorkspaceId);
+  const runtimeUrl = useWorkspaceViewerTabsStore((s) => s.runtimeUrl);
+  const { invalidateWorkspaceFiles } = useWorkspaceFilesCache();
+
+  const refreshFiles = useCallback(() => {
+    if (!runtimeUrl || !materializedWorkspaceId) {
+      return;
+    }
+
+    void Promise.all([
+      invalidateWorkspaceFiles({
+        runtimeUrl,
+        workspaceId: materializedWorkspaceId,
+      }),
+      refetchChanges(),
+    ]);
+  }, [
+    invalidateWorkspaceFiles,
+    materializedWorkspaceId,
+    refetchChanges,
+    runtimeUrl,
+  ]);
+
+  return {
+    refreshFiles,
+  };
+}

--- a/desktop/src/lib/domain/automations/automation-ui-records.ts
+++ b/desktop/src/lib/domain/automations/automation-ui-records.ts
@@ -1,0 +1,91 @@
+export type AutomationExecutionTarget = "cloud" | "local";
+
+export interface AutomationScheduleInput {
+  rrule: string;
+  timezone: string;
+}
+
+export interface AutomationScheduleRecord extends AutomationScheduleInput {
+  summary: string;
+  nextRunAt: string | null;
+}
+
+export interface AutomationRecord {
+  id: string;
+  gitOwner: string;
+  gitRepoName: string;
+  title: string;
+  prompt: string;
+  schedule: AutomationScheduleRecord;
+  executionTarget: AutomationExecutionTarget;
+  agentKind: string | null;
+  modelId: string | null;
+  modeId: string | null;
+  reasoningEffort: string | null;
+  enabled: boolean;
+  pausedAt: string | null;
+  lastScheduledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationRunRecord {
+  id: string;
+  automationId: string;
+  triggerKind: "scheduled" | "manual";
+  scheduledFor: string | null;
+  executionTarget: AutomationExecutionTarget;
+  status:
+    | "queued"
+    | "claimed"
+    | "creating_workspace"
+    | "provisioning_workspace"
+    | "creating_session"
+    | "dispatching"
+    | "dispatched"
+    | "failed"
+    | "cancelled";
+  titleSnapshot: string;
+  agentKindSnapshot: string | null;
+  modelIdSnapshot: string | null;
+  modeIdSnapshot: string | null;
+  reasoningEffortSnapshot: string | null;
+  claimExpiresAt: string | null;
+  dispatchStartedAt: string | null;
+  dispatchedAt: string | null;
+  failedAt: string | null;
+  cloudWorkspaceId: string | null;
+  anyharnessWorkspaceId: string | null;
+  anyharnessSessionId: string | null;
+  cancelledAt: string | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAutomationInput {
+  title: string;
+  prompt: string;
+  gitOwner: string;
+  gitRepoName: string;
+  schedule: AutomationScheduleInput;
+  executionTarget: AutomationExecutionTarget;
+  agentKind?: string | null;
+  modelId?: string | null;
+  modeId?: string | null;
+  reasoningEffort?: string | null;
+}
+
+export interface UpdateAutomationInput {
+  title?: string | null;
+  prompt?: string | null;
+  gitOwner?: string | null;
+  gitRepoName?: string | null;
+  schedule?: AutomationScheduleInput | null;
+  executionTarget?: AutomationExecutionTarget | null;
+  agentKind?: string | null;
+  modelId?: string | null;
+  modeId?: string | null;
+  reasoningEffort?: string | null;
+}

--- a/desktop/src/lib/domain/automations/view-model.test.ts
+++ b/desktop/src/lib/domain/automations/view-model.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type {
-  AutomationResponse,
-  AutomationRunResponse,
-} from "@/lib/access/cloud/client";
+  AutomationRecord,
+  AutomationRunRecord,
+} from "@/lib/domain/automations/automation-ui-records";
 import {
   automationRunStatusLabel,
   buildAutomationRowViewModel,
@@ -10,7 +10,7 @@ import {
 } from "./view-model";
 import { validateAutomationTimezone } from "./schedule";
 
-function automation(overrides: Partial<AutomationResponse> = {}): AutomationResponse {
+function automation(overrides: Partial<AutomationRecord> = {}): AutomationRecord {
   return {
     id: "automation-1",
     gitOwner: "proliferate-ai",
@@ -37,7 +37,7 @@ function automation(overrides: Partial<AutomationResponse> = {}): AutomationResp
   };
 }
 
-function run(overrides: Partial<AutomationRunResponse> = {}): AutomationRunResponse {
+function run(overrides: Partial<AutomationRunRecord> = {}): AutomationRunRecord {
   return {
     id: "run-1",
     automationId: "automation-1",
@@ -171,7 +171,7 @@ describe("automationRunStatusLabel", () => {
 
   it("keeps unknown statuses visible", () => {
     expect(automationRunStatusLabel(run({
-      status: "bogus" as AutomationRunResponse["status"],
+      status: "bogus" as AutomationRunRecord["status"],
     }))).toBe("Unknown status: bogus");
   });
 });

--- a/desktop/src/lib/domain/automations/view-model.ts
+++ b/desktop/src/lib/domain/automations/view-model.ts
@@ -1,8 +1,8 @@
 import { AUTOMATION_RUN_COPY } from "@/copy/automations/automation-copy";
 import type {
-  AutomationResponse,
-  AutomationRunResponse,
-} from "@/lib/access/cloud/client";
+  AutomationRecord,
+  AutomationRunRecord,
+} from "@/lib/domain/automations/automation-ui-records";
 import { formatAutomationTimestamp } from "./schedule";
 
 export interface AutomationRowViewModel {
@@ -30,7 +30,7 @@ function compactStatusMessage(message: string): string {
 }
 
 export function buildAutomationRowViewModel(
-  automation: AutomationResponse,
+  automation: AutomationRecord,
 ): AutomationRowViewModel {
   const paused = !automation.enabled;
   return {
@@ -142,7 +142,7 @@ function formatMonthDay(date: Date, timezone?: string | null): string {
   }).format(date);
 }
 
-export function automationRunStatusLabel(run: AutomationRunResponse): string {
+export function automationRunStatusLabel(run: AutomationRunRecord): string {
   switch (run.status) {
     case "queued":
       return run.executionTarget === "local"
@@ -175,7 +175,7 @@ export function automationRunStatusLabel(run: AutomationRunResponse): string {
   }
 }
 
-export function automationRunTimestampLabel(run: AutomationRunResponse): string {
+export function automationRunTimestampLabel(run: AutomationRunRecord): string {
   if (run.triggerKind === "manual") {
     return `Requested ${formatAutomationTimestamp(run.createdAt)}`;
   }

--- a/desktop/src/lib/domain/support/formatting.ts
+++ b/desktop/src/lib/domain/support/formatting.ts
@@ -1,5 +1,5 @@
-import type { SupportMessageContext } from "@/lib/access/cloud/client";
 import { SUPPORT_MESSAGE_MAX_LENGTH } from "@/lib/domain/support/constants";
+import type { SupportMessageContext } from "@/lib/domain/support/types";
 
 export function formatSupportContextLabel(
   context: SupportMessageContext,

--- a/desktop/src/lib/domain/support/types.ts
+++ b/desktop/src/lib/domain/support/types.ts
@@ -1,0 +1,8 @@
+export interface SupportMessageContext {
+  source: "sidebar" | "home" | "settings" | "cloud_gated";
+  intent: "general" | "unlimited_cloud" | "team_features";
+  pathname?: string | null;
+  workspaceId?: string | null;
+  workspaceName?: string | null;
+  workspaceLocation?: "cloud" | "local" | null;
+}

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -7,27 +7,13 @@ ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-acti
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts 4 raw AnyHarness client before access migration
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts 3 raw AnyHarness client before access migration
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/lib/workflows/sessions/session-runtime.ts 6 raw AnyHarness client before access migration
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/editor/AutomationEditorModal.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/list/AutomationDetailContent.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/list/AutomationListContent.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/list/AutomationRow.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/screen/AutomationsScreen.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/automations/timeline/AutomationRunTimeline.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/support/SupportDialog.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx 4 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/workspace/open-target/OpenTargetIcon.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/workspace/open-target/OpenTargetMenu.tsx 1 component owns access/cache before component cleanup
-COMPONENT_FORBIDDEN_ACCESS desktop/src/components/workspace/open-target/SplitButton.tsx 1 component owns access/cache before component cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/automations/local-executor.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/automations/target-selection.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/automations/view-model.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/chat/__fixtures__/playground.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/cloud/runtime-input-sync.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/files/file-visuals.ts 2 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/mcp/local-stdio-finalizer.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/support/formatting.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/telemetry/events.ts 1 domain imports transport or UI types before lib cleanup
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx 4 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/agents/use-agent-auto-reconcile.ts 4 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/agents/use-agent-installation-actions.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/agents/use-local-agent-credentials.ts 3 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- moves workspace files cache ownership behind an access/cache hook
- routes workspace file refresh through a workflow hook
- moves automation UI record shapes and support target types into domain files
- removes the matching frontend-boundary allowlist entries

## Verification

- python3 scripts/check_frontend_boundaries.py
- pnpm --dir desktop exec vitest run src/lib/domain/automations/view-model.test.ts
- pnpm --dir desktop exec tsc --noEmit
- git diff --check
