### PR TITLE
refactor(desktop): split session runtime summary and history

### DIFF
--- a/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -1,0 +1,501 @@
+import {
+  type SessionEventEnvelope,
+  type TranscriptState,
+} from "@anyharness/sdk";
+import { useCallback } from "react";
+import {
+  mergeFetchedHistoryWithExistingEvents,
+  mergeFetchedHistoryWithNewerEvents,
+} from "@/lib/domain/sessions/history/history-event-merge";
+import { resolveSessionStatus } from "@/lib/domain/sessions/activity";
+import {
+  appendHistoryTail,
+  replaySessionHistory,
+} from "@/lib/domain/sessions/stream/stream-state";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
+import {
+  finishOrCancelMeasurementOperation,
+  markOperationForNextCommit,
+  recordMeasurementMetric,
+  recordMeasurementWorkflowStep,
+  startMeasurementOperation,
+  type MeasurementOperationId,
+  type MeasurementOperationKind,
+  type MeasurementSurface,
+} from "@/lib/infra/measurement/debug-measurement";
+import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation-ids";
+import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
+import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
+import { fetchSessionHistory } from "@/lib/workflows/sessions/session-runtime";
+import { useLinkedSessionMounting } from "@/hooks/chat/subagents/use-linked-session-mounting";
+import {
+  activityFromTranscript,
+  useSessionDirectoryStore,
+} from "@/stores/sessions/session-directory-store";
+import { getSessionRecord } from "@/stores/sessions/session-records";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
+
+const SESSION_APPLY_MEASUREMENT_SURFACES: readonly MeasurementSurface[] = [
+  "session-transcript-pane",
+  "transcript-list",
+  "chat-surface",
+  "header-tabs",
+  "workspace-sidebar",
+  "global-header",
+  "chat-composer-dock",
+];
+const SESSION_HISTORY_APPLY_MAX_DURATION_MS = 30_000;
+
+interface SessionHistoryHydrationOptions {
+  afterSeq?: number;
+  beforeSeq?: number;
+  limit?: number;
+  turnLimit?: number;
+  replace?: boolean;
+  requestHeaders?: HeadersInit;
+  measurementOperationId?: MeasurementOperationId | null;
+  timeoutMs?: number;
+  isCurrent?: () => boolean;
+}
+
+/**
+ * Owns fetching, replaying, and applying historical session events.
+ * Stream handle lifecycle stays in useSessionRuntimeActions.
+ */
+export function useSessionHistoryHydration() {
+  const { mountSubagentChildrenFromEvents } = useLinkedSessionMounting();
+
+  const rehydrateSessionSlotFromHistory = useCallback(async (
+    sessionId: string,
+    options?: SessionHistoryHydrationOptions,
+  ): Promise<boolean> => {
+    const startedAt = performance.now();
+    let standaloneMeasurementOperationId: MeasurementOperationId | null = null;
+    try {
+      if (options?.isCurrent && !options.isCurrent()) {
+        return false;
+      }
+      const slot = getSessionRecord(sessionId);
+      if (!slot) {
+        return false;
+      }
+
+      const afterSeq = options?.replace ? undefined : options?.afterSeq;
+      const beforeSeq = options?.replace || afterSeq != null ? undefined : options?.beforeSeq;
+      standaloneMeasurementOperationId = startMeasurementOperation({
+        kind: resolveHistoryApplyOperationKind({ afterSeq, beforeSeq }),
+        surfaces: SESSION_APPLY_MEASUREMENT_SURFACES,
+        maxDurationMs: SESSION_HISTORY_APPLY_MAX_DURATION_MS,
+      });
+      const requestMeasurementOperationId =
+        options?.measurementOperationId ?? standaloneMeasurementOperationId;
+      const historyApplyOperationIds = uniqueMeasurementOperationIds([
+        options?.measurementOperationId,
+        standaloneMeasurementOperationId,
+      ]);
+      for (const operationId of historyApplyOperationIds) {
+        recordHistoryStateCounts(
+          operationId,
+          "before",
+          slot.events,
+          slot.transcript,
+        );
+      }
+      const fetchStartedAt = performance.now();
+      const events = await fetchSessionHistory(
+        sessionId,
+        afterSeq != null
+          || beforeSeq != null
+          || options?.limit != null
+          || options?.turnLimit != null
+          || options?.requestHeaders
+          || requestMeasurementOperationId
+          || options?.timeoutMs != null
+          ? {
+            ...(afterSeq != null ? { afterSeq } : {}),
+            ...(beforeSeq != null ? { beforeSeq } : {}),
+            ...(options?.limit != null ? { limit: options.limit } : {}),
+            ...(options?.turnLimit != null ? { turnLimit: options.turnLimit } : {}),
+            ...(options?.requestHeaders
+              ? { requestHeaders: options.requestHeaders }
+              : {}),
+            ...(requestMeasurementOperationId
+              ? { measurementOperationId: requestMeasurementOperationId }
+              : {}),
+            ...(options?.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {}),
+          }
+          : undefined,
+      );
+      for (const operationId of historyApplyOperationIds) {
+        recordMeasurementWorkflowStep({
+          operationId,
+          step: "session.history.fetch",
+          startedAt: fetchStartedAt,
+          count: events.length,
+        });
+        recordMeasurementMetric({
+          type: "state_count",
+          operationId,
+          target: "session.history.events_fetched",
+          count: events.length,
+        });
+      }
+      const currentSlot = getSessionRecord(sessionId);
+      if (!currentSlot || (options?.isCurrent && !options.isCurrent())) {
+        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "aborted");
+        return false;
+      }
+
+      if (afterSeq != null) {
+        const replayStartedAt = performance.now();
+        const nextState = appendHistoryTail(
+          {
+            events: currentSlot.events,
+            transcript: currentSlot.transcript,
+          },
+          events,
+        );
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementMetric({
+            type: "reducer",
+            category: "session.events.list",
+            operationId,
+            durationMs: performance.now() - replayStartedAt,
+            count: events.length,
+          });
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.replay",
+            startedAt: replayStartedAt,
+            count: events.length,
+          });
+        }
+
+        if (!nextState.applied) {
+          finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed");
+          logLatency("session.history.rehydrate.noop", {
+            sessionId,
+            eventCount: events.length,
+            afterSeq,
+            elapsedMs: Math.round(performance.now() - startedAt),
+          });
+          return true;
+        }
+
+        const storeStartedAt = performance.now();
+        applyHistoryStateToStores(sessionId, currentSlot, {
+          events: nextState.state.events,
+          transcript: nextState.state.transcript,
+        });
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementMetric({
+            type: "store",
+            category: "session.events.list",
+            operationId,
+            durationMs: performance.now() - storeStartedAt,
+          });
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.store",
+            startedAt: storeStartedAt,
+          });
+        }
+        for (const operationId of historyApplyOperationIds) {
+          recordHistoryStateCounts(
+            operationId,
+            "after",
+            nextState.state.events,
+            nextState.state.transcript,
+          );
+        }
+        const mountStartedAt = performance.now();
+        mountSubagentChildrenFromEvents(
+          currentSlot.workspaceId,
+          events,
+          options?.requestHeaders,
+        );
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.mount_subagents",
+            startedAt: mountStartedAt,
+          });
+          markSessionApplyForNextCommit(operationId);
+        }
+        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
+        logLatency("session.history.rehydrate.success", {
+          sessionId,
+          eventCount: events.length,
+          appended: true,
+          elapsedMs: Math.round(performance.now() - startedAt),
+        });
+        return true;
+      }
+
+      if (beforeSeq != null) {
+        const replayStartedAt = performance.now();
+        const replacementEvents = mergeFetchedHistoryWithExistingEvents(
+          events,
+          currentSlot.events,
+        );
+        const nextState = replaySessionHistory(sessionId, replacementEvents);
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementMetric({
+            type: "reducer",
+            category: "session.events.list",
+            operationId,
+            durationMs: performance.now() - replayStartedAt,
+            count: events.length,
+          });
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.replay",
+            startedAt: replayStartedAt,
+            count: events.length,
+          });
+        }
+
+        const storeStartedAt = performance.now();
+        applyHistoryStateToStores(sessionId, currentSlot, {
+          events: replacementEvents,
+          transcript: nextState.transcript,
+        });
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementMetric({
+            type: "store",
+            category: "session.events.list",
+            operationId,
+            durationMs: performance.now() - storeStartedAt,
+          });
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.store",
+            startedAt: storeStartedAt,
+          });
+        }
+        for (const operationId of historyApplyOperationIds) {
+          recordHistoryStateCounts(
+            operationId,
+            "after",
+            replacementEvents,
+            nextState.transcript,
+          );
+        }
+        const mountStartedAt = performance.now();
+        mountSubagentChildrenFromEvents(
+          currentSlot.workspaceId,
+          events,
+          options?.requestHeaders,
+        );
+        for (const operationId of historyApplyOperationIds) {
+          recordMeasurementWorkflowStep({
+            operationId,
+            step: "session.history.mount_subagents",
+            startedAt: mountStartedAt,
+          });
+          markSessionApplyForNextCommit(operationId);
+        }
+        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
+        logLatency("session.history.rehydrate.success", {
+          sessionId,
+          eventCount: events.length,
+          prepended: true,
+          totalEventCount: replacementEvents.length,
+          elapsedMs: Math.round(performance.now() - startedAt),
+        });
+        return events.length > 0;
+      }
+
+      const replayStartedAt = performance.now();
+      const replacementEvents = options?.replace
+        ? mergeFetchedHistoryWithNewerEvents(events, currentSlot.events)
+        : events;
+      const nextState = replaySessionHistory(sessionId, replacementEvents);
+      for (const operationId of historyApplyOperationIds) {
+        recordMeasurementMetric({
+          type: "reducer",
+          category: "session.events.list",
+          operationId,
+          durationMs: performance.now() - replayStartedAt,
+          count: replacementEvents.length,
+        });
+        recordMeasurementWorkflowStep({
+          operationId,
+          step: "session.history.replay",
+          startedAt: replayStartedAt,
+          count: replacementEvents.length,
+        });
+      }
+      const storeStartedAt = performance.now();
+      applyHistoryStateToStores(sessionId, currentSlot, {
+        events: nextState.events,
+        transcript: nextState.transcript,
+      });
+      for (const operationId of historyApplyOperationIds) {
+        recordMeasurementMetric({
+          type: "store",
+          category: "session.events.list",
+          operationId,
+          durationMs: performance.now() - storeStartedAt,
+        });
+        recordMeasurementWorkflowStep({
+          operationId,
+          step: "session.history.store",
+          startedAt: storeStartedAt,
+        });
+      }
+      for (const operationId of historyApplyOperationIds) {
+        recordHistoryStateCounts(
+          operationId,
+          "after",
+          nextState.events,
+          nextState.transcript,
+        );
+      }
+      const mountStartedAt = performance.now();
+      mountSubagentChildrenFromEvents(
+        currentSlot.workspaceId,
+        replacementEvents,
+        options?.requestHeaders,
+      );
+      for (const operationId of historyApplyOperationIds) {
+        recordMeasurementWorkflowStep({
+          operationId,
+          step: "session.history.mount_subagents",
+          startedAt: mountStartedAt,
+        });
+        markSessionApplyForNextCommit(operationId);
+      }
+      finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
+      logLatency("session.history.rehydrate.success", {
+        sessionId,
+        eventCount: replacementEvents.length,
+        appended: false,
+        elapsedMs: Math.round(performance.now() - startedAt),
+      });
+      return true;
+    } catch (error) {
+      if (import.meta.env.DEV && !isSessionHistoryTimeoutAbort(error)) {
+        console.debug("[session-runtime] session history rehydrate failed", error);
+      }
+      logLatency("session.history.rehydrate.failed", {
+        sessionId,
+        afterSeq: options?.afterSeq ?? null,
+        beforeSeq: options?.beforeSeq ?? null,
+        limit: options?.limit ?? null,
+        turnLimit: options?.turnLimit ?? null,
+        timeoutMs: options?.timeoutMs ?? null,
+        elapsedMs: Math.round(performance.now() - startedAt),
+        errorName: error instanceof Error ? error.name : "unknown",
+      });
+      finishStandaloneApplyOperation(standaloneMeasurementOperationId, "error_sanitized");
+      return false;
+    }
+  }, [mountSubagentChildrenFromEvents]);
+
+  return {
+    rehydrateSessionSlotFromHistory,
+  };
+}
+
+function isSessionHistoryTimeoutAbort(error: unknown): boolean {
+  return error instanceof Error
+    && error.name === "AbortError"
+    && error.message === "Session history request timed out";
+}
+
+function resolveHistoryApplyOperationKind(input: {
+  afterSeq?: number;
+  beforeSeq?: number;
+}): MeasurementOperationKind {
+  if (input.beforeSeq != null) {
+    return "session_history_older_chunk";
+  }
+  if (input.afterSeq != null) {
+    return "session_history_tail_reconcile";
+  }
+  return "session_history_initial_hydrate";
+}
+
+function finishStandaloneApplyOperation(
+  operationId: MeasurementOperationId | null,
+  reason: "completed" | "aborted" | "error_sanitized",
+  waitForPaint = false,
+): void {
+  if (!operationId) {
+    return;
+  }
+  const finish = () => finishOrCancelMeasurementOperation(operationId, reason);
+  if (waitForPaint) {
+    scheduleAfterNextPaint(finish);
+    return;
+  }
+  finish();
+}
+
+function markSessionApplyForNextCommit(operationId: MeasurementOperationId | null | undefined): void {
+  if (!operationId) {
+    return;
+  }
+  markOperationForNextCommit(operationId, SESSION_APPLY_MEASUREMENT_SURFACES);
+}
+
+function applyHistoryStateToStores(
+  sessionId: string,
+  currentRecord: SessionRuntimeRecord,
+  nextState: {
+    events: SessionEventEnvelope[];
+    transcript: TranscriptState;
+  },
+): void {
+  const status = resolveSessionStatus(currentRecord.status, {
+    executionSummary: currentRecord.executionSummary,
+    streamConnectionState: currentRecord.streamConnectionState,
+    transcript: nextState.transcript,
+  });
+  batchSessionStoreWrites(() => {
+    useSessionTranscriptStore.getState().patchEntry(sessionId, {
+      events: nextState.events,
+      transcript: nextState.transcript,
+    });
+    useSessionDirectoryStore.getState().patchEntry(sessionId, {
+      status,
+      modeId: nextState.transcript.currentModeId ?? currentRecord.modeId,
+      activity: activityFromTranscript(nextState.transcript, {
+        status,
+        executionSummary: currentRecord.executionSummary,
+      }),
+    });
+  });
+}
+
+function recordHistoryStateCounts(
+  operationId: MeasurementOperationId | null | undefined,
+  phase: "before" | "after",
+  events: readonly SessionEventEnvelope[],
+  transcript: TranscriptState,
+): void {
+  if (!operationId) {
+    return;
+  }
+  const isBefore = phase === "before";
+  recordMeasurementMetric({
+    type: "state_count",
+    operationId,
+    target: isBefore ? "session.history.events_before" : "session.history.events_after",
+    count: events.length,
+  });
+  recordMeasurementMetric({
+    type: "state_count",
+    operationId,
+    target: isBefore ? "session.history.turns_before" : "session.history.turns_after",
+    count: transcript.turnOrder.length,
+  });
+  recordMeasurementMetric({
+    type: "state_count",
+    operationId,
+    target: isBefore ? "session.history.items_before" : "session.history.items_after",
+    count: Object.keys(transcript.itemsById).length,
+  });
+}

--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -1,21 +1,9 @@
 import {
-  appendHistoryTail,
-  replaySessionHistory,
-} from "@/lib/domain/sessions/stream/stream-state";
-import {
-  mergeFetchedHistoryWithExistingEvents,
-  mergeFetchedHistoryWithNewerEvents,
-} from "@/lib/domain/sessions/history/history-event-merge";
-import {
   createTranscriptState,
-  type Session,
-  type SessionEventEnvelope,
   type SessionStreamHandle,
-  type TranscriptState,
 } from "@anyharness/sdk";
 import { useCallback } from "react";
 import {
-  fetchSessionHistory,
   fetchSessionSummary,
   getSessionClientAndWorkspace,
   openSessionStream,
@@ -25,16 +13,11 @@ import {
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   finishOrCancelMeasurementOperation,
-  markOperationForNextCommit,
   recordMeasurementMetric,
   recordMeasurementWorkflowStep,
   startMeasurementOperation,
   type MeasurementOperationId,
-  type MeasurementOperationKind,
-  type MeasurementSurface,
 } from "@/lib/infra/measurement/debug-measurement";
-import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation-ids";
-import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import { markLatencyFlowLiveAttached } from "@/lib/infra/measurement/latency-flow";
 import {
   resolveSessionViewState,
@@ -42,44 +25,27 @@ import {
   shouldSkipColdIdleSessionStream,
 } from "@/lib/domain/sessions/activity";
 import {
-  getAuthoritativeConfigValue,
-  hasQueuedPendingConfigChanges,
-  reconcilePendingConfigChanges,
-  shouldAcceptAuthoritativeLiveConfig,
-  type PendingSessionConfigChange,
-} from "@/lib/domain/sessions/pending-config";
-import { shouldClearOptimisticPromptAfterSessionSummary } from "@/lib/domain/chat/outbox/pending-prompts";
-import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
-import {
   clearSessionReconnectTimer,
   scheduleSessionReconnectTimer,
 } from "@/lib/workflows/sessions/session-reconnect-state";
-import {
-  rememberLastViewedSession,
-  trackWorkspaceInteraction,
-} from "@/stores/preferences/workspace-ui-store";
+import { rememberLastViewedSession } from "@/stores/preferences/workspace-ui-store";
 import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { useToastStore } from "@/stores/toast/toast-store";
-import { persistDefaultSessionModePreference } from "@/hooks/sessions/session-mode-preferences";
-import { useWorkspaceSurfaceLookup } from "@/hooks/workspaces/use-workspace-surface-lookup";
 import {
   isCurrentStreamHandle,
   shouldReconnectStream,
 } from "@/hooks/sessions/session-runtime-helpers";
-import {
-  clearPendingConfigRollbackCheck,
-} from "@/hooks/sessions/session-runtime-pending-config";
 import { useLinkedSessionMounting } from "@/hooks/chat/subagents/use-linked-session-mounting";
 import {
   useSessionStreamFlushControllerFactory,
   type SessionStreamFlushController,
 } from "@/hooks/sessions/use-session-stream-flush";
 import { useSessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
-import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
+import { useSessionHistoryHydration } from "@/hooks/sessions/lifecycle/use-session-history-hydration";
+import { useSessionSummaryActions } from "@/hooks/sessions/workflows/use-session-summary-actions";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
-  activityFromTranscript,
   activitySnapshotFromDirectoryEntry,
   useSessionDirectoryStore,
 } from "@/stores/sessions/session-directory-store";
@@ -89,56 +55,26 @@ import {
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionIngestStore } from "@/stores/sessions/session-ingest-store";
-import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import {
   clearSessionStreamHandle,
   closeSessionStreamHandle,
   setSessionStreamHandle,
 } from "@/lib/access/anyharness/session-stream-handles";
-import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
 
 const ACTIVE_SUMMARY_REFRESH_DELAY_MS = 8_000;
-const SESSION_APPLY_MEASUREMENT_SURFACES: readonly MeasurementSurface[] = [
-  "session-transcript-pane",
-  "transcript-list",
-  "chat-surface",
-  "header-tabs",
-  "workspace-sidebar",
-  "global-header",
-  "chat-composer-dock",
-];
-const SESSION_HISTORY_APPLY_MAX_DURATION_MS = 30_000;
 
 export function useSessionRuntimeActions() {
   const sessionStreamCache = useSessionStreamCache();
-  const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
   const showToast = useToastStore((state) => state.show);
+  const { mountSubagentChildSession } = useLinkedSessionMounting();
   const {
-    mountSubagentChildSession,
-    mountSubagentChildrenFromEvents,
-  } = useLinkedSessionMounting();
+    applySessionSummary,
+    persistReconciledModePreferences,
+  } = useSessionSummaryActions();
+  const { rehydrateSessionSlotFromHistory } = useSessionHistoryHydration();
   const pluginsInCodingSessionsEnabled = useUserPreferencesStore(
     (state) => state.pluginsInCodingSessionsEnabled,
   );
-
-  const persistReconciledModePreferences = useCallback((
-    workspaceId: string | null | undefined,
-    agentKind: string | null | undefined,
-    liveConfigRawConfigId: string | null | undefined,
-    reconciledChanges: PendingSessionConfigChange[],
-    liveConfigValueResolver: (rawConfigId: string) => string | null,
-  ) => {
-    const workspaceSurface = getWorkspaceSurface(workspaceId);
-    for (const change of reconciledChanges) {
-      persistDefaultSessionModePreference({
-        agentKind,
-        liveConfigRawConfigId,
-        rawConfigId: change.rawConfigId,
-        modeId: liveConfigValueResolver(change.rawConfigId),
-        workspaceSurface,
-      });
-    }
-  }, [getWorkspaceSurface]);
 
   const activateSession = useCallback((sessionId: string | null) => {
     useSessionSelectionStore.getState().setActiveSessionId(sessionId);
@@ -162,435 +98,6 @@ export function useSessionRuntimeActions() {
       }
     }
   }, []);
-
-  const applySessionSummary = useCallback((
-    sessionId: string,
-    session: Session,
-    workspaceId: string,
-  ) => {
-    const existing = getSessionRecord(sessionId);
-    if (!existing) {
-      return;
-    }
-
-    const patch = buildSessionSlotPatchFromSummary(
-      session,
-      workspaceId,
-      existing.transcript ?? createTranscriptState(sessionId),
-    );
-    const shouldApplyLiveConfig = shouldAcceptAuthoritativeLiveConfig(
-      existing.liveConfig,
-      patch.liveConfig,
-    );
-    const shouldApplyConfigFields = shouldApplyLiveConfig || !existing.liveConfig;
-    const effectiveLiveConfig = shouldApplyLiveConfig
-      ? patch.liveConfig
-      : existing.liveConfig;
-    const nextTranscript = {
-      ...patch.transcript,
-      currentModeId: shouldApplyConfigFields
-        ? patch.transcript.currentModeId
-        : existing.transcript.currentModeId,
-    };
-    const reconcileResult = reconcilePendingConfigChanges(
-      effectiveLiveConfig,
-      existing.pendingConfigChanges,
-    );
-
-    const resolvedWorkspaceId = existing.workspaceId ?? workspaceId;
-    const nextStatus = resolveSessionStatus(patch.status, {
-      executionSummary: patch.executionSummary,
-      streamConnectionState: existing.streamConnectionState,
-      transcript: nextTranscript,
-    });
-    batchSessionStoreWrites(() => {
-      useSessionDirectoryStore.getState().patchEntry(sessionId, {
-        materializedSessionId: session.id,
-        agentKind: patch.agentKind,
-        workspaceId: patch.workspaceId,
-        modelId: shouldApplyConfigFields ? patch.modelId : existing.modelId,
-        modeId: shouldApplyConfigFields ? patch.modeId : existing.modeId,
-        title: patch.title,
-        actionCapabilities: patch.actionCapabilities,
-        liveConfig: effectiveLiveConfig,
-        executionSummary: patch.executionSummary,
-        mcpBindingSummaries: patch.mcpBindingSummaries,
-        pendingConfigChanges: reconcileResult.pendingConfigChanges,
-        status: nextStatus,
-        lastPromptAt: patch.lastPromptAt,
-        activity: activityFromTranscript(nextTranscript, {
-          status: nextStatus,
-          executionSummary: patch.executionSummary,
-        }),
-      });
-      useSessionTranscriptStore.getState().patchEntry(sessionId, {
-        transcript: nextTranscript,
-        optimisticPrompt:
-          shouldClearOptimisticPromptAfterSessionSummary(patch.status)
-            ? null
-            : existing.optimisticPrompt,
-      });
-    });
-
-    const interactionTimestamp =
-      patch.executionSummary?.updatedAt
-      ?? session.updatedAt
-      ?? session.lastPromptAt
-      ?? null;
-    if (resolvedWorkspaceId && interactionTimestamp) {
-      trackWorkspaceInteraction(resolvedWorkspaceId, interactionTimestamp);
-    }
-
-    persistReconciledModePreferences(
-      resolvedWorkspaceId,
-      patch.agentKind,
-      effectiveLiveConfig?.normalizedControls.mode?.rawConfigId ?? null,
-      reconcileResult.reconciledChanges,
-      (rawConfigId) => getAuthoritativeConfigValue(effectiveLiveConfig, rawConfigId),
-    );
-
-    if (!hasQueuedPendingConfigChanges(reconcileResult.pendingConfigChanges)) {
-      clearPendingConfigRollbackCheck(sessionId);
-    }
-  }, [persistReconciledModePreferences]);
-
-  const rehydrateSessionSlotFromHistory = useCallback(async (
-    sessionId: string,
-    options?: {
-      afterSeq?: number;
-      beforeSeq?: number;
-      limit?: number;
-      turnLimit?: number;
-      replace?: boolean;
-      requestHeaders?: HeadersInit;
-      measurementOperationId?: MeasurementOperationId | null;
-      timeoutMs?: number;
-      isCurrent?: () => boolean;
-    },
-  ): Promise<boolean> => {
-    const startedAt = performance.now();
-    let standaloneMeasurementOperationId: MeasurementOperationId | null = null;
-    try {
-      if (options?.isCurrent && !options.isCurrent()) {
-        return false;
-      }
-      const slot = getSessionRecord(sessionId);
-      if (!slot) {
-        return false;
-      }
-
-      const afterSeq = options?.replace ? undefined : options?.afterSeq;
-      const beforeSeq = options?.replace || afterSeq != null ? undefined : options?.beforeSeq;
-      standaloneMeasurementOperationId = startMeasurementOperation({
-        kind: resolveHistoryApplyOperationKind({ afterSeq, beforeSeq }),
-        surfaces: SESSION_APPLY_MEASUREMENT_SURFACES,
-        maxDurationMs: SESSION_HISTORY_APPLY_MAX_DURATION_MS,
-      });
-      const requestMeasurementOperationId =
-        options?.measurementOperationId ?? standaloneMeasurementOperationId;
-      const historyApplyOperationIds = uniqueMeasurementOperationIds([
-        options?.measurementOperationId,
-        standaloneMeasurementOperationId,
-      ]);
-      for (const operationId of historyApplyOperationIds) {
-        recordHistoryStateCounts(
-          operationId,
-          "before",
-          slot.events,
-          slot.transcript,
-        );
-      }
-      const fetchStartedAt = performance.now();
-      const events = await fetchSessionHistory(
-        sessionId,
-        afterSeq != null
-          || beforeSeq != null
-          || options?.limit != null
-          || options?.turnLimit != null
-          || options?.requestHeaders
-          || requestMeasurementOperationId
-          || options?.timeoutMs != null
-          ? {
-            ...(afterSeq != null ? { afterSeq } : {}),
-            ...(beforeSeq != null ? { beforeSeq } : {}),
-            ...(options?.limit != null ? { limit: options.limit } : {}),
-            ...(options?.turnLimit != null ? { turnLimit: options.turnLimit } : {}),
-            ...(options?.requestHeaders
-              ? { requestHeaders: options.requestHeaders }
-              : {}),
-            ...(requestMeasurementOperationId
-              ? { measurementOperationId: requestMeasurementOperationId }
-              : {}),
-            ...(options?.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {}),
-          }
-          : undefined,
-      );
-      for (const operationId of historyApplyOperationIds) {
-        recordMeasurementWorkflowStep({
-          operationId,
-          step: "session.history.fetch",
-          startedAt: fetchStartedAt,
-          count: events.length,
-        });
-        recordMeasurementMetric({
-          type: "state_count",
-          operationId,
-          target: "session.history.events_fetched",
-          count: events.length,
-        });
-      }
-      const currentSlot = getSessionRecord(sessionId);
-      if (!currentSlot || (options?.isCurrent && !options.isCurrent())) {
-        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "aborted");
-        return false;
-      }
-
-      if (afterSeq != null) {
-        const replayStartedAt = performance.now();
-        const nextState = appendHistoryTail(
-          {
-            events: currentSlot.events,
-            transcript: currentSlot.transcript,
-          },
-          events,
-        );
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementMetric({
-            type: "reducer",
-            category: "session.events.list",
-            operationId,
-            durationMs: performance.now() - replayStartedAt,
-            count: events.length,
-          });
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.replay",
-            startedAt: replayStartedAt,
-            count: events.length,
-          });
-        }
-
-        if (!nextState.applied) {
-          finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed");
-          logLatency("session.history.rehydrate.noop", {
-            sessionId,
-            eventCount: events.length,
-            afterSeq,
-            elapsedMs: Math.round(performance.now() - startedAt),
-          });
-          return true;
-        }
-
-        const storeStartedAt = performance.now();
-        applyHistoryStateToStores(sessionId, currentSlot, {
-          events: nextState.state.events,
-          transcript: nextState.state.transcript,
-        });
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementMetric({
-            type: "store",
-            category: "session.events.list",
-            operationId,
-            durationMs: performance.now() - storeStartedAt,
-          });
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.store",
-            startedAt: storeStartedAt,
-          });
-        }
-        for (const operationId of historyApplyOperationIds) {
-          recordHistoryStateCounts(
-            operationId,
-            "after",
-            nextState.state.events,
-            nextState.state.transcript,
-          );
-        }
-        const mountStartedAt = performance.now();
-        mountSubagentChildrenFromEvents(
-          currentSlot.workspaceId,
-          events,
-          options?.requestHeaders,
-        );
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.mount_subagents",
-            startedAt: mountStartedAt,
-          });
-          markSessionApplyForNextCommit(operationId);
-        }
-        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
-        logLatency("session.history.rehydrate.success", {
-          sessionId,
-          eventCount: events.length,
-          appended: true,
-          elapsedMs: Math.round(performance.now() - startedAt),
-        });
-        return true;
-      }
-
-      if (beforeSeq != null) {
-        const replayStartedAt = performance.now();
-        const replacementEvents = mergeFetchedHistoryWithExistingEvents(
-          events,
-          currentSlot.events,
-        );
-        const nextState = replaySessionHistory(sessionId, replacementEvents);
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementMetric({
-            type: "reducer",
-            category: "session.events.list",
-            operationId,
-            durationMs: performance.now() - replayStartedAt,
-            count: events.length,
-          });
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.replay",
-            startedAt: replayStartedAt,
-            count: events.length,
-          });
-        }
-
-        const storeStartedAt = performance.now();
-        applyHistoryStateToStores(sessionId, currentSlot, {
-          events: replacementEvents,
-          transcript: nextState.transcript,
-        });
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementMetric({
-            type: "store",
-            category: "session.events.list",
-            operationId,
-            durationMs: performance.now() - storeStartedAt,
-          });
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.store",
-            startedAt: storeStartedAt,
-          });
-        }
-        for (const operationId of historyApplyOperationIds) {
-          recordHistoryStateCounts(
-            operationId,
-            "after",
-            replacementEvents,
-            nextState.transcript,
-          );
-        }
-        const mountStartedAt = performance.now();
-        mountSubagentChildrenFromEvents(
-          currentSlot.workspaceId,
-          events,
-          options?.requestHeaders,
-        );
-        for (const operationId of historyApplyOperationIds) {
-          recordMeasurementWorkflowStep({
-            operationId,
-            step: "session.history.mount_subagents",
-            startedAt: mountStartedAt,
-          });
-          markSessionApplyForNextCommit(operationId);
-        }
-        finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
-        logLatency("session.history.rehydrate.success", {
-          sessionId,
-          eventCount: events.length,
-          prepended: true,
-          totalEventCount: replacementEvents.length,
-          elapsedMs: Math.round(performance.now() - startedAt),
-        });
-        return events.length > 0;
-      }
-
-      const replayStartedAt = performance.now();
-      const replacementEvents = options?.replace
-        ? mergeFetchedHistoryWithNewerEvents(events, currentSlot.events)
-        : events;
-      const nextState = replaySessionHistory(sessionId, replacementEvents);
-      for (const operationId of historyApplyOperationIds) {
-        recordMeasurementMetric({
-          type: "reducer",
-          category: "session.events.list",
-          operationId,
-          durationMs: performance.now() - replayStartedAt,
-          count: replacementEvents.length,
-        });
-        recordMeasurementWorkflowStep({
-          operationId,
-          step: "session.history.replay",
-          startedAt: replayStartedAt,
-          count: replacementEvents.length,
-        });
-      }
-      const storeStartedAt = performance.now();
-      applyHistoryStateToStores(sessionId, currentSlot, {
-        events: nextState.events,
-        transcript: nextState.transcript,
-      });
-      for (const operationId of historyApplyOperationIds) {
-        recordMeasurementMetric({
-          type: "store",
-          category: "session.events.list",
-          operationId,
-          durationMs: performance.now() - storeStartedAt,
-        });
-        recordMeasurementWorkflowStep({
-          operationId,
-          step: "session.history.store",
-          startedAt: storeStartedAt,
-        });
-      }
-      for (const operationId of historyApplyOperationIds) {
-        recordHistoryStateCounts(
-          operationId,
-          "after",
-          nextState.events,
-          nextState.transcript,
-        );
-      }
-      const mountStartedAt = performance.now();
-      mountSubagentChildrenFromEvents(
-        currentSlot.workspaceId,
-        replacementEvents,
-        options?.requestHeaders,
-      );
-      for (const operationId of historyApplyOperationIds) {
-        recordMeasurementWorkflowStep({
-          operationId,
-          step: "session.history.mount_subagents",
-          startedAt: mountStartedAt,
-        });
-        markSessionApplyForNextCommit(operationId);
-      }
-      finishStandaloneApplyOperation(standaloneMeasurementOperationId, "completed", true);
-      logLatency("session.history.rehydrate.success", {
-        sessionId,
-        eventCount: replacementEvents.length,
-        appended: false,
-        elapsedMs: Math.round(performance.now() - startedAt),
-      });
-      return true;
-    } catch (error) {
-      if (import.meta.env.DEV && !isSessionHistoryTimeoutAbort(error)) {
-        console.debug("[session-runtime] session history rehydrate failed", error);
-      }
-      logLatency("session.history.rehydrate.failed", {
-        sessionId,
-        afterSeq: options?.afterSeq ?? null,
-        beforeSeq: options?.beforeSeq ?? null,
-        limit: options?.limit ?? null,
-        turnLimit: options?.turnLimit ?? null,
-        timeoutMs: options?.timeoutMs ?? null,
-        elapsedMs: Math.round(performance.now() - startedAt),
-        errorName: error instanceof Error ? error.name : "unknown",
-      });
-      finishStandaloneApplyOperation(standaloneMeasurementOperationId, "error_sanitized");
-      return false;
-    }
-  }, [mountSubagentChildrenFromEvents]);
 
   const refreshSessionSlotMeta = useCallback(async (
     sessionId: string,
@@ -1126,77 +633,6 @@ export function useSessionRuntimeActions() {
   };
 }
 
-function isSessionHistoryTimeoutAbort(error: unknown): boolean {
-  return error instanceof Error
-    && error.name === "AbortError"
-    && error.message === "Session history request timed out";
-}
-
-function resolveHistoryApplyOperationKind(input: {
-  afterSeq?: number;
-  beforeSeq?: number;
-}): MeasurementOperationKind {
-  if (input.beforeSeq != null) {
-    return "session_history_older_chunk";
-  }
-  if (input.afterSeq != null) {
-    return "session_history_tail_reconcile";
-  }
-  return "session_history_initial_hydrate";
-}
-
-function finishStandaloneApplyOperation(
-  operationId: MeasurementOperationId | null,
-  reason: "completed" | "aborted" | "error_sanitized",
-  waitForPaint = false,
-): void {
-  if (!operationId) {
-    return;
-  }
-  const finish = () => finishOrCancelMeasurementOperation(operationId, reason);
-  if (waitForPaint) {
-    scheduleAfterNextPaint(finish);
-    return;
-  }
-  finish();
-}
-
-function markSessionApplyForNextCommit(operationId: MeasurementOperationId | null | undefined): void {
-  if (!operationId) {
-    return;
-  }
-  markOperationForNextCommit(operationId, SESSION_APPLY_MEASUREMENT_SURFACES);
-}
-
-function applyHistoryStateToStores(
-  sessionId: string,
-  currentRecord: SessionRuntimeRecord,
-  nextState: {
-    events: SessionEventEnvelope[];
-    transcript: TranscriptState;
-  },
-): void {
-  const status = resolveSessionStatus(currentRecord.status, {
-    executionSummary: currentRecord.executionSummary,
-    streamConnectionState: currentRecord.streamConnectionState,
-    transcript: nextState.transcript,
-  });
-  batchSessionStoreWrites(() => {
-    useSessionTranscriptStore.getState().patchEntry(sessionId, {
-      events: nextState.events,
-      transcript: nextState.transcript,
-    });
-    useSessionDirectoryStore.getState().patchEntry(sessionId, {
-      status,
-      modeId: nextState.transcript.currentModeId ?? currentRecord.modeId,
-      activity: activityFromTranscript(nextState.transcript, {
-        status,
-        executionSummary: currentRecord.executionSummary,
-      }),
-    });
-  });
-}
-
 function createFlushAwareSessionStreamHandle(
   handle: SessionStreamHandle,
   streamFlushController: SessionStreamFlushController,
@@ -1217,34 +653,4 @@ function createFlushAwareSessionStreamHandle(
       streamFlushController.flushNow();
     },
   };
-}
-
-function recordHistoryStateCounts(
-  operationId: MeasurementOperationId | null | undefined,
-  phase: "before" | "after",
-  events: readonly SessionEventEnvelope[],
-  transcript: TranscriptState,
-): void {
-  if (!operationId) {
-    return;
-  }
-  const isBefore = phase === "before";
-  recordMeasurementMetric({
-    type: "state_count",
-    operationId,
-    target: isBefore ? "session.history.events_before" : "session.history.events_after",
-    count: events.length,
-  });
-  recordMeasurementMetric({
-    type: "state_count",
-    operationId,
-    target: isBefore ? "session.history.turns_before" : "session.history.turns_after",
-    count: transcript.turnOrder.length,
-  });
-  recordMeasurementMetric({
-    type: "state_count",
-    operationId,
-    target: isBefore ? "session.history.items_before" : "session.history.items_after",
-    count: Object.keys(transcript.itemsById).length,
-  });
 }

--- a/desktop/src/hooks/sessions/workflows/use-session-summary-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-summary-actions.ts
@@ -1,0 +1,151 @@
+import {
+  createTranscriptState,
+  type Session,
+} from "@anyharness/sdk";
+import { useCallback } from "react";
+import { shouldClearOptimisticPromptAfterSessionSummary } from "@/lib/domain/chat/outbox/pending-prompts";
+import {
+  resolveSessionStatus,
+} from "@/lib/domain/sessions/activity";
+import {
+  getAuthoritativeConfigValue,
+  hasQueuedPendingConfigChanges,
+  reconcilePendingConfigChanges,
+  shouldAcceptAuthoritativeLiveConfig,
+  type PendingSessionConfigChange,
+} from "@/lib/domain/sessions/pending-config";
+import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
+import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
+import { persistDefaultSessionModePreference } from "@/hooks/sessions/session-mode-preferences";
+import { clearPendingConfigRollbackCheck } from "@/hooks/sessions/session-runtime-pending-config";
+import { useWorkspaceSurfaceLookup } from "@/hooks/workspaces/use-workspace-surface-lookup";
+import {
+  activityFromTranscript,
+  useSessionDirectoryStore,
+} from "@/stores/sessions/session-directory-store";
+import { getSessionRecord } from "@/stores/sessions/session-records";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import { trackWorkspaceInteraction } from "@/stores/preferences/workspace-ui-store";
+
+/**
+ * Owns applying authoritative session summaries to the session stores.
+ * Stream connection and history hydration stay in the runtime/history hooks.
+ */
+export function useSessionSummaryActions() {
+  const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
+
+  const persistReconciledModePreferences = useCallback((
+    workspaceId: string | null | undefined,
+    agentKind: string | null | undefined,
+    liveConfigRawConfigId: string | null | undefined,
+    reconciledChanges: PendingSessionConfigChange[],
+    liveConfigValueResolver: (rawConfigId: string) => string | null,
+  ) => {
+    const workspaceSurface = getWorkspaceSurface(workspaceId);
+    for (const change of reconciledChanges) {
+      persistDefaultSessionModePreference({
+        agentKind,
+        liveConfigRawConfigId,
+        rawConfigId: change.rawConfigId,
+        modeId: liveConfigValueResolver(change.rawConfigId),
+        workspaceSurface,
+      });
+    }
+  }, [getWorkspaceSurface]);
+
+  const applySessionSummary = useCallback((
+    sessionId: string,
+    session: Session,
+    workspaceId: string,
+  ) => {
+    const existing = getSessionRecord(sessionId);
+    if (!existing) {
+      return;
+    }
+
+    const patch = buildSessionSlotPatchFromSummary(
+      session,
+      workspaceId,
+      existing.transcript ?? createTranscriptState(sessionId),
+    );
+    const shouldApplyLiveConfig = shouldAcceptAuthoritativeLiveConfig(
+      existing.liveConfig,
+      patch.liveConfig,
+    );
+    const shouldApplyConfigFields = shouldApplyLiveConfig || !existing.liveConfig;
+    const effectiveLiveConfig = shouldApplyLiveConfig
+      ? patch.liveConfig
+      : existing.liveConfig;
+    const nextTranscript = {
+      ...patch.transcript,
+      currentModeId: shouldApplyConfigFields
+        ? patch.transcript.currentModeId
+        : existing.transcript.currentModeId,
+    };
+    const reconcileResult = reconcilePendingConfigChanges(
+      effectiveLiveConfig,
+      existing.pendingConfigChanges,
+    );
+
+    const resolvedWorkspaceId = existing.workspaceId ?? workspaceId;
+    const nextStatus = resolveSessionStatus(patch.status, {
+      executionSummary: patch.executionSummary,
+      streamConnectionState: existing.streamConnectionState,
+      transcript: nextTranscript,
+    });
+    batchSessionStoreWrites(() => {
+      useSessionDirectoryStore.getState().patchEntry(sessionId, {
+        materializedSessionId: session.id,
+        agentKind: patch.agentKind,
+        workspaceId: patch.workspaceId,
+        modelId: shouldApplyConfigFields ? patch.modelId : existing.modelId,
+        modeId: shouldApplyConfigFields ? patch.modeId : existing.modeId,
+        title: patch.title,
+        actionCapabilities: patch.actionCapabilities,
+        liveConfig: effectiveLiveConfig,
+        executionSummary: patch.executionSummary,
+        mcpBindingSummaries: patch.mcpBindingSummaries,
+        pendingConfigChanges: reconcileResult.pendingConfigChanges,
+        status: nextStatus,
+        lastPromptAt: patch.lastPromptAt,
+        activity: activityFromTranscript(nextTranscript, {
+          status: nextStatus,
+          executionSummary: patch.executionSummary,
+        }),
+      });
+      useSessionTranscriptStore.getState().patchEntry(sessionId, {
+        transcript: nextTranscript,
+        optimisticPrompt:
+          shouldClearOptimisticPromptAfterSessionSummary(patch.status)
+            ? null
+            : existing.optimisticPrompt,
+      });
+    });
+
+    const interactionTimestamp =
+      patch.executionSummary?.updatedAt
+      ?? session.updatedAt
+      ?? session.lastPromptAt
+      ?? null;
+    if (resolvedWorkspaceId && interactionTimestamp) {
+      trackWorkspaceInteraction(resolvedWorkspaceId, interactionTimestamp);
+    }
+
+    persistReconciledModePreferences(
+      resolvedWorkspaceId,
+      patch.agentKind,
+      effectiveLiveConfig?.normalizedControls.mode?.rawConfigId ?? null,
+      reconcileResult.reconciledChanges,
+      (rawConfigId) => getAuthoritativeConfigValue(effectiveLiveConfig, rawConfigId),
+    );
+
+    if (!hasQueuedPendingConfigChanges(reconcileResult.pendingConfigChanges)) {
+      clearPendingConfigRollbackCheck(sessionId);
+    }
+  }, [persistReconciledModePreferences]);
+
+  return {
+    applySessionSummary,
+    persistReconciledModePreferences,
+  };
+}


### PR DESCRIPTION
## Summary\n- split session summary reconciliation into a dedicated workflow hook\n- split session history hydration into a dedicated lifecycle hook\n- keep useSessionRuntimeActions as the compatibility facade plus stream lifecycle owner\n\n## Verification\n- pnpm --dir desktop exec tsc --noEmit\n- pnpm --dir desktop exec vitest run src/hooks/sessions/use-session-stream-flush.test.ts src/hooks/sessions/session-stream-side-effects.test.ts src/lib/domain/sessions/history/history-event-merge.test.ts src/lib/domain/sessions/summary.test.ts\n- python3 scripts/check_frontend_boundaries.py\n- python3 scripts/check_max_lines.py\n- git diff --check