### PR TITLE
refactor(server): clean cloud repos auth ownership

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -13,7 +13,6 @@ INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/daytona.py 1 
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sandbox/e2b.py 1 transitional integration depends on product domain types/logic
 SERVICE_ORM_IMPORT server/proliferate/server/ai_magic/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional service imports ORM/auth model
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/repos/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/anonymous_telemetry.py 1 transitional store owns transaction commit

--- a/server/proliferate/server/cloud/repos/access.py
+++ b/server/proliferate/server/cloud/repos/access.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.constants.cloud import SUPPORTED_GIT_PROVIDER
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.repos.domain.github_credentials import (
+    CloudRepoGitHubCredentials,
+    build_cloud_repo_github_credentials,
+)
+
+
+def current_cloud_repo_github_credentials(
+    user: User = Depends(current_active_user),
+) -> CloudRepoGitHubCredentials:
+    return build_cloud_repo_github_credentials(
+        user_id=user.id,
+        oauth_accounts=user.oauth_accounts,
+        oauth_name=SUPPORTED_GIT_PROVIDER,
+    )
+
+
+CloudRepoGitHubCredentialsDependency = Annotated[
+    CloudRepoGitHubCredentials,
+    Depends(current_cloud_repo_github_credentials),
+]

--- a/server/proliferate/server/cloud/repos/api.py
+++ b/server/proliferate/server/cloud/repos/api.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 
-from proliferate.auth.dependencies import current_active_user
-from proliferate.db.models.auth import User
+from proliferate.server.cloud.repos.access import CloudRepoGitHubCredentialsDependency
 from proliferate.server.cloud.repos.models import RepoBranchesResponse
 from proliferate.server.cloud.repos.service import get_cloud_repo_branches
 
@@ -14,10 +13,10 @@ router = APIRouter()
 async def get_cloud_repo_branches_endpoint(
     git_owner: str,
     git_repo_name: str,
-    user: User = Depends(current_active_user),
+    credentials: CloudRepoGitHubCredentialsDependency,
 ) -> RepoBranchesResponse:
     return await get_cloud_repo_branches(
-        user,
+        credentials,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
     )

--- a/server/proliferate/server/cloud/repos/domain/github_credentials.py
+++ b/server/proliferate/server/cloud/repos/domain/github_credentials.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import UUID
+
+
+class OAuthAccountLike(Protocol):
+    oauth_name: object
+    access_token: object
+
+
+@dataclass(frozen=True)
+class CloudRepoGitHubCredentials:
+    user_id: UUID
+    access_token: str | None
+
+
+def find_oauth_account(
+    oauth_accounts: Iterable[OAuthAccountLike],
+    *,
+    oauth_name: str,
+) -> OAuthAccountLike | None:
+    for account in oauth_accounts:
+        if getattr(account, "oauth_name", None) == oauth_name:
+            return account
+    return None
+
+
+def build_cloud_repo_github_credentials(
+    *,
+    user_id: UUID,
+    oauth_accounts: Iterable[OAuthAccountLike],
+    oauth_name: str,
+) -> CloudRepoGitHubCredentials:
+    account = find_oauth_account(oauth_accounts, oauth_name=oauth_name)
+    access_token = getattr(account, "access_token", None) if account else None
+    return CloudRepoGitHubCredentials(
+        user_id=user_id,
+        access_token=str(access_token) if access_token else None,
+    )

--- a/server/proliferate/server/cloud/repos/service.py
+++ b/server/proliferate/server/cloud/repos/service.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Iterable
+from typing import Protocol
+from uuid import UUID
 
 from proliferate.constants.cloud import SUPPORTED_GIT_PROVIDER
-from proliferate.db.models.auth import (
-    OAuthAccount,
-    User,
-)
 from proliferate.integrations.github import (
     GitHubIntegrationError,
     GitHubRepoAccessRequired,
@@ -15,38 +14,60 @@ from proliferate.integrations.github import (
 )
 from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repos.domain.github_credentials import (
+    CloudRepoGitHubCredentials,
+    OAuthAccountLike,
+    build_cloud_repo_github_credentials,
+    find_oauth_account,
+)
 from proliferate.server.cloud.repos.models import RepoBranchesResponse
 from proliferate.utils.time import duration_ms
 
 
-def get_linked_github_account(user: User) -> OAuthAccount | None:
-    for account in user.oauth_accounts:
-        if getattr(account, "oauth_name", None) == SUPPORTED_GIT_PROVIDER:
-            return account
-    return None
+class CloudRepoUserLike(Protocol):
+    id: UUID
+    oauth_accounts: Iterable[OAuthAccountLike]
 
 
-def _require_github_access_token(user: User, message: str) -> str:
-    github_account = get_linked_github_account(user)
-    access_token = getattr(github_account, "access_token", None) if github_account else None
-    if not access_token:
+def get_linked_github_account(user: CloudRepoUserLike) -> OAuthAccountLike | None:
+    return find_oauth_account(
+        user.oauth_accounts,
+        oauth_name=SUPPORTED_GIT_PROVIDER,
+    )
+
+
+def build_cloud_repo_credentials_for_user(
+    user: CloudRepoUserLike,
+) -> CloudRepoGitHubCredentials:
+    return build_cloud_repo_github_credentials(
+        user_id=user.id,
+        oauth_accounts=user.oauth_accounts,
+        oauth_name=SUPPORTED_GIT_PROVIDER,
+    )
+
+
+def _require_github_access_token(
+    credentials: CloudRepoGitHubCredentials,
+    message: str,
+) -> str:
+    if not credentials.access_token:
         raise CloudApiError(
             "github_link_required",
             message,
             status_code=400,
         )
-    return str(access_token)
+    return credentials.access_token
 
 
-async def get_repo_branches_for_user(
-    user: User,
+async def get_repo_branches_for_credentials(
+    credentials: CloudRepoGitHubCredentials,
     *,
     git_owner: str,
     git_repo_name: str,
     missing_access_message: str,
     repo_access_required_message: str | None = None,
 ) -> GitHubRepoBranches:
-    access_token = _require_github_access_token(user, missing_access_message)
+    access_token = _require_github_access_token(credentials, missing_access_message)
     lookup_started = time.perf_counter()
     try:
         branch_info = await get_github_repo_branches(access_token, git_owner, git_repo_name)
@@ -72,14 +93,31 @@ async def get_repo_branches_for_user(
     return branch_info
 
 
+async def get_repo_branches_for_user(
+    user: CloudRepoUserLike,
+    *,
+    git_owner: str,
+    git_repo_name: str,
+    missing_access_message: str,
+    repo_access_required_message: str | None = None,
+) -> GitHubRepoBranches:
+    return await get_repo_branches_for_credentials(
+        build_cloud_repo_credentials_for_user(user),
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        missing_access_message=missing_access_message,
+        repo_access_required_message=repo_access_required_message,
+    )
+
+
 async def get_cloud_repo_branches(
-    user: User,
+    credentials: CloudRepoGitHubCredentials,
     *,
     git_owner: str,
     git_repo_name: str,
 ) -> RepoBranchesResponse:
-    branch_info = await get_repo_branches_for_user(
-        user,
+    branch_info = await get_repo_branches_for_credentials(
+        credentials,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         missing_access_message="Connect a GitHub account before browsing cloud branches.",
@@ -89,7 +127,7 @@ async def get_cloud_repo_branches(
     )
     log_cloud_event(
         "cloud repo branch metadata loaded",
-        user_id=user.id,
+        user_id=credentials.user_id,
         repo=f"{git_owner}/{git_repo_name}",
         default_branch=branch_info.default_branch,
         branch_count=len(branch_info.branches),

--- a/server/tests/unit/test_repos_service.py
+++ b/server/tests/unit/test_repos_service.py
@@ -18,10 +18,15 @@ from proliferate.integrations.github import (
     list_branches,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repos.domain.github_credentials import (
+    CloudRepoGitHubCredentials,
+)
 from proliferate.server.cloud.repos.service import (
     _require_github_access_token,
+    build_cloud_repo_credentials_for_user,
     get_cloud_repo_branches,
     get_linked_github_account,
+    get_repo_branches_for_credentials,
     get_repo_branches_for_user,
 )
 
@@ -59,15 +64,35 @@ class TestGetLinkedGithubAccount:
 
 class TestRequireGithubAccessToken:
     def test_returns_token_when_present(self) -> None:
-        user = _make_user(github_token="gh-token")
-        assert _require_github_access_token(user, "msg") == "gh-token"
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token="gh-token",
+        )
+        assert _require_github_access_token(credentials, "msg") == "gh-token"
 
     def test_raises_cloud_error_when_missing(self) -> None:
-        user = _make_user()
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token=None,
+        )
         with pytest.raises(CloudApiError) as exc_info:
-            _require_github_access_token(user, "connect first")
+            _require_github_access_token(credentials, "connect first")
         assert exc_info.value.code == "github_link_required"
         assert exc_info.value.status_code == 400
+
+
+class TestBuildCloudRepoCredentialsForUser:
+    def test_returns_user_id_and_token(self) -> None:
+        user = _make_user(github_token="gh-token")
+        credentials = build_cloud_repo_credentials_for_user(user)
+        assert credentials.user_id == user.id
+        assert credentials.access_token == "gh-token"
+
+    def test_returns_none_token_when_unlinked(self) -> None:
+        user = _make_user()
+        credentials = build_cloud_repo_credentials_for_user(user)
+        assert credentials.user_id == user.id
+        assert credentials.access_token is None
 
 
 class TestGetRepoBranchesForUser:
@@ -163,10 +188,37 @@ class TestGetRepoBranchesForUser:
         assert exc_info.value.code == "github_link_required"
 
 
+class TestGetRepoBranchesForCredentials:
+    @pytest.mark.asyncio
+    async def test_delegates_to_integration_adapter(self) -> None:
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token="gh-token",
+        )
+        branches = GitHubRepoBranches(default_branch="main", branches=["main", "dev"])
+
+        with patch(
+            "proliferate.server.cloud.repos.service.get_github_repo_branches",
+            new_callable=AsyncMock,
+            return_value=branches,
+        ) as mock:
+            result = await get_repo_branches_for_credentials(
+                credentials,
+                git_owner="acme",
+                git_repo_name="rocket",
+                missing_access_message="msg",
+            )
+            mock.assert_awaited_once_with("gh-token", "acme", "rocket")
+            assert result is branches
+
+
 class TestGetCloudRepoBranches:
     @pytest.mark.asyncio
     async def test_shapes_response_for_api(self) -> None:
-        user = _make_user(github_token="gh-token")
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token="gh-token",
+        )
         branches = GitHubRepoBranches(
             default_branch="main",
             branches=["main", "release", "stable"],
@@ -178,7 +230,7 @@ class TestGetCloudRepoBranches:
             return_value=branches,
         ):
             result = await get_cloud_repo_branches(
-                user,
+                credentials,
                 git_owner="acme",
                 git_repo_name="rocket",
             )


### PR DESCRIPTION
## Summary
- add a cloud repos access dependency that converts the authenticated user into a GitHub credentials snapshot
- update cloud repos service to consume credentials snapshots instead of importing auth ORM models
- keep compatibility helpers for deferred Phase 8 callers while removing the cloud repos SERVICE_ORM_IMPORT allowlist entry

## Verification
- /opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py
- /opt/homebrew/bin/python3.12 scripts/check_max_lines.py
- cd server && DEBUG=1 uv run --python 3.12 --extra dev ruff check proliferate/server/cloud/repos tests/unit/test_repos_service.py
- cd server && DEBUG=1 uv run --python 3.12 --extra dev pytest -q tests/unit/test_repos_service.py
- cd server && DEBUG=1 uv run --python 3.12 --extra dev python - <<'PY'
from proliferate.server.cloud.repos.api import router
print(len(router.routes))
PY
- git diff --check