### PR TITLE
refactor(desktop): split workspace file editor components

### DIFF
--- a/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -1,86 +1,44 @@
 import {
-  useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
-  type PointerEvent as ReactPointerEvent,
-  type ReactNode,
-  type Ref,
 } from "react";
-import Editor, { type BeforeMount, type OnMount } from "@monaco-editor/react";
-import type {
-  GitBranchDiffFilesResponse,
-  GitChangedFile,
-} from "@anyharness/sdk";
+import Editor from "@monaco-editor/react";
 import { Button } from "@/components/ui/Button";
 import { LoadingState } from "@/components/feedback/LoadingIllustration";
-import { PickerPopoverContent } from "@/components/ui/PickerPopoverContent";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
-import { DiffViewer } from "@/components/ui/content/DiffViewer";
 import { MarkdownRenderer } from "@/components/ui/content/MarkdownRenderer";
-import { FileTreeEntryIcon } from "@/components/ui/file-icons";
-import {
-  Check,
-  ChevronDown,
-  Copy,
-  FilePen,
-  FileText,
-  GitBranch,
-  RefreshCw,
-  SplitPanel,
-} from "@/components/ui/icons";
-import { Tooltip } from "@/components/ui/Tooltip";
 import {
   useGitBranchDiffFilesQuery,
-  useGitDiffQuery,
   useGitStatusQuery,
   useReadWorkspaceFileQuery,
 } from "@anyharness/sdk-react";
+import { CenterMessage } from "@/components/workspace/files/viewer/CenterMessage";
+import { FileDiffPane } from "@/components/workspace/files/viewer/FileDiffPane";
+import { FileViewerFrame } from "@/components/workspace/files/viewer/FileViewerFrame";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
+import { useFileEditorCommands } from "@/hooks/workspaces/files/ui/use-file-editor-commands";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import { canPreviewAsMarkdown } from "@/lib/domain/files/document-preview";
 import { resolveReadableCodeFontScale } from "@/lib/domain/preferences/appearance";
 import {
-  REDO_COMMAND_EVENT,
-  SELECT_ALL_COMMAND_EVENT,
-  UNDO_COMMAND_EVENT,
-  selectElementContents,
-} from "@/lib/infra/dom/dom-select-all";
-import { runShortcutHandler } from "@/lib/domain/shortcuts/registry";
+  buildDiffScopeOptions,
+  diffScopeFromIncludedState,
+  resolveActiveDiffOption,
+  type FileDiffTarget,
+} from "@/lib/domain/workspaces/viewer/file-diff-options";
+import { inferWorkspaceFileLanguage } from "@/lib/domain/workspaces/viewer/file-language";
 import {
   defaultFileViewerMode,
-  fileDiffViewerTarget,
   type FileDiffViewerScope,
-  type FileViewerMode,
-  type ViewerTarget,
   type ViewerTargetKey,
 } from "@/lib/domain/workspaces/viewer/viewer-target";
 import {
-  proliferateDarkTheme,
-  proliferateLightTheme,
-  THEME_NAME_DARK,
   THEME_NAME_LIGHT,
+  THEME_NAME_DARK,
 } from "@/lib/infra/editor/monaco-theme";
 import { useWorkspaceFileBuffersStore } from "@/stores/editor/workspace-file-buffers-store";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-
-function inferLanguage(path: string): string {
-  const ext = path.split(".").pop()?.toLowerCase() ?? "";
-  const map: Record<string, string> = {
-    ts: "typescript", tsx: "typescriptreact",
-    js: "javascript", jsx: "javascriptreact",
-    rs: "rust", py: "python", go: "go",
-    json: "json", toml: "toml", yaml: "yaml", yml: "yaml",
-    md: "markdown", mdx: "markdown",
-    css: "css", scss: "scss", html: "html",
-    sql: "sql", sh: "shell", bash: "shell",
-    xml: "xml", svg: "xml",
-  };
-  return map[ext] ?? "plaintext";
-}
 
 interface FileEditorViewProps {
   filePath: string;
@@ -88,118 +46,7 @@ interface FileEditorViewProps {
   diffTarget?: FileDiffTarget;
 }
 
-type FileDiffTarget = Extract<ViewerTarget, { kind: "fileDiff" }>;
-type MonacoStandaloneEditor = Parameters<OnMount>[0];
-type MonacoApi = Parameters<OnMount>[1];
-type EditorEditCommand = "selectAll" | "undo" | "redo";
-type DiffScopeOption = {
-  scope: FileDiffViewerScope;
-  label: string;
-  description: string;
-  target: FileDiffTarget;
-};
-
-function selectEditorContents(editor: MonacoStandaloneEditor): boolean {
-  const model = editor.getModel();
-  if (!model) {
-    return false;
-  }
-
-  editor.focus();
-  editor.setSelection(model.getFullModelRange());
-  return true;
-}
-
-function undoEditorChange(editor: MonacoStandaloneEditor): boolean {
-  const model = editor.getModel();
-  if (!model) {
-    return false;
-  }
-
-  editor.focus();
-  void model.undo();
-  return true;
-}
-
-function redoEditorChange(editor: MonacoStandaloneEditor): boolean {
-  const model = editor.getModel();
-  if (!model) {
-    return false;
-  }
-
-  editor.focus();
-  void model.redo();
-  return true;
-}
-
-function registerEditorEditKeybindings(
-  editor: MonacoStandaloneEditor,
-  monaco: MonacoApi,
-): void {
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyA, () => {
-    runEditorEditCommand(editor, "selectAll");
-  });
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyZ, () => {
-    runEditorEditCommand(editor, "undo");
-  });
-  editor.addCommand(
-    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyZ,
-    () => {
-      runEditorEditCommand(editor, "redo");
-    },
-  );
-  editor.addCommand(
-    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.LeftArrow,
-    () => {
-      runShortcutHandler("workspace.previous-tab", { source: "keyboard" });
-    },
-  );
-  editor.addCommand(
-    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.RightArrow,
-    () => {
-      runShortcutHandler("workspace.next-tab", { source: "keyboard" });
-    },
-  );
-}
-
-function runEditorEditCommand(
-  editor: MonacoStandaloneEditor,
-  command: EditorEditCommand,
-): boolean {
-  if (command === "selectAll") {
-    return selectEditorContents(editor);
-  }
-  if (command === "undo") {
-    return undoEditorChange(editor);
-  }
-  return redoEditorChange(editor);
-}
-
-function editCommandFromKeyboardEvent(event: KeyboardEvent): EditorEditCommand | null {
-  if (!(event.metaKey || event.ctrlKey) || event.altKey) {
-    return null;
-  }
-
-  const key = event.key.toLowerCase();
-  if (key === "a" && !event.shiftKey) {
-    return "selectAll";
-  }
-  if (key === "z") {
-    return event.shiftKey ? "redo" : "undo";
-  }
-  return null;
-}
-
-function consumeEditorShortcutEvent(event: KeyboardEvent): void {
-  event.preventDefault();
-  event.stopPropagation();
-  event.stopImmediatePropagation();
-}
-
 export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorViewProps) {
-  const viewerRootRef = useRef<HTMLDivElement | null>(null);
-  const viewerContentRef = useRef<HTMLDivElement | null>(null);
-  const editorRef = useRef<MonacoStandaloneEditor | null>(null);
   const buffer = useWorkspaceFileBuffersStore((s) => s.buffersByPath[filePath]);
   const ensureBufferFromRead = useWorkspaceFileBuffersStore((s) => s.ensureBufferFromRead);
   const updateBuffer = useWorkspaceFileBuffersStore((s) => s.updateBuffer);
@@ -253,161 +100,29 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
     path: filePath,
     enabled: requiresFileRead,
   });
+  const {
+    viewerRootRef,
+    viewerContentRef,
+    handleBeforeMount,
+    handleEditorMount,
+    handleContentPointerDownCapture,
+  } = useFileEditorCommands({
+    effectiveMode,
+    targetKey,
+    filePath,
+    isDirty: buffer?.isDirty ?? false,
+    onSaveFile: saveFile,
+  });
 
   useEffect(() => {
     setSelectedDiffScope(diffTarget?.scope ?? null);
   }, [diffTarget?.scope, targetKey]);
-
-  const handleBeforeMount: BeforeMount = useCallback((monaco) => {
-    monaco.editor.defineTheme(THEME_NAME_DARK, proliferateDarkTheme);
-    monaco.editor.defineTheme(THEME_NAME_LIGHT, proliferateLightTheme);
-  }, []);
-
-  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
-    editorRef.current = editor;
-    registerEditorEditKeybindings(editor, monaco);
-    editor.focus();
-  }, []);
-
-  const handleContentPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (effectiveMode === "edit" || isInteractiveElement(event.target)) {
-      return;
-    }
-
-    viewerRootRef.current?.focus({ preventScroll: true });
-  }, [effectiveMode]);
 
   useEffect(() => {
     if (requiresFileRead && readQuery.data) {
       ensureBufferFromRead(filePath, readQuery.data);
     }
   }, [ensureBufferFromRead, filePath, readQuery.data, requiresFileRead]);
-
-  useEffect(() => {
-    if (effectiveMode !== "edit") {
-      viewerRootRef.current?.focus({ preventScroll: true });
-    }
-  }, [effectiveMode, targetKey]);
-
-  const handleSaveShortcut = useCallback(
-    (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
-        e.preventDefault();
-        if (buffer?.isDirty && effectiveMode === "edit") {
-          void saveFile(filePath);
-        }
-      }
-    },
-    [buffer?.isDirty, effectiveMode, filePath, saveFile],
-  );
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleSaveShortcut);
-    return () => window.removeEventListener("keydown", handleSaveShortcut);
-  }, [handleSaveShortcut]);
-
-  const handleEditorEditShortcut = useCallback((event: KeyboardEvent) => {
-    if (event.defaultPrevented) {
-      return;
-    }
-    const command = editCommandFromKeyboardEvent(event);
-    if (!command || effectiveMode !== "edit") {
-      return;
-    }
-
-    const editor = editorRef.current;
-    const shouldHandle = editor
-      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
-      : false;
-    if (!editor || !shouldHandle) {
-      return;
-    }
-
-    if (runEditorEditCommand(editor, command)) {
-      consumeEditorShortcutEvent(event);
-    }
-  }, [effectiveMode]);
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleEditorEditShortcut, true);
-    return () => window.removeEventListener("keydown", handleEditorEditShortcut, true);
-  }, [handleEditorEditShortcut]);
-
-  const handleSelectAllCommand = useCallback((event: Event) => {
-    if (effectiveMode === "edit") {
-      const editor = editorRef.current;
-      const shouldHandle = editor
-        ? shouldHandleEditorCommand(viewerRootRef.current, editor)
-        : false;
-      if (!editor || !shouldHandle) {
-        return;
-      }
-
-      if (runEditorEditCommand(editor, "selectAll")) {
-        event.preventDefault();
-      }
-      return;
-    }
-
-    if (!shouldHandleViewerCommand(viewerRootRef.current)) {
-      return;
-    }
-
-    const content = viewerContentRef.current;
-    if (content && selectElementContents(content)) {
-      event.preventDefault();
-    }
-  }, [effectiveMode]);
-
-  const handleUndoCommand = useCallback((event: Event) => {
-    if (effectiveMode !== "edit") {
-      return;
-    }
-
-    const editor = editorRef.current;
-    const shouldHandle = editor
-      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
-      : false;
-    if (!editor || !shouldHandle) {
-      return;
-    }
-
-    if (runEditorEditCommand(editor, "undo")) {
-      event.preventDefault();
-    }
-  }, [effectiveMode]);
-
-  const handleRedoCommand = useCallback((event: Event) => {
-    if (effectiveMode !== "edit") {
-      return;
-    }
-
-    const editor = editorRef.current;
-    const shouldHandle = editor
-      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
-      : false;
-    if (!editor || !shouldHandle) {
-      return;
-    }
-
-    if (runEditorEditCommand(editor, "redo")) {
-      event.preventDefault();
-    }
-  }, [effectiveMode]);
-
-  useEffect(() => {
-    window.addEventListener(SELECT_ALL_COMMAND_EVENT, handleSelectAllCommand);
-    return () => window.removeEventListener(SELECT_ALL_COMMAND_EVENT, handleSelectAllCommand);
-  }, [handleSelectAllCommand]);
-
-  useEffect(() => {
-    window.addEventListener(UNDO_COMMAND_EVENT, handleUndoCommand);
-    window.addEventListener(REDO_COMMAND_EVENT, handleRedoCommand);
-    return () => {
-      window.removeEventListener(UNDO_COMMAND_EVENT, handleUndoCommand);
-      window.removeEventListener(REDO_COMMAND_EVENT, handleRedoCommand);
-    };
-  }, [handleRedoCommand, handleUndoCommand]);
 
   const read = readQuery.data;
 
@@ -511,7 +226,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         ) : (
           <Editor
             height="100%"
-            language={inferLanguage(filePath)}
+            language={inferWorkspaceFileLanguage(filePath)}
             value={buffer?.localContent ?? read.content ?? ""}
             onChange={(value) => {
               if (value !== undefined) {
@@ -563,445 +278,5 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         </div>
       )}
     </FileViewerFrame>
-  );
-}
-
-function FileViewerFrame({
-  rootRef,
-  filePath,
-  mode,
-  canRenderMarkdown: markdown,
-  canRenderDiff,
-  diffScopeOptions,
-  activeDiffScope,
-  diffLayout,
-  dirty,
-  saveState,
-  onModeChange,
-  onDiffScopeChange,
-  onToggleDiffLayout,
-  onCopyPath,
-  onReload,
-  onSave,
-  children,
-}: {
-  rootRef?: Ref<HTMLDivElement>;
-  filePath: string;
-  mode: FileViewerMode;
-  canRenderMarkdown: boolean;
-  canRenderDiff: boolean;
-  diffScopeOptions: readonly DiffScopeOption[];
-  activeDiffScope: FileDiffViewerScope | null;
-  diffLayout: "unified" | "split";
-  dirty: boolean;
-  saveState: string;
-  onModeChange: (mode: FileViewerMode) => void;
-  onDiffScopeChange: (scope: FileDiffViewerScope) => void;
-  onToggleDiffLayout: () => void;
-  onCopyPath: () => void;
-  onReload: () => void;
-  onSave: () => void;
-  children: ReactNode;
-}) {
-  const basename = filePath.split("/").pop() ?? filePath;
-  const parentPath = filePath.split("/").slice(0, -1).join("/");
-  return (
-    <div ref={rootRef} tabIndex={-1} className="flex h-full min-w-0 flex-col overflow-hidden outline-none">
-      <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-background px-3">
-        <FileTreeEntryIcon name={basename} path={filePath} kind="file" className="size-4 shrink-0" />
-        <div className="min-w-0 flex-1" title={filePath}>
-          <div className="truncate text-sm font-medium leading-4 text-foreground [direction:ltr] [unicode-bidi:plaintext]">
-            {basename}
-          </div>
-          {parentPath && (
-            <div className="truncate text-[10px] leading-3 text-muted-foreground [direction:ltr] [unicode-bidi:plaintext]">
-              {parentPath}
-            </div>
-          )}
-        </div>
-        {dirty && <span className="size-1.5 shrink-0 rounded-full bg-foreground/50" />}
-        {(markdown || canRenderDiff) && (
-          <div className="flex shrink-0 items-center gap-1 border-l border-border pl-2">
-            {canRenderDiff && (
-              <FileViewerModeButton
-                active={mode === "diff"}
-                label="Diff"
-                onClick={() => onModeChange("diff")}
-              >
-                <GitBranch className="size-3.5" />
-              </FileViewerModeButton>
-            )}
-            {markdown && (
-              <FileViewerModeButton
-                active={mode === "rendered"}
-                label="Preview"
-                onClick={() => onModeChange("rendered")}
-              >
-                <FileText className="size-3.5" />
-              </FileViewerModeButton>
-            )}
-            <FileViewerModeButton
-              active={mode === "edit"}
-              label="Edit"
-              onClick={() => onModeChange("edit")}
-            >
-              <FilePen className="size-3.5" />
-            </FileViewerModeButton>
-          </div>
-        )}
-        {canRenderDiff && mode === "diff" && diffScopeOptions.length > 1 && activeDiffScope && (
-          <DiffScopePicker
-            options={diffScopeOptions}
-            activeScope={activeDiffScope}
-            onScopeChange={onDiffScopeChange}
-          />
-        )}
-        {canRenderDiff && mode === "diff" && (
-          <Tooltip content={diffLayout === "split" ? "Unified diff" : "Split diff"}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={onToggleDiffLayout}
-              aria-label="Toggle diff layout"
-              className="size-7"
-            >
-              <SplitPanel className="size-3.5" />
-            </Button>
-          </Tooltip>
-        )}
-        <Tooltip content="Copy path">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onCopyPath}
-            aria-label="Copy file path"
-            className="size-7"
-          >
-            <Copy className="size-3.5" />
-          </Button>
-        </Tooltip>
-        <Tooltip content="Reload">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onReload}
-            aria-label="Reload file"
-            className="size-7"
-          >
-            <RefreshCw className="size-3.5" />
-          </Button>
-        </Tooltip>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={onSave}
-          disabled={mode !== "edit" || !dirty || saveState === "saving"}
-          loading={saveState === "saving"}
-          className="h-7 px-2 text-xs"
-        >
-          Save
-        </Button>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
-    </div>
-  );
-}
-
-function FileViewerModeButton({
-  active,
-  label,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  label: string;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      aria-pressed={active}
-      onClick={onClick}
-      className={`h-7 gap-1.5 rounded-md px-2 text-xs ${active
-        ? "bg-accent text-foreground"
-        : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"}`}
-    >
-      {children}
-      <span>{label}</span>
-    </Button>
-  );
-}
-
-function DiffScopePicker({
-  options,
-  activeScope,
-  onScopeChange,
-}: {
-  options: readonly DiffScopeOption[];
-  activeScope: FileDiffViewerScope;
-  onScopeChange: (scope: FileDiffViewerScope) => void;
-}) {
-  const activeOption = options.find((option) => option.scope === activeScope) ?? options[0];
-
-  return (
-    <PopoverButton
-      trigger={(
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 rounded-md px-2 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
-          aria-label="Diff scope"
-        >
-          {activeOption.label}
-          <ChevronDown className="size-3" />
-        </Button>
-      )}
-      align="end"
-      className="w-48 rounded-xl border border-border bg-popover p-1 shadow-floating"
-    >
-      {(close) => (
-        <PickerPopoverContent className="max-h-72">
-          {options.map((option) => (
-            <PopoverMenuItem
-              key={option.scope}
-              label={option.label}
-              icon={<GitBranch className="size-3.5 text-muted-foreground" />}
-              trailing={option.scope === activeScope
-                ? <Check className="size-3.5 text-foreground/70" />
-                : null}
-              onClick={() => {
-                onScopeChange(option.scope);
-                close();
-              }}
-            >
-              <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                {option.description}
-              </span>
-            </PopoverMenuItem>
-          ))}
-        </PickerPopoverContent>
-      )}
-    </PopoverButton>
-  );
-}
-
-function FileDiffPane({
-  workspaceId,
-  target,
-  layout,
-}: {
-  workspaceId: string | null;
-  target: FileDiffTarget;
-  layout: "unified" | "split";
-}) {
-  const diffQuery = useGitDiffQuery({
-    workspaceId,
-    path: target.path,
-    scope: target.scope,
-    baseRef: target.scope === "branch" ? target.baseRef : null,
-    oldPath: target.scope === "branch" ? target.oldPath : null,
-  });
-
-  if (diffQuery.isLoading) {
-    return (
-      <p className="px-4 py-8 text-center text-sm text-muted-foreground">Loading diff</p>
-    );
-  }
-
-  if (diffQuery.data?.patch) {
-    return (
-      <div className="min-h-0 flex-1 overflow-auto">
-        <DiffViewer patch={diffQuery.data.patch} layout={layout} />
-      </div>
-    );
-  }
-
-  if (diffQuery.data?.binary) {
-    return (
-      <CenterMessage message="Binary file changed" />
-    );
-  }
-
-  return (
-    <CenterMessage message="No diff available" />
-  );
-}
-
-function diffScopeFromIncludedState(
-  includedState: "included" | "excluded" | "partial",
-): FileDiffViewerScope {
-  return includedState === "included" ? "staged" : "unstaged";
-}
-
-function buildDiffScopeOptions({
-  filePath,
-  statusFile,
-  branchDiff,
-  explicitTarget,
-}: {
-  filePath: string;
-  statusFile: GitChangedFile | null;
-  branchDiff: GitBranchDiffFilesResponse | undefined;
-  explicitTarget?: FileDiffTarget;
-}): DiffScopeOption[] {
-  const byScope = new Map<FileDiffViewerScope, DiffScopeOption>();
-
-  if (statusFile) {
-    for (const scope of diffScopesForStatusFile(statusFile)) {
-      byScope.set(scope, {
-        scope,
-        label: diffScopeLabel(scope),
-        description: diffScopeDescription(scope, null),
-        target: fileDiffViewerTarget({
-          path: statusFile.path,
-          oldPath: statusFile.oldPath ?? null,
-          scope,
-        }) as FileDiffTarget,
-      });
-    }
-  }
-
-  const branchFile = branchDiff?.files.find((file) =>
-    file.path === filePath || file.oldPath === filePath
-  );
-  if (branchDiff && branchFile) {
-    const scope = "branch" as const;
-    byScope.set(scope, {
-      scope,
-      label: diffScopeLabel(scope),
-      description: diffScopeDescription(scope, branchDiff.baseRef),
-      target: fileDiffViewerTarget({
-        path: branchFile.path,
-        oldPath: branchFile.oldPath ?? null,
-        scope,
-        baseRef: branchDiff.baseRef,
-        baseOid: branchDiff.mergeBaseOid,
-        headOid: branchDiff.headOid,
-      }) as FileDiffTarget,
-    });
-  }
-
-  if (explicitTarget && !byScope.has(explicitTarget.scope)) {
-    byScope.set(explicitTarget.scope, {
-      scope: explicitTarget.scope,
-      label: diffScopeLabel(explicitTarget.scope),
-      description: diffScopeDescription(explicitTarget.scope, explicitTarget.baseRef),
-      target: explicitTarget,
-    });
-  }
-
-  return (["unstaged", "staged", "branch"] as const)
-    .flatMap((scope) => byScope.get(scope) ? [byScope.get(scope)!] : []);
-}
-
-function resolveActiveDiffOption(
-  options: readonly DiffScopeOption[],
-  selectedScope: FileDiffViewerScope | null,
-  preferredScope: FileDiffViewerScope | null,
-): DiffScopeOption | null {
-  return (
-    options.find((option) => option.scope === selectedScope)
-    ?? options.find((option) => option.scope === preferredScope)
-    ?? options[0]
-    ?? null
-  );
-}
-
-function diffScopesForStatusFile(file: GitChangedFile): FileDiffViewerScope[] {
-  if (file.includedState === "partial") {
-    return ["unstaged", "staged"];
-  }
-  return file.includedState === "included" ? ["staged"] : ["unstaged"];
-}
-
-function diffScopeLabel(scope: FileDiffViewerScope): string {
-  if (scope === "staged") {
-    return "Staged";
-  }
-  if (scope === "branch") {
-    return "Branch";
-  }
-  return "Unstaged";
-}
-
-function diffScopeDescription(scope: FileDiffViewerScope, baseRef: string | null): string {
-  if (scope === "staged") {
-    return "Index changes";
-  }
-  if (scope === "branch") {
-    return baseRef ? `Compared with ${baseRef}` : "Branch changes";
-  }
-  return "Working tree changes";
-}
-
-function isInteractiveElement(target: EventTarget): boolean {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-
-  return Boolean(target.closest(
-    "a,button,input,select,textarea,[contenteditable='true'],[role='button']",
-  ));
-}
-
-function shouldHandleViewerCommand(root: HTMLElement | null): boolean {
-  if (!root || !root.isConnected) {
-    return false;
-  }
-
-  const activeElement = document.activeElement;
-  if (!activeElement || activeElement === document.body) {
-    return true;
-  }
-
-  return activeElement instanceof Node && root.contains(activeElement);
-}
-
-function shouldHandleEditorCommand(
-  root: HTMLElement | null,
-  editor: MonacoStandaloneEditor,
-): boolean {
-  if (!root || !root.isConnected) {
-    return false;
-  }
-
-  if (safeEditorHasTextFocus(editor)) {
-    return true;
-  }
-
-  const activeElement = document.activeElement;
-  const editorNode = editor.getDomNode();
-  if (activeElement instanceof Node && editorNode?.contains(activeElement)) {
-    return true;
-  }
-
-  if (!activeElement || activeElement === document.body) {
-    return true;
-  }
-
-  return activeElement instanceof Node && root.contains(activeElement);
-}
-
-function safeEditorHasTextFocus(editor: MonacoStandaloneEditor): boolean {
-  try {
-    return editor.hasTextFocus();
-  } catch {
-    return false;
-  }
-}
-
-function CenterMessage({ message }: { message: string }) {
-  return (
-    <div className="flex items-center justify-center h-full">
-      <p className="text-xs text-muted-foreground">{message}</p>
-    </div>
   );
 }

--- a/desktop/src/components/workspace/files/panel/FileTreeEntryContextMenu.tsx
+++ b/desktop/src/components/workspace/files/panel/FileTreeEntryContextMenu.tsx
@@ -1,0 +1,142 @@
+import type { ReactElement, Ref } from "react";
+import type { WorkspaceFileEntry } from "@anyharness/sdk";
+import { Button } from "@/components/ui/Button";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+import { FilePlus, FolderPlus, Pencil, Trash } from "@/components/ui/icons";
+import {
+  TargetIcon,
+} from "@/components/workspace/open-target/OpenTargetMenu";
+import type { OpenTarget } from "@/hooks/access/tauri/use-shell-actions";
+
+type PopoverTriggerElement = ReactElement<{
+  onClick?: (...args: unknown[]) => void;
+  onDoubleClick?: (...args: unknown[]) => void;
+  onContextMenu?: (...args: unknown[]) => void;
+  ref?: Ref<HTMLElement>;
+}>;
+
+export function FileTreeEntryContextMenu({
+  entry,
+  targets,
+  trigger,
+  onOpenInProliferate,
+  onOpenTarget,
+  onNewFile,
+  onNewFolder,
+  onRename,
+  onDelete,
+}: {
+  entry: WorkspaceFileEntry;
+  targets: OpenTarget[];
+  trigger: PopoverTriggerElement;
+  onOpenInProliferate: () => void;
+  onOpenTarget: (targetId: string) => void;
+  onNewFile: () => void;
+  onNewFolder: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <PopoverButton
+      trigger={trigger}
+      triggerMode="contextMenu"
+      stopPropagation
+      className="w-52 rounded-lg border border-border bg-popover p-1 shadow-floating"
+    >
+      {(close) => (
+        <div className="flex flex-col gap-px">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onOpenInProliferate();
+              close();
+            }}
+            className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
+          >
+            <FileTreeEntryIcon
+              name={entry.name}
+              path={entry.path}
+              kind={entry.kind}
+              className="size-3.5 shrink-0"
+            />
+            <span>Open in Proliferate</span>
+          </Button>
+          <div className="my-1 h-px bg-border" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onNewFile();
+              close();
+            }}
+            className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
+          >
+            <FilePlus className="size-3.5 shrink-0" />
+            <span>New File</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onNewFolder();
+              close();
+            }}
+            className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
+          >
+            <FolderPlus className="size-3.5 shrink-0" />
+            <span>New Folder</span>
+          </Button>
+          <div className="my-1 h-px bg-border" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onRename();
+              close();
+            }}
+            className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
+          >
+            <Pencil className="size-3.5 shrink-0" />
+            <span>Rename</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onDelete();
+              close();
+            }}
+            className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-destructive hover:bg-accent/40 hover:text-destructive"
+          >
+            <Trash className="size-3.5 shrink-0" />
+            <span>Delete</span>
+          </Button>
+          {targets.length > 0 && <div className="my-1 h-px bg-border" />}
+          {targets.map((target) => (
+            <Button
+              key={target.id}
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                onOpenTarget(target.id);
+                close();
+              }}
+              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
+            >
+              <TargetIcon target={target} size="size-3.5" />
+              <span>{target.label}</span>
+            </Button>
+          ))}
+        </div>
+      )}
+    </PopoverButton>
+  );
+}

--- a/desktop/src/components/workspace/files/panel/FileTreeEntryRow.tsx
+++ b/desktop/src/components/workspace/files/panel/FileTreeEntryRow.tsx
@@ -1,0 +1,67 @@
+import { forwardRef, type MouseEvent } from "react";
+import type { WorkspaceFileEntry } from "@anyharness/sdk";
+import { ChevronRight } from "@/components/ui/icons";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+
+export const FileTreeEntryRow = forwardRef<HTMLDivElement, {
+  entry: WorkspaceFileEntry;
+  level: number;
+  isActive: boolean;
+  isExpanded: boolean;
+  onClick: () => void;
+  onContextMenuCapture: (event: MouseEvent) => void;
+}>(function FileTreeEntryRow({
+  entry,
+  level,
+  isActive,
+  isExpanded,
+  onClick,
+  onContextMenuCapture,
+}, ref) {
+  const isDir = entry.kind === "directory";
+  return (
+    <div
+      ref={ref}
+      data-file-tree-entry
+      role="treeitem"
+      aria-level={level + 1}
+      aria-selected={isActive}
+      aria-expanded={isDir ? isExpanded : undefined}
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(event) => event.key === "Enter" && onClick()}
+      onContextMenuCapture={onContextMenuCapture}
+      className={`flex h-7 items-center gap-2 px-3 mx-2 rounded cursor-pointer text-[0.5rem] transition-colors group ${
+        isActive
+          ? "bg-sidebar-accent text-sidebar-foreground"
+          : "text-sidebar-foreground/80 hover:bg-sidebar-accent"
+      }`}
+    >
+      {isDir ? (
+        <div className="relative size-3.5 shrink-0">
+          <FileTreeEntryIcon
+            name={entry.name}
+            path={entry.path}
+            kind={entry.kind}
+            isExpanded={isExpanded}
+            className="size-3.5 shrink-0 group-hover:invisible"
+          />
+          <ChevronRight
+            className={`size-3.5 absolute inset-0 text-muted-foreground invisible group-hover:visible transition-transform duration-150 ${
+              isExpanded ? "rotate-90" : ""
+            }`}
+          />
+        </div>
+      ) : (
+        <FileTreeEntryIcon
+          name={entry.name}
+          path={entry.path}
+          kind={entry.kind}
+        />
+      )}
+
+      <span className="truncate min-w-0 flex-1 text-[0.5rem]">{entry.name}</span>
+      <div className="shrink-0 flex items-center gap-0.5 invisible group-hover:visible" />
+    </div>
+  );
+});

--- a/desktop/src/components/workspace/files/panel/FileTreeNode.tsx
+++ b/desktop/src/components/workspace/files/panel/FileTreeNode.tsx
@@ -1,36 +1,9 @@
 import { memo } from "react";
 import type { WorkspaceFileEntry } from "@anyharness/sdk";
-import { Button } from "@/components/ui/Button";
-import { useWorkspaceFileTreeUiStore } from "@/stores/editor/workspace-file-tree-ui-store";
-import {
-  useDeleteWorkspaceEntryMutation,
-  useRenameWorkspaceEntryMutation,
-  useWorkspaceFilesQuery,
-} from "@anyharness/sdk-react";
-import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
-import { useFileTreeNativeContextMenu } from "@/hooks/editor/ui/use-file-tree-native-context-menu";
-import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
-import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
-import { ChevronRight, FilePlus, FolderPlus, Pencil, Trash } from "@/components/ui/icons";
-import { FileTreeEntryIcon } from "@/components/ui/file-icons";
-import {
-  parseViewerTargetKey,
-  pathIsWithinWorkspaceEntry,
-  remapViewerTargetPathWithinWorkspaceEntry,
-  viewerTargetEditablePath,
-  viewerTargetKey,
-  type ViewerTarget,
-  type ViewerTargetKey,
-} from "@/lib/domain/workspaces/viewer/viewer-target";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import { TargetIcon } from "@/components/workspace/open-target/OpenTargetMenu";
-import { useWorkspaceFileBuffersStore } from "@/stores/editor/workspace-file-buffers-store";
-import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
-import { useToastStore } from "@/stores/toast/toast-store";
-import {
-  type OpenTarget,
-  useTauriShellActions,
-} from "@/hooks/access/tauri/use-shell-actions";
+import type { OpenTarget } from "@/hooks/access/tauri/use-shell-actions";
+import { useFileTreeEntryActions } from "@/hooks/workspaces/files/workflows/use-file-tree-entry-actions";
+import { FileTreeEntryContextMenu } from "./FileTreeEntryContextMenu";
+import { FileTreeEntryRow } from "./FileTreeEntryRow";
 
 interface FileTreeNodeProps {
   entry: WorkspaceFileEntry;
@@ -39,350 +12,63 @@ interface FileTreeNodeProps {
 }
 
 function FileTreeNodeInner({ entry, level, targets }: FileTreeNodeProps) {
-  const treeStateKey = useWorkspaceViewerTabsStore((s) => s.treeStateKey);
-  const workspaceUiKey = useWorkspaceViewerTabsStore((s) => s.workspaceUiKey);
-  const activeTargetKey = useWorkspaceViewerTabsStore((s) => s.activeTargetKey);
-  const materializedWorkspaceId = useWorkspaceViewerTabsStore((s) => s.materializedWorkspaceId);
-  const renamePathReferences = useWorkspaceViewerTabsStore((s) => s.renamePathReferences);
-  const closePathReferences = useWorkspaceViewerTabsStore((s) => s.closePathReferences);
-  const setSelectedDirectory = useWorkspaceFileTreeUiStore((state) => state.setSelectedDirectory);
-  const startCreateDraft = useWorkspaceFileTreeUiStore((state) => state.startCreateDraft);
-  const expandDirectory = useWorkspaceFileTreeUiStore((state) => state.expandDirectory);
-  const isExpanded = useWorkspaceFileTreeUiStore((state) => (
-    treeStateKey
-      ? Boolean(state.expandedDirectoriesByTreeKey[treeStateKey]?.[entry.path])
-      : false
-  ));
-  const { toggleDirectory, openFile } = useWorkspaceFileActions();
-  const { activateChatShell, activateViewerTarget } = useWorkspaceShellActivation();
-  const renameBufferPathPrefix = useWorkspaceFileBuffersStore((state) => state.renamePathPrefix);
-  const clearBufferPathPrefix = useWorkspaceFileBuffersStore((state) => state.clearPathPrefix);
-  const { openTarget: execOpenTarget } = useTauriShellActions();
-  const showToast = useToastStore((state) => state.show);
-  const renameMutation = useRenameWorkspaceEntryMutation({
-    workspaceId: materializedWorkspaceId,
-  });
-  const deleteMutation = useDeleteWorkspaceEntryMutation({
-    workspaceId: materializedWorkspaceId,
-  });
-
-  const isDir = entry.kind === "directory";
-  const childQuery = useWorkspaceFilesQuery({
-    workspaceId: materializedWorkspaceId,
-    path: entry.path,
-    enabled: isDir && isExpanded && !!materializedWorkspaceId,
-  });
-  const activeTarget = activeTargetKey ? parseViewerTargetKey(activeTargetKey) : null;
-  const isActive = activeTarget?.kind === "file" && activeTarget.path === entry.path;
-  const children = childQuery.data?.entries;
-
-  const handleClick = () => {
-    if (isDir) {
-      if (treeStateKey) {
-        setSelectedDirectory(treeStateKey, entry.path);
-      }
-      toggleDirectory(entry.path);
-    } else {
-      if (treeStateKey) {
-        const parent = entry.path.split("/").slice(0, -1).join("/");
-        setSelectedDirectory(treeStateKey, parent);
-      }
-      openFile(entry.path);
-    }
-  };
-  const handleOpenTarget = (targetId: string) => {
-    void execOpenTarget(targetId, entry.path);
-  };
-  const createParentPath = isDir ? entry.path : parentDirectoryPath(entry.path);
-  const startCreate = (kind: "file" | "directory") => {
-    if (!treeStateKey) {
-      return;
-    }
-    if (createParentPath) {
-      expandDirectory(treeStateKey, createParentPath);
-    }
-    startCreateDraft(treeStateKey, { kind, parentPath: createParentPath });
-  };
-  const handleRename = async () => {
-    const nextName = window.prompt(`Rename ${entry.name}`, entry.name);
-    if (nextName === null) {
-      return;
-    }
-    const trimmedName = nextName.trim();
-    if (!trimmedName || trimmedName === entry.name) {
-      return;
-    }
-    if (trimmedName.includes("/")) {
-      showToast("Use a name, not a path, when renaming from the file tree.");
-      return;
-    }
-    const parent = parentDirectoryPath(entry.path);
-    const newPath = parent ? `${parent}/${trimmedName}` : trimmedName;
-    const dirtyPaths = affectedDirtyBufferPaths(entry.path);
-    if (dirtyPaths.length > 0) {
-      showToast(`Save or close unsaved files before renaming ${entry.name}.`);
-      return;
-    }
-    const previousViewerState = useWorkspaceViewerTabsStore.getState();
-    try {
-      const result = await renameMutation.mutateAsync({
-        path: entry.path,
-        newPath,
-      });
-      const renamePlan = buildRenameViewerTargetPlan(
-        previousViewerState.openTargets,
-        entry.path,
-        result.entry.path,
-      );
-      renamePathReferences(entry.path, result.entry.path);
-      renameBufferPathPrefix(entry.path, result.entry.path);
-      applyRenamedShellKeys(workspaceUiKey, renamePlan.keyMap);
-      const nextActiveTarget = previousViewerState.activeTargetKey
-        ? renamePlan.targetByOldKey.get(previousViewerState.activeTargetKey)
-        : null;
-      if (nextActiveTarget && materializedWorkspaceId) {
-        activateViewerTarget({
-          workspaceId: materializedWorkspaceId,
-          shellWorkspaceId: workspaceUiKey,
-          target: nextActiveTarget,
-          mode: "focus-existing",
-        });
-      }
-      if (isDir && treeStateKey && isExpanded) {
-        expandDirectory(treeStateKey, result.entry.path);
-      }
-      if (!isDir && renamePlan.keyMap.size === 0) {
-        openFile(result.entry.path);
-      }
-      showToast(`Renamed ${entry.name}`, "info");
-    } catch (error) {
-      showToast(error instanceof Error ? error.message : `Failed to rename ${entry.name}`);
-    }
-  };
-  const handleDelete = async () => {
-    const dirtyPaths = affectedDirtyBufferPaths(entry.path);
-    if (dirtyPaths.length > 0) {
-      showToast(`Save or close unsaved files before deleting ${entry.name}.`);
-      return;
-    }
-    const label = isDir
-      ? `Delete folder "${entry.name}" and all of its contents?`
-      : `Delete file "${entry.name}"?`;
-    if (!window.confirm(label)) {
-      return;
-    }
-    const previousViewerState = useWorkspaceViewerTabsStore.getState();
-    const closingTargetKeys = affectedViewerTargetKeys(
-      previousViewerState.openTargets,
-      entry.path,
-    );
-    try {
-      await deleteMutation.mutateAsync({ path: entry.path });
-      closePathReferences(entry.path);
-      clearBufferPathPrefix(entry.path);
-      removeShellKeys(workspaceUiKey, closingTargetKeys);
-      if (previousViewerState.activeTargetKey && closingTargetKeys.has(previousViewerState.activeTargetKey)) {
-        const nextViewerState = useWorkspaceViewerTabsStore.getState();
-        const nextActiveTarget = nextViewerState.activeTargetKey
-          ? nextViewerState.openTargets.find((target) =>
-            viewerTargetKey(target) === nextViewerState.activeTargetKey
-          ) ?? null
-          : null;
-        if (nextActiveTarget && materializedWorkspaceId) {
-          activateViewerTarget({
-            workspaceId: materializedWorkspaceId,
-            shellWorkspaceId: workspaceUiKey,
-            target: nextActiveTarget,
-            mode: "focus-existing",
-          });
-        } else if (materializedWorkspaceId) {
-          activateChatShell({
-            workspaceId: materializedWorkspaceId,
-            shellWorkspaceId: workspaceUiKey,
-            reason: "delete_file_tree_entry",
-          });
-        }
-      }
-      showToast(`Deleted ${entry.name}`, "info");
-    } catch (error) {
-      showToast(error instanceof Error ? error.message : `Failed to delete ${entry.name}`);
-    }
-  };
-  const { onContextMenuCapture } = useFileTreeNativeContextMenu({
-    targets,
-    onOpenInProliferate: handleClick,
-    onOpenTarget: handleOpenTarget,
-    onNewFile: () => startCreate("file"),
-    onNewFolder: () => startCreate("directory"),
-    onRename: () => {
-      void handleRename();
-    },
-    onDelete: () => {
-      void handleDelete();
-    },
-  });
+  const {
+    isDir,
+    isExpanded,
+    isActive,
+    childEntries,
+    isChildLoading,
+    isChildError,
+    handleClick,
+    handleOpenTarget,
+    handleDelete,
+    handleRename,
+    onContextMenuCapture,
+    startCreate,
+  } = useFileTreeEntryActions({ entry, targets });
 
   const treeRow = (
-    <div
-      data-file-tree-entry
-      role="treeitem"
-      aria-level={level + 1}
-      aria-selected={isActive}
-      aria-expanded={isDir ? isExpanded : undefined}
-      tabIndex={0}
+    <FileTreeEntryRow
+      entry={entry}
+      level={level}
+      isActive={isActive}
+      isExpanded={isExpanded}
       onClick={handleClick}
-      onKeyDown={(e) => e.key === "Enter" && handleClick()}
       onContextMenuCapture={onContextMenuCapture}
-      className={`flex h-7 items-center gap-2 px-3 mx-2 rounded cursor-pointer text-[0.5rem] transition-colors group ${
-        isActive
-          ? "bg-sidebar-accent text-sidebar-foreground"
-          : "text-sidebar-foreground/80 hover:bg-sidebar-accent"
-      }`}
-    >
-      {isDir ? (
-        <div className="relative size-3.5 shrink-0">
-          <FileTreeEntryIcon
-            name={entry.name}
-            path={entry.path}
-            kind={entry.kind}
-            isExpanded={isExpanded}
-            className="size-3.5 shrink-0 group-hover:invisible"
-          />
-          <ChevronRight
-            className={`size-3.5 absolute inset-0 text-muted-foreground invisible group-hover:visible transition-transform duration-150 ${
-              isExpanded ? "rotate-90" : ""
-            }`}
-          />
-        </div>
-      ) : (
-        <FileTreeEntryIcon
-          name={entry.name}
-          path={entry.path}
-          kind={entry.kind}
-        />
-      )}
-
-      <span className="truncate min-w-0 flex-1 text-[0.5rem]">{entry.name}</span>
-      <div className="shrink-0 flex items-center gap-0.5 invisible group-hover:visible" />
-    </div>
+    />
   );
 
   return (
     <div>
-      <PopoverButton
+      <FileTreeEntryContextMenu
+        entry={entry}
+        targets={targets}
         trigger={treeRow}
-        triggerMode="contextMenu"
-        stopPropagation
-        className="w-52 rounded-lg border border-border bg-popover p-1 shadow-floating"
-      >
-        {(close) => (
-          <div className="flex flex-col gap-px">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                handleClick();
-                close();
-              }}
-              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
-            >
-              <FileTreeEntryIcon
-                name={entry.name}
-                path={entry.path}
-                kind={entry.kind}
-                className="size-3.5 shrink-0"
-              />
-              <span>Open in Proliferate</span>
-            </Button>
-            <div className="my-1 h-px bg-border" />
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                startCreate("file");
-                close();
-              }}
-              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
-            >
-              <FilePlus className="size-3.5 shrink-0" />
-              <span>New File</span>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                startCreate("directory");
-                close();
-              }}
-              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
-            >
-              <FolderPlus className="size-3.5 shrink-0" />
-              <span>New Folder</span>
-            </Button>
-            <div className="my-1 h-px bg-border" />
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                void handleRename();
-                close();
-              }}
-              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
-            >
-              <Pencil className="size-3.5 shrink-0" />
-              <span>Rename</span>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                void handleDelete();
-                close();
-              }}
-              className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-destructive hover:bg-accent/40 hover:text-destructive"
-            >
-              <Trash className="size-3.5 shrink-0" />
-              <span>Delete</span>
-            </Button>
-            {targets.length > 0 && <div className="my-1 h-px bg-border" />}
-            {targets.map((target) => (
-              <Button
-                key={target.id}
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  handleOpenTarget(target.id);
-                  close();
-                }}
-                className="h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-[0.5rem] text-foreground/80 hover:bg-accent/40 hover:text-foreground"
-              >
-                <TargetIcon target={target} size="size-3.5" />
-                <span>{target.label}</span>
-              </Button>
-            ))}
-          </div>
-        )}
-      </PopoverButton>
+        onOpenInProliferate={handleClick}
+        onOpenTarget={handleOpenTarget}
+        onNewFile={() => startCreate("file")}
+        onNewFolder={() => startCreate("directory")}
+        onRename={() => {
+          void handleRename();
+        }}
+        onDelete={() => {
+          void handleDelete();
+        }}
+      />
 
       {isDir && isExpanded && (
         <div className="pl-4">
-          {childQuery.isLoading && (
+          {isChildLoading && (
             <div className="py-1 pl-[22px] text-[11px] text-muted-foreground">
               Loading...
             </div>
           )}
-          {childQuery.isError && (
+          {isChildError && (
             <div className="py-1 pl-[22px] text-[11px] text-destructive">
               Failed to load
             </div>
           )}
-          {children?.map((child) => (
+          {childEntries?.map((child) => (
             <FileTreeNode key={child.path} entry={child} level={level + 1} targets={targets} />
           ))}
         </div>
@@ -393,86 +79,3 @@ function FileTreeNodeInner({ entry, level, targets }: FileTreeNodeProps) {
 
 export const FileTreeNode = memo(FileTreeNodeInner);
 FileTreeNode.displayName = "FileTreeNode";
-
-function parentDirectoryPath(path: string): string {
-  return path.split("/").slice(0, -1).join("/");
-}
-
-function affectedDirtyBufferPaths(entryPath: string): string[] {
-  return Object.values(useWorkspaceFileBuffersStore.getState().buffersByPath)
-    .filter((buffer) => buffer.isDirty && pathIsWithinWorkspaceEntry(buffer.path, entryPath))
-    .map((buffer) => buffer.path);
-}
-
-function affectedViewerTargetKeys(
-  targets: readonly ViewerTarget[],
-  entryPath: string,
-): Set<ViewerTargetKey> {
-  return new Set(targets
-    .filter((target) => {
-      const editablePath = viewerTargetEditablePath(target);
-      return !!editablePath && pathIsWithinWorkspaceEntry(editablePath, entryPath);
-    })
-    .map(viewerTargetKey));
-}
-
-function buildRenameViewerTargetPlan(
-  targets: readonly ViewerTarget[],
-  fromPath: string,
-  toPath: string,
-): {
-  keyMap: Map<ViewerTargetKey, ViewerTargetKey>;
-  targetByOldKey: Map<ViewerTargetKey, ViewerTarget>;
-} {
-  const keyMap = new Map<ViewerTargetKey, ViewerTargetKey>();
-  const targetByOldKey = new Map<ViewerTargetKey, ViewerTarget>();
-  for (const target of targets) {
-    const nextTarget = remapViewerTargetPathWithinWorkspaceEntry(target, fromPath, toPath);
-    const oldKey = viewerTargetKey(target);
-    const nextKey = viewerTargetKey(nextTarget);
-    if (oldKey !== nextKey) {
-      keyMap.set(oldKey, nextKey);
-      targetByOldKey.set(oldKey, nextTarget);
-    }
-  }
-  return { keyMap, targetByOldKey };
-}
-
-function applyRenamedShellKeys(
-  workspaceUiKey: string | null,
-  keyMap: ReadonlyMap<ViewerTargetKey, ViewerTargetKey>,
-): void {
-  if (!workspaceUiKey || keyMap.size === 0) {
-    return;
-  }
-  const ui = useWorkspaceUiStore.getState();
-  const currentOrder = ui.shellTabOrderByWorkspace[workspaceUiKey];
-  if (currentOrder) {
-    ui.setShellTabOrderForWorkspace(
-      workspaceUiKey,
-      currentOrder.map((key) => keyMap.get(key as ViewerTargetKey) ?? key),
-    );
-  }
-  const activeKey = ui.activeShellTabKeyByWorkspace[workspaceUiKey];
-  const nextActiveKey = activeKey ? keyMap.get(activeKey as ViewerTargetKey) : null;
-  if (nextActiveKey) {
-    ui.setActiveShellTabKeyForWorkspace(workspaceUiKey, nextActiveKey);
-  }
-}
-
-function removeShellKeys(
-  workspaceUiKey: string | null,
-  keys: ReadonlySet<ViewerTargetKey>,
-): void {
-  if (!workspaceUiKey || keys.size === 0) {
-    return;
-  }
-  const ui = useWorkspaceUiStore.getState();
-  const currentOrder = ui.shellTabOrderByWorkspace[workspaceUiKey];
-  if (currentOrder) {
-    ui.setShellTabOrderForWorkspace(
-      workspaceUiKey,
-      currentOrder.filter((key) => !keys.has(key as ViewerTargetKey)),
-    );
-  }
-}

--- a/desktop/src/components/workspace/files/viewer/CenterMessage.tsx
+++ b/desktop/src/components/workspace/files/viewer/CenterMessage.tsx
@@ -1,0 +1,7 @@
+export function CenterMessage({ message }: { message: string }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <p className="text-xs text-muted-foreground">{message}</p>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/files/viewer/FileDiffPane.tsx
+++ b/desktop/src/components/workspace/files/viewer/FileDiffPane.tsx
@@ -1,0 +1,46 @@
+import { useGitDiffQuery } from "@anyharness/sdk-react";
+import { DiffViewer } from "@/components/ui/content/DiffViewer";
+import type { FileDiffTarget } from "@/lib/domain/workspaces/viewer/file-diff-options";
+import { CenterMessage } from "./CenterMessage";
+
+export function FileDiffPane({
+  workspaceId,
+  target,
+  layout,
+}: {
+  workspaceId: string | null;
+  target: FileDiffTarget;
+  layout: "unified" | "split";
+}) {
+  const diffQuery = useGitDiffQuery({
+    workspaceId,
+    path: target.path,
+    scope: target.scope,
+    baseRef: target.scope === "branch" ? target.baseRef : null,
+    oldPath: target.scope === "branch" ? target.oldPath : null,
+  });
+
+  if (diffQuery.isLoading) {
+    return (
+      <p className="px-4 py-8 text-center text-sm text-muted-foreground">Loading diff</p>
+    );
+  }
+
+  if (diffQuery.data?.patch) {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto">
+        <DiffViewer patch={diffQuery.data.patch} layout={layout} />
+      </div>
+    );
+  }
+
+  if (diffQuery.data?.binary) {
+    return (
+      <CenterMessage message="Binary file changed" />
+    );
+  }
+
+  return (
+    <CenterMessage message="No diff available" />
+  );
+}

--- a/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -1,0 +1,252 @@
+import type {
+  ReactNode,
+  Ref,
+} from "react";
+import { Button } from "@/components/ui/Button";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  FilePen,
+  FileText,
+  GitBranch,
+  RefreshCw,
+  SplitPanel,
+} from "@/components/ui/icons";
+import { PickerPopoverContent } from "@/components/ui/PickerPopoverContent";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
+import { Tooltip } from "@/components/ui/Tooltip";
+import type { DiffScopeOption } from "@/lib/domain/workspaces/viewer/file-diff-options";
+import type {
+  FileDiffViewerScope,
+  FileViewerMode,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+
+export function FileViewerFrame({
+  rootRef,
+  filePath,
+  mode,
+  canRenderMarkdown: markdown,
+  canRenderDiff,
+  diffScopeOptions,
+  activeDiffScope,
+  diffLayout,
+  dirty,
+  saveState,
+  onModeChange,
+  onDiffScopeChange,
+  onToggleDiffLayout,
+  onCopyPath,
+  onReload,
+  onSave,
+  children,
+}: {
+  rootRef?: Ref<HTMLDivElement>;
+  filePath: string;
+  mode: FileViewerMode;
+  canRenderMarkdown: boolean;
+  canRenderDiff: boolean;
+  diffScopeOptions: readonly DiffScopeOption[];
+  activeDiffScope: FileDiffViewerScope | null;
+  diffLayout: "unified" | "split";
+  dirty: boolean;
+  saveState: string;
+  onModeChange: (mode: FileViewerMode) => void;
+  onDiffScopeChange: (scope: FileDiffViewerScope) => void;
+  onToggleDiffLayout: () => void;
+  onCopyPath: () => void;
+  onReload: () => void;
+  onSave: () => void;
+  children: ReactNode;
+}) {
+  const basename = filePath.split("/").pop() ?? filePath;
+  const parentPath = filePath.split("/").slice(0, -1).join("/");
+  return (
+    <div ref={rootRef} tabIndex={-1} className="flex h-full min-w-0 flex-col overflow-hidden outline-none">
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border bg-background px-3">
+        <FileTreeEntryIcon name={basename} path={filePath} kind="file" className="size-4 shrink-0" />
+        <div className="min-w-0 flex-1" title={filePath}>
+          <div className="truncate text-sm font-medium leading-4 text-foreground [direction:ltr] [unicode-bidi:plaintext]">
+            {basename}
+          </div>
+          {parentPath && (
+            <div className="truncate text-[10px] leading-3 text-muted-foreground [direction:ltr] [unicode-bidi:plaintext]">
+              {parentPath}
+            </div>
+          )}
+        </div>
+        {dirty && <span className="size-1.5 shrink-0 rounded-full bg-foreground/50" />}
+        {(markdown || canRenderDiff) && (
+          <div className="flex shrink-0 items-center gap-1 border-l border-border pl-2">
+            {canRenderDiff && (
+              <FileViewerModeButton
+                active={mode === "diff"}
+                label="Diff"
+                onClick={() => onModeChange("diff")}
+              >
+                <GitBranch className="size-3.5" />
+              </FileViewerModeButton>
+            )}
+            {markdown && (
+              <FileViewerModeButton
+                active={mode === "rendered"}
+                label="Preview"
+                onClick={() => onModeChange("rendered")}
+              >
+                <FileText className="size-3.5" />
+              </FileViewerModeButton>
+            )}
+            <FileViewerModeButton
+              active={mode === "edit"}
+              label="Edit"
+              onClick={() => onModeChange("edit")}
+            >
+              <FilePen className="size-3.5" />
+            </FileViewerModeButton>
+          </div>
+        )}
+        {canRenderDiff && mode === "diff" && diffScopeOptions.length > 1 && activeDiffScope && (
+          <DiffScopePicker
+            options={diffScopeOptions}
+            activeScope={activeDiffScope}
+            onScopeChange={onDiffScopeChange}
+          />
+        )}
+        {canRenderDiff && mode === "diff" && (
+          <Tooltip content={diffLayout === "split" ? "Unified diff" : "Split diff"}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={onToggleDiffLayout}
+              aria-label="Toggle diff layout"
+              className="size-7"
+            >
+              <SplitPanel className="size-3.5" />
+            </Button>
+          </Tooltip>
+        )}
+        <Tooltip content="Copy path">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onCopyPath}
+            aria-label="Copy file path"
+            className="size-7"
+          >
+            <Copy className="size-3.5" />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Reload">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onReload}
+            aria-label="Reload file"
+            className="size-7"
+          >
+            <RefreshCw className="size-3.5" />
+          </Button>
+        </Tooltip>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={onSave}
+          disabled={mode !== "edit" || !dirty || saveState === "saving"}
+          loading={saveState === "saving"}
+          className="h-7 px-2 text-xs"
+        >
+          Save
+        </Button>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+function FileViewerModeButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`h-7 gap-1.5 rounded-md px-2 text-xs ${active
+        ? "bg-accent text-foreground"
+        : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"}`}
+    >
+      {children}
+      <span>{label}</span>
+    </Button>
+  );
+}
+
+function DiffScopePicker({
+  options,
+  activeScope,
+  onScopeChange,
+}: {
+  options: readonly DiffScopeOption[];
+  activeScope: FileDiffViewerScope;
+  onScopeChange: (scope: FileDiffViewerScope) => void;
+}) {
+  const activeOption = options.find((option) => option.scope === activeScope) ?? options[0];
+
+  return (
+    <PopoverButton
+      trigger={(
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 rounded-md px-2 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+          aria-label="Diff scope"
+        >
+          {activeOption.label}
+          <ChevronDown className="size-3" />
+        </Button>
+      )}
+      align="end"
+      className="w-48 rounded-xl border border-border bg-popover p-1 shadow-floating"
+    >
+      {(close) => (
+        <PickerPopoverContent className="max-h-72">
+          {options.map((option) => (
+            <PopoverMenuItem
+              key={option.scope}
+              label={option.label}
+              icon={<GitBranch className="size-3.5 text-muted-foreground" />}
+              trailing={option.scope === activeScope
+                ? <Check className="size-3.5 text-foreground/70" />
+                : null}
+              onClick={() => {
+                onScopeChange(option.scope);
+                close();
+              }}
+            >
+              <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                {option.description}
+              </span>
+            </PopoverMenuItem>
+          ))}
+        </PickerPopoverContent>
+      )}
+    </PopoverButton>
+  );
+}

--- a/desktop/src/hooks/workspaces/files/ui/use-file-editor-commands.ts
+++ b/desktop/src/hooks/workspaces/files/ui/use-file-editor-commands.ts
@@ -1,0 +1,354 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { BeforeMount, OnMount } from "@monaco-editor/react";
+import {
+  REDO_COMMAND_EVENT,
+  SELECT_ALL_COMMAND_EVENT,
+  UNDO_COMMAND_EVENT,
+  selectElementContents,
+} from "@/lib/infra/dom/dom-select-all";
+import {
+  proliferateDarkTheme,
+  proliferateLightTheme,
+  THEME_NAME_DARK,
+  THEME_NAME_LIGHT,
+} from "@/lib/infra/editor/monaco-theme";
+import { runShortcutHandler } from "@/lib/domain/shortcuts/registry";
+import type {
+  FileViewerMode,
+  ViewerTargetKey,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+
+type MonacoStandaloneEditor = Parameters<OnMount>[0];
+type MonacoApi = Parameters<OnMount>[1];
+type EditorEditCommand = "selectAll" | "undo" | "redo";
+
+interface UseFileEditorCommandsInput {
+  effectiveMode: FileViewerMode;
+  targetKey: ViewerTargetKey;
+  filePath: string;
+  isDirty: boolean;
+  onSaveFile: (filePath: string) => void | Promise<void>;
+}
+
+export function useFileEditorCommands({
+  effectiveMode,
+  targetKey,
+  filePath,
+  isDirty,
+  onSaveFile,
+}: UseFileEditorCommandsInput) {
+  const viewerRootRef = useRef<HTMLDivElement | null>(null);
+  const viewerContentRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<MonacoStandaloneEditor | null>(null);
+
+  const handleBeforeMount: BeforeMount = useCallback((monaco) => {
+    monaco.editor.defineTheme(THEME_NAME_DARK, proliferateDarkTheme);
+    monaco.editor.defineTheme(THEME_NAME_LIGHT, proliferateLightTheme);
+  }, []);
+
+  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
+    editorRef.current = editor;
+    registerEditorEditKeybindings(editor, monaco);
+    editor.focus();
+  }, []);
+
+  const handleContentPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (effectiveMode === "edit" || isInteractiveElement(event.target)) {
+      return;
+    }
+
+    viewerRootRef.current?.focus({ preventScroll: true });
+  }, [effectiveMode]);
+
+  useEffect(() => {
+    if (effectiveMode !== "edit") {
+      viewerRootRef.current?.focus({ preventScroll: true });
+    }
+  }, [effectiveMode, targetKey]);
+
+  const handleSaveShortcut = useCallback(
+    (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        if (isDirty && effectiveMode === "edit") {
+          void onSaveFile(filePath);
+        }
+      }
+    },
+    [effectiveMode, filePath, isDirty, onSaveFile],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleSaveShortcut);
+    return () => window.removeEventListener("keydown", handleSaveShortcut);
+  }, [handleSaveShortcut]);
+
+  const handleEditorEditShortcut = useCallback((event: KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    const command = editCommandFromKeyboardEvent(event);
+    if (!command || effectiveMode !== "edit") {
+      return;
+    }
+
+    const editor = editorRef.current;
+    const shouldHandle = editor
+      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
+      : false;
+    if (!editor || !shouldHandle) {
+      return;
+    }
+
+    if (runEditorEditCommand(editor, command)) {
+      consumeEditorShortcutEvent(event);
+    }
+  }, [effectiveMode]);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleEditorEditShortcut, true);
+    return () => window.removeEventListener("keydown", handleEditorEditShortcut, true);
+  }, [handleEditorEditShortcut]);
+
+  const handleSelectAllCommand = useCallback((event: Event) => {
+    if (effectiveMode === "edit") {
+      const editor = editorRef.current;
+      const shouldHandle = editor
+        ? shouldHandleEditorCommand(viewerRootRef.current, editor)
+        : false;
+      if (!editor || !shouldHandle) {
+        return;
+      }
+
+      if (runEditorEditCommand(editor, "selectAll")) {
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (!shouldHandleViewerCommand(viewerRootRef.current)) {
+      return;
+    }
+
+    const content = viewerContentRef.current;
+    if (content && selectElementContents(content)) {
+      event.preventDefault();
+    }
+  }, [effectiveMode]);
+
+  const handleUndoCommand = useCallback((event: Event) => {
+    if (effectiveMode !== "edit") {
+      return;
+    }
+
+    const editor = editorRef.current;
+    const shouldHandle = editor
+      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
+      : false;
+    if (!editor || !shouldHandle) {
+      return;
+    }
+
+    if (runEditorEditCommand(editor, "undo")) {
+      event.preventDefault();
+    }
+  }, [effectiveMode]);
+
+  const handleRedoCommand = useCallback((event: Event) => {
+    if (effectiveMode !== "edit") {
+      return;
+    }
+
+    const editor = editorRef.current;
+    const shouldHandle = editor
+      ? shouldHandleEditorCommand(viewerRootRef.current, editor)
+      : false;
+    if (!editor || !shouldHandle) {
+      return;
+    }
+
+    if (runEditorEditCommand(editor, "redo")) {
+      event.preventDefault();
+    }
+  }, [effectiveMode]);
+
+  useEffect(() => {
+    window.addEventListener(SELECT_ALL_COMMAND_EVENT, handleSelectAllCommand);
+    return () => window.removeEventListener(SELECT_ALL_COMMAND_EVENT, handleSelectAllCommand);
+  }, [handleSelectAllCommand]);
+
+  useEffect(() => {
+    window.addEventListener(UNDO_COMMAND_EVENT, handleUndoCommand);
+    window.addEventListener(REDO_COMMAND_EVENT, handleRedoCommand);
+    return () => {
+      window.removeEventListener(UNDO_COMMAND_EVENT, handleUndoCommand);
+      window.removeEventListener(REDO_COMMAND_EVENT, handleRedoCommand);
+    };
+  }, [handleRedoCommand, handleUndoCommand]);
+
+  return {
+    viewerRootRef,
+    viewerContentRef,
+    handleBeforeMount,
+    handleEditorMount,
+    handleContentPointerDownCapture,
+  };
+}
+
+function selectEditorContents(editor: MonacoStandaloneEditor): boolean {
+  const model = editor.getModel();
+  if (!model) {
+    return false;
+  }
+
+  editor.focus();
+  editor.setSelection(model.getFullModelRange());
+  return true;
+}
+
+function undoEditorChange(editor: MonacoStandaloneEditor): boolean {
+  const model = editor.getModel();
+  if (!model) {
+    return false;
+  }
+
+  editor.focus();
+  void model.undo();
+  return true;
+}
+
+function redoEditorChange(editor: MonacoStandaloneEditor): boolean {
+  const model = editor.getModel();
+  if (!model) {
+    return false;
+  }
+
+  editor.focus();
+  void model.redo();
+  return true;
+}
+
+function registerEditorEditKeybindings(
+  editor: MonacoStandaloneEditor,
+  monaco: MonacoApi,
+): void {
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyA, () => {
+    runEditorEditCommand(editor, "selectAll");
+  });
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyZ, () => {
+    runEditorEditCommand(editor, "undo");
+  });
+  editor.addCommand(
+    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyZ,
+    () => {
+      runEditorEditCommand(editor, "redo");
+    },
+  );
+  editor.addCommand(
+    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.LeftArrow,
+    () => {
+      runShortcutHandler("workspace.previous-tab", { source: "keyboard" });
+    },
+  );
+  editor.addCommand(
+    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.RightArrow,
+    () => {
+      runShortcutHandler("workspace.next-tab", { source: "keyboard" });
+    },
+  );
+}
+
+function runEditorEditCommand(
+  editor: MonacoStandaloneEditor,
+  command: EditorEditCommand,
+): boolean {
+  if (command === "selectAll") {
+    return selectEditorContents(editor);
+  }
+  if (command === "undo") {
+    return undoEditorChange(editor);
+  }
+  return redoEditorChange(editor);
+}
+
+function editCommandFromKeyboardEvent(event: KeyboardEvent): EditorEditCommand | null {
+  if (!(event.metaKey || event.ctrlKey) || event.altKey) {
+    return null;
+  }
+
+  const key = event.key.toLowerCase();
+  if (key === "a" && !event.shiftKey) {
+    return "selectAll";
+  }
+  if (key === "z") {
+    return event.shiftKey ? "redo" : "undo";
+  }
+  return null;
+}
+
+function consumeEditorShortcutEvent(event: KeyboardEvent): void {
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+}
+
+function isInteractiveElement(target: EventTarget): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return Boolean(target.closest(
+    "a,button,input,select,textarea,[contenteditable='true'],[role='button']",
+  ));
+}
+
+function shouldHandleViewerCommand(root: HTMLElement | null): boolean {
+  if (!root || !root.isConnected) {
+    return false;
+  }
+
+  const activeElement = document.activeElement;
+  if (!activeElement || activeElement === document.body) {
+    return true;
+  }
+
+  return activeElement instanceof Node && root.contains(activeElement);
+}
+
+function shouldHandleEditorCommand(
+  root: HTMLElement | null,
+  editor: MonacoStandaloneEditor,
+): boolean {
+  if (!root || !root.isConnected) {
+    return false;
+  }
+
+  if (safeEditorHasTextFocus(editor)) {
+    return true;
+  }
+
+  const activeElement = document.activeElement;
+  const editorNode = editor.getDomNode();
+  if (activeElement instanceof Node && editorNode?.contains(activeElement)) {
+    return true;
+  }
+
+  if (!activeElement || activeElement === document.body) {
+    return true;
+  }
+
+  return activeElement instanceof Node && root.contains(activeElement);
+}
+
+function safeEditorHasTextFocus(editor: MonacoStandaloneEditor): boolean {
+  try {
+    return editor.hasTextFocus();
+  } catch {
+    return false;
+  }
+}

--- a/desktop/src/hooks/workspaces/files/workflows/use-file-tree-entry-actions.ts
+++ b/desktop/src/hooks/workspaces/files/workflows/use-file-tree-entry-actions.ts
@@ -1,0 +1,355 @@
+import { useCallback } from "react";
+import type { WorkspaceFileEntry } from "@anyharness/sdk";
+import {
+  useDeleteWorkspaceEntryMutation,
+  useRenameWorkspaceEntryMutation,
+  useWorkspaceFilesQuery,
+} from "@anyharness/sdk-react";
+import {
+  parseViewerTargetKey,
+  pathIsWithinWorkspaceEntry,
+  remapViewerTargetPathWithinWorkspaceEntry,
+  viewerTargetEditablePath,
+  viewerTargetKey,
+  type ViewerTarget,
+  type ViewerTargetKey,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+import { useFileTreeNativeContextMenu } from "@/hooks/editor/ui/use-file-tree-native-context-menu";
+import { useTauriShellActions, type OpenTarget } from "@/hooks/access/tauri/use-shell-actions";
+import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
+import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
+import { useWorkspaceFileBuffersStore } from "@/stores/editor/workspace-file-buffers-store";
+import { useWorkspaceFileTreeUiStore } from "@/stores/editor/workspace-file-tree-ui-store";
+import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+interface UseFileTreeEntryActionsInput {
+  entry: WorkspaceFileEntry;
+  targets: OpenTarget[];
+}
+
+export function useFileTreeEntryActions({
+  entry,
+  targets,
+}: UseFileTreeEntryActionsInput) {
+  const treeStateKey = useWorkspaceViewerTabsStore((s) => s.treeStateKey);
+  const workspaceUiKey = useWorkspaceViewerTabsStore((s) => s.workspaceUiKey);
+  const activeTargetKey = useWorkspaceViewerTabsStore((s) => s.activeTargetKey);
+  const materializedWorkspaceId = useWorkspaceViewerTabsStore((s) => s.materializedWorkspaceId);
+  const renamePathReferences = useWorkspaceViewerTabsStore((s) => s.renamePathReferences);
+  const closePathReferences = useWorkspaceViewerTabsStore((s) => s.closePathReferences);
+  const setSelectedDirectory = useWorkspaceFileTreeUiStore((state) => state.setSelectedDirectory);
+  const startCreateDraft = useWorkspaceFileTreeUiStore((state) => state.startCreateDraft);
+  const expandDirectory = useWorkspaceFileTreeUiStore((state) => state.expandDirectory);
+  const isExpanded = useWorkspaceFileTreeUiStore((state) => (
+    treeStateKey
+      ? Boolean(state.expandedDirectoriesByTreeKey[treeStateKey]?.[entry.path])
+      : false
+  ));
+  const { toggleDirectory, openFile } = useWorkspaceFileActions();
+  const { activateChatShell, activateViewerTarget } = useWorkspaceShellActivation();
+  const renameBufferPathPrefix = useWorkspaceFileBuffersStore((state) => state.renamePathPrefix);
+  const clearBufferPathPrefix = useWorkspaceFileBuffersStore((state) => state.clearPathPrefix);
+  const { openTarget: execOpenTarget } = useTauriShellActions();
+  const showToast = useToastStore((state) => state.show);
+  const renameMutation = useRenameWorkspaceEntryMutation({
+    workspaceId: materializedWorkspaceId,
+  });
+  const deleteMutation = useDeleteWorkspaceEntryMutation({
+    workspaceId: materializedWorkspaceId,
+  });
+
+  const isDir = entry.kind === "directory";
+  const childQuery = useWorkspaceFilesQuery({
+    workspaceId: materializedWorkspaceId,
+    path: entry.path,
+    enabled: isDir && isExpanded && !!materializedWorkspaceId,
+  });
+  const activeTarget = activeTargetKey ? parseViewerTargetKey(activeTargetKey) : null;
+  const isActive = activeTarget?.kind === "file" && activeTarget.path === entry.path;
+  const createParentPath = isDir ? entry.path : parentDirectoryPath(entry.path);
+
+  const handleClick = useCallback(() => {
+    if (isDir) {
+      if (treeStateKey) {
+        setSelectedDirectory(treeStateKey, entry.path);
+      }
+      toggleDirectory(entry.path);
+      return;
+    }
+
+    if (treeStateKey) {
+      const parent = parentDirectoryPath(entry.path);
+      setSelectedDirectory(treeStateKey, parent);
+    }
+    openFile(entry.path);
+  }, [
+    entry.path,
+    isDir,
+    openFile,
+    setSelectedDirectory,
+    toggleDirectory,
+    treeStateKey,
+  ]);
+
+  const handleOpenTarget = useCallback((targetId: string) => {
+    void execOpenTarget(targetId, entry.path);
+  }, [entry.path, execOpenTarget]);
+
+  const startCreate = useCallback((kind: "file" | "directory") => {
+    if (!treeStateKey) {
+      return;
+    }
+    if (createParentPath) {
+      expandDirectory(treeStateKey, createParentPath);
+    }
+    startCreateDraft(treeStateKey, { kind, parentPath: createParentPath });
+  }, [createParentPath, expandDirectory, startCreateDraft, treeStateKey]);
+
+  const handleRename = useCallback(async () => {
+    const nextName = window.prompt(`Rename ${entry.name}`, entry.name);
+    if (nextName === null) {
+      return;
+    }
+    const trimmedName = nextName.trim();
+    if (!trimmedName || trimmedName === entry.name) {
+      return;
+    }
+    if (trimmedName.includes("/")) {
+      showToast("Use a name, not a path, when renaming from the file tree.");
+      return;
+    }
+    const parent = parentDirectoryPath(entry.path);
+    const newPath = parent ? `${parent}/${trimmedName}` : trimmedName;
+    const dirtyPaths = affectedDirtyBufferPaths(entry.path);
+    if (dirtyPaths.length > 0) {
+      showToast(`Save or close unsaved files before renaming ${entry.name}.`);
+      return;
+    }
+    const previousViewerState = useWorkspaceViewerTabsStore.getState();
+    try {
+      const result = await renameMutation.mutateAsync({
+        path: entry.path,
+        newPath,
+      });
+      const renamePlan = buildRenameViewerTargetPlan(
+        previousViewerState.openTargets,
+        entry.path,
+        result.entry.path,
+      );
+      renamePathReferences(entry.path, result.entry.path);
+      renameBufferPathPrefix(entry.path, result.entry.path);
+      applyRenamedShellKeys(workspaceUiKey, renamePlan.keyMap);
+      const nextActiveTarget = previousViewerState.activeTargetKey
+        ? renamePlan.targetByOldKey.get(previousViewerState.activeTargetKey)
+        : null;
+      if (nextActiveTarget && materializedWorkspaceId) {
+        activateViewerTarget({
+          workspaceId: materializedWorkspaceId,
+          shellWorkspaceId: workspaceUiKey,
+          target: nextActiveTarget,
+          mode: "focus-existing",
+        });
+      }
+      if (isDir && treeStateKey && isExpanded) {
+        expandDirectory(treeStateKey, result.entry.path);
+      }
+      if (!isDir && renamePlan.keyMap.size === 0) {
+        openFile(result.entry.path);
+      }
+      showToast(`Renamed ${entry.name}`, "info");
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : `Failed to rename ${entry.name}`);
+    }
+  }, [
+    activateViewerTarget,
+    entry.name,
+    entry.path,
+    expandDirectory,
+    isDir,
+    isExpanded,
+    materializedWorkspaceId,
+    openFile,
+    renameBufferPathPrefix,
+    renameMutation,
+    renamePathReferences,
+    showToast,
+    treeStateKey,
+    workspaceUiKey,
+  ]);
+
+  const handleDelete = useCallback(async () => {
+    const dirtyPaths = affectedDirtyBufferPaths(entry.path);
+    if (dirtyPaths.length > 0) {
+      showToast(`Save or close unsaved files before deleting ${entry.name}.`);
+      return;
+    }
+    const label = isDir
+      ? `Delete folder "${entry.name}" and all of its contents?`
+      : `Delete file "${entry.name}"?`;
+    if (!window.confirm(label)) {
+      return;
+    }
+    const previousViewerState = useWorkspaceViewerTabsStore.getState();
+    const closingTargetKeys = affectedViewerTargetKeys(
+      previousViewerState.openTargets,
+      entry.path,
+    );
+    try {
+      await deleteMutation.mutateAsync({ path: entry.path });
+      closePathReferences(entry.path);
+      clearBufferPathPrefix(entry.path);
+      removeShellKeys(workspaceUiKey, closingTargetKeys);
+      if (previousViewerState.activeTargetKey && closingTargetKeys.has(previousViewerState.activeTargetKey)) {
+        const nextViewerState = useWorkspaceViewerTabsStore.getState();
+        const nextActiveTarget = nextViewerState.activeTargetKey
+          ? nextViewerState.openTargets.find((target) =>
+            viewerTargetKey(target) === nextViewerState.activeTargetKey
+          ) ?? null
+          : null;
+        if (nextActiveTarget && materializedWorkspaceId) {
+          activateViewerTarget({
+            workspaceId: materializedWorkspaceId,
+            shellWorkspaceId: workspaceUiKey,
+            target: nextActiveTarget,
+            mode: "focus-existing",
+          });
+        } else if (materializedWorkspaceId) {
+          activateChatShell({
+            workspaceId: materializedWorkspaceId,
+            shellWorkspaceId: workspaceUiKey,
+            reason: "delete_file_tree_entry",
+          });
+        }
+      }
+      showToast(`Deleted ${entry.name}`, "info");
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : `Failed to delete ${entry.name}`);
+    }
+  }, [
+    activateChatShell,
+    activateViewerTarget,
+    clearBufferPathPrefix,
+    closePathReferences,
+    deleteMutation,
+    entry.name,
+    entry.path,
+    isDir,
+    materializedWorkspaceId,
+    showToast,
+    workspaceUiKey,
+  ]);
+
+  const { onContextMenuCapture } = useFileTreeNativeContextMenu({
+    targets,
+    onOpenInProliferate: handleClick,
+    onOpenTarget: handleOpenTarget,
+    onNewFile: () => startCreate("file"),
+    onNewFolder: () => startCreate("directory"),
+    onRename: () => {
+      void handleRename();
+    },
+    onDelete: () => {
+      void handleDelete();
+    },
+  });
+
+  return {
+    isDir,
+    isExpanded,
+    isActive,
+    childEntries: childQuery.data?.entries,
+    isChildLoading: childQuery.isLoading,
+    isChildError: childQuery.isError,
+    handleClick,
+    handleOpenTarget,
+    handleDelete,
+    handleRename,
+    onContextMenuCapture,
+    startCreate,
+  };
+}
+
+function parentDirectoryPath(path: string): string {
+  return path.split("/").slice(0, -1).join("/");
+}
+
+function affectedDirtyBufferPaths(entryPath: string): string[] {
+  return Object.values(useWorkspaceFileBuffersStore.getState().buffersByPath)
+    .filter((buffer) => buffer.isDirty && pathIsWithinWorkspaceEntry(buffer.path, entryPath))
+    .map((buffer) => buffer.path);
+}
+
+function affectedViewerTargetKeys(
+  targets: readonly ViewerTarget[],
+  entryPath: string,
+): Set<ViewerTargetKey> {
+  return new Set(targets
+    .filter((target) => {
+      const editablePath = viewerTargetEditablePath(target);
+      return !!editablePath && pathIsWithinWorkspaceEntry(editablePath, entryPath);
+    })
+    .map(viewerTargetKey));
+}
+
+function buildRenameViewerTargetPlan(
+  targets: readonly ViewerTarget[],
+  fromPath: string,
+  toPath: string,
+): {
+  keyMap: Map<ViewerTargetKey, ViewerTargetKey>;
+  targetByOldKey: Map<ViewerTargetKey, ViewerTarget>;
+} {
+  const keyMap = new Map<ViewerTargetKey, ViewerTargetKey>();
+  const targetByOldKey = new Map<ViewerTargetKey, ViewerTarget>();
+  for (const target of targets) {
+    const nextTarget = remapViewerTargetPathWithinWorkspaceEntry(target, fromPath, toPath);
+    const oldKey = viewerTargetKey(target);
+    const nextKey = viewerTargetKey(nextTarget);
+    if (oldKey !== nextKey) {
+      keyMap.set(oldKey, nextKey);
+      targetByOldKey.set(oldKey, nextTarget);
+    }
+  }
+  return { keyMap, targetByOldKey };
+}
+
+function applyRenamedShellKeys(
+  workspaceUiKey: string | null,
+  keyMap: ReadonlyMap<ViewerTargetKey, ViewerTargetKey>,
+): void {
+  if (!workspaceUiKey || keyMap.size === 0) {
+    return;
+  }
+  const ui = useWorkspaceUiStore.getState();
+  const currentOrder = ui.shellTabOrderByWorkspace[workspaceUiKey];
+  if (currentOrder) {
+    ui.setShellTabOrderForWorkspace(
+      workspaceUiKey,
+      currentOrder.map((key) => keyMap.get(key as ViewerTargetKey) ?? key),
+    );
+  }
+  const activeKey = ui.activeShellTabKeyByWorkspace[workspaceUiKey];
+  const nextActiveKey = activeKey ? keyMap.get(activeKey as ViewerTargetKey) : null;
+  if (nextActiveKey) {
+    ui.setActiveShellTabKeyForWorkspace(workspaceUiKey, nextActiveKey);
+  }
+}
+
+function removeShellKeys(
+  workspaceUiKey: string | null,
+  keys: ReadonlySet<ViewerTargetKey>,
+): void {
+  if (!workspaceUiKey || keys.size === 0) {
+    return;
+  }
+  const ui = useWorkspaceUiStore.getState();
+  const currentOrder = ui.shellTabOrderByWorkspace[workspaceUiKey];
+  if (currentOrder) {
+    ui.setShellTabOrderForWorkspace(
+      workspaceUiKey,
+      currentOrder.filter((key) => !keys.has(key as ViewerTargetKey)),
+    );
+  }
+}

--- a/desktop/src/lib/domain/workspaces/viewer/file-diff-options.ts
+++ b/desktop/src/lib/domain/workspaces/viewer/file-diff-options.ts
@@ -1,0 +1,125 @@
+import type {
+  GitBranchDiffFilesResponse,
+  GitChangedFile,
+} from "@anyharness/sdk";
+import {
+  fileDiffViewerTarget,
+  type FileDiffViewerScope,
+  type ViewerTarget,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+
+export type FileDiffTarget = Extract<ViewerTarget, { kind: "fileDiff" }>;
+
+export interface DiffScopeOption {
+  scope: FileDiffViewerScope;
+  label: string;
+  description: string;
+  target: FileDiffTarget;
+}
+
+export function diffScopeFromIncludedState(
+  includedState: "included" | "excluded" | "partial",
+): FileDiffViewerScope {
+  return includedState === "included" ? "staged" : "unstaged";
+}
+
+export function buildDiffScopeOptions({
+  filePath,
+  statusFile,
+  branchDiff,
+  explicitTarget,
+}: {
+  filePath: string;
+  statusFile: GitChangedFile | null;
+  branchDiff: GitBranchDiffFilesResponse | undefined;
+  explicitTarget?: FileDiffTarget;
+}): DiffScopeOption[] {
+  const byScope = new Map<FileDiffViewerScope, DiffScopeOption>();
+
+  if (statusFile) {
+    for (const scope of diffScopesForStatusFile(statusFile)) {
+      byScope.set(scope, {
+        scope,
+        label: diffScopeLabel(scope),
+        description: diffScopeDescription(scope, null),
+        target: fileDiffViewerTarget({
+          path: statusFile.path,
+          oldPath: statusFile.oldPath ?? null,
+          scope,
+        }) as FileDiffTarget,
+      });
+    }
+  }
+
+  const branchFile = branchDiff?.files.find((file) =>
+    file.path === filePath || file.oldPath === filePath
+  );
+  if (branchDiff && branchFile) {
+    const scope = "branch" as const;
+    byScope.set(scope, {
+      scope,
+      label: diffScopeLabel(scope),
+      description: diffScopeDescription(scope, branchDiff.baseRef),
+      target: fileDiffViewerTarget({
+        path: branchFile.path,
+        oldPath: branchFile.oldPath ?? null,
+        scope,
+        baseRef: branchDiff.baseRef,
+        baseOid: branchDiff.mergeBaseOid,
+        headOid: branchDiff.headOid,
+      }) as FileDiffTarget,
+    });
+  }
+
+  if (explicitTarget && !byScope.has(explicitTarget.scope)) {
+    byScope.set(explicitTarget.scope, {
+      scope: explicitTarget.scope,
+      label: diffScopeLabel(explicitTarget.scope),
+      description: diffScopeDescription(explicitTarget.scope, explicitTarget.baseRef),
+      target: explicitTarget,
+    });
+  }
+
+  return (["unstaged", "staged", "branch"] as const)
+    .flatMap((scope) => byScope.get(scope) ? [byScope.get(scope)!] : []);
+}
+
+export function resolveActiveDiffOption(
+  options: readonly DiffScopeOption[],
+  selectedScope: FileDiffViewerScope | null,
+  preferredScope: FileDiffViewerScope | null,
+): DiffScopeOption | null {
+  return (
+    options.find((option) => option.scope === selectedScope)
+    ?? options.find((option) => option.scope === preferredScope)
+    ?? options[0]
+    ?? null
+  );
+}
+
+function diffScopesForStatusFile(file: GitChangedFile): FileDiffViewerScope[] {
+  if (file.includedState === "partial") {
+    return ["unstaged", "staged"];
+  }
+  return file.includedState === "included" ? ["staged"] : ["unstaged"];
+}
+
+function diffScopeLabel(scope: FileDiffViewerScope): string {
+  if (scope === "staged") {
+    return "Staged";
+  }
+  if (scope === "branch") {
+    return "Branch";
+  }
+  return "Unstaged";
+}
+
+function diffScopeDescription(scope: FileDiffViewerScope, baseRef: string | null): string {
+  if (scope === "staged") {
+    return "Index changes";
+  }
+  if (scope === "branch") {
+    return baseRef ? `Compared with ${baseRef}` : "Branch changes";
+  }
+  return "Working tree changes";
+}

--- a/desktop/src/lib/domain/workspaces/viewer/file-language.ts
+++ b/desktop/src/lib/domain/workspaces/viewer/file-language.ts
@@ -1,0 +1,27 @@
+export function inferWorkspaceFileLanguage(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const languages: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescriptreact",
+    js: "javascript",
+    jsx: "javascriptreact",
+    rs: "rust",
+    py: "python",
+    go: "go",
+    json: "json",
+    toml: "toml",
+    yaml: "yaml",
+    yml: "yaml",
+    md: "markdown",
+    mdx: "markdown",
+    css: "css",
+    scss: "scss",
+    html: "html",
+    sql: "sql",
+    sh: "shell",
+    bash: "shell",
+    xml: "xml",
+    svg: "xml",
+  };
+  return languages[ext] ?? "plaintext";
+}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -41,7 +41,6 @@ desktop/src/components/ui/content/DiffViewer.tsx
 desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
 desktop/src/components/workspace/changes/AllChangesFrame.tsx
 desktop/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
-desktop/src/components/workspace/files/FileEditorView.tsx
 desktop/src/hooks/sessions/use-session-control-actions.ts
 desktop/src/hooks/sessions/use-session-creation-actions.ts
 desktop/src/hooks/sessions/use-session-runtime-actions.ts


### PR DESCRIPTION
## Summary

- Splits the workspace file editor/viewer into smaller rendering components.
- Moves Monaco command wiring into a workspace-files UI hook.
- Extracts file tree entry actions and viewer display helpers into focused files.

## Validation

- `pnpm --dir desktop exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
