### PR TITLE
refactor(cloud): extract workspace lifecycle rules

### DIFF
--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -10,8 +10,9 @@ should remain in that module.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
+from typing import Final, Literal
 
 # ---------------------------------------------------------------------------
 # Supported cloud agent kinds
@@ -121,6 +122,126 @@ class WorkspacePostReadyPhase(StrEnum):
     starting_setup = "starting_setup"
     completed = "completed"
     failed = "failed"
+
+
+SETUP_RUN_STATUS_PENDING: Final = "pending"
+SETUP_RUN_STATUS_RUNNING: Final = "running"
+SETUP_RUN_STATUS_SUCCEEDED: Final = "succeeded"
+SETUP_RUN_STATUS_FAILED: Final = "failed"
+SETUP_RUN_STATUS_TIMED_OUT: Final = "timed_out"
+SETUP_RUN_STATUS_STALE: Final = "stale"
+SETUP_RUN_ACTIVE_STATUSES: Final = frozenset(
+    {
+        SETUP_RUN_STATUS_PENDING,
+        SETUP_RUN_STATUS_RUNNING,
+    }
+)
+MAX_SETUP_MONITOR_ERROR_CHARS: Final = 2000
+SETUP_RUN_MISSING_WORKSPACE_ERROR: Final = "Cloud workspace no longer exists."
+SETUP_RUN_SUPERSEDED_ERROR: Final = "Setup run was superseded by a newer apply."
+SETUP_RUN_DEFAULT_FAILURE_ERROR: Final = "Repo setup failed"
+
+
+@dataclass(frozen=True)
+class SetupRunWorkspaceFinalization:
+    phase: WorkspacePostReadyPhase
+    status_detail: str
+    repo_setup_applied_version: int | None = None
+    repo_files_last_error: str | None = None
+
+
+@dataclass(frozen=True)
+class SetupRunFinalizationDecision:
+    run_status: str
+    run_last_error: str | None
+    should_update_workspace: bool
+    set_last_polled_at: bool
+    clear_next_poll_at: bool
+    workspace_update: SetupRunWorkspaceFinalization | None = None
+
+
+def bounded_setup_monitor_error(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value[:MAX_SETUP_MONITOR_ERROR_CHARS]
+
+
+def setup_run_has_active_workspace_token(
+    *,
+    workspace_apply_token: str | None,
+    workspace_phase: WorkspacePostReadyPhase | str | None,
+    run_apply_token: str,
+    command_run_id: str | None,
+) -> bool:
+    phase_value = (
+        workspace_phase.value if isinstance(workspace_phase, StrEnum) else workspace_phase
+    )
+    return bool(
+        workspace_apply_token == run_apply_token
+        and command_run_id
+        and phase_value == WorkspacePostReadyPhase.starting_setup.value
+    )
+
+
+def classify_setup_run_finalization(
+    *,
+    workspace_exists: bool,
+    workspace_apply_token: str | None,
+    workspace_phase: WorkspacePostReadyPhase | str | None,
+    run_apply_token: str,
+    command_run_id: str | None,
+    final_status: str,
+    success: bool,
+    last_error: str | None,
+    setup_script_version: int,
+) -> SetupRunFinalizationDecision:
+    if not workspace_exists:
+        return SetupRunFinalizationDecision(
+            run_status=SETUP_RUN_STATUS_STALE,
+            run_last_error=SETUP_RUN_MISSING_WORKSPACE_ERROR,
+            should_update_workspace=False,
+            set_last_polled_at=False,
+            clear_next_poll_at=False,
+        )
+
+    if not setup_run_has_active_workspace_token(
+        workspace_apply_token=workspace_apply_token,
+        workspace_phase=workspace_phase,
+        run_apply_token=run_apply_token,
+        command_run_id=command_run_id,
+    ):
+        return SetupRunFinalizationDecision(
+            run_status=SETUP_RUN_STATUS_STALE,
+            run_last_error=SETUP_RUN_SUPERSEDED_ERROR,
+            should_update_workspace=False,
+            set_last_polled_at=False,
+            clear_next_poll_at=False,
+        )
+
+    bounded_last_error = bounded_setup_monitor_error(last_error)
+    if success:
+        workspace_update = SetupRunWorkspaceFinalization(
+            phase=WorkspacePostReadyPhase.completed,
+            repo_setup_applied_version=setup_script_version,
+            repo_files_last_error=None,
+            status_detail="Ready",
+        )
+    else:
+        workspace_update = SetupRunWorkspaceFinalization(
+            phase=WorkspacePostReadyPhase.failed,
+            repo_setup_applied_version=None,
+            repo_files_last_error=bounded_last_error or SETUP_RUN_DEFAULT_FAILURE_ERROR,
+            status_detail="Repo setup failed",
+        )
+
+    return SetupRunFinalizationDecision(
+        run_status=final_status,
+        run_last_error=bounded_last_error,
+        should_update_workspace=True,
+        set_last_polled_at=True,
+        clear_next_poll_at=True,
+        workspace_update=workspace_update,
+    )
 
 
 WORKSPACE_REPO_APPLY_LOCK_SALT: int = 4_203_902

--- a/server/proliferate/db/store/cloud_workspace_setup_runs.py
+++ b/server/proliferate/db/store/cloud_workspace_setup_runs.py
@@ -8,21 +8,18 @@ from uuid import UUID
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.cloud import WorkspacePostReadyPhase
+from proliferate.constants.cloud import (
+    SETUP_RUN_ACTIVE_STATUSES,
+    SETUP_RUN_STATUS_RUNNING,
+    bounded_setup_monitor_error,
+    classify_setup_run_finalization,
+)
 from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.workspaces import CloudWorkspace, CloudWorkspaceSetupRun
 from proliferate.utils.time import utcnow
 
-SETUP_RUN_ACTIVE_STATUSES = ("pending", "running")
 SETUP_MONITOR_CLAIM_TTL = timedelta(seconds=45)
 SETUP_MONITOR_POLL_INTERVAL = timedelta(seconds=5)
-MAX_SETUP_MONITOR_ERROR_CHARS = 2000
-
-
-def _bounded_error(value: str | None) -> str | None:
-    if value is None:
-        return None
-    return value[:MAX_SETUP_MONITOR_ERROR_CHARS]
 
 
 async def create_cloud_workspace_setup_run(
@@ -34,7 +31,7 @@ async def create_cloud_workspace_setup_run(
     setup_script_version: int,
     apply_token: str,
     deadline_at: datetime,
-    status: str = "running",
+    status: str = SETUP_RUN_STATUS_RUNNING,
 ) -> CloudWorkspaceSetupRun:
     async with db_engine.async_session_factory() as db:
         now = utcnow()
@@ -112,7 +109,7 @@ async def claim_due_setup_runs(
 async def release_setup_run_claim(
     setup_run_id: UUID,
     *,
-    status: str = "running",
+    status: str = SETUP_RUN_STATUS_RUNNING,
     next_poll_at: datetime | None = None,
     last_error: str | None = None,
 ) -> None:
@@ -126,7 +123,7 @@ async def release_setup_run_claim(
         run.claim_until = None
         run.last_polled_at = now
         run.next_poll_at = next_poll_at or (now + SETUP_MONITOR_POLL_INTERVAL)
-        run.last_error = _bounded_error(last_error)
+        run.last_error = bounded_setup_monitor_error(last_error)
         run.updated_at = now
         await db.commit()
 
@@ -155,49 +152,44 @@ async def _finalize_setup_run(
         return
     now = utcnow()
     workspace = await db.get(CloudWorkspace, run.workspace_id)
-    if workspace is None:
-        run.status = "stale"
-        run.claim_owner = None
-        run.claim_until = None
-        run.last_error = "Cloud workspace no longer exists."
-        run.updated_at = now
-        return
-
-    active_matches = bool(
-        workspace.repo_post_ready_apply_token == run.apply_token
-        and run.command_run_id
-        and workspace.repo_post_ready_phase == WorkspacePostReadyPhase.starting_setup.value
+    decision = classify_setup_run_finalization(
+        workspace_exists=workspace is not None,
+        workspace_apply_token=(
+            workspace.repo_post_ready_apply_token if workspace is not None else None
+        ),
+        workspace_phase=workspace.repo_post_ready_phase if workspace is not None else None,
+        run_apply_token=run.apply_token,
+        command_run_id=run.command_run_id,
+        final_status=final_status,
+        success=success,
+        last_error=last_error,
+        setup_script_version=run.setup_script_version,
     )
-    if not active_matches:
-        run.status = "stale"
-        run.claim_owner = None
-        run.claim_until = None
-        run.last_error = "Setup run was superseded by a newer apply."
-        run.updated_at = now
-        return
 
-    run.status = final_status
+    run.status = decision.run_status
     run.claim_owner = None
     run.claim_until = None
-    run.last_polled_at = now
-    run.next_poll_at = None
-    run.last_error = _bounded_error(last_error)
+    if decision.set_last_polled_at:
+        run.last_polled_at = now
+    if decision.clear_next_poll_at:
+        run.next_poll_at = None
+    run.last_error = decision.run_last_error
     run.updated_at = now
 
+    if not decision.should_update_workspace or workspace is None:
+        return
+    workspace_update = decision.workspace_update
+    if workspace_update is None:
+        return
     workspace.repo_post_ready_completed_at = now
     workspace.repo_post_ready_apply_token = None
     workspace.updated_at = now
-    if success:
-        workspace.repo_post_ready_phase = WorkspacePostReadyPhase.completed.value
-        workspace.repo_setup_applied_version = run.setup_script_version
-        workspace.repo_files_last_failed_path = None
-        workspace.repo_files_last_error = None
-        workspace.status_detail = "Ready"
-    else:
-        workspace.repo_post_ready_phase = WorkspacePostReadyPhase.failed.value
-        workspace.repo_files_last_failed_path = None
-        workspace.repo_files_last_error = _bounded_error(last_error) or "Repo setup failed"
-        workspace.status_detail = "Repo setup failed"
+    workspace.repo_post_ready_phase = workspace_update.phase.value
+    if workspace_update.repo_setup_applied_version is not None:
+        workspace.repo_setup_applied_version = workspace_update.repo_setup_applied_version
+    workspace.repo_files_last_failed_path = None
+    workspace.repo_files_last_error = workspace_update.repo_files_last_error
+    workspace.status_detail = workspace_update.status_detail
 
 
 async def mark_setup_run_timed_out(setup_run_id: UUID) -> None:

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -16,6 +16,7 @@ from proliferate.constants.cloud import (
     WORKSPACE_REPO_APPLY_LOCK_SALT,
     CloudWorkspaceCleanupState,
     CloudWorkspaceStatus,
+    WorkspacePostReadyPhase,
     WorkspaceStatus,
 )
 from proliferate.db import engine as db_engine
@@ -200,7 +201,7 @@ async def create_cloud_workspace_record(
         repo_env_vars_ciphertext=repo_env_vars_ciphertext,
         repo_files_applied_version=0,
         repo_setup_applied_version=0,
-        repo_post_ready_phase="idle",
+        repo_post_ready_phase=WorkspacePostReadyPhase.idle.value,
         repo_post_ready_files_total=0,
         repo_post_ready_files_applied=0,
         repo_post_ready_apply_token=None,

--- a/server/proliferate/server/cloud/workspaces/domain/lifecycle.py
+++ b/server/proliferate/server/cloud/workspaces/domain/lifecycle.py
@@ -1,0 +1,187 @@
+"""Pure cloud workspace lifecycle decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from proliferate.constants.cloud import CloudWorkspaceStatus
+
+PROVISIONING_STATUSES: frozenset[str] = frozenset(
+    {
+        CloudWorkspaceStatus.pending.value,
+        CloudWorkspaceStatus.materializing.value,
+    }
+)
+
+VALID_STATUS_TRANSITIONS: dict[CloudWorkspaceStatus, frozenset[CloudWorkspaceStatus]] = {
+    CloudWorkspaceStatus.pending: frozenset(
+        {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        }
+    ),
+    CloudWorkspaceStatus.materializing: frozenset(
+        {
+            CloudWorkspaceStatus.ready,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        }
+    ),
+    CloudWorkspaceStatus.ready: frozenset(
+        {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        }
+    ),
+    CloudWorkspaceStatus.archived: frozenset(
+        {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.error,
+        }
+    ),
+    CloudWorkspaceStatus.error: frozenset(
+        {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+        }
+    ),
+}
+
+
+@dataclass(frozen=True)
+class WorkspaceStatusTransitionDecision:
+    allowed: bool
+    current_status: CloudWorkspaceStatus
+    target_status: CloudWorkspaceStatus
+    status_detail: str
+    error_code: str | None = None
+    error_message: str | None = None
+    status_code: int | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceStartDecision:
+    action: Literal["return_current", "queue_pending", "return_ready", "restart_materializing"]
+    refresh_repo_env_snapshot: bool
+    clear_last_error: bool
+    persist_before_schedule: bool
+    schedule_provision: bool
+    target_status: CloudWorkspaceStatus | None = None
+    status_detail: str | None = None
+
+
+@dataclass(frozen=True)
+class ProviderFailureDebugStateDecision:
+    sandbox_status: str
+    preserve_workspace_runtime_metadata: bool
+    clear_workspace_runtime_metadata: bool
+    clear_active_sandbox: bool
+
+
+def normalize_workspace_status(status: CloudWorkspaceStatus | str) -> CloudWorkspaceStatus:
+    if isinstance(status, CloudWorkspaceStatus):
+        return status
+    try:
+        return CloudWorkspaceStatus(str(status))
+    except ValueError:
+        return CloudWorkspaceStatus.error
+
+
+def workspace_status_detail(status: CloudWorkspaceStatus) -> str:
+    return status.value.replace("_", " ").title()
+
+
+def decide_workspace_status_transition(
+    current_status: CloudWorkspaceStatus | str,
+    target_status: CloudWorkspaceStatus,
+    *,
+    status_detail: str | None = None,
+) -> WorkspaceStatusTransitionDecision:
+    normalized_current = normalize_workspace_status(current_status)
+    resolved_detail = status_detail or workspace_status_detail(target_status)
+    allowed_targets = VALID_STATUS_TRANSITIONS.get(normalized_current, frozenset())
+    if target_status in allowed_targets:
+        return WorkspaceStatusTransitionDecision(
+            allowed=True,
+            current_status=normalized_current,
+            target_status=target_status,
+            status_detail=resolved_detail,
+        )
+    return WorkspaceStatusTransitionDecision(
+        allowed=False,
+        current_status=normalized_current,
+        target_status=target_status,
+        status_detail=resolved_detail,
+        error_code="invalid_status_transition",
+        error_message=(
+            f"Cannot transition workspace from '{current_status}' to '{target_status.value}'."
+        ),
+        status_code=409,
+    )
+
+
+def start_request_should_return_existing(status: CloudWorkspaceStatus | str) -> bool:
+    return normalize_workspace_status(status) == CloudWorkspaceStatus.materializing
+
+
+def decide_workspace_start_after_validation(
+    status: CloudWorkspaceStatus | str,
+    *,
+    ready_at_exists: bool,
+) -> WorkspaceStartDecision:
+    refresh_repo_env_snapshot = not ready_at_exists
+    normalized_status = normalize_workspace_status(status)
+    if normalized_status == CloudWorkspaceStatus.pending:
+        return WorkspaceStartDecision(
+            action="queue_pending",
+            refresh_repo_env_snapshot=refresh_repo_env_snapshot,
+            clear_last_error=True,
+            persist_before_schedule=True,
+            schedule_provision=True,
+        )
+    if normalized_status == CloudWorkspaceStatus.ready:
+        return WorkspaceStartDecision(
+            action="return_ready",
+            refresh_repo_env_snapshot=refresh_repo_env_snapshot,
+            clear_last_error=False,
+            persist_before_schedule=False,
+            schedule_provision=False,
+        )
+    if normalized_status == CloudWorkspaceStatus.materializing:
+        return WorkspaceStartDecision(
+            action="return_current",
+            refresh_repo_env_snapshot=False,
+            clear_last_error=False,
+            persist_before_schedule=False,
+            schedule_provision=False,
+        )
+    return WorkspaceStartDecision(
+        action="restart_materializing",
+        refresh_repo_env_snapshot=refresh_repo_env_snapshot,
+        clear_last_error=True,
+        persist_before_schedule=True,
+        schedule_provision=True,
+        target_status=CloudWorkspaceStatus.materializing,
+        status_detail="Preparing runtime",
+    )
+
+
+def provider_failure_debug_state(
+    operation: Literal["stop", "destroy"],
+) -> ProviderFailureDebugStateDecision:
+    if operation == "stop":
+        return ProviderFailureDebugStateDecision(
+            sandbox_status="error",
+            preserve_workspace_runtime_metadata=True,
+            clear_workspace_runtime_metadata=False,
+            clear_active_sandbox=False,
+        )
+    return ProviderFailureDebugStateDecision(
+        sandbox_status="error",
+        preserve_workspace_runtime_metadata=False,
+        clear_workspace_runtime_metadata=True,
+        clear_active_sandbox=True,
+    )

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -85,6 +85,12 @@ from proliferate.server.cloud.runtime.service import (
     sync_workspace_credentials,
 )
 from proliferate.server.cloud.workspaces.access import cloud_workspace_user_can_read
+from proliferate.server.cloud.workspaces.domain.lifecycle import (
+    decide_workspace_start_after_validation,
+    decide_workspace_status_transition,
+    provider_failure_debug_state,
+    start_request_should_return_existing,
+)
 from proliferate.server.cloud.workspaces.models import (
     WorkspaceConnection,
     WorkspaceCreatorContext,
@@ -143,50 +149,6 @@ class ResolvedCloudWorkspaceCreate:
     cloud_repo_limit: int | None
 
 
-PROVISIONING_STATUSES: frozenset[str] = frozenset(
-    {
-        CloudWorkspaceStatus.pending.value,
-        CloudWorkspaceStatus.materializing.value,
-    }
-)
-
-# Valid status transitions.  Each key lists the statuses that may follow it.
-# Every active or terminal state allows archive so that workspace stop/delete is
-# always permitted, and explicit start can revive an archived workspace.
-VALID_TRANSITIONS: dict[str, frozenset[str]] = {
-    CloudWorkspaceStatus.pending.value: frozenset(
-        {
-            CloudWorkspaceStatus.materializing.value,
-            CloudWorkspaceStatus.archived.value,
-            CloudWorkspaceStatus.error.value,
-        }
-    ),
-    CloudWorkspaceStatus.materializing.value: frozenset(
-        {
-            CloudWorkspaceStatus.ready.value,
-            CloudWorkspaceStatus.archived.value,
-            CloudWorkspaceStatus.error.value,
-        }
-    ),
-    CloudWorkspaceStatus.ready.value: frozenset(
-        {
-            CloudWorkspaceStatus.materializing.value,
-            CloudWorkspaceStatus.archived.value,
-            CloudWorkspaceStatus.error.value,
-        }
-    ),
-    CloudWorkspaceStatus.archived.value: frozenset(
-        {
-            CloudWorkspaceStatus.materializing.value,
-            CloudWorkspaceStatus.error.value,
-        }
-    ),
-    CloudWorkspaceStatus.error.value: frozenset(
-        {CloudWorkspaceStatus.materializing.value, CloudWorkspaceStatus.archived.value}
-    ),
-}
-
-
 def transition_workspace_status(
     workspace: CloudWorkspace,
     target: CloudWorkspaceStatus,
@@ -199,18 +161,19 @@ def transition_workspace_status(
     ``status_detail`` overrides the human-readable detail; when *None* the
     detail is derived from the target status.
     """
-    current = workspace.status
-    if current not in VALID_TRANSITIONS:
-        current = CloudWorkspaceStatus.error.value
-    allowed = VALID_TRANSITIONS.get(current)
-    if allowed is None or target.value not in allowed:
+    decision = decide_workspace_status_transition(
+        workspace.status,
+        target,
+        status_detail=status_detail,
+    )
+    if not decision.allowed:
         raise CloudApiError(
-            "invalid_status_transition",
-            f"Cannot transition workspace from '{workspace.status}' to '{target}'.",
-            status_code=409,
+            decision.error_code or "invalid_status_transition",
+            decision.error_message or "Invalid workspace status transition.",
+            status_code=decision.status_code or 409,
         )
-    workspace.status = target.value
-    workspace.status_detail = status_detail or target.value.replace("_", " ").title()
+    workspace.status = decision.target_status.value
+    workspace.status_detail = decision.status_detail
     workspace.updated_at = utcnow()
 
 
@@ -769,10 +732,7 @@ async def start_cloud_workspace(
     requested_base_sha: str | None = None,
 ) -> WorkspaceDetail:
     workspace = await cloud_workspace_user_can_read(user.id, workspace_id)
-    if (
-        workspace.status in PROVISIONING_STATUSES
-        and workspace.status != CloudWorkspaceStatus.pending.value
-    ):
+    if start_request_should_return_existing(workspace.status):
         return await _build_workspace_detail(workspace)
 
     repo_branches = await get_github_repo_branches(
@@ -815,12 +775,22 @@ async def start_cloud_workspace(
         active_sandbox_count=authorization.active_sandbox_count,
     )
 
-    if workspace.ready_at is None:
+    start_decision = decide_workspace_start_after_validation(
+        workspace.status,
+        ready_at_exists=workspace.ready_at is not None,
+    )
+    if start_decision.refresh_repo_env_snapshot:
         workspace = await _refresh_repo_env_snapshot_for_workspace(workspace)
+        start_decision = decide_workspace_start_after_validation(
+            workspace.status,
+            ready_at_exists=workspace.ready_at is not None,
+        )
 
-    if workspace.status == CloudWorkspaceStatus.pending.value:
-        workspace.last_error = None
-        await save_workspace(workspace)
+    if start_decision.action == "queue_pending":
+        if start_decision.clear_last_error:
+            workspace.last_error = None
+        if start_decision.persist_before_schedule:
+            await save_workspace(workspace)
         log_cloud_event(
             "cloud workspace queued",
             workspace_id=workspace.id,
@@ -829,22 +799,31 @@ async def start_cloud_workspace(
             branch_name=workspace.git_branch,
             requested_base_sha=requested_base_sha,
         )
-        schedule_workspace_provision(
-            workspace.id,
-            requested_base_sha=requested_base_sha,
+        if start_decision.schedule_provision:
+            schedule_workspace_provision(
+                workspace.id,
+                requested_base_sha=requested_base_sha,
+            )
+        return await _build_workspace_detail(workspace)
+
+    if start_decision.action in {"return_ready", "return_current"}:
+        return await _build_workspace_detail(workspace)
+
+    if start_decision.target_status is None:
+        raise CloudApiError(
+            "invalid_status_transition",
+            "Invalid workspace status transition.",
+            status_code=409,
         )
-        return await _build_workspace_detail(workspace)
-
-    if workspace.status == CloudWorkspaceStatus.ready.value:
-        return await _build_workspace_detail(workspace)
-
     transition_workspace_status(
         workspace,
-        CloudWorkspaceStatus.materializing,
-        status_detail="Preparing runtime",
+        start_decision.target_status,
+        status_detail=start_decision.status_detail,
     )
-    workspace.last_error = None
-    await save_workspace(workspace)
+    if start_decision.clear_last_error:
+        workspace.last_error = None
+    if start_decision.persist_before_schedule:
+        await save_workspace(workspace)
     log_cloud_event(
         "cloud workspace restart queued",
         workspace_id=workspace.id,
@@ -853,10 +832,11 @@ async def start_cloud_workspace(
         branch_name=workspace.git_branch,
         requested_base_sha=requested_base_sha,
     )
-    schedule_workspace_provision(
-        workspace.id,
-        requested_base_sha=requested_base_sha,
-    )
+    if start_decision.schedule_provision:
+        schedule_workspace_provision(
+            workspace.id,
+            requested_base_sha=requested_base_sha,
+        )
     return await _build_workspace_detail(workspace)
 
 
@@ -964,7 +944,8 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
         try:
             await provider.pause_sandbox(sandbox.external_sandbox_id)
         except Exception:
-            await update_sandbox_status(sandbox, "error")
+            failure_state = provider_failure_debug_state("stop")
+            await update_sandbox_status(sandbox, failure_state.sandbox_status)
             log_cloud_event(
                 "cloud sandbox pause failed",
                 level=logging.WARNING,
@@ -1011,7 +992,8 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
         try:
             await provider.destroy_sandbox(sandbox.external_sandbox_id)
         except Exception:
-            await update_sandbox_status(sandbox, "error")
+            failure_state = provider_failure_debug_state("destroy")
+            await update_sandbox_status(sandbox, failure_state.sandbox_status)
             log_cloud_event(
                 "cloud sandbox destroy failed",
                 level=logging.WARNING,

--- a/server/tests/unit/test_cloud_workspace_lifecycle_domain.py
+++ b/server/tests/unit/test_cloud_workspace_lifecycle_domain.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from proliferate.constants.cloud import (
+    CloudWorkspaceStatus,
+    SETUP_RUN_DEFAULT_FAILURE_ERROR,
+    SETUP_RUN_MISSING_WORKSPACE_ERROR,
+    SETUP_RUN_STATUS_STALE,
+    SETUP_RUN_SUPERSEDED_ERROR,
+    WorkspacePostReadyPhase,
+    classify_setup_run_finalization,
+    setup_run_has_active_workspace_token,
+)
+from proliferate.server.cloud.workspaces.domain.lifecycle import (
+    VALID_STATUS_TRANSITIONS,
+    decide_workspace_start_after_validation,
+    decide_workspace_status_transition,
+    provider_failure_debug_state,
+    start_request_should_return_existing,
+)
+
+
+def test_workspace_status_transition_table_allows_current_lifecycle_edges() -> None:
+    expected = {
+        CloudWorkspaceStatus.pending: {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        },
+        CloudWorkspaceStatus.materializing: {
+            CloudWorkspaceStatus.ready,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        },
+        CloudWorkspaceStatus.ready: {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+            CloudWorkspaceStatus.error,
+        },
+        CloudWorkspaceStatus.archived: {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.error,
+        },
+        CloudWorkspaceStatus.error: {
+            CloudWorkspaceStatus.materializing,
+            CloudWorkspaceStatus.archived,
+        },
+    }
+
+    expected_transitions = {status: frozenset(targets) for status, targets in expected.items()}
+    assert expected_transitions == VALID_STATUS_TRANSITIONS
+    for current, targets in expected.items():
+        for target in targets:
+            decision = decide_workspace_status_transition(current.value, target)
+            assert decision.allowed is True
+            assert decision.status_detail == target.value.replace("_", " ").title()
+
+
+def test_workspace_status_transition_rejects_representative_denied_edges() -> None:
+    denied_edges = (
+        (CloudWorkspaceStatus.pending, CloudWorkspaceStatus.ready),
+        (CloudWorkspaceStatus.archived, CloudWorkspaceStatus.ready),
+        (CloudWorkspaceStatus.error, CloudWorkspaceStatus.ready),
+    )
+
+    for current, target in denied_edges:
+        decision = decide_workspace_status_transition(current.value, target)
+        assert decision.allowed is False
+        assert decision.error_code == "invalid_status_transition"
+        assert decision.status_code == 409
+
+
+def test_unknown_workspace_status_is_treated_as_error_for_recovery() -> None:
+    allowed = decide_workspace_status_transition("unknown", CloudWorkspaceStatus.materializing)
+    denied = decide_workspace_status_transition("unknown", CloudWorkspaceStatus.ready)
+
+    assert allowed.allowed is True
+    assert allowed.current_status == CloudWorkspaceStatus.error
+    assert denied.allowed is False
+    assert denied.current_status == CloudWorkspaceStatus.error
+
+
+def test_workspace_start_decision_preserves_current_behavior_by_status() -> None:
+    materializing = decide_workspace_start_after_validation(
+        CloudWorkspaceStatus.materializing.value,
+        ready_at_exists=False,
+    )
+    pending = decide_workspace_start_after_validation(
+        CloudWorkspaceStatus.pending.value,
+        ready_at_exists=False,
+    )
+    ready = decide_workspace_start_after_validation(
+        CloudWorkspaceStatus.ready.value,
+        ready_at_exists=True,
+    )
+    archived = decide_workspace_start_after_validation(
+        CloudWorkspaceStatus.archived.value,
+        ready_at_exists=True,
+    )
+
+    assert start_request_should_return_existing(CloudWorkspaceStatus.materializing.value)
+    assert materializing.action == "return_current"
+    assert pending.action == "queue_pending"
+    assert pending.clear_last_error is True
+    assert pending.refresh_repo_env_snapshot is True
+    assert pending.schedule_provision is True
+    assert ready.action == "return_ready"
+    assert ready.schedule_provision is False
+    assert archived.action == "restart_materializing"
+    assert archived.target_status == CloudWorkspaceStatus.materializing
+    assert archived.status_detail == "Preparing runtime"
+
+
+def test_setup_run_active_token_requires_matching_token_command_and_phase() -> None:
+    assert setup_run_has_active_workspace_token(
+        workspace_apply_token="token",
+        workspace_phase=WorkspacePostReadyPhase.starting_setup.value,
+        run_apply_token="token",
+        command_run_id="command-1",
+    )
+    assert not setup_run_has_active_workspace_token(
+        workspace_apply_token="other",
+        workspace_phase=WorkspacePostReadyPhase.starting_setup.value,
+        run_apply_token="token",
+        command_run_id="command-1",
+    )
+    assert not setup_run_has_active_workspace_token(
+        workspace_apply_token="token",
+        workspace_phase=WorkspacePostReadyPhase.completed.value,
+        run_apply_token="token",
+        command_run_id="command-1",
+    )
+    assert not setup_run_has_active_workspace_token(
+        workspace_apply_token="token",
+        workspace_phase=WorkspacePostReadyPhase.starting_setup.value,
+        run_apply_token="token",
+        command_run_id="",
+    )
+
+
+def test_setup_run_finalization_classifies_stale_and_active_results() -> None:
+    missing = classify_setup_run_finalization(
+        workspace_exists=False,
+        workspace_apply_token=None,
+        workspace_phase=None,
+        run_apply_token="token",
+        command_run_id="command-1",
+        final_status="succeeded",
+        success=True,
+        last_error=None,
+        setup_script_version=4,
+    )
+    stale = classify_setup_run_finalization(
+        workspace_exists=True,
+        workspace_apply_token="new-token",
+        workspace_phase=WorkspacePostReadyPhase.starting_setup,
+        run_apply_token="old-token",
+        command_run_id="command-1",
+        final_status="succeeded",
+        success=True,
+        last_error=None,
+        setup_script_version=4,
+    )
+    failed = classify_setup_run_finalization(
+        workspace_exists=True,
+        workspace_apply_token="token",
+        workspace_phase=WorkspacePostReadyPhase.starting_setup,
+        run_apply_token="token",
+        command_run_id="command-1",
+        final_status="failed",
+        success=False,
+        last_error=None,
+        setup_script_version=4,
+    )
+
+    assert missing.run_status == SETUP_RUN_STATUS_STALE
+    assert missing.run_last_error == SETUP_RUN_MISSING_WORKSPACE_ERROR
+    assert missing.should_update_workspace is False
+    assert stale.run_status == SETUP_RUN_STATUS_STALE
+    assert stale.run_last_error == SETUP_RUN_SUPERSEDED_ERROR
+    assert stale.should_update_workspace is False
+    assert failed.run_status == "failed"
+    assert failed.should_update_workspace is True
+    assert failed.workspace_update is not None
+    assert failed.workspace_update.phase == WorkspacePostReadyPhase.failed
+    assert failed.workspace_update.repo_files_last_error == SETUP_RUN_DEFAULT_FAILURE_ERROR
+
+
+def test_provider_failure_debug_state_preserves_stop_but_clears_destroy() -> None:
+    stop = provider_failure_debug_state("stop")
+    destroy = provider_failure_debug_state("destroy")
+
+    assert stop.sandbox_status == "error"
+    assert stop.preserve_workspace_runtime_metadata is True
+    assert stop.clear_workspace_runtime_metadata is False
+    assert stop.clear_active_sandbox is False
+    assert destroy.sandbox_status == "error"
+    assert destroy.preserve_workspace_runtime_metadata is False
+    assert destroy.clear_workspace_runtime_metadata is True
+    assert destroy.clear_active_sandbox is True


### PR DESCRIPTION
## Summary
- Extract workspace visible status transition and start-state decisions into a pure workspace lifecycle domain helper.
- Centralize setup-run active-token and finalization/stale classification as pure cloud lifecycle rules while preserving setup-run store transaction boundaries.
- Make provider failure retry/debug state decisions explicit for stop vs destroy behavior.

## Phase 8
- Wave 2: Pure Domain Extraction
- Lane: 2C Workspace domain

## Invariants touched
- Workspace visible status transition table and start behavior for pending, materializing, ready, archived, and error states.
- Repo post-ready initial phase and setup-run active-token matching.
- Setup-run stale vs final classification for missing workspaces, superseded tokens, success, failure, and timeout callers.
- Stop/delete provider failure behavior that preserves stop retry/debug state and clears destroy state as before.

## Verification
- `DEBUG=true uv run --python /opt/homebrew/bin/python3.12 --extra dev python -m pytest -q tests/unit/test_cloud_workspace_lifecycle_domain.py tests/unit/test_cloud_workspace_service.py tests/integration/test_cloud_workspace_lifecycle_store.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`