### PR TITLE
refactor(desktop): purify domain import boundaries

### DIFF
--- a/desktop/src/lib/domain/chat/__fixtures__/playground.ts
+++ b/desktop/src/lib/domain/chat/__fixtures__/playground.ts
@@ -16,7 +16,10 @@ import {
   type CloudWorkspaceStatusScreenModel,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
 import type { SelectedCloudRuntimeViewModel } from "@/lib/domain/workspaces/cloud/cloud-runtime-state";
-import type { CloudWorkspaceStatus, CloudWorkspaceSummary } from "@/lib/access/cloud/client";
+import type {
+  CloudWorkspaceStatus,
+  CloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 export const TODOS_SHORT: PlanEntry[] = [
   { content: "Read authoritative repo docs and MCP spec material", status: "completed" },

--- a/desktop/src/lib/domain/cloud/runtime-input-sync.ts
+++ b/desktop/src/lib/domain/cloud/runtime-input-sync.ts
@@ -1,4 +1,4 @@
-import type { CloudAgentKind } from "@/lib/access/cloud/client";
+import type { CloudAgentKind } from "@/lib/domain/cloud/credentials";
 
 export type RuntimeInputSyncSourceKind =
   | "credential"

--- a/desktop/src/lib/domain/mcp/local-stdio-finalizer.ts
+++ b/desktop/src/lib/domain/mcp/local-stdio-finalizer.ts
@@ -2,8 +2,36 @@ import type {
   SessionMcpBindingSummary,
   SessionMcpServer,
 } from "@anyharness/sdk";
-import type { LocalStdioCandidate } from "@/lib/access/cloud/client";
 import type { ConnectorLaunchResolutionWarning } from "@/lib/domain/mcp/types";
+
+type LocalStdioTemplateSource =
+  | { kind: "static"; value: string }
+  | { kind: "workspace_path" };
+
+interface LocalStdioArgTemplate {
+  source: LocalStdioTemplateSource;
+}
+
+interface LocalStdioEnvTemplate {
+  name: string;
+  source: Extract<LocalStdioTemplateSource, { kind: "static" }>;
+}
+
+export interface LocalStdioCandidate {
+  connectionId: string;
+  catalogEntryId: string;
+  serverName: string;
+  connectorName: string;
+  setupKind: "none" | "local_oauth";
+  localOauth?: {
+    provider: "google_workspace";
+    userGoogleEmail: string;
+    requiredScope: string;
+  } | null;
+  command: string;
+  args: LocalStdioArgTemplate[];
+  env: LocalStdioEnvTemplate[];
+}
 
 export interface LocalStdioFinalizationContext {
   workspacePath: string | null;

--- a/desktop/src/lib/domain/telemetry/events.ts
+++ b/desktop/src/lib/domain/telemetry/events.ts
@@ -1,4 +1,4 @@
-import type { CloudAgentKind } from "@/lib/access/cloud/client";
+import type { CloudAgentKind } from "@/lib/domain/cloud/credentials";
 import type { TelemetryFailureKind } from "./failures";
 
 export type DesktopTelemetryRoute =

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -39,6 +39,9 @@ QUERY_CACHE_CALL_RE = re.compile(
     + "|".join(sorted(QUERY_CACHE_METHODS))
     + r")\s*\("
 )
+REACT_IMPORT_RE = re.compile(
+    r"^\s*import(?:\s+type)?(?:\s+[^;]*\s+from)?\s+['\"]react['\"]"
+)
 
 
 @dataclass(frozen=True)
@@ -152,6 +155,7 @@ def check_file(path: Path) -> list[Violation]:
         contains_openapi_client_verb = bool(OPENAPI_CLIENT_VERB_RE.search(line))
         contains_use_query_client = "useQueryClient" in line
         contains_query_cache_call = bool(QUERY_CACHE_CALL_RE.search(line))
+        contains_react_import = bool(REACT_IMPORT_RE.search(line))
         contains_legacy_access = (
             "@/platform/tauri" in line
             or "@/lib/integrations/cloud" in line
@@ -204,8 +208,7 @@ def check_file(path: Path) -> list[Violation]:
             add_if(
                 violations,
                 (
-                    '"react"' in line
-                    or "'react'" in line
+                    contains_react_import
                     or "@tanstack/react-query" in line
                     or "@/hooks/" in line
                     or "@/stores/" in line
@@ -223,8 +226,7 @@ def check_file(path: Path) -> list[Violation]:
             add_if(
                 violations,
                 (
-                    '"react"' in line
-                    or "'react'" in line
+                    contains_react_import
                     or "@tanstack/react-query" in line
                     or "@/components/" in line
                     or "@/hooks/" in line

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -7,11 +7,6 @@ ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-acti
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts 4 raw AnyHarness client before access migration
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts 3 raw AnyHarness client before access migration
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/lib/workflows/sessions/session-runtime.ts 6 raw AnyHarness client before access migration
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/chat/__fixtures__/playground.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/cloud/runtime-input-sync.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/files/file-visuals.ts 2 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/mcp/local-stdio-finalizer.ts 1 domain imports transport or UI types before lib cleanup
-DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/telemetry/events.ts 1 domain imports transport or UI types before lib cleanup
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts 5 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- move domain cloud/telemetry/playground fixtures off cloud access transport types
- define the local stdio candidate shape inside the MCP domain finalizer instead of importing the cloud access alias
- tighten the frontend boundary checker so React import checks do not flag ordinary string literals such as file visual names
- remove the remaining `DOMAIN_FORBIDDEN_IMPORT` allowlist entries

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/lib/workflows/sessions/session-mcp-launch.test.ts src/lib/domain/files/file-visuals.test.ts`
- `git diff --check`
