### PR TITLE
refactor(server): remove AI magic service ORM coupling

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,7 +11,6 @@ INTEGRATION_DB_IMPORT server/proliferate/integrations/anonymous_telemetry.py 1 t
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/daytona.py 1 transitional integration depends on product domain types/logic
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/e2b.py 1 transitional integration depends on product domain types/logic
-SERVICE_ORM_IMPORT server/proliferate/server/ai_magic/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/repos/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model

--- a/server/proliferate/server/ai_magic/api.py
+++ b/server/proliferate/server/ai_magic/api.py
@@ -18,5 +18,5 @@ async def generate_session_title_endpoint(
     body: GenerateSessionTitleRequest,
     user: User = Depends(current_active_user),
 ) -> GenerateSessionTitleResponse:
-    title = await generate_session_title(user, prompt_text=body.prompt_text)
+    title = await generate_session_title(user.id, prompt_text=body.prompt_text)
     return GenerateSessionTitleResponse(title=title)

--- a/server/proliferate/server/ai_magic/service.py
+++ b/server/proliferate/server/ai_magic/service.py
@@ -4,6 +4,7 @@ import re
 from collections import deque
 from threading import Lock
 from time import monotonic
+from uuid import UUID
 
 from proliferate.config import settings
 from proliferate.constants.ai_magic import (
@@ -12,7 +13,6 @@ from proliferate.constants.ai_magic import (
     SESSION_TITLE_RATE_LIMIT_REQUESTS,
     SESSION_TITLE_RATE_LIMIT_WINDOW_SECONDS,
 )
-from proliferate.db.models.auth import User
 from proliferate.integrations.anthropic import (
     AnthropicIntegrationError,
     generate_message_text,
@@ -57,7 +57,7 @@ def _normalize_title(raw_title: str) -> str:
     return title
 
 
-async def generate_session_title(user: User, *, prompt_text: str) -> str:
+async def generate_session_title(user_id: UUID, *, prompt_text: str) -> str:
     api_key = settings.anthropic_api_key.strip()
     if not api_key:
         raise AiMagicError(
@@ -80,7 +80,7 @@ async def generate_session_title(user: User, *, prompt_text: str) -> str:
             message="Prompt text is too long to title.",
         )
 
-    _enforce_session_title_rate_limit(str(user.id))
+    _enforce_session_title_rate_limit(str(user_id))
 
     try:
         raw_title = await generate_message_text(


### PR DESCRIPTION
## Summary
- pass the authenticated user ID into AI magic service instead of the auth ORM object
- remove the stale server boundary allowlist entry for `ai_magic/service.py`

## Verification
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `DEBUG=1 JWT_SECRET=test-secret CLOUD_SECRET_KEY=test-cloud-secret uv run --python 3.12 --extra dev pytest -q tests/integration/test_ai_magic_api.py`
- `DEBUG=1 JWT_SECRET=test-secret CLOUD_SECRET_KEY=test-cloud-secret uv run --python 3.12 --extra dev pytest -q tests/unit/test_server_boundary_checker.py`
- `git diff --check`
