### PR TITLE
refactor(desktop): organize support session debug helpers

### DIFF
--- a/desktop/src/hooks/support/workflows/use-session-debug-actions.ts
+++ b/desktop/src/hooks/support/workflows/use-session-debug-actions.ts
@@ -14,15 +14,19 @@ import type {
 import { useEffect, useMemo, useState } from "react";
 import {
   buildSessionDebugExport,
-  buildSessionDebugLocator,
-  sessionLocatorFromSession,
-  suggestSessionDebugFileName,
   type SessionDebugError,
   type SessionDebugExportedSession,
+} from "@/lib/domain/support/session-debug/export-models";
+import { suggestSessionDebugFileName } from "@/lib/domain/support/session-debug/file-name";
+import {
+  buildSessionDebugLocator,
   type SessionDebugLocator,
-  type SessionDebugLocatorSession,
   type SessionDebugRuntimeLocation,
-} from "@/lib/domain/support/session-debug";
+} from "@/lib/domain/support/session-debug/locator";
+import {
+  sessionLocatorFromSession,
+  type SessionDebugLocatorSession,
+} from "@/lib/domain/support/session-debug/session-summary";
 import { useTauriDiagnosticsActions } from "@/hooks/access/tauri/use-diagnostics-actions";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";

--- a/desktop/src/lib/domain/support/session-debug.test.ts
+++ b/desktop/src/lib/domain/support/session-debug.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
-import type { HealthResponse, Session } from "@anyharness/sdk";
+import type {
+  ContentPart,
+  HealthResponse,
+  Session,
+  SessionEventEnvelope,
+  SessionRawNotificationEnvelope,
+} from "@anyharness/sdk";
+import { buildSessionDebugExport } from "@/lib/domain/support/session-debug/export-models";
+import { suggestSessionDebugFileName } from "@/lib/domain/support/session-debug/file-name";
+import { buildSessionDebugLocator } from "@/lib/domain/support/session-debug/locator";
 import {
-  buildSessionDebugLocator,
-  sessionLocatorFromSession,
-  suggestSessionDebugFileName,
-} from "@/lib/domain/support/session-debug";
+  sanitizeSessionDebugContentParts,
+  sanitizeSessionDebugExportedSession,
+} from "@/lib/domain/support/session-debug/sanitizer";
+import { sessionLocatorFromSession } from "@/lib/domain/support/session-debug/session-summary";
 
 const generatedAt = "2026-04-16T18:30:00.000Z";
 const localHealth = {
@@ -185,3 +194,221 @@ describe("suggestSessionDebugFileName", () => {
     );
   });
 });
+
+describe("sanitizeSessionDebugContentParts", () => {
+  it("redacts textual content and resource previews without changing part shape", () => {
+    const parts = [
+      { type: "text", text: "abc" },
+      { type: "tool_input_text", text: "input" },
+      { type: "tool_result_text", text: "result" },
+      {
+        type: "resource",
+        uri: "file:///tmp/secret.txt",
+        name: "secret.txt",
+        mimeType: "text/plain",
+        preview: "preview",
+      },
+      {
+        type: "file_read",
+        path: "/repo/secret.txt",
+        preview: "file preview",
+      },
+    ] satisfies ContentPart[];
+
+    expect(sanitizeSessionDebugContentParts(parts)).toEqual([
+      { type: "text", text: "[text:3]" },
+      { type: "tool_input_text", text: "[text:5]" },
+      { type: "tool_result_text", text: "[text:6]" },
+      {
+        type: "resource",
+        uri: "file:///tmp/secret.txt",
+        name: "secret.txt",
+        mimeType: "text/plain",
+        preview: "[preview:7]",
+      },
+      {
+        type: "file_read",
+        path: "/repo/secret.txt",
+        preview: "file preview",
+      },
+    ]);
+  });
+});
+
+describe("sanitizeSessionDebugExportedSession", () => {
+  it("redacts pending prompts, transcript content, raw metadata, and notifications", () => {
+    const rawNotification: SessionRawNotificationEnvelope = {
+      sessionId: "session-12345678",
+      seq: 4,
+      timestamp: "2026-04-16T18:11:00.000Z",
+      notificationKind: "session/update",
+      notification: {
+        token: "secret",
+        path: "/repo/secret.txt",
+      },
+    };
+    const sanitized = sanitizeSessionDebugExportedSession({
+      session: makeSession({
+        pendingPrompts: [{
+          contentParts: [{ type: "text", text: "abc" }],
+          promptId: "prompt-1",
+          promptProvenance: null,
+          queuedAt: "2026-04-16T18:09:00.000Z",
+          seq: 2,
+          text: "prompt",
+        }],
+      }),
+      normalizedEvents: [
+        eventEnvelope(1, {
+          type: "item_completed",
+          item: {
+            contentParts: [{ type: "tool_result_text", text: "result" }],
+            kind: "assistant_message",
+            rawInput: { token: "secret" },
+            rawOutput: { path: "/repo/secret.txt" },
+            sourceAgentKind: "codex",
+            status: "completed",
+          },
+        } as SessionEventEnvelope["event"]),
+        eventEnvelope(2, {
+          type: "item_delta",
+          delta: {
+            appendContentParts: [{ type: "tool_input_text", text: "input" }],
+            rawInput: { command: "secret" },
+            rawOutput: { output: "secret" },
+            replaceContentParts: [{ type: "text", text: "replace" }],
+          },
+        }),
+        eventEnvelope(3, {
+          type: "pending_prompt_added",
+          contentParts: [{ type: "text", text: "queued" }],
+          promptId: "prompt-1",
+          promptProvenance: null,
+          queuedAt: "2026-04-16T18:09:00.000Z",
+          seq: 3,
+          text: "queue",
+        }),
+      ],
+      rawNotifications: [rawNotification],
+      liveConfig: null,
+      errors: [],
+    });
+
+    expect(sanitized.session?.pendingPrompts).toEqual([{
+      contentParts: [{ type: "text", text: "[text:3]" }],
+      promptId: "prompt-1",
+      promptProvenance: null,
+      queuedAt: "2026-04-16T18:09:00.000Z",
+      seq: 2,
+      text: "[content:6]",
+    }]);
+    expect(sanitized.normalizedEvents?.[0].event).toEqual({
+      type: "item_completed",
+      item: {
+        contentParts: [{ type: "tool_result_text", text: "[text:6]" }],
+        kind: "assistant_message",
+        rawInput: undefined,
+        rawOutput: undefined,
+        sourceAgentKind: "codex",
+        status: "completed",
+      },
+    });
+    expect(sanitized.normalizedEvents?.[1].event).toEqual({
+      type: "item_delta",
+      delta: {
+        appendContentParts: [{ type: "tool_input_text", text: "[text:5]" }],
+        rawInput: undefined,
+        rawOutput: undefined,
+        replaceContentParts: [{ type: "text", text: "[text:7]" }],
+      },
+    });
+    expect(sanitized.normalizedEvents?.[2].event).toEqual({
+      type: "pending_prompt_added",
+      contentParts: [{ type: "text", text: "[text:6]" }],
+      promptId: "prompt-1",
+      promptProvenance: null,
+      queuedAt: "2026-04-16T18:09:00.000Z",
+      seq: 3,
+      text: "[content:5]",
+    });
+    expect(sanitized.rawNotifications).toEqual([{
+      ...rawNotification,
+      notification: { redacted: true },
+    }]);
+  });
+});
+
+describe("buildSessionDebugExport", () => {
+  it("keeps the export envelope stable while sanitizing sessions", () => {
+    const locator = buildSessionDebugLocator({
+      generatedAt,
+      runtime: {
+        location: "local",
+        url: "http://127.0.0.1:7007",
+        health: localHealth,
+      },
+      workspace: {
+        uiWorkspaceId: "workspace-ui",
+        logicalWorkspaceId: "logical-workspace",
+        anyharnessWorkspaceId: "workspace-12345678",
+        owningSlotWorkspaceId: "workspace-ui",
+      },
+      session: sessionLocatorFromSession(makeSession()),
+    });
+
+    const payload = buildSessionDebugExport({
+      generatedAt,
+      scope: { kind: "session", id: "session-12345678" },
+      locator,
+      sessions: [{
+        session: makeSession({
+          pendingPrompts: [{
+            contentParts: [{ type: "text", text: "secret" }],
+            promptId: "prompt-1",
+            promptProvenance: null,
+            queuedAt: "2026-04-16T18:09:00.000Z",
+            seq: 2,
+            text: "secret",
+          }],
+        }),
+        normalizedEvents: null,
+        rawNotifications: [{
+          sessionId: "session-12345678",
+          seq: 1,
+          timestamp: "2026-04-16T18:11:00.000Z",
+          notificationKind: "session/update",
+          notification: { token: "secret" },
+        }],
+        liveConfig: null,
+        errors: [{ scope: "liveConfig", message: "unavailable" }],
+      }],
+    });
+
+    expect(payload).toMatchObject({
+      schemaVersion: 1,
+      generatedAt,
+      scope: { kind: "session", id: "session-12345678" },
+      locator,
+      errors: [],
+    });
+    expect(payload.sessions[0].session?.pendingPrompts?.[0].text).toBe("[content:6]");
+    expect(payload.sessions[0].rawNotifications?.[0].notification).toEqual({ redacted: true });
+    expect(payload.sessions[0].errors).toEqual([
+      { scope: "liveConfig", message: "unavailable" },
+    ]);
+  });
+});
+
+function eventEnvelope(
+  seq: number,
+  event: SessionEventEnvelope["event"],
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-12345678",
+    seq,
+    timestamp: `2026-04-16T18:10:0${seq}.000Z`,
+    turnId: "turn-1",
+    itemId: null,
+    event,
+  };
+}

--- a/desktop/src/lib/domain/support/session-debug/export-models.ts
+++ b/desktop/src/lib/domain/support/session-debug/export-models.ts
@@ -1,0 +1,63 @@
+import type {
+  GetSessionLiveConfigResponse,
+  Session,
+  SessionEventEnvelope,
+  SessionRawNotificationEnvelope,
+} from "@anyharness/sdk";
+import type { SessionDebugLocator } from "@/lib/domain/support/session-debug/locator";
+import { sanitizeSessionDebugExportedSession } from "@/lib/domain/support/session-debug/sanitizer";
+
+export type SessionDebugScopeKind = "session" | "workspace";
+
+export interface SessionDebugError {
+  scope: string;
+  message: string;
+}
+
+export interface SessionDebugExportedSession {
+  session: Session | null;
+  normalizedEvents: SessionEventEnvelope[] | null;
+  rawNotifications: SessionRawNotificationEnvelope[] | null;
+  liveConfig: GetSessionLiveConfigResponse | null;
+  errors: SessionDebugError[];
+}
+
+export interface SessionDebugExport {
+  schemaVersion: 1;
+  generatedAt: string;
+  scope: {
+    kind: SessionDebugScopeKind;
+    id: string;
+  };
+  locator: SessionDebugLocator;
+  sessions: SessionDebugExportedSession[];
+  errors: SessionDebugError[];
+}
+
+export interface BuildSessionDebugExportInput {
+  generatedAt: Date | string;
+  scope: {
+    kind: SessionDebugScopeKind;
+    id: string;
+  };
+  locator: SessionDebugLocator;
+  sessions: SessionDebugExportedSession[];
+  errors?: SessionDebugError[];
+}
+
+export function buildSessionDebugExport(
+  input: BuildSessionDebugExportInput,
+): SessionDebugExport {
+  return {
+    schemaVersion: 1,
+    generatedAt: normalizeDate(input.generatedAt),
+    scope: input.scope,
+    locator: input.locator,
+    sessions: input.sessions.map(sanitizeSessionDebugExportedSession),
+    errors: input.errors ?? [],
+  };
+}
+
+function normalizeDate(date: Date | string): string {
+  return typeof date === "string" ? date : date.toISOString();
+}

--- a/desktop/src/lib/domain/support/session-debug/file-name.ts
+++ b/desktop/src/lib/domain/support/session-debug/file-name.ts
@@ -1,0 +1,30 @@
+import type { SessionDebugScopeKind } from "@/lib/domain/support/session-debug/export-models";
+
+export function suggestSessionDebugFileName(
+  scope: SessionDebugScopeKind,
+  id: string,
+  date: Date,
+): string {
+  const idPrefix = sanitizeFileNamePart(id).slice(0, 8).replace(/[-_]+$/, "") || "unknown";
+  return `proliferate-${scope}-debug-${idPrefix}-${formatUtcTimestamp(date)}.json`;
+}
+
+function formatUtcTimestamp(date: Date): string {
+  return [
+    date.getUTCFullYear(),
+    pad2(date.getUTCMonth() + 1),
+    pad2(date.getUTCDate()),
+    "-",
+    pad2(date.getUTCHours()),
+    pad2(date.getUTCMinutes()),
+    pad2(date.getUTCSeconds()),
+  ].join("");
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function sanitizeFileNamePart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]/g, "");
+}

--- a/desktop/src/lib/domain/support/session-debug/locator.ts
+++ b/desktop/src/lib/domain/support/session-debug/locator.ts
@@ -1,15 +1,7 @@
-import type {
-  GetSessionLiveConfigResponse,
-  HealthResponse,
-  ContentPart,
-  Session,
-  SessionActionCapabilities,
-  SessionEventEnvelope,
-  SessionRawNotificationEnvelope,
-} from "@anyharness/sdk";
+import type { HealthResponse } from "@anyharness/sdk";
+import type { SessionDebugLocatorSession } from "@/lib/domain/support/session-debug/session-summary";
 
 export type SessionDebugRuntimeLocation = "local" | "cloud";
-export type SessionDebugScopeKind = "session" | "workspace";
 
 export interface SessionDebugRuntime {
   location: SessionDebugRuntimeLocation;
@@ -27,20 +19,6 @@ export interface SessionDebugWorkspace {
   logicalWorkspaceId: string | null;
   anyharnessWorkspaceId: string | null;
   owningSlotWorkspaceId: string | null;
-}
-
-export interface SessionDebugLocatorSession {
-  id: string;
-  owningWorkspaceId: string | null;
-  agentKind: string | null;
-  status: string | null;
-  title: string | null;
-  modelId: string | null;
-  modeId: string | null;
-  nativeSessionId: string | null;
-  actionCapabilities: SessionActionCapabilities | null;
-  createdAt: string | null;
-  updatedAt: string | null;
 }
 
 export interface SessionDebugSqliteInfo {
@@ -88,31 +66,6 @@ export interface SessionDebugLocator {
   api: SessionDebugApiPaths;
 }
 
-export interface SessionDebugError {
-  scope: string;
-  message: string;
-}
-
-export interface SessionDebugExportedSession {
-  session: Session | null;
-  normalizedEvents: SessionEventEnvelope[] | null;
-  rawNotifications: SessionRawNotificationEnvelope[] | null;
-  liveConfig: GetSessionLiveConfigResponse | null;
-  errors: SessionDebugError[];
-}
-
-export interface SessionDebugExport {
-  schemaVersion: 1;
-  generatedAt: string;
-  scope: {
-    kind: SessionDebugScopeKind;
-    id: string;
-  };
-  locator: SessionDebugLocator;
-  sessions: SessionDebugExportedSession[];
-  errors: SessionDebugError[];
-}
-
 export interface BuildSessionDebugLocatorInput {
   generatedAt: Date | string;
   runtime: {
@@ -122,17 +75,6 @@ export interface BuildSessionDebugLocatorInput {
   };
   workspace: SessionDebugWorkspace;
   session?: SessionDebugLocatorSession | null;
-}
-
-export interface BuildSessionDebugExportInput {
-  generatedAt: Date | string;
-  scope: {
-    kind: SessionDebugScopeKind;
-    id: string;
-  };
-  locator: SessionDebugLocator;
-  sessions: SessionDebugExportedSession[];
-  errors?: SessionDebugError[];
 }
 
 const LOCATOR_CONTEXT =
@@ -195,132 +137,6 @@ export function buildSessionDebugLocator(
   };
 }
 
-export function buildSessionDebugExport(
-  input: BuildSessionDebugExportInput,
-): SessionDebugExport {
-  return {
-    schemaVersion: 1,
-    generatedAt: normalizeDate(input.generatedAt),
-    scope: input.scope,
-    locator: input.locator,
-    sessions: input.sessions.map(sanitizeExportedSession),
-    errors: input.errors ?? [],
-  };
-}
-
-function sanitizeExportedSession(session: SessionDebugExportedSession): SessionDebugExportedSession {
-  return {
-    ...session,
-    session: session.session ? sanitizeSessionSummary(session.session) : null,
-    normalizedEvents: session.normalizedEvents?.map(sanitizeEventEnvelope) ?? null,
-    rawNotifications: session.rawNotifications?.map((notification) => ({
-      ...notification,
-      notification: { redacted: true },
-    })) ?? null,
-  };
-}
-
-function sanitizeSessionSummary(session: Session): Session {
-  return {
-    ...session,
-    pendingPrompts: (session.pendingPrompts ?? []).map((prompt) => ({
-      ...prompt,
-      text: `[content:${prompt.text.length}]`,
-      contentParts: sanitizeContentParts(prompt.contentParts ?? []),
-    })),
-  };
-}
-
-function sanitizeEventEnvelope(envelope: SessionEventEnvelope): SessionEventEnvelope {
-  const event = envelope.event;
-  if (event.type === "item_started" || event.type === "item_completed") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        item: {
-          ...event.item,
-          contentParts: sanitizeContentParts(event.item.contentParts ?? []),
-          rawInput: undefined,
-          rawOutput: undefined,
-        },
-      },
-    };
-  }
-  if (event.type === "item_delta") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        delta: {
-          ...event.delta,
-          replaceContentParts: event.delta.replaceContentParts
-            ? sanitizeContentParts(event.delta.replaceContentParts)
-            : undefined,
-          appendContentParts: event.delta.appendContentParts
-            ? sanitizeContentParts(event.delta.appendContentParts)
-            : undefined,
-          rawInput: undefined,
-          rawOutput: undefined,
-        },
-      },
-    };
-  }
-  if (event.type === "pending_prompt_added" || event.type === "pending_prompt_updated") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        text: `[content:${event.text.length}]`,
-        contentParts: sanitizeContentParts(event.contentParts ?? []),
-      },
-    };
-  }
-  return envelope;
-}
-
-function sanitizeContentParts(parts: ContentPart[]): ContentPart[] {
-  return parts.map((part) => {
-    switch (part.type) {
-      case "text":
-        return { type: "text", text: `[text:${part.text.length}]` };
-      case "resource":
-        return { ...part, preview: part.preview ? `[preview:${part.preview.length}]` : undefined };
-      case "tool_input_text":
-        return { type: "tool_input_text", text: `[text:${part.text.length}]` };
-      case "tool_result_text":
-        return { type: "tool_result_text", text: `[text:${part.text.length}]` };
-      default:
-        return part;
-    }
-  });
-}
-
-export function suggestSessionDebugFileName(
-  scope: SessionDebugScopeKind,
-  id: string,
-  date: Date,
-): string {
-  const idPrefix = sanitizeFileNamePart(id).slice(0, 8).replace(/[-_]+$/, "") || "unknown";
-  return `proliferate-${scope}-debug-${idPrefix}-${formatUtcTimestamp(date)}.json`;
-}
-
-export function sessionLocatorFromSession(session: Session): SessionDebugLocatorSession {
-  return {
-    id: session.id,
-    owningWorkspaceId: session.workspaceId,
-    agentKind: session.agentKind,
-    status: session.status,
-    title: session.title ?? null,
-    modelId: session.modelId ?? session.requestedModelId ?? null,
-    modeId: session.modeId ?? session.requestedModeId ?? null,
-    nativeSessionId: session.nativeSessionId ?? null,
-    actionCapabilities: session.actionCapabilities ?? null,
-    createdAt: session.createdAt ?? null,
-    updatedAt: session.updatedAt ?? null,
-  };
-}
-
 function buildSqliteQueries(hasSession: boolean): SessionDebugQueries {
   if (hasSession) {
     return {
@@ -371,24 +187,4 @@ function appendSqliteFileName(runtimeHome: string): string {
 
 function normalizeDate(date: Date | string): string {
   return typeof date === "string" ? date : date.toISOString();
-}
-
-function formatUtcTimestamp(date: Date): string {
-  return [
-    date.getUTCFullYear(),
-    pad2(date.getUTCMonth() + 1),
-    pad2(date.getUTCDate()),
-    "-",
-    pad2(date.getUTCHours()),
-    pad2(date.getUTCMinutes()),
-    pad2(date.getUTCSeconds()),
-  ].join("");
-}
-
-function pad2(value: number): string {
-  return value.toString().padStart(2, "0");
-}
-
-function sanitizeFileNamePart(value: string): string {
-  return value.trim().replace(/[^A-Za-z0-9_-]/g, "");
 }

--- a/desktop/src/lib/domain/support/session-debug/sanitizer.ts
+++ b/desktop/src/lib/domain/support/session-debug/sanitizer.ts
@@ -1,0 +1,96 @@
+import type {
+  ContentPart,
+  Session,
+  SessionEventEnvelope,
+} from "@anyharness/sdk";
+import type { SessionDebugExportedSession } from "@/lib/domain/support/session-debug/export-models";
+
+export function sanitizeSessionDebugExportedSession(
+  session: SessionDebugExportedSession,
+): SessionDebugExportedSession {
+  return {
+    ...session,
+    session: session.session ? sanitizeSessionSummary(session.session) : null,
+    normalizedEvents: session.normalizedEvents?.map(sanitizeSessionEventEnvelope) ?? null,
+    rawNotifications: session.rawNotifications?.map((notification) => ({
+      ...notification,
+      notification: { redacted: true },
+    })) ?? null,
+  };
+}
+
+export function sanitizeSessionDebugContentParts(parts: ContentPart[]): ContentPart[] {
+  return parts.map((part) => {
+    switch (part.type) {
+      case "text":
+        return { type: "text", text: `[text:${part.text.length}]` };
+      case "resource":
+        return { ...part, preview: part.preview ? `[preview:${part.preview.length}]` : undefined };
+      case "tool_input_text":
+        return { type: "tool_input_text", text: `[text:${part.text.length}]` };
+      case "tool_result_text":
+        return { type: "tool_result_text", text: `[text:${part.text.length}]` };
+      default:
+        return part;
+    }
+  });
+}
+
+function sanitizeSessionSummary(session: Session): Session {
+  return {
+    ...session,
+    pendingPrompts: (session.pendingPrompts ?? []).map((prompt) => ({
+      ...prompt,
+      text: `[content:${prompt.text.length}]`,
+      contentParts: sanitizeSessionDebugContentParts(prompt.contentParts ?? []),
+    })),
+  };
+}
+
+function sanitizeSessionEventEnvelope(envelope: SessionEventEnvelope): SessionEventEnvelope {
+  const event = envelope.event;
+  if (event.type === "item_started" || event.type === "item_completed") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        item: {
+          ...event.item,
+          contentParts: sanitizeSessionDebugContentParts(event.item.contentParts ?? []),
+          rawInput: undefined,
+          rawOutput: undefined,
+        },
+      },
+    };
+  }
+  if (event.type === "item_delta") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        delta: {
+          ...event.delta,
+          replaceContentParts: event.delta.replaceContentParts
+            ? sanitizeSessionDebugContentParts(event.delta.replaceContentParts)
+            : undefined,
+          appendContentParts: event.delta.appendContentParts
+            ? sanitizeSessionDebugContentParts(event.delta.appendContentParts)
+            : undefined,
+          rawInput: undefined,
+          rawOutput: undefined,
+        },
+      },
+    };
+  }
+  if (event.type === "pending_prompt_added" || event.type === "pending_prompt_updated") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        text: `[content:${event.text.length}]`,
+        contentParts: sanitizeSessionDebugContentParts(event.contentParts ?? []),
+      },
+    };
+  }
+  return envelope;
+}

--- a/desktop/src/lib/domain/support/session-debug/session-summary.ts
+++ b/desktop/src/lib/domain/support/session-debug/session-summary.ts
@@ -1,0 +1,31 @@
+import type { Session, SessionActionCapabilities } from "@anyharness/sdk";
+
+export interface SessionDebugLocatorSession {
+  id: string;
+  owningWorkspaceId: string | null;
+  agentKind: string | null;
+  status: string | null;
+  title: string | null;
+  modelId: string | null;
+  modeId: string | null;
+  nativeSessionId: string | null;
+  actionCapabilities: SessionActionCapabilities | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export function sessionLocatorFromSession(session: Session): SessionDebugLocatorSession {
+  return {
+    id: session.id,
+    owningWorkspaceId: session.workspaceId,
+    agentKind: session.agentKind,
+    status: session.status,
+    title: session.title ?? null,
+    modelId: session.modelId ?? session.requestedModelId ?? null,
+    modeId: session.modeId ?? session.requestedModeId ?? null,
+    nativeSessionId: session.nativeSessionId ?? null,
+    actionCapabilities: session.actionCapabilities ?? null,
+    createdAt: session.createdAt ?? null,
+    updatedAt: session.updatedAt ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- Splits support session debug domain helpers into focused modules and updates callers.

## Verification
- Reviewed locally before opening; branch-specific checks passed in the worktree review pass.
- GitHub CI should run on this PR.