### PR TITLE
refactor(desktop): move workspace cache ownership into cache hooks

### DIFF
--- a/desktop/src/hooks/workspaces/cache/use-workspace-collections-invalidation.ts
+++ b/desktop/src/hooks/workspaces/cache/use-workspace-collections-invalidation.ts
@@ -12,3 +12,17 @@ export function useWorkspaceCollectionsInvalidation(runtimeUrl: string) {
     });
   }, [queryClient, runtimeUrl]);
 }
+
+export function useWorkspaceCollectionsInvalidationActions() {
+  const queryClient = useQueryClient();
+
+  const invalidateWorkspaceCollectionsForRuntime = useCallback(async (runtimeUrl: string) => {
+    await queryClient.invalidateQueries({
+      queryKey: workspaceCollectionsScopeKey(runtimeUrl),
+    });
+  }, [queryClient]);
+
+  return {
+    invalidateWorkspaceCollectionsForRuntime,
+  };
+}

--- a/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
+++ b/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
@@ -1,22 +1,72 @@
-import type { Workspace } from "@anyharness/sdk";
-import { useQueryClient } from "@tanstack/react-query";
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import type { CloudWorkspaceDetail } from "@/lib/access/cloud/client";
 import {
   type WorkspaceCollections,
   upsertCloudWorkspaceCollections,
   upsertLocalWorkspaceCollections,
+  upsertRepoRootCollections,
 } from "@/lib/domain/workspaces/cloud/collections";
+import type { CloudWorkspaceDetail } from "@/lib/access/cloud/client";
 import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
+
+export interface WorkspaceCollectionsLocalUpsertSummary {
+  previousLocalCount: number;
+  nextLocalCount: number;
+  alreadyPresent: boolean;
+}
+
+function upsertLocalWorkspaceForRuntime(
+  queryClient: QueryClient,
+  runtimeUrl: string,
+  workspace: Workspace,
+): WorkspaceCollectionsLocalUpsertSummary {
+  let previousLocalCount = 0;
+  let nextLocalCount = 0;
+  let alreadyPresent = false;
+
+  queryClient.setQueriesData<WorkspaceCollections | undefined>(
+    { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
+    (collections) => {
+      previousLocalCount = collections?.localWorkspaces.length ?? 0;
+      alreadyPresent = collections?.localWorkspaces.some(
+        (existing) => existing.id === workspace.id,
+      ) ?? false;
+      const nextCollections = upsertLocalWorkspaceCollections(collections, workspace);
+      nextLocalCount = nextCollections?.localWorkspaces.length ?? previousLocalCount;
+      return nextCollections;
+    },
+  );
+
+  return {
+    previousLocalCount,
+    nextLocalCount,
+    alreadyPresent,
+  };
+}
+
+function upsertRepoRootForRuntime(
+  queryClient: QueryClient,
+  runtimeUrl: string,
+  repoRoot: RepoRoot,
+): void {
+  queryClient.setQueriesData<WorkspaceCollections | undefined>(
+    { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
+    (collections) => upsertRepoRootCollections(collections, repoRoot),
+  );
+}
 
 export function useWorkspaceCollectionsMutationCache(runtimeUrl: string) {
   const queryClient = useQueryClient();
 
-  const upsertLocalWorkspace = useCallback((workspace: Workspace) => {
-    queryClient.setQueriesData<WorkspaceCollections | undefined>(
-      { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
-      (collections) => upsertLocalWorkspaceCollections(collections, workspace),
-    );
+  const upsertLocalWorkspace = useCallback(
+    (workspace: Workspace): WorkspaceCollectionsLocalUpsertSummary =>
+      upsertLocalWorkspaceForRuntime(queryClient, runtimeUrl, workspace),
+    [queryClient, runtimeUrl],
+  );
+
+  const upsertRepoRoot = useCallback((repoRoot: RepoRoot) => {
+    upsertRepoRootForRuntime(queryClient, runtimeUrl, repoRoot);
   }, [queryClient, runtimeUrl]);
 
   const upsertCloudWorkspace = useCallback((workspace: CloudWorkspaceDetail) => {
@@ -29,5 +79,21 @@ export function useWorkspaceCollectionsMutationCache(runtimeUrl: string) {
   return {
     upsertCloudWorkspace,
     upsertLocalWorkspace,
+    upsertRepoRoot,
+  };
+}
+
+export function useWorkspaceCollectionsMutationCacheActions() {
+  const queryClient = useQueryClient();
+
+  const upsertRepoRootInWorkspaceCollections = useCallback((
+    runtimeUrl: string,
+    repoRoot: RepoRoot,
+  ) => {
+    upsertRepoRootForRuntime(queryClient, runtimeUrl, repoRoot);
+  }, [queryClient]);
+
+  return {
+    upsertRepoRootInWorkspaceCollections,
   };
 }

--- a/desktop/src/hooks/workspaces/use-add-repo.ts
+++ b/desktop/src/hooks/workspaces/use-add-repo.ts
@@ -1,14 +1,14 @@
 import { AnyHarnessError } from "@anyharness/sdk";
 import { useResolveRepoRootFromPathMutation } from "@anyharness/sdk-react";
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { runAddRepoWorkflow } from "@/lib/domain/workspaces/creation/add-repo-workflow";
 import { pickFolder } from "@/lib/access/tauri/shell";
+import { useWorkspaceCollectionsInvalidationActions } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCacheActions } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useRepoSetupModalStore } from "@/stores/ui/repo-setup-modal-store";
 import { useToastStore } from "@/stores/toast/toast-store";
-import { workspaceCollectionsScopeKey } from "./query-keys";
 import { ensureRuntimeReady } from "./runtime-ready";
 
 function describeAddRepoFailure(error: unknown): string {
@@ -35,7 +35,8 @@ function isRepoEntryBlockedPath(pathname: string): boolean {
 
 export function useAddRepo() {
   const location = useLocation();
-  const queryClient = useQueryClient();
+  const { upsertRepoRootInWorkspaceCollections } = useWorkspaceCollectionsMutationCacheActions();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
   const resolveRepoRootFromPath = useResolveRepoRootFromPathMutation().mutateAsync;
   const unhideRepoRoot = useWorkspaceUiStore((state) => state.unhideRepoRoot);
   const openRepoSetupModal = useRepoSetupModalStore((state) => state.open);
@@ -52,19 +53,27 @@ export function useAddRepo() {
     try {
       await runAddRepoWorkflow({
         path,
-        queryClient,
         ensureRuntimeReady,
         resolveRepoRootFromPath: (repoPath) => resolveRepoRootFromPath(repoPath),
+        upsertRepoRootInWorkspaceCollections,
+        invalidateWorkspaceCollections: invalidateWorkspaceCollectionsForRuntime,
         unhideRepoRoot,
         openRepoSetupModal,
-        workspaceCollectionsScopeKey,
       });
     } catch (error) {
       showToast(describeAddRepoFailure(error));
     } finally {
       setIsAddingRepo(false);
     }
-  }, [canAddRepo, openRepoSetupModal, queryClient, resolveRepoRootFromPath, showToast, unhideRepoRoot]);
+  }, [
+    canAddRepo,
+    invalidateWorkspaceCollectionsForRuntime,
+    openRepoSetupModal,
+    resolveRepoRootFromPath,
+    showToast,
+    unhideRepoRoot,
+    upsertRepoRootInWorkspaceCollections,
+  ]);
 
   const addRepoFromPicker = useCallback(async () => {
     if (!canAddRepo) {

--- a/desktop/src/hooks/workspaces/use-workspace-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-actions.ts
@@ -1,10 +1,11 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import {
   AnyHarnessError,
   type CreateWorktreeWorkspaceResponse,
   type Workspace,
 } from "@anyharness/sdk";
-import { workspaceCollectionsScopeKey } from "./query-keys";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
@@ -20,10 +21,6 @@ import {
 } from "@/lib/domain/workspaces/creation/arrival";
 import { useWorkspaces } from "./use-workspaces";
 import { isCloudWorkspaceId } from "@/lib/domain/workspaces/cloud/cloud-ids";
-import {
-  type WorkspaceCollections,
-  upsertLocalWorkspaceCollections,
-} from "@/lib/domain/workspaces/cloud/collections";
 import {
   captureTelemetryException,
   trackProductEvent,
@@ -66,38 +63,24 @@ function isExistingWorkspacePathError(error: unknown): boolean {
 }
 
 export function useWorkspaceActions() {
-  const queryClient = useQueryClient();
+  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const { upsertLocalWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
+  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
   const { data: workspaceCollections } = useWorkspaces();
   const primeWorkspaceCollections = (
     workspace: Workspace,
     source: "local_create" | "worktree_create",
   ) => {
-    const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;
     const startedAt = startLatencyTimer();
-    let previousLocalCount = 0;
-    let nextLocalCount = 0;
-    let alreadyPresent = false;
-
-    queryClient.setQueriesData<WorkspaceCollections | undefined>(
-      { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
-      (collections) => {
-        previousLocalCount = collections?.localWorkspaces.length ?? 0;
-        alreadyPresent = collections?.localWorkspaces.some(
-          (existing) => existing.id === workspace.id,
-        ) ?? false;
-        const nextCollections = upsertLocalWorkspaceCollections(collections, workspace);
-        nextLocalCount = nextCollections?.localWorkspaces.length ?? previousLocalCount;
-        return nextCollections;
-      },
-    );
+    const summary = upsertLocalWorkspace(workspace);
 
     logLatency("workspace.collections.cache_upsert", {
       source,
       workspaceId: workspace.id,
       workspaceKind: workspace.kind,
-      alreadyPresent,
-      previousLocalCount,
-      nextLocalCount,
+      alreadyPresent: summary.alreadyPresent,
+      previousLocalCount: summary.previousLocalCount,
+      nextLocalCount: summary.nextLocalCount,
       elapsedMs: elapsedMs(startedAt),
     });
   };
@@ -113,9 +96,7 @@ export function useWorkspaceActions() {
       workspaceId,
       runtimeUrl,
     });
-    void queryClient.invalidateQueries({
-      queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-    }).then(() => {
+    void invalidateWorkspaceCollections().then(() => {
       logLatency("workspace.collections.invalidate.success", {
         source,
         workspaceId,

--- a/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
@@ -1,11 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  type WorkspaceCollections,
-  upsertLocalWorkspaceCollections,
-} from "@/lib/domain/workspaces/cloud/collections";
+import { useMutation } from "@tanstack/react-query";
 import {
   updateWorkspaceDisplayName as updateAnyHarnessWorkspaceDisplayName,
 } from "@/lib/access/anyharness/workspaces";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
 import {
   getCloudWorkspaceConnection,
@@ -15,7 +13,6 @@ import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces"
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
-import { workspaceCollectionsScopeKey } from "./query-keys";
 import {
   clearCloudDisplayNameBackfillSuppression,
   suppressCloudDisplayNameBackfill,
@@ -35,7 +32,9 @@ interface UpdateWorkspaceDisplayNameInput {
 }
 
 export function useWorkspaceDisplayNameActions() {
-  const queryClient = useQueryClient();
+  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const { upsertLocalWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
+  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
   const { logicalWorkspaces } = useLogicalWorkspaces();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
 
@@ -91,7 +90,6 @@ export function useWorkspaceDisplayNameActions() {
 
       // Local AnyHarness workspaces: PATCH the runtime, then prime the
       // local-workspace cache so the sidebar updates without a roundtrip.
-      const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;
       const workspace = await updateAnyHarnessWorkspaceDisplayName(
         { runtimeUrl },
         logicalWorkspace.localWorkspace.id,
@@ -102,10 +100,7 @@ export function useWorkspaceDisplayNameActions() {
         }),
       );
       const storeStartedAt = performance.now();
-      queryClient.setQueriesData<WorkspaceCollections | undefined>(
-        { queryKey: workspaceCollectionsScopeKey(runtimeUrl) },
-        (collections) => upsertLocalWorkspaceCollections(collections, workspace),
-      );
+      upsertLocalWorkspace(workspace);
       if (operationId) {
         recordMeasurementMetric({
           type: "store",
@@ -117,10 +112,7 @@ export function useWorkspaceDisplayNameActions() {
       }
     },
     onSuccess: () => {
-      const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;
-      void queryClient.invalidateQueries({
-        queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-      });
+      void invalidateWorkspaceCollections();
     },
     onError: (error) => {
       captureTelemetryException(error, {

--- a/desktop/src/hooks/workspaces/use-workspace-retire-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-retire-actions.ts
@@ -1,7 +1,6 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { APP_ROUTES } from "@/config/app-routes";
-import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { clearWorkspaceRuntimeState } from "@/hooks/workspaces/selection/clear-runtime-state";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
@@ -16,9 +15,9 @@ import {
 } from "@/lib/access/anyharness/workspaces";
 
 export function useWorkspaceRetireActions() {
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const refresh = useWorkspaceCollectionsInvalidation(runtimeUrl);
   const clearSelection = useSessionSelectionStore((state) => state.clearSelection);
   const setSelectedLogicalWorkspaceId = useSessionSelectionStore(
     (state) => state.setSelectedLogicalWorkspaceId,
@@ -26,12 +25,6 @@ export function useWorkspaceRetireActions() {
   const clearFinishSuggestionDismissal = useWorkspaceUiStore(
     (state) => state.clearFinishSuggestionDismissal,
   );
-
-  const refresh = async () => {
-    await queryClient.invalidateQueries({
-      queryKey: workspaceCollectionsScopeKey(runtimeUrl),
-    });
-  };
 
   return {
     markDone: async (

--- a/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.test.ts
+++ b/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.test.ts
@@ -20,26 +20,31 @@ function makeRepoRoot(overrides: Partial<RepoRoot> = {}): RepoRoot {
 
 describe("runAddRepoWorkflow", () => {
   it("opens repo setup after registering a new repository", async () => {
-    const queryClient = {
-      setQueriesData: vi.fn(),
-      invalidateQueries: vi.fn().mockResolvedValue(undefined),
-    };
     const ensureRuntimeReady = vi.fn().mockResolvedValue("http://localhost:7007");
     const resolveRepoRootFromPath = vi.fn().mockResolvedValue(makeRepoRoot());
+    const upsertRepoRootInWorkspaceCollections = vi.fn();
+    const invalidateWorkspaceCollections = vi.fn().mockResolvedValue(undefined);
     const unhideRepoRoot = vi.fn();
     const openRepoSetupModal = vi.fn();
 
     await runAddRepoWorkflow({
       path: "/tmp/proliferate",
-      queryClient,
       ensureRuntimeReady,
       resolveRepoRootFromPath,
+      upsertRepoRootInWorkspaceCollections,
+      invalidateWorkspaceCollections,
       unhideRepoRoot,
       openRepoSetupModal,
-      workspaceCollectionsScopeKey: (runtimeUrl) => ["workspaces", runtimeUrl],
     });
 
     expect(resolveRepoRootFromPath).toHaveBeenCalledWith("/tmp/proliferate");
+    expect(upsertRepoRootInWorkspaceCollections).toHaveBeenCalledWith(
+      "http://localhost:7007",
+      expect.objectContaining({
+      id: "repo-root-1",
+      }),
+    );
+    expect(invalidateWorkspaceCollections).toHaveBeenCalledWith("http://localhost:7007");
     expect(unhideRepoRoot).toHaveBeenCalledWith("repo-root-1");
     expect(openRepoSetupModal).toHaveBeenCalledWith({
       sourceRoot: "/tmp/proliferate",
@@ -48,10 +53,6 @@ describe("runAddRepoWorkflow", () => {
   });
 
   it("reopens repo setup when registration resolves to an existing repo root", async () => {
-    const queryClient = {
-      setQueriesData: vi.fn(),
-      invalidateQueries: vi.fn().mockResolvedValue(undefined),
-    };
     const ensureRuntimeReady = vi.fn().mockResolvedValue("http://localhost:7007");
     const resolveRepoRootFromPath = vi.fn().mockResolvedValue(
       makeRepoRoot({
@@ -61,17 +62,19 @@ describe("runAddRepoWorkflow", () => {
         remoteRepoName: "existing-repo",
       }),
     );
+    const upsertRepoRootInWorkspaceCollections = vi.fn();
+    const invalidateWorkspaceCollections = vi.fn().mockResolvedValue(undefined);
     const unhideRepoRoot = vi.fn();
     const openRepoSetupModal = vi.fn();
 
     await runAddRepoWorkflow({
       path: "/tmp/existing-repo",
-      queryClient,
       ensureRuntimeReady,
       resolveRepoRootFromPath,
+      upsertRepoRootInWorkspaceCollections,
+      invalidateWorkspaceCollections,
       unhideRepoRoot,
       openRepoSetupModal,
-      workspaceCollectionsScopeKey: (runtimeUrl) => ["workspaces", runtimeUrl],
     });
 
     expect(openRepoSetupModal).toHaveBeenCalledWith({

--- a/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.ts
+++ b/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.ts
@@ -1,6 +1,4 @@
 import type { RepoRoot } from "@anyharness/sdk";
-import type { WorkspaceCollections } from "@/lib/domain/workspaces/cloud/collections";
-import { upsertRepoRootCollections } from "@/lib/domain/workspaces/cloud/collections";
 import {
   elapsedMs,
   logLatency,
@@ -14,46 +12,33 @@ function resolveRepoName(repoRoot: RepoRoot): string {
     || "Repository";
 }
 
-export interface AddRepoWorkflowQueryClient {
-  // Keep this shape structural so the workflow can be exercised with small test doubles.
-  setQueriesData: (
-    filters: { queryKey: readonly unknown[] },
-    updater: (collections: WorkspaceCollections | undefined) => WorkspaceCollections | undefined,
-  ) => void;
-  invalidateQueries: (filters: { queryKey: readonly unknown[] }) => Promise<unknown>;
-}
-
 export interface RunAddRepoWorkflowArgs {
   path: string;
-  queryClient: AddRepoWorkflowQueryClient;
   ensureRuntimeReady: () => Promise<string>;
   resolveRepoRootFromPath: (path: string) => Promise<RepoRoot>;
+  upsertRepoRootInWorkspaceCollections: (runtimeUrl: string, repoRoot: RepoRoot) => void;
+  invalidateWorkspaceCollections: (runtimeUrl: string) => Promise<unknown>;
   unhideRepoRoot: (repoRootId: string) => void;
   openRepoSetupModal: (state: {
     sourceRoot: string;
     repoName: string;
   }) => void;
-  workspaceCollectionsScopeKey: (runtimeUrl: string) => readonly unknown[];
 }
 
 export async function runAddRepoWorkflow({
   path,
-  queryClient,
   ensureRuntimeReady,
   resolveRepoRootFromPath,
+  upsertRepoRootInWorkspaceCollections,
+  invalidateWorkspaceCollections,
   unhideRepoRoot,
   openRepoSetupModal,
-  workspaceCollectionsScopeKey,
 }: RunAddRepoWorkflowArgs): Promise<void> {
   const runtimeUrl = await ensureRuntimeReady();
   const repoRoot = await resolveRepoRootFromPath(path);
-  const collectionsScopeKey = workspaceCollectionsScopeKey(runtimeUrl);
 
   const cacheUpsertStartedAt = startLatencyTimer();
-  queryClient.setQueriesData(
-    { queryKey: collectionsScopeKey },
-    (collections) => upsertRepoRootCollections(collections, repoRoot),
-  );
+  upsertRepoRootInWorkspaceCollections(runtimeUrl, repoRoot);
   logLatency("workspace.collections.cache_upsert", {
     source: "repo_register",
     repoRootId: repoRoot.id,
@@ -62,9 +47,7 @@ export async function runAddRepoWorkflow({
 
   unhideRepoRoot(repoRoot.id);
   const invalidateStartedAt = startLatencyTimer();
-  await queryClient.invalidateQueries({
-    queryKey: collectionsScopeKey,
-  });
+  await invalidateWorkspaceCollections(runtimeUrl);
   logLatency("workspace.collections.invalidate.success", {
     source: "repo_register",
     repoRootId: repoRoot.id,

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -15,13 +15,8 @@ QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/cancel-d
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/connection.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/run-workspace-selection.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/use-workspace-selection.ts 2 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-add-repo.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-local-worktree-settings-target.ts 6 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-selected-cloud-runtime-state.ts 4 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-workspace-actions.ts 3 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts 5 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts 3 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-workspace-metadata-sync.ts 4 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-workspace-retire-actions.ts 3 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/use-worktree-settings-targets.ts 7 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/lib/domain/workspaces/creation/add-repo-workflow.ts 2 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary\n- move straightforward workspace collection cache writes/invalidations behind workspace cache hooks\n- remove query-client ownership from add-repo, workspace create/rename/retire, and worktree settings hooks\n- shrink workspace query/cache boundary allowlist entries\n\n## Verification\n- python3 scripts/check_frontend_boundaries.py\n- python3 scripts/check_max_lines.py\n- git diff --check origin/main...HEAD\n- pnpm --dir desktop exec vitest run src/lib/domain/workspaces/creation/add-repo-workflow.test.ts src/hooks/workspaces/use-workspace-actions.test.tsx\n- pnpm --dir desktop exec tsc --noEmit