### PR TITLE
refactor(desktop): move chat prompt cache ownership

### DIFF
--- a/desktop/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts
+++ b/desktop/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts
@@ -1,0 +1,25 @@
+import type { GetSetupStatusResponse } from "@anyharness/sdk";
+import { anyHarnessWorkspaceSetupStatusKey } from "@anyharness/sdk-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+export type CachedWorkspaceSetupStatus = GetSetupStatusResponse["status"] | null;
+
+// Owns cached AnyHarness workspace setup-status reads for product workflows.
+export function useWorkspaceSetupStatusCache() {
+  const queryClient = useQueryClient();
+  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+
+  const getCachedWorkspaceSetupStatus = useCallback((
+    workspaceId: string,
+  ): CachedWorkspaceSetupStatus => {
+    return queryClient.getQueryData<GetSetupStatusResponse>(
+      anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
+    )?.status ?? null;
+  }, [queryClient, runtimeUrl]);
+
+  return {
+    getCachedWorkspaceSetupStatus,
+  };
+}

--- a/desktop/src/hooks/chat/chat-submit-effects.test.ts
+++ b/desktop/src/hooks/chat/chat-submit-effects.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { WorkspaceArrivalEvent } from "@/lib/domain/workspaces/creation/arrival";
-import { isWorkspaceSetupActive } from "./chat-submit-effects";
+import {
+  completeChatPromptSubmitSideEffects,
+  isWorkspaceSetupActive,
+} from "./chat-submit-effects";
+
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  trackProductEvent: vi.fn(),
+}));
 
 function arrival(
   overrides: Partial<WorkspaceArrivalEvent> = {},
@@ -64,5 +71,37 @@ describe("isWorkspaceSetupActive", () => {
       workspaceId: "workspace-1",
       cachedSetupStatus: "succeeded",
     })).toBe(false);
+  });
+});
+
+describe("completeChatPromptSubmitSideEffects", () => {
+  it("reads the current workspace arrival event when completion runs", () => {
+    let currentArrival: WorkspaceArrivalEvent | null = arrival({
+      setupScript: {
+        status: "running",
+      } as WorkspaceArrivalEvent["setupScript"],
+    });
+    const setWorkspaceArrivalEvent = vi.fn();
+
+    completeChatPromptSubmitSideEffects({
+      workspaceId: "workspace-1",
+      getWorkspaceArrivalEvent: () => currentArrival,
+      getCachedWorkspaceSetupStatus: () => null,
+      agentKind: "test-agent",
+      reuseSession: false,
+      setWorkspaceArrivalEvent,
+    });
+    expect(setWorkspaceArrivalEvent).not.toHaveBeenCalled();
+
+    currentArrival = null;
+    completeChatPromptSubmitSideEffects({
+      workspaceId: "workspace-1",
+      getWorkspaceArrivalEvent: () => currentArrival,
+      getCachedWorkspaceSetupStatus: () => null,
+      agentKind: "test-agent",
+      reuseSession: false,
+      setWorkspaceArrivalEvent,
+    });
+    expect(setWorkspaceArrivalEvent).toHaveBeenCalledWith(null);
   });
 });

--- a/desktop/src/hooks/chat/chat-submit-effects.test.ts
+++ b/desktop/src/hooks/chat/chat-submit-effects.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceArrivalEvent } from "@/lib/domain/workspaces/creation/arrival";
+import { isWorkspaceSetupActive } from "./chat-submit-effects";
+
+function arrival(
+  overrides: Partial<WorkspaceArrivalEvent> = {},
+): WorkspaceArrivalEvent {
+  return {
+    workspaceId: "workspace-1",
+    source: "local-created",
+    setupScript: null,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+describe("isWorkspaceSetupActive", () => {
+  it("uses cached running setup status", () => {
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival(),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: "running",
+    })).toBe(true);
+  });
+
+  it("uses arrival setup status when cache is empty", () => {
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival({
+        setupScript: {
+          status: "queued",
+        } as WorkspaceArrivalEvent["setupScript"],
+      }),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: null,
+    })).toBe(true);
+  });
+
+  it("keeps async local arrivals active until the first cached setup status", () => {
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival({
+        source: "worktree-created",
+        setupScript: null,
+      }),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: null,
+    })).toBe(true);
+  });
+
+  it("does not keep unrelated or completed arrivals active", () => {
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival({ workspaceId: "workspace-2" }),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: "running",
+    })).toBe(false);
+
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival({ source: "cloud-created" }),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: null,
+    })).toBe(false);
+
+    expect(isWorkspaceSetupActive({
+      workspaceArrivalEvent: arrival(),
+      workspaceId: "workspace-1",
+      cachedSetupStatus: "succeeded",
+    })).toBe(false);
+  });
+});

--- a/desktop/src/hooks/chat/chat-submit-effects.ts
+++ b/desktop/src/hooks/chat/chat-submit-effects.ts
@@ -1,22 +1,26 @@
-import type { QueryClient } from "@tanstack/react-query";
-import { anyHarnessWorkspaceSetupStatusKey } from "@anyharness/sdk-react";
+import type { GetSetupStatusResponse } from "@anyharness/sdk";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import type { WorkspaceArrivalEvent } from "@/lib/domain/workspaces/creation/arrival";
 import { trackProductEvent } from "@/lib/integrations/telemetry/client";
-import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
-export function isWorkspaceSetupActive(
-  queryClient: QueryClient,
-  runtimeUrl: string,
-  workspaceId: string | null,
-): boolean {
+type CachedWorkspaceSetupStatus = GetSetupStatusResponse["status"] | null;
+
+interface WorkspaceSetupActivityInput {
+  workspaceArrivalEvent: WorkspaceArrivalEvent | null;
+  workspaceId: string | null;
+  cachedSetupStatus: CachedWorkspaceSetupStatus;
+}
+
+export function isWorkspaceSetupActive({
+  workspaceArrivalEvent,
+  workspaceId,
+  cachedSetupStatus,
+}: WorkspaceSetupActivityInput): boolean {
   if (!workspaceId) return false;
-  const arrival = useSessionSelectionStore.getState().workspaceArrivalEvent;
+  const arrival = workspaceArrivalEvent;
   if (!arrival || arrival.workspaceId !== workspaceId) return false;
 
-  const cachedStatus = queryClient.getQueryData<{ status?: string }>(
-    anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
-  );
-  const status = cachedStatus?.status ?? arrival.setupScript?.status ?? null;
+  const status = cachedSetupStatus ?? arrival.setupScript?.status ?? null;
   // For async-setup sources the creation endpoint returns setupScript: null
   // and setup runs in the background. Treat a cache miss (no poll result yet)
   // as potentially active so the panel isn't prematurely dismissed before the
@@ -28,21 +32,25 @@ export function isWorkspaceSetupActive(
 }
 
 export function completeChatPromptSubmitSideEffects({
-  queryClient,
-  runtimeUrl,
   workspaceId,
+  workspaceArrivalEvent,
+  getCachedWorkspaceSetupStatus,
   agentKind,
   reuseSession,
   setWorkspaceArrivalEvent,
 }: {
-  queryClient: QueryClient;
-  runtimeUrl: string;
   workspaceId: string;
+  workspaceArrivalEvent: WorkspaceArrivalEvent | null;
+  getCachedWorkspaceSetupStatus: (workspaceId: string) => CachedWorkspaceSetupStatus;
   agentKind: string;
   reuseSession: boolean;
   setWorkspaceArrivalEvent: (event: null) => void;
 }): void {
-  if (!isWorkspaceSetupActive(queryClient, runtimeUrl, workspaceId)) {
+  if (!isWorkspaceSetupActive({
+    workspaceArrivalEvent,
+    workspaceId,
+    cachedSetupStatus: getCachedWorkspaceSetupStatus(workspaceId),
+  })) {
     setWorkspaceArrivalEvent(null);
   }
   trackProductEvent("chat_prompt_submitted", {

--- a/desktop/src/hooks/chat/chat-submit-effects.ts
+++ b/desktop/src/hooks/chat/chat-submit-effects.ts
@@ -33,21 +33,21 @@ export function isWorkspaceSetupActive({
 
 export function completeChatPromptSubmitSideEffects({
   workspaceId,
-  workspaceArrivalEvent,
+  getWorkspaceArrivalEvent,
   getCachedWorkspaceSetupStatus,
   agentKind,
   reuseSession,
   setWorkspaceArrivalEvent,
 }: {
   workspaceId: string;
-  workspaceArrivalEvent: WorkspaceArrivalEvent | null;
+  getWorkspaceArrivalEvent: () => WorkspaceArrivalEvent | null;
   getCachedWorkspaceSetupStatus: (workspaceId: string) => CachedWorkspaceSetupStatus;
   agentKind: string;
   reuseSession: boolean;
   setWorkspaceArrivalEvent: (event: null) => void;
 }): void {
   if (!isWorkspaceSetupActive({
-    workspaceArrivalEvent,
+    workspaceArrivalEvent: getWorkspaceArrivalEvent(),
     workspaceId,
     cachedSetupStatus: getCachedWorkspaceSetupStatus(workspaceId),
   })) {

--- a/desktop/src/hooks/chat/use-chat-prompt-actions.ts
+++ b/desktop/src/hooks/chat/use-chat-prompt-actions.ts
@@ -45,7 +45,6 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
   const forceNewSession = options?.forceNewSession ?? false;
   const showToast = useToastStore((store) => store.show);
   const setWorkspaceArrivalEvent = useSessionSelectionStore((state) => state.setWorkspaceArrivalEvent);
-  const workspaceArrivalEvent = useSessionSelectionStore((state) => state.workspaceArrivalEvent);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore((state) => state.selectedLogicalWorkspaceId);
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
@@ -197,7 +196,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
       }
       completeChatPromptSubmitSideEffects({
         workspaceId: selectedWorkspaceId,
-        workspaceArrivalEvent,
+        getWorkspaceArrivalEvent: () => useSessionSelectionStore.getState().workspaceArrivalEvent,
         getCachedWorkspaceSetupStatus,
         agentKind: launchSelection?.kind ?? "unknown",
         reuseSession: targetSessionId !== null,
@@ -243,7 +242,6 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     setWorkspaceArrivalEvent,
     showToast,
     scopedLaunchIdentity,
-    workspaceArrivalEvent,
   ]);
 
   const handleCancel = useCallback(() => {

--- a/desktop/src/hooks/chat/use-chat-prompt-actions.ts
+++ b/desktop/src/hooks/chat/use-chat-prompt-actions.ts
@@ -1,14 +1,13 @@
 import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import type { ContentPart, PromptInputBlock } from "@anyharness/sdk";
 import {
   captureTelemetryException,
 } from "@/lib/integrations/telemetry/client";
+import { useWorkspaceSetupStatusCache } from "@/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache";
 import { useSessionActions } from "@/hooks/sessions/use-session-actions";
 import { useSessionPromptWorkflow } from "@/hooks/sessions/use-session-prompt-workflow";
 import { isSessionModelAvailabilityInterruption } from "@/hooks/sessions/use-session-model-availability-workflow";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import {
@@ -44,13 +43,13 @@ import { completeChatPromptSubmitSideEffects } from "./chat-submit-effects";
 
 export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
   const forceNewSession = options?.forceNewSession ?? false;
-  const queryClient = useQueryClient();
   const showToast = useToastStore((store) => store.show);
   const setWorkspaceArrivalEvent = useSessionSelectionStore((state) => state.setWorkspaceArrivalEvent);
+  const workspaceArrivalEvent = useSessionSelectionStore((state) => state.workspaceArrivalEvent);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore((state) => state.selectedLogicalWorkspaceId);
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const { getCachedWorkspaceSetupStatus } = useWorkspaceSetupStatusCache();
   const {
     cancelActiveSession,
     createSessionWithResolvedConfig,
@@ -197,9 +196,9 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
         return true;
       }
       completeChatPromptSubmitSideEffects({
-        queryClient,
-        runtimeUrl,
         workspaceId: selectedWorkspaceId,
+        workspaceArrivalEvent,
+        getCachedWorkspaceSetupStatus,
         agentKind: launchSelection?.kind ?? "unknown",
         reuseSession: targetSessionId !== null,
         setWorkspaceArrivalEvent,
@@ -232,19 +231,19 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     configuredLaunch.selection,
     createSessionWithResolvedConfig,
     findOrCreateSession,
+    getCachedWorkspaceSetupStatus,
     hasSlot,
     forceNewSession,
     isDisabled,
     pendingWorkspaceEntry,
     promptActiveSession,
     promptSession,
-    queryClient,
-    runtimeUrl,
     selectedLogicalWorkspaceId,
     selectedWorkspaceId,
     setWorkspaceArrivalEvent,
     showToast,
     scopedLaunchIdentity,
+    workspaceArrivalEvent,
   ]);
 
   const handleCancel = useCallback(() => {

--- a/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
+++ b/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
@@ -100,7 +100,6 @@ export function useProposedPlanActions() {
   const setWorkspaceArrivalEvent = useSessionSelectionStore(
     (state) => state.setWorkspaceArrivalEvent,
   );
-  const workspaceArrivalEvent = useSessionSelectionStore((state) => state.workspaceArrivalEvent);
   const { getCachedWorkspaceSetupStatus } = useWorkspaceSetupStatusCache();
   const showToast = useToastStore((state) => state.show);
   const [isImplementingPlan, setIsImplementingPlan] = useState(false);
@@ -187,7 +186,7 @@ export function useProposedPlanActions() {
         onPromptSubmitted: ({ workspaceId, agentKind, reuseSession }) =>
           completeChatPromptSubmitSideEffects({
             workspaceId,
-            workspaceArrivalEvent,
+            getWorkspaceArrivalEvent: () => useSessionSelectionStore.getState().workspaceArrivalEvent,
             getCachedWorkspaceSetupStatus,
             agentKind,
             reuseSession,
@@ -209,7 +208,6 @@ export function useProposedPlanActions() {
     setActiveSessionConfigOption,
     setWorkspaceArrivalEvent,
     showToast,
-    workspaceArrivalEvent,
   ]);
 
   return {

--- a/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
+++ b/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
@@ -16,6 +16,7 @@ import {
   useFetchPlanMutation,
   useRejectPlanMutation,
 } from "@anyharness/sdk-react";
+import { useWorkspaceSetupStatusCache } from "@/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache";
 import { completeChatPromptSubmitSideEffects } from "@/hooks/chat/chat-submit-effects";
 import { useChatAvailabilityState } from "@/hooks/chat/derived/use-chat-availability-state";
 import { useReviewActions } from "@/hooks/reviews/workflows/use-review-actions";
@@ -99,6 +100,8 @@ export function useProposedPlanActions() {
   const setWorkspaceArrivalEvent = useSessionSelectionStore(
     (state) => state.setWorkspaceArrivalEvent,
   );
+  const workspaceArrivalEvent = useSessionSelectionStore((state) => state.workspaceArrivalEvent);
+  const { getCachedWorkspaceSetupStatus } = useWorkspaceSetupStatusCache();
   const showToast = useToastStore((state) => state.show);
   const [isImplementingPlan, setIsImplementingPlan] = useState(false);
   const isImplementingPlanRef = useRef(false);
@@ -183,9 +186,9 @@ export function useProposedPlanActions() {
         chatDisabledReason: availability.disabledReason,
         onPromptSubmitted: ({ workspaceId, agentKind, reuseSession }) =>
           completeChatPromptSubmitSideEffects({
-            queryClient,
-            runtimeUrl,
             workspaceId,
+            workspaceArrivalEvent,
+            getCachedWorkspaceSetupStatus,
             agentKind,
             reuseSession,
             setWorkspaceArrivalEvent,
@@ -200,11 +203,13 @@ export function useProposedPlanActions() {
     promptActiveSession,
     availability.disabledReason,
     availability.isDisabled,
+    getCachedWorkspaceSetupStatus,
     queryClient,
     runtimeUrl,
     setActiveSessionConfigOption,
     setWorkspaceArrivalEvent,
     showToast,
+    workspaceArrivalEvent,
   ]);
 
   return {

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -2,5 +2,4 @@
 #
 # Format:
 # RULE_ID path count reason
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- Move cached AnyHarness workspace setup-status reads behind a workspace access cache hook.
- Remove direct `useQueryClient` usage from `use-chat-prompt-actions.ts` and delete its frontend boundary allowlist entry.
- Make chat prompt submit side effects receive cached setup status through a callback and cover the setup-active decision with focused tests.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm --dir desktop exec vitest run src/hooks/chat/chat-submit-effects.test.ts src/hooks/chat/use-prompt-outbox-dispatcher.test.ts src/hooks/chat/ui/use-composer-submit-gate.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
