### PR TITLE
refactor(desktop): move cloud cache ownership to access hooks

### DIFF
--- a/desktop/src/hooks/access/cloud/use-cloud-credential-cache.ts
+++ b/desktop/src/hooks/access/cloud/use-cloud-credential-cache.ts
@@ -1,0 +1,15 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { cloudCredentialsKey } from "@/hooks/access/cloud/query-keys";
+
+export function useCloudCredentialCache() {
+  const queryClient = useQueryClient();
+
+  const invalidateCloudCredentials = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: cloudCredentialsKey() });
+  }, [queryClient]);
+
+  return {
+    invalidateCloudCredentials,
+  };
+}

--- a/desktop/src/hooks/access/cloud/use-cloud-repo-config-cache.ts
+++ b/desktop/src/hooks/access/cloud/use-cloud-repo-config-cache.ts
@@ -1,0 +1,37 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import {
+  cloudRepoConfigKey,
+  cloudRepoConfigsKey,
+  isCloudWorkspaceRepoConfigStatusQueryKey,
+} from "@/hooks/access/cloud/query-keys";
+
+export function useCloudRepoConfigCache() {
+  const queryClient = useQueryClient();
+
+  const invalidateCloudRepoConfigs = useCallback(async (input?: {
+    gitOwner?: string | null;
+    gitRepoName?: string | null;
+  }) => {
+    const gitOwner = input?.gitOwner?.trim() ?? "";
+    const gitRepoName = input?.gitRepoName?.trim() ?? "";
+    const invalidations: Promise<unknown>[] = [
+      queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() }),
+      queryClient.invalidateQueries({
+        predicate: (query) => isCloudWorkspaceRepoConfigStatusQueryKey(query.queryKey),
+      }),
+    ];
+
+    if (gitOwner && gitRepoName) {
+      invalidations.push(
+        queryClient.invalidateQueries({ queryKey: cloudRepoConfigKey(gitOwner, gitRepoName) }),
+      );
+    }
+
+    await Promise.all(invalidations);
+  }, [queryClient]);
+
+  return {
+    invalidateCloudRepoConfigs,
+  };
+}

--- a/desktop/src/hooks/access/cloud/use-cloud-workspace-connection-cache.ts
+++ b/desktop/src/hooks/access/cloud/use-cloud-workspace-connection-cache.ts
@@ -1,9 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { cloudWorkspaceConnectionKey } from "@/hooks/access/cloud/query-keys";
+import { clearCachedCloudConnections } from "@/hooks/access/cloud/cloud-connection-cache";
 
 export function useCloudWorkspaceConnectionCache() {
   const queryClient = useQueryClient();
+
+  const clearCachedCloudWorkspaceConnections = useCallback(async (workspaceId?: string) => {
+    await clearCachedCloudConnections(queryClient, workspaceId);
+  }, [queryClient]);
 
   const invalidateCloudWorkspaceConnection = useCallback(async (workspaceId: string) => {
     await queryClient.invalidateQueries({
@@ -13,6 +18,7 @@ export function useCloudWorkspaceConnectionCache() {
   }, [queryClient]);
 
   return {
+    clearCachedCloudWorkspaceConnections,
     invalidateCloudWorkspaceConnection,
   };
 }

--- a/desktop/src/hooks/cloud/lifecycle/use-runtime-input-sync-runtime.ts
+++ b/desktop/src/hooks/cloud/lifecycle/use-runtime-input-sync-runtime.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   createRuntimeInputSyncQueueState,
   dequeueRuntimeInputSyncDescriptor,
@@ -18,15 +17,11 @@ import { getCloudRepoConfig } from "@/lib/access/cloud/repo-configs";
 import { useTauriCredentialsActions } from "@/hooks/access/tauri/use-credentials-actions";
 import { trackProductEvent } from "@/lib/integrations/telemetry/client";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
+import { useCloudCredentialCache } from "@/hooks/access/cloud/use-cloud-credential-cache";
+import { useCloudRepoConfigCache } from "@/hooks/access/cloud/use-cloud-repo-config-cache";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
-import {
-  cloudCredentialsKey,
-  cloudRepoConfigKey,
-  cloudRepoConfigsKey,
-  isCloudWorkspaceRepoConfigStatusQueryKey,
-} from "@/hooks/access/cloud/query-keys";
 import { syncLocalCloudCredentialToCloud } from "@/lib/access/cloud/credential-sync";
 import { subscribeRuntimeInputSyncEvents } from "./runtime-input-sync-events";
 
@@ -88,7 +83,6 @@ function classifyRuntimeInputSyncFailure(error: unknown): RuntimeInputSyncFailur
 }
 
 export function useRuntimeInputSyncRuntime() {
-  const queryClient = useQueryClient();
   const { listSyncableCloudCredentials } = useTauriCredentialsActions();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const preferencesHydrated = useUserPreferencesStore((state) => state._hydrated);
@@ -100,17 +94,15 @@ export function useRuntimeInputSyncRuntime() {
   const queueRef = useRef<RuntimeInputSyncQueueState>(createRuntimeInputSyncQueueState());
   const inFlightRef = useRef(false);
   const runtimeUrlRef = useRef(runtimeUrl);
-  const queryClientRef = useRef(queryClient);
   const keepFreshActiveRef = useRef(false);
   const previousOnlineRef = useRef(online);
+  const { invalidateCloudCredentials } = useCloudCredentialCache();
+  const { invalidateCloudRepoConfigs } = useCloudRepoConfigCache();
+  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
 
   useEffect(() => {
     runtimeUrlRef.current = runtimeUrl;
   }, [runtimeUrl]);
-
-  useEffect(() => {
-    queryClientRef.current = queryClient;
-  }, [queryClient]);
 
   const keepFreshActive =
     preferencesHydrated && cloudRuntimeInputSyncEnabled && cloudActive && online;
@@ -162,20 +154,12 @@ export function useRuntimeInputSyncRuntime() {
         content,
       },
     );
-    await Promise.all([
-      queryClientRef.current.invalidateQueries({ queryKey: cloudRepoConfigsKey() }),
-      queryClientRef.current.invalidateQueries({
-        queryKey: cloudRepoConfigKey(descriptor.gitOwner, descriptor.gitRepoName),
-      }),
-      queryClientRef.current.invalidateQueries({
-        predicate: (query) => isCloudWorkspaceRepoConfigStatusQueryKey(query.queryKey),
-      }),
-    ]);
+    await invalidateCloudRepoConfigs(descriptor);
     trackProductEvent("cloud_repo_file_resynced", {
       tracked_file_count: response.trackedFiles.length,
       tracked_file_source: file.sourceKind,
     });
-  }, []);
+  }, [invalidateCloudRepoConfigs]);
 
   const processDescriptor = useCallback(async (
     descriptor: RuntimeInputSyncDescriptor,
@@ -184,17 +168,15 @@ export function useRuntimeInputSyncRuntime() {
       case "credential":
         await syncLocalCloudCredentialToCloud(descriptor.provider);
         await Promise.all([
-          queryClientRef.current.invalidateQueries({ queryKey: cloudCredentialsKey() }),
-          queryClientRef.current.invalidateQueries({
-            queryKey: workspaceCollectionsScopeKey(runtimeUrlRef.current),
-          }),
+          invalidateCloudCredentials(),
+          invalidateWorkspaceCollections(),
         ]);
         return;
       case "repo_tracked_file":
         await syncRepoFile(descriptor);
         return;
     }
-  }, [syncRepoFile]);
+  }, [invalidateCloudCredentials, invalidateWorkspaceCollections, syncRepoFile]);
 
   const runQueuedDescriptors = useCallback(async (trigger: RuntimeInputSyncTrigger) => {
     if (

--- a/desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts
+++ b/desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import type {
   CloudWorkspaceDetail,
 } from "@/lib/access/cloud/client";
@@ -8,19 +8,16 @@ import {
   startCloudWorkspace,
   updateCloudWorkspaceBranch,
 } from "@/lib/access/cloud/workspaces";
-import {
-  type WorkspaceCollections,
-  upsertCloudWorkspaceCollections,
-} from "@/lib/domain/workspaces/cloud/collections";
 import { autoSyncDetectedCloudCredentialsIfNeeded } from "@/lib/access/cloud/credential-recovery";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
-import { clearCachedCloudConnections } from "@/hooks/access/cloud/cloud-connection-cache";
+import { useCloudWorkspaceConnectionCache } from "@/hooks/access/cloud/use-cloud-workspace-connection-cache";
+import { useInvalidateCloudBillingState } from "@/hooks/access/cloud/use-cloud-billing";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { getWorkspaceSessionRecords } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
-import { cloudBillingKey } from "@/hooks/access/cloud/query-keys";
-import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useCloudCredentialActions } from "@/hooks/cloud/workflows/use-cloud-credential-actions";
 import { clearViewedSessionErrors } from "@/stores/preferences/workspace-ui-store";
 import {
@@ -42,31 +39,20 @@ function resolveCloudWorkspaceRuntimeId(workspaceId: string): string {
 }
 
 export function useCloudWorkspaceActions() {
-  const queryClient = useQueryClient();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const { selectWorkspace, clearWorkspaceRuntimeState } = useWorkspaceSelection();
   const { syncCloudCredential } = useCloudCredentialActions();
+  const invalidateCloudBillingState = useInvalidateCloudBillingState();
+  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
+  const { upsertCloudWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
+  const { clearCachedCloudWorkspaceConnections } = useCloudWorkspaceConnectionCache();
   const clearDeferredLaunchesForWorkspace = useDeferredHomeLaunchStore((state) =>
     state.clearForWorkspace
   );
 
   async function invalidateCloudResources() {
-    await Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-      }),
-      queryClient.invalidateQueries({
-        queryKey: cloudBillingKey(),
-      }),
-    ]);
-  }
-
-  function primeCloudWorkspace(workspace: CloudWorkspaceDetail) {
-    queryClient.setQueriesData<WorkspaceCollections | undefined>(
-      { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
-      (collections) => upsertCloudWorkspaceCollections(collections, workspace),
-    );
+    await invalidateCloudBillingState();
   }
 
   const refreshMutation = useMutation<CloudWorkspaceDetail, Error, string>({
@@ -79,10 +65,8 @@ export function useCloudWorkspaceActions() {
       return workspace;
     },
     onSuccess: async (workspace) => {
-      primeCloudWorkspace(workspace);
-      await queryClient.invalidateQueries({
-        queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-      });
+      upsertCloudWorkspace(workspace);
+      await invalidateWorkspaceCollections();
     },
   });
 
@@ -108,8 +92,8 @@ export function useCloudWorkspaceActions() {
       }
     },
     onSuccess: async (workspace) => {
-      await clearCachedCloudConnections(queryClient, workspace.id);
-      primeCloudWorkspace(workspace);
+      await clearCachedCloudWorkspaceConnections(workspace.id);
+      upsertCloudWorkspace(workspace);
       await invalidateCloudResources();
       const syntheticWorkspaceId = cloudWorkspaceSyntheticId(workspace.id);
       const pendingWorkspaceEntry = useSessionSelectionStore.getState().pendingWorkspaceEntry;
@@ -154,7 +138,7 @@ export function useCloudWorkspaceActions() {
         ? workspaceId.slice("cloud:".length)
         : workspaceId;
       await deleteCloudWorkspace(cloudWorkspaceId);
-      await clearCachedCloudConnections(queryClient, cloudWorkspaceId);
+      await clearCachedCloudWorkspaceConnections(cloudWorkspaceId);
     },
     onSuccess: async (_, workspaceId, context) => {
       const runtimeWorkspaceId = resolveCloudWorkspaceRuntimeId(workspaceId);
@@ -191,7 +175,7 @@ export function useCloudWorkspaceActions() {
       return updateCloudWorkspaceBranch(cloudWorkspaceId, branchName);
     },
     onSuccess: async (workspace) => {
-      primeCloudWorkspace(workspace);
+      upsertCloudWorkspace(workspace);
       await invalidateCloudResources();
     },
   });

--- a/desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
+++ b/desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import type {
   CloudWorkspaceDetail,
   CreateCloudWorkspaceRequest,
@@ -18,7 +18,9 @@ import {
   createPendingWorkspaceAttemptId,
   type PendingWorkspaceEntry,
 } from "@/lib/domain/workspaces/creation/pending-entry";
-import { clearCachedCloudConnections } from "@/hooks/access/cloud/cloud-connection-cache";
+import { useCloudCredentialCache } from "@/hooks/access/cloud/use-cloud-credential-cache";
+import { useCloudWorkspaceConnectionCache } from "@/hooks/access/cloud/use-cloud-workspace-connection-cache";
+import { useInvalidateCloudBillingState } from "@/hooks/access/cloud/use-cloud-billing";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import { useWorkspaceEntryFlow } from "@/hooks/workspaces/use-workspace-entry-flow";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
@@ -26,12 +28,8 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 import { ensureRepoGroupExpanded } from "@/stores/preferences/workspace-ui-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import { workspaceCollectionsScopeKey, getWorkspaceCollectionsFromCache } from "@/hooks/workspaces/query-keys";
-import {
-  type WorkspaceCollections,
-  upsertCloudWorkspaceCollections,
-} from "@/lib/domain/workspaces/cloud/collections";
-import { cloudBillingKey, cloudCredentialsKey } from "@/hooks/access/cloud/query-keys";
+import { useWorkspaceCollectionsCache } from "@/hooks/workspaces/cache/use-workspace-collections-cache";
+import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useCloudCredentialActions } from "@/hooks/cloud/workflows/use-cloud-credential-actions";
 import { autoSyncDetectedCloudCredentialsIfNeeded } from "@/lib/access/cloud/credential-recovery";
 import {
@@ -75,7 +73,6 @@ function buildRepoTargetFromRequest(
 }
 
 export function useCreateCloudWorkspace() {
-  const queryClient = useQueryClient();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const setPendingWorkspaceEntry = useSessionSelectionStore((state) => state.setPendingWorkspaceEntry);
   const branchPrefixType = useUserPreferencesStore((state) => state.branchPrefixType);
@@ -83,6 +80,14 @@ export function useCreateCloudWorkspace() {
   const { selectWorkspace } = useWorkspaceSelection();
   const { beginPendingWorkspace, failPendingEntry, finalizeSelection } = useWorkspaceEntryFlow();
   const { syncCloudCredential } = useCloudCredentialActions();
+  const { invalidateCloudCredentials } = useCloudCredentialCache();
+  const invalidateCloudBillingState = useInvalidateCloudBillingState();
+  const { clearCachedCloudWorkspaceConnections } = useCloudWorkspaceConnectionCache();
+  const { getWorkspaceCollections } = useWorkspaceCollectionsCache({
+    runtimeUrl,
+    cloudActive: true,
+  });
+  const { upsertCloudWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
 
   const createMutation = useMutation<CloudWorkspaceDetail, Error, Parameters<typeof createCloudWorkspace>[0]>({
     meta: {
@@ -103,21 +108,11 @@ export function useCreateCloudWorkspace() {
       }
     },
     onSuccess: async (workspace) => {
-      await clearCachedCloudConnections(queryClient, workspace.id);
-      queryClient.setQueriesData<WorkspaceCollections | undefined>(
-        { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
-        (collections) => upsertCloudWorkspaceCollections(collections, workspace),
-      );
+      await clearCachedCloudWorkspaceConnections(workspace.id);
+      upsertCloudWorkspace(workspace);
       await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: cloudBillingKey(),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: cloudCredentialsKey(),
-        }),
+        invalidateCloudBillingState(),
+        invalidateCloudCredentials(),
       ]);
     },
   });
@@ -133,10 +128,7 @@ export function useCreateCloudWorkspace() {
     const startedAt = startLatencyTimer();
     const repoLabel = `${args.target.gitOwner}/${args.target.gitRepoName}`;
     const attemptId = createPendingWorkspaceAttemptId();
-    const cloudWorkspaces = getWorkspaceCollectionsFromCache(
-      queryClient,
-      runtimeUrl,
-    )?.cloudWorkspaces ?? [];
+    const cloudWorkspaces = getWorkspaceCollections()?.cloudWorkspaces ?? [];
     const knownBranchNames = collectKnownCloudBranchNames({
       target: args.target,
       cloudWorkspaces,
@@ -297,8 +289,7 @@ export function useCreateCloudWorkspace() {
     createCloudWorkspaceMutation,
     failPendingEntry,
     finalizeSelection,
-    queryClient,
-    runtimeUrl,
+    getWorkspaceCollections,
     selectWorkspace,
     setPendingWorkspaceEntry,
   ]);

--- a/desktop/src/hooks/cloud/workflows/use-resync-cloud-repo-file.ts
+++ b/desktop/src/hooks/cloud/workflows/use-resync-cloud-repo-file.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { resyncCloudRepoFileFromLocal } from "@/lib/access/cloud/repo-configs";
 import { readRepoTrackedTextFile } from "@/lib/access/anyharness/workspace-file-transport";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
@@ -8,16 +8,12 @@ import {
   captureTelemetryException,
   trackProductEvent,
 } from "@/lib/integrations/telemetry/client";
-import {
-  cloudRepoConfigKey,
-  cloudRepoConfigsKey,
-  isCloudWorkspaceRepoConfigStatusQueryKey,
-} from "@/hooks/access/cloud/query-keys";
+import { useCloudRepoConfigCache } from "@/hooks/access/cloud/use-cloud-repo-config-cache";
 import { emitRuntimeInputSyncEvent } from "../lifecycle/runtime-input-sync-events";
 
 export function useResyncCloudRepoFile(repository: SettingsRepositoryEntry | null) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const queryClient = useQueryClient();
+  const { invalidateCloudRepoConfigs } = useCloudRepoConfigCache();
 
   return useMutation<CloudRepoConfig, Error, { relativePath: string }>({
     meta: {
@@ -52,15 +48,7 @@ export function useResyncCloudRepoFile(repository: SettingsRepositoryEntry | nul
         return;
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() }),
-        queryClient.invalidateQueries({
-          queryKey: cloudRepoConfigKey(repository.gitOwner, repository.gitRepoName),
-        }),
-        queryClient.invalidateQueries({
-          predicate: (query) => isCloudWorkspaceRepoConfigStatusQueryKey(query.queryKey),
-        }),
-      ]);
+      await invalidateCloudRepoConfigs(repository);
 
       trackProductEvent("cloud_repo_file_resynced", {
         tracked_file_count: response.trackedFiles.length,

--- a/desktop/src/hooks/cloud/workflows/use-save-cloud-repo-config.ts
+++ b/desktop/src/hooks/cloud/workflows/use-save-cloud-repo-config.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { saveCloudRepoConfig } from "@/lib/access/cloud/repo-configs";
 import { readRepoTrackedTextFile } from "@/lib/access/anyharness/workspace-file-transport";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
@@ -8,11 +8,7 @@ import {
   captureTelemetryException,
   trackProductEvent,
 } from "@/lib/integrations/telemetry/client";
-import {
-  cloudRepoConfigKey,
-  cloudRepoConfigsKey,
-  isCloudWorkspaceRepoConfigStatusQueryKey,
-} from "@/hooks/access/cloud/query-keys";
+import { useCloudRepoConfigCache } from "@/hooks/access/cloud/use-cloud-repo-config-cache";
 import { emitRuntimeInputSyncEvent } from "../lifecycle/runtime-input-sync-events";
 
 interface SaveCloudRepoConfigInput {
@@ -53,7 +49,7 @@ export async function buildTrackedFilesPayload(
 
 export function useSaveCloudRepoConfig(repository: SettingsRepositoryEntry | null) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const queryClient = useQueryClient();
+  const { invalidateCloudRepoConfigs } = useCloudRepoConfigCache();
 
   return useMutation<CloudRepoConfig, Error, SaveCloudRepoConfigInput>({
     meta: {
@@ -89,15 +85,7 @@ export function useSaveCloudRepoConfig(repository: SettingsRepositoryEntry | nul
         return;
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() }),
-        queryClient.invalidateQueries({
-          queryKey: cloudRepoConfigKey(repository.gitOwner, repository.gitRepoName),
-        }),
-        queryClient.invalidateQueries({
-          predicate: (query) => isCloudWorkspaceRepoConfigStatusQueryKey(query.queryKey),
-        }),
-      ]);
+      await invalidateCloudRepoConfigs(repository);
 
       trackProductEvent("cloud_repo_config_saved", {
         env_var_count: Object.keys(variables.envVars).length,

--- a/desktop/src/hooks/workspaces/cache/use-workspace-collections-cache.ts
+++ b/desktop/src/hooks/workspaces/cache/use-workspace-collections-cache.ts
@@ -1,6 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { workspaceCollectionsKey } from "@/hooks/workspaces/query-keys";
+import {
+  getWorkspaceCollectionsFromCache,
+  workspaceCollectionsKey,
+} from "@/hooks/workspaces/query-keys";
 
 export function useWorkspaceCollectionsCache(args: {
   runtimeUrl: string;
@@ -17,7 +20,12 @@ export function useWorkspaceCollectionsCache(args: {
     return queryClient.getQueryState(queryKey);
   }, [queryClient, queryKey]);
 
+  const getWorkspaceCollections = useCallback(() => {
+    return getWorkspaceCollectionsFromCache(queryClient, runtimeUrl);
+  }, [queryClient, runtimeUrl]);
+
   return {
+    getWorkspaceCollections,
     getWorkspaceCollectionsCacheState,
     queryKey,
   };

--- a/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
+++ b/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
@@ -1,8 +1,10 @@
 import type { Workspace } from "@anyharness/sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import type { CloudWorkspaceDetail } from "@/lib/access/cloud/client";
 import {
   type WorkspaceCollections,
+  upsertCloudWorkspaceCollections,
   upsertLocalWorkspaceCollections,
 } from "@/lib/domain/workspaces/cloud/collections";
 import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
@@ -17,7 +19,15 @@ export function useWorkspaceCollectionsMutationCache(runtimeUrl: string) {
     );
   }, [queryClient, runtimeUrl]);
 
+  const upsertCloudWorkspace = useCallback((workspace: CloudWorkspaceDetail) => {
+    queryClient.setQueriesData<WorkspaceCollections | undefined>(
+      { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
+      (collections) => upsertCloudWorkspaceCollections(collections, workspace),
+    );
+  }, [queryClient, runtimeUrl]);
+
   return {
+    upsertCloudWorkspace,
     upsertLocalWorkspace,
   };
 }

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -13,11 +13,6 @@ DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/files/file-visuals.ts 2 domain im
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/mcp/local-stdio-finalizer.ts 1 domain imports transport or UI types before lib cleanup
 DOMAIN_FORBIDDEN_IMPORT desktop/src/lib/domain/telemetry/events.ts 1 domain imports transport or UI types before lib cleanup
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.ts 2 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts 5 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts 5 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-resync-cloud-repo-file.ts 5 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/lifecycle/use-runtime-input-sync-runtime.ts 2 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/cloud/workflows/use-save-cloud-repo-config.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/session-stream-side-effects.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/use-session-runtime-actions.ts 2 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- move cloud workflow/lifecycle React Query cache writes behind access/cache hooks
- add cloud credential and repo-config cache hooks for invalidation
- extend workspace collection and cloud connection cache hooks used by cloud workspace flows
- remove the cloud `QUERY_CLIENT_OUTSIDE_CACHE_OWNER` allowlist entries

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec vitest run src/hooks/cloud/workflows/use-save-cloud-repo-config.test.ts src/hooks/cloud/lifecycle/runtime-input-sync-events.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
