### PR TITLE
refactor(desktop): move session runtime access cache ownership

### DIFF
--- a/desktop/src/hooks/sessions/cache/use-session-stream-cache.ts
+++ b/desktop/src/hooks/sessions/cache/use-session-stream-cache.ts
@@ -1,0 +1,65 @@
+import {
+  anyHarnessCoworkManagedWorkspacesKey,
+  anyHarnessGitStatusKey,
+  anyHarnessSessionReviewsKey,
+  anyHarnessSessionSubagentsKey,
+} from "@anyharness/sdk-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
+
+export interface SessionStreamCache {
+  invalidateWorkspaceCollections(runtimeUrl: string): void;
+  invalidateSessionSubagents(input: {
+    runtimeUrl: string;
+    workspaceId: string | null;
+    sessionId: string;
+  }): void;
+  invalidateCoworkManagedWorkspaces(input: {
+    runtimeUrl: string;
+    sessionId: string;
+  }): void;
+  invalidateSessionReviews(input: {
+    runtimeUrl: string;
+    workspaceId: string | null;
+    parentSessionId: string;
+  }): void;
+  invalidateGitStatus(input: {
+    runtimeUrl: string;
+    workspaceId: string;
+  }): void;
+}
+
+// Owns React Query invalidation triggered by session stream events.
+// Does not interpret stream envelopes or mutate session stores.
+export function useSessionStreamCache(): SessionStreamCache {
+  const queryClient = useQueryClient();
+
+  return useMemo<SessionStreamCache>(() => ({
+    invalidateWorkspaceCollections(runtimeUrl) {
+      void queryClient.invalidateQueries({
+        queryKey: workspaceCollectionsScopeKey(runtimeUrl),
+      });
+    },
+    invalidateSessionSubagents({ runtimeUrl, workspaceId, sessionId }) {
+      void queryClient.invalidateQueries({
+        queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, sessionId),
+      });
+    },
+    invalidateCoworkManagedWorkspaces({ runtimeUrl, sessionId }) {
+      void queryClient.invalidateQueries({
+        queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, sessionId),
+      });
+    },
+    invalidateSessionReviews({ runtimeUrl, workspaceId, parentSessionId }) {
+      void queryClient.invalidateQueries({
+        queryKey: anyHarnessSessionReviewsKey(runtimeUrl, workspaceId, parentSessionId),
+      });
+    },
+    invalidateGitStatus({ runtimeUrl, workspaceId }) {
+      void queryClient.invalidateQueries({
+        queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+      });
+    },
+  }), [queryClient]);
+}

--- a/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
@@ -1,4 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
 import {
   beforeEach,
   describe,
@@ -11,6 +10,7 @@ import {
   type SessionEventEnvelope,
 } from "@anyharness/sdk";
 import { applyBatchedStreamSideEffects } from "@/hooks/sessions/session-stream-side-effects";
+import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
 import type { SessionRelationship } from "@/stores/sessions/session-types";
 
@@ -100,6 +100,25 @@ describe("applyBatchedStreamSideEffects", () => {
     );
   });
 
+  it("delegates stream cache invalidations to the session cache helper", () => {
+    const sessionStreamCache = createTestSessionStreamCache();
+
+    applyBatchedStreamSideEffects({
+      ...baseInput(),
+      sessionStreamCache,
+      envelopes: [
+        turnEnded(2),
+      ],
+    });
+
+    expect(sessionStreamCache.invalidateWorkspaceCollections)
+      .toHaveBeenCalledWith("http://runtime.test");
+    expect(sessionStreamCache.invalidateGitStatus).toHaveBeenCalledWith({
+      runtimeUrl: "http://runtime.test",
+      workspaceId: "workspace-1",
+    });
+  });
+
   it("acknowledges selected activity in the same side-effect pass", () => {
     const acknowledgeWorkspaceActivity = vi.fn((workspaceId: string, timestamp: string) => {
       mocks.effectOrder.push(`ack:${workspaceId}:${timestamp}`);
@@ -161,7 +180,7 @@ function baseInput(overrides?: {
   const sessionRelationship: SessionRelationship | null =
     overrides?.sessionRelationship ?? { kind: "pending" };
   return {
-    queryClient: new QueryClient(),
+    sessionStreamCache: createTestSessionStreamCache(),
     sessionId: "session-1",
     runtimeUrl: "http://runtime.test",
     workspaceId: "workspace-1",
@@ -180,6 +199,16 @@ function baseInput(overrides?: {
     clearActiveSummaryRefreshTimer: vi.fn(),
     scheduleActiveSummaryRefresh: vi.fn(),
     scheduleStartupReadyRefresh: vi.fn(),
+  };
+}
+
+function createTestSessionStreamCache(): SessionStreamCache {
+  return {
+    invalidateWorkspaceCollections: vi.fn(),
+    invalidateSessionSubagents: vi.fn(),
+    invalidateCoworkManagedWorkspaces: vi.fn(),
+    invalidateSessionReviews: vi.fn(),
+    invalidateGitStatus: vi.fn(),
   };
 }
 

--- a/desktop/src/hooks/sessions/session-stream-side-effects.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.ts
@@ -1,17 +1,9 @@
-import {
-  anyHarnessCoworkManagedWorkspacesKey,
-  anyHarnessGitStatusKey,
-  anyHarnessSessionReviewsKey,
-  anyHarnessSessionSubagentsKey,
-} from "@anyharness/sdk-react";
-import type { QueryClient } from "@tanstack/react-query";
 import type {
   SessionEventEnvelope,
   SessionLiveConfigSnapshot,
   ToolCallItem,
   TranscriptState,
 } from "@anyharness/sdk";
-import { workspaceCollectionsScopeKey } from "@/hooks/workspaces/query-keys";
 import {
   getAuthoritativeConfigValue,
   hasQueuedPendingConfigChanges,
@@ -36,6 +28,7 @@ import {
   schedulePendingConfigRollbackCheck,
 } from "@/hooks/sessions/session-runtime-pending-config";
 import type { MeasurementOperationId } from "@/lib/infra/measurement/debug-measurement";
+import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 
 export interface ReconciledStreamConfigIntent {
   liveConfig: SessionLiveConfigSnapshot;
@@ -53,7 +46,7 @@ type OrderedStreamSideEffect =
   };
 
 export function applyBatchedStreamSideEffects(input: {
-  queryClient: QueryClient;
+  sessionStreamCache: SessionStreamCache;
   sessionId: string;
   runtimeUrl: string;
   workspaceId: string | null;
@@ -238,46 +231,36 @@ export function applyBatchedStreamSideEffects(input: {
   }
 
   if (shouldInvalidateWorkspaceCollections) {
-    void input.queryClient.invalidateQueries({
-      queryKey: workspaceCollectionsScopeKey(input.runtimeUrl),
-    });
+    input.sessionStreamCache.invalidateWorkspaceCollections(input.runtimeUrl);
   }
   if (lastActivityTimestamp && input.workspaceId) {
     trackWorkspaceInteraction(input.workspaceId, lastActivityTimestamp);
     input.acknowledgeWorkspaceActivity?.(input.workspaceId, lastActivityTimestamp);
   }
   if (shouldInvalidateSessionSubagents) {
-    void input.queryClient.invalidateQueries({
-      queryKey: anyHarnessSessionSubagentsKey(
-        input.runtimeUrl,
-        input.workspaceId,
-        input.sessionId,
-      ),
+    input.sessionStreamCache.invalidateSessionSubagents({
+      runtimeUrl: input.runtimeUrl,
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId,
     });
   }
   if (shouldInvalidateCowork) {
-    void input.queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkManagedWorkspacesKey(
-        input.runtimeUrl,
-        input.sessionId,
-      ),
+    input.sessionStreamCache.invalidateCoworkManagedWorkspaces({
+      runtimeUrl: input.runtimeUrl,
+      sessionId: input.sessionId,
     });
   }
   for (const parentSessionId of reviewParentSessionIds) {
-    void input.queryClient.invalidateQueries({
-      queryKey: anyHarnessSessionReviewsKey(
-        input.runtimeUrl,
-        input.workspaceId,
-        parentSessionId,
-      ),
+    input.sessionStreamCache.invalidateSessionReviews({
+      runtimeUrl: input.runtimeUrl,
+      workspaceId: input.workspaceId,
+      parentSessionId,
     });
   }
   if (shouldInvalidateGitStatus && input.workspaceId) {
-    void input.queryClient.invalidateQueries({
-      queryKey: anyHarnessGitStatusKey(
-        input.runtimeUrl,
-        input.workspaceId,
-      ),
+    input.sessionStreamCache.invalidateGitStatus({
+      runtimeUrl: input.runtimeUrl,
+      workspaceId: input.workspaceId,
     });
   }
 

--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -10,7 +10,6 @@ import {
   type TranscriptState,
 } from "@anyharness/sdk";
 import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   fetchSessionHistory,
   fetchSessionSummary,
@@ -71,6 +70,7 @@ import {
   useSessionStreamFlushControllerFactory,
   type SessionStreamFlushController,
 } from "@/hooks/sessions/use-session-stream-flush";
+import { useSessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
@@ -105,7 +105,7 @@ const SESSION_APPLY_MEASUREMENT_SURFACES: readonly MeasurementSurface[] = [
 const SESSION_HISTORY_APPLY_MAX_DURATION_MS = 30_000;
 
 export function useSessionRuntimeActions() {
-  const queryClient = useQueryClient();
+  const sessionStreamCache = useSessionStreamCache();
   const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
   const showToast = useToastStore((state) => state.show);
   const {
@@ -635,7 +635,7 @@ export function useSessionRuntimeActions() {
   }, [applySessionSummary, pluginsInCodingSessionsEnabled]);
 
   const createSessionStreamFlushController = useSessionStreamFlushControllerFactory({
-    queryClient,
+    sessionStreamCache,
     mountSubagentChildSession,
     persistReconciledModePreferences,
     refreshSessionSlotMeta,

--- a/desktop/src/hooks/sessions/use-session-stream-flush.test.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.test.ts
@@ -1,4 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEventEnvelope } from "@anyharness/sdk";
 import { replaySessionHistory } from "@/lib/domain/sessions/stream/stream-state";
@@ -17,6 +16,7 @@ import {
   createSessionStreamFlushController,
   type SessionStreamFlushScheduler,
 } from "@/hooks/sessions/use-session-stream-flush";
+import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 
 const originalPatchTranscriptEntry = useSessionTranscriptStore.getState().patchEntry;
 
@@ -243,7 +243,7 @@ function createTestController(options?: {
   refreshSessionSlotMeta?: () => Promise<void>;
 }) {
   return createSessionStreamFlushController({
-    queryClient: new QueryClient(),
+    sessionStreamCache: createTestSessionStreamCache(),
     mountSubagentChildSession: vi.fn(),
     persistReconciledModePreferences: vi.fn(),
     refreshSessionSlotMeta: options?.refreshSessionSlotMeta ?? vi.fn(),
@@ -259,6 +259,16 @@ function createTestController(options?: {
     scheduleActiveSummaryRefresh: options?.scheduleActiveSummaryRefresh ?? vi.fn(),
     scheduleStartupReadyRefresh: vi.fn(),
   });
+}
+
+function createTestSessionStreamCache(): SessionStreamCache {
+  return {
+    invalidateWorkspaceCollections: vi.fn(),
+    invalidateSessionSubagents: vi.fn(),
+    invalidateCoworkManagedWorkspaces: vi.fn(),
+    invalidateSessionReviews: vi.fn(),
+    invalidateGitStatus: vi.fn(),
+  };
 }
 
 function createManualScheduler() {

--- a/desktop/src/hooks/sessions/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.ts
@@ -1,4 +1,3 @@
-import type { QueryClient } from "@tanstack/react-query";
 import type {
   SessionEventEnvelope,
   TranscriptState,
@@ -35,6 +34,7 @@ import {
   applyBatchedStreamSideEffects,
   type ReconciledStreamConfigIntent,
 } from "@/hooks/sessions/session-stream-side-effects";
+import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
@@ -71,7 +71,7 @@ export interface SessionStreamFlushController {
 }
 
 interface SessionStreamFlushFactoryDeps {
-  queryClient: QueryClient;
+  sessionStreamCache: SessionStreamCache;
   mountSubagentChildSession: (input: {
     childSessionId: string;
     label: string | null;
@@ -165,7 +165,7 @@ export const animationFrameSessionStreamFlushScheduler: SessionStreamFlushSchedu
 };
 
 export function useSessionStreamFlushControllerFactory({
-  queryClient,
+  sessionStreamCache,
   mountSubagentChildSession,
   persistReconciledModePreferences,
   refreshSessionSlotMeta,
@@ -175,7 +175,7 @@ export function useSessionStreamFlushControllerFactory({
   return useCallback((options: SessionStreamFlushControllerOptions) =>
     createSessionStreamFlushController({
       ...options,
-      queryClient,
+      sessionStreamCache,
       mountSubagentChildSession,
       persistReconciledModePreferences,
       refreshSessionSlotMeta,
@@ -184,9 +184,9 @@ export function useSessionStreamFlushControllerFactory({
     }), [
     mountSubagentChildSession,
     persistReconciledModePreferences,
-    queryClient,
     refreshSessionSlotMeta,
     scheduler,
+    sessionStreamCache,
     showToast,
   ]);
 }

--- a/desktop/src/lib/access/anyharness/sessions.ts
+++ b/desktop/src/lib/access/anyharness/sessions.ts
@@ -13,7 +13,11 @@ import {
 
 type SessionConnection = AnyHarnessClientConnection | AnyHarnessResolvedConnection;
 type AnyHarnessClient = ReturnType<typeof getAnyHarnessClient>;
-type ListSessionsOptions = Parameters<AnyHarnessClient["sessions"]["list"]>[1];
+export type AnyHarnessSessionConnection = SessionConnection;
+export type AnyHarnessWorkspaceSessionConnection = AnyHarnessResolvedConnection;
+export type ListSessionsOptions = Parameters<AnyHarnessClient["sessions"]["list"]>[1];
+export type ListSessionEventsOptions =
+  Parameters<AnyHarnessClient["sessions"]["listEvents"]>[1];
 type RestoreDismissedSessionOptions =
   Parameters<AnyHarnessClient["sessions"]["restoreDismissed"]>[1];
 type UpdateSessionTitleOptions =
@@ -21,6 +25,8 @@ type UpdateSessionTitleOptions =
 type GetSessionOptions = Parameters<AnyHarnessClient["sessions"]["get"]>[1];
 type PromptSessionOptions = Parameters<AnyHarnessClient["sessions"]["prompt"]>[2];
 type CreateSessionOptions = Parameters<AnyHarnessClient["sessions"]["create"]>[1];
+type ResumeSessionRequest = Parameters<AnyHarnessClient["sessions"]["resume"]>[1];
+type ResumeSessionOptions = Parameters<AnyHarnessClient["sessions"]["resume"]>[2];
 type GetSubagentsOptions = Parameters<AnyHarnessClient["sessions"]["getSubagents"]>[1];
 
 export function listWorkspaceSessions(
@@ -49,6 +55,14 @@ export function getSession(
   return getAnyHarnessClient(connection).sessions.get(sessionId, options);
 }
 
+export function listSessionEvents(
+  connection: SessionConnection,
+  sessionId: string,
+  options?: ListSessionEventsOptions,
+) {
+  return getAnyHarnessClient(connection).sessions.listEvents(sessionId, options);
+}
+
 export function fetchPromptAttachment(
   connection: SessionConnection,
   sessionId: string,
@@ -67,6 +81,15 @@ export function promptSession(
   options?: PromptSessionOptions,
 ) {
   return getAnyHarnessClient(connection).sessions.prompt(sessionId, request, options);
+}
+
+export function resumeSession(
+  connection: SessionConnection,
+  sessionId: string,
+  request: ResumeSessionRequest,
+  options?: ResumeSessionOptions,
+) {
+  return getAnyHarnessClient(connection).sessions.resume(sessionId, request, options);
 }
 
 export function setSessionConfigOption(

--- a/desktop/src/lib/workflows/sessions/session-runtime.ts
+++ b/desktop/src/lib/workflows/sessions/session-runtime.ts
@@ -1,4 +1,3 @@
-import { getAnyHarnessClient, type AnyHarnessClientConnection } from "@anyharness/sdk-react";
 import {
   type PendingPromptEntry,
   streamSession,
@@ -27,6 +26,15 @@ import {
   resolveRuntimeTargetForWorkspace,
   type RuntimeTarget,
 } from "@/lib/access/anyharness/runtime-target";
+import {
+  getSession,
+  listSessionEvents,
+  listWorkspaceSessions,
+  resumeSession as resumeRuntimeSession,
+  type AnyHarnessWorkspaceSessionConnection,
+  type ListSessionsOptions,
+} from "@/lib/access/anyharness/sessions";
+import { getWorkspace } from "@/lib/access/anyharness/workspaces";
 import { resolveSessionMcpServersForLaunch } from "@/lib/workflows/sessions/session-mcp-launch";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
@@ -59,8 +67,12 @@ interface SessionStreamCallbacks {
 export type FlushAwareSessionStreamHandle = ManagedSessionStreamHandle;
 
 const SESSION_HISTORY_FETCH_TIMEOUT_MS = 10_000;
-function buildConnection(baseUrl: string, authToken?: string): AnyHarnessClientConnection {
-  return { runtimeUrl: baseUrl, authToken };
+function buildConnection(target: RuntimeTarget): AnyHarnessWorkspaceSessionConnection {
+  return {
+    runtimeUrl: target.baseUrl,
+    authToken: target.authToken,
+    anyharnessWorkspaceId: target.anyharnessWorkspaceId,
+  };
 }
 
 async function measureSessionWorkflowStep<T>(
@@ -136,9 +148,9 @@ export function createSessionRuntimeRecordFromSummary(
 export function getWorkspaceClientAndId(
   runtimeUrl: string,
   workspaceId: string,
-): Promise<{ connection: AnyHarnessClientConnection; target: RuntimeTarget }> {
+): Promise<{ connection: AnyHarnessWorkspaceSessionConnection; target: RuntimeTarget }> {
   return resolveRuntimeTargetForWorkspace(runtimeUrl, workspaceId).then((target) => ({
-    connection: buildConnection(target.baseUrl, target.authToken),
+    connection: buildConnection(target),
     target,
   }));
 }
@@ -146,19 +158,16 @@ export function getWorkspaceClientAndId(
 export async function fetchWorkspaceSessionSummaries(
   runtimeUrl: string,
   workspaceId: string,
-  options?: Parameters<ReturnType<typeof getAnyHarnessClient>["sessions"]["list"]>[1],
+  options?: ListSessionsOptions,
 ): Promise<Session[]> {
-  const { connection, target } = await getWorkspaceClientAndId(runtimeUrl, workspaceId);
-  return getAnyHarnessClient(connection).sessions.list(
-    target.anyharnessWorkspaceId,
-    options,
-  );
+  const { connection } = await getWorkspaceClientAndId(runtimeUrl, workspaceId);
+  return listWorkspaceSessions(connection, options);
 }
 
 export async function getSessionClientAndWorkspace(
   sessionId: string,
 ): Promise<{
-  connection: AnyHarnessClientConnection;
+  connection: AnyHarnessWorkspaceSessionConnection;
   target: RuntimeTarget;
   workspaceId: string;
   materializedSessionId: string;
@@ -213,7 +222,6 @@ export async function fetchSessionHistory(
         signal,
       ),
     );
-    const client = getAnyHarnessClient(connection);
     const request = getMeasurementRequestOptions({
       operationId: options?.measurementOperationId,
       category: "session.events.list",
@@ -228,7 +236,8 @@ export async function fetchSessionHistory(
       || options?.turnLimit != null
       || !!requestWithTimeout;
 
-    const eventsPromise = client.sessions.listEvents(
+    const eventsPromise = listSessionEvents(
+      connection,
       materializedSessionId,
       hasHistoryOptions
         ? {
@@ -260,7 +269,8 @@ export async function fetchSessionSummary(
     "session.summary.resolve_target",
     () => getSessionClientAndWorkspace(sessionId),
   );
-  return getAnyHarnessClient(connection).sessions.get(
+  return getSession(
+    connection,
     materializedSessionId,
     getMeasurementRequestOptions({
       operationId: options?.measurementOperationId,
@@ -284,11 +294,11 @@ export async function resumeSession(
     "session.resume.resolve_target",
     () => getSessionClientAndWorkspace(sessionId),
   );
-  const client = getAnyHarnessClient(connection);
   const workspace = await measureSessionWorkflowStep(
     measurementOperationId,
     "session.resume.workspace_get",
-    () => client.workspaces.get(
+    () => getWorkspace(
+      connection,
       target.anyharnessWorkspaceId,
       getMeasurementRequestOptions({
         operationId: measurementOperationId,
@@ -330,7 +340,8 @@ export async function resumeSession(
     });
   }
   try {
-    return await client.sessions.resume(
+    return await resumeRuntimeSession(
+      connection,
       materializedSessionId,
       {
         mcpServers,

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -2,11 +2,8 @@
 #
 # Format:
 # RULE_ID path count reason
-ANYHARNESS_CLIENT_OUTSIDE_ACCESS desktop/src/lib/workflows/sessions/session-runtime.ts 6 raw AnyHarness client before access migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/chat/use-chat-prompt-actions.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts 3 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/session-stream-side-effects.ts 5 query cache ownership before access/cache migration
-QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/sessions/use-session-runtime-actions.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/cancel-display-queries.ts 1 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/connection.ts 2 query cache ownership before access/cache migration
 QUERY_CLIENT_OUTSIDE_CACHE_OWNER desktop/src/hooks/workspaces/selection/run-workspace-selection.ts 2 query cache ownership before access/cache migration


### PR DESCRIPTION
## Summary

- route session runtime AnyHarness client calls through the AnyHarness access layer
- move session stream query invalidation behind a session cache hook
- remove the targeted session runtime access/cache allowlist entries

## Verification

- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- pnpm --dir desktop exec vitest run src/hooks/sessions/use-session-stream-flush.test.ts src/hooks/sessions/session-stream-side-effects.test.ts src/hooks/sessions/session-activation-guard.test.ts
- pnpm --dir desktop exec tsc --noEmit
- git diff --check