### PR TITLE
refactor(server): clean up support domain ownership

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -20,7 +20,6 @@ SERVICE_ORM_IMPORT server/proliferate/server/cloud/repos/service.py 1 transition
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/organizations/service.py 1 transitional service imports ORM/auth model
-SERVICE_ORM_IMPORT server/proliferate/server/support/service.py 1 transitional service imports ORM/auth model
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/anonymous_telemetry.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 12 transitional store owns transaction commit

--- a/server/proliferate/integrations/anonymous_telemetry.py
+++ b/server/proliferate/integrations/anonymous_telemetry.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 _VERSION_INTERVAL_SECONDS = 24 * 60 * 60
 _SURFACE = "server"
 
+AnonymousTelemetryEvent = anonymous_telemetry_service.AnonymousTelemetryEvent
+VersionPayload = anonymous_telemetry_service.VersionPayload
+load_or_create_local_install_id = anonymous_telemetry_service.load_or_create_local_install_id
+
 
 def _server_version() -> str:
     try:
@@ -30,17 +34,17 @@ def _server_version() -> str:
         return "0.1.0"
 
 
-def _version_payload() -> anonymous_telemetry_service.VersionPayload:
-    return anonymous_telemetry_service.VersionPayload(
+def _version_payload() -> VersionPayload:
+    return VersionPayload(
         app_version=_server_version(),
         platform=platform.system().lower() or "unknown",
         arch=platform.machine().lower() or "unknown",
     )
 
 
-async def _build_server_event() -> anonymous_telemetry_service.AnonymousTelemetryEvent:
-    return anonymous_telemetry_service.AnonymousTelemetryEvent(
-        install_uuid=await anonymous_telemetry_service.load_or_create_local_install_id(_SURFACE),
+async def _build_server_event() -> AnonymousTelemetryEvent:
+    return AnonymousTelemetryEvent(
+        install_uuid=await load_or_create_local_install_id(_SURFACE),
         surface=_SURFACE,
         telemetry_mode=get_server_telemetry_mode(),
         record_type="VERSION",
@@ -48,7 +52,7 @@ async def _build_server_event() -> anonymous_telemetry_service.AnonymousTelemetr
     )
 
 
-async def _post_remote_event(event: anonymous_telemetry_service.AnonymousTelemetryEvent) -> None:
+async def _post_remote_event(event: AnonymousTelemetryEvent) -> None:
     async with httpx.AsyncClient(timeout=5.0) as client:
         response = await client.post(
             settings.anonymous_telemetry_endpoint,
@@ -68,7 +72,7 @@ async def _post_remote_event(event: anonymous_telemetry_service.AnonymousTelemet
 
 
 async def record_anonymous_telemetry(
-    event: anonymous_telemetry_service.AnonymousTelemetryEvent,
+    event: AnonymousTelemetryEvent,
 ) -> None:
     async with db_engine.async_session_factory() as db, db.begin():
         await anonymous_telemetry_service.record_anonymous_telemetry(db, event)

--- a/server/proliferate/integrations/anonymous_telemetry.py
+++ b/server/proliferate/integrations/anonymous_telemetry.py
@@ -11,12 +11,7 @@ import httpx
 from proliferate.config import settings
 from proliferate.db import engine as db_engine
 from proliferate.integrations.sentry import capture_server_sentry_exception
-from proliferate.server.anonymous_telemetry.service import (
-    AnonymousTelemetryEvent,
-    VersionPayload,
-    load_or_create_local_install_id,
-    record_anonymous_telemetry as record_anonymous_telemetry_with_db,
-)
+from proliferate.server.anonymous_telemetry import service as anonymous_telemetry_service
 from proliferate.utils.telemetry_mode import (
     get_server_telemetry_mode,
     is_anonymous_telemetry_enabled,
@@ -35,17 +30,17 @@ def _server_version() -> str:
         return "0.1.0"
 
 
-def _version_payload() -> VersionPayload:
-    return VersionPayload(
+def _version_payload() -> anonymous_telemetry_service.VersionPayload:
+    return anonymous_telemetry_service.VersionPayload(
         app_version=_server_version(),
         platform=platform.system().lower() or "unknown",
         arch=platform.machine().lower() or "unknown",
     )
 
 
-async def _build_server_event() -> AnonymousTelemetryEvent:
-    return AnonymousTelemetryEvent(
-        install_uuid=await load_or_create_local_install_id(_SURFACE),
+async def _build_server_event() -> anonymous_telemetry_service.AnonymousTelemetryEvent:
+    return anonymous_telemetry_service.AnonymousTelemetryEvent(
+        install_uuid=await anonymous_telemetry_service.load_or_create_local_install_id(_SURFACE),
         surface=_SURFACE,
         telemetry_mode=get_server_telemetry_mode(),
         record_type="VERSION",
@@ -53,7 +48,7 @@ async def _build_server_event() -> AnonymousTelemetryEvent:
     )
 
 
-async def _post_remote_event(event: AnonymousTelemetryEvent) -> None:
+async def _post_remote_event(event: anonymous_telemetry_service.AnonymousTelemetryEvent) -> None:
     async with httpx.AsyncClient(timeout=5.0) as client:
         response = await client.post(
             settings.anonymous_telemetry_endpoint,
@@ -72,10 +67,11 @@ async def _post_remote_event(event: AnonymousTelemetryEvent) -> None:
         response.raise_for_status()
 
 
-async def record_anonymous_telemetry(event: AnonymousTelemetryEvent) -> None:
-    async with db_engine.async_session_factory() as db:
-        async with db.begin():
-            await record_anonymous_telemetry_with_db(db, event)
+async def record_anonymous_telemetry(
+    event: anonymous_telemetry_service.AnonymousTelemetryEvent,
+) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await anonymous_telemetry_service.record_anonymous_telemetry(db, event)
 
 
 async def emit_server_anonymous_version() -> None:

--- a/server/proliferate/integrations/anyharness/__init__.py
+++ b/server/proliferate/integrations/anyharness/__init__.py
@@ -39,14 +39,14 @@ from proliferate.integrations.anyharness.workspace_ops import (
     start_remote_workspace_setup,
     write_remote_workspace_file,
 )
-from proliferate.integrations.anyharness.worktrees import (
-    run_runtime_worktree_retention,
-    update_runtime_worktree_retention_policy,
-)
 from proliferate.integrations.anyharness.workspaces import (
     list_runtime_workspaces,
     prepare_runtime_mobility_destination,
     resolve_runtime_workspace,
+)
+from proliferate.integrations.anyharness.worktrees import (
+    run_runtime_worktree_retention,
+    update_runtime_worktree_retention_policy,
 )
 
 __all__ = [

--- a/server/proliferate/integrations/anyharness/runtime.py
+++ b/server/proliferate/integrations/anyharness/runtime.py
@@ -67,9 +67,7 @@ async def check_runtime_auth_enforcement(
                 headers=auth_headers(access_token),
             )
             unauth_response = (
-                await client.get(f"{runtime_url}/v1/agents")
-                if auth_response.is_success
-                else None
+                await client.get(f"{runtime_url}/v1/agents") if auth_response.is_success else None
             )
     except httpx.HTTPError as exc:
         raise CloudRuntimeReconnectError(
@@ -105,11 +103,7 @@ async def list_runtime_agents(
         raise CloudRuntimeReconnectError("Failed to list cloud runtime agents.") from exc
     if not isinstance(payload, list):
         raise CloudRuntimeReconnectError("Cloud runtime did not return a valid agent list.")
-    return [
-        summary
-        for item in payload
-        if (summary := _parse_agent_summary(item)) is not None
-    ]
+    return [summary for item in payload if (summary := _parse_agent_summary(item)) is not None]
 
 
 async def install_runtime_agent(

--- a/server/proliferate/integrations/slack/messages.py
+++ b/server/proliferate/integrations/slack/messages.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+SLACK_SECTION_FIELD_LIMIT = 10
+
+
+@dataclass(frozen=True)
+class SlackMessageField:
+    label: str
+    value: str
+
+
+def build_mrkdwn_message_blocks(
+    *,
+    title: str,
+    body: str,
+    fields: tuple[SlackMessageField, ...] = (),
+) -> list[dict[str, object]]:
+    blocks: list[dict[str, object]] = [
+        _section(_escape_mrkdwn(title)),
+        _section(_escape_mrkdwn(body)),
+    ]
+    if fields:
+        blocks.append(
+            {
+                "type": "section",
+                "fields": [
+                    _mrkdwn_field(field)
+                    for field in fields[:SLACK_SECTION_FIELD_LIMIT]
+                ],
+            }
+        )
+    return blocks
+
+
+def _section(text: str) -> dict[str, object]:
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": text,
+        },
+    }
+
+
+def _mrkdwn_field(field: SlackMessageField) -> dict[str, str]:
+    return {
+        "type": "mrkdwn",
+        "text": f"*{_escape_mrkdwn(field.label)}*\n{_escape_mrkdwn(field.value)}",
+    }
+
+
+def _escape_mrkdwn(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")

--- a/server/proliferate/integrations/slack/messages.py
+++ b/server/proliferate/integrations/slack/messages.py
@@ -25,10 +25,7 @@ def build_mrkdwn_message_blocks(
         blocks.append(
             {
                 "type": "section",
-                "fields": [
-                    _mrkdwn_field(field)
-                    for field in fields[:SLACK_SECTION_FIELD_LIMIT]
-                ],
+                "fields": [_mrkdwn_field(field) for field in fields[:SLACK_SECTION_FIELD_LIMIT]],
             }
         )
     return blocks

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -12,7 +12,6 @@ import proliferate.db.models.anonymous_telemetry  # noqa: F401
 import proliferate.db.models.automations  # noqa: F401
 import proliferate.db.models.cloud  # noqa: F401
 import proliferate.db.models.organizations  # noqa: F401
-from proliferate.errors import ProliferateError
 from proliferate.auth.dependencies import fastapi_users
 from proliferate.auth.desktop.api import router as desktop_router
 from proliferate.auth.jwt import auth_backend
@@ -22,6 +21,7 @@ from proliferate.config import get_cors_allow_origins, settings
 from proliferate.constants.app import APP_NAME
 from proliferate.db import engine as db_engine
 from proliferate.db.migrations import validate_database_schema
+from proliferate.errors import ProliferateError
 from proliferate.integrations.anonymous_telemetry import (
     start_server_anonymous_telemetry_sender,
     stop_server_anonymous_telemetry_sender,

--- a/server/proliferate/server/ai_magic/errors.py
+++ b/server/proliferate/server/ai_magic/errors.py
@@ -5,4 +5,3 @@ from proliferate.errors import ProliferateError
 
 class AiMagicError(ProliferateError):
     """Raised when an AI magic request fails with a client-facing error."""
-

--- a/server/proliferate/server/anonymous_telemetry/service.py
+++ b/server/proliferate/server/anonymous_telemetry/service.py
@@ -8,10 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store.anonymous_telemetry import (
     AnonymousTelemetryEventInsert,
-    load_or_create_local_install_id as load_or_create_local_install_id_store,
+    record_anonymous_telemetry_event,
 )
 from proliferate.db.store.anonymous_telemetry import (
-    record_anonymous_telemetry_event,
+    load_or_create_local_install_id as load_or_create_local_install_id_store,
 )
 
 type TelemetrySurface = Literal["desktop", "server"]

--- a/server/proliferate/server/support/api.py
+++ b/server/proliferate/server/support/api.py
@@ -21,7 +21,8 @@ async def send_support_message_endpoint(
     user: User = Depends(current_active_user),
 ) -> SupportMessageResponse:
     await send_support_message(
-        user,
+        sender_email=user.email,
+        sender_display_name=user.display_name,
         message=body.message,
         context=body.context.model_dump(exclude_none=True) if body.context else None,
     )

--- a/server/proliferate/server/support/domain/__init__.py
+++ b/server/proliferate/server/support/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure support-domain helpers."""

--- a/server/proliferate/server/support/domain/message.py
+++ b/server/proliferate/server/support/domain/message.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SupportMessageField:
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class SupportMessagePlan:
+    message: str
+    fallback_text: str
+    fields: tuple[SupportMessageField, ...]
+
+
+def normalize_support_message(message: str) -> str | None:
+    cleaned = message.strip()
+    return cleaned or None
+
+
+def build_support_message_plan(
+    *,
+    sender_name: str,
+    sender_email: str,
+    message: str,
+    context: Mapping[str, object] | None = None,
+    request_id: str | None = None,
+) -> SupportMessagePlan:
+    payload_context = context or {}
+    fields = [
+        SupportMessageField("From", sender_name),
+        SupportMessageField("Email", sender_email),
+    ]
+
+    _append_context_field(fields, "Source", payload_context.get("source"))
+    _append_context_field(fields, "Intent", payload_context.get("intent"))
+    _append_context_field(fields, "Page", payload_context.get("pathname"))
+    _append_workspace_field(
+        fields,
+        name=payload_context.get("workspace_name"),
+        location=payload_context.get("workspace_location"),
+    )
+    _append_context_field(fields, "Workspace ID", payload_context.get("workspace_id"))
+    _append_context_field(fields, "Request ID", request_id)
+
+    return SupportMessagePlan(
+        message=message,
+        fallback_text=f"Support message from {sender_name}: {message[:140]}",
+        fields=tuple(fields),
+    )
+
+
+def _append_context_field(
+    fields: list[SupportMessageField],
+    label: str,
+    value: object | None,
+) -> None:
+    if value:
+        fields.append(SupportMessageField(label, str(value)))
+
+
+def _append_workspace_field(
+    fields: list[SupportMessageField],
+    *,
+    name: object | None,
+    location: object | None,
+) -> None:
+    if name:
+        workspace_value = str(name)
+        if location:
+            workspace_value = f"{location} · {workspace_value}"
+        fields.append(SupportMessageField("Workspace", workspace_value))
+    elif location:
+        fields.append(SupportMessageField("Workspace", str(location)))

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -44,10 +44,7 @@ async def send_support_message(
     blocks = build_mrkdwn_message_blocks(
         title="*New support message*",
         body=plan.message,
-        fields=tuple(
-            SlackMessageField(field.label, field.value)
-            for field in plan.fields
-        ),
+        fields=tuple(SlackMessageField(field.label, field.value) for field in plan.fields),
     )
 
     try:

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from proliferate.config import settings
-from proliferate.db.models.auth import User
 from proliferate.integrations.slack.errors import SlackWebhookError
+from proliferate.integrations.slack.messages import (
+    SlackMessageField,
+    build_mrkdwn_message_blocks,
+)
 from proliferate.integrations.slack.webhooks import post_incoming_webhook
 from proliferate.middleware.request_context import get_request_id
+from proliferate.server.support.domain.message import (
+    build_support_message_plan,
+    normalize_support_message,
+)
 from proliferate.server.support.errors import (
     SupportDeliveryFailed,
     SupportMessageEmpty,
@@ -12,20 +19,10 @@ from proliferate.server.support.errors import (
 )
 
 
-def _escape_slack_text(value: str) -> str:
-    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
-def _field(label: str, value: str) -> dict[str, str]:
-    return {
-        "type": "mrkdwn",
-        "text": f"*{_escape_slack_text(label)}*\n{_escape_slack_text(value)}",
-    }
-
-
 async def send_support_message(
-    user: User,
     *,
+    sender_email: str,
+    sender_display_name: str | None,
     message: str,
     context: dict[str, object] | None = None,
 ) -> None:
@@ -33,67 +30,30 @@ async def send_support_message(
     if not webhook_url:
         raise SupportUnavailable()
 
-    cleaned_message = message.strip()
+    cleaned_message = normalize_support_message(message)
     if not cleaned_message:
         raise SupportMessageEmpty()
 
-    payload_context = context or {}
-    sender_name = user.display_name or user.email
-    pathname = payload_context.get("pathname")
-    source = payload_context.get("source")
-    intent = payload_context.get("intent")
-    workspace_name = payload_context.get("workspace_name")
-    workspace_location = payload_context.get("workspace_location")
-    workspace_id = payload_context.get("workspace_id")
-    request_id = get_request_id()
-
-    fields = [
-        _field("From", sender_name),
-        _field("Email", user.email),
-    ]
-    if source:
-        fields.append(_field("Source", str(source)))
-    if intent:
-        fields.append(_field("Intent", str(intent)))
-    if pathname:
-        fields.append(_field("Page", str(pathname)))
-    if workspace_name:
-        workspace_value = str(workspace_name)
-        if workspace_location:
-            workspace_value = f"{workspace_location} · {workspace_value}"
-        fields.append(_field("Workspace", workspace_value))
-    elif workspace_location:
-        fields.append(_field("Workspace", str(workspace_location)))
-    if workspace_id:
-        fields.append(_field("Workspace ID", str(workspace_id)))
-    if request_id:
-        fields.append(_field("Request ID", request_id))
-
-    blocks: list[dict[str, object]] = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "*New support message*",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": _escape_slack_text(cleaned_message),
-            },
-        },
-    ]
-    if fields:
-        blocks.append({"type": "section", "fields": fields[:10]})
-
-    fallback_text = f"Support message from {sender_name}: {cleaned_message[:140]}"
+    plan = build_support_message_plan(
+        sender_name=sender_display_name or sender_email,
+        sender_email=sender_email,
+        message=cleaned_message,
+        context=context,
+        request_id=get_request_id(),
+    )
+    blocks = build_mrkdwn_message_blocks(
+        title="*New support message*",
+        body=plan.message,
+        fields=tuple(
+            SlackMessageField(field.label, field.value)
+            for field in plan.fields
+        ),
+    )
 
     try:
         await post_incoming_webhook(
             webhook_url=webhook_url,
-            text=fallback_text,
+            text=plan.fallback_text,
             blocks=blocks,
         )
     except SlackWebhookError as exc:

--- a/server/tests/integration/test_cloud_credentials_api.py
+++ b/server/tests/integration/test_cloud_credentials_api.py
@@ -91,9 +91,7 @@ async def test_cloud_credential_sync_list_and_delete_thread_request_db(
 
     response = await client.get("/v1/cloud/credentials", headers=headers)
     assert response.status_code == 200
-    claude_status = next(
-        item for item in response.json() if item["provider"] == "claude"
-    )
+    claude_status = next(item for item in response.json() if item["provider"] == "claude")
     assert claude_status["synced"] is True
 
     response = await client.put(
@@ -108,14 +106,18 @@ async def test_cloud_credential_sync_list_and_delete_thread_request_db(
     assert response.json() == {"ok": True, "changed": False}
 
     records = (
-        await db_session.execute(
-            select(CloudCredential).where(
-                CloudCredential.user_id == uuid.UUID(tokens["user_id"]),
-                CloudCredential.provider == "claude",
-                CloudCredential.revoked_at.is_(None),
+        (
+            await db_session.execute(
+                select(CloudCredential).where(
+                    CloudCredential.user_id == uuid.UUID(tokens["user_id"]),
+                    CloudCredential.provider == "claude",
+                    CloudCredential.revoked_at.is_(None),
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(records) == 1
 
     response = await client.delete("/v1/cloud/credentials/claude", headers=headers)
@@ -124,9 +126,7 @@ async def test_cloud_credential_sync_list_and_delete_thread_request_db(
 
     response = await client.get("/v1/cloud/credentials", headers=headers)
     assert response.status_code == 200
-    claude_status = next(
-        item for item in response.json() if item["provider"] == "claude"
-    )
+    claude_status = next(item for item in response.json() if item["provider"] == "claude")
     assert claude_status["synced"] is False
 
 

--- a/server/tests/unit/test_slack_messages.py
+++ b/server/tests/unit/test_slack_messages.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from proliferate.integrations.slack.messages import (
+    SLACK_SECTION_FIELD_LIMIT,
+    SlackMessageField,
+    build_mrkdwn_message_blocks,
+)
+
+
+def test_build_mrkdwn_message_blocks_escapes_text_and_fields() -> None:
+    blocks = build_mrkdwn_message_blocks(
+        title="*New <support> message*",
+        body="Need help with A&B > C",
+        fields=(
+            SlackMessageField("From", "Pablo <pablo@example.com>"),
+            SlackMessageField("Workspace", "A&B"),
+        ),
+    )
+
+    assert blocks[0]["text"]["text"] == "*New &lt;support&gt; message*"
+    assert blocks[1]["text"]["text"] == "Need help with A&amp;B &gt; C"
+    assert blocks[2]["fields"] == [
+        {"type": "mrkdwn", "text": "*From*\nPablo &lt;pablo@example.com&gt;"},
+        {"type": "mrkdwn", "text": "*Workspace*\nA&amp;B"},
+    ]
+
+
+def test_build_mrkdwn_message_blocks_limits_section_fields() -> None:
+    fields = tuple(
+        SlackMessageField(f"Field {index}", str(index))
+        for index in range(SLACK_SECTION_FIELD_LIMIT + 2)
+    )
+
+    blocks = build_mrkdwn_message_blocks(
+        title="Title",
+        body="Body",
+        fields=fields,
+    )
+
+    assert len(blocks[2]["fields"]) == SLACK_SECTION_FIELD_LIMIT

--- a/server/tests/unit/test_support_message_domain.py
+++ b/server/tests/unit/test_support_message_domain.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from proliferate.server.support.domain.message import (
+    build_support_message_plan,
+    normalize_support_message,
+)
+
+
+def test_normalize_support_message_trims_content() -> None:
+    assert normalize_support_message("  Need help.  ") == "Need help."
+
+
+def test_normalize_support_message_rejects_blank_content() -> None:
+    assert normalize_support_message("   ") is None
+
+
+def test_build_support_message_plan_includes_sender_context_and_request_id() -> None:
+    plan = build_support_message_plan(
+        sender_name="Support Tester",
+        sender_email="support@example.com",
+        message="Need help.",
+        context={
+            "source": "sidebar",
+            "intent": "general",
+            "pathname": "/chat",
+            "workspace_name": "acme/api",
+            "workspace_location": "cloud",
+            "workspace_id": "cloud:123",
+        },
+        request_id="req_123",
+    )
+
+    assert plan.message == "Need help."
+    assert plan.fallback_text == "Support message from Support Tester: Need help."
+    assert [(field.label, field.value) for field in plan.fields] == [
+        ("From", "Support Tester"),
+        ("Email", "support@example.com"),
+        ("Source", "sidebar"),
+        ("Intent", "general"),
+        ("Page", "/chat"),
+        ("Workspace", "cloud · acme/api"),
+        ("Workspace ID", "cloud:123"),
+        ("Request ID", "req_123"),
+    ]
+
+
+def test_build_support_message_plan_uses_location_without_workspace_name() -> None:
+    plan = build_support_message_plan(
+        sender_name="Support Tester",
+        sender_email="support@example.com",
+        message="Need help.",
+        context={"workspace_location": "local"},
+    )
+
+    assert ("Workspace", "local") in [
+        (field.label, field.value)
+        for field in plan.fields
+    ]

--- a/server/tests/unit/test_support_message_domain.py
+++ b/server/tests/unit/test_support_message_domain.py
@@ -52,7 +52,4 @@ def test_build_support_message_plan_uses_location_without_workspace_name() -> No
         context={"workspace_location": "local"},
     )
 
-    assert ("Workspace", "local") in [
-        (field.label, field.value)
-        for field in plan.fields
-    ]
+    assert ("Workspace", "local") in [(field.label, field.value) for field in plan.fields]


### PR DESCRIPTION
## Summary
- move support message planning into pure support-domain helpers
- move Slack mrkdwn block construction into the Slack integration boundary
- remove the support service ORM/auth-model import and shrink the server boundary allowlist

## Verification
- python3.12 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check
- cd server && uv run --extra dev ruff check proliferate/server/support proliferate/integrations/slack tests/unit/test_support_message_domain.py tests/unit/test_slack_messages.py
- cd server && DEBUG=true uv run --extra dev python -m pytest -q tests/unit/test_support_message_domain.py tests/unit/test_slack_messages.py tests/integration/test_support_api.py