### PR TITLE
test(desktop): add pure domain cleanup coverage

### DIFF
--- a/desktop/src/lib/domain/chat/transcript/transcript-actions.test.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-actions.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { createTranscriptState, type ToolCallItem } from "@anyharness/sdk";
+import {
+  classifyCollapsedAction,
+  formatCollapsedActionsSummary,
+  getToolCallParsedCommands,
+  getToolCallShellCommand,
+  getToolCallShellCommandName,
+  summarizeCollapsedActions,
+} from "@/lib/domain/chat/transcript/transcript-actions";
+import {
+  bareNativeToolItem,
+  parsedCommandItem,
+  terminalItem,
+  toolItem,
+} from "@/lib/domain/chat/transcript/transcript-presentation-test-fixtures";
+
+describe("transcript actions", () => {
+  it("classifies representative tool calls for collapsed action grouping", () => {
+    expect(classifyCollapsedAction(toolItem("read", "turn-1", 1, "file_read"))).toBe("read");
+    expect(classifyCollapsedAction(toolItem("edit", "turn-1", 2, "file_change"))).toBe("edit");
+    expect(classifyCollapsedAction(toolItem("search", "turn-1", 3, "search"))).toBe("search");
+    expect(classifyCollapsedAction(toolItem("fetch", "turn-1", 4, "fetch"))).toBe("fetch");
+    expect(classifyCollapsedAction(bareNativeToolItem("list", "turn-1", 5, "LS", "list"))).toBe("listing");
+    expect(classifyCollapsedAction(terminalItem("test", "turn-1", 6, "pnpm test"))).toBe("command");
+  });
+
+  it("treats mixed parsed exploration and real commands as visible action work", () => {
+    const mixed = parsedCommandItem("mixed", "turn-1", 1, [
+      {
+        type: "read",
+        cmd: "sed -n '1,80p' desktop/src/App.tsx",
+        path: "desktop/src/App.tsx",
+      },
+      {
+        type: "command",
+        cmd: "pnpm test",
+      },
+    ]);
+    const commandOnly = parsedCommandItem("command", "turn-1", 2, [
+      {
+        type: "command",
+        cmd: "pnpm test",
+      },
+    ]);
+
+    expect(classifyCollapsedAction(mixed)).toBe("action");
+    expect(classifyCollapsedAction(commandOnly)).toBe("command");
+  });
+
+  it("extracts shell commands and display command names from raw input variants", () => {
+    const arrayCommand = {
+      ...terminalItem("array", "turn-1", 1),
+      rawInput: {
+        command: ["/bin/zsh", "-lc", "cd /repo && pnpm test"],
+      },
+    } satisfies ToolCallItem;
+    const cmdCommand = {
+      ...terminalItem("cmd", "turn-1", 2),
+      rawInput: {
+        cmd: "rg useEffect desktop/src -n",
+      },
+    } satisfies ToolCallItem;
+
+    expect(getToolCallShellCommand(arrayCommand)).toBe("cd /repo && pnpm test");
+    expect(getToolCallShellCommandName(arrayCommand)).toBe("pnpm");
+    expect(getToolCallShellCommand(cmdCommand)).toBe("rg useEffect desktop/src -n");
+    expect(getToolCallShellCommandName(cmdCommand)).toBe("rg");
+  });
+
+  it("expands parsed operation batches into normalized command metadata", () => {
+    const item = parsedCommandItem("scan", "turn-1", 1, [{
+      type: "unknown",
+      cmd: [
+        "ops=(",
+        "  'rg \"useEffect\" desktop/src -n'",
+        "  'sed -n \"1,120p\" desktop/src/App.tsx'",
+        "  'curl https://example.test/feed.json'",
+        ")",
+        "for cmd in \"${ops[@]}\"; do eval \"$cmd\"; done",
+      ].join("\n"),
+    }]);
+
+    expect(getToolCallParsedCommands(item)).toEqual([
+      {
+        kind: "search",
+        command: "rg \"useEffect\" desktop/src -n",
+        path: "desktop/src",
+        name: "src",
+        query: "useEffect",
+      },
+      {
+        kind: "read",
+        command: "sed -n \"1,120p\" desktop/src/App.tsx",
+        path: "desktop/src/App.tsx",
+        name: "App.tsx",
+        query: null,
+      },
+      {
+        kind: "fetch",
+        command: "curl https://example.test/feed.json",
+        path: null,
+        name: null,
+        query: null,
+      },
+    ]);
+  });
+
+  it("summarizes and formats collapsed action copy from transcript items", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      read: toolItem("read", "turn-1", 1, "file_read"),
+      list: bareNativeToolItem("list", "turn-1", 2, "LS", "list"),
+      grep: terminalItem("grep", "turn-1", 3, "rg useEffect desktop/src -n"),
+      fetch: terminalItem("fetch", "turn-1", 4, "curl https://example.test/feed.json"),
+      command: terminalItem("command", "turn-1", 5, "pnpm test"),
+      edit: toolItem("edit", "turn-1", 6, "file_change"),
+      action: parsedCommandItem("action", "turn-1", 7, [
+        {
+          type: "read",
+          cmd: "sed -n '1,80p' desktop/src/App.tsx",
+        },
+        {
+          type: "command",
+          cmd: "pnpm lint",
+        },
+      ]),
+    };
+
+    const summary = summarizeCollapsedActions([
+      "read",
+      "list",
+      "grep",
+      "fetch",
+      "command",
+      "edit",
+      "action",
+      "missing",
+    ], transcript);
+
+    expect(summary).toEqual({
+      reads: 2,
+      listings: 1,
+      searches: 1,
+      fetches: 1,
+      commands: 2,
+      edits: 1,
+      actions: 0,
+    });
+    expect(formatCollapsedActionsSummary(summary)).toBe(
+      "Explored 2 files, 1 listing, 1 search, 1 fetch, running 2 commands, edited 1 file",
+    );
+    expect(formatCollapsedActionsSummary({
+      reads: 0,
+      listings: 0,
+      searches: 0,
+      fetches: 0,
+      commands: 0,
+      edits: 0,
+      actions: 0,
+    })).toBe("Worked");
+  });
+});

--- a/desktop/src/lib/domain/preferences/user-preferences.test.ts
+++ b/desktop/src/lib/domain/preferences/user-preferences.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  getForwardCompatibleUserPreferenceExtras,
+  hasDeprecatedUserPreferenceKeys,
+  migrateUserPreferences,
+  pickLegacyUserPreferencesInput,
+  USER_PREFERENCE_DEFAULTS,
+  WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,
+} from "@/lib/domain/preferences/user-preferences";
+
+describe("user preferences", () => {
+  it("migrates legacy model and powers preferences into the current shape", () => {
+    const result = migrateUserPreferences({
+      defaultChatAgentKind: " claude ",
+      defaultChatModelId: " claude-sonnet-4-5-1m ",
+      powersInCodingSessionsEnabled: true,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.preferences.defaultChatAgentKind).toBe("claude");
+    expect(result.preferences.defaultChatModelIdByAgentKind).toEqual({
+      claude: "sonnet[1m]",
+    });
+    expect(result.preferences.pluginsInCodingSessionsEnabled).toBe(true);
+    expect(result.preferences).not.toHaveProperty("powersInCodingSessionsEnabled");
+  });
+
+  it("sanitizes per-agent model, session mode, and live control maps", () => {
+    const result = migrateUserPreferences({
+      defaultChatModelIdByAgentKind: {
+        " claude ": " claude-opus-4-5 ",
+        assistant: " gpt-5 ",
+        " ": "ignored",
+        empty: " ",
+      },
+      defaultSessionModeByAgentKind: {
+        assistant: " plan ",
+        empty: " ",
+        " ": "code",
+      },
+      defaultLiveSessionControlValuesByAgentKind: {
+        assistant: {
+          effort: " high ",
+          reasoning: " medium ",
+          ignored: "value",
+        },
+        empty: {
+          effort: " ",
+        },
+        " ": {
+          effort: "low",
+        },
+      } as unknown as typeof USER_PREFERENCE_DEFAULTS.defaultLiveSessionControlValuesByAgentKind,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.preferences.defaultChatModelIdByAgentKind).toEqual({
+      claude: "opus[1m]",
+      assistant: "gpt-5",
+    });
+    expect(result.preferences.defaultSessionModeByAgentKind).toEqual({
+      assistant: " plan ",
+    });
+    expect(result.preferences.defaultLiveSessionControlValuesByAgentKind).toEqual({
+      assistant: {
+        effort: "high",
+        reasoning: "medium",
+      },
+    });
+  });
+
+  it("falls back invalid persisted values without changing new-user defaults", () => {
+    const result = migrateUserPreferences({
+      subagentsEnabled: "yes" as unknown as boolean,
+      coworkWorkspaceDelegationEnabled: "yes" as unknown as boolean,
+      cloudRuntimeInputSyncEnabled: "yes" as unknown as boolean,
+      worktreeAutoDeleteLimit: 8,
+      pasteAttachmentsEnabled: "yes" as unknown as boolean,
+      uiFontSizeId: "giant" as typeof USER_PREFERENCE_DEFAULTS.uiFontSizeId,
+      readableCodeFontSizeId: "tiny" as typeof USER_PREFERENCE_DEFAULTS.readableCodeFontSizeId,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.preferences.subagentsEnabled).toBe(true);
+    expect(result.preferences.coworkWorkspaceDelegationEnabled).toBe(true);
+    expect(result.preferences.cloudRuntimeInputSyncEnabled).toBe(false);
+    expect(result.preferences.worktreeAutoDeleteLimit).toBe(WORKTREE_AUTO_DELETE_LIMIT_DEFAULT);
+    expect(result.preferences.pasteAttachmentsEnabled).toBe(true);
+    expect(result.preferences.uiFontSizeId).toBe("default");
+    expect(result.preferences.readableCodeFontSizeId).toBe("default");
+    expect(USER_PREFERENCE_DEFAULTS.transparentChromeEnabled).toBe(false);
+  });
+
+  it("splits known legacy input from forward-compatible extras", () => {
+    const persisted = {
+      themePreset: "mono",
+      defaultChatModelId: "gpt-5",
+      powersInCodingSessionsEnabled: false,
+      onboardingCompletedVersion: 2,
+      futureBoolean: true,
+      futureNested: { enabled: true },
+    };
+
+    expect(pickLegacyUserPreferencesInput(persisted)).toEqual({
+      themePreset: "mono",
+      defaultChatModelId: "gpt-5",
+      powersInCodingSessionsEnabled: false,
+    });
+    expect(getForwardCompatibleUserPreferenceExtras(persisted)).toEqual({
+      futureBoolean: true,
+      futureNested: { enabled: true },
+    });
+    expect(hasDeprecatedUserPreferenceKeys(persisted)).toBe(true);
+  });
+});

--- a/desktop/src/lib/domain/preferences/workspace-ui-state.test.ts
+++ b/desktop/src/lib/domain/preferences/workspace-ui-state.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  getChangedWorkspaceUiStateKeys,
+  isNonPersistedWorkspaceUiStateKey,
+  migrateWorkspaceUiState,
+  selectPersistedWorkspaceUiState,
+  WORKSPACE_SIDEBAR_MAX_WIDTH,
+  WORKSPACE_UI_DEFAULTS,
+  WORKSPACE_UI_MIGRATION_VERSION,
+  type PersistedWorkspaceUiState,
+  type WorkspaceUiChangeTrackedState,
+} from "@/lib/domain/preferences/workspace-ui-state";
+import {
+  chatShellWorkspaceIntentKey,
+  chatWorkspaceShellTabKey,
+  fileWorkspaceShellTabKey,
+} from "@/lib/domain/workspaces/tabs/shell-tabs";
+
+describe("workspace UI state", () => {
+  it("applies migration defaults and resets pre-identity-cutover persisted state", () => {
+    const result = migrateWorkspaceUiState({
+      ...WORKSPACE_UI_DEFAULTS,
+      migrationVersion: 1,
+      archivedWorkspaceIds: ["archived-workspace"],
+      lastViewedAt: { "workspace-1": "2026-04-04T00:00:00Z" },
+      lastViewedSessionByWorkspace: { "workspace-1": "session-1" },
+      workspaceLastInteracted: { "workspace-1": "2026-04-04T00:00:00Z" },
+      collapsedRepoGroups: {
+        "repo-a": true,
+        "repo-b": false,
+      } as unknown as string[],
+      sidebarOpen: "open" as unknown as boolean,
+      showArchived: "yes" as unknown as boolean,
+      sidebarWidth: 999,
+    });
+
+    expect(result.didMigrate).toBe(true);
+    expect(result.state.migrationVersion).toBe(WORKSPACE_UI_MIGRATION_VERSION);
+    expect(result.state.archivedWorkspaceIds).toEqual([]);
+    expect(result.state.lastViewedAt).toEqual({});
+    expect(result.state.lastViewedSessionByWorkspace).toEqual({});
+    expect(result.state.workspaceLastInteracted).toEqual({});
+    expect(result.state.collapsedRepoGroups).toEqual(["repo-a"]);
+    expect(result.state.sidebarOpen).toBe(false);
+    expect(result.state.showArchived).toBe(false);
+    expect(result.state.sidebarWidth).toBe(WORKSPACE_SIDEBAR_MAX_WIDTH);
+  });
+
+  it("normalizes durable shell tab intent and order without transient chat sessions", () => {
+    const stableChatKey = chatWorkspaceShellTabKey("session-1");
+    const transientChatKey = chatWorkspaceShellTabKey("client-session:tmp");
+    const pendingChatKey = chatWorkspaceShellTabKey("pending-session:tmp");
+    const fileKey = fileWorkspaceShellTabKey("src/App.tsx");
+    const chatShellKey = chatShellWorkspaceIntentKey();
+
+    const result = migrateWorkspaceUiState({
+      ...WORKSPACE_UI_DEFAULTS,
+      migrationVersion: WORKSPACE_UI_MIGRATION_VERSION,
+      activeShellTabKeyByWorkspace: {
+        "workspace-chat": stableChatKey,
+        "workspace-transient": transientChatKey,
+        "workspace-shell": chatShellKey,
+        "workspace-file": fileKey,
+        "workspace-invalid": "not-a-tab",
+      },
+      shellTabOrderByWorkspace: {
+        "workspace-1": [
+          transientChatKey,
+          stableChatKey,
+          fileKey,
+          fileKey,
+          "not-a-tab",
+          pendingChatKey,
+        ],
+      },
+    } as PersistedWorkspaceUiState);
+
+    expect(result.didMigrate).toBe(true);
+    expect(result.state.activeShellTabKeyByWorkspace).toEqual({
+      "workspace-chat": stableChatKey,
+      "workspace-shell": chatShellKey,
+      "workspace-file": fileKey,
+    });
+    expect(result.state.shellTabOrderByWorkspace).toEqual({
+      "workspace-1": [stableChatKey, fileKey],
+    });
+  });
+
+  it("sanitizes persisted chat slices and excludes non-persisted runtime state", () => {
+    const selected = selectPersistedWorkspaceUiState({
+      ...WORKSPACE_UI_DEFAULTS,
+      migrationVersion: 3,
+      lastViewedSessionByWorkspace: {
+        "workspace-1": "session-1",
+        "workspace-2": "client-session:tmp",
+      },
+      visibleChatSessionIdsByWorkspace: {
+        "workspace-1": [
+          "session-1",
+          "client-session:tmp",
+          "session-1",
+          "pending-session:tmp",
+        ],
+      },
+      recentlyHiddenChatSessionIdsByWorkspace: {
+        "workspace-1": ["session-2", "pending-session:tmp"],
+      },
+      collapsedChatGroupsByWorkspace: {
+        "workspace-1": ["session-2", "session-2", "client-session:tmp"],
+      },
+      manualChatGroupsByWorkspace: {
+        "workspace-1": [{
+          id: "manual:review",
+          label: " Review ",
+          colorId: "magenta",
+          sessionIds: ["session-1", "client-session:tmp", "session-2", "session-2"],
+        }],
+        "workspace-2": [{
+          id: "manual:transient",
+          label: "Transient",
+          colorId: "blue",
+          sessionIds: ["client-session:one", "pending-session:two"],
+        }],
+      },
+      shellActivationEpochByWorkspace: { "workspace-1": 2 },
+      pendingChatActivationByWorkspace: { "workspace-1": { kind: "chat" } },
+      urgentHighlightedChatSessionByWorkspace: { "workspace-1": "session-1" },
+    } as WorkspaceUiChangeTrackedState);
+
+    expect(selected.migrationVersion).toBe(WORKSPACE_UI_MIGRATION_VERSION);
+    expect(selected.lastViewedSessionByWorkspace).toEqual({
+      "workspace-1": "session-1",
+    });
+    expect(selected.visibleChatSessionIdsByWorkspace).toEqual({
+      "workspace-1": ["session-1"],
+    });
+    expect(selected.recentlyHiddenChatSessionIdsByWorkspace).toEqual({
+      "workspace-1": ["session-2"],
+    });
+    expect(selected.collapsedChatGroupsByWorkspace).toEqual({
+      "workspace-1": ["session-2"],
+    });
+    expect(selected.manualChatGroupsByWorkspace).toEqual({
+      "workspace-1": [{
+        id: "manual:review",
+        label: "Review",
+        colorId: "magenta",
+        sessionIds: ["session-1", "session-2"],
+      }],
+    });
+    expect(selected).not.toHaveProperty("shellActivationEpochByWorkspace");
+    expect(selected).not.toHaveProperty("pendingChatActivationByWorkspace");
+    expect(selected).not.toHaveProperty("urgentHighlightedChatSessionByWorkspace");
+  });
+
+  it("tracks persisted and runtime-only keys separately", () => {
+    const previous = {
+      ...WORKSPACE_UI_DEFAULTS,
+      shellActivationEpochByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      urgentHighlightedChatSessionByWorkspace: {},
+    } satisfies WorkspaceUiChangeTrackedState;
+    const next = {
+      ...previous,
+      sidebarOpen: true,
+      shellActivationEpochByWorkspace: { "workspace-1": 1 },
+      urgentHighlightedChatSessionByWorkspace: { "workspace-1": "session-1" },
+    } satisfies WorkspaceUiChangeTrackedState;
+
+    expect(getChangedWorkspaceUiStateKeys(previous, next)).toEqual([
+      "sidebarOpen",
+      "shellActivationEpochByWorkspace",
+      "urgentHighlightedChatSessionByWorkspace",
+    ]);
+    expect(isNonPersistedWorkspaceUiStateKey("shellActivationEpochByWorkspace")).toBe(true);
+    expect(isNonPersistedWorkspaceUiStateKey("pendingChatActivationByWorkspace")).toBe(true);
+    expect(isNonPersistedWorkspaceUiStateKey("urgentHighlightedChatSessionByWorkspace")).toBe(true);
+    expect(isNonPersistedWorkspaceUiStateKey("sidebarOpen")).toBe(false);
+  });
+});

--- a/desktop/src/lib/domain/workspaces/mobility/presentation.test.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/presentation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMobilityOverlayTitle,
+  mobilityActionableCopy,
+  mobilityBlockerCopy,
+  mobilityBranchSyncLoadingCopy,
+  mobilityDetailCopyLabel,
+  mobilityLocationLabel,
+  mobilityReconnectCopy,
+  mobilityStatusCopy,
+} from "@/lib/domain/workspaces/mobility/presentation";
+
+describe("workspace mobility presentation", () => {
+  it("maps workspace locations to labels, detail labels, and primary actions", () => {
+    expect(mobilityLocationLabel("local_workspace")).toBe("Local workspace");
+    expect(mobilityLocationLabel("local_worktree")).toBe("Local worktree");
+    expect(mobilityLocationLabel("cloud_workspace")).toBe("Cloud workspace");
+
+    expect(mobilityDetailCopyLabel("local_workspace")).toBe("Path");
+    expect(mobilityDetailCopyLabel("cloud_workspace")).toBe("Repository");
+
+    expect(mobilityActionableCopy("local_workspace")).toEqual({
+      headline: "Move to cloud",
+      body: "Move this local workspace to a cloud runtime.",
+      actionLabel: "Move to cloud",
+      direction: "local_to_cloud",
+    });
+    expect(mobilityActionableCopy("local_worktree")).toEqual({
+      headline: "Move to cloud",
+      body: "Move this local worktree to a cloud runtime.",
+      actionLabel: "Move to cloud",
+      direction: "local_to_cloud",
+    });
+    expect(mobilityActionableCopy("cloud_workspace")).toEqual({
+      headline: "Bring back local",
+      body: "Move this workspace from cloud back to your local machine.",
+      actionLabel: "Bring back local",
+      direction: "cloud_to_local",
+    });
+  });
+
+  it("maps mobility phases and directions to status copy and overlay titles", () => {
+    expect(mobilityStatusCopy("provisioning", "local_to_cloud")).toEqual({
+      title: "Preparing cloud workspace",
+      description: "Starting this branch in the cloud.",
+    });
+    expect(mobilityStatusCopy("provisioning", "cloud_to_local")).toEqual({
+      title: "Preparing local workspace",
+      description: "Preparing this branch on your machine.",
+    });
+    expect(mobilityStatusCopy("transferring", "local_to_cloud")).toEqual({
+      title: "Syncing workspace",
+      description: "Moving workspace state to the new runtime.",
+    });
+    expect(mobilityStatusCopy("success", "local_to_cloud")).toEqual({
+      title: "Now in cloud",
+      description: "This workspace has moved to the cloud.",
+    });
+    expect(mobilityStatusCopy("success", "cloud_to_local")).toEqual({
+      title: "Now local",
+      description: "This workspace has moved back to your local machine.",
+    });
+    expect(mobilityStatusCopy("failed", "local_to_cloud")).toEqual({
+      title: "Move did not finish",
+      description: "The workspace stayed where it was.",
+    });
+
+    expect(getMobilityOverlayTitle("local_to_cloud", "finalizing")).toBe("Moving to cloud");
+    expect(getMobilityOverlayTitle("cloud_to_local", "cleanup_pending")).toBe("Bringing back local");
+    expect(getMobilityOverlayTitle("local_to_cloud", "cleanup_failed")).toBe("Cleanup needs retry");
+  });
+
+  it("maps reconnection and branch-sync states to copy", () => {
+    expect(mobilityReconnectCopy("local_to_cloud")).toBe("Reconnect any MCP tools you need in cloud.");
+    expect(mobilityReconnectCopy("cloud_to_local")).toBe(
+      "Reconnect any MCP tools you need in this local environment.",
+    );
+    expect(mobilityBranchSyncLoadingCopy()).toEqual({
+      headline: "Checking local branch sync",
+      body: "Comparing your local branch with GitHub.",
+    });
+  });
+
+  it("maps blocker codes to actionable copy", () => {
+    expect(mobilityBlockerCopy({
+      code: "branch_not_published",
+      direction: "local_to_cloud",
+      branchName: "feature/test-gap",
+    })).toEqual({
+      headline: "Can't move this workspace to cloud yet",
+      body: "This branch isn't on GitHub yet.",
+      helper: "Publish `feature/test-gap` before moving to cloud.",
+      actionLabel: "Publish branch",
+    });
+
+    expect(mobilityBlockerCopy({
+      code: "cloud_repo_access",
+      direction: "cloud_to_local",
+    })).toEqual({
+      headline: "Can't bring this workspace back local yet",
+      body: "GitHub access for this repo is not authorized.",
+      helper: "You can be signed in while Proliferate is still missing access to this repository or organization.",
+      actionLabel: "Manage GitHub access",
+    });
+
+    expect(mobilityBlockerCopy({
+      code: "unknown",
+      direction: "local_to_cloud",
+      rawMessage: "Runtime owner changed.",
+    })).toEqual({
+      headline: "Can't move this workspace to cloud yet",
+      body: "Runtime owner changed.",
+      helper: "Resolve the issue and try again.",
+      actionLabel: "Got it",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused tests for pure domain helpers touched by the frontend cleanup migration.

## Verification
- Reviewed locally before opening; branch-specific checks passed in the worktree review pass.
- GitHub CI should run on this PR.