### PR TITLE
refactor(desktop): split review defaults section

### DIFF
--- a/desktop/src/components/settings/panes/review/ReviewDefaultOptionRows.tsx
+++ b/desktop/src/components/settings/panes/review/ReviewDefaultOptionRows.tsx
@@ -1,0 +1,58 @@
+import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import {
+  clampRounds,
+  DEFAULT_REVIEW_MAX_ROUNDS,
+  MAX_REVIEW_ROUNDS,
+  type StoredReviewKindDefaults,
+} from "@/lib/domain/reviews/review-config";
+
+interface ReviewDefaultOptionRowsProps {
+  effective: StoredReviewKindDefaults;
+  onUpdate: (patch: Partial<StoredReviewKindDefaults>) => void;
+}
+
+export function ReviewDefaultOptionRows({
+  effective,
+  onUpdate,
+}: ReviewDefaultOptionRowsProps) {
+  return (
+    <>
+      <SettingsCardRow
+        label="Max rounds"
+        description={`One-click launches use ${DEFAULT_REVIEW_MAX_ROUNDS} rounds unless overridden.`}
+      >
+        <Input
+          type="number"
+          min={1}
+          max={MAX_REVIEW_ROUNDS}
+          value={effective.maxRounds}
+          className="w-24"
+          onChange={(event) => {
+            const nextValue = event.target.valueAsNumber;
+            onUpdate({
+              maxRounds: Number.isFinite(nextValue)
+                ? clampRounds(nextValue)
+                : DEFAULT_REVIEW_MAX_ROUNDS,
+            });
+          }}
+        />
+      </SettingsCardRow>
+
+      <SettingsCardRow
+        label="Auto iterate"
+        description="Automatically send feedback when a review round requests revisions."
+      >
+        <Label className="flex items-center gap-2 text-sm text-foreground">
+          <Checkbox
+            checked={effective.autoIterate}
+            onChange={(event) => onUpdate({ autoIterate: event.target.checked })}
+          />
+          Enabled
+        </Label>
+      </SettingsCardRow>
+    </>
+  );
+}

--- a/desktop/src/components/settings/panes/review/ReviewDefaultReviewerControls.tsx
+++ b/desktop/src/components/settings/panes/review/ReviewDefaultReviewerControls.tsx
@@ -1,0 +1,205 @@
+import type { ReviewKind } from "@anyharness/sdk";
+import { Button } from "@/components/ui/Button";
+import {
+  Plus,
+  X,
+} from "@/components/ui/icons";
+import type { AgentModelGroup } from "@/lib/domain/agents/model-options";
+import {
+  MAX_REVIEWERS_PER_RUN,
+  nextAvailableReviewPersonaTemplate,
+  nextReviewReviewerId,
+  resolveReviewDefaultReviewerRows,
+  resolveReviewExecutionModeIdForAgent,
+  type ReviewPersonaTemplate,
+  type ReviewSetupReviewerDraft,
+  type StoredReviewKindDefaults,
+} from "@/lib/domain/reviews/review-config";
+import {
+  ReviewDefaultModeMenu,
+  ReviewDefaultModelMenu,
+  ReviewDefaultPersonalityMenu,
+} from "./ReviewDefaultReviewerMenus";
+
+interface ReviewDefaultReviewerControlsProps {
+  kind: ReviewKind;
+  defaults: StoredReviewKindDefaults | null;
+  effective: StoredReviewKindDefaults;
+  personalityTemplates: ReviewPersonaTemplate[];
+  modelGroups: AgentModelGroup[];
+  modelsLoading: boolean;
+  onUpdate: (patch: Partial<StoredReviewKindDefaults>) => void;
+}
+
+export function ReviewDefaultReviewerControls({
+  kind,
+  defaults,
+  effective,
+  personalityTemplates,
+  modelGroups,
+  modelsLoading,
+  onUpdate,
+}: ReviewDefaultReviewerControlsProps) {
+  const reviewerRows = resolveReviewDefaultReviewerRows({
+    kind,
+    defaults: effective,
+    personalityTemplates,
+  });
+  const reviewersLabel = defaults === null
+    ? "Unset, uses built-in reviewers"
+    : effective.reviewers.mode === "inherit"
+      ? "Built-in reviewers"
+      : `${effective.reviewers.items.length} custom ${
+        effective.reviewers.items.length === 1 ? "reviewer" : "reviewers"
+      }`;
+
+  const updateReviewerRows = (items: ReviewSetupReviewerDraft[]) => {
+    const firstReviewer = items[0] ?? null;
+    onUpdate({
+      agentKind: firstReviewer?.agentKind.trim() ?? "",
+      modelId: firstReviewer?.modelId.trim() ?? "",
+      modeId: firstReviewer?.modeId.trim() ?? "",
+      reviewers: { mode: "custom", items: items.slice(0, MAX_REVIEWERS_PER_RUN) },
+    });
+  };
+  const updateReviewer = (
+    index: number,
+    patch: Partial<ReviewSetupReviewerDraft>,
+  ) => {
+    updateReviewerRows(reviewerRows.map((reviewer, reviewerIndex) => (
+      reviewerIndex === index ? { ...reviewer, ...patch } : reviewer
+    )));
+  };
+  const addReviewer = () => {
+    const template = nextAvailableReviewPersonaTemplate(personalityTemplates, reviewerRows);
+    if (!template || reviewerRows.length >= MAX_REVIEWERS_PER_RUN) {
+      return;
+    }
+    updateReviewerRows([
+      ...reviewerRows,
+      {
+        id: nextReviewReviewerId(template.id, reviewerRows),
+        label: template.label,
+        prompt: template.prompt,
+        agentKind: "",
+        modelId: "",
+        modeId: "",
+      },
+    ]);
+  };
+  const removeReviewer = (index: number) => {
+    updateReviewerRows(reviewerRows.filter((_, reviewerIndex) => reviewerIndex !== index));
+  };
+
+  return (
+    <div className="space-y-3 p-3">
+      <div className="flex min-w-0 items-start justify-between gap-6">
+        <div className="min-w-0 space-y-0.5">
+          <div className="text-sm font-medium">Reviewer defaults</div>
+          <div className="text-sm text-muted-foreground">
+            Personality, harness, model, and mode for one-click review.
+          </div>
+        </div>
+        <div className="shrink-0 text-xs text-muted-foreground">{reviewersLabel}</div>
+      </div>
+
+      <div className="space-y-2" data-telemetry-mask>
+        {reviewerRows.length > 0 ? (
+          reviewerRows.map((reviewer, index) => (
+            <div
+              key={`${reviewer.id}-${index}`}
+              className="grid grid-cols-1 items-center gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,0.72fr)_auto]"
+            >
+              <ReviewDefaultPersonalityMenu
+                reviewer={reviewer}
+                reviewerIndex={index}
+                reviewers={reviewerRows}
+                personalityTemplates={personalityTemplates}
+                onSelect={(template) => updateReviewer(index, {
+                  id: nextReviewReviewerId(template.id, reviewerRows, index),
+                  label: template.label,
+                  prompt: template.prompt,
+                })}
+              />
+              <ReviewDefaultModelMenu
+                reviewer={reviewer}
+                modelGroups={modelGroups}
+                modelsLoading={modelsLoading}
+                onSelect={(group, modelId) => updateReviewer(index, {
+                  agentKind: group.kind,
+                  modelId,
+                  modeId: resolveReviewExecutionModeIdForAgent(group.kind, reviewer.modeId),
+                })}
+                onInherit={() => updateReviewer(index, {
+                  agentKind: "",
+                  modelId: "",
+                  modeId: "",
+                })}
+              />
+              <ReviewDefaultModeMenu
+                reviewer={reviewer}
+                onSelect={(modeId) => updateReviewer(index, { modeId })}
+                onInherit={() => updateReviewer(index, { modeId: "" })}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Remove ${reviewer.label || `reviewer ${index + 1}`}`}
+                className="h-9 w-9 px-0"
+                onClick={() => removeReviewer(index)}
+              >
+                <X className="size-3.5" />
+              </Button>
+            </div>
+          ))
+        ) : (
+          <div className="rounded-md border border-border bg-foreground/5 px-3 py-2 text-sm text-muted-foreground">
+            One-click review will open configuration until reviewers are saved.
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={reviewerRows.length >= MAX_REVIEWERS_PER_RUN || personalityTemplates.length === 0}
+          onClick={addReviewer}
+        >
+          <Plus className="size-3.5" />
+          Add reviewer
+        </Button>
+        <Button
+          type="button"
+          variant={effective.reviewers.mode === "inherit" ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => onUpdate({
+            agentKind: "",
+            modelId: "",
+            modeId: "",
+            reviewers: { mode: "inherit" },
+          })}
+        >
+          Use built-ins
+        </Button>
+        <Button
+          type="button"
+          variant={effective.reviewers.mode === "custom" && effective.reviewers.items.length === 0
+            ? "secondary"
+            : "outline"}
+          size="sm"
+          onClick={() => onUpdate({
+            agentKind: "",
+            modelId: "",
+            modeId: "",
+            reviewers: { mode: "custom", items: [] },
+          })}
+        >
+          Require config
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/panes/review/ReviewDefaultReviewerMenus.tsx
+++ b/desktop/src/components/settings/panes/review/ReviewDefaultReviewerMenus.tsx
@@ -1,0 +1,188 @@
+import { SessionControlIcon } from "@/components/session-controls/SessionControlIcon";
+import { SettingsMenu } from "@/components/ui/SettingsMenu";
+import {
+  Brain,
+  ProviderIcon,
+  Sparkles,
+} from "@/components/ui/icons";
+import type { AgentModelGroup } from "@/lib/domain/agents/model-options";
+import {
+  listConfiguredSessionControlValues,
+  resolveConfiguredSessionControlValue,
+} from "@/lib/domain/chat/session-controls/session-mode-control";
+import {
+  reviewerMatchesReviewPersonaTemplate,
+  reviewerPersonalityLabel,
+  type ReviewPersonaTemplate,
+  type ReviewSetupReviewerDraft,
+} from "@/lib/domain/reviews/review-config";
+
+export function ReviewDefaultPersonalityMenu({
+  reviewer,
+  reviewerIndex,
+  reviewers,
+  personalityTemplates,
+  onSelect,
+}: {
+  reviewer: ReviewSetupReviewerDraft;
+  reviewerIndex: number;
+  reviewers: ReviewSetupReviewerDraft[];
+  personalityTemplates: ReviewPersonaTemplate[];
+  onSelect: (template: ReviewPersonaTemplate) => void;
+}) {
+  return (
+    <SettingsMenu
+      label={reviewerPersonalityLabel(personalityTemplates, reviewer) || `Reviewer ${reviewerIndex + 1}`}
+      leading={<Brain className="size-3.5 text-muted-foreground" />}
+      className="w-full min-w-0"
+      menuClassName="w-80"
+      groups={[{
+        id: "personalities",
+        options: personalityTemplates.map((template) => ({
+          id: template.id,
+          label: template.label,
+          detail: template.prompt,
+          icon: <Brain className="size-3.5" />,
+          selected: reviewerMatchesReviewPersonaTemplate(
+            reviewer,
+            template,
+            reviewers,
+            reviewerIndex,
+          ),
+          onSelect: () => onSelect(template),
+        })),
+      }]}
+    />
+  );
+}
+
+export function ReviewDefaultModelMenu({
+  reviewer,
+  modelGroups,
+  modelsLoading,
+  onSelect,
+  onInherit,
+}: {
+  reviewer: ReviewSetupReviewerDraft;
+  modelGroups: AgentModelGroup[];
+  modelsLoading: boolean;
+  onSelect: (group: AgentModelGroup, modelId: string) => void;
+  onInherit: () => void;
+}) {
+  const selected = selectedDefaultModel(modelGroups, reviewer);
+  const hasStoredSelection = !!reviewer.agentKind || !!reviewer.modelId;
+  const label = selected
+    ? `${selected.group.providerDisplayName} · ${selected.model.displayName}`
+    : modelsLoading
+      ? "Loading models"
+      : hasStoredSelection
+        ? "Saved model unavailable"
+        : "Active session model";
+  const leading = selected
+    ? <ProviderIcon kind={selected.group.kind} className="size-3.5" />
+    : <Sparkles className="size-3.5 text-muted-foreground" />;
+
+  return (
+    <SettingsMenu
+      label={label}
+      leading={leading}
+      className="w-full min-w-0"
+      menuClassName="w-80"
+      groups={[
+        {
+          id: "inherit",
+          options: [{
+            id: "inherit-active-session-model",
+            label: "Active session model",
+            detail: "Use the parent session agent and model",
+            icon: <Sparkles className="size-3.5" />,
+            selected: !reviewer.agentKind && !reviewer.modelId,
+            onSelect: onInherit,
+          }],
+        },
+        ...modelGroups.map((group) => ({
+          id: group.kind,
+          label: group.providerDisplayName,
+          options: group.models.map((model) => ({
+            id: `${group.kind}:${model.modelId}`,
+            label: model.displayName,
+            detail: model.description,
+            icon: <ProviderIcon kind={group.kind} className="size-3.5" />,
+            selected: reviewer.agentKind === group.kind && reviewer.modelId === model.modelId,
+            onSelect: () => onSelect(group, model.modelId),
+          })),
+        })),
+      ]}
+    />
+  );
+}
+
+export function ReviewDefaultModeMenu({
+  reviewer,
+  onSelect,
+  onInherit,
+}: {
+  reviewer: ReviewSetupReviewerDraft;
+  onSelect: (modeId: string) => void;
+  onInherit: () => void;
+}) {
+  const modeOptions = listConfiguredSessionControlValues(reviewer.agentKind, "mode");
+  const selectedMode = resolveConfiguredSessionControlValue(
+    reviewer.agentKind,
+    "mode",
+    reviewer.modeId,
+  );
+  const label = !reviewer.agentKind
+    ? "Active session mode"
+    : selectedMode
+      ? selectedMode.shortLabel ?? selectedMode.label
+      : "Default mode";
+  const groups = [
+    {
+      id: "inherit",
+      options: [{
+        id: "inherit-active-session-mode",
+        label: reviewer.agentKind ? "Default mode" : "Active session mode",
+        detail: reviewer.agentKind
+          ? "Use the active session mode when available"
+          : "Choose a model default to customize this",
+        icon: <Sparkles className="size-3.5" />,
+        selected: !reviewer.modeId,
+        onSelect: onInherit,
+      }],
+    },
+    ...(modeOptions.length > 0 ? [{
+      id: "modes",
+      label: "Modes",
+      options: modeOptions.map((mode) => ({
+        id: mode.value,
+        label: mode.label,
+        detail: mode.description,
+        icon: <SessionControlIcon icon={mode.icon} className="size-3.5" />,
+        selected: reviewer.modeId === mode.value,
+        onSelect: () => onSelect(mode.value),
+      })),
+    }] : []),
+  ];
+
+  return (
+    <SettingsMenu
+      label={label}
+      leading={selectedMode
+        ? <SessionControlIcon icon={selectedMode.icon} className="size-3.5" />
+        : <Sparkles className="size-3.5 text-muted-foreground" />}
+      className="w-full min-w-0"
+      menuClassName="w-72"
+      groups={groups}
+    />
+  );
+}
+
+function selectedDefaultModel(
+  modelGroups: AgentModelGroup[],
+  reviewer: ReviewSetupReviewerDraft,
+): { group: AgentModelGroup; model: AgentModelGroup["models"][number] } | null {
+  const group = modelGroups.find((candidate) => candidate.kind === reviewer.agentKind) ?? null;
+  const model = group?.models.find((candidate) => candidate.modelId === reviewer.modelId) ?? null;
+  return group && model ? { group, model } : null;
+}

--- a/desktop/src/components/settings/panes/review/ReviewDefaultsSection.tsx
+++ b/desktop/src/components/settings/panes/review/ReviewDefaultsSection.tsx
@@ -1,38 +1,15 @@
 import type { ReviewKind } from "@anyharness/sdk";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
-import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
 import { Button } from "@/components/ui/Button";
-import { Checkbox } from "@/components/ui/Checkbox";
-import { Input } from "@/components/ui/Input";
-import { Label } from "@/components/ui/Label";
-import { SettingsMenu } from "@/components/ui/SettingsMenu";
-import { SessionControlIcon } from "@/components/session-controls/SessionControlIcon";
-import {
-  Brain,
-  Plus,
-  ProviderIcon,
-  RefreshCw,
-  Sparkles,
-  X,
-} from "@/components/ui/icons";
+import { RefreshCw } from "@/components/ui/icons";
 import type { AgentModelGroup } from "@/lib/domain/agents/model-options";
 import {
-  listConfiguredSessionControlValues,
-  resolveConfiguredSessionControlValue,
-} from "@/lib/domain/chat/session-controls/session-mode-control";
-import {
-  clampRounds,
-  DEFAULT_REVIEW_MAX_ROUNDS,
-  MAX_REVIEW_ROUNDS,
-  MAX_REVIEWERS_PER_RUN,
-  findReviewPersonaTemplateForReviewer,
-  isBuiltInReviewPersonaId,
-  nextReviewReviewerId,
-  resolveReviewExecutionModeIdForAgent,
+  createStoredReviewKindDefaults,
   type ReviewPersonaTemplate,
-  type ReviewSetupReviewerDraft,
   type StoredReviewKindDefaults,
 } from "@/lib/domain/reviews/review-config";
+import { ReviewDefaultOptionRows } from "./ReviewDefaultOptionRows";
+import { ReviewDefaultReviewerControls } from "./ReviewDefaultReviewerControls";
 
 interface ReviewDefaultsSectionProps {
   kind: ReviewKind;
@@ -59,59 +36,14 @@ export function ReviewDefaultsSection({
   modelsLoading,
   onChange,
 }: ReviewDefaultsSectionProps) {
-  const effective = defaults ?? createDefaultReviewDefaults();
-  const reviewerRows = resolveDefaultReviewerRows(kind, effective, personalityTemplates);
-  const reviewersLabel = defaults === null
-    ? "Unset, uses built-in reviewers"
-    : effective.reviewers.mode === "inherit"
-      ? "Built-in reviewers"
-      : `${effective.reviewers.items.length} custom ${
-        effective.reviewers.items.length === 1 ? "reviewer" : "reviewers"
-      }`;
+  const effective = defaults ?? createStoredReviewKindDefaults();
 
   const update = (patch: Partial<StoredReviewKindDefaults>) => {
     onChange((current) => ({
-      ...createDefaultReviewDefaults(),
+      ...createStoredReviewKindDefaults(),
       ...current,
       ...patch,
     }));
-  };
-  const updateReviewerRows = (items: ReviewSetupReviewerDraft[]) => {
-    const firstReviewer = items[0] ?? null;
-    update({
-      agentKind: firstReviewer?.agentKind.trim() ?? "",
-      modelId: firstReviewer?.modelId.trim() ?? "",
-      modeId: firstReviewer?.modeId.trim() ?? "",
-      reviewers: { mode: "custom", items: items.slice(0, MAX_REVIEWERS_PER_RUN) },
-    });
-  };
-  const updateReviewer = (
-    index: number,
-    patch: Partial<ReviewSetupReviewerDraft>,
-  ) => {
-    updateReviewerRows(reviewerRows.map((reviewer, reviewerIndex) => (
-      reviewerIndex === index ? { ...reviewer, ...patch } : reviewer
-    )));
-  };
-  const addReviewer = () => {
-    const template = nextAvailablePersonaTemplate(personalityTemplates, reviewerRows);
-    if (!template || reviewerRows.length >= MAX_REVIEWERS_PER_RUN) {
-      return;
-    }
-    updateReviewerRows([
-      ...reviewerRows,
-      {
-        id: nextReviewReviewerId(template.id, reviewerRows),
-        label: template.label,
-        prompt: template.prompt,
-        agentKind: "",
-        modelId: "",
-        modeId: "",
-      },
-    ]);
-  };
-  const removeReviewer = (index: number) => {
-    updateReviewerRows(reviewerRows.filter((_, reviewerIndex) => reviewerIndex !== index));
   };
 
   return (
@@ -130,387 +62,20 @@ export function ReviewDefaultsSection({
       </div>
 
       <SettingsCard>
-        <div className="space-y-3 p-3">
-          <div className="flex min-w-0 items-start justify-between gap-6">
-            <div className="min-w-0 space-y-0.5">
-              <div className="text-sm font-medium">Reviewer defaults</div>
-              <div className="text-sm text-muted-foreground">
-                Personality, harness, model, and mode for one-click review.
-              </div>
-            </div>
-            <div className="shrink-0 text-xs text-muted-foreground">{reviewersLabel}</div>
-          </div>
-
-          <div className="space-y-2" data-telemetry-mask>
-            {reviewerRows.length > 0 ? (
-              reviewerRows.map((reviewer, index) => (
-                <div
-                  key={`${reviewer.id}-${index}`}
-                  className="grid grid-cols-1 items-center gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,0.72fr)_auto]"
-                >
-                  <ReviewDefaultPersonalityMenu
-                    reviewer={reviewer}
-                    reviewerIndex={index}
-                    reviewers={reviewerRows}
-                    personalityTemplates={personalityTemplates}
-                    onSelect={(template) => updateReviewer(index, {
-                      id: nextReviewReviewerId(template.id, reviewerRows, index),
-                      label: template.label,
-                      prompt: template.prompt,
-                    })}
-                  />
-                  <ReviewDefaultModelMenu
-                    reviewer={reviewer}
-                    modelGroups={modelGroups}
-                    modelsLoading={modelsLoading}
-                    onSelect={(group, modelId) => updateReviewer(index, {
-                      agentKind: group.kind,
-                      modelId,
-                      modeId: resolveReviewExecutionModeIdForAgent(group.kind, reviewer.modeId),
-                    })}
-                    onInherit={() => updateReviewer(index, {
-                      agentKind: "",
-                      modelId: "",
-                      modeId: "",
-                    })}
-                  />
-                  <ReviewDefaultModeMenu
-                    reviewer={reviewer}
-                    onSelect={(modeId) => updateReviewer(index, { modeId })}
-                    onInherit={() => updateReviewer(index, { modeId: "" })}
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={`Remove ${reviewer.label || `reviewer ${index + 1}`}`}
-                    className="h-9 w-9 px-0"
-                    onClick={() => removeReviewer(index)}
-                  >
-                    <X className="size-3.5" />
-                  </Button>
-                </div>
-              ))
-            ) : (
-              <div className="rounded-md border border-border bg-foreground/5 px-3 py-2 text-sm text-muted-foreground">
-                One-click review will open configuration until reviewers are saved.
-              </div>
-            )}
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2 pt-1">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={reviewerRows.length >= MAX_REVIEWERS_PER_RUN || personalityTemplates.length === 0}
-              onClick={addReviewer}
-            >
-              <Plus className="size-3.5" />
-              Add reviewer
-            </Button>
-            <Button
-              type="button"
-              variant={effective.reviewers.mode === "inherit" ? "secondary" : "outline"}
-              size="sm"
-              onClick={() => update({
-                agentKind: "",
-                modelId: "",
-                modeId: "",
-                reviewers: { mode: "inherit" },
-              })}
-            >
-              Use built-ins
-            </Button>
-            <Button
-              type="button"
-              variant={effective.reviewers.mode === "custom" && effective.reviewers.items.length === 0
-                ? "secondary"
-                : "outline"}
-              size="sm"
-              onClick={() => update({
-                agentKind: "",
-                modelId: "",
-                modeId: "",
-                reviewers: { mode: "custom", items: [] },
-              })}
-            >
-              Require config
-            </Button>
-          </div>
-        </div>
-
-        <SettingsCardRow
-          label="Max rounds"
-          description={`One-click launches use ${DEFAULT_REVIEW_MAX_ROUNDS} rounds unless overridden.`}
-        >
-          <Input
-            type="number"
-            min={1}
-            max={MAX_REVIEW_ROUNDS}
-            value={effective.maxRounds}
-            className="w-24"
-            onChange={(event) => {
-              const nextValue = event.target.valueAsNumber;
-              update({
-                maxRounds: Number.isFinite(nextValue)
-                  ? clampRounds(nextValue)
-                  : DEFAULT_REVIEW_MAX_ROUNDS,
-              });
-            }}
-          />
-        </SettingsCardRow>
-
-        <SettingsCardRow
-          label="Auto iterate"
-          description="Automatically send feedback when a review round requests revisions."
-        >
-          <Label className="flex items-center gap-2 text-sm text-foreground">
-            <Checkbox
-              checked={effective.autoIterate}
-              onChange={(event) => update({ autoIterate: event.target.checked })}
-            />
-            Enabled
-          </Label>
-        </SettingsCardRow>
+        <ReviewDefaultReviewerControls
+          kind={kind}
+          defaults={defaults}
+          effective={effective}
+          personalityTemplates={personalityTemplates}
+          modelGroups={modelGroups}
+          modelsLoading={modelsLoading}
+          onUpdate={update}
+        />
+        <ReviewDefaultOptionRows
+          effective={effective}
+          onUpdate={update}
+        />
       </SettingsCard>
     </section>
   );
-}
-
-function ReviewDefaultPersonalityMenu({
-  reviewer,
-  reviewerIndex,
-  reviewers,
-  personalityTemplates,
-  onSelect,
-}: {
-  reviewer: ReviewSetupReviewerDraft;
-  reviewerIndex: number;
-  reviewers: ReviewSetupReviewerDraft[];
-  personalityTemplates: ReviewPersonaTemplate[];
-  onSelect: (template: ReviewPersonaTemplate) => void;
-}) {
-  return (
-    <SettingsMenu
-      label={personalityLabel(personalityTemplates, reviewer) || `Reviewer ${reviewerIndex + 1}`}
-      leading={<Brain className="size-3.5 text-muted-foreground" />}
-      className="w-full min-w-0"
-      menuClassName="w-80"
-      groups={[{
-        id: "personalities",
-        options: personalityTemplates.map((template) => ({
-          id: template.id,
-          label: template.label,
-          detail: template.prompt,
-          icon: <Brain className="size-3.5" />,
-          selected: reviewerMatchesTemplate(reviewer, template, reviewers, reviewerIndex),
-          onSelect: () => onSelect(template),
-        })),
-      }]}
-    />
-  );
-}
-
-function ReviewDefaultModelMenu({
-  reviewer,
-  modelGroups,
-  modelsLoading,
-  onSelect,
-  onInherit,
-}: {
-  reviewer: ReviewSetupReviewerDraft;
-  modelGroups: AgentModelGroup[];
-  modelsLoading: boolean;
-  onSelect: (group: AgentModelGroup, modelId: string) => void;
-  onInherit: () => void;
-}) {
-  const selected = selectedDefaultModel(modelGroups, reviewer);
-  const hasStoredSelection = !!reviewer.agentKind || !!reviewer.modelId;
-  const label = selected
-    ? `${selected.group.providerDisplayName} · ${selected.model.displayName}`
-    : modelsLoading
-      ? "Loading models"
-      : hasStoredSelection
-        ? "Saved model unavailable"
-        : "Active session model";
-  const leading = selected
-    ? <ProviderIcon kind={selected.group.kind} className="size-3.5" />
-    : <Sparkles className="size-3.5 text-muted-foreground" />;
-
-  return (
-    <SettingsMenu
-      label={label}
-      leading={leading}
-      className="w-full min-w-0"
-      menuClassName="w-80"
-      groups={[
-        {
-          id: "inherit",
-          options: [{
-            id: "inherit-active-session-model",
-            label: "Active session model",
-            detail: "Use the parent session agent and model",
-            icon: <Sparkles className="size-3.5" />,
-            selected: !reviewer.agentKind && !reviewer.modelId,
-            onSelect: onInherit,
-          }],
-        },
-        ...modelGroups.map((group) => ({
-          id: group.kind,
-          label: group.providerDisplayName,
-          options: group.models.map((model) => ({
-            id: `${group.kind}:${model.modelId}`,
-            label: model.displayName,
-            detail: model.description,
-            icon: <ProviderIcon kind={group.kind} className="size-3.5" />,
-            selected: reviewer.agentKind === group.kind && reviewer.modelId === model.modelId,
-            onSelect: () => onSelect(group, model.modelId),
-          })),
-        })),
-      ]}
-    />
-  );
-}
-
-function ReviewDefaultModeMenu({
-  reviewer,
-  onSelect,
-  onInherit,
-}: {
-  reviewer: ReviewSetupReviewerDraft;
-  onSelect: (modeId: string) => void;
-  onInherit: () => void;
-}) {
-  const modeOptions = listConfiguredSessionControlValues(reviewer.agentKind, "mode");
-  const selectedMode = resolveConfiguredSessionControlValue(
-    reviewer.agentKind,
-    "mode",
-    reviewer.modeId,
-  );
-  const label = !reviewer.agentKind
-    ? "Active session mode"
-    : selectedMode
-      ? selectedMode.shortLabel ?? selectedMode.label
-      : "Default mode";
-  const groups = [
-    {
-      id: "inherit",
-      options: [{
-        id: "inherit-active-session-mode",
-        label: reviewer.agentKind ? "Default mode" : "Active session mode",
-        detail: reviewer.agentKind
-          ? "Use the active session mode when available"
-          : "Choose a model default to customize this",
-        icon: <Sparkles className="size-3.5" />,
-        selected: !reviewer.modeId,
-        onSelect: onInherit,
-      }],
-    },
-    ...(modeOptions.length > 0 ? [{
-      id: "modes",
-      label: "Modes",
-      options: modeOptions.map((mode) => ({
-        id: mode.value,
-        label: mode.label,
-        detail: mode.description,
-        icon: <SessionControlIcon icon={mode.icon} className="size-3.5" />,
-        selected: reviewer.modeId === mode.value,
-        onSelect: () => onSelect(mode.value),
-      })),
-    }] : []),
-  ];
-
-  return (
-    <SettingsMenu
-      label={label}
-      leading={selectedMode
-        ? <SessionControlIcon icon={selectedMode.icon} className="size-3.5" />
-        : <Sparkles className="size-3.5 text-muted-foreground" />}
-      className="w-full min-w-0"
-      menuClassName="w-72"
-      groups={groups}
-    />
-  );
-}
-
-function selectedDefaultModel(
-  modelGroups: AgentModelGroup[],
-  reviewer: ReviewSetupReviewerDraft,
-): { group: AgentModelGroup; model: AgentModelGroup["models"][number] } | null {
-  const group = modelGroups.find((candidate) => candidate.kind === reviewer.agentKind) ?? null;
-  const model = group?.models.find((candidate) => candidate.modelId === reviewer.modelId) ?? null;
-  return group && model ? { group, model } : null;
-}
-
-function resolveDefaultReviewerRows(
-  kind: ReviewKind,
-  defaults: StoredReviewKindDefaults,
-  personalityTemplates: ReviewPersonaTemplate[],
-): ReviewSetupReviewerDraft[] {
-  if (defaults.reviewers.mode === "custom") {
-    return defaults.reviewers.items;
-  }
-
-  const builtInTemplates = personalityTemplates.filter((template) =>
-    isBuiltInReviewPersonaId(kind, template.id)
-  );
-  const sourceTemplates = builtInTemplates.length > 0 ? builtInTemplates : personalityTemplates;
-  return sourceTemplates.slice(0, 2).map((template) => ({
-    id: template.id,
-    label: template.label,
-    prompt: template.prompt,
-    agentKind: defaults.agentKind,
-    modelId: defaults.modelId,
-    modeId: defaults.modeId,
-  }));
-}
-
-function nextAvailablePersonaTemplate(
-  personalityTemplates: ReviewPersonaTemplate[],
-  reviewers: ReviewSetupReviewerDraft[],
-): ReviewPersonaTemplate | null {
-  return personalityTemplates.find((template) => (
-    !reviewers.some((reviewer) => (
-      findReviewPersonaTemplateForReviewer([template], reviewer.id) !== null
-    ))
-  )) ?? personalityTemplates[0] ?? null;
-}
-
-function reviewerMatchesTemplate(
-  reviewer: ReviewSetupReviewerDraft,
-  template: ReviewPersonaTemplate,
-  reviewers: ReviewSetupReviewerDraft[],
-  reviewerIndex: number,
-): boolean {
-  return nextReviewReviewerId(template.id, reviewers, reviewerIndex) === reviewer.id
-    && reviewer.label === template.label
-    && reviewer.prompt === template.prompt;
-}
-
-function personalityLabel(
-  personalityTemplates: ReviewPersonaTemplate[],
-  reviewer: ReviewSetupReviewerDraft,
-): string {
-  const exact = personalityTemplates.find((template) =>
-    findReviewPersonaTemplateForReviewer([template], reviewer.id)
-    && reviewer.label === template.label
-    && reviewer.prompt === template.prompt
-  );
-  if (exact) {
-    return exact.label;
-  }
-  const base = findReviewPersonaTemplateForReviewer(personalityTemplates, reviewer.id);
-  return base ? `${base.label} edited` : reviewer.label || "Choose personality";
-}
-
-function createDefaultReviewDefaults(): StoredReviewKindDefaults {
-  return {
-    maxRounds: DEFAULT_REVIEW_MAX_ROUNDS,
-    autoIterate: true,
-    agentKind: "",
-    modelId: "",
-    modeId: "",
-    reviewers: { mode: "inherit" },
-  };
 }

--- a/desktop/src/components/workspace/reviews/ReviewSetupReviewerList.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewSetupReviewerList.tsx
@@ -1,7 +1,8 @@
 import type { AgentModelGroup } from "@/lib/domain/agents/model-options";
 import {
-  findReviewPersonaTemplateForReviewer,
   nextReviewReviewerId,
+  reviewerMatchesReviewPersonaTemplate,
+  reviewerPersonalityLabel,
   resolveReviewExecutionModeIdForAgent,
   type ReviewPersonaTemplate,
   type ReviewSetupDraft,
@@ -113,7 +114,7 @@ function ReviewPersonalitySettingsMenu({
 }) {
   return (
     <SettingsMenu
-      label={personalityLabel(templates, reviewer) || `Reviewer ${reviewerIndex + 1}`}
+      label={reviewerPersonalityLabel(templates, reviewer) || `Reviewer ${reviewerIndex + 1}`}
       leading={<Brain className="size-4 text-muted-foreground" />}
       className="w-full min-w-0"
       menuClassName="w-80"
@@ -125,7 +126,12 @@ function ReviewPersonalitySettingsMenu({
             label: template.label,
             detail: template.prompt,
             icon: <Brain className="size-3.5" />,
-            selected: reviewerMatchesTemplate(reviewer, template, reviewers, reviewerIndex),
+            selected: reviewerMatchesReviewPersonaTemplate(
+              reviewer,
+              template,
+              reviewers,
+              reviewerIndex,
+            ),
             onSelect: () => onSelect(template),
           })),
         },
@@ -152,33 +158,6 @@ function reviewerHasRequiredFields(
     && !!reviewer.agentKind.trim()
     && !!reviewer.modelId.trim()
     && !!reviewer.modeId.trim();
-}
-
-function reviewerMatchesTemplate(
-  reviewer: ReviewSetupDraft["reviewers"][number],
-  template: ReviewPersonaTemplate,
-  reviewers: ReviewSetupDraft["reviewers"],
-  reviewerIndex: number,
-): boolean {
-  return nextReviewReviewerId(template.id, reviewers, reviewerIndex) === reviewer.id
-    && reviewer.label === template.label
-    && reviewer.prompt === template.prompt;
-}
-
-function personalityLabel(
-  templates: ReviewPersonaTemplate[],
-  reviewer: ReviewSetupDraft["reviewers"][number],
-): string {
-  const exact = templates.find((template) =>
-    findReviewPersonaTemplateForReviewer([template], reviewer.id)
-    && reviewer.label === template.label
-    && reviewer.prompt === template.prompt
-  );
-  if (exact) {
-    return exact.label;
-  }
-  const base = findReviewPersonaTemplateForReviewer(templates, reviewer.id);
-  return base ? `${base.label} edited` : reviewer.label || "Choose personality";
 }
 
 function updateReviewer(

--- a/desktop/src/lib/domain/reviews/review-config.test.ts
+++ b/desktop/src/lib/domain/reviews/review-config.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  createStoredReviewKindDefaults,
   createReviewSetupDraft,
   createReviewSetupReviewerDraft,
   clampRounds,
   draftToStoredReviewDefaults,
   listReviewPersonaTemplates,
   MAX_REVIEW_ROUNDS,
+  nextAvailableReviewPersonaTemplate,
   nextReviewReviewerId,
+  reviewerMatchesReviewPersonaTemplate,
+  reviewerPersonalityLabel,
+  resolveReviewDefaultReviewerRows,
   resolveReviewPersonaTemplates,
   resolveReviewExecutionModeIdForAgent,
   type ReviewSessionDefaults,
@@ -123,6 +128,59 @@ describe("review setup config", () => {
     expect(nextReviewReviewerId("implementation-readiness", reviewers, 0)).toBe(
       "implementation-readiness-2",
     );
+  });
+
+  it("resolves one-click default reviewer rows from built-in personalities", () => {
+    const defaults = {
+      ...createStoredReviewKindDefaults(),
+      agentKind: "codex",
+      modelId: "gpt-5.4",
+      modeId: "full-access",
+    };
+    const rows = resolveReviewDefaultReviewerRows({
+      kind: "plan",
+      defaults,
+      personalityTemplates: listReviewPersonaTemplates("plan"),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["plan-skeptic", "implementation-readiness"]);
+    expect(rows[0]).toMatchObject({
+      agentKind: "codex",
+      modelId: "gpt-5.4",
+      modeId: "full-access",
+    });
+  });
+
+  it("labels and matches reusable reviewer personalities", () => {
+    const templates = listReviewPersonaTemplates("plan");
+    const planSkeptic = templates[0];
+    if (!planSkeptic) {
+      throw new Error("Missing plan skeptic template");
+    }
+    const reviewers = [
+      reviewer({
+        id: "plan-skeptic",
+        label: "Plan skeptic",
+        prompt: planSkeptic.prompt,
+      }),
+      reviewer({ id: "implementation-readiness" }),
+    ];
+
+    expect(reviewerPersonalityLabel(templates, reviewers[0])).toBe("Plan skeptic");
+    expect(reviewerPersonalityLabel(templates, {
+      ...reviewers[0],
+      prompt: "Edited prompt.",
+    })).toBe("Plan skeptic edited");
+    expect(reviewerMatchesReviewPersonaTemplate(
+      reviewers[0],
+      planSkeptic,
+      reviewers,
+      0,
+    )).toBe(true);
+    expect(nextAvailableReviewPersonaTemplate(templates, [reviewers[0]])?.id).toBe(
+      "implementation-readiness",
+    );
+    expect(nextAvailableReviewPersonaTemplate(templates, reviewers)?.id).toBe("plan-skeptic");
   });
 
   it("uses execution mode defaults for selected reviewer harnesses", () => {

--- a/desktop/src/lib/domain/reviews/review-config.ts
+++ b/desktop/src/lib/domain/reviews/review-config.ts
@@ -62,6 +62,17 @@ export interface ReviewPersonalityPreference {
 
 export type StoredReviewPersonalitiesByKind = Record<ReviewKind, ReviewPersonalityPreference[]>;
 
+export function createStoredReviewKindDefaults(): StoredReviewKindDefaults {
+  return {
+    maxRounds: DEFAULT_REVIEW_MAX_ROUNDS,
+    autoIterate: true,
+    agentKind: "",
+    modelId: "",
+    modeId: "",
+    reviewers: { mode: "inherit" },
+  };
+}
+
 const PLAN_REVIEW_PERSONAS: ReviewPersonaTemplate[] = [
   {
     id: "plan-skeptic",
@@ -221,6 +232,69 @@ export function createReviewSetupDraft(args: {
         };
       }),
   };
+}
+
+export function resolveReviewDefaultReviewerRows(args: {
+  kind: ReviewKind;
+  defaults: StoredReviewKindDefaults;
+  personalityTemplates: ReviewPersonaTemplate[];
+}): ReviewSetupReviewerDraft[] {
+  if (args.defaults.reviewers.mode === "custom") {
+    return args.defaults.reviewers.items;
+  }
+
+  const builtInTemplates = args.personalityTemplates.filter((template) =>
+    isBuiltInReviewPersonaId(args.kind, template.id)
+  );
+  const sourceTemplates = builtInTemplates.length > 0
+    ? builtInTemplates
+    : args.personalityTemplates;
+  return sourceTemplates.slice(0, 2).map((template) => ({
+    id: template.id,
+    label: template.label,
+    prompt: template.prompt,
+    agentKind: args.defaults.agentKind,
+    modelId: args.defaults.modelId,
+    modeId: args.defaults.modeId,
+  }));
+}
+
+export function nextAvailableReviewPersonaTemplate(
+  personalityTemplates: ReviewPersonaTemplate[],
+  reviewers: ReviewSetupReviewerDraft[],
+): ReviewPersonaTemplate | null {
+  return personalityTemplates.find((template) => (
+    !reviewers.some((reviewer) => (
+      findReviewPersonaTemplateForReviewer([template], reviewer.id) !== null
+    ))
+  )) ?? personalityTemplates[0] ?? null;
+}
+
+export function reviewerMatchesReviewPersonaTemplate(
+  reviewer: ReviewSetupReviewerDraft,
+  template: ReviewPersonaTemplate,
+  reviewers: ReviewSetupReviewerDraft[],
+  reviewerIndex: number,
+): boolean {
+  return nextReviewReviewerId(template.id, reviewers, reviewerIndex) === reviewer.id
+    && reviewer.label === template.label
+    && reviewer.prompt === template.prompt;
+}
+
+export function reviewerPersonalityLabel(
+  personalityTemplates: ReviewPersonaTemplate[],
+  reviewer: ReviewSetupReviewerDraft,
+): string {
+  const exact = personalityTemplates.find((template) =>
+    findReviewPersonaTemplateForReviewer([template], reviewer.id)
+    && reviewer.label === template.label
+    && reviewer.prompt === template.prompt
+  );
+  if (exact) {
+    return exact.label;
+  }
+  const base = findReviewPersonaTemplateForReviewer(personalityTemplates, reviewer.id);
+  return base ? `${base.label} edited` : reviewer.label || "Choose personality";
 }
 
 function resolveStoredReviewers(

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -33,7 +33,6 @@ anyharness/sdk/src/reducer/transcript.ts
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts
 anyharness/sdk-react/src/hooks/sessions.ts
 desktop/src/components/ui/icons.tsx
-desktop/src/components/settings/panes/review/ReviewDefaultsSection.tsx
 desktop/src/components/ui/content/DiffViewer.tsx
 desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
 desktop/src/components/workspace/changes/AllChangesFrame.tsx


### PR DESCRIPTION
## Summary

Split review defaults controls and option rows into smaller components while preserving existing review defaults behavior.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
