### PR TITLE
refactor(server): extract runtime domain decisions

### DIFF
--- a/server/proliferate/server/cloud/runtime/credential_freshness.py
+++ b/server/proliferate/server/cloud/runtime/credential_freshness.py
@@ -7,10 +7,8 @@ import re
 import shlex
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
 from uuid import UUID
 
-from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS, CloudRuntimeEnvironmentStatus
 from proliferate.db.models.cloud.runtime_environments import CloudRuntimeEnvironment
 from proliferate.db.store.cloud_credentials import CloudCredentialRecord
 from proliferate.db.store.cloud_repo_config import load_cloud_repo_config_for_user
@@ -43,6 +41,15 @@ from proliferate.server.cloud.runtime.credentials import (
     normalize_provision_credentials,
     write_credential_files,
 )
+from proliferate.server.cloud.runtime.domain.credential_revision import (
+    CredentialFreshnessStatus,
+    CredentialRevisionPlan,
+    build_credential_revision_plan,
+    classify_credential_freshness,
+    credential_apply_is_already_current,
+    decide_process_credential_restart,
+    filter_active_supported_credentials,
+)
 from proliferate.server.cloud.runtime.sandbox_exec import (
     assert_command_succeeded,
     build_detached_runtime_launch_command,
@@ -55,16 +62,6 @@ from proliferate.server.cloud.runtime.sandbox_exec import (
 from proliferate.utils.crypto import decrypt_json, decrypt_text
 from proliferate.utils.time import utcnow
 
-CredentialFreshnessStatus = Literal[
-    "current",
-    "stale",
-    "restart_required",
-    "apply_failed",
-    "missing_credentials",
-]
-
-_EMPTY_FILES_REVISION = "credential-files:v1:empty"
-_EMPTY_PROCESS_REVISION = "credential-process:v1:empty"
 _RUNNING_SANDBOX_STATES = frozenset({"running", "started"})
 
 logger = logging.getLogger("proliferate.cloud")
@@ -76,6 +73,14 @@ class CredentialRevisionState:
     process_revision: str
     credentials: ProvisionCredentials
     missing_credentials: bool
+
+    @property
+    def plan(self) -> CredentialRevisionPlan:
+        return CredentialRevisionPlan(
+            files_revision=self.files_revision,
+            process_revision=self.process_revision,
+            missing_credentials=self.missing_credentials,
+        )
 
 
 @dataclass(frozen=True)
@@ -93,36 +98,22 @@ class CredentialFreshnessSnapshot:
 def _active_supported_credentials(
     records: list[CloudCredentialRecord],
 ) -> list[CloudCredentialRecord]:
-    return [
-        record
-        for record in records
-        if record.provider in SUPPORTED_CLOUD_AGENTS and record.revoked_at is None
-    ]
-
-
-def _revision_for(records: list[CloudCredentialRecord], auth_mode: str, prefix: str) -> str:
-    parts = sorted(
-        f"{record.provider}:{record.auth_mode}:{record.payload_format}:{record.id}"
-        for record in records
-        if record.auth_mode == auth_mode
-    )
-    if not parts:
-        return _EMPTY_FILES_REVISION if auth_mode == "file" else _EMPTY_PROCESS_REVISION
-    return f"{prefix}:v1:{','.join(parts)}"
+    return filter_active_supported_credentials(records)
 
 
 def build_credential_revision_state(
     records: list[CloudCredentialRecord],
 ) -> CredentialRevisionState:
     active_records = _active_supported_credentials(records)
+    revision_plan = build_credential_revision_plan(active_records)
     credential_payloads = {
         record.provider: decrypt_json(record.payload_ciphertext) for record in active_records
     }
     return CredentialRevisionState(
-        files_revision=_revision_for(active_records, "file", "credential-files"),
-        process_revision=_revision_for(active_records, "env", "credential-process"),
+        files_revision=revision_plan.files_revision,
+        process_revision=revision_plan.process_revision,
         credentials=normalize_provision_credentials(credential_payloads),
-        missing_credentials=not active_records,
+        missing_credentials=revision_plan.missing_credentials,
     )
 
 
@@ -140,56 +131,26 @@ def build_credential_freshness_snapshot(
     environment: CloudRuntimeEnvironment,
     revisions: CredentialRevisionState,
 ) -> CredentialFreshnessSnapshot:
-    assume_legacy_current = not revisions.missing_credentials
-    files_current = _revision_is_current(
-        environment,
-        applied_revision=environment.credential_files_applied_revision,
-        desired_revision=revisions.files_revision,
-        assume_legacy_current=assume_legacy_current,
+    decision = classify_credential_freshness(
+        runtime_status=environment.status,
+        active_sandbox_id=environment.active_sandbox_id,
+        files_applied_revision=environment.credential_files_applied_revision,
+        process_applied_revision=environment.credential_process_applied_revision,
+        credential_last_error=environment.credential_last_error,
+        credential_last_error_at=environment.credential_last_error_at,
+        credential_files_applied_at=environment.credential_files_applied_at,
+        credential_process_applied_at=environment.credential_process_applied_at,
+        revisions=revisions.plan,
     )
-    process_current = _revision_is_current(
-        environment,
-        applied_revision=environment.credential_process_applied_revision,
-        desired_revision=revisions.process_revision,
-        assume_legacy_current=assume_legacy_current,
-    )
-    requires_restart = not process_current
-    if files_current and process_current:
-        status: CredentialFreshnessStatus = (
-            "missing_credentials" if revisions.missing_credentials else "current"
-        )
-    elif environment.credential_last_error:
-        status = "apply_failed"
-    elif requires_restart:
-        status = "restart_required"
-    else:
-        status = "stale"
     return CredentialFreshnessSnapshot(
-        status=status,
-        files_current=files_current,
-        process_current=process_current,
-        requires_restart=requires_restart,
-        last_error=environment.credential_last_error,
-        last_error_at=environment.credential_last_error_at,
-        files_applied_at=environment.credential_files_applied_at,
-        process_applied_at=environment.credential_process_applied_at,
-    )
-
-
-def _revision_is_current(
-    environment: CloudRuntimeEnvironment,
-    *,
-    applied_revision: str | None,
-    desired_revision: str,
-    assume_legacy_current: bool,
-) -> bool:
-    if applied_revision == desired_revision:
-        return True
-    return (
-        applied_revision is None
-        and assume_legacy_current
-        and environment.status == CloudRuntimeEnvironmentStatus.running.value
-        and environment.active_sandbox_id is not None
+        status=decision.status,
+        files_current=decision.files_current,
+        process_current=decision.process_current,
+        requires_restart=decision.requires_restart,
+        last_error=decision.last_error,
+        last_error_at=decision.last_error_at,
+        files_applied_at=decision.files_applied_at,
+        process_applied_at=decision.process_applied_at,
     )
 
 
@@ -462,9 +423,7 @@ async def ensure_runtime_environment_credentials_current(
         records = await load_cloud_credentials_for_user(environment.user_id)
         revisions = build_credential_revision_state(records)
         snapshot = build_credential_freshness_snapshot(environment, revisions)
-        if snapshot.status == "current" or (
-            revisions.missing_credentials and snapshot.files_current and snapshot.process_current
-        ):
+        if credential_apply_is_already_current(snapshot, revisions.plan):
             return snapshot
 
         try:
@@ -504,7 +463,12 @@ async def ensure_runtime_environment_credentials_current(
                     )
                 return snapshot
 
-            if not allow_process_restart:
+            restart_decision = decide_process_credential_restart(
+                requires_restart=snapshot.requires_restart,
+                allow_process_restart=allow_process_restart,
+                runtime_has_live_sessions=False,
+            )
+            if not restart_decision.allowed:
                 return snapshot
 
             (
@@ -515,11 +479,17 @@ async def ensure_runtime_environment_credentials_current(
             runtime_url = environment.runtime_url
             if not runtime_url:
                 raise CloudRuntimeReconnectError("Cloud runtime URL is not available.")
-            if await _runtime_has_live_sessions(
+            has_live_sessions = await _runtime_has_live_sessions(
                 runtime_url,
                 access_token,
                 workspace_id=workspace_id,
-            ):
+            )
+            restart_decision = decide_process_credential_restart(
+                requires_restart=snapshot.requires_restart,
+                allow_process_restart=allow_process_restart,
+                runtime_has_live_sessions=has_live_sessions,
+            )
+            if not restart_decision.allowed:
                 return snapshot
 
             await _relaunch_runtime_with_credentials(

--- a/server/proliferate/server/cloud/runtime/domain/__init__.py
+++ b/server/proliferate/server/cloud/runtime/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure runtime lifecycle decisions."""

--- a/server/proliferate/server/cloud/runtime/domain/credential_revision.py
+++ b/server/proliferate/server/cloud/runtime/domain/credential_revision.py
@@ -1,0 +1,198 @@
+"""Pure credential freshness and restart decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Protocol
+
+from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS, CloudRuntimeEnvironmentStatus
+
+CredentialFreshnessStatus = Literal[
+    "current",
+    "stale",
+    "restart_required",
+    "apply_failed",
+    "missing_credentials",
+]
+
+CredentialRestartDecisionReason = Literal[
+    "not_required",
+    "restart_disallowed",
+    "live_sessions",
+    "allowed",
+]
+
+EMPTY_FILES_REVISION = "credential-files:v1:empty"
+EMPTY_PROCESS_REVISION = "credential-process:v1:empty"
+
+
+class CredentialRecordForRevision(Protocol):
+    provider: str
+    auth_mode: str
+    payload_format: str
+    id: object
+    revoked_at: object | None
+
+
+class CredentialFreshnessLike(Protocol):
+    status: CredentialFreshnessStatus
+    files_current: bool
+    process_current: bool
+
+
+@dataclass(frozen=True)
+class CredentialRevisionPlan:
+    files_revision: str
+    process_revision: str
+    missing_credentials: bool
+
+
+@dataclass(frozen=True)
+class CredentialFreshnessDecision:
+    status: CredentialFreshnessStatus
+    files_current: bool
+    process_current: bool
+    requires_restart: bool
+    last_error: str | None
+    last_error_at: datetime | None
+    files_applied_at: datetime | None
+    process_applied_at: datetime | None
+
+
+@dataclass(frozen=True)
+class CredentialProcessRestartDecision:
+    allowed: bool
+    reason: CredentialRestartDecisionReason
+
+
+def filter_active_supported_credentials[CredentialRecordT: CredentialRecordForRevision](
+    records: Iterable[CredentialRecordT],
+    *,
+    supported_providers: Iterable[str] = SUPPORTED_CLOUD_AGENTS,
+) -> list[CredentialRecordT]:
+    supported = frozenset(supported_providers)
+    return [
+        record
+        for record in records
+        if record.provider in supported and record.revoked_at is None
+    ]
+
+
+def build_credential_revision_plan(
+    records: Iterable[CredentialRecordForRevision],
+) -> CredentialRevisionPlan:
+    active_records = filter_active_supported_credentials(records)
+    return CredentialRevisionPlan(
+        files_revision=_revision_for(active_records, "file", "credential-files"),
+        process_revision=_revision_for(active_records, "env", "credential-process"),
+        missing_credentials=not active_records,
+    )
+
+
+def classify_credential_freshness(
+    *,
+    runtime_status: str,
+    active_sandbox_id: object | None,
+    files_applied_revision: str | None,
+    process_applied_revision: str | None,
+    credential_last_error: str | None,
+    credential_last_error_at: datetime | None,
+    credential_files_applied_at: datetime | None,
+    credential_process_applied_at: datetime | None,
+    revisions: CredentialRevisionPlan,
+) -> CredentialFreshnessDecision:
+    assume_legacy_current = not revisions.missing_credentials
+    files_current = revision_is_current(
+        applied_revision=files_applied_revision,
+        desired_revision=revisions.files_revision,
+        assume_legacy_current=assume_legacy_current,
+        runtime_status=runtime_status,
+        active_sandbox_id=active_sandbox_id,
+    )
+    process_current = revision_is_current(
+        applied_revision=process_applied_revision,
+        desired_revision=revisions.process_revision,
+        assume_legacy_current=assume_legacy_current,
+        runtime_status=runtime_status,
+        active_sandbox_id=active_sandbox_id,
+    )
+    requires_restart = not process_current
+    if files_current and process_current:
+        status: CredentialFreshnessStatus = (
+            "missing_credentials" if revisions.missing_credentials else "current"
+        )
+    elif credential_last_error:
+        status = "apply_failed"
+    elif requires_restart:
+        status = "restart_required"
+    else:
+        status = "stale"
+    return CredentialFreshnessDecision(
+        status=status,
+        files_current=files_current,
+        process_current=process_current,
+        requires_restart=requires_restart,
+        last_error=credential_last_error,
+        last_error_at=credential_last_error_at,
+        files_applied_at=credential_files_applied_at,
+        process_applied_at=credential_process_applied_at,
+    )
+
+
+def revision_is_current(
+    *,
+    applied_revision: str | None,
+    desired_revision: str,
+    assume_legacy_current: bool,
+    runtime_status: str,
+    active_sandbox_id: object | None,
+) -> bool:
+    if applied_revision == desired_revision:
+        return True
+    return (
+        applied_revision is None
+        and assume_legacy_current
+        and runtime_status == CloudRuntimeEnvironmentStatus.running.value
+        and active_sandbox_id is not None
+    )
+
+
+def credential_apply_is_already_current(
+    decision: CredentialFreshnessLike,
+    revisions: CredentialRevisionPlan,
+) -> bool:
+    return decision.status == "current" or (
+        revisions.missing_credentials and decision.files_current and decision.process_current
+    )
+
+
+def decide_process_credential_restart(
+    *,
+    requires_restart: bool,
+    allow_process_restart: bool,
+    runtime_has_live_sessions: bool,
+) -> CredentialProcessRestartDecision:
+    if not requires_restart:
+        return CredentialProcessRestartDecision(allowed=False, reason="not_required")
+    if not allow_process_restart:
+        return CredentialProcessRestartDecision(allowed=False, reason="restart_disallowed")
+    if runtime_has_live_sessions:
+        return CredentialProcessRestartDecision(allowed=False, reason="live_sessions")
+    return CredentialProcessRestartDecision(allowed=True, reason="allowed")
+
+
+def _revision_for(
+    records: Iterable[CredentialRecordForRevision],
+    auth_mode: str,
+    prefix: str,
+) -> str:
+    parts = sorted(
+        f"{record.provider}:{record.auth_mode}:{record.payload_format}:{record.id}"
+        for record in records
+        if record.auth_mode == auth_mode
+    )
+    if not parts:
+        return EMPTY_FILES_REVISION if auth_mode == "file" else EMPTY_PROCESS_REVISION
+    return f"{prefix}:v1:{','.join(parts)}"

--- a/server/proliferate/server/cloud/runtime/domain/credential_revision.py
+++ b/server/proliferate/server/cloud/runtime/domain/credential_revision.py
@@ -74,9 +74,7 @@ def filter_active_supported_credentials[CredentialRecordT: CredentialRecordForRe
 ) -> list[CredentialRecordT]:
     supported = frozenset(supported_providers)
     return [
-        record
-        for record in records
-        if record.provider in supported and record.revoked_at is None
+        record for record in records if record.provider in supported and record.revoked_at is None
     ]
 
 

--- a/server/proliferate/server/cloud/runtime/domain/provider_events.py
+++ b/server/proliferate/server/cloud/runtime/domain/provider_events.py
@@ -1,0 +1,32 @@
+"""Pure provider lifecycle event classification."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from proliferate.constants.billing import PROVIDER_EVENT_KIND_PRECEDENCE
+
+
+def provider_event_kind(event_type: str) -> str | None:
+    suffix = event_type.removeprefix("sandbox.lifecycle.")
+    if suffix in PROVIDER_EVENT_KIND_PRECEDENCE:
+        return suffix
+    return None
+
+
+def is_stale_provider_event(
+    *,
+    last_event_at: datetime | None,
+    last_event_kind: str | None,
+    incoming_event_at: datetime,
+    incoming_event_kind: str,
+) -> bool:
+    if last_event_at is None:
+        return False
+    if incoming_event_at < last_event_at:
+        return True
+    if incoming_event_at > last_event_at:
+        return False
+    return PROVIDER_EVENT_KIND_PRECEDENCE.get(
+        incoming_event_kind, 0
+    ) <= PROVIDER_EVENT_KIND_PRECEDENCE.get(last_event_kind or "", 0)

--- a/server/proliferate/server/cloud/runtime/domain/reconnect_policy.py
+++ b/server/proliferate/server/cloud/runtime/domain/reconnect_policy.py
@@ -1,0 +1,59 @@
+"""Pure reconnect policy for persistent runtime sandboxes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class SandboxReconnectAction(StrEnum):
+    connect = "connect"
+    resume = "resume"
+    unavailable = "unavailable"
+
+
+@dataclass(frozen=True)
+class HealthWaitConfig:
+    total_attempts: int
+    delay_seconds: float
+
+
+DEFAULT_ENDPOINT_HEALTH = HealthWaitConfig(total_attempts=4, delay_seconds=0.5)
+DEFAULT_RESTART_HEALTH = HealthWaitConfig(total_attempts=12, delay_seconds=0.5)
+DAYTONA_ENDPOINT_HEALTH = HealthWaitConfig(total_attempts=30, delay_seconds=1.0)
+DAYTONA_RESTART_HEALTH = HealthWaitConfig(total_attempts=45, delay_seconds=1.0)
+
+RUNNING_SANDBOX_STATES = frozenset({"running", "started"})
+RESUMABLE_SANDBOX_STATES = frozenset({"paused", "stopped"})
+
+
+def endpoint_health_wait_config(provider_kind: object) -> HealthWaitConfig:
+    if _normalized_provider_kind(provider_kind) == "daytona":
+        return DAYTONA_ENDPOINT_HEALTH
+    return DEFAULT_ENDPOINT_HEALTH
+
+
+def restart_health_wait_config(provider_kind: object) -> HealthWaitConfig:
+    if _normalized_provider_kind(provider_kind) == "daytona":
+        return DAYTONA_RESTART_HEALTH
+    return DEFAULT_RESTART_HEALTH
+
+
+def reconnect_action_for_sandbox_state(sandbox_state: str) -> SandboxReconnectAction:
+    normalized_state = sandbox_state.strip().lower()
+    if normalized_state in RUNNING_SANDBOX_STATES:
+        return SandboxReconnectAction.connect
+    if normalized_state in RESUMABLE_SANDBOX_STATES:
+        return SandboxReconnectAction.resume
+    return SandboxReconnectAction.unavailable
+
+
+def should_persist_rotated_runtime_url(
+    current_runtime_url: str | None,
+    resolved_runtime_url: str,
+) -> bool:
+    return resolved_runtime_url != current_runtime_url
+
+
+def _normalized_provider_kind(provider_kind: object) -> str:
+    return str(getattr(provider_kind, "value", provider_kind)).strip().lower()

--- a/server/proliferate/server/cloud/runtime/domain/runtime_state.py
+++ b/server/proliferate/server/cloud/runtime/domain/runtime_state.py
@@ -1,0 +1,98 @@
+"""Pure runtime environment state mutation rules."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from uuid import UUID
+
+from proliferate.constants.cloud import CloudRuntimeEnvironmentStatus
+
+RuntimeStateUpdate = dict[str, object]
+
+
+class RuntimeLifecycleChange(StrEnum):
+    url_rotated = "url_rotated"
+    process_relaunched = "process_relaunched"
+    token_rotated = "token_rotated"
+    provider_destroyed = "provider_destroyed"
+
+
+_GENERATION_CHANGING_EVENTS = frozenset(
+    {
+        RuntimeLifecycleChange.process_relaunched,
+        RuntimeLifecycleChange.token_rotated,
+        RuntimeLifecycleChange.provider_destroyed,
+    }
+)
+
+
+def runtime_generation_changes_for(change: RuntimeLifecycleChange) -> bool:
+    return change in _GENERATION_CHANGING_EVENTS
+
+
+def runtime_endpoint_rotated_update(runtime_url: str) -> RuntimeStateUpdate:
+    return {"runtime_url": runtime_url}
+
+
+def runtime_process_relaunched_update(runtime_url: str) -> RuntimeStateUpdate:
+    return {
+        "runtime_url": runtime_url,
+        "increment_runtime_generation": runtime_generation_changes_for(
+            RuntimeLifecycleChange.process_relaunched
+        ),
+    }
+
+
+def runtime_connected_sandbox_update(
+    *,
+    runtime_url: str,
+    active_sandbox_id: UUID,
+) -> RuntimeStateUpdate:
+    return {
+        "status": CloudRuntimeEnvironmentStatus.running.value,
+        "runtime_url": runtime_url,
+        "active_sandbox_id": active_sandbox_id,
+        "last_error": None,
+    }
+
+
+def runtime_ready_update(
+    *,
+    runtime_url: str,
+    runtime_token_ciphertext: str,
+    root_anyharness_workspace_id: str,
+    root_anyharness_repo_root_id: str,
+    launched_runtime: bool,
+    repo_env_applied_version: int,
+) -> RuntimeStateUpdate:
+    return {
+        "status": CloudRuntimeEnvironmentStatus.running.value,
+        "runtime_url": runtime_url,
+        "runtime_token_ciphertext": runtime_token_ciphertext,
+        "root_anyharness_workspace_id": root_anyharness_workspace_id,
+        "root_anyharness_repo_root_id": root_anyharness_repo_root_id,
+        "increment_runtime_generation": launched_runtime,
+        "repo_env_applied_version": repo_env_applied_version,
+        "last_error": None,
+    }
+
+
+def runtime_provider_running_update() -> RuntimeStateUpdate:
+    return {"status": CloudRuntimeEnvironmentStatus.running.value}
+
+
+def runtime_provider_paused_update() -> RuntimeStateUpdate:
+    return {"status": CloudRuntimeEnvironmentStatus.paused.value}
+
+
+def runtime_provider_destroyed_update() -> RuntimeStateUpdate:
+    return {
+        "status": CloudRuntimeEnvironmentStatus.error.value,
+        "runtime_url": None,
+        "runtime_token_ciphertext": None,
+        "active_sandbox_id": None,
+        "increment_runtime_generation": runtime_generation_changes_for(
+            RuntimeLifecycleChange.provider_destroyed
+        ),
+        "last_error": "Provider reported sandbox killed.",
+    }

--- a/server/proliferate/server/cloud/runtime/ensure_running.py
+++ b/server/proliferate/server/cloud/runtime/ensure_running.py
@@ -16,13 +16,23 @@ from proliferate.db.store.cloud_workspaces import (
 from proliferate.integrations.anyharness import CloudRuntimeReconnectError
 from proliferate.integrations.sandbox import (
     SandboxProvider,
-    SandboxProviderKind,
     SandboxRuntimeContext,
     get_sandbox_provider,
 )
 from proliferate.server.cloud.runtime.anyharness_api import (
     verify_runtime_auth_enforced,
     wait_for_runtime_health,
+)
+from proliferate.server.cloud.runtime.domain.reconnect_policy import (
+    SandboxReconnectAction,
+    endpoint_health_wait_config,
+    reconnect_action_for_sandbox_state,
+    restart_health_wait_config,
+    should_persist_rotated_runtime_url,
+)
+from proliferate.server.cloud.runtime.domain.runtime_state import (
+    runtime_endpoint_rotated_update,
+    runtime_process_relaunched_update,
 )
 from proliferate.server.cloud.runtime.sandbox_exec import (
     build_detached_runtime_launch_command,
@@ -34,16 +44,6 @@ from proliferate.server.cloud.runtime.sandbox_exec import (
     runtime_launcher_path,
 )
 
-_DEFAULT_ENDPOINT_HEALTH_ATTEMPTS = 4
-_DEFAULT_ENDPOINT_HEALTH_DELAY_SECONDS = 0.5
-_DEFAULT_RESTART_HEALTH_ATTEMPTS = 12
-_DEFAULT_RESTART_HEALTH_DELAY_SECONDS = 0.5
-_DAYTONA_ENDPOINT_HEALTH_ATTEMPTS = 30
-_DAYTONA_ENDPOINT_HEALTH_DELAY_SECONDS = 1.0
-_DAYTONA_RESTART_HEALTH_ATTEMPTS = 45
-_DAYTONA_RESTART_HEALTH_DELAY_SECONDS = 1.0
-_RUNNING_SANDBOX_STATES = frozenset({"running", "started"})
-_RESUMABLE_SANDBOX_STATES = frozenset({"paused", "stopped"})
 _ANYHARNESS_DEFER_STARTUP_RETENTION_ENV = "ANYHARNESS_DEFER_STARTUP_RETENTION"
 
 
@@ -123,22 +123,6 @@ async def _relaunch_runtime(
         raise CloudRuntimeReconnectError(f"Cloud runtime relaunch failed: {stderr.strip()[:400]}")
 
 
-def _is_daytona_provider(provider_kind: str | SandboxProviderKind) -> bool:
-    return provider_kind == SandboxProviderKind.daytona or provider_kind == "daytona"
-
-
-def _endpoint_health_wait_config(provider_kind: str | SandboxProviderKind) -> tuple[int, float]:
-    if _is_daytona_provider(provider_kind):
-        return _DAYTONA_ENDPOINT_HEALTH_ATTEMPTS, _DAYTONA_ENDPOINT_HEALTH_DELAY_SECONDS
-    return _DEFAULT_ENDPOINT_HEALTH_ATTEMPTS, _DEFAULT_ENDPOINT_HEALTH_DELAY_SECONDS
-
-
-def _restart_health_wait_config(provider_kind: str | SandboxProviderKind) -> tuple[int, float]:
-    if _is_daytona_provider(provider_kind):
-        return _DAYTONA_RESTART_HEALTH_ATTEMPTS, _DAYTONA_RESTART_HEALTH_DELAY_SECONDS
-    return _DEFAULT_RESTART_HEALTH_ATTEMPTS, _DEFAULT_RESTART_HEALTH_DELAY_SECONDS
-
-
 async def _runtime_is_ready(
     runtime_url: str,
     *,
@@ -170,8 +154,8 @@ async def _connect_or_resume_sandbox(
     sandbox_id: str,
     sandbox_state: str,
 ) -> object:
-    normalized_state = sandbox_state.strip().lower()
-    if normalized_state in _RUNNING_SANDBOX_STATES:
+    reconnect_action = reconnect_action_for_sandbox_state(sandbox_state)
+    if reconnect_action == SandboxReconnectAction.connect:
         try:
             return await provider.connect_running_sandbox(
                 sandbox_id,
@@ -180,7 +164,7 @@ async def _connect_or_resume_sandbox(
         except Exception as exc:
             raise CloudRuntimeReconnectError("Failed to reconnect to the cloud sandbox.") from exc
 
-    if normalized_state in _RESUMABLE_SANDBOX_STATES:
+    if reconnect_action == SandboxReconnectAction.resume:
         try:
             return await provider.resume_sandbox(
                 sandbox_id,
@@ -233,17 +217,17 @@ async def ensure_workspace_runtime_ready(
     # Daytona preview URLs are signed and may rotate even while the same
     # sandbox and AnyHarness process remain healthy. Probe the fresh endpoint
     # before deciding that the runtime itself needs a restart.
-    endpoint_probe_attempts, endpoint_probe_delay_seconds = _endpoint_health_wait_config(
+    endpoint_probe = endpoint_health_wait_config(
         sandbox_record.provider,
     )
     if await _runtime_is_ready(
         endpoint.runtime_url,
         workspace_id=workspace.id,
         access_token=access_token,
-        total_attempts=endpoint_probe_attempts,
-        delay_seconds=endpoint_probe_delay_seconds,
+        total_attempts=endpoint_probe.total_attempts,
+        delay_seconds=endpoint_probe.delay_seconds,
     ):
-        if endpoint.runtime_url != workspace.runtime_url:
+        if should_persist_rotated_runtime_url(workspace.runtime_url, endpoint.runtime_url):
             await persist_runtime_reconnect_state_for_workspace(
                 workspace,
                 sandbox_record,
@@ -266,7 +250,7 @@ async def ensure_workspace_runtime_ready(
         workspace.id,
     )
     await _relaunch_runtime(provider, sandbox, runtime_context, workspace.id)
-    restart_probe_attempts, restart_probe_delay_seconds = _restart_health_wait_config(
+    restart_probe = restart_health_wait_config(
         sandbox_record.provider,
     )
     try:
@@ -274,8 +258,8 @@ async def ensure_workspace_runtime_ready(
             endpoint.runtime_url,
             workspace_id=workspace.id,
             required_successes=1,
-            total_attempts=restart_probe_attempts,
-            delay_seconds=restart_probe_delay_seconds,
+            total_attempts=restart_probe.total_attempts,
+            delay_seconds=restart_probe.delay_seconds,
         )
     except CloudRuntimeReconnectError:
         debug_report = await collect_runtime_debug_report(
@@ -343,20 +327,20 @@ async def ensure_environment_runtime_ready(
     )
 
     endpoint = await provider.resolve_runtime_endpoint(sandbox)
-    endpoint_probe_attempts, endpoint_probe_delay_seconds = _endpoint_health_wait_config(
+    endpoint_probe = endpoint_health_wait_config(
         sandbox_record.provider,
     )
     if await _runtime_is_ready(
         endpoint.runtime_url,
         workspace_id=workspace_id,
         access_token=access_token,
-        total_attempts=endpoint_probe_attempts,
-        delay_seconds=endpoint_probe_delay_seconds,
+        total_attempts=endpoint_probe.total_attempts,
+        delay_seconds=endpoint_probe.delay_seconds,
     ):
-        if endpoint.runtime_url != environment.runtime_url:
+        if should_persist_rotated_runtime_url(environment.runtime_url, endpoint.runtime_url):
             await save_runtime_environment_state(
                 environment.id,
-                runtime_url=endpoint.runtime_url,
+                **runtime_endpoint_rotated_update(endpoint.runtime_url),
             )
         return endpoint.runtime_url
 
@@ -371,7 +355,7 @@ async def ensure_environment_runtime_ready(
         workspace_id,
     )
     await _relaunch_runtime(provider, sandbox, runtime_context, workspace_id)
-    restart_probe_attempts, restart_probe_delay_seconds = _restart_health_wait_config(
+    restart_probe = restart_health_wait_config(
         sandbox_record.provider,
     )
     try:
@@ -379,8 +363,8 @@ async def ensure_environment_runtime_ready(
             endpoint.runtime_url,
             workspace_id=workspace_id,
             required_successes=1,
-            total_attempts=restart_probe_attempts,
-            delay_seconds=restart_probe_delay_seconds,
+            total_attempts=restart_probe.total_attempts,
+            delay_seconds=restart_probe.delay_seconds,
         )
     except CloudRuntimeReconnectError:
         debug_report = await collect_runtime_debug_report(
@@ -402,7 +386,6 @@ async def ensure_environment_runtime_ready(
     )
     await save_runtime_environment_state(
         environment.id,
-        runtime_url=endpoint.runtime_url,
-        increment_runtime_generation=True,
+        **runtime_process_relaunched_update(endpoint.runtime_url),
     )
     return endpoint.runtime_url

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -14,10 +14,7 @@ from proliferate.constants.billing import (
     USAGE_SEGMENT_CLOSED_BY_PROVISION_FAILURE,
     USAGE_SEGMENT_OPENED_BY_PROVISION,
 )
-from proliferate.constants.cloud import (
-    CloudRuntimeEnvironmentStatus,
-    CloudWorkspaceStatus,
-)
+from proliferate.constants.cloud import CloudWorkspaceStatus
 from proliferate.constants.cloud import (
     WorkspaceStatus as LegacyWorkspaceStatus,
 )
@@ -76,6 +73,14 @@ from proliferate.server.cloud.runtime.credentials import (
     write_credential_files,
 )
 from proliferate.server.cloud.runtime.data_key import generate_anyharness_data_key
+from proliferate.server.cloud.runtime.domain.reconnect_policy import (
+    SandboxReconnectAction,
+    reconnect_action_for_sandbox_state,
+)
+from proliferate.server.cloud.runtime.domain.runtime_state import (
+    runtime_connected_sandbox_update,
+    runtime_ready_update,
+)
 from proliferate.server.cloud.runtime.git_operations import (
     checkout_cloud_branch,
     clone_repository,
@@ -366,13 +371,14 @@ async def _connect_existing_environment_sandbox(
             tracker.complete(reused_sandbox=False, reason="provider_state_missing")
             return None
 
-        state = provider_state.state.strip().lower()
-        if state in {"running", "started"}:
+        observed_state = provider_state.state.strip().lower()
+        reconnect_action = reconnect_action_for_sandbox_state(observed_state)
+        if reconnect_action == SandboxReconnectAction.connect:
             sandbox = await provider.connect_running_sandbox(sandbox_record.external_sandbox_id)
-        elif state in {"paused", "stopped"}:
+        elif reconnect_action == SandboxReconnectAction.resume:
             sandbox = await provider.resume_sandbox(sandbox_record.external_sandbox_id)
         else:
-            tracker.complete(reused_sandbox=False, provider_state=state)
+            tracker.complete(reused_sandbox=False, provider_state=observed_state)
             return None
 
         runtime_context = await provider.resolve_runtime_context(sandbox)
@@ -397,10 +403,10 @@ async def _connect_existing_environment_sandbox(
     )
     await save_runtime_environment_state(
         ctx.runtime_environment_id,
-        status=CloudRuntimeEnvironmentStatus.running.value,
-        runtime_url=endpoint.runtime_url,
-        active_sandbox_id=sandbox_record.id,
-        last_error=None,
+        **runtime_connected_sandbox_update(
+            runtime_url=endpoint.runtime_url,
+            active_sandbox_id=sandbox_record.id,
+        ),
     )
     tracker.complete(runtime_url=endpoint.runtime_url, reused_sandbox=True)
 
@@ -970,16 +976,14 @@ async def provision_workspace(
             anyharness_workspace_id=handshake.anyharness_workspace_id,
             template_version=connected.handle.template_version,
         )
-        runtime_state_updates: dict[str, object] = {
-            "status": CloudRuntimeEnvironmentStatus.running.value,
-            "runtime_url": connected.endpoint.runtime_url,
-            "runtime_token_ciphertext": encrypt_text(handshake.runtime_token),
-            "root_anyharness_workspace_id": handshake.root_anyharness_workspace_id,
-            "root_anyharness_repo_root_id": handshake.anyharness_repo_root_id,
-            "increment_runtime_generation": launched_runtime_this_attempt,
-            "repo_env_applied_version": ctx.repo_env_version,
-            "last_error": None,
-        }
+        runtime_state_updates = runtime_ready_update(
+            runtime_url=connected.endpoint.runtime_url,
+            runtime_token_ciphertext=encrypt_text(handshake.runtime_token),
+            root_anyharness_workspace_id=handshake.root_anyharness_workspace_id,
+            root_anyharness_repo_root_id=handshake.anyharness_repo_root_id,
+            launched_runtime=launched_runtime_this_attempt,
+            repo_env_applied_version=ctx.repo_env_version,
+        )
         if launched_runtime_this_attempt:
             runtime_state_updates.update(
                 {

--- a/server/proliferate/server/cloud/webhooks/service.py
+++ b/server/proliferate/server/cloud/webhooks/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from uuid import UUID
 
 from proliferate.constants.billing import (
@@ -8,7 +7,6 @@ from proliferate.constants.billing import (
     PROVIDER_EVENT_KIND_CREATED,
     PROVIDER_EVENT_KIND_KILLED,
     PROVIDER_EVENT_KIND_PAUSED,
-    PROVIDER_EVENT_KIND_PRECEDENCE,
     PROVIDER_EVENT_KIND_RESUMED,
     USAGE_SEGMENT_CLOSED_BY_QUOTA_ENFORCEMENT,
     USAGE_SEGMENT_CLOSED_BY_WEBHOOK_KILLED,
@@ -16,7 +14,6 @@ from proliferate.constants.billing import (
     USAGE_SEGMENT_OPENED_BY_PROVISION,
     USAGE_SEGMENT_OPENED_BY_WEBHOOK_RESUMED,
 )
-from proliferate.constants.cloud import CloudRuntimeEnvironmentStatus
 from proliferate.db.store.billing import (
     close_usage_segment_for_sandbox,
     open_usage_segment_for_sandbox,
@@ -39,6 +36,17 @@ from proliferate.integrations.sandbox import (
 )
 from proliferate.server.billing.service import get_billing_snapshot_for_subject
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.runtime.domain.provider_events import (
+    is_stale_provider_event as _is_stale_provider_event,
+)
+from proliferate.server.cloud.runtime.domain.provider_events import (
+    provider_event_kind as _provider_event_kind,
+)
+from proliferate.server.cloud.runtime.domain.runtime_state import (
+    runtime_provider_destroyed_update,
+    runtime_provider_paused_update,
+    runtime_provider_running_update,
+)
 from proliferate.server.cloud.webhooks.models import E2BWebhookEvent, E2BWebhookReceipt
 
 _E2B_WEBHOOK_ERROR_RESPONSE = {
@@ -58,31 +66,6 @@ def _verify_e2b_signature(raw_body: bytes, signature: str | None) -> None:
             exc.message,
             status_code=status_code,
         ) from exc
-
-
-def _provider_event_kind(event_type: str) -> str | None:
-    suffix = event_type.removeprefix("sandbox.lifecycle.")
-    if suffix in PROVIDER_EVENT_KIND_PRECEDENCE:
-        return suffix
-    return None
-
-
-def _is_stale_provider_event(
-    *,
-    last_event_at: datetime | None,
-    last_event_kind: str | None,
-    incoming_event_at: datetime,
-    incoming_event_kind: str,
-) -> bool:
-    if last_event_at is None:
-        return False
-    if incoming_event_at < last_event_at:
-        return True
-    if incoming_event_at > last_event_at:
-        return False
-    return PROVIDER_EVENT_KIND_PRECEDENCE.get(
-        incoming_event_kind, 0
-    ) <= PROVIDER_EVENT_KIND_PRECEDENCE.get(last_event_kind or "", 0)
 
 
 def _metadata_sandbox_id(metadata: dict[str, str]) -> UUID | None:
@@ -180,7 +163,7 @@ async def handle_e2b_webhook(
             if runtime_environment is not None:
                 await save_runtime_environment_state(
                     runtime_environment.id,
-                    status=CloudRuntimeEnvironmentStatus.paused.value,
+                    **runtime_provider_paused_update(),
                 )
             return E2BWebhookReceipt()
 
@@ -216,7 +199,7 @@ async def handle_e2b_webhook(
         if runtime_environment is not None:
             await save_runtime_environment_state(
                 runtime_environment.id,
-                status=CloudRuntimeEnvironmentStatus.running.value,
+                **runtime_provider_running_update(),
             )
         return E2BWebhookReceipt()
 
@@ -237,7 +220,7 @@ async def handle_e2b_webhook(
         if runtime_environment is not None:
             await save_runtime_environment_state(
                 runtime_environment.id,
-                status=CloudRuntimeEnvironmentStatus.paused.value,
+                **runtime_provider_paused_update(),
             )
         return E2BWebhookReceipt()
 
@@ -258,12 +241,7 @@ async def handle_e2b_webhook(
         if runtime_environment is not None:
             await save_runtime_environment_state(
                 runtime_environment.id,
-                status=CloudRuntimeEnvironmentStatus.error.value,
-                runtime_url=None,
-                runtime_token_ciphertext=None,
-                active_sandbox_id=None,
-                increment_runtime_generation=True,
-                last_error="Provider reported sandbox killed.",
+                **runtime_provider_destroyed_update(),
             )
         return E2BWebhookReceipt()
 

--- a/server/tests/unit/test_cloud_runtime_domain.py
+++ b/server/tests/unit/test_cloud_runtime_domain.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+from proliferate.server.cloud.runtime.domain.credential_revision import (
+    EMPTY_FILES_REVISION,
+    EMPTY_PROCESS_REVISION,
+    CredentialRevisionPlan,
+    build_credential_revision_plan,
+    classify_credential_freshness,
+    decide_process_credential_restart,
+)
+from proliferate.server.cloud.runtime.domain.provider_events import (
+    is_stale_provider_event,
+    provider_event_kind,
+)
+from proliferate.server.cloud.runtime.domain.reconnect_policy import (
+    SandboxReconnectAction,
+    endpoint_health_wait_config,
+    reconnect_action_for_sandbox_state,
+    restart_health_wait_config,
+    should_persist_rotated_runtime_url,
+)
+from proliferate.server.cloud.runtime.domain.runtime_state import (
+    RuntimeLifecycleChange,
+    runtime_endpoint_rotated_update,
+    runtime_generation_changes_for,
+    runtime_process_relaunched_update,
+    runtime_provider_destroyed_update,
+)
+
+
+def test_credential_revision_plan_filters_supported_active_credentials() -> None:
+    file_id = uuid4()
+    process_id = uuid4()
+    revoked_id = uuid4()
+    unsupported_id = uuid4()
+    records = [
+        SimpleNamespace(
+            id=file_id,
+            provider="codex",
+            auth_mode="file",
+            payload_format="json-v1",
+            revoked_at=None,
+        ),
+        SimpleNamespace(
+            id=process_id,
+            provider="claude",
+            auth_mode="env",
+            payload_format="json-v1",
+            revoked_at=None,
+        ),
+        SimpleNamespace(
+            id=revoked_id,
+            provider="gemini",
+            auth_mode="env",
+            payload_format="json-v1",
+            revoked_at=datetime.now(UTC),
+        ),
+        SimpleNamespace(
+            id=unsupported_id,
+            provider="other",
+            auth_mode="env",
+            payload_format="json-v1",
+            revoked_at=None,
+        ),
+    ]
+
+    plan = build_credential_revision_plan(records)
+
+    assert plan.missing_credentials is False
+    assert str(file_id) in plan.files_revision
+    assert str(process_id) in plan.process_revision
+    assert str(revoked_id) not in plan.process_revision
+    assert str(unsupported_id) not in plan.process_revision
+
+
+def test_credential_revision_plan_uses_empty_revisions_when_no_credentials() -> None:
+    plan = build_credential_revision_plan([])
+
+    assert plan.files_revision == EMPTY_FILES_REVISION
+    assert plan.process_revision == EMPTY_PROCESS_REVISION
+    assert plan.missing_credentials is True
+
+
+def test_credential_freshness_treats_legacy_running_runtime_as_current() -> None:
+    decision = classify_credential_freshness(
+        runtime_status="running",
+        active_sandbox_id=uuid4(),
+        files_applied_revision=None,
+        process_applied_revision=None,
+        credential_last_error=None,
+        credential_last_error_at=None,
+        credential_files_applied_at=None,
+        credential_process_applied_at=None,
+        revisions=CredentialRevisionPlan(
+            files_revision="credential-files:v1:file",
+            process_revision="credential-process:v1:process",
+            missing_credentials=False,
+        ),
+    )
+
+    assert decision.status == "current"
+    assert decision.files_current is True
+    assert decision.process_current is True
+    assert decision.requires_restart is False
+
+
+def test_credential_freshness_prioritizes_apply_failure_before_restart() -> None:
+    decision = classify_credential_freshness(
+        runtime_status="running",
+        active_sandbox_id=uuid4(),
+        files_applied_revision="credential-files:v1:old",
+        process_applied_revision="credential-process:v1:old",
+        credential_last_error="sanitized",
+        credential_last_error_at=None,
+        credential_files_applied_at=None,
+        credential_process_applied_at=None,
+        revisions=CredentialRevisionPlan(
+            files_revision="credential-files:v1:new",
+            process_revision="credential-process:v1:new",
+            missing_credentials=False,
+        ),
+    )
+
+    assert decision.status == "apply_failed"
+    assert decision.requires_restart is True
+
+
+def test_process_credential_restart_decision_blocks_disallowed_and_live_sessions() -> None:
+    assert (
+        decide_process_credential_restart(
+            requires_restart=False,
+            allow_process_restart=True,
+            runtime_has_live_sessions=False,
+        ).reason
+        == "not_required"
+    )
+    assert (
+        decide_process_credential_restart(
+            requires_restart=True,
+            allow_process_restart=False,
+            runtime_has_live_sessions=False,
+        ).reason
+        == "restart_disallowed"
+    )
+    assert (
+        decide_process_credential_restart(
+            requires_restart=True,
+            allow_process_restart=True,
+            runtime_has_live_sessions=True,
+        ).reason
+        == "live_sessions"
+    )
+    assert (
+        decide_process_credential_restart(
+            requires_restart=True,
+            allow_process_restart=True,
+            runtime_has_live_sessions=False,
+        ).allowed
+        is True
+    )
+
+
+def test_reconnect_policy_classifies_sandbox_state_and_provider_waits() -> None:
+    assert reconnect_action_for_sandbox_state(" Running ") == SandboxReconnectAction.connect
+    assert reconnect_action_for_sandbox_state("stopped") == SandboxReconnectAction.resume
+    assert reconnect_action_for_sandbox_state("destroyed") == SandboxReconnectAction.unavailable
+
+    assert endpoint_health_wait_config("daytona").total_attempts == 30
+    assert endpoint_health_wait_config("e2b").total_attempts == 4
+    assert restart_health_wait_config(SimpleNamespace(value="daytona")).total_attempts == 45
+    assert restart_health_wait_config("e2b").total_attempts == 12
+
+    assert should_persist_rotated_runtime_url("https://old.invalid", "https://new.invalid")
+    assert not should_persist_rotated_runtime_url(
+        "https://runtime.invalid",
+        "https://runtime.invalid",
+    )
+
+
+def test_runtime_generation_updates_distinguish_url_rotation_from_identity_change() -> None:
+    assert runtime_generation_changes_for(RuntimeLifecycleChange.url_rotated) is False
+    assert runtime_generation_changes_for(RuntimeLifecycleChange.process_relaunched) is True
+    assert runtime_generation_changes_for(RuntimeLifecycleChange.provider_destroyed) is True
+
+    assert runtime_endpoint_rotated_update("https://fresh.invalid") == {
+        "runtime_url": "https://fresh.invalid",
+    }
+    assert runtime_process_relaunched_update("https://fresh.invalid") == {
+        "runtime_url": "https://fresh.invalid",
+        "increment_runtime_generation": True,
+    }
+    assert runtime_provider_destroyed_update() == {
+        "status": "error",
+        "runtime_url": None,
+        "runtime_token_ciphertext": None,
+        "active_sandbox_id": None,
+        "increment_runtime_generation": True,
+        "last_error": "Provider reported sandbox killed.",
+    }
+
+
+def test_provider_event_classification_and_stale_precedence() -> None:
+    event_time = datetime.now(UTC)
+
+    assert provider_event_kind("sandbox.lifecycle.killed") == "killed"
+    assert provider_event_kind("sandbox.lifecycle.ignored") is None
+    assert provider_event_kind("other.event") is None
+    assert is_stale_provider_event(
+        last_event_at=event_time,
+        last_event_kind="paused",
+        incoming_event_at=event_time - timedelta(seconds=1),
+        incoming_event_kind="killed",
+    )
+    assert not is_stale_provider_event(
+        last_event_at=event_time,
+        last_event_kind="paused",
+        incoming_event_at=event_time,
+        incoming_event_kind="killed",
+    )
+    assert is_stale_provider_event(
+        last_event_at=event_time,
+        last_event_kind="killed",
+        incoming_event_at=event_time,
+        incoming_event_kind="paused",
+    )


### PR DESCRIPTION
## Summary

Phase 8 Wave 2, Lane 2D: Cloud Runtime Lifecycle.

- Extracted pure runtime decision helpers under `server/proliferate/server/cloud/runtime/domain/`.
- Moved credential revision/freshness decisions, reconnect policy, runtime state update planning, and provider event classification out of orchestration code.
- Rewired credential freshness, reconnect/provision reuse, and E2B webhook runtime updates to call the pure helpers without changing DB/session ownership or checkpoint boundaries.

## Invariants

- URL rotation does not increment runtime generation.
- Runtime process relaunch and provider destroyed/killed transitions increment generation.
- Provider killed events still clear runtime URL/token/active sandbox and mark the runtime error.
- Process credential restarts remain blocked when AnyHarness reports live sessions.
- Provider webhook event kind classification and stale-event precedence stay unchanged.

## Not Included

- No checkpoint service implementation.
- No DB threading changes.
- No store wrapper deletion.
- No provisioning transaction changes.

## Verification

- `DEBUG=1 uv run --python /opt/homebrew/bin/python3.12 --extra dev pytest -q tests/unit/test_cloud_runtime_domain.py tests/unit/test_cloud_runtime_credential_freshness.py tests/unit/test_cloud_runtime_ensure_running.py tests/unit/test_cloud_runtime_environment_store.py tests/unit/test_cloud_runtime_provision.py tests/unit/test_cloud_webhook_service.py` (`55 passed`)
- `DEBUG=1 uv run --python /opt/homebrew/bin/python3.12 --extra dev ruff check proliferate/server/cloud/runtime/domain/credential_revision.py proliferate/server/cloud/runtime/domain/provider_events.py proliferate/server/cloud/runtime/domain/reconnect_policy.py proliferate/server/cloud/runtime/domain/runtime_state.py proliferate/server/cloud/runtime/credential_freshness.py proliferate/server/cloud/runtime/ensure_running.py proliferate/server/cloud/runtime/provision.py proliferate/server/cloud/webhooks/service.py tests/unit/test_cloud_runtime_domain.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`