### PR TITLE
refactor(desktop): split workspace browser panel

### DIFF
--- a/desktop/src/components/workspace/browser/BrowserFallbackStates.tsx
+++ b/desktop/src/components/workspace/browser/BrowserFallbackStates.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/Button";
+import {
+  CircleAlert,
+  ExternalLink,
+  Globe,
+} from "@/components/ui/icons";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+
+export function BrowserUnavailableOverlay({
+  title,
+  description,
+  url,
+}: {
+  title: string;
+  description: string;
+  url: string;
+}) {
+  const { openExternal } = useTauriShellActions();
+
+  return (
+    <div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-sidebar-background/95 px-8 backdrop-blur">
+      <div className="flex max-w-72 flex-col items-center text-center">
+        <div className="mb-4 flex size-11 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
+          <CircleAlert className="size-5" />
+        </div>
+        <p className="text-sm font-medium text-sidebar-foreground">
+          {title}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-sidebar-muted-foreground">
+          {description}
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="mt-4 h-7 border border-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent"
+          onClick={() => {
+            void openExternal(url);
+          }}
+        >
+          <ExternalLink className="size-3.5" />
+          Open externally
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function BrowserEmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center px-8 text-center">
+      <div className="flex max-w-72 flex-col items-center">
+        <div className="mb-4 flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
+          <Globe className="size-6 opacity-70" />
+        </div>
+        <p className="text-sm font-medium text-sidebar-foreground">{title}</p>
+        <p className="mt-1 text-xs leading-5 text-sidebar-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/browser/BrowserFrame.tsx
+++ b/desktop/src/components/workspace/browser/BrowserFrame.tsx
@@ -1,0 +1,87 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import { browserIframeSandbox } from "@/lib/domain/workspaces/shell/browser-url";
+import { BrowserUnavailableOverlay } from "./BrowserFallbackStates";
+import type { FrameStatus } from "./BrowserPanelTypes";
+
+export function BrowserFrame({
+  tab,
+  active,
+  status,
+  onStatusChange,
+}: {
+  tab: RightPanelBrowserTab;
+  active: boolean;
+  status: FrameStatus;
+  onStatusChange: (tabId: string, status: FrameStatus) => void;
+}) {
+  const appOrigin = typeof window === "undefined" ? "" : window.location.origin;
+  const sandbox = useMemo(
+    () => tab.url ? browserIframeSandbox(tab.url, appOrigin) : "allow-scripts allow-forms",
+    [appOrigin, tab.url],
+  );
+  const timeoutRef = useRef<number | null>(null);
+
+  const clearFrameTimeout = useCallback(() => {
+    if (timeoutRef.current === null) {
+      return;
+    }
+    window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    clearFrameTimeout();
+    if (!tab.url) {
+      onStatusChange(tab.id, "idle");
+      return;
+    }
+    onStatusChange(tab.id, "loading");
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = null;
+      onStatusChange(tab.id, "blocked");
+    }, 10_000);
+    return clearFrameTimeout;
+  }, [clearFrameTimeout, onStatusChange, tab.id, tab.url]);
+
+  if (!tab.url) {
+    return null;
+  }
+
+  return (
+    <div
+      className={active ? "absolute inset-0" : "hidden pointer-events-none"}
+      aria-hidden={!active}
+      tabIndex={active ? undefined : -1}
+    >
+      {status === "blocked" && active && (
+        <BrowserUnavailableOverlay
+          title="This site may block embedding."
+          description="The tab stays editable. Open it externally if the preview does not load."
+          url={tab.url}
+        />
+      )}
+      <iframe
+        src={tab.url}
+        title="Browser preview"
+        sandbox={sandbox}
+        referrerPolicy="no-referrer"
+        allow=""
+        className="h-full w-full border-0 bg-background"
+        onLoad={() => {
+          clearFrameTimeout();
+          onStatusChange(tab.id, "loaded");
+        }}
+        onError={() => {
+          clearFrameTimeout();
+          onStatusChange(tab.id, "blocked");
+        }}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/browser/BrowserNativeSurface.tsx
+++ b/desktop/src/components/workspace/browser/BrowserNativeSurface.tsx
@@ -1,0 +1,184 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type RefObject,
+} from "react";
+import { useTauriBrowserWebviewActions } from "@/hooks/access/tauri/use-browser-webview-actions";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import { BrowserUnavailableOverlay } from "./BrowserFallbackStates";
+import type { FrameStatus } from "./BrowserPanelTypes";
+
+export function BrowserNativeSurface({
+  workspaceId,
+  tab,
+  active,
+  isPanelVisible,
+  nativeOverlaysHidden,
+  reloadKey,
+  contentRef,
+  status,
+  onStatusChange,
+}: {
+  workspaceId: string | null;
+  tab: RightPanelBrowserTab;
+  active: boolean;
+  isPanelVisible: boolean;
+  nativeOverlaysHidden: boolean;
+  reloadKey: number;
+  contentRef: RefObject<HTMLDivElement | null>;
+  status: FrameStatus;
+  onStatusChange: (tabId: string, status: FrameStatus) => void;
+}) {
+  const {
+    browserWebviewLabel,
+    closeBrowserWebview,
+    ensureBrowserWebview,
+    hideBrowserWebview,
+  } = useTauriBrowserWebviewActions();
+  const label = useMemo(
+    () => browserWebviewLabel(workspaceId, tab.id),
+    [browserWebviewLabel, tab.id, workspaceId],
+  );
+  const lastLoadKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      void closeBrowserWebview(label);
+    };
+  }, [closeBrowserWebview, label]);
+
+  useEffect(() => {
+    if (!tab.url) {
+      lastLoadKeyRef.current = null;
+      onStatusChange(tab.id, "idle");
+      void closeBrowserWebview(label);
+      return;
+    }
+
+    if (!active || !isPanelVisible || nativeOverlaysHidden) {
+      void hideBrowserWebview(label);
+      return;
+    }
+
+    let canceled = false;
+    const loadKey = `${tab.url}:${reloadKey}`;
+    const syncWebview = () => {
+      if (canceled || !tab.url) {
+        return;
+      }
+      const bounds = browserWebviewBoundsFromElement(contentRef.current);
+      if (!bounds) {
+        void hideBrowserWebview(label);
+        return;
+      }
+      if (lastLoadKeyRef.current !== loadKey) {
+        lastLoadKeyRef.current = loadKey;
+        onStatusChange(tab.id, "loading");
+      }
+      void ensureBrowserWebview({
+        label,
+        url: tab.url,
+        bounds,
+        visible: true,
+        reloadKey,
+      })
+        .then(() => {
+          if (!canceled) {
+            onStatusChange(tab.id, "loaded");
+          }
+        })
+        .catch(() => {
+          if (!canceled) {
+            void hideBrowserWebview(label);
+            if (browserWebviewDiagnosticLoggingEnabled()) {
+              console.debug("[browser-webview]", "native failed", {
+                label,
+              });
+            }
+            onStatusChange(tab.id, "blocked");
+          }
+        });
+    };
+
+    syncWebview();
+    return observeBrowserViewport(contentRef.current, syncWebview, () => {
+      canceled = true;
+    });
+  }, [
+    active,
+    contentRef,
+    closeBrowserWebview,
+    ensureBrowserWebview,
+    hideBrowserWebview,
+    isPanelVisible,
+    label,
+    nativeOverlaysHidden,
+    onStatusChange,
+    reloadKey,
+    tab.id,
+    tab.url,
+  ]);
+
+  if (!tab.url) {
+    return null;
+  }
+
+  return (
+    <div
+      className={active ? "pointer-events-none absolute inset-0" : "hidden pointer-events-none"}
+      aria-hidden={!active}
+      tabIndex={active ? undefined : -1}
+    >
+      {status === "blocked" && active && (
+        <BrowserUnavailableOverlay
+          title="This page could not be opened."
+          description="The tab stays editable. Open it externally or try another URL."
+          url={tab.url}
+        />
+      )}
+    </div>
+  );
+}
+
+function browserWebviewBoundsFromElement(element: HTMLElement | null) {
+  if (!element) {
+    return null;
+  }
+  const rect = element.getBoundingClientRect();
+  const width = Math.round(rect.width);
+  const height = Math.round(rect.height);
+  if (width < 2 || height < 2) {
+    return null;
+  }
+  return {
+    x: Math.round(rect.left),
+    y: Math.round(rect.top),
+    width,
+    height,
+  };
+}
+
+function observeBrowserViewport(
+  element: HTMLElement | null,
+  onChange: () => void,
+  onCleanup: () => void,
+): () => void {
+  let resizeObserver: ResizeObserver | null = null;
+  if (element && typeof ResizeObserver !== "undefined") {
+    resizeObserver = new ResizeObserver(onChange);
+    resizeObserver.observe(element);
+  }
+  window.addEventListener("resize", onChange);
+  window.addEventListener("scroll", onChange, true);
+  return () => {
+    onCleanup();
+    resizeObserver?.disconnect();
+    window.removeEventListener("resize", onChange);
+    window.removeEventListener("scroll", onChange, true);
+  };
+}
+
+function browserWebviewDiagnosticLoggingEnabled(): boolean {
+  return import.meta.env.DEV && import.meta.env.MODE !== "test";
+}

--- a/desktop/src/components/workspace/browser/BrowserPanelTypes.tsx
+++ b/desktop/src/components/workspace/browser/BrowserPanelTypes.tsx
@@ -1,0 +1,1 @@
+export type FrameStatus = "idle" | "loading" | "loaded" | "blocked";

--- a/desktop/src/components/workspace/browser/BrowserSurfaces.tsx
+++ b/desktop/src/components/workspace/browser/BrowserSurfaces.tsx
@@ -1,0 +1,58 @@
+import type { RefObject } from "react";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import { BrowserFrame } from "./BrowserFrame";
+import { BrowserNativeSurface } from "./BrowserNativeSurface";
+import type { FrameStatus } from "./BrowserPanelTypes";
+
+export function BrowserSurfaces({
+  activeBrowserId,
+  contentRef,
+  isPanelVisible,
+  nativeOverlaysHidden,
+  nativeWebviewsAvailable,
+  reloadNonceById,
+  statusById,
+  tabs,
+  workspaceId,
+  onStatusChange,
+}: {
+  activeBrowserId: string | null;
+  contentRef: RefObject<HTMLDivElement | null>;
+  isPanelVisible: boolean;
+  nativeOverlaysHidden: boolean;
+  nativeWebviewsAvailable: boolean;
+  reloadNonceById: Record<string, number>;
+  statusById: Record<string, FrameStatus>;
+  tabs: readonly RightPanelBrowserTab[];
+  workspaceId: string | null;
+  onStatusChange: (tabId: string, status: FrameStatus) => void;
+}) {
+  return (
+    <>
+      {tabs.map((tab) =>
+        nativeWebviewsAvailable ? (
+          <BrowserNativeSurface
+            key={`${tab.id}:${reloadNonceById[tab.id] ?? 0}`}
+            workspaceId={workspaceId}
+            tab={tab}
+            active={tab.id === activeBrowserId}
+            isPanelVisible={isPanelVisible}
+            nativeOverlaysHidden={nativeOverlaysHidden}
+            reloadKey={reloadNonceById[tab.id] ?? 0}
+            contentRef={contentRef}
+            status={statusById[tab.id] ?? (tab.url ? "loading" : "idle")}
+            onStatusChange={onStatusChange}
+          />
+        ) : (
+          <BrowserFrame
+            key={`${tab.id}:${reloadNonceById[tab.id] ?? 0}`}
+            tab={tab}
+            active={isPanelVisible && tab.id === activeBrowserId}
+            status={statusById[tab.id] ?? (tab.url ? "loading" : "idle")}
+            onStatusChange={onStatusChange}
+          />
+        )
+      )}
+    </>
+  );
+}

--- a/desktop/src/components/workspace/browser/BrowserToolbar.tsx
+++ b/desktop/src/components/workspace/browser/BrowserToolbar.tsx
@@ -1,0 +1,110 @@
+import type { FormEvent } from "react";
+import { IconButton } from "@/components/ui/IconButton";
+import { Input } from "@/components/ui/Input";
+import { Tooltip } from "@/components/ui/Tooltip";
+import {
+  ArrowRight,
+  ExternalLink,
+  Globe,
+  RefreshCw,
+} from "@/components/ui/icons";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { FrameStatus } from "./BrowserPanelTypes";
+
+export function BrowserToolbar({
+  activeDraft,
+  activeStatus,
+  activeTab,
+  urlError,
+  onDraftChange,
+  onReload,
+  onSubmit,
+}: {
+  activeDraft: string;
+  activeStatus: FrameStatus;
+  activeTab: RightPanelBrowserTab | null;
+  urlError: boolean;
+  onDraftChange: (tabId: string, value: string) => void;
+  onReload: (tabId: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  const { openExternal } = useTauriShellActions();
+
+  return (
+    <div className="shrink-0 border-b border-sidebar-border bg-sidebar-background">
+      <form className="flex h-10 min-w-0 items-center gap-1.5 px-2" onSubmit={onSubmit}>
+        <Tooltip content={activeStatus === "loading" ? "Loading" : "Reload"} singleLine>
+          <IconButton
+            type="button"
+            size="xs"
+            tone="sidebar"
+            title={activeStatus === "loading" ? "Loading" : "Reload"}
+            disabled={!activeTab?.url}
+            onClick={() => {
+              if (activeTab) {
+                onReload(activeTab.id);
+              }
+            }}
+          >
+            <RefreshCw className={`size-3.5 ${activeStatus === "loading" ? "animate-spin" : ""}`} />
+          </IconButton>
+        </Tooltip>
+        <div className="mx-0.5 h-4 w-px shrink-0 bg-sidebar-border" aria-hidden="true" />
+        <div className="relative min-w-0 flex-1">
+          <Globe
+            className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-sidebar-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            value={activeDraft}
+            disabled={!activeTab}
+            placeholder="Enter URL or localhost port"
+            className={`h-7 rounded-md border-sidebar-border bg-foreground/5 pl-7 pr-8 text-xs text-sidebar-foreground placeholder:text-sidebar-muted-foreground focus:ring-sidebar-border ${
+              urlError ? "border-destructive" : ""
+            }`}
+            spellCheck={false}
+            autoComplete="off"
+            aria-invalid={urlError}
+            onChange={(event) => {
+              if (activeTab) {
+                onDraftChange(activeTab.id, event.target.value);
+              }
+            }}
+          />
+          <IconButton
+            type="submit"
+            size="xs"
+            tone="sidebar"
+            title="Navigate"
+            disabled={!activeTab || !activeDraft.trim()}
+            className="absolute right-1 top-1/2 size-5 -translate-y-1/2"
+          >
+            <ArrowRight className="size-3.5" />
+          </IconButton>
+        </div>
+        <Tooltip content="Open externally" singleLine>
+          <IconButton
+            type="button"
+            size="xs"
+            tone="sidebar"
+            title="Open externally"
+            disabled={!activeTab?.url}
+            onClick={() => {
+              if (activeTab?.url) {
+                void openExternal(activeTab.url);
+              }
+            }}
+          >
+            <ExternalLink className="size-3.5" />
+          </IconButton>
+        </Tooltip>
+      </form>
+      {urlError && (
+        <p className="border-t border-sidebar-border px-3 py-1 text-[11px] leading-4 text-sidebar-muted-foreground">
+          Enter a valid http or https URL, localhost host, or port.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
+++ b/desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
@@ -5,28 +5,14 @@ import {
   useRef,
   useState,
   type FormEvent,
-  type RefObject,
 } from "react";
-import { Button } from "@/components/ui/Button";
-import { IconButton } from "@/components/ui/IconButton";
-import { Input } from "@/components/ui/Input";
-import { Tooltip } from "@/components/ui/Tooltip";
-import {
-  ArrowRight,
-  CircleAlert,
-  ExternalLink,
-  Globe,
-  RefreshCw,
-} from "@/components/ui/icons";
 import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
-import {
-  browserIframeSandbox,
-  normalizeBrowserUrl,
-} from "@/lib/domain/workspaces/shell/browser-url";
-import {
-  useTauriBrowserWebviewActions,
-} from "@/hooks/access/tauri/use-browser-webview-actions";
-import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { normalizeBrowserUrl } from "@/lib/domain/workspaces/shell/browser-url";
+import { useTauriBrowserWebviewActions } from "@/hooks/access/tauri/use-browser-webview-actions";
+import { BrowserEmptyState } from "./BrowserFallbackStates";
+import type { FrameStatus } from "./BrowserPanelTypes";
+import { BrowserSurfaces } from "./BrowserSurfaces";
+import { BrowserToolbar } from "./BrowserToolbar";
 
 interface WorkspaceBrowserPanelProps {
   workspaceId: string | null;
@@ -37,8 +23,6 @@ interface WorkspaceBrowserPanelProps {
   onUpdateUrl: (browserId: string, url: string) => void;
 }
 
-type FrameStatus = "idle" | "loading" | "loaded" | "blocked";
-
 export function WorkspaceBrowserPanel({
   workspaceId,
   tabs,
@@ -48,10 +32,7 @@ export function WorkspaceBrowserPanel({
   onUpdateUrl,
 }: WorkspaceBrowserPanelProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
-  const {
-    isBrowserWebviewAvailable,
-  } = useTauriBrowserWebviewActions();
-  const { openExternal } = useTauriShellActions();
+  const { isBrowserWebviewAvailable } = useTauriBrowserWebviewActions();
   const activeTab = tabs.find((tab) => tab.id === activeBrowserId) ?? null;
   const [draftById, setDraftById] = useState<Record<string, string>>({});
   const [statusById, setStatusById] = useState<Record<string, FrameStatus>>({});
@@ -61,14 +42,6 @@ export function WorkspaceBrowserPanel({
     () => isBrowserWebviewAvailable(),
     [isBrowserWebviewAvailable],
   );
-  useEffect(() => {
-    if (browserWebviewDiagnosticLoggingEnabled() && !nativeWebviewsAvailable) {
-      console.debug("[browser-webview]", "native unavailable; iframe fallback active");
-    }
-  }, [nativeWebviewsAvailable]);
-  const handleFrameStatusChange = useCallback((tabId: string, status: FrameStatus) => {
-    setStatusById((current) => ({ ...current, [tabId]: status }));
-  }, []);
   const activeDraft = activeTab
     ? draftById[activeTab.id] ?? activeTab.url ?? ""
     : "";
@@ -77,10 +50,24 @@ export function WorkspaceBrowserPanel({
     : "idle";
 
   useEffect(() => {
+    if (browserWebviewDiagnosticLoggingEnabled() && !nativeWebviewsAvailable) {
+      console.debug("[browser-webview]", "native unavailable; iframe fallback active");
+    }
+  }, [nativeWebviewsAvailable]);
+
+  useEffect(() => {
     if (activeTab?.url !== activeDraft) {
       setUrlError(false);
     }
   }, [activeDraft, activeTab?.url]);
+
+  const handleFrameStatusChange = useCallback((tabId: string, status: FrameStatus) => {
+    setStatusById((current) => ({ ...current, [tabId]: status }));
+  }, []);
+
+  const handleDraftChange = useCallback((tabId: string, value: string) => {
+    setDraftById((current) => ({ ...current, [tabId]: value }));
+  }, []);
 
   const reloadTab = useCallback((tabId: string) => {
     setStatusById((current) => ({ ...current, [tabId]: "loading" }));
@@ -116,85 +103,15 @@ export function WorkspaceBrowserPanel({
       data-telemetry-block
       data-focus-zone="browser"
     >
-      <div className="shrink-0 border-b border-sidebar-border bg-sidebar-background">
-        <form className="flex h-10 min-w-0 items-center gap-1.5 px-2" onSubmit={handleSubmit}>
-          <Tooltip content={activeStatus === "loading" ? "Loading" : "Reload"} singleLine>
-            <IconButton
-              type="button"
-              size="xs"
-              tone="sidebar"
-              title={activeStatus === "loading" ? "Loading" : "Reload"}
-              disabled={!activeTab?.url}
-              onClick={() => {
-                if (!activeTab) {
-                  return;
-                }
-                reloadTab(activeTab.id);
-              }}
-            >
-              <RefreshCw className={`size-3.5 ${activeStatus === "loading" ? "animate-spin" : ""}`} />
-            </IconButton>
-          </Tooltip>
-          <div className="mx-0.5 h-4 w-px shrink-0 bg-sidebar-border" aria-hidden="true" />
-          <div className="relative min-w-0 flex-1">
-            <Globe
-              className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-sidebar-muted-foreground"
-              aria-hidden="true"
-            />
-            <Input
-              value={activeDraft}
-              disabled={!activeTab}
-              placeholder="Enter URL or localhost port"
-              className={`h-7 rounded-md border-sidebar-border bg-foreground/5 pl-7 pr-8 text-xs text-sidebar-foreground placeholder:text-sidebar-muted-foreground focus:ring-sidebar-border ${
-                urlError ? "border-destructive" : ""
-              }`}
-              spellCheck={false}
-              autoComplete="off"
-              aria-invalid={urlError}
-              onChange={(event) => {
-                if (!activeTab) {
-                  return;
-                }
-                setDraftById((current) => ({
-                  ...current,
-                  [activeTab.id]: event.target.value,
-                }));
-              }}
-            />
-            <IconButton
-              type="submit"
-              size="xs"
-              tone="sidebar"
-              title="Navigate"
-              disabled={!activeTab || !activeDraft.trim()}
-              className="absolute right-1 top-1/2 size-5 -translate-y-1/2"
-            >
-              <ArrowRight className="size-3.5" />
-            </IconButton>
-          </div>
-          <Tooltip content="Open externally" singleLine>
-            <IconButton
-              type="button"
-              size="xs"
-              tone="sidebar"
-              title="Open externally"
-              disabled={!activeTab?.url}
-              onClick={() => {
-                if (activeTab?.url) {
-                  void openExternal(activeTab.url);
-                }
-              }}
-            >
-              <ExternalLink className="size-3.5" />
-            </IconButton>
-          </Tooltip>
-        </form>
-        {urlError && (
-          <p className="border-t border-sidebar-border px-3 py-1 text-[11px] leading-4 text-sidebar-muted-foreground">
-            Enter a valid http or https URL, localhost host, or port.
-          </p>
-        )}
-      </div>
+      <BrowserToolbar
+        activeDraft={activeDraft}
+        activeStatus={activeStatus}
+        activeTab={activeTab}
+        urlError={urlError}
+        onDraftChange={handleDraftChange}
+        onReload={reloadTab}
+        onSubmit={handleSubmit}
+      />
 
       <div ref={contentRef} className="relative min-h-0 flex-1 overflow-hidden">
         {!activeTab ? (
@@ -209,340 +126,21 @@ export function WorkspaceBrowserPanel({
           />
         ) : null}
 
-        {tabs.map((tab) =>
-          nativeWebviewsAvailable ? (
-            <BrowserNativeSurface
-              key={`${tab.id}:${reloadNonceById[tab.id] ?? 0}`}
-              workspaceId={workspaceId}
-              tab={tab}
-              active={tab.id === activeBrowserId}
-              isPanelVisible={isVisible}
-              nativeOverlaysHidden={nativeOverlaysHidden}
-              reloadKey={reloadNonceById[tab.id] ?? 0}
-              contentRef={contentRef}
-              status={statusById[tab.id] ?? (tab.url ? "loading" : "idle")}
-              onStatusChange={handleFrameStatusChange}
-            />
-          ) : (
-            <BrowserFrame
-              key={`${tab.id}:${reloadNonceById[tab.id] ?? 0}`}
-              tab={tab}
-              active={isVisible && tab.id === activeBrowserId}
-              status={statusById[tab.id] ?? (tab.url ? "loading" : "idle")}
-              onStatusChange={handleFrameStatusChange}
-            />
-          )
-        )}
-      </div>
-    </div>
-  );
-}
-
-function BrowserNativeSurface({
-  workspaceId,
-  tab,
-  active,
-  isPanelVisible,
-  nativeOverlaysHidden,
-  reloadKey,
-  contentRef,
-  status,
-  onStatusChange,
-}: {
-  workspaceId: string | null;
-  tab: RightPanelBrowserTab;
-  active: boolean;
-  isPanelVisible: boolean;
-  nativeOverlaysHidden: boolean;
-  reloadKey: number;
-  contentRef: RefObject<HTMLDivElement | null>;
-  status: FrameStatus;
-  onStatusChange: (tabId: string, status: FrameStatus) => void;
-}) {
-  const {
-    browserWebviewLabel,
-    closeBrowserWebview,
-    ensureBrowserWebview,
-    hideBrowserWebview,
-  } = useTauriBrowserWebviewActions();
-  const label = useMemo(
-    () => browserWebviewLabel(workspaceId, tab.id),
-    [browserWebviewLabel, tab.id, workspaceId],
-  );
-  const lastLoadKeyRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    return () => {
-      void closeBrowserWebview(label);
-    };
-  }, [closeBrowserWebview, label]);
-
-  useEffect(() => {
-    if (!tab.url) {
-      lastLoadKeyRef.current = null;
-      onStatusChange(tab.id, "idle");
-      void closeBrowserWebview(label);
-      return;
-    }
-
-    if (!active || !isPanelVisible || nativeOverlaysHidden) {
-      void hideBrowserWebview(label);
-      return;
-    }
-
-    let canceled = false;
-    const loadKey = `${tab.url}:${reloadKey}`;
-    const syncWebview = () => {
-      if (canceled || !tab.url) {
-        return;
-      }
-      const bounds = browserWebviewBoundsFromElement(contentRef.current);
-      if (!bounds) {
-        void hideBrowserWebview(label);
-        return;
-      }
-      if (lastLoadKeyRef.current !== loadKey) {
-        lastLoadKeyRef.current = loadKey;
-        onStatusChange(tab.id, "loading");
-      }
-      void ensureBrowserWebview({
-        label,
-        url: tab.url,
-        bounds,
-        visible: true,
-        reloadKey,
-      })
-        .then(() => {
-          if (!canceled) {
-            onStatusChange(tab.id, "loaded");
-          }
-        })
-        .catch(() => {
-          if (!canceled) {
-            void hideBrowserWebview(label);
-            if (browserWebviewDiagnosticLoggingEnabled()) {
-              console.debug("[browser-webview]", "native failed", {
-                label,
-              });
-            }
-            onStatusChange(tab.id, "blocked");
-          }
-        });
-    };
-
-    syncWebview();
-    return observeBrowserViewport(contentRef.current, syncWebview, () => {
-      canceled = true;
-    });
-  }, [
-    active,
-    contentRef,
-    closeBrowserWebview,
-    ensureBrowserWebview,
-    hideBrowserWebview,
-    isPanelVisible,
-    label,
-    nativeOverlaysHidden,
-    onStatusChange,
-    reloadKey,
-    tab.id,
-    tab.url,
-  ]);
-
-  if (!tab.url) {
-    return null;
-  }
-
-  return (
-    <div
-      className={active ? "pointer-events-none absolute inset-0" : "hidden pointer-events-none"}
-      aria-hidden={!active}
-      tabIndex={active ? undefined : -1}
-    >
-      {status === "blocked" && active && (
-        <BrowserUnavailableOverlay
-          title="This page could not be opened."
-          description="The tab stays editable. Open it externally or try another URL."
-          url={tab.url}
+        <BrowserSurfaces
+          activeBrowserId={activeBrowserId}
+          contentRef={contentRef}
+          isPanelVisible={isVisible}
+          nativeOverlaysHidden={nativeOverlaysHidden}
+          nativeWebviewsAvailable={nativeWebviewsAvailable}
+          reloadNonceById={reloadNonceById}
+          statusById={statusById}
+          tabs={tabs}
+          workspaceId={workspaceId}
+          onStatusChange={handleFrameStatusChange}
         />
-      )}
-    </div>
-  );
-}
-
-function BrowserFrame({
-  tab,
-  active,
-  status,
-  onStatusChange,
-}: {
-  tab: RightPanelBrowserTab;
-  active: boolean;
-  status: FrameStatus;
-  onStatusChange: (tabId: string, status: FrameStatus) => void;
-}) {
-  const appOrigin = typeof window === "undefined" ? "" : window.location.origin;
-  const sandbox = useMemo(
-    () => tab.url ? browserIframeSandbox(tab.url, appOrigin) : "allow-scripts allow-forms",
-    [appOrigin, tab.url],
-  );
-  const timeoutRef = useRef<number | null>(null);
-
-  const clearFrameTimeout = useCallback(() => {
-    if (timeoutRef.current === null) {
-      return;
-    }
-    window.clearTimeout(timeoutRef.current);
-    timeoutRef.current = null;
-  }, []);
-
-  useEffect(() => {
-    clearFrameTimeout();
-    if (!tab.url) {
-      onStatusChange(tab.id, "idle");
-      return;
-    }
-    onStatusChange(tab.id, "loading");
-    timeoutRef.current = window.setTimeout(() => {
-      timeoutRef.current = null;
-      onStatusChange(tab.id, "blocked");
-    }, 10_000);
-    return clearFrameTimeout;
-  }, [clearFrameTimeout, onStatusChange, tab.id, tab.url]);
-
-  if (!tab.url) {
-    return null;
-  }
-
-  return (
-    <div
-      className={active ? "absolute inset-0" : "hidden pointer-events-none"}
-      aria-hidden={!active}
-      tabIndex={active ? undefined : -1}
-    >
-      {status === "blocked" && active && (
-        <BrowserUnavailableOverlay
-          title="This site may block embedding."
-          description="The tab stays editable. Open it externally if the preview does not load."
-          url={tab.url}
-        />
-      )}
-      <iframe
-        src={tab.url}
-        title="Browser preview"
-        sandbox={sandbox}
-        referrerPolicy="no-referrer"
-        allow=""
-        className="h-full w-full border-0 bg-background"
-        onLoad={() => {
-          clearFrameTimeout();
-          onStatusChange(tab.id, "loaded");
-        }}
-        onError={() => {
-          clearFrameTimeout();
-          onStatusChange(tab.id, "blocked");
-        }}
-      />
-    </div>
-  );
-}
-
-function BrowserUnavailableOverlay({
-  title,
-  description,
-  url,
-}: {
-  title: string;
-  description: string;
-  url: string;
-}) {
-  const { openExternal } = useTauriShellActions();
-
-  return (
-    <div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-sidebar-background/95 px-8 backdrop-blur">
-      <div className="flex max-w-72 flex-col items-center text-center">
-        <div className="mb-4 flex size-11 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
-          <CircleAlert className="size-5" />
-        </div>
-        <p className="text-sm font-medium text-sidebar-foreground">
-          {title}
-        </p>
-        <p className="mt-1 text-xs leading-5 text-sidebar-muted-foreground">
-          {description}
-        </p>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="mt-4 h-7 border border-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent"
-          onClick={() => {
-            void openExternal(url);
-          }}
-        >
-          <ExternalLink className="size-3.5" />
-          Open externally
-        </Button>
       </div>
     </div>
   );
-}
-
-function BrowserEmptyState({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="flex h-full items-center justify-center px-8 text-center">
-      <div className="flex max-w-72 flex-col items-center">
-        <div className="mb-4 flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
-          <Globe className="size-6 opacity-70" />
-        </div>
-        <p className="text-sm font-medium text-sidebar-foreground">{title}</p>
-        <p className="mt-1 text-xs leading-5 text-sidebar-muted-foreground">{description}</p>
-      </div>
-    </div>
-  );
-}
-
-function browserWebviewBoundsFromElement(element: HTMLElement | null) {
-  if (!element) {
-    return null;
-  }
-  const rect = element.getBoundingClientRect();
-  const width = Math.round(rect.width);
-  const height = Math.round(rect.height);
-  if (width < 2 || height < 2) {
-    return null;
-  }
-  return {
-    x: Math.round(rect.left),
-    y: Math.round(rect.top),
-    width,
-    height,
-  };
-}
-
-function observeBrowserViewport(
-  element: HTMLElement | null,
-  onChange: () => void,
-  onCleanup: () => void,
-): () => void {
-  let resizeObserver: ResizeObserver | null = null;
-  if (element && typeof ResizeObserver !== "undefined") {
-    resizeObserver = new ResizeObserver(onChange);
-    resizeObserver.observe(element);
-  }
-  window.addEventListener("resize", onChange);
-  window.addEventListener("scroll", onChange, true);
-  return () => {
-    onCleanup();
-    resizeObserver?.disconnect();
-    window.removeEventListener("resize", onChange);
-    window.removeEventListener("scroll", onChange, true);
-  };
 }
 
 function browserWebviewDiagnosticLoggingEnabled(): boolean {

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -33,7 +33,6 @@ anyharness/sdk/src/reducer/transcript.ts
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts
 anyharness/sdk-react/src/hooks/sessions.ts
 desktop/src/components/ui/icons.tsx
-desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
 desktop/src/components/workspace/changes/AllChangesFrame.tsx
 desktop/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
 desktop/src/hooks/sessions/use-session-creation-actions.ts


### PR DESCRIPTION
## Summary

Split the workspace browser panel into focused toolbar, frame, surface, native-surface, and fallback components.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
