### PR TITLE
refactor(desktop): move workspace file cache ownership

### DIFF
--- a/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
+++ b/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
@@ -1,9 +1,33 @@
 import { useQueryClient } from "@tanstack/react-query";
 import {
+  type AnyHarnessClientConnection,
+  anyHarnessWorkspaceFileKey,
   anyHarnessWorkspaceFileSearchScopeKey,
+  anyHarnessWorkspaceFileTreeKey,
   anyHarnessWorkspaceFilesScopeKey,
 } from "@anyharness/sdk-react";
 import { useCallback } from "react";
+import {
+  listWorkspaceFiles,
+  readWorkspaceFile,
+} from "@/lib/access/anyharness/workspace-file-transport";
+
+function buildConnection(
+  runtimeUrl: string,
+  authToken?: string | null,
+): AnyHarnessClientConnection {
+  return {
+    runtimeUrl,
+    authToken: authToken ?? undefined,
+  };
+}
+
+interface WorkspaceFileCacheTarget {
+  materializedWorkspaceId: string;
+  anyharnessWorkspaceId: string;
+  runtimeUrl: string;
+  authToken?: string | null;
+}
 
 export function useWorkspaceFilesCache() {
   const queryClient = useQueryClient();
@@ -25,7 +49,56 @@ export function useWorkspaceFilesCache() {
     ]);
   }, [queryClient]);
 
+  const prefetchWorkspaceDirectory = useCallback(async ({
+    materializedWorkspaceId,
+    anyharnessWorkspaceId,
+    runtimeUrl,
+    authToken,
+    dirPath,
+  }: WorkspaceFileCacheTarget & {
+    dirPath: string;
+  }) => {
+    await queryClient.prefetchQuery({
+      queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, materializedWorkspaceId, dirPath),
+      queryFn: async ({ signal }) => {
+        return listWorkspaceFiles(
+          buildConnection(runtimeUrl, authToken),
+          anyharnessWorkspaceId,
+          dirPath,
+          { signal },
+        );
+      },
+    });
+  }, [queryClient]);
+
+  const reloadWorkspaceFile = useCallback(async ({
+    materializedWorkspaceId,
+    anyharnessWorkspaceId,
+    runtimeUrl,
+    authToken,
+    filePath,
+  }: WorkspaceFileCacheTarget & {
+    filePath: string;
+  }) => {
+    const queryKey = anyHarnessWorkspaceFileKey(runtimeUrl, materializedWorkspaceId, filePath);
+    await queryClient.invalidateQueries({ queryKey, exact: true });
+    return queryClient.fetchQuery({
+      queryKey,
+      queryFn: async ({ signal }) => {
+        return readWorkspaceFile(
+          buildConnection(runtimeUrl, authToken),
+          anyharnessWorkspaceId,
+          filePath,
+          { signal },
+        );
+      },
+      staleTime: 0,
+    });
+  }, [queryClient]);
+
   return {
     invalidateWorkspaceFiles,
+    prefetchWorkspaceDirectory,
+    reloadWorkspaceFile,
   };
 }

--- a/desktop/src/hooks/workspaces/files/use-workspace-file-actions.ts
+++ b/desktop/src/hooks/workspaces/files/use-workspace-file-actions.ts
@@ -1,13 +1,10 @@
 import { useCallback } from "react";
 import { AnyHarnessError } from "@anyharness/sdk";
 import {
-  type AnyHarnessClientConnection,
-  anyHarnessWorkspaceFileKey,
-  anyHarnessWorkspaceFileTreeKey,
   useReadWorkspaceFileQuery,
   useWriteWorkspaceFileMutation,
 } from "@anyharness/sdk-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useWorkspaceFilesCache } from "@/hooks/access/anyharness/files/use-workspace-files-cache";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/use-workspace-runtime-block";
 import { deriveWorkspaceFileTabSeed } from "@/lib/domain/workspaces/tabs/shell-file-seed";
 import { resolveWithWorkspaceFallback } from "@/lib/domain/workspaces/selection/workspace-keyed-preferences";
@@ -18,25 +15,11 @@ import {
   type FileDiffViewerScope,
   type ViewerTarget,
 } from "@/lib/domain/workspaces/viewer/viewer-target";
-import {
-  listWorkspaceFiles,
-  readWorkspaceFile,
-} from "@/lib/access/anyharness/workspace-file-transport";
 import { useWorkspaceFileBuffersStore } from "@/stores/editor/workspace-file-buffers-store";
 import { useWorkspaceFileTreeUiStore } from "@/stores/editor/workspace-file-tree-ui-store";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useToastStore } from "@/stores/toast/toast-store";
-
-function buildConnection(
-  runtimeUrl: string,
-  authToken?: string | null,
-): AnyHarnessClientConnection {
-  return {
-    runtimeUrl,
-    authToken: authToken ?? undefined,
-  };
-}
 
 function directoryPathDepth(dirPath: string): number {
   return dirPath.split("/").filter(Boolean).length;
@@ -49,7 +32,7 @@ function getExpandedDirectoryPaths(treeStateKey: string): string[] {
 }
 
 export function useWorkspaceFileActions() {
-  const queryClient = useQueryClient();
+  const { prefetchWorkspaceDirectory, reloadWorkspaceFile } = useWorkspaceFilesCache();
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const showToast = useToastStore((state) => state.show);
   const prepareWorkspace = useWorkspaceViewerTabsStore((state) => state.prepareWorkspace);
@@ -77,32 +60,6 @@ export function useWorkspaceFileActions() {
     }
     return true;
   }, [getWorkspaceRuntimeBlockReason, showToast]);
-
-  const prefetchDirectory = useCallback(async ({
-    materializedWorkspaceId,
-    anyharnessWorkspaceId,
-    runtimeUrl,
-    authToken,
-    dirPath,
-  }: {
-    materializedWorkspaceId: string;
-    anyharnessWorkspaceId: string;
-    runtimeUrl: string;
-    authToken?: string | null;
-    dirPath: string;
-  }) => {
-    await queryClient.prefetchQuery({
-      queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, materializedWorkspaceId, dirPath),
-      queryFn: async ({ signal }) => {
-        return listWorkspaceFiles(
-          buildConnection(runtimeUrl, authToken),
-          anyharnessWorkspaceId,
-          dirPath,
-          { signal },
-        );
-      },
-    });
-  }, [queryClient]);
 
   const prepareFileWorkspace = useCallback(({
     workspaceUiKey,
@@ -179,7 +136,7 @@ export function useWorkspaceFileActions() {
     if (isCurrent && !isCurrent()) {
       return;
     }
-    await prefetchDirectory({
+    await prefetchWorkspaceDirectory({
       materializedWorkspaceId,
       anyharnessWorkspaceId,
       runtimeUrl,
@@ -191,7 +148,7 @@ export function useWorkspaceFileActions() {
         return;
       }
       try {
-        await prefetchDirectory({
+        await prefetchWorkspaceDirectory({
           materializedWorkspaceId,
           anyharnessWorkspaceId,
           runtimeUrl,
@@ -206,7 +163,7 @@ export function useWorkspaceFileActions() {
     }
   }, [
     assertWorkspaceRuntimeReady,
-    prefetchDirectory,
+    prefetchWorkspaceDirectory,
     removeExpandedDirectory,
   ]);
 
@@ -262,7 +219,7 @@ export function useWorkspaceFileActions() {
     }
     expandDirectory(treeStateKey, dirPath);
     if (assertWorkspaceRuntimeReady(materializedWorkspaceId)) {
-      await prefetchDirectory({
+      await prefetchWorkspaceDirectory({
         materializedWorkspaceId,
         anyharnessWorkspaceId,
         runtimeUrl,
@@ -274,7 +231,7 @@ export function useWorkspaceFileActions() {
     assertWorkspaceRuntimeReady,
     collapseDirectory,
     expandDirectory,
-    prefetchDirectory,
+    prefetchWorkspaceDirectory,
   ]);
 
   const openViewerTarget = useCallback((target: ViewerTarget) => {
@@ -345,22 +302,15 @@ export function useWorkspaceFileActions() {
       return;
     }
 
-    const queryKey = anyHarnessWorkspaceFileKey(runtimeUrl, materializedWorkspaceId, filePath);
-    await queryClient.invalidateQueries({ queryKey, exact: true });
-    const read = await queryClient.fetchQuery({
-      queryKey,
-      queryFn: async ({ signal }) => {
-        return readWorkspaceFile(
-          buildConnection(runtimeUrl, authToken),
-          anyharnessWorkspaceId,
-          filePath,
-          { signal },
-        );
-      },
-      staleTime: 0,
+    const read = await reloadWorkspaceFile({
+      materializedWorkspaceId,
+      anyharnessWorkspaceId,
+      runtimeUrl,
+      authToken,
+      filePath,
     });
     replaceBufferFromRead(filePath, read);
-  }, [queryClient, replaceBufferFromRead]);
+  }, [reloadWorkspaceFile, replaceBufferFromRead]);
 
   return {
     initForWorkspace,

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -7,7 +7,6 @@ QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/session-stream-side-effects.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/use-session-runtime-actions.ts 2 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/files/use-workspace-file-actions.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/mobility/reset-workspace-owner-flip-state.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/mobility/use-cloud-to-local-handoff.ts 5 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/mobility/use-local-to-cloud-handoff.ts 5 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary
- move workspace file prefetch/reload cache operations into the AnyHarness files cache hook
- keep workspace file actions focused on product workflow wiring
- remove the workspace files query-client allowlist entry

## Verification
- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check
- pnpm --dir desktop exec tsc --noEmit
