### PR TITLE
test(server): pin billing phase 8 behavior

### DIFF
--- a/server/tests/integration/test_billing_accounting.py
+++ b/server/tests/integration/test_billing_accounting.py
@@ -10,10 +10,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.constants.billing import (
+    BILLING_MODE_ENFORCE,
     BILLING_MODE_OBSERVE,
+    BILLING_USAGE_EXPORT_STATUS_FAILED_RETRYABLE,
+    BILLING_USAGE_EXPORT_STATUS_FAILED_TERMINAL,
     BILLING_USAGE_EXPORT_STATUS_OBSERVED,
     BILLING_USAGE_EXPORT_STATUS_PENDING,
     BILLING_USAGE_EXPORT_STATUS_SENDING,
+    BILLING_USAGE_EXPORT_STATUS_SUCCEEDED,
     BILLING_USAGE_EXPORT_STATUS_WRITTEN_OFF,
     FREE_INCLUDED_GRANT_TYPE,
     MONTHLY_CLOUD_GRANT_TYPE,
@@ -21,6 +25,7 @@ from proliferate.constants.billing import (
     REFILL_10H_GRANT_TYPE,
 )
 from proliferate.db.models.billing import (
+    BillingDecisionEvent,
     BillingEntitlement,
     BillingGrant,
     BillingGrantConsumption,
@@ -36,6 +41,7 @@ from proliferate.db.store.billing import (
     ensure_personal_billing_subject,
 )
 from proliferate.server.billing import service as billing_service
+from proliferate.integrations.billing import stripe as stripe_billing
 from tests.integration.billing_accounting_helpers import (
     patch_global_session_factory,
     seed_usage_segment,
@@ -702,3 +708,166 @@ async def test_paid_accounting_does_not_export_pre_subscription_free_overage(
         )
     ).scalar_one()
     assert cursor.accounted_until == segment_ended_at
+
+
+@pytest.mark.asyncio
+async def test_observe_mode_does_not_send_pending_meter_exports(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_global_session_factory(test_engine, monkeypatch)
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_OBSERVE)
+    user_id = uuid.uuid4()
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    subject.stripe_customer_id = "cus_observe_export"
+    now = datetime.now(UTC)
+    export = BillingUsageExport(
+        billing_subject_id=subject.id,
+        billing_subscription_id=None,
+        usage_segment_id=uuid.uuid4(),
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=29),
+        accounted_from=now - timedelta(hours=1),
+        accounted_until=now,
+        quantity_seconds=1800.0,
+        meter_quantity_cents=100,
+        cap_cents_snapshot=2000,
+        cap_used_cents_snapshot=0,
+        idempotency_key=f"observe-export:{uuid.uuid4()}",
+        status=BILLING_USAGE_EXPORT_STATUS_PENDING,
+    )
+    db_session.add(export)
+    await db_session.commit()
+    export_id = export.id
+
+    async def _create_meter_event(**_kwargs: object) -> dict[str, str]:
+        raise AssertionError("observe mode must not send Stripe meter events")
+
+    monkeypatch.setattr(stripe_billing, "create_meter_event", _create_meter_event)
+
+    await billing_service.send_pending_usage_exports()
+    db_session.expire_all()
+
+    export = await db_session.get(BillingUsageExport, export_id)
+    assert export is not None
+    assert export.status == BILLING_USAGE_EXPORT_STATUS_PENDING
+    assert export.stripe_meter_event_identifier is None
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_export_success_retryable_and_terminal_paths(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_global_session_factory(test_engine, monkeypatch)
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(
+        settings,
+        "stripe_managed_cloud_overage_meter_event_name",
+        "managed_cloud_hours",
+    )
+    now = datetime.now(UTC)
+    billable_subject = await ensure_personal_billing_subject(db_session, uuid.uuid4())
+    billable_subject.stripe_customer_id = "cus_export_paths"
+    missing_customer_subject = await ensure_personal_billing_subject(db_session, uuid.uuid4())
+    success_export = BillingUsageExport(
+        billing_subject_id=billable_subject.id,
+        billing_subscription_id=None,
+        usage_segment_id=uuid.uuid4(),
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=29),
+        accounted_from=now - timedelta(hours=3),
+        accounted_until=now - timedelta(hours=2),
+        quantity_seconds=3600.0,
+        meter_quantity_cents=200,
+        cap_cents_snapshot=2000,
+        cap_used_cents_snapshot=0,
+        idempotency_key=f"export-success:{uuid.uuid4()}",
+        status=BILLING_USAGE_EXPORT_STATUS_PENDING,
+    )
+    retryable_export = BillingUsageExport(
+        billing_subject_id=billable_subject.id,
+        billing_subscription_id=None,
+        usage_segment_id=uuid.uuid4(),
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=29),
+        accounted_from=now - timedelta(hours=2),
+        accounted_until=now - timedelta(hours=1),
+        quantity_seconds=1800.0,
+        meter_quantity_cents=100,
+        cap_cents_snapshot=2000,
+        cap_used_cents_snapshot=200,
+        idempotency_key=f"export-retry:{uuid.uuid4()}",
+        status=BILLING_USAGE_EXPORT_STATUS_PENDING,
+    )
+    terminal_export = BillingUsageExport(
+        billing_subject_id=missing_customer_subject.id,
+        billing_subscription_id=None,
+        usage_segment_id=uuid.uuid4(),
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=29),
+        accounted_from=now - timedelta(hours=1),
+        accounted_until=now,
+        quantity_seconds=900.0,
+        meter_quantity_cents=50,
+        cap_cents_snapshot=2000,
+        cap_used_cents_snapshot=300,
+        idempotency_key=f"export-terminal:{uuid.uuid4()}",
+        status=BILLING_USAGE_EXPORT_STATUS_PENDING,
+    )
+    db_session.add_all([success_export, retryable_export, terminal_export])
+    await db_session.commit()
+    success_id = success_export.id
+    retryable_id = retryable_export.id
+    terminal_id = terminal_export.id
+    calls: list[dict[str, object]] = []
+
+    async def _create_meter_event(**kwargs: object) -> dict[str, str]:
+        calls.append(kwargs)
+        if kwargs["idempotency_key"] == retryable_export.idempotency_key:
+            raise stripe_billing.StripeBillingError(
+                "stripe_rate_limited",
+                "Stripe rate limited the meter event.",
+                status_code=429,
+            )
+        return {"identifier": str(kwargs["identifier"])}
+
+    monkeypatch.setattr(stripe_billing, "create_meter_event", _create_meter_event)
+
+    await billing_service.send_pending_usage_exports(limit=10)
+    db_session.expire_all()
+
+    success = await db_session.get(BillingUsageExport, success_id)
+    retryable = await db_session.get(BillingUsageExport, retryable_id)
+    terminal = await db_session.get(BillingUsageExport, terminal_id)
+    assert success is not None
+    assert retryable is not None
+    assert terminal is not None
+    assert [call["idempotency_key"] for call in calls] == [
+        success_export.idempotency_key,
+        retryable_export.idempotency_key,
+    ]
+    assert calls[0]["identifier"] == f"usage_export:{success_id}"
+    assert success.status == BILLING_USAGE_EXPORT_STATUS_SUCCEEDED
+    assert success.stripe_meter_event_identifier == f"usage_export:{success_id}"
+    assert retryable.status == BILLING_USAGE_EXPORT_STATUS_FAILED_RETRYABLE
+    assert retryable.error == "Stripe rate limited the meter event."
+    assert terminal.status == BILLING_USAGE_EXPORT_STATUS_FAILED_TERMINAL
+    assert terminal.error == "Billing subject has no Stripe customer id."
+
+    decisions = list(
+        (
+            await db_session.execute(
+                select(BillingDecisionEvent).order_by(BillingDecisionEvent.created_at.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [decision.reason for decision in decisions] == [
+        BILLING_USAGE_EXPORT_STATUS_SUCCEEDED,
+        "failed_retryable",
+        BILLING_USAGE_EXPORT_STATUS_FAILED_TERMINAL,
+    ]

--- a/server/tests/integration/test_billing_api.py
+++ b/server/tests/integration/test_billing_api.py
@@ -312,6 +312,89 @@ class TestBillingApi:
         assert payload["concurrentSandboxLimit"] is None
 
     @pytest.mark.asyncio
+    async def test_cloud_checkout_routes_paid_subject_to_portal(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "pro_billing_enabled", False)
+        monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_cloud")
+        monkeypatch.setattr(settings, "stripe_checkout_success_url", "https://app.test/success")
+        monkeypatch.setattr(settings, "stripe_checkout_cancel_url", "https://app.test/cancel")
+        monkeypatch.setattr(
+            settings,
+            "stripe_customer_portal_return_url",
+            "https://app.test/portal",
+        )
+        captured: dict[str, object] = {}
+
+        async def fake_validate_cloud_subscription_price_configuration() -> None:
+            captured["validated"] = True
+
+        async def fake_create_subscription_checkout_session(**_kwargs: object) -> object:
+            raise AssertionError("paid subjects should not get duplicate checkout sessions")
+
+        async def fake_create_customer_portal_session(
+            **kwargs: object,
+        ) -> stripe_billing.StripeUrlResponse:
+            captured["portal"] = kwargs
+            return stripe_billing.StripeUrlResponse(url="https://portal.test/active")
+
+        monkeypatch.setattr(
+            stripe_billing,
+            "validate_cloud_subscription_price_configuration",
+            fake_validate_cloud_subscription_price_configuration,
+        )
+        monkeypatch.setattr(
+            stripe_billing,
+            "create_subscription_checkout_session",
+            fake_create_subscription_checkout_session,
+        )
+        monkeypatch.setattr(
+            stripe_billing,
+            "create_customer_portal_session",
+            fake_create_customer_portal_session,
+        )
+
+        session = await _register_and_login(client, "billing-checkout-portal@example.com")
+        headers = {"Authorization": f"Bearer {session['access_token']}"}
+        user_id = uuid.UUID(session["user_id"])
+        subject = await ensure_personal_billing_subject(db_session, user_id)
+        subject.stripe_customer_id = "cus_checkout_portal"
+        now = datetime.now(UTC)
+        db_session.add(
+            BillingSubscription(
+                billing_subject_id=subject.id,
+                stripe_subscription_id="sub_checkout_portal",
+                stripe_customer_id="cus_checkout_portal",
+                status="active",
+                cancel_at_period_end=False,
+                canceled_at=None,
+                current_period_start=now - timedelta(days=1),
+                current_period_end=now + timedelta(days=29),
+                cloud_monthly_price_id="price_cloud",
+                overage_price_id=None,
+                monthly_subscription_item_id="si_checkout_portal",
+                metered_subscription_item_id=None,
+                latest_invoice_id=None,
+                latest_invoice_status=None,
+                hosted_invoice_url=None,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.post("/v1/billing/cloud-checkout", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json() == {"url": "https://portal.test/active"}
+        portal = captured["portal"]
+        assert isinstance(portal, dict)
+        assert portal["stripe_customer_id"] == "cus_checkout_portal"
+        assert portal["return_url"] == "https://app.test/portal"
+        assert portal["idempotency_key"] == f"portal:active-cloud:{subject.id}"
+
+    @pytest.mark.asyncio
     async def test_pro_overage_used_is_scoped_to_current_period(
         self,
         client: AsyncClient,

--- a/server/tests/integration/test_billing_store_invariants.py
+++ b/server/tests/integration/test_billing_store_invariants.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.billing import (
+    bind_stripe_customer_to_billing_subject,
+    ensure_organization_billing_subject,
+    ensure_personal_billing_subject,
+)
+from tests.integration.billing_accounting_helpers import patch_global_session_factory
+
+
+@pytest.mark.asyncio
+async def test_personal_and_organization_billing_subjects_are_unique(
+    db_session: AsyncSession,
+) -> None:
+    user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+
+    personal = await ensure_personal_billing_subject(db_session, user_id)
+    same_personal = await ensure_personal_billing_subject(db_session, user_id)
+    organization = await ensure_organization_billing_subject(db_session, organization_id)
+    same_organization = await ensure_organization_billing_subject(db_session, organization_id)
+
+    assert same_personal.id == personal.id
+    assert same_personal.user_id == user_id
+    assert same_personal.organization_id is None
+    assert same_organization.id == organization.id
+    assert same_organization.organization_id == organization_id
+    assert same_organization.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_stripe_customer_id_binds_to_only_one_billing_subject(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_global_session_factory(test_engine, monkeypatch)
+    first = await ensure_personal_billing_subject(db_session, uuid.uuid4())
+    second = await ensure_personal_billing_subject(db_session, uuid.uuid4())
+    await db_session.commit()
+
+    bound = await bind_stripe_customer_to_billing_subject(
+        billing_subject_id=first.id,
+        stripe_customer_id="cus_unique_subject",
+    )
+    assert bound.stripe_customer_id == "cus_unique_subject"
+
+    with pytest.raises(IntegrityError):
+        await bind_stripe_customer_to_billing_subject(
+            billing_subject_id=second.id,
+            stripe_customer_id="cus_unique_subject",
+        )

--- a/server/tests/integration/test_stripe_webhooks.py
+++ b/server/tests/integration/test_stripe_webhooks.py
@@ -21,7 +21,13 @@ from proliferate.constants.organizations import (
 )
 from proliferate.db import engine as engine_module
 from proliferate.db.models.auth import User
-from proliferate.db.models.billing import BillingGrant, BillingSeatAdjustment, BillingSubscription
+from proliferate.db.models.billing import (
+    BillingGrant,
+    BillingHold,
+    BillingSeatAdjustment,
+    BillingSubscription,
+    WebhookEventReceipt,
+)
 from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store.billing import (
     ensure_organization_billing_subject,
@@ -101,6 +107,132 @@ async def test_stripe_webhook_requires_configuration(
 
     assert response.status_code == 503
     assert response.json()["detail"]["code"] == "stripe_webhook_unconfigured"
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason=(
+        "Current receipt claim logic reclaims processed events because processed "
+        "receipts have no active lease; Phase 8 webhook idempotency cleanup "
+        "should make this return an ack without dispatch."
+    ),
+    strict=True,
+)
+async def test_stripe_webhook_duplicate_processed_event_does_not_dispatch_again(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    secret = "whsec_test_secret"
+    monkeypatch.setattr(settings, "stripe_webhook_secret", secret)
+    payload = json.dumps(
+        {
+            "id": "evt_duplicate",
+            "livemode": False,
+            "type": "invoice.payment_failed",
+            "data": {"object": {"id": "in_duplicate"}},
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    signature = _stripe_signature(payload, secret=secret)
+    dispatched: list[str] = []
+
+    async def _dispatch(event: dict[str, object]) -> None:
+        dispatched.append(str(event["id"]))
+
+    monkeypatch.setattr(stripe_webhooks, "_dispatch_stripe_event", _dispatch)
+
+    first = await stripe_webhooks.handle_stripe_webhook(
+        payload=payload,
+        signature_header=signature,
+    )
+    second = await stripe_webhooks.handle_stripe_webhook(
+        payload=payload,
+        signature_header=signature,
+    )
+
+    assert first == second
+    assert dispatched == ["evt_duplicate"]
+    receipt = (
+        await db_session.execute(
+            select(WebhookEventReceipt).where(WebhookEventReceipt.event_id == "evt_duplicate")
+        )
+    ).scalar_one()
+    assert receipt.provider == "stripe"
+    assert receipt.status == "processed"
+    assert receipt.attempt_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_failed_event_can_be_reclaimed_and_processed(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    secret = "whsec_test_secret"
+    monkeypatch.setattr(settings, "stripe_webhook_secret", secret)
+    payload = json.dumps(
+        {
+            "id": "evt_retry_after_failure",
+            "type": "invoice.paid",
+            "data": {"object": {"id": "in_retry_after_failure"}},
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    signature = _stripe_signature(payload, secret=secret)
+    attempts = 0
+
+    async def _dispatch(_event: dict[str, object]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient webhook failure")
+
+    monkeypatch.setattr(stripe_webhooks, "_dispatch_stripe_event", _dispatch)
+
+    with pytest.raises(RuntimeError, match="transient webhook failure"):
+        await stripe_webhooks.handle_stripe_webhook(
+            payload=payload,
+            signature_header=signature,
+        )
+
+    failed = (
+        await db_session.execute(
+            select(WebhookEventReceipt).where(
+                WebhookEventReceipt.event_id == "evt_retry_after_failure"
+            )
+        )
+    ).scalar_one()
+    assert failed.status == "failed"
+    assert failed.attempt_count == 1
+    assert failed.last_error == "transient webhook failure"
+
+    await stripe_webhooks.handle_stripe_webhook(
+        payload=payload,
+        signature_header=signature,
+    )
+    db_session.expire_all()
+    processed = (
+        await db_session.execute(
+            select(WebhookEventReceipt).where(
+                WebhookEventReceipt.event_id == "evt_retry_after_failure"
+            )
+        )
+    ).scalar_one()
+    assert attempts == 2
+    assert processed.status == "processed"
+    assert processed.attempt_count == 2
+    assert processed.last_error is None
 
 
 @pytest.mark.asyncio
@@ -544,6 +676,124 @@ async def test_org_pro_subscription_sync_reconciles_active_seats_before_period_g
     assert subscription.seat_quantity == 3
     assert len(grants) == 1
     assert grants[0].hours_granted == 60.0
+
+
+@pytest.mark.asyncio
+async def test_invoice_failed_hold_blocks_until_invoice_paid_clears_it(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro")
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_managed_cloud_overage_price_id", "price_overage")
+
+    user_id = uuid.uuid4()
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    subject.stripe_customer_id = "cus_payment_hold"
+    subject_id = subject.id
+    await db_session.commit()
+
+    subscription_payload = {
+        "id": "sub_payment_hold",
+        "customer": "cus_payment_hold",
+        "status": "active",
+        "cancel_at_period_end": False,
+        "canceled_at": None,
+        "current_period_start": 1_776_586_422,
+        "current_period_end": 1_779_178_422,
+        "latest_invoice": "in_paid_after_hold",
+        "metadata": {
+            "billing_subject_id": str(subject_id),
+            "purpose": "cloud_subscription",
+        },
+        "items": {
+            "data": [
+                {
+                    "id": "si_hold_monthly",
+                    "quantity": 1,
+                    "price": {"id": "price_pro"},
+                },
+                {
+                    "id": "si_hold_overage",
+                    "price": {"id": "price_overage"},
+                },
+            ]
+        },
+    }
+
+    async def _retrieve_subscription(subscription_id: str) -> dict[str, object]:
+        assert subscription_id == "sub_payment_hold"
+        return subscription_payload
+
+    monkeypatch.setattr(
+        stripe_webhooks.stripe_billing,
+        "retrieve_subscription",
+        _retrieve_subscription,
+    )
+
+    await stripe_webhooks._handle_invoice_payment_failed(
+        {
+            "id": "in_failed_hold",
+            "customer": "cus_payment_hold",
+            "subscription": "sub_payment_hold",
+            "metadata": {"billing_subject_id": str(subject_id)},
+        }
+    )
+    db_session.expire_all()
+    hold = (
+        await db_session.execute(
+            select(BillingHold).where(BillingHold.billing_subject_id == subject_id)
+        )
+    ).scalar_one()
+    assert hold.kind == "payment_failed"
+    assert hold.status == "active"
+    assert hold.source_ref == "in_failed_hold"
+
+    await stripe_webhooks._handle_invoice_paid(
+        {
+            "id": "in_paid_after_hold",
+            "customer": "cus_payment_hold",
+            "subscription": "sub_payment_hold",
+            "metadata": {"billing_subject_id": str(subject_id)},
+            "lines": {
+                "data": [
+                    {
+                        "id": "il_paid_hold",
+                        "pricing": {
+                            "price_details": {
+                                "price": "price_pro",
+                                "product": "prod_pro",
+                            },
+                            "type": "price_details",
+                        },
+                        "parent": {
+                            "subscription_item_details": {
+                                "subscription": "sub_payment_hold",
+                                "subscription_item": "si_hold_monthly",
+                            },
+                            "type": "subscription_item_details",
+                        },
+                    }
+                ]
+            },
+        }
+    )
+    db_session.expire_all()
+    hold = (
+        await db_session.execute(
+            select(BillingHold).where(BillingHold.billing_subject_id == subject_id)
+        )
+    ).scalar_one()
+    assert hold.status == "resolved"
+    assert hold.resolved_at is not None
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_billing_reconciler.py
+++ b/server/tests/unit/test_billing_reconciler.py
@@ -40,6 +40,31 @@ async def test_billing_reconciler_loop_captures_recovered_failures(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_pass_skips_work_when_lock_is_already_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def _with_lock(_callback):
+        calls.append("lock")
+        return False, None
+
+    async def _run_billing_accounting_pass() -> None:
+        calls.append("accounting")
+
+    monkeypatch.setattr(reconciler, "with_billing_reconciler_lock", _with_lock)
+    monkeypatch.setattr(
+        reconciler,
+        "run_billing_accounting_pass",
+        _run_billing_accounting_pass,
+    )
+
+    await reconciler.run_billing_reconcile_pass()
+
+    assert calls == ["lock"]
+
+
+@pytest.mark.asyncio
 async def test_reconcile_segment_confirms_missing_list_state_before_marking_paused(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/server/tests/unit/test_billing_service_policy.py
+++ b/server/tests/unit/test_billing_service_policy.py
@@ -9,8 +9,12 @@ from proliferate.constants.billing import (
     BILLING_MODE_ENFORCE,
     BILLING_MODE_OBSERVE,
     BILLING_MODE_OFF,
+    BILLING_PRICE_CLASS_LEGACY_CLOUD,
+    BILLING_PRICE_CLASS_PRO,
+    BILLING_PRICE_CLASS_UNKNOWN,
 )
 from proliferate.server.billing.models import BillingSnapshot
+from proliferate.server.billing.pricing import classify_monthly_price_id
 from proliferate.server.billing.service import repo_limit_for_billing_snapshot
 
 
@@ -79,3 +83,27 @@ def test_repo_limit_is_disabled_when_billing_mode_is_off() -> None:
         )
         is None
     )
+
+
+def test_price_classification_distinguishes_pro_legacy_and_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro")
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_legacy_alias")
+    monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "price_legacy")
+
+    assert classify_monthly_price_id("price_pro") == BILLING_PRICE_CLASS_PRO
+    assert classify_monthly_price_id("price_legacy") == BILLING_PRICE_CLASS_LEGACY_CLOUD
+    assert classify_monthly_price_id("price_legacy_alias") == BILLING_PRICE_CLASS_UNKNOWN
+    assert classify_monthly_price_id("price_unknown") == BILLING_PRICE_CLASS_UNKNOWN
+    assert classify_monthly_price_id(None) == BILLING_PRICE_CLASS_UNKNOWN
+
+
+def test_price_classification_treats_cloud_monthly_as_pro_alias_without_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_cloud_alias")
+    monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
+
+    assert classify_monthly_price_id("price_cloud_alias") == BILLING_PRICE_CLASS_PRO


### PR DESCRIPTION
## Summary
- add Phase 8 Wave 1 tests for billing accounting, policy, reconciliation, store, API, and Stripe webhook invariants
- pin account idempotency, checkout/preflight balance policy, reconciler no-double-charge behavior, spend lockouts, store atomicity, and webhook receipt behavior
- document the current duplicate processed Stripe webhook dispatch bug with a strict xfail so Phase 8 cleanup can fix it without changing expected behavior silently

## Wave / Lane
- Phase 8 Wave 1: Test Pinning
- Lane E: Billing Invariants

## Verification
- `DEBUG=true JWT_SECRET=test-secret uv run --extra dev --python /opt/homebrew/bin/python3.12 python -m pytest -q tests/integration/test_billing_accounting.py tests/integration/test_billing_api.py tests/integration/test_billing_store_invariants.py tests/integration/test_stripe_webhooks.py tests/unit/test_billing_reconciler.py tests/unit/test_billing_service_policy.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`
