### PR TITLE
refactor(desktop): extract stream side-effect planner

### DIFF
--- a/desktop/src/hooks/sessions/session-stream-side-effects.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.ts
@@ -1,19 +1,16 @@
 import type {
   SessionEventEnvelope,
-  SessionLiveConfigSnapshot,
-  ToolCallItem,
   TranscriptState,
 } from "@anyharness/sdk";
 import {
   getAuthoritativeConfigValue,
-  hasQueuedPendingConfigChanges,
   type PendingSessionConfigChange,
   type PendingSessionConfigChanges,
 } from "@/lib/domain/sessions/pending-config";
 import {
-  parseSubagentLaunchResult,
-  resolveSubagentLaunchDisplay,
-} from "@/lib/domain/chat/subagents/subagent-launch";
+  planBatchedStreamSideEffects,
+  type ReconciledStreamConfigIntent,
+} from "@/lib/domain/sessions/stream/stream-side-effect-plan";
 import { trackWorkspaceInteraction } from "@/stores/preferences/workspace-ui-store";
 import {
   notifyTurnEnd,
@@ -29,21 +26,6 @@ import {
 } from "@/hooks/sessions/session-runtime-pending-config";
 import type { MeasurementOperationId } from "@/lib/infra/measurement/debug-measurement";
 import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
-
-export interface ReconciledStreamConfigIntent {
-  liveConfig: SessionLiveConfigSnapshot;
-  reconciledChanges: PendingSessionConfigChange[];
-}
-
-type OrderedStreamSideEffect =
-  | { kind: "clear_pending_config_rollback" }
-  | { kind: "schedule_active_summary_refresh" }
-  | { kind: "clear_active_summary_refresh" }
-  | { kind: "schedule_pending_config_rollback" }
-  | {
-    kind: "notify_turn_end";
-    eventType: "turn_ended" | "error";
-  };
 
 export function applyBatchedStreamSideEffects(input: {
   sessionStreamCache: SessionStreamCache;
@@ -94,133 +76,37 @@ export function applyBatchedStreamSideEffects(input: {
     delayMs: number,
   ) => void;
 }) {
-  let shouldInvalidateWorkspaceCollections = false;
-  let shouldInvalidateGitStatus = false;
-  let lastActivityTimestamp: string | null = null;
-  let shouldInvalidateSessionSubagents = false;
-  let shouldInvalidateCowork = false;
-  const reviewParentSessionIds = new Set<string>();
-  const orderedEffects: OrderedStreamSideEffect[] = [];
+  const plan = planBatchedStreamSideEffects({
+    sessionId: input.sessionId,
+    workspaceId: input.workspaceId,
+    envelopes: input.envelopes,
+    transcript: input.transcript,
+    pendingConfigChanges: input.pendingConfigChanges,
+    reconciledIntents: input.reconciledIntents,
+  });
 
-  for (const envelope of input.envelopes) {
-    const event = envelope.event;
-    if (event.type === "available_commands_update") {
-      input.scheduleStartupReadyRefresh("available_commands", 0);
-    }
-    if (event.type === "turn_started" || event.type === "session_ended") {
-      appendOrderedEffect(orderedEffects, { kind: "clear_pending_config_rollback" });
-    }
-    if (shouldScheduleActiveSummaryRefresh(event.type)) {
-      appendOrderedEffect(orderedEffects, { kind: "schedule_active_summary_refresh" });
-    }
-    if (
-      event.type === "turn_ended"
-      || event.type === "error"
-      || event.type === "session_ended"
-    ) {
-      appendOrderedEffect(orderedEffects, { kind: "clear_active_summary_refresh" });
-    }
-    if (
-      event.type === "turn_started"
-      || event.type === "interaction_requested"
-      || event.type === "interaction_resolved"
-      || event.type === "turn_ended"
-      || event.type === "error"
-      || event.type === "session_ended"
-    ) {
-      shouldInvalidateWorkspaceCollections = true;
-    }
-    if (input.workspaceId && shouldTrackWorkspaceWorkActivity(event.type)) {
-      lastActivityTimestamp = envelope.timestamp;
-    }
-    if (event.type === "turn_ended" || event.type === "error") {
-      shouldInvalidateGitStatus = !!input.workspaceId;
-      if (hasQueuedPendingConfigChanges(input.pendingConfigChanges)) {
-        appendOrderedEffect(orderedEffects, { kind: "schedule_pending_config_rollback" });
-      }
-      orderedEffects.push({
-        kind: "notify_turn_end",
-        eventType: event.type,
-      });
-    }
-    if (event.type === "subagent_turn_completed") {
-      input.recordSessionRelationshipHint(event.childSessionId, {
-        kind: "subagent_child",
-        parentSessionId: event.parentSessionId,
-        sessionLinkId: event.sessionLinkId,
-        relation: "subagent",
-        workspaceId: input.workspaceId,
-      });
-      void input.mountSubagentChildSession({
-        childSessionId: event.childSessionId,
-        label: event.label ?? null,
-        workspaceId: input.workspaceId,
-        parentSessionId: event.parentSessionId,
-        sessionLinkId: event.sessionLinkId,
-        requestHeaders: input.requestHeaders,
-      });
-      shouldInvalidateSessionSubagents = true;
-    }
-    if (
-      event.type === "session_link_turn_completed"
-      && event.relation === "cowork_coding_session"
-    ) {
-      input.recordSessionRelationshipHint(event.childSessionId, {
-        kind: "cowork_child",
-        parentSessionId: event.parentSessionId,
-        sessionLinkId: event.sessionLinkId,
-        relation: event.relation,
-        workspaceId: input.workspaceId,
-      });
-      shouldInvalidateCowork = true;
-    } else if (event.type === "session_link_turn_completed") {
-      input.recordSessionRelationshipHint(event.childSessionId, {
-        kind: "linked_child",
-        parentSessionId: event.parentSessionId,
-        sessionLinkId: event.sessionLinkId,
-        relation: event.relation,
-        workspaceId: input.workspaceId,
-      });
-    }
-    if (event.type === "review_run_updated") {
-      reviewParentSessionIds.add(event.parentSessionId);
-    }
-    if (event.type === "item_completed" && envelope.itemId) {
-      const item = input.transcript.itemsById[envelope.itemId];
-      if (item?.kind === "tool_call" && isSubagentMcpMutation(item)) {
-        const launchResult = parseSubagentLaunchResult(item);
-        const display = resolveSubagentLaunchDisplay(item);
-        if (launchResult?.childSessionId) {
-          input.recordSessionRelationshipHint(launchResult.childSessionId, {
-            kind: "subagent_child",
-            parentSessionId: input.sessionId,
-            sessionLinkId: launchResult.sessionLinkId,
-            relation: "subagent",
-            workspaceId: input.workspaceId,
-          });
-          void input.mountSubagentChildSession({
-            childSessionId: launchResult.childSessionId,
-            label: display.title,
-            workspaceId: input.workspaceId,
-            parentSessionId: input.sessionId,
-            sessionLinkId: launchResult.sessionLinkId,
-            requestHeaders: input.requestHeaders,
-          });
-        }
-        shouldInvalidateSessionSubagents = true;
-      }
-      if (
-        item?.kind === "tool_call"
-        && item.status === "completed"
-        && isCoworkCodingCreateMcpMutation(item)
-      ) {
-        shouldInvalidateCowork = true;
-        shouldInvalidateWorkspaceCollections = true;
-      }
+  for (const effect of plan.eventEffects) {
+    switch (effect.kind) {
+      case "schedule_startup_ready_refresh":
+        input.scheduleStartupReadyRefresh(effect.reason, effect.delayMs);
+        break;
+      case "record_session_relationship_hint":
+        input.recordSessionRelationshipHint(effect.sessionId, effect.relationship);
+        break;
+      case "mount_subagent_child_session":
+        void input.mountSubagentChildSession({
+          childSessionId: effect.childSessionId,
+          label: effect.label,
+          workspaceId: effect.workspaceId,
+          parentSessionId: effect.parentSessionId,
+          sessionLinkId: effect.sessionLinkId,
+          requestHeaders: input.requestHeaders,
+        });
+        break;
     }
   }
 
-  for (const intent of input.reconciledIntents) {
+  for (const intent of plan.persistReconciledModePreferences) {
     input.persistReconciledModePreferences(
       input.workspaceId,
       input.agentKind,
@@ -230,44 +116,41 @@ export function applyBatchedStreamSideEffects(input: {
     );
   }
 
-  if (shouldInvalidateWorkspaceCollections) {
+  if (plan.invalidateWorkspaceCollections) {
     input.sessionStreamCache.invalidateWorkspaceCollections(input.runtimeUrl);
   }
-  if (lastActivityTimestamp && input.workspaceId) {
-    trackWorkspaceInteraction(input.workspaceId, lastActivityTimestamp);
-    input.acknowledgeWorkspaceActivity?.(input.workspaceId, lastActivityTimestamp);
+  if (plan.lastActivityTimestamp && input.workspaceId) {
+    trackWorkspaceInteraction(input.workspaceId, plan.lastActivityTimestamp);
+    input.acknowledgeWorkspaceActivity?.(input.workspaceId, plan.lastActivityTimestamp);
   }
-  if (shouldInvalidateSessionSubagents) {
+  if (plan.invalidateSessionSubagents) {
     input.sessionStreamCache.invalidateSessionSubagents({
       runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
     });
   }
-  if (shouldInvalidateCowork) {
+  if (plan.invalidateCowork) {
     input.sessionStreamCache.invalidateCoworkManagedWorkspaces({
       runtimeUrl: input.runtimeUrl,
       sessionId: input.sessionId,
     });
   }
-  for (const parentSessionId of reviewParentSessionIds) {
+  for (const parentSessionId of plan.reviewParentSessionIds) {
     input.sessionStreamCache.invalidateSessionReviews({
       runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
       parentSessionId,
     });
   }
-  if (shouldInvalidateGitStatus && input.workspaceId) {
+  if (plan.invalidateGitStatus && input.workspaceId) {
     input.sessionStreamCache.invalidateGitStatus({
       runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
     });
   }
 
-  if (!hasQueuedPendingConfigChanges(input.pendingConfigChanges)) {
-    appendOrderedEffect(orderedEffects, { kind: "clear_pending_config_rollback" });
-  }
-  for (const effect of orderedEffects) {
+  for (const effect of plan.orderedEffects) {
     switch (effect.kind) {
       case "clear_pending_config_rollback":
         clearPendingConfigRollbackCheck(input.sessionId);
@@ -292,64 +175,5 @@ export function applyBatchedStreamSideEffects(input: {
         }
         break;
     }
-  }
-}
-
-function appendOrderedEffect(
-  effects: OrderedStreamSideEffect[],
-  effect: OrderedStreamSideEffect,
-): void {
-  const previous = effects[effects.length - 1];
-  if (previous?.kind === effect.kind && effect.kind !== "notify_turn_end") {
-    return;
-  }
-  effects.push(effect);
-}
-
-function isSubagentMcpMutation(item: ToolCallItem): boolean {
-  const nativeToolName = item.nativeToolName?.trim().toLowerCase();
-  return nativeToolName === "mcp__subagents__create_subagent"
-    || nativeToolName === "mcp__subagents__send_subagent_message"
-    || nativeToolName === "mcp__subagents__schedule_subagent_wake";
-}
-
-function isCoworkCodingCreateMcpMutation(item: ToolCallItem): boolean {
-  const nativeToolName = item.nativeToolName?.trim().toLowerCase();
-  return nativeToolName === "mcp__cowork__create_coding_workspace"
-    || nativeToolName === "mcp__cowork__create_coding_session"
-    || nativeToolName === "mcp__cowork__send_coding_message"
-    || nativeToolName === "mcp__cowork__schedule_coding_wake";
-}
-
-function shouldScheduleActiveSummaryRefresh(eventType: string): boolean {
-  switch (eventType) {
-    case "turn_started":
-    case "item_started":
-    case "item_delta":
-    case "item_completed":
-    case "usage_update":
-    case "interaction_resolved":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function shouldTrackWorkspaceWorkActivity(eventType: string): boolean {
-  switch (eventType) {
-    case "turn_started":
-    case "item_started":
-    case "item_completed":
-    case "interaction_requested":
-    case "interaction_resolved":
-    case "turn_ended":
-    case "error":
-    case "session_ended":
-    case "subagent_turn_completed":
-    case "session_link_turn_completed":
-    case "review_run_updated":
-      return true;
-    default:
-      return false;
   }
 }

--- a/desktop/src/hooks/sessions/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.ts
@@ -33,8 +33,8 @@ import {
 import { shouldClearOptimisticPendingPromptForEnvelope } from "@/lib/domain/chat/outbox/pending-prompts";
 import {
   applyBatchedStreamSideEffects,
-  type ReconciledStreamConfigIntent,
 } from "@/hooks/sessions/session-stream-side-effects";
+import type { ReconciledStreamConfigIntent } from "@/lib/domain/sessions/stream/stream-side-effect-plan";
 import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";

--- a/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
+++ b/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
@@ -1,0 +1,400 @@
+import {
+  createTranscriptState,
+  type SessionEventEnvelope,
+  type SessionLiveConfigSnapshot,
+  type ToolCallItem,
+  type TranscriptState,
+} from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import { planBatchedStreamSideEffects } from "@/lib/domain/sessions/stream/stream-side-effect-plan";
+
+describe("planBatchedStreamSideEffects", () => {
+  it("plans ordered terminal and new-turn effects without executing them", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput({
+        pendingConfigChanges: queuedPendingConfigChanges(),
+      }),
+      envelopes: [
+        turnEnded(2),
+        turnStarted(3),
+      ],
+    });
+
+    expect(plan.invalidateWorkspaceCollections).toBe(true);
+    expect(plan.invalidateGitStatus).toBe(true);
+    expect(plan.lastActivityTimestamp).toBe("2026-04-04T00:00:03Z");
+    expect(plan.orderedEffects).toEqual([
+      { kind: "clear_active_summary_refresh" },
+      { kind: "schedule_pending_config_rollback" },
+      { kind: "notify_turn_end", eventType: "turn_ended" },
+      { kind: "clear_pending_config_rollback" },
+      { kind: "schedule_active_summary_refresh" },
+    ]);
+  });
+
+  it("plans final rollback clearing when no queued config changes remain", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [],
+    });
+
+    expect(plan.orderedEffects).toEqual([
+      { kind: "clear_pending_config_rollback" },
+    ]);
+  });
+
+  it("plans startup refreshes from available command updates", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        availableCommandsUpdate(2),
+      ],
+    });
+
+    expect(plan.eventEffects).toEqual([
+      {
+        kind: "schedule_startup_ready_refresh",
+        reason: "available_commands",
+        delayMs: 0,
+      },
+    ]);
+  });
+
+  it("plans subagent relationship, mount, and cache invalidation commands", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        subagentTurnCompleted(2),
+      ],
+    });
+
+    expect(plan.invalidateSessionSubagents).toBe(true);
+    expect(plan.eventEffects).toEqual([
+      {
+        kind: "record_session_relationship_hint",
+        sessionId: "child-session",
+        relationship: {
+          kind: "subagent_child",
+          parentSessionId: "session-1",
+          sessionLinkId: "link-1",
+          relation: "subagent",
+          workspaceId: "workspace-1",
+        },
+      },
+      {
+        kind: "mount_subagent_child_session",
+        childSessionId: "child-session",
+        label: "Child",
+        workspaceId: "workspace-1",
+        parentSessionId: "session-1",
+        sessionLinkId: "link-1",
+      },
+    ]);
+  });
+
+  it("plans cowork relationship and invalidation commands", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        sessionLinkTurnCompleted(2, "cowork_coding_session"),
+      ],
+    });
+
+    expect(plan.invalidateCowork).toBe(true);
+    expect(plan.eventEffects).toEqual([
+      {
+        kind: "record_session_relationship_hint",
+        sessionId: "child-session",
+        relationship: {
+          kind: "cowork_child",
+          parentSessionId: "session-1",
+          sessionLinkId: "link-1",
+          relation: "cowork_coding_session",
+          workspaceId: "workspace-1",
+        },
+      },
+    ]);
+  });
+
+  it("dedupes review parent ids while preserving first-seen order", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        reviewRunUpdated(2, "parent-1"),
+        reviewRunUpdated(3, "parent-2"),
+        reviewRunUpdated(4, "parent-1"),
+      ],
+    });
+
+    expect(plan.reviewParentSessionIds).toEqual(["parent-1", "parent-2"]);
+    expect(plan.lastActivityTimestamp).toBe("2026-04-04T00:00:04Z");
+  });
+
+  it("plans subagent effects from completed MCP tool calls", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById["tool-1"] = toolCallItem({
+      itemId: "tool-1",
+      nativeToolName: "mcp__subagents__create_subagent",
+      status: "completed",
+      title: "create_subagent",
+      rawInput: {
+        label: "repo-reviewer",
+      },
+      rawOutput: {
+        childSessionId: "child-session",
+        sessionLinkId: "link-1",
+      },
+    });
+
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput({ transcript }),
+      envelopes: [
+        itemCompleted(2, "tool-1"),
+      ],
+    });
+
+    expect(plan.invalidateSessionSubagents).toBe(true);
+    expect(plan.eventEffects).toEqual([
+      {
+        kind: "record_session_relationship_hint",
+        sessionId: "child-session",
+        relationship: {
+          kind: "subagent_child",
+          parentSessionId: "session-1",
+          sessionLinkId: "link-1",
+          relation: "subagent",
+          workspaceId: "workspace-1",
+        },
+      },
+      {
+        kind: "mount_subagent_child_session",
+        childSessionId: "child-session",
+        label: "repo-reviewer",
+        workspaceId: "workspace-1",
+        parentSessionId: "session-1",
+        sessionLinkId: "link-1",
+      },
+    ]);
+  });
+
+  it("plans cowork invalidation from completed MCP tool calls", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById["tool-1"] = toolCallItem({
+      itemId: "tool-1",
+      nativeToolName: "mcp__cowork__create_coding_session",
+      status: "completed",
+    });
+
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput({ transcript }),
+      envelopes: [
+        itemCompleted(2, "tool-1"),
+      ],
+    });
+
+    expect(plan.invalidateCowork).toBe(true);
+    expect(plan.invalidateWorkspaceCollections).toBe(true);
+  });
+
+  it("carries reconciled mode preference intents into the plan", () => {
+    const liveConfig = liveConfigSnapshot();
+    const reconciledChange = {
+      rawConfigId: "mode",
+      value: "plan",
+      status: "queued" as const,
+      mutationId: 1,
+    };
+
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      reconciledIntents: [
+        {
+          liveConfig,
+          reconciledChanges: [reconciledChange],
+        },
+      ],
+    });
+
+    expect(plan.persistReconciledModePreferences).toEqual([
+      {
+        liveConfig,
+        reconciledChanges: [reconciledChange],
+      },
+    ]);
+  });
+});
+
+function baseInput(overrides?: {
+  pendingConfigChanges?: PendingSessionConfigChanges;
+  transcript?: TranscriptState;
+}) {
+  return {
+    sessionId: "session-1",
+    workspaceId: "workspace-1",
+    envelopes: [] as SessionEventEnvelope[],
+    transcript: overrides?.transcript ?? createTranscriptState("session-1"),
+    pendingConfigChanges: overrides?.pendingConfigChanges ?? {},
+    reconciledIntents: [],
+  };
+}
+
+function queuedPendingConfigChanges(): PendingSessionConfigChanges {
+  return {
+    mode: {
+      rawConfigId: "mode",
+      value: "plan",
+      status: "queued",
+      mutationId: 1,
+    },
+  };
+}
+
+function availableCommandsUpdate(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "available_commands_update",
+    availableCommands: [],
+  });
+}
+
+function turnStarted(seq: number): SessionEventEnvelope {
+  return envelope(seq, { type: "turn_started" });
+}
+
+function turnEnded(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "turn_ended",
+    stopReason: "end_turn",
+  });
+}
+
+function subagentTurnCompleted(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "subagent_turn_completed",
+    childSessionId: "child-session",
+    parentSessionId: "session-1",
+    sessionLinkId: "link-1",
+    childTurnId: "child-turn-1",
+    childLastEventSeq: 10,
+    completionId: "completion-1",
+    outcome: "completed",
+    label: "Child",
+  });
+}
+
+function sessionLinkTurnCompleted(seq: number, relation: string): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "session_link_turn_completed",
+    childSessionId: "child-session",
+    parentSessionId: "session-1",
+    sessionLinkId: "link-1",
+    childTurnId: "child-turn-1",
+    childLastEventSeq: 10,
+    completionId: "completion-1",
+    outcome: "completed",
+    relation,
+  });
+}
+
+function reviewRunUpdated(seq: number, parentSessionId: string): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "review_run_updated",
+    parentSessionId,
+    reviewRunId: `review-${seq}`,
+    kind: "code",
+    status: "reviewing",
+    autoIterate: false,
+    currentRoundNumber: 1,
+    maxRounds: 1,
+    activeRoundId: null,
+    updatedAt: `2026-04-04T00:00:0${seq}Z`,
+  });
+}
+
+function itemCompleted(seq: number, itemId: string): SessionEventEnvelope {
+  return {
+    ...envelope(seq, {
+      type: "item_completed",
+      item: {
+        kind: "tool_call",
+        status: "completed",
+        sourceAgentKind: "codex",
+        contentParts: [],
+      },
+    } as unknown as SessionEventEnvelope["event"]),
+    itemId,
+  };
+}
+
+function envelope(seq: number, event: SessionEventEnvelope["event"]): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:0${seq}Z`,
+    turnId: "turn-1",
+    event,
+  };
+}
+
+function toolCallItem(overrides: Partial<ToolCallItem>): ToolCallItem {
+  return {
+    kind: "tool_call",
+    itemId: "tool-1",
+    turnId: "turn-1",
+    status: "in_progress",
+    sourceAgentKind: "codex",
+    messageId: null,
+    title: null,
+    nativeToolName: "Agent",
+    parentToolCallId: null,
+    rawInput: undefined,
+    rawOutput: undefined,
+    contentParts: [],
+    timestamp: "2026-04-04T00:00:00Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: null,
+    completedAt: null,
+    toolCallId: "toolu_1",
+    toolKind: "think",
+    semanticKind: "subagent",
+    approvalState: "none",
+    ...overrides,
+  };
+}
+
+function liveConfigSnapshot(): SessionLiveConfigSnapshot {
+  return {
+    rawConfigOptions: [
+      {
+        id: "mode",
+        name: "Mode",
+        type: "select",
+        currentValue: "plan",
+        options: [
+          { value: "plan", name: "Plan" },
+        ],
+      },
+    ],
+    normalizedControls: {
+      model: null,
+      collaborationMode: null,
+      mode: {
+        key: "mode",
+        rawConfigId: "mode",
+        label: "Mode",
+        currentValue: "plan",
+        settable: true,
+        values: [
+          { value: "plan", label: "Plan" },
+        ],
+      },
+      reasoning: null,
+      effort: null,
+      fastMode: null,
+      extras: [],
+    },
+    sourceSeq: 1,
+    updatedAt: "2026-04-04T00:00:00Z",
+  };
+}

--- a/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
+++ b/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
@@ -1,0 +1,316 @@
+import type {
+  SessionEventEnvelope,
+  SessionLiveConfigSnapshot,
+  ToolCallItem,
+  TranscriptState,
+} from "@anyharness/sdk";
+import {
+  hasQueuedPendingConfigChanges,
+  type PendingSessionConfigChange,
+  type PendingSessionConfigChanges,
+} from "@/lib/domain/sessions/pending-config";
+import {
+  parseSubagentLaunchResult,
+  resolveSubagentLaunchDisplay,
+} from "@/lib/domain/chat/subagents/subagent-launch";
+
+export interface ReconciledStreamConfigIntent {
+  liveConfig: SessionLiveConfigSnapshot;
+  reconciledChanges: PendingSessionConfigChange[];
+}
+
+export type PlannedSessionChildRelationship =
+  | {
+    kind: "subagent_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "cowork_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "linked_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  };
+
+export type PlannedStreamEventEffect =
+  | {
+    kind: "schedule_startup_ready_refresh";
+    reason: "available_commands";
+    delayMs: number;
+  }
+  | {
+    kind: "record_session_relationship_hint";
+    sessionId: string;
+    relationship: PlannedSessionChildRelationship;
+  }
+  | {
+    kind: "mount_subagent_child_session";
+    childSessionId: string;
+    label: string | null;
+    workspaceId: string | null;
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+  };
+
+export type OrderedStreamSideEffect =
+  | { kind: "clear_pending_config_rollback" }
+  | { kind: "schedule_active_summary_refresh" }
+  | { kind: "clear_active_summary_refresh" }
+  | { kind: "schedule_pending_config_rollback" }
+  | {
+    kind: "notify_turn_end";
+    eventType: "turn_ended" | "error";
+  };
+
+export interface BatchedStreamSideEffectPlan {
+  eventEffects: PlannedStreamEventEffect[];
+  persistReconciledModePreferences: ReconciledStreamConfigIntent[];
+  invalidateWorkspaceCollections: boolean;
+  invalidateGitStatus: boolean;
+  lastActivityTimestamp: string | null;
+  invalidateSessionSubagents: boolean;
+  invalidateCowork: boolean;
+  reviewParentSessionIds: string[];
+  orderedEffects: OrderedStreamSideEffect[];
+}
+
+export function planBatchedStreamSideEffects(input: {
+  sessionId: string;
+  workspaceId: string | null;
+  envelopes: SessionEventEnvelope[];
+  transcript: TranscriptState;
+  pendingConfigChanges: PendingSessionConfigChanges;
+  reconciledIntents: ReconciledStreamConfigIntent[];
+}): BatchedStreamSideEffectPlan {
+  let invalidateWorkspaceCollections = false;
+  let invalidateGitStatus = false;
+  let lastActivityTimestamp: string | null = null;
+  let invalidateSessionSubagents = false;
+  let invalidateCowork = false;
+  const reviewParentSessionIds = new Set<string>();
+  const eventEffects: PlannedStreamEventEffect[] = [];
+  const orderedEffects: OrderedStreamSideEffect[] = [];
+
+  for (const envelope of input.envelopes) {
+    const event = envelope.event;
+    if (event.type === "available_commands_update") {
+      eventEffects.push({
+        kind: "schedule_startup_ready_refresh",
+        reason: "available_commands",
+        delayMs: 0,
+      });
+    }
+    if (event.type === "turn_started" || event.type === "session_ended") {
+      appendOrderedEffect(orderedEffects, { kind: "clear_pending_config_rollback" });
+    }
+    if (shouldScheduleActiveSummaryRefresh(event.type)) {
+      appendOrderedEffect(orderedEffects, { kind: "schedule_active_summary_refresh" });
+    }
+    if (
+      event.type === "turn_ended"
+      || event.type === "error"
+      || event.type === "session_ended"
+    ) {
+      appendOrderedEffect(orderedEffects, { kind: "clear_active_summary_refresh" });
+    }
+    if (
+      event.type === "turn_started"
+      || event.type === "interaction_requested"
+      || event.type === "interaction_resolved"
+      || event.type === "turn_ended"
+      || event.type === "error"
+      || event.type === "session_ended"
+    ) {
+      invalidateWorkspaceCollections = true;
+    }
+    if (input.workspaceId && shouldTrackWorkspaceWorkActivity(event.type)) {
+      lastActivityTimestamp = envelope.timestamp;
+    }
+    if (event.type === "turn_ended" || event.type === "error") {
+      invalidateGitStatus = !!input.workspaceId;
+      if (hasQueuedPendingConfigChanges(input.pendingConfigChanges)) {
+        appendOrderedEffect(orderedEffects, { kind: "schedule_pending_config_rollback" });
+      }
+      orderedEffects.push({
+        kind: "notify_turn_end",
+        eventType: event.type,
+      });
+    }
+    if (event.type === "subagent_turn_completed") {
+      eventEffects.push({
+        kind: "record_session_relationship_hint",
+        sessionId: event.childSessionId,
+        relationship: {
+          kind: "subagent_child",
+          parentSessionId: event.parentSessionId,
+          sessionLinkId: event.sessionLinkId,
+          relation: "subagent",
+          workspaceId: input.workspaceId,
+        },
+      });
+      eventEffects.push({
+        kind: "mount_subagent_child_session",
+        childSessionId: event.childSessionId,
+        label: event.label ?? null,
+        workspaceId: input.workspaceId,
+        parentSessionId: event.parentSessionId,
+        sessionLinkId: event.sessionLinkId,
+      });
+      invalidateSessionSubagents = true;
+    }
+    if (
+      event.type === "session_link_turn_completed"
+      && event.relation === "cowork_coding_session"
+    ) {
+      eventEffects.push({
+        kind: "record_session_relationship_hint",
+        sessionId: event.childSessionId,
+        relationship: {
+          kind: "cowork_child",
+          parentSessionId: event.parentSessionId,
+          sessionLinkId: event.sessionLinkId,
+          relation: event.relation,
+          workspaceId: input.workspaceId,
+        },
+      });
+      invalidateCowork = true;
+    } else if (event.type === "session_link_turn_completed") {
+      eventEffects.push({
+        kind: "record_session_relationship_hint",
+        sessionId: event.childSessionId,
+        relationship: {
+          kind: "linked_child",
+          parentSessionId: event.parentSessionId,
+          sessionLinkId: event.sessionLinkId,
+          relation: event.relation,
+          workspaceId: input.workspaceId,
+        },
+      });
+    }
+    if (event.type === "review_run_updated") {
+      reviewParentSessionIds.add(event.parentSessionId);
+    }
+    if (event.type === "item_completed" && envelope.itemId) {
+      const item = input.transcript.itemsById[envelope.itemId];
+      if (item?.kind === "tool_call" && isSubagentMcpMutation(item)) {
+        const launchResult = parseSubagentLaunchResult(item);
+        const display = resolveSubagentLaunchDisplay(item);
+        if (launchResult?.childSessionId) {
+          eventEffects.push({
+            kind: "record_session_relationship_hint",
+            sessionId: launchResult.childSessionId,
+            relationship: {
+              kind: "subagent_child",
+              parentSessionId: input.sessionId,
+              sessionLinkId: launchResult.sessionLinkId,
+              relation: "subagent",
+              workspaceId: input.workspaceId,
+            },
+          });
+          eventEffects.push({
+            kind: "mount_subagent_child_session",
+            childSessionId: launchResult.childSessionId,
+            label: display.title,
+            workspaceId: input.workspaceId,
+            parentSessionId: input.sessionId,
+            sessionLinkId: launchResult.sessionLinkId,
+          });
+        }
+        invalidateSessionSubagents = true;
+      }
+      if (
+        item?.kind === "tool_call"
+        && item.status === "completed"
+        && isCoworkCodingCreateMcpMutation(item)
+      ) {
+        invalidateCowork = true;
+        invalidateWorkspaceCollections = true;
+      }
+    }
+  }
+
+  if (!hasQueuedPendingConfigChanges(input.pendingConfigChanges)) {
+    appendOrderedEffect(orderedEffects, { kind: "clear_pending_config_rollback" });
+  }
+
+  return {
+    eventEffects,
+    persistReconciledModePreferences: input.reconciledIntents,
+    invalidateWorkspaceCollections,
+    invalidateGitStatus,
+    lastActivityTimestamp,
+    invalidateSessionSubagents,
+    invalidateCowork,
+    reviewParentSessionIds: [...reviewParentSessionIds],
+    orderedEffects,
+  };
+}
+
+function appendOrderedEffect(
+  effects: OrderedStreamSideEffect[],
+  effect: OrderedStreamSideEffect,
+): void {
+  const previous = effects[effects.length - 1];
+  if (previous?.kind === effect.kind && effect.kind !== "notify_turn_end") {
+    return;
+  }
+  effects.push(effect);
+}
+
+function isSubagentMcpMutation(item: ToolCallItem): boolean {
+  const nativeToolName = item.nativeToolName?.trim().toLowerCase();
+  return nativeToolName === "mcp__subagents__create_subagent"
+    || nativeToolName === "mcp__subagents__send_subagent_message"
+    || nativeToolName === "mcp__subagents__schedule_subagent_wake";
+}
+
+function isCoworkCodingCreateMcpMutation(item: ToolCallItem): boolean {
+  const nativeToolName = item.nativeToolName?.trim().toLowerCase();
+  return nativeToolName === "mcp__cowork__create_coding_workspace"
+    || nativeToolName === "mcp__cowork__create_coding_session"
+    || nativeToolName === "mcp__cowork__send_coding_message"
+    || nativeToolName === "mcp__cowork__schedule_coding_wake";
+}
+
+function shouldScheduleActiveSummaryRefresh(eventType: string): boolean {
+  switch (eventType) {
+    case "turn_started":
+    case "item_started":
+    case "item_delta":
+    case "item_completed":
+    case "usage_update":
+    case "interaction_resolved":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function shouldTrackWorkspaceWorkActivity(eventType: string): boolean {
+  switch (eventType) {
+    case "turn_started":
+    case "item_started":
+    case "item_completed":
+    case "interaction_requested":
+    case "interaction_resolved":
+    case "turn_ended":
+    case "error":
+    case "session_ended":
+    case "subagent_turn_completed":
+    case "session_link_turn_completed":
+    case "review_run_updated":
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts session stream side-effect planning into a pure domain planner under `lib/domain/sessions/stream`.
- Leaves `applyBatchedStreamSideEffects` as the executor for store/cache/timer/notification effects.
- Adds planner tests for ordered timer effects, startup refresh, subagent/cowork relationships, review invalidation, MCP tool side effects, and reconciled config intents.

## Verification

- `pnpm --dir desktop exec vitest run src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts src/hooks/sessions/session-stream-side-effects.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
