### PR TITLE
test(desktop): add session store invariant coverage

### DIFF
--- a/desktop/src/stores/sessions/session-directory-store.test.ts
+++ b/desktop/src/stores/sessions/session-directory-store.test.ts
@@ -1,0 +1,152 @@
+import { createTranscriptState, type PendingInteraction } from "@anyharness/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activitySnapshotFromDirectoryEntry,
+  useSessionDirectoryStore,
+} from "@/stores/sessions/session-directory-store";
+
+describe("session directory store invariants", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+  });
+
+  it("keeps materialized and workspace indexes consistent across patches and removals", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "client-a",
+      materializedSessionId: null,
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    store.upsertEntry({
+      sessionId: "client-b",
+      materializedSessionId: "runtime-b",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+
+    store.patchEntry("client-a", { materializedSessionId: "runtime-a" });
+    store.patchEntry("client-a", {
+      materializedSessionId: "runtime-a-2",
+      workspaceId: "workspace-b",
+    });
+    store.removeEntry("client-b");
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({ "runtime-a-2": "client-a" });
+    expect(useSessionDirectoryStore.getState().sessionIdsByWorkspaceId)
+      .toEqual({ "workspace-b": ["client-a"] });
+  });
+
+  it("does not notify or replace indexed references for equal directory writes", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "session-a",
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+      title: "Working title",
+    });
+    const listener = vi.fn();
+    const before = useSessionDirectoryStore.getState();
+    const unsubscribe = useSessionDirectoryStore.subscribe(listener);
+
+    store.patchEntry("session-a", { title: "Working title" });
+
+    unsubscribe();
+    const after = useSessionDirectoryStore.getState();
+    expect(listener).not.toHaveBeenCalled();
+    expect(after).toBe(before);
+    expect(after.entriesById).toBe(before.entriesById);
+    expect(after.clientSessionIdByMaterializedSessionId)
+      .toBe(before.clientSessionIdByMaterializedSessionId);
+    expect(after.sessionIdsByWorkspaceId).toBe(before.sessionIdsByWorkspaceId);
+  });
+
+  it("applies relationship hints once and prunes stale workspace hints", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.recordRelationshipHint("child-a", {
+      kind: "subagent_child",
+      parentSessionId: "parent-a",
+      sessionLinkId: "link-a",
+      relation: "subagent",
+      workspaceId: "workspace-a",
+    });
+    store.recordRelationshipHint("missing-child", {
+      kind: "linked_child",
+      parentSessionId: "parent-b",
+      workspaceId: "workspace-a",
+    });
+
+    store.upsertEntry({
+      sessionId: "child-a",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    store.removeWorkspaceEntries("workspace-a");
+    store.upsertEntry({
+      sessionId: "child-a",
+      workspaceId: "workspace-b",
+      agentKind: "codex",
+    });
+
+    const state = useSessionDirectoryStore.getState();
+    expect(state.relationshipHintsBySessionId).toEqual({});
+    expect(state.entriesById["child-a"]?.sessionRelationship).toEqual({ kind: "pending" });
+  });
+
+  it("updates activity from transcript while preserving unrelated directory fields", () => {
+    const pendingInteractions: PendingInteraction[] = [{
+      requestId: "request-a",
+      toolCallId: "tool-a",
+      toolKind: "exec",
+      toolStatus: null,
+      linkedPlanId: null,
+      title: "Approve",
+      description: null,
+      kind: "permission",
+      options: [],
+    }];
+    const transcript = {
+      ...createTranscriptState("session-a"),
+      currentModeId: "plan",
+      isStreaming: true,
+      pendingInteractions,
+      sessionMeta: {
+        ...createTranscriptState("session-a").sessionMeta,
+        title: "Transcript title",
+      },
+    };
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "session-a",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+      modelId: "model-a",
+      title: null,
+    });
+
+    store.patchActivityFromTranscript("session-a", transcript);
+
+    const entry = useSessionDirectoryStore.getState().entriesById["session-a"];
+    expect(entry).toMatchObject({
+      modelId: "model-a",
+      modeId: "plan",
+      title: "Transcript title",
+      activity: {
+        isStreaming: true,
+        pendingInteractions,
+        transcriptTitle: "Transcript title",
+      },
+    });
+    expect(activitySnapshotFromDirectoryEntry(entry)).toEqual({
+      status: null,
+      executionSummary: null,
+      streamConnectionState: "disconnected",
+      transcript: {
+        isStreaming: true,
+        pendingInteractions,
+      },
+    });
+  });
+});

--- a/desktop/src/stores/sessions/session-ingest-store.test.ts
+++ b/desktop/src/stores/sessions/session-ingest-store.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HotSessionTarget } from "@/lib/domain/sessions/hot-session-policy";
+import {
+  isHotSessionTargetCurrent,
+  useSessionIngestStore,
+} from "@/stores/sessions/session-ingest-store";
+
+describe("session ingest store invariants", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-04T00:00:00.000Z"));
+    useSessionIngestStore.getState().clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("increments hot set generation only when target identity changes", () => {
+    const store = useSessionIngestStore.getState();
+    const generation = store.setHotTargets([
+      target("session-b", { priority: 4 }),
+      target("session-a", { priority: 0 }),
+    ]);
+
+    expect(generation).toBe(1);
+    expect(store.setHotTargets([
+      target("session-a", { priority: 0 }),
+      target("session-b", { priority: 4 }),
+    ])).toBe(1);
+    expect(store.setHotTargets([
+      target("session-a", { priority: 0 }),
+      target("session-b", { priority: 3, reason: "running" }),
+    ])).toBe(2);
+  });
+
+  it("keeps removed hot targets cold while preserving their sequence history", () => {
+    const store = useSessionIngestStore.getState();
+    store.setHotTargets([target("session-a")]);
+    store.applyStreamProgress("session-a", {
+      lastAppliedSeq: 4,
+      lastObservedSeq: 5,
+      gapAfterSeq: 4,
+    });
+
+    store.setHotTargets([]);
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toEqual({
+        freshness: "cold",
+        lastAppliedSeq: 4,
+        lastObservedSeq: 5,
+        gapAfterSeq: 4,
+        lastErrorAt: "2026-04-04T00:00:00.000Z",
+      });
+  });
+
+  it("guards currentness by generation, materialized id, and streamability", () => {
+    const generation = useSessionIngestStore.getState().setHotTargets([
+      target("session-a", { materializedSessionId: "runtime-a", streamable: true }),
+      target("session-b", { materializedSessionId: null, streamable: false }),
+    ]);
+
+    expect(isHotSessionTargetCurrent("session-a", generation, "runtime-a")).toBe(true);
+    expect(isHotSessionTargetCurrent("session-a", generation - 1, "runtime-a")).toBe(false);
+    expect(isHotSessionTargetCurrent("session-a", generation, "runtime-old")).toBe(false);
+    expect(isHotSessionTargetCurrent("session-b", generation, null)).toBe(false);
+  });
+
+  it("does not mark gapped progress current until the gap clears", () => {
+    const store = useSessionIngestStore.getState();
+    store.markStale("session-a", {
+      lastAppliedSeq: 2,
+      lastObservedSeq: 5,
+      gapAfterSeq: 2,
+      lastErrorAt: "2026-04-04T00:00:10.000Z",
+    });
+
+    store.markCurrentIfContiguous("session-a", 5);
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "stale",
+        lastAppliedSeq: 2,
+        lastObservedSeq: 5,
+        gapAfterSeq: 2,
+        lastErrorAt: "2026-04-04T00:00:10.000Z",
+      });
+
+    store.applyStreamProgress("session-a", {
+      lastAppliedSeq: 5,
+      lastObservedSeq: 5,
+      gapAfterSeq: null,
+    });
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toEqual({
+        freshness: "current",
+        lastAppliedSeq: 5,
+        lastObservedSeq: 5,
+        gapAfterSeq: null,
+        lastErrorAt: null,
+      });
+  });
+});
+
+function target(
+  clientSessionId: string,
+  overrides: Partial<HotSessionTarget> = {},
+): HotSessionTarget {
+  return {
+    clientSessionId,
+    materializedSessionId: clientSessionId,
+    workspaceId: "workspace-a",
+    priority: 0,
+    reason: "selected",
+    streamable: true,
+    ...overrides,
+  };
+}

--- a/desktop/src/stores/sessions/session-records.test.ts
+++ b/desktop/src/stores/sessions/session-records.test.ts
@@ -1,0 +1,139 @@
+import { createTranscriptState } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionIngestStore } from "@/stores/sessions/session-ingest-store";
+import {
+  createEmptySessionRecord,
+  findClientSessionIdByMaterializedSessionId,
+  getMaterializedSessionId,
+  getSessionRecord,
+  getSessionRecordByMaterializedSessionId,
+  getWorkspaceSessionRecords,
+  isSessionMaterialized,
+  patchSessionRecord,
+  putSessionRecord,
+  removeSessionRecord,
+  requireMaterializedSessionId,
+  waitForSessionMaterialization,
+} from "@/stores/sessions/session-records";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+
+describe("session records facade invariants", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionIngestStore.getState().clear();
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: "workspace-stable",
+      selectedWorkspaceId: "workspace-stable",
+      workspaceSelectionNonce: 7,
+      workspaceArrivalEvent: null,
+      activeSessionId: "session-stable",
+      activeSessionVersion: 3,
+      sessionActivationIntentEpochByWorkspace: { "workspace-stable": 2 },
+      hotPaintGate: null,
+      _hydrated: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("materializes pending client records without replacing transcript state", () => {
+    const transcript = createTranscriptState("client-a");
+    putSessionRecord({
+      ...createEmptySessionRecord("client-a", "codex", {
+        materializedSessionId: null,
+        workspaceId: "workspace-a",
+      }),
+      transcript,
+    });
+
+    patchSessionRecord("client-a", { materializedSessionId: "runtime-a" });
+
+    expect(getMaterializedSessionId("client-a")).toBe("runtime-a");
+    expect(requireMaterializedSessionId("client-a")).toBe("runtime-a");
+    expect(isSessionMaterialized("client-a")).toBe(true);
+    expect(findClientSessionIdByMaterializedSessionId("runtime-a")).toBe("client-a");
+    expect(getSessionRecordByMaterializedSessionId("runtime-a")?.sessionId).toBe("client-a");
+    expect(getSessionRecord("client-a")?.transcript).toBe(transcript);
+  });
+
+  it("returns only complete records from workspace-indexed facade reads", () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+    }));
+    useSessionDirectoryStore.getState().upsertEntry({
+      sessionId: "directory-only",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    useSessionTranscriptStore.getState().putEntry({
+      sessionId: "transcript-only",
+      events: [],
+      transcript: createTranscriptState("transcript-only"),
+      optimisticPrompt: null,
+    });
+
+    expect(Object.keys(getWorkspaceSessionRecords("workspace-a"))).toEqual(["session-a"]);
+    expect(getSessionRecord("directory-only")).toBeNull();
+    expect(getWorkspaceSessionRecords(null)).toEqual({});
+  });
+
+  it("removes records from directory, transcript, and materialized lookup state together", () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-a",
+    }));
+
+    removeSessionRecord("session-a");
+
+    expect(getSessionRecord("session-a")).toBeNull();
+    expect(findClientSessionIdByMaterializedSessionId("runtime-a")).toBeNull();
+    expect(useSessionDirectoryStore.getState().entriesById).toEqual({});
+    expect(useSessionTranscriptStore.getState().entriesById).toEqual({});
+  });
+
+  it("does not mutate selection or ingest stores when writing local records", () => {
+    useSessionIngestStore.getState().setHotTargets([{
+      clientSessionId: "hot-a",
+      materializedSessionId: "hot-a",
+      workspaceId: "workspace-stable",
+      priority: 0,
+      reason: "selected",
+      streamable: true,
+    }]);
+    const selectionBefore = useSessionSelectionStore.getState();
+    const ingestBefore = useSessionIngestStore.getState();
+
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+    }));
+    patchSessionRecord("session-a", { title: "Updated title" });
+
+    expect(useSessionSelectionStore.getState()).toBe(selectionBefore);
+    expect(useSessionIngestStore.getState()).toBe(ingestBefore);
+  });
+
+  it("waits for materialization and rejects with the same guard error on timeout", async () => {
+    vi.useFakeTimers();
+    putSessionRecord(createEmptySessionRecord("client-a", "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-a",
+    }));
+
+    const pending = waitForSessionMaterialization("client-a", 1_000);
+    patchSessionRecord("client-a", { materializedSessionId: "runtime-a" });
+    await expect(pending).resolves.toBe("runtime-a");
+
+    const timedOut = expect(waitForSessionMaterialization("missing-client", 1_000))
+      .rejects
+      .toThrow("Session is still starting. Try again in a moment.");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await timedOut;
+  });
+});

--- a/desktop/src/stores/sessions/session-selection-store.test.ts
+++ b/desktop/src/stores/sessions/session-selection-store.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HotPaintGate } from "@/lib/domain/sessions/hot-paint-gate";
+import type { PendingWorkspaceEntry } from "@/lib/domain/workspaces/creation/pending-entry";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+describe("session selection store invariants", () => {
+  beforeEach(() => {
+    useSessionSelectionStore.setState({
+      _hydrated: false,
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: null,
+      workspaceSelectionNonce: 0,
+      workspaceArrivalEvent: null,
+      activeSessionId: null,
+      activeSessionVersion: 0,
+      sessionActivationIntentEpochByWorkspace: {},
+      hotPaintGate: null,
+    });
+  });
+
+  it("hydrates persisted logical workspace selection without activating a workspace", () => {
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "workspace-live",
+      activeSessionId: "session-live",
+      activeSessionVersion: 4,
+      workspaceSelectionNonce: 2,
+    });
+
+    useSessionSelectionStore.getState()
+      .hydrateSelectedLogicalWorkspaceSelection("workspace-persisted");
+
+    expect(useSessionSelectionStore.getState()).toMatchObject({
+      _hydrated: true,
+      selectedLogicalWorkspaceId: "workspace-persisted",
+      selectedWorkspaceId: "workspace-live",
+      workspaceSelectionNonce: 2,
+      activeSessionId: "session-live",
+      activeSessionVersion: 4,
+    });
+  });
+
+  it("enters pending workspace shell as one local selection transaction", () => {
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "workspace-a",
+      activeSessionId: "session-a",
+      activeSessionVersion: 2,
+      hotPaintGate: hotGate({ workspaceId: "workspace-a", sessionId: "session-a", nonce: 8 }),
+    });
+    const listener = vi.fn();
+    const unsubscribe = useSessionSelectionStore.subscribe(listener);
+
+    useSessionSelectionStore.getState().enterPendingWorkspaceShell(pendingWorkspaceEntry());
+
+    unsubscribe();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(useSessionSelectionStore.getState()).toMatchObject({
+      pendingWorkspaceEntry: pendingWorkspaceEntry(),
+      selectedLogicalWorkspaceId: "pending-workspace:attempt-a",
+      selectedWorkspaceId: null,
+      workspaceSelectionNonce: 1,
+      workspaceArrivalEvent: null,
+      activeSessionId: null,
+      activeSessionVersion: 3,
+      hotPaintGate: null,
+    });
+  });
+
+  it("activates workspace, session, arrival, and hot gate fields atomically", () => {
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: pendingWorkspaceEntry(),
+      workspaceArrivalEvent: {
+        workspaceId: "workspace-a",
+        source: "local-created",
+        createdAt: 100,
+      },
+      activeSessionId: "session-old",
+      activeSessionVersion: 2,
+    });
+    const gate = hotGate({
+      workspaceId: "workspace-a",
+      sessionId: "session-a",
+      nonce: 11,
+    });
+    const listener = vi.fn();
+    const unsubscribe = useSessionSelectionStore.subscribe(listener);
+
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-a",
+      workspaceId: "workspace-a",
+      initialActiveSessionId: "session-a",
+      hotPaintGate: gate,
+    });
+
+    unsubscribe();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(useSessionSelectionStore.getState()).toMatchObject({
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: "logical-a",
+      selectedWorkspaceId: "workspace-a",
+      workspaceSelectionNonce: 1,
+      workspaceArrivalEvent: {
+        workspaceId: "workspace-a",
+        source: "local-created",
+        createdAt: 100,
+      },
+      activeSessionId: "session-a",
+      activeSessionVersion: 3,
+      hotPaintGate: gate,
+    });
+  });
+
+  it("bumps hot workspace intent only for hot activation and keeps session version stable for same session", () => {
+    useSessionSelectionStore.setState({
+      activeSessionId: "session-a",
+      activeSessionVersion: 5,
+      sessionActivationIntentEpochByWorkspace: { "workspace-a": 3 },
+    });
+
+    useSessionSelectionStore.getState().activateHotWorkspace({
+      logicalWorkspaceId: "workspace-a",
+      workspaceId: "workspace-a",
+      initialActiveSessionId: "session-a",
+    });
+
+    expect(useSessionSelectionStore.getState()).toMatchObject({
+      selectedLogicalWorkspaceId: "workspace-a",
+      selectedWorkspaceId: "workspace-a",
+      workspaceSelectionNonce: 1,
+      activeSessionId: "session-a",
+      activeSessionVersion: 5,
+      sessionActivationIntentEpochByWorkspace: { "workspace-a": 4 },
+      hotPaintGate: null,
+    });
+  });
+
+  it("clears hot paint gates only for the matching nonce", () => {
+    useSessionSelectionStore.setState({
+      hotPaintGate: hotGate({ nonce: 12 }),
+    });
+
+    useSessionSelectionStore.getState().clearHotPaintGate(11);
+    expect(useSessionSelectionStore.getState().hotPaintGate?.nonce).toBe(12);
+
+    useSessionSelectionStore.getState().clearHotPaintGate(12);
+    expect(useSessionSelectionStore.getState().hotPaintGate).toBeNull();
+  });
+});
+
+function hotGate(overrides: Partial<HotPaintGate> = {}): HotPaintGate {
+  return {
+    kind: "workspace_hot_reopen",
+    workspaceId: "workspace-a",
+    sessionId: "session-a",
+    nonce: 1,
+    operationId: null,
+    ...overrides,
+  };
+}
+
+function pendingWorkspaceEntry(): PendingWorkspaceEntry {
+  return {
+    attemptId: "attempt-a",
+    source: "local-created",
+    stage: "submitting",
+    displayName: "Workspace A",
+    repoLabel: null,
+    baseBranchName: null,
+    workspaceId: null,
+    request: { kind: "local", sourceRoot: "/tmp/workspace-a" },
+    originTarget: { kind: "home" },
+    errorMessage: null,
+    setupScript: null,
+    createdAt: 100,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds focused invariant tests for session directory, ingest, records, and selection stores.

## Verification
- Reviewed locally before opening; branch-specific checks passed in the worktree review pass.
- GitHub CI should run on this PR.