### PR TITLE
refactor(desktop): organize workspace command palette hooks

### DIFF
--- a/desktop/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx
+++ b/desktop/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx
@@ -11,7 +11,7 @@ import { FileTreeEntryIcon } from "@/components/ui/file-icons";
 import {
   CommandPaletteGlyph,
 } from "@/components/ui/icons";
-import { useWorkspaceCommandPalette } from "@/hooks/workspaces/use-workspace-command-palette";
+import { useWorkspaceCommandPalette } from "@/hooks/workspaces/facade/use-workspace-command-palette";
 import type {
   CommandPaletteEntry,
   CommandPaletteIconId,

--- a/desktop/src/hooks/workspaces/derived/use-workspace-command-palette-open-files.ts
+++ b/desktop/src/hooks/workspaces/derived/use-workspace-command-palette-open-files.ts
@@ -14,6 +14,7 @@ export interface CommandPaletteOpenFileEntry {
   isActive: boolean;
 }
 
+// Derives open file entries for command-palette rendering from viewer tab state.
 export function useWorkspaceCommandPaletteOpenFiles(
   selectedWorkspaceId: string | null,
 ): CommandPaletteOpenFileEntry[] {

--- a/desktop/src/hooks/workspaces/facade/use-workspace-command-palette.ts
+++ b/desktop/src/hooks/workspaces/facade/use-workspace-command-palette.ts
@@ -2,9 +2,9 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { SHORTCUTS } from "@/config/shortcuts";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
-import { useWorkspaceCommandPaletteFileSearch } from "@/hooks/workspaces/use-workspace-command-palette-file-search";
-import { useWorkspaceCommandPaletteOpenFiles } from "@/hooks/workspaces/use-workspace-command-palette-open-files";
-import { useWorkspaceCommandPaletteTabs } from "@/hooks/workspaces/use-workspace-command-palette-tabs";
+import { useWorkspaceCommandPaletteFileSearch } from "@/hooks/workspaces/ui/use-workspace-command-palette-file-search";
+import { useWorkspaceCommandPaletteOpenFiles } from "@/hooks/workspaces/derived/use-workspace-command-palette-open-files";
+import { useWorkspaceCommandPaletteTabs } from "@/hooks/workspaces/workflows/use-workspace-command-palette-tabs";
 import { useAppCommandActionsContext } from "@/providers/AppCommandActionsProvider";
 import {
   commandPaletteCommandValue,
@@ -41,6 +41,8 @@ interface UseWorkspaceCommandPaletteArgs {
   onToggleRightPanel: () => void;
 }
 
+// Owns the command palette view-model for the workspace shell.
+// Search mechanics, open-file state, and tab actions live in narrower hooks.
 export function useWorkspaceCommandPalette({
   open,
   query,

--- a/desktop/src/hooks/workspaces/ui/use-workspace-command-palette-file-search.ts
+++ b/desktop/src/hooks/workspaces/ui/use-workspace-command-palette-file-search.ts
@@ -15,6 +15,7 @@ interface UseWorkspaceCommandPaletteFileSearchArgs {
   query: string;
 }
 
+// Owns command-palette-specific file search debouncing and query state.
 export function useWorkspaceCommandPaletteFileSearch({
   open,
   selectedWorkspaceId,

--- a/desktop/src/hooks/workspaces/workflows/use-workspace-command-palette-tabs.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-workspace-command-palette-tabs.ts
@@ -16,6 +16,7 @@ import {
   startLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
 
+// Owns command-palette tab actions. It does not build palette entries.
 export function useWorkspaceCommandPaletteTabs() {
   const model = useWorkspaceHeaderTabsViewModel();
   const selectedWorkspaceId = model.selectedWorkspaceId;


### PR DESCRIPTION
## Summary
- Move workspace command-palette hooks into responsibility folders under `hooks/workspaces`.
- Keep the command-palette view-model as a facade, open-file state as derived, file search as UI search mechanics, and tab actions as workflows.
- Update the command palette component import.

## Verification
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/lib/domain/command-palette/entries.test.ts`