### PR TITLE
test(server): pin cloud mobility phase 8 behavior

### DIFF
--- a/server/tests/unit/test_cloud_mobility_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_lifecycle.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from proliferate.db import engine as db_engine
+from proliferate.db.models.cloud.mobility import (
+    CloudWorkspaceHandoffOp,
+    CloudWorkspaceMobility,
+)
+from proliferate.db.store.cloud_mobility import (
+    complete_cloud_workspace_handoff_cleanup,
+    create_cloud_workspace_handoff_op,
+    create_cloud_workspace_handoff_op_for_user,
+    expire_stale_cloud_workspace_handoff_op_for_user,
+    fail_cloud_workspace_handoff_op,
+    finalize_cloud_workspace_handoff_op,
+    get_active_handoff_for_mobility,
+    get_active_user_handoff_op,
+    heartbeat_cloud_workspace_handoff_op,
+    load_cloud_workspace_mobility_for_user,
+)
+
+pytestmark = pytest.mark.usefixtures("mobility_session_factory")
+
+
+@pytest_asyncio.fixture
+async def mobility_session_factory(monkeypatch: pytest.MonkeyPatch, test_engine):
+    original_session_factory = db_engine.async_session_factory
+    db_engine.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    yield
+    db_engine.async_session_factory = original_session_factory
+
+
+def _mobility_record(
+    *,
+    user_id: UUID,
+    owner: str = "local",
+    lifecycle_state: str | None = None,
+) -> CloudWorkspaceMobility:
+    return CloudWorkspaceMobility(
+        user_id=user_id,
+        display_name="Rocket",
+        git_provider="github",
+        git_owner="acme",
+        git_repo_name=f"rocket-{uuid4()}",
+        git_branch="feature/cloud",
+        owner=owner,
+        lifecycle_state=lifecycle_state or f"{owner}_active",
+        status_detail=None,
+        last_error=None,
+        cloud_workspace_id=None,
+        active_handoff_op_id=None,
+        last_handoff_op_id=None,
+        cloud_lost_at=None,
+        cloud_lost_reason=None,
+    )
+
+
+def _handoff_record(
+    *,
+    mobility_workspace: CloudWorkspaceMobility,
+    phase: str = "start_requested",
+    finalized_at: datetime | None = None,
+    heartbeat_at: datetime | None = None,
+) -> CloudWorkspaceHandoffOp:
+    now = datetime.now(UTC)
+    return CloudWorkspaceHandoffOp(
+        mobility_workspace_id=mobility_workspace.id,
+        user_id=mobility_workspace.user_id,
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        phase=phase,
+        requested_branch=mobility_workspace.git_branch,
+        requested_base_sha="abc123",
+        exclude_paths_json="[]",
+        failure_code=None,
+        failure_detail=None,
+        started_at=now,
+        heartbeat_at=heartbeat_at or now,
+        finalized_at=finalized_at,
+        cleanup_completed_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _create_mobility(
+    db_session: AsyncSession,
+    *,
+    user_id: UUID,
+    owner: str = "local",
+) -> CloudWorkspaceMobility:
+    mobility = _mobility_record(user_id=user_id, owner=owner)
+    db_session.add(mobility)
+    await db_session.commit()
+    await db_session.refresh(mobility)
+    return mobility
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_sets_active_pointer_and_moving_state(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+
+    handoff = await create_cloud_workspace_handoff_op(
+        db_session,
+        mobility_workspace=mobility,
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=["node_modules"],
+    )
+
+    refreshed = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert refreshed is not None
+    assert refreshed.active_handoff_op_id == handoff.id
+    assert refreshed.last_handoff_op_id == handoff.id
+    assert refreshed.owner == "local"
+    assert refreshed.lifecycle_state == "moving_to_cloud"
+    assert refreshed.status_detail == "Handoff started"
+    assert refreshed.active_handoff is not None
+    assert refreshed.active_handoff.exclude_paths == ("node_modules",)
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_for_user_rejects_existing_active_workspace_handoff(
+    db_session: AsyncSession,
+    mobility_session_factory,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = _handoff_record(mobility_workspace=mobility)
+    db_session.add(handoff)
+    await db_session.flush()
+    mobility.active_handoff_op_id = handoff.id
+    mobility.last_handoff_op_id = handoff.id
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="handoff already in progress for workspace"):
+        await create_cloud_workspace_handoff_op_for_user(
+            user_id=user_id,
+            mobility_workspace_id=mobility.id,
+            direction="local_to_cloud",
+            source_owner="local",
+            target_owner="cloud",
+            requested_branch="feature/cloud",
+            requested_base_sha="abc123",
+            exclude_paths=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failed_handoff_counts_as_active(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = _handoff_record(mobility_workspace=mobility, phase="cleanup_failed")
+    db_session.add(handoff)
+    await db_session.flush()
+    mobility.active_handoff_op_id = handoff.id
+    mobility.last_handoff_op_id = handoff.id
+    await db_session.commit()
+
+    active_for_workspace = await get_active_handoff_for_mobility(
+        db_session,
+        mobility_workspace_id=mobility.id,
+    )
+    active_for_user = await get_active_user_handoff_op(db_session, user_id=user_id)
+
+    assert active_for_workspace is not None
+    assert active_for_workspace.id == handoff.id
+    assert active_for_user is not None
+    assert active_for_user.id == handoff.id
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_refreshes_timestamp_without_changing_phase(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    old_heartbeat = datetime.now(UTC) - timedelta(minutes=10)
+    handoff = _handoff_record(
+        mobility_workspace=mobility,
+        phase="source_frozen",
+        heartbeat_at=old_heartbeat,
+    )
+    db_session.add(handoff)
+    await db_session.commit()
+
+    value = await heartbeat_cloud_workspace_handoff_op(db_session, handoff_op=handoff)
+
+    assert value.phase == "source_frozen"
+    assert value.heartbeat_at > old_heartbeat
+
+
+@pytest.mark.asyncio
+async def test_finalize_flips_owner_before_cleanup_clears_active_handoff(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = await create_cloud_workspace_handoff_op(
+        db_session,
+        mobility_workspace=mobility,
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=[],
+    )
+
+    handoff_record = await db_session.get(CloudWorkspaceHandoffOp, handoff.id)
+    mobility_record = await db_session.get(CloudWorkspaceMobility, mobility.id)
+    assert handoff_record is not None
+    assert mobility_record is not None
+    finalized = await finalize_cloud_workspace_handoff_op(
+        db_session,
+        handoff_op=handoff_record,
+        mobility_workspace=mobility_record,
+        cloud_workspace_id=None,
+    )
+
+    visible = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert finalized.phase == "cleanup_pending"
+    assert finalized.finalized_at is not None
+    assert visible is not None
+    assert visible.owner == "cloud"
+    assert visible.lifecycle_state == "cloud_active"
+    assert visible.active_handoff_op_id == handoff.id
+    assert visible.status_detail == "Awaiting source cleanup"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_completion_clears_active_handoff_and_marks_completed(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = await create_cloud_workspace_handoff_op(
+        db_session,
+        mobility_workspace=mobility,
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=[],
+    )
+    handoff_record = await db_session.get(CloudWorkspaceHandoffOp, handoff.id)
+    mobility_record = await db_session.get(CloudWorkspaceMobility, mobility.id)
+    assert handoff_record is not None
+    assert mobility_record is not None
+
+    completed = await complete_cloud_workspace_handoff_cleanup(
+        db_session,
+        handoff_op=handoff_record,
+        mobility_workspace=mobility_record,
+    )
+
+    visible = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert completed.phase == "completed"
+    assert completed.cleanup_completed_at is not None
+    assert visible is not None
+    assert visible.active_handoff_op_id is None
+    assert visible.status_detail == "Ready"
+
+
+@pytest.mark.asyncio
+async def test_failure_clears_active_handoff_and_truncates_visible_error(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = await create_cloud_workspace_handoff_op(
+        db_session,
+        mobility_workspace=mobility,
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=[],
+    )
+    handoff_record = await db_session.get(CloudWorkspaceHandoffOp, handoff.id)
+    mobility_record = await db_session.get(CloudWorkspaceMobility, mobility.id)
+    assert handoff_record is not None
+    assert mobility_record is not None
+    failure_detail = "x" * 2100
+
+    failed = await fail_cloud_workspace_handoff_op(
+        db_session,
+        handoff_op=handoff_record,
+        mobility_workspace=mobility_record,
+        failure_code="provisioning_failed",
+        failure_detail=failure_detail,
+    )
+
+    visible = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert failed.phase == "handoff_failed"
+    assert failed.failure_detail == failure_detail
+    assert visible is not None
+    assert visible.active_handoff_op_id is None
+    assert visible.lifecycle_state == "handoff_failed"
+    assert visible.status_detail == "x" * 255
+    assert visible.last_error == "x" * 2000
+
+
+@pytest.mark.asyncio
+async def test_stale_expiry_before_finalize_marks_failed_and_clears_active_handoff(
+    db_session: AsyncSession,
+    mobility_session_factory,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = _handoff_record(
+        mobility_workspace=mobility,
+        phase="source_frozen",
+        heartbeat_at=datetime.now(UTC) - timedelta(minutes=10),
+    )
+    db_session.add(handoff)
+    await db_session.flush()
+    mobility.active_handoff_op_id = handoff.id
+    mobility.last_handoff_op_id = handoff.id
+    await db_session.commit()
+
+    expired = await expire_stale_cloud_workspace_handoff_op_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+        handoff_op_id=handoff.id,
+        failure_code="handoff_stale",
+        failure_detail="Workspace mobility heartbeat expired.",
+    )
+
+    visible = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert expired.phase == "handoff_failed"
+    assert visible is not None
+    assert visible.active_handoff_op_id is None
+    assert visible.lifecycle_state == "handoff_failed"
+
+
+@pytest.mark.asyncio
+async def test_stale_expiry_after_finalize_marks_cleanup_failed_and_keeps_active(
+    db_session: AsyncSession,
+    mobility_session_factory,
+) -> None:
+    user_id = uuid4()
+    mobility = await _create_mobility(db_session, user_id=user_id)
+    handoff = _handoff_record(
+        mobility_workspace=mobility,
+        phase="cleanup_pending",
+        finalized_at=datetime.now(UTC) - timedelta(minutes=10),
+        heartbeat_at=datetime.now(UTC) - timedelta(minutes=10),
+    )
+    db_session.add(handoff)
+    await db_session.flush()
+    mobility.owner = "cloud"
+    mobility.lifecycle_state = "cloud_active"
+    mobility.active_handoff_op_id = handoff.id
+    mobility.last_handoff_op_id = handoff.id
+    await db_session.commit()
+
+    expired = await expire_stale_cloud_workspace_handoff_op_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+        handoff_op_id=handoff.id,
+        failure_code="cleanup_stale",
+        failure_detail="Workspace mobility cleanup heartbeat expired.",
+    )
+
+    visible = await load_cloud_workspace_mobility_for_user(
+        user_id=user_id,
+        mobility_workspace_id=mobility.id,
+    )
+    assert expired.phase == "cleanup_failed"
+    assert visible is not None
+    assert visible.active_handoff_op_id == handoff.id
+    assert visible.lifecycle_state == "cleanup_failed"

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from proliferate.db.store.cloud_mobility import (
+    CloudWorkspaceHandoffOpValue,
+    CloudWorkspaceMobilityValue,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.mobility import service as mobility_service
+
+
+def _workspace(
+    *,
+    owner: str = "local",
+    user_id=None,
+    active_handoff: CloudWorkspaceHandoffOpValue | None = None,
+    cloud_lost_at=None,
+) -> CloudWorkspaceMobilityValue:
+    now = datetime.now(UTC)
+    return CloudWorkspaceMobilityValue(
+        id=uuid4(),
+        user_id=user_id or uuid4(),
+        display_name="Rocket",
+        git_provider="github",
+        git_owner="acme",
+        git_repo_name="rocket",
+        git_branch="feature/cloud",
+        cloud_lost_at=cloud_lost_at,
+        cloud_lost_reason=None,
+        owner=owner,
+        lifecycle_state=f"{owner}_active",
+        status_detail=None,
+        last_error=None,
+        cloud_workspace_id=None,
+        active_handoff_op_id=active_handoff.id if active_handoff is not None else None,
+        last_handoff_op_id=active_handoff.id if active_handoff is not None else None,
+        active_handoff=active_handoff,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _handoff(*, mobility_workspace_id=None) -> CloudWorkspaceHandoffOpValue:
+    now = datetime.now(UTC)
+    return CloudWorkspaceHandoffOpValue(
+        id=uuid4(),
+        mobility_workspace_id=mobility_workspace_id or uuid4(),
+        user_id=uuid4(),
+        direction="local_to_cloud",
+        source_owner="local",
+        target_owner="cloud",
+        phase="start_requested",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=(),
+        failure_code=None,
+        failure_detail=None,
+        started_at=now,
+        heartbeat_at=now,
+        finalized_at=None,
+        cleanup_completed_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _noop_expire(*, user_id):
+    return None
+
+
+def _stub_common_preflight_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    workspace: CloudWorkspaceMobilityValue,
+    active_handoff: CloudWorkspaceHandoffOpValue | None = None,
+) -> None:
+    async def _get_detail(**_kwargs):
+        return workspace
+
+    async def _load_active_user_handoff(*, user_id):
+        return active_handoff
+
+    async def _load_user(_user_id):
+        return SimpleNamespace(id=_user_id)
+
+    async def _repo_branches(*_args, **_kwargs):
+        return SimpleNamespace(
+            branches=["feature/cloud"],
+            branch_heads_by_name={"feature/cloud": "abc123"},
+        )
+
+    async def _load_repo_config(**_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        mobility_service,
+        "expire_stale_cloud_workspace_handoffs_for_user",
+        _noop_expire,
+    )
+    monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
+    monkeypatch.setattr(
+        mobility_service,
+        "load_active_user_handoff_op_for_user",
+        _load_active_user_handoff,
+    )
+    monkeypatch.setattr(
+        mobility_service,
+        "load_user_with_oauth_accounts_by_id",
+        _load_user,
+    )
+    monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
+    monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_another_active_handoff_for_same_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    workspace = _workspace(user_id=user_id)
+    other_handoff = _handoff(mobility_workspace_id=uuid4())
+    _stub_common_preflight_dependencies(
+        monkeypatch,
+        workspace=workspace,
+        active_handoff=other_handoff,
+    )
+
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        user_id=user_id,
+        mobility_workspace_id=workspace.id,
+        direction="local_to_cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+    )
+
+    assert response.can_start is False
+    assert "another handoff is already in progress for this user" in response.blockers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("owner", "direction", "blocker"),
+    [
+        ("cloud", "local_to_cloud", "workspace is not currently local-owned"),
+        ("local", "cloud_to_local", "workspace is not currently cloud-owned"),
+    ],
+)
+async def test_preflight_blocks_owner_direction_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    owner: str,
+    direction: str,
+    blocker: str,
+) -> None:
+    workspace = _workspace(owner=owner)
+    _stub_common_preflight_dependencies(monkeypatch, workspace=workspace)
+
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        user_id=uuid4(),
+        mobility_workspace_id=workspace.id,
+        direction=direction,
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+    )
+
+    assert response.can_start is False
+    assert blocker in response.blockers
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_cloud_lost_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(cloud_lost_at=datetime.now(UTC))
+    _stub_common_preflight_dependencies(monkeypatch, workspace=workspace)
+
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        user_id=uuid4(),
+        mobility_workspace_id=workspace.id,
+        direction="local_to_cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+    )
+
+    assert response.can_start is False
+    assert "cloud workspace is in cloud_lost state" in response.blockers
+
+
+@pytest.mark.asyncio
+async def test_start_local_to_cloud_creates_handoff_before_provisioning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    workspace = _workspace(user_id=user_id)
+    handoff = _handoff(mobility_workspace_id=workspace.id)
+    cloud_workspace_id = uuid4()
+    events: list[str] = []
+
+    async def _get_detail(**_kwargs):
+        return workspace
+
+    async def _preflight(**_kwargs):
+        return SimpleNamespace(can_start=True, blockers=[])
+
+    async def _create(**_kwargs):
+        events.append("handoff_created")
+        return handoff
+
+    async def _load_user(_user_id):
+        return SimpleNamespace(id=_user_id)
+
+    async def _ensure_cloud_workspace(*_args, **_kwargs):
+        assert events == ["handoff_created"]
+        events.append("workspace_ensured")
+        return SimpleNamespace(id=cloud_workspace_id)
+
+    async def _start_cloud_workspace(*_args, **_kwargs):
+        assert events == ["handoff_created", "workspace_ensured"]
+        events.append("workspace_started")
+
+    async def _update_phase(**kwargs):
+        events.append("phase_updated")
+        assert kwargs["handoff_op_id"] == handoff.id
+        assert kwargs["phase"] == "start_requested"
+        assert kwargs["cloud_workspace_id"] == cloud_workspace_id
+        return handoff
+
+    monkeypatch.setattr(
+        mobility_service,
+        "expire_stale_cloud_workspace_handoffs_for_user",
+        _noop_expire,
+    )
+    monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
+    monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
+    monkeypatch.setattr(
+        mobility_service,
+        "create_cloud_workspace_handoff_op_for_user",
+        _create,
+    )
+    monkeypatch.setattr(
+        mobility_service,
+        "load_user_with_oauth_accounts_by_id",
+        _load_user,
+    )
+    monkeypatch.setattr(
+        mobility_service,
+        "ensure_cloud_workspace_for_existing_branch",
+        _ensure_cloud_workspace,
+    )
+    monkeypatch.setattr(mobility_service, "start_cloud_workspace", _start_cloud_workspace)
+    monkeypatch.setattr(
+        mobility_service,
+        "update_cloud_workspace_handoff_phase_for_user",
+        _update_phase,
+    )
+
+    await mobility_service.start_cloud_workspace_handoff(
+        user_id=user_id,
+        mobility_workspace_id=workspace.id,
+        direction="local_to_cloud",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=[],
+    )
+
+    assert events == [
+        "handoff_created",
+        "workspace_ensured",
+        "workspace_started",
+        "phase_updated",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_cloud_to_local_creates_handoff_without_cloud_provisioning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    workspace = _workspace(user_id=user_id, owner="cloud")
+    handoff = _handoff(mobility_workspace_id=workspace.id)
+    events: list[str] = []
+
+    async def _get_detail(**_kwargs):
+        return workspace
+
+    async def _preflight(**_kwargs):
+        return SimpleNamespace(can_start=True, blockers=[])
+
+    async def _create(**_kwargs):
+        events.append("handoff_created")
+        return handoff
+
+    async def _unexpected(*_args, **_kwargs):
+        raise AssertionError("cloud provisioning should not run for cloud_to_local")
+
+    monkeypatch.setattr(
+        mobility_service,
+        "expire_stale_cloud_workspace_handoffs_for_user",
+        _noop_expire,
+    )
+    monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
+    monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
+    monkeypatch.setattr(
+        mobility_service,
+        "create_cloud_workspace_handoff_op_for_user",
+        _create,
+    )
+    monkeypatch.setattr(
+        mobility_service,
+        "ensure_cloud_workspace_for_existing_branch",
+        _unexpected,
+    )
+    monkeypatch.setattr(mobility_service, "start_cloud_workspace", _unexpected)
+
+    result = await mobility_service.start_cloud_workspace_handoff(
+        user_id=user_id,
+        mobility_workspace_id=workspace.id,
+        direction="cloud_to_local",
+        requested_branch="feature/cloud",
+        requested_base_sha="abc123",
+        exclude_paths=[],
+    )
+
+    assert result == handoff
+    assert events == ["handoff_created"]
+
+
+@pytest.mark.asyncio
+async def test_update_handoff_phase_rejects_unsupported_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mobility_service,
+        "expire_stale_cloud_workspace_handoffs_for_user",
+        _noop_expire,
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await mobility_service.update_cloud_workspace_handoff_phase(
+            user_id=uuid4(),
+            mobility_workspace_id=uuid4(),
+            handoff_op_id=uuid4(),
+            phase="teleported",
+            status_detail=None,
+            cloud_workspace_id=None,
+        )
+
+    assert exc_info.value.code == "invalid_handoff_phase"
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary
- add Phase 8 Wave 1 tests for cloud mobility handoff invariants
- pin blockers, durable handoff creation, no-op cloud-to-local behavior, invalid phase rejection, cleanup, failure, and stale-expiry behavior

## Wave / Lane
- Phase 8 Wave 1: Test Pinning
- Lane B: Cloud Mobility Lifecycle

## Verification
- `DEBUG=1 uv run --python 3.12 --extra dev python -m pytest -q tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_service_lifecycle.py tests/unit/test_cloud_mobility_store.py tests/unit/test_cloud_mobility_lifecycle.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`
