### PR TITLE
refactor(desktop): organize telemetry hooks

### DIFF
--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-agent-seed.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-agent-seed.ts
@@ -3,6 +3,8 @@ import { useRuntimeHealthQuery } from "@anyharness/sdk-react";
 import { trackProductEvent } from "@/lib/integrations/telemetry/client";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
+// Owns agent seed hydration telemetry emitted from runtime health changes.
+// Does not own runtime health fetching or agent setup behavior.
 export function useTelemetryAgentSeed() {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/integrations/telemetry/client";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
+// Owns telemetry user identity and auth-status tags. Does not own auth state.
 export function useTelemetryAuthIdentity() {
   const authStatus = useAuthStore((state) => state.status);
   const user = useAuthStore((state) => state.user);

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
@@ -4,6 +4,7 @@ import { useTelemetryRouteViews } from "./use-telemetry-route-views";
 import { useTelemetryRuntimeState } from "./use-telemetry-runtime-state";
 import { useTelemetryWorkspaceSelection } from "./use-telemetry-workspace-selection";
 
+// Owns mounting app-wide telemetry lifecycle hooks. Does not own telemetry transport.
 export function useTelemetryBootstrap() {
   useTelemetryAuthIdentity();
   useTelemetryAgentSeed();

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-latency-flows.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-latency-flows.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useActiveSessionSurfaceSnapshot } from "@/hooks/chat/use-active-chat-session-selectors";
+import { useChatSurfaceState } from "@/hooks/chat/use-chat-surface-state";
+import {
+  finishLatencyFlow,
+  listActiveLatencyFlows,
+} from "@/lib/infra/measurement/latency-flow";
+import { collectTelemetryLatencyFlowCompletions } from "@/lib/domain/telemetry/latency-flow-completion";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+// Owns finishing telemetry latency flows when the visible app state catches up.
+// Does not own latency-flow stage planning; that pure decision lives in domain telemetry.
+export function useTelemetryLatencyFlows() {
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const { mode } = useChatSurfaceState();
+  const {
+    activeSessionId,
+    sessionViewState,
+  } = useActiveSessionSurfaceSnapshot();
+
+  useEffect(() => {
+    const completions = collectTelemetryLatencyFlowCompletions({
+      activeFlows: listActiveLatencyFlows(),
+      selectedWorkspaceId,
+      activeSessionId,
+      sessionViewState,
+      modeKind: mode.kind,
+    });
+    for (const completion of completions) {
+      finishLatencyFlow(completion.flowId, completion.stage);
+    }
+  }, [
+    activeSessionId,
+    mode.kind,
+    selectedWorkspaceId,
+    sessionViewState,
+  ]);
+}

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-route-views.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-route-views.ts
@@ -1,27 +1,19 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import type { DesktopTelemetryRoute } from "@/lib/domain/telemetry/events";
+import { resolveDesktopTelemetryRoute } from "@/lib/domain/telemetry/routes";
 import {
   setTelemetryTag,
   trackProductEvent,
 } from "@/lib/integrations/telemetry/client";
 
-function routeName(pathname: string): DesktopTelemetryRoute {
-  if (pathname === "/") return "main";
-  if (pathname === "/login") return "login";
-  if (pathname === "/settings") return "settings";
-  if (pathname === "/automations" || pathname.startsWith("/automations/")) {
-    return "automations";
-  }
-  return "unknown";
-}
-
+// Owns route view telemetry tags and events. Does not own route classification rules.
 export function useTelemetryRouteViews() {
   const location = useLocation();
   const previousRouteRef = useRef<DesktopTelemetryRoute | null>(null);
 
   useEffect(() => {
-    const currentRoute = routeName(location.pathname);
+    const currentRoute = resolveDesktopTelemetryRoute(location.pathname);
     if (previousRouteRef.current === currentRoute) return;
     previousRouteRef.current = currentRoute;
 

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-runtime-state.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-runtime-state.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/integrations/telemetry/client";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
+// Owns runtime connection telemetry tags and events. Does not own runtime connection state.
 export function useTelemetryRuntimeState() {
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
   const runtimeError = useHarnessConnectionStore((state) => state.error);

--- a/desktop/src/hooks/telemetry/lifecycle/use-telemetry-workspace-selection.ts
+++ b/desktop/src/hooks/telemetry/lifecycle/use-telemetry-workspace-selection.ts
@@ -1,17 +1,12 @@
 import { useEffect, useRef } from "react";
-import type { DesktopWorkspaceKind } from "@/lib/domain/telemetry/events";
-import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { resolveDesktopTelemetryWorkspaceKind } from "@/lib/domain/telemetry/workspace-kind";
 import {
   setTelemetryTag,
   trackProductEvent,
 } from "@/lib/integrations/telemetry/client";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
-function workspaceKind(workspaceId: string | null): DesktopWorkspaceKind | "none" {
-  if (!workspaceId) return "none";
-  return parseCloudWorkspaceSyntheticId(workspaceId) ? "cloud" : "local";
-}
-
+// Owns selected-workspace telemetry tags and events. Does not own workspace kind classification.
 export function useTelemetryWorkspaceSelection() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const previousWorkspaceIdRef = useRef<string | null>(null);
@@ -20,7 +15,7 @@ export function useTelemetryWorkspaceSelection() {
     if (previousWorkspaceIdRef.current === selectedWorkspaceId) return;
     previousWorkspaceIdRef.current = selectedWorkspaceId;
 
-    const kind = workspaceKind(selectedWorkspaceId);
+    const kind = resolveDesktopTelemetryWorkspaceKind(selectedWorkspaceId);
     setTelemetryTag("workspace_kind", kind);
 
     if (kind === "none") return;

--- a/desktop/src/lib/domain/telemetry/latency-flow-completion.test.ts
+++ b/desktop/src/lib/domain/telemetry/latency-flow-completion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LatencyFlowRecord } from "@/lib/infra/measurement/latency-flow";
-import { collectTelemetryLatencyFlowCompletions } from "./use-telemetry-latency-flows";
+import { collectTelemetryLatencyFlowCompletions } from "./latency-flow-completion";
 
 function createFlow(overrides: Partial<LatencyFlowRecord>): LatencyFlowRecord {
   return {

--- a/desktop/src/lib/domain/telemetry/latency-flow-completion.ts
+++ b/desktop/src/lib/domain/telemetry/latency-flow-completion.ts
@@ -1,19 +1,13 @@
-import { useEffect } from "react";
-import { useActiveSessionSurfaceSnapshot } from "@/hooks/chat/use-active-chat-session-selectors";
-import { useChatSurfaceState } from "@/hooks/chat/use-chat-surface-state";
-import {
-  finishLatencyFlow,
-  type LatencyFlowRecord,
-  type LatencyFlowStage,
-  listActiveLatencyFlows,
+import type {
+  LatencyFlowRecord,
+  LatencyFlowStage,
 } from "@/lib/infra/measurement/latency-flow";
-import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
 function isSurfaceReady(modeKind: string): boolean {
   return modeKind !== "no-workspace" && modeKind !== "session-loading";
 }
 
-interface TelemetryLatencyFlowState {
+export interface TelemetryLatencyFlowState {
   activeFlows: LatencyFlowRecord[];
   selectedWorkspaceId: string | null;
   activeSessionId: string | null;
@@ -21,7 +15,7 @@ interface TelemetryLatencyFlowState {
   modeKind: string;
 }
 
-interface LatencyFlowCompletion {
+export interface LatencyFlowCompletion {
   flowId: string;
   stage: Extract<LatencyFlowStage, "optimistic_visible" | "processing_started" | "surface_ready">;
 }
@@ -88,31 +82,4 @@ export function collectTelemetryLatencyFlowCompletions(
   }
 
   return completions;
-}
-
-export function useTelemetryLatencyFlows() {
-  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
-  const { mode } = useChatSurfaceState();
-  const {
-    activeSessionId,
-    sessionViewState,
-  } = useActiveSessionSurfaceSnapshot();
-
-  useEffect(() => {
-    const completions = collectTelemetryLatencyFlowCompletions({
-      activeFlows: listActiveLatencyFlows(),
-      selectedWorkspaceId,
-      activeSessionId,
-      sessionViewState,
-      modeKind: mode.kind,
-    });
-    for (const completion of completions) {
-      finishLatencyFlow(completion.flowId, completion.stage);
-    }
-  }, [
-    activeSessionId,
-    mode.kind,
-    selectedWorkspaceId,
-    sessionViewState,
-  ]);
 }

--- a/desktop/src/lib/domain/telemetry/routes.test.ts
+++ b/desktop/src/lib/domain/telemetry/routes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveDesktopTelemetryRoute } from "./routes";
+
+describe("resolveDesktopTelemetryRoute", () => {
+  it("classifies known desktop routes", () => {
+    expect(resolveDesktopTelemetryRoute("/")).toBe("main");
+    expect(resolveDesktopTelemetryRoute("/login")).toBe("login");
+    expect(resolveDesktopTelemetryRoute("/settings")).toBe("settings");
+    expect(resolveDesktopTelemetryRoute("/automations")).toBe("automations");
+    expect(resolveDesktopTelemetryRoute("/automations/run-1")).toBe("automations");
+  });
+
+  it("falls back to unknown for unclassified routes", () => {
+    expect(resolveDesktopTelemetryRoute("/workspace")).toBe("unknown");
+  });
+});

--- a/desktop/src/lib/domain/telemetry/routes.ts
+++ b/desktop/src/lib/domain/telemetry/routes.ts
@@ -1,0 +1,11 @@
+import type { DesktopTelemetryRoute } from "@/lib/domain/telemetry/events";
+
+export function resolveDesktopTelemetryRoute(pathname: string): DesktopTelemetryRoute {
+  if (pathname === "/") return "main";
+  if (pathname === "/login") return "login";
+  if (pathname === "/settings") return "settings";
+  if (pathname === "/automations" || pathname.startsWith("/automations/")) {
+    return "automations";
+  }
+  return "unknown";
+}

--- a/desktop/src/lib/domain/telemetry/workspace-kind.test.ts
+++ b/desktop/src/lib/domain/telemetry/workspace-kind.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { resolveDesktopTelemetryWorkspaceKind } from "./workspace-kind";
+
+describe("resolveDesktopTelemetryWorkspaceKind", () => {
+  it("classifies missing workspace selection as none", () => {
+    expect(resolveDesktopTelemetryWorkspaceKind(null)).toBe("none");
+  });
+
+  it("classifies cloud synthetic workspace ids as cloud", () => {
+    expect(resolveDesktopTelemetryWorkspaceKind(
+      cloudWorkspaceSyntheticId("cloud-workspace-1"),
+    )).toBe("cloud");
+  });
+
+  it("classifies regular workspace ids as local", () => {
+    expect(resolveDesktopTelemetryWorkspaceKind("workspace-1")).toBe("local");
+  });
+});

--- a/desktop/src/lib/domain/telemetry/workspace-kind.ts
+++ b/desktop/src/lib/domain/telemetry/workspace-kind.ts
@@ -1,0 +1,9 @@
+import type { DesktopWorkspaceKind } from "@/lib/domain/telemetry/events";
+import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+
+export function resolveDesktopTelemetryWorkspaceKind(
+  workspaceId: string | null,
+): DesktopWorkspaceKind | "none" {
+  if (!workspaceId) return "none";
+  return parseCloudWorkspaceSyntheticId(workspaceId) ? "cloud" : "local";
+}

--- a/desktop/src/providers/TelemetryProvider.tsx
+++ b/desktop/src/providers/TelemetryProvider.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { useTelemetryBootstrap } from "@/hooks/telemetry/use-telemetry-bootstrap";
+import { useTelemetryBootstrap } from "@/hooks/telemetry/lifecycle/use-telemetry-bootstrap";
 
 export function TelemetryProvider({ children }: { children: ReactNode }) {
   useTelemetryBootstrap();

--- a/docs/analytics/anonymous-telemetry.md
+++ b/docs/analytics/anonymous-telemetry.md
@@ -166,7 +166,7 @@ Runtime config, not env:
 - Bundled agent seed telemetry:
   - trigger: desktop observes runtime health reporting seed status
   - code path:
-    - `desktop/src/hooks/telemetry/use-telemetry-agent-seed.ts`
+    - `desktop/src/hooks/telemetry/lifecycle/use-telemetry-agent-seed.ts`
     - `desktop/src/lib/domain/telemetry/events.ts`
     - `desktop/src/lib/domain/telemetry/anonymous-events.ts`
   - sends product events only with low-cardinality fields:

--- a/docs/analytics/posthog.md
+++ b/docs/analytics/posthog.md
@@ -48,8 +48,8 @@ enabled.
   - trigger: auth state changes in the telemetry bootstrap flow
   - code path:
     - `desktop/src/providers/TelemetryProvider.tsx`
-    - `desktop/src/hooks/telemetry/use-telemetry-bootstrap.ts`
-    - `desktop/src/hooks/telemetry/use-telemetry-auth-identity.ts`
+    - `desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts`
+    - `desktop/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts`
     - `desktop/src/lib/integrations/telemetry/client.ts`
     - `desktop/src/lib/integrations/telemetry/posthog.ts`
   - sends:
@@ -113,7 +113,7 @@ No server PostHog env vars exist in the current implementation.
 - Desktop PostHog adapter:
   - `desktop/src/lib/integrations/telemetry/posthog.ts`
 - Desktop auth identity hook:
-  - `desktop/src/hooks/telemetry/use-telemetry-auth-identity.ts`
+  - `desktop/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts`
 - Exact events currently captured:
   - `chat_session_created`
   - `chat_prompt_submitted`


### PR DESCRIPTION
## Summary

- Move telemetry side-effect hooks into `hooks/telemetry/lifecycle`.
- Extract pure telemetry route, workspace-kind, and latency-flow completion decisions into `lib/domain/telemetry`.
- Update telemetry docs that referenced the moved hook paths.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `pnpm --dir desktop exec vitest run src/lib/domain/telemetry`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check origin/main...HEAD`
