### PR TITLE
refactor(frontend): share workspace cloud model

### DIFF
--- a/desktop/src/lib/domain/workspaces/creation/pending-entry.ts
+++ b/desktop/src/lib/domain/workspaces/creation/pending-entry.ts
@@ -1,5 +1,4 @@
 import type { SetupScriptExecution } from "@anyharness/sdk";
-import type { CreateCloudWorkspaceRequest } from "@/lib/access/cloud/client";
 import type { CreateWorktreeWorkspaceInput } from "@/lib/domain/workspaces/creation/workspace-creation";
 
 export type PendingWorkspaceSource =
@@ -21,10 +20,21 @@ export interface PendingCoworkRequestInput {
   sourceWorkspaceId?: string | null;
 }
 
+export interface PendingCloudWorkspaceRequestInput {
+  gitProvider: "github";
+  gitOwner: string;
+  gitRepoName: string;
+  baseBranch?: string | null;
+  branchName: string;
+  displayName?: string | null;
+  ownerScope: "personal" | "organization";
+  organizationId?: string | null;
+}
+
 export type PendingWorkspaceRequest =
   | { kind: "local"; sourceRoot: string }
   | { kind: "worktree"; input: CreateWorktreeWorkspaceInput }
-  | { kind: "cloud"; input: CreateCloudWorkspaceRequest }
+  | { kind: "cloud"; input: PendingCloudWorkspaceRequestInput }
   | { kind: "cowork"; input: PendingCoworkRequestInput }
   | { kind: "select-existing"; workspaceId: string };
 

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-blockers.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-blockers.ts
@@ -1,8 +1,10 @@
 import type { WorkspaceMobilityPreflightResponse } from "@anyharness/sdk";
-import type { CloudWorkspaceMobilityPreflightResponse } from "@/lib/access/cloud/client";
 import { mobilityBlockerCopy } from "@/lib/domain/workspaces/mobility/presentation";
-import type { WorkspaceMobilityDirection } from "@/lib/domain/workspaces/mobility/types";
-import type { WorkspaceMobilityBlockerCode } from "@/lib/domain/workspaces/mobility/types";
+import type {
+  WorkspaceMobilityBlockerCode,
+  WorkspaceMobilityCloudPreflightResponse,
+  WorkspaceMobilityDirection,
+} from "@/lib/domain/workspaces/mobility/types";
 
 export type WorkspaceMobilityNormalizedBlockerCode =
   | WorkspaceMobilityBlockerCode
@@ -134,7 +136,7 @@ function buildPrimaryBlocker(args: {
 
 export function pickPrimaryMobilityBlocker(args: {
   sourcePreflight: WorkspaceMobilityPreflightResponse | null;
-  cloudPreflight: CloudWorkspaceMobilityPreflightResponse | null;
+  cloudPreflight: WorkspaceMobilityCloudPreflightResponse | null;
   direction: WorkspaceMobilityDirection | null;
   branchName?: string | null;
 }): WorkspaceMobilityPrimaryBlocker | null {

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts
@@ -1,6 +1,6 @@
-import type { CloudMobilityHandoffSummary } from "@/lib/access/cloud/client";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
 import { mobilityStatusCopy } from "@/lib/domain/workspaces/mobility/presentation";
+import type { WorkspaceMobilityHandoffSummary } from "@/lib/domain/workspaces/mobility/types";
 
 export type WorkspaceMobilityUiPhase =
   | "idle"
@@ -15,7 +15,7 @@ export type WorkspaceMobilityUiPhase =
 export interface WorkspaceMobilityStatusModel {
   direction: "local_to_cloud" | "cloud_to_local" | null;
   phase: WorkspaceMobilityUiPhase;
-  activeHandoff: CloudMobilityHandoffSummary | null;
+  activeHandoff: WorkspaceMobilityHandoffSummary | null;
   title: string | null;
   description: string | null;
   isBlocking: boolean;
@@ -60,7 +60,7 @@ function normalizeDirection(
 }
 
 function summarizeActivePhase(
-  handoff: CloudMobilityHandoffSummary,
+  handoff: WorkspaceMobilityHandoffSummary,
 ): Pick<WorkspaceMobilityStatusModel, "phase" | "title" | "description" | "isBlocking" | "isFailure" | "canRetryCleanup"> {
   const direction = normalizeDirection(handoff.direction);
 
@@ -139,7 +139,7 @@ function summarizeActivePhase(
 
 export function resolveWorkspaceMobilityStatusModel(
   logicalWorkspace: LogicalWorkspace | null,
-  handoff: CloudMobilityHandoffSummary | null,
+  handoff: WorkspaceMobilityHandoffSummary | null,
 ): WorkspaceMobilityStatusModel {
   if (handoff) {
     return {

--- a/desktop/src/lib/domain/workspaces/mobility/types.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/types.ts
@@ -1,7 +1,34 @@
 import type { WorkspaceMobilityPreflightResponse } from "@anyharness/sdk";
-import type { CloudWorkspaceMobilityPreflightResponse } from "@/lib/access/cloud/client";
 
 export type WorkspaceMobilityDirection = "local_to_cloud" | "cloud_to_local";
+
+export interface WorkspaceMobilityCloudPreflightResponse {
+  canStart: boolean;
+  blockers: string[];
+  excludedPaths: string[];
+  workspace?: {
+    repo?: {
+      branch?: string | null;
+    } | null;
+  } | null;
+}
+
+export interface WorkspaceMobilityHandoffSummary {
+  id: string;
+  direction: string;
+  sourceOwner: string;
+  targetOwner: string;
+  phase: string;
+  requestedBranch: string;
+  requestedBaseSha?: string | null;
+  excludePaths: string[];
+  failureCode?: string | null;
+  failureDetail?: string | null;
+  startedAt: string;
+  heartbeatAt: string;
+  finalizedAt?: string | null;
+  cleanupCompletedAt?: string | null;
+}
 
 export interface WorkspaceMobilityConfirmSnapshot {
   logicalWorkspaceId: string;
@@ -9,7 +36,7 @@ export interface WorkspaceMobilityConfirmSnapshot {
   sourceWorkspaceId: string;
   mobilityWorkspaceId: string;
   sourcePreflight: WorkspaceMobilityPreflightResponse;
-  cloudPreflight: CloudWorkspaceMobilityPreflightResponse;
+  cloudPreflight: WorkspaceMobilityCloudPreflightResponse;
 }
 
 export type WorkspaceMobilityLocationKind =

--- a/desktop/src/lib/domain/workspaces/sidebar/cloud-workspace.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/cloud-workspace.ts
@@ -1,0 +1,78 @@
+export type SidebarCloudWorkspaceStatus =
+  | "pending"
+  | "materializing"
+  | "ready"
+  | "archived"
+  | "error";
+
+export type SidebarCloudRuntimeStatus =
+  | "pending"
+  | "provisioning"
+  | "running"
+  | "paused"
+  | "error"
+  | "disabled";
+
+export interface SidebarCloudWorkspaceRepoRef {
+  provider: string;
+  owner: string;
+  name: string;
+  branch: string;
+  baseBranch: string;
+}
+
+export type SidebarCloudWorkspaceOriginContext = {
+  kind: "human" | "cowork" | "api" | "system";
+  entrypoint: "desktop" | "cloud" | "local_runtime" | "cowork";
+} | null | undefined;
+
+export type SidebarCloudWorkspaceCreatorContext =
+  | {
+    kind: "human";
+    label?: string | null;
+  }
+  | {
+    kind: "automation";
+    automationId?: string | null;
+    automationRunId?: string | null;
+    label?: string | null;
+  }
+  | {
+    kind: "agent";
+    sourceSessionId?: string | null;
+    sourceSessionWorkspaceId?: string | null;
+    sessionLinkId?: string | null;
+    sourceWorkspaceId?: string | null;
+    label?: string | null;
+  };
+
+export interface SidebarCloudWorkspaceRuntimeSummary {
+  environmentId: string | null;
+  status: SidebarCloudRuntimeStatus;
+  generation: number;
+  actionBlockKind?: string | null;
+  actionBlockReason?: string | null;
+}
+
+export interface SidebarCloudWorkspaceSummary {
+  id: string;
+  displayName: string | null;
+  repo: SidebarCloudWorkspaceRepoRef;
+  status: SidebarCloudWorkspaceStatus;
+  workspaceStatus: SidebarCloudWorkspaceStatus;
+  runtime?: SidebarCloudWorkspaceRuntimeSummary;
+  statusDetail: string | null;
+  lastError: string | null;
+  templateVersion: string | null;
+  actionBlockKind?: string | null;
+  actionBlockReason?: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  postReadyPhase: string;
+  postReadyFilesTotal: number;
+  postReadyFilesApplied: number;
+  postReadyStartedAt: string | null;
+  postReadyCompletedAt: string | null;
+  origin?: SidebarCloudWorkspaceOriginContext;
+  creatorContext?: SidebarCloudWorkspaceCreatorContext | null;
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/cloud-workspace.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/cloud-workspace.ts
@@ -1,78 +1,17 @@
-export type SidebarCloudWorkspaceStatus =
-  | "pending"
-  | "materializing"
-  | "ready"
-  | "archived"
-  | "error";
+import type {
+  CloudRuntimeStatus,
+  CloudWorkspaceCreatorContext,
+  CloudWorkspaceOriginContext,
+  CloudWorkspaceRepoRef,
+  CloudWorkspaceRuntimeSummary,
+  CloudWorkspaceStatus,
+  CloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
-export type SidebarCloudRuntimeStatus =
-  | "pending"
-  | "provisioning"
-  | "running"
-  | "paused"
-  | "error"
-  | "disabled";
-
-export interface SidebarCloudWorkspaceRepoRef {
-  provider: string;
-  owner: string;
-  name: string;
-  branch: string;
-  baseBranch: string;
-}
-
-export type SidebarCloudWorkspaceOriginContext = {
-  kind: "human" | "cowork" | "api" | "system";
-  entrypoint: "desktop" | "cloud" | "local_runtime" | "cowork";
-} | null | undefined;
-
-export type SidebarCloudWorkspaceCreatorContext =
-  | {
-    kind: "human";
-    label?: string | null;
-  }
-  | {
-    kind: "automation";
-    automationId?: string | null;
-    automationRunId?: string | null;
-    label?: string | null;
-  }
-  | {
-    kind: "agent";
-    sourceSessionId?: string | null;
-    sourceSessionWorkspaceId?: string | null;
-    sessionLinkId?: string | null;
-    sourceWorkspaceId?: string | null;
-    label?: string | null;
-  };
-
-export interface SidebarCloudWorkspaceRuntimeSummary {
-  environmentId: string | null;
-  status: SidebarCloudRuntimeStatus;
-  generation: number;
-  actionBlockKind?: string | null;
-  actionBlockReason?: string | null;
-}
-
-export interface SidebarCloudWorkspaceSummary {
-  id: string;
-  displayName: string | null;
-  repo: SidebarCloudWorkspaceRepoRef;
-  status: SidebarCloudWorkspaceStatus;
-  workspaceStatus: SidebarCloudWorkspaceStatus;
-  runtime?: SidebarCloudWorkspaceRuntimeSummary;
-  statusDetail: string | null;
-  lastError: string | null;
-  templateVersion: string | null;
-  actionBlockKind?: string | null;
-  actionBlockReason?: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
-  postReadyPhase: string;
-  postReadyFilesTotal: number;
-  postReadyFilesApplied: number;
-  postReadyStartedAt: string | null;
-  postReadyCompletedAt: string | null;
-  origin?: SidebarCloudWorkspaceOriginContext;
-  creatorContext?: SidebarCloudWorkspaceCreatorContext | null;
-}
+export type SidebarCloudWorkspaceStatus = CloudWorkspaceStatus;
+export type SidebarCloudRuntimeStatus = CloudRuntimeStatus;
+export type SidebarCloudWorkspaceRepoRef = CloudWorkspaceRepoRef;
+export type SidebarCloudWorkspaceOriginContext = CloudWorkspaceOriginContext | null | undefined;
+export type SidebarCloudWorkspaceCreatorContext = CloudWorkspaceCreatorContext;
+export type SidebarCloudWorkspaceRuntimeSummary = CloudWorkspaceRuntimeSummary;
+export type SidebarCloudWorkspaceSummary = CloudWorkspaceSummary;

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
@@ -4,8 +4,8 @@ import { resolveWorkspaceExecutionSidebarActivityState } from "@/lib/domain/sess
 import { isCloudWorkspacePending } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
 import { automationWorkspaceDefaultDisplayNameFromBranch } from "@/lib/domain/workspaces/display/workspace-display";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import type { SidebarCloudWorkspaceSummary } from "./cloud-workspace";
 
 export type SidebarWorkspaceVariant = "local" | "worktree" | "cloud";
 
@@ -388,7 +388,7 @@ function localWorkspaceCreatedByAutomation(workspace: Workspace): boolean {
     );
 }
 
-function cloudWorkspaceCreatedByAutomation(workspace: CloudWorkspaceSummary): boolean {
+function cloudWorkspaceCreatedByAutomation(workspace: SidebarCloudWorkspaceSummary): boolean {
   return isSystemOrigin(workspace.origin, "cloud");
 }
 

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
@@ -1,7 +1,7 @@
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import type { SidebarSessionActivityState } from "@/lib/domain/sessions/activity";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
-import type { CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type { SidebarCloudWorkspaceSummary } from "./cloud-workspace";
 import {
   buildSidebarGroupStates,
   DEFAULT_SIDEBAR_WORKSPACE_TYPES,
@@ -96,11 +96,11 @@ export function makeCloudWorkspace(args: {
   repoName?: string;
   branch?: string;
   displayName?: string | null;
-  origin?: CloudWorkspaceSummary["origin"];
-  creatorContext?: CloudWorkspaceSummary["creatorContext"];
-  status?: CloudWorkspaceSummary["status"];
+  origin?: SidebarCloudWorkspaceSummary["origin"];
+  creatorContext?: SidebarCloudWorkspaceSummary["creatorContext"];
+  status?: SidebarCloudWorkspaceSummary["status"];
   updatedAt?: string;
-}): CloudWorkspaceSummary {
+}): SidebarCloudWorkspaceSummary {
   const {
     id,
     repoName = "proliferate",
@@ -206,8 +206,8 @@ export function makeCloudLogicalWorkspace(args: {
   repoKey: string;
   repoName: string;
   branch?: string;
-  origin?: CloudWorkspaceSummary["origin"];
-  creatorContext?: CloudWorkspaceSummary["creatorContext"];
+  origin?: SidebarCloudWorkspaceSummary["origin"];
+  creatorContext?: SidebarCloudWorkspaceSummary["creatorContext"];
   updatedAt?: string;
 }): LogicalWorkspace {
   const {

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar.ts
@@ -12,9 +12,9 @@ import {
   resolveLogicalWorkspaceRecency,
 } from "@/lib/domain/workspaces/sidebar/recency";
 import type {
-  CloudWorkspaceStatus,
-  CloudWorkspaceSummary,
-} from "@/lib/access/cloud/client";
+  SidebarCloudWorkspaceStatus,
+  SidebarCloudWorkspaceSummary,
+} from "./cloud-workspace";
 import {
   humanizeBranchName,
   workspaceCurrentBranchName,
@@ -64,7 +64,7 @@ export interface CloudSidebarWorkspaceEntry {
   id: string;
   cloudWorkspaceId: string;
   repoKey: string;
-  workspace: CloudWorkspaceSummary;
+  workspace: SidebarCloudWorkspaceSummary;
 }
 
 export type SidebarWorkspaceEntry =
@@ -119,7 +119,7 @@ export interface SidebarWorkspaceItemState {
   variant: SidebarWorkspaceVariant;
   statusIndicator: SidebarStatusIndicator | null;
   detailIndicators: SidebarDetailIndicator[];
-  cloudStatus: CloudWorkspaceStatus | null;
+  cloudStatus: SidebarCloudWorkspaceStatus | null;
   lastInteracted: string | null;
   needsReview: boolean;
 }
@@ -148,7 +148,7 @@ interface WorkspaceNeedsReviewInput {
 
 export function buildSidebarWorkspaceEntries(
   localWorkspaces: Workspace[],
-  cloudWorkspaces: CloudWorkspaceSummary[],
+  cloudWorkspaces: SidebarCloudWorkspaceSummary[],
 ): SidebarWorkspaceEntry[] {
   const entries: SidebarWorkspaceEntry[] = [
     ...localWorkspaces.map((workspace) => ({
@@ -447,7 +447,7 @@ export function buildSidebarGroupStates(args: {
               : null,
           ),
           cloudStatus: preferredCloudWorkspace
-            ? preferredCloudWorkspace.status as CloudWorkspaceStatus
+            ? preferredCloudWorkspace.status as SidebarCloudWorkspaceStatus
             : null,
           lastInteracted,
           needsReview,

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -36,13 +36,6 @@ DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/files/file-visuals.ts 2 domain im
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/mcp/local-stdio-finalizer.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/support/formatting.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/telemetry/events.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/creation/pending-entry.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/mobility/mobility-blockers.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/mobility/types.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/workspaces/sidebar/sidebar.ts 1 domain imports transport or UI types before lib cleanup
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx 4 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/agents/use-agent-auto-reconcile.ts 4 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/agents/use-agent-installation-actions.ts 5 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- adds the shared workspace cloud domain model on the core workspace-domain branch
- rewrites sidebar cloud workspace types as aliases to the shared cloud model
- avoids parallel sidebar-specific cloud workspace shape drift before the domain branches merge

## Verification

- python3 scripts/check_frontend_boundaries.py
- pnpm --dir desktop exec vitest run src/lib/domain/workspaces/sidebar/sidebar.test.ts src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
- pnpm --dir desktop exec tsc --noEmit
- git diff --check
