### PR TITLE
refactor(server): extract mobility lifecycle domain rules

### DIFF
--- a/server/proliferate/db/store/cloud_mobility.py
+++ b/server/proliferate/db/store/cloud_mobility.py
@@ -133,20 +133,21 @@ def _require_handoff_belongs_to_workspace(
     return mobility_workspace, handoff_op
 
 
-def _active_lifecycle_state(owner: str) -> str:
-    return "cloud_active" if owner == "cloud" else "local_active"
-
-
 def _clear_retryable_handoff_failure(
     record: CloudWorkspaceMobility,
     *,
     owner_hint: str,
+    active_lifecycle_state: str,
+    retryable_lifecycle_state: str,
 ) -> bool:
-    if record.lifecycle_state != "handoff_failed" or record.active_handoff_op_id is not None:
+    if (
+        record.lifecycle_state != retryable_lifecycle_state
+        or record.active_handoff_op_id is not None
+    ):
         return False
 
     record.owner = owner_hint
-    record.lifecycle_state = _active_lifecycle_state(owner_hint)
+    record.lifecycle_state = active_lifecycle_state
     record.status_detail = None
     record.last_error = None
     return True
@@ -246,15 +247,14 @@ async def get_active_user_handoff_op(
     db: AsyncSession,
     *,
     user_id: UUID,
+    final_handoff_phases: tuple[str, ...],
 ) -> CloudWorkspaceHandoffOp | None:
     return (
         await db.execute(
             select(CloudWorkspaceHandoffOp)
             .where(
                 CloudWorkspaceHandoffOp.user_id == user_id,
-                CloudWorkspaceHandoffOp.phase.not_in(
-                    ["completed", "handoff_failed"],
-                ),
+                CloudWorkspaceHandoffOp.phase.not_in(final_handoff_phases),
             )
             .order_by(CloudWorkspaceHandoffOp.created_at.desc())
         )
@@ -265,12 +265,13 @@ async def get_active_handoff_for_mobility(
     db: AsyncSession,
     *,
     mobility_workspace_id: UUID,
+    final_handoff_phases: tuple[str, ...],
 ) -> CloudWorkspaceHandoffOp | None:
     return (
         await db.execute(
             select(CloudWorkspaceHandoffOp).where(
                 CloudWorkspaceHandoffOp.mobility_workspace_id == mobility_workspace_id,
-                CloudWorkspaceHandoffOp.phase.not_in(["completed", "handoff_failed"]),
+                CloudWorkspaceHandoffOp.phase.not_in(final_handoff_phases),
             )
         )
     ).scalar_one_or_none()
@@ -285,6 +286,8 @@ async def ensure_cloud_workspace_mobility(
     git_repo_name: str,
     git_branch: str,
     owner_hint: str,
+    active_lifecycle_state: str,
+    retryable_lifecycle_state: str,
     display_name: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceMobilityValue:
@@ -306,7 +309,7 @@ async def ensure_cloud_workspace_mobility(
             git_repo_name=git_repo_name,
             git_branch=git_branch,
             owner=owner_hint,
-            lifecycle_state=_active_lifecycle_state(owner_hint),
+            lifecycle_state=active_lifecycle_state,
             status_detail=None,
             last_error=None,
             cloud_workspace_id=cloud_workspace_id,
@@ -322,7 +325,12 @@ async def ensure_cloud_workspace_mobility(
         await db.refresh(record)
         return _mobility_value(record)
 
-    changed = _clear_retryable_handoff_failure(record, owner_hint=owner_hint)
+    changed = _clear_retryable_handoff_failure(
+        record,
+        owner_hint=owner_hint,
+        active_lifecycle_state=active_lifecycle_state,
+        retryable_lifecycle_state=retryable_lifecycle_state,
+    )
     if display_name is not None and display_name != record.display_name:
         record.display_name = display_name
         changed = True
@@ -348,6 +356,8 @@ async def backfill_cloud_workspace_mobility_from_workspace(
     db: AsyncSession,
     *,
     workspace: CloudWorkspace,
+    active_lifecycle_state: str,
+    retryable_lifecycle_state: str,
 ) -> CloudWorkspaceMobilityValue:
     return await ensure_cloud_workspace_mobility(
         db,
@@ -357,6 +367,8 @@ async def backfill_cloud_workspace_mobility_from_workspace(
         git_repo_name=workspace.git_repo_name,
         git_branch=workspace.git_branch,
         owner_hint="cloud",
+        active_lifecycle_state=active_lifecycle_state,
+        retryable_lifecycle_state=retryable_lifecycle_state,
         display_name=workspace.display_name,
         cloud_workspace_id=workspace.id,
     )
@@ -369,6 +381,7 @@ async def create_cloud_workspace_handoff_op(
     direction: str,
     source_owner: str,
     target_owner: str,
+    moving_lifecycle_state: str,
     requested_branch: str,
     requested_base_sha: str | None,
     exclude_paths: list[str],
@@ -399,9 +412,7 @@ async def create_cloud_workspace_handoff_op(
     mobility_workspace.active_handoff_op_id = record.id
     mobility_workspace.last_handoff_op_id = record.id
     mobility_workspace.owner = source_owner
-    mobility_workspace.lifecycle_state = (
-        "moving_to_cloud" if target_owner == "cloud" else "moving_to_local"
-    )
+    mobility_workspace.lifecycle_state = moving_lifecycle_state
     mobility_workspace.status_detail = "Handoff started"
     mobility_workspace.last_error = None
     mobility_workspace.updated_at = now
@@ -506,20 +517,24 @@ async def fail_cloud_workspace_handoff_op(
     *,
     handoff_op: CloudWorkspaceHandoffOp,
     mobility_workspace: CloudWorkspaceMobility,
+    phase: str,
+    lifecycle_state: str,
     failure_code: str,
     failure_detail: str,
+    status_detail: str | None,
+    last_error: str,
 ) -> CloudWorkspaceHandoffOpValue:
     now = utcnow()
-    handoff_op.phase = "handoff_failed"
+    handoff_op.phase = phase
     handoff_op.failure_code = failure_code
     handoff_op.failure_detail = failure_detail
     handoff_op.heartbeat_at = now
     handoff_op.updated_at = now
 
     mobility_workspace.active_handoff_op_id = None
-    mobility_workspace.lifecycle_state = "handoff_failed"
-    mobility_workspace.status_detail = failure_detail[:255] if failure_detail else None
-    mobility_workspace.last_error = failure_detail[:2000]
+    mobility_workspace.lifecycle_state = lifecycle_state
+    mobility_workspace.status_detail = status_detail
+    mobility_workspace.last_error = last_error
     mobility_workspace.updated_at = now
 
     await db.commit()
@@ -578,6 +593,8 @@ async def ensure_cloud_workspace_mobility_for_user(
     git_repo_name: str,
     git_branch: str,
     owner_hint: str,
+    active_lifecycle_state: str,
+    retryable_lifecycle_state: str,
     display_name: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceMobilityValue:
@@ -590,6 +607,8 @@ async def ensure_cloud_workspace_mobility_for_user(
             git_repo_name=git_repo_name,
             git_branch=git_branch,
             owner_hint=owner_hint,
+            active_lifecycle_state=active_lifecycle_state,
+            retryable_lifecycle_state=retryable_lifecycle_state,
             display_name=display_name,
             cloud_workspace_id=cloud_workspace_id,
         )
@@ -598,17 +617,29 @@ async def ensure_cloud_workspace_mobility_for_user(
 async def backfill_cloud_workspace_mobility_for_workspace(
     *,
     workspace: CloudWorkspace,
+    active_lifecycle_state: str,
+    retryable_lifecycle_state: str,
 ) -> CloudWorkspaceMobilityValue:
     async with db_engine.async_session_factory() as db:
-        return await backfill_cloud_workspace_mobility_from_workspace(db, workspace=workspace)
+        return await backfill_cloud_workspace_mobility_from_workspace(
+            db,
+            workspace=workspace,
+            active_lifecycle_state=active_lifecycle_state,
+            retryable_lifecycle_state=retryable_lifecycle_state,
+        )
 
 
 async def load_active_user_handoff_op_for_user(
     *,
     user_id: UUID,
+    final_handoff_phases: tuple[str, ...],
 ) -> CloudWorkspaceHandoffOpValue | None:
     async with db_engine.async_session_factory() as db:
-        record = await get_active_user_handoff_op(db, user_id=user_id)
+        record = await get_active_user_handoff_op(
+            db,
+            user_id=user_id,
+            final_handoff_phases=final_handoff_phases,
+        )
         return _handoff_value(record) if record is not None else None
 
 
@@ -633,6 +664,8 @@ async def create_cloud_workspace_handoff_op_for_user(
     direction: str,
     source_owner: str,
     target_owner: str,
+    moving_lifecycle_state: str,
+    final_handoff_phases: tuple[str, ...],
     requested_branch: str,
     requested_base_sha: str | None,
     exclude_paths: list[str],
@@ -648,6 +681,7 @@ async def create_cloud_workspace_handoff_op_for_user(
         existing_handoff = await get_active_handoff_for_mobility(
             db,
             mobility_workspace_id=mobility_workspace_id,
+            final_handoff_phases=final_handoff_phases,
         )
         if existing_handoff is not None:
             raise ValueError("handoff already in progress for workspace")
@@ -657,6 +691,7 @@ async def create_cloud_workspace_handoff_op_for_user(
             direction=direction,
             source_owner=source_owner,
             target_owner=target_owner,
+            moving_lifecycle_state=moving_lifecycle_state,
             requested_branch=requested_branch,
             requested_base_sha=requested_base_sha,
             exclude_paths=exclude_paths,
@@ -776,8 +811,12 @@ async def fail_cloud_workspace_handoff_op_for_user(
     user_id: UUID,
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
+    phase: str,
+    lifecycle_state: str,
     failure_code: str,
     failure_detail: str,
+    status_detail: str | None,
+    last_error: str,
 ) -> CloudWorkspaceHandoffOpValue:
     async with db_engine.async_session_factory() as db:
         mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
@@ -796,8 +835,12 @@ async def fail_cloud_workspace_handoff_op_for_user(
             db,
             handoff_op=handoff_op,
             mobility_workspace=mobility_workspace,
+            phase=phase,
+            lifecycle_state=lifecycle_state,
             failure_code=failure_code,
             failure_detail=failure_detail,
+            status_detail=status_detail,
+            last_error=last_error,
         )
 
 
@@ -806,8 +849,13 @@ async def expire_stale_cloud_workspace_handoff_op_for_user(
     user_id: UUID,
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
+    phase: str,
+    lifecycle_state: str,
+    keep_active_handoff: bool,
     failure_code: str,
     failure_detail: str,
+    status_detail: str | None,
+    last_error: str,
 ) -> CloudWorkspaceHandoffOpValue:
     async with db_engine.async_session_factory() as db:
         mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
@@ -828,18 +876,16 @@ async def expire_stale_cloud_workspace_handoff_op_for_user(
         handoff_op.failure_detail = failure_detail
         handoff_op.heartbeat_at = now
         handoff_op.updated_at = now
-        mobility_workspace.status_detail = failure_detail[:255] if failure_detail else None
-        mobility_workspace.last_error = failure_detail[:2000]
+        mobility_workspace.status_detail = status_detail
+        mobility_workspace.last_error = last_error
         mobility_workspace.updated_at = now
 
-        if handoff_op.finalized_at is not None and handoff_op.cleanup_completed_at is None:
-            handoff_op.phase = "cleanup_failed"
-            mobility_workspace.lifecycle_state = "cleanup_failed"
+        handoff_op.phase = phase
+        mobility_workspace.lifecycle_state = lifecycle_state
+        if keep_active_handoff:
             mobility_workspace.active_handoff_op_id = handoff_op.id
         else:
-            handoff_op.phase = "handoff_failed"
             mobility_workspace.active_handoff_op_id = None
-            mobility_workspace.lifecycle_state = "handoff_failed"
 
         await db.commit()
         await db.refresh(handoff_op)

--- a/server/proliferate/server/cloud/mobility/domain/lifecycle.py
+++ b/server/proliferate/server/cloud/mobility/domain/lifecycle.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+OWNER_LOCAL = "local"
+OWNER_CLOUD = "cloud"
+VALID_OWNERS: frozenset[str] = frozenset({OWNER_LOCAL, OWNER_CLOUD})
+
+DIRECTION_LOCAL_TO_CLOUD = "local_to_cloud"
+DIRECTION_CLOUD_TO_LOCAL = "cloud_to_local"
+VALID_HANDOFF_DIRECTIONS: frozenset[str] = frozenset(
+    {DIRECTION_LOCAL_TO_CLOUD, DIRECTION_CLOUD_TO_LOCAL}
+)
+
+HANDOFF_PHASE_START_REQUESTED = "start_requested"
+HANDOFF_PHASE_SOURCE_FROZEN = "source_frozen"
+HANDOFF_PHASE_DESTINATION_READY = "destination_ready"
+HANDOFF_PHASE_INSTALL_SUCCEEDED = "install_succeeded"
+HANDOFF_PHASE_CLEANUP_PENDING = "cleanup_pending"
+HANDOFF_PHASE_CLEANUP_FAILED = "cleanup_failed"
+HANDOFF_PHASE_COMPLETED = "completed"
+HANDOFF_PHASE_HANDOFF_FAILED = "handoff_failed"
+VALID_HANDOFF_PHASES: frozenset[str] = frozenset(
+    {
+        HANDOFF_PHASE_START_REQUESTED,
+        HANDOFF_PHASE_SOURCE_FROZEN,
+        HANDOFF_PHASE_DESTINATION_READY,
+        HANDOFF_PHASE_INSTALL_SUCCEEDED,
+        HANDOFF_PHASE_CLEANUP_PENDING,
+        HANDOFF_PHASE_CLEANUP_FAILED,
+        HANDOFF_PHASE_COMPLETED,
+        HANDOFF_PHASE_HANDOFF_FAILED,
+    }
+)
+FINAL_HANDOFF_PHASES: tuple[str, ...] = (
+    HANDOFF_PHASE_COMPLETED,
+    HANDOFF_PHASE_HANDOFF_FAILED,
+)
+
+LIFECYCLE_LOCAL_ACTIVE = "local_active"
+LIFECYCLE_CLOUD_ACTIVE = "cloud_active"
+LIFECYCLE_MOVING_TO_CLOUD = "moving_to_cloud"
+LIFECYCLE_MOVING_TO_LOCAL = "moving_to_local"
+LIFECYCLE_HANDOFF_FAILED = "handoff_failed"
+LIFECYCLE_CLEANUP_FAILED = "cleanup_failed"
+
+STATUS_HANDOFF_STARTED = "Handoff started"
+STATUS_AWAITING_SOURCE_CLEANUP = "Awaiting source cleanup"
+STATUS_READY = "Ready"
+
+STALE_HANDOFF_FAILURE_CODE = "handoff_stale"
+STALE_HANDOFF_FAILURE_DETAIL = "Workspace mobility heartbeat expired."
+STALE_CLEANUP_FAILURE_CODE = "cleanup_stale"
+STALE_CLEANUP_FAILURE_DETAIL = "Workspace mobility cleanup heartbeat expired."
+FAILURE_STATUS_DETAIL_MAX_LENGTH = 255
+FAILURE_LAST_ERROR_MAX_LENGTH = 2000
+
+_OWNER_RULES_BY_DIRECTION = {
+    DIRECTION_LOCAL_TO_CLOUD: (OWNER_LOCAL, OWNER_CLOUD, "workspace is not currently local-owned"),
+    DIRECTION_CLOUD_TO_LOCAL: (OWNER_CLOUD, OWNER_LOCAL, "workspace is not currently cloud-owned"),
+}
+
+
+@dataclass(frozen=True)
+class HandoffOwnerRule:
+    required_owner: str
+    target_owner: str
+    mismatch_blocker: str
+
+
+@dataclass(frozen=True)
+class StaleHandoffOutcome:
+    phase: str
+    lifecycle_state: str
+    failure_code: str
+    failure_detail: str
+    keep_active_handoff: bool
+
+
+def is_valid_owner(owner: str) -> bool:
+    return owner in VALID_OWNERS
+
+
+def is_valid_handoff_direction(direction: str) -> bool:
+    return direction in VALID_HANDOFF_DIRECTIONS
+
+
+def is_local_to_cloud_direction(direction: str) -> bool:
+    return direction == DIRECTION_LOCAL_TO_CLOUD
+
+
+def is_valid_handoff_phase(phase: str) -> bool:
+    return phase in VALID_HANDOFF_PHASES
+
+
+def is_final_handoff_phase(phase: str) -> bool:
+    return phase in FINAL_HANDOFF_PHASES
+
+
+def is_active_handoff_phase(phase: str) -> bool:
+    return is_valid_handoff_phase(phase) and not is_final_handoff_phase(phase)
+
+
+def handoff_owner_rule(direction: str) -> HandoffOwnerRule:
+    try:
+        required_owner, target_owner, blocker = _OWNER_RULES_BY_DIRECTION[direction]
+    except KeyError as error:
+        raise ValueError("unsupported handoff direction") from error
+    return HandoffOwnerRule(
+        required_owner=required_owner,
+        target_owner=target_owner,
+        mismatch_blocker=blocker,
+    )
+
+
+def target_owner_for_direction(direction: str) -> str:
+    return handoff_owner_rule(direction).target_owner
+
+
+def owner_direction_blocker(*, owner: str, direction: str) -> str | None:
+    rule = handoff_owner_rule(direction)
+    if owner == rule.required_owner:
+        return None
+    return rule.mismatch_blocker
+
+
+def active_lifecycle_state(owner: str) -> str:
+    if owner == OWNER_CLOUD:
+        return LIFECYCLE_CLOUD_ACTIVE
+    if owner == OWNER_LOCAL:
+        return LIFECYCLE_LOCAL_ACTIVE
+    raise ValueError("unsupported mobility owner")
+
+
+def moving_lifecycle_state(target_owner: str) -> str:
+    if target_owner == OWNER_CLOUD:
+        return LIFECYCLE_MOVING_TO_CLOUD
+    if target_owner == OWNER_LOCAL:
+        return LIFECYCLE_MOVING_TO_LOCAL
+    raise ValueError("unsupported handoff target owner")
+
+
+def is_retryable_mobility_failure(
+    *,
+    lifecycle_state: str,
+    has_active_handoff: bool,
+) -> bool:
+    return lifecycle_state == LIFECYCLE_HANDOFF_FAILED and not has_active_handoff
+
+
+def stale_handoff_outcome(
+    *,
+    finalized_at: datetime | None,
+    cleanup_completed_at: datetime | None,
+) -> StaleHandoffOutcome:
+    if finalized_at is not None and cleanup_completed_at is None:
+        return StaleHandoffOutcome(
+            phase=HANDOFF_PHASE_CLEANUP_FAILED,
+            lifecycle_state=LIFECYCLE_CLEANUP_FAILED,
+            failure_code=STALE_CLEANUP_FAILURE_CODE,
+            failure_detail=STALE_CLEANUP_FAILURE_DETAIL,
+            keep_active_handoff=True,
+        )
+    return StaleHandoffOutcome(
+        phase=HANDOFF_PHASE_HANDOFF_FAILED,
+        lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        failure_code=STALE_HANDOFF_FAILURE_CODE,
+        failure_detail=STALE_HANDOFF_FAILURE_DETAIL,
+        keep_active_handoff=False,
+    )
+
+
+def visible_failure_status_detail(failure_detail: str) -> str | None:
+    return failure_detail[:FAILURE_STATUS_DETAIL_MAX_LENGTH] if failure_detail else None
+
+
+def visible_failure_last_error(failure_detail: str) -> str:
+    return failure_detail[:FAILURE_LAST_ERROR_MAX_LENGTH]

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -33,6 +33,23 @@ from proliferate.db.store.cloud_workspaces import (
 from proliferate.db.store.users import load_user_with_oauth_accounts_by_id
 from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    FINAL_HANDOFF_PHASES,
+    HANDOFF_PHASE_HANDOFF_FAILED,
+    LIFECYCLE_HANDOFF_FAILED,
+    OWNER_CLOUD,
+    active_lifecycle_state,
+    is_local_to_cloud_direction,
+    is_valid_handoff_direction,
+    is_valid_handoff_phase,
+    is_valid_owner,
+    moving_lifecycle_state,
+    owner_direction_blocker,
+    stale_handoff_outcome,
+    target_owner_for_direction,
+    visible_failure_last_error,
+    visible_failure_status_detail,
+)
 from proliferate.server.cloud.mobility.models import (
     WorkspaceMobilityPreflightResponse,
     mobility_workspace_detail_payload,
@@ -44,18 +61,6 @@ from proliferate.server.cloud.workspaces.service import (
 )
 from proliferate.utils.time import duration_ms, utcnow
 
-_VALID_HANDOFF_PHASES: frozenset[str] = frozenset(
-    {
-        "start_requested",
-        "source_frozen",
-        "destination_ready",
-        "install_succeeded",
-        "cleanup_pending",
-        "cleanup_failed",
-        "completed",
-        "handoff_failed",
-    }
-)
 _STALE_HANDOFF_AFTER = timedelta(seconds=120)
 _BRANCH_NOT_PUBLISHED_BLOCKER = "The branch '{branch}' was not found on GitHub."
 _BRANCH_HEAD_MISMATCH_BLOCKER = "The branch '{branch}' on GitHub is not at the requested commit."
@@ -68,22 +73,21 @@ async def expire_stale_cloud_workspace_handoffs_for_user(*, user_id: UUID) -> No
         active_handoff = workspace.active_handoff
         if active_handoff is None or active_handoff.heartbeat_at >= stale_before:
             continue
+        outcome = stale_handoff_outcome(
+            finalized_at=active_handoff.finalized_at,
+            cleanup_completed_at=active_handoff.cleanup_completed_at,
+        )
         await expire_stale_cloud_workspace_handoff_op_for_user(
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             handoff_op_id=active_handoff.id,
-            failure_code=(
-                "cleanup_stale"
-                if active_handoff.finalized_at is not None
-                and active_handoff.cleanup_completed_at is None
-                else "handoff_stale"
-            ),
-            failure_detail=(
-                "Workspace mobility cleanup heartbeat expired."
-                if active_handoff.finalized_at is not None
-                and active_handoff.cleanup_completed_at is None
-                else "Workspace mobility heartbeat expired."
-            ),
+            phase=outcome.phase,
+            lifecycle_state=outcome.lifecycle_state,
+            keep_active_handoff=outcome.keep_active_handoff,
+            failure_code=outcome.failure_code,
+            failure_detail=outcome.failure_detail,
+            status_detail=visible_failure_status_detail(outcome.failure_detail),
+            last_error=visible_failure_last_error(outcome.failure_detail),
         )
 
 
@@ -93,7 +97,11 @@ async def list_cloud_workspace_mobility_for_user(
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
     workspaces = await list_cloud_workspaces_store(user_id)
     for workspace in workspaces:
-        await backfill_cloud_workspace_mobility_for_workspace(workspace=workspace)
+        await backfill_cloud_workspace_mobility_for_workspace(
+            workspace=workspace,
+            active_lifecycle_state=active_lifecycle_state(OWNER_CLOUD),
+            retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        )
     return await list_cloud_workspace_mobility_store(user_id=user_id)
 
 
@@ -108,7 +116,7 @@ async def ensure_cloud_workspace_mobility(
     owner_hint: str,
 ) -> CloudWorkspaceMobilityValue:
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
-    if owner_hint not in {"local", "cloud"}:
+    if not is_valid_owner(owner_hint):
         raise CloudApiError(
             "invalid_owner_hint",
             "ownerHint must be either 'local' or 'cloud'.",
@@ -133,6 +141,8 @@ async def ensure_cloud_workspace_mobility(
         git_repo_name=git_repo_name,
         git_branch=git_branch,
         owner_hint=owner_hint,
+        active_lifecycle_state=active_lifecycle_state(owner_hint),
+        retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
         display_name=resolved_display_name,
         cloud_workspace_id=cloud_workspace_id,
     )
@@ -181,7 +191,7 @@ async def preflight_cloud_workspace_handoff(
     )
     detail_elapsed_ms = duration_ms(detail_started)
     blockers: list[str] = []
-    if direction not in {"local_to_cloud", "cloud_to_local"}:
+    if not is_valid_handoff_direction(direction):
         raise CloudApiError(
             "invalid_handoff_direction",
             "direction must be either 'local_to_cloud' or 'cloud_to_local'.",
@@ -191,14 +201,16 @@ async def preflight_cloud_workspace_handoff(
         blockers.append("cloud workspace is in cloud_lost state")
     if workspace.active_handoff is not None:
         blockers.append("handoff already in progress for workspace")
-    active_handoff = await load_active_user_handoff_op_for_user(user_id=user_id)
+    active_handoff = await load_active_user_handoff_op_for_user(
+        user_id=user_id,
+        final_handoff_phases=FINAL_HANDOFF_PHASES,
+    )
     if active_handoff is not None and active_handoff.mobility_workspace_id != workspace.id:
         blockers.append("another handoff is already in progress for this user")
-    if direction == "local_to_cloud" and workspace.owner != "local":
-        blockers.append("workspace is not currently local-owned")
-    if direction == "cloud_to_local" and workspace.owner != "cloud":
-        blockers.append("workspace is not currently cloud-owned")
-    if direction == "local_to_cloud":
+    owner_blocker = owner_direction_blocker(owner=workspace.owner, direction=direction)
+    if owner_blocker is not None:
+        blockers.append(owner_blocker)
+    if is_local_to_cloud_direction(direction):
         user = await load_user_with_oauth_accounts_by_id(user_id)
         if user is None:
             raise CloudApiError("user_not_found", "User not found.", status_code=404)
@@ -302,7 +314,7 @@ async def start_cloud_workspace_handoff(
             status_code=409,
         )
     source_owner = workspace.owner
-    target_owner = "cloud" if direction == "local_to_cloud" else "local"
+    target_owner = target_owner_for_direction(direction)
     try:
         handoff = await create_cloud_workspace_handoff_op_for_user(
             user_id=user_id,
@@ -310,6 +322,8 @@ async def start_cloud_workspace_handoff(
             direction=direction,
             source_owner=source_owner,
             target_owner=target_owner,
+            moving_lifecycle_state=moving_lifecycle_state(target_owner),
+            final_handoff_phases=FINAL_HANDOFF_PHASES,
             requested_branch=requested_branch,
             requested_base_sha=requested_base_sha,
             exclude_paths=exclude_paths,
@@ -360,8 +374,12 @@ async def start_cloud_workspace_handoff(
                     user_id=user_id,
                     mobility_workspace_id=mobility_workspace_id,
                     handoff_op_id=handoff.id,
+                    phase=HANDOFF_PHASE_HANDOFF_FAILED,
+                    lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
                     failure_code=failure_code,
                     failure_detail=failure_detail,
+                    status_detail=visible_failure_status_detail(failure_detail),
+                    last_error=visible_failure_last_error(failure_detail),
                 )
             raise
         return await update_cloud_workspace_handoff_phase_for_user(
@@ -402,7 +420,7 @@ async def update_cloud_workspace_handoff_phase(
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceHandoffOpValue:
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
-    if phase not in _VALID_HANDOFF_PHASES:
+    if not is_valid_handoff_phase(phase):
         raise CloudApiError(
             "invalid_handoff_phase",
             f"Unsupported handoff phase '{phase}'.",
@@ -471,8 +489,12 @@ async def fail_cloud_workspace_handoff(
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
+            phase=HANDOFF_PHASE_HANDOFF_FAILED,
+            lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
             failure_code=failure_code,
             failure_detail=failure_detail,
+            status_detail=visible_failure_status_detail(failure_detail),
+            last_error=visible_failure_last_error(failure_detail),
         )
     except ValueError as error:
         raise CloudApiError("handoff_not_found", str(error), status_code=404) from error

--- a/server/tests/unit/test_cloud_mobility_domain.py
+++ b/server/tests/unit/test_cloud_mobility_domain.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    DIRECTION_CLOUD_TO_LOCAL,
+    DIRECTION_LOCAL_TO_CLOUD,
+    HANDOFF_PHASE_CLEANUP_FAILED,
+    HANDOFF_PHASE_COMPLETED,
+    HANDOFF_PHASE_HANDOFF_FAILED,
+    LIFECYCLE_CLEANUP_FAILED,
+    LIFECYCLE_CLOUD_ACTIVE,
+    LIFECYCLE_HANDOFF_FAILED,
+    LIFECYCLE_LOCAL_ACTIVE,
+    LIFECYCLE_MOVING_TO_CLOUD,
+    OWNER_CLOUD,
+    OWNER_LOCAL,
+    STALE_CLEANUP_FAILURE_CODE,
+    STALE_HANDOFF_FAILURE_CODE,
+    active_lifecycle_state,
+    is_active_handoff_phase,
+    is_final_handoff_phase,
+    is_retryable_mobility_failure,
+    moving_lifecycle_state,
+    owner_direction_blocker,
+    stale_handoff_outcome,
+    target_owner_for_direction,
+    visible_failure_last_error,
+    visible_failure_status_detail,
+)
+
+
+def test_handoff_phase_classification_keeps_cleanup_failed_active() -> None:
+    assert is_final_handoff_phase(HANDOFF_PHASE_COMPLETED)
+    assert is_final_handoff_phase(HANDOFF_PHASE_HANDOFF_FAILED)
+    assert is_active_handoff_phase(HANDOFF_PHASE_CLEANUP_FAILED)
+
+
+def test_owner_direction_compatibility() -> None:
+    assert target_owner_for_direction(DIRECTION_LOCAL_TO_CLOUD) == OWNER_CLOUD
+    assert target_owner_for_direction(DIRECTION_CLOUD_TO_LOCAL) == OWNER_LOCAL
+    assert owner_direction_blocker(owner=OWNER_LOCAL, direction=DIRECTION_LOCAL_TO_CLOUD) is None
+    assert owner_direction_blocker(owner=OWNER_CLOUD, direction=DIRECTION_CLOUD_TO_LOCAL) is None
+    assert (
+        owner_direction_blocker(owner=OWNER_CLOUD, direction=DIRECTION_LOCAL_TO_CLOUD)
+        == "workspace is not currently local-owned"
+    )
+    assert (
+        owner_direction_blocker(owner=OWNER_LOCAL, direction=DIRECTION_CLOUD_TO_LOCAL)
+        == "workspace is not currently cloud-owned"
+    )
+
+
+def test_owner_direction_rejects_unknown_direction() -> None:
+    with pytest.raises(ValueError, match="unsupported handoff direction"):
+        target_owner_for_direction("teleport")
+
+
+def test_lifecycle_state_helpers_follow_owner_and_target_owner() -> None:
+    assert active_lifecycle_state(OWNER_LOCAL) == LIFECYCLE_LOCAL_ACTIVE
+    assert active_lifecycle_state(OWNER_CLOUD) == LIFECYCLE_CLOUD_ACTIVE
+    assert moving_lifecycle_state(OWNER_CLOUD) == LIFECYCLE_MOVING_TO_CLOUD
+
+
+def test_retryability_requires_failed_lifecycle_without_active_handoff() -> None:
+    assert is_retryable_mobility_failure(
+        lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        has_active_handoff=False,
+    )
+    assert not is_retryable_mobility_failure(
+        lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        has_active_handoff=True,
+    )
+    assert not is_retryable_mobility_failure(
+        lifecycle_state=LIFECYCLE_CLEANUP_FAILED,
+        has_active_handoff=False,
+    )
+
+
+def test_stale_expiry_before_finalize_fails_handoff_and_clears_active_pointer() -> None:
+    outcome = stale_handoff_outcome(finalized_at=None, cleanup_completed_at=None)
+
+    assert outcome.phase == HANDOFF_PHASE_HANDOFF_FAILED
+    assert outcome.lifecycle_state == LIFECYCLE_HANDOFF_FAILED
+    assert outcome.failure_code == STALE_HANDOFF_FAILURE_CODE
+    assert outcome.keep_active_handoff is False
+
+
+def test_stale_expiry_after_finalize_marks_cleanup_failed_and_keeps_active_pointer() -> None:
+    outcome = stale_handoff_outcome(
+        finalized_at=datetime.now(UTC),
+        cleanup_completed_at=None,
+    )
+
+    assert outcome.phase == HANDOFF_PHASE_CLEANUP_FAILED
+    assert outcome.lifecycle_state == LIFECYCLE_CLEANUP_FAILED
+    assert outcome.failure_code == STALE_CLEANUP_FAILURE_CODE
+    assert outcome.keep_active_handoff is True
+
+
+def test_failure_visibility_truncates_status_and_last_error_separately() -> None:
+    detail = "x" * 2100
+
+    assert visible_failure_status_detail(detail) == "x" * 255
+    assert visible_failure_last_error(detail) == "x" * 2000
+    assert visible_failure_status_detail("") is None
+    assert visible_failure_last_error("") == ""

--- a/server/tests/unit/test_cloud_mobility_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_lifecycle.py
@@ -24,6 +24,16 @@ from proliferate.db.store.cloud_mobility import (
     heartbeat_cloud_workspace_handoff_op,
     load_cloud_workspace_mobility_for_user,
 )
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    FINAL_HANDOFF_PHASES,
+    HANDOFF_PHASE_HANDOFF_FAILED,
+    LIFECYCLE_HANDOFF_FAILED,
+    OWNER_CLOUD,
+    moving_lifecycle_state,
+    stale_handoff_outcome,
+    visible_failure_last_error,
+    visible_failure_status_detail,
+)
 
 pytestmark = pytest.mark.usefixtures("mobility_session_factory")
 
@@ -116,6 +126,7 @@ async def test_create_handoff_sets_active_pointer_and_moving_state(
         direction="local_to_cloud",
         source_owner="local",
         target_owner="cloud",
+        moving_lifecycle_state=moving_lifecycle_state(OWNER_CLOUD),
         requested_branch="feature/cloud",
         requested_base_sha="abc123",
         exclude_paths=["node_modules"],
@@ -156,6 +167,8 @@ async def test_create_handoff_for_user_rejects_existing_active_workspace_handoff
             direction="local_to_cloud",
             source_owner="local",
             target_owner="cloud",
+            moving_lifecycle_state=moving_lifecycle_state(OWNER_CLOUD),
+            final_handoff_phases=FINAL_HANDOFF_PHASES,
             requested_branch="feature/cloud",
             requested_base_sha="abc123",
             exclude_paths=[],
@@ -178,8 +191,13 @@ async def test_cleanup_failed_handoff_counts_as_active(
     active_for_workspace = await get_active_handoff_for_mobility(
         db_session,
         mobility_workspace_id=mobility.id,
+        final_handoff_phases=FINAL_HANDOFF_PHASES,
     )
-    active_for_user = await get_active_user_handoff_op(db_session, user_id=user_id)
+    active_for_user = await get_active_user_handoff_op(
+        db_session,
+        user_id=user_id,
+        final_handoff_phases=FINAL_HANDOFF_PHASES,
+    )
 
     assert active_for_workspace is not None
     assert active_for_workspace.id == handoff.id
@@ -220,6 +238,7 @@ async def test_finalize_flips_owner_before_cleanup_clears_active_handoff(
         direction="local_to_cloud",
         source_owner="local",
         target_owner="cloud",
+        moving_lifecycle_state=moving_lifecycle_state(OWNER_CLOUD),
         requested_branch="feature/cloud",
         requested_base_sha="abc123",
         exclude_paths=[],
@@ -261,6 +280,7 @@ async def test_cleanup_completion_clears_active_handoff_and_marks_completed(
         direction="local_to_cloud",
         source_owner="local",
         target_owner="cloud",
+        moving_lifecycle_state=moving_lifecycle_state(OWNER_CLOUD),
         requested_branch="feature/cloud",
         requested_base_sha="abc123",
         exclude_paths=[],
@@ -299,6 +319,7 @@ async def test_failure_clears_active_handoff_and_truncates_visible_error(
         direction="local_to_cloud",
         source_owner="local",
         target_owner="cloud",
+        moving_lifecycle_state=moving_lifecycle_state(OWNER_CLOUD),
         requested_branch="feature/cloud",
         requested_base_sha="abc123",
         exclude_paths=[],
@@ -313,8 +334,12 @@ async def test_failure_clears_active_handoff_and_truncates_visible_error(
         db_session,
         handoff_op=handoff_record,
         mobility_workspace=mobility_record,
+        phase=HANDOFF_PHASE_HANDOFF_FAILED,
+        lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
         failure_code="provisioning_failed",
         failure_detail=failure_detail,
+        status_detail=visible_failure_status_detail(failure_detail),
+        last_error=visible_failure_last_error(failure_detail),
     )
 
     visible = await load_cloud_workspace_mobility_for_user(
@@ -347,13 +372,22 @@ async def test_stale_expiry_before_finalize_marks_failed_and_clears_active_hando
     mobility.active_handoff_op_id = handoff.id
     mobility.last_handoff_op_id = handoff.id
     await db_session.commit()
+    stale_outcome = stale_handoff_outcome(
+        finalized_at=handoff.finalized_at,
+        cleanup_completed_at=handoff.cleanup_completed_at,
+    )
 
     expired = await expire_stale_cloud_workspace_handoff_op_for_user(
         user_id=user_id,
         mobility_workspace_id=mobility.id,
         handoff_op_id=handoff.id,
-        failure_code="handoff_stale",
-        failure_detail="Workspace mobility heartbeat expired.",
+        phase=stale_outcome.phase,
+        lifecycle_state=stale_outcome.lifecycle_state,
+        keep_active_handoff=stale_outcome.keep_active_handoff,
+        failure_code=stale_outcome.failure_code,
+        failure_detail=stale_outcome.failure_detail,
+        status_detail=visible_failure_status_detail(stale_outcome.failure_detail),
+        last_error=visible_failure_last_error(stale_outcome.failure_detail),
     )
 
     visible = await load_cloud_workspace_mobility_for_user(
@@ -386,13 +420,22 @@ async def test_stale_expiry_after_finalize_marks_cleanup_failed_and_keeps_active
     mobility.active_handoff_op_id = handoff.id
     mobility.last_handoff_op_id = handoff.id
     await db_session.commit()
+    stale_outcome = stale_handoff_outcome(
+        finalized_at=handoff.finalized_at,
+        cleanup_completed_at=handoff.cleanup_completed_at,
+    )
 
     expired = await expire_stale_cloud_workspace_handoff_op_for_user(
         user_id=user_id,
         mobility_workspace_id=mobility.id,
         handoff_op_id=handoff.id,
-        failure_code="cleanup_stale",
-        failure_detail="Workspace mobility cleanup heartbeat expired.",
+        phase=stale_outcome.phase,
+        lifecycle_state=stale_outcome.lifecycle_state,
+        keep_active_handoff=stale_outcome.keep_active_handoff,
+        failure_code=stale_outcome.failure_code,
+        failure_detail=stale_outcome.failure_detail,
+        status_detail=visible_failure_status_detail(stale_outcome.failure_detail),
+        last_error=visible_failure_last_error(stale_outcome.failure_detail),
     )
 
     visible = await load_cloud_workspace_mobility_for_user(

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -12,6 +12,10 @@ from proliferate.db.store.cloud_mobility import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.mobility import service as mobility_service
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    HANDOFF_PHASE_HANDOFF_FAILED,
+    LIFECYCLE_HANDOFF_FAILED,
+)
 
 
 def _workspace(
@@ -85,7 +89,7 @@ async def test_preflight_blocks_when_workspace_handoff_is_already_active(
     async def _get_detail(**_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id):
+    async def _load_active_user_handoff(*, user_id, **_kwargs):
         return None
 
     async def _load_user(_user_id):
@@ -140,7 +144,7 @@ async def test_preflight_blocks_when_github_repo_access_is_missing(
     async def _get_detail(**_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id):
+    async def _load_active_user_handoff(*, user_id, **_kwargs):
         return None
 
     async def _load_user(_user_id):
@@ -198,7 +202,7 @@ async def test_preflight_blocks_when_branch_is_not_published(
     async def _get_detail(**_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id):
+    async def _load_active_user_handoff(*, user_id, **_kwargs):
         return None
 
     async def _load_user(_user_id):
@@ -253,7 +257,7 @@ async def test_preflight_blocks_when_github_branch_head_is_behind_requested_comm
     async def _get_detail(**_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id):
+    async def _load_active_user_handoff(*, user_id, **_kwargs):
         return None
 
     async def _load_user(_user_id):
@@ -429,8 +433,16 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
             "user_id": user_id,
             "mobility_workspace_id": workspace.id,
             "handoff_op_id": handoff.id,
+            "phase": HANDOFF_PHASE_HANDOFF_FAILED,
+            "lifecycle_state": LIFECYCLE_HANDOFF_FAILED,
             "failure_code": "github_repo_access_required",
             "failure_detail": (
+                "Reconnect GitHub and grant repository access before creating a cloud workspace."
+            ),
+            "status_detail": (
+                "Reconnect GitHub and grant repository access before creating a cloud workspace."
+            ),
+            "last_error": (
                 "Reconnect GitHub and grant repository access before creating a cloud workspace."
             ),
         }

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -82,7 +82,7 @@ def _stub_common_preflight_dependencies(
     async def _get_detail(**_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id):
+    async def _load_active_user_handoff(*, user_id, **_kwargs):
         return active_handoff
 
     async def _load_user(_user_id):

--- a/server/tests/unit/test_cloud_mobility_store.py
+++ b/server/tests/unit/test_cloud_mobility_store.py
@@ -7,6 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.cloud.mobility import CloudWorkspaceMobility
 from proliferate.db.store.cloud_mobility import ensure_cloud_workspace_mobility
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    LIFECYCLE_HANDOFF_FAILED,
+    OWNER_LOCAL,
+    active_lifecycle_state,
+)
 
 
 @pytest.mark.asyncio
@@ -43,6 +48,8 @@ async def test_ensure_clears_retryable_handoff_failure(
         git_repo_name="proliferate",
         git_branch="gannet",
         owner_hint="local",
+        active_lifecycle_state=active_lifecycle_state(OWNER_LOCAL),
+        retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
         display_name="Gannet",
         cloud_workspace_id=None,
     )


### PR DESCRIPTION
## Summary

Wave 2 Lane B: Cloud Mobility.

- Add pure mobility lifecycle helpers for handoff phase classification, owner/direction compatibility, stale-expiry outcomes, retryability, and failure visibility truncation.
- Route mobility service decisions through the pure domain helpers while preserving current store-owned session and commit checkpoints.
- Update the existing Wave 1 mobility lifecycle/service tests and add direct pure-domain coverage.

## Invariants

- `cleanup_failed` remains an active handoff phase; only `completed` and `handoff_failed` are final.
- Stale expiry before finalization becomes `handoff_failed` and clears the active pointer.
- Stale expiry after finalization but before cleanup becomes `cleanup_failed` and keeps the active pointer.
- `handoff_failed` without an active handoff remains the retryable ensure path.
- `local_to_cloud` requires a local-owned workspace; `cloud_to_local` requires a cloud-owned workspace.

## Verification

- `DEBUG=1 uv run --python /opt/homebrew/bin/python3.12 --extra dev python -m pytest -q tests/unit/test_cloud_mobility_domain.py tests/unit/test_cloud_mobility_lifecycle.py tests/unit/test_cloud_mobility_service_lifecycle.py tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_store.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`
- `DEBUG=1 uv run --python /opt/homebrew/bin/python3.12 --extra dev python -m ruff check proliferate/server/cloud/mobility proliferate/db/store/cloud_mobility.py tests/unit/test_cloud_mobility_domain.py tests/unit/test_cloud_mobility_lifecycle.py tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_service_lifecycle.py tests/unit/test_cloud_mobility_store.py`