### PR TITLE
refactor(server): thread automation API store sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -22,7 +22,7 @@ SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 trans
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/anonymous_telemetry.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 12 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 4 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mcp_connections.py 4 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transitional store owns transaction commit
@@ -36,7 +36,7 @@ STORE_FORBIDDEN_IMPORT server/proliferate/db/store/cloud_mcp/compat.py 1 transit
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/anonymous_telemetry.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 13 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 8 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/cloud workspace helper still opens isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_credentials.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
@@ -54,7 +54,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 3 transitional s
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/anonymous_telemetry.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 worker/cloud workspace helper still imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/billing.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_credentials.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/auth.py 1 materialization refresh wrappers import DB session factory

--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -193,6 +193,7 @@ async def _load_automation_value(
 
 
 async def create_automation_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     cloud_repo_config_id: UUID,
@@ -208,61 +209,63 @@ async def create_automation_for_user(
     reasoning_effort: str | None,
     next_run_at: datetime | None,
 ) -> AutomationValue:
-    async with db_engine.async_session_factory() as db:
-        now = utcnow()
-        record = Automation(
-            user_id=user_id,
-            cloud_repo_config_id=cloud_repo_config_id,
-            title=title,
-            prompt=prompt,
-            schedule_rrule=schedule_rrule,
-            schedule_timezone=schedule_timezone,
-            schedule_summary=schedule_summary,
-            execution_target=execution_target,
-            agent_kind=agent_kind,
-            model_id=model_id,
-            mode_id=mode_id,
-            reasoning_effort=reasoning_effort,
-            enabled=True,
-            paused_at=None,
-            next_run_at=next_run_at,
-            last_scheduled_at=None,
-            created_at=now,
-            updated_at=now,
-        )
-        db.add(record)
-        await db.commit()
-        value = await _load_automation_value(db, user_id=user_id, automation_id=record.id)
-        if value is None:
-            raise RuntimeError("Created automation could not be loaded.")
-        return value
+    now = utcnow()
+    record = Automation(
+        user_id=user_id,
+        cloud_repo_config_id=cloud_repo_config_id,
+        title=title,
+        prompt=prompt,
+        schedule_rrule=schedule_rrule,
+        schedule_timezone=schedule_timezone,
+        schedule_summary=schedule_summary,
+        execution_target=execution_target,
+        agent_kind=agent_kind,
+        model_id=model_id,
+        mode_id=mode_id,
+        reasoning_effort=reasoning_effort,
+        enabled=True,
+        paused_at=None,
+        next_run_at=next_run_at,
+        last_scheduled_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(record)
+    await db.flush()
+    value = await _load_automation_value(db, user_id=user_id, automation_id=record.id)
+    if value is None:
+        raise RuntimeError("Created automation could not be loaded.")
+    return value
 
 
-async def list_automations_for_user(user_id: UUID) -> list[AutomationValue]:
-    async with db_engine.async_session_factory() as db:
-        rows = list(
-            (
-                await db.execute(
-                    select(Automation, CloudRepoConfig)
-                    .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
-                    .where(Automation.user_id == user_id)
-                    .order_by(Automation.created_at.desc())
-                )
-            ).all()
-        )
-        return [_automation_value(record, repo_config) for record, repo_config in rows]
+async def list_automations_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> list[AutomationValue]:
+    rows = list(
+        (
+            await db.execute(
+                select(Automation, CloudRepoConfig)
+                .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
+                .where(Automation.user_id == user_id)
+                .order_by(Automation.created_at.desc())
+            )
+        ).all()
+    )
+    return [_automation_value(record, repo_config) for record, repo_config in rows]
 
 
 async def load_automation_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     automation_id: UUID,
 ) -> AutomationValue | None:
-    async with db_engine.async_session_factory() as db:
-        return await _load_automation_value(db, user_id=user_id, automation_id=automation_id)
+    return await _load_automation_value(db, user_id=user_id, automation_id=automation_id)
 
 
 async def update_automation_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     automation_id: UUID,
@@ -280,142 +283,140 @@ async def update_automation_for_user(
     paused_at: object = _UNSET,
     next_run_at: object = _UNSET,
 ) -> AutomationValue | None:
-    async with db_engine.async_session_factory() as db:
-        record = (
-            await db.execute(
-                select(Automation).where(
-                    Automation.id == automation_id,
-                    Automation.user_id == user_id,
-                )
+    record = (
+        await db.execute(
+            select(Automation).where(
+                Automation.id == automation_id,
+                Automation.user_id == user_id,
             )
-        ).scalar_one_or_none()
-        if record is None:
-            return None
-        if title is not _UNSET:
-            record.title = title  # type: ignore[assignment]
-        if prompt is not _UNSET:
-            record.prompt = prompt  # type: ignore[assignment]
-        if schedule_rrule is not _UNSET:
-            record.schedule_rrule = schedule_rrule  # type: ignore[assignment]
-        if schedule_timezone is not _UNSET:
-            record.schedule_timezone = schedule_timezone  # type: ignore[assignment]
-        if schedule_summary is not _UNSET:
-            record.schedule_summary = schedule_summary  # type: ignore[assignment]
-        if execution_target is not _UNSET:
-            record.execution_target = execution_target  # type: ignore[assignment]
-        if agent_kind is not _UNSET:
-            record.agent_kind = agent_kind  # type: ignore[assignment]
-        if model_id is not _UNSET:
-            record.model_id = model_id  # type: ignore[assignment]
-        if mode_id is not _UNSET:
-            record.mode_id = mode_id  # type: ignore[assignment]
-        if reasoning_effort is not _UNSET:
-            record.reasoning_effort = reasoning_effort  # type: ignore[assignment]
-        if enabled is not _UNSET:
-            record.enabled = enabled  # type: ignore[assignment]
-        if paused_at is not _UNSET:
-            record.paused_at = paused_at  # type: ignore[assignment]
-        if next_run_at is not _UNSET:
-            record.next_run_at = next_run_at  # type: ignore[assignment]
-        record.updated_at = utcnow()
-        await db.commit()
-        return await _load_automation_value(db, user_id=user_id, automation_id=automation_id)
+        )
+    ).scalar_one_or_none()
+    if record is None:
+        return None
+    if title is not _UNSET:
+        record.title = title  # type: ignore[assignment]
+    if prompt is not _UNSET:
+        record.prompt = prompt  # type: ignore[assignment]
+    if schedule_rrule is not _UNSET:
+        record.schedule_rrule = schedule_rrule  # type: ignore[assignment]
+    if schedule_timezone is not _UNSET:
+        record.schedule_timezone = schedule_timezone  # type: ignore[assignment]
+    if schedule_summary is not _UNSET:
+        record.schedule_summary = schedule_summary  # type: ignore[assignment]
+    if execution_target is not _UNSET:
+        record.execution_target = execution_target  # type: ignore[assignment]
+    if agent_kind is not _UNSET:
+        record.agent_kind = agent_kind  # type: ignore[assignment]
+    if model_id is not _UNSET:
+        record.model_id = model_id  # type: ignore[assignment]
+    if mode_id is not _UNSET:
+        record.mode_id = mode_id  # type: ignore[assignment]
+    if reasoning_effort is not _UNSET:
+        record.reasoning_effort = reasoning_effort  # type: ignore[assignment]
+    if enabled is not _UNSET:
+        record.enabled = enabled  # type: ignore[assignment]
+    if paused_at is not _UNSET:
+        record.paused_at = paused_at  # type: ignore[assignment]
+    if next_run_at is not _UNSET:
+        record.next_run_at = next_run_at  # type: ignore[assignment]
+    record.updated_at = utcnow()
+    await db.flush()
+    return await _load_automation_value(db, user_id=user_id, automation_id=automation_id)
 
 
 async def create_manual_run_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     automation_id: UUID,
 ) -> AutomationRunValue | None:
-    async with db_engine.async_session_factory() as db:
-        row = (
-            await db.execute(
-                select(Automation, CloudRepoConfig)
-                .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
-                .where(
-                    Automation.id == automation_id,
-                    Automation.user_id == user_id,
-                )
+    row = (
+        await db.execute(
+            select(Automation, CloudRepoConfig)
+            .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
+            .where(
+                Automation.id == automation_id,
+                Automation.user_id == user_id,
             )
-        ).one_or_none()
-        if row is None:
-            return None
-        automation, repo_config = row
-        now = utcnow()
-        run = AutomationRun(
-            automation_id=automation.id,
-            user_id=user_id,
-            trigger_kind=AUTOMATION_RUN_TRIGGER_MANUAL,
-            scheduled_for=None,
-            execution_target=automation.execution_target,
-            status=AUTOMATION_RUN_STATUS_QUEUED,
-            title_snapshot=automation.title,
-            prompt_snapshot=automation.prompt,
-            git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
-            git_owner_snapshot=repo_config.git_owner,
-            git_repo_name_snapshot=repo_config.git_repo_name,
-            cloud_repo_config_id_snapshot=automation.cloud_repo_config_id,
-            agent_kind_snapshot=automation.agent_kind,
-            model_id_snapshot=automation.model_id,
-            mode_id_snapshot=automation.mode_id,
-            reasoning_effort_snapshot=automation.reasoning_effort,
-            executor_kind=None,
-            executor_id=None,
-            claim_id=None,
-            claimed_at=None,
-            claim_expires_at=None,
-            last_heartbeat_at=None,
-            dispatch_started_at=None,
-            dispatched_at=None,
-            failed_at=None,
-            cloud_workspace_id=None,
-            anyharness_workspace_id=None,
-            anyharness_session_id=None,
-            cancelled_at=None,
-            last_error_code=None,
-            last_error_message=None,
-            created_at=now,
-            updated_at=now,
         )
-        db.add(run)
-        await db.commit()
-        await db.refresh(run)
-        return _run_value(run)
+    ).one_or_none()
+    if row is None:
+        return None
+    automation, repo_config = row
+    now = utcnow()
+    run = AutomationRun(
+        automation_id=automation.id,
+        user_id=user_id,
+        trigger_kind=AUTOMATION_RUN_TRIGGER_MANUAL,
+        scheduled_for=None,
+        execution_target=automation.execution_target,
+        status=AUTOMATION_RUN_STATUS_QUEUED,
+        title_snapshot=automation.title,
+        prompt_snapshot=automation.prompt,
+        git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
+        git_owner_snapshot=repo_config.git_owner,
+        git_repo_name_snapshot=repo_config.git_repo_name,
+        cloud_repo_config_id_snapshot=automation.cloud_repo_config_id,
+        agent_kind_snapshot=automation.agent_kind,
+        model_id_snapshot=automation.model_id,
+        mode_id_snapshot=automation.mode_id,
+        reasoning_effort_snapshot=automation.reasoning_effort,
+        executor_kind=None,
+        executor_id=None,
+        claim_id=None,
+        claimed_at=None,
+        claim_expires_at=None,
+        last_heartbeat_at=None,
+        dispatch_started_at=None,
+        dispatched_at=None,
+        failed_at=None,
+        cloud_workspace_id=None,
+        anyharness_workspace_id=None,
+        anyharness_session_id=None,
+        cancelled_at=None,
+        last_error_code=None,
+        last_error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(run)
+    await db.flush()
+    return _run_value(run)
 
 
 async def list_runs_for_automation_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     automation_id: UUID,
     limit: int,
 ) -> list[AutomationRunValue] | None:
-    async with db_engine.async_session_factory() as db:
-        exists = (
-            await db.execute(
-                select(Automation.id).where(
-                    Automation.id == automation_id,
-                    Automation.user_id == user_id,
-                )
+    exists = (
+        await db.execute(
+            select(Automation.id).where(
+                Automation.id == automation_id,
+                Automation.user_id == user_id,
             )
-        ).scalar_one_or_none()
-        if exists is None:
-            return None
-        records = list(
-            (
-                await db.execute(
-                    select(AutomationRun)
-                    .where(
-                        AutomationRun.automation_id == automation_id,
-                        AutomationRun.user_id == user_id,
-                    )
-                    .order_by(AutomationRun.created_at.desc(), AutomationRun.id.desc())
-                    .limit(limit)
-                )
-            )
-            .scalars()
-            .all()
         )
-        return [_run_value(record) for record in records]
+    ).scalar_one_or_none()
+    if exists is None:
+        return None
+    records = list(
+        (
+            await db.execute(
+                select(AutomationRun)
+                .where(
+                    AutomationRun.automation_id == automation_id,
+                    AutomationRun.user_id == user_id,
+                )
+                .order_by(AutomationRun.created_at.desc(), AutomationRun.id.desc())
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [_run_value(record) for record in records]
 
 
 async def list_latest_runs_by_cloud_workspace_ids_for_user(

--- a/server/proliferate/server/automations/api.py
+++ b/server/proliferate/server/automations/api.py
@@ -6,12 +6,14 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
 from proliferate.constants.automations import (
     AUTOMATION_RUN_LIST_DEFAULT_LIMIT,
     AUTOMATION_RUN_LIST_MAX_LIMIT,
 )
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.automations.local_executor_service import (
     attach_local_run_session,
@@ -56,17 +58,19 @@ router = APIRouter(prefix="/automations", tags=["automations"])
 
 @router.get("", response_model=AutomationListResponse)
 async def list_automations_endpoint(
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationListResponse:
-    return await list_automations(user.id)
+    return await list_automations(db, user.id)
 
 
 @router.post("", response_model=AutomationResponse)
 async def create_automation_endpoint(
     body: CreateAutomationRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await create_automation(user.id, body)
+    return await create_automation(db, user.id, body)
 
 
 @router.post("/executor/local/claims", response_model=LocalAutomationClaimListResponse)
@@ -188,42 +192,47 @@ async def mark_local_run_failed_endpoint(
 @router.get("/{automation_id}", response_model=AutomationResponse)
 async def get_automation_endpoint(
     automation_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await get_automation(user.id, automation_id)
+    return await get_automation(db, user.id, automation_id)
 
 
 @router.patch("/{automation_id}", response_model=AutomationResponse)
 async def update_automation_endpoint(
     automation_id: UUID,
     body: UpdateAutomationRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await update_automation(user.id, automation_id, body)
+    return await update_automation(db, user.id, automation_id, body)
 
 
 @router.post("/{automation_id}/pause", response_model=AutomationResponse)
 async def pause_automation_endpoint(
     automation_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await pause_automation(user.id, automation_id)
+    return await pause_automation(db, user.id, automation_id)
 
 
 @router.post("/{automation_id}/resume", response_model=AutomationResponse)
 async def resume_automation_endpoint(
     automation_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await resume_automation(user.id, automation_id)
+    return await resume_automation(db, user.id, automation_id)
 
 
 @router.post("/{automation_id}/run-now", response_model=AutomationRunResponse)
 async def run_automation_now_endpoint(
     automation_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationRunResponse:
-    return await run_automation_now(user.id, automation_id)
+    return await run_automation_now(db, user.id, automation_id)
 
 
 @router.get("/{automation_id}/runs", response_model=AutomationRunListResponse)
@@ -232,6 +241,7 @@ async def list_automation_runs_endpoint(
     limit: Annotated[int, Query(ge=1, le=AUTOMATION_RUN_LIST_MAX_LIMIT)] = (
         AUTOMATION_RUN_LIST_DEFAULT_LIMIT
     ),
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationRunListResponse:
-    return await list_automation_runs(user.id, automation_id, limit=limit)
+    return await list_automation_runs(db, user.id, automation_id, limit=limit)

--- a/server/proliferate/server/automations/service.py
+++ b/server/proliferate/server/automations/service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.constants.automations import (
     AUTOMATION_RUN_LIST_DEFAULT_LIMIT,
 )
@@ -84,19 +86,27 @@ async def _ensure_repo_config_id(
     return repo_config.id
 
 
-async def list_automations(user_id: UUID) -> AutomationListResponse:
-    values = await list_automations_for_user(user_id)
+async def list_automations(db: AsyncSession, user_id: UUID) -> AutomationListResponse:
+    values = await list_automations_for_user(db, user_id)
     return AutomationListResponse(automations=[automation_payload(value) for value in values])
 
 
-async def get_automation(user_id: UUID, automation_id: UUID) -> AutomationResponse:
-    value = await load_automation_for_user(user_id=user_id, automation_id=automation_id)
+async def get_automation(
+    db: AsyncSession,
+    user_id: UUID,
+    automation_id: UUID,
+) -> AutomationResponse:
+    value = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if value is None:
         raise AutomationNotFound()
     return automation_payload(value)
 
 
-async def create_automation(user_id: UUID, body: CreateAutomationRequest) -> AutomationResponse:
+async def create_automation(
+    db: AsyncSession,
+    user_id: UUID,
+    body: CreateAutomationRequest,
+) -> AutomationResponse:
     now = utcnow()
     git_owner = normalize_repo_part(body.git_owner, field_name="gitOwner")
     git_repo_name = normalize_repo_part(body.git_repo_name, field_name="gitRepoName")
@@ -114,6 +124,7 @@ async def create_automation(user_id: UUID, body: CreateAutomationRequest) -> Aut
     agent_kind = normalize_agent_kind(body.agent_kind)
     require_agent_kind(execution_target, agent_kind)
     value = await create_automation_for_user(
+        db,
         user_id=user_id,
         cloud_repo_config_id=repo_config_id,
         title=normalize_title(body.title),
@@ -132,11 +143,12 @@ async def create_automation(user_id: UUID, body: CreateAutomationRequest) -> Aut
 
 
 async def update_automation(
+    db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
     body: UpdateAutomationRequest,
 ) -> AutomationResponse:
-    existing = await load_automation_for_user(user_id=user_id, automation_id=automation_id)
+    existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
     if "git_owner" in body.model_fields_set or "git_repo_name" in body.model_fields_set:
@@ -185,6 +197,7 @@ async def update_automation(
     require_agent_kind(resolved_execution_target, resolved_agent_kind)
 
     value = await update_automation_for_user(
+        db,
         user_id=user_id,
         automation_id=automation_id,
         **updates,
@@ -194,8 +207,13 @@ async def update_automation(
     return automation_payload(value)
 
 
-async def pause_automation(user_id: UUID, automation_id: UUID) -> AutomationResponse:
+async def pause_automation(
+    db: AsyncSession,
+    user_id: UUID,
+    automation_id: UUID,
+) -> AutomationResponse:
     value = await update_automation_for_user(
+        db,
         user_id=user_id,
         automation_id=automation_id,
         enabled=False,
@@ -207,8 +225,12 @@ async def pause_automation(user_id: UUID, automation_id: UUID) -> AutomationResp
     return automation_payload(value)
 
 
-async def resume_automation(user_id: UUID, automation_id: UUID) -> AutomationResponse:
-    existing = await load_automation_for_user(user_id=user_id, automation_id=automation_id)
+async def resume_automation(
+    db: AsyncSession,
+    user_id: UUID,
+    automation_id: UUID,
+) -> AutomationResponse:
+    existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
     require_agent_kind(existing.execution_target, existing.agent_kind)
@@ -218,6 +240,7 @@ async def resume_automation(user_id: UUID, automation_id: UUID) -> AutomationRes
         now=utcnow(),
     )
     value = await update_automation_for_user(
+        db,
         user_id=user_id,
         automation_id=automation_id,
         enabled=True,
@@ -229,8 +252,12 @@ async def resume_automation(user_id: UUID, automation_id: UUID) -> AutomationRes
     return automation_payload(value)
 
 
-async def run_automation_now(user_id: UUID, automation_id: UUID) -> AutomationRunResponse:
-    existing = await load_automation_for_user(user_id=user_id, automation_id=automation_id)
+async def run_automation_now(
+    db: AsyncSession,
+    user_id: UUID,
+    automation_id: UUID,
+) -> AutomationRunResponse:
+    existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
     if not existing.enabled:
@@ -241,13 +268,14 @@ async def run_automation_now(user_id: UUID, automation_id: UUID) -> AutomationRu
         git_owner=existing.git_owner,
         git_repo_name=existing.git_repo_name,
     )
-    value = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+    value = await create_manual_run_for_user(db, user_id=user_id, automation_id=automation_id)
     if value is None:
         raise AutomationNotFound()
     return automation_run_payload(value)
 
 
 async def list_automation_runs(
+    db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
     *,
@@ -255,6 +283,7 @@ async def list_automation_runs(
 ) -> AutomationRunListResponse:
     bounded_limit = bounded_run_list_limit(limit)
     values = await list_runs_for_automation_for_user(
+        db,
         user_id=user_id,
         automation_id=automation_id,
         limit=bounded_limit,

--- a/server/tests/unit/test_automation_executor.py
+++ b/server/tests/unit/test_automation_executor.py
@@ -144,6 +144,17 @@ async def _create_local_automation(user_id: uuid.UUID, now: datetime) -> uuid.UU
         return automation.id
 
 
+async def _create_manual_run(user_id: uuid.UUID, automation_id: uuid.UUID):
+    async with engine_module.async_session_factory() as session:
+        run = await create_manual_run_for_user(
+            session,
+            user_id=user_id,
+            automation_id=automation_id,
+        )
+        await session.commit()
+        return run
+
+
 @pytest.mark.asyncio
 async def test_manual_run_snapshots_inputs_and_claim_uses_snapshot(
     test_engine,  # type: ignore[no-untyped-def]
@@ -155,7 +166,7 @@ async def test_manual_run_snapshots_inputs_and_claim_uses_snapshot(
 
     try:
         automation_id = await _create_cloud_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
 
         async with engine_module.async_session_factory() as session:
@@ -196,7 +207,7 @@ async def test_claim_cloud_run_without_agent_snapshot_fails_at_claim_time(
 
     try:
         automation_id = await _create_cloud_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
 
         async with engine_module.async_session_factory() as session:
@@ -235,7 +246,7 @@ async def test_stale_claim_cannot_mutate_after_reclaim(
 
     try:
         automation_id = await _create_cloud_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
 
         first = (
@@ -285,7 +296,7 @@ async def test_local_claim_matches_user_and_canonical_repo_identity(
 
     try:
         automation_id = await _create_local_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
 
         wrong_user_claims = await claim_local_automation_runs(
@@ -337,7 +348,7 @@ async def test_local_claim_transition_requires_local_target_and_workspace_attach
 
     try:
         automation_id = await _create_local_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
         claim = (
             await claim_local_automation_runs(
@@ -416,7 +427,7 @@ async def test_local_reclaimed_attached_workspace_can_resume_provisioning(
 
     try:
         automation_id = await _create_local_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
         claim = (
             await claim_local_automation_runs(
@@ -470,7 +481,7 @@ async def test_expired_dispatching_run_is_swept_to_failed(
 
     try:
         automation_id = await _create_cloud_automation(user_id, now)
-        run = await create_manual_run_for_user(user_id=user_id, automation_id=automation_id)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
         assert run is not None
         claim = (
             await claim_cloud_automation_runs(
@@ -515,11 +526,11 @@ async def test_expired_dispatching_sweep_is_bounded_and_ordered(
 
     try:
         automation_id = await _create_cloud_automation(user_id, now)
-        first_run = await create_manual_run_for_user(
+        first_run = await _create_manual_run(
             user_id=user_id,
             automation_id=automation_id,
         )
-        second_run = await create_manual_run_for_user(
+        second_run = await _create_manual_run(
             user_id=user_id,
             automation_id=automation_id,
         )

--- a/server/tests/unit/test_automation_service.py
+++ b/server/tests/unit/test_automation_service.py
@@ -46,21 +46,24 @@ async def test_create_automation_bootstraps_repo_config(
     user_id = uuid.uuid4()
 
     try:
-        response = await automation_service.create_automation(
-            user_id,
-            CreateAutomationRequest(
-                title="Daily check",
-                prompt="Check the repo.",
-                gitOwner="proliferate-ai",
-                gitRepoName="proliferate",
-                schedule=AutomationScheduleRequest(
-                    rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
-                    timezone="UTC",
+        async with engine_module.async_session_factory() as session:
+            response = await automation_service.create_automation(
+                session,
+                user_id,
+                CreateAutomationRequest(
+                    title="Daily check",
+                    prompt="Check the repo.",
+                    gitOwner="proliferate-ai",
+                    gitRepoName="proliferate",
+                    schedule=AutomationScheduleRequest(
+                        rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                        timezone="UTC",
+                    ),
+                    executionTarget="cloud",
+                    agentKind="codex",
                 ),
-                executionTarget="cloud",
-                agentKind="codex",
-            ),
-        )
+            )
+            await session.commit()
 
         async with engine_module.async_session_factory() as session:
             repo_config = (
@@ -121,8 +124,9 @@ async def test_resume_cloud_automation_requires_agent_kind(
             )
             await session.commit()
 
-        with pytest.raises(AutomationAgentRequired) as exc:
-            await automation_service.resume_automation(user_id, automation_id)
+        async with engine_module.async_session_factory() as session:
+            with pytest.raises(AutomationAgentRequired) as exc:
+                await automation_service.resume_automation(session, user_id, automation_id)
 
         assert exc.value.code == "automation_agent_required"
     finally:
@@ -144,21 +148,23 @@ async def test_create_cloud_automation_requires_agent_kind(
     user_id = uuid.uuid4()
 
     try:
-        with pytest.raises(AutomationAgentRequired) as exc:
-            await automation_service.create_automation(
-                user_id,
-                CreateAutomationRequest(
-                    title="Daily check",
-                    prompt="Check the repo.",
-                    gitOwner="proliferate-ai",
-                    gitRepoName="proliferate",
-                    schedule=AutomationScheduleRequest(
-                        rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
-                        timezone="UTC",
+        async with engine_module.async_session_factory() as session:
+            with pytest.raises(AutomationAgentRequired) as exc:
+                await automation_service.create_automation(
+                    session,
+                    user_id,
+                    CreateAutomationRequest(
+                        title="Daily check",
+                        prompt="Check the repo.",
+                        gitOwner="proliferate-ai",
+                        gitRepoName="proliferate",
+                        schedule=AutomationScheduleRequest(
+                            rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                            timezone="UTC",
+                        ),
+                        executionTarget="cloud",
                     ),
-                    executionTarget="cloud",
-                ),
-            )
+                )
 
         assert exc.value.code == "automation_agent_required"
     finally:


### PR DESCRIPTION
## Summary
- thread automation API/service store calls through request-scoped DB sessions
- reduce automation store transaction/session factory boundary debt
- update automation tests for explicit DB session ownership

## Verification
- /opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py
- /opt/homebrew/bin/python3.12 scripts/check_max_lines.py
- JWT_SECRET=test-jwt-secret CLOUD_SECRET_KEY=test-cloud-secret uv run pytest -q tests/unit/test_automation_service.py tests/unit/test_automation_executor.py tests/unit/test_automation_store.py