### PR TITLE
refactor(server): move E2B webhook verification into integration

### DIFF
--- a/server/proliferate/integrations/sandbox/__init__.py
+++ b/server/proliferate/integrations/sandbox/__init__.py
@@ -9,6 +9,10 @@ from proliferate.integrations.sandbox.base import (
     SandboxProviderKind,
     SandboxRuntimeContext,
 )
+from proliferate.integrations.sandbox.e2b_webhooks import (
+    E2BWebhookSignatureError,
+    verify_e2b_webhook_signature,
+)
 from proliferate.integrations.sandbox.factory import (
     get_configured_sandbox_provider,
     get_sandbox_provider,
@@ -22,6 +26,8 @@ __all__ = [
     "SandboxProvider",
     "SandboxProviderError",
     "SandboxProviderKind",
+    "E2BWebhookSignatureError",
     "get_configured_sandbox_provider",
     "get_sandbox_provider",
+    "verify_e2b_webhook_signature",
 ]

--- a/server/proliferate/integrations/sandbox/e2b_webhooks.py
+++ b/server/proliferate/integrations/sandbox/e2b_webhooks.py
@@ -1,0 +1,42 @@
+"""E2B webhook integration helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from proliferate.config import settings
+
+
+class E2BWebhookSignatureError(RuntimeError):
+    def __init__(self, code: str, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def verify_e2b_webhook_signature(raw_body: bytes, signature: str | None) -> None:
+    secret = settings.e2b_webhook_signature_secret.strip()
+    if not secret:
+        raise E2BWebhookSignatureError(
+            "webhook_unavailable",
+            "E2B webhook verification is not configured.",
+            status_code=503,
+        )
+    if not signature:
+        raise E2BWebhookSignatureError(
+            "invalid_webhook_signature",
+            "E2B webhook signature is required.",
+            status_code=401,
+        )
+
+    digest = hashlib.sha256(secret.encode("utf-8") + raw_body).digest()
+    expected = base64.b64encode(digest).decode("utf-8").rstrip("=")
+    legacy_expected = expected.replace("+", "-").replace("/", "_")
+    if signature not in {expected, legacy_expected}:
+        raise E2BWebhookSignatureError(
+            "invalid_webhook_signature",
+            "E2B webhook signature is invalid.",
+            status_code=401,
+        )

--- a/server/proliferate/server/cloud/webhooks/service.py
+++ b/server/proliferate/server/cloud/webhooks/service.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import base64
-import hashlib
 from datetime import datetime
 from uuid import UUID
 
-from proliferate.config import settings
 from proliferate.constants.billing import (
     BILLING_MODE_ENFORCE,
     PROVIDER_EVENT_KIND_CREATED,
@@ -35,36 +32,25 @@ from proliferate.db.store.cloud_workspaces import (
     load_cloud_workspace_by_id,
     save_sandbox_provider_state,
 )
-from proliferate.integrations.sandbox import get_sandbox_provider
+from proliferate.integrations.sandbox import (
+    E2BWebhookSignatureError,
+    get_sandbox_provider,
+    verify_e2b_webhook_signature,
+)
 from proliferate.server.billing.service import get_billing_snapshot_for_subject
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.webhooks.models import E2BWebhookEvent, E2BWebhookReceipt
 
 
 def _verify_e2b_signature(raw_body: bytes, signature: str | None) -> None:
-    secret = settings.e2b_webhook_signature_secret.strip()
-    if not secret:
+    try:
+        verify_e2b_webhook_signature(raw_body, signature)
+    except E2BWebhookSignatureError as exc:
         raise CloudApiError(
-            "webhook_unavailable",
-            "E2B webhook verification is not configured.",
-            status_code=503,
-        )
-    if not signature:
-        raise CloudApiError(
-            "invalid_webhook_signature",
-            "E2B webhook signature is required.",
-            status_code=401,
-        )
-
-    digest = hashlib.sha256(secret.encode("utf-8") + raw_body).digest()
-    expected = base64.b64encode(digest).decode("utf-8").rstrip("=")
-    legacy_expected = expected.replace("+", "-").replace("/", "_")
-    if signature not in {expected, legacy_expected}:
-        raise CloudApiError(
-            "invalid_webhook_signature",
-            "E2B webhook signature is invalid.",
-            status_code=401,
-        )
+            exc.code,
+            exc.message,
+            status_code=exc.status_code,
+        ) from exc
 
 
 def _provider_event_kind(event_type: str) -> str | None:

--- a/server/tests/unit/test_cloud_webhook_service.py
+++ b/server/tests/unit/test_cloud_webhook_service.py
@@ -1,0 +1,16 @@
+import pytest
+
+from proliferate.config import settings
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.webhooks.service import _verify_e2b_signature
+
+
+def test_e2b_webhook_translates_signature_failure(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "e2b_webhook_signature_secret", "test-secret")
+
+    with pytest.raises(CloudApiError) as exc_info:
+        _verify_e2b_signature(b"{}", "bad-signature")
+
+    assert exc_info.value.code == "invalid_webhook_signature"
+    assert exc_info.value.message == "E2B webhook signature is invalid."
+    assert exc_info.value.status_code == 401

--- a/server/tests/unit/test_e2b_webhooks_integration.py
+++ b/server/tests/unit/test_e2b_webhooks_integration.py
@@ -1,0 +1,74 @@
+import base64
+import hashlib
+
+import pytest
+
+from proliferate.config import settings
+from proliferate.integrations.sandbox import (
+    E2BWebhookSignatureError,
+    verify_e2b_webhook_signature,
+)
+
+
+def _sign_webhook(secret: str, body: bytes) -> str:
+    digest = hashlib.sha256(secret.encode("utf-8") + body).digest()
+    return base64.b64encode(digest).decode("utf-8").rstrip("=")
+
+
+def test_verify_e2b_webhook_signature_accepts_signed_payload(monkeypatch) -> None:
+    body = b'{"id":"evt-test"}'
+    monkeypatch.setattr(settings, "e2b_webhook_signature_secret", "test-secret")
+
+    verify_e2b_webhook_signature(body, _sign_webhook("test-secret", body))
+
+
+def test_verify_e2b_webhook_signature_accepts_legacy_url_safe_signature(monkeypatch) -> None:
+    body = b"\x01\x02find-plus-and-slash"
+    monkeypatch.setattr(settings, "e2b_webhook_signature_secret", "test-secret")
+    signature = _sign_webhook("test-secret", body).replace("+", "-").replace("/", "_")
+
+    verify_e2b_webhook_signature(body, signature)
+
+
+@pytest.mark.parametrize(
+    ("secret", "signature", "expected_code", "expected_message", "expected_status"),
+    [
+        (
+            "",
+            "signature",
+            "webhook_unavailable",
+            "E2B webhook verification is not configured.",
+            503,
+        ),
+        (
+            "test-secret",
+            None,
+            "invalid_webhook_signature",
+            "E2B webhook signature is required.",
+            401,
+        ),
+        (
+            "test-secret",
+            "bad-signature",
+            "invalid_webhook_signature",
+            "E2B webhook signature is invalid.",
+            401,
+        ),
+    ],
+)
+def test_verify_e2b_webhook_signature_reports_failures(
+    monkeypatch,
+    secret: str,
+    signature: str | None,
+    expected_code: str,
+    expected_message: str,
+    expected_status: int,
+) -> None:
+    monkeypatch.setattr(settings, "e2b_webhook_signature_secret", secret)
+
+    with pytest.raises(E2BWebhookSignatureError) as exc_info:
+        verify_e2b_webhook_signature(b"{}", signature)
+
+    assert exc_info.value.code == expected_code
+    assert exc_info.value.message == expected_message
+    assert exc_info.value.status_code == expected_status


### PR DESCRIPTION
## Summary
- move E2B webhook signature digest verification behind the sandbox integration boundary
- translate integration signature failures back to the existing CloudApiError response metadata
- add focused unit coverage for integration verification and service-level error translation

## Verification
- DEBUG=1 uv run --extra dev python -m pytest -q tests/unit/test_e2b_runtime.py tests/unit/test_e2b_webhooks_integration.py tests/unit/test_cloud_webhook_service.py
- uv run --extra dev ruff check proliferate/integrations/sandbox/__init__.py proliferate/integrations/sandbox/e2b.py proliferate/integrations/sandbox/e2b_webhooks.py proliferate/server/cloud/webhooks/service.py tests/unit/test_e2b_runtime.py tests/unit/test_e2b_webhooks_integration.py tests/unit/test_cloud_webhook_service.py
- python3.12 scripts/check_server_boundaries.py
- python3.12 scripts/check_max_lines.py
- git diff --check

## Note
- Existing ASGI webhook route behavior was also spot-checked earlier with test_e2b_webhook_signature_rejected; the assertion passed, but local Postgres teardown failed while dropping the temporary database due to insufficient privileges to terminate another backend process.