### PR TITLE
refactor(desktop): split workspace shell components

### DIFF
--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -2,28 +2,23 @@ import {
   memo,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type Dispatch,
-  type PointerEvent as ReactPointerEvent,
   type SetStateAction,
 } from "react";
 import { useTerminalsQuery } from "@anyharness/sdk-react";
 import { useNavigate } from "react-router-dom";
-import { WorkspaceBrowserPanel } from "@/components/workspace/browser/WorkspaceBrowserPanel";
-import { WorkspaceFilesPanel } from "@/components/workspace/files/panel/WorkspaceFilesPanel";
-import { GitPanel } from "@/components/workspace/git/GitPanel";
-import { TerminalPanel } from "@/components/workspace/terminals/TerminalPanel";
-import { CloudWorkspaceSettingsPanel } from "@/components/cloud/workspace-settings/CloudWorkspaceSettingsPanel";
+import { RightPanelContent } from "@/components/workspace/shell/right-panel/RightPanelContent";
+import { RightPanelHeaderTabs } from "@/components/workspace/shell/right-panel/RightPanelHeaderTabs";
 import { useTerminalActions } from "@/hooks/terminals/workflows/use-terminal-actions";
+import { useRightPanelHeaderEntries } from "@/hooks/workspaces/derived/use-right-panel-header-entries";
+import { useRightPanelRootFocus } from "@/hooks/workspaces/ui/use-right-panel-root-focus";
+import { useRightPanelStateUpdater } from "@/hooks/workspaces/ui/use-right-panel-state-updater";
 import {
   RIGHT_PANEL_BROWSER_TAB_LIMIT,
-  availableRightPanelTools,
-  canCreateRightPanelBrowserTab,
   createBrowserTabInRightPanelState,
   createRightPanelBrowserTabId,
-  parseRightPanelHeaderEntryKey,
   reconcileRightPanelWorkspaceState,
   removeBrowserTabFromRightPanelState,
   removeTerminalFromRightPanelState,
@@ -38,9 +33,6 @@ import {
   type RightPanelWorkspaceState,
 } from "@/lib/domain/workspaces/shell/right-panel";
 import {
-  orderBrowserTabs,
-  orderTerminals,
-  resolvePrimaryDigitShortcutIndex,
   rightPanelStateEqual,
 } from "@/lib/domain/workspaces/shell/right-panel-view";
 import { useTerminalStore } from "@/stores/terminal/terminal-store";
@@ -50,35 +42,9 @@ import {
   rightPanelNewTabMenuDefaultFromEvent,
   type RightPanelNewTabMenuDefault,
 } from "@/lib/infra/right-panel-new-tab-menu";
-import {
-  RightPanelHeaderTabs,
-  type HeaderEntry,
-} from "@/components/workspace/shell/right-panel/RightPanelHeaderTabs";
-import { RightPanelPlaceholder } from "@/components/workspace/shell/right-panel/RightPanelPlaceholder";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
 
 const EMPTY_TERMINALS: never[] = [];
-
-function shouldPreservePointerFocus(target: EventTarget): boolean {
-  if (!(target instanceof Element)) {
-    return true;
-  }
-
-  return Boolean(target.closest(
-    [
-      "a",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "iframe",
-      "[contenteditable='true']",
-      "[role='button']",
-      "[tabindex]:not([tabindex='-1'])",
-      "[data-focus-zone='terminal']",
-      "[data-focus-zone='browser']",
-    ].join(","),
-  ));
-}
 
 interface TerminalActivationRequest {
   token: number;
@@ -128,7 +94,6 @@ export const RightPanel = memo(function RightPanel({
   }>({ token: 0, defaultKind: "terminal" });
   const rootRef = useRef<HTMLDivElement>(null);
   const handledActivationRequestRef = useRef<string | null>(null);
-  const handledFocusRequestRef = useRef(0);
   // One-shot per mounted shell: users who close the starter terminal should not
   // get a replacement every time they revisit the workspace in the same session.
   const autoTerminalWorkspaceIdsRef = useRef(new Set<string>());
@@ -138,97 +103,27 @@ export const RightPanel = memo(function RightPanel({
     enabled: Boolean(workspaceId && shouldRenderContent),
   });
   const terminals = terminalsQuery.data ?? EMPTY_TERMINALS;
-  const terminalIdsInHeader = useMemo(
-    () => new Set(terminalIdsFromHeaderOrder(state.headerOrder)),
-    [state.headerOrder],
-  );
-  const visibleTerminals = useMemo(
-    () => terminals.filter((terminal) =>
-      terminal.purpose !== "setup" || terminalIdsInHeader.has(terminal.id)
-    ),
-    [terminalIdsInHeader, terminals],
-  );
-  const terminalById = useMemo(
-    () => new Map(visibleTerminals.map((terminal) => [terminal.id, terminal])),
-    [visibleTerminals],
-  );
-  const orderedTerminals = useMemo(
-    () => orderTerminals(visibleTerminals, state.headerOrder),
-    [state.headerOrder, visibleTerminals],
-  );
-  const activeEntry = useMemo(
-    () => parseRightPanelHeaderEntryKey(state.activeEntryKey),
-    [state.activeEntryKey],
-  );
-  const activeTool = activeEntry?.kind === "tool" ? activeEntry.tool : null;
-  const activeTerminalId = activeEntry?.kind === "terminal" ? activeEntry.terminalId : null;
-  const activeBrowserId = activeEntry?.kind === "browser" ? activeEntry.browserId : null;
+  const {
+    activeTool,
+    activeTerminalId,
+    activeBrowserId,
+    visibleTerminals,
+    orderedTerminals,
+    browserTabs,
+    canCreateBrowserTab,
+    headerEntries,
+  } = useRightPanelHeaderEntries({
+    state,
+    terminals,
+    isCloudWorkspaceSelected,
+  });
   const terminalActivationRequestToken = terminalActivationRequest?.workspaceId === workspaceId
     ? terminalActivationRequest.token
     : 0;
-  const browserTabs = useMemo(
-    () => orderBrowserTabs(state.browserTabsById, state.headerOrder),
-    [state.browserTabsById, state.headerOrder],
-  );
-  const canCreateBrowserTab = canCreateRightPanelBrowserTab(state);
-
-  const headerEntries = useMemo<HeaderEntry[]>(() => {
-    const entries: HeaderEntry[] = [];
-    const seenKeys = new Set<RightPanelHeaderEntryKey>();
-    const availableToolSet = new Set(availableRightPanelTools(isCloudWorkspaceSelected));
-
-    for (const key of state.headerOrder) {
-      const entry = parseRightPanelHeaderEntryKey(key);
-      if (!entry || seenKeys.has(key)) {
-        continue;
-      }
-      if (entry.kind === "tool" && availableToolSet.has(entry.tool)) {
-        entries.push({ kind: "tool", key, tool: entry.tool });
-        seenKeys.add(key);
-      }
-      if (entry.kind === "terminal") {
-        entries.push({
-          kind: "terminal",
-          key,
-          terminalId: entry.terminalId,
-          terminal: terminalById.get(entry.terminalId) ?? null,
-        });
-        seenKeys.add(key);
-      }
-      if (entry.kind === "browser") {
-        const tab = state.browserTabsById[entry.browserId];
-        if (tab) {
-          entries.push({ kind: "browser", key, tab });
-          seenKeys.add(key);
-        }
-      }
-    }
-
-    return entries;
-  }, [isCloudWorkspaceSelected, state.browserTabsById, state.headerOrder, terminalById]);
-
-  const updateState = useCallback(
-    (value: SetStateAction<RightPanelWorkspaceState>) => {
-      onStateChange((previous) => {
-        const current = reconcileRightPanelWorkspaceState(previous, {
-          isCloudWorkspaceSelected,
-        });
-        const next = typeof value === "function"
-          ? (value as (previousValue: RightPanelWorkspaceState) => RightPanelWorkspaceState)(
-              current,
-            )
-          : value;
-        const reconciledNext = reconcileRightPanelWorkspaceState(next, {
-          isCloudWorkspaceSelected,
-        });
-        if (!rightPanelStateEqual(current, reconciledNext)) {
-          return reconciledNext;
-        }
-        return rightPanelStateEqual(previous, current) ? previous : current;
-      });
-    },
-    [isCloudWorkspaceSelected, onStateChange],
-  );
+  const updateState = useRightPanelStateUpdater({
+    isCloudWorkspaceSelected,
+    onStateChange,
+  });
 
   useEffect(() => {
     const next = reconcileRightPanelWorkspaceState(state, {
@@ -420,7 +315,7 @@ export const RightPanel = memo(function RightPanel({
   }, [updateState]);
 
   const activateHeaderEntry = useCallback(
-    (entry: HeaderEntry) => {
+    (entry: RightPanelHeaderEntry) => {
       if (entry.kind === "tool") {
         activateTool(entry.tool);
         return;
@@ -434,54 +329,13 @@ export const RightPanel = memo(function RightPanel({
     [activateTool, selectBrowser, selectTerminal],
   );
 
-  const handleRootPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (shouldPreservePointerFocus(event.target)) {
-      return;
-    }
-
-    rootRef.current?.focus({ preventScroll: true });
-  }, []);
-
-  useEffect(() => {
-    if (
-      !isOpen
-      || focusRequestToken <= 0
-      || handledFocusRequestRef.current === focusRequestToken
-    ) {
-      return;
-    }
-
-    handledFocusRequestRef.current = focusRequestToken;
-    rootRef.current?.focus({ preventScroll: true });
-  }, [focusRequestToken, isOpen]);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const shortcutIndex = resolvePrimaryDigitShortcutIndex(event);
-      if (shortcutIndex === null) {
-        return;
-      }
-
-      const root = rootRef.current;
-      const activeElement = document.activeElement;
-      if (!root || !(activeElement instanceof Element) || !root.contains(activeElement)) {
-        return;
-      }
-
-      const entry = headerEntries[shortcutIndex];
-      if (!entry) {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-      activateHeaderEntry(entry);
-    };
-
-    window.addEventListener("keydown", handleKeyDown, true);
-    return () => window.removeEventListener("keydown", handleKeyDown, true);
-  }, [activateHeaderEntry, headerEntries]);
+  const handleRootPointerDownCapture = useRightPanelRootFocus({
+    rootRef,
+    isOpen,
+    focusRequestToken,
+    headerEntries,
+    onActivateHeaderEntry: activateHeaderEntry,
+  });
 
   const handleCloseTerminal = useCallback(
     (terminalId: string) => {
@@ -606,67 +460,33 @@ export const RightPanel = memo(function RightPanel({
         onOpenRepoSettings={() => navigate(repoSettingsHref)}
       />
 
-      <div
-        data-panel="true"
-        id="workspace-side-panel"
-        className="relative min-h-0 flex-1 overflow-hidden"
-      >
-        {!shouldRenderContent ? (
-          <RightPanelPlaceholder activeEntryKey={state.activeEntryKey} />
-        ) : (
-          <>
-            {activeTool === "files" && (
-              <div className="absolute inset-0">
-                <WorkspaceFilesPanel showHeader={false} />
-              </div>
-            )}
-            {activeTool === "settings" && (
-              <div className="absolute inset-0">
-                <CloudWorkspaceSettingsPanel />
-              </div>
-            )}
-            {activeTool === "git" && (
-              <div className="absolute inset-0">
-                <GitPanel />
-              </div>
-            )}
-            {shouldMountBrowserPanel && (
-              <div className={activeBrowserId ? "absolute inset-0" : "hidden"}>
-                <WorkspaceBrowserPanel
-                  workspaceId={workspaceId}
-                  tabs={browserTabs}
-                  activeBrowserId={activeBrowserId}
-                  isVisible={isOpen && activeBrowserId !== null}
-                  nativeOverlaysHidden={nativeOverlaysHidden}
-                  onUpdateUrl={handleUpdateBrowserUrl}
-                />
-              </div>
-            )}
-            {shouldMountTerminalPanel && (
-              <div className={activeTerminalId ? "absolute inset-0" : "hidden"}>
-                <TerminalPanel
-                  workspaceId={workspaceId}
-                  terminals={orderedTerminals}
-                  activeTerminalId={activeTerminalId}
-                  isVisible={activeTerminalId !== null}
-                  isRuntimeReady={isWorkspaceReady}
-                  canConnect={terminalsQuery.isSuccess}
-                  isLoading={terminalsQuery.isLoading && !terminalsQuery.data}
-                  errorMessage={terminalsQuery.isError ? "Terminal list unavailable" : null}
-                  focusRequestToken={terminalActivationRequestToken + terminalFocusNonce}
-                  unreadByTerminal={unreadByTerminal}
-                  onNewTerminal={() => {
-                    void createTerminal({ activate: true });
-                  }}
-                  onSelectTerminal={selectTerminal}
-                  onCloseTerminal={handleCloseTerminal}
-                  onRenameTerminal={handleRenameTerminal}
-                />
-              </div>
-            )}
-          </>
-        )}
-      </div>
+      <RightPanelContent
+        workspaceId={workspaceId}
+        activeEntryKey={state.activeEntryKey}
+        activeTool={activeTool}
+        activeBrowserId={activeBrowserId}
+        activeTerminalId={activeTerminalId}
+        browserTabs={browserTabs}
+        orderedTerminals={orderedTerminals}
+        shouldRenderContent={shouldRenderContent}
+        shouldMountBrowserPanel={shouldMountBrowserPanel}
+        shouldMountTerminalPanel={shouldMountTerminalPanel}
+        isOpen={isOpen}
+        isWorkspaceReady={isWorkspaceReady}
+        canConnectTerminals={terminalsQuery.isSuccess}
+        isLoadingTerminals={terminalsQuery.isLoading && !terminalsQuery.data}
+        terminalListErrorMessage={terminalsQuery.isError ? "Terminal list unavailable" : null}
+        terminalFocusRequestToken={terminalActivationRequestToken + terminalFocusNonce}
+        unreadByTerminal={unreadByTerminal}
+        nativeOverlaysHidden={nativeOverlaysHidden}
+        onUpdateBrowserUrl={handleUpdateBrowserUrl}
+        onNewTerminal={() => {
+          void createTerminal({ activate: true });
+        }}
+        onSelectTerminal={selectTerminal}
+        onCloseTerminal={handleCloseTerminal}
+        onRenameTerminal={handleRenameTerminal}
+      />
     </div>
   );
 });

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
@@ -1,0 +1,123 @@
+import { WorkspaceBrowserPanel } from "@/components/workspace/browser/WorkspaceBrowserPanel";
+import { CloudWorkspaceSettingsPanel } from "@/components/cloud/workspace-settings/CloudWorkspaceSettingsPanel";
+import { WorkspaceFilesPanel } from "@/components/workspace/files/panel/WorkspaceFilesPanel";
+import { GitPanel } from "@/components/workspace/git/GitPanel";
+import { RightPanelPlaceholder } from "@/components/workspace/shell/right-panel/RightPanelPlaceholder";
+import { TerminalPanel } from "@/components/workspace/terminals/TerminalPanel";
+import type { TerminalRecord } from "@anyharness/sdk";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelActiveEntryKey, RightPanelTool } from "@/lib/domain/workspaces/shell/right-panel";
+
+interface RightPanelContentProps {
+  workspaceId: string | null;
+  activeEntryKey: RightPanelActiveEntryKey;
+  activeTool: RightPanelTool | null;
+  activeBrowserId: string | null;
+  activeTerminalId: string | null;
+  browserTabs: readonly RightPanelBrowserTab[];
+  orderedTerminals: readonly TerminalRecord[];
+  shouldRenderContent: boolean;
+  shouldMountBrowserPanel: boolean;
+  shouldMountTerminalPanel: boolean;
+  isOpen: boolean;
+  isWorkspaceReady: boolean;
+  canConnectTerminals: boolean;
+  isLoadingTerminals: boolean;
+  terminalListErrorMessage: string | null;
+  terminalFocusRequestToken: number;
+  unreadByTerminal: Record<string, boolean>;
+  nativeOverlaysHidden: boolean;
+  onUpdateBrowserUrl: (browserId: string, url: string) => void;
+  onNewTerminal: () => void;
+  onSelectTerminal: (terminalId: string) => void;
+  onCloseTerminal: (terminalId: string) => void;
+  onRenameTerminal: (terminalId: string, title: string) => Promise<void>;
+}
+
+export function RightPanelContent({
+  workspaceId,
+  activeEntryKey,
+  activeTool,
+  activeBrowserId,
+  activeTerminalId,
+  browserTabs,
+  orderedTerminals,
+  shouldRenderContent,
+  shouldMountBrowserPanel,
+  shouldMountTerminalPanel,
+  isOpen,
+  isWorkspaceReady,
+  canConnectTerminals,
+  isLoadingTerminals,
+  terminalListErrorMessage,
+  terminalFocusRequestToken,
+  unreadByTerminal,
+  nativeOverlaysHidden,
+  onUpdateBrowserUrl,
+  onNewTerminal,
+  onSelectTerminal,
+  onCloseTerminal,
+  onRenameTerminal,
+}: RightPanelContentProps) {
+  return (
+    <div
+      data-panel="true"
+      id="workspace-side-panel"
+      className="relative min-h-0 flex-1 overflow-hidden"
+    >
+      {!shouldRenderContent ? (
+        <RightPanelPlaceholder activeEntryKey={activeEntryKey} />
+      ) : (
+        <>
+          {activeTool === "files" && (
+            <div className="absolute inset-0">
+              <WorkspaceFilesPanel showHeader={false} />
+            </div>
+          )}
+          {activeTool === "settings" && (
+            <div className="absolute inset-0">
+              <CloudWorkspaceSettingsPanel />
+            </div>
+          )}
+          {activeTool === "git" && (
+            <div className="absolute inset-0">
+              <GitPanel />
+            </div>
+          )}
+          {shouldMountBrowserPanel && (
+            <div className={activeBrowserId ? "absolute inset-0" : "hidden"}>
+              <WorkspaceBrowserPanel
+                workspaceId={workspaceId}
+                tabs={browserTabs}
+                activeBrowserId={activeBrowserId}
+                isVisible={isOpen && activeBrowserId !== null}
+                nativeOverlaysHidden={nativeOverlaysHidden}
+                onUpdateUrl={onUpdateBrowserUrl}
+              />
+            </div>
+          )}
+          {shouldMountTerminalPanel && (
+            <div className={activeTerminalId ? "absolute inset-0" : "hidden"}>
+              <TerminalPanel
+                workspaceId={workspaceId}
+                terminals={orderedTerminals}
+                activeTerminalId={activeTerminalId}
+                isVisible={activeTerminalId !== null}
+                isRuntimeReady={isWorkspaceReady}
+                canConnect={canConnectTerminals}
+                isLoading={isLoadingTerminals}
+                errorMessage={terminalListErrorMessage}
+                focusRequestToken={terminalFocusRequestToken}
+                unreadByTerminal={unreadByTerminal}
+                onNewTerminal={onNewTerminal}
+                onSelectTerminal={onSelectTerminal}
+                onCloseTerminal={onCloseTerminal}
+                onRenameTerminal={onRenameTerminal}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
@@ -1,0 +1,60 @@
+import { IconButton } from "@/components/ui/IconButton";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { Settings } from "@/components/ui/icons";
+import { RightPanelNewTabMenu } from "@/components/workspace/shell/right-panel/RightPanelNewTabMenu";
+import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
+
+interface RightPanelHeaderActionsProps {
+  newTabMenuOpen: boolean;
+  newTabMenuDefaultKind: RightPanelNewTabMenuDefault;
+  isWorkspaceReady: boolean;
+  canCreateBrowserTab: boolean;
+  onNewTabMenuOpenChange: (isOpen: boolean) => void;
+  onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
+  onOpenRepoSettings: () => void;
+}
+
+export function RightPanelHeaderActions({
+  newTabMenuOpen,
+  newTabMenuDefaultKind,
+  isWorkspaceReady,
+  canCreateBrowserTab,
+  onNewTabMenuOpenChange,
+  onCreateTerminal,
+  onCreateBrowser,
+  onOpenRepoSettings,
+}: RightPanelHeaderActionsProps) {
+  return (
+    <div className="ui-tab-system-section ui-tab-system-section__trailing">
+      <div className="editor-panel-overflow-action">
+        <Tooltip
+          content="Repo's settings"
+          className="right-panel-repo-settings-tooltip"
+          singleLine
+        >
+          <IconButton
+            size="xs"
+            tone="sidebar"
+            title="Repo's settings"
+            className="ui-icon-button glass-editor-panel-new-tab-menu-trigger"
+            onClick={onOpenRepoSettings}
+          >
+            <Settings className="ui-icon" />
+          </IconButton>
+        </Tooltip>
+      </div>
+      <div className="editor-panel-overflow-action">
+        <RightPanelNewTabMenu
+          open={newTabMenuOpen}
+          defaultKind={newTabMenuDefaultKind}
+          isWorkspaceReady={isWorkspaceReady}
+          canCreateBrowserTab={canCreateBrowserTab}
+          onOpenChange={onNewTabMenuOpenChange}
+          onCreateTerminal={onCreateTerminal}
+          onCreateBrowser={onCreateBrowser}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
@@ -1,0 +1,53 @@
+import { useCallback, type PointerEvent, type ReactNode } from "react";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel";
+
+interface RightPanelHeaderEntryDropZoneProps {
+  entryKey: RightPanelHeaderEntryKey;
+  isDragging: boolean;
+  dragOffsetX: number;
+  showDropIndicator: boolean;
+  onRegister: (entryKey: RightPanelHeaderEntryKey, node: HTMLDivElement | null) => void;
+  onPointerDown: (
+    entryKey: RightPanelHeaderEntryKey,
+    event: PointerEvent<HTMLDivElement>,
+  ) => void;
+  onPointerMove: (event: PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: PointerEvent<HTMLDivElement>) => void;
+  onPointerCancel: (event: PointerEvent<HTMLDivElement>) => void;
+  children: ReactNode;
+}
+
+export function RightPanelHeaderEntryDropZone({
+  entryKey,
+  isDragging,
+  dragOffsetX,
+  showDropIndicator,
+  onRegister,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onPointerCancel,
+  children,
+}: RightPanelHeaderEntryDropZoneProps) {
+  const setNode = useCallback(
+    (node: HTMLDivElement | null) => onRegister(entryKey, node),
+    [entryKey, onRegister],
+  );
+
+  return (
+    <div
+      ref={setNode}
+      className="right-panel-header-entry-shell"
+      data-dragging={isDragging ? true : undefined}
+      data-drop-before={showDropIndicator ? true : undefined}
+      style={isDragging ? { transform: `translateX(${dragOffsetX}px)` } : undefined}
+      onPointerDown={(event) => onPointerDown(entryKey, event)}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onLostPointerCapture={onPointerCancel}
+    >
+      {children}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
@@ -1,0 +1,131 @@
+import { BrowserHeaderButton } from "@/components/workspace/shell/right-panel/BrowserHeaderButton";
+import { RightPanelHeaderEntryDropZone } from "@/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone";
+import { TerminalHeaderButton } from "@/components/workspace/shell/right-panel/TerminalHeaderButton";
+import { ToolHeaderButton } from "@/components/workspace/shell/right-panel/ToolHeaderButton";
+import type { RightPanelHeaderDragController } from "@/hooks/workspaces/ui/use-right-panel-header-drag";
+import {
+  browserHeaderDisplayTitle,
+  terminalHeaderDisplayTitle,
+  type RightPanelHeaderEntry,
+} from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+import type {
+  RightPanelHeaderEntryKey,
+  RightPanelTool,
+} from "@/lib/domain/workspaces/shell/right-panel";
+
+interface RightPanelHeaderEntryListProps {
+  entries: readonly RightPanelHeaderEntry[];
+  activeEntryKey: RightPanelHeaderEntryKey;
+  unreadByTerminal: Record<string, boolean>;
+  isWorkspaceReady: boolean;
+  drag: RightPanelHeaderDragController;
+  onActivateTool: (tool: RightPanelTool) => void;
+  onSelectTerminal: (terminalId: string) => void;
+  onSelectBrowser: (browserId: string) => void;
+  onCloseTerminal: (terminalId: string) => void;
+  onCloseBrowser: (browserId: string) => void;
+  onRenameTerminal: (terminalId: string, title: string) => Promise<void>;
+}
+
+export function RightPanelHeaderEntryList({
+  entries,
+  activeEntryKey,
+  unreadByTerminal,
+  isWorkspaceReady,
+  drag,
+  onActivateTool,
+  onSelectTerminal,
+  onSelectBrowser,
+  onCloseTerminal,
+  onCloseBrowser,
+  onRenameTerminal,
+}: RightPanelHeaderEntryListProps) {
+  return (
+    <>
+      {entries.map((entry) => {
+        const dragState = drag.getEntryDragState(entry.key);
+
+        if (entry.kind === "tool") {
+          return (
+            <RightPanelHeaderEntryDropZone
+              key={entry.key}
+              entryKey={entry.key}
+              isDragging={dragState.isDragging}
+              dragOffsetX={dragState.dragOffsetX}
+              showDropIndicator={dragState.showDropIndicator}
+              onRegister={drag.registerHeaderEntryNode}
+              onPointerDown={drag.handleHeaderPointerDown}
+              onPointerMove={drag.handleHeaderPointerMove}
+              onPointerUp={drag.finishHeaderPointerDrag}
+              onPointerCancel={drag.cancelHeaderPointerDrag}
+            >
+              <ToolHeaderButton
+                tool={entry.tool}
+                isActive={activeEntryKey === entry.key}
+                isDragging={drag.draggedHeaderKey === entry.key}
+                shouldSuppressClick={drag.shouldSuppressHeaderClick}
+                onSelect={() => onActivateTool(entry.tool)}
+              />
+            </RightPanelHeaderEntryDropZone>
+          );
+        }
+
+        if (entry.kind === "terminal") {
+          return (
+            <RightPanelHeaderEntryDropZone
+              key={entry.key}
+              entryKey={entry.key}
+              isDragging={dragState.isDragging}
+              dragOffsetX={dragState.dragOffsetX}
+              showDropIndicator={dragState.showDropIndicator}
+              onRegister={drag.registerHeaderEntryNode}
+              onPointerDown={drag.handleHeaderPointerDown}
+              onPointerMove={drag.handleHeaderPointerMove}
+              onPointerUp={drag.finishHeaderPointerDrag}
+              onPointerCancel={drag.cancelHeaderPointerDrag}
+            >
+              <TerminalHeaderButton
+                terminalId={entry.terminalId}
+                terminal={entry.terminal}
+                displayTitle={terminalHeaderDisplayTitle(entries, entry)}
+                isActive={activeEntryKey === entry.key}
+                unread={unreadByTerminal[entry.terminalId] === true}
+                isRuntimeReady={isWorkspaceReady && Boolean(entry.terminal)}
+                isDragging={drag.draggedHeaderKey === entry.key}
+                shouldSuppressClick={drag.shouldSuppressHeaderClick}
+                onSelect={() => onSelectTerminal(entry.terminalId)}
+                onClose={() => onCloseTerminal(entry.terminalId)}
+                onRename={(title) => onRenameTerminal(entry.terminalId, title)}
+              />
+            </RightPanelHeaderEntryDropZone>
+          );
+        }
+
+        return (
+          <RightPanelHeaderEntryDropZone
+            key={entry.key}
+            entryKey={entry.key}
+            isDragging={dragState.isDragging}
+            dragOffsetX={dragState.dragOffsetX}
+            showDropIndicator={dragState.showDropIndicator}
+            onRegister={drag.registerHeaderEntryNode}
+            onPointerDown={drag.handleHeaderPointerDown}
+            onPointerMove={drag.handleHeaderPointerMove}
+            onPointerUp={drag.finishHeaderPointerDrag}
+            onPointerCancel={drag.cancelHeaderPointerDrag}
+          >
+            <BrowserHeaderButton
+              browserId={entry.tab.id}
+              displayTitle={browserHeaderDisplayTitle(entries, entry)}
+              isActive={activeEntryKey === entry.key}
+              isDragging={drag.draggedHeaderKey === entry.key}
+              shouldSuppressClick={drag.shouldSuppressHeaderClick}
+              onSelect={() => onSelectBrowser(entry.tab.id)}
+              onClose={() => onCloseBrowser(entry.tab.id)}
+            />
+          </RightPanelHeaderEntryDropZone>
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -1,58 +1,19 @@
 import {
-  useCallback,
   useEffect,
-  useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type PointerEvent,
-  type ReactNode,
 } from "react";
-import type { TerminalRecord } from "@anyharness/sdk";
-import { IconButton } from "@/components/ui/IconButton";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
-import { Tooltip } from "@/components/ui/Tooltip";
+import { RightPanelHeaderActions } from "@/components/workspace/shell/right-panel/RightPanelHeaderActions";
+import { RightPanelHeaderEntryList } from "@/components/workspace/shell/right-panel/RightPanelHeaderEntryList";
+import { useRightPanelHeaderDrag } from "@/hooks/workspaces/ui/use-right-panel-header-drag";
 import {
-  Plus,
-  Settings,
-  Terminal as TerminalIcon,
-  Globe,
-} from "@/components/ui/icons";
-import {
-  browserTabTitle,
-  type RightPanelBrowserTab,
   type RightPanelHeaderEntryKey,
   type RightPanelTool,
 } from "@/lib/domain/workspaces/shell/right-panel";
-import { ToolHeaderButton } from "@/components/workspace/shell/right-panel/ToolHeaderButton";
-import { TerminalHeaderButton } from "@/components/workspace/shell/right-panel/TerminalHeaderButton";
-import { BrowserHeaderButton } from "@/components/workspace/shell/right-panel/BrowserHeaderButton";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
 import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
 
-const HEADER_DRAG_THRESHOLD_PX = 4;
-
-export type HeaderEntry =
-  | { kind: "tool"; key: RightPanelHeaderEntryKey; tool: RightPanelTool }
-  | { kind: "terminal"; key: RightPanelHeaderEntryKey; terminalId: string; terminal: TerminalRecord | null }
-  | { kind: "browser"; key: RightPanelHeaderEntryKey; tab: RightPanelBrowserTab };
-
-interface HeaderDragSession {
-  key: RightPanelHeaderEntryKey;
-  pointerId: number;
-  startX: number;
-  startY: number;
-  beforeKey: RightPanelHeaderEntryKey | null;
-  isDragging: boolean;
-}
-
-interface HeaderDragPreview {
-  key: RightPanelHeaderEntryKey;
-  offsetX: number;
-  beforeKey: RightPanelHeaderEntryKey | null;
-}
-
 interface RightPanelHeaderTabsProps {
-  entries: readonly HeaderEntry[];
+  entries: readonly RightPanelHeaderEntry[];
   activeEntryKey: RightPanelHeaderEntryKey;
   unreadByTerminal: Record<string, boolean>;
   isWorkspaceReady: boolean;
@@ -93,136 +54,14 @@ export function RightPanelHeaderTabs({
   onOpenRepoSettings,
   onReorderHeaderEntry,
 }: RightPanelHeaderTabsProps) {
-  const [headerDragPreview, setHeaderDragPreview] = useState<HeaderDragPreview | null>(null);
   const [newTabMenuOpen, setNewTabMenuOpen] = useState(false);
-  const draggedHeaderKey = headerDragPreview?.key ?? null;
-  const headerEntryNodesRef = useRef(new Map<RightPanelHeaderEntryKey, HTMLDivElement>());
-  const headerDragSessionRef = useRef<HeaderDragSession | null>(null);
-  const suppressNextHeaderClickRef = useRef(false);
-
-  const registerHeaderEntryNode = useCallback((
-    entryKey: RightPanelHeaderEntryKey,
-    node: HTMLDivElement | null,
-  ) => {
-    if (node) {
-      headerEntryNodesRef.current.set(entryKey, node);
-      return;
-    }
-    headerEntryNodesRef.current.delete(entryKey);
-  }, []);
-
-  const resolveHeaderDropBeforeKey = useCallback((
-    clientX: number,
-    draggedKey: RightPanelHeaderEntryKey,
-  ): RightPanelHeaderEntryKey | null => {
-    const candidates = [...headerEntryNodesRef.current.entries()]
-      .filter(([entryKey]) => entryKey !== draggedKey)
-      .map(([entryKey, node]) => ({
-        entryKey,
-        rect: node.getBoundingClientRect(),
-      }))
-      .sort((left, right) => left.rect.left - right.rect.left);
-
-    const target = candidates.find(({ rect }) => clientX < rect.left + rect.width / 2);
-    return target?.entryKey ?? null;
-  }, []);
-
-  const suppressNextHeaderClick = useCallback(() => {
-    suppressNextHeaderClickRef.current = true;
-    window.setTimeout(() => {
-      suppressNextHeaderClickRef.current = false;
-    }, 50);
-  }, []);
-
-  const shouldSuppressHeaderClick = useCallback(() => {
-    if (!suppressNextHeaderClickRef.current) {
-      return false;
-    }
-    suppressNextHeaderClickRef.current = false;
-    return true;
-  }, []);
+  const drag = useRightPanelHeaderDrag({ onReorderHeaderEntry });
 
   useEffect(() => {
     if (newTabMenuRequestToken > 0) {
       setNewTabMenuOpen(true);
     }
   }, [newTabMenuRequestToken]);
-
-  const handleHeaderPointerDown = useCallback((
-    entryKey: RightPanelHeaderEntryKey,
-    event: PointerEvent<HTMLDivElement>,
-  ) => {
-    if (event.button !== 0) {
-      return;
-    }
-    const target = event.target instanceof Element ? event.target : null;
-    if (target?.closest("[data-right-panel-tab-no-drag='true']")) {
-      return;
-    }
-
-    headerDragSessionRef.current = {
-      key: entryKey,
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
-      beforeKey: null,
-      isDragging: false,
-    };
-    event.currentTarget.setPointerCapture(event.pointerId);
-  }, []);
-
-  const handleHeaderPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
-    const session = headerDragSessionRef.current;
-    if (!session || session.pointerId !== event.pointerId) {
-      return;
-    }
-
-    if (!session.isDragging) {
-      const distance = Math.hypot(event.clientX - session.startX, event.clientY - session.startY);
-      if (distance < HEADER_DRAG_THRESHOLD_PX) {
-        return;
-      }
-      session.isDragging = true;
-    }
-
-    event.preventDefault();
-    const beforeKey = resolveHeaderDropBeforeKey(event.clientX, session.key);
-    session.beforeKey = beforeKey;
-    setHeaderDragPreview({
-      key: session.key,
-      offsetX: event.clientX - session.startX,
-      beforeKey,
-    });
-  }, [resolveHeaderDropBeforeKey]);
-
-  const finishHeaderPointerDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
-    const session = headerDragSessionRef.current;
-    if (!session || session.pointerId !== event.pointerId) {
-      return;
-    }
-    if (session.isDragging) {
-      event.preventDefault();
-      onReorderHeaderEntry(session.key, session.beforeKey);
-      suppressNextHeaderClick();
-    }
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    headerDragSessionRef.current = null;
-    setHeaderDragPreview(null);
-  }, [onReorderHeaderEntry, suppressNextHeaderClick]);
-
-  const cancelHeaderPointerDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
-    const session = headerDragSessionRef.current;
-    if (!session || session.pointerId !== event.pointerId) {
-      return;
-    }
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    headerDragSessionRef.current = null;
-    setHeaderDragPreview(null);
-  }, []);
 
   return (
     <div className="right-panel-tab-system ui-tab-system editor-panel-tab-root editor-panel-tab-root--simple-tabs border-b border-sidebar-border/70">
@@ -245,112 +84,22 @@ export function RightPanelHeaderTabs({
               aria-orientation="horizontal"
             >
               <div className="ui-tab-system-tabs__section" data-tab-section="workspace">
-                {entries.map((entry) => {
-                  if (entry.kind === "tool") {
-                    const isActive = activeEntryKey === entry.key;
-                    const isEntryDragging = headerDragPreview?.key === entry.key;
-                    return (
-                      <RightPanelHeaderEntryDropZone
-                        key={entry.key}
-                        entryKey={entry.key}
-                        isDragging={isEntryDragging}
-                        dragOffsetX={isEntryDragging ? headerDragPreview.offsetX : 0}
-                        showDropIndicator={headerDragPreview?.beforeKey === entry.key}
-                        onRegister={registerHeaderEntryNode}
-                        onPointerDown={handleHeaderPointerDown}
-                        onPointerMove={handleHeaderPointerMove}
-                        onPointerUp={finishHeaderPointerDrag}
-                        onPointerCancel={cancelHeaderPointerDrag}
-                      >
-                        <ToolHeaderButton
-                          tool={entry.tool}
-                          isActive={isActive}
-                          isDragging={draggedHeaderKey === entry.key}
-                          shouldSuppressClick={shouldSuppressHeaderClick}
-                          onSelect={() => onActivateTool(entry.tool)}
-                        />
-                      </RightPanelHeaderEntryDropZone>
-                    );
-                  }
-
-                  if (entry.kind === "terminal") {
-                    const terminalIndex = entries
-                      .filter((candidate) => candidate.kind === "terminal")
-                      .findIndex((candidate) =>
-                        candidate.kind === "terminal" && candidate.terminalId === entry.terminalId
-                      );
-                    const isActive = activeEntryKey === entry.key;
-                    const fallbackTitle = `Terminal ${terminalIndex + 1}`;
-                    const displayTitle = entry.terminal?.title === "Terminal"
-                      ? fallbackTitle
-                      : entry.terminal?.title ?? fallbackTitle;
-                    const isEntryDragging = headerDragPreview?.key === entry.key;
-                    return (
-                      <RightPanelHeaderEntryDropZone
-                        key={entry.key}
-                        entryKey={entry.key}
-                        isDragging={isEntryDragging}
-                        dragOffsetX={isEntryDragging ? headerDragPreview.offsetX : 0}
-                        showDropIndicator={headerDragPreview?.beforeKey === entry.key}
-                        onRegister={registerHeaderEntryNode}
-                        onPointerDown={handleHeaderPointerDown}
-                        onPointerMove={handleHeaderPointerMove}
-                        onPointerUp={finishHeaderPointerDrag}
-                        onPointerCancel={cancelHeaderPointerDrag}
-                      >
-                        <TerminalHeaderButton
-                          terminalId={entry.terminalId}
-                          terminal={entry.terminal}
-                          displayTitle={displayTitle}
-                          isActive={isActive}
-                          unread={unreadByTerminal[entry.terminalId] === true}
-                          isRuntimeReady={isWorkspaceReady && Boolean(entry.terminal)}
-                          isDragging={draggedHeaderKey === entry.key}
-                          shouldSuppressClick={shouldSuppressHeaderClick}
-                          onSelect={() => onSelectTerminal(entry.terminalId)}
-                          onClose={() => onCloseTerminal(entry.terminalId)}
-                          onRename={(title) => onRenameTerminal(entry.terminalId, title)}
-                        />
-                      </RightPanelHeaderEntryDropZone>
-                    );
-                  }
-
-                  const browserIndex = entries
-                    .filter((candidate) => candidate.kind === "browser")
-                    .findIndex((candidate) =>
-                      candidate.kind === "browser" && candidate.tab.id === entry.tab.id
-                    );
-                  const isActive = activeEntryKey === entry.key;
-                  const isEntryDragging = headerDragPreview?.key === entry.key;
-                  return (
-                    <RightPanelHeaderEntryDropZone
-                      key={entry.key}
-                      entryKey={entry.key}
-                      isDragging={isEntryDragging}
-                      dragOffsetX={isEntryDragging ? headerDragPreview.offsetX : 0}
-                      showDropIndicator={headerDragPreview?.beforeKey === entry.key}
-                      onRegister={registerHeaderEntryNode}
-                      onPointerDown={handleHeaderPointerDown}
-                      onPointerMove={handleHeaderPointerMove}
-                      onPointerUp={finishHeaderPointerDrag}
-                      onPointerCancel={cancelHeaderPointerDrag}
-                    >
-                      <BrowserHeaderButton
-                        browserId={entry.tab.id}
-                        displayTitle={browserTabTitle(entry.tab, browserIndex)}
-                        isActive={isActive}
-                        isDragging={draggedHeaderKey === entry.key}
-                        shouldSuppressClick={shouldSuppressHeaderClick}
-                        onSelect={() => onSelectBrowser(entry.tab.id)}
-                        onClose={() => onCloseBrowser(entry.tab.id)}
-                      />
-                    </RightPanelHeaderEntryDropZone>
-                  );
-                })}
-
+                <RightPanelHeaderEntryList
+                  entries={entries}
+                  activeEntryKey={activeEntryKey}
+                  unreadByTerminal={unreadByTerminal}
+                  isWorkspaceReady={isWorkspaceReady}
+                  drag={drag}
+                  onActivateTool={onActivateTool}
+                  onSelectTerminal={onSelectTerminal}
+                  onSelectBrowser={onSelectBrowser}
+                  onCloseTerminal={onCloseTerminal}
+                  onCloseBrowser={onCloseBrowser}
+                  onRenameTerminal={onRenameTerminal}
+                />
                 <div
                   className="right-panel-tab-drop-target"
-                  data-drop-before={headerDragPreview?.beforeKey === null ? true : undefined}
+                  data-drop-before={drag.showEndDropIndicator ? true : undefined}
                 />
               </div>
             </div>
@@ -358,176 +107,17 @@ export function RightPanelHeaderTabs({
           </div>
         </div>
 
-        <div className="ui-tab-system-section ui-tab-system-section__trailing">
-          <div className="editor-panel-overflow-action">
-            <Tooltip
-              content="Repo's settings"
-              className="right-panel-repo-settings-tooltip"
-              singleLine
-            >
-              <IconButton
-                size="xs"
-                tone="sidebar"
-                title="Repo's settings"
-                className="ui-icon-button glass-editor-panel-new-tab-menu-trigger"
-                onClick={onOpenRepoSettings}
-              >
-                <Settings className="ui-icon" />
-              </IconButton>
-            </Tooltip>
-          </div>
-          <div className="editor-panel-overflow-action">
-            <Tooltip
-              content="Open new tab menu"
-              className="right-panel-new-tab-tooltip"
-              singleLine
-            >
-              <PopoverButton
-                align="end"
-                externalOpen={newTabMenuOpen}
-                onOpenChange={setNewTabMenuOpen}
-                trigger={
-                  <IconButton
-                    size="xs"
-                    tone="sidebar"
-                    title="Open new tab menu"
-                    className="ui-icon-button glass-editor-panel-new-tab-menu-trigger"
-                  >
-                    <Plus className="ui-icon" />
-                  </IconButton>
-                }
-                className="w-40 rounded-md border border-border bg-popover p-1 shadow-floating"
-              >
-                {(close) => (
-                  <NewTabMenuContent
-                    defaultKind={newTabMenuDefaultKind}
-                    isWorkspaceReady={isWorkspaceReady}
-                    canCreateBrowserTab={canCreateBrowserTab}
-                    onCreateTerminal={() => {
-                      close();
-                      onCreateTerminal();
-                    }}
-                    onCreateBrowser={() => {
-                      close();
-                      onCreateBrowser();
-                    }}
-                  />
-                )}
-              </PopoverButton>
-            </Tooltip>
-          </div>
-        </div>
+        <RightPanelHeaderActions
+          newTabMenuOpen={newTabMenuOpen}
+          newTabMenuDefaultKind={newTabMenuDefaultKind}
+          isWorkspaceReady={isWorkspaceReady}
+          canCreateBrowserTab={canCreateBrowserTab}
+          onNewTabMenuOpenChange={setNewTabMenuOpen}
+          onCreateTerminal={onCreateTerminal}
+          onCreateBrowser={onCreateBrowser}
+          onOpenRepoSettings={onOpenRepoSettings}
+        />
       </div>
-    </div>
-  );
-}
-
-function NewTabMenuContent({
-  defaultKind,
-  isWorkspaceReady,
-  canCreateBrowserTab,
-  onCreateTerminal,
-  onCreateBrowser,
-}: {
-  defaultKind: RightPanelNewTabMenuDefault;
-  isWorkspaceReady: boolean;
-  canCreateBrowserTab: boolean;
-  onCreateTerminal: () => void;
-  onCreateBrowser: () => void;
-}) {
-  const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
-      return;
-    }
-
-    const buttons = [...event.currentTarget.querySelectorAll<HTMLButtonElement>(
-      "button:not(:disabled)",
-    )];
-    if (buttons.length === 0) {
-      return;
-    }
-
-    const activeButton = document.activeElement instanceof HTMLButtonElement
-      ? document.activeElement
-      : null;
-    const currentIndex = activeButton ? buttons.indexOf(activeButton) : -1;
-    const direction = event.key === "ArrowDown" ? 1 : -1;
-    const nextIndex = currentIndex < 0
-      ? 0
-      : (currentIndex + direction + buttons.length) % buttons.length;
-    buttons[nextIndex]?.focus();
-    event.preventDefault();
-  }, []);
-
-  return (
-    <div onKeyDown={handleKeyDown}>
-      <PopoverMenuItem
-        label="Terminal"
-        variant="sidebar"
-        icon={<TerminalIcon className="size-4" />}
-        disabled={!isWorkspaceReady}
-        autoFocus={defaultKind === "terminal"}
-        onClick={onCreateTerminal}
-      />
-      <PopoverMenuItem
-        label="Browser"
-        variant="sidebar"
-        icon={<Globe className="size-4" />}
-        disabled={!isWorkspaceReady || !canCreateBrowserTab}
-        autoFocus={defaultKind === "browser"}
-        onClick={onCreateBrowser}
-      />
-    </div>
-  );
-}
-
-interface RightPanelHeaderEntryDropZoneProps {
-  entryKey: RightPanelHeaderEntryKey;
-  isDragging: boolean;
-  dragOffsetX: number;
-  showDropIndicator: boolean;
-  onRegister: (entryKey: RightPanelHeaderEntryKey, node: HTMLDivElement | null) => void;
-  onPointerDown: (
-    entryKey: RightPanelHeaderEntryKey,
-    event: PointerEvent<HTMLDivElement>,
-  ) => void;
-  onPointerMove: (event: PointerEvent<HTMLDivElement>) => void;
-  onPointerUp: (event: PointerEvent<HTMLDivElement>) => void;
-  onPointerCancel: (event: PointerEvent<HTMLDivElement>) => void;
-  children: ReactNode;
-}
-
-function RightPanelHeaderEntryDropZone({
-  entryKey,
-  isDragging,
-  dragOffsetX,
-  showDropIndicator,
-  onRegister,
-  onPointerDown,
-  onPointerMove,
-  onPointerUp,
-  onPointerCancel,
-  children,
-}: RightPanelHeaderEntryDropZoneProps) {
-  const setNode = useCallback(
-    (node: HTMLDivElement | null) => onRegister(entryKey, node),
-    [entryKey, onRegister],
-  );
-
-  return (
-    <div
-      ref={setNode}
-      className="right-panel-header-entry-shell"
-      data-dragging={isDragging ? true : undefined}
-      data-drop-before={showDropIndicator ? true : undefined}
-      style={isDragging ? { transform: `translateX(${dragOffsetX}px)` } : undefined}
-      onPointerDown={(event) => onPointerDown(entryKey, event)}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerCancel}
-      onLostPointerCapture={onPointerCancel}
-    >
-      {children}
     </div>
   );
 }

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -1,0 +1,131 @@
+import { useCallback, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { IconButton } from "@/components/ui/IconButton";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
+import { Tooltip } from "@/components/ui/Tooltip";
+import {
+  Globe,
+  Plus,
+  Terminal as TerminalIcon,
+} from "@/components/ui/icons";
+import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
+
+interface RightPanelNewTabMenuProps {
+  open: boolean;
+  defaultKind: RightPanelNewTabMenuDefault;
+  isWorkspaceReady: boolean;
+  canCreateBrowserTab: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
+}
+
+export function RightPanelNewTabMenu({
+  open,
+  defaultKind,
+  isWorkspaceReady,
+  canCreateBrowserTab,
+  onOpenChange,
+  onCreateTerminal,
+  onCreateBrowser,
+}: RightPanelNewTabMenuProps) {
+  return (
+    <Tooltip
+      content="Open new tab menu"
+      className="right-panel-new-tab-tooltip"
+      singleLine
+    >
+      <PopoverButton
+        align="end"
+        externalOpen={open}
+        onOpenChange={onOpenChange}
+        trigger={
+          <IconButton
+            size="xs"
+            tone="sidebar"
+            title="Open new tab menu"
+            className="ui-icon-button glass-editor-panel-new-tab-menu-trigger"
+          >
+            <Plus className="ui-icon" />
+          </IconButton>
+        }
+        className="w-40 rounded-md border border-border bg-popover p-1 shadow-floating"
+      >
+        {(close) => (
+          <NewTabMenuContent
+            defaultKind={defaultKind}
+            isWorkspaceReady={isWorkspaceReady}
+            canCreateBrowserTab={canCreateBrowserTab}
+            onCreateTerminal={() => {
+              close();
+              onCreateTerminal();
+            }}
+            onCreateBrowser={() => {
+              close();
+              onCreateBrowser();
+            }}
+          />
+        )}
+      </PopoverButton>
+    </Tooltip>
+  );
+}
+
+function NewTabMenuContent({
+  defaultKind,
+  isWorkspaceReady,
+  canCreateBrowserTab,
+  onCreateTerminal,
+  onCreateBrowser,
+}: {
+  defaultKind: RightPanelNewTabMenuDefault;
+  isWorkspaceReady: boolean;
+  canCreateBrowserTab: boolean;
+  onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
+}) {
+  const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+      return;
+    }
+
+    const buttons = [...event.currentTarget.querySelectorAll<HTMLButtonElement>(
+      "button:not(:disabled)",
+    )];
+    if (buttons.length === 0) {
+      return;
+    }
+
+    const activeButton = document.activeElement instanceof HTMLButtonElement
+      ? document.activeElement
+      : null;
+    const currentIndex = activeButton ? buttons.indexOf(activeButton) : -1;
+    const direction = event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = currentIndex < 0
+      ? 0
+      : (currentIndex + direction + buttons.length) % buttons.length;
+    buttons[nextIndex]?.focus();
+    event.preventDefault();
+  }, []);
+
+  return (
+    <div onKeyDown={handleKeyDown}>
+      <PopoverMenuItem
+        label="Terminal"
+        variant="sidebar"
+        icon={<TerminalIcon className="size-4" />}
+        disabled={!isWorkspaceReady}
+        autoFocus={defaultKind === "terminal"}
+        onClick={onCreateTerminal}
+      />
+      <PopoverMenuItem
+        label="Browser"
+        variant="sidebar"
+        icon={<Globe className="size-4" />}
+        disabled={!isWorkspaceReady || !canCreateBrowserTab}
+        autoFocus={defaultKind === "browser"}
+        onClick={onCreateBrowser}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
@@ -1,10 +1,7 @@
 import {
   useCallback,
-  useEffect,
-  useRef,
   useState,
 } from "react";
-import { flushSync } from "react-dom";
 import { Button } from "@/components/ui/Button";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import { ListFilter, Plus } from "@/components/ui/icons";
@@ -46,10 +43,11 @@ import { useShellTabDrag } from "@/hooks/workspaces/tabs/use-tab-drag";
 import { useWorkspaceHeaderTabsViewModelContext } from "@/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext";
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
 import { useWorkspaceTabActions } from "@/hooks/workspaces/use-workspace-tab-actions";
-import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
+import { useHeaderTabsUrgentHighlight } from "@/hooks/workspaces/ui/use-header-tabs-urgent-highlight";
 import {
   TAB_GROUP_PILL_WIDTH,
 } from "@/lib/domain/workspaces/tabs/chrome-layout";
+import { hasAnyHeaderSubagentChildren } from "@/lib/domain/workspaces/tabs/group-rows";
 import {
   viewerTargetKey,
   viewerTargetLabel,
@@ -57,7 +55,6 @@ import {
   viewerTargetEditablePath,
 } from "@/lib/domain/workspaces/viewer/viewer-target";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
-import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
 
@@ -85,20 +82,6 @@ export function HeaderTabs() {
   const { activateViewerTarget } = useWorkspaceShellActivation();
 
   const [renamingSessionId, setRenamingSessionId] = useState<string | null>(null);
-  const urgentHighlightedChatSessionId = useWorkspaceUiStore((state) =>
-    viewModel.workspaceUiKey
-      ? state.urgentHighlightedChatSessionByWorkspace[viewModel.workspaceUiKey] ?? null
-      : null
-  );
-  const setUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
-    (state) => state.setUrgentHighlightedChatSessionForWorkspace,
-  );
-  const clearUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
-    (state) => state.clearUrgentHighlightedChatSessionForWorkspace,
-  );
-  const urgentChatActivationAttemptRef = useRef(0);
-  const cancelUrgentChatActivationRef = useRef<(() => void) | null>(null);
-  const urgentHighlightTimeoutRef = useRef<number | null>(null);
   const shellStrip = useResizeObserverWidth<HTMLDivElement>();
   const shellTabOrderActions = useShellTabOrderActions({
     workspaceId: viewModel.workspaceUiKey,
@@ -189,118 +172,19 @@ export function HeaderTabs() {
       cooldownMs: 2000,
     });
   }, []);
-  const clearUrgentChatHighlight = useCallback(() => {
-    urgentChatActivationAttemptRef.current += 1;
-    cancelUrgentChatActivationRef.current?.();
-    cancelUrgentChatActivationRef.current = null;
-    if (urgentHighlightTimeoutRef.current !== null) {
-      window.clearTimeout(urgentHighlightTimeoutRef.current);
-      urgentHighlightTimeoutRef.current = null;
-    }
-    if (viewModel.workspaceUiKey) {
-      clearUrgentHighlightedChatSessionForWorkspace(viewModel.workspaceUiKey);
-    }
-  }, [clearUrgentHighlightedChatSessionForWorkspace, viewModel.workspaceUiKey]);
-  const previewHeaderChatTab = useCallback((sessionId: string) => {
-    const workspaceUiKey = viewModel.workspaceUiKey;
-    if (!workspaceUiKey) {
-      return;
-    }
-    const attempt = urgentChatActivationAttemptRef.current + 1;
-    urgentChatActivationAttemptRef.current = attempt;
-    cancelUrgentChatActivationRef.current?.();
-    cancelUrgentChatActivationRef.current = null;
-    if (urgentHighlightTimeoutRef.current !== null) {
-      window.clearTimeout(urgentHighlightTimeoutRef.current);
-      urgentHighlightTimeoutRef.current = null;
-    }
-
-    flushSync(() => {
-      setUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
-    });
-    urgentHighlightTimeoutRef.current = window.setTimeout(() => {
-      if (urgentChatActivationAttemptRef.current !== attempt) {
-        return;
-      }
-      urgentHighlightTimeoutRef.current = null;
-      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
-    }, 700);
-  }, [
-    clearUrgentHighlightedChatSessionForWorkspace,
-    setUrgentHighlightedChatSessionForWorkspace,
-    viewModel.workspaceUiKey,
-  ]);
-  const activateHeaderChatTab = useCallback((sessionId: string) => {
-    const workspaceUiKey = viewModel.workspaceUiKey;
-    if (!workspaceUiKey) {
-      return;
-    }
-    const attempt = urgentChatActivationAttemptRef.current + 1;
-    urgentChatActivationAttemptRef.current = attempt;
-    cancelUrgentChatActivationRef.current?.();
-    cancelUrgentChatActivationRef.current = null;
-    if (urgentHighlightTimeoutRef.current !== null) {
-      window.clearTimeout(urgentHighlightTimeoutRef.current);
-      urgentHighlightTimeoutRef.current = null;
-    }
-
-    flushSync(() => {
-      setUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
-    });
-    urgentHighlightTimeoutRef.current = window.setTimeout(() => {
-      if (urgentChatActivationAttemptRef.current !== attempt) {
-        return;
-      }
-      urgentHighlightTimeoutRef.current = null;
-      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
-    }, 1500);
-
-    cancelUrgentChatActivationRef.current = scheduleAfterNextPaint(() => {
-      if (urgentChatActivationAttemptRef.current !== attempt) {
-        return;
-      }
-      cancelUrgentChatActivationRef.current = null;
-      chatVisibilityActions.showChatSessionTab(sessionId, { select: true });
-    });
-  }, [
-    chatVisibilityActions,
-    clearUrgentHighlightedChatSessionForWorkspace,
-    setUrgentHighlightedChatSessionForWorkspace,
-    viewModel.workspaceUiKey,
-  ]);
-
-  useEffect(() => () => {
-    cancelUrgentChatActivationRef.current?.();
-    if (urgentHighlightTimeoutRef.current !== null) {
-      window.clearTimeout(urgentHighlightTimeoutRef.current);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!urgentHighlightedChatSessionId) {
-      return;
-    }
-    if (
-      viewModel.activeShellTab?.kind === "chat"
-      && viewModel.activeShellTab.sessionId === urgentHighlightedChatSessionId
-    ) {
-      if (urgentHighlightTimeoutRef.current !== null) {
-        window.clearTimeout(urgentHighlightTimeoutRef.current);
-        urgentHighlightTimeoutRef.current = null;
-      }
-      if (viewModel.workspaceUiKey) {
-        clearUrgentHighlightedChatSessionForWorkspace(
-          viewModel.workspaceUiKey,
-          urgentHighlightedChatSessionId,
-        );
-      }
-    }
-  }, [
-    clearUrgentHighlightedChatSessionForWorkspace,
+  const activateChatSessionFromHeader = useCallback((sessionId: string) => {
+    chatVisibilityActions.showChatSessionTab(sessionId, { select: true });
+  }, [chatVisibilityActions.showChatSessionTab]);
+  const {
     urgentHighlightedChatSessionId,
-    viewModel.activeShellTab,
-    viewModel.workspaceUiKey,
-  ]);
+    clearUrgentChatHighlight,
+    previewHeaderChatTab,
+    activateHeaderChatTab,
+  } = useHeaderTabsUrgentHighlight({
+    workspaceUiKey: viewModel.workspaceUiKey,
+    activeShellTab: viewModel.activeShellTab,
+    onActivateChatSession: activateChatSessionFromHeader,
+  });
 
   return (
     <DebugProfiler id="header-tabs">
@@ -551,7 +435,8 @@ export function HeaderTabs() {
         })}
       </WorkspaceTabStrip>
 
-      {(viewModel.menuChatTabs.length > 1 || hasAnySubagents(viewModel.childrenByParentSessionId)) && (
+      {(viewModel.menuChatTabs.length > 1
+        || hasAnyHeaderSubagentChildren(viewModel.childrenByParentSessionId)) && (
         <PopoverButton
           align="end"
           trigger={(
@@ -609,13 +494,4 @@ export function HeaderTabs() {
       </div>
     </DebugProfiler>
   );
-}
-
-function hasAnySubagents(childrenByParentSessionId: Map<string, unknown[]>): boolean {
-  for (const children of childrenByParentSessionId.values()) {
-    if (children.length > 0) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/desktop/src/hooks/workspaces/derived/use-right-panel-header-entries.ts
+++ b/desktop/src/hooks/workspaces/derived/use-right-panel-header-entries.ts
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import type { TerminalRecord } from "@anyharness/sdk";
+import {
+  availableRightPanelTools,
+  canCreateRightPanelBrowserTab,
+  parseRightPanelHeaderEntryKey,
+  terminalIdsFromHeaderOrder,
+  type RightPanelHeaderEntryKey,
+  type RightPanelWorkspaceState,
+} from "@/lib/domain/workspaces/shell/right-panel";
+import {
+  orderBrowserTabs,
+  orderTerminals,
+} from "@/lib/domain/workspaces/shell/right-panel-view";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+
+export interface RightPanelHeaderEntriesState {
+  activeEntry: ReturnType<typeof parseRightPanelHeaderEntryKey>;
+  activeTool: Extract<ReturnType<typeof parseRightPanelHeaderEntryKey>, { kind: "tool" }>["tool"]
+    | null;
+  activeTerminalId: string | null;
+  activeBrowserId: string | null;
+  visibleTerminals: TerminalRecord[];
+  orderedTerminals: TerminalRecord[];
+  browserTabs: ReturnType<typeof orderBrowserTabs>;
+  canCreateBrowserTab: boolean;
+  headerEntries: RightPanelHeaderEntry[];
+}
+
+export function useRightPanelHeaderEntries({
+  state,
+  terminals,
+  isCloudWorkspaceSelected,
+}: {
+  state: RightPanelWorkspaceState;
+  terminals: readonly TerminalRecord[];
+  isCloudWorkspaceSelected: boolean;
+}): RightPanelHeaderEntriesState {
+  const terminalIdsInHeader = useMemo(
+    () => new Set(terminalIdsFromHeaderOrder(state.headerOrder)),
+    [state.headerOrder],
+  );
+  const visibleTerminals = useMemo(
+    () => terminals.filter((terminal) =>
+      terminal.purpose !== "setup" || terminalIdsInHeader.has(terminal.id)
+    ),
+    [terminalIdsInHeader, terminals],
+  );
+  const terminalById = useMemo(
+    () => new Map(visibleTerminals.map((terminal) => [terminal.id, terminal])),
+    [visibleTerminals],
+  );
+  const orderedTerminals = useMemo(
+    () => orderTerminals(visibleTerminals, state.headerOrder),
+    [state.headerOrder, visibleTerminals],
+  );
+  const activeEntry = useMemo(
+    () => parseRightPanelHeaderEntryKey(state.activeEntryKey),
+    [state.activeEntryKey],
+  );
+  const browserTabs = useMemo(
+    () => orderBrowserTabs(state.browserTabsById, state.headerOrder),
+    [state.browserTabsById, state.headerOrder],
+  );
+  const headerEntries = useMemo<RightPanelHeaderEntry[]>(() => {
+    const entries: RightPanelHeaderEntry[] = [];
+    const seenKeys = new Set<RightPanelHeaderEntryKey>();
+    const availableToolSet = new Set(availableRightPanelTools(isCloudWorkspaceSelected));
+
+    for (const key of state.headerOrder) {
+      const entry = parseRightPanelHeaderEntryKey(key);
+      if (!entry || seenKeys.has(key)) {
+        continue;
+      }
+      if (entry.kind === "tool" && availableToolSet.has(entry.tool)) {
+        entries.push({ kind: "tool", key, tool: entry.tool });
+        seenKeys.add(key);
+      }
+      if (entry.kind === "terminal") {
+        entries.push({
+          kind: "terminal",
+          key,
+          terminalId: entry.terminalId,
+          terminal: terminalById.get(entry.terminalId) ?? null,
+        });
+        seenKeys.add(key);
+      }
+      if (entry.kind === "browser") {
+        const tab = state.browserTabsById[entry.browserId];
+        if (tab) {
+          entries.push({ kind: "browser", key, tab });
+          seenKeys.add(key);
+        }
+      }
+    }
+
+    return entries;
+  }, [isCloudWorkspaceSelected, state.browserTabsById, state.headerOrder, terminalById]);
+
+  const activeTool = activeEntry?.kind === "tool" ? activeEntry.tool : null;
+  const activeTerminalId = activeEntry?.kind === "terminal" ? activeEntry.terminalId : null;
+  const activeBrowserId = activeEntry?.kind === "browser" ? activeEntry.browserId : null;
+
+  return {
+    activeEntry,
+    activeTool,
+    activeTerminalId,
+    activeBrowserId,
+    visibleTerminals,
+    orderedTerminals,
+    browserTabs,
+    canCreateBrowserTab: canCreateRightPanelBrowserTab(state),
+    headerEntries,
+  };
+}

--- a/desktop/src/hooks/workspaces/ui/use-header-tabs-urgent-highlight.ts
+++ b/desktop/src/hooks/workspaces/ui/use-header-tabs-urgent-highlight.ts
@@ -1,0 +1,140 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+import { flushSync } from "react-dom";
+import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
+import type { WorkspaceShellTab } from "@/lib/domain/workspaces/tabs/shell-tabs";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+
+export function useHeaderTabsUrgentHighlight({
+  workspaceUiKey,
+  activeShellTab,
+  onActivateChatSession,
+}: {
+  workspaceUiKey: string | null;
+  activeShellTab: WorkspaceShellTab | null;
+  onActivateChatSession: (sessionId: string) => void;
+}) {
+  const urgentHighlightedChatSessionId = useWorkspaceUiStore((state) =>
+    workspaceUiKey
+      ? state.urgentHighlightedChatSessionByWorkspace[workspaceUiKey] ?? null
+      : null
+  );
+  const setUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
+    (state) => state.setUrgentHighlightedChatSessionForWorkspace,
+  );
+  const clearUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
+    (state) => state.clearUrgentHighlightedChatSessionForWorkspace,
+  );
+  const urgentChatActivationAttemptRef = useRef(0);
+  const cancelUrgentChatActivationRef = useRef<(() => void) | null>(null);
+  const urgentHighlightTimeoutRef = useRef<number | null>(null);
+
+  const clearUrgentChatHighlight = useCallback(() => {
+    urgentChatActivationAttemptRef.current += 1;
+    cancelUrgentChatActivationRef.current?.();
+    cancelUrgentChatActivationRef.current = null;
+    if (urgentHighlightTimeoutRef.current !== null) {
+      window.clearTimeout(urgentHighlightTimeoutRef.current);
+      urgentHighlightTimeoutRef.current = null;
+    }
+    if (workspaceUiKey) {
+      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey);
+    }
+  }, [clearUrgentHighlightedChatSessionForWorkspace, workspaceUiKey]);
+
+  const setUrgentHighlightWithTimeout = useCallback((
+    sessionId: string,
+    timeoutMs: number,
+  ) => {
+    if (!workspaceUiKey) {
+      return null;
+    }
+    const attempt = urgentChatActivationAttemptRef.current + 1;
+    urgentChatActivationAttemptRef.current = attempt;
+    cancelUrgentChatActivationRef.current?.();
+    cancelUrgentChatActivationRef.current = null;
+    if (urgentHighlightTimeoutRef.current !== null) {
+      window.clearTimeout(urgentHighlightTimeoutRef.current);
+      urgentHighlightTimeoutRef.current = null;
+    }
+
+    flushSync(() => {
+      setUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
+    });
+    urgentHighlightTimeoutRef.current = window.setTimeout(() => {
+      if (urgentChatActivationAttemptRef.current !== attempt) {
+        return;
+      }
+      urgentHighlightTimeoutRef.current = null;
+      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
+    }, timeoutMs);
+
+    return attempt;
+  }, [
+    clearUrgentHighlightedChatSessionForWorkspace,
+    setUrgentHighlightedChatSessionForWorkspace,
+    workspaceUiKey,
+  ]);
+
+  const previewHeaderChatTab = useCallback((sessionId: string) => {
+    setUrgentHighlightWithTimeout(sessionId, 700);
+  }, [setUrgentHighlightWithTimeout]);
+
+  const activateHeaderChatTab = useCallback((sessionId: string) => {
+    const attempt = setUrgentHighlightWithTimeout(sessionId, 1500);
+    if (attempt === null) {
+      return;
+    }
+
+    cancelUrgentChatActivationRef.current = scheduleAfterNextPaint(() => {
+      if (urgentChatActivationAttemptRef.current !== attempt) {
+        return;
+      }
+      cancelUrgentChatActivationRef.current = null;
+      onActivateChatSession(sessionId);
+    });
+  }, [onActivateChatSession, setUrgentHighlightWithTimeout]);
+
+  useEffect(() => () => {
+    cancelUrgentChatActivationRef.current?.();
+    if (urgentHighlightTimeoutRef.current !== null) {
+      window.clearTimeout(urgentHighlightTimeoutRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!urgentHighlightedChatSessionId) {
+      return;
+    }
+    if (
+      activeShellTab?.kind === "chat"
+      && activeShellTab.sessionId === urgentHighlightedChatSessionId
+    ) {
+      if (urgentHighlightTimeoutRef.current !== null) {
+        window.clearTimeout(urgentHighlightTimeoutRef.current);
+        urgentHighlightTimeoutRef.current = null;
+      }
+      if (workspaceUiKey) {
+        clearUrgentHighlightedChatSessionForWorkspace(
+          workspaceUiKey,
+          urgentHighlightedChatSessionId,
+        );
+      }
+    }
+  }, [
+    activeShellTab,
+    clearUrgentHighlightedChatSessionForWorkspace,
+    urgentHighlightedChatSessionId,
+    workspaceUiKey,
+  ]);
+
+  return {
+    urgentHighlightedChatSessionId,
+    clearUrgentChatHighlight,
+    previewHeaderChatTab,
+    activateHeaderChatTab,
+  };
+}

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-header-drag.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-header-drag.ts
@@ -1,0 +1,198 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type PointerEvent,
+} from "react";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel";
+
+const HEADER_DRAG_THRESHOLD_PX = 4;
+
+interface HeaderDragSession {
+  key: RightPanelHeaderEntryKey;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  beforeKey: RightPanelHeaderEntryKey | null;
+  isDragging: boolean;
+}
+
+interface HeaderDragPreview {
+  key: RightPanelHeaderEntryKey;
+  offsetX: number;
+  beforeKey: RightPanelHeaderEntryKey | null;
+}
+
+export interface RightPanelHeaderEntryDragState {
+  isDragging: boolean;
+  dragOffsetX: number;
+  showDropIndicator: boolean;
+}
+
+export interface RightPanelHeaderDragController {
+  draggedHeaderKey: RightPanelHeaderEntryKey | null;
+  showEndDropIndicator: boolean;
+  getEntryDragState(entryKey: RightPanelHeaderEntryKey): RightPanelHeaderEntryDragState;
+  registerHeaderEntryNode(entryKey: RightPanelHeaderEntryKey, node: HTMLDivElement | null): void;
+  handleHeaderPointerDown(
+    entryKey: RightPanelHeaderEntryKey,
+    event: PointerEvent<HTMLDivElement>,
+  ): void;
+  handleHeaderPointerMove(event: PointerEvent<HTMLDivElement>): void;
+  finishHeaderPointerDrag(event: PointerEvent<HTMLDivElement>): void;
+  cancelHeaderPointerDrag(event: PointerEvent<HTMLDivElement>): void;
+  shouldSuppressHeaderClick(): boolean;
+}
+
+export function useRightPanelHeaderDrag({
+  onReorderHeaderEntry,
+}: {
+  onReorderHeaderEntry: (
+    entryKey: RightPanelHeaderEntryKey,
+    beforeEntryKey: RightPanelHeaderEntryKey | null,
+  ) => void;
+}): RightPanelHeaderDragController {
+  const [headerDragPreview, setHeaderDragPreview] = useState<HeaderDragPreview | null>(null);
+  const headerEntryNodesRef = useRef(new Map<RightPanelHeaderEntryKey, HTMLDivElement>());
+  const headerDragSessionRef = useRef<HeaderDragSession | null>(null);
+  const suppressNextHeaderClickRef = useRef(false);
+
+  const registerHeaderEntryNode = useCallback((
+    entryKey: RightPanelHeaderEntryKey,
+    node: HTMLDivElement | null,
+  ) => {
+    if (node) {
+      headerEntryNodesRef.current.set(entryKey, node);
+      return;
+    }
+    headerEntryNodesRef.current.delete(entryKey);
+  }, []);
+
+  const resolveHeaderDropBeforeKey = useCallback((
+    clientX: number,
+    draggedKey: RightPanelHeaderEntryKey,
+  ): RightPanelHeaderEntryKey | null => {
+    const candidates = [...headerEntryNodesRef.current.entries()]
+      .filter(([entryKey]) => entryKey !== draggedKey)
+      .map(([entryKey, node]) => ({
+        entryKey,
+        rect: node.getBoundingClientRect(),
+      }))
+      .sort((left, right) => left.rect.left - right.rect.left);
+
+    const target = candidates.find(({ rect }) => clientX < rect.left + rect.width / 2);
+    return target?.entryKey ?? null;
+  }, []);
+
+  const suppressNextHeaderClick = useCallback(() => {
+    suppressNextHeaderClickRef.current = true;
+    window.setTimeout(() => {
+      suppressNextHeaderClickRef.current = false;
+    }, 50);
+  }, []);
+
+  const shouldSuppressHeaderClick = useCallback(() => {
+    if (!suppressNextHeaderClickRef.current) {
+      return false;
+    }
+    suppressNextHeaderClickRef.current = false;
+    return true;
+  }, []);
+
+  const handleHeaderPointerDown = useCallback((
+    entryKey: RightPanelHeaderEntryKey,
+    event: PointerEvent<HTMLDivElement>,
+  ) => {
+    if (event.button !== 0) {
+      return;
+    }
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest("[data-right-panel-tab-no-drag='true']")) {
+      return;
+    }
+
+    headerDragSessionRef.current = {
+      key: entryKey,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      beforeKey: null,
+      isDragging: false,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const handleHeaderPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const session = headerDragSessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if (!session.isDragging) {
+      const distance = Math.hypot(event.clientX - session.startX, event.clientY - session.startY);
+      if (distance < HEADER_DRAG_THRESHOLD_PX) {
+        return;
+      }
+      session.isDragging = true;
+    }
+
+    event.preventDefault();
+    const beforeKey = resolveHeaderDropBeforeKey(event.clientX, session.key);
+    session.beforeKey = beforeKey;
+    setHeaderDragPreview({
+      key: session.key,
+      offsetX: event.clientX - session.startX,
+      beforeKey,
+    });
+  }, [resolveHeaderDropBeforeKey]);
+
+  const finishHeaderPointerDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const session = headerDragSessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) {
+      return;
+    }
+    if (session.isDragging) {
+      event.preventDefault();
+      onReorderHeaderEntry(session.key, session.beforeKey);
+      suppressNextHeaderClick();
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    headerDragSessionRef.current = null;
+    setHeaderDragPreview(null);
+  }, [onReorderHeaderEntry, suppressNextHeaderClick]);
+
+  const cancelHeaderPointerDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const session = headerDragSessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) {
+      return;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    headerDragSessionRef.current = null;
+    setHeaderDragPreview(null);
+  }, []);
+
+  const getEntryDragState = useCallback((entryKey: RightPanelHeaderEntryKey) => {
+    const isDragging = headerDragPreview?.key === entryKey;
+    return {
+      isDragging,
+      dragOffsetX: isDragging ? headerDragPreview.offsetX : 0,
+      showDropIndicator: headerDragPreview?.beforeKey === entryKey,
+    };
+  }, [headerDragPreview]);
+
+  return {
+    draggedHeaderKey: headerDragPreview?.key ?? null,
+    showEndDropIndicator: headerDragPreview?.beforeKey === null,
+    getEntryDragState,
+    registerHeaderEntryNode,
+    handleHeaderPointerDown,
+    handleHeaderPointerMove,
+    finishHeaderPointerDrag,
+    cancelHeaderPointerDrag,
+    shouldSuppressHeaderClick,
+  };
+}

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-root-focus.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-root-focus.ts
@@ -1,0 +1,96 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from "react";
+import { resolvePrimaryDigitShortcutIndex } from "@/lib/domain/workspaces/shell/right-panel-view";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+
+function shouldPreservePointerFocus(target: EventTarget): boolean {
+  if (!(target instanceof Element)) {
+    return true;
+  }
+
+  return Boolean(target.closest(
+    [
+      "a",
+      "button",
+      "input",
+      "select",
+      "textarea",
+      "iframe",
+      "[contenteditable='true']",
+      "[role='button']",
+      "[tabindex]:not([tabindex='-1'])",
+      "[data-focus-zone='terminal']",
+      "[data-focus-zone='browser']",
+    ].join(","),
+  ));
+}
+
+export function useRightPanelRootFocus({
+  rootRef,
+  isOpen,
+  focusRequestToken,
+  headerEntries,
+  onActivateHeaderEntry,
+}: {
+  rootRef: RefObject<HTMLDivElement | null>;
+  isOpen: boolean;
+  focusRequestToken: number;
+  headerEntries: readonly RightPanelHeaderEntry[];
+  onActivateHeaderEntry: (entry: RightPanelHeaderEntry) => void;
+}) {
+  const handledFocusRequestRef = useRef(0);
+
+  useEffect(() => {
+    if (
+      !isOpen
+      || focusRequestToken <= 0
+      || handledFocusRequestRef.current === focusRequestToken
+    ) {
+      return;
+    }
+
+    handledFocusRequestRef.current = focusRequestToken;
+    rootRef.current?.focus({ preventScroll: true });
+  }, [focusRequestToken, isOpen, rootRef]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const shortcutIndex = resolvePrimaryDigitShortcutIndex(event);
+      if (shortcutIndex === null) {
+        return;
+      }
+
+      const root = rootRef.current;
+      const activeElement = document.activeElement;
+      if (!root || !(activeElement instanceof Element) || !root.contains(activeElement)) {
+        return;
+      }
+
+      const entry = headerEntries[shortcutIndex];
+      if (!entry) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      onActivateHeaderEntry(entry);
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [headerEntries, onActivateHeaderEntry, rootRef]);
+
+  return useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (shouldPreservePointerFocus(event.target)) {
+      return;
+    }
+
+    rootRef.current?.focus({ preventScroll: true });
+  }, [rootRef]);
+}

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-state-updater.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-state-updater.ts
@@ -1,0 +1,41 @@
+import {
+  useCallback,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import {
+  reconcileRightPanelWorkspaceState,
+  type RightPanelWorkspaceState,
+} from "@/lib/domain/workspaces/shell/right-panel";
+import { rightPanelStateEqual } from "@/lib/domain/workspaces/shell/right-panel-view";
+
+export function useRightPanelStateUpdater({
+  isCloudWorkspaceSelected,
+  onStateChange,
+}: {
+  isCloudWorkspaceSelected: boolean;
+  onStateChange: Dispatch<SetStateAction<RightPanelWorkspaceState>>;
+}) {
+  return useCallback(
+    (value: SetStateAction<RightPanelWorkspaceState>) => {
+      onStateChange((previous) => {
+        const current = reconcileRightPanelWorkspaceState(previous, {
+          isCloudWorkspaceSelected,
+        });
+        const next = typeof value === "function"
+          ? (value as (previousValue: RightPanelWorkspaceState) => RightPanelWorkspaceState)(
+              current,
+            )
+          : value;
+        const reconciledNext = reconcileRightPanelWorkspaceState(next, {
+          isCloudWorkspaceSelected,
+        });
+        if (!rightPanelStateEqual(current, reconciledNext)) {
+          return reconciledNext;
+        }
+        return rightPanelStateEqual(previous, current) ? previous : current;
+      });
+    },
+    [isCloudWorkspaceSelected, onStateChange],
+  );
+}

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-header-entry.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-header-entry.ts
@@ -1,0 +1,44 @@
+import type { TerminalRecord } from "@anyharness/sdk";
+import {
+  browserTabTitle,
+  type RightPanelBrowserTab,
+  type RightPanelHeaderEntryKey,
+  type RightPanelTool,
+} from "@/lib/domain/workspaces/shell/right-panel";
+
+export type RightPanelHeaderEntry =
+  | { kind: "tool"; key: RightPanelHeaderEntryKey; tool: RightPanelTool }
+  | {
+    kind: "terminal";
+    key: RightPanelHeaderEntryKey;
+    terminalId: string;
+    terminal: TerminalRecord | null;
+  }
+  | { kind: "browser"; key: RightPanelHeaderEntryKey; tab: RightPanelBrowserTab };
+
+export function terminalHeaderDisplayTitle(
+  entries: readonly RightPanelHeaderEntry[],
+  entry: Extract<RightPanelHeaderEntry, { kind: "terminal" }>,
+): string {
+  const terminalIndex = entries
+    .filter((candidate) => candidate.kind === "terminal")
+    .findIndex((candidate) =>
+      candidate.kind === "terminal" && candidate.terminalId === entry.terminalId
+    );
+  const fallbackTitle = `Terminal ${terminalIndex + 1}`;
+  return entry.terminal?.title === "Terminal"
+    ? fallbackTitle
+    : entry.terminal?.title ?? fallbackTitle;
+}
+
+export function browserHeaderDisplayTitle(
+  entries: readonly RightPanelHeaderEntry[],
+  entry: Extract<RightPanelHeaderEntry, { kind: "browser" }>,
+): string {
+  const browserIndex = entries
+    .filter((candidate) => candidate.kind === "browser")
+    .findIndex((candidate) =>
+      candidate.kind === "browser" && candidate.tab.id === entry.tab.id
+    );
+  return browserTabTitle(entry.tab, browserIndex);
+}

--- a/desktop/src/lib/domain/workspaces/tabs/group-rows.ts
+++ b/desktop/src/lib/domain/workspaces/tabs/group-rows.ts
@@ -31,6 +31,17 @@ export type HeaderStripRow<TTab extends GroupedChatTab = GroupedChatTab> =
   | PillRow
   | TabRow<TTab>;
 
+export function hasAnyHeaderSubagentChildren(
+  childrenByParentSessionId: ReadonlyMap<string, readonly unknown[]>,
+): boolean {
+  for (const children of childrenByParentSessionId.values()) {
+    if (children.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function buildHeaderStripRows<TTab extends GroupedChatTab>(args: {
   groupedTabs: TTab[];
   childrenByParentSessionId: ReadonlyMap<string, readonly unknown[]>;

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -44,9 +44,6 @@ desktop/src/components/workspace/chat/transcript/MessageList.tsx
 desktop/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
 desktop/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
 desktop/src/components/workspace/files/FileEditorView.tsx
-desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
-desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
-desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
 desktop/src/hooks/sessions/use-session-control-actions.ts
 desktop/src/hooks/sessions/use-session-creation-actions.ts
 desktop/src/hooks/sessions/use-session-runtime-actions.ts


### PR DESCRIPTION
## Summary

- Split oversized workspace shell/header/right-panel components into focused render, derived, and UI hooks.
- Moved right-panel header entry display helpers into domain logic and drag/focus/urgent-highlight behavior into UI hooks.
- Removed stale max-lines allowlist entries now that the shell components are below the component hard limit.

## Verification

- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/lib/domain/workspaces/shell/right-panel.test.ts src/components/workspace/shell/right-panel/RightPanel.test.tsx`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`