### PR TITLE
refactor(server): clean users invitation DB wrappers

### DIFF
--- a/reference/server_phase7_remainder_audit.md
+++ b/reference/server_phase7_remainder_audit.md
@@ -47,8 +47,8 @@ missed cleanup from systems that need Phase 8 design before implementation.
 | `server/proliferate/db/store/cloud_mcp/oauth_clients.py` | store opens session | Intentional isolated wrapper | Same materialization/OAuth refresh boundary. |
 | `server/proliferate/db/store/cloud_repo_config.py` | store opens session | Intentional isolated wrapper | Remaining reads serve deferred runtime/workspace flows. |
 | `server/proliferate/db/store/cloud_worktree_policy.py` | store opens session | Intentional isolated wrapper | Remaining policy read serves deferred runtime policy sync. |
-| `server/proliferate/db/store/organization_invitations.py` | store opens session | Small follow-up | Convert create/rotate paths only after pinning transaction timing around email delivery. |
-| `server/proliferate/db/store/users.py` | store opens session | Small follow-up | Thread request/session dependencies through auth/desktop user callers. |
+| `server/proliferate/db/store/organization_invitations.py` | store opens session | Intentional isolated wrapper | Create/rotate must commit the invitation before external email delivery; replace only with an explicit delivery checkpoint or outbox design. |
+| `server/proliferate/db/store/users.py` | store opens session | Intentional isolated wrapper | Unused wrappers are removed; the remaining OAuth-account user load serves deferred runtime, mobility, and worker callers. |
 
 ## File-Size Debt
 
@@ -80,7 +80,6 @@ These are not blockers for Phase 7 completion. Assign them only with narrow
 path ownership and behavior-preserving goals.
 
 - `server/proliferate/server/organizations/service.py`
-- `server/proliferate/db/store/organization_invitations.py`
 - `server/proliferate/auth/desktop/service.py`
 - `server/proliferate/integrations/sandbox/daytona.py`
 - `server/proliferate/integrations/sandbox/e2b.py`
@@ -105,6 +104,8 @@ only when the deferred caller owning the transaction boundary migrates.
 - `server/proliferate/db/store/cloud_mcp/oauth_clients.py`
 - `server/proliferate/db/store/cloud_worktree_policy.py`
 - `server/proliferate/db/store/organizations.py`
+- `server/proliferate/db/store/organization_invitations.py`
+- `server/proliferate/db/store/users.py`
 
 ## Phase 7 Result
 

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -40,9 +40,9 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environment
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 26 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 transitional invitation create/rotate commit before email delivery
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 4 transitional wrappers used by deferred billing/cloud callers
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 3 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/anonymous_telemetry.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
@@ -56,6 +56,6 @@ STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_runtime_environme
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspace_setup_runs.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspaces.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organization_invitations.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organization_invitations.py 1 intentional create/rotate transaction commits before external email delivery
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organizations.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/users.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load

--- a/server/proliferate/db/store/organization_invitations.py
+++ b/server/proliferate/db/store/organization_invitations.py
@@ -65,6 +65,9 @@ async def create_or_rotate_organization_invitation(
     invited_by_user_id: UUID,
     expires_at: datetime,
 ) -> InvitationCreateRecord | None:
+    # Intentionally isolated: invitation rows must commit before the service
+    # sends external email. Replace this only with an explicit delivery
+    # checkpoint/outbox design that preserves that ordering.
     normalized_email = normalize_invitation_email(email)
     now = utcnow()
     async with db_engine.async_session_factory() as db, db.begin():
@@ -210,6 +213,8 @@ async def rotate_organization_invitation(
     token_hash: str,
     expires_at: datetime,
 ) -> InvitationCreateRecord | None:
+    # Intentionally isolated for the same pre-email durability boundary as
+    # create_or_rotate_organization_invitation.
     async with db_engine.async_session_factory() as db, db.begin():
         invitation = (
             await db.execute(

--- a/server/proliferate/db/store/users.py
+++ b/server/proliferate/db/store/users.py
@@ -57,16 +57,8 @@ async def update_user_github_profile(
     return user
 
 
-async def load_user_by_id(user_id: UUID) -> User | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_user_by_id(db, user_id)
-
-
-async def load_active_user_by_id(user_id: UUID) -> User | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_active_user_by_id(db, user_id)
-
-
 async def load_user_with_oauth_accounts_by_id(user_id: UUID) -> User | None:
+    # Transitional isolated read for deferred runtime/mobility/worker flows.
+    # Request-scoped callers should use get_user_with_oauth_accounts_by_id(db, ...).
     async with db_engine.async_session_factory() as db:
         return await get_user_with_oauth_accounts_by_id(db, user_id)


### PR DESCRIPTION
## Summary
- remove unused self-opening user store wrappers and ratchet the users store allowlist count from 3 calls to 1
- keep the remaining OAuth-account user loader documented for deferred runtime/mobility/worker callers
- document organization invitation create/rotate wrappers as intentional pre-email delivery transaction boundaries instead of ambiguous small-follow-up debt

## Verification
- /opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py
- /opt/homebrew/bin/python3.12 scripts/check_max_lines.py
- env -u PYTHONPATH -u PYTHONHOME DEBUG=true uv run --python 3.12 --extra dev python -m pytest -q tests/integration/test_organizations_api.py tests/unit/test_server_boundary_checker.py
- git diff --check
