### PR TITLE
refactor(desktop): extract session selection planner

### DIFF
--- a/desktop/src/hooks/sessions/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-selection-actions.ts
@@ -40,6 +40,7 @@ import {
   type MeasurementOperationId,
 } from "@/lib/infra/measurement/debug-measurement";
 import { isHotReopenEligibleSessionSlot } from "@/lib/domain/workspaces/selection/hot-reopen";
+import { resolveTrustedSessionSelectionRelationship } from "@/lib/domain/sessions/selection/trusted-session-selection";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import {
   commitHotActiveSession,
@@ -81,18 +82,24 @@ type SessionLatencyFlowOptions = SelectSessionOptionsWithoutGuard & {
 export function classifyTrustedSessionSelection(sessionId: string): SessionRelationship {
   const state = useSessionDirectoryStore.getState();
   const slot = state.entriesById[sessionId] ?? null;
-  if (slot && slot.sessionRelationship.kind !== "pending") {
-    return slot.sessionRelationship;
-  }
   const relationshipHint =
     state.relationshipHintsBySessionId[sessionId] as SessionChildRelationship | undefined;
-  const relationship = relationshipHint ?? { kind: "root" as const };
-  if (relationship.kind === "root") {
-    state.setSessionRelationship(sessionId, relationship);
-  } else {
-    state.recordRelationshipHint(sessionId, relationship);
+
+  const plan = resolveTrustedSessionSelectionRelationship<
+    SessionRelationship,
+    SessionChildRelationship
+  >({
+    currentRelationship: slot?.sessionRelationship ?? null,
+    relationshipHint,
+    rootRelationship: { kind: "root" },
+  });
+
+  if (plan.commitAction === "promote_root") {
+    state.setSessionRelationship(sessionId, plan.relationship);
+  } else if (plan.commitAction === "apply_hint") {
+    state.recordRelationshipHint(sessionId, plan.relationship);
   }
-  return relationship;
+  return plan.relationship;
 }
 
 export async function fetchWorkspaceSessions(

--- a/desktop/src/lib/domain/sessions/selection/trusted-session-selection.test.ts
+++ b/desktop/src/lib/domain/sessions/selection/trusted-session-selection.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrustedSessionSelectionRelationship } from "@/lib/domain/sessions/selection/trusted-session-selection";
+
+type TestRelationship =
+  | { kind: "pending" }
+  | { kind: "root" }
+  | { kind: "child"; parentSessionId: string };
+
+type TestChildRelationship = Extract<TestRelationship, { kind: "child" }>;
+
+const ROOT_RELATIONSHIP: TestRelationship = { kind: "root" };
+
+describe("resolveTrustedSessionSelectionRelationship", () => {
+  it("keeps an already trusted relationship without a store commit", () => {
+    const currentRelationship: TestRelationship = {
+      kind: "child",
+      parentSessionId: "parent-session",
+    };
+
+    expect(resolveTrustedSessionSelectionRelationship<TestRelationship, TestChildRelationship>({
+      currentRelationship,
+      relationshipHint: null,
+      rootRelationship: ROOT_RELATIONSHIP,
+    })).toEqual({
+      commitAction: "none",
+      relationship: currentRelationship,
+    });
+  });
+
+  it("applies a child hint when the current relationship is pending", () => {
+    const relationshipHint: TestChildRelationship = {
+      kind: "child",
+      parentSessionId: "parent-session",
+    };
+
+    expect(resolveTrustedSessionSelectionRelationship<TestRelationship, TestChildRelationship>({
+      currentRelationship: { kind: "pending" },
+      relationshipHint,
+      rootRelationship: ROOT_RELATIONSHIP,
+    })).toEqual({
+      commitAction: "apply_hint",
+      relationship: relationshipHint,
+    });
+  });
+
+  it("promotes a pending session to root when no child hint exists", () => {
+    expect(resolveTrustedSessionSelectionRelationship<TestRelationship, TestChildRelationship>({
+      currentRelationship: { kind: "pending" },
+      relationshipHint: null,
+      rootRelationship: ROOT_RELATIONSHIP,
+    })).toEqual({
+      commitAction: "promote_root",
+      relationship: ROOT_RELATIONSHIP,
+    });
+  });
+});

--- a/desktop/src/lib/domain/sessions/selection/trusted-session-selection.ts
+++ b/desktop/src/lib/domain/sessions/selection/trusted-session-selection.ts
@@ -1,0 +1,46 @@
+type SessionRelationshipKind = "pending" | string;
+
+export type TrustedSessionSelectionRelationshipPlan<
+  TRelationship extends { kind: SessionRelationshipKind },
+  TChildRelationship extends TRelationship,
+> =
+  | {
+    commitAction: "none";
+    relationship: TRelationship;
+  }
+  | {
+    commitAction: "promote_root";
+    relationship: TRelationship;
+  }
+  | {
+    commitAction: "apply_hint";
+    relationship: TChildRelationship;
+  };
+
+export function resolveTrustedSessionSelectionRelationship<
+  TRelationship extends { kind: SessionRelationshipKind },
+  TChildRelationship extends TRelationship,
+>(input: {
+  currentRelationship: TRelationship | null | undefined;
+  relationshipHint: TChildRelationship | null | undefined;
+  rootRelationship: TRelationship;
+}): TrustedSessionSelectionRelationshipPlan<TRelationship, TChildRelationship> {
+  if (input.currentRelationship && input.currentRelationship.kind !== "pending") {
+    return {
+      commitAction: "none",
+      relationship: input.currentRelationship,
+    };
+  }
+
+  if (input.relationshipHint) {
+    return {
+      commitAction: "apply_hint",
+      relationship: input.relationshipHint,
+    };
+  }
+
+  return {
+    commitAction: "promote_root",
+    relationship: input.rootRelationship,
+  };
+}


### PR DESCRIPTION
## Summary

- Add a pure session selection relationship planner under `lib/domain/sessions/selection`.
- Keep the existing `classifyTrustedSessionSelection` hook helper as the store adapter that reads hints and commits the selected relationship.
- Add domain planner coverage while preserving existing store behavior tests.

## Verification

- `pnpm --dir desktop exec vitest run src/lib/domain/sessions/selection/trusted-session-selection.test.ts src/hooks/sessions/use-session-selection-actions.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
