### PR TITLE
refactor(server): extract automation claim lifecycle domain

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,7 +11,8 @@ SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional s
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 12 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions own transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 3 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transitional store owns transaction commit
@@ -21,7 +22,8 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 16 transit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 1 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 13 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions open DB sessions
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 4 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/cloud workspace helper still opens isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -38,6 +38,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 4 transitional wrappers used by deferred billing/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 worker/cloud workspace helper still imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/billing.py 1 transitional store imports DB session factory

--- a/server/proliferate/db/store/automation_cloud_workspace_claims.py
+++ b/server/proliferate/db/store/automation_cloud_workspace_claims.py
@@ -8,11 +8,14 @@ from uuid import UUID
 from proliferate.constants.automations import (
     AUTOMATION_EXECUTION_TARGET_CLOUD,
     AUTOMATION_EXECUTOR_KIND_CLOUD,
-    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
 )
 from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
-from proliferate.db.store.automation_run_claims import load_claimed_run_for_update
+from proliferate.db.store.automation_run_claims import (
+    ClaimActivePredicate,
+    ClaimTransitionRule,
+    load_claimed_run_for_update,
+)
 from proliferate.db.store.cloud_workspaces import create_cloud_workspace_record
 
 
@@ -30,6 +33,8 @@ async def create_cloud_workspace_for_claimed_run(
     origin_json: str | None,
     template_version: str,
     now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
     cloud_repo_limit: int | None = None,
 ) -> CloudWorkspace | None:
     async with db_engine.async_session_factory() as db:
@@ -38,9 +43,10 @@ async def create_cloud_workspace_for_claimed_run(
             run_id=run_id,
             claim_id=claim_id,
             now=now,
-            allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_WORKSPACE}),
+            allowed_statuses=transition.allowed_statuses,
             execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
             executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+            claim_is_active=claim_is_active,
             user_id=user_id,
         )
         if run is None:

--- a/server/proliferate/db/store/automation_run_claim_transitions.py
+++ b/server/proliferate/db/store/automation_run_claim_transitions.py
@@ -19,6 +19,7 @@ from proliferate.constants.automations import (
     AUTOMATION_RUN_STATUS_FAILED,
     AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
 )
+from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import AutomationRun
 from proliferate.db.store.automation_run_claim_values import (
     AutomationRunClaimValue,
@@ -28,7 +29,6 @@ from proliferate.db.store.automation_run_claims import (
     ClaimActivePredicate,
     ClaimTransitionRule,
     clear_claim_metadata,
-    db_engine,
     load_claimed_run_for_update,
 )
 

--- a/server/proliferate/db/store/automation_run_claim_transitions.py
+++ b/server/proliferate/db/store/automation_run_claim_transitions.py
@@ -1,0 +1,377 @@
+"""Executor claim transition persistence for automation runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_EXECUTION_TARGET_LOCAL,
+    AUTOMATION_EXECUTOR_KIND_CLOUD,
+    AUTOMATION_EXECUTOR_KIND_DESKTOP,
+    AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+    AUTOMATION_RUN_STATUS_DISPATCHED,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    AUTOMATION_RUN_STATUS_FAILED,
+    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+)
+from proliferate.db.models.automations import AutomationRun
+from proliferate.db.store.automation_run_claim_values import (
+    AutomationRunClaimValue,
+    claim_value,
+)
+from proliferate.db.store.automation_run_claims import (
+    ClaimActivePredicate,
+    ClaimTransitionRule,
+    clear_claim_metadata,
+    db_engine,
+    load_claimed_run_for_update,
+)
+
+
+def _transition_requirements_satisfied(
+    run: AutomationRun,
+    rule: ClaimTransitionRule,
+) -> bool:
+    if rule.requires_cloud_workspace and run.cloud_workspace_id is None:
+        return False
+    if rule.requires_anyharness_workspace and run.anyharness_workspace_id is None:
+        return False
+    return not (rule.requires_anyharness_session and run.anyharness_session_id is None)
+
+
+async def _load_run_for_transition(
+    db: AsyncSession,
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    execution_target: str,
+    executor_kind: str,
+    claim_is_active: ClaimActivePredicate,
+    user_id: UUID | None = None,
+) -> AutomationRun | None:
+    run = await load_claimed_run_for_update(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        allowed_statuses=transition.allowed_statuses,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None or not _transition_requirements_satisfied(run, transition):
+        return None
+    return run
+
+
+async def _mark_claim_status(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    status: str,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str,
+    executor_kind: str,
+    user_id: UUID | None = None,
+    anyharness_workspace_id: str | None = None,
+    dispatch_started_at: datetime | None = None,
+) -> AutomationRunClaimValue | None:
+    async with db_engine.async_session_factory() as db:
+        run = await _load_run_for_transition(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
+            user_id=user_id,
+        )
+        if run is None:
+            return None
+        run.status = status
+        if anyharness_workspace_id is not None:
+            run.anyharness_workspace_id = anyharness_workspace_id
+        if dispatch_started_at is not None:
+            run.dispatch_started_at = dispatch_started_at
+        run.updated_at = now
+        await db.commit()
+        return claim_value(run)
+
+
+async def mark_run_creating_workspace(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    return await _mark_claim_status(
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+    )
+
+
+async def attach_cloud_workspace_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    cloud_workspace_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> bool:
+    async with db_engine.async_session_factory() as db:
+        run = await _load_run_for_transition(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+            claim_is_active=claim_is_active,
+        )
+        if run is None:
+            return False
+        run.cloud_workspace_id = cloud_workspace_id
+        run.updated_at = now
+        await db.commit()
+        return True
+
+
+async def attach_anyharness_workspace_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_LOCAL,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_DESKTOP,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    async with db_engine.async_session_factory() as db:
+        run = await _load_run_for_transition(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
+            user_id=user_id,
+        )
+        if run is None:
+            return None
+        run.anyharness_workspace_id = anyharness_workspace_id
+        run.updated_at = now
+        await db.commit()
+        return claim_value(run)
+
+
+async def mark_run_provisioning_workspace(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    return await _mark_claim_status(
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+    )
+
+
+async def mark_run_creating_session(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    return await _mark_claim_status(
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+    )
+
+
+async def attach_anyharness_session_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    anyharness_session_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> bool:
+    async with db_engine.async_session_factory() as db:
+        run = await _load_run_for_transition(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
+            user_id=user_id,
+        )
+        if run is None:
+            return False
+        run.anyharness_workspace_id = anyharness_workspace_id
+        run.anyharness_session_id = anyharness_session_id
+        run.updated_at = now
+        await db.commit()
+        return True
+
+
+async def mark_run_dispatching(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    return await _mark_claim_status(
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_DISPATCHING,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+        dispatch_started_at=now,
+    )
+
+
+async def mark_run_dispatched(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    anyharness_session_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> bool:
+    async with db_engine.async_session_factory() as db:
+        run = await _load_run_for_transition(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
+            user_id=user_id,
+        )
+        if run is None:
+            return False
+        run.status = AUTOMATION_RUN_STATUS_DISPATCHED
+        run.dispatched_at = now
+        run.anyharness_workspace_id = anyharness_workspace_id
+        run.anyharness_session_id = anyharness_session_id
+        clear_claim_metadata(run)
+        run.updated_at = now
+        await db.commit()
+        return True
+
+
+async def mark_run_failed(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    error_code: str,
+    message: str,
+    now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> bool:
+    async with db_engine.async_session_factory() as db:
+        run = await load_claimed_run_for_update(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            allowed_statuses=active_statuses,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
+            user_id=user_id,
+        )
+        if run is None:
+            return False
+        run.status = AUTOMATION_RUN_STATUS_FAILED
+        run.failed_at = now
+        run.last_error_code = error_code
+        run.last_error_message = message
+        clear_claim_metadata(run)
+        run.updated_at = now
+        await db.commit()
+        return True

--- a/server/proliferate/db/store/automation_run_claim_values.py
+++ b/server/proliferate/db/store/automation_run_claim_values.py
@@ -1,81 +1,12 @@
-"""Shared automation run claim value objects and error copy."""
+"""Shared automation run claim value objects."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final
 from uuid import UUID
 
-from proliferate.constants.automations import (
-    AUTOMATION_RUN_STATUS_CANCELLED,
-    AUTOMATION_RUN_STATUS_CLAIMED,
-    AUTOMATION_RUN_STATUS_CREATING_SESSION,
-    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-    AUTOMATION_RUN_STATUS_DISPATCHED,
-    AUTOMATION_RUN_STATUS_DISPATCHING,
-    AUTOMATION_RUN_STATUS_FAILED,
-    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-)
 from proliferate.db.models.automations import AutomationRun
-
-AUTOMATION_ERROR_DISPATCH_UNCERTAIN: Final = "dispatch_uncertain"
-AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE: Final = (
-    "Prompt delivery could not be confirmed after the executor stopped responding."
-)
-AUTOMATION_ERROR_AGENT_NOT_CONFIGURED: Final = "agent_not_configured"
-AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE: Final = (
-    "Choose an agent before this automation can run."
-)
-AUTOMATION_ERROR_MESSAGES: Final = {
-    AUTOMATION_ERROR_AGENT_NOT_CONFIGURED: AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE,
-    "agent_not_ready": "The requested cloud agent is not ready in the runtime.",
-    "user_not_found": "The automation owner is no longer available.",
-    "workspace_missing": "The cloud workspace for this run could not be found.",
-    "workspace_create_stale_claim": "The executor lost its claim while creating the workspace.",
-    "workspace_provision_failed": "Cloud workspace provisioning failed.",
-    "runtime_not_ready": "The runtime was not ready.",
-    "session_create_failed": "The runtime could not create a session.",
-    "config_apply_failed": "The runtime could not apply the requested configuration.",
-    "prompt_send_failed": "The runtime could not accept the automation prompt.",
-    "stale_claim": "The executor lost its claim before the run was dispatched.",
-    "unexpected_executor_error": "The executor could not dispatch this run.",
-    "local_repo_not_available": "This repository is not available in the local runtime.",
-    "local_agent_not_ready": "The requested local agent is not ready in the runtime.",
-    "local_workspace_create_failed": "The local worktree could not be created or reused.",
-    "local_workspace_setup_failed": "The local worktree setup script did not complete.",
-    "local_session_create_failed": "The local runtime could not create a session.",
-    "local_config_apply_failed": "The local runtime could not apply the requested configuration.",
-    "local_prompt_send_failed": "The local runtime could not accept the automation prompt.",
-    "local_unexpected_executor_error": "The local executor could not dispatch this run.",
-    AUTOMATION_ERROR_DISPATCH_UNCERTAIN: AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE,
-}
-AUTOMATION_ERROR_DEFAULT_MESSAGE: Final = "The executor could not dispatch this run."
-
-RECLAIMABLE_STATUSES: Final = frozenset(
-    {
-        AUTOMATION_RUN_STATUS_CLAIMED,
-        AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-        AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-        AUTOMATION_RUN_STATUS_CREATING_SESSION,
-    }
-)
-ACTIVE_CLAIM_STATUSES: Final = frozenset(
-    {
-        AUTOMATION_RUN_STATUS_CLAIMED,
-        AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-        AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-        AUTOMATION_RUN_STATUS_CREATING_SESSION,
-        AUTOMATION_RUN_STATUS_DISPATCHING,
-    }
-)
-TERMINAL_STATUSES: Final = frozenset(
-    {
-        AUTOMATION_RUN_STATUS_DISPATCHED,
-        AUTOMATION_RUN_STATUS_FAILED,
-        AUTOMATION_RUN_STATUS_CANCELLED,
-    }
-)
 
 
 @dataclass(frozen=True)
@@ -101,34 +32,6 @@ class AutomationRunClaimValue:
     cloud_workspace_id: UUID | None
     anyharness_workspace_id: str | None
     anyharness_session_id: str | None
-
-
-@dataclass(frozen=True)
-class LocalAutomationRepoIdentity:
-    provider: str
-    owner: str
-    name: str
-
-
-def automation_error_message(code: str) -> str:
-    return AUTOMATION_ERROR_MESSAGES.get(code, AUTOMATION_ERROR_DEFAULT_MESSAGE)
-
-
-def canonical_repo_identity(
-    provider: str,
-    owner: str,
-    name: str,
-) -> LocalAutomationRepoIdentity | None:
-    normalized_provider = provider.strip().lower()
-    normalized_owner = owner.strip().lower()
-    normalized_name = name.strip().lower()
-    if not normalized_provider or not normalized_owner or not normalized_name:
-        return None
-    return LocalAutomationRepoIdentity(
-        provider=normalized_provider,
-        owner=normalized_owner,
-        name=normalized_name,
-    )
 
 
 def claim_value(run: AutomationRun) -> AutomationRunClaimValue:

--- a/server/proliferate/db/store/automation_run_claims.py
+++ b/server/proliferate/db/store/automation_run_claims.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Protocol
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, func, or_, select
@@ -14,31 +15,37 @@ from proliferate.constants.automations import (
     AUTOMATION_EXECUTOR_KIND_CLOUD,
     AUTOMATION_EXECUTOR_KIND_DESKTOP,
     AUTOMATION_RUN_STATUS_CLAIMED,
-    AUTOMATION_RUN_STATUS_CREATING_SESSION,
-    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-    AUTOMATION_RUN_STATUS_DISPATCHED,
-    AUTOMATION_RUN_STATUS_DISPATCHING,
     AUTOMATION_RUN_STATUS_FAILED,
-    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
     AUTOMATION_RUN_STATUS_QUEUED,
 )
 from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import AutomationRun
 from proliferate.db.store.automation_run_claim_values import (
-    ACTIVE_CLAIM_STATUSES,
-    AUTOMATION_ERROR_AGENT_NOT_CONFIGURED,
-    AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE,
-    AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
-    AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE,
-    RECLAIMABLE_STATUSES,
     AutomationRunClaimValue,
-    LocalAutomationRepoIdentity,
     claim_value,
 )
 
 
-def _claim_is_active(run: AutomationRun, now: datetime) -> bool:
-    return run.claim_expires_at is not None and run.claim_expires_at > now
+class ClaimFailure(Protocol):
+    code: str
+    message: str
+
+
+class ClaimTransitionRule(Protocol):
+    allowed_statuses: frozenset[str]
+    requires_cloud_workspace: bool
+    requires_anyharness_workspace: bool
+    requires_anyharness_session: bool
+
+
+class LocalAutomationRepoIdentity(Protocol):
+    provider: str
+    owner: str
+    name: str
+
+
+class ClaimActivePredicate(Protocol):
+    def __call__(self, claim_expires_at: datetime | None, now: datetime) -> bool: ...
 
 
 async def load_claimed_run_for_update(
@@ -50,6 +57,7 @@ async def load_claimed_run_for_update(
     allowed_statuses: frozenset[str],
     execution_target: str,
     executor_kind: str,
+    claim_is_active: ClaimActivePredicate,
     user_id: UUID | None = None,
 ) -> AutomationRun | None:
     predicates = [
@@ -65,24 +73,28 @@ async def load_claimed_run_for_update(
     run = (
         await db.execute(select(AutomationRun).where(*predicates).with_for_update())
     ).scalar_one_or_none()
-    if run is None or not _claim_is_active(run, now):
+    if run is None or not claim_is_active(run.claim_expires_at, now):
         return None
     return run
 
 
-def _clear_claim(run: AutomationRun) -> None:
+def clear_claim_metadata(run: AutomationRun) -> None:
     run.executor_kind = None
     run.executor_id = None
     run.claim_id = None
     run.claim_expires_at = None
 
 
-def _fail_unconfigured_agent(run: AutomationRun, now: datetime) -> None:
+def _fail_unconfigured_agent(
+    run: AutomationRun,
+    now: datetime,
+    failure: ClaimFailure,
+) -> None:
     run.status = AUTOMATION_RUN_STATUS_FAILED
     run.failed_at = now
-    run.last_error_code = AUTOMATION_ERROR_AGENT_NOT_CONFIGURED
-    run.last_error_message = AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE
-    _clear_claim(run)
+    run.last_error_code = failure.code
+    run.last_error_message = failure.message
+    clear_claim_metadata(run)
     run.updated_at = now
 
 
@@ -92,6 +104,8 @@ async def claim_cloud_automation_runs(
     claim_ttl: timedelta,
     limit: int,
     now: datetime,
+    reclaimable_statuses: frozenset[str],
+    unconfigured_agent_failure: ClaimFailure,
 ) -> list[AutomationRunClaimValue]:
     return await _claim_automation_runs(
         executor_id=executor_id,
@@ -100,6 +114,8 @@ async def claim_cloud_automation_runs(
         claim_ttl=claim_ttl,
         limit=limit,
         now=now,
+        reclaimable_statuses=reclaimable_statuses,
+        unconfigured_agent_failure=unconfigured_agent_failure,
         user_id=None,
         repo_identities=None,
     )
@@ -113,6 +129,8 @@ async def claim_local_automation_runs(
     claim_ttl: timedelta,
     limit: int,
     now: datetime,
+    reclaimable_statuses: frozenset[str],
+    unconfigured_agent_failure: ClaimFailure,
 ) -> list[AutomationRunClaimValue]:
     identities = {
         (identity.provider, identity.owner, identity.name)
@@ -128,11 +146,10 @@ async def claim_local_automation_runs(
         claim_ttl=claim_ttl,
         limit=limit,
         now=now,
+        reclaimable_statuses=reclaimable_statuses,
+        unconfigured_agent_failure=unconfigured_agent_failure,
         user_id=user_id,
-        repo_identities=[
-            LocalAutomationRepoIdentity(provider=provider, owner=owner, name=name)
-            for provider, owner, name in sorted(identities)
-        ],
+        repo_identities=sorted(identities),
     )
 
 
@@ -144,15 +161,17 @@ async def _claim_automation_runs(
     claim_ttl: timedelta,
     limit: int,
     now: datetime,
+    reclaimable_statuses: frozenset[str],
+    unconfigured_agent_failure: ClaimFailure,
     user_id: UUID | None,
-    repo_identities: list[LocalAutomationRepoIdentity] | None,
+    repo_identities: list[tuple[str, str, str]] | None,
 ) -> list[AutomationRunClaimValue]:
     predicates = [
         AutomationRun.execution_target == execution_target,
         or_(
             AutomationRun.status == AUTOMATION_RUN_STATUS_QUEUED,
             (
-                AutomationRun.status.in_(RECLAIMABLE_STATUSES)
+                AutomationRun.status.in_(reclaimable_statuses)
                 & (AutomationRun.claim_expires_at.is_not(None))
                 & (AutomationRun.claim_expires_at <= now)
             ),
@@ -165,11 +184,11 @@ async def _claim_automation_runs(
             or_(
                 *[
                     and_(
-                        func.lower(AutomationRun.git_provider_snapshot) == identity.provider,
-                        func.lower(AutomationRun.git_owner_snapshot) == identity.owner,
-                        func.lower(AutomationRun.git_repo_name_snapshot) == identity.name,
+                        func.lower(AutomationRun.git_provider_snapshot) == provider,
+                        func.lower(AutomationRun.git_owner_snapshot) == owner,
+                        func.lower(AutomationRun.git_repo_name_snapshot) == name,
                     )
-                    for identity in repo_identities
+                    for provider, owner, name in repo_identities
                 ]
             )
         )
@@ -192,7 +211,7 @@ async def _claim_automation_runs(
         values: list[AutomationRunClaimValue] = []
         for run in rows:
             if run.agent_kind_snapshot is None:
-                _fail_unconfigured_agent(run, now)
+                _fail_unconfigured_agent(run, now, unconfigured_agent_failure)
                 continue
             run.status = AUTOMATION_RUN_STATUS_CLAIMED
             run.executor_kind = executor_kind
@@ -215,6 +234,8 @@ async def load_current_run_claim(
     run_id: UUID,
     claim_id: UUID,
     now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
     execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
@@ -225,9 +246,10 @@ async def load_current_run_claim(
             run_id=run_id,
             claim_id=claim_id,
             now=now,
-            allowed_statuses=ACTIVE_CLAIM_STATUSES,
+            allowed_statuses=active_statuses,
             execution_target=execution_target,
             executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
             user_id=user_id,
         )
         if run is None:
@@ -241,6 +263,8 @@ async def heartbeat_run_claim(
     claim_id: UUID,
     claim_ttl: timedelta,
     now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
     execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
@@ -251,9 +275,10 @@ async def heartbeat_run_claim(
             run_id=run_id,
             claim_id=claim_id,
             now=now,
-            allowed_statuses=ACTIVE_CLAIM_STATUSES,
+            allowed_statuses=active_statuses,
             execution_target=execution_target,
             executor_kind=executor_kind,
+            claim_is_active=claim_is_active,
             user_id=user_id,
         )
         if run is None:
@@ -265,310 +290,13 @@ async def heartbeat_run_claim(
         return claim_value(run)
 
 
-async def mark_run_creating_workspace(
+async def sweep_expired_dispatching_runs(
     *,
-    run_id: UUID,
-    claim_id: UUID,
     now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CLAIMED}),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        run.status = AUTOMATION_RUN_STATUS_CREATING_WORKSPACE
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
-
-
-async def attach_cloud_workspace_to_run(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    cloud_workspace_id: UUID,
-    now: datetime,
-) -> bool:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset(
-                {
-                    AUTOMATION_RUN_STATUS_CLAIMED,
-                    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-                    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-                }
-            ),
-            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-        )
-        if run is None:
-            return False
-        run.cloud_workspace_id = cloud_workspace_id
-        run.updated_at = now
-        await db.commit()
-        return True
-
-
-async def attach_anyharness_workspace_to_run(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    anyharness_workspace_id: str,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_LOCAL,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_DESKTOP,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset(
-                {
-                    AUTOMATION_RUN_STATUS_CLAIMED,
-                    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-                    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-                    AUTOMATION_RUN_STATUS_CREATING_SESSION,
-                }
-            ),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
-
-
-async def mark_run_provisioning_workspace(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset(
-                {
-                    AUTOMATION_RUN_STATUS_CLAIMED,
-                    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-                    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-                }
-            ),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        if (
-            execution_target == AUTOMATION_EXECUTION_TARGET_CLOUD
-            and run.cloud_workspace_id is None
-        ):
-            return None
-        if (
-            execution_target == AUTOMATION_EXECUTION_TARGET_LOCAL
-            and run.anyharness_workspace_id is None
-        ):
-            return None
-        run.status = AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
-
-
-async def mark_run_creating_session(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    anyharness_workspace_id: str,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset(
-                {
-                    AUTOMATION_RUN_STATUS_CLAIMED,
-                    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-                    AUTOMATION_RUN_STATUS_CREATING_SESSION,
-                }
-            ),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        run.status = AUTOMATION_RUN_STATUS_CREATING_SESSION
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
-
-
-async def attach_anyharness_session_to_run(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    anyharness_workspace_id: str,
-    anyharness_session_id: str,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> bool:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_SESSION}),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.anyharness_session_id = anyharness_session_id
-        run.updated_at = now
-        await db.commit()
-        return True
-
-
-async def mark_run_dispatching(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_SESSION}),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None or run.anyharness_session_id is None or run.anyharness_workspace_id is None:
-            return None
-        run.status = AUTOMATION_RUN_STATUS_DISPATCHING
-        run.dispatch_started_at = now
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
-
-
-async def mark_run_dispatched(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    anyharness_workspace_id: str,
-    anyharness_session_id: str,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> bool:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_DISPATCHING}),
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.status = AUTOMATION_RUN_STATUS_DISPATCHED
-        run.dispatched_at = now
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.anyharness_session_id = anyharness_session_id
-        _clear_claim(run)
-        run.updated_at = now
-        await db.commit()
-        return True
-
-
-async def mark_run_failed(
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    error_code: str,
-    message: str,
-    now: datetime,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> bool:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=ACTIVE_CLAIM_STATUSES,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.status = AUTOMATION_RUN_STATUS_FAILED
-        run.failed_at = now
-        run.last_error_code = error_code
-        run.last_error_message = message
-        _clear_claim(run)
-        run.updated_at = now
-        await db.commit()
-        return True
-
-
-async def sweep_expired_dispatching_runs(*, now: datetime, limit: int = 100) -> int:
+    dispatching_status: str,
+    dispatch_uncertain_failure: ClaimFailure,
+    limit: int = 100,
+) -> int:
     if limit <= 0:
         return 0
     async with db_engine.async_session_factory() as db:
@@ -577,7 +305,7 @@ async def sweep_expired_dispatching_runs(*, now: datetime, limit: int = 100) -> 
                 await db.execute(
                     select(AutomationRun)
                     .where(
-                        AutomationRun.status == AUTOMATION_RUN_STATUS_DISPATCHING,
+                        AutomationRun.status == dispatching_status,
                         AutomationRun.claim_expires_at.is_not(None),
                         AutomationRun.claim_expires_at <= now,
                     )
@@ -592,9 +320,9 @@ async def sweep_expired_dispatching_runs(*, now: datetime, limit: int = 100) -> 
         for run in runs:
             run.status = AUTOMATION_RUN_STATUS_FAILED
             run.failed_at = now
-            run.last_error_code = AUTOMATION_ERROR_DISPATCH_UNCERTAIN
-            run.last_error_message = AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE
-            _clear_claim(run)
+            run.last_error_code = dispatch_uncertain_failure.code
+            run.last_error_message = dispatch_uncertain_failure.message
+            clear_claim_metadata(run)
             run.updated_at = now
         await db.commit()
         return len(runs)

--- a/server/proliferate/server/automations/domain/claim_lifecycle.py
+++ b/server/proliferate/server/automations/domain/claim_lifecycle.py
@@ -1,0 +1,270 @@
+"""Pure automation run claim lifecycle rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Final
+from uuid import UUID
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_LOCAL,
+    AUTOMATION_LOCAL_FALLBACK_ERROR_CODE,
+    AUTOMATION_LOCAL_SHARED_ERROR_CODES,
+    AUTOMATION_RUN_STATUS_CANCELLED,
+    AUTOMATION_RUN_STATUS_CLAIMED,
+    AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+    AUTOMATION_RUN_STATUS_DISPATCHED,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    AUTOMATION_RUN_STATUS_FAILED,
+    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+)
+
+AUTOMATION_ERROR_DISPATCH_UNCERTAIN: Final = "dispatch_uncertain"
+AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE: Final = (
+    "Prompt delivery could not be confirmed after the executor stopped responding."
+)
+AUTOMATION_ERROR_AGENT_NOT_CONFIGURED: Final = "agent_not_configured"
+AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE: Final = (
+    "Choose an agent before this automation can run."
+)
+AUTOMATION_ERROR_MESSAGES: Final = {
+    AUTOMATION_ERROR_AGENT_NOT_CONFIGURED: AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE,
+    "agent_not_ready": "The requested cloud agent is not ready in the runtime.",
+    "user_not_found": "The automation owner is no longer available.",
+    "workspace_missing": "The cloud workspace for this run could not be found.",
+    "workspace_create_stale_claim": "The executor lost its claim while creating the workspace.",
+    "workspace_provision_failed": "Cloud workspace provisioning failed.",
+    "runtime_not_ready": "The runtime was not ready.",
+    "session_create_failed": "The runtime could not create a session.",
+    "config_apply_failed": "The runtime could not apply the requested configuration.",
+    "prompt_send_failed": "The runtime could not accept the automation prompt.",
+    "stale_claim": "The executor lost its claim before the run was dispatched.",
+    "unexpected_executor_error": "The executor could not dispatch this run.",
+    "local_repo_not_available": "This repository is not available in the local runtime.",
+    "local_agent_not_ready": "The requested local agent is not ready in the runtime.",
+    "local_workspace_create_failed": "The local worktree could not be created or reused.",
+    "local_workspace_setup_failed": "The local worktree setup script did not complete.",
+    "local_session_create_failed": "The local runtime could not create a session.",
+    "local_config_apply_failed": "The local runtime could not apply the requested configuration.",
+    "local_prompt_send_failed": "The local runtime could not accept the automation prompt.",
+    "local_unexpected_executor_error": "The local executor could not dispatch this run.",
+    AUTOMATION_ERROR_DISPATCH_UNCERTAIN: AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE,
+}
+AUTOMATION_ERROR_DEFAULT_MESSAGE: Final = "The executor could not dispatch this run."
+
+RECLAIMABLE_STATUSES: Final = frozenset(
+    {
+        AUTOMATION_RUN_STATUS_CLAIMED,
+        AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    }
+)
+ACTIVE_CLAIM_STATUSES: Final = frozenset(
+    {
+        AUTOMATION_RUN_STATUS_CLAIMED,
+        AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        AUTOMATION_RUN_STATUS_DISPATCHING,
+    }
+)
+TERMINAL_STATUSES: Final = frozenset(
+    {
+        AUTOMATION_RUN_STATUS_DISPATCHED,
+        AUTOMATION_RUN_STATUS_FAILED,
+        AUTOMATION_RUN_STATUS_CANCELLED,
+    }
+)
+
+
+@dataclass(frozen=True)
+class ClaimFailure:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ClaimTransitionRule:
+    allowed_statuses: frozenset[str]
+    requires_cloud_workspace: bool = False
+    requires_anyharness_workspace: bool = False
+    requires_anyharness_session: bool = False
+
+
+@dataclass(frozen=True)
+class ClaimIdentity:
+    run_id: UUID
+    claim_id: UUID | None
+    execution_target: str
+    executor_kind: str | None
+    user_id: UUID | None
+
+
+@dataclass(frozen=True)
+class LocalAutomationRepoIdentity:
+    provider: str
+    owner: str
+    name: str
+
+
+CREATING_WORKSPACE_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CLAIMED})
+)
+CLOUD_WORKSPACE_CREATION_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_WORKSPACE})
+)
+CLOUD_WORKSPACE_ATTACHMENT_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset(
+        {
+            AUTOMATION_RUN_STATUS_CLAIMED,
+            AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+            AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        }
+    )
+)
+ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset(
+        {
+            AUTOMATION_RUN_STATUS_CLAIMED,
+            AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+            AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+            AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        }
+    )
+)
+CLOUD_PROVISIONING_WORKSPACE_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset(
+        {
+            AUTOMATION_RUN_STATUS_CLAIMED,
+            AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+            AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        }
+    ),
+    requires_cloud_workspace=True,
+)
+LOCAL_PROVISIONING_WORKSPACE_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=CLOUD_PROVISIONING_WORKSPACE_TRANSITION.allowed_statuses,
+    requires_anyharness_workspace=True,
+)
+CREATING_SESSION_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset(
+        {
+            AUTOMATION_RUN_STATUS_CLAIMED,
+            AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+            AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        }
+    )
+)
+ANYHARNESS_SESSION_ATTACHMENT_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_SESSION})
+)
+DISPATCHING_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_CREATING_SESSION}),
+    requires_anyharness_workspace=True,
+    requires_anyharness_session=True,
+)
+DISPATCHED_TRANSITION: Final = ClaimTransitionRule(
+    allowed_statuses=frozenset({AUTOMATION_RUN_STATUS_DISPATCHING})
+)
+
+
+def claim_is_active(claim_expires_at: datetime | None, now: datetime) -> bool:
+    return claim_expires_at is not None and claim_expires_at > now
+
+
+def is_reclaimable_status(status: str) -> bool:
+    return status in RECLAIMABLE_STATUSES
+
+
+def is_active_claim_status(status: str) -> bool:
+    return status in ACTIVE_CLAIM_STATUSES
+
+
+def is_terminal_status(status: str) -> bool:
+    return status in TERMINAL_STATUSES
+
+
+def is_expired_reclaimable_claim(
+    status: str,
+    claim_expires_at: datetime | None,
+    now: datetime,
+) -> bool:
+    return (
+        is_reclaimable_status(status) and claim_expires_at is not None and claim_expires_at <= now
+    )
+
+
+def is_expired_dispatching_claim(
+    status: str,
+    claim_expires_at: datetime | None,
+    now: datetime,
+) -> bool:
+    return (
+        status == AUTOMATION_RUN_STATUS_DISPATCHING
+        and claim_expires_at is not None
+        and claim_expires_at <= now
+    )
+
+
+def provisioning_workspace_transition(execution_target: str) -> ClaimTransitionRule:
+    if execution_target == AUTOMATION_EXECUTION_TARGET_LOCAL:
+        return LOCAL_PROVISIONING_WORKSPACE_TRANSITION
+    return CLOUD_PROVISIONING_WORKSPACE_TRANSITION
+
+
+def claim_identity_matches(expected: ClaimIdentity, actual: ClaimIdentity) -> bool:
+    if actual.run_id != expected.run_id:
+        return False
+    if actual.claim_id != expected.claim_id:
+        return False
+    if actual.execution_target != expected.execution_target:
+        return False
+    if actual.executor_kind != expected.executor_kind:
+        return False
+    return expected.user_id is None or actual.user_id == expected.user_id
+
+
+def unconfigured_agent_failure() -> ClaimFailure:
+    return ClaimFailure(
+        code=AUTOMATION_ERROR_AGENT_NOT_CONFIGURED,
+        message=AUTOMATION_ERROR_AGENT_NOT_CONFIGURED_MESSAGE,
+    )
+
+
+def dispatch_uncertain_failure() -> ClaimFailure:
+    return ClaimFailure(
+        code=AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
+        message=AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE,
+    )
+
+
+def automation_error_message(code: str) -> str:
+    return AUTOMATION_ERROR_MESSAGES.get(code, AUTOMATION_ERROR_DEFAULT_MESSAGE)
+
+
+def normalize_local_error_code(error_code: str) -> str:
+    if error_code.startswith("local_") and error_code in AUTOMATION_ERROR_MESSAGES:
+        return error_code
+    if error_code in AUTOMATION_LOCAL_SHARED_ERROR_CODES:
+        return error_code
+    return AUTOMATION_LOCAL_FALLBACK_ERROR_CODE
+
+
+def canonical_repo_identity(
+    provider: str,
+    owner: str,
+    name: str,
+) -> LocalAutomationRepoIdentity | None:
+    normalized_provider = provider.strip().lower()
+    normalized_owner = owner.strip().lower()
+    normalized_name = name.strip().lower()
+    if not normalized_provider or not normalized_owner or not normalized_name:
+        return None
+    return LocalAutomationRepoIdentity(
+        provider=normalized_provider,
+        owner=normalized_owner,
+        name=normalized_name,
+    )

--- a/server/proliferate/server/automations/local_executor_service.py
+++ b/server/proliferate/server/automations/local_executor_service.py
@@ -17,27 +17,42 @@ from proliferate.constants.automations import (
     AUTOMATION_LOCAL_CLAIM_MAX_LIMIT,
     AUTOMATION_LOCAL_CLAIM_TTL_SECONDS,
     AUTOMATION_LOCAL_ERROR_CODE_MAX_LENGTH,
-    AUTOMATION_LOCAL_FALLBACK_ERROR_CODE,
     AUTOMATION_LOCAL_REPOSITORY_IDENTITIES_MAX_LIMIT,
-    AUTOMATION_LOCAL_SHARED_ERROR_CODES,
 )
-from proliferate.db.store.automation_run_claim_values import (
-    AUTOMATION_ERROR_MESSAGES,
-    AutomationRunClaimValue,
-    automation_error_message,
-    canonical_repo_identity,
-)
-from proliferate.db.store.automation_run_claims import (
+from proliferate.db.store.automation_run_claim_transitions import (
     attach_anyharness_session_to_run,
     attach_anyharness_workspace_to_run,
-    claim_local_automation_runs,
-    heartbeat_run_claim,
     mark_run_creating_session,
     mark_run_creating_workspace,
     mark_run_dispatched,
     mark_run_dispatching,
     mark_run_failed,
     mark_run_provisioning_workspace,
+)
+from proliferate.db.store.automation_run_claim_values import (
+    AutomationRunClaimValue,
+)
+from proliferate.db.store.automation_run_claims import (
+    claim_local_automation_runs,
+    heartbeat_run_claim,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    ACTIVE_CLAIM_STATUSES,
+    ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+    ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
+    CREATING_SESSION_TRANSITION,
+    CREATING_WORKSPACE_TRANSITION,
+    DISPATCHED_TRANSITION,
+    DISPATCHING_TRANSITION,
+    RECLAIMABLE_STATUSES,
+    automation_error_message,
+    canonical_repo_identity,
+    claim_is_active,
+    provisioning_workspace_transition,
+    unconfigured_agent_failure,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    normalize_local_error_code as map_local_error_code,
 )
 from proliferate.server.automations.domain.validation import normalize_required_text
 from proliferate.server.automations.models import (
@@ -80,11 +95,7 @@ def _normalize_local_error_code(value: str) -> str:
         field_name="errorCode",
         max_length=AUTOMATION_LOCAL_ERROR_CODE_MAX_LENGTH,
     )
-    if error_code.startswith("local_") and error_code in AUTOMATION_ERROR_MESSAGES:
-        return error_code
-    if error_code in AUTOMATION_LOCAL_SHARED_ERROR_CODES:
-        return error_code
-    return AUTOMATION_LOCAL_FALLBACK_ERROR_CODE
+    return map_local_error_code(error_code)
 
 
 async def claim_local_runs(
@@ -106,6 +117,8 @@ async def claim_local_runs(
         claim_ttl=_local_claim_ttl(),
         limit=limit,
         now=utcnow(),
+        reclaimable_statuses=RECLAIMABLE_STATUSES,
+        unconfigured_agent_failure=unconfigured_agent_failure(),
     )
     return LocalAutomationClaimListResponse(runs=[local_claim_payload(value) for value in values])
 
@@ -121,6 +134,8 @@ async def heartbeat_local_run(
         claim_id=body.claim_id,
         claim_ttl=_local_claim_ttl(),
         now=utcnow(),
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -138,6 +153,8 @@ async def mark_local_run_creating_workspace(
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
+        transition=CREATING_WORKSPACE_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -160,6 +177,8 @@ async def attach_local_run_workspace(
             max_length=AUTOMATION_EXTERNAL_ID_MAX_LENGTH,
         ),
         now=utcnow(),
+        transition=ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -177,6 +196,8 @@ async def mark_local_run_provisioning_workspace(
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
+        transition=provisioning_workspace_transition(AUTOMATION_EXECUTION_TARGET_LOCAL),
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -199,6 +220,8 @@ async def mark_local_run_creating_session(
             max_length=AUTOMATION_EXTERNAL_ID_MAX_LENGTH,
         ),
         now=utcnow(),
+        transition=CREATING_SESSION_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -226,6 +249,8 @@ async def attach_local_run_session(
             max_length=AUTOMATION_EXTERNAL_ID_MAX_LENGTH,
         ),
         now=utcnow(),
+        transition=ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -243,6 +268,8 @@ async def mark_local_run_dispatching(
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
+        transition=DISPATCHING_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -270,6 +297,8 @@ async def mark_local_run_dispatched(
             max_length=AUTOMATION_EXTERNAL_ID_MAX_LENGTH,
         ),
         now=utcnow(),
+        transition=DISPATCHED_TRANSITION,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,
@@ -290,6 +319,8 @@ async def mark_local_run_failed(
         error_code=error_code,
         message=automation_error_message(error_code),
         now=utcnow(),
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
         execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
         executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
         user_id=user_id,

--- a/server/proliferate/server/automations/worker/cloud_executor.py
+++ b/server/proliferate/server/automations/worker/cloud_executor.py
@@ -8,6 +8,10 @@ import logging
 from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS
 from proliferate.db.store.automation_run_claim_values import AutomationRunClaimValue
 from proliferate.db.store.automation_run_claims import claim_cloud_automation_runs
+from proliferate.server.automations.domain.claim_lifecycle import (
+    RECLAIMABLE_STATUSES,
+    unconfigured_agent_failure,
+)
 from proliferate.server.automations.worker.cloud_executor_claims import (
     fail_claim,
     heartbeat_loop,
@@ -119,6 +123,8 @@ async def run_cloud_executor_loop(
                     claim_ttl=resolved.claim_ttl,
                     limit=available,
                     now=utcnow(),
+                    reclaimable_statuses=RECLAIMABLE_STATUSES,
+                    unconfigured_agent_failure=unconfigured_agent_failure(),
                 )
                 for claim in claims:
                     tasks.add(

--- a/server/proliferate/server/automations/worker/cloud_executor_claims.py
+++ b/server/proliferate/server/automations/worker/cloud_executor_claims.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from proliferate.db.store.automation_run_claim_transitions import (
+    mark_run_failed,
+)
 from proliferate.db.store.automation_run_claim_values import (
     AutomationRunClaimValue,
-    automation_error_message,
 )
 from proliferate.db.store.automation_run_claims import (
     heartbeat_run_claim,
     load_current_run_claim,
-    mark_run_failed,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    ACTIVE_CLAIM_STATUSES,
+    automation_error_message,
+    claim_is_active,
 )
 from proliferate.server.automations.worker.cloud_executor_config import CloudExecutorConfig
 from proliferate.utils.time import utcnow
@@ -32,6 +38,8 @@ async def fail_claim(
         error_code=code,
         message=(message or automation_error_message(code)),
         now=utcnow(),
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
     )
     if not failed:
         logger.info(
@@ -60,6 +68,8 @@ async def heartbeat_loop(
                 claim_id=claim.claim_id,
                 claim_ttl=config.claim_ttl,
                 now=utcnow(),
+                active_statuses=ACTIVE_CLAIM_STATUSES,
+                claim_is_active=claim_is_active,
             )
         except Exception:
             logger.exception("automation cloud executor heartbeat failed run_id=%s", claim.id)
@@ -77,6 +87,8 @@ async def require_current_claim(
         run_id=claim.id,
         claim_id=claim.claim_id,
         now=utcnow(),
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
     )
     if current is None:
         logger.info("automation cloud executor claim is no longer current run_id=%s", claim.id)

--- a/server/proliferate/server/automations/worker/cloud_executor_session.py
+++ b/server/proliferate/server/automations/worker/cloud_executor_session.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from proliferate.db.store.automation_run_claim_values import (
-    AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
-    AutomationRunClaimValue,
-)
-from proliferate.db.store.automation_run_claims import (
+from proliferate.db.store.automation_run_claim_transitions import (
     attach_anyharness_session_to_run,
     mark_run_creating_session,
     mark_run_dispatched,
     mark_run_dispatching,
+)
+from proliferate.db.store.automation_run_claim_values import (
+    AutomationRunClaimValue,
 )
 from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
 from proliferate.integrations.anyharness import (
@@ -24,6 +23,14 @@ from proliferate.integrations.anyharness import (
     close_runtime_session,
     create_runtime_session,
     prompt_runtime_session,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+    AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
+    CREATING_SESSION_TRANSITION,
+    DISPATCHED_TRANSITION,
+    DISPATCHING_TRANSITION,
+    claim_is_active,
 )
 from proliferate.server.automations.worker.cloud_executor_claims import (
     fail_claim,
@@ -86,6 +93,8 @@ async def create_or_load_session(
         claim_id=claim.claim_id,
         anyharness_workspace_id=target.anyharness_workspace_id,
         now=utcnow(),
+        transition=CREATING_SESSION_TRANSITION,
+        claim_is_active=claim_is_active,
     )
     if current is None:
         return None
@@ -115,6 +124,8 @@ async def create_or_load_session(
         anyharness_workspace_id=target.anyharness_workspace_id,
         anyharness_session_id=session.session_id,
         now=utcnow(),
+        transition=ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+        claim_is_active=claim_is_active,
     )
     if not attached:
         try:
@@ -179,6 +190,8 @@ async def send_prompt(context: CloudRunSessionContext) -> None:
         run_id=claim.id,
         claim_id=claim.claim_id,
         now=utcnow(),
+        transition=DISPATCHING_TRANSITION,
+        claim_is_active=claim_is_active,
     )
     if dispatching is None:
         return
@@ -212,6 +225,8 @@ async def send_prompt(context: CloudRunSessionContext) -> None:
         anyharness_workspace_id=target_workspace_id,
         anyharness_session_id=session_id,
         now=utcnow(),
+        transition=DISPATCHED_TRANSITION,
+        claim_is_active=claim_is_active,
     )
     if dispatched:
         logger.info("automation cloud executor dispatched run_id=%s", claim.id)

--- a/server/proliferate/server/automations/worker/cloud_executor_workspace.py
+++ b/server/proliferate/server/automations/worker/cloud_executor_workspace.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import logging
 
 from proliferate.constants.cloud import CloudWorkspaceStatus
-from proliferate.db.store.automation_run_claim_values import AutomationRunClaimValue
-from proliferate.db.store.automation_run_claims import (
+from proliferate.db.store.automation_run_claim_transitions import (
     mark_run_creating_workspace,
     mark_run_provisioning_workspace,
 )
+from proliferate.db.store.automation_run_claim_values import AutomationRunClaimValue
 from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
 from proliferate.db.store.users import load_user_with_oauth_accounts_by_id
+from proliferate.server.automations.domain.claim_lifecycle import (
+    CREATING_WORKSPACE_TRANSITION,
+    claim_is_active,
+    provisioning_workspace_transition,
+)
 from proliferate.server.automations.worker.cloud_executor_claims import (
     fail_claim,
     require_current_claim,
@@ -37,6 +42,8 @@ async def create_or_load_workspace(
         run_id=claim.id,
         claim_id=claim.claim_id,
         now=utcnow(),
+        transition=CREATING_WORKSPACE_TRANSITION,
+        claim_is_active=claim_is_active,
     )
     if current is None:
         return None
@@ -75,6 +82,8 @@ async def provision_workspace_for_claim(
         run_id=claim.id,
         claim_id=claim.claim_id,
         now=utcnow(),
+        transition=provisioning_workspace_transition(claim.execution_target),
+        claim_is_active=claim_is_active,
     )
     if current is None or current.cloud_workspace_id is None:
         return None

--- a/server/proliferate/server/automations/worker/service.py
+++ b/server/proliferate/server/automations/worker/service.py
@@ -13,6 +13,10 @@ from proliferate.db.store.automations import (
     AutomationScheduleFields,
     create_due_scheduled_runs_batch,
 )
+from proliferate.server.automations.domain.claim_lifecycle import (
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    dispatch_uncertain_failure,
+)
 from proliferate.server.automations.domain.schedule import due_and_next_occurrences
 from proliferate.utils.time import utcnow
 
@@ -37,7 +41,11 @@ def _resolve_due_schedule(
 
 
 async def run_scheduler_tick(*, batch_size: int = 100) -> SchedulerTickResult:
-    swept_dispatching_runs = await sweep_expired_dispatching_runs(now=utcnow())
+    swept_dispatching_runs = await sweep_expired_dispatching_runs(
+        now=utcnow(),
+        dispatching_status=AUTOMATION_RUN_STATUS_DISPATCHING,
+        dispatch_uncertain_failure=dispatch_uncertain_failure(),
+    )
     created_runs = await create_due_scheduled_runs_batch(
         now=utcnow(),
         limit=max(1, batch_size),

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -53,6 +53,10 @@ from proliferate.db.store.cloud_workspaces import (
 )
 from proliferate.integrations.anyharness import CloudRuntimeReconnectError
 from proliferate.integrations.sandbox import get_configured_sandbox_provider, get_sandbox_provider
+from proliferate.server.automations.domain.claim_lifecycle import (
+    CLOUD_WORKSPACE_CREATION_TRANSITION,
+    claim_is_active,
+)
 from proliferate.server.billing.models import BillingSnapshot, SandboxStartAuthorization
 from proliferate.server.billing.service import (
     authorize_sandbox_start,
@@ -635,6 +639,8 @@ async def create_cloud_workspace_for_automation_run(
             origin_json=CLOUD_SYSTEM_ORIGIN_JSON,
             template_version=get_configured_sandbox_provider().template_version,
             now=utcnow(),
+            transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
+            claim_is_active=claim_is_active,
             cloud_repo_limit=resolved.cloud_repo_limit,
         )
     except CloudRepoLimitExceededError as error:

--- a/server/tests/unit/automation_claim_store_helpers.py
+++ b/server/tests/unit/automation_claim_store_helpers.py
@@ -1,0 +1,143 @@
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+)
+from proliferate.db.store.automation_cloud_workspace_claims import (
+    create_cloud_workspace_for_claimed_run as create_cloud_workspace_for_claimed_run_store,
+)
+from proliferate.db.store.automation_run_claim_transitions import (
+    attach_anyharness_session_to_run as attach_anyharness_session_to_run_store,
+    attach_anyharness_workspace_to_run as attach_anyharness_workspace_to_run_store,
+    mark_run_creating_session as mark_run_creating_session_store,
+    mark_run_creating_workspace as mark_run_creating_workspace_store,
+    mark_run_dispatched as mark_run_dispatched_store,
+    mark_run_dispatching as mark_run_dispatching_store,
+    mark_run_failed as mark_run_failed_store,
+    mark_run_provisioning_workspace as mark_run_provisioning_workspace_store,
+)
+from proliferate.db.store.automation_run_claims import (
+    claim_cloud_automation_runs as claim_cloud_automation_runs_store,
+    claim_local_automation_runs as claim_local_automation_runs_store,
+    heartbeat_run_claim as heartbeat_run_claim_store,
+    sweep_expired_dispatching_runs as sweep_expired_dispatching_runs_store,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    ACTIVE_CLAIM_STATUSES,
+    ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+    ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
+    CLOUD_WORKSPACE_CREATION_TRANSITION,
+    CREATING_SESSION_TRANSITION,
+    CREATING_WORKSPACE_TRANSITION,
+    DISPATCHED_TRANSITION,
+    DISPATCHING_TRANSITION,
+    RECLAIMABLE_STATUSES,
+    claim_is_active,
+    dispatch_uncertain_failure,
+    provisioning_workspace_transition,
+    unconfigured_agent_failure,
+)
+
+
+async def claim_cloud_automation_runs(**kwargs):  # type: ignore[no-untyped-def]
+    return await claim_cloud_automation_runs_store(
+        **kwargs,
+        reclaimable_statuses=RECLAIMABLE_STATUSES,
+        unconfigured_agent_failure=unconfigured_agent_failure(),
+    )
+
+
+async def claim_local_automation_runs(**kwargs):  # type: ignore[no-untyped-def]
+    return await claim_local_automation_runs_store(
+        **kwargs,
+        reclaimable_statuses=RECLAIMABLE_STATUSES,
+        unconfigured_agent_failure=unconfigured_agent_failure(),
+    )
+
+
+async def heartbeat_run_claim(**kwargs):  # type: ignore[no-untyped-def]
+    return await heartbeat_run_claim_store(
+        **kwargs,
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_creating_workspace(**kwargs):  # type: ignore[no-untyped-def]
+    return await mark_run_creating_workspace_store(
+        **kwargs,
+        transition=CREATING_WORKSPACE_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def attach_anyharness_workspace_to_run(**kwargs):  # type: ignore[no-untyped-def]
+    return await attach_anyharness_workspace_to_run_store(
+        **kwargs,
+        transition=ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_provisioning_workspace(**kwargs):  # type: ignore[no-untyped-def]
+    execution_target = kwargs.get("execution_target", AUTOMATION_EXECUTION_TARGET_CLOUD)
+    return await mark_run_provisioning_workspace_store(
+        **kwargs,
+        transition=provisioning_workspace_transition(execution_target),
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_creating_session(**kwargs):  # type: ignore[no-untyped-def]
+    return await mark_run_creating_session_store(
+        **kwargs,
+        transition=CREATING_SESSION_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def attach_anyharness_session_to_run(**kwargs):  # type: ignore[no-untyped-def]
+    return await attach_anyharness_session_to_run_store(
+        **kwargs,
+        transition=ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_dispatching(**kwargs):  # type: ignore[no-untyped-def]
+    return await mark_run_dispatching_store(
+        **kwargs,
+        transition=DISPATCHING_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_dispatched(**kwargs):  # type: ignore[no-untyped-def]
+    return await mark_run_dispatched_store(
+        **kwargs,
+        transition=DISPATCHED_TRANSITION,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def mark_run_failed(**kwargs):  # type: ignore[no-untyped-def]
+    return await mark_run_failed_store(
+        **kwargs,
+        active_statuses=ACTIVE_CLAIM_STATUSES,
+        claim_is_active=claim_is_active,
+    )
+
+
+async def sweep_expired_dispatching_runs(**kwargs):  # type: ignore[no-untyped-def]
+    return await sweep_expired_dispatching_runs_store(
+        **kwargs,
+        dispatching_status=AUTOMATION_RUN_STATUS_DISPATCHING,
+        dispatch_uncertain_failure=dispatch_uncertain_failure(),
+    )
+
+
+async def create_cloud_workspace_for_claimed_run(**kwargs):  # type: ignore[no-untyped-def]
+    return await create_cloud_workspace_for_claimed_run_store(
+        **kwargs,
+        transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
+        claim_is_active=claim_is_active,
+    )

--- a/server/tests/unit/test_automation_claim_contracts.py
+++ b/server/tests/unit/test_automation_claim_contracts.py
@@ -20,13 +20,14 @@ from proliferate.db import engine as engine_module
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
-from proliferate.db.store.automation_cloud_workspace_claims import (
-    create_cloud_workspace_for_claimed_run,
+from proliferate.server.automations.domain.claim_lifecycle import (
+    LocalAutomationRepoIdentity,
 )
-from proliferate.db.store.automation_run_claim_values import LocalAutomationRepoIdentity
-from proliferate.db.store.automation_run_claims import (
+from proliferate.db.store.automations import create_manual_run_for_user
+from tests.unit.automation_claim_store_helpers import (
     claim_cloud_automation_runs,
     claim_local_automation_runs,
+    create_cloud_workspace_for_claimed_run,
     heartbeat_run_claim,
     mark_run_creating_session,
     mark_run_creating_workspace,
@@ -34,7 +35,6 @@ from proliferate.db.store.automation_run_claims import (
     mark_run_dispatching,
     mark_run_failed,
 )
-from proliferate.db.store.automations import create_manual_run_for_user
 
 
 def _patch_session_factory(test_engine):  # type: ignore[no-untyped-def]

--- a/server/tests/unit/test_automation_claim_lifecycle.py
+++ b/server/tests/unit/test_automation_claim_lifecycle.py
@@ -1,0 +1,155 @@
+from datetime import UTC, datetime, timedelta
+import uuid
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_EXECUTION_TARGET_LOCAL,
+    AUTOMATION_RUN_STATUS_CANCELLED,
+    AUTOMATION_RUN_STATUS_CLAIMED,
+    AUTOMATION_RUN_STATUS_CREATING_SESSION,
+    AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+    AUTOMATION_RUN_STATUS_DISPATCHED,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    AUTOMATION_RUN_STATUS_FAILED,
+    AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+)
+from proliferate.server.automations.domain.claim_lifecycle import (
+    ACTIVE_CLAIM_STATUSES,
+    AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
+    AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE,
+    RECLAIMABLE_STATUSES,
+    TERMINAL_STATUSES,
+    ClaimIdentity,
+    automation_error_message,
+    canonical_repo_identity,
+    claim_identity_matches,
+    claim_is_active,
+    dispatch_uncertain_failure,
+    is_expired_dispatching_claim,
+    is_expired_reclaimable_claim,
+    normalize_local_error_code,
+    provisioning_workspace_transition,
+)
+
+
+def test_status_sets_preserve_dispatching_as_active_but_not_reclaimable() -> None:
+    assert (
+        frozenset(
+            {
+                AUTOMATION_RUN_STATUS_CLAIMED,
+                AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+                AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+                AUTOMATION_RUN_STATUS_CREATING_SESSION,
+            }
+        )
+        == RECLAIMABLE_STATUSES
+    )
+    assert RECLAIMABLE_STATUSES | {AUTOMATION_RUN_STATUS_DISPATCHING} == ACTIVE_CLAIM_STATUSES
+    assert (
+        frozenset(
+            {
+                AUTOMATION_RUN_STATUS_DISPATCHED,
+                AUTOMATION_RUN_STATUS_FAILED,
+                AUTOMATION_RUN_STATUS_CANCELLED,
+            }
+        )
+        == TERMINAL_STATUSES
+    )
+
+
+def test_expired_claim_classification_distinguishes_reclaim_and_dispatching() -> None:
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    expired_at = now - timedelta(seconds=1)
+
+    assert claim_is_active(now + timedelta(seconds=1), now) is True
+    assert claim_is_active(expired_at, now) is False
+    assert is_expired_reclaimable_claim(
+        AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        expired_at,
+        now,
+    )
+    assert not is_expired_reclaimable_claim(
+        AUTOMATION_RUN_STATUS_DISPATCHING,
+        expired_at,
+        now,
+    )
+    assert is_expired_dispatching_claim(
+        AUTOMATION_RUN_STATUS_DISPATCHING,
+        expired_at,
+        now,
+    )
+
+
+def test_claim_identity_requires_current_claim_and_optional_user_scope() -> None:
+    run_id = uuid.uuid4()
+    claim_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    expected = ClaimIdentity(
+        run_id=run_id,
+        claim_id=claim_id,
+        execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+        executor_kind="desktop",
+        user_id=user_id,
+    )
+    matching = ClaimIdentity(
+        run_id=run_id,
+        claim_id=claim_id,
+        execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+        executor_kind="desktop",
+        user_id=user_id,
+    )
+    wrong_user = ClaimIdentity(
+        run_id=run_id,
+        claim_id=claim_id,
+        execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+        executor_kind="desktop",
+        user_id=uuid.uuid4(),
+    )
+    global_expected = ClaimIdentity(
+        run_id=run_id,
+        claim_id=claim_id,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        executor_kind="cloud",
+        user_id=None,
+    )
+    cloud_actual = ClaimIdentity(
+        run_id=run_id,
+        claim_id=claim_id,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        executor_kind="cloud",
+        user_id=uuid.uuid4(),
+    )
+
+    assert claim_identity_matches(expected, matching)
+    assert not claim_identity_matches(expected, wrong_user)
+    assert claim_identity_matches(global_expected, cloud_actual)
+
+
+def test_transition_rules_encode_cloud_and_local_workspace_requirements() -> None:
+    cloud = provisioning_workspace_transition(AUTOMATION_EXECUTION_TARGET_CLOUD)
+    local = provisioning_workspace_transition(AUTOMATION_EXECUTION_TARGET_LOCAL)
+
+    assert cloud.allowed_statuses == local.allowed_statuses
+    assert cloud.requires_cloud_workspace is True
+    assert cloud.requires_anyharness_workspace is False
+    assert local.requires_cloud_workspace is False
+    assert local.requires_anyharness_workspace is True
+
+
+def test_error_mapping_and_local_code_normalization_are_domain_rules() -> None:
+    failure = dispatch_uncertain_failure()
+
+    assert failure.code == AUTOMATION_ERROR_DISPATCH_UNCERTAIN
+    assert failure.message == AUTOMATION_ERROR_DISPATCH_UNCERTAIN_MESSAGE
+    assert automation_error_message("local_prompt_send_failed").startswith("The local runtime")
+    assert automation_error_message("unknown") == "The executor could not dispatch this run."
+    assert normalize_local_error_code("dispatch_uncertain") == "dispatch_uncertain"
+    assert normalize_local_error_code("local_prompt_send_failed") == "local_prompt_send_failed"
+    assert normalize_local_error_code("raw/path/leak") == "local_unexpected_executor_error"
+
+
+def test_canonical_repo_identity_normalizes_and_rejects_blank_parts() -> None:
+    assert canonical_repo_identity(" GitHub ", " Proliferate-AI ", " Proliferate ") == (
+        canonical_repo_identity("github", "proliferate-ai", "proliferate")
+    )
+    assert canonical_repo_identity("github", "", "proliferate") is None

--- a/server/tests/unit/test_automation_executor.py
+++ b/server/tests/unit/test_automation_executor.py
@@ -15,19 +15,10 @@ from proliferate.constants.automations import (
 from proliferate.db import engine as engine_module
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
-from proliferate.db.store.automation_run_claim_values import (
+from proliferate.server.automations.domain.claim_lifecycle import (
     AUTOMATION_ERROR_AGENT_NOT_CONFIGURED,
     AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
     LocalAutomationRepoIdentity,
-)
-from proliferate.db.store.automation_run_claims import (
-    attach_anyharness_workspace_to_run,
-    claim_cloud_automation_runs,
-    claim_local_automation_runs,
-    heartbeat_run_claim,
-    mark_run_creating_workspace,
-    mark_run_provisioning_workspace,
-    sweep_expired_dispatching_runs,
 )
 from proliferate.db.store.automations import (
     create_manual_run_for_user,
@@ -36,6 +27,15 @@ from proliferate.server.automations.local_executor_service import (
     _normalize_local_error_code,
 )
 from proliferate.server.automations.worker.main import _parse_args
+from tests.unit.automation_claim_store_helpers import (
+    attach_anyharness_workspace_to_run,
+    claim_cloud_automation_runs,
+    claim_local_automation_runs,
+    heartbeat_run_claim,
+    mark_run_creating_workspace,
+    mark_run_provisioning_workspace,
+    sweep_expired_dispatching_runs,
+)
 
 
 def test_local_executor_service_caps_claims_and_allowlists_error_codes() -> None:


### PR DESCRIPTION
## Summary
- Add a pure automation claim lifecycle domain for status sets, transition predicates, stale/expired/dispatching classification, claim identity checks, and claim error mapping.
- Parameterize automation claim stores/services with those pure decisions while preserving existing DB ownership and self-opening wrapper behavior.
- Split transition wrappers and update focused automation claim tests around the new domain helpers.

## Verification
- `DEBUG=1 uv run --python 3.12 --extra dev pytest -q tests/unit/test_automation_claim_lifecycle.py tests/unit/test_automation_claim_contracts.py tests/unit/test_automation_store.py tests/unit/test_automation_executor.py tests/unit/test_automation_service.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`

## Notes
- Draft PR for Phase 8 Wave 2 automation-domain coordination.
- No DB transaction boundary or worker scheduling changes intended.
