### PR TITLE
refactor(desktop): move plans cache ownership

### DIFF
--- a/desktop/src/hooks/plans/cache/use-proposed-plan-cache.ts
+++ b/desktop/src/hooks/plans/cache/use-proposed-plan-cache.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type {
+  ProposedPlanDetail,
+  ProposedPlanSummary,
+} from "@anyharness/sdk";
+import {
+  anyHarnessPlanKey,
+  anyHarnessPlansKey,
+} from "@anyharness/sdk-react";
+
+interface ProposedPlanCacheOptions {
+  runtimeUrl: string;
+  selectedWorkspaceId: string | null;
+}
+
+// Owns query-cache writes needed by proposed-plan card actions.
+export function useProposedPlanCache({
+  runtimeUrl,
+  selectedWorkspaceId,
+}: ProposedPlanCacheOptions) {
+  const queryClient = useQueryClient();
+
+  const patchPlanDecisionQueries = useCallback((plan: ProposedPlanDetail) => {
+    queryClient.setQueryData(
+      anyHarnessPlanKey(runtimeUrl, selectedWorkspaceId, plan.id),
+      plan,
+    );
+    queryClient.setQueryData<ProposedPlanSummary[]>(
+      anyHarnessPlansKey(runtimeUrl, selectedWorkspaceId),
+      (plans) => plans?.map((cachedPlan) => (
+        cachedPlan.id === plan.id ? { ...cachedPlan, ...plan } : cachedPlan
+      )),
+    );
+  }, [queryClient, runtimeUrl, selectedWorkspaceId]);
+
+  return {
+    patchPlanDecisionQueries,
+  };
+}

--- a/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
+++ b/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
@@ -1,5 +1,4 @@
 import { useCallback, useRef, useState } from "react";
-import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
   AnyHarnessError,
   type ContentPart,
@@ -7,11 +6,8 @@ import {
   type PlanDecisionResponse,
   type PromptInputBlock,
   type ProposedPlanDetail,
-  type ProposedPlanSummary,
 } from "@anyharness/sdk";
 import {
-  anyHarnessPlanKey,
-  anyHarnessPlansKey,
   useApprovePlanMutation,
   useFetchPlanMutation,
   useRejectPlanMutation,
@@ -19,6 +15,7 @@ import {
 import { useWorkspaceSetupStatusCache } from "@/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache";
 import { completeChatPromptSubmitSideEffects } from "@/hooks/chat/chat-submit-effects";
 import { useChatAvailabilityState } from "@/hooks/chat/derived/use-chat-availability-state";
+import { useProposedPlanCache } from "@/hooks/plans/cache/use-proposed-plan-cache";
 import { useReviewActions } from "@/hooks/reviews/workflows/use-review-actions";
 import { useSessionActions } from "@/hooks/sessions/use-session-actions";
 import { createPromptId } from "@/lib/domain/chat/composer/prompt-id";
@@ -94,7 +91,6 @@ interface ExecutePlanImplementationInput {
 
 // Owns proposed-plan card actions. Does not own transcript row rendering or session runtime.
 export function useProposedPlanActions() {
-  const queryClient = useQueryClient();
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const setWorkspaceArrivalEvent = useSessionSelectionStore(
@@ -112,11 +108,17 @@ export function useProposedPlanActions() {
   const { promptActiveSession, setActiveSessionConfigOption } = useSessionActions();
   const approvePlanMutation = approveMutation.mutateAsync;
   const rejectPlanMutation = rejectMutation.mutateAsync;
+  const {
+    patchPlanDecisionQueries,
+  } = useProposedPlanCache({
+    runtimeUrl,
+    selectedWorkspaceId,
+  });
 
   const applyPlanDecision = useCallback((plan: ProposedPlanDetail) => {
-    patchCachedPlanQueries(queryClient, runtimeUrl, selectedWorkspaceId, plan);
+    patchPlanDecisionQueries(plan);
     patchCachedPlanTranscripts(plan);
-  }, [queryClient, runtimeUrl, selectedWorkspaceId]);
+  }, [patchPlanDecisionQueries]);
 
   const refreshAndApplyPlanDecision = useCallback(async (planId: string) => {
     const plan = await fetchPlanMutation.mutateAsync({
@@ -186,7 +188,8 @@ export function useProposedPlanActions() {
         onPromptSubmitted: ({ workspaceId, agentKind, reuseSession }) =>
           completeChatPromptSubmitSideEffects({
             workspaceId,
-            getWorkspaceArrivalEvent: () => useSessionSelectionStore.getState().workspaceArrivalEvent,
+            getWorkspaceArrivalEvent: () =>
+              useSessionSelectionStore.getState().workspaceArrivalEvent,
             getCachedWorkspaceSetupStatus,
             agentKind,
             reuseSession,
@@ -203,8 +206,6 @@ export function useProposedPlanActions() {
     availability.disabledReason,
     availability.isDisabled,
     getCachedWorkspaceSetupStatus,
-    queryClient,
-    runtimeUrl,
     setActiveSessionConfigOption,
     setWorkspaceArrivalEvent,
     showToast,
@@ -270,24 +271,6 @@ async function runPlanDecisionMutation({
     const message = error instanceof Error ? error.message : String(error);
     showToast(`${failurePrefix}: ${message}`);
   }
-}
-
-function patchCachedPlanQueries(
-  queryClient: QueryClient,
-  runtimeUrl: string | null,
-  workspaceId: string | null,
-  plan: ProposedPlanDetail,
-): void {
-  queryClient.setQueryData(
-    anyHarnessPlanKey(runtimeUrl, workspaceId, plan.id),
-    plan,
-  );
-  queryClient.setQueryData<ProposedPlanSummary[]>(
-    anyHarnessPlansKey(runtimeUrl, workspaceId),
-    (plans) => plans?.map((cachedPlan) => (
-      cachedPlan.id === plan.id ? { ...cachedPlan, ...plan } : cachedPlan
-    )),
-  );
 }
 
 function patchCachedPlanTranscripts(plan: ProposedPlanDetail): void {

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -2,4 +2,3 @@
 #
 # Format:
 # RULE_ID path count reason
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- move proposed-plan query cache writes into a product cache hook
- keep proposed-plan workflow actions focused on action orchestration and transcript patching
- remove the proposed-plan query-client boundary allowlist entry

## Verification

- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- pnpm --dir desktop exec vitest run src/hooks/plans
- pnpm --dir desktop exec tsc --noEmit
- git diff --check