### PR TITLE
test(server): pin cloud runtime phase 8 behavior

### DIFF
--- a/server/tests/unit/test_cloud_runtime_credential_freshness.py
+++ b/server/tests/unit/test_cloud_runtime_credential_freshness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from uuid import UUID, uuid4
@@ -304,3 +305,226 @@ async def test_file_only_apply_reconciles_remote_agents(monkeypatch: pytest.Monk
     assert reconciles == [
         ("https://runtime.invalid", "runtime-token", ("codex",)),
     ]
+
+
+@pytest.mark.asyncio
+async def test_process_refresh_refuses_restart_when_runtime_has_live_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    env_record = _credential(
+        user_id,
+        provider="claude",
+        auth_mode="env",
+        payload={
+            "provider": "claude",
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "key"},
+        },
+    )
+    revisions = build_credential_revision_state([env_record])
+    environment = _environment(user_id)
+    environment.runtime_url = "https://runtime.invalid"
+    environment.runtime_token_ciphertext = encrypt_text("runtime-token")
+    environment.anyharness_data_key_ciphertext = encrypt_text("data-key")
+    environment.credential_files_applied_revision = revisions.files_revision
+    environment.credential_process_applied_revision = "credential-process:v1:old"
+
+    @asynccontextmanager
+    async def _lock(_runtime_environment_id):
+        yield
+
+    async def _load_environment(_runtime_environment_id):
+        return environment
+
+    async def _load_credentials(_user_id):
+        return [env_record]
+
+    async def _connect_runtime_sandbox(_environment):
+        return (
+            SimpleNamespace(),
+            object(),
+            SandboxRuntimeContext(
+                home_dir="/home/user",
+                runtime_workdir="/home/user/workspace",
+                runtime_binary_path="/home/user/anyharness",
+                base_env={},
+            ),
+        )
+
+    async def _load_runtime_credentials_context(_environment):
+        return "runtime-token", "data-key", {}
+
+    async def _runtime_has_live_sessions(*_args, **_kwargs):
+        return True
+
+    async def _unexpected_relaunch(*_args, **_kwargs):
+        raise AssertionError("live sessions must block process credential restart")
+
+    monkeypatch.setattr(
+        credential_freshness,
+        "runtime_environment_credential_apply_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "load_runtime_environment_by_id",
+        _load_environment,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "load_cloud_credentials_for_user",
+        _load_credentials,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "_connect_runtime_sandbox",
+        _connect_runtime_sandbox,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "_load_runtime_credentials_context",
+        _load_runtime_credentials_context,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "_runtime_has_live_sessions",
+        _runtime_has_live_sessions,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "_relaunch_runtime_with_credentials",
+        _unexpected_relaunch,
+    )
+
+    snapshot = await ensure_runtime_environment_credentials_current(
+        environment.id,
+        workspace_id=uuid4(),
+        allow_process_restart=True,
+    )
+
+    assert snapshot.status == "restart_required"
+    assert snapshot.requires_restart is True
+
+
+@pytest.mark.asyncio
+async def test_credential_apply_is_serialized_per_runtime_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    file_record = _credential(
+        user_id,
+        provider="codex",
+        auth_mode="file",
+        payload={
+            "provider": "codex",
+            "authMode": "file",
+            "files": {".codex/auth.json": '{"access_token":"opaque"}'},
+        },
+    )
+    revisions = build_credential_revision_state([file_record])
+    environment = _environment(user_id)
+    environment.runtime_url = "https://runtime.invalid"
+    environment.runtime_token_ciphertext = encrypt_text("runtime-token")
+    environment.credential_files_applied_revision = "credential-files:v1:old"
+    environment.credential_process_applied_revision = revisions.process_revision
+    apply_lock = asyncio.Lock()
+    active_applies = 0
+    max_active_applies = 0
+    writes = 0
+
+    @asynccontextmanager
+    async def _lock(_runtime_environment_id):
+        nonlocal active_applies, max_active_applies
+        async with apply_lock:
+            active_applies += 1
+            max_active_applies = max(max_active_applies, active_applies)
+            try:
+                yield
+            finally:
+                active_applies -= 1
+
+    async def _load_environment(_runtime_environment_id):
+        return environment
+
+    async def _load_credentials(_user_id):
+        return [file_record]
+
+    async def _connect_runtime_sandbox(_environment):
+        return (
+            SimpleNamespace(),
+            object(),
+            SandboxRuntimeContext(
+                home_dir="/home/user",
+                runtime_workdir="/home/user/workspace",
+                runtime_binary_path="/home/user/anyharness",
+                base_env={},
+            ),
+        )
+
+    async def _write_credential_files(*_args, **_kwargs):
+        nonlocal writes
+        writes += 1
+        await asyncio.sleep(0)
+
+    async def _save_runtime_environment_state(_environment_id, **kwargs):
+        for key, value in kwargs.items():
+            setattr(environment, key, value)
+        return environment
+
+    async def _reconcile_remote_agents(*_args, **_kwargs):
+        return ["codex"]
+
+    monkeypatch.setattr(
+        credential_freshness,
+        "runtime_environment_credential_apply_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "load_runtime_environment_by_id",
+        _load_environment,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "load_cloud_credentials_for_user",
+        _load_credentials,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "_connect_runtime_sandbox",
+        _connect_runtime_sandbox,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "write_credential_files",
+        _write_credential_files,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "save_runtime_environment_state",
+        _save_runtime_environment_state,
+    )
+    monkeypatch.setattr(
+        credential_freshness,
+        "reconcile_remote_agents",
+        _reconcile_remote_agents,
+    )
+
+    first, second = await asyncio.gather(
+        ensure_runtime_environment_credentials_current(
+            environment.id,
+            workspace_id=uuid4(),
+            allow_process_restart=True,
+        ),
+        ensure_runtime_environment_credentials_current(
+            environment.id,
+            workspace_id=uuid4(),
+            allow_process_restart=True,
+        ),
+    )
+
+    assert first.status == "current"
+    assert second.status == "current"
+    assert writes == 1
+    assert max_active_applies == 1

--- a/server/tests/unit/test_cloud_runtime_ensure_running.py
+++ b/server/tests/unit/test_cloud_runtime_ensure_running.py
@@ -139,6 +139,83 @@ async def test_ensure_workspace_runtime_ready_rotates_to_fresh_endpoint_without_
 
 
 @pytest.mark.asyncio
+async def test_ensure_environment_runtime_ready_rotates_url_without_generation_increment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = SimpleNamespace(
+        id=uuid4(),
+        active_sandbox_id=uuid4(),
+        runtime_url="https://expired.invalid",
+    )
+    sandbox_record = SimpleNamespace(
+        provider="e2b",
+        external_sandbox_id="sandbox-123",
+    )
+    saved: list[dict[str, object]] = []
+
+    class _Provider:
+        async def connect_running_sandbox(
+            self,
+            sandbox_id: str,
+            *,
+            timeout_seconds: int | None = None,
+        ) -> object:
+            assert sandbox_id == "sandbox-123"
+            assert timeout_seconds is None
+            return object()
+
+        async def get_sandbox_state(self, sandbox_id: str) -> ProviderSandboxState:
+            return ProviderSandboxState(
+                external_sandbox_id=sandbox_id,
+                state="running",
+                started_at=None,
+                end_at=None,
+                observed_at=datetime.now(UTC),
+                metadata={},
+            )
+
+        async def resolve_runtime_endpoint(self, _sandbox: object) -> SimpleNamespace:
+            return SimpleNamespace(runtime_url="https://fresh.invalid")
+
+        async def resolve_runtime_context(self, _sandbox: object) -> SimpleNamespace:
+            raise AssertionError("URL rotation should not relaunch the runtime")
+
+    async def _wait(runtime_url: str, **_kwargs: object) -> None:
+        if runtime_url == environment.runtime_url:
+            raise CloudRuntimeReconnectError("expired")
+
+    async def _verify(runtime_url: str, access_token: str, **_kwargs: object) -> None:
+        assert runtime_url == "https://fresh.invalid"
+        assert access_token == "runtime-token"
+
+    async def _load_cloud_sandbox_by_id(_sandbox_id: object) -> object:
+        return sandbox_record
+
+    async def _save_runtime_environment_state(_environment_id: object, **kwargs: object) -> None:
+        saved.append(kwargs)
+
+    monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
+    monkeypatch.setattr(ensure_running, "verify_runtime_auth_enforced", _verify)
+    monkeypatch.setattr(ensure_running, "load_cloud_sandbox_by_id", _load_cloud_sandbox_by_id)
+    monkeypatch.setattr(ensure_running, "get_sandbox_provider", lambda _kind: _Provider())
+    monkeypatch.setattr(
+        ensure_running,
+        "save_runtime_environment_state",
+        _save_runtime_environment_state,
+    )
+
+    runtime_url = await ensure_running.ensure_environment_runtime_ready(
+        environment,
+        workspace_id=uuid4(),
+        allow_launcher_restart=True,
+        access_token="runtime-token",
+    )
+
+    assert runtime_url == "https://fresh.invalid"
+    assert saved == [{"runtime_url": "https://fresh.invalid"}]
+
+
+@pytest.mark.asyncio
 async def test_ensure_workspace_runtime_ready_resumes_paused_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/server/tests/unit/test_cloud_runtime_environment_store.py
+++ b/server/tests/unit/test_cloud_runtime_environment_store.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from proliferate.db.models.cloud.runtime_environments import CloudRuntimeEnvironment
+from proliferate.db.store.cloud_runtime_environments import persist_runtime_environment_state
+
+
+def _environment() -> CloudRuntimeEnvironment:
+    user_id = uuid4()
+    return CloudRuntimeEnvironment(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=None,
+        created_by_user_id=user_id,
+        billing_subject_id=user_id,
+        git_provider="github",
+        git_owner="acme",
+        git_repo_name="rocket",
+        git_owner_norm="acme",
+        git_repo_name_norm="rocket",
+        isolation_policy="repo_shared",
+        status="running",
+        runtime_url="https://old.invalid",
+        runtime_token_ciphertext="old-token",
+        runtime_generation=7,
+        credential_snapshot_version=0,
+        repo_env_applied_version=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_url_rotation_does_not_increment_generation(db_session) -> None:
+    environment = _environment()
+    db_session.add(environment)
+    await db_session.flush()
+
+    await persist_runtime_environment_state(
+        db_session,
+        environment,
+        runtime_url="https://rotated.invalid",
+    )
+
+    assert environment.runtime_url == "https://rotated.invalid"
+    assert environment.runtime_generation == 7
+
+
+@pytest.mark.asyncio
+async def test_runtime_process_identity_checkpoint_increments_generation(db_session) -> None:
+    environment = _environment()
+    db_session.add(environment)
+    await db_session.flush()
+
+    await persist_runtime_environment_state(
+        db_session,
+        environment,
+        runtime_url="https://relaunched.invalid",
+        runtime_token_ciphertext="new-token",
+        increment_runtime_generation=True,
+    )
+
+    assert environment.runtime_url == "https://relaunched.invalid"
+    assert environment.runtime_token_ciphertext == "new-token"
+    assert environment.runtime_generation == 8

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -1159,3 +1159,140 @@ class TestProvisionWorkspaceGitSetup:
             "Sandbox limit reached. Archive or delete another cloud workspace before "
             "starting a new one."
         ]
+
+    @pytest.mark.asyncio
+    async def test_provision_workspace_cleans_up_new_sandbox_after_setup_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ctx = _make_provision_input(codex_enabled=True)
+        sandbox_record = SimpleNamespace(
+            id=uuid.uuid4(),
+            external_sandbox_id="sandbox-db-123",
+        )
+        connected = SimpleNamespace(
+            handle=SimpleNamespace(
+                sandbox_id="sandbox-provider-123",
+                template_version="v1",
+            ),
+            sandbox=object(),
+            endpoint=SimpleNamespace(runtime_url="https://runtime.invalid"),
+        )
+        destroyed: list[str] = []
+        closed_usage: list[dict[str, object]] = []
+        sandbox_statuses: list[tuple[object, str]] = []
+        workspace_errors: list[dict[str, object]] = []
+
+        class _Provider(SimpleNamespace):
+            async def destroy_sandbox(self, sandbox_id: str) -> None:
+                destroyed.append(sandbox_id)
+
+        provider = _Provider(
+            kind=SandboxProviderKind.daytona,
+            template_version="v1",
+        )
+
+        async def _load_provision_input(_workspace_id, *, requested_base_sha=None):
+            return ctx
+
+        async def _authorize_sandbox_start(*args, **kwargs):
+            return SimpleNamespace(allowed=True, message=None)
+
+        async def _connect_existing_environment_sandbox(*args, **kwargs):
+            return None
+
+        async def _reserve_and_attach_sandbox_for_environment(*args, **kwargs):
+            return sandbox_record
+
+        async def _create_and_connect_sandbox(*args, **kwargs):
+            return connected
+
+        async def _prepare_runtime_template(*args, **kwargs) -> None:
+            raise RuntimeError("template setup failed")
+
+        async def _set_workspace_status(*args, **kwargs) -> None:
+            return None
+
+        async def _load_cloud_sandbox_by_id(_sandbox_id):
+            return sandbox_record
+
+        async def _close_usage_segment_for_sandbox(**kwargs):
+            closed_usage.append(kwargs)
+
+        async def _update_sandbox_status(sandbox, status: str, **_kwargs):
+            sandbox_statuses.append((sandbox, status))
+
+        async def _mark_workspace_error_by_id(_workspace_id, message: str, **kwargs):
+            workspace_errors.append({"message": message, **kwargs})
+
+        monkeypatch.setattr(runtime_provision, "_load_provision_input", _load_provision_input)
+        monkeypatch.setattr(runtime_provision, "get_configured_sandbox_provider", lambda: provider)
+        monkeypatch.setattr(runtime_provision, "authorize_sandbox_start", _authorize_sandbox_start)
+        monkeypatch.setattr(
+            runtime_provision,
+            "_connect_existing_environment_sandbox",
+            _connect_existing_environment_sandbox,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "reserve_and_attach_sandbox_for_environment",
+            _reserve_and_attach_sandbox_for_environment,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "_create_and_connect_sandbox",
+            _create_and_connect_sandbox,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "_prepare_runtime_template",
+            _prepare_runtime_template,
+        )
+        monkeypatch.setattr(runtime_provision, "_set_workspace_status", _set_workspace_status)
+        monkeypatch.setattr(
+            runtime_provision,
+            "load_cloud_sandbox_by_id",
+            _load_cloud_sandbox_by_id,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "close_usage_segment_for_sandbox",
+            _close_usage_segment_for_sandbox,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "update_sandbox_status",
+            _update_sandbox_status,
+        )
+        monkeypatch.setattr(
+            runtime_provision,
+            "mark_workspace_error_by_id",
+            _mark_workspace_error_by_id,
+        )
+        monkeypatch.setattr(runtime_provision, "log_cloud_event", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            runtime_provision,
+            "_log_provision_summary",
+            lambda *args, **kwargs: None,
+        )
+
+        with pytest.raises(RuntimeError, match="template setup failed"):
+            await runtime_provision.provision_workspace(ctx.workspace_id)
+
+        assert destroyed == ["sandbox-provider-123"]
+        assert closed_usage == [
+            {
+                "sandbox_id": sandbox_record.id,
+                "ended_at": closed_usage[0]["ended_at"],
+                "closed_by": "provision_failure",
+                "is_billable": False,
+            }
+        ]
+        assert sandbox_statuses == [(sandbox_record, "destroyed")]
+        assert workspace_errors == [
+            {
+                "message": "template setup failed",
+                "clear_runtime_metadata": True,
+                "clear_active_sandbox": True,
+            }
+        ]

--- a/server/tests/unit/test_cloud_webhook_service.py
+++ b/server/tests/unit/test_cloud_webhook_service.py
@@ -1,8 +1,17 @@
+from datetime import UTC, datetime
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
 import pytest
 
 from proliferate.config import settings
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.webhooks.service import _verify_e2b_signature
+from proliferate.server.cloud.webhooks import service as webhook_service
+from proliferate.server.cloud.webhooks.service import (
+    _is_stale_provider_event,
+    _verify_e2b_signature,
+)
 
 
 def test_e2b_webhook_translates_signature_failure(monkeypatch) -> None:
@@ -14,3 +23,163 @@ def test_e2b_webhook_translates_signature_failure(monkeypatch) -> None:
     assert exc_info.value.code == "invalid_webhook_signature"
     assert exc_info.value.message == "E2B webhook signature is invalid."
     assert exc_info.value.status_code == 401
+
+
+def test_provider_event_precedence_keeps_same_timestamp_terminal_event() -> None:
+    event_time = datetime.now(UTC)
+
+    assert (
+        _is_stale_provider_event(
+            last_event_at=event_time,
+            last_event_kind="paused",
+            incoming_event_at=event_time,
+            incoming_event_kind="killed",
+        )
+        is False
+    )
+    assert (
+        _is_stale_provider_event(
+            last_event_at=event_time,
+            last_event_kind="killed",
+            incoming_event_at=event_time,
+            incoming_event_kind="paused",
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_e2b_webhook_returns_before_state_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_id = f"evt-{uuid4()}"
+    payload = json.dumps(
+        {
+            "id": event_id,
+            "type": "sandbox.lifecycle.killed",
+            "sandboxId": "sandbox-123",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "eventData": {"sandbox_metadata": {}},
+        }
+    ).encode()
+
+    async def _remember_sandbox_event_receipt(**_kwargs: object) -> bool:
+        return False
+
+    async def _unexpected(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("duplicate webhook should stop after receipt dedupe")
+
+    monkeypatch.setattr(webhook_service, "_verify_e2b_signature", lambda *_args: None)
+    monkeypatch.setattr(
+        webhook_service,
+        "remember_sandbox_event_receipt",
+        _remember_sandbox_event_receipt,
+    )
+    monkeypatch.setattr(webhook_service, "load_cloud_sandbox_by_external_id", _unexpected)
+
+    receipt = await webhook_service.handle_e2b_webhook(payload=payload, signature=None)
+
+    assert receipt.received is True
+
+
+@pytest.mark.asyncio
+async def test_killed_e2b_webhook_clears_runtime_metadata_and_increments_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_id = uuid4()
+    runtime_environment_id = uuid4()
+    event_time = datetime.now(UTC)
+    payload = json.dumps(
+        {
+            "id": f"evt-{uuid4()}",
+            "type": "sandbox.lifecycle.killed",
+            "sandboxId": "sandbox-123",
+            "timestamp": event_time.isoformat(),
+            "eventData": {"sandbox_metadata": {"cloud_sandbox_id": str(sandbox_id)}},
+        }
+    ).encode()
+    sandbox = SimpleNamespace(
+        id=sandbox_id,
+        runtime_environment_id=runtime_environment_id,
+        cloud_workspace_id=None,
+        provider="e2b",
+        external_sandbox_id="sandbox-123",
+        last_provider_event_at=None,
+        last_provider_event_kind=None,
+    )
+    runtime_environment = SimpleNamespace(id=runtime_environment_id)
+    sandbox_state_updates: list[dict[str, object]] = []
+    runtime_state_updates: list[dict[str, object]] = []
+
+    async def _remember_sandbox_event_receipt(**_kwargs: object) -> bool:
+        return True
+
+    async def _load_cloud_sandbox_by_external_id(_external_sandbox_id: str) -> object:
+        return sandbox
+
+    async def _load_runtime_environment_by_id(_runtime_environment_id: object) -> object:
+        return runtime_environment
+
+    async def _save_sandbox_provider_state(_sandbox_id: object, **kwargs: object) -> None:
+        sandbox_state_updates.append(kwargs)
+
+    async def _close_usage_segment_for_sandbox(**_kwargs: object) -> None:
+        return None
+
+    async def _save_runtime_environment_state(
+        _runtime_environment_id: object,
+        **kwargs: object,
+    ) -> None:
+        runtime_state_updates.append(kwargs)
+
+    monkeypatch.setattr(webhook_service, "_verify_e2b_signature", lambda *_args: None)
+    monkeypatch.setattr(
+        webhook_service,
+        "remember_sandbox_event_receipt",
+        _remember_sandbox_event_receipt,
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "load_cloud_sandbox_by_external_id",
+        _load_cloud_sandbox_by_external_id,
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "load_runtime_environment_by_id",
+        _load_runtime_environment_by_id,
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "save_sandbox_provider_state",
+        _save_sandbox_provider_state,
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "close_usage_segment_for_sandbox",
+        _close_usage_segment_for_sandbox,
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "save_runtime_environment_state",
+        _save_runtime_environment_state,
+    )
+
+    receipt = await webhook_service.handle_e2b_webhook(payload=payload, signature=None)
+
+    assert receipt.received is True
+    assert sandbox_state_updates[-1] == {
+        "status": "destroyed",
+        "stopped_at": event_time,
+        "last_provider_event_at": event_time,
+        "last_provider_event_kind": "killed",
+    }
+    assert runtime_state_updates == [
+        {
+            "status": "error",
+            "runtime_url": None,
+            "runtime_token_ciphertext": None,
+            "active_sandbox_id": None,
+            "increment_runtime_generation": True,
+            "last_error": "Provider reported sandbox killed.",
+        }
+    ]


### PR DESCRIPTION
## Summary
- add Phase 8 Wave 1 tests for cloud runtime generation, credential, process-refresh, provisioning, and webhook invariants
- pin generation bump semantics, URL rotation semantics, stale/duplicate webhook handling, credential serialization, live-session process refresh refusal, and provisioning failure cleanup

## Wave / Lane
- Phase 8 Wave 1: Test Pinning
- Lane D: Cloud Runtime Lifecycle

## Verification
- `DEBUG=true uv run --extra dev --python /opt/homebrew/bin/python3.12 python -m pytest -q tests/unit/test_cloud_runtime_environment_store.py tests/unit/test_cloud_runtime_ensure_running.py tests/unit/test_cloud_runtime_credential_freshness.py tests/unit/test_cloud_runtime_provision.py tests/unit/test_cloud_webhook_service.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`
