### PR TITLE
refactor(desktop): split shell panel components

### DIFF
--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -9,8 +9,7 @@ import {
 } from "react";
 import { useTerminalsQuery } from "@anyharness/sdk-react";
 import { useNavigate } from "react-router-dom";
-import { RightPanelContent } from "@/components/workspace/shell/right-panel/RightPanelContent";
-import { RightPanelHeaderTabs } from "@/components/workspace/shell/right-panel/RightPanelHeaderTabs";
+import { RightPanelFrame } from "@/components/workspace/shell/right-panel/RightPanelFrame";
 import { useTerminalActions } from "@/hooks/terminals/workflows/use-terminal-actions";
 import { useRightPanelHeaderEntries } from "@/hooks/workspaces/derived/use-right-panel-header-entries";
 import { useRightPanelRootFocus } from "@/hooks/workspaces/ui/use-right-panel-root-focus";
@@ -430,63 +429,44 @@ export const RightPanel = memo(function RightPanel({
   const shouldMountBrowserPanel = browserTabs.length > 0;
 
   return (
-    <div
-      ref={rootRef}
-      data-right-panel-root="true"
-      data-group="true"
-      tabIndex={-1}
+    <RightPanelFrame
+      rootRef={rootRef}
       onPointerDownCapture={handleRootPointerDownCapture}
-      className="relative flex h-full flex-col overflow-hidden rounded-tl-lg border-l border-t border-sidebar-border bg-sidebar-background outline-none"
-    >
-      <RightPanelHeaderTabs
-        entries={headerEntries}
-        activeEntryKey={state.activeEntryKey}
-        unreadByTerminal={unreadByTerminal}
-        isWorkspaceReady={isWorkspaceReady}
-        canCreateBrowserTab={canCreateBrowserTab}
-        newTabMenuRequestToken={newTabMenuRequest.token}
-        newTabMenuDefaultKind={newTabMenuRequest.defaultKind}
-        onActivateTool={activateTool}
-        onSelectTerminal={selectTerminal}
-        onSelectBrowser={selectBrowser}
-        onCloseTerminal={handleCloseTerminal}
-        onCloseBrowser={handleCloseBrowser}
-        onRenameTerminal={handleRenameTerminal}
-        onCreateTerminal={() => {
-          void createTerminal({ activate: true });
-        }}
-        onCreateBrowser={handleCreateBrowser}
-        onReorderHeaderEntry={handleReorderHeaderEntry}
-        onOpenRepoSettings={() => navigate(repoSettingsHref)}
-      />
-
-      <RightPanelContent
-        workspaceId={workspaceId}
-        activeEntryKey={state.activeEntryKey}
-        activeTool={activeTool}
-        activeBrowserId={activeBrowserId}
-        activeTerminalId={activeTerminalId}
-        browserTabs={browserTabs}
-        orderedTerminals={orderedTerminals}
-        shouldRenderContent={shouldRenderContent}
-        shouldMountBrowserPanel={shouldMountBrowserPanel}
-        shouldMountTerminalPanel={shouldMountTerminalPanel}
-        isOpen={isOpen}
-        isWorkspaceReady={isWorkspaceReady}
-        canConnectTerminals={terminalsQuery.isSuccess}
-        isLoadingTerminals={terminalsQuery.isLoading && !terminalsQuery.data}
-        terminalListErrorMessage={terminalsQuery.isError ? "Terminal list unavailable" : null}
-        terminalFocusRequestToken={terminalActivationRequestToken + terminalFocusNonce}
-        unreadByTerminal={unreadByTerminal}
-        nativeOverlaysHidden={nativeOverlaysHidden}
-        onUpdateBrowserUrl={handleUpdateBrowserUrl}
-        onNewTerminal={() => {
-          void createTerminal({ activate: true });
-        }}
-        onSelectTerminal={selectTerminal}
-        onCloseTerminal={handleCloseTerminal}
-        onRenameTerminal={handleRenameTerminal}
-      />
-    </div>
+      workspaceId={workspaceId}
+      activeEntryKey={state.activeEntryKey}
+      activeTool={activeTool}
+      activeBrowserId={activeBrowserId}
+      activeTerminalId={activeTerminalId}
+      entries={headerEntries}
+      unreadByTerminal={unreadByTerminal}
+      browserTabs={browserTabs}
+      orderedTerminals={orderedTerminals}
+      isOpen={isOpen}
+      isWorkspaceReady={isWorkspaceReady}
+      shouldRenderContent={shouldRenderContent}
+      shouldMountBrowserPanel={shouldMountBrowserPanel}
+      shouldMountTerminalPanel={shouldMountTerminalPanel}
+      canCreateBrowserTab={canCreateBrowserTab}
+      canConnectTerminals={terminalsQuery.isSuccess}
+      isLoadingTerminals={terminalsQuery.isLoading && !terminalsQuery.data}
+      terminalListErrorMessage={terminalsQuery.isError ? "Terminal list unavailable" : null}
+      terminalFocusRequestToken={terminalActivationRequestToken + terminalFocusNonce}
+      newTabMenuRequestToken={newTabMenuRequest.token}
+      newTabMenuDefaultKind={newTabMenuRequest.defaultKind}
+      nativeOverlaysHidden={nativeOverlaysHidden}
+      onActivateTool={activateTool}
+      onSelectTerminal={selectTerminal}
+      onSelectBrowser={selectBrowser}
+      onCloseTerminal={handleCloseTerminal}
+      onCloseBrowser={handleCloseBrowser}
+      onRenameTerminal={handleRenameTerminal}
+      onCreateTerminal={() => {
+        void createTerminal({ activate: true });
+      }}
+      onCreateBrowser={handleCreateBrowser}
+      onOpenRepoSettings={() => navigate(repoSettingsHref)}
+      onReorderHeaderEntry={handleReorderHeaderEntry}
+      onUpdateBrowserUrl={handleUpdateBrowserUrl}
+    />
   );
 });

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -1,0 +1,151 @@
+import type {
+  PointerEventHandler,
+  RefObject,
+} from "react";
+import type { TerminalRecord } from "@anyharness/sdk";
+import { RightPanelContent } from "@/components/workspace/shell/right-panel/RightPanelContent";
+import { RightPanelHeaderTabs } from "@/components/workspace/shell/right-panel/RightPanelHeaderTabs";
+import type {
+  RightPanelActiveEntryKey,
+  RightPanelBrowserTab,
+  RightPanelHeaderEntryKey,
+  RightPanelTool,
+} from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
+
+interface RightPanelFrameProps {
+  rootRef: RefObject<HTMLDivElement | null>;
+  onPointerDownCapture: PointerEventHandler<HTMLDivElement>;
+  workspaceId: string | null;
+  activeEntryKey: RightPanelActiveEntryKey;
+  activeTool: RightPanelTool | null;
+  activeBrowserId: string | null;
+  activeTerminalId: string | null;
+  entries: readonly RightPanelHeaderEntry[];
+  unreadByTerminal: Record<string, boolean>;
+  browserTabs: readonly RightPanelBrowserTab[];
+  orderedTerminals: readonly TerminalRecord[];
+  isOpen: boolean;
+  isWorkspaceReady: boolean;
+  shouldRenderContent: boolean;
+  shouldMountBrowserPanel: boolean;
+  shouldMountTerminalPanel: boolean;
+  canCreateBrowserTab: boolean;
+  canConnectTerminals: boolean;
+  isLoadingTerminals: boolean;
+  terminalListErrorMessage: string | null;
+  terminalFocusRequestToken: number;
+  newTabMenuRequestToken: number;
+  newTabMenuDefaultKind: RightPanelNewTabMenuDefault;
+  nativeOverlaysHidden: boolean;
+  onActivateTool: (tool: RightPanelTool) => void;
+  onSelectTerminal: (terminalId: string) => void;
+  onSelectBrowser: (browserId: string) => void;
+  onCloseTerminal: (terminalId: string) => void;
+  onCloseBrowser: (browserId: string) => void;
+  onRenameTerminal: (terminalId: string, title: string) => Promise<void>;
+  onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
+  onOpenRepoSettings: () => void;
+  onReorderHeaderEntry: (
+    entryKey: RightPanelHeaderEntryKey,
+    beforeEntryKey: RightPanelHeaderEntryKey | null,
+  ) => void;
+  onUpdateBrowserUrl: (browserId: string, url: string) => void;
+}
+
+export function RightPanelFrame({
+  rootRef,
+  onPointerDownCapture,
+  workspaceId,
+  activeEntryKey,
+  activeTool,
+  activeBrowserId,
+  activeTerminalId,
+  entries,
+  unreadByTerminal,
+  browserTabs,
+  orderedTerminals,
+  isOpen,
+  isWorkspaceReady,
+  shouldRenderContent,
+  shouldMountBrowserPanel,
+  shouldMountTerminalPanel,
+  canCreateBrowserTab,
+  canConnectTerminals,
+  isLoadingTerminals,
+  terminalListErrorMessage,
+  terminalFocusRequestToken,
+  newTabMenuRequestToken,
+  newTabMenuDefaultKind,
+  nativeOverlaysHidden,
+  onActivateTool,
+  onSelectTerminal,
+  onSelectBrowser,
+  onCloseTerminal,
+  onCloseBrowser,
+  onRenameTerminal,
+  onCreateTerminal,
+  onCreateBrowser,
+  onOpenRepoSettings,
+  onReorderHeaderEntry,
+  onUpdateBrowserUrl,
+}: RightPanelFrameProps) {
+  return (
+    <div
+      ref={rootRef}
+      data-right-panel-root="true"
+      data-group="true"
+      tabIndex={-1}
+      onPointerDownCapture={onPointerDownCapture}
+      className="relative flex h-full flex-col overflow-hidden rounded-tl-lg border-l border-t border-sidebar-border bg-sidebar-background outline-none"
+    >
+      <RightPanelHeaderTabs
+        entries={entries}
+        activeEntryKey={activeEntryKey}
+        unreadByTerminal={unreadByTerminal}
+        isWorkspaceReady={isWorkspaceReady}
+        canCreateBrowserTab={canCreateBrowserTab}
+        newTabMenuRequestToken={newTabMenuRequestToken}
+        newTabMenuDefaultKind={newTabMenuDefaultKind}
+        onActivateTool={onActivateTool}
+        onSelectTerminal={onSelectTerminal}
+        onSelectBrowser={onSelectBrowser}
+        onCloseTerminal={onCloseTerminal}
+        onCloseBrowser={onCloseBrowser}
+        onRenameTerminal={onRenameTerminal}
+        onCreateTerminal={onCreateTerminal}
+        onCreateBrowser={onCreateBrowser}
+        onReorderHeaderEntry={onReorderHeaderEntry}
+        onOpenRepoSettings={onOpenRepoSettings}
+      />
+
+      <RightPanelContent
+        workspaceId={workspaceId}
+        activeEntryKey={activeEntryKey}
+        activeTool={activeTool}
+        activeBrowserId={activeBrowserId}
+        activeTerminalId={activeTerminalId}
+        browserTabs={browserTabs}
+        orderedTerminals={orderedTerminals}
+        shouldRenderContent={shouldRenderContent}
+        shouldMountBrowserPanel={shouldMountBrowserPanel}
+        shouldMountTerminalPanel={shouldMountTerminalPanel}
+        isOpen={isOpen}
+        isWorkspaceReady={isWorkspaceReady}
+        canConnectTerminals={canConnectTerminals}
+        isLoadingTerminals={isLoadingTerminals}
+        terminalListErrorMessage={terminalListErrorMessage}
+        terminalFocusRequestToken={terminalFocusRequestToken}
+        unreadByTerminal={unreadByTerminal}
+        nativeOverlaysHidden={nativeOverlaysHidden}
+        onUpdateBrowserUrl={onUpdateBrowserUrl}
+        onNewTerminal={onCreateTerminal}
+        onSelectTerminal={onSelectTerminal}
+        onCloseTerminal={onCloseTerminal}
+        onRenameTerminal={onRenameTerminal}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -4,35 +4,17 @@ import { useShallow } from "zustand/react/shallow";
 import { SupportDialog } from "@/components/support/SupportDialog";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import { SidebarFooter } from "./SidebarFooter";
-import { SidebarRowSurface } from "./SidebarRowSurface";
-import { SidebarActionButton } from "./SidebarActionButton";
-import { SidebarWorkspaceVariantIcon } from "./SidebarWorkspaceVariantIcon";
+import { SidebarPrimaryNavigation } from "./SidebarPrimaryNavigation";
+import { SidebarRepositoriesHeader } from "./SidebarRepositoriesHeader";
 import { SidebarWorkspaceContent } from "./SidebarWorkspaceContent";
 import { WorkspaceCleanupAttentionSection } from "./WorkspaceCleanupAttentionSection";
 import { CoworkThreadsSection } from "@/components/workspace/cowork/sidebar/CoworkThreadsSection";
-import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import {
-  isDefaultSidebarWorkspaceTypes,
-  type SidebarWorkspaceVariant,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+import { isDefaultSidebarWorkspaceTypes } from "@/lib/domain/workspaces/sidebar/sidebar";
 import { buildConfiguredCloudRepoKeys } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import {
   titleForStartBlockReason,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
-import {
-  Archive,
-  Calendar,
-  Check,
-  CollapseAll,
-  ExpandAll,
-  Filter,
-  FolderPlusFilled,
-  Grid,
-  Home,
-  CircleQuestion,
-} from "@/components/ui/icons";
 import { CAPABILITY_COPY } from "@/copy/capabilities/capability-copy";
 import { APP_ROUTES } from "@/config/app-routes";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
@@ -51,15 +33,6 @@ import {
   buildCloudRepoSettingsHref,
 } from "@/lib/domain/settings/navigation";
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
-
-const SIDEBAR_WORKSPACE_TYPE_OPTIONS: Array<{
-  label: string;
-  variant: SidebarWorkspaceVariant;
-}> = [
-  { label: "Local", variant: "local" },
-  { label: "Worktrees", variant: "worktree" },
-  { label: "Cloud", variant: "cloud" },
-];
 
 export function MainSidebar() {
   useDebugRenderCount("workspace-sidebar");
@@ -182,59 +155,16 @@ export function MainSidebar() {
         />
       )}
       <div className="flex flex-col flex-1 min-h-0 w-full min-w-0">
-        {/* Top actions */}
-        <div className="px-2">
-          <div className="flex flex-col gap-px">
-            <SidebarRowSurface
-              active={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
-              onPress={actions.handleGoHome}
-              className="h-[30px] px-2 py-1 gap-1.5 text-sm leading-4 focus-visible:outline-offset-[-2px]"
-            >
-              <div className="flex w-4 shrink-0 items-center justify-center">
-                <Home className="size-3" />
-              </div>
-              <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-foreground">
-                <span className="truncate">Home</span>
-              </div>
-            </SidebarRowSurface>
-            <SidebarRowSurface
-              active={isOnPlugins}
-              onPress={actions.handleGoPlugins}
-              className="h-[30px] px-2 py-1 gap-1.5 text-sm leading-4 focus-visible:outline-offset-[-2px]"
-            >
-              <div className="flex w-4 shrink-0 items-center justify-center">
-                <Grid className="size-4" />
-              </div>
-              <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-foreground">
-                <span className="truncate">Plugins</span>
-              </div>
-            </SidebarRowSurface>
-            <SidebarRowSurface
-              active={isOnAutomations}
-              onPress={actions.handleGoAutomations}
-              className="h-[30px] px-2 py-1 gap-1.5 text-sm leading-4 focus-visible:outline-offset-[-2px]"
-            >
-              <div className="flex w-4 shrink-0 items-center justify-center">
-                <Calendar className="size-4" />
-              </div>
-              <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-foreground">
-                <span className="truncate">Automations</span>
-              </div>
-            </SidebarRowSurface>
-            <SidebarRowSurface
-              active={supportOpen}
-              onPress={() => setSupportOpen(true)}
-              className="h-[30px] px-2 py-1 gap-1.5 text-sm leading-4 focus-visible:outline-offset-[-2px]"
-            >
-              <div className="flex w-4 shrink-0 items-center justify-center">
-                <CircleQuestion className="size-4" />
-              </div>
-              <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-foreground">
-                <span className="truncate">Support</span>
-              </div>
-            </SidebarRowSurface>
-          </div>
-        </div>
+        <SidebarPrimaryNavigation
+          homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
+          pluginsActive={isOnPlugins}
+          automationsActive={isOnAutomations}
+          supportActive={supportOpen}
+          onGoHome={actions.handleGoHome}
+          onGoPlugins={actions.handleGoPlugins}
+          onGoAutomations={actions.handleGoAutomations}
+          onOpenSupport={() => setSupportOpen(true)}
+        />
 
         <div className="relative overflow-hidden flex-1 w-full min-w-0 min-h-0">
           <AutoHideScrollArea
@@ -248,78 +178,17 @@ export function MainSidebar() {
               onRetryCleanup={actions.handleRetryWorkspaceCleanup}
             />
 
-            {/* Repositories heading — text left-aligned with the row icon column (8px row-pl inside the 8px viewport gutter). */}
-            <div className="text-foreground/50 text-base opacity-75 pl-2 pt-3 pb-1">
-              <div className="flex items-center justify-between gap-2">
-                <span>Repositories</span>
-                <div className="flex shrink-0 items-center gap-1">
-                  {allRepoKeys.length > 0 && (
-                    <SidebarActionButton
-                      onClick={handleToggleAllRepoGroups}
-                      title={allRepoGroupsCollapsed ? "Expand all repositories" : "Collapse all repositories"}
-                      variant="section"
-                    >
-                      {allRepoGroupsCollapsed ? (
-                        <ExpandAll className="size-3" />
-                      ) : (
-                        <CollapseAll className="size-3" />
-                      )}
-                    </SidebarActionButton>
-                  )}
-                  <PopoverButton
-                    trigger={
-                      <SidebarActionButton
-                        title="Filter workspaces"
-                        active={filtersActive}
-                        variant="section"
-                      >
-                        <Filter className="size-3" />
-                      </SidebarActionButton>
-                    }
-                  >
-                    {() => (
-                      <>
-                        <PopoverMenuItem
-                          onClick={() => {
-                            setShowArchived(!showArchived);
-                          }}
-                          variant="sidebar"
-                          icon={<Archive className="size-3.5 text-muted-foreground" />}
-                          label="Archived workspaces"
-                          trailing={showArchived ? <Check className="size-3.5 text-foreground/60" /> : null}
-                        />
-                        <div className="my-1 h-px bg-border" />
-                        {SIDEBAR_WORKSPACE_TYPE_OPTIONS.map(({ label, variant }) => {
-                          const selected = workspaceTypes.includes(variant);
-                          const disabled = selected && workspaceTypes.length === 1;
-
-                          return (
-                            <PopoverMenuItem
-                              key={variant}
-                              onClick={() => {
-                                toggleSidebarWorkspaceType(variant);
-                              }}
-                              disabled={disabled}
-                              variant="sidebar"
-                              icon={<SidebarWorkspaceVariantIcon variant={variant} className="size-3.5 text-muted-foreground" />}
-                              label={label}
-                              trailing={selected ? <Check className="size-3.5 text-foreground/60" /> : null}
-                            />
-                          );
-                        })}
-                      </>
-                    )}
-                  </PopoverButton>
-                  <SidebarActionButton
-                    onClick={actions.handleAddRepo}
-                    title="Add repository"
-                    variant="section"
-                  >
-                    <FolderPlusFilled className="size-3" />
-                  </SidebarActionButton>
-                </div>
-              </div>
-            </div>
+            <SidebarRepositoriesHeader
+              hasRepoGroups={allRepoKeys.length > 0}
+              allRepoGroupsCollapsed={allRepoGroupsCollapsed}
+              filtersActive={filtersActive}
+              showArchived={showArchived}
+              workspaceTypes={workspaceTypes}
+              onToggleAllRepoGroups={handleToggleAllRepoGroups}
+              onToggleShowArchived={() => setShowArchived(!showArchived)}
+              onToggleWorkspaceType={toggleSidebarWorkspaceType}
+              onAddRepo={actions.handleAddRepo}
+            />
 
             <SidebarWorkspaceContent
               emptyState={emptyState}

--- a/desktop/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+import {
+  Calendar,
+  CircleQuestion,
+  Grid,
+  Home,
+} from "@/components/ui/icons";
+import { SidebarRowSurface } from "@/components/workspace/shell/sidebar/SidebarRowSurface";
+
+interface SidebarPrimaryNavigationProps {
+  homeActive: boolean;
+  pluginsActive: boolean;
+  automationsActive: boolean;
+  supportActive: boolean;
+  onGoHome: () => void;
+  onGoPlugins: () => void;
+  onGoAutomations: () => void;
+  onOpenSupport: () => void;
+}
+
+export function SidebarPrimaryNavigation({
+  homeActive,
+  pluginsActive,
+  automationsActive,
+  supportActive,
+  onGoHome,
+  onGoPlugins,
+  onGoAutomations,
+  onOpenSupport,
+}: SidebarPrimaryNavigationProps) {
+  return (
+    <div className="px-2">
+      <div className="flex flex-col gap-px">
+        <SidebarPrimaryNavigationRow
+          active={homeActive}
+          icon={<Home className="size-3" />}
+          label="Home"
+          onPress={onGoHome}
+        />
+        <SidebarPrimaryNavigationRow
+          active={pluginsActive}
+          icon={<Grid className="size-4" />}
+          label="Plugins"
+          onPress={onGoPlugins}
+        />
+        <SidebarPrimaryNavigationRow
+          active={automationsActive}
+          icon={<Calendar className="size-4" />}
+          label="Automations"
+          onPress={onGoAutomations}
+        />
+        <SidebarPrimaryNavigationRow
+          active={supportActive}
+          icon={<CircleQuestion className="size-4" />}
+          label="Support"
+          onPress={onOpenSupport}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SidebarPrimaryNavigationRow({
+  active,
+  icon,
+  label,
+  onPress,
+}: {
+  active: boolean;
+  icon: ReactNode;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <SidebarRowSurface
+      active={active}
+      onPress={onPress}
+      className="h-[30px] px-2 py-1 gap-1.5 text-sm leading-4 focus-visible:outline-offset-[-2px]"
+    >
+      <div className="flex w-4 shrink-0 items-center justify-center">
+        {icon}
+      </div>
+      <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-foreground">
+        <span className="truncate">{label}</span>
+      </div>
+    </SidebarRowSurface>
+  );
+}

--- a/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
@@ -1,0 +1,121 @@
+import {
+  Archive,
+  Check,
+  CollapseAll,
+  ExpandAll,
+  Filter,
+  FolderPlusFilled,
+} from "@/components/ui/icons";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
+import { SidebarActionButton } from "@/components/workspace/shell/sidebar/SidebarActionButton";
+import { SidebarWorkspaceVariantIcon } from "@/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar";
+
+const SIDEBAR_WORKSPACE_TYPE_OPTIONS: Array<{
+  label: string;
+  variant: SidebarWorkspaceVariant;
+}> = [
+  { label: "Local", variant: "local" },
+  { label: "Worktrees", variant: "worktree" },
+  { label: "Cloud", variant: "cloud" },
+];
+
+interface SidebarRepositoriesHeaderProps {
+  hasRepoGroups: boolean;
+  allRepoGroupsCollapsed: boolean;
+  filtersActive: boolean;
+  showArchived: boolean;
+  workspaceTypes: SidebarWorkspaceVariant[];
+  onToggleAllRepoGroups: () => void;
+  onToggleShowArchived: () => void;
+  onToggleWorkspaceType: (variant: SidebarWorkspaceVariant) => void;
+  onAddRepo: () => void;
+}
+
+export function SidebarRepositoriesHeader({
+  hasRepoGroups,
+  allRepoGroupsCollapsed,
+  filtersActive,
+  showArchived,
+  workspaceTypes,
+  onToggleAllRepoGroups,
+  onToggleShowArchived,
+  onToggleWorkspaceType,
+  onAddRepo,
+}: SidebarRepositoriesHeaderProps) {
+  return (
+    <div className="text-foreground/50 text-base opacity-75 pl-2 pt-3 pb-1">
+      <div className="flex items-center justify-between gap-2">
+        <span>Repositories</span>
+        <div className="flex shrink-0 items-center gap-1">
+          {hasRepoGroups && (
+            <SidebarActionButton
+              onClick={onToggleAllRepoGroups}
+              title={allRepoGroupsCollapsed ? "Expand all repositories" : "Collapse all repositories"}
+              variant="section"
+            >
+              {allRepoGroupsCollapsed ? (
+                <ExpandAll className="size-3" />
+              ) : (
+                <CollapseAll className="size-3" />
+              )}
+            </SidebarActionButton>
+          )}
+          <PopoverButton
+            trigger={
+              <SidebarActionButton
+                title="Filter workspaces"
+                active={filtersActive}
+                variant="section"
+              >
+                <Filter className="size-3" />
+              </SidebarActionButton>
+            }
+          >
+            {() => (
+              <>
+                <PopoverMenuItem
+                  onClick={onToggleShowArchived}
+                  variant="sidebar"
+                  icon={<Archive className="size-3.5 text-muted-foreground" />}
+                  label="Archived workspaces"
+                  trailing={showArchived ? <Check className="size-3.5 text-foreground/60" /> : null}
+                />
+                <div className="my-1 h-px bg-border" />
+                {SIDEBAR_WORKSPACE_TYPE_OPTIONS.map(({ label, variant }) => {
+                  const selected = workspaceTypes.includes(variant);
+                  const disabled = selected && workspaceTypes.length === 1;
+
+                  return (
+                    <PopoverMenuItem
+                      key={variant}
+                      onClick={() => onToggleWorkspaceType(variant)}
+                      disabled={disabled}
+                      variant="sidebar"
+                      icon={(
+                        <SidebarWorkspaceVariantIcon
+                          variant={variant}
+                          className="size-3.5 text-muted-foreground"
+                        />
+                      )}
+                      label={label}
+                      trailing={selected ? <Check className="size-3.5 text-foreground/60" /> : null}
+                    />
+                  );
+                })}
+              </>
+            )}
+          </PopoverButton>
+          <SidebarActionButton
+            onClick={onAddRepo}
+            title="Add repository"
+            variant="section"
+          >
+            <FolderPlusFilled className="size-3" />
+          </SidebarActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderChatTab.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderChatTab.tsx
@@ -1,0 +1,158 @@
+import type {
+  MouseEvent,
+  PointerEvent,
+} from "react";
+import { ChatTabWithMenu } from "@/components/workspace/shell/tabs/ChatTabWithMenu";
+import type { ManualChatGroupEditorAnchorRect } from "@/components/workspace/shell/tabs/ManualChatGroupEditorPopover";
+import {
+  isPrimaryMultiSelectClick,
+  isPrimaryMultiSelectPointer,
+} from "@/hooks/workspaces/tabs/use-header-tabs-multi-select";
+import type { HeaderChatTabEntry } from "@/hooks/workspaces/tabs/workspace-header-tabs-view-model-types";
+
+interface HeaderChatTabProps {
+  tab: HeaderChatTabEntry;
+  rowDragProps?: { "data-tab-drag-row-id": string };
+  width: number;
+  position: number;
+  dragOffset: number;
+  isDragging: boolean;
+  canDragTab: boolean;
+  hideLeftDivider: boolean;
+  hideRightDivider: boolean;
+  renamingSessionId: string | null;
+  multiSelectedSessionIds: ReadonlySet<string>;
+  selectedTopLevelSessionIds: readonly string[];
+  onPointerEnter: () => void;
+  shouldSuppressClick: () => boolean;
+  onRenameOpenChange: (sessionId: string, isOpen: boolean) => void;
+  onStartRename: (sessionId: string) => void;
+  onRename: (sessionId: string, title: string) => Promise<unknown>;
+  onCreateGroup: (sessionIds: readonly string[]) => void;
+  onContextMenuTarget: (
+    sessionId: string,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onFork: (sessionId: string) => void;
+  onPreview: (sessionId: string) => void;
+  onActivate: (sessionId: string) => void;
+  onSuppressSelect: () => void;
+  onClose: (sessionId: string) => void;
+  onCloseOthers: (sessionId: string) => void;
+  onCloseRight: (sessionId: string) => void;
+  onDismiss: (sessionId: string) => void;
+  clearSelection: () => void;
+  toggleSelection: (sessionId: string) => void;
+  suppressNextSelectClick: (sessionId: string) => void;
+  consumeSuppressedSelectClick: (sessionId: string) => boolean;
+}
+
+export function HeaderChatTab({
+  tab,
+  rowDragProps,
+  width,
+  position,
+  dragOffset,
+  isDragging,
+  canDragTab,
+  hideLeftDivider,
+  hideRightDivider,
+  renamingSessionId,
+  multiSelectedSessionIds,
+  selectedTopLevelSessionIds,
+  onPointerEnter,
+  shouldSuppressClick,
+  onRenameOpenChange,
+  onStartRename,
+  onRename,
+  onCreateGroup,
+  onContextMenuTarget,
+  onFork,
+  onPreview,
+  onActivate,
+  onSuppressSelect,
+  onClose,
+  onCloseOthers,
+  onCloseRight,
+  onDismiss,
+  clearSelection,
+  toggleSelection,
+  suppressNextSelectClick,
+  consumeSuppressedSelectClick,
+}: HeaderChatTabProps) {
+  const canMultiSelect = !tab.isChild;
+  const canCreateGroup = canMultiSelect
+    && multiSelectedSessionIds.has(tab.id)
+    && selectedTopLevelSessionIds.length >= 2;
+
+  const handleSelectPointerDownCapture = (event: PointerEvent<HTMLButtonElement>) => {
+    if (!canMultiSelect || !isPrimaryMultiSelectPointer(event)) {
+      if (event.isPrimary && event.button === 0) {
+        onPreview(tab.id);
+      }
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    suppressNextSelectClick(tab.id);
+    toggleSelection(tab.id);
+  };
+
+  const handleSelect = (event: MouseEvent<HTMLButtonElement>) => {
+    if (shouldSuppressClick()) {
+      onSuppressSelect();
+      return;
+    }
+    if (consumeSuppressedSelectClick(tab.id)) {
+      event.preventDefault();
+      return;
+    }
+    if (canMultiSelect && isPrimaryMultiSelectClick(event)) {
+      event.preventDefault();
+      toggleSelection(tab.id);
+      return;
+    }
+    clearSelection();
+    onActivate(tab.id);
+  };
+
+  return (
+    <div
+      {...(rowDragProps ?? {})}
+      onPointerEnter={onPointerEnter}
+      className={`absolute bottom-0 h-9 app-region-no-drag ${
+        isDragging
+          ? "z-[20] cursor-grabbing opacity-80"
+          : `${tab.isActive ? "z-[5]" : "z-[1] hover:z-[2]"} ${
+            canDragTab ? "cursor-grab" : "cursor-default"
+          } transition-transform duration-150`
+      }`}
+      style={{
+        width,
+        transform: `translate3d(${position + dragOffset}px, 0, 0)`,
+      }}
+    >
+      <ChatTabWithMenu
+        tab={tab}
+        width={width}
+        hideLeftDivider={hideLeftDivider}
+        hideRightDivider={hideRightDivider}
+        renaming={renamingSessionId === tab.id}
+        onRenameOpenChange={(isOpen) => onRenameOpenChange(tab.id, isOpen)}
+        onStartRename={() => onStartRename(tab.id)}
+        onRename={(title) => onRename(tab.id, title)}
+        isMultiSelected={!tab.isActive && multiSelectedSessionIds.has(tab.id)}
+        canCreateGroup={canCreateGroup}
+        onCreateGroup={() => onCreateGroup(selectedTopLevelSessionIds)}
+        onFork={() => onFork(tab.id)}
+        onSelectPointerDownCapture={handleSelectPointerDownCapture}
+        onContextMenuTarget={(anchorRect) => onContextMenuTarget(tab.id, anchorRect)}
+        onSelect={handleSelect}
+        onClose={() => onClose(tab.id)}
+        onCloseOthers={() => onCloseOthers(tab.id)}
+        onCloseRight={() => onCloseRight(tab.id)}
+        onDismiss={() => onDismiss(tab.id)}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderGroupPillTab.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderGroupPillTab.tsx
@@ -1,0 +1,78 @@
+import type { ManualChatGroupEditorAnchorRect } from "@/components/workspace/shell/tabs/ManualChatGroupEditorPopover";
+import { TabGroupPillWithMenu } from "@/components/workspace/shell/tabs/TabGroupPillWithMenu";
+import type { ManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+import type { PillRow } from "@/lib/domain/workspaces/tabs/group-rows";
+
+interface HeaderGroupPillTabProps {
+  row: PillRow;
+  rowDragProps?: { "data-tab-drag-row-id": string };
+  width: number;
+  position: number;
+  dragOffset: number;
+  isDragging: boolean;
+  onToggle: (groupId: string) => void;
+  onRenameManualGroup: (
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onChangeManualGroupColor: (
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onUngroupManualGroup: (groupId: ManualChatGroupId) => void;
+  shouldSuppressClick: () => boolean;
+}
+
+export function HeaderGroupPillTab({
+  row,
+  rowDragProps,
+  width,
+  position,
+  dragOffset,
+  isDragging,
+  onToggle,
+  onRenameManualGroup,
+  onChangeManualGroupColor,
+  onUngroupManualGroup,
+  shouldSuppressClick,
+}: HeaderGroupPillTabProps) {
+  return (
+    <div
+      {...(rowDragProps ?? {})}
+      className={`absolute bottom-0 flex h-9 items-end pb-2 app-region-no-drag ${
+        isDragging
+          ? "z-[20] cursor-grabbing opacity-80"
+          : `z-[3] transition-transform duration-150 hover:z-[4] ${
+            row.groupKind === "subagent" ? "cursor-grab" : ""
+          }`
+      }`}
+      style={{
+        width,
+        transform: `translate3d(${position + dragOffset}px, 0, 0)`,
+      }}
+    >
+      <TabGroupPillWithMenu
+        groupKind={row.groupKind}
+        label={row.label}
+        color={row.color}
+        width={width}
+        isCollapsed={row.isCollapsed}
+        onToggle={() => {
+          if (shouldSuppressClick()) {
+            return;
+          }
+          onToggle(row.groupId);
+        }}
+        onRename={row.groupKind === "manual"
+          ? (anchorRect) => onRenameManualGroup(row.manualGroupId, anchorRect)
+          : undefined}
+        onChangeColor={row.groupKind === "manual"
+          ? (anchorRect) => onChangeManualGroupColor(row.manualGroupId, anchorRect)
+          : undefined}
+        onUngroup={row.groupKind === "manual"
+          ? () => onUngroupManualGroup(row.manualGroupId)
+          : undefined}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
@@ -2,22 +2,14 @@ import {
   useCallback,
   useState,
 } from "react";
-import { Button } from "@/components/ui/Button";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
-import { ListFilter, Plus } from "@/components/ui/icons";
-import { PopoverButton } from "@/components/ui/PopoverButton";
-import { ChatTabWithMenu } from "@/components/workspace/shell/tabs/ChatTabWithMenu";
-import { ChatTabsMenu } from "@/components/workspace/shell/tabs/ChatTabsMenu";
-import { FileTabWithMenu } from "@/components/workspace/shell/tabs/FileTabWithMenu";
 import {
   ManualChatGroupEditorPopover,
+  type ManualChatGroupEditorAnchorRect,
 } from "@/components/workspace/shell/tabs/ManualChatGroupEditorPopover";
-import { TabGroupPillWithMenu } from "@/components/workspace/shell/tabs/TabGroupPillWithMenu";
 import { WorkspaceTabStrip } from "@/components/workspace/shell/tabs/WorkspaceTabStrip";
-import {
-  renderChatMenuStatus,
-  renderChatTabIcon,
-} from "@/components/workspace/shell/tabs/tab-rendering";
+import { HeaderTabsActions } from "@/components/workspace/shell/topbar/HeaderTabsActions";
+import { HeaderTabsStripRows } from "@/components/workspace/shell/topbar/HeaderTabsStripRows";
 import { useShortcutHandler } from "@/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import { useSessionDismissActions } from "@/hooks/sessions/workflows/use-session-dismiss-actions";
 import { useSessionForkActions } from "@/hooks/sessions/workflows/use-session-fork-actions";
@@ -27,14 +19,9 @@ import { useResizeObserverWidth } from "@/hooks/ui/use-resize-observer-width";
 import { useHeaderTabsCloseActions } from "@/hooks/workspaces/tabs/use-header-tabs-close-actions";
 import { useHeaderTabsGroupEditor } from "@/hooks/workspaces/tabs/use-header-tabs-group-editor";
 import {
-  getShellDragRowId,
   useHeaderTabsLayout,
 } from "@/hooks/workspaces/tabs/use-header-tabs-layout";
-import {
-  isPrimaryMultiSelectClick,
-  isPrimaryMultiSelectPointer,
-  useHeaderTabsMultiSelect,
-} from "@/hooks/workspaces/tabs/use-header-tabs-multi-select";
+import { useHeaderTabsMultiSelect } from "@/hooks/workspaces/tabs/use-header-tabs-multi-select";
 import { useManualChatGroupActions } from "@/hooks/workspaces/tabs/use-manual-chat-group-actions";
 import { useChatTabVisibilityActions } from "@/hooks/workspaces/tabs/use-chat-tab-visibility-actions";
 import { useTabGroupActions } from "@/hooks/workspaces/tabs/use-tab-group-actions";
@@ -44,16 +31,8 @@ import { useWorkspaceHeaderTabsViewModelContext } from "@/components/workspace/s
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/tabs/use-workspace-shell-activation";
 import { useWorkspaceTabActions } from "@/hooks/workspaces/use-workspace-tab-actions";
 import { useHeaderTabsUrgentHighlight } from "@/hooks/workspaces/ui/use-header-tabs-urgent-highlight";
-import {
-  TAB_GROUP_PILL_WIDTH,
-} from "@/lib/domain/workspaces/tabs/chrome-layout";
-import { hasAnyHeaderSubagentChildren } from "@/lib/domain/workspaces/tabs/group-rows";
-import {
-  viewerTargetKey,
-  viewerTargetLabel,
-  viewerTargetDisplayPath,
-  viewerTargetEditablePath,
-} from "@/lib/domain/workspaces/viewer/viewer-target";
+import type { ManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+import type { ViewerTarget } from "@/lib/domain/workspaces/viewer/viewer-target";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
@@ -185,6 +164,98 @@ export function HeaderTabs() {
     activeShellTab: viewModel.activeShellTab,
     onActivateChatSession: activateChatSessionFromHeader,
   });
+  const handleSelectViewerTarget = useCallback((target: ViewerTarget) => {
+    if (!viewModel.selectedWorkspaceId) {
+      return;
+    }
+    clearUrgentChatHighlight();
+    activateViewerTarget({
+      workspaceId: viewModel.selectedWorkspaceId,
+      shellWorkspaceId: viewModel.workspaceUiKey,
+      target,
+      mode: "focus-existing",
+    });
+  }, [
+    activateViewerTarget,
+    clearUrgentChatHighlight,
+    viewModel.selectedWorkspaceId,
+    viewModel.workspaceUiKey,
+  ]);
+  const handleCloseViewerTarget = useCallback((target: ViewerTarget) => {
+    closeWorkspaceTabs([{ kind: "viewer", target }]);
+  }, [closeWorkspaceTabs]);
+  const handleCloseOtherViewerTargets = useCallback((target: ViewerTarget) => {
+    closeOtherWorkspaceTabs({ kind: "viewer", target });
+  }, [closeOtherWorkspaceTabs]);
+  const handleCloseViewerTargetsToRight = useCallback((target: ViewerTarget) => {
+    closeWorkspaceTabsToRight({ kind: "viewer", target });
+  }, [closeWorkspaceTabsToRight]);
+  const handleRenameManualGroup = useCallback((
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => {
+    groupEditorWorkflow.openEditGroupEditor(groupId, "rename", anchorRect);
+  }, [groupEditorWorkflow.openEditGroupEditor]);
+  const handleChangeManualGroupColor = useCallback((
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => {
+    groupEditorWorkflow.openEditGroupEditor(groupId, "color", anchorRect);
+  }, [groupEditorWorkflow.openEditGroupEditor]);
+  const handleUngroupManualGroup = useCallback((groupId: ManualChatGroupId) => {
+    if (!viewModel.workspaceUiKey) {
+      return;
+    }
+    deleteManualChatGroup(viewModel.workspaceUiKey, groupId);
+    multiSelect.clearSelection();
+  }, [
+    deleteManualChatGroup,
+    multiSelect.clearSelection,
+    viewModel.workspaceUiKey,
+  ]);
+  const handleRenameOpenChange = useCallback((_sessionId: string, isOpen: boolean) => {
+    if (!isOpen) {
+      setRenamingSessionId(null);
+    }
+  }, []);
+  const handleStartRename = useCallback((sessionId: string) => {
+    setRenamingSessionId(sessionId);
+  }, []);
+  const handleRenameChatTab = useCallback((sessionId: string, title: string) =>
+    updateSessionTitle(sessionId, title), [updateSessionTitle]);
+  const handleCreateGroup = useCallback((sessionIds: readonly string[]) => {
+    groupEditorWorkflow.openCreateGroupEditor([...sessionIds]);
+  }, [groupEditorWorkflow.openCreateGroupEditor]);
+  const handleChatContextMenuTarget = useCallback((
+    sessionId: string,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => {
+    groupEditorWorkflow.rememberAnchorRect(anchorRect);
+    if (!multiSelect.multiSelectedSessionIds.has(sessionId)) {
+      multiSelect.clearSelection();
+    }
+  }, [
+    groupEditorWorkflow.rememberAnchorRect,
+    multiSelect.clearSelection,
+    multiSelect.multiSelectedSessionIds,
+  ]);
+  const handleForkChatTab = useCallback((sessionId: string) => {
+    multiSelect.clearSelection();
+    forkSession(sessionId);
+  }, [forkSession, multiSelect.clearSelection]);
+  const handleCloseChatTab = useCallback((sessionId: string) => {
+    multiSelect.clearSelection();
+    chatVisibilityActions.hideChatSessionTabs([sessionId], { selectFallback: true });
+  }, [
+    chatVisibilityActions.hideChatSessionTabs,
+    multiSelect.clearSelection,
+  ]);
+  const handleCloseOtherChatTabs = useCallback((sessionId: string) => {
+    closeOtherWorkspaceTabs({ kind: "chat", sessionId });
+  }, [closeOtherWorkspaceTabs]);
+  const handleCloseChatTabsToRight = useCallback((sessionId: string) => {
+    closeWorkspaceTabsToRight({ kind: "chat", sessionId });
+  }, [closeWorkspaceTabsToRight]);
 
   return (
     <DebugProfiler id="header-tabs">
@@ -203,283 +274,62 @@ export function HeaderTabs() {
             style={{
               left: range.left + shellDrag.getRowDragOffset(`pill:${range.groupId}`),
               width: range.width,
-              backgroundColor: range.color,
-            }}
-          />
-        ))}
-        {viewModel.shellRows.map((shellRow, index) => {
-          const rowKind = shellRow.kind === "chat" && shellRow.row.kind === "pill" ? "pill" : "tab";
-          const width = layout.widths[index] ?? (rowKind === "pill" ? TAB_GROUP_PILL_WIDTH : 160);
-          const position = layout.positions[index] ?? 0;
-          const rowId = getShellDragRowId(shellRow);
-          const isDragging = shellDrag.isDraggingRow(rowId);
-          const dragOffset = shellDrag.getRowDragOffset(rowId);
-          if (shellRow.kind === "viewer") {
-            const target = shellRow.target;
-            const targetKey = viewerTargetKey(target);
-            const displayPath = viewerTargetDisplayPath(target);
-            const isActive = !urgentHighlightedChatSessionId
-              && viewModel.activeShellTab?.kind === "viewer"
-              && viewerTargetKey(viewModel.activeShellTab.target) === targetKey;
-            const bufferPath = viewerTargetEditablePath(target);
-            const buf = bufferPath ? viewModel.buffersByPath[bufferPath] : null;
-            const isDirty = buf?.isDirty ?? false;
-            const isAllChanges = target.kind === "allChanges";
-            const isDiff = !isAllChanges && viewModel.tabModes[targetKey] === "diff";
-            return (
-              <div
-                key={targetKey}
-                {...shellDrag.getRowDragProps(rowId)}
-                onPointerEnter={handleHeaderTabHover}
-                className={`absolute bottom-0 h-9 app-region-no-drag ${
-                  isDragging
-                    ? "z-[20] cursor-grabbing opacity-80"
-                    : `${isActive ? "z-[5]" : "z-[1] hover:z-[2]"} cursor-grab transition-transform duration-150`
-                }`}
-                style={{
-                  width,
-                  transform: `translate3d(${position + dragOffset}px, 0, 0)`,
-                }}
-              >
-                <FileTabWithMenu
-                  path={displayPath ?? viewerTargetLabel(target)}
-                  label={viewerTargetLabel(target)}
-                  isActive={isActive}
-                  isDirty={isDirty}
-                  isDiff={isDiff}
-                  isAllChanges={isAllChanges}
-                  width={width}
-                  hideLeftDivider={index === 0}
-                  hideRightDivider={index === viewModel.shellRows.length - 1}
-                  onSelect={() => {
-                    if (shellDrag.shouldSuppressClick(rowId)) {
-                      return;
-                    }
-                    if (viewModel.selectedWorkspaceId) {
-                      clearUrgentChatHighlight();
-                      activateViewerTarget({
-                        workspaceId: viewModel.selectedWorkspaceId,
-                        shellWorkspaceId: viewModel.workspaceUiKey,
-                        target,
-                        mode: "focus-existing",
-                      });
-                    }
-                  }}
-                  onClose={() => closeWorkspaceTabs([{ kind: "viewer", target }])}
-                  onCloseOthers={() => closeOtherWorkspaceTabs({ kind: "viewer", target })}
-                  onCloseRight={() => closeWorkspaceTabsToRight({ kind: "viewer", target })}
-                />
-              </div>
-            );
-          }
-
-          const row = shellRow.row;
-          if (row.kind === "pill") {
-            return (
-              <div
-                key={`pill-${row.groupId}`}
-                {...(row.groupKind === "subagent" ? shellDrag.getRowDragProps(rowId) : {})}
-                className={`absolute bottom-0 flex h-9 items-end pb-2 app-region-no-drag ${
-                  isDragging
-                    ? "z-[20] cursor-grabbing opacity-80"
-                    : `z-[3] transition-transform duration-150 hover:z-[4] ${
-                      row.groupKind === "subagent" ? "cursor-grab" : ""
-                    }`
-                }`}
-                style={{
-                  width,
-                  transform: `translate3d(${position + dragOffset}px, 0, 0)`,
-                }}
-              >
-                <TabGroupPillWithMenu
-                  groupKind={row.groupKind}
-                  label={row.label}
-                  color={row.color}
-                  width={width}
-                  isCollapsed={row.isCollapsed}
-                  onToggle={() => {
-                    if (shellDrag.shouldSuppressClick(rowId)) {
-                      return;
-                    }
-                    tabGroupActions.toggleGroupCollapsed(row.groupId);
-                  }}
-                  onRename={row.groupKind === "manual"
-                    ? (anchorRect) =>
-                      groupEditorWorkflow.openEditGroupEditor(
-                        row.manualGroupId,
-                        "rename",
-                        anchorRect,
-                      )
-                    : undefined}
-                  onChangeColor={row.groupKind === "manual"
-                    ? (anchorRect) =>
-                      groupEditorWorkflow.openEditGroupEditor(
-                        row.manualGroupId,
-                        "color",
-                        anchorRect,
-                      )
-                    : undefined}
-                  onUngroup={row.groupKind === "manual"
-                    ? () => {
-                      if (!viewModel.workspaceUiKey) {
-                        return;
-                      }
-                      deleteManualChatGroup(viewModel.workspaceUiKey, row.manualGroupId);
-                      multiSelect.clearSelection();
-                    }
-                    : undefined}
-                />
-              </div>
-            );
-          }
-
-          const tab = urgentHighlightedChatSessionId
-            ? {
-              ...row.tab,
-              isActive: row.tab.id === urgentHighlightedChatSessionId,
-            }
-            : row.tab;
-          const canMultiSelect = !tab.isChild;
-          const canCreateGroup = canMultiSelect
-            && multiSelect.multiSelectedSessionIds.has(tab.id)
-            && multiSelect.selectedTopLevelSessionIds.length >= 2;
-          const canDragTab = !tab.isReviewAgentChild;
-          const previousShellRow = viewModel.shellRows[index - 1];
-          const nextShellRow = viewModel.shellRows[index + 1];
-          const previousIsChatTab =
-            previousShellRow?.kind === "chat" && previousShellRow.row.kind === "tab";
-          const nextIsChatTab =
-            nextShellRow?.kind === "chat" && nextShellRow.row.kind === "tab";
-          return (
-            <div
-              key={tab.id}
-              {...(canDragTab ? shellDrag.getRowDragProps(rowId) : {})}
-              onPointerEnter={handleHeaderTabHover}
-              className={`absolute bottom-0 h-9 app-region-no-drag ${
-                isDragging
-                  ? "z-[20] cursor-grabbing opacity-80"
-                  : `${tab.isActive ? "z-[5]" : "z-[1] hover:z-[2]"} ${
-                    canDragTab ? "cursor-grab" : "cursor-default"
-                  } transition-transform duration-150`
-              }`}
-              style={{
-                width,
-                transform: `translate3d(${position + dragOffset}px, 0, 0)`,
-              }}
-            >
-              <ChatTabWithMenu
-                tab={tab}
-                width={width}
-                hideLeftDivider={!previousIsChatTab}
-                hideRightDivider={!nextIsChatTab}
-                renaming={renamingSessionId === tab.id}
-                onRenameOpenChange={(isOpen) => {
-                  if (!isOpen) setRenamingSessionId(null);
-                }}
-                onStartRename={() => setRenamingSessionId(tab.id)}
-                onRename={(title) => updateSessionTitle(tab.id, title)}
-                isMultiSelected={!tab.isActive && multiSelect.multiSelectedSessionIds.has(tab.id)}
-                canCreateGroup={canCreateGroup}
-                onCreateGroup={() =>
-                  groupEditorWorkflow.openCreateGroupEditor(multiSelect.selectedTopLevelSessionIds)
-                }
-                onFork={() => {
-                  multiSelect.clearSelection();
-                  forkSession(tab.id);
-                }}
-                onSelectPointerDownCapture={(event) => {
-                  if (!canMultiSelect || !isPrimaryMultiSelectPointer(event)) {
-                    if (event.isPrimary && event.button === 0) {
-                      previewHeaderChatTab(tab.id);
-                    }
-                    return;
-                  }
-                  event.preventDefault();
-                  event.stopPropagation();
-                  multiSelect.suppressNextSelectClick(tab.id);
-                  multiSelect.toggleSelection(tab.id);
-                }}
-                onContextMenuTarget={(anchorRect) => {
-                  groupEditorWorkflow.rememberAnchorRect(anchorRect);
-                  if (!multiSelect.multiSelectedSessionIds.has(tab.id)) {
-                    multiSelect.clearSelection();
-                  }
-                }}
-                onSelect={(event) => {
-                  if (shellDrag.shouldSuppressClick(rowId)) {
-                    clearUrgentChatHighlight();
-                    return;
-                  }
-                  if (multiSelect.consumeSuppressedSelectClick(tab.id)) {
-                    event.preventDefault();
-                    return;
-                  }
-                  if (canMultiSelect && isPrimaryMultiSelectClick(event)) {
-                    event.preventDefault();
-                    multiSelect.toggleSelection(tab.id);
-                    return;
-                  }
-                  multiSelect.clearSelection();
-                  activateHeaderChatTab(tab.id);
-                }}
-                onClose={() => {
-                  multiSelect.clearSelection();
-                  chatVisibilityActions.hideChatSessionTabs([tab.id], { selectFallback: true });
-                }}
-                onCloseOthers={() => closeOtherWorkspaceTabs({ kind: "chat", sessionId: tab.id })}
-                onCloseRight={() => closeWorkspaceTabsToRight({ kind: "chat", sessionId: tab.id })}
-                onDismiss={() => dismissChatSession(tab.id)}
-              />
-            </div>
-          );
-        })}
+            backgroundColor: range.color,
+          }}
+        />
+      ))}
+        <HeaderTabsStripRows
+          shellRows={viewModel.shellRows}
+          widths={layout.widths}
+          positions={layout.positions}
+          shellDrag={shellDrag}
+          renamingSessionId={renamingSessionId}
+          activeShellTab={viewModel.activeShellTab}
+          urgentHighlightedChatSessionId={urgentHighlightedChatSessionId}
+          buffersByPath={viewModel.buffersByPath}
+          tabModes={viewModel.tabModes}
+          multiSelectedSessionIds={multiSelect.multiSelectedSessionIds}
+          selectedTopLevelSessionIds={multiSelect.selectedTopLevelSessionIds}
+          onHeaderTabHover={handleHeaderTabHover}
+          onSelectViewerTarget={handleSelectViewerTarget}
+          onCloseViewerTarget={handleCloseViewerTarget}
+          onCloseOtherViewerTargets={handleCloseOtherViewerTargets}
+          onCloseViewerTargetsToRight={handleCloseViewerTargetsToRight}
+          onToggleGroup={tabGroupActions.toggleGroupCollapsed}
+          onRenameManualGroup={handleRenameManualGroup}
+          onChangeManualGroupColor={handleChangeManualGroupColor}
+          onUngroupManualGroup={handleUngroupManualGroup}
+          onRenameOpenChange={handleRenameOpenChange}
+          onStartRename={handleStartRename}
+          onRenameChatTab={handleRenameChatTab}
+          onCreateGroup={handleCreateGroup}
+          onChatContextMenuTarget={handleChatContextMenuTarget}
+          onForkChatTab={handleForkChatTab}
+          onPreviewChatTab={previewHeaderChatTab}
+          onActivateChatTab={activateHeaderChatTab}
+          onSuppressChatTabSelect={clearUrgentChatHighlight}
+          onCloseChatTab={handleCloseChatTab}
+          onCloseOtherChatTabs={handleCloseOtherChatTabs}
+          onCloseChatTabsToRight={handleCloseChatTabsToRight}
+          onDismissChatSession={dismissChatSession}
+          clearSelection={multiSelect.clearSelection}
+          toggleSelection={multiSelect.toggleSelection}
+          suppressNextSelectClick={multiSelect.suppressNextSelectClick}
+          consumeSuppressedSelectClick={multiSelect.consumeSuppressedSelectClick}
+        />
       </WorkspaceTabStrip>
 
-      {(viewModel.menuChatTabs.length > 1
-        || hasAnyHeaderSubagentChildren(viewModel.childrenByParentSessionId)) && (
-        <PopoverButton
-          align="end"
-          trigger={(
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              title="Open chat tabs"
-              className="mb-1.5 size-6 shrink-0 rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
-            >
-              <ListFilter className="size-3.5" />
-            </Button>
-          )}
-          className="w-72 rounded-lg border border-border bg-popover p-1 shadow-floating"
-        >
-          {(close) => (
-            <ChatTabsMenu
-              workspaceId={viewModel.selectedWorkspaceId}
-              rows={viewModel.menuChatTabs}
-              childrenByParentSessionId={viewModel.childrenByParentSessionId}
-              renderIcon={renderChatTabIcon}
-              renderStatus={renderChatMenuStatus}
-              onOpenSession={(sessionId) => {
-                chatVisibilityActions.showChatSessionTab(sessionId, { select: true });
-                close();
-              }}
-            />
-          )}
-        </PopoverButton>
-      )}
-
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        disabled={!tabActions.canOpenNewSessionTab}
-        onClick={() => tabActions.openNewSessionTab()}
-        title={tabActions.newSessionDisabledReason ?? "New chat"}
-        data-chat-new-tab-button
-        className="mb-1.5 ml-0.5 size-6 shrink-0 rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-      >
-        <Plus className="size-3" />
-      </Button>
+      <HeaderTabsActions
+        workspaceId={viewModel.selectedWorkspaceId}
+        menuChatTabs={viewModel.menuChatTabs}
+        childrenByParentSessionId={viewModel.childrenByParentSessionId}
+        canOpenNewSessionTab={tabActions.canOpenNewSessionTab}
+        newSessionDisabledReason={tabActions.newSessionDisabledReason}
+        onOpenSession={(sessionId) => {
+          chatVisibilityActions.showChatSessionTab(sessionId, { select: true });
+        }}
+        onOpenNewSessionTab={() => tabActions.openNewSessionTab()}
+      />
 
       {groupEditorWorkflow.groupEditor && (
         <ManualChatGroupEditorPopover

--- a/desktop/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/Button";
+import { ListFilter, Plus } from "@/components/ui/icons";
+import { PopoverButton } from "@/components/ui/PopoverButton";
+import { ChatTabsMenu } from "@/components/workspace/shell/tabs/ChatTabsMenu";
+import {
+  renderChatMenuStatus,
+  renderChatTabIcon,
+} from "@/components/workspace/shell/tabs/tab-rendering";
+import type {
+  HeaderChatMenuEntry,
+} from "@/hooks/workspaces/tabs/workspace-header-tabs-view-model-types";
+import type {
+  HeaderSubagentChildRow,
+} from "@/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy";
+import { hasAnyHeaderSubagentChildren } from "@/lib/domain/workspaces/tabs/group-rows";
+
+interface HeaderTabsActionsProps {
+  workspaceId: string | null;
+  menuChatTabs: HeaderChatMenuEntry[];
+  childrenByParentSessionId: Map<string, HeaderSubagentChildRow[]>;
+  canOpenNewSessionTab: boolean;
+  newSessionDisabledReason: string | null;
+  onOpenSession: (sessionId: string) => void;
+  onOpenNewSessionTab: () => void;
+}
+
+export function HeaderTabsActions({
+  workspaceId,
+  menuChatTabs,
+  childrenByParentSessionId,
+  canOpenNewSessionTab,
+  newSessionDisabledReason,
+  onOpenSession,
+  onOpenNewSessionTab,
+}: HeaderTabsActionsProps) {
+  const showMenu = menuChatTabs.length > 1
+    || hasAnyHeaderSubagentChildren(childrenByParentSessionId);
+
+  return (
+    <>
+      {showMenu && (
+        <PopoverButton
+          align="end"
+          trigger={(
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              title="Open chat tabs"
+              className="mb-1.5 size-6 shrink-0 rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+            >
+              <ListFilter className="size-3.5" />
+            </Button>
+          )}
+          className="w-72 rounded-lg border border-border bg-popover p-1 shadow-floating"
+        >
+          {(close) => (
+            <ChatTabsMenu
+              workspaceId={workspaceId}
+              rows={menuChatTabs}
+              childrenByParentSessionId={childrenByParentSessionId}
+              renderIcon={renderChatTabIcon}
+              renderStatus={renderChatMenuStatus}
+              onOpenSession={(sessionId) => {
+                onOpenSession(sessionId);
+                close();
+              }}
+            />
+          )}
+        </PopoverButton>
+      )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={!canOpenNewSessionTab}
+        onClick={onOpenNewSessionTab}
+        title={newSessionDisabledReason ?? "New chat"}
+        data-chat-new-tab-button
+        className="mb-1.5 ml-0.5 size-6 shrink-0 rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+      >
+        <Plus className="size-3" />
+      </Button>
+    </>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderTabsStripRows.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderTabsStripRows.tsx
@@ -1,0 +1,244 @@
+import type { ManualChatGroupEditorAnchorRect } from "@/components/workspace/shell/tabs/ManualChatGroupEditorPopover";
+import { HeaderChatTab } from "@/components/workspace/shell/topbar/HeaderChatTab";
+import { HeaderGroupPillTab } from "@/components/workspace/shell/topbar/HeaderGroupPillTab";
+import { HeaderViewerTab } from "@/components/workspace/shell/topbar/HeaderViewerTab";
+import type {
+  HeaderWorkspaceShellStripRow,
+} from "@/hooks/workspaces/tabs/workspace-header-tabs-view-model-types";
+import { getShellDragRowId } from "@/hooks/workspaces/tabs/use-header-tabs-layout";
+import {
+  TAB_GROUP_PILL_WIDTH,
+} from "@/lib/domain/workspaces/tabs/chrome-layout";
+import type { ManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+import type { WorkspaceShellTab } from "@/lib/domain/workspaces/tabs/shell-tabs";
+import type {
+  FileViewerMode,
+  ViewerTarget,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+import {
+  viewerTargetDisplayPath,
+  viewerTargetEditablePath,
+  viewerTargetKey,
+  viewerTargetLabel,
+} from "@/lib/domain/workspaces/viewer/viewer-target";
+import type { WorkspaceFileBuffer } from "@/stores/editor/workspace-file-buffers-store";
+
+interface HeaderTabsDragControls {
+  getRowDragProps: (rowId: string) => { "data-tab-drag-row-id": string };
+  isDraggingRow: (rowId: string) => boolean;
+  getRowDragOffset: (rowId: string) => number;
+  shouldSuppressClick: (rowId: string) => boolean;
+}
+
+interface HeaderTabsStripRowsProps {
+  shellRows: HeaderWorkspaceShellStripRow[];
+  widths: number[];
+  positions: number[];
+  shellDrag: HeaderTabsDragControls;
+  renamingSessionId: string | null;
+  activeShellTab: WorkspaceShellTab | null;
+  urgentHighlightedChatSessionId: string | null;
+  buffersByPath: Record<string, WorkspaceFileBuffer>;
+  tabModes: Record<string, FileViewerMode>;
+  multiSelectedSessionIds: ReadonlySet<string>;
+  selectedTopLevelSessionIds: readonly string[];
+  onHeaderTabHover: () => void;
+  onSelectViewerTarget: (target: ViewerTarget) => void;
+  onCloseViewerTarget: (target: ViewerTarget) => void;
+  onCloseOtherViewerTargets: (target: ViewerTarget) => void;
+  onCloseViewerTargetsToRight: (target: ViewerTarget) => void;
+  onToggleGroup: (groupId: string) => void;
+  onRenameManualGroup: (
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onChangeManualGroupColor: (
+    groupId: ManualChatGroupId,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onUngroupManualGroup: (groupId: ManualChatGroupId) => void;
+  onRenameOpenChange: (sessionId: string, isOpen: boolean) => void;
+  onStartRename: (sessionId: string) => void;
+  onRenameChatTab: (sessionId: string, title: string) => Promise<unknown>;
+  onCreateGroup: (sessionIds: readonly string[]) => void;
+  onChatContextMenuTarget: (
+    sessionId: string,
+    anchorRect: ManualChatGroupEditorAnchorRect,
+  ) => void;
+  onForkChatTab: (sessionId: string) => void;
+  onPreviewChatTab: (sessionId: string) => void;
+  onActivateChatTab: (sessionId: string) => void;
+  onSuppressChatTabSelect: () => void;
+  onCloseChatTab: (sessionId: string) => void;
+  onCloseOtherChatTabs: (sessionId: string) => void;
+  onCloseChatTabsToRight: (sessionId: string) => void;
+  onDismissChatSession: (sessionId: string) => void;
+  clearSelection: () => void;
+  toggleSelection: (sessionId: string) => void;
+  suppressNextSelectClick: (sessionId: string) => void;
+  consumeSuppressedSelectClick: (sessionId: string) => boolean;
+}
+
+export function HeaderTabsStripRows({
+  shellRows,
+  widths,
+  positions,
+  shellDrag,
+  renamingSessionId,
+  activeShellTab,
+  urgentHighlightedChatSessionId,
+  buffersByPath,
+  tabModes,
+  multiSelectedSessionIds,
+  selectedTopLevelSessionIds,
+  onHeaderTabHover,
+  onSelectViewerTarget,
+  onCloseViewerTarget,
+  onCloseOtherViewerTargets,
+  onCloseViewerTargetsToRight,
+  onToggleGroup,
+  onRenameManualGroup,
+  onChangeManualGroupColor,
+  onUngroupManualGroup,
+  onRenameOpenChange,
+  onStartRename,
+  onRenameChatTab,
+  onCreateGroup,
+  onChatContextMenuTarget,
+  onForkChatTab,
+  onPreviewChatTab,
+  onActivateChatTab,
+  onSuppressChatTabSelect,
+  onCloseChatTab,
+  onCloseOtherChatTabs,
+  onCloseChatTabsToRight,
+  onDismissChatSession,
+  clearSelection,
+  toggleSelection,
+  suppressNextSelectClick,
+  consumeSuppressedSelectClick,
+}: HeaderTabsStripRowsProps) {
+  return (
+    <>
+      {shellRows.map((shellRow, index) => {
+        const rowKind = shellRow.kind === "chat" && shellRow.row.kind === "pill" ? "pill" : "tab";
+        const width = widths[index] ?? (rowKind === "pill" ? TAB_GROUP_PILL_WIDTH : 160);
+        const position = positions[index] ?? 0;
+        const rowId = getShellDragRowId(shellRow);
+        const isDragging = shellDrag.isDraggingRow(rowId);
+        const dragOffset = shellDrag.getRowDragOffset(rowId);
+        const shouldSuppressClick = () => shellDrag.shouldSuppressClick(rowId);
+
+        if (shellRow.kind === "viewer") {
+          const target = shellRow.target;
+          const targetKey = viewerTargetKey(target);
+          const displayPath = viewerTargetDisplayPath(target);
+          const isActive = !urgentHighlightedChatSessionId
+            && activeShellTab?.kind === "viewer"
+            && viewerTargetKey(activeShellTab.target) === targetKey;
+          const bufferPath = viewerTargetEditablePath(target);
+          const buf = bufferPath ? buffersByPath[bufferPath] : null;
+          const isAllChanges = target.kind === "allChanges";
+
+          return (
+            <HeaderViewerTab
+              key={targetKey}
+              rowDragProps={shellDrag.getRowDragProps(rowId)}
+              width={width}
+              position={position}
+              dragOffset={dragOffset}
+              isDragging={isDragging}
+              path={displayPath ?? viewerTargetLabel(target)}
+              label={viewerTargetLabel(target)}
+              isActive={isActive}
+              isDirty={buf?.isDirty ?? false}
+              isDiff={!isAllChanges && tabModes[targetKey] === "diff"}
+              isAllChanges={isAllChanges}
+              hideLeftDivider={index === 0}
+              hideRightDivider={index === shellRows.length - 1}
+              onPointerEnter={onHeaderTabHover}
+              shouldSuppressClick={shouldSuppressClick}
+              onSelect={() => onSelectViewerTarget(target)}
+              onClose={() => onCloseViewerTarget(target)}
+              onCloseOthers={() => onCloseOtherViewerTargets(target)}
+              onCloseRight={() => onCloseViewerTargetsToRight(target)}
+            />
+          );
+        }
+
+        const row = shellRow.row;
+        if (row.kind === "pill") {
+          return (
+            <HeaderGroupPillTab
+              key={`pill-${row.groupId}`}
+              row={row}
+              rowDragProps={row.groupKind === "subagent"
+                ? shellDrag.getRowDragProps(rowId)
+                : undefined}
+              width={width}
+              position={position}
+              dragOffset={dragOffset}
+              isDragging={isDragging}
+              shouldSuppressClick={shouldSuppressClick}
+              onToggle={onToggleGroup}
+              onRenameManualGroup={onRenameManualGroup}
+              onChangeManualGroupColor={onChangeManualGroupColor}
+              onUngroupManualGroup={onUngroupManualGroup}
+            />
+          );
+        }
+
+        const tab = urgentHighlightedChatSessionId
+          ? {
+            ...row.tab,
+            isActive: row.tab.id === urgentHighlightedChatSessionId,
+          }
+          : row.tab;
+        const previousShellRow = shellRows[index - 1];
+        const nextShellRow = shellRows[index + 1];
+        const previousIsChatTab =
+          previousShellRow?.kind === "chat" && previousShellRow.row.kind === "tab";
+        const nextIsChatTab =
+          nextShellRow?.kind === "chat" && nextShellRow.row.kind === "tab";
+        const canDragTab = !tab.isReviewAgentChild;
+
+        return (
+          <HeaderChatTab
+            key={tab.id}
+            tab={tab}
+            rowDragProps={canDragTab ? shellDrag.getRowDragProps(rowId) : undefined}
+            width={width}
+            position={position}
+            dragOffset={dragOffset}
+            isDragging={isDragging}
+            canDragTab={canDragTab}
+            hideLeftDivider={!previousIsChatTab}
+            hideRightDivider={!nextIsChatTab}
+            renamingSessionId={renamingSessionId}
+            multiSelectedSessionIds={multiSelectedSessionIds}
+            selectedTopLevelSessionIds={selectedTopLevelSessionIds}
+            onPointerEnter={onHeaderTabHover}
+            shouldSuppressClick={shouldSuppressClick}
+            onRenameOpenChange={onRenameOpenChange}
+            onStartRename={onStartRename}
+            onRename={onRenameChatTab}
+            onCreateGroup={onCreateGroup}
+            onContextMenuTarget={onChatContextMenuTarget}
+            onFork={onForkChatTab}
+            onPreview={onPreviewChatTab}
+            onActivate={onActivateChatTab}
+            onSuppressSelect={onSuppressChatTabSelect}
+            onClose={onCloseChatTab}
+            onCloseOthers={onCloseOtherChatTabs}
+            onCloseRight={onCloseChatTabsToRight}
+            onDismiss={onDismissChatSession}
+            clearSelection={clearSelection}
+            toggleSelection={toggleSelection}
+            suppressNextSelectClick={suppressNextSelectClick}
+            consumeSuppressedSelectClick={consumeSuppressedSelectClick}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/desktop/src/components/workspace/shell/topbar/HeaderViewerTab.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderViewerTab.tsx
@@ -1,0 +1,82 @@
+import { FileTabWithMenu } from "@/components/workspace/shell/tabs/FileTabWithMenu";
+
+interface HeaderViewerTabProps {
+  rowDragProps: { "data-tab-drag-row-id": string };
+  width: number;
+  position: number;
+  dragOffset: number;
+  isDragging: boolean;
+  path: string;
+  label: string;
+  isActive: boolean;
+  isDirty: boolean;
+  isDiff: boolean;
+  isAllChanges: boolean;
+  hideLeftDivider: boolean;
+  hideRightDivider: boolean;
+  onPointerEnter: () => void;
+  shouldSuppressClick: () => boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  onCloseOthers: () => void;
+  onCloseRight: () => void;
+}
+
+export function HeaderViewerTab({
+  rowDragProps,
+  width,
+  position,
+  dragOffset,
+  isDragging,
+  path,
+  label,
+  isActive,
+  isDirty,
+  isDiff,
+  isAllChanges,
+  hideLeftDivider,
+  hideRightDivider,
+  onPointerEnter,
+  shouldSuppressClick,
+  onSelect,
+  onClose,
+  onCloseOthers,
+  onCloseRight,
+}: HeaderViewerTabProps) {
+  return (
+    <div
+      {...rowDragProps}
+      onPointerEnter={onPointerEnter}
+      className={`absolute bottom-0 h-9 app-region-no-drag ${
+        isDragging
+          ? "z-[20] cursor-grabbing opacity-80"
+          : `${isActive ? "z-[5]" : "z-[1] hover:z-[2]"} cursor-grab transition-transform duration-150`
+      }`}
+      style={{
+        width,
+        transform: `translate3d(${position + dragOffset}px, 0, 0)`,
+      }}
+    >
+      <FileTabWithMenu
+        path={path}
+        label={label}
+        isActive={isActive}
+        isDirty={isDirty}
+        isDiff={isDiff}
+        isAllChanges={isAllChanges}
+        width={width}
+        hideLeftDivider={hideLeftDivider}
+        hideRightDivider={hideRightDivider}
+        onSelect={() => {
+          if (shouldSuppressClick()) {
+            return;
+          }
+          onSelect();
+        }}
+        onClose={onClose}
+        onCloseOthers={onCloseOthers}
+        onCloseRight={onCloseRight}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Split header tab rendering into focused viewer, chat, group, action, and strip row components.
- Extracted the right panel JSX shell into `RightPanelFrame` while preserving existing state and workflow hooks.
- Split sidebar primary navigation and repository header controls out of `MainSidebar`.

## Validation
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `pnpm exec tsc --noEmit` from `desktop/`
- `pnpm exec vitest run src/components/workspace/shell/right-panel/RightPanel.test.tsx src/components/workspace/shell/sidebar/MainSidebar.test.tsx src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx src/components/workspace/shell/tabs/ManualChatGroupEditorPopover.test.tsx` from `desktop/`