### PR TITLE
refactor(server): clean cloud repo config ownership

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,11 +11,9 @@ INTEGRATION_DB_IMPORT server/proliferate/integrations/anonymous_telemetry.py 1 t
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/daytona.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/e2b.py 1 transitional integration depends on product domain types/logic
-MODELS_ORM_IMPORT server/proliferate/server/cloud/repo_config/models.py 1 transitional Pydantic constructor still accepts ORM type
 MODELS_ORM_IMPORT server/proliferate/server/cloud/workspaces/models.py 1 transitional Pydantic constructor still accepts ORM type
 SERVICE_ORM_IMPORT server/proliferate/server/ai_magic/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional service imports ORM/auth model
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/repo_config/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/repos/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
@@ -43,11 +41,11 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 mater
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp_connections.py 4 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 13 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environments.py 7 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 26 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 2 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 7 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 8 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 3 transitional store opens DB session
@@ -61,11 +59,11 @@ STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/auth.py 1 mat
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp_connections.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mobility.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_repo_config.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_repo_config.py 1 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_runtime_environments.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspace_setup_runs.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspaces.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_worktree_policy.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organization_invitations.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organizations.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/users.py 1 transitional store imports DB session factory

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -127,6 +127,16 @@ WORKSPACE_REPO_APPLY_LOCK_SALT: int = 4_203_902
 
 
 # ---------------------------------------------------------------------------
+# Cloud worktree retention policy
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO = 20
+MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO = 10
+MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO = 100
+DEFAULT_WORKTREE_POLICY_UPDATED_AT = "1970-01-01T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
 # Git provider
 # ---------------------------------------------------------------------------
 

--- a/server/proliferate/db/store/cloud_worktree_policy.py
+++ b/server/proliferate/db/store/cloud_worktree_policy.py
@@ -10,13 +10,8 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud import CloudWorktreeRetentionPolicy
 from proliferate.utils.time import utcnow
-
-DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO = 20
-MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO = 10
-MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO = 100
 
 
 @dataclass(frozen=True)
@@ -83,18 +78,8 @@ async def save_cloud_worktree_policy(
 async def load_cloud_worktree_policy_for_user(
     user_id: UUID,
 ) -> CloudWorktreePolicyValue | None:
+    # Transitional runtime-sync read; Phase 8 should thread this session boundary.
+    from proliferate.db import engine as db_engine
+
     async with db_engine.async_session_factory() as db:
         return await get_cloud_worktree_policy(db, user_id)
-
-
-async def persist_cloud_worktree_policy_for_user(
-    *,
-    user_id: UUID,
-    max_materialized_worktrees_per_repo: int,
-) -> CloudWorktreePolicyValue:
-    async with db_engine.async_session_factory() as db, db.begin():
-        return await save_cloud_worktree_policy(
-            db,
-            user_id=user_id,
-            max_materialized_worktrees_per_repo=max_materialized_worktrees_per_repo,
-        )

--- a/server/proliferate/server/cloud/repo_config/domain/workspace_status.py
+++ b/server/proliferate/server/cloud/repo_config/domain/workspace_status.py
@@ -1,0 +1,48 @@
+"""Pure value types for workspace repo-config response construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class RepoConfigTrackedFileStatus:
+    relative_path: str
+    content_sha256: str
+    byte_size: int
+    updated_at: datetime
+    last_synced_at: datetime
+
+
+@dataclass(frozen=True)
+class WorkspaceRepoConfigStatus:
+    current_repo_files_version: int
+    repo_files_applied_version: int
+    repo_files_applied_at: datetime | None
+    files_out_of_sync: bool
+    tracked_files: tuple[RepoConfigTrackedFileStatus, ...]
+    env_var_keys: tuple[str, ...]
+    post_ready_phase: str
+    post_ready_files_total: int
+    post_ready_files_applied: int
+    post_ready_started_at: datetime | None
+    post_ready_completed_at: datetime | None
+    last_apply_failed_path: str | None
+    last_apply_error: str | None
+
+
+@dataclass(frozen=True)
+class ResyncWorkspaceRepoConfigStatus:
+    workspace_id: UUID
+    status: WorkspaceRepoConfigStatus
+
+
+@dataclass(frozen=True)
+class RunWorkspaceSetupStatus:
+    workspace_id: UUID
+    command: str
+    terminal_id: str | None
+    command_run_id: str | None
+    status: str

--- a/server/proliferate/server/cloud/repo_config/models.py
+++ b/server/proliferate/server/cloud/repo_config/models.py
@@ -6,11 +6,16 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from proliferate.db.models.cloud import CloudWorkspace
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigSummaryValue,
     CloudRepoConfigValue,
     CloudRepoFileValue,
+)
+from proliferate.server.cloud.repo_config.domain.workspace_status import (
+    RepoConfigTrackedFileStatus,
+    ResyncWorkspaceRepoConfigStatus,
+    RunWorkspaceSetupStatus,
+    WorkspaceRepoConfigStatus,
 )
 
 
@@ -106,7 +111,9 @@ def repo_config_summary_payload(value: CloudRepoConfigSummaryValue) -> CloudRepo
     )
 
 
-def repo_file_metadata_payload(value: CloudRepoFileValue) -> CloudRepoFileMetadata:
+def repo_file_metadata_payload(
+    value: CloudRepoFileValue | RepoConfigTrackedFileStatus,
+) -> CloudRepoFileMetadata:
     return CloudRepoFileMetadata(
         relative_path=value.relative_path,
         content_sha256=value.content_sha256,
@@ -130,68 +137,54 @@ def repo_config_payload(value: CloudRepoConfigValue) -> CloudRepoConfigResponse:
 
 
 def workspace_repo_config_status_payload(
-    workspace: CloudWorkspace,
-    repo_config: CloudRepoConfigValue | None,
+    status: WorkspaceRepoConfigStatus,
 ) -> CloudWorkspaceRepoConfigStatusResponse:
-    tracked_files = (
-        []
-        if repo_config is None
-        else [repo_file_metadata_payload(item) for item in repo_config.tracked_files]
-    )
-    env_var_keys = [] if repo_config is None else sorted(repo_config.env_vars)
-    current_version = 0 if repo_config is None else repo_config.files_version
     return CloudWorkspaceRepoConfigStatusResponse(
-        current_repo_files_version=current_version,
-        repo_files_applied_version=workspace.repo_files_applied_version,
-        repo_files_applied_at=_to_iso(workspace.repo_files_applied_at),
-        files_out_of_sync=workspace.repo_files_applied_version != current_version,
-        tracked_files=tracked_files,
-        env_var_keys=env_var_keys,
-        post_ready_phase=workspace.repo_post_ready_phase,
-        post_ready_files_total=workspace.repo_post_ready_files_total,
-        post_ready_files_applied=workspace.repo_post_ready_files_applied,
-        post_ready_started_at=_to_iso(workspace.repo_post_ready_started_at),
-        post_ready_completed_at=_to_iso(workspace.repo_post_ready_completed_at),
-        last_apply_failed_path=workspace.repo_files_last_failed_path,
-        last_apply_error=workspace.repo_files_last_error,
-    )
-
-
-def resync_cloud_workspace_files_payload(
-    workspace: CloudWorkspace,
-    repo_config: CloudRepoConfigValue | None,
-) -> ResyncCloudWorkspaceFilesResponse:
-    status = workspace_repo_config_status_payload(workspace, repo_config)
-    return ResyncCloudWorkspaceFilesResponse(
-        workspace_id=str(workspace.id),
         current_repo_files_version=status.current_repo_files_version,
         repo_files_applied_version=status.repo_files_applied_version,
-        repo_files_applied_at=status.repo_files_applied_at,
+        repo_files_applied_at=_to_iso(status.repo_files_applied_at),
         files_out_of_sync=status.files_out_of_sync,
-        tracked_files=status.tracked_files,
-        env_var_keys=status.env_var_keys,
+        tracked_files=[repo_file_metadata_payload(item) for item in status.tracked_files],
+        env_var_keys=list(status.env_var_keys),
         post_ready_phase=status.post_ready_phase,
         post_ready_files_total=status.post_ready_files_total,
         post_ready_files_applied=status.post_ready_files_applied,
-        post_ready_started_at=status.post_ready_started_at,
-        post_ready_completed_at=status.post_ready_completed_at,
+        post_ready_started_at=_to_iso(status.post_ready_started_at),
+        post_ready_completed_at=_to_iso(status.post_ready_completed_at),
         last_apply_failed_path=status.last_apply_failed_path,
         last_apply_error=status.last_apply_error,
     )
 
 
+def resync_cloud_workspace_files_payload(
+    status: ResyncWorkspaceRepoConfigStatus,
+) -> ResyncCloudWorkspaceFilesResponse:
+    response = workspace_repo_config_status_payload(status.status)
+    return ResyncCloudWorkspaceFilesResponse(
+        workspace_id=str(status.workspace_id),
+        current_repo_files_version=response.current_repo_files_version,
+        repo_files_applied_version=response.repo_files_applied_version,
+        repo_files_applied_at=response.repo_files_applied_at,
+        files_out_of_sync=response.files_out_of_sync,
+        tracked_files=response.tracked_files,
+        env_var_keys=response.env_var_keys,
+        post_ready_phase=response.post_ready_phase,
+        post_ready_files_total=response.post_ready_files_total,
+        post_ready_files_applied=response.post_ready_files_applied,
+        post_ready_started_at=response.post_ready_started_at,
+        post_ready_completed_at=response.post_ready_completed_at,
+        last_apply_failed_path=response.last_apply_failed_path,
+        last_apply_error=response.last_apply_error,
+    )
+
+
 def run_cloud_workspace_setup_payload(
-    workspace: CloudWorkspace,
-    *,
-    command: str,
-    terminal_id: str | None,
-    command_run_id: str | None,
-    status: str,
+    status: RunWorkspaceSetupStatus,
 ) -> RunCloudWorkspaceSetupResponse:
     return RunCloudWorkspaceSetupResponse(
-        workspace_id=str(workspace.id),
-        command=command,
-        terminal_id=terminal_id,
-        command_run_id=command_run_id,
-        status=status,
+        workspace_id=str(status.workspace_id),
+        command=status.command,
+        terminal_id=status.terminal_id,
+        command_run_id=status.command_run_id,
+        status=status.status,
     )

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import NoReturn
+from datetime import datetime
+from typing import NoReturn, Protocol
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.models.cloud import CloudWorkspace
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigLimitExceededError,
     CloudRepoConfigValue,
@@ -26,6 +26,12 @@ from proliferate.server.billing.service import (
     repo_limit_for_billing_snapshot,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repo_config.domain.workspace_status import (
+    RepoConfigTrackedFileStatus,
+    ResyncWorkspaceRepoConfigStatus,
+    RunWorkspaceSetupStatus,
+    WorkspaceRepoConfigStatus,
+)
 from proliferate.server.cloud.repo_config.models import (
     CloudRepoConfigResponse,
     CloudRepoConfigsListResponse,
@@ -56,6 +62,24 @@ from proliferate.server.cloud.runtime.repo_config_apply import (
 from proliferate.server.cloud.runtime.service import get_workspace_connection
 
 
+class _WorkspaceRepoConfigRecord(Protocol):
+    id: UUID
+    owner_scope: str
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    git_owner: str
+    git_repo_name: str
+    repo_files_applied_version: int
+    repo_files_applied_at: datetime | None
+    repo_post_ready_phase: str
+    repo_post_ready_files_total: int
+    repo_post_ready_files_applied: int
+    repo_post_ready_started_at: datetime | None
+    repo_post_ready_completed_at: datetime | None
+    repo_files_last_failed_path: str | None
+    repo_files_last_error: str | None
+
+
 def _default_repo_config_response() -> CloudRepoConfigResponse:
     return CloudRepoConfigResponse(
         configured=False,
@@ -84,7 +108,7 @@ def _raise_org_cloud_not_ready() -> NoReturn:
 async def _load_authorized_workspace_for_repo_config(
     user_id: UUID,
     workspace_id: UUID,
-) -> CloudWorkspace:
+) -> _WorkspaceRepoConfigRecord:
     workspace = await load_cloud_workspace_by_id(workspace_id)
     if workspace is None:
         _raise_workspace_not_found()
@@ -104,6 +128,53 @@ async def _load_authorized_workspace_for_repo_config(
         _raise_org_cloud_not_ready()
 
     _raise_workspace_not_found()
+
+
+def _workspace_repo_config_status(
+    workspace: _WorkspaceRepoConfigRecord,
+    repo_config: CloudRepoConfigValue | None,
+) -> WorkspaceRepoConfigStatus:
+    tracked_files = (
+        ()
+        if repo_config is None
+        else tuple(
+            RepoConfigTrackedFileStatus(
+                relative_path=item.relative_path,
+                content_sha256=item.content_sha256,
+                byte_size=item.byte_size,
+                updated_at=item.updated_at,
+                last_synced_at=item.last_synced_at,
+            )
+            for item in repo_config.tracked_files
+        )
+    )
+    env_var_keys = () if repo_config is None else tuple(sorted(repo_config.env_vars))
+    current_version = 0 if repo_config is None else repo_config.files_version
+    return WorkspaceRepoConfigStatus(
+        current_repo_files_version=current_version,
+        repo_files_applied_version=workspace.repo_files_applied_version,
+        repo_files_applied_at=workspace.repo_files_applied_at,
+        files_out_of_sync=workspace.repo_files_applied_version != current_version,
+        tracked_files=tracked_files,
+        env_var_keys=env_var_keys,
+        post_ready_phase=workspace.repo_post_ready_phase,
+        post_ready_files_total=workspace.repo_post_ready_files_total,
+        post_ready_files_applied=workspace.repo_post_ready_files_applied,
+        post_ready_started_at=workspace.repo_post_ready_started_at,
+        post_ready_completed_at=workspace.repo_post_ready_completed_at,
+        last_apply_failed_path=workspace.repo_files_last_failed_path,
+        last_apply_error=workspace.repo_files_last_error,
+    )
+
+
+def _resync_workspace_repo_config_status(
+    workspace: _WorkspaceRepoConfigRecord,
+    repo_config: CloudRepoConfigValue | None,
+) -> ResyncWorkspaceRepoConfigStatus:
+    return ResyncWorkspaceRepoConfigStatus(
+        workspace_id=workspace.id,
+        status=_workspace_repo_config_status(workspace, repo_config),
+    )
 
 
 async def list_repo_configs(
@@ -308,7 +379,9 @@ async def get_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return workspace_repo_config_status_payload(workspace, repo_config)
+    return workspace_repo_config_status_payload(
+        _workspace_repo_config_status(workspace, repo_config)
+    )
 
 
 async def build_resync_workspace_repo_config_status(
@@ -323,7 +396,9 @@ async def build_resync_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(workspace, repo_config)
+    return resync_cloud_workspace_files_payload(
+        _resync_workspace_repo_config_status(workspace, repo_config)
+    )
 
 
 def _runtime_access_from_target(
@@ -349,10 +424,11 @@ async def resync_workspace_files(
 ) -> ResyncCloudWorkspaceFilesResponse:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
 
-    target = await get_workspace_connection(workspace)
+    # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
+    target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
     try:
         await apply_workspace_repo_config(
-            workspace,
+            workspace,  # type: ignore[arg-type]
             runtime=_runtime_access_from_target(target),
             run_setup=False,
         )
@@ -376,7 +452,9 @@ async def resync_workspace_files(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(workspace, repo_config)
+    return resync_cloud_workspace_files_payload(
+        _resync_workspace_repo_config_status(workspace, repo_config)
+    )
 
 
 async def run_workspace_setup(
@@ -386,10 +464,11 @@ async def run_workspace_setup(
 ) -> RunCloudWorkspaceSetupResponse:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
 
-    target = await get_workspace_connection(workspace)
+    # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
+    target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
     try:
         started = await run_workspace_saved_setup(
-            workspace,
+            workspace,  # type: ignore[arg-type]
             runtime=_runtime_access_from_target(target),
         )
     except WorkspaceRepoApplyBusyError as error:
@@ -407,9 +486,11 @@ async def run_workspace_setup(
 
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
     return run_cloud_workspace_setup_payload(
-        workspace,
-        command=started.command,
-        terminal_id=started.terminal_id,
-        command_run_id=started.command_run_id,
-        status=started.status,
+        RunWorkspaceSetupStatus(
+            workspace_id=workspace.id,
+            command=started.command,
+            terminal_id=started.terminal_id,
+            command_run_id=started.command_run_id,
+            status=started.status,
+        )
     )

--- a/server/proliferate/server/cloud/worktree_policy/service.py
+++ b/server/proliferate/server/cloud/worktree_policy/service.py
@@ -4,10 +4,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.store.cloud_worktree_policy import (
+from proliferate.constants.cloud import (
     DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+    DEFAULT_WORKTREE_POLICY_UPDATED_AT,
     MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO,
     MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+)
+from proliferate.db.store.cloud_worktree_policy import (
     get_cloud_worktree_policy,
     load_cloud_worktree_policy_for_user,
     save_cloud_worktree_policy,
@@ -17,8 +20,6 @@ from proliferate.server.cloud.worktree_policy.models import (
     CloudWorktreeRetentionPolicyResponse,
     cloud_worktree_policy_payload,
 )
-
-DEFAULT_POLICY_UPDATED_AT = "1970-01-01T00:00:00+00:00"
 
 
 def validate_worktree_policy_limit(value: int) -> int:
@@ -47,7 +48,7 @@ async def get_worktree_retention_policy(
     if value is None:
         return CloudWorktreeRetentionPolicyResponse(
             max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
-            updated_at=DEFAULT_POLICY_UPDATED_AT,
+            updated_at=DEFAULT_WORKTREE_POLICY_UPDATED_AT,
             source="default",
         )
     return cloud_worktree_policy_payload(value)
@@ -76,7 +77,7 @@ async def load_worktree_retention_policy_for_runtime(
     if value is None:
         return CloudWorktreeRetentionPolicyResponse(
             max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
-            updated_at=DEFAULT_POLICY_UPDATED_AT,
+            updated_at=DEFAULT_WORKTREE_POLICY_UPDATED_AT,
             source="default",
         )
     return cloud_worktree_policy_payload(value)


### PR DESCRIPTION
## Summary
- remove ORM response construction from cloud repo-config transport models by introducing pure repo-config status value types
- centralize cloud worktree retention policy constants under `constants/cloud.py`
- remove unused self-opening worktree policy persistence wrapper and shrink/relabel related boundary allowlist debt

## Verification
- `uv run --project server --extra dev ruff check server/proliferate/server/cloud/repo_config server/proliferate/server/cloud/worktree_policy server/proliferate/db/store/cloud_repo_config.py server/proliferate/db/store/cloud_worktree_policy.py server/proliferate/constants/cloud.py`
- `DEBUG=true uv run --project server --extra dev mypy server/proliferate/server/cloud/repo_config server/proliferate/server/cloud/worktree_policy server/proliferate/db/store/cloud_worktree_policy.py`
- `uv run --project server --extra dev python scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `DEBUG=true uv run --project server --extra dev python -m pytest -q server/tests/integration/test_cloud_api.py::TestCloudWorktreeRetentionPolicy server/tests/integration/test_cloud_api.py::TestCloudRepoConfig server/tests/unit/test_cloud_worktree_policy_sync.py`
- `git diff --check origin/main...HEAD`

## Deferred
- remaining self-opening repo-config/worktree-policy reads are left in place because they are used by deferred runtime/workspace flows; the allowlist reasons now call that out explicitly.
