### PR TITLE
refactor(desktop): move easy AnyHarness access leftovers

### DIFF
--- a/desktop/src/hooks/playground/use-replay-session.ts
+++ b/desktop/src/hooks/playground/use-replay-session.ts
@@ -1,9 +1,19 @@
-import { getAnyHarnessClient } from "@anyharness/sdk-react";
 import type { ReplayRecordingSummary } from "@anyharness/sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { resolveSessionViewState } from "@/lib/domain/sessions/activity";
 import { DESKTOP_ORIGIN } from "@/lib/domain/sessions/desktop-origin";
 import { closeSessionStreamHandle } from "@/lib/access/anyharness/session-stream-handles";
+import { closeSession } from "@/lib/access/anyharness/sessions";
+import {
+  advanceReplaySession,
+  createReplaySession as createReplaySessionAccess,
+  getReplayRuntimeHealth,
+  listReplayRecordings,
+} from "@/lib/access/anyharness/replay";
+import {
+  getWorkspace,
+  resolveWorkspaceFromPath,
+} from "@/lib/access/anyharness/workspaces";
 import { useSessionRuntimeActions } from "@/hooks/sessions/use-session-runtime-actions";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
@@ -36,7 +46,7 @@ export interface PlaygroundReplayState {
 
 export function useReplaySession(recordingId: string | null): PlaygroundReplayState {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const client = useMemo(() => getAnyHarnessClient({ runtimeUrl }), [runtimeUrl]);
+  const connection = useMemo(() => ({ runtimeUrl }), [runtimeUrl]);
   const { ensureSessionStreamConnected } = useSessionRuntimeActions();
   const ensureSessionStreamConnectedRef = useRef(ensureSessionStreamConnected);
   const [enabled, setEnabled] = useState(false);
@@ -69,7 +79,7 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
 
     async function loadRecordings() {
       try {
-        const health = await client.runtime.getHealth();
+        const health = await getReplayRuntimeHealth(connection);
         const replayEnabled = health.capabilities?.replay === true;
         if (cancelled) {
           return;
@@ -79,7 +89,7 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
           setRecordings([]);
           return;
         }
-        const response = await client.replay.listRecordings();
+        const response = await listReplayRecordings(connection);
         if (!cancelled) {
           setRecordings(response.recordings);
         }
@@ -101,7 +111,7 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [connection]);
 
   useEffect(() => {
     if (!enabled || !recordingId) {
@@ -120,20 +130,20 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
     async function createReplaySession() {
       try {
         const resolvedWorkspaceId = await resolveReplayWorkspaceId(
-          client,
+          connection,
           useSessionSelectionStore.getState().selectedWorkspaceId,
         );
         if (cancelled) {
           return;
         }
-        const response = await client.replay.createSession({
+        const response = await createReplaySessionAccess(connection, {
           workspaceId: resolvedWorkspaceId,
           recordingId: activeRecordingId,
         });
         const session = response.session;
         createdSessionId = session.id;
         if (cancelled) {
-          cleanupReplaySession(client, session.id);
+          cleanupReplaySession(connection, session.id);
           return;
         }
         putSessionRecord({
@@ -179,11 +189,11 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
     return () => {
       cancelled = true;
       if (createdSessionId) {
-        cleanupReplaySession(client, createdSessionId);
+        cleanupReplaySession(connection, createdSessionId);
       }
     };
   }, [
-    client,
+    connection,
     enabled,
     recordingId,
   ]);
@@ -216,13 +226,13 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
     setIsAdvancing(true);
     setError(null);
     try {
-      await client.replay.advanceSession(sessionId);
+      await advanceReplaySession(connection, sessionId);
     } catch (advanceError) {
       setError(errorMessage(advanceError));
     } finally {
       setIsAdvancing(false);
     }
-  }, [canAdvance, client, sessionId]);
+  }, [canAdvance, connection, sessionId]);
 
   return {
     enabled,
@@ -241,19 +251,19 @@ export function useReplaySession(recordingId: string | null): PlaygroundReplaySt
 }
 
 async function resolveReplayWorkspaceId(
-  client: ReturnType<typeof getAnyHarnessClient>,
+  connection: Parameters<typeof getReplayRuntimeHealth>[0],
   selectedWorkspaceId: string | null,
 ): Promise<string> {
   if (selectedWorkspaceId) {
     try {
-      await client.workspaces.get(selectedWorkspaceId);
+      await getWorkspace(connection, selectedWorkspaceId);
       return selectedWorkspaceId;
     } catch {
       // Fall back to the dev replay workspace below.
     }
   }
 
-  const response = await client.workspaces.resolveFromPath({
+  const response = await resolveWorkspaceFromPath(connection, {
     path: PLAYGROUND_REPLAY_WORKSPACE_PATH,
     origin: DESKTOP_ORIGIN,
   });
@@ -261,7 +271,7 @@ async function resolveReplayWorkspaceId(
 }
 
 function cleanupReplaySession(
-  client: ReturnType<typeof getAnyHarnessClient>,
+  connection: Parameters<typeof getReplayRuntimeHealth>[0],
   sessionId: string,
 ): void {
   closeSessionStreamHandle(sessionId);
@@ -270,7 +280,7 @@ function cleanupReplaySession(
   if (state.activeSessionId === sessionId) {
     state.setActiveSessionId(null);
   }
-  void client.sessions.close(sessionId).catch(() => {});
+  void closeSession(connection, sessionId).catch(() => {});
 }
 
 function errorMessage(error: unknown): string {

--- a/desktop/src/hooks/workspaces/use-workspace-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-actions.ts
@@ -1,4 +1,3 @@
-import { getAnyHarnessClient } from "@anyharness/sdk-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AnyHarnessError,
@@ -10,6 +9,11 @@ import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { getHomeDir } from "@/lib/access/tauri/shell";
+import {
+  createWorkspace,
+  createWorktreeWorkspace,
+  resolveWorkspaceFromPath,
+} from "@/lib/access/anyharness/workspaces";
 import {
   collectWorktreeBasenamesForRepo,
   generateWorkspaceSlug,
@@ -127,14 +131,14 @@ export function useWorkspaceActions() {
     },
     mutationFn: async (sourceRoot) => {
       const readyRuntimeUrl = await ensureRuntimeReady();
-      const client = getAnyHarnessClient({ runtimeUrl: readyRuntimeUrl });
+      const connection = { runtimeUrl: readyRuntimeUrl };
       const request = {
         path: sourceRoot,
         origin: DESKTOP_ORIGIN,
       };
 
       try {
-        const response = await client.workspaces.create(request);
+        const response = await createWorkspace(connection, request);
         return {
           workspace: response.workspace,
           created: true,
@@ -144,7 +148,7 @@ export function useWorkspaceActions() {
           throw error;
         }
 
-        const response = await client.workspaces.resolveFromPath(request);
+        const response = await resolveWorkspaceFromPath(connection, request);
         return {
           workspace: response.workspace,
           created: false,
@@ -182,7 +186,7 @@ export function useWorkspaceActions() {
     },
     mutationFn: async ({ params, latencyFlowId }) => {
       const readyRuntimeUrl = await ensureRuntimeReady();
-      return getAnyHarnessClient({ runtimeUrl: readyRuntimeUrl }).workspaces.createWorktree({
+      return createWorktreeWorkspace({ runtimeUrl: readyRuntimeUrl }, {
         repoRootId: params.repoRootId,
         targetPath: params.targetPath,
         newBranchName: params.branchName,

--- a/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
@@ -2,7 +2,6 @@ import {
   anyHarnessModelRegistriesKey,
   anyHarnessSessionsKey,
   anyHarnessWorkspaceSessionLaunchKey,
-  getAnyHarnessClient,
   type AnyHarnessResolvedConnection,
 } from "@anyharness/sdk-react";
 import type { AnyHarnessRequestOptions, ModelRegistry } from "@anyharness/sdk";
@@ -12,6 +11,9 @@ import { useShallow } from "zustand/react/shallow";
 import { orderChatLaunchAgents, shouldExposeChatLaunchAgent } from "@/config/chat-launch";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
 import { useWorkspaces } from "@/hooks/workspaces/use-workspaces";
+import { listModelRegistries } from "@/lib/access/anyharness/model-registries";
+import { listWorkspaceSessions } from "@/lib/access/anyharness/sessions";
+import { getWorkspaceSessionLaunchCatalog } from "@/lib/access/anyharness/workspaces";
 import { useSessionActions } from "@/hooks/sessions/use-session-actions";
 import { useSessionRuntimeActions } from "@/hooks/sessions/use-session-runtime-actions";
 import { isSessionModelAvailabilityInterruption } from "@/hooks/sessions/use-session-model-availability-workflow";
@@ -136,10 +138,7 @@ async function fetchWorkspaceSessionsWithConnection(
       const requestOptions = options?.includeDismissed
         ? { ...timedRequestOptions, includeDismissed: true }
         : timedRequestOptions;
-      return await getAnyHarnessClient(workspaceConnection).sessions.list(
-        workspaceConnection.anyharnessWorkspaceId,
-        requestOptions,
-      );
+      return await listWorkspaceSessions(workspaceConnection, requestOptions);
     },
   );
   return sessions.map((session) => ({
@@ -156,8 +155,8 @@ async function fetchWorkspaceLaunchCatalog(
   const requestOptions = latencyFlowId
     ? { headers: getLatencyFlowRequestHeaders(latencyFlowId) }
     : undefined;
-  return getAnyHarnessClient(workspaceConnection).workspaces.getSessionLaunchCatalog(
-    workspaceConnection.anyharnessWorkspaceId,
+  return getWorkspaceSessionLaunchCatalog(
+    workspaceConnection,
     signal ? requestOptionsWithSignal(requestOptions, signal) : requestOptions,
   );
 }
@@ -463,9 +462,7 @@ export function useWorkspaceBootstrapActions() {
       }).catch(() => null);
       const modelRegistries = await queryClient.ensureQueryData({
         queryKey: anyHarnessModelRegistriesKey(runtimeUrl),
-        queryFn: ({ signal }) => getAnyHarnessClient(workspaceConnection)
-          .modelRegistries
-          .list({ signal }),
+        queryFn: ({ signal }) => listModelRegistries(workspaceConnection, { signal }),
       }).catch(() => EMPTY_MODEL_REGISTRIES);
 
       logLatency("workspace.select.launch_catalog_loaded", {

--- a/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
@@ -1,9 +1,11 @@
-import { getAnyHarnessClient } from "@anyharness/sdk-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   type WorkspaceCollections,
   upsertLocalWorkspaceCollections,
 } from "@/lib/domain/workspaces/cloud/collections";
+import {
+  updateWorkspaceDisplayName as updateAnyHarnessWorkspaceDisplayName,
+} from "@/lib/access/anyharness/workspaces";
 import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
 import {
   getCloudWorkspaceConnection,
@@ -90,7 +92,8 @@ export function useWorkspaceDisplayNameActions() {
       // Local AnyHarness workspaces: PATCH the runtime, then prime the
       // local-workspace cache so the sidebar updates without a roundtrip.
       const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;
-      const workspace = await getAnyHarnessClient({ runtimeUrl }).workspaces.updateDisplayName(
+      const workspace = await updateAnyHarnessWorkspaceDisplayName(
+        { runtimeUrl },
         logicalWorkspace.localWorkspace.id,
         { displayName },
         getMeasurementRequestOptions({
@@ -151,10 +154,11 @@ async function clearCloudRuntimeWorkspaceDisplayName(input: {
       return;
     }
 
-    await getAnyHarnessClient({
-      runtimeUrl: connectionInfo.runtimeUrl,
-      authToken: connectionInfo.accessToken,
-    }).workspaces.updateDisplayName(
+    await updateAnyHarnessWorkspaceDisplayName(
+      {
+        runtimeUrl: connectionInfo.runtimeUrl,
+        authToken: connectionInfo.accessToken,
+      },
       connectionInfo.anyharnessWorkspaceId,
       { displayName: null },
       getMeasurementRequestOptions({

--- a/desktop/src/lib/access/anyharness/replay.ts
+++ b/desktop/src/lib/access/anyharness/replay.ts
@@ -1,5 +1,35 @@
+import type {
+  AnyHarnessRequestOptions,
+  CreateReplaySessionRequest,
+} from "@anyharness/sdk";
 import { getAnyHarnessClient, type AnyHarnessClientConnection } from "@anyharness/sdk-react";
 
-export function createReplayAccessClient(connection: AnyHarnessClientConnection) {
-  return getAnyHarnessClient(connection);
+export function getReplayRuntimeHealth(
+  connection: AnyHarnessClientConnection,
+  options?: AnyHarnessRequestOptions,
+) {
+  return getAnyHarnessClient(connection).runtime.getHealth(options);
+}
+
+export function listReplayRecordings(
+  connection: AnyHarnessClientConnection,
+  options?: AnyHarnessRequestOptions,
+) {
+  return getAnyHarnessClient(connection).replay.listRecordings(options);
+}
+
+export function createReplaySession(
+  connection: AnyHarnessClientConnection,
+  request: CreateReplaySessionRequest,
+  options?: AnyHarnessRequestOptions,
+) {
+  return getAnyHarnessClient(connection).replay.createSession(request, options);
+}
+
+export function advanceReplaySession(
+  connection: AnyHarnessClientConnection,
+  sessionId: string,
+  options?: AnyHarnessRequestOptions,
+) {
+  return getAnyHarnessClient(connection).replay.advanceSession(sessionId, options);
 }

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -2,10 +2,6 @@
 #
 # Format:
 # RULE_ID path count reason
-ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/playground/use-replay-session.ts 4 raw AnyHarness client before access migration
-ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-actions.ts 3 raw AnyHarness client before access migration
-ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts 4 raw AnyHarness client before access migration
-ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts 3 raw AnyHarness client before access migration
 ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/lib/workflows/sessions/session-runtime.ts 6 raw AnyHarness client before access migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- moves easy raw AnyHarness client construction out of playground/workspace hooks and through `lib/access/anyharness` helpers
- adds replay-specific AnyHarness access helpers for the playground replay hook
- removes four `ANYHARNESS_CLIENT_OUTSIDE_ACCESS` allowlist entries; leaves session runtime deferred intentionally

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/hooks/workspaces/use-workspace-actions.test.tsx`
