### PR TITLE
refactor(desktop): extract pending config map helpers

### DIFF
--- a/desktop/src/hooks/sessions/session-runtime-pending-config.ts
+++ b/desktop/src/hooks/sessions/session-runtime-pending-config.ts
@@ -2,7 +2,7 @@ import {
   collectFailedQueuedChangesMatchingMutationIds,
   hasQueuedPendingConfigChanges,
   snapshotQueuedPendingConfigMutationIds,
-  type PendingSessionConfigChanges,
+  withoutPendingConfigChanges,
 } from "@/lib/domain/sessions/pending-config";
 import {
   getSessionRecord,
@@ -10,22 +10,6 @@ import {
 } from "@/stores/sessions/session-records";
 
 const pendingConfigRollbackTimers = new Map<string, number>();
-
-function withoutPendingConfigChanges(
-  pendingConfigChanges: PendingSessionConfigChanges,
-  rawConfigIds: string[],
-): PendingSessionConfigChanges {
-  if (rawConfigIds.length === 0) {
-    return pendingConfigChanges;
-  }
-
-  const nextPendingConfigChanges = { ...pendingConfigChanges };
-  for (const rawConfigId of rawConfigIds) {
-    delete nextPendingConfigChanges[rawConfigId];
-  }
-
-  return nextPendingConfigChanges;
-}
 
 export function clearPendingConfigRollbackCheck(sessionId: string): void {
   const timer = pendingConfigRollbackTimers.get(sessionId);

--- a/desktop/src/hooks/sessions/use-session-control-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-control-actions.ts
@@ -20,8 +20,8 @@ import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/use-workspace-runti
 import {
   getAuthoritativeConfigValue,
   shouldAcceptAuthoritativeLiveConfig,
-  type PendingSessionConfigChange,
-  type PendingSessionConfigChanges,
+  withPendingConfigChange,
+  withoutPendingConfigChange,
 } from "@/lib/domain/sessions/pending-config";
 import { persistDefaultSessionModePreference } from "@/hooks/sessions/session-mode-preferences";
 import { useWorkspaceSurfaceLookup } from "@/hooks/workspaces/use-workspace-surface-lookup";
@@ -101,28 +101,6 @@ interface SessionControlDeps {
 }
 
 let nextPendingConfigMutationId = 0;
-
-function withPendingConfigChange(
-  pendingConfigChanges: PendingSessionConfigChanges,
-  pendingChange: PendingSessionConfigChange,
-): PendingSessionConfigChanges {
-  return {
-    ...pendingConfigChanges,
-    [pendingChange.rawConfigId]: pendingChange,
-  };
-}
-
-function withoutPendingConfigChange(
-  pendingConfigChanges: PendingSessionConfigChanges,
-  rawConfigId: string,
-): PendingSessionConfigChanges {
-  if (!pendingConfigChanges[rawConfigId]) {
-    return pendingConfigChanges;
-  }
-
-  const { [rawConfigId]: _removed, ...rest } = pendingConfigChanges;
-  return rest;
-}
 
 export function useSessionControlActions({
   activateSession,

--- a/desktop/src/lib/domain/sessions/pending-config.test.ts
+++ b/desktop/src/lib/domain/sessions/pending-config.test.ts
@@ -8,6 +8,9 @@ import {
   resolveDisplayedSessionControlState,
   snapshotQueuedPendingConfigMutationIds,
   shouldAcceptAuthoritativeLiveConfig,
+  withPendingConfigChange,
+  withoutPendingConfigChange,
+  withoutPendingConfigChanges,
   type PendingSessionConfigChanges,
 } from "./pending-config";
 
@@ -90,6 +93,95 @@ const LIVE_CONFIG: SessionLiveConfigSnapshot = {
 };
 
 describe("pending-config helpers", () => {
+  it("adds or replaces a pending change by raw config id", () => {
+    const existing: PendingSessionConfigChanges = {
+      effort: {
+        rawConfigId: "effort",
+        value: "high",
+        status: "queued",
+        mutationId: 1,
+      },
+    };
+    const pendingChange = {
+      rawConfigId: "effort",
+      value: "medium",
+      status: "submitting" as const,
+      mutationId: 2,
+    };
+
+    expect(withPendingConfigChange(existing, pendingChange)).toEqual({
+      effort: pendingChange,
+    });
+  });
+
+  it("removes one pending change without mutating the original map", () => {
+    const existing: PendingSessionConfigChanges = {
+      effort: {
+        rawConfigId: "effort",
+        value: "high",
+        status: "queued",
+        mutationId: 1,
+      },
+      fast_mode: {
+        rawConfigId: "fast_mode",
+        value: "on",
+        status: "queued",
+        mutationId: 2,
+      },
+    };
+
+    expect(withoutPendingConfigChange(existing, "effort")).toEqual({
+      fast_mode: existing.fast_mode,
+    });
+    expect(existing.effort).toBeDefined();
+  });
+
+  it("returns the original pending change map when removing a missing raw config id", () => {
+    const existing: PendingSessionConfigChanges = {
+      effort: {
+        rawConfigId: "effort",
+        value: "high",
+        status: "queued",
+        mutationId: 1,
+      },
+    };
+
+    expect(withoutPendingConfigChange(existing, "missing")).toBe(existing);
+  });
+
+  it("removes multiple pending changes", () => {
+    const existing: PendingSessionConfigChanges = {
+      effort: {
+        rawConfigId: "effort",
+        value: "high",
+        status: "queued",
+        mutationId: 1,
+      },
+      fast_mode: {
+        rawConfigId: "fast_mode",
+        value: "on",
+        status: "queued",
+        mutationId: 2,
+      },
+      mode: {
+        rawConfigId: "mode",
+        value: "plan",
+        status: "submitting",
+        mutationId: 3,
+      },
+    };
+
+    expect(withoutPendingConfigChanges(existing, ["effort", "mode"])).toEqual({
+      fast_mode: existing.fast_mode,
+    });
+  });
+
+  it("returns the original pending change map when removing no config ids", () => {
+    const existing: PendingSessionConfigChanges = {};
+
+    expect(withoutPendingConfigChanges(existing, [])).toBe(existing);
+  });
+
   it("overlays only the matching raw config id", () => {
     const pendingConfigChanges: PendingSessionConfigChanges = {
       effort: {

--- a/desktop/src/lib/domain/sessions/pending-config.ts
+++ b/desktop/src/lib/domain/sessions/pending-config.ts
@@ -36,6 +36,47 @@ export function getPendingSessionConfigChange(
   return pendingConfigChanges[rawConfigId] ?? null;
 }
 
+export function withPendingConfigChange(
+  pendingConfigChanges: PendingSessionConfigChanges,
+  pendingChange: PendingSessionConfigChange,
+): PendingSessionConfigChanges {
+  return {
+    ...pendingConfigChanges,
+    [pendingChange.rawConfigId]: pendingChange,
+  };
+}
+
+export function withoutPendingConfigChange(
+  pendingConfigChanges: PendingSessionConfigChanges,
+  rawConfigId: string,
+): PendingSessionConfigChanges {
+  if (!pendingConfigChanges[rawConfigId]) {
+    return pendingConfigChanges;
+  }
+
+  const { [rawConfigId]: _removed, ...rest } = pendingConfigChanges;
+  return rest;
+}
+
+export function withoutPendingConfigChanges(
+  pendingConfigChanges: PendingSessionConfigChanges,
+  rawConfigIds: readonly string[],
+): PendingSessionConfigChanges {
+  if (rawConfigIds.length === 0) {
+    return pendingConfigChanges;
+  }
+
+  let nextPendingConfigChanges = pendingConfigChanges;
+  for (const rawConfigId of rawConfigIds) {
+    nextPendingConfigChanges = withoutPendingConfigChange(
+      nextPendingConfigChanges,
+      rawConfigId,
+    );
+  }
+
+  return nextPendingConfigChanges;
+}
+
 export function resolveDisplayedSessionControlState(
   control: NormalizedSessionControl,
   pendingConfigChanges: PendingSessionConfigChanges | null | undefined,


### PR DESCRIPTION
## Summary

- Move pending session config map add/remove helpers into `lib/domain/sessions/pending-config.ts`.
- Update session control and pending rollback hooks to consume the domain helpers instead of local duplicates.
- Add focused domain coverage for add/replace and single/multiple removal behavior.

## Verification

- `pnpm --dir desktop exec vitest run src/lib/domain/sessions/pending-config.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
