### PR TITLE
refactor(desktop): extract session creation domain helpers

### DIFF
--- a/desktop/src/hooks/sessions/session-creation-helpers.ts
+++ b/desktop/src/hooks/sessions/session-creation-helpers.ts
@@ -1,16 +1,10 @@
 import type {
   ContentPart,
-  ModelRegistry,
-  ModelRegistryModel,
   PromptInputBlock,
-  Session,
-  WorkspaceSessionLaunchCatalog,
 } from "@anyharness/sdk";
 import type { ConnectorLaunchResolutionWarning } from "@/lib/domain/mcp/types";
 import { getLatencyFlowRequestHeaders } from "@/lib/infra/measurement/latency-flow";
 import { trackProductEvent } from "@/lib/integrations/telemetry/client";
-import { resolveCoworkDefaultSessionModeId } from "@/lib/domain/cowork/session-mode-defaults";
-import type { PausedSessionModelAvailability } from "@/hooks/sessions/workflows/use-session-model-availability-workflow";
 import type { MeasurementOperationId } from "@/lib/infra/measurement/debug-measurement";
 import type { PromptAttachmentSnapshot } from "@/lib/domain/chat/composer/prompt-attachment-snapshot";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
@@ -20,24 +14,6 @@ import {
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
-
-export function resolveSessionCreationModeId(input: {
-  explicitModeId?: string | null;
-  workspaceSurface: string | null | undefined;
-  agentKind: string;
-  preferredModeId?: string | null;
-}): string | undefined {
-  const explicitModeId = input.explicitModeId?.trim() || undefined;
-  if (explicitModeId) {
-    return explicitModeId;
-  }
-
-  if (input.workspaceSurface === "cowork") {
-    return resolveCoworkDefaultSessionModeId(input.agentKind);
-  }
-
-  return input.preferredModeId?.trim() || undefined;
-}
 
 export function buildLatencyRequestOptions(latencyFlowId?: string | null) {
   const headers = getLatencyFlowRequestHeaders(latencyFlowId);
@@ -150,97 +126,4 @@ export function reportConnectorLaunchWarnings(
   }
 
   showToast(`${warnings.length} connectors weren't available in this session.`, "info");
-}
-
-function modelMatchesId(model: Pick<ModelRegistryModel, "id" | "aliases">, modelId: string): boolean {
-  return model.id === modelId || (model.aliases ?? []).includes(modelId);
-}
-
-function findRegistryModel(
-  registries: ModelRegistry[],
-  agentKind: string,
-  modelId: string,
-) {
-  const registry = registries.find((candidate) => candidate.kind === agentKind) ?? null;
-  const model = registry?.models.find((candidate) => modelMatchesId(candidate, modelId)) ?? null;
-  return { registry, model };
-}
-
-function launchCatalogExposesModel(input: {
-  launchCatalog: WorkspaceSessionLaunchCatalog;
-  agentKind: string;
-  requestedModelId: string;
-  requestedModel: ModelRegistryModel;
-}): boolean {
-  const agent = input.launchCatalog.agents.find((candidate) =>
-    candidate.kind === input.agentKind
-  );
-  if (!agent) {
-    return false;
-  }
-
-  const acceptedIds = new Set([
-    input.requestedModelId,
-    input.requestedModel.id,
-    ...(input.requestedModel.aliases ?? []),
-  ]);
-  return agent.models.some((model) => acceptedIds.has(model.id));
-}
-
-export function hasImmediateLaunchModelMismatch(input: {
-  session: Session;
-  agentKind: string;
-  registries: ModelRegistry[];
-  launchCatalog: WorkspaceSessionLaunchCatalog;
-}): boolean {
-  const requestedModelId = input.session.requestedModelId;
-  const currentModelId = input.session.modelId;
-  if (!requestedModelId || !currentModelId || requestedModelId === currentModelId) {
-    return false;
-  }
-
-  const requested = findRegistryModel(
-    input.registries,
-    input.agentKind,
-    requestedModelId,
-  );
-  if (!requested.model?.launchRemediation) {
-    return false;
-  }
-
-  return !launchCatalogExposesModel({
-    launchCatalog: input.launchCatalog,
-    agentKind: input.agentKind,
-    requestedModelId,
-    requestedModel: requested.model,
-  });
-}
-
-export function buildPausedModelAvailability(input: {
-  session: Session;
-  workspaceId: string;
-  agentKind: string;
-  registries: ModelRegistry[];
-}): PausedSessionModelAvailability {
-  const requestedModelId = input.session.requestedModelId ?? "";
-  const currentModelId = input.session.modelId ?? "";
-  const requested = findRegistryModel(input.registries, input.agentKind, requestedModelId);
-  const current = findRegistryModel(input.registries, input.agentKind, currentModelId);
-  const providerDisplayName =
-    requested.registry?.displayName
-    ?? current.registry?.displayName
-    ?? input.agentKind;
-
-  return {
-    id: `${input.session.id}:${requestedModelId}:${currentModelId}`,
-    sessionId: input.session.id,
-    workspaceId: input.workspaceId,
-    agentKind: input.agentKind,
-    providerDisplayName,
-    requestedModelId,
-    requestedModelDisplayName: requested.model?.displayName ?? requestedModelId,
-    currentModelId,
-    currentModelDisplayName: current.model?.displayName ?? currentModelId,
-    remediation: requested.model?.launchRemediation ?? null,
-  };
 }

--- a/desktop/src/hooks/sessions/use-session-creation-actions.test.ts
+++ b/desktop/src/hooks/sessions/use-session-creation-actions.test.ts
@@ -1,15 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import type {
-  ModelRegistry,
-  Session,
-  WorkspaceSessionLaunchCatalog,
-} from "@anyharness/sdk";
 import {
   buildModelAvailabilityRetryOptions,
-  hasImmediateLaunchModelMismatch,
   materializeSessionRecord,
   removeSessionRecordAndClearSelection,
-  resolveSessionCreationModeId,
 } from "@/hooks/sessions/session-creation-helpers";
 import {
   createEmptySessionRecord,
@@ -24,135 +17,6 @@ beforeEach(() => {
   useSessionSelectionStore.getState().clearSelection();
   useSessionDirectoryStore.getState().clearEntries();
   useSessionTranscriptStore.getState().clearEntries();
-});
-
-describe("resolveSessionCreationModeId", () => {
-  it("lets an explicit mode override the stored user default", () => {
-    expect(resolveSessionCreationModeId({
-      explicitModeId: "bypassPermissions",
-      workspaceSurface: "coding",
-      agentKind: "claude",
-      preferredModeId: "plan",
-    })).toBe("bypassPermissions");
-  });
-
-  it("lets an explicit mode override the cowork default", () => {
-    expect(resolveSessionCreationModeId({
-      explicitModeId: "default",
-      workspaceSurface: "cowork",
-      agentKind: "claude",
-      preferredModeId: "plan",
-    })).toBe("default");
-  });
-
-  it("falls back to the cowork default when no explicit mode is provided", () => {
-    expect(resolveSessionCreationModeId({
-      workspaceSurface: "cowork",
-      agentKind: "codex",
-      preferredModeId: "read-only",
-    })).toBe("full-access");
-  });
-
-  it("falls back to the stored user default outside cowork", () => {
-    expect(resolveSessionCreationModeId({
-      workspaceSurface: "coding",
-      agentKind: "codex",
-      preferredModeId: "auto",
-    })).toBe("auto");
-  });
-});
-
-const registry: ModelRegistry = {
-  kind: "codex",
-  displayName: "Codex",
-  defaultModelId: "gpt-5.4",
-  models: [
-    {
-      id: "gpt-5.5",
-      displayName: "GPT 5.5",
-      isDefault: false,
-      status: "active",
-      aliases: ["gpt-5.5-latest"],
-      minRuntimeVersion: null,
-      launchRemediation: {
-        kind: "managed_reinstall",
-        message: "Update Codex tools and retry.",
-      },
-    },
-    {
-      id: "gpt-5.4",
-      displayName: "GPT 5.4",
-      isDefault: true,
-      status: "active",
-      aliases: [],
-      minRuntimeVersion: null,
-      launchRemediation: null,
-    },
-  ],
-};
-
-function sessionModelPair(
-  requestedModelId: string,
-  modelId: string,
-): Session {
-  return {
-    id: "session-1",
-    workspaceId: "workspace-1",
-    agentKind: "codex",
-    requestedModelId,
-    modelId,
-    status: "idle",
-    createdAt: "2026-04-28T00:00:00.000Z",
-    updatedAt: "2026-04-28T00:00:00.000Z",
-  } as Session;
-}
-
-function launchCatalog(modelIds: string[]): WorkspaceSessionLaunchCatalog {
-  return {
-    workspaceId: "workspace-1",
-    catalogVersion: "test",
-    agents: [
-      {
-        kind: "codex",
-        displayName: "Codex",
-        defaultModelId: modelIds[0] ?? null,
-        models: modelIds.map((id) => ({
-          id,
-          displayName: id,
-          isDefault: id === modelIds[0],
-        })),
-      },
-    ],
-  };
-}
-
-describe("hasImmediateLaunchModelMismatch", () => {
-  it("requires a remediable requested model that is absent from the live launch catalog", () => {
-    expect(hasImmediateLaunchModelMismatch({
-      session: sessionModelPair("gpt-5.5", "gpt-5.4"),
-      agentKind: "codex",
-      registries: [registry],
-      launchCatalog: launchCatalog(["gpt-5.4"]),
-    })).toBe(true);
-  });
-
-  it("does not treat live-exposed aliases as unavailable", () => {
-    expect(hasImmediateLaunchModelMismatch({
-      session: sessionModelPair("gpt-5.5", "gpt-5.4"),
-      agentKind: "codex",
-      registries: [registry],
-      launchCatalog: launchCatalog(["gpt-5.5-latest"]),
-    })).toBe(false);
-  });
-
-  it("does not pause for mismatches without remediation metadata", () => {
-    expect(hasImmediateLaunchModelMismatch({
-      session: sessionModelPair("gpt-5.4", "gpt-5.5"),
-      agentKind: "codex",
-      registries: [registry],
-      launchCatalog: launchCatalog(["gpt-5.5"]),
-    })).toBe(false);
-  });
 });
 
 describe("projected session materialization", () => {

--- a/desktop/src/hooks/sessions/use-session-creation-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-creation-actions.ts
@@ -10,6 +10,16 @@ import { createSessionLaunchDefaultsClient } from "@/lib/access/anyharness/sessi
 import { resolveRuntimeTargetForWorkspace } from "@/lib/access/anyharness/runtime-target";
 import { restartHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap";
 import { resolveStatusFromExecutionSummary } from "@/lib/domain/sessions/activity";
+import { findCompatibleExistingSession } from "@/lib/domain/sessions/creation/compatible-session";
+import {
+  mergeLiveDefaultLaunchControls,
+  pickLiveDefaultLaunchControls,
+} from "@/lib/domain/sessions/creation/launch-controls";
+import {
+  buildPausedModelAvailability,
+  hasImmediateLaunchModelMismatch,
+} from "@/lib/domain/sessions/creation/model-availability";
+import { resolveSessionCreationModeId } from "@/lib/domain/sessions/creation/mode";
 import { captureTelemetryException, trackProductEvent } from "@/lib/integrations/telemetry/client";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { useAgentInstallationActions } from "@/hooks/agents/workflows/use-agent-installation-actions";
@@ -68,12 +78,9 @@ import {
 import {
   buildLatencyRequestOptions,
   buildModelAvailabilityRetryOptions,
-  buildPausedModelAvailability,
-  hasImmediateLaunchModelMismatch,
   materializeSessionRecord,
   removeSessionRecordAndClearSelection,
   reportConnectorLaunchWarnings,
-  resolveSessionCreationModeId,
 } from "@/hooks/sessions/session-creation-helpers";
 import {
   inFlightSessionCreatesByWorkspace,
@@ -723,69 +730,12 @@ export function useSessionCreationActions() {
   };
 }
 
-function pickLiveDefaultLaunchControls(
-  values: Record<string, string> | undefined,
-): Partial<Record<"collaboration_mode" | "reasoning" | "effort" | "fast_mode", string>> {
-  if (!values) {
-    return {};
-  }
-  return Object.fromEntries(
-    Object.entries(values).filter(([key, value]) =>
-      (
-        key === "collaboration_mode"
-        || key === "reasoning"
-        || key === "effort"
-        || key === "fast_mode"
-      )
-      && value.trim().length > 0
-    ),
-  ) as Partial<Record<"collaboration_mode" | "reasoning" | "effort" | "fast_mode", string>>;
-}
-
 function pendingConfigValuesForSession(sessionId: string): Record<string, string> {
   const pendingConfigChanges = getSessionRecord(sessionId)?.pendingConfigChanges ?? {};
   return Object.fromEntries(
     Object.values(pendingConfigChanges)
       .map((change) => [change.rawConfigId, change.value] as const),
   );
-}
-
-function mergeLiveDefaultLaunchControls({
-  defaults,
-  agentKind,
-  values,
-}: {
-  defaults: Record<string, Partial<Record<"collaboration_mode" | "reasoning" | "effort" | "fast_mode", string>>>;
-  agentKind: string;
-  values: Record<string, string>;
-}): Record<string, Partial<Record<"collaboration_mode" | "reasoning" | "effort" | "fast_mode", string>>> {
-  const liveControls = pickLiveDefaultLaunchControls(values);
-  if (Object.keys(liveControls).length === 0) {
-    return defaults;
-  }
-
-  return {
-    ...defaults,
-    [agentKind]: {
-      ...(defaults[agentKind] ?? {}),
-      ...liveControls,
-    },
-  };
-}
-
-function findCompatibleExistingSession({
-  sessions,
-  agentKind,
-  modelId,
-}: {
-  sessions: readonly Session[];
-  agentKind: string;
-  modelId: string;
-}): Session | null {
-  return sessions.find((session) =>
-    session.agentKind === agentKind
-    && (!session.modelId || session.modelId === modelId)
-  ) ?? null;
 }
 
 function materializedRecordFromExistingSession({

--- a/desktop/src/hooks/sessions/workflows/use-session-model-availability-workflow.test.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-model-availability-workflow.test.ts
@@ -6,8 +6,8 @@ import {
 import {
   resetSessionModelAvailabilityStore,
   useSessionModelAvailabilityStore,
-  type PausedSessionModelAvailability,
 } from "@/stores/sessions/model-availability-store";
+import type { PausedSessionModelAvailability } from "@/lib/domain/sessions/creation/model-availability";
 
 const PAUSED_LAUNCH: PausedSessionModelAvailability = {
   id: "session-1:gpt-5.5:gpt-5.4",

--- a/desktop/src/hooks/sessions/workflows/use-session-model-availability-workflow.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-model-availability-workflow.ts
@@ -1,12 +1,11 @@
 import { useCallback } from "react";
 import {
-  type PausedSessionModelAvailability,
   type SessionModelAvailabilityDecision,
   useSessionModelAvailabilityStore,
 } from "@/stores/sessions/model-availability-store";
+import type { PausedSessionModelAvailability } from "@/lib/domain/sessions/creation/model-availability";
 
 export type {
-  PausedSessionModelAvailability,
   SessionModelAvailabilityDecision,
   SessionModelAvailabilityDecisionKind,
 } from "@/stores/sessions/model-availability-store";

--- a/desktop/src/lib/domain/sessions/creation/compatible-session.test.ts
+++ b/desktop/src/lib/domain/sessions/creation/compatible-session.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "@anyharness/sdk";
+import { findCompatibleExistingSession } from "@/lib/domain/sessions/creation/compatible-session";
+
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: "session-1",
+    workspaceId: "workspace-1",
+    agentKind: "codex",
+    modelId: "gpt-5.4",
+    status: "idle",
+    createdAt: "2026-04-28T00:00:00.000Z",
+    updatedAt: "2026-04-28T00:00:00.000Z",
+    ...overrides,
+  } as Session;
+}
+
+describe("findCompatibleExistingSession", () => {
+  it("matches sessions with the requested agent and model", () => {
+    const matched = session({ id: "match", modelId: "gpt-5.5" });
+
+    expect(findCompatibleExistingSession({
+      sessions: [
+        session({ id: "wrong-agent", agentKind: "claude", modelId: "gpt-5.5" }),
+        matched,
+      ],
+      agentKind: "codex",
+      modelId: "gpt-5.5",
+    })).toBe(matched);
+  });
+
+  it("treats missing model ids as compatible", () => {
+    const matched = session({ id: "match", modelId: null });
+
+    expect(findCompatibleExistingSession({
+      sessions: [matched],
+      agentKind: "codex",
+      modelId: "gpt-5.5",
+    })).toBe(matched);
+  });
+
+  it("returns null when no session matches", () => {
+    expect(findCompatibleExistingSession({
+      sessions: [session({ id: "wrong-model", modelId: "gpt-5.4" })],
+      agentKind: "codex",
+      modelId: "gpt-5.5",
+    })).toBeNull();
+  });
+});

--- a/desktop/src/lib/domain/sessions/creation/compatible-session.ts
+++ b/desktop/src/lib/domain/sessions/creation/compatible-session.ts
@@ -1,0 +1,16 @@
+import type { Session } from "@anyharness/sdk";
+
+export function findCompatibleExistingSession({
+  sessions,
+  agentKind,
+  modelId,
+}: {
+  sessions: readonly Session[];
+  agentKind: string;
+  modelId: string;
+}): Session | null {
+  return sessions.find((session) =>
+    session.agentKind === agentKind
+    && (!session.modelId || session.modelId === modelId)
+  ) ?? null;
+}

--- a/desktop/src/lib/domain/sessions/creation/launch-controls.test.ts
+++ b/desktop/src/lib/domain/sessions/creation/launch-controls.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeLiveDefaultLaunchControls,
+  pickLiveDefaultLaunchControls,
+} from "@/lib/domain/sessions/creation/launch-controls";
+
+describe("pickLiveDefaultLaunchControls", () => {
+  it("keeps only launch controls that should become live defaults", () => {
+    expect(pickLiveDefaultLaunchControls({
+      collaboration_mode: "solo",
+      reasoning: "high",
+      effort: "",
+      fast_mode: "enabled",
+      mode: "danger",
+      access_mode: "read-only",
+    })).toEqual({
+      collaboration_mode: "solo",
+      reasoning: "high",
+      fast_mode: "enabled",
+    });
+  });
+
+  it("returns an empty object for missing values", () => {
+    expect(pickLiveDefaultLaunchControls(undefined)).toEqual({});
+  });
+});
+
+describe("mergeLiveDefaultLaunchControls", () => {
+  it("overlays picked controls for the requested agent", () => {
+    expect(mergeLiveDefaultLaunchControls({
+      defaults: {
+        codex: {
+          reasoning: "medium",
+          effort: "low",
+        },
+      },
+      agentKind: "codex",
+      values: {
+        reasoning: "high",
+        collaboration_mode: "solo",
+        mode: "ignored",
+      },
+    })).toEqual({
+      codex: {
+        reasoning: "high",
+        effort: "low",
+        collaboration_mode: "solo",
+      },
+    });
+  });
+
+  it("returns the same defaults when no live controls are present", () => {
+    const defaults = { codex: { reasoning: "medium" } };
+
+    expect(mergeLiveDefaultLaunchControls({
+      defaults,
+      agentKind: "codex",
+      values: { mode: "ignored" },
+    })).toBe(defaults);
+  });
+});

--- a/desktop/src/lib/domain/sessions/creation/launch-controls.ts
+++ b/desktop/src/lib/domain/sessions/creation/launch-controls.ts
@@ -1,0 +1,52 @@
+export type LiveDefaultLaunchControlId =
+  | "collaboration_mode"
+  | "reasoning"
+  | "effort"
+  | "fast_mode";
+
+export type LiveDefaultLaunchControls = Partial<Record<LiveDefaultLaunchControlId, string>>;
+
+export type LiveDefaultLaunchControlsByAgent = Record<string, LiveDefaultLaunchControls>;
+
+const LIVE_DEFAULT_LAUNCH_CONTROL_IDS = new Set<string>([
+  "collaboration_mode",
+  "reasoning",
+  "effort",
+  "fast_mode",
+]);
+
+export function pickLiveDefaultLaunchControls(
+  values: Record<string, string> | undefined,
+): LiveDefaultLaunchControls {
+  if (!values) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(values).filter(([key, value]) =>
+      LIVE_DEFAULT_LAUNCH_CONTROL_IDS.has(key) && value.trim().length > 0
+    ),
+  ) as LiveDefaultLaunchControls;
+}
+
+export function mergeLiveDefaultLaunchControls({
+  defaults,
+  agentKind,
+  values,
+}: {
+  defaults: LiveDefaultLaunchControlsByAgent;
+  agentKind: string;
+  values: Record<string, string>;
+}): LiveDefaultLaunchControlsByAgent {
+  const liveControls = pickLiveDefaultLaunchControls(values);
+  if (Object.keys(liveControls).length === 0) {
+    return defaults;
+  }
+
+  return {
+    ...defaults,
+    [agentKind]: {
+      ...(defaults[agentKind] ?? {}),
+      ...liveControls,
+    },
+  };
+}

--- a/desktop/src/lib/domain/sessions/creation/mode.test.ts
+++ b/desktop/src/lib/domain/sessions/creation/mode.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionCreationModeId } from "@/lib/domain/sessions/creation/mode";
+
+describe("resolveSessionCreationModeId", () => {
+  it("lets an explicit mode override the stored user default", () => {
+    expect(resolveSessionCreationModeId({
+      explicitModeId: "bypassPermissions",
+      workspaceSurface: "coding",
+      agentKind: "claude",
+      preferredModeId: "plan",
+    })).toBe("bypassPermissions");
+  });
+
+  it("lets an explicit mode override the cowork default", () => {
+    expect(resolveSessionCreationModeId({
+      explicitModeId: "default",
+      workspaceSurface: "cowork",
+      agentKind: "claude",
+      preferredModeId: "plan",
+    })).toBe("default");
+  });
+
+  it("falls back to the cowork default when no explicit mode is provided", () => {
+    expect(resolveSessionCreationModeId({
+      workspaceSurface: "cowork",
+      agentKind: "codex",
+      preferredModeId: "read-only",
+    })).toBe("full-access");
+  });
+
+  it("falls back to the stored user default outside cowork", () => {
+    expect(resolveSessionCreationModeId({
+      workspaceSurface: "coding",
+      agentKind: "codex",
+      preferredModeId: "auto",
+    })).toBe("auto");
+  });
+});

--- a/desktop/src/lib/domain/sessions/creation/mode.ts
+++ b/desktop/src/lib/domain/sessions/creation/mode.ts
@@ -1,0 +1,19 @@
+import { resolveCoworkDefaultSessionModeId } from "@/lib/domain/cowork/session-mode-defaults";
+
+export function resolveSessionCreationModeId(input: {
+  explicitModeId?: string | null;
+  workspaceSurface: string | null | undefined;
+  agentKind: string;
+  preferredModeId?: string | null;
+}): string | undefined {
+  const explicitModeId = input.explicitModeId?.trim() || undefined;
+  if (explicitModeId) {
+    return explicitModeId;
+  }
+
+  if (input.workspaceSurface === "cowork") {
+    return resolveCoworkDefaultSessionModeId(input.agentKind);
+  }
+
+  return input.preferredModeId?.trim() || undefined;
+}

--- a/desktop/src/lib/domain/sessions/creation/model-availability.test.ts
+++ b/desktop/src/lib/domain/sessions/creation/model-availability.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ModelRegistry,
+  Session,
+  WorkspaceSessionLaunchCatalog,
+} from "@anyharness/sdk";
+import {
+  buildPausedModelAvailability,
+  hasImmediateLaunchModelMismatch,
+} from "@/lib/domain/sessions/creation/model-availability";
+
+const registry: ModelRegistry = {
+  kind: "codex",
+  displayName: "Codex",
+  defaultModelId: "gpt-5.4",
+  models: [
+    {
+      id: "gpt-5.5",
+      displayName: "GPT 5.5",
+      isDefault: false,
+      status: "active",
+      aliases: ["gpt-5.5-latest"],
+      minRuntimeVersion: null,
+      launchRemediation: {
+        kind: "managed_reinstall",
+        message: "Update Codex tools and retry.",
+      },
+    },
+    {
+      id: "gpt-5.4",
+      displayName: "GPT 5.4",
+      isDefault: true,
+      status: "active",
+      aliases: [],
+      minRuntimeVersion: null,
+      launchRemediation: null,
+    },
+  ],
+};
+
+function sessionModelPair(
+  requestedModelId: string,
+  modelId: string,
+): Session {
+  return {
+    id: "session-1",
+    workspaceId: "workspace-1",
+    agentKind: "codex",
+    requestedModelId,
+    modelId,
+    status: "idle",
+    createdAt: "2026-04-28T00:00:00.000Z",
+    updatedAt: "2026-04-28T00:00:00.000Z",
+  } as Session;
+}
+
+function launchCatalog(modelIds: string[]): WorkspaceSessionLaunchCatalog {
+  return {
+    workspaceId: "workspace-1",
+    catalogVersion: "test",
+    agents: [
+      {
+        kind: "codex",
+        displayName: "Codex",
+        defaultModelId: modelIds[0] ?? null,
+        models: modelIds.map((id) => ({
+          id,
+          displayName: id,
+          isDefault: id === modelIds[0],
+        })),
+      },
+    ],
+  };
+}
+
+describe("hasImmediateLaunchModelMismatch", () => {
+  it("requires a remediable requested model that is absent from the live launch catalog", () => {
+    expect(hasImmediateLaunchModelMismatch({
+      session: sessionModelPair("gpt-5.5", "gpt-5.4"),
+      agentKind: "codex",
+      registries: [registry],
+      launchCatalog: launchCatalog(["gpt-5.4"]),
+    })).toBe(true);
+  });
+
+  it("does not treat live-exposed aliases as unavailable", () => {
+    expect(hasImmediateLaunchModelMismatch({
+      session: sessionModelPair("gpt-5.5", "gpt-5.4"),
+      agentKind: "codex",
+      registries: [registry],
+      launchCatalog: launchCatalog(["gpt-5.5-latest"]),
+    })).toBe(false);
+  });
+
+  it("does not pause for mismatches without remediation metadata", () => {
+    expect(hasImmediateLaunchModelMismatch({
+      session: sessionModelPair("gpt-5.4", "gpt-5.5"),
+      agentKind: "codex",
+      registries: [registry],
+      launchCatalog: launchCatalog(["gpt-5.5"]),
+    })).toBe(false);
+  });
+});
+
+describe("buildPausedModelAvailability", () => {
+  it("builds the paused launch descriptor from requested and current models", () => {
+    expect(buildPausedModelAvailability({
+      session: sessionModelPair("gpt-5.5", "gpt-5.4"),
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      registries: [registry],
+    })).toEqual({
+      id: "session-1:gpt-5.5:gpt-5.4",
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      providerDisplayName: "Codex",
+      requestedModelId: "gpt-5.5",
+      requestedModelDisplayName: "GPT 5.5",
+      currentModelId: "gpt-5.4",
+      currentModelDisplayName: "GPT 5.4",
+      remediation: {
+        kind: "managed_reinstall",
+        message: "Update Codex tools and retry.",
+      },
+    });
+  });
+});

--- a/desktop/src/lib/domain/sessions/creation/model-availability.ts
+++ b/desktop/src/lib/domain/sessions/creation/model-availability.ts
@@ -1,0 +1,113 @@
+import type {
+  ModelLaunchRemediation,
+  ModelRegistry,
+  ModelRegistryModel,
+  Session,
+  WorkspaceSessionLaunchCatalog,
+} from "@anyharness/sdk";
+
+export interface PausedSessionModelAvailability {
+  id: string;
+  sessionId: string;
+  workspaceId: string;
+  agentKind: string;
+  providerDisplayName: string;
+  requestedModelId: string;
+  requestedModelDisplayName: string;
+  currentModelId: string;
+  currentModelDisplayName: string;
+  remediation: ModelLaunchRemediation | null;
+}
+
+function modelMatchesId(model: Pick<ModelRegistryModel, "id" | "aliases">, modelId: string): boolean {
+  return model.id === modelId || (model.aliases ?? []).includes(modelId);
+}
+
+function findRegistryModel(
+  registries: ModelRegistry[],
+  agentKind: string,
+  modelId: string,
+) {
+  const registry = registries.find((candidate) => candidate.kind === agentKind) ?? null;
+  const model = registry?.models.find((candidate) => modelMatchesId(candidate, modelId)) ?? null;
+  return { registry, model };
+}
+
+function launchCatalogExposesModel(input: {
+  launchCatalog: WorkspaceSessionLaunchCatalog;
+  agentKind: string;
+  requestedModelId: string;
+  requestedModel: ModelRegistryModel;
+}): boolean {
+  const agent = input.launchCatalog.agents.find((candidate) =>
+    candidate.kind === input.agentKind
+  );
+  if (!agent) {
+    return false;
+  }
+
+  const acceptedIds = new Set([
+    input.requestedModelId,
+    input.requestedModel.id,
+    ...(input.requestedModel.aliases ?? []),
+  ]);
+  return agent.models.some((model) => acceptedIds.has(model.id));
+}
+
+export function hasImmediateLaunchModelMismatch(input: {
+  session: Session;
+  agentKind: string;
+  registries: ModelRegistry[];
+  launchCatalog: WorkspaceSessionLaunchCatalog;
+}): boolean {
+  const requestedModelId = input.session.requestedModelId;
+  const currentModelId = input.session.modelId;
+  if (!requestedModelId || !currentModelId || requestedModelId === currentModelId) {
+    return false;
+  }
+
+  const requested = findRegistryModel(
+    input.registries,
+    input.agentKind,
+    requestedModelId,
+  );
+  if (!requested.model?.launchRemediation) {
+    return false;
+  }
+
+  return !launchCatalogExposesModel({
+    launchCatalog: input.launchCatalog,
+    agentKind: input.agentKind,
+    requestedModelId,
+    requestedModel: requested.model,
+  });
+}
+
+export function buildPausedModelAvailability(input: {
+  session: Session;
+  workspaceId: string;
+  agentKind: string;
+  registries: ModelRegistry[];
+}): PausedSessionModelAvailability {
+  const requestedModelId = input.session.requestedModelId ?? "";
+  const currentModelId = input.session.modelId ?? "";
+  const requested = findRegistryModel(input.registries, input.agentKind, requestedModelId);
+  const current = findRegistryModel(input.registries, input.agentKind, currentModelId);
+  const providerDisplayName =
+    requested.registry?.displayName
+    ?? current.registry?.displayName
+    ?? input.agentKind;
+
+  return {
+    id: `${input.session.id}:${requestedModelId}:${currentModelId}`,
+    sessionId: input.session.id,
+    workspaceId: input.workspaceId,
+    agentKind: input.agentKind,
+    providerDisplayName,
+    requestedModelId,
+    requestedModelDisplayName: requested.model?.displayName ?? requestedModelId,
+    currentModelId,
+    currentModelDisplayName: current.model?.displayName ?? currentModelId,
+    remediation: requested.model?.launchRemediation ?? null,
+  };
+}

--- a/desktop/src/stores/sessions/model-availability-store.ts
+++ b/desktop/src/stores/sessions/model-availability-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ModelLaunchRemediation } from "@anyharness/sdk";
+import type { PausedSessionModelAvailability } from "@/lib/domain/sessions/creation/model-availability";
 
 export type SessionModelAvailabilityDecisionKind =
   | "managed_reinstall"
@@ -10,19 +10,6 @@ export type SessionModelAvailabilityDecisionKind =
 
 export interface SessionModelAvailabilityDecision {
   kind: SessionModelAvailabilityDecisionKind;
-}
-
-export interface PausedSessionModelAvailability {
-  id: string;
-  sessionId: string;
-  workspaceId: string;
-  agentKind: string;
-  providerDisplayName: string;
-  requestedModelId: string;
-  requestedModelDisplayName: string;
-  currentModelId: string;
-  currentModelDisplayName: string;
-  remediation: ModelLaunchRemediation | null;
 }
 
 type DecisionResolver = (decision: SessionModelAvailabilityDecision) => void;


### PR DESCRIPTION
## Summary
- move pure session creation mode, launch-control, compatible-session, and model-availability logic into lib/domain/sessions/creation
- move PausedSessionModelAvailability ownership out of the store and into the creation domain model
- keep store-coupled session creation helpers in the hook layer for later workflow/lifecycle lanes

## Verification
- pnpm --dir desktop exec vitest run src/lib/domain/sessions/creation/mode.test.ts src/lib/domain/sessions/creation/launch-controls.test.ts src/lib/domain/sessions/creation/compatible-session.test.ts src/lib/domain/sessions/creation/model-availability.test.ts src/hooks/sessions/use-session-creation-actions.test.ts src/hooks/sessions/workflows/use-session-model-availability-workflow.test.ts
- pnpm --dir desktop exec tsc --noEmit
- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check