### PR TITLE
refactor(server): thread organization request sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -29,8 +29,7 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transition
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 16 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/organization_invitations.py 3 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 2 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 1 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/cloud_mcp/compat.py 1 transitional store imports product/integration code
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/anonymous_telemetry.py 1 transitional store opens DB session
@@ -48,8 +47,8 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environment
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 26 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 2 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 7 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 8 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 transitional invitation create/rotate commit before email delivery
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 4 transitional wrappers used by deferred billing/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 3 transitional store opens DB session
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/anonymous_telemetry.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory

--- a/server/proliferate/db/store/organization_invitations.py
+++ b/server/proliferate/db/store/organization_invitations.py
@@ -146,61 +146,61 @@ async def create_or_rotate_organization_invitation(
         )
 
 
-async def list_organization_invitations(organization_id: UUID) -> list[InvitationRecord]:
+async def list_organization_invitations(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> list[InvitationRecord]:
     now = utcnow()
-    async with db_engine.async_session_factory() as db:
-        await db.execute(
-            update(OrganizationInvitation)
-            .where(
-                OrganizationInvitation.organization_id == organization_id,
-                OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
-                OrganizationInvitation.expires_at <= now,
-            )
-            .values(
-                status=ORGANIZATION_INVITATION_STATUS_EXPIRED,
-                expired_at=now,
-                handoff_token_hash=None,
-                handoff_expires_at=None,
-                updated_at=now,
-            )
+    await db.execute(
+        update(OrganizationInvitation)
+        .where(
+            OrganizationInvitation.organization_id == organization_id,
+            OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
+            OrganizationInvitation.expires_at <= now,
         )
-        await db.commit()
-        rows = (
-            await db.execute(
-                select(OrganizationInvitation)
-                .where(OrganizationInvitation.organization_id == organization_id)
-                .order_by(OrganizationInvitation.created_at.desc())
-            )
-        ).scalars()
-        return [invitation_record(invitation) for invitation in rows.all()]
+        .values(
+            status=ORGANIZATION_INVITATION_STATUS_EXPIRED,
+            expired_at=now,
+            handoff_token_hash=None,
+            handoff_expires_at=None,
+            updated_at=now,
+        )
+    )
+    rows = (
+        await db.execute(
+            select(OrganizationInvitation)
+            .where(OrganizationInvitation.organization_id == organization_id)
+            .order_by(OrganizationInvitation.created_at.desc())
+        )
+    ).scalars()
+    return [invitation_record(invitation) for invitation in rows.all()]
 
 
 async def revoke_organization_invitation(
+    db: AsyncSession,
     *,
     organization_id: UUID,
     invitation_id: UUID,
 ) -> InvitationRecord | None:
-    async with db_engine.async_session_factory() as db:
-        invitation = (
-            await db.execute(
-                select(OrganizationInvitation).where(
-                    OrganizationInvitation.id == invitation_id,
-                    OrganizationInvitation.organization_id == organization_id,
-                )
+    invitation = (
+        await db.execute(
+            select(OrganizationInvitation).where(
+                OrganizationInvitation.id == invitation_id,
+                OrganizationInvitation.organization_id == organization_id,
             )
-        ).scalar_one_or_none()
-        if invitation is None:
-            return None
-        now = utcnow()
-        if invitation.status == ORGANIZATION_INVITATION_STATUS_PENDING:
-            invitation.status = ORGANIZATION_INVITATION_STATUS_REVOKED
-            invitation.revoked_at = now
-            invitation.handoff_token_hash = None
-            invitation.handoff_expires_at = None
-            invitation.updated_at = now
-            await db.commit()
-            await db.refresh(invitation)
-        return invitation_record(invitation)
+        )
+    ).scalar_one_or_none()
+    if invitation is None:
+        return None
+    now = utcnow()
+    if invitation.status == ORGANIZATION_INVITATION_STATUS_PENDING:
+        invitation.status = ORGANIZATION_INVITATION_STATUS_REVOKED
+        invitation.revoked_at = now
+        invitation.handoff_token_hash = None
+        invitation.handoff_expires_at = None
+        invitation.updated_at = now
+        await db.flush()
+    return invitation_record(invitation)
 
 
 async def rotate_organization_invitation(
@@ -243,36 +243,36 @@ async def rotate_organization_invitation(
 
 
 async def mark_invitation_delivery(
+    db: AsyncSession,
     *,
     invitation_id: UUID,
     sent: bool,
     skipped: bool,
     error: str | None = None,
 ) -> InvitationRecord | None:
-    async with db_engine.async_session_factory() as db:
-        invitation = await db.get(OrganizationInvitation, invitation_id)
-        if invitation is None:
-            return None
-        now = utcnow()
-        if sent:
-            invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_SENT
-            invitation.delivery_error = None
-            invitation.delivered_at = now
-        elif skipped:
-            invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_SKIPPED
-            invitation.delivery_error = None
-            invitation.delivered_at = None
-        else:
-            invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_FAILED
-            invitation.delivery_error = error[:1000] if error else "Invitation delivery failed."
-            invitation.delivered_at = None
-        invitation.updated_at = now
-        await db.commit()
-        await db.refresh(invitation)
-        return invitation_record(invitation)
+    invitation = await db.get(OrganizationInvitation, invitation_id)
+    if invitation is None:
+        return None
+    now = utcnow()
+    if sent:
+        invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_SENT
+        invitation.delivery_error = None
+        invitation.delivered_at = now
+    elif skipped:
+        invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_SKIPPED
+        invitation.delivery_error = None
+        invitation.delivered_at = None
+    else:
+        invitation.delivery_status = ORGANIZATION_INVITATION_DELIVERY_FAILED
+        invitation.delivery_error = error[:1000] if error else "Invitation delivery failed."
+        invitation.delivered_at = None
+    invitation.updated_at = now
+    await db.flush()
+    return invitation_record(invitation)
 
 
 async def create_invitation_handoff(
+    db: AsyncSession,
     *,
     token_hash: str,
     handoff_token_hash: str,
@@ -280,41 +280,41 @@ async def create_invitation_handoff(
     handoff_expires_at: datetime,
 ) -> InvitationHandoffRecord | None:
     now = utcnow()
-    async with db_engine.async_session_factory() as db, db.begin():
-        row = (
-            await db.execute(
-                select(OrganizationInvitation, Organization)
-                .join(
-                    Organization,
-                    Organization.id == OrganizationInvitation.organization_id,
-                )
-                .where(
-                    OrganizationInvitation.token_hash == token_hash,
-                    OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
-                )
-                .with_for_update()
+    row = (
+        await db.execute(
+            select(OrganizationInvitation, Organization)
+            .join(
+                Organization,
+                Organization.id == OrganizationInvitation.organization_id,
             )
-        ).one_or_none()
-        if row is None:
-            return None
-        invitation, organization = row
-        if invitation.expires_at <= now:
-            invitation.status = ORGANIZATION_INVITATION_STATUS_EXPIRED
-            invitation.expired_at = now
-            invitation.updated_at = now
-            return None
-        invitation.handoff_token_hash = handoff_token_hash
-        invitation.handoff_expires_at = handoff_expires_at
-        invitation.updated_at = now
-        return InvitationHandoffRecord(
-            organization_id=organization.id,
-            organization_name=organization.name,
-            invite_email=invitation.email,
-            handoff_token=handoff_token,
+            .where(
+                OrganizationInvitation.token_hash == token_hash,
+                OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
+            )
+            .with_for_update()
         )
+    ).one_or_none()
+    if row is None:
+        return None
+    invitation, organization = row
+    if invitation.expires_at <= now:
+        invitation.status = ORGANIZATION_INVITATION_STATUS_EXPIRED
+        invitation.expired_at = now
+        invitation.updated_at = now
+        return None
+    invitation.handoff_token_hash = handoff_token_hash
+    invitation.handoff_expires_at = handoff_expires_at
+    invitation.updated_at = now
+    return InvitationHandoffRecord(
+        organization_id=organization.id,
+        organization_name=organization.name,
+        invite_email=invitation.email,
+        handoff_token=handoff_token,
+    )
 
 
 async def accept_invitation_handoff(
+    db: AsyncSession,
     *,
     handoff_token_hash: str,
     authenticated_user_id: UUID,
@@ -322,82 +322,81 @@ async def accept_invitation_handoff(
 ) -> tuple[InvitationAcceptRecord | None, str | None]:
     now = utcnow()
     normalized_email = normalize_invitation_email(authenticated_email)
-    async with db_engine.async_session_factory() as db, db.begin():
-        row = (
-            await db.execute(
-                select(OrganizationInvitation, Organization)
-                .join(
-                    Organization,
-                    Organization.id == OrganizationInvitation.organization_id,
-                )
-                .where(
-                    OrganizationInvitation.handoff_token_hash == handoff_token_hash,
-                    OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
-                )
-                .with_for_update()
+    row = (
+        await db.execute(
+            select(OrganizationInvitation, Organization)
+            .join(
+                Organization,
+                Organization.id == OrganizationInvitation.organization_id,
             )
-        ).one_or_none()
-        if row is None:
-            return None, "invalid_invitation"
-        invitation, organization = row
-        if invitation.expires_at <= now:
-            invitation.status = ORGANIZATION_INVITATION_STATUS_EXPIRED
-            invitation.expired_at = now
-            invitation.handoff_token_hash = None
-            invitation.handoff_expires_at = None
-            invitation.updated_at = now
-            return None, "invitation_expired"
-        if invitation.handoff_expires_at is None or invitation.handoff_expires_at <= now:
-            invitation.handoff_token_hash = None
-            invitation.handoff_expires_at = None
-            invitation.updated_at = now
-            return None, "invitation_handoff_expired"
-        if invitation.email != normalized_email:
-            return None, "invitation_email_mismatch"
-
-        result = await db.execute(
-            pg_insert(OrganizationMembership)
-            .values(
-                organization_id=invitation.organization_id,
-                user_id=authenticated_user_id,
-                role=invitation.role,
-                status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-                joined_at=now,
-                removed_at=None,
-                created_at=now,
-                updated_at=now,
+            .where(
+                OrganizationInvitation.handoff_token_hash == handoff_token_hash,
+                OrganizationInvitation.status == ORGANIZATION_INVITATION_STATUS_PENDING,
             )
-            .on_conflict_do_update(
-                constraint="uq_organization_membership_org_user",
-                set_={
-                    "role": invitation.role,
-                    "status": ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-                    "removed_at": None,
-                    "updated_at": now,
-                },
-            )
-            .returning(OrganizationMembership.id)
+            .with_for_update()
         )
-        membership_id = result.scalar_one()
-        membership = await db.get(OrganizationMembership, membership_id)
-        if membership is None:
-            raise RuntimeError("Organization membership disappeared after invitation accept.")
-
-        invitation.status = ORGANIZATION_INVITATION_STATUS_ACCEPTED
-        invitation.accepted_by_user_id = authenticated_user_id
-        invitation.accepted_at = now
+    ).one_or_none()
+    if row is None:
+        return None, "invalid_invitation"
+    invitation, organization = row
+    if invitation.expires_at <= now:
+        invitation.status = ORGANIZATION_INVITATION_STATUS_EXPIRED
+        invitation.expired_at = now
         invitation.handoff_token_hash = None
         invitation.handoff_expires_at = None
         invitation.updated_at = now
-        await maybe_create_org_seat_adjustment(
-            db,
+        return None, "invitation_expired"
+    if invitation.handoff_expires_at is None or invitation.handoff_expires_at <= now:
+        invitation.handoff_token_hash = None
+        invitation.handoff_expires_at = None
+        invitation.updated_at = now
+        return None, "invitation_handoff_expired"
+    if invitation.email != normalized_email:
+        return None, "invitation_email_mismatch"
+
+    result = await db.execute(
+        pg_insert(OrganizationMembership)
+        .values(
             organization_id=invitation.organization_id,
-            membership_id=membership.id,
+            user_id=authenticated_user_id,
+            role=invitation.role,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            removed_at=None,
+            created_at=now,
+            updated_at=now,
         )
-        return (
-            InvitationAcceptRecord(
-                organization=organization_record(organization),
-                membership=membership_record(membership),
-            ),
-            None,
+        .on_conflict_do_update(
+            constraint="uq_organization_membership_org_user",
+            set_={
+                "role": invitation.role,
+                "status": ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+                "removed_at": None,
+                "updated_at": now,
+            },
         )
+        .returning(OrganizationMembership.id)
+    )
+    membership_id = result.scalar_one()
+    membership = await db.get(OrganizationMembership, membership_id)
+    if membership is None:
+        raise RuntimeError("Organization membership disappeared after invitation accept.")
+
+    invitation.status = ORGANIZATION_INVITATION_STATUS_ACCEPTED
+    invitation.accepted_by_user_id = authenticated_user_id
+    invitation.accepted_at = now
+    invitation.handoff_token_hash = None
+    invitation.handoff_expires_at = None
+    invitation.updated_at = now
+    await maybe_create_org_seat_adjustment(
+        db,
+        organization_id=invitation.organization_id,
+        membership_id=membership.id,
+    )
+    return (
+        InvitationAcceptRecord(
+            organization=organization_record(organization),
+            membership=membership_record(membership),
+        ),
+        None,
+    )

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -76,43 +76,6 @@ async def _list_organizations_for_user(
     ]
 
 
-async def create_organization_with_creator(
-    *,
-    name: str,
-    logo_domain: str | None,
-    creator_user_id: UUID,
-) -> OrganizationWithMembershipRecord:
-    now = utcnow()
-    async with db_engine.async_session_factory() as db:
-        async with db.begin():
-            organization = Organization(
-                name=name,
-                logo_domain=logo_domain,
-                logo_image=None,
-                created_at=now,
-                updated_at=now,
-            )
-            db.add(organization)
-            await db.flush()
-            membership = OrganizationMembership(
-                organization_id=organization.id,
-                user_id=creator_user_id,
-                role=ORGANIZATION_ROLE_OWNER,
-                status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-                joined_at=now,
-                removed_at=None,
-                created_at=now,
-                updated_at=now,
-            )
-            db.add(membership)
-            await ensure_organization_billing_subject(db, organization.id)
-            await db.flush()
-        return OrganizationWithMembershipRecord(
-            organization=organization_record(organization),
-            membership=membership_record(membership),
-        )
-
-
 async def list_organizations_for_user(
     db: AsyncSession,
     user_id: UUID,
@@ -227,52 +190,54 @@ async def load_active_membership(
 
 
 async def update_organization_settings(
+    db: AsyncSession,
     *,
     organization_id: UUID,
     name: str | None,
     logo_image: str | None,
     update_logo_image: bool,
 ) -> OrganizationRecord | None:
-    async with db_engine.async_session_factory() as db:
-        organization = await _load_organization(db, organization_id)
-        if organization is None:
-            return None
-        if name is not None:
-            organization.name = name
-        if update_logo_image:
-            organization.logo_image = logo_image
-        organization.updated_at = utcnow()
-        await db.commit()
-        await db.refresh(organization)
-        return organization_record(organization)
+    organization = await _load_organization(db, organization_id)
+    if organization is None:
+        return None
+    if name is not None:
+        organization.name = name
+    if update_logo_image:
+        organization.logo_image = logo_image
+    organization.updated_at = utcnow()
+    await db.flush()
+    return organization_record(organization)
 
 
-async def list_organization_members(organization_id: UUID) -> list[MemberRecord]:
-    async with db_engine.async_session_factory() as db:
-        rows = (
-            await db.execute(
-                select(OrganizationMembership, User)
-                .join(User, User.id == OrganizationMembership.user_id)
-                .where(OrganizationMembership.organization_id == organization_id)
-                .order_by(
-                    OrganizationMembership.status.asc(),
-                    OrganizationMembership.role.asc(),
-                    User.email.asc(),
-                )
+async def list_organization_members(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> list[MemberRecord]:
+    rows = (
+        await db.execute(
+            select(OrganizationMembership, User)
+            .join(User, User.id == OrganizationMembership.user_id)
+            .where(OrganizationMembership.organization_id == organization_id)
+            .order_by(
+                OrganizationMembership.status.asc(),
+                OrganizationMembership.role.asc(),
+                User.email.asc(),
             )
-        ).all()
-        return [
-            MemberRecord(
-                membership=membership_record(membership),
-                email=user.email,
-                display_name=user.display_name,
-                avatar_url=user.avatar_url,
-            )
-            for membership, user in rows
-        ]
+        )
+    ).all()
+    return [
+        MemberRecord(
+            membership=membership_record(membership),
+            email=user.email,
+            display_name=user.display_name,
+            avatar_url=user.avatar_url,
+        )
+        for membership, user in rows
+    ]
 
 
 async def update_organization_membership(
+    db: AsyncSession,
     *,
     organization_id: UUID,
     membership_id: UUID,
@@ -281,48 +246,43 @@ async def update_organization_membership(
     can_modify_owner: bool,
 ) -> tuple[MembershipRecord | None, str | None]:
     now = utcnow()
-    async with db_engine.async_session_factory() as db, db.begin():
-        membership = (
-            await db.execute(
-                select(OrganizationMembership)
-                .where(
-                    OrganizationMembership.id == membership_id,
-                    OrganizationMembership.organization_id == organization_id,
-                )
-                .with_for_update()
+    membership = (
+        await db.execute(
+            select(OrganizationMembership)
+            .where(
+                OrganizationMembership.id == membership_id,
+                OrganizationMembership.organization_id == organization_id,
             )
-        ).scalar_one_or_none()
-        if membership is None:
-            return None, None
-        touches_owner = (
-            membership.role == ORGANIZATION_ROLE_OWNER or role == ORGANIZATION_ROLE_OWNER
+            .with_for_update()
         )
-        if touches_owner and not can_modify_owner:
-            return None, "owner_membership_requires_owner"
-        removing_owner = membership.role == ORGANIZATION_ROLE_OWNER and (
-            (role is not None and role != ORGANIZATION_ROLE_OWNER)
-            or status == ORGANIZATION_MEMBERSHIP_STATUS_REMOVED
+    ).scalar_one_or_none()
+    if membership is None:
+        return None, None
+    touches_owner = membership.role == ORGANIZATION_ROLE_OWNER or role == ORGANIZATION_ROLE_OWNER
+    if touches_owner and not can_modify_owner:
+        return None, "owner_membership_requires_owner"
+    removing_owner = membership.role == ORGANIZATION_ROLE_OWNER and (
+        (role is not None and role != ORGANIZATION_ROLE_OWNER)
+        or status == ORGANIZATION_MEMBERSHIP_STATUS_REMOVED
+    )
+    if removing_owner and await _active_owner_count(db, organization_id) <= 1:
+        return None, "last_owner_cannot_be_removed"
+    if role is not None:
+        membership.role = role
+    if status is not None:
+        membership.status = status
+        membership.removed_at = now if status == ORGANIZATION_MEMBERSHIP_STATUS_REMOVED else None
+        if status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE and membership.joined_at is None:
+            membership.joined_at = now
+    membership.updated_at = now
+    await db.flush()
+    if status is not None:
+        await maybe_create_org_seat_adjustment(
+            db,
+            organization_id=organization_id,
+            membership_id=membership.id,
         )
-        if removing_owner and await _active_owner_count(db, organization_id) <= 1:
-            return None, "last_owner_cannot_be_removed"
-        if role is not None:
-            membership.role = role
-        if status is not None:
-            membership.status = status
-            membership.removed_at = (
-                now if status == ORGANIZATION_MEMBERSHIP_STATUS_REMOVED else None
-            )
-            if status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE and membership.joined_at is None:
-                membership.joined_at = now
-        membership.updated_at = now
-        await db.flush()
-        if status is not None:
-            await maybe_create_org_seat_adjustment(
-                db,
-                organization_id=organization_id,
-                membership_id=membership.id,
-            )
-        return membership_record(membership), None
+    return membership_record(membership), None
 
 
 async def ensure_organization_billing_subject_id(organization_id: UUID) -> UUID:

--- a/server/proliferate/server/organizations/api.py
+++ b/server/proliferate/server/organizations/api.py
@@ -49,8 +49,11 @@ router = APIRouter(prefix="/organizations", tags=["organizations"])
     response_class=HTMLResponse,
     include_in_schema=False,
 )
-async def organization_invitation_landing(token: str) -> HTMLResponse:
-    html = await create_invitation_landing_handoff(token)
+async def organization_invitation_landing(
+    token: str,
+    db: AsyncSession = Depends(get_async_session),
+) -> HTMLResponse:
+    html = await create_invitation_landing_handoff(db, token)
     return HTMLResponse(html)
 
 
@@ -58,8 +61,9 @@ async def organization_invitation_landing(token: str) -> HTMLResponse:
 async def accept_organization_invitation_endpoint(
     body: OrganizationInvitationAcceptRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationAcceptResponse:
-    record = await accept_invitation(user, body.invite_handoff)
+    record = await accept_invitation(db, user, body.invite_handoff)
     return OrganizationInvitationAcceptResponse(
         organization=organization_with_membership_response(record),
     )
@@ -108,8 +112,9 @@ async def update_organization_endpoint(
 async def list_organization_members_endpoint(
     organization_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembersResponse:
-    members = await list_members(user, organization_id)
+    members = await list_members(db, user, organization_id)
     return OrganizationMembersResponse(members=[member_response(member) for member in members])
 
 
@@ -122,8 +127,10 @@ async def update_organization_membership_endpoint(
     membership_id: UUID,
     body: OrganizationMembershipUpdateRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembershipResponse:
     membership = await update_membership(
+        db,
         user,
         organization_id,
         membership_id,
@@ -141,8 +148,9 @@ async def remove_organization_membership_endpoint(
     organization_id: UUID,
     membership_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembershipResponse:
-    membership = await remove_membership(user, organization_id, membership_id)
+    membership = await remove_membership(db, user, organization_id, membership_id)
     return membership_response(membership)
 
 
@@ -150,8 +158,9 @@ async def remove_organization_membership_endpoint(
 async def list_organization_invitations_endpoint(
     organization_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationsResponse:
-    invitations = await list_invitations(user, organization_id)
+    invitations = await list_invitations(db, user, organization_id)
     return OrganizationInvitationsResponse(
         invitations=[invitation_response(invitation) for invitation in invitations],
     )
@@ -166,8 +175,10 @@ async def create_organization_invitation_endpoint(
     organization_id: UUID,
     body: OrganizationInviteRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
     result = await create_invitation(
+        db,
         user,
         organization_id,
         email=str(body.email),
@@ -184,8 +195,9 @@ async def resend_organization_invitation_endpoint(
     organization_id: UUID,
     invitation_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
-    result = await resend_invitation(user, organization_id, invitation_id)
+    result = await resend_invitation(db, user, organization_id, invitation_id)
     return invitation_response(result.invitation)
 
 
@@ -197,6 +209,7 @@ async def revoke_organization_invitation_endpoint(
     organization_id: UUID,
     invitation_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
-    invitation = await revoke_invitation(user, organization_id, invitation_id)
+    invitation = await revoke_invitation(db, user, organization_id, invitation_id)
     return invitation_response(invitation)

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -31,7 +31,10 @@ from proliferate.constants.organizations import (
 )
 from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import organizations as organization_store
-from proliferate.db.store.billing import get_or_create_stripe_customer_state_for_user
+from proliferate.db.store.billing import (
+    ensure_organization_billing_subject,
+    get_or_create_stripe_customer_state_for_user,
+)
 from proliferate.db.store.organization_records import (
     InvitationCreateRecord,
     InvitationRecord,
@@ -217,6 +220,30 @@ async def resolve_owner_context(
     )
 
 
+async def _resolve_organization_owner_context(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+    organization_id: UUID,
+) -> OwnerContext:
+    record = await organization_store.get_organization_with_membership(
+        db,
+        organization_id=organization_id,
+        user_id=actor_user.id,
+    )
+    if record is None:
+        raise _org_not_found()
+    subject = await ensure_organization_billing_subject(db, organization_id)
+    return OwnerContext(
+        owner_scope="organization",
+        actor_user_id=actor_user.id,
+        owner_user_id=None,
+        organization_id=organization_id,
+        membership_id=record.membership.id,
+        membership_role=record.membership.role,
+        billing_subject_id=subject.id,
+    )
+
+
 async def list_organizations(
     db: AsyncSession,
     actor_user: OrganizationActor,
@@ -256,12 +283,14 @@ async def update_organization(
     logo_image: str | None,
     update_logo_image: bool,
 ) -> OrganizationWithMembershipRecord:
-    context = await resolve_owner_context(
+    context = await _resolve_organization_owner_context(
+        db,
         actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
+        organization_id,
     )
     require_org_role(context, organization_admin_roles())
     updated = await organization_store.update_organization_settings(
+        db,
         organization_id=organization_id,
         name=_clean_organization_name(name) if name is not None else None,
         logo_image=_sanitize_logo_image(logo_image) if update_logo_image else None,
@@ -276,17 +305,16 @@ async def update_organization(
 
 
 async def list_members(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
 ) -> list[MemberRecord]:
-    await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
-    return await organization_store.list_organization_members(organization_id)
+    await _resolve_organization_owner_context(db, actor_user, organization_id)
+    return await organization_store.list_organization_members(db, organization_id)
 
 
 async def update_membership(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
     membership_id: UUID,
@@ -294,10 +322,7 @@ async def update_membership(
     role: str | None,
     status: str | None,
 ) -> MembershipRecord:
-    context = await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
+    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
     require_org_role(context, organization_admin_roles())
     _raise_if_denied(can_modify_membership(context, membership_id))
     can_modify_owner = can_modify_owner_memberships(context)
@@ -310,6 +335,7 @@ async def update_membership(
             status_code=400,
         )
     membership, error = await organization_store.update_organization_membership(
+        db,
         organization_id=organization_id,
         membership_id=membership_id,
         role=role,
@@ -334,11 +360,13 @@ async def update_membership(
 
 
 async def remove_membership(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
     membership_id: UUID,
 ) -> MembershipRecord:
     return await update_membership(
+        db,
         actor_user,
         organization_id,
         membership_id,
@@ -348,16 +376,14 @@ async def remove_membership(
 
 
 async def create_invitation(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
     *,
     email: str,
     role: str,
 ) -> OrganizationInvitationEmailResult:
-    context = await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
+    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
     require_org_role(context, required_roles_for_invitation_role(role))
     normalized_email = normalize_invitation_email(email)
     token = _new_token()
@@ -371,11 +397,12 @@ async def create_invitation(
     )
     if record is None:
         raise _org_not_found()
-    delivery = await _send_invitation_email(record, token, actor_user)
+    delivery = await _send_invitation_email(db, record, token, actor_user)
     invitation = record.invitation
     if delivery.sent or delivery.skipped:
         invitation = (
             await invitation_store.mark_invitation_delivery(
+                db,
                 invitation_id=record.invitation.id,
                 sent=delivery.sent,
                 skipped=delivery.skipped,
@@ -389,14 +416,12 @@ async def create_invitation(
 
 
 async def resend_invitation(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
     invitation_id: UUID,
 ) -> OrganizationInvitationEmailResult:
-    context = await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
+    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
     require_org_role(context, organization_admin_roles())
     token = _new_token()
     record = await invitation_store.rotate_organization_invitation(
@@ -411,11 +436,12 @@ async def resend_invitation(
             "Organization invitation not found.",
             status_code=404,
         )
-    delivery = await _send_invitation_email(record, token, actor_user)
+    delivery = await _send_invitation_email(db, record, token, actor_user)
     invitation = record.invitation
     if delivery.sent or delivery.skipped:
         invitation = (
             await invitation_store.mark_invitation_delivery(
+                db,
                 invitation_id=record.invitation.id,
                 sent=delivery.sent,
                 skipped=delivery.skipped,
@@ -429,6 +455,7 @@ async def resend_invitation(
 
 
 async def _send_invitation_email(
+    db: AsyncSession,
     record: InvitationCreateRecord,
     token: str,
     actor_user: OrganizationActor,
@@ -443,6 +470,7 @@ async def _send_invitation_email(
         )
     except resend.ResendEmailError as error:
         await invitation_store.mark_invitation_delivery(
+            db,
             invitation_id=record.invitation.id,
             sent=False,
             skipped=False,
@@ -462,27 +490,24 @@ def _invitation_landing_url(token: str) -> str:
 
 
 async def list_invitations(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
 ) -> list[InvitationRecord]:
-    await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
-    return await invitation_store.list_organization_invitations(organization_id)
+    await _resolve_organization_owner_context(db, actor_user, organization_id)
+    return await invitation_store.list_organization_invitations(db, organization_id)
 
 
 async def revoke_invitation(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     organization_id: UUID,
     invitation_id: UUID,
 ) -> InvitationRecord:
-    context = await resolve_owner_context(
-        actor_user,
-        OwnerSelection(owner_scope="organization", organization_id=organization_id),
-    )
+    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
     require_org_role(context, organization_admin_roles())
     invitation = await invitation_store.revoke_organization_invitation(
+        db,
         organization_id=organization_id,
         invitation_id=invitation_id,
     )
@@ -495,9 +520,10 @@ async def revoke_invitation(
     return invitation
 
 
-async def create_invitation_landing_handoff(raw_token: str) -> str:
+async def create_invitation_landing_handoff(db: AsyncSession, raw_token: str) -> str:
     handoff_token = _new_token()
     handoff = await invitation_store.create_invitation_handoff(
+        db,
         token_hash=_hash_token(raw_token, ORGANIZATION_INVITE_TOKEN_DOMAIN),
         handoff_token_hash=_hash_token(handoff_token, ORGANIZATION_INVITE_HANDOFF_TOKEN_DOMAIN),
         handoff_token=handoff_token,
@@ -514,10 +540,12 @@ async def create_invitation_landing_handoff(raw_token: str) -> str:
 
 
 async def accept_invitation(
+    db: AsyncSession,
     actor_user: OrganizationActor,
     invite_handoff: str,
 ) -> OrganizationWithMembershipRecord:
     accepted, error = await invitation_store.accept_invitation_handoff(
+        db,
         handoff_token_hash=_hash_token(invite_handoff, ORGANIZATION_INVITE_HANDOFF_TOKEN_DOMAIN),
         authenticated_user_id=actor_user.id,
         authenticated_email=actor_user.email,


### PR DESCRIPTION
## Summary

- thread request-scoped database sessions through organization member and invitation endpoints
- convert safe organization and invitation store operations to accept `AsyncSession` and flush instead of self-opening/committing
- keep invitation create/rotate and deferred billing/cloud wrappers as explicit transitional carve-outs, then shrink the server boundary allowlist counts

## Verification

- `DEBUG=true JWT_SECRET=test CLOUD_SECRET_KEY=test uv run --extra dev pytest -q tests/unit/test_organization_domain.py tests/unit/test_organization_errors.py tests/integration/test_organizations_api.py`
- `uv run --extra dev ruff check proliferate/server/organizations proliferate/db/store/organizations.py proliferate/db/store/organization_invitations.py`
- `uv --directory server run --extra dev python ../scripts/check_server_boundaries.py`
- `uv --directory server run --extra dev python ../scripts/check_max_lines.py`
- `git diff --check`
