### PR TITLE
refactor(server): thread cloud credential store reads

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -38,7 +38,6 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspac
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 13 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 8 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_credentials.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp_connections.py 4 transitional store opens DB session
@@ -56,7 +55,6 @@ STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_worksp
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/billing.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_credentials.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/auth.py 1 materialization refresh wrappers import DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp_connections.py 1 transitional store imports DB session factory

--- a/server/proliferate/db/store/cloud_credentials.py
+++ b/server/proliferate/db/store/cloud_credentials.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
@@ -10,7 +12,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import CloudAgentKind
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud import CloudCredential
 from proliferate.utils.crypto import decrypt_json
 from proliferate.utils.time import utcnow
@@ -18,11 +19,23 @@ from proliferate.utils.time import utcnow
 CloudCredentialPayloadMatches = Callable[[str], bool]
 
 
+@dataclass(frozen=True)
+class CloudCredentialRecord:
+    id: UUID
+    provider: str
+    auth_mode: str
+    payload_ciphertext: str
+    payload_format: str
+    revoked_at: datetime | None
+    last_synced_at: datetime | None
+    updated_at: datetime | None
+
+
 async def get_user_cloud_credentials(
     db: AsyncSession,
     user_id: UUID,
-) -> list[CloudCredential]:
-    return list(
+) -> list[CloudCredentialRecord]:
+    records = (
         (
             await db.execute(
                 select(CloudCredential)
@@ -33,6 +46,7 @@ async def get_user_cloud_credentials(
         .scalars()
         .all()
     )
+    return [_credential_record(record) for record in records]
 
 
 async def sync_cloud_credential_if_changed(
@@ -121,6 +135,14 @@ async def delete_cloud_credential(
     return bool(records)
 
 
-async def load_cloud_credentials_for_user(user_id: UUID) -> list[CloudCredential]:
-    async with db_engine.async_session_factory() as db:
-        return await get_user_cloud_credentials(db, user_id)
+def _credential_record(record: CloudCredential) -> CloudCredentialRecord:
+    return CloudCredentialRecord(
+        id=record.id,
+        provider=record.provider,
+        auth_mode=record.auth_mode,
+        payload_ciphertext=record.payload_ciphertext,
+        payload_format=record.payload_format,
+        revoked_at=record.revoked_at,
+        last_synced_at=record.last_synced_at,
+        updated_at=record.updated_at,
+    )

--- a/server/proliferate/server/cloud/credentials/service.py
+++ b/server/proliferate/server/cloud/credentials/service.py
@@ -12,7 +12,6 @@ from proliferate.constants.cloud import (
 from proliferate.db.store.cloud_credentials import (
     delete_cloud_credential,
     get_user_cloud_credentials,
-    load_cloud_credentials_for_user,
     sync_cloud_credential_if_changed,
 )
 from proliferate.server.cloud.credentials.domain.status import (
@@ -29,6 +28,9 @@ from proliferate.server.cloud.credentials.models import (
     CredentialStatus,
     SyncCloudCredentialRequest,
     credential_status_payload,
+)
+from proliferate.server.cloud.credentials.session_loader import (
+    load_cloud_credentials_for_user,
 )
 from proliferate.utils.crypto import decrypt_json, encrypt_json
 

--- a/server/proliferate/server/cloud/credentials/session_loader.py
+++ b/server/proliferate/server/cloud/credentials/session_loader.py
@@ -1,0 +1,16 @@
+"""Temporary credential readers for flows that do not yet thread request DB."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from proliferate.db.engine import async_session_factory
+from proliferate.db.store.cloud_credentials import (
+    CloudCredentialRecord,
+    get_user_cloud_credentials,
+)
+
+
+async def load_cloud_credentials_for_user(user_id: UUID) -> list[CloudCredentialRecord]:
+    async with async_session_factory() as db:
+        return await get_user_cloud_credentials(db, user_id)

--- a/server/proliferate/server/cloud/credentials/session_loader.py
+++ b/server/proliferate/server/cloud/credentials/session_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from proliferate.db.engine import async_session_factory
+from proliferate.db import engine as db_engine
 from proliferate.db.store.cloud_credentials import (
     CloudCredentialRecord,
     get_user_cloud_credentials,
@@ -12,5 +12,5 @@ from proliferate.db.store.cloud_credentials import (
 
 
 async def load_cloud_credentials_for_user(user_id: UUID) -> list[CloudCredentialRecord]:
-    async with async_session_factory() as db:
+    async with db_engine.async_session_factory() as db:
         return await get_user_cloud_credentials(db, user_id)

--- a/server/proliferate/server/cloud/runtime/credential_freshness.py
+++ b/server/proliferate/server/cloud/runtime/credential_freshness.py
@@ -11,8 +11,8 @@ from typing import Literal
 from uuid import UUID
 
 from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS, CloudRuntimeEnvironmentStatus
-from proliferate.db.models.cloud import CloudCredential, CloudRuntimeEnvironment
-from proliferate.db.store.cloud_credentials import load_cloud_credentials_for_user
+from proliferate.db.models.cloud import CloudRuntimeEnvironment
+from proliferate.db.store.cloud_credentials import CloudCredentialRecord
 from proliferate.db.store.cloud_repo_config import load_cloud_repo_config_for_user
 from proliferate.db.store.cloud_runtime_environments import (
     load_runtime_environment_by_id,
@@ -27,6 +27,7 @@ from proliferate.integrations.sandbox import (
     get_sandbox_provider,
 )
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
+from proliferate.server.cloud.credentials.session_loader import load_cloud_credentials_for_user
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime.anyharness_api import (
     reconcile_remote_agents,
@@ -89,7 +90,9 @@ class CredentialFreshnessSnapshot:
     process_applied_at: datetime | None
 
 
-def _active_supported_credentials(records: list[CloudCredential]) -> list[CloudCredential]:
+def _active_supported_credentials(
+    records: list[CloudCredentialRecord],
+) -> list[CloudCredentialRecord]:
     return [
         record
         for record in records
@@ -97,7 +100,7 @@ def _active_supported_credentials(records: list[CloudCredential]) -> list[CloudC
     ]
 
 
-def _revision_for(records: list[CloudCredential], auth_mode: str, prefix: str) -> str:
+def _revision_for(records: list[CloudCredentialRecord], auth_mode: str, prefix: str) -> str:
     parts = sorted(
         f"{record.provider}:{record.auth_mode}:{record.payload_format}:{record.id}"
         for record in records
@@ -109,7 +112,7 @@ def _revision_for(records: list[CloudCredential], auth_mode: str, prefix: str) -
 
 
 def build_credential_revision_state(
-    records: list[CloudCredential],
+    records: list[CloudCredentialRecord],
 ) -> CredentialRevisionState:
     active_records = _active_supported_credentials(records)
     credential_payloads = {

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -25,7 +25,6 @@ from proliferate.db.store.billing import (
     close_usage_segment_for_sandbox,
     open_usage_segment_for_sandbox,
 )
-from proliferate.db.store.cloud_credentials import load_cloud_credentials_for_user
 from proliferate.db.store.cloud_repo_config import load_cloud_repo_config_for_user
 from proliferate.db.store.cloud_runtime_environments import (
     ensure_runtime_environment_for_workspace_id,
@@ -51,6 +50,7 @@ from proliferate.integrations.sandbox import (
 )
 from proliferate.server.billing.service import authorize_sandbox_start
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
+from proliferate.server.cloud.credentials.session_loader import load_cloud_credentials_for_user
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.repos.service import get_linked_github_account
 from proliferate.server.cloud.runtime.anyharness_api import (

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -33,7 +33,6 @@ from proliferate.db.store.automations import (
 from proliferate.db.store.billing import (
     close_usage_segment_for_sandbox,
 )
-from proliferate.db.store.cloud_credentials import load_cloud_credentials_for_user
 from proliferate.db.store.cloud_runtime_environments import load_runtime_environment_for_workspace
 from proliferate.db.store.cloud_workspaces import (
     CloudRepoLimitExceededError,
@@ -63,6 +62,7 @@ from proliferate.server.billing.service import (
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
 from proliferate.server.cloud.credentials.domain.status import allowed_agent_kinds
 from proliferate.server.cloud.credentials.service import load_cloud_credential_statuses
+from proliferate.server.cloud.credentials.session_loader import load_cloud_credentials_for_user
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.repo_config.service import (
     bootstrap_repo_config,

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -59,7 +59,7 @@ def _make_workspace(user_id: uuid.UUID) -> CloudWorkspace:
 @pytest.fixture
 def _patched_session_factory(monkeypatch: pytest.MonkeyPatch, test_engine) -> None:
     factory = async_sessionmaker(test_engine, expire_on_commit=False)
-    monkeypatch.setattr(cloud_credential_session_loader, "async_session_factory", factory)
+    monkeypatch.setattr(cloud_credential_session_loader.db_engine, "async_session_factory", factory)
     monkeypatch.setattr(cloud_workspaces.db_engine, "async_session_factory", factory)
     monkeypatch.setattr(users.db_engine, "async_session_factory", factory)
 

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -10,12 +10,13 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from proliferate.db.models.auth import OAuthAccount, User
 from proliferate.db.models.cloud import CloudCredential, CloudWorkspace
-from proliferate.db.store import cloud_credentials, cloud_workspaces, users
+from proliferate.db.store import cloud_workspaces, users
+from proliferate.integrations.anyharness import ResolvedRemoteWorkspace
 from proliferate.integrations.sandbox import SandboxProviderKind
+from proliferate.server.cloud.credentials import session_loader as cloud_credential_session_loader
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime import bootstrap as runtime_bootstrap
 from proliferate.server.cloud.runtime import provision as runtime_provision
-from proliferate.integrations.anyharness import ResolvedRemoteWorkspace
 from proliferate.server.cloud.runtime.data_key import generate_anyharness_data_key
 from proliferate.server.cloud.runtime.credentials import (
     ClaudeProvisionCredential,
@@ -58,7 +59,7 @@ def _make_workspace(user_id: uuid.UUID) -> CloudWorkspace:
 @pytest.fixture
 def _patched_session_factory(monkeypatch: pytest.MonkeyPatch, test_engine) -> None:
     factory = async_sessionmaker(test_engine, expire_on_commit=False)
-    monkeypatch.setattr(cloud_credentials.db_engine, "async_session_factory", factory)
+    monkeypatch.setattr(cloud_credential_session_loader, "async_session_factory", factory)
     monkeypatch.setattr(cloud_workspaces.db_engine, "async_session_factory", factory)
     monkeypatch.setattr(users.db_engine, "async_session_factory", factory)
 

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -59,7 +59,11 @@ def _make_workspace(user_id: uuid.UUID) -> CloudWorkspace:
 @pytest.fixture
 def _patched_session_factory(monkeypatch: pytest.MonkeyPatch, test_engine) -> None:
     factory = async_sessionmaker(test_engine, expire_on_commit=False)
-    monkeypatch.setattr(cloud_credential_session_loader.db_engine, "async_session_factory", factory)
+    monkeypatch.setattr(
+        cloud_credential_session_loader.db_engine,
+        "async_session_factory",
+        factory,
+    )
     monkeypatch.setattr(cloud_workspaces.db_engine, "async_session_factory", factory)
     monkeypatch.setattr(users.db_engine, "async_session_factory", factory)
 


### PR DESCRIPTION
## Summary
- return frozen cloud credential records from the store instead of ORM rows
- move the temporary self-opening credential read to the cloud credentials package for deferred runtime/workspace flows
- remove the cloud credentials store session-factory allowlist entries

## Verification
- uv run python ../scripts/check_server_boundaries.py
- python3 ../scripts/check_max_lines.py
- git diff --check
- uv run --extra dev ruff check proliferate/db/store/cloud_credentials.py proliferate/server/cloud/credentials/service.py proliferate/server/cloud/credentials/session_loader.py proliferate/server/cloud/runtime/provision.py proliferate/server/cloud/runtime/credential_freshness.py proliferate/server/cloud/workspaces/service.py tests/unit/test_cloud_runtime_provision.py
- DEBUG=1 uv run --extra dev python -m pytest -q tests/unit/test_cloud_credentials_domain.py tests/unit/test_cloud_runtime_provision.py tests/unit/test_cloud_runtime_credential_freshness.py tests/integration/test_cloud_credentials_api.py