### PR TITLE
refactor(desktop): split workspace files and git components

### DIFF
--- a/desktop/src/components/workspace/files/FileEditorContent.tsx
+++ b/desktop/src/components/workspace/files/FileEditorContent.tsx
@@ -1,0 +1,144 @@
+import type { ReadWorkspaceFileResponse } from "@anyharness/sdk";
+import Editor, {
+  type BeforeMount,
+  type OnMount,
+} from "@monaco-editor/react";
+import type {
+  PointerEventHandler,
+  RefObject,
+} from "react";
+import { LoadingState } from "@/components/feedback/LoadingIllustration";
+import { Button } from "@/components/ui/Button";
+import { MarkdownRenderer } from "@/components/ui/content/MarkdownRenderer";
+import { CenterMessage } from "@/components/workspace/files/viewer/CenterMessage";
+import { FileDiffPane } from "@/components/workspace/files/viewer/FileDiffPane";
+import type { FileDiffTarget } from "@/lib/domain/workspaces/viewer/file-diff-options";
+import { inferWorkspaceFileLanguage } from "@/lib/domain/workspaces/viewer/file-language";
+import type { FileViewerMode } from "@/lib/domain/workspaces/viewer/viewer-target";
+import {
+  THEME_NAME_LIGHT,
+  THEME_NAME_DARK,
+} from "@/lib/infra/editor/monaco-theme";
+import type { WorkspaceFileBuffer } from "@/stores/editor/workspace-file-buffers-store";
+
+interface FileEditorContentProps {
+  filePath: string;
+  workspaceId: string | null;
+  effectiveMode: FileViewerMode;
+  read: ReadWorkspaceFileResponse | undefined;
+  buffer: WorkspaceFileBuffer | undefined;
+  activeDiffTarget: FileDiffTarget | null;
+  diffLayout: "unified" | "split";
+  canShowMarkdownPreview: boolean;
+  resolvedMode: "dark" | "light";
+  monacoFontSize: number;
+  monacoLineHeight: number;
+  viewerContentRef: RefObject<HTMLDivElement | null>;
+  onContentPointerDownCapture: PointerEventHandler<HTMLDivElement>;
+  onUpdateBuffer: (path: string, content: string) => void;
+  onReloadFile: (path: string) => void | Promise<void>;
+  onBeforeMount: BeforeMount;
+  onEditorMount: OnMount;
+}
+
+export function FileEditorContent({
+  filePath,
+  workspaceId,
+  effectiveMode,
+  read,
+  buffer,
+  activeDiffTarget,
+  diffLayout,
+  canShowMarkdownPreview,
+  resolvedMode,
+  monacoFontSize,
+  monacoLineHeight,
+  viewerContentRef,
+  onContentPointerDownCapture,
+  onUpdateBuffer,
+  onReloadFile,
+  onBeforeMount,
+  onEditorMount,
+}: FileEditorContentProps) {
+  return (
+    <>
+      <div
+        ref={viewerContentRef}
+        onPointerDownCapture={onContentPointerDownCapture}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        {effectiveMode === "diff" && activeDiffTarget ? (
+          <FileDiffPane
+            workspaceId={workspaceId}
+            target={activeDiffTarget}
+            layout={diffLayout}
+          />
+        ) : !read ? (
+          <div className="flex items-center justify-center h-full">
+            <LoadingState message="Loading file" subtext={filePath.split("/").pop()} />
+          </div>
+        ) : read.tooLarge ? (
+          <CenterMessage message={`${filePath} is too large to edit`} />
+        ) : !read.isText ? (
+          <CenterMessage message={`${filePath} is a binary file and cannot be edited`} />
+        ) : effectiveMode === "rendered" && canShowMarkdownPreview ? (
+          <div className="h-full overflow-auto px-8 py-6">
+            <MarkdownRenderer content={buffer?.localContent ?? read.content ?? ""} />
+          </div>
+        ) : (
+          <Editor
+            height="100%"
+            language={inferWorkspaceFileLanguage(filePath)}
+            value={buffer?.localContent ?? read.content ?? ""}
+            onChange={(value) => {
+              if (value !== undefined) {
+                onUpdateBuffer(filePath, value);
+              }
+            }}
+            beforeMount={onBeforeMount}
+            onMount={onEditorMount}
+            theme={resolvedMode === "dark" ? THEME_NAME_DARK : THEME_NAME_LIGHT}
+            options={{
+              minimap: { enabled: false },
+              fontSize: monacoFontSize,
+              lineHeight: monacoLineHeight,
+              fontFamily: "'Geist Mono', monospace",
+              fontLigatures: false,
+              padding: { top: 0 },
+              scrollBeyondLastLine: false,
+              wordWrap: "on",
+              automaticLayout: true,
+              tabSize: 2,
+              renderLineHighlight: "line",
+              lineNumbersMinChars: 7,
+              glyphMargin: false,
+              folding: true,
+              foldingHighlight: false,
+              overviewRulerLanes: 0,
+              hideCursorInOverviewRuler: true,
+              scrollbar: { verticalScrollbarSize: 6, horizontalScrollbarSize: 6, useShadows: false },
+              renderWhitespace: "none",
+            }}
+          />
+        )}
+      </div>
+
+      {buffer?.saveState === "conflict" && (
+        <div className="flex items-center justify-between px-3 py-2 bg-destructive/10 border-t border-destructive/20 shrink-0">
+          <span className="text-xs text-destructive">
+            File changed on disk. Your local changes are preserved.
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onReloadFile(filePath)}
+            className="ml-2 h-auto shrink-0 bg-transparent p-0 text-xs text-destructive hover:bg-transparent hover:underline"
+          >
+            Reload from disk
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -3,17 +3,14 @@ import {
   useMemo,
   useState,
 } from "react";
-import Editor from "@monaco-editor/react";
-import { Button } from "@/components/ui/Button";
+import { FileEditorContent } from "./FileEditorContent";
 import { LoadingState } from "@/components/feedback/LoadingIllustration";
-import { MarkdownRenderer } from "@/components/ui/content/MarkdownRenderer";
 import {
   useGitBranchDiffFilesQuery,
   useGitStatusQuery,
   useReadWorkspaceFileQuery,
 } from "@anyharness/sdk-react";
 import { CenterMessage } from "@/components/workspace/files/viewer/CenterMessage";
-import { FileDiffPane } from "@/components/workspace/files/viewer/FileDiffPane";
 import { FileViewerFrame } from "@/components/workspace/files/viewer/FileViewerFrame";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
 import { useFileEditorCommands } from "@/hooks/workspaces/files/ui/use-file-editor-commands";
@@ -26,16 +23,11 @@ import {
   resolveActiveDiffOption,
   type FileDiffTarget,
 } from "@/lib/domain/workspaces/viewer/file-diff-options";
-import { inferWorkspaceFileLanguage } from "@/lib/domain/workspaces/viewer/file-language";
 import {
   defaultFileViewerMode,
   type FileDiffViewerScope,
   type ViewerTargetKey,
 } from "@/lib/domain/workspaces/viewer/viewer-target";
-import {
-  THEME_NAME_LIGHT,
-  THEME_NAME_DARK,
-} from "@/lib/infra/editor/monaco-theme";
 import { useWorkspaceFileBuffersStore } from "@/stores/editor/workspace-file-buffers-store";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
@@ -200,83 +192,25 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       onReload={() => void reloadFile(filePath)}
       onSave={() => void saveFile(filePath)}
     >
-      <div
-        ref={viewerContentRef}
-        onPointerDownCapture={handleContentPointerDownCapture}
-        className="flex min-h-0 flex-1 flex-col overflow-hidden"
-      >
-        {effectiveMode === "diff" && activeDiffTarget ? (
-          <FileDiffPane
-            workspaceId={materializedWorkspaceId}
-            target={activeDiffTarget}
-            layout={diffLayout}
-          />
-        ) : !read ? (
-          <div className="flex items-center justify-center h-full">
-            <LoadingState message="Loading file" subtext={filePath.split("/").pop()} />
-          </div>
-        ) : read.tooLarge ? (
-          <CenterMessage message={`${filePath} is too large to edit`} />
-        ) : !read.isText ? (
-          <CenterMessage message={`${filePath} is a binary file and cannot be edited`} />
-        ) : effectiveMode === "rendered" && canShowMarkdownPreview ? (
-          <div className="h-full overflow-auto px-8 py-6">
-            <MarkdownRenderer content={buffer?.localContent ?? read.content ?? ""} />
-          </div>
-        ) : (
-          <Editor
-            height="100%"
-            language={inferWorkspaceFileLanguage(filePath)}
-            value={buffer?.localContent ?? read.content ?? ""}
-            onChange={(value) => {
-              if (value !== undefined) {
-                updateBuffer(filePath, value);
-              }
-            }}
-            beforeMount={handleBeforeMount}
-            onMount={handleEditorMount}
-            theme={resolvedMode === "dark" ? THEME_NAME_DARK : THEME_NAME_LIGHT}
-            options={{
-              minimap: { enabled: false },
-              fontSize: readableCodeScale.monacoFontSize,
-              lineHeight: readableCodeScale.monacoLineHeight,
-              fontFamily: "'Geist Mono', monospace",
-              fontLigatures: false,
-              padding: { top: 0 },
-              scrollBeyondLastLine: false,
-              wordWrap: "on",
-              automaticLayout: true,
-              tabSize: 2,
-              renderLineHighlight: "line",
-              lineNumbersMinChars: 7,
-              glyphMargin: false,
-              folding: true,
-              foldingHighlight: false,
-              overviewRulerLanes: 0,
-              hideCursorInOverviewRuler: true,
-              scrollbar: { verticalScrollbarSize: 6, horizontalScrollbarSize: 6, useShadows: false },
-              renderWhitespace: "none",
-            }}
-          />
-        )}
-      </div>
-
-      {buffer?.saveState === "conflict" && (
-        <div className="flex items-center justify-between px-3 py-2 bg-destructive/10 border-t border-destructive/20 shrink-0">
-          <span className="text-xs text-destructive">
-            File changed on disk. Your local changes are preserved.
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => reloadFile(filePath)}
-            className="ml-2 h-auto shrink-0 bg-transparent p-0 text-xs text-destructive hover:bg-transparent hover:underline"
-          >
-            Reload from disk
-          </Button>
-        </div>
-      )}
+      <FileEditorContent
+        filePath={filePath}
+        workspaceId={materializedWorkspaceId}
+        effectiveMode={effectiveMode}
+        read={read}
+        buffer={buffer}
+        activeDiffTarget={activeDiffTarget}
+        diffLayout={diffLayout}
+        canShowMarkdownPreview={canShowMarkdownPreview}
+        resolvedMode={resolvedMode}
+        monacoFontSize={readableCodeScale.monacoFontSize}
+        monacoLineHeight={readableCodeScale.monacoLineHeight}
+        viewerContentRef={viewerContentRef}
+        onContentPointerDownCapture={handleContentPointerDownCapture}
+        onUpdateBuffer={updateBuffer}
+        onReloadFile={reloadFile}
+        onBeforeMount={handleBeforeMount}
+        onEditorMount={handleEditorMount}
+      />
     </FileViewerFrame>
   );
 }

--- a/desktop/src/components/workspace/files/panel/ChangedFilesList.tsx
+++ b/desktop/src/components/workspace/files/panel/ChangedFilesList.tsx
@@ -1,0 +1,205 @@
+import { Button } from "@/components/ui/Button";
+import { FileChangeStats } from "@/components/ui/content/FileDiffCard";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+import { ArrowUpRight, ChevronRight } from "@/components/ui/icons";
+import { Tooltip } from "@/components/ui/Tooltip";
+import {
+  buildChangedFileTree,
+  type ChangedFileTreeNode,
+} from "@/lib/domain/workspaces/changes/changed-file-tree";
+import type {
+  GitPanelFile,
+  GitPanelSectionScope,
+} from "@/lib/domain/workspaces/changes/git-panel-diff";
+
+type OpenFile = (path: string) => Promise<void>;
+type OpenFileDiff = (
+  path: string,
+  options?: {
+    scope?: GitPanelSectionScope | null;
+    baseRef?: string | null;
+    oldPath?: string | null;
+  },
+) => Promise<void>;
+
+interface ChangedFilesListProps {
+  sections: {
+    scope: GitPanelSectionScope;
+    label: string;
+    files: GitPanelFile[];
+  }[];
+  baseRef: string | null;
+  isBranchMode: boolean;
+  isLoading: boolean;
+  errorMessage: string | null;
+  runtimeBlockedReason: string | null;
+  emptyMessage: string;
+  changedFileCount: number;
+  openFile: OpenFile;
+  openFileDiff: OpenFileDiff;
+}
+
+export function ChangedFilesList({
+  sections,
+  baseRef,
+  isBranchMode,
+  isLoading,
+  errorMessage,
+  runtimeBlockedReason,
+  emptyMessage,
+  changedFileCount,
+  openFile,
+  openFileDiff,
+}: ChangedFilesListProps) {
+  return (
+    <div className="h-full overflow-auto px-2 py-2">
+      {isLoading && (
+        <p className="px-2 py-3 text-xs text-sidebar-muted-foreground">Loading changed files...</p>
+      )}
+      {errorMessage && (
+        <p className="px-2 py-3 text-xs text-destructive">{errorMessage}</p>
+      )}
+      {!errorMessage && runtimeBlockedReason && (
+        <p className="px-2 py-3 text-xs text-sidebar-muted-foreground">
+          {runtimeBlockedReason}
+        </p>
+      )}
+      {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length === 0 && (
+        <p className="px-2 py-3 text-center text-xs text-sidebar-muted-foreground">
+          {emptyMessage}
+        </p>
+      )}
+      {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <p className="px-1 text-[10px] text-sidebar-muted-foreground">
+            {changedFileCount} changed file{changedFileCount === 1 ? "" : "s"}
+          </p>
+          {sections.map((section) => {
+            const tree = buildChangedFileTree(section.files);
+            return (
+              <div key={section.scope} className="flex flex-col gap-1">
+                {sections.length > 1 && (
+                  <div className="px-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-sidebar-muted-foreground">
+                    {section.label}
+                  </div>
+                )}
+                {tree.map((node) => (
+                  <ChangedFileTreeNodeRow
+                    key={`${section.scope}:${node.path}`}
+                    node={node}
+                    level={0}
+                    sectionScope={section.scope}
+                    baseRef={baseRef}
+                    isBranchMode={isBranchMode}
+                    openFile={openFile}
+                    openFileDiff={openFileDiff}
+                  />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChangedFileTreeNodeRow({
+  node,
+  level,
+  sectionScope,
+  baseRef,
+  isBranchMode,
+  openFile,
+  openFileDiff,
+}: {
+  node: ChangedFileTreeNode;
+  level: number;
+  sectionScope: GitPanelSectionScope;
+  baseRef: string | null;
+  isBranchMode: boolean;
+  openFile: OpenFile;
+  openFileDiff: OpenFileDiff;
+}) {
+  if (node.kind === "directory") {
+    return (
+      <div>
+        <div
+          className="mx-0 flex h-7 items-center gap-2 rounded-md px-2 text-[0.65rem] text-sidebar-muted-foreground"
+          style={{ paddingLeft: `${8 + level * 14}px` }}
+        >
+          <ChevronRight className="size-3 shrink-0 rotate-90" />
+          <FileTreeEntryIcon
+            name={node.name}
+            path={node.path}
+            kind="directory"
+            isExpanded
+            className="size-3.5 shrink-0"
+          />
+          <span className="min-w-0 truncate">{node.name}</span>
+        </div>
+        {node.children.map((child) => (
+          <ChangedFileTreeNodeRow
+            key={child.path}
+            node={child}
+            level={level + 1}
+            sectionScope={sectionScope}
+            baseRef={baseRef}
+            isBranchMode={isBranchMode}
+            openFile={openFile}
+            openFileDiff={openFileDiff}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const file = node.file;
+  const baseName = file.displayPath.split("/").pop() ?? file.displayPath;
+  return (
+    <div
+      className="group ml-2 flex items-center gap-1 rounded-md border border-sidebar-border/60 bg-sidebar-accent/20 pr-1 transition-colors hover:border-sidebar-border hover:bg-sidebar-accent/70"
+      style={{ marginLeft: `${level * 14}px` }}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => void openFile(file.path)}
+        title={file.displayPath}
+        className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md bg-transparent px-2 py-1.5 text-left hover:bg-transparent"
+      >
+        <FileTreeEntryIcon
+          name={baseName}
+          path={file.path}
+          kind="file"
+          className="size-3.5 shrink-0"
+        />
+        <span className="min-w-0 flex-1 truncate text-[0.68rem] text-sidebar-foreground [direction:ltr] [unicode-bidi:plaintext]">
+          {file.displayPath}
+        </span>
+        <FileChangeStats
+          additions={file.additions}
+          deletions={file.deletions}
+          className="text-[10px]"
+        />
+      </Button>
+      <Tooltip content="Open diff">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => void openFileDiff(file.path, {
+            scope: sectionScope,
+            baseRef: isBranchMode ? baseRef : null,
+            oldPath: isBranchMode ? file.oldPath : null,
+          })}
+          aria-label={`Open ${baseName} diff`}
+          className="size-6 shrink-0 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+        >
+          <ArrowUpRight className="size-3" />
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx
+++ b/desktop/src/components/workspace/files/panel/WorkspaceFilesPanel.tsx
@@ -1,25 +1,15 @@
 import { useMemo, useState } from "react";
 import { useSearchWorkspaceFilesQuery } from "@anyharness/sdk-react";
+import { ChangedFilesList } from "./ChangedFilesList";
 import { FileTreePane } from "./FileTreePane";
 import { FileBrowserToolbar, type FileBrowserScopeFilter } from "./FileBrowserToolbar";
 import { FileCreateDraftRow } from "./FileCreateDraftRow";
 import { Button } from "@/components/ui/Button";
-import { FileChangeStats } from "@/components/ui/content/FileDiffCard";
 import { FileTreeEntryIcon } from "@/components/ui/file-icons";
-import { ArrowUpRight, ChevronRight } from "@/components/ui/icons";
-import { Tooltip } from "@/components/ui/Tooltip";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
 import { useWorkspaceFilesRefresh } from "@/hooks/workspaces/files/workflows/use-workspace-files-refresh";
 import { useGitPanelState } from "@/hooks/workspaces/derived/use-git-panel-state";
-import {
-  buildChangedFileTree,
-  type ChangedFileTreeNode,
-} from "@/lib/domain/workspaces/changes/changed-file-tree";
-import {
-  gitPanelEmptyMessage,
-  type GitPanelFile,
-  type GitPanelSectionScope,
-} from "@/lib/domain/workspaces/changes/git-panel-diff";
+import { gitPanelEmptyMessage } from "@/lib/domain/workspaces/changes/git-panel-diff";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 
 interface WorkspaceFilesPanelProps {
@@ -130,200 +120,6 @@ export function WorkspaceFilesPanel({ showHeader = true }: WorkspaceFilesPanelPr
           <FileTreePane />
         )}
       </div>
-    </div>
-  );
-}
-
-function ChangedFilesList({
-  sections,
-  baseRef,
-  isBranchMode,
-  isLoading,
-  errorMessage,
-  runtimeBlockedReason,
-  emptyMessage,
-  changedFileCount,
-  openFile,
-  openFileDiff,
-}: {
-  sections: {
-    scope: GitPanelSectionScope;
-    label: string;
-    files: GitPanelFile[];
-  }[];
-  baseRef: string | null;
-  isBranchMode: boolean;
-  isLoading: boolean;
-  errorMessage: string | null;
-  runtimeBlockedReason: string | null;
-  emptyMessage: string;
-  changedFileCount: number;
-  openFile: (path: string) => Promise<void>;
-  openFileDiff: (
-    path: string,
-    options?: {
-      scope?: GitPanelSectionScope | null;
-      baseRef?: string | null;
-      oldPath?: string | null;
-    },
-  ) => Promise<void>;
-}) {
-  return (
-    <div className="h-full overflow-auto px-2 py-2">
-      {isLoading && (
-        <p className="px-2 py-3 text-xs text-sidebar-muted-foreground">Loading changed files...</p>
-      )}
-      {errorMessage && (
-        <p className="px-2 py-3 text-xs text-destructive">{errorMessage}</p>
-      )}
-      {!errorMessage && runtimeBlockedReason && (
-        <p className="px-2 py-3 text-xs text-sidebar-muted-foreground">
-          {runtimeBlockedReason}
-        </p>
-      )}
-      {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length === 0 && (
-        <p className="px-2 py-3 text-center text-xs text-sidebar-muted-foreground">
-          {emptyMessage}
-        </p>
-      )}
-      {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <p className="px-1 text-[10px] text-sidebar-muted-foreground">
-            {changedFileCount} changed file{changedFileCount === 1 ? "" : "s"}
-          </p>
-          {sections.map((section) => {
-            const tree = buildChangedFileTree(section.files);
-            return (
-              <div key={section.scope} className="flex flex-col gap-1">
-                {sections.length > 1 && (
-                  <div className="px-1 pt-1 text-[10px] font-medium uppercase tracking-wide text-sidebar-muted-foreground">
-                    {section.label}
-                  </div>
-                )}
-                {tree.map((node) => (
-                  <ChangedFileTreeNodeRow
-                    key={`${section.scope}:${node.path}`}
-                    node={node}
-                    level={0}
-                    sectionScope={section.scope}
-                    baseRef={baseRef}
-                    isBranchMode={isBranchMode}
-                    openFile={openFile}
-                    openFileDiff={openFileDiff}
-                  />
-                ))}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ChangedFileTreeNodeRow({
-  node,
-  level,
-  sectionScope,
-  baseRef,
-  isBranchMode,
-  openFile,
-  openFileDiff,
-}: {
-  node: ChangedFileTreeNode;
-  level: number;
-  sectionScope: GitPanelSectionScope;
-  baseRef: string | null;
-  isBranchMode: boolean;
-  openFile: (path: string) => Promise<void>;
-  openFileDiff: (
-    path: string,
-    options?: {
-      scope?: GitPanelSectionScope | null;
-      baseRef?: string | null;
-      oldPath?: string | null;
-    },
-  ) => Promise<void>;
-}) {
-  if (node.kind === "directory") {
-    return (
-      <div>
-        <div
-          className="mx-0 flex h-7 items-center gap-2 rounded-md px-2 text-[0.65rem] text-sidebar-muted-foreground"
-          style={{ paddingLeft: `${8 + level * 14}px` }}
-        >
-          <ChevronRight className="size-3 shrink-0 rotate-90" />
-          <FileTreeEntryIcon
-            name={node.name}
-            path={node.path}
-            kind="directory"
-            isExpanded
-            className="size-3.5 shrink-0"
-          />
-          <span className="min-w-0 truncate">{node.name}</span>
-        </div>
-        {node.children.map((child) => (
-          <ChangedFileTreeNodeRow
-            key={child.path}
-            node={child}
-            level={level + 1}
-            sectionScope={sectionScope}
-            baseRef={baseRef}
-            isBranchMode={isBranchMode}
-            openFile={openFile}
-            openFileDiff={openFileDiff}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  const file = node.file;
-  const baseName = file.displayPath.split("/").pop() ?? file.displayPath;
-  return (
-    <div
-      className="group ml-2 flex items-center gap-1 rounded-md border border-sidebar-border/60 bg-sidebar-accent/20 pr-1 transition-colors hover:border-sidebar-border hover:bg-sidebar-accent/70"
-      style={{ marginLeft: `${level * 14}px` }}
-    >
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        onClick={() => void openFile(file.path)}
-        title={file.displayPath}
-        className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md bg-transparent px-2 py-1.5 text-left hover:bg-transparent"
-      >
-        <FileTreeEntryIcon
-          name={baseName}
-          path={file.path}
-          kind="file"
-          className="size-3.5 shrink-0"
-        />
-        <span className="min-w-0 flex-1 truncate text-[0.68rem] text-sidebar-foreground [direction:ltr] [unicode-bidi:plaintext]">
-          {file.displayPath}
-        </span>
-        <FileChangeStats
-          additions={file.additions}
-          deletions={file.deletions}
-          className="text-[10px]"
-        />
-      </Button>
-      <Tooltip content="Open diff">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => void openFileDiff(file.path, {
-            scope: sectionScope,
-            baseRef: isBranchMode ? baseRef : null,
-            oldPath: isBranchMode ? file.oldPath : null,
-          })}
-          aria-label={`Open ${baseName} diff`}
-          className="size-6 shrink-0 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-        >
-          <ArrowUpRight className="size-3" />
-        </Button>
-      </Tooltip>
     </div>
   );
 }

--- a/desktop/src/components/workspace/git/ChangesFileRow.tsx
+++ b/desktop/src/components/workspace/git/ChangesFileRow.tsx
@@ -1,0 +1,147 @@
+import { Button } from "@/components/ui/Button";
+import { FileChangeStats } from "@/components/ui/content/FileDiffCard";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+import { ArrowUpRight, Check, FileText, Plus } from "@/components/ui/icons";
+import { Tooltip } from "@/components/ui/Tooltip";
+import type {
+  GitPanelFile,
+  GitPanelSectionScope,
+} from "@/lib/domain/workspaces/changes/git-panel-diff";
+
+type StagePath = (path: string) => Promise<unknown>;
+type OpenFile = (path: string) => Promise<void>;
+type OpenFileDiff = (
+  path: string,
+  options?: {
+    scope?: GitPanelSectionScope | null;
+    baseRef?: string | null;
+    oldPath?: string | null;
+  },
+) => Promise<void>;
+
+interface ChangesFileRowProps {
+  file: GitPanelFile;
+  sectionScope: GitPanelSectionScope;
+  baseRef: string | null;
+  isBranchMode: boolean;
+  isRuntimeReady: boolean;
+  stagePath: StagePath;
+  unstagePath: StagePath;
+  openFile: OpenFile;
+  openFileDiff: OpenFileDiff;
+}
+
+export function ChangesFileRow({
+  file,
+  sectionScope,
+  baseRef,
+  isBranchMode,
+  isRuntimeReady,
+  stagePath,
+  unstagePath,
+  openFile,
+  openFileDiff,
+}: ChangesFileRowProps) {
+  const baseName = file.displayPath.split("/").pop() ?? file.displayPath;
+  const shouldUnstage = sectionScope === "staged";
+  const stateLabel = isBranchMode
+    ? file.status
+    : shouldUnstage
+      ? "staged"
+      : "unstaged";
+  const openDiff = () => openFileDiff(file.path, {
+    scope: sectionScope,
+    baseRef: isBranchMode ? baseRef : null,
+    oldPath: isBranchMode ? file.oldPath : null,
+  });
+
+  return (
+    <div className="group rounded-md border border-sidebar-border/60 bg-sidebar-accent/20 transition-colors hover:border-sidebar-border hover:bg-sidebar-accent/70">
+      <div className="flex min-w-0 items-center gap-1 pr-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void openDiff()}
+          disabled={!isRuntimeReady}
+          title={`Open ${file.displayPath} diff`}
+          className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md bg-transparent px-2 py-2 text-left hover:bg-transparent"
+        >
+          <FileTreeEntryIcon
+            name={baseName}
+            path={file.path}
+            kind="file"
+            className="size-3.5 shrink-0"
+          />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[0.68rem] font-medium text-sidebar-foreground [direction:ltr] [unicode-bidi:plaintext]">
+              {file.displayPath}
+            </span>
+            <span className="mt-0.5 flex items-center gap-2 text-[10px] text-sidebar-muted-foreground">
+              <span className="capitalize">{stateLabel}</span>
+              <FileChangeStats
+                additions={file.additions}
+                deletions={file.deletions}
+              />
+            </span>
+          </span>
+        </Button>
+        <Tooltip content="Open file">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void openFile(file.path)}
+            disabled={!isRuntimeReady}
+            aria-label={`Open ${baseName} file`}
+            className="size-6 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <FileText className="size-3" />
+          </Button>
+        </Tooltip>
+        {!isBranchMode && (
+          <Tooltip content={shouldUnstage ? "Unstage" : "Stage"}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => {
+                if (shouldUnstage) {
+                  void unstagePath(file.path);
+                } else {
+                  void stagePath(file.path);
+                }
+              }}
+              disabled={!isRuntimeReady}
+              aria-label={shouldUnstage ? `Unstage ${baseName}` : `Stage ${baseName}`}
+              className={`size-6 hover:bg-sidebar-accent ${
+                shouldUnstage
+                  ? "text-git-green"
+                  : "text-sidebar-muted-foreground hover:text-sidebar-foreground"
+              }`}
+            >
+              {shouldUnstage ? (
+                <Check className="size-3" />
+              ) : (
+                <Plus className="size-3" />
+              )}
+            </Button>
+          </Tooltip>
+        )}
+        <Tooltip singleLine content="Open diff">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void openDiff()}
+            disabled={!isRuntimeReady}
+            aria-label={`Open ${baseName} diff`}
+            className="size-6 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <ArrowUpRight className="size-3" />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.tsx
@@ -3,21 +3,15 @@ import {
   useStageGitPathsMutation,
   useUnstageGitPathsMutation,
 } from "@anyharness/sdk-react";
+import { ChangesFileRow } from "./ChangesFileRow";
+import { GitPanelHeader } from "./GitPanelHeader";
 import { Button } from "@/components/ui/Button";
-import { FileChangeStats } from "@/components/ui/content/FileDiffCard";
-import { FileTreeEntryIcon } from "@/components/ui/file-icons";
-import { ArrowUpRight, Check, ChevronDown, FileText, Plus, RefreshCw } from "@/components/ui/icons";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import { Tooltip } from "@/components/ui/Tooltip";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
 import { useGitPanelState } from "@/hooks/workspaces/derived/use-git-panel-state";
 import {
-  GIT_PANEL_MODE_OPTIONS,
   gitPanelEmptyMessage,
-  type GitPanelFile,
   type GitPanelMode,
-  type GitPanelSectionScope,
 } from "@/lib/domain/workspaces/changes/git-panel-diff";
 import { allChangesViewerTarget } from "@/lib/domain/workspaces/viewer/viewer-target";
 
@@ -43,71 +37,16 @@ export function GitPanel() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center justify-between border-b border-sidebar-border/70 px-2 py-2">
-        <p className="px-1 text-xs text-sidebar-muted-foreground">
-          {totalChangedCount === 0
-            ? isBranchMode
-              ? "No branch changes"
-              : "Working tree clean"
-            : `${visibleChangedCount} ${activeFilterLabel.toLowerCase()} file${visibleChangedCount !== 1 ? "s" : ""}`}
-        </p>
-        <div className="flex items-center gap-1">
-          <PopoverButton
-            trigger={
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="h-6 gap-1 rounded-md border-sidebar-border/70 bg-sidebar-accent px-2 text-[10px] text-sidebar-foreground hover:bg-sidebar-accent"
-              >
-                <span>{activeFilterLabel}</span>
-                <ChevronDown className="size-2.5" />
-              </Button>
-            }
-            align="end"
-            className="w-36 rounded-lg border border-border bg-popover p-1 shadow-floating"
-          >
-            {(close) => (
-              <div className="flex flex-col gap-px">
-                {GIT_PANEL_MODE_OPTIONS.map((option) => (
-                  <Button
-                    key={option.id}
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setChangesFilter(option.id);
-                      close();
-                    }}
-                    className={`h-auto w-full justify-between rounded-md px-2 py-1.5 text-xs hover:bg-accent ${
-                      changesFilter === option.id
-                        ? "text-foreground"
-                        : "text-muted-foreground"
-                    }`}
-                  >
-                    <span>{option.label}</span>
-                    {changesFilter === option.id && (
-                      <Check className="size-3 text-foreground" />
-                    )}
-                  </Button>
-                ))}
-              </div>
-            )}
-          </PopoverButton>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => void refetch()}
-            disabled={!isRuntimeReady}
-            className="h-6 w-6 rounded-md text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-            title="Refresh changes"
-            aria-label="Refresh changes"
-          >
-            <RefreshCw className="size-3" />
-          </Button>
-        </div>
-      </div>
+      <GitPanelHeader
+        changesFilter={changesFilter}
+        activeFilterLabel={activeFilterLabel}
+        totalChangedCount={totalChangedCount}
+        visibleChangedCount={visibleChangedCount}
+        isBranchMode={isBranchMode}
+        isRuntimeReady={isRuntimeReady}
+        onFilterChange={setChangesFilter}
+        onRefresh={() => void refetch()}
+      />
 
       <AutoHideScrollArea className="min-h-0 flex-1" viewportClassName="px-2 py-2">
         {isLoading && (
@@ -172,138 +111,6 @@ export function GitPanel() {
           </div>
         )}
       </AutoHideScrollArea>
-    </div>
-  );
-}
-
-function ChangesFileRow({
-  file,
-  sectionScope,
-  baseRef,
-  isBranchMode,
-  isRuntimeReady,
-  stagePath,
-  unstagePath,
-  openFile,
-  openFileDiff,
-}: {
-  file: GitPanelFile;
-  sectionScope: GitPanelSectionScope;
-  baseRef: string | null;
-  isBranchMode: boolean;
-  isRuntimeReady: boolean;
-  stagePath: (path: string) => Promise<unknown>;
-  unstagePath: (path: string) => Promise<unknown>;
-  openFile: (path: string) => Promise<void>;
-  openFileDiff: (
-    path: string,
-    options?: {
-      scope?: GitPanelSectionScope | null;
-      baseRef?: string | null;
-      oldPath?: string | null;
-    },
-  ) => Promise<void>;
-}) {
-  const baseName = file.displayPath.split("/").pop() ?? file.displayPath;
-  const shouldUnstage = sectionScope === "staged";
-  const stateLabel = isBranchMode
-    ? file.status
-    : shouldUnstage
-      ? "staged"
-      : "unstaged";
-  const openDiff = () => openFileDiff(file.path, {
-    scope: sectionScope,
-    baseRef: isBranchMode ? baseRef : null,
-    oldPath: isBranchMode ? file.oldPath : null,
-  });
-
-  return (
-    <div className="group rounded-md border border-sidebar-border/60 bg-sidebar-accent/20 transition-colors hover:border-sidebar-border hover:bg-sidebar-accent/70">
-      <div className="flex min-w-0 items-center gap-1 pr-1">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => void openDiff()}
-          disabled={!isRuntimeReady}
-          title={`Open ${file.displayPath} diff`}
-          className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md bg-transparent px-2 py-2 text-left hover:bg-transparent"
-        >
-          <FileTreeEntryIcon
-            name={baseName}
-            path={file.path}
-            kind="file"
-            className="size-3.5 shrink-0"
-          />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-[0.68rem] font-medium text-sidebar-foreground [direction:ltr] [unicode-bidi:plaintext]">
-              {file.displayPath}
-            </span>
-            <span className="mt-0.5 flex items-center gap-2 text-[10px] text-sidebar-muted-foreground">
-              <span className="capitalize">{stateLabel}</span>
-              <FileChangeStats
-                additions={file.additions}
-                deletions={file.deletions}
-              />
-            </span>
-          </span>
-        </Button>
-        <Tooltip content="Open file">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => void openFile(file.path)}
-            disabled={!isRuntimeReady}
-            aria-label={`Open ${baseName} file`}
-            className="size-6 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-          >
-            <FileText className="size-3" />
-          </Button>
-        </Tooltip>
-        {!isBranchMode && (
-          <Tooltip content={shouldUnstage ? "Unstage" : "Stage"}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => {
-                if (shouldUnstage) {
-                  void unstagePath(file.path);
-                } else {
-                  void stagePath(file.path);
-                }
-              }}
-              disabled={!isRuntimeReady}
-              aria-label={shouldUnstage ? `Unstage ${baseName}` : `Stage ${baseName}`}
-              className={`size-6 hover:bg-sidebar-accent ${
-                shouldUnstage
-                  ? "text-git-green"
-                  : "text-sidebar-muted-foreground hover:text-sidebar-foreground"
-              }`}
-            >
-              {shouldUnstage ? (
-                <Check className="size-3" />
-              ) : (
-                <Plus className="size-3" />
-              )}
-            </Button>
-          </Tooltip>
-        )}
-        <Tooltip singleLine content="Open diff">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => void openDiff()}
-            disabled={!isRuntimeReady}
-            aria-label={`Open ${baseName} diff`}
-            className="size-6 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-          >
-            <ArrowUpRight className="size-3" />
-          </Button>
-        </Tooltip>
-      </div>
     </div>
   );
 }

--- a/desktop/src/components/workspace/git/GitPanelHeader.tsx
+++ b/desktop/src/components/workspace/git/GitPanelHeader.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@/components/ui/Button";
+import { Check, ChevronDown, RefreshCw } from "@/components/ui/icons";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import {
+  GIT_PANEL_MODE_OPTIONS,
+  type GitPanelMode,
+} from "@/lib/domain/workspaces/changes/git-panel-diff";
+
+interface GitPanelHeaderProps {
+  changesFilter: GitPanelMode;
+  activeFilterLabel: string;
+  totalChangedCount: number;
+  visibleChangedCount: number;
+  isBranchMode: boolean;
+  isRuntimeReady: boolean;
+  onFilterChange: (mode: GitPanelMode) => void;
+  onRefresh: () => void;
+}
+
+export function GitPanelHeader({
+  changesFilter,
+  activeFilterLabel,
+  totalChangedCount,
+  visibleChangedCount,
+  isBranchMode,
+  isRuntimeReady,
+  onFilterChange,
+  onRefresh,
+}: GitPanelHeaderProps) {
+  return (
+    <div className="flex shrink-0 items-center justify-between border-b border-sidebar-border/70 px-2 py-2">
+      <p className="px-1 text-xs text-sidebar-muted-foreground">
+        {totalChangedCount === 0
+          ? isBranchMode
+            ? "No branch changes"
+            : "Working tree clean"
+          : `${visibleChangedCount} ${activeFilterLabel.toLowerCase()} file${visibleChangedCount !== 1 ? "s" : ""}`}
+      </p>
+      <div className="flex items-center gap-1">
+        <PopoverButton
+          trigger={
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-6 gap-1 rounded-md border-sidebar-border/70 bg-sidebar-accent px-2 text-[10px] text-sidebar-foreground hover:bg-sidebar-accent"
+            >
+              <span>{activeFilterLabel}</span>
+              <ChevronDown className="size-2.5" />
+            </Button>
+          }
+          align="end"
+          className="w-36 rounded-lg border border-border bg-popover p-1 shadow-floating"
+        >
+          {(close) => (
+            <div className="flex flex-col gap-px">
+              {GIT_PANEL_MODE_OPTIONS.map((option) => (
+                <Button
+                  key={option.id}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    onFilterChange(option.id);
+                    close();
+                  }}
+                  className={`h-auto w-full justify-between rounded-md px-2 py-1.5 text-xs hover:bg-accent ${
+                    changesFilter === option.id
+                      ? "text-foreground"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  <span>{option.label}</span>
+                  {changesFilter === option.id && (
+                    <Check className="size-3 text-foreground" />
+                  )}
+                </Button>
+              ))}
+            </div>
+          )}
+        </PopoverButton>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRefresh}
+          disabled={!isRuntimeReady}
+          className="h-6 w-6 rounded-md text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          title="Refresh changes"
+          aria-label="Refresh changes"
+        >
+          <RefreshCw className="size-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/git/PublishChangedFiles.tsx
+++ b/desktop/src/components/workspace/git/PublishChangedFiles.tsx
@@ -1,0 +1,70 @@
+import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
+
+export interface PublishFileRow {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+interface PublishChangedFilesProps {
+  groups: {
+    staged: PublishFileRow[];
+    partial: PublishFileRow[];
+    unstaged: PublishFileRow[];
+  };
+  scroll: boolean;
+}
+
+export function PublishChangedFiles({ groups, scroll }: PublishChangedFilesProps) {
+  const content = (
+    <div className="space-y-3">
+      <PublishFileSection title="Staged" files={groups.staged} />
+      <PublishFileSection title="Partially staged" files={groups.partial} />
+      <PublishFileSection title="Unstaged" files={groups.unstaged} />
+    </div>
+  );
+
+  if (!scroll) return content;
+
+  return (
+    <AutoHideScrollArea
+      className="max-h-56 min-h-0"
+      viewportClassName="max-h-56 pr-2"
+    >
+      {content}
+    </AutoHideScrollArea>
+  );
+}
+
+function PublishFileSection({
+  title,
+  files,
+}: {
+  title: string;
+  files: PublishFileRow[];
+}) {
+  if (files.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-normal text-muted-foreground">{title}</p>
+        <span className="text-xs text-muted-foreground">{files.length}</span>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-border/60">
+        {files.map((file) => (
+          <div
+            key={`${title}:${file.path}`}
+            className="flex items-center gap-3 border-b border-border/60 bg-background px-3 py-2 last:border-b-0"
+          >
+            <span className="min-w-0 flex-1 truncate text-start text-xs text-foreground [direction:rtl]" title={file.path}>
+              <span className="[direction:ltr] [unicode-bidi:plaintext]">{file.path}</span>
+            </span>
+            <span className="shrink-0 text-xs tabular-nums text-git-green">+{file.additions}</span>
+            <span className="shrink-0 text-xs tabular-nums text-git-red">-{file.deletions}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/components/workspace/git/PublishDialog.tsx
+++ b/desktop/src/components/workspace/git/PublishDialog.tsx
@@ -1,5 +1,7 @@
-import { useId, type ReactNode } from "react";
+import { useId } from "react";
 import type { CurrentPullRequestResponse } from "@anyharness/sdk";
+import { PublishChangedFiles } from "./PublishChangedFiles";
+import { PublishSection } from "./PublishSection";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -257,89 +259,5 @@ export function PublishDialog({
         </AutoHideScrollArea>
       </div>
     </ModalShell>
-  );
-}
-
-function PublishSection({
-  children,
-  flush = false,
-}: {
-  children: ReactNode;
-  flush?: boolean;
-}) {
-  return (
-    <section className={flush ? "space-y-3" : "space-y-3 border-t border-border/60 pt-4"}>
-      {children}
-    </section>
-  );
-}
-
-function PublishChangedFiles({
-  groups,
-  scroll,
-}: {
-  groups: {
-    staged: PublishFileRow[];
-    partial: PublishFileRow[];
-    unstaged: PublishFileRow[];
-  };
-  scroll: boolean;
-}) {
-  const content = (
-    <div className="space-y-3">
-      <PublishFileSection title="Staged" files={groups.staged} />
-      <PublishFileSection title="Partially staged" files={groups.partial} />
-      <PublishFileSection title="Unstaged" files={groups.unstaged} />
-    </div>
-  );
-
-  if (!scroll) return content;
-
-  return (
-    <AutoHideScrollArea
-      className="max-h-56 min-h-0"
-      viewportClassName="max-h-56 pr-2"
-    >
-      {content}
-    </AutoHideScrollArea>
-  );
-}
-
-interface PublishFileRow {
-  path: string;
-  additions: number;
-  deletions: number;
-}
-
-function PublishFileSection({
-  title,
-  files,
-}: {
-  title: string;
-  files: PublishFileRow[];
-}) {
-  if (files.length === 0) return null;
-
-  return (
-    <section className="space-y-2">
-      <div className="flex items-center justify-between">
-        <p className="text-xs font-medium uppercase tracking-normal text-muted-foreground">{title}</p>
-        <span className="text-xs text-muted-foreground">{files.length}</span>
-      </div>
-      <div className="overflow-hidden rounded-lg border border-border/60">
-        {files.map((file) => (
-          <div
-            key={`${title}:${file.path}`}
-            className="flex items-center gap-3 border-b border-border/60 bg-background px-3 py-2 last:border-b-0"
-          >
-            <span className="min-w-0 flex-1 truncate text-start text-xs text-foreground [direction:rtl]" title={file.path}>
-              <span className="[direction:ltr] [unicode-bidi:plaintext]">{file.path}</span>
-            </span>
-            <span className="shrink-0 text-xs tabular-nums text-git-green">+{file.additions}</span>
-            <span className="shrink-0 text-xs tabular-nums text-git-red">-{file.deletions}</span>
-          </div>
-        ))}
-      </div>
-    </section>
   );
 }

--- a/desktop/src/components/workspace/git/PublishSection.tsx
+++ b/desktop/src/components/workspace/git/PublishSection.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+interface PublishSectionProps {
+  children: ReactNode;
+  flush?: boolean;
+}
+
+export function PublishSection({ children, flush = false }: PublishSectionProps) {
+  return (
+    <section className={flush ? "space-y-3" : "space-y-3 border-t border-border/60 pt-4"}>
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Split the workspace Files panel changed-file tree into a sibling component.
- Split the file editor render body out of the file editor state/query shell.
- Split the Git panel header, changed-file row, and publish dialog changed-file sections into direct component imports.

## Validation

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `git diff --cached --check`
- `pnpm --dir desktop exec vitest run src/components/workspace/files/FileEditorView.test.tsx src/components/workspace/git/GitPanel.test.tsx src/components/workspace/git/PublishDialog.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`