### PR TITLE
refactor(server): clean repo config transport ownership

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,7 +11,6 @@ INTEGRATION_DB_IMPORT server/proliferate/integrations/anonymous_telemetry.py 1 t
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/daytona.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/e2b.py 1 transitional integration depends on product domain types/logic
-MODELS_ORM_IMPORT server/proliferate/server/cloud/repo_config/models.py 1 transitional Pydantic constructor still accepts ORM type
 MODELS_ORM_IMPORT server/proliferate/server/cloud/workspaces/models.py 1 transitional Pydantic constructor still accepts ORM type
 SERVICE_ORM_IMPORT server/proliferate/server/ai_magic/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional service imports ORM/auth model

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -38,6 +38,8 @@ RESERVED_CLOUD_REPO_ENV_VARS: frozenset[str] = frozenset(
         "OPENAI_API_KEY",
     }
 )
+CLOUD_REPO_TRACKED_FILE_MAX_BYTES: int = 1_048_576
+CLOUD_REPO_ENV_VAR_KEY_PATTERN: str = r"^[A-Za-z_][A-Za-z0-9_]*$"
 
 # ---------------------------------------------------------------------------
 # Allowed credential auth files

--- a/server/proliferate/server/cloud/repo_config/domain/__init__.py
+++ b/server/proliferate/server/cloud/repo_config/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure repo-config domain values and rules."""

--- a/server/proliferate/server/cloud/repo_config/domain/status.py
+++ b/server/proliferate/server/cloud/repo_config/domain/status.py
@@ -1,0 +1,43 @@
+"""Pure value objects for cloud repo-config status payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class CloudRepoFileMetadataValue:
+    relative_path: str
+    content_sha256: str
+    byte_size: int
+    updated_at: datetime
+    last_synced_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudWorkspaceRepoConfigStatusValue:
+    workspace_id: UUID
+    current_repo_files_version: int
+    repo_files_applied_version: int
+    repo_files_applied_at: datetime | None
+    files_out_of_sync: bool
+    tracked_files: tuple[CloudRepoFileMetadataValue, ...]
+    env_var_keys: tuple[str, ...]
+    post_ready_phase: str
+    post_ready_files_total: int
+    post_ready_files_applied: int
+    post_ready_started_at: datetime | None
+    post_ready_completed_at: datetime | None
+    last_apply_failed_path: str | None
+    last_apply_error: str | None
+
+
+@dataclass(frozen=True)
+class CloudWorkspaceSetupRunValue:
+    workspace_id: UUID
+    command: str
+    terminal_id: str | None
+    command_run_id: str | None
+    status: str

--- a/server/proliferate/server/cloud/repo_config/models.py
+++ b/server/proliferate/server/cloud/repo_config/models.py
@@ -6,11 +6,15 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from proliferate.db.models.cloud import CloudWorkspace
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigSummaryValue,
     CloudRepoConfigValue,
     CloudRepoFileValue,
+)
+from proliferate.server.cloud.repo_config.domain.status import (
+    CloudRepoFileMetadataValue,
+    CloudWorkspaceRepoConfigStatusValue,
+    CloudWorkspaceSetupRunValue,
 )
 
 
@@ -106,7 +110,9 @@ def repo_config_summary_payload(value: CloudRepoConfigSummaryValue) -> CloudRepo
     )
 
 
-def repo_file_metadata_payload(value: CloudRepoFileValue) -> CloudRepoFileMetadata:
+def repo_file_metadata_payload(
+    value: CloudRepoFileValue | CloudRepoFileMetadataValue,
+) -> CloudRepoFileMetadata:
     return CloudRepoFileMetadata(
         relative_path=value.relative_path,
         content_sha256=value.content_sha256,
@@ -130,40 +136,31 @@ def repo_config_payload(value: CloudRepoConfigValue) -> CloudRepoConfigResponse:
 
 
 def workspace_repo_config_status_payload(
-    workspace: CloudWorkspace,
-    repo_config: CloudRepoConfigValue | None,
+    value: CloudWorkspaceRepoConfigStatusValue,
 ) -> CloudWorkspaceRepoConfigStatusResponse:
-    tracked_files = (
-        []
-        if repo_config is None
-        else [repo_file_metadata_payload(item) for item in repo_config.tracked_files]
-    )
-    env_var_keys = [] if repo_config is None else sorted(repo_config.env_vars)
-    current_version = 0 if repo_config is None else repo_config.files_version
     return CloudWorkspaceRepoConfigStatusResponse(
-        current_repo_files_version=current_version,
-        repo_files_applied_version=workspace.repo_files_applied_version,
-        repo_files_applied_at=_to_iso(workspace.repo_files_applied_at),
-        files_out_of_sync=workspace.repo_files_applied_version != current_version,
-        tracked_files=tracked_files,
-        env_var_keys=env_var_keys,
-        post_ready_phase=workspace.repo_post_ready_phase,
-        post_ready_files_total=workspace.repo_post_ready_files_total,
-        post_ready_files_applied=workspace.repo_post_ready_files_applied,
-        post_ready_started_at=_to_iso(workspace.repo_post_ready_started_at),
-        post_ready_completed_at=_to_iso(workspace.repo_post_ready_completed_at),
-        last_apply_failed_path=workspace.repo_files_last_failed_path,
-        last_apply_error=workspace.repo_files_last_error,
+        current_repo_files_version=value.current_repo_files_version,
+        repo_files_applied_version=value.repo_files_applied_version,
+        repo_files_applied_at=_to_iso(value.repo_files_applied_at),
+        files_out_of_sync=value.files_out_of_sync,
+        tracked_files=[repo_file_metadata_payload(item) for item in value.tracked_files],
+        env_var_keys=list(value.env_var_keys),
+        post_ready_phase=value.post_ready_phase,
+        post_ready_files_total=value.post_ready_files_total,
+        post_ready_files_applied=value.post_ready_files_applied,
+        post_ready_started_at=_to_iso(value.post_ready_started_at),
+        post_ready_completed_at=_to_iso(value.post_ready_completed_at),
+        last_apply_failed_path=value.last_apply_failed_path,
+        last_apply_error=value.last_apply_error,
     )
 
 
 def resync_cloud_workspace_files_payload(
-    workspace: CloudWorkspace,
-    repo_config: CloudRepoConfigValue | None,
+    value: CloudWorkspaceRepoConfigStatusValue,
 ) -> ResyncCloudWorkspaceFilesResponse:
-    status = workspace_repo_config_status_payload(workspace, repo_config)
+    status = workspace_repo_config_status_payload(value)
     return ResyncCloudWorkspaceFilesResponse(
-        workspace_id=str(workspace.id),
+        workspace_id=str(value.workspace_id),
         current_repo_files_version=status.current_repo_files_version,
         repo_files_applied_version=status.repo_files_applied_version,
         repo_files_applied_at=status.repo_files_applied_at,
@@ -181,17 +178,12 @@ def resync_cloud_workspace_files_payload(
 
 
 def run_cloud_workspace_setup_payload(
-    workspace: CloudWorkspace,
-    *,
-    command: str,
-    terminal_id: str | None,
-    command_run_id: str | None,
-    status: str,
+    value: CloudWorkspaceSetupRunValue,
 ) -> RunCloudWorkspaceSetupResponse:
     return RunCloudWorkspaceSetupResponse(
-        workspace_id=str(workspace.id),
-        command=command,
-        terminal_id=terminal_id,
-        command_run_id=command_run_id,
-        status=status,
+        workspace_id=str(value.workspace_id),
+        command=value.command,
+        terminal_id=value.terminal_id,
+        command_run_id=value.command_run_id,
+        status=value.status,
     )

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -10,6 +10,7 @@ from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigLimitExceededError,
     CloudRepoConfigValue,
     CloudRepoFileInput,
+    CloudRepoFileValue,
     bootstrap_cloud_repo_config_for_user,
     get_cloud_repo_config,
     list_cloud_repo_configs,
@@ -26,6 +27,11 @@ from proliferate.server.billing.service import (
     repo_limit_for_billing_snapshot,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repo_config.domain.status import (
+    CloudRepoFileMetadataValue,
+    CloudWorkspaceRepoConfigStatusValue,
+    CloudWorkspaceSetupRunValue,
+)
 from proliferate.server.cloud.repo_config.models import (
     CloudRepoConfigResponse,
     CloudRepoConfigsListResponse,
@@ -66,6 +72,45 @@ def _default_repo_config_response() -> CloudRepoConfigResponse:
         run_command="",
         files_version=0,
         tracked_files=[],
+    )
+
+
+def _repo_file_metadata_value(value: CloudRepoFileValue) -> CloudRepoFileMetadataValue:
+    return CloudRepoFileMetadataValue(
+        relative_path=value.relative_path,
+        content_sha256=value.content_sha256,
+        byte_size=value.byte_size,
+        updated_at=value.updated_at,
+        last_synced_at=value.last_synced_at,
+    )
+
+
+def _workspace_repo_config_status_value(
+    workspace: CloudWorkspace,
+    repo_config: CloudRepoConfigValue | None,
+) -> CloudWorkspaceRepoConfigStatusValue:
+    tracked_files = (
+        ()
+        if repo_config is None
+        else tuple(_repo_file_metadata_value(item) for item in repo_config.tracked_files)
+    )
+    env_var_keys = () if repo_config is None else tuple(sorted(repo_config.env_vars))
+    current_version = 0 if repo_config is None else repo_config.files_version
+    return CloudWorkspaceRepoConfigStatusValue(
+        workspace_id=workspace.id,
+        current_repo_files_version=current_version,
+        repo_files_applied_version=workspace.repo_files_applied_version,
+        repo_files_applied_at=workspace.repo_files_applied_at,
+        files_out_of_sync=workspace.repo_files_applied_version != current_version,
+        tracked_files=tracked_files,
+        env_var_keys=env_var_keys,
+        post_ready_phase=workspace.repo_post_ready_phase,
+        post_ready_files_total=workspace.repo_post_ready_files_total,
+        post_ready_files_applied=workspace.repo_post_ready_files_applied,
+        post_ready_started_at=workspace.repo_post_ready_started_at,
+        post_ready_completed_at=workspace.repo_post_ready_completed_at,
+        last_apply_failed_path=workspace.repo_files_last_failed_path,
+        last_apply_error=workspace.repo_files_last_error,
     )
 
 
@@ -308,7 +353,9 @@ async def get_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return workspace_repo_config_status_payload(workspace, repo_config)
+    return workspace_repo_config_status_payload(
+        _workspace_repo_config_status_value(workspace, repo_config)
+    )
 
 
 async def build_resync_workspace_repo_config_status(
@@ -323,7 +370,9 @@ async def build_resync_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(workspace, repo_config)
+    return resync_cloud_workspace_files_payload(
+        _workspace_repo_config_status_value(workspace, repo_config)
+    )
 
 
 def _runtime_access_from_target(
@@ -376,7 +425,9 @@ async def resync_workspace_files(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(workspace, repo_config)
+    return resync_cloud_workspace_files_payload(
+        _workspace_repo_config_status_value(workspace, repo_config)
+    )
 
 
 async def run_workspace_setup(
@@ -407,9 +458,11 @@ async def run_workspace_setup(
 
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
     return run_cloud_workspace_setup_payload(
-        workspace,
-        command=started.command,
-        terminal_id=started.terminal_id,
-        command_run_id=started.command_run_id,
-        status=started.status,
+        CloudWorkspaceSetupRunValue(
+            workspace_id=workspace.id,
+            command=started.command,
+            terminal_id=started.terminal_id,
+            command_run_id=started.command_run_id,
+            status=started.status,
+        )
     )

--- a/server/proliferate/server/cloud/repo_config/validation.py
+++ b/server/proliferate/server/cloud/repo_config/validation.py
@@ -6,13 +6,14 @@ import re
 
 from proliferate.constants.cloud import (
     ANYHARNESS_RESERVED_ENV_PREFIX,
+    CLOUD_REPO_ENV_VAR_KEY_PATTERN,
+    CLOUD_REPO_TRACKED_FILE_MAX_BYTES,
     PROLIFERATE_RESERVED_ENV_PREFIX,
     RESERVED_CLOUD_REPO_ENV_VARS,
 )
 from proliferate.server.cloud.errors import CloudApiError
 
-_MAX_TRACKED_FILE_BYTES = 1_048_576
-_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENV_KEY_RE = re.compile(CLOUD_REPO_ENV_VAR_KEY_PATTERN)
 
 
 def normalize_repo_file_path(value: str) -> str:
@@ -55,7 +56,7 @@ def normalize_repo_file_path(value: str) -> str:
 
 
 def validate_tracked_file_content(content: str) -> None:
-    if len(content.encode("utf-8")) > _MAX_TRACKED_FILE_BYTES:
+    if len(content.encode("utf-8")) > CLOUD_REPO_TRACKED_FILE_MAX_BYTES:
         raise CloudApiError(
             "repo_file_too_large",
             "Tracked files must be 1 MiB or smaller.",

--- a/server/tests/unit/test_cloud_repo_config_models.py
+++ b/server/tests/unit/test_cloud_repo_config_models.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from proliferate.server.cloud.repo_config.domain.status import (
+    CloudRepoFileMetadataValue,
+    CloudWorkspaceRepoConfigStatusValue,
+    CloudWorkspaceSetupRunValue,
+)
+from proliferate.server.cloud.repo_config.models import (
+    resync_cloud_workspace_files_payload,
+    run_cloud_workspace_setup_payload,
+    workspace_repo_config_status_payload,
+)
+
+
+def test_workspace_repo_config_status_payload_uses_transport_value() -> None:
+    workspace_id = uuid4()
+    applied_at = datetime(2026, 5, 9, 10, 30, tzinfo=UTC)
+    file_updated_at = datetime(2026, 5, 9, 10, 0, tzinfo=UTC)
+    value = CloudWorkspaceRepoConfigStatusValue(
+        workspace_id=workspace_id,
+        current_repo_files_version=3,
+        repo_files_applied_version=2,
+        repo_files_applied_at=applied_at,
+        files_out_of_sync=True,
+        tracked_files=(
+            CloudRepoFileMetadataValue(
+                relative_path="scripts/setup.sh",
+                content_sha256="abc123",
+                byte_size=42,
+                updated_at=file_updated_at,
+                last_synced_at=file_updated_at,
+            ),
+        ),
+        env_var_keys=("API_BASE_URL",),
+        post_ready_phase="applying_files",
+        post_ready_files_total=4,
+        post_ready_files_applied=2,
+        post_ready_started_at=applied_at,
+        post_ready_completed_at=None,
+        last_apply_failed_path="scripts/setup.sh",
+        last_apply_error="failed",
+    )
+
+    payload = workspace_repo_config_status_payload(value)
+
+    assert payload.current_repo_files_version == 3
+    assert payload.repo_files_applied_version == 2
+    assert payload.repo_files_applied_at == applied_at.isoformat()
+    assert payload.files_out_of_sync is True
+    assert payload.env_var_keys == ["API_BASE_URL"]
+    assert payload.tracked_files[0].relative_path == "scripts/setup.sh"
+    assert payload.tracked_files[0].updated_at == file_updated_at.isoformat()
+    assert payload.last_apply_failed_path == "scripts/setup.sh"
+    assert payload.last_apply_error == "failed"
+
+    resync_payload = resync_cloud_workspace_files_payload(value)
+    assert resync_payload.workspace_id == str(workspace_id)
+    assert resync_payload.current_repo_files_version == payload.current_repo_files_version
+
+
+def test_run_cloud_workspace_setup_payload_uses_transport_value() -> None:
+    workspace_id = uuid4()
+
+    payload = run_cloud_workspace_setup_payload(
+        CloudWorkspaceSetupRunValue(
+            workspace_id=workspace_id,
+            command="pnpm install",
+            terminal_id="terminal-1",
+            command_run_id="run-1",
+            status="running",
+        )
+    )
+
+    assert payload.workspace_id == str(workspace_id)
+    assert payload.command == "pnpm install"
+    assert payload.terminal_id == "terminal-1"
+    assert payload.command_run_id == "run-1"
+    assert payload.status == "running"


### PR DESCRIPTION
## Summary
- Move cloud repo config validation policy values into shared cloud constants.
- Add repo-config transport value objects so Pydantic payload builders no longer accept CloudWorkspace ORM objects.
- Remove the stale repo-config MODELS_ORM_IMPORT allowlist entry and add focused payload tests.

## Verification
- uv run python scripts/check_server_boundaries.py
- uv run python scripts/check_max_lines.py
- git diff --check
- uv run --extra dev ruff check proliferate/constants/cloud.py proliferate/server/cloud/repo_config tests/unit/test_cloud_repo_config_models.py
- DEBUG=true uv run --extra dev python -m pytest -q tests/unit/test_cloud_repo_config_models.py