### PR TITLE
test(server): pin automation claim phase 8 behavior

### DIFF
--- a/server/tests/unit/test_automation_claim_contracts.py
+++ b/server/tests/unit/test_automation_claim_contracts.py
@@ -13,7 +13,6 @@ from proliferate.constants.automations import (
     AUTOMATION_RUN_STATUS_CREATING_SESSION,
     AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
     AUTOMATION_RUN_STATUS_DISPATCHED,
-    AUTOMATION_RUN_STATUS_DISPATCHING,
     AUTOMATION_RUN_STATUS_FAILED,
     AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
 )
@@ -359,7 +358,11 @@ async def test_cloud_executor_claims_only_cloud_target_runs_globally(
             user_id=first_user_id,
             executor_id="desktop-executor",
             available_repositories=[
-                LocalAutomationRepoIdentity(provider="github", owner="proliferate-ai", name="local")
+                LocalAutomationRepoIdentity(
+                    provider="github",
+                    owner="proliferate-ai",
+                    name="local",
+                )
             ],
             claim_ttl=timedelta(minutes=5),
             limit=10,

--- a/server/tests/unit/test_automation_claim_contracts.py
+++ b/server/tests/unit/test_automation_claim_contracts.py
@@ -1,0 +1,465 @@
+from datetime import UTC, datetime, timedelta
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_EXECUTION_TARGET_LOCAL,
+    AUTOMATION_EXECUTOR_KIND_CLOUD,
+    AUTOMATION_RUN_STATUS_CLAIMED,
+    AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+    AUTOMATION_RUN_STATUS_DISPATCHED,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    AUTOMATION_RUN_STATUS_FAILED,
+    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+)
+from proliferate.db import engine as engine_module
+from proliferate.db.models.automations import Automation, AutomationRun
+from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.db.store.automation_cloud_workspace_claims import (
+    create_cloud_workspace_for_claimed_run,
+)
+from proliferate.db.store.automation_run_claim_values import LocalAutomationRepoIdentity
+from proliferate.db.store.automation_run_claims import (
+    claim_cloud_automation_runs,
+    claim_local_automation_runs,
+    heartbeat_run_claim,
+    mark_run_creating_session,
+    mark_run_creating_workspace,
+    mark_run_dispatched,
+    mark_run_dispatching,
+    mark_run_failed,
+)
+from proliferate.db.store.automations import create_manual_run_for_user
+
+
+def _patch_session_factory(test_engine):  # type: ignore[no-untyped-def]
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    return original_factory
+
+
+async def _create_automation(
+    *,
+    user_id: uuid.UUID,
+    now: datetime,
+    execution_target: str,
+    git_owner: str = "proliferate-ai",
+    git_repo_name: str = "proliferate",
+) -> uuid.UUID:
+    async with engine_module.async_session_factory() as session:
+        repo = CloudRepoConfig(
+            user_id=user_id,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            configured=execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD,
+            configured_at=now if execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD else None,
+            default_branch="main",
+            env_vars_ciphertext="",
+            env_vars_version=0,
+            setup_script="",
+            setup_script_version=0,
+            files_version=0,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(repo)
+        await session.flush()
+        automation = Automation(
+            user_id=user_id,
+            cloud_repo_config_id=repo.id,
+            title=f"{execution_target} automation",
+            prompt="Check the repo",
+            schedule_rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+            schedule_timezone="UTC",
+            schedule_summary="Daily at 09:00 in UTC",
+            execution_target=execution_target,
+            agent_kind="codex",
+            model_id="gpt-5.4" if execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD else None,
+            mode_id="code" if execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD else None,
+            reasoning_effort=(
+                "medium" if execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD else None
+            ),
+            enabled=True,
+            paused_at=None,
+            next_run_at=now,
+            last_scheduled_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(automation)
+        await session.commit()
+        return automation.id
+
+
+async def _create_manual_run(
+    *,
+    user_id: uuid.UUID,
+    automation_id: uuid.UUID,
+):
+    async with engine_module.async_session_factory() as session:
+        run = await create_manual_run_for_user(
+            session,
+            user_id=user_id,
+            automation_id=automation_id,
+        )
+        await session.commit()
+        assert run is not None
+        return run
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_only_extends_current_claim(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = _patch_session_factory(test_engine)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        automation_id = await _create_automation(
+            user_id=user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        )
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        first_claim = (
+            await claim_cloud_automation_runs(
+                executor_id="executor-1",
+                claim_ttl=timedelta(minutes=5),
+                limit=1,
+                now=now,
+            )
+        )[0]
+        second_claim = (
+            await claim_cloud_automation_runs(
+                executor_id="executor-2",
+                claim_ttl=timedelta(minutes=5),
+                limit=1,
+                now=now + timedelta(minutes=6),
+            )
+        )[0]
+
+        stale_heartbeat = await heartbeat_run_claim(
+            run_id=run.id,
+            claim_id=first_claim.claim_id,
+            claim_ttl=timedelta(hours=1),
+            now=now + timedelta(minutes=6, seconds=1),
+        )
+        current_heartbeat = await heartbeat_run_claim(
+            run_id=run.id,
+            claim_id=second_claim.claim_id,
+            claim_ttl=timedelta(minutes=10),
+            now=now + timedelta(minutes=6, seconds=2),
+        )
+
+        async with engine_module.async_session_factory() as session:
+            record = await session.get(AutomationRun, run.id)
+            assert record is not None
+
+        assert stale_heartbeat is None
+        assert current_heartbeat is not None
+        assert record.claim_id == second_claim.claim_id
+        assert record.executor_id == "executor-2"
+        assert record.claim_expires_at == now + timedelta(minutes=16, seconds=2)
+        assert record.last_heartbeat_at == now + timedelta(minutes=6, seconds=2)
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [
+        AUTOMATION_RUN_STATUS_CLAIMED,
+        AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    ],
+)
+async def test_expired_reclaimable_statuses_can_be_reclaimed(
+    test_engine,  # type: ignore[no-untyped-def]
+    status: str,
+) -> None:
+    original_factory = _patch_session_factory(test_engine)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        automation_id = await _create_automation(
+            user_id=user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        )
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        first_claim = (
+            await claim_cloud_automation_runs(
+                executor_id="executor-1",
+                claim_ttl=timedelta(minutes=5),
+                limit=1,
+                now=now,
+            )
+        )[0]
+        async with engine_module.async_session_factory() as session:
+            record = await session.get(AutomationRun, run.id)
+            assert record is not None
+            record.status = status
+            record.claim_expires_at = now - timedelta(seconds=1)
+            await session.commit()
+
+        second_claim = (
+            await claim_cloud_automation_runs(
+                executor_id="executor-2",
+                claim_ttl=timedelta(minutes=5),
+                limit=1,
+                now=now,
+            )
+        )[0]
+
+        assert second_claim.id == run.id
+        assert second_claim.claim_id != first_claim.claim_id
+        assert second_claim.status == AUTOMATION_RUN_STATUS_CLAIMED
+        assert second_claim.executor_kind == AUTOMATION_EXECUTOR_KIND_CLOUD
+        assert second_claim.executor_id == "executor-2"
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+async def test_final_dispatched_and_failed_states_clear_claim_metadata(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = _patch_session_factory(test_engine)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        automation_id = await _create_automation(
+            user_id=user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        )
+        dispatched_run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        failed_run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        dispatched_claim, failed_claim = await claim_cloud_automation_runs(
+            executor_id="executor-1",
+            claim_ttl=timedelta(minutes=5),
+            limit=2,
+            now=now,
+        )
+
+        creating_session = await mark_run_creating_session(
+            run_id=dispatched_claim.id,
+            claim_id=dispatched_claim.claim_id,
+            anyharness_workspace_id="workspace-1",
+            now=now + timedelta(seconds=1),
+        )
+        assert creating_session is not None
+        async with engine_module.async_session_factory() as session:
+            record = await session.get(AutomationRun, dispatched_claim.id)
+            assert record is not None
+            record.anyharness_session_id = "session-1"
+            await session.commit()
+        dispatching = await mark_run_dispatching(
+            run_id=dispatched_claim.id,
+            claim_id=dispatched_claim.claim_id,
+            now=now + timedelta(seconds=2),
+        )
+        dispatched = await mark_run_dispatched(
+            run_id=dispatched_claim.id,
+            claim_id=dispatched_claim.claim_id,
+            anyharness_workspace_id="workspace-1",
+            anyharness_session_id="session-1",
+            now=now + timedelta(seconds=3),
+        )
+        failed = await mark_run_failed(
+            run_id=failed_claim.id,
+            claim_id=failed_claim.claim_id,
+            error_code="unexpected_executor_error",
+            message="executor failed",
+            now=now + timedelta(seconds=4),
+        )
+
+        async with engine_module.async_session_factory() as session:
+            dispatched_record = await session.get(AutomationRun, dispatched_run.id)
+            failed_record = await session.get(AutomationRun, failed_run.id)
+            assert dispatched_record is not None
+            assert failed_record is not None
+
+        assert dispatching is not None
+        assert dispatched is True
+        assert failed is True
+        assert dispatched_record.status == AUTOMATION_RUN_STATUS_DISPATCHED
+        assert dispatched_record.executor_kind is None
+        assert dispatched_record.executor_id is None
+        assert dispatched_record.claim_id is None
+        assert dispatched_record.claim_expires_at is None
+        assert dispatched_record.anyharness_workspace_id == "workspace-1"
+        assert dispatched_record.anyharness_session_id == "session-1"
+        assert failed_record.status == AUTOMATION_RUN_STATUS_FAILED
+        assert failed_record.executor_kind is None
+        assert failed_record.executor_id is None
+        assert failed_record.claim_id is None
+        assert failed_record.claim_expires_at is None
+        assert failed_record.last_error_code == "unexpected_executor_error"
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+async def test_cloud_executor_claims_only_cloud_target_runs_globally(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = _patch_session_factory(test_engine)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    first_user_id = uuid.uuid4()
+    second_user_id = uuid.uuid4()
+
+    try:
+        first_cloud_id = await _create_automation(
+            user_id=first_user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+            git_repo_name="cloud-one",
+        )
+        second_cloud_id = await _create_automation(
+            user_id=second_user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+            git_repo_name="cloud-two",
+        )
+        local_id = await _create_automation(
+            user_id=first_user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+            git_repo_name="local",
+        )
+        first_cloud_run = await _create_manual_run(
+            user_id=first_user_id,
+            automation_id=first_cloud_id,
+        )
+        second_cloud_run = await _create_manual_run(
+            user_id=second_user_id,
+            automation_id=second_cloud_id,
+        )
+        local_run = await _create_manual_run(user_id=first_user_id, automation_id=local_id)
+
+        cloud_claims = await claim_cloud_automation_runs(
+            executor_id="cloud-executor",
+            claim_ttl=timedelta(minutes=5),
+            limit=10,
+            now=now,
+        )
+        local_claims = await claim_local_automation_runs(
+            user_id=first_user_id,
+            executor_id="desktop-executor",
+            available_repositories=[
+                LocalAutomationRepoIdentity(provider="github", owner="proliferate-ai", name="local")
+            ],
+            claim_ttl=timedelta(minutes=5),
+            limit=10,
+            now=now,
+        )
+
+        assert {claim.id for claim in cloud_claims} == {first_cloud_run.id, second_cloud_run.id}
+        assert all(
+            claim.execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD for claim in cloud_claims
+        )
+        assert [claim.id for claim in local_claims] == [local_run.id]
+        assert local_claims[0].execution_target == AUTOMATION_EXECUTION_TARGET_LOCAL
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+async def test_workspace_creation_and_run_attachment_are_gated_by_current_claim(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = _patch_session_factory(test_engine)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        automation_id = await _create_automation(
+            user_id=user_id,
+            now=now,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        )
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        claim = (
+            await claim_cloud_automation_runs(
+                executor_id="executor-1",
+                claim_ttl=timedelta(minutes=5),
+                limit=1,
+                now=now,
+            )
+        )[0]
+        creating = await mark_run_creating_workspace(
+            run_id=claim.id,
+            claim_id=claim.claim_id,
+            now=now,
+        )
+        assert creating is not None
+
+        stale_workspace = await create_cloud_workspace_for_claimed_run(
+            run_id=run.id,
+            claim_id=uuid.uuid4(),
+            user_id=user_id,
+            display_name="stale",
+            git_provider="github",
+            git_owner="proliferate-ai",
+            git_repo_name="proliferate",
+            git_branch="automation/stale",
+            git_base_branch="main",
+            origin_json=None,
+            template_version="v1",
+            now=now + timedelta(seconds=1),
+        )
+        workspace = await create_cloud_workspace_for_claimed_run(
+            run_id=run.id,
+            claim_id=claim.claim_id,
+            user_id=user_id,
+            display_name="current",
+            git_provider="github",
+            git_owner="proliferate-ai",
+            git_repo_name="proliferate",
+            git_branch="automation/current",
+            git_base_branch="main",
+            origin_json=None,
+            template_version="v1",
+            now=now + timedelta(seconds=2),
+        )
+        duplicate_workspace = await create_cloud_workspace_for_claimed_run(
+            run_id=run.id,
+            claim_id=claim.claim_id,
+            user_id=user_id,
+            display_name="duplicate",
+            git_provider="github",
+            git_owner="proliferate-ai",
+            git_repo_name="proliferate",
+            git_branch="automation/duplicate",
+            git_base_branch="main",
+            origin_json=None,
+            template_version="v1",
+            now=now + timedelta(seconds=3),
+        )
+
+        async with engine_module.async_session_factory() as session:
+            record = await session.get(AutomationRun, run.id)
+            workspace_count = (
+                await session.execute(select(func.count()).select_from(CloudWorkspace))
+            ).scalar_one()
+            assert record is not None
+
+        assert stale_workspace is None
+        assert workspace is not None
+        assert duplicate_workspace is None
+        assert record.cloud_workspace_id == workspace.id
+        assert workspace_count == 1
+    finally:
+        engine_module.async_session_factory = original_factory

--- a/server/tests/unit/test_automation_store.py
+++ b/server/tests/unit/test_automation_store.py
@@ -6,6 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from proliferate.constants.automations import AUTOMATION_EXECUTION_TARGET_CLOUD
+from proliferate.constants.automations import AUTOMATION_RUN_STATUS_QUEUED
+from proliferate.constants.automations import AUTOMATION_RUN_TRIGGER_SCHEDULED
 from proliferate.db import engine as engine_module
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
@@ -144,5 +146,128 @@ async def test_due_scheduler_disables_bad_schedule_and_continues_batch(
         assert runs[0].git_owner_snapshot == "proliferate-ai"
         assert runs[0].git_repo_name_snapshot == "good"
         assert runs[0].agent_kind_snapshot == "codex"
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+async def test_due_scheduler_advances_after_duplicate_scheduled_slot(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        async with engine_module.async_session_factory() as session:
+            repo = CloudRepoConfig(
+                user_id=user_id,
+                git_owner="proliferate-ai",
+                git_repo_name="duplicate-slot",
+                configured=True,
+                configured_at=now,
+                default_branch="main",
+                env_vars_ciphertext="",
+                env_vars_version=0,
+                setup_script="",
+                setup_script_version=0,
+                files_version=0,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(repo)
+            await session.flush()
+            automation = Automation(
+                user_id=user_id,
+                cloud_repo_config_id=repo.id,
+                title="Duplicate slot",
+                prompt="Run once",
+                schedule_rrule="RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=0",
+                schedule_timezone="UTC",
+                schedule_summary="Hourly at :00 in UTC",
+                execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+                agent_kind="codex",
+                model_id=None,
+                mode_id=None,
+                reasoning_effort=None,
+                enabled=True,
+                paused_at=None,
+                next_run_at=now,
+                last_scheduled_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(automation)
+            await session.flush()
+            duplicate_run = AutomationRun(
+                automation_id=automation.id,
+                user_id=user_id,
+                trigger_kind=AUTOMATION_RUN_TRIGGER_SCHEDULED,
+                scheduled_for=now,
+                execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+                status=AUTOMATION_RUN_STATUS_QUEUED,
+                title_snapshot=automation.title,
+                prompt_snapshot=automation.prompt,
+                git_provider_snapshot="github",
+                git_owner_snapshot=repo.git_owner,
+                git_repo_name_snapshot=repo.git_repo_name,
+                cloud_repo_config_id_snapshot=repo.id,
+                agent_kind_snapshot=automation.agent_kind,
+                model_id_snapshot=automation.model_id,
+                mode_id_snapshot=automation.mode_id,
+                reasoning_effort_snapshot=automation.reasoning_effort,
+                executor_kind=None,
+                executor_id=None,
+                claim_id=None,
+                claimed_at=None,
+                claim_expires_at=None,
+                last_heartbeat_at=None,
+                dispatch_started_at=None,
+                dispatched_at=None,
+                failed_at=None,
+                cloud_workspace_id=None,
+                anyharness_workspace_id=None,
+                anyharness_session_id=None,
+                cancelled_at=None,
+                last_error_code=None,
+                last_error_message=None,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(duplicate_run)
+            await session.commit()
+            automation_id = automation.id
+
+        def _advance(fields, _now):  # type: ignore[no-untyped-def]
+            return AutomationScheduleAdvance(
+                scheduled_for=fields.next_run_at,
+                next_run_at=now + timedelta(hours=1),
+            )
+
+        created = await create_due_scheduled_runs_batch(
+            now=now,
+            limit=10,
+            schedule_advance_resolver=_advance,
+        )
+
+        async with engine_module.async_session_factory() as session:
+            automation = await session.get(Automation, automation_id)
+            runs = list(
+                (
+                    await session.execute(
+                        select(AutomationRun).where(AutomationRun.automation_id == automation_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert created == 0
+        assert automation is not None
+        assert automation.next_run_at == now + timedelta(hours=1)
+        assert automation.last_scheduled_at is None
+        assert len(runs) == 1
+        assert runs[0].scheduled_for == now
     finally:
         engine_module.async_session_factory = original_factory


### PR DESCRIPTION
## Summary
- add Phase 8 Wave 1 tests for automation worker claim invariants
- pin claim identity gating, heartbeat behavior, reclaim behavior, terminal claim cleanup, cloud/local scoping, workspace attachment gating, and scheduled duplicate-slot behavior

## Wave / Lane
- Phase 8 Wave 1: Test Pinning
- Lane A: Automation Worker Claims

## Verification
- `DEBUG=1 uv run --python 3.12 --extra dev pytest -q tests/unit/test_automation_claim_contracts.py tests/unit/test_automation_store.py tests/unit/test_automation_executor.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`
