### PR TITLE
refactor(desktop): extract session history domain helpers

### DIFF
--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -3,6 +3,10 @@ import {
   replaySessionHistory,
 } from "@/lib/domain/sessions/stream/stream-state";
 import {
+  mergeFetchedHistoryWithExistingEvents,
+  mergeFetchedHistoryWithNewerEvents,
+} from "@/lib/domain/sessions/history/history-event-merge";
+import {
   createTranscriptState,
   type Session,
   type SessionEventEnvelope,
@@ -29,6 +33,7 @@ import {
   type MeasurementOperationKind,
   type MeasurementSurface,
 } from "@/lib/infra/measurement/debug-measurement";
+import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation-ids";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import { markLatencyFlowLiveAttached } from "@/lib/infra/measurement/latency-flow";
 import {
@@ -1127,25 +1132,6 @@ function isSessionHistoryTimeoutAbort(error: unknown): boolean {
     && error.message === "Session history request timed out";
 }
 
-function mergeFetchedHistoryWithNewerEvents(
-  fetchedEvents: SessionEventEnvelope[],
-  currentEvents: SessionEventEnvelope[],
-): SessionEventEnvelope[] {
-  const fetchedLastSeq = fetchedEvents.length > 0
-    ? fetchedEvents[fetchedEvents.length - 1]?.seq ?? 0
-    : 0;
-  if (fetchedLastSeq <= 0) {
-    return fetchedEvents;
-  }
-
-  const newerEvents = currentEvents.filter((event) => event.seq > fetchedLastSeq);
-  if (newerEvents.length === 0) {
-    return fetchedEvents;
-  }
-
-  return [...fetchedEvents, ...newerEvents].sort((a, b) => a.seq - b.seq);
-}
-
 function resolveHistoryApplyOperationKind(input: {
   afterSeq?: number;
   beforeSeq?: number;
@@ -1211,12 +1197,6 @@ function applyHistoryStateToStores(
   });
 }
 
-function uniqueMeasurementOperationIds(
-  operationIds: readonly (MeasurementOperationId | null | undefined)[],
-): MeasurementOperationId[] {
-  return [...new Set(operationIds.filter((id): id is MeasurementOperationId => !!id))];
-}
-
 function createFlushAwareSessionStreamHandle(
   handle: SessionStreamHandle,
   streamFlushController: SessionStreamFlushController,
@@ -1267,23 +1247,4 @@ function recordHistoryStateCounts(
     target: isBefore ? "session.history.items_before" : "session.history.items_after",
     count: Object.keys(transcript.itemsById).length,
   });
-}
-
-function mergeFetchedHistoryWithExistingEvents(
-  fetchedEvents: SessionEventEnvelope[],
-  currentEvents: SessionEventEnvelope[],
-): SessionEventEnvelope[] {
-  if (fetchedEvents.length === 0) {
-    return currentEvents;
-  }
-
-  const eventsBySeq = new Map<number, SessionEventEnvelope>();
-  for (const event of currentEvents) {
-    eventsBySeq.set(event.seq, event);
-  }
-  for (const event of fetchedEvents) {
-    eventsBySeq.set(event.seq, event);
-  }
-
-  return Array.from(eventsBySeq.values()).sort((a, b) => a.seq - b.seq);
 }

--- a/desktop/src/hooks/sessions/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.ts
@@ -13,6 +13,7 @@ import {
   type MeasurementOperationId,
   type MeasurementSurface,
 } from "@/lib/infra/measurement/debug-measurement";
+import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation-ids";
 import type {
   SessionChildRelationship,
   SessionRelationship,
@@ -472,12 +473,6 @@ function reconcileBatchPendingConfigChanges(
     pendingConfigChanges: nextPendingConfigChanges,
     reconciledIntents,
   };
-}
-
-function uniqueMeasurementOperationIds(
-  operationIds: readonly (MeasurementOperationId | null | undefined)[],
-): MeasurementOperationId[] {
-  return [...new Set(operationIds.filter((id): id is MeasurementOperationId => !!id))];
 }
 
 function recordStreamStateCounts(

--- a/desktop/src/lib/domain/sessions/history/history-event-merge.test.ts
+++ b/desktop/src/lib/domain/sessions/history/history-event-merge.test.ts
@@ -1,0 +1,57 @@
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  mergeFetchedHistoryWithExistingEvents,
+  mergeFetchedHistoryWithNewerEvents,
+} from "@/lib/domain/sessions/history/history-event-merge";
+
+function event(seq: number, marker = `event-${seq}`): SessionEventEnvelope {
+  return { seq, marker } as unknown as SessionEventEnvelope;
+}
+
+describe("mergeFetchedHistoryWithNewerEvents", () => {
+  it("keeps fetched history and appends newer current events by seq", () => {
+    const fetched = [event(1), event(3)];
+    const current = [event(2), event(5), event(4)];
+
+    expect(mergeFetchedHistoryWithNewerEvents(fetched, current)).toEqual([
+      event(1),
+      event(3),
+      event(4),
+      event(5),
+    ]);
+  });
+
+  it("returns fetched events when current has no newer events", () => {
+    const fetched = [event(1), event(3)];
+    const current = [event(1), event(2), event(3)];
+
+    expect(mergeFetchedHistoryWithNewerEvents(fetched, current)).toBe(fetched);
+  });
+
+  it("does not append current events when fetched history has no positive seq tail", () => {
+    const fetched = [event(0)];
+    const current = [event(1)];
+
+    expect(mergeFetchedHistoryWithNewerEvents(fetched, current)).toBe(fetched);
+  });
+});
+
+describe("mergeFetchedHistoryWithExistingEvents", () => {
+  it("merges by seq and lets fetched history replace existing events", () => {
+    const current = [event(2, "current-2"), event(4, "current-4")];
+    const fetched = [event(1, "fetched-1"), event(2, "fetched-2")];
+
+    expect(mergeFetchedHistoryWithExistingEvents(fetched, current)).toEqual([
+      event(1, "fetched-1"),
+      event(2, "fetched-2"),
+      event(4, "current-4"),
+    ]);
+  });
+
+  it("returns current events when fetched history is empty", () => {
+    const current = [event(2), event(4)];
+
+    expect(mergeFetchedHistoryWithExistingEvents([], current)).toBe(current);
+  });
+});

--- a/desktop/src/lib/domain/sessions/history/history-event-merge.ts
+++ b/desktop/src/lib/domain/sessions/history/history-event-merge.ts
@@ -1,0 +1,39 @@
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+
+export function mergeFetchedHistoryWithNewerEvents(
+  fetchedEvents: SessionEventEnvelope[],
+  currentEvents: SessionEventEnvelope[],
+): SessionEventEnvelope[] {
+  const fetchedLastSeq = fetchedEvents.length > 0
+    ? fetchedEvents[fetchedEvents.length - 1]?.seq ?? 0
+    : 0;
+  if (fetchedLastSeq <= 0) {
+    return fetchedEvents;
+  }
+
+  const newerEvents = currentEvents.filter((event) => event.seq > fetchedLastSeq);
+  if (newerEvents.length === 0) {
+    return fetchedEvents;
+  }
+
+  return [...fetchedEvents, ...newerEvents].sort((a, b) => a.seq - b.seq);
+}
+
+export function mergeFetchedHistoryWithExistingEvents(
+  fetchedEvents: SessionEventEnvelope[],
+  currentEvents: SessionEventEnvelope[],
+): SessionEventEnvelope[] {
+  if (fetchedEvents.length === 0) {
+    return currentEvents;
+  }
+
+  const eventsBySeq = new Map<number, SessionEventEnvelope>();
+  for (const event of currentEvents) {
+    eventsBySeq.set(event.seq, event);
+  }
+  for (const event of fetchedEvents) {
+    eventsBySeq.set(event.seq, event);
+  }
+
+  return Array.from(eventsBySeq.values()).sort((a, b) => a.seq - b.seq);
+}

--- a/desktop/src/lib/infra/measurement/operation-ids.test.ts
+++ b/desktop/src/lib/infra/measurement/operation-ids.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { MeasurementOperationId } from "@/lib/infra/measurement/debug-measurement";
+import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation-ids";
+
+function operationId(id: string): MeasurementOperationId {
+  return id as MeasurementOperationId;
+}
+
+describe("uniqueMeasurementOperationIds", () => {
+  it("removes empty ids and preserves the first occurrence order", () => {
+    expect(uniqueMeasurementOperationIds([
+      null,
+      operationId("op-1"),
+      undefined,
+      operationId("op-2"),
+      operationId("op-1"),
+    ])).toEqual([
+      operationId("op-1"),
+      operationId("op-2"),
+    ]);
+  });
+});

--- a/desktop/src/lib/infra/measurement/operation-ids.ts
+++ b/desktop/src/lib/infra/measurement/operation-ids.ts
@@ -1,0 +1,7 @@
+import type { MeasurementOperationId } from "@/lib/infra/measurement/debug-measurement";
+
+export function uniqueMeasurementOperationIds(
+  operationIds: readonly (MeasurementOperationId | null | undefined)[],
+): MeasurementOperationId[] {
+  return [...new Set(operationIds.filter((id): id is MeasurementOperationId => !!id))];
+}


### PR DESCRIPTION
## Summary

- Move pure session history event merge helpers into `lib/domain/sessions/history`.
- Move measurement operation id deduplication into `lib/infra/measurement` and reuse it from runtime history and stream flush code.
- Keep store writes, measurement finishing, and stream side effects in the existing session hooks.

## Verification

- `pnpm --dir desktop exec vitest run src/lib/domain/sessions/history/history-event-merge.test.ts src/lib/infra/measurement/operation-ids.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
