### PR TITLE
docs(server): clarify backend ownership guides

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -107,19 +107,70 @@ server/proliferate/
 Do not add new top-level server folders without updating this doc and the
 focused guide that owns the layer.
 
+## Transitional State
+
+This doc describes the **target** architecture. The codebase is migrating
+toward it; some existing patterns still need to be reshaped before every
+hard rule below holds true everywhere.
+
+Files named in the target shape that **do not yet exist** (or are partial):
+
+- `server/proliferate/errors.py` — the shared base for `ProliferateError`,
+  `NotFoundError`, `PermissionDenied`, `Conflict`. Today error types are
+  scattered or per-domain only.
+- `auth/authorization.py` — `require_org_role`, `OwnerContext`,
+  `PolicyVerdict` are currently in `server/organizations/service.py`; they
+  migrate to a dedicated module so domains stop cross-importing from
+  organizations.
+- `server/<domain>/access.py` — resource-access route deps. Most domains
+  don't have one today; access checks happen inline in services.
+- `server/<domain>/domain/policy.py` — pure product-rule verdicts. Today
+  most product rules are inline `if not condition: raise HTTPException(...)`
+  blocks in services.
+
+Patterns that **need migration**:
+
+- **DB session threading.** Today many handlers receive only `User` (no
+  `db`), and stores self-open sessions internally. Target: handlers receive
+  `db: AsyncSession = Depends(get_async_session)`, services accept and
+  thread `db`, stores never open sessions or commit. See
+  [guides/database.md](guides/database.md).
+- **Vendor clients in product code.** `server/cloud/runtime/anyharness_api.py`,
+  `session_api.py`, and `workspace_operations.py` are the AnyHarness HTTP
+  client living inside the product domain. Target: move to
+  `integrations/anyharness/`.
+- **Sibling helper files importing ORM.** `billing/reconciler.py`,
+  `billing/stripe_webhooks.py`, several `cloud/runtime/*.py` files import
+  from `db.models` and do service-layer work. Target: see
+  [guides/domains.md](guides/domains.md) on service decomposition.
+- **God files.** `db/store/billing.py` (2746 lines), `cloud/workspaces/service.py`
+  (1135), `cloud/runtime/provision.py` (1082), and others need
+  decomposition under the rules in the relevant guide.
+- **Pydantic constructors accepting ORM.** Currently in
+  `cloud/repo_config/models.py` and `cloud/workspaces/models.py`. Target:
+  every constructor takes a dataclass.
+
+Cleanup work should preserve current behavior, then incrementally move to
+the target shape. New code should follow the rules below. PRs that
+introduce new code in the **old** patterns require a justification.
+
 ## Hard Rules
 
 ### Layer law
 
 - `api.py` is transport only. It parses the request, calls the right service,
-  and returns the response. It must not import `db/store/**`, `AsyncSessionDep`,
-  `get_async_session`, `async_session_factory`, or SQLAlchemy directly. The
-  only ORM model import allowed in handlers is `User` from auth.
+  and returns the response. It may import `Depends`, `get_async_session`, and
+  `current_active_user` (or equivalent auth dep) **only for use as
+  `Depends(...)` injections** — never to call directly. It must not import
+  `db/store/**`, must not call `AsyncSession` methods, and must not import
+  SQLAlchemy. The only ORM model import allowed in handlers is `User` from
+  auth.
 - `service.py` owns business logic, orchestration, invariants, and validation.
-  It may call stores and integrations. It must not import `AsyncSession`,
-  `AsyncSessionDep`, `get_async_session`, `async_session_factory`, or
-  SQLAlchemy directly. It must not run `select(...)`, `insert(...)`,
-  `update(...)`, `delete(...)`, or `db.execute(...)`.
+  It accepts an `AsyncSession` parameter passed by the handler and threads it
+  to stores. It must not import `async_session_factory` or open its own
+  sessions. It must not import SQLAlchemy directly. It must not run
+  `select(...)`, `insert(...)`, `update(...)`, `delete(...)`, or
+  `db.execute(...)`.
 - All database access lives in `db/store/**`. Stores own query construction
   and DB execution.
 - `db/models/**` owns ORM table definitions only.
@@ -128,8 +179,9 @@ focused guide that owns the layer.
   dataclass intermediate layer is mandatory.
 - Raw third-party SDK and API calls belong behind `integrations/**`.
 - Pure product rules belong in `server/<domain>/domain/<concern>.py`. They
-  must not import React, async, I/O, stores, the query client, or platform
-  APIs. They return data, never `Promise[*]`-equivalent (no async exports).
+  must not import FastAPI, SQLAlchemy, async I/O libraries, integrations,
+  stores, config, or HTTP exception types. They are synchronous: no `async
+  def` exports. They return data.
 - `middleware/**` is only for cross-cutting HTTP request lifecycle concerns.
 
 ### Type pipeline
@@ -314,8 +366,8 @@ Persistence rule:
 - `service.py` calls stores in `db/store/**`, integrations in `integrations/**`,
   pure functions in `<domain>/domain/**`, and other domains' public service
   functions (writes) or stores (reads).
-- `<domain>/domain/**` is pure: it does not import React-equivalent (FastAPI),
-  `db/store/**`, the query client, integrations, or platform APIs.
+- `<domain>/domain/**` is pure: it does not import FastAPI, SQLAlchemy,
+  `db/store/**`, integrations, async I/O libraries, or HTTP exception types.
 - `db/store/**` calls `db/models/**` and SQLAlchemy. Nothing else may import
   SQLAlchemy.
 - `db/models/**` is leaf: it does not import services, stores, or integrations.

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -29,9 +29,12 @@ Guides:
   route deps, and `<domain>/domain/policy.py` product rules.
 - [guides/integrations.md](guides/integrations.md) for `integrations/<vendor>/`
   shapes and adapter conventions.
-- [guides/workers.md](guides/workers.md) for `worker.py`, `reconciler.py`,
-  schedulers, the `worker/` subfolder pattern, and worker-side service
-  decomposition.
+- [guides/config.md](guides/config.md) for `config.py`,
+  `constants/<area>.py`, env-derived settings, hardcoded policy values, and
+  file-local constants.
+- [guides/workers.md](guides/workers.md) for the current lightweight
+  background-job conventions: `worker.py`, `reconciler.py`, earned
+  `worker/` subfolders, and worker-side service decomposition.
 
 Specs (when added) define product/surface contracts: lifecycle invariants,
 edge cases, and focused verification for a specific cross-cutting flow such as
@@ -247,10 +250,13 @@ introduce new code in the **old** patterns require a justification.
 - `config.py` owns env-derived runtime settings only (secrets, URLs,
   deployment values, feature flags).
 - `constants/<area>.py` owns shared hardcoded policy values: limits, timeouts,
-  retry counts, page sizes, validation bounds, sentinel values, headers.
+  retry counts, page sizes, validation bounds, sentinel values, headers,
+  default statuses, and protocol labels.
 - Module-level numeric or string constants in `service.py`, `api.py`, or
-  `db/store/**` files are forbidden unless the value is genuinely file-local
-  with no policy meaning.
+  `db/store/**` files are forbidden when they carry product policy. Move them
+  to `constants/<area>.py` or `config.py`. File-local mechanical constants
+  such as SQL aliases, private regex fragments, or query column labels may
+  stay local.
 - `localhost` literals outside `config.py` defaults are forbidden.
 
 ### File size thresholds
@@ -348,8 +354,8 @@ Use the lowest layer that can own the logic cleanly.
 | Third-party providers and SDKs | `integrations/<vendor>.py` (single file) or `integrations/<vendor>/` (folder) | Typed adapters only. | [integrations.md](guides/integrations.md) |
 | Multi-vendor protocol | `integrations/<protocol>/` with `base.py`, `<provider>.py`, `factory.py` | Abstract over vendors implementing the same protocol. | [integrations.md](guides/integrations.md) |
 | Cross-cutting HTTP behavior | `middleware/**` | Request context, tracing, correlation IDs. No product logic. | — |
-| Env-driven runtime configuration | `config.py` | Secrets, URLs, flags, limits that vary by deployment. | this doc |
-| Hardcoded policy values | `constants/<area>.py` | Limits, timeouts, sentinel values, headers. | this doc |
+| Env-driven runtime configuration | `config.py` | Secrets, URLs, flags, limits that vary by deployment. | [config.md](guides/config.md) |
+| Hardcoded policy values | `constants/<area>.py` | Limits, timeouts, sentinel values, headers, protocol labels. | [config.md](guides/config.md) |
 | Shared base errors | `server/proliferate/errors.py` | `ProliferateError`, `NotFoundError`, `PermissionDenied`, `Conflict`. | this doc |
 | Domain-specific errors | `server/<domain>/errors.py` | Inherit from the shared base. | this doc |
 | Integration-specific errors | `integrations/<vendor>/errors.py` or inline | Stay integration-local. | [integrations.md](guides/integrations.md) |

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -6,144 +6,301 @@ Scope:
 
 - `server/**`
 
-## 1. File Tree
+Use this doc first to understand the server ownership model. Then read the
+focused guide that applies to the code you are changing.
 
-Use this as the default backend shape. Do not create new top-level backend
-folders without a clear ownership reason.
+## Read Order
+
+Always start here.
+
+Guides define reusable engineering standards: where code goes, what each layer
+may own, and which patterns are allowed.
+
+Guides:
+
+- [guides/domains.md](guides/domains.md) for `server/<domain>/` shape, the
+  api/service/models triplet, `domain/` for pure logic, subdomain promotion,
+  and cross-domain coordination.
+- [guides/database.md](guides/database.md) for `db/store/`, `db/models/`,
+  transactions, the ORM → dataclass → Pydantic type pipeline, and DB column
+  conventions.
+- [guides/auth.md](guides/auth.md) for authentication, the
+  `auth/authorization` shared helpers, `<domain>/access.py` resource-access
+  route deps, and `<domain>/domain/policy.py` product rules.
+- [guides/integrations.md](guides/integrations.md) for `integrations/<vendor>/`
+  shapes and adapter conventions.
+- [guides/workers.md](guides/workers.md) for `worker.py`, `reconciler.py`,
+  schedulers, the `worker/` subfolder pattern, and worker-side service
+  decomposition.
+
+Specs (when added) define product/surface contracts: lifecycle invariants,
+edge cases, and focused verification for a specific cross-cutting flow such as
+billing, runtime provisioning, or MCP. None are written yet.
+
+When a change touches `server/artifact-runtime/**`, also read
+[../../server/artifact-runtime/README.md](../../server/artifact-runtime/README.md).
+That README owns the hosted artifact viewer contract, the desktop/runtime
+`postMessage` protocol, and the per-type renderer behavior.
+
+## Target Shape
+
+This is the target architecture. Some existing code is still transitional; new
+code and cleanup work should move toward this shape.
 
 ```text
 server/proliferate/
   main.py
   config.py
+  errors.py
   constants/
+    <area>.py
   utils/
   auth/
+    dependencies.py
+    authorization.py
     desktop/
+    jwt.py
+    oauth.py
+    pkce.py
+    users.py
+    models.py
   db/
+    engine.py
     models/
+      <resource>.py
     store/
+      <resource>.py                   # flat, default
+      <area>/                         # folder when ≥4 related stores cluster
+        <resource>.py
   integrations/
+    <vendor>.py                       # single file (default)
+    <vendor>/                         # folder for multi-concern or polymorphic
+      __init__.py
+      client.py
+      models.py
+      errors.py
+      <concern>.py
   middleware/
   server/
     <domain>/
+      api.py                          # transport
+      service.py                      # orchestration
+      models.py                       # Pydantic transport schemas
+      access.py                       # resource-access route deps (when needed)
+      errors.py                       # domain-specific error types (when needed)
+      domain/                         # pure logic
+        policy.py                     # product rules returning PolicyVerdict
+        <concern>.py
+      worker.py                       # non-HTTP entry point (when applicable)
+      reconciler.py                   # state-drift loop (when applicable)
+      worker/                         # promoted: substantial worker-side logic
+        main.py
+        service.py
+        <concern>.py
+      <subdomain>/                    # promoted: own product concept
+        api.py
+        service.py
+        models.py
+        domain/
 ```
 
-Domain packages are the default product shape under `server/`.
+Do not add new top-level server folders without updating this doc and the
+focused guide that owns the layer.
 
-Smaller domains should usually stay as:
+## Hard Rules
 
-```text
-server/<domain>/
-  api.py
-  models.py
-  service.py
-```
+### Layer law
 
-Larger centralized domains may keep their own nested structure when the domain
-is broad and cohesive. `cloud/` is the main example:
-
-```text
-server/cloud/
-  api.py
-  <shared domain modules>.py
-  <subdomain>/
-    api.py
-    models.py
-    service.py
-```
-
-That is acceptable when the folder still reads as one domain with clear
-internal ownership.
-
-## 2. Non-Negotiable Rules
-
-- Route handlers stay extremely thin.
 - `api.py` is transport only. It parses the request, calls the right service,
-  and returns the response.
+  and returns the response. It must not import `db/store/**`, `AsyncSessionDep`,
+  `get_async_session`, `async_session_factory`, or SQLAlchemy directly. The
+  only ORM model import allowed in handlers is `User` from auth.
 - `service.py` owns business logic, orchestration, invariants, and validation.
-- Database access belongs in `db/store/**` only.
-- `service.py` must not run direct ORM queries or call `db.execute(...)`
-  inline. If a service needs data, add a store function and call that.
+  It may call stores and integrations. It must not import `AsyncSession`,
+  `AsyncSessionDep`, `get_async_session`, `async_session_factory`, or
+  SQLAlchemy directly. It must not run `select(...)`, `insert(...)`,
+  `update(...)`, `delete(...)`, or `db.execute(...)`.
+- All database access lives in `db/store/**`. Stores own query construction
+  and DB execution.
 - `db/models/**` owns ORM table definitions only.
-- `server/<domain>/models.py` owns API request and response models only.
+- `server/<domain>/models.py` owns Pydantic API request and response schemas
+  only. It must not accept ORM objects in payload builder functions; the
+  dataclass intermediate layer is mandatory.
 - Raw third-party SDK and API calls belong behind `integrations/**`.
+- Pure product rules belong in `server/<domain>/domain/<concern>.py`. They
+  must not import React, async, I/O, stores, the query client, or platform
+  APIs. They return data, never `Promise[*]`-equivalent (no async exports).
 - `middleware/**` is only for cross-cutting HTTP request lifecycle concerns.
-- `config.py` owns env-derived runtime settings only.
-- `constants/**` owns shared hardcoded values only.
-- `utils/**` is for truly generic backend helpers that are not owned by one
-  product domain.
-- Prefer composition over inheritance.
-- Keep inheritance shallow and explicit. Do not build deep `Base*` hierarchies
-  for services, Pydantic models, dataclasses, or domain logic.
-- Use Pydantic models for API transport schemas.
-- Route handlers must declare a typed Pydantic return type. Never use
-  `dict[str, Any]`, `list[dict[str, Any]]`, or any other `Any`-bearing type as
-  a route return annotation. ANN401 is enforced by ruff — fix the model, do not
-  suppress the lint rule.
-- Use dataclasses for small internal value objects when a lightweight typed
-  container helps and no framework behavior is needed.
-- Do not use Pydantic models as ORM models or general-purpose domain objects.
-- Map explicitly between ORM models, dataclasses, and Pydantic schemas instead
-  of blurring those layers together.
-- The layered ownership rule for types is: ORM model (persistence) →
-  dataclass (internal domain value) → Pydantic model (wire format). Each layer
-  owns its own type. The mapping between them is explicit and lives at the
-  boundary — typically in `models.py` constructor functions.
-- Pydantic belongs at trust boundaries: HTTP request parsing and response
-  serialization. It does not belong inside service functions as a general
-  container for data that never leaves the backend.
+
+### Type pipeline
+
+- Three layers always distinct: ORM (`db/models/`), dataclass (colocated with
+  owner, typically the store file), Pydantic (`server/<domain>/models.py`).
+- ORM never leaves the store boundary. Store functions return frozen
+  dataclasses, not ORM objects.
+- Pydantic never accepts ORM. Pydantic constructor functions take dataclasses.
+- `@dataclass(frozen=True)` for read-result dataclasses.
+- Use enums on dataclass fields, not strings. Wire-format string mapping
+  happens in the Pydantic constructor.
 - Do not use `model_config = ConfigDict(from_attributes=True)` to map ORM
-  objects directly into Pydantic response models. This collapses the dataclass
-  layer, couples your wire format to ORM column names, and makes independent
-  evolution of the two harder. Map explicitly instead.
-- Prefer `@dataclass(frozen=True)` for dataclasses that represent read results
-  from a store or service. Immutability makes the intent clear and prevents
-  accidental mutation across call sites.
-- Do not create junk-drawer modules such as `helpers.py`, `misc.py`, or
-  catch-all `services/`.
-- Preserve current API shapes and auth behavior unless an explicit change is
-  requested.
-- Delete dead compatibility paths instead of keeping duplicate old and new
-  flows alive.
+  objects directly into Pydantic response models.
 
-### Layer Law
+### Transactions
 
-- `api.py` is transport only and may call `service.py` only.
-- `api.py` must not import `db/store/**`.
-- `api.py` must not import `AsyncSessionDep`, `get_async_session`, or
-  `async_session_factory`.
-- `api.py` must not import SQLAlchemy directly.
-- `api.py` may keep the current auth dependency return type import
-  `from proliferate.db.models.auth import User`; no other ORM model imports are
-  allowed in handlers.
-- `service.py` may call stores and integrations, but may not import SQLAlchemy,
-  `AsyncSession`, `AsyncSessionDep`, `get_async_session`, or
-  `async_session_factory`.
-- Runtime helpers under `server/**` follow the same no-session/no-SQLAlchemy
-  rule as services unless they themselves live under `db/store/**`.
-- Multi-step database transactions belong in store facades under `db/store/**`,
-  not in services.
+- Store functions take `db: AsyncSession` as a parameter. They never commit
+  and never open sessions.
+- HTTP handlers use the request session via `Depends(get_async_session)`. The
+  dep commits on success and rolls back on exception.
+- Workers, reconcilers, and schedulers open a session at the entry point with
+  `async with async_session_factory() as db: async with db.begin(): ...`.
+- For narrower atomicity within a request, services use
+  `async with db.begin_nested():` around the relevant store calls.
+- No `db.commit()` outside session-management code (the FastAPI dep, the
+  worker entry point).
 
-## 3. Ownership Model
+### Authorization
+
+- Authentication (returning `User`) lives in `auth/dependencies.py`.
+- Shared authorization helpers (`require_org_role`, `OwnerContext`,
+  `PolicyVerdict`) live in `auth/authorization.py`.
+- Resource-access route deps (returning the resource or raising 403/404) live
+  in `server/<domain>/access.py`.
+- Product rules (given state, is the action permitted) live in
+  `server/<domain>/domain/policy.py` as pure functions returning
+  `PolicyAllowed | PolicyDenied`.
+- Authorization checks must not appear inline in `api.py` route handler
+  bodies. Use deps.
+- Authorization checks should not appear inline in `service.py` when they
+  could have been route deps (fail-fast wins). Product rules from
+  `domain/policy.py` are called from `service.py`.
+
+### Errors
+
+- A single root `server/proliferate/errors.py` defines the base
+  `ProliferateError` class and shared types (`NotFoundError`,
+  `PermissionDenied`, `Conflict`).
+- Domain-specific errors live in `server/<domain>/errors.py` and inherit from
+  the shared base.
+- Integration errors stay integration-local (`integrations/<vendor>.py` or
+  `integrations/<vendor>/errors.py`).
+- A FastAPI exception handler maps `ProliferateError` subclasses to
+  `HTTPException` with the `code` field as the JSON error code. Services
+  raise domain errors; the handler does HTTP translation.
+- Do not catch `Exception` broadly without re-raising.
+- Do not raise `HTTPException` from `domain/policy.py` or `db/store/`. Only
+  services and api handlers raise HTTP-aware errors.
+
+### Configs and constants
+
+- `config.py` owns env-derived runtime settings only (secrets, URLs,
+  deployment values, feature flags).
+- `constants/<area>.py` owns shared hardcoded policy values: limits, timeouts,
+  retry counts, page sizes, validation bounds, sentinel values, headers.
+- Module-level numeric or string constants in `service.py`, `api.py`, or
+  `db/store/**` files are forbidden unless the value is genuinely file-local
+  with no policy meaning.
+- `localhost` literals outside `config.py` defaults are forbidden.
+
+### File size thresholds
+
+| Layer | Soft (split before) | Hard (split or justify) |
+|---|---|---|
+| `server/<domain>/api.py` | 200 | 400 |
+| `server/<domain>/service.py` | 500 | 800 |
+| `server/<domain>/models.py` | 300 | 500 |
+| `server/<domain>/domain/*.py` | 250 | 500 |
+| `db/store/<resource>.py` | 400 | 700 |
+| `db/models/*.py` | 300 | 500 |
+| `integrations/<vendor>/*.py` | 300 | — |
+
+Soft is a PR-review prompt. Hard requires a justification in the PR
+description (typically a tracking issue + reason it can't split now).
+
+### Naming
+
+- Canonical files (`api.py`, `service.py`, `models.py`, `worker.py`,
+  `reconciler.py`, `scheduler.py`) are never prefixed or suffixed.
+- Domain subdirectory files use descriptive nouns (`pricing.py`, `policy.py`,
+  `validation.py`). No `_service`, `_helper`, or `_utils` suffixes.
+- Subdomain folders use singular product concepts (`subscriptions/`,
+  `seats/`). No "manager"/"handler" suffixes.
+- Store files match the ORM resource name. Flat: prefixed
+  (`cloud_workspaces.py`). Folder: un-prefixed inside (`cloud_mcp/connections.py`).
+- No underscore-prefixed module names at module scope (`_logging.py` is
+  forbidden).
+- Constants use `UPPER_SNAKE_CASE` and live in `constants/<area>.py`.
+
+### Folder hygiene
+
+- Single-file folders are forbidden. If a folder has only one file, inline it.
+- Domain folders answer "what product area?" — not transport (`cloud/`,
+  `api/`, `tauri/` are forbidden as `server/` children; transport stays in
+  `integrations/` or `db/`) and not UI shape.
+- Pick one shape per parent. A folder either has subfolder children
+  consistently or is flat. Mixed shapes are forbidden.
+- New top-level `server/proliferate/` folders require a doc-touching PR with
+  a one-paragraph rationale.
+- No junk-drawer modules: `helpers.py`, `misc.py`, `utils.py` at any
+  domain level. `utils/` at the project root is for truly generic helpers
+  only.
+
+### Cross-domain coordination
+
+- Reads cross via store: a service may import another domain's store to read
+  data.
+- Writes cross via service: a service must go through another domain's public
+  service functions to mutate that domain's resources.
+- Service-to-service imports are limited to public functions. Importing
+  another service's private helpers is forbidden.
+- Cross-domain imports for auth infrastructure use `auth.authorization`,
+  never another domain's `service.py`.
+
+### Forbidden patterns across all layers
+
+- Sibling helper files alongside `service.py` that import `db.models.*` or do
+  service-layer work. Helpers live in `domain/` (pure) or are promoted to a
+  subdomain.
+- Cross-resource transactional writes spread across multiple service calls
+  without a transaction boundary.
+- Pydantic models used as ORM models or general-purpose internal containers.
+- `datetime.utcnow()` anywhere in the codebase. Use
+  `datetime.now(timezone.utc)`.
+- `TIMESTAMP` columns without timezone. Use `TIMESTAMPTZ` everywhere.
+- `is_deleted` boolean columns. Use `deleted_at TIMESTAMPTZ NULL` for soft
+  delete; default to hard delete.
+- Raw integer primary keys for new resources. UUID primary keys with
+  `gen_random_uuid()` defaults.
+- Lazy ORM attribute access reaching past the store boundary.
+
+## Ownership Model
 
 Use the lowest layer that can own the logic cleanly.
 
-| Concern | Owner | Rule of thumb |
-| --- | --- | --- |
-| Route handlers | `server/<domain>/api.py` | Thin request/response transport only. |
-| API request and response models | `server/<domain>/models.py` | Transport-facing schemas only. |
-| Product business logic | `server/<domain>/service.py` | Orchestration, invariants, validation, and coordination across stores and integrations. |
-| Larger centralized domain logic | `server/<large-domain>/**` | Allowed for broad cohesive domains like `cloud/`; keep subpackages inside the domain instead of inventing parallel top-level folders. |
-| ORM schema | `db/models/*.py` | Persisted schema only. |
-| Database reads and writes | `db/store/*.py` | All DB access goes here, including query construction and `db.execute(...)`. |
-| Auth, token, OAuth, PKCE, and auth dependencies | `auth/**` | Auth stays separate from product-domain business logic. |
-| Third-party providers and vendor SDKs | `integrations/**` | Typed adapters only. Small integrations can be one file; larger ones should split into folders. |
-| Cross-cutting request lifecycle behavior | `middleware/**` | Request context, tracing, logging correlation, and other HTTP-wide behavior. |
-| Env-driven runtime configuration | `config.py` | Secrets, URLs, flags, limits, and other deployment-specific values. |
-| Shared hardcoded values | `constants/**` | Stable code-level constants, defaults, and protocol labels. |
-| Shared generic helpers | `utils/**` | Only for helpers that are truly generic across backend domains, such as shared crypto, telemetry, or time helpers. |
-| API transport schemas | Pydantic models in `server/<domain>/models.py` | Validate and serialize request/response shapes at the transport boundary. |
-| Small internal typed value objects | dataclasses in the owning module or domain package | Use for internal structure, not as a substitute for ORM or API schemas. |
+| Concern | Owner | Rule of thumb | Details |
+| --- | --- | --- | --- |
+| Route handlers | `server/<domain>/api.py` | Thin request/response transport only. | [domains.md](guides/domains.md) |
+| API request/response models | `server/<domain>/models.py` | Pydantic transport schemas. Constructor functions take dataclasses, never ORM. | [domains.md](guides/domains.md), [database.md](guides/database.md) |
+| Product business logic | `server/<domain>/service.py` | Orchestration, invariants, validation. Calls stores and integrations. | [domains.md](guides/domains.md) |
+| Pure product rules | `server/<domain>/domain/<concern>.py` | State machines, validators, calculators, planners. No I/O. | [domains.md](guides/domains.md) |
+| Subdomain | `server/<domain>/<subdomain>/` | Promoted product concept with its own api/service/models. | [domains.md](guides/domains.md) |
+| Worker process entry point | `server/<domain>/worker.py` (or `worker/main.py`) | argparse, signals, async loop setup. Calls service. | [workers.md](guides/workers.md) |
+| Reconciliation loop | `server/<domain>/reconciler.py` (or `worker/reconciler.py`) | State-drift loop. Calls service. | [workers.md](guides/workers.md) |
+| Resource-access route deps | `server/<domain>/access.py` | Lookup + access check + return resource. | [auth.md](guides/auth.md) |
+| Product policy rules | `server/<domain>/domain/policy.py` | Pure verdict functions. | [auth.md](guides/auth.md) |
+| Authentication | `auth/dependencies.py` | `get_current_user`, platform-admin checks. | [auth.md](guides/auth.md) |
+| Shared authorization helpers | `auth/authorization.py` | `require_org_role`, `OwnerContext`, `PolicyVerdict`. | [auth.md](guides/auth.md) |
+| ORM schema | `db/models/<resource>.py` | Persisted schema only. | [database.md](guides/database.md) |
+| Database reads/writes | `db/store/<resource>.py` (flat) or `db/store/<area>/<resource>.py` (folder) | One ORM resource per file. Returns frozen dataclasses. Takes `db: AsyncSession`. Never commits. | [database.md](guides/database.md) |
+| Read-result dataclasses | Co-located in the owning store file | `@dataclass(frozen=True)` snapshots returned to services. | [database.md](guides/database.md) |
+| Internal value types | dataclasses in the owning module | Use for typed internal containers, not ORM or API substitutes. | [database.md](guides/database.md) |
+| Third-party providers and SDKs | `integrations/<vendor>.py` (single file) or `integrations/<vendor>/` (folder) | Typed adapters only. | [integrations.md](guides/integrations.md) |
+| Multi-vendor protocol | `integrations/<protocol>/` with `base.py`, `<provider>.py`, `factory.py` | Abstract over vendors implementing the same protocol. | [integrations.md](guides/integrations.md) |
+| Cross-cutting HTTP behavior | `middleware/**` | Request context, tracing, correlation IDs. No product logic. | — |
+| Env-driven runtime configuration | `config.py` | Secrets, URLs, flags, limits that vary by deployment. | this doc |
+| Hardcoded policy values | `constants/<area>.py` | Limits, timeouts, sentinel values, headers. | this doc |
+| Shared base errors | `server/proliferate/errors.py` | `ProliferateError`, `NotFoundError`, `PermissionDenied`, `Conflict`. | this doc |
+| Domain-specific errors | `server/<domain>/errors.py` | Inherit from the shared base. | this doc |
+| Integration-specific errors | `integrations/<vendor>/errors.py` or inline | Stay integration-local. | [integrations.md](guides/integrations.md) |
 
 Persistence rule:
 
@@ -151,74 +308,22 @@ Persistence rule:
 - Stores talk to the database.
 - Handlers and services do not become ad hoc persistence layers.
 
-## 4. Folder Guide
+## Dependency Direction
 
-- `server/<domain>/`
-  - Default home for backend product domains.
-  - Small domains should usually be `api.py`, `models.py`, and `service.py`.
-  - Larger domains like `cloud/` may keep nested subpackages when the domain is
-    broad, centralized, and still clearly owned as one domain.
-
-- `auth/`
-  - Owns authentication, token handling, reusable authorization dependencies,
-    OAuth, PKCE, and desktop auth flow logic.
-  - Do not bury product-domain rules such as billing or workspace lifecycle
-    behavior here.
-
-- `db/models/`
-  - ORM tables only.
-  - Do not put request models, transport serializers, or service logic here.
-
-- `db/store/`
-  - All database operations live here.
-  - If code needs `select(...)`, `insert(...)`, `update(...)`, `delete(...)`, or
-    `db.execute(...)`, it belongs here rather than in a service or handler.
-
-- `server/<domain>/models.py`
-  - Pydantic request and response schemas only.
-  - Keep inheritance shallow. Shared transport bases are fine when they remove
-    obvious duplication, but avoid deep schema hierarchies.
-  - Do not turn these models into ORM or generic domain objects.
-
-- `integrations/`
-  - Owns typed boundaries to third-party systems.
-  - Keep vendor auth, client setup, payload normalization, and provider-specific
-    error handling here.
-  - Split a provider into a folder when one file stops being clear. `slack/`
-    is preferable to one giant `slack.py` once the integration grows.
-
-- `middleware/`
-  - Owns HTTP-wide request lifecycle behavior.
-  - Good examples are request context, tracing, correlation IDs, or shared
-    request instrumentation.
-  - Do not put product business logic or domain-specific permissions here.
-
-- `constants/`
-  - Shared hardcoded values only.
-  - If a value comes from env or deployment settings, it belongs in `config.py`
-    instead.
-
-- `config.py`
-  - Runtime settings only.
-  - Do not turn it into a general global-values bucket for hardcoded constants.
-
-- `utils/`
-  - Shared generic backend helpers only when they are not naturally owned by a
-    domain.
-  - This is the right home for truly generic helpers such as shared crypto,
-    telemetry, or time utilities.
-  - Do not move domain business logic here just because it is reused twice.
-
-- dataclasses
-  - Use for small internal typed containers, parsed values, or normalized
-    results that stay inside the backend.
-  - Prefer explicit construction and mapping over clever inheritance.
-
-- `main.py`
-  - App bootstrap and route registration only.
-  - Keep app construction separate from product behavior and persistence logic.
-
-When a change touches `server/artifact-runtime/**`, also read
-`server/artifact-runtime/README.md`. That README owns the hosted artifact
-viewer contract, the desktop/runtime `postMessage` protocol, and the per-type
-renderer behavior.
+- `api.py` calls `service.py` and depends on access deps from `<domain>/access.py`.
+- `service.py` calls stores in `db/store/**`, integrations in `integrations/**`,
+  pure functions in `<domain>/domain/**`, and other domains' public service
+  functions (writes) or stores (reads).
+- `<domain>/domain/**` is pure: it does not import React-equivalent (FastAPI),
+  `db/store/**`, the query client, integrations, or platform APIs.
+- `db/store/**` calls `db/models/**` and SQLAlchemy. Nothing else may import
+  SQLAlchemy.
+- `db/models/**` is leaf: it does not import services, stores, or integrations.
+- `integrations/<vendor>/**` is leaf: it does not import server domain code.
+  Each vendor folder exposes a public API via `__init__.py`; internals stay
+  vendor-local.
+- `auth/**` may be imported by every layer. Cross-domain authorization helpers
+  always come from `auth.authorization`, never from another domain's
+  `service.py`.
+- Workers (`worker.py`, `reconciler.py`, `worker/`) follow the same dependency
+  direction as api/service. They call services, not stores directly.

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -372,8 +372,9 @@ Persistence rule:
   SQLAlchemy.
 - `db/models/**` is leaf: it does not import services, stores, or integrations.
 - `integrations/<vendor>/**` is leaf: it does not import server domain code.
-  Each vendor folder exposes a public API via `__init__.py`; internals stay
-  vendor-local.
+  Each vendor folder exposes a public API via `__init__.py`; this is the
+  explicit Python integration-package exception to the repo-wide no-barrel
+  rule. Internals stay vendor-local.
 - `auth/**` may be imported by every layer. Cross-domain authorization helpers
   always come from `auth.authorization`, never from another domain's
   `service.py`.

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -27,6 +27,9 @@ Guides:
 - [guides/auth.md](guides/auth.md) for authentication, the
   `auth/authorization` shared helpers, `<domain>/access.py` resource-access
   route deps, and `<domain>/domain/policy.py` product rules.
+- [guides/errors.md](guides/errors.md) for shared product errors,
+  domain-specific errors, integration-error translation, and global HTTP
+  exception mapping.
 - [guides/integrations.md](guides/integrations.md) for `integrations/<vendor>/`
   shapes and adapter conventions.
 - [guides/config.md](guides/config.md) for `config.py`,
@@ -121,10 +124,10 @@ Files named in the target shape that **do not yet exist** (or are partial):
 - `server/proliferate/errors.py` — the shared base for `ProliferateError`,
   `NotFoundError`, `PermissionDenied`, `Conflict`. Today error types are
   scattered or per-domain only.
-- `auth/authorization.py` — `require_org_role`, `OwnerContext`,
-  `PolicyVerdict` are currently in `server/organizations/service.py`; they
-  migrate to a dedicated module so domains stop cross-importing from
-  organizations.
+- `auth/authorization.py` — shared authorization context and policy verdict
+  helpers. Today some shared authorization helpers live inside product-domain
+  services; they migrate to a dedicated auth module so domains stop
+  cross-importing for authorization infrastructure.
 - `server/<domain>/access.py` — resource-access route deps. Most domains
   don't have one today; access checks happen inline in services.
 - `server/<domain>/domain/policy.py` — pure product-rule verdicts. Today
@@ -138,20 +141,18 @@ Patterns that **need migration**:
   `db: AsyncSession = Depends(get_async_session)`, services accept and
   thread `db`, stores never open sessions or commit. See
   [guides/database.md](guides/database.md).
-- **Vendor clients in product code.** `server/cloud/runtime/anyharness_api.py`,
-  `session_api.py`, and `workspace_operations.py` are the AnyHarness HTTP
-  client living inside the product domain. Target: move to
-  `integrations/anyharness/`.
-- **Sibling helper files importing ORM.** `billing/reconciler.py`,
-  `billing/stripe_webhooks.py`, several `cloud/runtime/*.py` files import
-  from `db.models` and do service-layer work. Target: see
+- **Protocol clients in product code.** Some raw HTTP/SDK clients still live
+  inside product domains. Target: move protocol access behind
+  `integrations/**`; product domains orchestrate results.
+- **Sibling helper files importing ORM.** Some domain-adjacent helper files do
+  service-layer or store-layer work while sitting outside the canonical
+  `api.py` / `service.py` / `models.py` / `domain/` shape. Target: see
   [guides/domains.md](guides/domains.md) on service decomposition.
-- **God files.** `db/store/billing.py` (2746 lines), `cloud/workspaces/service.py`
-  (1135), `cloud/runtime/provision.py` (1082), and others need
-  decomposition under the rules in the relevant guide.
-- **Pydantic constructors accepting ORM.** Currently in
-  `cloud/repo_config/models.py` and `cloud/workspaces/models.py`. Target:
-  every constructor takes a dataclass.
+- **God files.** Some stores, services, runtime flows, and workers are large
+  coupled modules that need staged decomposition under the relevant guide.
+  Treat these as senior-review migrations, not first-wave cleanup.
+- **Pydantic constructors accepting ORM.** Some response constructors still
+  accept ORM objects. Target: every constructor takes a dataclass.
 
 Cleanup work should preserve current behavior, then incrementally move to
 the target shape. New code should follow the rules below. PRs that
@@ -230,6 +231,8 @@ introduce new code in the **old** patterns require a justification.
   `domain/policy.py` are called from `service.py`.
 
 ### Errors
+
+See [guides/errors.md](guides/errors.md) for the detailed error model.
 
 - A single root `server/proliferate/errors.py` defines the base
   `ProliferateError` class and shared types (`NotFoundError`,
@@ -356,8 +359,8 @@ Use the lowest layer that can own the logic cleanly.
 | Cross-cutting HTTP behavior | `middleware/**` | Request context, tracing, correlation IDs. No product logic. | — |
 | Env-driven runtime configuration | `config.py` | Secrets, URLs, flags, limits that vary by deployment. | [config.md](guides/config.md) |
 | Hardcoded policy values | `constants/<area>.py` | Limits, timeouts, sentinel values, headers, protocol labels. | [config.md](guides/config.md) |
-| Shared base errors | `server/proliferate/errors.py` | `ProliferateError`, `NotFoundError`, `PermissionDenied`, `Conflict`. | this doc |
-| Domain-specific errors | `server/<domain>/errors.py` | Inherit from the shared base. | this doc |
+| Shared base errors | `server/proliferate/errors.py` | `ProliferateError`, `NotFoundError`, `PermissionDenied`, `Conflict`. | [errors.md](guides/errors.md) |
+| Domain-specific errors | `server/<domain>/errors.py` | Inherit from the shared base. | [errors.md](guides/errors.md) |
 | Integration-specific errors | `integrations/<vendor>/errors.py` or inline | Stay integration-local. | [integrations.md](guides/integrations.md) |
 
 Persistence rule:

--- a/docs/server/guides/auth.md
+++ b/docs/server/guides/auth.md
@@ -1,0 +1,323 @@
+# Auth
+
+Status: authoritative for authentication, authorization helpers,
+resource-access route deps, and product policy rules.
+
+Read after `docs/server/README.md`. This guide details the three-layer auth
+model and how each layer's responsibility is enforced.
+
+## Ownership
+
+Auth has three layers, each with a distinct responsibility and home:
+
+| Layer | Question | Lives in | Returns |
+|---|---|---|---|
+| **Authentication** | Is the request from a logged-in user? | `auth/dependencies.py` | `User` |
+| **Resource access** | Does this resource exist + can this user touch it? | `server/<domain>/access.py` | The resource (snapshot dataclass) or raises 403/404 |
+| **Product rule** | Given this state, is this action permitted right now? | `server/<domain>/domain/policy.py` | `PolicyVerdict` (allowed or denied) |
+
+Plus one shared module:
+
+| Module | What it holds |
+|---|---|
+| `auth/authorization.py` | Reusable helpers (`require_org_role`, `OwnerContext`, `PolicyVerdict`) used by both resource-access deps and policy functions |
+
+## Folder Shape
+
+```text
+auth/
+  __init__.py
+  dependencies.py          # get_current_user, platform-admin checks
+  authorization.py         # shared helpers: require_org_role, OwnerContext, PolicyVerdict
+  jwt.py
+  oauth.py
+  pkce.py
+  users.py
+  models.py
+  desktop/                 # desktop-specific auth flows
+
+server/<domain>/
+  access.py                # resource-access route deps (per domain)
+  domain/
+    policy.py              # pure product-rule verdicts (per domain)
+```
+
+Not every domain needs `access.py` or `domain/policy.py`. Only domains that
+protect resources need access deps. Only domains with product rules need
+policy.
+
+## Authentication
+
+`auth/dependencies.py` owns the authentication layer.
+
+### Allowed
+
+- `Depends(...)` functions returning `User`.
+- JWT parsing, session lookup.
+- Platform-level admin checks (e.g., `get_current_platform_admin`) that don't
+  scope to a resource — just identity.
+
+### Banned
+
+- Resource-scoped checks. Those are domain-specific and live in
+  `server/<domain>/access.py`.
+- Business logic.
+- ORM access except for the auth user lookup.
+
+### Standard shape
+
+```python
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_async_session),
+) -> User:
+    payload = decode_jwt(token)
+    user = await load_user_by_id(db, payload.sub)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid auth")
+    return user
+
+async def get_current_platform_admin(
+    user: User = Depends(get_current_user),
+) -> User:
+    if not user.is_platform_admin:
+        raise HTTPException(status_code=403, detail="Platform admin required")
+    return user
+```
+
+## Authorization Helpers
+
+`auth/authorization.py` owns shared building blocks used by both
+resource-access deps and policy functions.
+
+### Allowed
+
+- `require_org_role(context, allowed_roles)` and similar role-check helpers.
+- `OwnerContext` (or equivalent) dataclass representing a user's relationship
+  to a resource owner.
+- `PolicyVerdict` tagged union (`PolicyAllowed | PolicyDenied`).
+- `user_has_org_membership(user, organization_id)` and similar identity
+  checks.
+
+### Banned
+
+- Resource lookups. Those happen in `<domain>/access.py`.
+- HTTP-aware error raising. Helpers raise typed errors; callers decide the
+  HTTP translation.
+- Imports from `server/<domain>/**`. Auth helpers stay generic.
+
+### Standard shapes
+
+```python
+@dataclass(frozen=True)
+class OwnerContext:
+    user_id: UUID
+    organization_id: UUID | None
+    role: str | None
+
+def require_org_role(context: OwnerContext, allowed: Iterable[str]) -> None:
+    if context.organization_id is None:
+        raise PermissionDenied("Organization required")
+    if context.role not in allowed:
+        raise PermissionDenied(f"Role {context.role} not in allowed set")
+
+@dataclass(frozen=True)
+class PolicyAllowed:
+    pass
+
+@dataclass(frozen=True)
+class PolicyDenied:
+    code: str
+    reason: str
+
+PolicyVerdict = PolicyAllowed | PolicyDenied
+```
+
+## Resource-Access Route Deps
+
+`server/<domain>/access.py` owns deps that look up a resource, check the
+user can touch it, and return the resource (or raise 403/404).
+
+### Allowed
+
+- `async def` functions taking auth + path/query params and returning a
+  resource snapshot.
+- Calls to `db/store/**` for the lookup.
+- Calls to `auth/authorization.py` for role checks.
+- Calls to `domain/policy.py` for state-based access checks.
+- Raising 404 for missing resources, 403 for forbidden.
+
+### Banned
+
+- Mutating writes. Access deps are read-only.
+- Business logic beyond access.
+- Inline authorization helpers (use `auth/authorization`).
+- Returning Pydantic. Return the dataclass snapshot.
+
+### Standard shape
+
+```python
+# server/cloud/workspaces/access.py
+async def workspace_user_can_read(
+    workspace_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkspaceSnapshot:
+    snapshot = await store.cloud_workspaces.get_workspace_snapshot(
+        db, workspace_id
+    )
+    if snapshot is None:
+        raise HTTPException(404, "Workspace not found")
+    org_context = await store.organizations.get_owner_context(
+        db, snapshot.owner_id, user.id
+    )
+    require_org_role(org_context, {OWNER, ADMIN, MEMBER})
+    return snapshot
+
+async def workspace_user_can_admin(
+    workspace_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkspaceSnapshot:
+    # similar, but require admin role
+    ...
+```
+
+### Naming convention
+
+`<resource>_user_can_<action>` — e.g., `workspace_user_can_read`,
+`workspace_user_can_admin`, `subscription_user_can_cancel`. The function
+returns the resource snapshot when access is granted.
+
+### Resource-scoped admin
+
+When "admin" means "admin of *this specific* resource" (the common case),
+use `<resource>_user_can_admin` in `<domain>/access.py`. When it means
+"platform admin" (Proliferate staff with system-wide privileges), use
+`get_current_platform_admin` from `auth/dependencies.py`.
+
+## Product Policy Rules
+
+`server/<domain>/domain/policy.py` owns pure product-rule verdicts.
+
+### Allowed
+
+- Pure functions taking dataclasses and returning `PolicyVerdict`.
+- Reading dataclass fields, comparing values.
+- Calling other `domain/<concern>.py` functions.
+
+### Banned
+
+- Raising `HTTPException`. Return a verdict; let the service raise.
+- I/O, async, ORM, store imports.
+- Service.py imports.
+- Logging beyond pure data tracing.
+
+### Standard shape
+
+```python
+# server/cloud/workspaces/domain/policy.py
+from auth.authorization import PolicyAllowed, PolicyDenied, PolicyVerdict
+
+def can_delete_workspace(workspace: WorkspaceSnapshot) -> PolicyVerdict:
+    if workspace.status == WorkspaceStatus.DELETING:
+        return PolicyDenied(
+            code="ALREADY_DELETING",
+            reason="Workspace is already being deleted",
+        )
+    if workspace.has_active_sessions:
+        return PolicyDenied(
+            code="HAS_ACTIVE_SESSIONS",
+            reason="Cancel active sessions before deleting",
+        )
+    return PolicyAllowed()
+```
+
+### Service composition
+
+```python
+# server/cloud/workspaces/service.py
+async def delete_workspace(
+    db: AsyncSession,
+    *,
+    workspace: WorkspaceSnapshot,
+) -> None:
+    verdict = policy.can_delete_workspace(workspace)
+    if isinstance(verdict, PolicyDenied):
+        raise WorkspaceConflict(code=verdict.code, reason=verdict.reason)
+    await store.cloud_workspaces.mark_deleting(db, workspace.id)
+```
+
+The service raises a domain error; the global exception handler maps it to
+HTTPException with the `code` field.
+
+## End-to-End Example
+
+```python
+# server/cloud/workspaces/api.py
+@router.delete("/cloud/workspaces/{workspace_id}")
+async def delete_cloud_workspace(
+    workspace: WorkspaceSnapshot = Depends(workspace_user_can_admin),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkspaceResponse:
+    await service.delete_workspace(db, workspace=workspace)
+    return workspace_response(workspace)
+```
+
+Five files, each with one job:
+
+1. **`auth/dependencies.py`** — `get_current_user` (authentication).
+2. **`auth/authorization.py`** — `require_org_role`, `PolicyVerdict`
+   (shared helpers).
+3. **`cloud/workspaces/access.py`** — `workspace_user_can_admin` (resource
+   access; lookup + role check + return snapshot).
+4. **`cloud/workspaces/domain/policy.py`** — `can_delete_workspace` (pure
+   product rule).
+5. **`cloud/workspaces/service.py`** — `delete_workspace` (orchestration:
+   policy check + store call).
+
+The handler is three lines. No auth check is inline in the service body or
+the handler body.
+
+## Forbidden Patterns
+
+- Authorization checks inline in `api.py` route handler bodies. Use deps.
+- Authorization checks inline in `service.py` when they could have been
+  route deps. Front-load access checks via `Depends`.
+- Product rules buried as `if not condition: raise HTTPException(403)` in
+  `service.py`. Extract to pure verdict functions in `domain/policy.py`.
+- Cross-domain imports for auth infrastructure
+  (`from organizations.service import require_org_role`). Always import
+  from `auth.authorization`.
+- Returning Pydantic from access deps. Return the dataclass snapshot.
+- Catching `HTTPException` from a route dep to translate it. The dep raises
+  the right code; the handler shouldn't intercept.
+- Mixing authentication and authorization in one dep. Each dep does one
+  job; compose them via `Depends(... = Depends(...))`.
+
+## Migration Notes
+
+When moving authorization helpers to `auth/authorization.py`:
+
+1. Move `require_org_role` and related helpers from
+   `organizations/service.py`.
+2. Update every importer to use `from auth.authorization import
+   require_org_role`.
+3. Verify no domain-specific assumptions baked into the helpers; helpers
+   are domain-agnostic.
+
+When introducing `<domain>/access.py`:
+
+1. Identify endpoints currently doing authorization inline in service.py.
+2. Move the lookup + access check to a route dep returning the resource.
+3. Update the handler to take the resource via `Depends(...)`.
+4. Remove the inline authorization from the service.
+5. Service now operates on a snapshot known to be authorized.
+
+When introducing `<domain>/domain/policy.py`:
+
+1. Find inline `if not allowed: raise HTTPException(...)` blocks in
+   `service.py`.
+2. Convert each to a pure verdict function.
+3. Service calls the verdict, raises a domain error on `PolicyDenied`.
+4. Verify the function is unit-testable with no DB or HTTP context.

--- a/docs/server/guides/config.md
+++ b/docs/server/guides/config.md
@@ -63,6 +63,8 @@ Put it here when the value is:
   default policy
 - a protocol label, header name, sentinel value, or status string
 - meaningful enough that changing it is a product decision
+- part of an API-visible contract, even if only one parser or service uses it
+  today
 
 Examples:
 
@@ -92,7 +94,10 @@ Rules:
 ## File-Local Constants
 
 File-local constants are allowed only when they are mechanical implementation
-details with no broader product meaning.
+details with no broader product meaning. Do not keep a value local just
+because it has one caller; if changing it changes product behavior, API
+behavior, billing behavior, security behavior, or runtime protocol behavior,
+put it in `constants/<area>.py` or `config.py`.
 
 Allowed examples:
 
@@ -100,6 +105,7 @@ Allowed examples:
 _OWNER_ALIAS = "owner"
 _CURSOR_SEPARATOR = ":"
 _EMAIL_RE = re.compile(...)
+_DATEUTIL_ANCHOR_YEAR = 2020
 ```
 
 These values may stay in the file that owns the implementation.
@@ -111,6 +117,7 @@ MAX_WORKSPACES_PER_ORG = 10
 DEFAULT_AUTOMATION_TIMEOUT_SECONDS = 600
 RETRY_COUNT = 5
 SUPPORTED_RUNTIME_VERSION = "..."
+SUPPORTED_PROTOCOL_OPTIONS = {"mode", "interval", "timeout"}
 ```
 
 Those carry product or protocol policy and belong in `constants/<area>.py` or
@@ -123,7 +130,7 @@ Ask these in order:
 1. **Can an operator change it by env/deployment?** Put it in `config.py`.
 2. **Does changing it alter product/protocol behavior?** Put it in
    `constants/<area>.py`.
-3. **Is it only a private implementation detail in one file?** Keep it
+3. **Is it only a private mechanical detail in one file?** Keep it
    file-local.
 
 If unsure, prefer `constants/<area>.py` over scattering the value inline.

--- a/docs/server/guides/config.md
+++ b/docs/server/guides/config.md
@@ -1,0 +1,144 @@
+# Config And Constants
+
+Status: authoritative for `config.py`, `constants/<area>.py`, and server
+module-level constants.
+
+Read after `docs/server/README.md` when a change introduces or moves settings,
+limits, defaults, timeouts, headers, protocol labels, feature flags, URLs, or
+other shared values.
+
+## Ownership
+
+The server has three homes for values:
+
+| Value kind | Home | Question |
+|---|---|---|
+| Env-derived runtime setting | `config.py` | Can this vary by deployment, environment, secret, or operator choice? |
+| Shared hardcoded policy value | `constants/<area>.py` | Is this a product/protocol rule reused or meaningful outside one file? |
+| File-local mechanical value | the owning file | Is this only an implementation detail of one function/module? |
+
+Do not leave product policy values scattered through `api.py`, `service.py`,
+`db/store/**`, worker files, or integrations.
+
+## `config.py`
+
+`config.py` owns runtime settings derived from environment or deployment
+configuration.
+
+Put it here when the value is:
+
+- a secret or credential
+- a hostname, URL, origin, issuer, bucket, role ARN, or external endpoint
+- a feature flag
+- a timeout, limit, or mode that operators may tune per deployment
+- local-dev/self-hosted/production-specific
+
+Examples:
+
+```python
+DATABASE_URL = os.environ["DATABASE_URL"]
+STRIPE_WEBHOOK_SECRET = os.environ["STRIPE_WEBHOOK_SECRET"]
+CLOUD_RUNTIME_BASE_URL = os.getenv("CLOUD_RUNTIME_BASE_URL", "http://localhost:...")
+ENABLE_BILLING_RECONCILER = env_bool("ENABLE_BILLING_RECONCILER", default=False)
+```
+
+Rules:
+
+- Do not import product services or stores from `config.py`.
+- Do not put hardcoded product constants here just because many files need
+  them.
+- `localhost` defaults are allowed here. They are not allowed scattered in
+  services, stores, or integrations.
+- Integration files read credentials and vendor endpoints from `config.py`.
+
+## `constants/<area>.py`
+
+`constants/**` owns hardcoded shared values that are part of product behavior,
+protocol behavior, or validation policy.
+
+Put it here when the value is:
+
+- reused by more than one file
+- a product limit, validation bound, timeout, retry count, page size, or
+  default policy
+- a protocol label, header name, sentinel value, or status string
+- meaningful enough that changing it is a product decision
+
+Examples:
+
+```python
+# constants/billing.py
+DEFAULT_TRIAL_DAYS = 14
+USAGE_RECONCILE_BATCH_SIZE = 500
+
+# constants/cloud.py
+WORKSPACE_NAME_MAX_LENGTH = 120
+CLOUD_RUNTIME_CONNECT_TIMEOUT_SECONDS = 30
+
+# constants/http.py
+REQUEST_ID_HEADER = "x-request-id"
+```
+
+Rules:
+
+- Constants use `UPPER_SNAKE_CASE`.
+- Organize by area: `billing.py`, `cloud.py`, `auth.py`, `automations.py`,
+  `http.py`.
+- Do not create `constants/misc.py`, `constants/common.py`, or
+  `constants/helpers.py`.
+- If a value becomes deployment-specific, move it from `constants/**` to
+  `config.py`.
+
+## File-Local Constants
+
+File-local constants are allowed only when they are mechanical implementation
+details with no broader product meaning.
+
+Allowed examples:
+
+```python
+_OWNER_ALIAS = "owner"
+_CURSOR_SEPARATOR = ":"
+_EMAIL_RE = re.compile(...)
+```
+
+These values may stay in the file that owns the implementation.
+
+Banned examples:
+
+```python
+MAX_WORKSPACES_PER_ORG = 10
+DEFAULT_AUTOMATION_TIMEOUT_SECONDS = 600
+RETRY_COUNT = 5
+SUPPORTED_RUNTIME_VERSION = "..."
+```
+
+Those carry product or protocol policy and belong in `constants/<area>.py` or
+`config.py`.
+
+## Placement Test
+
+Ask these in order:
+
+1. **Can an operator change it by env/deployment?** Put it in `config.py`.
+2. **Does changing it alter product/protocol behavior?** Put it in
+   `constants/<area>.py`.
+3. **Is it only a private implementation detail in one file?** Keep it
+   file-local.
+
+If unsure, prefer `constants/<area>.py` over scattering the value inline.
+
+## Migration Notes
+
+When cleaning an existing domain:
+
+1. Search for module-level literals in `api.py`, `service.py`, worker files,
+   and `db/store/**`.
+2. Classify each as config, shared constant, or file-local mechanical detail.
+3. Move shared hardcoded policy values to `constants/<area>.py`.
+4. Move env-derived values or deployment defaults to `config.py`.
+5. Leave private mechanical values local and rename them with a leading
+   underscore if that clarifies scope.
+
+Do not mix constants cleanup with behavior changes. Moving a value should
+preserve the value exactly unless the task explicitly changes the policy.

--- a/docs/server/guides/database.md
+++ b/docs/server/guides/database.md
@@ -1,0 +1,438 @@
+# Database
+
+Status: authoritative for `db/store/`, `db/models/`, transactions, and the
+type pipeline between persistence, internal logic, and wire format.
+
+Read after `docs/server/README.md`. This guide details how database access is
+organized, how data flows from ORM to dataclass to Pydantic, how transactions
+are owned, and the column conventions that apply across the schema.
+
+## Ownership
+
+The database layer has three concerns:
+
+- **`db/models/`** owns ORM table definitions. Persistence schema only.
+- **`db/store/`** owns DB access — query construction, `db.execute(...)`,
+  reads, writes. The only place SQLAlchemy is used.
+- **The type pipeline** maps each persistence row through three layers: ORM
+  (mutable, session-coupled) → dataclass (frozen, internal) → Pydantic (wire
+  format).
+
+Transactions, dataclass conventions, and DB column conventions all live in
+this guide because they're all aspects of the database layer.
+
+## `db/models/`
+
+ORM tables. Nothing else.
+
+### Folder shape
+
+```text
+db/models/
+  __init__.py
+  base.py
+  <resource>.py        # one ORM file per resource cluster
+```
+
+Examples: `cloud.py`, `billing.py`, `automations.py`, `auth.py`,
+`organizations.py`. A single ORM file may declare multiple related table
+classes (a primary entity plus its junction tables).
+
+### Allowed
+
+- SQLAlchemy `Mapped[...]` declarations.
+- `__tablename__`, columns, indexes, constraints.
+- Foreign-key relationships.
+- Type-only enum imports (the Python enum lives in `domain/`).
+- Inheritance via the shared `Base` from `db/models/base.py`.
+
+### Banned
+
+- API request or response models.
+- Service logic.
+- Computed properties that do business work. Simple derived properties
+  (e.g., `is_active = Column(...)`) are fine.
+- Deep `BaseFoo → BaseBar → Concrete` hierarchies. Use composition, not
+  inheritance trees.
+- Importing `db/store/**`, `service.py`, integrations, or business code.
+
+## `db/store/`
+
+All DB access lives here.
+
+### Folder shape
+
+Default: flat file per resource.
+
+```text
+db/store/
+  __init__.py
+  <resource>.py
+```
+
+Each store file owns DB access for **one ORM resource** (and its tightly-related
+supporting tables — e.g., a junction table for many-to-many). The boundary is
+the ORM model, not the product concept.
+
+When ≥4 closely-related stores cluster, use a folder:
+
+```text
+db/store/<area>/
+  __init__.py
+  <resource>.py        # un-prefixed inside the folder
+```
+
+Inside the folder, file names drop the area prefix because context lives in
+the folder name. Example: `db/store/cloud_mcp/connections.py`, not
+`db/store/cloud_mcp/cloud_mcp_connections.py`.
+
+Pick one shape per area. A folder either has all of its area's stores inside,
+or none.
+
+### Allowed
+
+- `async def` functions taking `db: AsyncSession` as a parameter.
+- `select(...)`, `insert(...)`, `update(...)`, `delete(...)`,
+  `db.execute(...)`.
+- ORM model imports from `db/models/**`.
+- Frozen dataclasses returned to services (read-result snapshots).
+- Internal SQL helpers as private functions (`_build_filter_clause`).
+- Resource-specific constants (table aliases, query fragments) as module-level
+  constants.
+
+### Banned
+
+- Opening a session inside a store function (`async with
+  async_session_factory() as db`). Stores take a session; they don't open
+  one.
+- Calling `db.commit()` or `db.rollback()`. Callers own commits.
+- Calling another store function from within a store. Stores are leaves;
+  they don't call peers. If you need cross-store logic, that's service work.
+- Importing `service.py`, integrations, FastAPI, or business code.
+- Returning ORM objects to services. Always return frozen dataclasses.
+- Mixing parameter-injected and self-opening patterns in the same file.
+
+### Standard function shape
+
+```python
+@dataclass(frozen=True)
+class WorkspaceSnapshot:
+    id: UUID
+    status: WorkspaceStatus
+    runtime_generation: int
+    created_at: datetime
+
+async def get_workspace_snapshot(
+    db: AsyncSession, workspace_id: UUID
+) -> WorkspaceSnapshot | None:
+    workspace = await db.get(CloudWorkspace, workspace_id)
+    if workspace is None:
+        return None
+    return WorkspaceSnapshot(
+        id=workspace.id,
+        status=workspace.status,
+        runtime_generation=workspace.runtime_generation,
+        created_at=workspace.created_at,
+    )
+
+async def list_workspaces_for_owner(
+    db: AsyncSession, owner_id: UUID
+) -> tuple[WorkspaceSnapshot, ...]:
+    rows = await db.execute(
+        select(CloudWorkspace)
+        .where(CloudWorkspace.owner_id == owner_id)
+        .where(CloudWorkspace.deleted_at.is_(None))
+    )
+    return tuple(
+        WorkspaceSnapshot(...)
+        for w in rows.scalars().all()
+    )
+```
+
+Reads return dataclasses or tuples of dataclasses. Writes return primitive
+result types (`UUID`, `bool`, `None`) or a small frozen dataclass when more
+information is needed.
+
+### Eager loading
+
+Stores explicitly load relationships needed for the snapshot. No lazy
+attribute access leaks past the store boundary.
+
+```python
+# Good
+rows = await db.execute(
+    select(CloudWorkspace)
+    .options(selectinload(CloudWorkspace.runtime_environment))
+    .where(...)
+)
+
+# Bad — implicit lazy load when the service reads workspace.runtime_environment
+rows = await db.execute(select(CloudWorkspace).where(...))
+```
+
+If the dataclass needs a relationship's data, the store eager-loads it. If
+the relationship is only needed sometimes, define a separate read function
+that loads it.
+
+### Locking
+
+Row-level locks live in stores, named `acquire_<resource>_<purpose>_lock`.
+They require an open transaction.
+
+```python
+async def acquire_billing_subject_repo_limit_lock(
+    db: AsyncSession, billing_subject_id: UUID
+) -> None:
+    await db.execute(
+        select(BillingSubject)
+        .where(BillingSubject.id == billing_subject_id)
+        .with_for_update()
+    )
+```
+
+Callers must wrap in a transaction (request session or
+`async with db.begin():`).
+
+### Pagination
+
+Default to cursor pagination. The store returns a tuple
+`(items, next_cursor)`:
+
+```python
+@dataclass(frozen=True)
+class WorkspacePage:
+    items: tuple[WorkspaceSnapshot, ...]
+    next_cursor: str | None
+
+async def list_workspaces_page(
+    db: AsyncSession, *, owner_id: UUID, cursor: str | None, limit: int
+) -> WorkspacePage:
+    ...
+```
+
+Cursor encoding is a store concern. Services and handlers pass cursors as
+opaque strings.
+
+## The Type Pipeline
+
+```
+   db/models/<x>.py            db/store/<x>.py             server/<domain>/models.py
+   ┌──────────────┐           ┌──────────────┐            ┌──────────────────┐
+   │  ORM model   │ ────────▶ │  dataclass   │ ─────────▶ │  Pydantic model  │
+   │  (mutable,   │  store    │  (frozen,    │  payload   │  (wire format,   │
+   │  session)    │  function │  internal)   │  function  │  validated)      │
+   └──────────────┘           └──────────────┘            └──────────────────┘
+
+   Mapping #1: in the store function. Reads ORM, returns frozen dataclass.
+   Mapping #2: in models.py. Takes dataclass, returns Pydantic.
+   Service code only ever sees the dataclass.
+```
+
+### Why three layers
+
+ORM models are mutable, session-coupled, and lazy-loading. Service code that
+operates on them accidentally triggers DB calls and can corrupt persistence
+state. Pydantic models carry wire-format concerns (validation, serialization)
+that don't belong inside services. The dataclass is the isolation layer:
+immutable, no behavior, no I/O, easy to test.
+
+### Where dataclasses live
+
+Default rule: **colocated with what owns them**.
+
+- **Read-result dataclass** (returned from a store function) → defined in
+  that store file.
+- **Service-internal dataclass** (intermediate result) → defined in
+  `service.py`.
+- **Pure-domain dataclass** (state machine state, parsed value) → defined in
+  `server/<domain>/domain/<concern>.py`.
+- **Cross-resource composed dataclass** (workspace + runtime joined for one
+  read) → defined in the store file that owns the read.
+
+### Dataclass conventions
+
+- `@dataclass(frozen=True)` for read-result dataclasses. Immutability prevents
+  accidental mutation across calls.
+- Fields are only what the service needs, not every ORM column. Trim
+  aggressively.
+- Use enums on dataclass fields, not strings. Wire-format string mapping
+  happens in the Pydantic constructor.
+- Naming: `<Resource>Snapshot` for read-result dataclasses
+  (`WorkspaceSnapshot`). `<Resource>Update` / `<Resource>Insert` for mutation
+  parameter dataclasses. Pure-domain dataclasses use whatever name fits.
+
+### Pydantic constructor functions
+
+Live in `server/<domain>/models.py`. Take dataclasses, return Pydantic.
+
+```python
+# server/cloud/workspaces/models.py
+class WorkspaceResponse(BaseModel):
+    id: UUID
+    status: str
+    runtime_generation: int
+
+def workspace_response(snapshot: WorkspaceSnapshot) -> WorkspaceResponse:
+    return WorkspaceResponse(
+        id=snapshot.id,
+        status=snapshot.status.value,
+        runtime_generation=snapshot.runtime_generation,
+    )
+```
+
+The constructor is the only place enum-to-string conversion happens. Service
+code stays on the enum side; wire stays on the string side.
+
+### Forbidden type patterns
+
+- Pydantic constructor functions taking ORM objects. Always take dataclasses.
+- `model_config = ConfigDict(from_attributes=True)` to map ORM into Pydantic.
+- Pydantic models reused as ORM substitutes or general internal containers.
+- Services receiving ORM objects directly from any caller.
+- Returning Pydantic from services to handlers. The handler calls the
+  constructor function.
+
+## Transactions
+
+One pattern: **store functions take `db: AsyncSession` and never commit**.
+Callers own transactions.
+
+### HTTP handlers
+
+The request session is provided by the FastAPI dep. The dep commits on
+success and rolls back on exception:
+
+```python
+async def get_async_session() -> AsyncIterator[AsyncSession]:
+    async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+```
+
+Multi-step writes within one request commit together because they share the
+session.
+
+### Workers and reconcilers
+
+Open a session at the entry point, wrap operations in `async with db.begin():`:
+
+```python
+async def run_billing_reconcile_pass() -> None:
+    async with async_session_factory() as db:
+        async with db.begin():
+            await store.repair_placeholders(db)
+            await store.reconcile_segments(db)
+        # commits on context exit, rolls back on exception
+```
+
+### Narrower atomicity within a request
+
+When a service needs an inner transaction smaller than the request, use
+`db.begin_nested()`:
+
+```python
+async def cancel_subscription_with_seat_reconcile(
+    db: AsyncSession, subscription_id: UUID, subject_id: UUID
+) -> None:
+    async with db.begin_nested():
+        await store.subscriptions.mark_cancelled(db, subscription_id)
+        await store.seats.reconcile_after_cancel(db, subject_id)
+    # if anything in the block raises, only this savepoint rolls back
+```
+
+### Forbidden transaction patterns
+
+- Store functions opening their own session.
+- Store functions calling `db.commit()` or `db.rollback()`.
+- Services calling `db.commit()` directly.
+- `async with db.begin():` inside a store function. If narrower atomicity is
+  needed, the caller wraps the call in `db.begin_nested()`.
+- Transaction boundaries hidden inside store function names (`commit_x`,
+  `transactional_y`). The boundary is at the caller.
+
+## DB Column Conventions
+
+### Required columns on every resource table
+
+```sql
+id           UUID         PRIMARY KEY  DEFAULT gen_random_uuid()
+created_at   TIMESTAMPTZ  NOT NULL     DEFAULT now()
+updated_at   TIMESTAMPTZ  NOT NULL     DEFAULT now()
+```
+
+`updated_at` auto-bumps on row update. Use SQLAlchemy
+`onupdate=func.now()` consistently across models.
+
+### Timestamps
+
+- **Always `TIMESTAMPTZ`** (timezone-aware). Never naive `TIMESTAMP`.
+- **Always UTC** at the application boundary.
+- **DB defaults `now()`** for `created_at` / `updated_at`. Don't set them in
+  app code unless overriding.
+- **Python:** `datetime.now(timezone.utc)`. Ban `datetime.utcnow()` (returns
+  naive — silent timezone bug source).
+
+### Soft delete
+
+- **Only when needed.** Most resources don't need soft delete; default to
+  hard delete.
+- When used: `deleted_at TIMESTAMPTZ NULL`. No `is_deleted` boolean.
+- **Reads filter `deleted_at IS NULL` by default.** A separate function
+  (`load_x_including_deleted`) reads soft-deleted rows when explicitly needed.
+
+### UUIDs and foreign keys
+
+- **All primary keys are UUID** with DB default `gen_random_uuid()`.
+- **Foreign key column naming:** `<resource>_id` singular (`user_id`,
+  `workspace_id`).
+- **Foreign keys are NOT NULL** unless the relationship is genuinely optional.
+
+### Enums
+
+- **Python:** `StrEnum` (or regular `Enum` for non-string).
+- **DB:** native Postgres enum (preferred) or `VARCHAR` with a `CHECK`
+  constraint. Pick one project-wide.
+- **Enum changes require migrations.** Adding, renaming, or dropping a value
+  → alembic migration each time.
+- **Dataclasses use the Python enum** for the field type. Wire serialization
+  happens in the Pydantic constructor.
+
+### Index and constraint naming
+
+Configure SQLAlchemy's metadata naming convention once so this is automatic:
+
+- Indexes: `ix_<table>_<column>[_<column>...]`
+- Unique: `uq_<table>_<column>[_<column>...]`
+- Foreign keys: `fk_<table>_<column>`
+- Primary keys: `pk_<table>`
+- Check constraints: `ck_<table>_<description>`
+
+### Forbidden DB patterns
+
+- `TIMESTAMP` without timezone.
+- `datetime.utcnow()` anywhere.
+- `is_deleted` boolean.
+- Foreign keys named without `_id` suffix.
+- Raw integer primary keys for new resources.
+- Lazy ORM attribute access leaking past the store boundary.
+
+## Migrations
+
+All schema changes go through alembic. Each schema migration is its own
+revision. Data migrations and schema migrations are not mixed in one
+revision unless the data migration is required for the schema change to land
+safely.
+
+Conventions:
+
+- Migration revision filenames follow alembic's default scheme.
+- Each migration's `upgrade()` and `downgrade()` are reviewed together.
+- Adding a NOT NULL column to an existing table requires a backfill plan
+  (default value at the DB level, or a multi-step migration that adds
+  nullable, backfills, then sets NOT NULL).
+- Renaming a column or table requires a multi-step migration when the
+  application is running during the change.

--- a/docs/server/guides/domains.md
+++ b/docs/server/guides/domains.md
@@ -258,10 +258,16 @@ options applies.
 
 ### 2. Extract pure logic to `domain/<concern>.py`
 
-When part of the service is pure rules — pricing, policy, validation,
-calculation, mapping — move it. The domain file imports nothing from `db/`,
-`integrations/`, or `service.py`. Service imports the pure function, calls
-it, raises on the verdict.
+When part of the service is a meaningful pure rule — pricing, policy,
+validation, calculation, state transition, or mapping — move it. The domain
+file imports nothing from `db/`, `integrations/`, or `service.py`. Service
+imports the pure function, calls it, raises on the verdict.
+
+Do not extract every pure private helper. A tiny one-path helper may stay in
+`service.py` when it only supports one orchestration path and moving it would
+create a one-function domain file. Extract to `domain/` when the rule is
+product policy, reusable, directly testable, or materially clarifies the
+service flow.
 
 ### 3. Promote a subdomain
 

--- a/docs/server/guides/domains.md
+++ b/docs/server/guides/domains.md
@@ -419,7 +419,7 @@ cloud/runtime/
   api.py
   service.py                              ← cross-cutting only
   models.py                               ← shared types
-  
+
   provisioning/                           ← subdomain
     service.py                            ← was provision.py (further decomposed)
     models.py                             ← provision input/result types

--- a/docs/server/guides/domains.md
+++ b/docs/server/guides/domains.md
@@ -75,6 +75,8 @@ Allowed:
 - Route declarations with typed Pydantic return annotations.
 - Resource-access deps via `Depends(<domain>_user_can_<action>)`.
 - Authentication deps via `Depends(get_current_user)`.
+- Session injection via `db: AsyncSession = Depends(get_async_session)` —
+  the handler receives the request session and passes it to the service.
 - Response construction via `<domain>/models.py` payload functions.
 - Request body validation via Pydantic input models.
 
@@ -82,7 +84,11 @@ Banned:
 
 - Authorization checks inline in handler bodies. Use deps.
 - Direct `db/store/**` imports.
-- `AsyncSessionDep`, `get_async_session`, or `async_session_factory` imports.
+- Calling `AsyncSession` methods (`db.execute`, `db.commit`, `db.add`)
+  inside the handler body. The handler injects `db` and forwards it; only
+  services and stores call methods on it.
+- `async_session_factory` imports. The handler uses
+  `Depends(get_async_session)`, never opens its own session.
 - SQLAlchemy imports.
 - Business logic. Move to `service.py`.
 - ORM model imports other than `User` from auth.
@@ -96,20 +102,26 @@ between handlers and stores.
 
 Allowed:
 
-- Composing multiple store function calls within a single transaction.
+- `db: AsyncSession` as a parameter (passed by the handler or the worker
+  entry point). Service functions take this and thread it to stores.
+- Composing multiple store function calls within a single transaction
+  (the request session by default; `db.begin_nested()` for narrower
+  atomicity).
 - Calling integrations via their public API.
 - Calling pure functions in `domain/`.
 - Calling other domains' public service functions for *writes*.
 - Calling other domains' stores for *reads*.
 - Raising domain errors (`raise WorkspaceAlreadyDeleting(...)`).
-- `async with db.begin_nested():` for narrower atomicity.
 
 Banned:
 
-- `AsyncSession`, `AsyncSessionDep`, `get_async_session`,
-  `async_session_factory`, SQLAlchemy direct imports.
+- `async_session_factory` imports. Services don't open sessions; they
+  receive them.
+- SQLAlchemy direct imports (`from sqlalchemy import ...`).
 - `select()`, `insert()`, `update()`, `delete()`, `db.execute()`. All DB
   access goes through stores.
+- `db.commit()` or `db.rollback()`. Transactions are owned by the caller
+  (the FastAPI dep for HTTP handlers; the worker entry point for workers).
 - Authorization checks inline. Use route deps for resource access; call
   `domain/policy.py` for product rules.
 - Inline status-to-label maps or other repeated presentation logic.

--- a/docs/server/guides/domains.md
+++ b/docs/server/guides/domains.md
@@ -1,0 +1,462 @@
+# Server Domains
+
+Status: authoritative for `server/<domain>/` layout.
+
+Read after `docs/server/README.md`. This guide details the shape of a backend
+product domain: api/service/models layout, where pure logic goes, when to
+promote a subdomain, how worker-side logic fits in, and how domains coordinate
+with each other.
+
+## Ownership
+
+A `server/<domain>/` folder is one product area's home. It owns:
+
+- HTTP transport via `api.py`
+- Business orchestration via `service.py`
+- Pydantic transport schemas via `models.py`
+- Pure rules via `domain/<concern>.py`
+- Resource-access route deps via `access.py` (when the domain has protected resources)
+- Domain-specific errors via `errors.py` (when needed)
+- Non-HTTP entry points via `worker.py` / `reconciler.py` (when applicable)
+- Promoted subdomains via `<subdomain>/` (when earned)
+
+A domain folder must answer "what product area?" — not transport, not UI shape,
+not deployment target.
+
+## Folder Shape
+
+Default shape for a small or moderate domain:
+
+```text
+server/<domain>/
+  api.py
+  service.py
+  models.py
+```
+
+Extended shape when the domain has more structure:
+
+```text
+server/<domain>/
+  api.py
+  service.py
+  models.py
+  access.py                 # resource-access route deps
+  errors.py                 # domain-specific error types
+  domain/                   # pure logic
+    policy.py
+    <concern>.py
+  worker.py                 # non-HTTP entry point (or worker/ subfolder)
+  reconciler.py             # state-drift loop (when applicable)
+  <subdomain>/              # promoted subdomain
+    api.py
+    service.py
+    models.py
+    domain/
+```
+
+The hierarchy answers three questions, in order:
+
+1. What product area? — the domain folder name.
+2. Which surface within that area? — `api.py` (HTTP), `worker.py` (background),
+   `<subdomain>/` (promoted concept).
+3. What part of that surface? — `service.py` (orchestration), `domain/`
+   (pure rules), `access.py` (auth), `errors.py` (types).
+
+## What Each File Owns
+
+### `api.py`
+
+Transport only. Parses requests, calls services, returns responses. Stays
+thin. Long handler bodies are a smell.
+
+Allowed:
+
+- Route declarations with typed Pydantic return annotations.
+- Resource-access deps via `Depends(<domain>_user_can_<action>)`.
+- Authentication deps via `Depends(get_current_user)`.
+- Response construction via `<domain>/models.py` payload functions.
+- Request body validation via Pydantic input models.
+
+Banned:
+
+- Authorization checks inline in handler bodies. Use deps.
+- Direct `db/store/**` imports.
+- `AsyncSessionDep`, `get_async_session`, or `async_session_factory` imports.
+- SQLAlchemy imports.
+- Business logic. Move to `service.py`.
+- ORM model imports other than `User` from auth.
+- `try/except` around the whole handler. Let the error handler translate
+  domain errors to HTTPException.
+
+### `service.py`
+
+Business logic, orchestration, invariants, validation. The middle layer
+between handlers and stores.
+
+Allowed:
+
+- Composing multiple store function calls within a single transaction.
+- Calling integrations via their public API.
+- Calling pure functions in `domain/`.
+- Calling other domains' public service functions for *writes*.
+- Calling other domains' stores for *reads*.
+- Raising domain errors (`raise WorkspaceAlreadyDeleting(...)`).
+- `async with db.begin_nested():` for narrower atomicity.
+
+Banned:
+
+- `AsyncSession`, `AsyncSessionDep`, `get_async_session`,
+  `async_session_factory`, SQLAlchemy direct imports.
+- `select()`, `insert()`, `update()`, `delete()`, `db.execute()`. All DB
+  access goes through stores.
+- Authorization checks inline. Use route deps for resource access; call
+  `domain/policy.py` for product rules.
+- Inline status-to-label maps or other repeated presentation logic.
+- Calling another domain's `service.py` private helpers. Public functions only.
+- Calling another domain's `db/store/**` write functions. Writes go through
+  the owning service.
+
+### `models.py`
+
+Pydantic API request and response schemas. The wire format.
+
+Allowed:
+
+- Request models for input validation.
+- Response models for output serialization.
+- Constructor functions taking dataclasses (`def workspace_response(snapshot:
+  WorkspaceSnapshot) -> WorkspaceResponse`).
+- Discriminated unions for tagged responses.
+- Pydantic validators for input parsing.
+
+Banned:
+
+- Functions that take ORM objects (`def f(workspace: CloudWorkspace)`). Take
+  dataclasses instead.
+- `model_config = ConfigDict(from_attributes=True)`.
+- Pydantic models reused as ORM substitutes or general internal containers.
+- Deep schema inheritance hierarchies (`BaseFooModel` → `BaseBarModel` →
+  `BazResponse`). Keep flat.
+- ORM model imports for column-type re-use.
+
+### `domain/<concern>.py`
+
+Pure synchronous rules. The product's decision-making layer.
+
+Allowed:
+
+- Validators (`validate_<input>`).
+- State machines and reducers.
+- Calculators and pricing logic.
+- Mappings (status → tone, kind → label).
+- Planners (return command lists for an executor to run).
+- Frozen dataclasses for internal types.
+- Imports from `auth/authorization` (for `PolicyVerdict`, etc.) and other
+  `domain/` modules.
+
+Banned:
+
+- `async def` exports. Domain is synchronous; if it needs to be async, it's
+  not domain.
+- `db.models.*`, SQLAlchemy, `db/store/**` imports.
+- `httpx`, `requests`, integrations imports.
+- `fastapi` imports (no HTTP, no Depends).
+- `service.py` imports (domain doesn't depend on orchestration).
+- Side effects: file I/O, network, logging beyond pure data, environment
+  reads.
+
+### `domain/policy.py`
+
+Pure product-rule verdicts. A specific kind of `domain/` file.
+
+Allowed:
+
+- Functions returning `PolicyAllowed | PolicyDenied` (the tagged union).
+- Reading dataclass fields, comparing values, applying rules.
+
+Banned:
+
+- Raising `HTTPException`. Return a verdict; let the service raise.
+- I/O, imports from `db/`, `service.py`, integrations.
+
+### `access.py`
+
+Resource-access route dependencies. Looks up a resource, checks the user can
+touch it, returns the resource (or raises 403/404).
+
+Allowed:
+
+- `async def` functions taking `Depends(get_current_user)` and any path/query
+  params.
+- `db: AsyncSession = Depends(get_async_session)` for the lookup.
+- Calls to `db/store/**` for the resource lookup.
+- Calls to `auth/authorization.py` helpers (`require_org_role`, etc.).
+- Calls to `domain/policy.py` for state-based access checks.
+- Returning the resource as a frozen dataclass.
+
+Banned:
+
+- Mutating writes. Access deps are read-only.
+- Business logic beyond access.
+- Inline authorization helpers (use `auth/authorization`).
+
+### `errors.py`
+
+Domain-specific error types inheriting from the shared base.
+
+Allowed:
+
+- Subclasses of `ProliferateError`, `NotFoundError`, `PermissionDenied`,
+  `Conflict`.
+- A `code` class attribute matching the error kind.
+
+Banned:
+
+- Raising HTTPException directly. The shared exception handler maps the
+  domain error.
+- Catching and re-wrapping unrelated exceptions.
+- Error logic (just types).
+
+## Service Decomposition
+
+When `service.py` grows past comfortable, you have exactly five legal moves.
+Sibling helper files at the parent level are not one of them.
+
+### 1. Stay in `service.py` with internal sectioning
+
+For growth that's more orchestration of the same product concept. Up to
+~700–800 lines.
+
+```python
+# ──────────────────────────────────────
+# Subscription lifecycle
+# ──────────────────────────────────────
+async def start_subscription(...): ...
+async def cancel_subscription(...): ...
+
+# ──────────────────────────────────────
+# Usage reporting
+# ──────────────────────────────────────
+async def report_usage(...): ...
+```
+
+Beyond ~800 lines, the decomposition pressure is real and one of the next
+options applies.
+
+### 2. Extract pure logic to `domain/<concern>.py`
+
+When part of the service is pure rules — pricing, policy, validation,
+calculation, mapping — move it. The domain file imports nothing from `db/`,
+`integrations/`, or `service.py`. Service imports the pure function, calls
+it, raises on the verdict.
+
+### 3. Promote a subdomain
+
+When the spillover has its own product concept *and* its own orchestration
+mass — typically (but not always) signaled by its own API endpoints. New
+`<subdomain>/api.py + service.py + models.py`.
+
+A subdomain earns the folder when all three files would have meaningful
+content. If `models.py` would be three lines and `api.py` would have one
+route, you're over-engineering — keep it in the parent.
+
+Internal-only subdomains may have no `api.py` if the work is all background
+(e.g., a multi-step reconciliation flow). Still need `service.py` + `models.py`
+to count as a subdomain.
+
+### 4. Move vendor specifics to `integrations/<vendor>/`
+
+If the spillover is a vendor adapter — auth flow, payload normalization,
+webhook parsing — it leaves the product folder. See
+[integrations.md](integrations.md). No exceptions for "but only this domain
+uses it."
+
+### 5. Add a non-HTTP entry point
+
+`worker.py`, `scheduler.py`, `reconciler.py` for background work. See
+[workers.md](workers.md). Same layer law: no ORM imports, calls service or
+store functions.
+
+### Forbidden
+
+A top-level sibling file in `server/<domain>/` that:
+
+- Imports `db.models.*` and isn't `service.py`. Service-layer work in
+  disguise. Move to `service.py`, promote to a subdomain, or split into
+  store + service.
+- Has REST handlers. Those go in `api.py`.
+- Mixes business orchestration with vendor specifics. Split.
+- Is named `helpers.py`, `misc.py`, `utils.py`, or `common.py`. Junk-drawer.
+
+## Subdomain Promotion
+
+A subdomain earns its folder when all of:
+
+1. **Distinct product concept.** You'd describe it as a separate area in
+   product docs, not just an aspect of the parent.
+2. **Own orchestration mass.** Multi-step service-level workflows operating on
+   its own resources.
+3. **Filling api/service/models would produce meaningful content in all
+   three.**
+
+Examples that qualify in `cloud/`:
+
+- `workspaces/` — its own product concept, lifecycle, endpoints.
+- `repos/` — distinct from workspaces, own resources.
+- `mobility/` — workspace mobility is its own surface.
+
+Examples that don't qualify:
+
+- A pricing helper for billing — that's `domain/pricing.py`.
+- A reconciler — that's `reconciler.py` at the parent.
+- A two-function helper — keep inline.
+
+Internal-only subdomains exist when there's enough orchestration mass without
+external endpoints (e.g., a multi-step worker-driven flow). Same `service.py`
++ `models.py` requirement; `api.py` may be absent.
+
+## Cross-Domain Coordination
+
+Domains coordinate via two legal patterns:
+
+**Reads cross via store.** A service may import another domain's store to read
+data:
+
+```python
+# billing/service.py
+from db.store.cloud_workspaces import list_workspaces_for_subject
+
+async def compute_subject_usage(db: AsyncSession, subject_id: UUID):
+    workspaces = await list_workspaces_for_subject(db, subject_id)
+    return ...
+```
+
+The store boundary is safe — it returns frozen dataclasses, no behavior leaks.
+
+**Writes cross via service.** A service must go through another domain's
+public service functions to mutate that domain's resources:
+
+```python
+# billing/service.py
+from cloud.workspaces.service import suspend_workspace
+
+async def downgrade_subject(db: AsyncSession, subject_id: UUID):
+    workspaces = await list_workspaces_for_subject(db, subject_id)
+    for ws in workspaces:
+        await suspend_workspace(db, workspace_id=ws.id, reason="downgrade")
+```
+
+The owning service runs its own policy, invariants, and audit.
+
+### Forbidden cross-domain patterns
+
+- A service calling another domain's store *write* function directly.
+- Importing a service's private helpers (`from cloud.workspaces.service
+  import _internal`). Public functions only.
+- Cross-domain imports for auth infrastructure. Always use
+  `auth.authorization`.
+- Two domains both writing the same ORM resource. The resource has one
+  owning domain whose service is the write boundary.
+
+The same pattern applies to subdomains within a parent: read via store, write
+via service.
+
+## Worker-Side Logic
+
+When a domain has substantial worker-side logic that's distinct from
+HTTP-side work, promote it to a `worker/` (or `runtime/`) subfolder. Inside,
+the shape mirrors a subdomain: `main.py` (entry), `service.py` (worker-facing
+orchestration), other named modules for substantial concerns.
+
+```text
+server/automations/
+  api.py
+  service.py            # API-facing service: CRUD on automation definitions
+  models.py             # API schemas
+  domain/
+    recurrence.py       # pure RRULE parsing
+    policy.py
+  worker/
+    main.py             # process entry
+    service.py          # worker-facing service: pick due, dispatch, record
+    scheduler.py        # scheduler loop body
+    cloud_executor.py
+    local_executor.py
+```
+
+Two `service.py` files coexist when surfaces are genuinely distinct. They
+share `domain/` and the store. See [workers.md](workers.md) for the full
+worker organization.
+
+## Worked Example: Cloud Runtime Carving
+
+Today `cloud/runtime/` is a 17-file flat folder mixing five distinct
+concerns. Post-carving:
+
+```text
+integrations/anyharness/                  ← MOVED OUT
+  __init__.py
+  client.py                               ← was anyharness_api.py
+  sessions.py                             ← was session_api.py
+  workspace_operations.py                 ← was workspace_operations.py
+  errors.py
+  models.py
+
+cloud/runtime/
+  api.py
+  service.py                              ← cross-cutting only
+  models.py                               ← shared types
+  
+  provisioning/                           ← subdomain
+    service.py                            ← was provision.py (further decomposed)
+    models.py                             ← provision input/result types
+    bootstrap.py                          ← runtime startup setup
+    git_operations.py
+    sandbox_helpers.py                    ← was sandbox_exec.py
+    scheduler.py                          ← provision task scheduling
+    domain/
+      step_tracker.py                     ← _StepTracker extracted
+      identity_resolver.py                ← _resolve_git_identity extracted
+      data_key.py                         ← was top-level
+
+  credentials/                            ← subdomain
+    service.py                            ← sync_workspace_credentials
+    models.py                             ← provision credential dataclasses
+    domain/
+      freshness.py                        ← was credential_freshness.py
+
+  config_sync/                            ← subdomain
+    service.py                            ← combines repo + worktree policy
+    repo_config.py                        ← was repo_config_apply.py
+    worktree_policy.py                    ← was worktree_policy_sync.py
+
+  liveness/                               ← subdomain
+    service.py                            ← ensure_running orchestration
+    reconciler.py                         ← was setup_monitor.py
+    domain/
+      restart_policy.py                   ← pure restart logic
+      health_checks.py                    ← provider-specific health waits
+```
+
+Each subdomain is coherent and reasonably sized. The AnyHarness vendor client
+leaves product code entirely. `provisioning/service.py` is still large after
+the carving and needs internal decomposition as a follow-up — that work
+extracts the pure helpers (step tracker, identity resolver) into
+`provisioning/domain/`.
+
+## Patterns
+
+- A domain folder either has subfolder children consistently or is flat.
+  Mixed shapes (some subfolders, some flat sibling files belonging to a
+  subdomain) are forbidden.
+- Service composes; domain decides; store persists. If you find a service
+  computing a complex rule inline, the rule belongs in `domain/`. If you find
+  a domain function calling a store, it's not domain.
+- The `models.py` constructor functions are the explicit type boundary
+  between internal dataclasses and wire format. They never see ORM.
+- Services import dataclasses (not Pydantic) when calling each other across
+  domains. The Pydantic boundary is at `api.py`.
+- Long functions in `service.py` usually want to be a planner in `domain/`
+  plus a thin executor in `service.py`. The planner returns command-shaped
+  data; the executor runs it.

--- a/docs/server/guides/errors.md
+++ b/docs/server/guides/errors.md
@@ -1,0 +1,187 @@
+# Errors
+
+Status: authoritative for server error classes, integration-error
+translation, and HTTP error mapping.
+
+Read after `docs/server/README.md` when a change adds, moves, catches, or
+translates errors.
+
+## Ownership
+
+The server has three error layers:
+
+| Layer | Home | Owns |
+|---|---|---|
+| Shared product errors | `server/proliferate/errors.py` | Base class and common HTTP-shaped categories. |
+| Domain errors | `server/<domain>/errors.py` | Product/domain failures with stable error codes. |
+| Integration errors | `integrations/<vendor>/errors.py` or the integration file | Vendor/protocol failures. |
+
+HTTP translation is centralized. Product services raise product/domain errors;
+the FastAPI exception handler maps those errors to the JSON response shape.
+
+## Shared Product Errors
+
+`server/proliferate/errors.py` owns the common base and generic categories:
+
+```python
+class ProliferateError(Exception):
+    code: str
+    message: str
+    status_code: int
+
+
+class NotFoundError(ProliferateError): ...
+class PermissionDenied(ProliferateError): ...
+class Conflict(ProliferateError): ...
+class InvalidRequest(ProliferateError): ...
+```
+
+The exact class names may grow with usage, but the shape is stable:
+
+- `code` is the stable machine-readable error code.
+- `message` is the client-facing message.
+- `status_code` is the HTTP status chosen by the product error type.
+
+Do not make shared errors know about any one product domain.
+
+## Domain Errors
+
+Domain errors live beside the domain they describe:
+
+```text
+server/<domain>/
+  errors.py
+  service.py
+  api.py
+```
+
+Use a domain error when the failure is product behavior:
+
+- missing resource
+- forbidden action
+- invalid domain input
+- conflict with current state
+- product limit reached
+- domain-specific unavailable state
+
+Domain errors inherit from the shared base or one of the shared categories.
+
+```python
+class ResourceNotReady(Conflict):
+    code = "resource_not_ready"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
+```
+
+Services raise domain errors. APIs do not catch and translate them in each
+route; the global handler owns translation.
+
+## Integration Errors
+
+Integration errors stay inside the integration boundary.
+
+```text
+integrations/<vendor>/
+  errors.py
+  client.py
+```
+
+Integration errors should describe vendor/protocol failures, not product
+meaning. They do not inherit from `ProliferateError`.
+
+Product services catch integration errors and translate them into domain
+errors:
+
+```python
+try:
+    result = await vendor_call(...)
+except VendorIntegrationError as exc:
+    raise DomainUnavailable("Could not complete the operation.") from exc
+```
+
+That translation is where product meaning enters.
+
+## HTTP Translation
+
+The FastAPI app registers one handler for `ProliferateError` subclasses.
+
+The response shape is:
+
+```json
+{
+  "detail": {
+    "code": "stable_error_code",
+    "message": "Client-facing message."
+  }
+}
+```
+
+Route files should not repeat this translation:
+
+```python
+# Bad
+try:
+    await service.do_work(...)
+except DomainError as error:
+    raise HTTPException(
+        status_code=error.status_code,
+        detail={"code": error.code, "message": error.message},
+    )
+```
+
+Use the global handler instead:
+
+```python
+# Good
+await service.do_work(...)
+```
+
+## Direct `HTTPException`
+
+Direct `HTTPException` is allowed only at actual HTTP boundaries:
+
+- framework authentication/authorization dependencies that integrate directly
+  with FastAPI
+- routes returning non-product assets or callback pages where the response is
+  not the normal JSON error contract
+- temporary transitional route translation while a domain has not yet moved to
+  product errors
+
+It is banned in:
+
+- `db/store/**`
+- `server/<domain>/domain/**`
+- integrations
+- pure helpers
+- stores or service internals that can raise a product/domain error instead
+
+## Catching And Wrapping
+
+Allowed:
+
+- Service catches an integration error and raises a domain error.
+- Service catches a known lower-level product error and maps it to a
+  more-specific domain error.
+- Worker entry points catch unexpected exceptions to log/report and then
+  either re-raise or record failure state.
+
+Banned:
+
+- Broad `except Exception` that swallows the error.
+- Catching a domain error in an API route only to reformat it.
+- Integration code catching its own error type to produce an HTTP response.
+- Domain errors wrapping unrelated exceptions without adding product meaning.
+
+## Migration Notes
+
+When migrating a domain:
+
+1. Add or update `server/<domain>/errors.py`.
+2. Convert service-layer `*ServiceError` classes to domain errors.
+3. Register or reuse the global `ProliferateError` handler.
+4. Delete per-route `except DomainError: raise HTTPException(...)` blocks.
+5. Keep integration errors integration-local and translate them in services.
+
+Do not mix error migration with unrelated behavior changes. Preserve codes,
+messages, and status codes unless the task explicitly changes the contract.

--- a/docs/server/guides/integrations.md
+++ b/docs/server/guides/integrations.md
@@ -75,6 +75,8 @@ or any set of features that don't fit cleanly in one file.
 - `<concern>.py` — distinct features: `webhooks.py`, `oauth.py`,
   `notifications.py`.
 - `__init__.py` — exports the public API. Internals stay vendor-local.
+  This is the explicit Python-package exception to the repo-wide no-barrel
+  rule; use it only for integration package public APIs.
 
 Example (today): `slack/` with `webhooks.py` + `errors.py`.
 
@@ -147,6 +149,11 @@ For single-file integrations, the public API is whatever the file exports
 
 For folder integrations, the public API is what `__init__.py` exports.
 Everything else stays vendor-local.
+
+This `__init__.py` export surface is intentional for integration packages:
+services import the vendor API from one stable package boundary while
+integration internals remain private. Do not use this pattern as a general
+convenience re-export elsewhere in the server tree.
 
 ```python
 # integrations/stripe/__init__.py

--- a/docs/server/guides/integrations.md
+++ b/docs/server/guides/integrations.md
@@ -80,6 +80,13 @@ or any set of features that don't fit cleanly in one file.
 
 Example (today): `slack/` with `webhooks.py` + `errors.py`.
 
+Concern files should be coarse and meaningful. Do not mechanically mirror
+every endpoint, REST resource, or SDK method into its own file. Start with the
+operational seams that product code naturally cares about: auth, webhooks,
+OAuth, sessions, provisioning, file operations, notifications, etc. Split
+further only when a concern file grows large, has a distinct consumer set, or
+contains multiple independent policies.
+
 ### Shape 3: Folder, polymorphic
 
 ```text
@@ -120,6 +127,8 @@ Shape can change over time:
   webhooks, OAuth, etc.).
 - Single-provider folder → polymorphic folder when a second vendor is added
   for the same protocol.
+- Coarse concern file → narrower concern files only after the narrower split
+  earns its place. Avoid endpoint-per-file structures by default.
 
 ## What Goes Inside an Integration
 
@@ -245,8 +254,9 @@ service owns "what to do when the event arrives."
 
 - Single-file folders (e.g., `integrations/billing/stripe.py` as the only
   file). Flatten or add real content.
-- Vendor-specific code in product domains (`server/cloud/runtime/anyharness_api.py`
-  is the canonical violation — it belongs in `integrations/anyharness/`).
+- External protocol/client code in product domains. Product domains may
+  orchestrate results, but raw HTTP/SDK protocol access belongs behind the
+  owning integration boundary.
 - Cross-vendor imports (`integrations/stripe/` importing from
   `integrations/anthropic/`). Integrations are independent.
 - Imports from `server/<domain>/**` inside an integration. Integrations don't

--- a/docs/server/guides/integrations.md
+++ b/docs/server/guides/integrations.md
@@ -1,0 +1,274 @@
+# Integrations
+
+Status: provisional. Authoritative for `integrations/<vendor>/` shapes and
+adapter conventions until the integration patterns are revisited.
+
+Read after `docs/server/README.md`. This guide details how third-party SDK
+and API access is organized: when to use a single file, when to promote to a
+folder, and how multi-vendor protocols are abstracted.
+
+This guide is marked provisional because the current rules are based on a
+small number of existing integrations. Patterns may shift as new
+integrations expose gaps.
+
+## Ownership
+
+`integrations/` owns all third-party SDK and API access. Every external
+network call originates here. Product code calls integrations through their
+public API only; integration internals stay vendor-local.
+
+Integration code owns:
+
+- Vendor client construction
+- Authentication and credential handling for the vendor
+- Payload normalization (request/response shape adjustments)
+- Vendor-specific error handling and retry policies
+- Webhook signature verification (when applicable)
+- Vendor-specific data types
+
+Integration code does not own:
+
+- Product business logic.
+- Database access (no `db/store/**` imports).
+- Service-layer orchestration.
+
+## Folder Shape
+
+Three legal shapes, picked by what the integration is.
+
+### Shape 1: Single file (default)
+
+```text
+integrations/<vendor>.py
+```
+
+For simple integrations: one vendor, one cohesive purpose, < 300 lines.
+
+Inside the file:
+
+- Error class for the vendor's failures.
+- Client construction or authentication setup.
+- Payload dataclasses (when the integration parses structured responses).
+- Public functions exported to product code.
+
+Examples (today): `anthropic.py`, `customerio.py`, `github.py`, `resend.py`,
+`sentry.py`, `anonymous_telemetry.py`.
+
+### Shape 2: Folder, single provider
+
+```text
+integrations/<vendor>/
+  __init__.py
+  client.py
+  models.py
+  errors.py
+  <concern>.py
+```
+
+For a vendor with multiple distinct concerns: auth + webhooks + OAuth flows,
+or any set of features that don't fit cleanly in one file.
+
+- `client.py` — base client, authentication, low-level calls.
+- `models.py` — typed payload dataclasses (or Pydantic if parsing untrusted
+  input from the vendor).
+- `errors.py` — error types raised by the integration.
+- `<concern>.py` — distinct features: `webhooks.py`, `oauth.py`,
+  `notifications.py`.
+- `__init__.py` — exports the public API. Internals stay vendor-local.
+
+Example (today): `slack/` with `webhooks.py` + `errors.py`.
+
+### Shape 3: Folder, polymorphic
+
+```text
+integrations/<protocol>/
+  __init__.py
+  base.py
+  <provider>.py
+  factory.py
+  models.py
+  errors.py
+```
+
+For multiple vendors implementing the same protocol where product code
+selects an implementation at runtime.
+
+- `base.py` — abstract interface or protocol that all providers implement.
+- `<provider>.py` — each implementation (e.g., `daytona.py`, `e2b.py`).
+- `factory.py` — provider selection logic (config-driven, identity-driven,
+  etc.).
+- `models.py` — shared types across providers.
+- `errors.py` — shared error types raised by any provider.
+- `__init__.py` — exports the factory and shared types.
+
+Example (today): `sandbox/` with `base.py`, `daytona.py`, `e2b.py`,
+`factory.py`.
+
+## Picking a Shape
+
+| You have | Pick |
+|---|---|
+| One vendor, < 300 lines, one concern | Shape 1 (single file) |
+| One vendor, multiple distinct concerns | Shape 2 (single-provider folder) |
+| Multiple vendors implementing the same protocol | Shape 3 (polymorphic folder) |
+
+Shape can change over time:
+
+- Single file → single-provider folder when concerns split (extract
+  webhooks, OAuth, etc.).
+- Single-provider folder → polymorphic folder when a second vendor is added
+  for the same protocol.
+
+## What Goes Inside an Integration
+
+### Error class
+
+Every integration defines its own error type. Local to the vendor.
+
+```python
+class StripeIntegrationError(Exception):
+    """Raised on failures talking to Stripe."""
+```
+
+For folder integrations, the error class lives in `errors.py`. For
+single-file integrations, it's defined at the top of the file.
+
+Integration error types do **not** inherit from the shared
+`server/proliferate/errors.py` base (`ProliferateError`). The product
+service catches integration errors and translates to domain errors as
+needed.
+
+### Public API
+
+The functions exported to product code. These are what services call.
+
+For single-file integrations, the public API is whatever the file exports
+(non-underscore-prefixed names).
+
+For folder integrations, the public API is what `__init__.py` exports.
+Everything else stays vendor-local.
+
+```python
+# integrations/stripe/__init__.py
+from .client import create_stripe_customer, retrieve_stripe_subscription
+from .webhooks import verify_stripe_webhook
+from .errors import StripeIntegrationError
+
+__all__ = [
+    "create_stripe_customer",
+    "retrieve_stripe_subscription",
+    "verify_stripe_webhook",
+    "StripeIntegrationError",
+]
+```
+
+### Models
+
+Vendor-specific request/response shapes. Use dataclasses by default;
+Pydantic when parsing structured untrusted input (webhook payloads).
+
+For folder integrations, models live in `models.py`. For single-file
+integrations, they're inline.
+
+### Vendor-specific configuration
+
+Integration files read from `config.py` for credentials and endpoints. They
+do not hardcode URLs or secrets.
+
+## Allowed in Integrations
+
+- HTTP client libraries (`httpx`, vendor SDKs).
+- Webhook signature verification.
+- Credential retrieval from `config.py`.
+- Vendor-specific retry, backoff, and timeout policies.
+- Payload normalization (snake_case ↔ camelCase, etc.).
+- Throwing the integration's own error type on failure.
+
+## Banned in Integrations
+
+- Product business logic. The integration translates to/from the vendor;
+  it does not decide what to do with the result.
+- `db/store/**` imports. Integrations don't touch the database.
+- Service.py imports. Integrations are leaves.
+- Hardcoded credentials, URLs, or environment values. Use `config.py`.
+- Single-file folders (`integrations/<vendor>/<single-file>.py` with no
+  other content). Flatten until the folder has real content.
+- Catching the integration's own error type to translate to HTTPException.
+  HTTP translation happens in services or the global exception handler.
+
+## Vendor Boundary Discipline
+
+Product code calls the integration's public API and nothing else.
+
+```python
+# Allowed
+from integrations.stripe import create_stripe_customer, StripeIntegrationError
+
+# Forbidden
+from integrations.stripe.client import _internal_helper
+from integrations.stripe.client import _StripeRequestBuilder
+```
+
+Integration internals (private functions, internal classes) are not part of
+the contract.
+
+## Webhooks
+
+Webhook routes belong to the relevant product domain's `api.py`, not to
+integrations:
+
+```python
+# server/billing/api.py
+@router.post("/webhooks/stripe")
+async def stripe_webhook(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+) -> dict:
+    payload = await request.body()
+    signature = request.headers.get("stripe-signature")
+    event = verify_stripe_webhook(payload, signature)  # from integrations.stripe
+    await service.handle_stripe_event(db, event)
+    return {"received": True}
+```
+
+The integration owns signature verification and event parsing. The product
+service owns "what to do when the event arrives."
+
+## Forbidden Patterns
+
+- Single-file folders (e.g., `integrations/billing/stripe.py` as the only
+  file). Flatten or add real content.
+- Vendor-specific code in product domains (`server/cloud/runtime/anyharness_api.py`
+  is the canonical violation — it belongs in `integrations/anyharness/`).
+- Cross-vendor imports (`integrations/stripe/` importing from
+  `integrations/anthropic/`). Integrations are independent.
+- Imports from `server/<domain>/**` inside an integration. Integrations don't
+  know about product domains.
+- Database access from inside an integration.
+- The same vendor's code split across two locations.
+
+## Adding a New Integration
+
+1. **Pick a shape.** Single file (default), folder (multi-concern), or
+   polymorphic folder (multi-vendor protocol).
+2. **Define the error type.** First, before the public API.
+3. **Read credentials from `config.py`.** Never hardcode.
+4. **Build the client construction or authentication helper.** This is what
+   the public functions use internally.
+5. **Implement public functions** that product code will call.
+6. **Add unit tests** for the integration that mock the HTTP layer.
+7. **For folder integrations:** export the public API from `__init__.py`.
+
+## Forward Pass
+
+When the existing integrations are revisited:
+
+- The `billing/stripe.py` (single-file folder) anti-pattern needs flattening
+  to `integrations/stripe.py` until a second billing provider arrives.
+- `integrations/mcp_oauth.py` (450 lines) likely needs promotion to
+  `mcp_oauth/` with `client.py`, `flows.py`, `models.py`, `errors.py`.
+- `cloud/runtime/anyharness_api.py` (593 lines) + `session_api.py` (251) +
+  `workspace_operations.py` (222) need consolidation under
+  `integrations/anyharness/` as a single-provider folder.
+
+These are concrete cleanups, not rule changes.

--- a/docs/server/guides/workers.md
+++ b/docs/server/guides/workers.md
@@ -1,11 +1,23 @@
 # Workers
 
-Status: authoritative for `worker.py`, `reconciler.py`, scheduler files, the
-`worker/` subfolder pattern, and worker-side service decomposition.
+Status: provisional but authoritative for current background-job cleanup.
 
 Read after `docs/server/README.md`. This guide details how non-HTTP entry
 points are organized, how worker-side logic relates to HTTP-side logic, and
 when a worker subfolder is earned.
+
+This guide is intentionally modest. Proliferate does not yet have a robust
+worker framework, queue abstraction, or broad scheduler system. Do not use this
+guide as permission to invent one. It exists to keep the background jobs we
+already have from mixing entrypoint code, service orchestration, store access,
+and pure logic in the same files.
+
+Default to the simplest shape that keeps ownership clear:
+
+- a thin `worker.py` or `reconciler.py` when one file is enough
+- normal `service.py` functions for orchestration
+- `domain/` for pure computation shared with HTTP paths
+- `worker/` only when worker-only logic has multiple real concerns
 
 ## Ownership
 
@@ -16,7 +28,9 @@ lifecycle. Common shapes:
   with `main()`, argparse, and signal handlers.
 - **Reconciliation loops** — `reconciler.py` periodically compares expected
   vs actual state and fixes drift.
-- **Scheduled jobs** — `scheduler.py` declares cron-style schedules.
+- **Scheduled jobs** — when present, `scheduler.py` declares schedules or the
+  scheduler loop body. Do not add a scheduler layer unless an existing job
+  genuinely needs it.
 - **Queue handlers** — process messages from a queue.
 
 Worker code follows the same layer law as HTTP code:
@@ -66,9 +80,9 @@ server/<domain>/
     <concern>.py
 ```
 
-The trigger: substantial worker-only logic that doesn't naturally fit in
-`service.py`. Multiple files, distinct concerns, hundreds of lines that
-aren't API-facing.
+The trigger: substantial worker-only logic that already does not fit cleanly
+in `service.py`. Multiple files, distinct concerns, and hundreds of lines that
+aren't API-facing. Do not create `worker/` preemptively for a thin loop.
 
 When the worker subfolder is promoted:
 
@@ -221,6 +235,9 @@ they're separate processes, each has its own entry point file in `worker/`.
 - **The worker logic is < 200 lines total.** Keep flat.
 - **There's no real distinction between API-side and worker-side work.** One
   `service.py` is enough.
+- **You are creating the first background path for a domain.** Start with the
+  flat shape unless the first implementation already has multiple executor or
+  reconciliation concerns.
 
 The trigger is *substantial worker-only logic that doesn't naturally fit in
 `service.py`*. Without that, a sibling `worker.py` is enough.

--- a/docs/server/guides/workers.md
+++ b/docs/server/guides/workers.md
@@ -23,8 +23,10 @@ Worker code follows the same layer law as HTTP code:
 
 - Worker entry points call services. They don't run business logic
   themselves.
-- Workers don't import ORM directly. They call store functions.
-- Workers don't construct vendor clients. They call integrations.
+- Worker entry points and reconciliation loops don't import ORM directly.
+  They call services; worker-facing services call store functions.
+- Worker entry points don't construct vendor clients. Worker services or
+  executors call integrations through their public API.
 
 ## Folder Shape
 
@@ -107,7 +109,7 @@ Allowed:
 
 - The reconciliation loop structure (`while True: await pass()`).
 - Loop lifecycle: `start_*_reconciler`, `stop_*_reconciler`.
-- Calls to service or store functions.
+- Calls to service functions.
 - A pass function that does one round of reconciliation.
 
 Banned:
@@ -296,9 +298,11 @@ because all the executor and scheduling work has moved into `worker/`.
   Promote to `worker/` once you have the pattern.
 - The `_service` suffix on any worker-adjacent file. Files are `worker.py`,
   `reconciler.py`, `<name>_executor.py`, never `*_service.py`.
-- ORM imports in any worker file. Workers call store functions.
-- Direct vendor client construction in worker code. Workers call
-  integrations.
+- ORM imports in worker entry points, reconcilers, schedulers, or executors.
+  They call services; worker-facing services call store functions.
+- Direct vendor client construction in worker entry points, reconcilers, or
+  schedulers. Worker services or executors call integrations through their
+  public API.
 - Two `service.py` files at the same level. Either parent or `worker/`, not
   both at the same nesting.
 - A worker subfolder with only `main.py`. Promote when there's substantial

--- a/docs/server/guides/workers.md
+++ b/docs/server/guides/workers.md
@@ -1,0 +1,322 @@
+# Workers
+
+Status: authoritative for `worker.py`, `reconciler.py`, scheduler files, the
+`worker/` subfolder pattern, and worker-side service decomposition.
+
+Read after `docs/server/README.md`. This guide details how non-HTTP entry
+points are organized, how worker-side logic relates to HTTP-side logic, and
+when a worker subfolder is earned.
+
+## Ownership
+
+A worker is a non-HTTP entry point that runs domain work outside the request
+lifecycle. Common shapes:
+
+- **Process entry points** — `worker.py` files run as separate processes,
+  with `main()`, argparse, and signal handlers.
+- **Reconciliation loops** — `reconciler.py` periodically compares expected
+  vs actual state and fixes drift.
+- **Scheduled jobs** — `scheduler.py` declares cron-style schedules.
+- **Queue handlers** — process messages from a queue.
+
+Worker code follows the same layer law as HTTP code:
+
+- Worker entry points call services. They don't run business logic
+  themselves.
+- Workers don't import ORM directly. They call store functions.
+- Workers don't construct vendor clients. They call integrations.
+
+## Folder Shape
+
+### Default: sibling files at the domain root
+
+For a domain with one or two background-shape files:
+
+```text
+server/<domain>/
+  api.py
+  service.py
+  models.py
+  worker.py            # process entry point
+  reconciler.py        # reconciliation loop (when applicable)
+```
+
+The worker calls service functions. Service is the shared orchestration
+layer between API and worker.
+
+### Promoted: `worker/` subfolder
+
+When worker-side logic is substantial and distinct from HTTP-side work:
+
+```text
+server/<domain>/
+  api.py
+  service.py             # API-facing service
+  models.py              # API schemas
+  domain/                # pure logic shared between API and worker
+    policy.py
+    <concern>.py
+  worker/                # worker surface
+    main.py              # process entry: argparse, signals, async loop
+    service.py           # worker-facing service
+    scheduler.py         # scheduler loop body (if applicable)
+    <executor>.py        # alternative implementations of the worker's work
+    <concern>.py
+```
+
+The trigger: substantial worker-only logic that doesn't naturally fit in
+`service.py`. Multiple files, distinct concerns, hundreds of lines that
+aren't API-facing.
+
+When the worker subfolder is promoted:
+
+- Two `service.py` files coexist — one at the parent (API-facing), one in
+  `worker/` (worker-facing). They share `domain/` and stores.
+- `domain/` and stores stay at the parent level. They're shared.
+- The parent's `service.py` may shrink because some shared work moves to
+  `domain/`.
+
+## File Roles
+
+### `worker.py` (or `worker/main.py`)
+
+Process entry point. Loads config, parses args, sets up signal handlers,
+runs the async event loop.
+
+Allowed:
+
+- `main()` function and module-level CLI parsing (`argparse`).
+- Signal handler registration.
+- Async event loop setup (`asyncio.run`, `loop.create_task`).
+- Top-level structured logging configuration.
+- Calls to `service.py` (API-facing or worker-facing).
+
+Banned:
+
+- Business logic. Loop bodies belong in `service.py` or named modules.
+- ORM imports.
+- Direct vendor client construction.
+- Long handler functions. Keep `main` thin.
+
+### `reconciler.py`
+
+A specific kind of worker that reads expected state, reads actual state,
+computes drift, and takes corrective action on a periodic loop.
+
+Allowed:
+
+- The reconciliation loop structure (`while True: await pass()`).
+- Loop lifecycle: `start_*_reconciler`, `stop_*_reconciler`.
+- Calls to service or store functions.
+- A pass function that does one round of reconciliation.
+
+Banned:
+
+- Multiple distinct reconciliation flows in one file. Promote to
+  `worker/<name>_reconciler.py` siblings.
+- Substantial business logic inside the loop body. Extract to `service.py`.
+- ORM imports.
+
+### `scheduler.py`
+
+Declares schedules. No business logic. Just a registry of what runs when.
+
+Two shapes:
+
+- **Domain-root scheduler** (`server/<domain>/scheduler.py`) — schedule
+  registration for a single domain.
+- **Inside `worker/`** (`server/<domain>/worker/scheduler.py`) — the
+  scheduler loop body that picks due work and dispatches.
+
+The two are different. The first is a list of "every X, run Y." The second
+is the running loop that fires the dispatchers.
+
+Allowed in either:
+
+- Cron expressions or interval declarations.
+- Mappings from schedule names to handler functions in service.
+
+Banned:
+
+- Business logic.
+- ORM imports.
+- Side effects on import.
+
+### `<executor>.py` (in `worker/`)
+
+Alternative implementations of "do the worker's work." Two implementations
+of the same conceptual job (e.g., cloud vs local) live as siblings in
+`worker/`.
+
+Allowed:
+
+- The implementation's own setup, dependencies, and execution.
+- Calls to integrations and services.
+
+Banned:
+
+- Sharing implementation between executors via inheritance. If two
+  executors share logic, extract to `worker/<shared>.py` or `domain/`.
+- HTTP routes. Workers are not HTTP-facing.
+- The `_service` suffix in the filename. Files are `cloud_executor.py`, not
+  `cloud_executor_service.py`.
+
+## Worker-Side Service Decomposition
+
+When a domain has the worker subfolder pattern, both `service.py` files are
+real services with the same layer law (no ORM imports, call store
+functions). They differ in surface:
+
+- **Parent `service.py`** — called by `api.py`. CRUD on resources, read APIs,
+  request-driven mutations.
+- **`worker/service.py`** — called by `worker/main.py`. Pick work, dispatch
+  to an executor, record results, handle failures.
+
+They share:
+
+- `domain/` for pure logic (recurrence parsing, policy rules).
+- `db/store/<resource>.py` for data access.
+- Error types in the parent's `errors.py`.
+
+Worker-side service functions still take `db: AsyncSession` and never
+commit. The worker's `main.py` opens the session at the entry point and
+threads it through:
+
+```python
+# server/<domain>/worker/main.py
+async def main_loop() -> None:
+    async with async_session_factory() as db:
+        async with db.begin():
+            await service.process_due_work(db)
+        # commits on context exit
+```
+
+## Multiple Workers in One Domain
+
+When a domain has multiple distinct background flows:
+
+```text
+server/billing/
+  worker/
+    main.py
+    service.py
+    seat_reconciler.py
+    usage_reconciler.py
+    stripe_event_worker.py
+```
+
+Each `<flow>.py` is its own focused module under `worker/`. They share
+`worker/service.py` for common orchestration and the parent's `domain/` for
+pure logic.
+
+If a single `main.py` runs all of them in one process, that's fine. If
+they're separate processes, each has its own entry point file in `worker/`.
+
+## When NOT to Use the `worker/` Subfolder
+
+- **The worker is just a thin loop calling one service function.** Keep
+  `worker.py` at the parent. No subfolder.
+- **The worker logic is < 200 lines total.** Keep flat.
+- **There's no real distinction between API-side and worker-side work.** One
+  `service.py` is enough.
+
+The trigger is *substantial worker-only logic that doesn't naturally fit in
+`service.py`*. Without that, a sibling `worker.py` is enough.
+
+## Worked Example: Automations
+
+The automations domain has substantial worker-side work — multiple
+executors, scheduler logic, distinct from API-side CRUD on automation
+definitions. It's the canonical case for the `worker/` subfolder pattern.
+
+### Today (transitional)
+
+```text
+server/automations/
+  api.py
+  service.py
+  models.py
+  worker.py                    # entry point
+  schedule.py                  # MISNAMED — actually pure RRULE parsing logic
+  cloud_executor.py            # executor implementation
+  local_executor_service.py    # executor implementation (with bad _service suffix)
+```
+
+Issues:
+
+- `schedule.py` is pure parsing logic. Belongs in `domain/`, not at the
+  worker-shaped layer.
+- `local_executor_service.py` has the `_service` suffix that's forbidden
+  outside `service.py`.
+- All worker-side concerns (executors, scheduler logic) sit alongside the
+  API-side service.py with no organizational separation.
+
+### Target
+
+```text
+server/automations/
+  api.py                        # API routes: CRUD on automation definitions
+  service.py                    # API-facing service: CRUD logic
+  models.py                     # Pydantic API schemas
+  domain/                       # pure logic shared between API and worker
+    recurrence.py               # RRULE parsing (was schedule.py)
+    policy.py                   # scheduling rules, can-run rules
+  worker/                       # worker surface
+    main.py                     # process entry: argparse, signals, async loop
+    service.py                  # worker-facing service: pick due, dispatch, record
+    scheduler.py                # scheduler loop body
+    cloud_executor.py
+    local_executor.py           # was local_executor_service.py
+```
+
+What lives where:
+
+- `domain/recurrence.py` is pure: RRULE parsing, occurrence math, no I/O.
+  Used by both worker (to find due automations) and API (to validate user
+  input or render schedule descriptions).
+- `worker/scheduler.py` is the loop body that calls
+  `domain/recurrence.py` to find what's due, then dispatches via
+  `worker/service.py`.
+- `worker/service.py` orchestrates the worker side: pick next due, dispatch
+  to executor, record result, handle failures.
+- `worker/cloud_executor.py` and `worker/local_executor.py` are the two
+  alternative implementations of "run an automation."
+
+The parent `service.py` shrinks to just CRUD on automation definitions,
+because all the executor and scheduling work has moved into `worker/`.
+
+## Forbidden Patterns
+
+- Pure parsing or computation logic in worker-shaped files
+  (`worker.py`, `scheduler.py`, `reconciler.py`). That's `domain/` work.
+- Substantial business logic inside `worker.py`'s loop body. The body calls
+  `service.py`.
+- Multiple "executor" or "runner" sibling files at the parent domain level
+  (`automations/cloud_executor.py` + `automations/local_executor.py`).
+  Promote to `worker/` once you have the pattern.
+- The `_service` suffix on any worker-adjacent file. Files are `worker.py`,
+  `reconciler.py`, `<name>_executor.py`, never `*_service.py`.
+- ORM imports in any worker file. Workers call store functions.
+- Direct vendor client construction in worker code. Workers call
+  integrations.
+- Two `service.py` files at the same level. Either parent or `worker/`, not
+  both at the same nesting.
+- A worker subfolder with only `main.py`. Promote when there's substantial
+  content; otherwise keep `worker.py` at the parent.
+
+## Migration Notes
+
+When promoting an existing flat layout to `worker/`:
+
+1. Identify worker-only files (executors, scheduler loop bodies, queue
+   handlers).
+2. Identify pure logic that's shared between API and worker — move to
+   `domain/`.
+3. Create `worker/` and move worker-only files inside.
+4. Create `worker/main.py` for the process entry point. The old `worker.py`
+   becomes `worker/main.py`.
+5. Create `worker/service.py` for worker-facing orchestration extracted
+   from the old worker file or executors.
+6. Verify no file at the parent level still does worker-only work.
+7. Verify both `service.py` files don't share names with each other for the
+   same operation (each owns its surface).

--- a/docs/server/guides/workers.md
+++ b/docs/server/guides/workers.md
@@ -160,9 +160,15 @@ Banned:
 
 ### `<executor>.py` (in `worker/`)
 
-Alternative implementations of "do the worker's work." Two implementations
-of the same conceptual job (e.g., cloud vs local) live as siblings in
-`worker/`.
+Alternative implementations of "do the worker's work" that run inside the
+server-side worker process. Two implementations of the same conceptual job
+live as siblings in `worker/` only when both are worker-process
+implementations.
+
+An HTTP service used by an external executor to claim work, heartbeat, or
+record progress is not a `worker/` executor. It is API-facing service code,
+even if the caller is a worker process outside the server. Keep that surface
+near `api.py` / parent `service.py` unless it earns its own subdomain.
 
 Allowed:
 
@@ -242,67 +248,66 @@ they're separate processes, each has its own entry point file in `worker/`.
 The trigger is *substantial worker-only logic that doesn't naturally fit in
 `service.py`*. Without that, a sibling `worker.py` is enough.
 
-## Worked Example: Automations
+## Representative Promoted Shape
 
-The automations domain has substantial worker-side work — multiple
-executors, scheduler logic, distinct from API-side CRUD on automation
-definitions. It's the canonical case for the `worker/` subfolder pattern.
+A domain earns `worker/` when worker-side work has multiple real concerns:
+process entry, scheduler loop, worker-facing orchestration, and one or more
+server-side executors. The promoted shape should separate API-facing
+operations from worker-process operations.
 
 ### Today (transitional)
 
 ```text
-server/automations/
+server/<domain>/
   api.py
-  service.py
+  service.py                    # API-facing service
   models.py
-  worker.py                    # entry point
-  schedule.py                  # MISNAMED — actually pure RRULE parsing logic
-  cloud_executor.py            # executor implementation
-  local_executor_service.py    # executor implementation (with bad _service suffix)
+  worker.py                     # process entry point
+  schedule.py                   # pure recurrence logic in the wrong layer
+  cloud_executor.py             # worker-process executor implementation
+  <external_executor_surface>.py # API-facing surface for an external executor
 ```
 
 Issues:
 
-- `schedule.py` is pure parsing logic. Belongs in `domain/`, not at the
-  worker-shaped layer.
-- `local_executor_service.py` has the `_service` suffix that's forbidden
-  outside `service.py`.
-- All worker-side concerns (executors, scheduler logic) sit alongside the
-  API-side service.py with no organizational separation.
+- Pure parsing logic belongs in `domain/`, not at the worker-shaped layer.
+- Worker-process executors and scheduler logic sit alongside API-facing
+  service code with no organizational separation.
+- API-facing services for external executors must not be mistaken for
+  server-side worker executors.
 
 ### Target
 
 ```text
-server/automations/
-  api.py                        # API routes: CRUD on automation definitions
-  service.py                    # API-facing service: CRUD logic
-  models.py                     # Pydantic API schemas
-  domain/                       # pure logic shared between API and worker
-    recurrence.py               # RRULE parsing (was schedule.py)
-    policy.py                   # scheduling rules, can-run rules
-  worker/                       # worker surface
-    main.py                     # process entry: argparse, signals, async loop
-    service.py                  # worker-facing service: pick due, dispatch, record
-    scheduler.py                # scheduler loop body
-    cloud_executor.py
-    local_executor.py           # was local_executor_service.py
+server/<domain>/
+  api.py                         # API routes
+  service.py                     # API-facing service
+  models.py                      # Pydantic API schemas
+  <external_executor_surface>.py # API-facing external-executor surface
+  domain/                        # pure logic shared by API and worker
+    recurrence.py
+    policy.py
+  worker/                        # server-side worker process surface
+    main.py                      # process entry: argparse, signals, async loop
+    service.py                   # pick due, dispatch, record failures
+    scheduler.py                 # scheduler loop body
+    cloud_executor.py            # server-side executor implementation
 ```
 
 What lives where:
 
-- `domain/recurrence.py` is pure: RRULE parsing, occurrence math, no I/O.
-  Used by both worker (to find due automations) and API (to validate user
-  input or render schedule descriptions).
-- `worker/scheduler.py` is the loop body that calls
-  `domain/recurrence.py` to find what's due, then dispatches via
-  `worker/service.py`.
+- `domain/recurrence.py` is pure parsing and occurrence math, no I/O. Used by
+  both worker and API paths.
+- `worker/scheduler.py` is the loop body that finds due work, then dispatches
+  via `worker/service.py`.
 - `worker/service.py` orchestrates the worker side: pick next due, dispatch
   to executor, record result, handle failures.
-- `worker/cloud_executor.py` and `worker/local_executor.py` are the two
-  alternative implementations of "run an automation."
+- `worker/<executor>.py` files are server-side implementations of work.
+- API-facing external-executor services remain outside `worker/` because they
+  are request-driven surfaces, not worker-process implementation code.
 
-The parent `service.py` shrinks to just CRUD on automation definitions,
-because all the executor and scheduling work has moved into `worker/`.
+The parent `service.py` remains API-facing. Worker-process concerns move into
+`worker/`; external-executor HTTP surfaces stay API-facing.
 
 ## Forbidden Patterns
 
@@ -310,9 +315,8 @@ because all the executor and scheduling work has moved into `worker/`.
   (`worker.py`, `scheduler.py`, `reconciler.py`). That's `domain/` work.
 - Substantial business logic inside `worker.py`'s loop body. The body calls
   `service.py`.
-- Multiple "executor" or "runner" sibling files at the parent domain level
-  (`automations/cloud_executor.py` + `automations/local_executor.py`).
-  Promote to `worker/` once you have the pattern.
+- Multiple server-side "executor" or "runner" sibling files at the parent
+  domain level. Promote to `worker/` once you have the pattern.
 - The `_service` suffix on any worker-adjacent file. Files are `worker.py`,
   `reconciler.py`, `<name>_executor.py`, never `*_service.py`.
 - ORM imports in worker entry points, reconcilers, schedulers, or executors.


### PR DESCRIPTION
## Summary

- Clarifies server cleanup ownership docs without tying rules to one-off current file paths.
- Adds a focused server errors guide for shared product errors, domain errors, integration-error translation, and global HTTP mapping.
- Tightens integration, worker, and config/constants guidance ahead of the backend cleanup migration.

## Verification

- `git diff --check`

## Notes

Draft PR for review before we start the implementation waves.
