### PR TITLE
refactor(desktop): split chat input components

### DIFF
--- a/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -12,7 +12,6 @@ import {
   CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
   WORKSPACE_CHAT_COMPOSER_INPUT,
 } from "@/config/chat";
-import { CHAT_COMPOSER_LABELS } from "@/copy/chat/chat-copy";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import {
   useActiveSessionId,
@@ -46,18 +45,11 @@ import {
   PROMPT_SUBMIT_MEASUREMENT_MAX_DURATION_MS,
   PROMPT_SUBMIT_MEASUREMENT_SURFACES,
 } from "@/lib/infra/measurement/prompt-submit-measurement";
-import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
-import { ChatComposerActions } from "./ChatComposerActions";
-import { ComposerAddActionPopover } from "./ComposerAddActionPopover";
-import { ComposerMentionEditor } from "./ComposerMentionEditor";
-import { ComposerTextarea } from "./ComposerTextarea";
-import { ComposerTextareaFrame } from "./ComposerTextareaFrame";
-import { ModelSelector } from "./ModelSelector";
-import { SessionConfigControls } from "./SessionConfigControls";
+import { ChatInputControlRow } from "./ChatInputControlRow";
+import { ChatInputDraftArea } from "./ChatInputDraftArea";
+import { ChatInputHiddenFileInput } from "./ChatInputHiddenFileInput";
 import { ChatComposerSurface } from "./ChatComposerSurface";
-import { DraftAttachmentPreviewList } from "@/components/workspace/chat/content/PromptContentRenderer";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
 
 /**
@@ -126,45 +118,6 @@ export function ChatInput({
     workspaceUiKey,
     sdkWorkspaceId: materializedWorkspaceId,
   });
-  const canUseUtilityActions =
-    !effectiveIsEditingQueuedPrompt && !isDisabled && !areRuntimeControlsDisabled && !isSubmitting;
-  const canAttach = canUseUtilityActions && attachments.canAttachFiles;
-  // Plan references are resolved to markdown text by the runtime, so they do
-  // not depend on file/image attachment capabilities.
-  const canAttachPlan = canUseUtilityActions && !!workspaceUiKey && !!materializedWorkspaceId;
-  const canStartReview = canUseUtilityActions
-    && !suppressActiveSessionState
-    && reviewActions.canStartCodeReview
-    && !activeReview.hasBlockingReview
-    && !activeReview.startingReview;
-  const attachFileDetail = (() => {
-    if (canAttach) {
-      return "Upload image or text context.";
-    }
-    if (!attachments.supportsAttachments) {
-      return activeSessionIdForUi
-        ? "Attachments are not supported by this agent"
-        : "Attachments are available after a session starts";
-    }
-    return "Chat is unavailable right now";
-  })();
-  const attachPlanDetail = canAttachPlan
-    ? "Attach an existing plan snapshot."
-    : workspaceUiKey
-      ? "Chat is unavailable right now"
-      : "Select a workspace before attaching a plan";
-  const reviewDetail = (() => {
-    if (canStartReview) {
-      return "Start review agents for the current implementation.";
-    }
-    if (activeReview.hasBlockingReview || activeReview.startingReview) {
-      return "A review is already active for this session";
-    }
-    if (!activeSessionIdForUi) {
-      return "Review is available after a session starts";
-    }
-    return "Review agents are unavailable right now";
-  })();
   const promptText = serializeChatDraftToPrompt(draft);
   const hasDraftAttachments = attachments.hasAttachments || planAttachments.hasPlans;
   const effectiveIsEmpty = effectiveIsEditingQueuedPrompt
@@ -172,6 +125,12 @@ export function ChatInput({
     : isEmpty && !hasDraftAttachments;
   const canSubmit =
     !effectiveIsEmpty && !isDisabled && !planAttachments.hasUnresolvedPlans && !isSubmitting;
+  const canAcceptPastedAttachments =
+    !effectiveIsEditingQueuedPrompt
+    && !isDisabled
+    && !areRuntimeControlsDisabled
+    && !isSubmitting
+    && attachments.canAttachFiles;
   useComposerTextareaAutosize({
     textareaRef,
     value: editDraft,
@@ -280,7 +239,7 @@ export function ChatInput({
   }, [attachments, planAttachments]);
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
-    if (!canAttach) {
+    if (!canAcceptPastedAttachments) {
       return;
     }
     if (event.clipboardData.files.length > 0) {
@@ -292,7 +251,15 @@ export function ChatInput({
     if (text && attachments.addTextPaste(text)) {
       event.preventDefault();
     }
-  }, [attachments, canAttach]);
+  }, [attachments, canAcceptPastedAttachments]);
+
+  const handleComposerSurfaceClick = useCallback(() => {
+    if (effectiveIsEditingQueuedPrompt) {
+      textareaRef.current?.focus();
+      return;
+    }
+    focusChatInput();
+  }, [effectiveIsEditingQueuedPrompt]);
 
   useEffect(() => {
     if (!workspaceUiKey && !activeSessionIdForUi) {
@@ -341,118 +308,62 @@ export function ChatInput({
   return (
     <DebugProfiler id="chat-composer">
       <div className="relative">
-      <div ref={setMentionSearchHost} className="relative z-20 flex flex-col px-5" />
-      <ChatComposerSurface
-        overflowMode="clip"
-        onClick={() => {
-          if (effectiveIsEditingQueuedPrompt) {
-            textareaRef.current?.focus();
-            return;
-          }
-          focusChatInput();
-        }}
-        onPaste={handlePaste}
-      >
-        <form className="relative flex flex-col">
-          <Input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={handleFileInputChange}
-            accept="image/*,text/*,.md,.json,.ts,.tsx,.js,.jsx,.py,.rs,.go,.java,.css,.html,.xml,.yaml,.yml,.toml,.sql,.sh"
-          />
-          {effectiveIsEditingQueuedPrompt && (
-            <div className="mx-5 mt-3 flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
-              <span>Editing queued message</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={cancelEdit}
-                className="h-6 px-2 text-xs"
-              >
-                Cancel
-              </Button>
-            </div>
-          )}
-          {!effectiveIsEditingQueuedPrompt && (
-            <DraftAttachmentPreviewList
-              attachments={[...attachments.attachments, ...planAttachments.attachments]}
-              onRemove={handleRemoveDraftAttachment}
+        <div ref={setMentionSearchHost} className="relative z-20 flex flex-col px-5" />
+        <ChatComposerSurface
+          overflowMode="clip"
+          onClick={handleComposerSurfaceClick}
+          onPaste={handlePaste}
+        >
+          <form className="relative flex flex-col">
+            <ChatInputHiddenFileInput
+              ref={fileInputRef}
+              onChange={handleFileInputChange}
             />
-          )}
-          {effectiveIsEditingQueuedPrompt ? (
-            <ComposerTextareaFrame topInset="none">
-              <ComposerTextarea
-                data-chat-composer-editor
-                data-telemetry-mask
-                ref={textareaRef}
-                rows={WORKSPACE_CHAT_COMPOSER_INPUT.minRows}
-                value={editDraft}
-                onChange={(event) => setEditDraftText(event.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={CHAT_COMPOSER_LABELS.placeholder}
-                spellCheck={false}
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-              />
-            </ComposerTextareaFrame>
-          ) : (
-            <ComposerMentionEditor
+            <ChatInputDraftArea
+              isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
+              editDraft={editDraft}
+              onEditDraftChange={setEditDraftText}
+              textareaRef={textareaRef}
               draft={draft}
               onDraftChange={setDraft}
-              placeholder={CHAT_COMPOSER_LABELS.placeholder}
               canSubmit={canSubmit}
-              disabled={isDisabled}
+              isDisabled={isDisabled}
               onSubmit={onSubmit}
               onKeyDown={handleKeyDown}
-              topInset={hasDraftAttachments ? "none" : "standard"}
+              hasDraftAttachments={hasDraftAttachments}
+              draftAttachments={[...attachments.attachments, ...planAttachments.attachments]}
+              onRemoveDraftAttachment={handleRemoveDraftAttachment}
               searchHostElement={mentionSearchHost}
+              onCancelEdit={cancelEdit}
             />
-          )}
-
-          <div className="mb-2 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[5px] px-2">
-            <div
-              className={`flex min-w-0 flex-nowrap items-center gap-[5px] ${
-                areRuntimeControlsDisabled ? "pointer-events-none opacity-55" : ""
-              }`}
-            >
-              <ModelSelector {...modelSelectorProps} />
-              <SessionConfigControls
-                agentKind={effectiveAgentKind}
-                controls={effectiveSessionConfigControls}
-              />
-            </div>
-
-            <div className="flex items-center gap-[5px]">
-              {!effectiveIsEditingQueuedPrompt && (
-                <ComposerAddActionPopover
-                  canAttachFile={canAttach}
-                  attachFileDetail={attachFileDetail}
-                  canAttachPlan={canAttachPlan}
-                  attachPlanDetail={attachPlanDetail}
-                  canStartReview={canStartReview}
-                  reviewDetail={reviewDetail}
-                  workspaceUiKey={workspaceUiKey}
-                  sdkWorkspaceId={materializedWorkspaceId}
-                  onAttachFile={() => fileInputRef.current?.click()}
-                  onStartReview={reviewActions.startCodeReview}
-                  onConfigureReview={reviewActions.configureCodeReview}
-                />
-              )}
-              <ChatComposerActions
-                isRunning={isRunningForUi}
-                isEmpty={effectiveIsEmpty}
-                isDisabled={isDisabled || planAttachments.hasUnresolvedPlans || isSubmitting}
-                isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
-                onSubmit={onSubmit}
-                onCancel={onCancel}
-              />
-            </div>
-          </div>
-        </form>
-      </ChatComposerSurface>
+            <ChatInputControlRow
+              runtimeControlsDisabled={areRuntimeControlsDisabled}
+              modelSelectorProps={modelSelectorProps}
+              agentKind={effectiveAgentKind}
+              sessionConfigControls={effectiveSessionConfigControls}
+              isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
+              chatDisabled={isDisabled}
+              isSubmitting={isSubmitting}
+              supportsAttachments={attachments.supportsAttachments}
+              canAttachFiles={attachments.canAttachFiles}
+              activeSessionId={activeSessionIdForUi}
+              workspaceUiKey={workspaceUiKey}
+              sdkWorkspaceId={materializedWorkspaceId}
+              suppressActiveSessionState={suppressActiveSessionState}
+              canStartCodeReview={reviewActions.canStartCodeReview}
+              hasBlockingReview={activeReview.hasBlockingReview}
+              startingReview={!!activeReview.startingReview}
+              hasUnresolvedPlans={planAttachments.hasUnresolvedPlans}
+              onAttachFile={() => fileInputRef.current?.click()}
+              onStartReview={reviewActions.startCodeReview}
+              onConfigureReview={reviewActions.configureCodeReview}
+              isRunning={isRunningForUi}
+              isEmpty={effectiveIsEmpty}
+              onSubmit={onSubmit}
+              onCancel={onCancel}
+            />
+          </form>
+        </ChatComposerSurface>
       </div>
     </DebugProfiler>
   );

--- a/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -1,0 +1,129 @@
+import type { ComponentProps } from "react";
+import { ChatComposerActions } from "./ChatComposerActions";
+import { ComposerAddActionPopover } from "./ComposerAddActionPopover";
+import { ModelSelector } from "./ModelSelector";
+import { SessionConfigControls } from "./SessionConfigControls";
+
+export interface ChatInputControlRowProps {
+  runtimeControlsDisabled: boolean;
+  modelSelectorProps: ComponentProps<typeof ModelSelector>;
+  agentKind: ComponentProps<typeof SessionConfigControls>["agentKind"];
+  sessionConfigControls: ComponentProps<typeof SessionConfigControls>["controls"];
+  isEditingQueuedPrompt: boolean;
+  chatDisabled: boolean;
+  isSubmitting: boolean;
+  supportsAttachments: boolean;
+  canAttachFiles: boolean;
+  activeSessionId: string | null;
+  workspaceUiKey: string | null;
+  sdkWorkspaceId: string | null;
+  suppressActiveSessionState: boolean;
+  canStartCodeReview: boolean;
+  hasBlockingReview: boolean;
+  startingReview: boolean;
+  hasUnresolvedPlans: boolean;
+  onAttachFile: () => void;
+  onStartReview: () => void;
+  onConfigureReview: () => void;
+  isRunning: boolean;
+  isEmpty: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export function ChatInputControlRow({
+  runtimeControlsDisabled,
+  modelSelectorProps,
+  agentKind,
+  sessionConfigControls,
+  isEditingQueuedPrompt,
+  chatDisabled,
+  isSubmitting,
+  supportsAttachments,
+  canAttachFiles,
+  activeSessionId,
+  workspaceUiKey,
+  sdkWorkspaceId,
+  suppressActiveSessionState,
+  canStartCodeReview,
+  hasBlockingReview,
+  startingReview,
+  hasUnresolvedPlans,
+  onAttachFile,
+  onStartReview,
+  onConfigureReview,
+  isRunning,
+  isEmpty,
+  onSubmit,
+  onCancel,
+}: ChatInputControlRowProps) {
+  const canUseUtilityActions =
+    !isEditingQueuedPrompt && !chatDisabled && !runtimeControlsDisabled && !isSubmitting;
+  const canAttachFile = canUseUtilityActions && canAttachFiles;
+  // Plan references resolve to markdown text in the runtime, so they do not
+  // depend on file/image attachment capabilities.
+  const canAttachPlan = canUseUtilityActions && !!workspaceUiKey && !!sdkWorkspaceId;
+  const canStartReview = canUseUtilityActions
+    && !suppressActiveSessionState
+    && canStartCodeReview
+    && !hasBlockingReview
+    && !startingReview;
+  const attachFileDetail = canAttachFile
+    ? "Upload image or text context."
+    : !supportsAttachments
+      ? activeSessionId
+        ? "Attachments are not supported by this agent"
+        : "Attachments are available after a session starts"
+      : "Chat is unavailable right now";
+  const attachPlanDetail = canAttachPlan
+    ? "Attach an existing plan snapshot."
+    : workspaceUiKey
+      ? "Chat is unavailable right now"
+      : "Select a workspace before attaching a plan";
+  const reviewDetail = canStartReview
+    ? "Start review agents for the current implementation."
+    : hasBlockingReview || startingReview
+      ? "A review is already active for this session"
+      : !activeSessionId
+        ? "Review is available after a session starts"
+        : "Review agents are unavailable right now";
+
+  return (
+    <div className="mb-2 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[5px] px-2">
+      <div
+        className={`flex min-w-0 flex-nowrap items-center gap-[5px] ${
+          runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
+        }`}
+      >
+        <ModelSelector {...modelSelectorProps} />
+        <SessionConfigControls agentKind={agentKind} controls={sessionConfigControls} />
+      </div>
+
+      <div className="flex items-center gap-[5px]">
+        {!isEditingQueuedPrompt && (
+          <ComposerAddActionPopover
+            canAttachFile={canAttachFile}
+            attachFileDetail={attachFileDetail}
+            canAttachPlan={canAttachPlan}
+            attachPlanDetail={attachPlanDetail}
+            canStartReview={canStartReview}
+            reviewDetail={reviewDetail}
+            workspaceUiKey={workspaceUiKey}
+            sdkWorkspaceId={sdkWorkspaceId}
+            onAttachFile={onAttachFile}
+            onStartReview={onStartReview}
+            onConfigureReview={onConfigureReview}
+          />
+        )}
+        <ChatComposerActions
+          isRunning={isRunning}
+          isEmpty={isEmpty}
+          isDisabled={chatDisabled || hasUnresolvedPlans || isSubmitting}
+          isEditingQueuedPrompt={isEditingQueuedPrompt}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -1,0 +1,92 @@
+import type { KeyboardEventHandler, RefObject } from "react";
+import { WORKSPACE_CHAT_COMPOSER_INPUT } from "@/config/chat";
+import { CHAT_COMPOSER_LABELS } from "@/copy/chat/chat-copy";
+import type { ChatComposerDraft } from "@/lib/domain/chat/transcript/file-mentions";
+import {
+  DraftAttachmentPreviewList,
+  type DraftAttachmentPreviewListProps,
+} from "@/components/workspace/chat/content/PromptContentRenderer";
+import { ComposerMentionEditor } from "./ComposerMentionEditor";
+import { ComposerTextarea } from "./ComposerTextarea";
+import { ComposerTextareaFrame } from "./ComposerTextareaFrame";
+import { QueuedPromptEditBanner } from "./QueuedPromptEditBanner";
+
+interface ChatInputDraftAreaProps {
+  isEditingQueuedPrompt: boolean;
+  editDraft: string;
+  onEditDraftChange: (value: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  draft: ChatComposerDraft;
+  onDraftChange: (draft: ChatComposerDraft) => void;
+  canSubmit: boolean;
+  isDisabled: boolean;
+  onSubmit: () => void;
+  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+  hasDraftAttachments: boolean;
+  draftAttachments: DraftAttachmentPreviewListProps["attachments"];
+  onRemoveDraftAttachment: DraftAttachmentPreviewListProps["onRemove"];
+  searchHostElement: HTMLElement | null;
+  onCancelEdit: () => void;
+}
+
+export function ChatInputDraftArea({
+  isEditingQueuedPrompt,
+  editDraft,
+  onEditDraftChange,
+  textareaRef,
+  draft,
+  onDraftChange,
+  canSubmit,
+  isDisabled,
+  onSubmit,
+  onKeyDown,
+  hasDraftAttachments,
+  draftAttachments,
+  onRemoveDraftAttachment,
+  searchHostElement,
+  onCancelEdit,
+}: ChatInputDraftAreaProps) {
+  if (isEditingQueuedPrompt) {
+    return (
+      <>
+        <QueuedPromptEditBanner onCancel={onCancelEdit} />
+        <ComposerTextareaFrame topInset="none">
+          <ComposerTextarea
+            data-chat-composer-editor
+            data-telemetry-mask
+            ref={textareaRef}
+            rows={WORKSPACE_CHAT_COMPOSER_INPUT.minRows}
+            value={editDraft}
+            onChange={(event) => onEditDraftChange(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={CHAT_COMPOSER_LABELS.placeholder}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </ComposerTextareaFrame>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <DraftAttachmentPreviewList
+        attachments={draftAttachments}
+        onRemove={onRemoveDraftAttachment}
+      />
+      <ComposerMentionEditor
+        draft={draft}
+        onDraftChange={onDraftChange}
+        placeholder={CHAT_COMPOSER_LABELS.placeholder}
+        canSubmit={canSubmit}
+        disabled={isDisabled}
+        onSubmit={onSubmit}
+        onKeyDown={onKeyDown}
+        topInset={hasDraftAttachments ? "none" : "standard"}
+        searchHostElement={searchHostElement}
+      />
+    </>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/ChatInputHiddenFileInput.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatInputHiddenFileInput.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type ChangeEvent } from "react";
+import { Input } from "@/components/ui/Input";
+
+const CHAT_INPUT_ATTACHMENT_ACCEPT =
+  "image/*,text/*,.md,.json,.ts,.tsx,.js,.jsx,.py,.rs,.go,.java,.css,.html,.xml,.yaml,.yml,.toml,.sql,.sh";
+
+interface ChatInputHiddenFileInputProps {
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const ChatInputHiddenFileInput = forwardRef<
+  HTMLInputElement,
+  ChatInputHiddenFileInputProps
+>(function ChatInputHiddenFileInput({ onChange }, ref) {
+  return (
+    <Input
+      ref={ref}
+      type="file"
+      multiple
+      className="hidden"
+      onChange={onChange}
+      accept={CHAT_INPUT_ATTACHMENT_ACCEPT}
+    />
+  );
+});

--- a/desktop/src/components/workspace/chat/input/McpElicitationCard.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationCard.tsx
@@ -3,19 +3,16 @@ import type {
   McpElicitationInteractionPayload,
   McpElicitationSubmittedField,
 } from "@anyharness/sdk";
-import { type ReactNode, useState } from "react";
-import { Button } from "@/components/ui/Button";
-import { Checkbox } from "@/components/ui/Checkbox";
-import { Input } from "@/components/ui/Input";
-import { Label } from "@/components/ui/Label";
-import { Select } from "@/components/ui/Select";
+import { useState } from "react";
 import { useActivePendingInteractionState } from "@/hooks/chat/derived/use-active-chat-session-selectors";
 import { useChatMcpElicitationActions } from "@/hooks/chat/use-chat-mcp-elicitation-actions";
 import { ComposerAttachedPanel } from "./ComposerAttachedPanel";
+import { McpElicitationFormPanel } from "./McpElicitationFormPanel";
+import {
+  type McpDraftValue,
+} from "./McpElicitationFieldControl";
+import { McpElicitationUrlPanel } from "./McpElicitationUrlPanel";
 
-const BUTTON_CLASSNAME = "rounded-xl px-2.5 text-sm";
-
-type McpDraftValue = string | boolean | string[];
 type McpDrafts = Partial<Record<string, McpDraftValue>>;
 
 export interface McpElicitationCardProps {
@@ -72,66 +69,16 @@ export function McpElicitationCard({
 
     return (
       <ComposerAttachedPanel header={header}>
-        <div className="flex max-h-[min(40vh,360px)] flex-col">
-          <div className="min-h-0 overflow-y-auto p-3 pb-2">
-            <div className="flex flex-col gap-3">
-              <div className="space-y-1 text-sm">
-                <div className="text-muted-foreground">{payload.mode.message}</div>
-                <div className="text-xs text-muted-foreground">
-                  Destination: {payload.mode.urlDisplay}
-                </div>
-              </div>
-              {revealedUrl && (
-                <Input
-                  value={revealedUrl}
-                  readOnly
-                  data-telemetry-mask="true"
-                  className="font-mono text-xs"
-                />
-              )}
-              {error && <InlineError message={error} />}
-            </div>
-          </div>
-
-          <div className="flex shrink-0 flex-wrap items-center gap-2 px-3 pb-3 pt-2">
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              className={BUTTON_CLASSNAME}
-              onClick={() => { void reveal(); }}
-            >
-              Reveal URL
-            </Button>
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              className={BUTTON_CLASSNAME}
-              onClick={() => { void runAction(() => onAccept([])); }}
-            >
-              Accept
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              className={BUTTON_CLASSNAME}
-              onClick={() => { void runAction(onDecline); }}
-            >
-              Decline
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              className={BUTTON_CLASSNAME}
-              onClick={() => { void runAction(onCancel); }}
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
+        <McpElicitationUrlPanel
+          message={payload.mode.message}
+          urlDisplay={payload.mode.urlDisplay}
+          revealedUrl={revealedUrl}
+          error={error}
+          onReveal={() => { void reveal(); }}
+          onAccept={() => { void runAction(() => onAccept([])); }}
+          onDecline={() => { void runAction(onDecline); }}
+          onCancel={() => { void runAction(onCancel); }}
+        />
       </ComposerAttachedPanel>
     );
   }
@@ -158,170 +105,17 @@ export function McpElicitationCard({
 
   return (
     <ComposerAttachedPanel header={header}>
-      <div className="flex max-h-[min(40vh,360px)] flex-col">
-        <div className="min-h-0 overflow-y-auto p-3 pb-2">
-          <div className="flex flex-col gap-3">
-            <div className="text-sm text-muted-foreground">
-              {formMode.message}
-            </div>
-            <div className="flex flex-col gap-3">
-              {formFields.map((field) => (
-                <McpFieldControl
-                  key={field.fieldId}
-                  field={field}
-                  value={drafts[field.fieldId]}
-                  onChange={(value) => updateDraft(field.fieldId, value)}
-                />
-              ))}
-            </div>
-            {error && <InlineError message={error} />}
-          </div>
-        </div>
-
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 px-3 pb-3 pt-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className={BUTTON_CLASSNAME}
-            onClick={() => { void runAction(onCancel); }}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className={BUTTON_CLASSNAME}
-            onClick={() => { void runAction(onDecline); }}
-          >
-            Decline
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            className={BUTTON_CLASSNAME}
-            onClick={() => { void acceptForm(); }}
-          >
-            Submit
-          </Button>
-        </div>
-      </div>
-    </ComposerAttachedPanel>
-  );
-}
-
-function McpFieldControl({
-  field,
-  value,
-  onChange,
-}: {
-  field: McpElicitationField;
-  value: McpDraftValue | undefined;
-  onChange: (value: McpDraftValue) => void;
-}) {
-  const description = field.description ? (
-    <div className="mt-1 text-xs text-muted-foreground">{field.description}</div>
-  ) : null;
-  const label = `${field.label}${field.required ? " *" : ""}`;
-
-  if (field.fieldType === "boolean") {
-    return (
-      <div>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            checked={Boolean(value)}
-            onChange={(event) => onChange(event.currentTarget.checked)}
-          />
-          <Label className="mb-0 text-sm text-foreground">{label}</Label>
-        </div>
-        {description}
-      </div>
-    );
-  }
-
-  if (field.fieldType === "single_select") {
-    return (
-      <FieldFrame label={label} description={description}>
-        <Select
-          value={typeof value === "string" ? value : ""}
-          onChange={(event) => onChange(event.currentTarget.value)}
-        >
-          <option value="">Choose an option</option>
-          {(field.options ?? []).map((option) => (
-            <option key={option.optionId} value={option.optionId}>
-              {option.label}
-            </option>
-          ))}
-        </Select>
-      </FieldFrame>
-    );
-  }
-
-  if (field.fieldType === "multi_select") {
-    const selected = Array.isArray(value) ? value : [];
-    return (
-      <FieldFrame label={label} description={description}>
-        <div className="flex flex-col gap-2">
-          {(field.options ?? []).map((option) => (
-            <Button
-              key={option.optionId}
-              type="button"
-              variant={selected.includes(option.optionId) ? "primary" : "secondary"}
-              size="sm"
-              className="h-auto justify-start rounded-xl px-3 py-2 text-left"
-              onClick={() => {
-                onChange(selected.includes(option.optionId)
-                  ? selected.filter((entry) => entry !== option.optionId)
-                  : [...selected, option.optionId]);
-              }}
-            >
-              {option.label}
-            </Button>
-          ))}
-        </div>
-      </FieldFrame>
-    );
-  }
-
-  return (
-    <FieldFrame label={label} description={description}>
-      <Input
-        type={field.fieldType === "number" ? "number" : "text"}
-        value={typeof value === "string" ? value : ""}
-        min={field.fieldType === "number" ? field.minimum ?? undefined : undefined}
-        max={field.fieldType === "number" ? field.maximum ?? undefined : undefined}
-        onChange={(event) => onChange(event.currentTarget.value)}
-        data-telemetry-mask="true"
+      <McpElicitationFormPanel
+        message={formMode.message}
+        fields={formFields}
+        drafts={drafts}
+        error={error}
+        onFieldChange={updateDraft}
+        onCancel={() => { void runAction(onCancel); }}
+        onDecline={() => { void runAction(onDecline); }}
+        onSubmit={() => { void acceptForm(); }}
       />
-    </FieldFrame>
-  );
-}
-
-function FieldFrame({
-  label,
-  description,
-  children,
-}: {
-  label: string;
-  description: ReactNode;
-  children: ReactNode;
-}) {
-  return (
-    <div>
-      <Label>{label}</Label>
-      {children}
-      {description}
-    </div>
-  );
-}
-
-function InlineError({ message }: { message: string }) {
-  return (
-    <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-      {message}
-    </div>
+    </ComposerAttachedPanel>
   );
 }
 

--- a/desktop/src/components/workspace/chat/input/McpElicitationFieldControl.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationFieldControl.tsx
@@ -1,0 +1,116 @@
+import type { McpElicitationField } from "@anyharness/sdk";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { Select } from "@/components/ui/Select";
+
+export type McpDraftValue = string | boolean | string[];
+
+interface McpElicitationFieldControlProps {
+  field: McpElicitationField;
+  value: McpDraftValue | undefined;
+  onChange: (value: McpDraftValue) => void;
+}
+
+export function McpElicitationFieldControl({
+  field,
+  value,
+  onChange,
+}: McpElicitationFieldControlProps) {
+  const description = field.description ? (
+    <div className="mt-1 text-xs text-muted-foreground">{field.description}</div>
+  ) : null;
+  const label = `${field.label}${field.required ? " *" : ""}`;
+
+  if (field.fieldType === "boolean") {
+    return (
+      <div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={Boolean(value)}
+            onChange={(event) => onChange(event.currentTarget.checked)}
+          />
+          <Label className="mb-0 text-sm text-foreground">{label}</Label>
+        </div>
+        {description}
+      </div>
+    );
+  }
+
+  if (field.fieldType === "single_select") {
+    return (
+      <FieldFrame label={label} description={description}>
+        <Select
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        >
+          <option value="">Choose an option</option>
+          {(field.options ?? []).map((option) => (
+            <option key={option.optionId} value={option.optionId}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </FieldFrame>
+    );
+  }
+
+  if (field.fieldType === "multi_select") {
+    const selected = Array.isArray(value) ? value : [];
+    return (
+      <FieldFrame label={label} description={description}>
+        <div className="flex flex-col gap-2">
+          {(field.options ?? []).map((option) => (
+            <Button
+              key={option.optionId}
+              type="button"
+              variant={selected.includes(option.optionId) ? "primary" : "secondary"}
+              size="sm"
+              className="h-auto justify-start rounded-xl px-3 py-2 text-left"
+              onClick={() => {
+                onChange(selected.includes(option.optionId)
+                  ? selected.filter((entry) => entry !== option.optionId)
+                  : [...selected, option.optionId]);
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </FieldFrame>
+    );
+  }
+
+  return (
+    <FieldFrame label={label} description={description}>
+      <Input
+        type={field.fieldType === "number" ? "number" : "text"}
+        value={typeof value === "string" ? value : ""}
+        min={field.fieldType === "number" ? field.minimum ?? undefined : undefined}
+        max={field.fieldType === "number" ? field.maximum ?? undefined : undefined}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        data-telemetry-mask="true"
+      />
+    </FieldFrame>
+  );
+}
+
+function FieldFrame({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <Label>{label}</Label>
+      {children}
+      {description}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/McpElicitationFormPanel.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationFormPanel.tsx
@@ -1,0 +1,84 @@
+import type { McpElicitationField } from "@anyharness/sdk";
+import { Button } from "@/components/ui/Button";
+import {
+  McpElicitationFieldControl,
+  type McpDraftValue,
+} from "./McpElicitationFieldControl";
+import { McpElicitationInlineError } from "./McpElicitationInlineError";
+
+const BUTTON_CLASSNAME = "rounded-xl px-2.5 text-sm";
+
+interface McpElicitationFormPanelProps {
+  message: string;
+  fields: McpElicitationField[];
+  drafts: Partial<Record<string, McpDraftValue>>;
+  error: string | null;
+  onFieldChange: (fieldId: string, value: McpDraftValue) => void;
+  onCancel: () => void;
+  onDecline: () => void;
+  onSubmit: () => void;
+}
+
+export function McpElicitationFormPanel({
+  message,
+  fields,
+  drafts,
+  error,
+  onFieldChange,
+  onCancel,
+  onDecline,
+  onSubmit,
+}: McpElicitationFormPanelProps) {
+  return (
+    <div className="flex max-h-[min(40vh,360px)] flex-col">
+      <div className="min-h-0 overflow-y-auto p-3 pb-2">
+        <div className="flex flex-col gap-3">
+          <div className="text-sm text-muted-foreground">
+            {message}
+          </div>
+          <div className="flex flex-col gap-3">
+            {fields.map((field) => (
+              <McpElicitationFieldControl
+                key={field.fieldId}
+                field={field}
+                value={drafts[field.fieldId]}
+                onChange={(value) => onFieldChange(field.fieldId, value)}
+              />
+            ))}
+          </div>
+          {error && <McpElicitationInlineError message={error} />}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 px-3 pb-3 pt-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onDecline}
+        >
+          Decline
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onSubmit}
+        >
+          Submit
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/McpElicitationInlineError.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationInlineError.tsx
@@ -1,0 +1,7 @@
+export function McpElicitationInlineError({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      {message}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/McpElicitationUrlPanel.tsx
+++ b/desktop/src/components/workspace/chat/input/McpElicitationUrlPanel.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { McpElicitationInlineError } from "./McpElicitationInlineError";
+
+const BUTTON_CLASSNAME = "rounded-xl px-2.5 text-sm";
+
+interface McpElicitationUrlPanelProps {
+  message: string;
+  urlDisplay: string;
+  revealedUrl: string | null;
+  error: string | null;
+  onReveal: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
+  onCancel: () => void;
+}
+
+export function McpElicitationUrlPanel({
+  message,
+  urlDisplay,
+  revealedUrl,
+  error,
+  onReveal,
+  onAccept,
+  onDecline,
+  onCancel,
+}: McpElicitationUrlPanelProps) {
+  return (
+    <div className="flex max-h-[min(40vh,360px)] flex-col">
+      <div className="min-h-0 overflow-y-auto p-3 pb-2">
+        <div className="flex flex-col gap-3">
+          <div className="space-y-1 text-sm">
+            <div className="text-muted-foreground">{message}</div>
+            <div className="text-xs text-muted-foreground">
+              Destination: {urlDisplay}
+            </div>
+          </div>
+          {revealedUrl && (
+            <Input
+              value={revealedUrl}
+              readOnly
+              data-telemetry-mask="true"
+              className="font-mono text-xs"
+            />
+          )}
+          {error && <McpElicitationInlineError message={error} />}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2 px-3 pb-3 pt-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onReveal}
+        >
+          Reveal URL
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onAccept}
+        >
+          Accept
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onDecline}
+        >
+          Decline
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className={BUTTON_CLASSNAME}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/input/QueuedPromptEditBanner.tsx
+++ b/desktop/src/components/workspace/chat/input/QueuedPromptEditBanner.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@/components/ui/Button";
+
+interface QueuedPromptEditBannerProps {
+  onCancel: () => void;
+}
+
+export function QueuedPromptEditBanner({ onCancel }: QueuedPromptEditBannerProps) {
+  return (
+    <div className="mx-5 mt-3 flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+      <span>Editing queued message</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        className="h-6 px-2 text-xs"
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Split chat input rendering into focused UI components for the draft/editor area, control row, hidden file input, and queued-edit banner.
- Split MCP elicitation rendering into focused URL, form, field-control, and inline-error components while keeping validation and connected behavior in place.
- Preserved composer submit, cancel, paste, focus, keyboard, and dock behavior.

## Validation
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
- `pnpm --filter proliferate exec tsc --noEmit`
- `pnpm --filter proliferate test`
- Playwright smoke of all 83 configured `/playground` scenarios on `http://127.0.0.1:15320/playground`