### PR TITLE
refactor(desktop): split workspace domain helpers

### DIFF
--- a/desktop/src/components/workspace/browser/BrowserFrame.tsx
+++ b/desktop/src/components/workspace/browser/BrowserFrame.tsx
@@ -4,7 +4,7 @@ import {
   useMemo,
   useRef,
 } from "react";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
 import { browserIframeSandbox } from "@/lib/domain/workspaces/shell/browser-url";
 import { BrowserUnavailableOverlay } from "./BrowserFallbackStates";
 import type { FrameStatus } from "./BrowserPanelTypes";

--- a/desktop/src/components/workspace/browser/BrowserNativeSurface.tsx
+++ b/desktop/src/components/workspace/browser/BrowserNativeSurface.tsx
@@ -5,7 +5,7 @@ import {
   type RefObject,
 } from "react";
 import { useTauriBrowserWebviewActions } from "@/hooks/access/tauri/use-browser-webview-actions";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
 import { BrowserUnavailableOverlay } from "./BrowserFallbackStates";
 import type { FrameStatus } from "./BrowserPanelTypes";
 

--- a/desktop/src/components/workspace/browser/BrowserSurfaces.tsx
+++ b/desktop/src/components/workspace/browser/BrowserSurfaces.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from "react";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
 import { BrowserFrame } from "./BrowserFrame";
 import { BrowserNativeSurface } from "./BrowserNativeSurface";
 import type { FrameStatus } from "./BrowserPanelTypes";

--- a/desktop/src/components/workspace/browser/BrowserToolbar.tsx
+++ b/desktop/src/components/workspace/browser/BrowserToolbar.tsx
@@ -9,7 +9,7 @@ import {
   RefreshCw,
 } from "@/components/ui/icons";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
 import type { FrameStatus } from "./BrowserPanelTypes";
 
 export function BrowserToolbar({

--- a/desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
+++ b/desktop/src/components/workspace/browser/WorkspaceBrowserPanel.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
 import { normalizeBrowserUrl } from "@/lib/domain/workspaces/shell/browser-url";
 import { useTauriBrowserWebviewActions } from "@/hooks/access/tauri/use-browser-webview-actions";
 import { BrowserEmptyState } from "./BrowserFallbackStates";

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
@@ -6,7 +6,7 @@ import {
 import { SidebarStatusIndicatorView } from "@/components/workspace/shell/sidebar/SidebarIndicators";
 import { SidebarRowSurface } from "@/components/workspace/shell/sidebar/SidebarRowSurface";
 import type { SidebarSessionActivityState } from "@/lib/domain/sessions/activity";
-import { sidebarStatusIndicatorFromActivity } from "@/lib/domain/workspaces/sidebar/sidebar";
+import { sidebarStatusIndicatorFromActivity } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { formatSidebarRelativeTime } from "@/lib/domain/workspaces/display/workspace-display";
 import { coworkThreadTitle } from "@/lib/domain/cowork/threads";
 

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -9,7 +9,7 @@ import {
   DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
   rightPanelBrowserHeaderKey,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 import { isApplePlatform } from "@/lib/domain/shortcuts/matching";
 import { RightPanel } from "@/components/workspace/shell/right-panel/RightPanel";
 import { requestRightPanelNewTabMenu } from "@/lib/infra/right-panel-new-tab-menu";

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -16,21 +16,23 @@ import { useRightPanelRootFocus } from "@/hooks/workspaces/ui/use-right-panel-ro
 import { useRightPanelStateUpdater } from "@/hooks/workspaces/ui/use-right-panel-state-updater";
 import {
   RIGHT_PANEL_BROWSER_TAB_LIMIT,
-  createBrowserTabInRightPanelState,
-  createRightPanelBrowserTabId,
-  reconcileRightPanelWorkspaceState,
-  removeBrowserTabFromRightPanelState,
-  removeTerminalFromRightPanelState,
-  reorderHeaderEntryInRightPanelState,
   rightPanelBrowserHeaderKey,
   rightPanelTerminalHeaderKey,
   rightPanelToolHeaderKey,
   terminalIdsFromHeaderOrder,
-  updateBrowserTabUrlInRightPanelState,
   type RightPanelHeaderEntryKey,
   type RightPanelTool,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { createRightPanelBrowserTabId } from "@/lib/domain/workspaces/shell/right-panel-browser-tabs";
+import {
+  createBrowserTabInRightPanelState,
+  reconcileRightPanelWorkspaceState,
+  removeBrowserTabFromRightPanelState,
+  removeTerminalFromRightPanelState,
+  reorderHeaderEntryInRightPanelState,
+  updateBrowserTabUrlInRightPanelState,
+} from "@/lib/domain/workspaces/shell/right-panel-state";
 import {
   rightPanelStateEqual,
 } from "@/lib/domain/workspaces/shell/right-panel-view";

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
@@ -5,8 +5,11 @@ import { GitPanel } from "@/components/workspace/git/GitPanel";
 import { RightPanelPlaceholder } from "@/components/workspace/shell/right-panel/RightPanelPlaceholder";
 import { TerminalPanel } from "@/components/workspace/terminals/TerminalPanel";
 import type { TerminalRecord } from "@anyharness/sdk";
-import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel";
-import type { RightPanelActiveEntryKey, RightPanelTool } from "@/lib/domain/workspaces/shell/right-panel";
+import type {
+  RightPanelActiveEntryKey,
+  RightPanelBrowserTab,
+  RightPanelTool,
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 
 interface RightPanelContentProps {
   workspaceId: string | null;

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -10,7 +10,7 @@ import type {
   RightPanelBrowserTab,
   RightPanelHeaderEntryKey,
   RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
 import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
 

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
@@ -1,5 +1,5 @@
 import { useCallback, type PointerEvent, type ReactNode } from "react";
-import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel-model";
 
 interface RightPanelHeaderEntryDropZoneProps {
   entryKey: RightPanelHeaderEntryKey;

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
@@ -11,7 +11,7 @@ import {
 import type {
   RightPanelHeaderEntryKey,
   RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 
 interface RightPanelHeaderEntryListProps {
   entries: readonly RightPanelHeaderEntry[];

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -8,7 +8,7 @@ import { useRightPanelHeaderDrag } from "@/hooks/workspaces/ui/use-right-panel-h
 import {
   type RightPanelHeaderEntryKey,
   type RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
 import type { RightPanelNewTabMenuDefault } from "@/lib/infra/right-panel-new-tab-menu";
 

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx
@@ -1,7 +1,7 @@
 import {
   parseRightPanelHeaderEntryKey,
   type RightPanelActiveEntryKey,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 
 export function RightPanelPlaceholder({ activeEntryKey }: { activeEntryKey: RightPanelActiveEntryKey }) {
   const entry = parseRightPanelHeaderEntryKey(activeEntryKey);

--- a/desktop/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx
@@ -7,7 +7,7 @@ import {
   GitBranchIcon,
   type IconProps,
 } from "@/components/ui/icons";
-import type { RightPanelTool } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelTool } from "@/lib/domain/workspaces/shell/right-panel-model";
 
 const HEADER_STABLE_TAB_CLASS = "ui-tab-system-tab";
 

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -10,7 +10,9 @@ import { SidebarWorkspaceContent } from "./SidebarWorkspaceContent";
 import { WorkspaceCleanupAttentionSection } from "./WorkspaceCleanupAttentionSection";
 import { CoworkThreadsSection } from "@/components/workspace/cowork/sidebar/CoworkThreadsSection";
 import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
-import { isDefaultSidebarWorkspaceTypes } from "@/lib/domain/workspaces/sidebar/sidebar";
+import {
+  isDefaultSidebarWorkspaceTypes,
+} from "@/lib/domain/workspaces/sidebar/sidebar-workspace-types";
 import { buildConfiguredCloudRepoKeys } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import {
   titleForStartBlockReason,

--- a/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -12,7 +12,7 @@ import type {
   SidebarDetailIndicator,
   SidebarIndicatorAction,
   SidebarStatusIndicator,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import {
   SidebarDetailIndicatorsView,
   SidebarStatusGlyph,

--- a/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -18,7 +18,7 @@ import type {
   SidebarDetailIndicator,
   SidebarIndicatorAction,
   SidebarStatusIndicator,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { SidebarWorkspaceVariantIcon } from "./SidebarWorkspaceVariantIcon";
 
 interface SidebarStatusIndicatorViewProps {

--- a/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
@@ -10,7 +10,7 @@ import { PopoverButton } from "@/components/ui/PopoverButton";
 import { PopoverMenuItem } from "@/components/ui/PopoverMenuItem";
 import { SidebarActionButton } from "@/components/workspace/shell/sidebar/SidebarActionButton";
 import { SidebarWorkspaceVariantIcon } from "@/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon";
-import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 
 const SIDEBAR_WORKSPACE_TYPE_OPTIONS: Array<{
   label: string;

--- a/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -6,8 +6,8 @@ import {
   SIDEBAR_REPO_GROUP_ITEM_LIMIT,
   type SidebarEmptyState,
   type SidebarGroupState,
-  type SidebarIndicatorAction,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { BrailleSweepBadge } from "@/components/ui/icons";
 import { RepoGroup } from "./RepoGroup";
 import { SidebarShowToggleRow } from "./SidebarShowToggleRow";

--- a/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx
@@ -1,6 +1,6 @@
 import { CloudIcon, Monitor, Tree } from "@/components/ui/icons";
 import { Tooltip } from "@/components/ui/Tooltip";
-import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 
 const VARIANT_ICONS: Record<SidebarWorkspaceVariant, typeof Monitor> = {
   local: Monitor,

--- a/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -16,7 +16,7 @@ import type {
   SidebarIndicatorAction,
   SidebarStatusIndicator,
   SidebarWorkspaceVariant,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { formatSidebarRelativeTime } from "@/lib/domain/workspaces/display/workspace-display";
 import {
   SidebarDetailIndicatorsView,

--- a/desktop/src/hooks/main/facade/use-main-screen-state.ts
+++ b/desktop/src/hooks/main/facade/use-main-screen-state.ts
@@ -36,10 +36,10 @@ import {
   RIGHT_PANEL_MIN_WIDTH,
   clampRightPanelWidth,
   normalizeRightPanelDurableState,
-  reconcileRightPanelWorkspaceState,
   type RightPanelDurableState,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { reconcileRightPanelWorkspaceState } from "@/lib/domain/workspaces/shell/right-panel-state";
 import { resolveSelectedWorkspaceIdentity } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 import { resolveWithWorkspaceFallback } from "@/lib/domain/workspaces/selection/workspace-keyed-preferences";
 import { useChatLaunchIntentStore } from "@/stores/chat/chat-launch-intent-store";

--- a/desktop/src/hooks/main/workflows/use-main-screen-actions.test.tsx
+++ b/desktop/src/hooks/main/workflows/use-main-screen-actions.test.tsx
@@ -8,7 +8,7 @@ import type { CurrentPullRequestResponse } from "@anyharness/sdk";
 import {
   DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 import { useMainScreenActions } from "./use-main-screen-actions";
 import type { MainScreenLayoutState } from "@/hooks/main/facade/use-main-screen-state";
 

--- a/desktop/src/hooks/main/workflows/use-main-screen-actions.ts
+++ b/desktop/src/hooks/main/workflows/use-main-screen-actions.ts
@@ -13,7 +13,7 @@ import {
   rightPanelTerminalHeaderKey,
   rightPanelToolHeaderKey,
   type RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 import type {
   MainScreenDataState,
   MainScreenLayoutState,
@@ -22,7 +22,7 @@ import {
   CLOSED_PUBLISH_DIALOG_STATE,
   openPublishDialogState,
 } from "@/lib/domain/workspaces/creation/publish-dialog-state";
-import type { PublishIntent } from "@/lib/domain/workspaces/creation/publish-workflow";
+import type { PublishIntent } from "@/lib/domain/workspaces/creation/publish-workflow-model";
 
 interface UseMainScreenActionsArgs {
   layout: MainScreenLayoutState;

--- a/desktop/src/hooks/workspaces/derived/use-right-panel-header-entries.ts
+++ b/desktop/src/hooks/workspaces/derived/use-right-panel-header-entries.ts
@@ -2,12 +2,12 @@ import { useMemo } from "react";
 import type { TerminalRecord } from "@anyharness/sdk";
 import {
   availableRightPanelTools,
-  canCreateRightPanelBrowserTab,
   parseRightPanelHeaderEntryKey,
   terminalIdsFromHeaderOrder,
   type RightPanelHeaderEntryKey,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { canCreateRightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-state";
 import {
   orderBrowserTabs,
   orderTerminals,

--- a/desktop/src/hooks/workspaces/derived/use-sidebar-shortcut-targets.ts
+++ b/desktop/src/hooks/workspaces/derived/use-sidebar-shortcut-targets.ts
@@ -4,8 +4,10 @@ import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces"
 import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-projection";
 import {
   buildSidebarGroupStates,
+} from "@/lib/domain/workspaces/sidebar/sidebar-groups";
+import {
   SIDEBAR_REPO_GROUP_ITEM_LIMIT,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { visibleSidebarShortcutTargetIds } from "@/lib/domain/workspaces/sidebar/sidebar-shortcut-targets";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";

--- a/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
+++ b/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
@@ -8,9 +8,11 @@ import {
 import {
   buildSidebarGroupStates,
   resolveSidebarEmptyState,
-  type SidebarEmptyState,
-  type SidebarGroupState,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-groups";
+import type {
+  SidebarEmptyState,
+  SidebarGroupState,
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces";
 import { useStandardRepoProjection } from "@/hooks/workspaces/use-standard-repo-projection";
 import { useWorkspaceMetadataSync } from "@/hooks/workspaces/lifecycle/use-workspace-metadata-sync";

--- a/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.test.tsx
+++ b/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   buildGroups,
   makeLocalLogicalWorkspace,

--- a/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.ts
+++ b/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.ts
@@ -3,12 +3,14 @@ import { useShallow } from "zustand/react/shallow";
 import {
   findLogicalWorkspace,
   logicalWorkspaceRelatedIds,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
   resolveAutoShowMoreRepoKey,
+} from "@/lib/domain/workspaces/sidebar/sidebar-groups";
+import {
   SIDEBAR_REPO_GROUP_ITEM_LIMIT,
   type SidebarGroupState,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { useLogicalWorkspaces } from "@/hooks/workspaces/use-logical-workspaces";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";

--- a/desktop/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
+++ b/desktop/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
@@ -12,7 +12,7 @@ import type {
 } from "@/lib/access/cloud/client";
 import {
   buildRemoteLogicalWorkspaceId,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-id";
 import {
   CLOUD_DISPLAY_NAME_SYNC_RETRY_INTERVAL_MS,
   markCloudDisplayNameSyncCompleted,

--- a/desktop/src/hooks/workspaces/mobility/use-cloud-to-local-handoff.ts
+++ b/desktop/src/hooks/workspaces/mobility/use-cloud-to-local-handoff.ts
@@ -20,7 +20,7 @@ import { useWorkspaceMobilityCache } from "@/hooks/workspaces/cache/use-workspac
 import { useWorkspaceMobilityUiStore } from "@/stores/workspaces/workspace-mobility-ui-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { describeMobilityPreflightLoadFailure } from "@/lib/domain/workspaces/mobility/mobility-preflight-error";
 import { elapsedMs, logLatency, startLatencyTimer } from "@/lib/infra/measurement/debug-latency";
 import { deriveHandoffFailureRecovery } from "./handoff-failure-recovery";

--- a/desktop/src/hooks/workspaces/mobility/use-local-to-cloud-handoff.ts
+++ b/desktop/src/hooks/workspaces/mobility/use-local-to-cloud-handoff.ts
@@ -22,7 +22,7 @@ import { useCloudWorkspaceReadinessWaiter } from "@/hooks/workspaces/mobility/us
 import { useWorkspaceMobilityUiStore } from "@/stores/workspaces/workspace-mobility-ui-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { describeMobilityPreflightLoadFailure } from "@/lib/domain/workspaces/mobility/mobility-preflight-error";
 import { elapsedMs, logLatency, startLatencyTimer } from "@/lib/infra/measurement/debug-latency";
 import { deriveHandoffFailureRecovery } from "./handoff-failure-recovery";

--- a/desktop/src/hooks/workspaces/mobility/use-workspace-mobility-state.ts
+++ b/desktop/src/hooks/workspaces/mobility/use-workspace-mobility-state.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSelectedLogicalWorkspace } from "@/hooks/workspaces/use-selected-logical-workspace";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
-import { resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
   isWorkspaceMobilityTransitionPhase,
   resolveWorkspaceMobilityStatusModel,

--- a/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
+++ b/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
@@ -1,4 +1,5 @@
-import { findLogicalWorkspace, resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import { resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
   resolveHotReopenCandidate,
 } from "@/lib/domain/workspaces/selection/hot-reopen";

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/infra/measurement/latency-flow";
 import { ProliferateClientError } from "@/lib/access/cloud/client";
 import { startCloudWorkspace } from "@/lib/access/cloud/workspaces";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { runWorkspaceSelection } from "./run-workspace-selection";
 import { resolveCloudWorkspaceReadiness } from "./cloud-readiness";
 import { resolveSelectionConnection } from "./connection";

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
@@ -1,7 +1,8 @@
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import { findLogicalWorkspace, resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import { resolveLogicalWorkspaceMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
   markWorkspaceViewed,
   markWorkspaceViewedAt,

--- a/desktop/src/hooks/workspaces/selection/types.ts
+++ b/desktop/src/hooks/workspaces/selection/types.ts
@@ -1,7 +1,7 @@
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import type { Workspace } from "@anyharness/sdk";
 import type { WorkspaceSession } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 
 export interface WorkspaceSelectionOptions {
   force?: boolean;

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-header-drag.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-header-drag.ts
@@ -4,7 +4,7 @@ import {
   useState,
   type PointerEvent,
 } from "react";
-import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel-model";
 
 const HEADER_DRAG_THRESHOLD_PX = 4;
 

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-state-updater.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-state-updater.ts
@@ -5,8 +5,8 @@ import {
 } from "react";
 import {
   reconcileRightPanelWorkspaceState,
-  type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-state";
+import type { RightPanelWorkspaceState } from "@/lib/domain/workspaces/shell/right-panel-model";
 import { rightPanelStateEqual } from "@/lib/domain/workspaces/shell/right-panel-view";
 
 export function useRightPanelStateUpdater({

--- a/desktop/src/hooks/workspaces/use-logical-workspaces.ts
+++ b/desktop/src/hooks/workspaces/use-logical-workspaces.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { useCloudMobilityWorkspaces } from "@/hooks/access/cloud/use-cloud-mobility-workspaces";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { buildLogicalWorkspaces } from "@/lib/domain/workspaces/cloud/logical-workspaces";

--- a/desktop/src/hooks/workspaces/use-selected-logical-workspace.ts
+++ b/desktop/src/hooks/workspaces/use-selected-logical-workspace.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import { useLogicalWorkspaces } from "./use-logical-workspaces";
 
 export function useSelectedLogicalWorkspace() {

--- a/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.test.tsx
+++ b/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { makeLocalLogicalWorkspace } from "@/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
 import {
   WORKSPACE_UI_DEFAULTS,

--- a/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-activity-acknowledgement.ts
@@ -3,7 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import {
   findLogicalWorkspace,
   latestLogicalWorkspaceTimestamp,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
   isDocumentVisibleAndFocused,
   useDocumentFocusVisibilityNonce,

--- a/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-display-name-actions.ts
@@ -4,7 +4,7 @@ import {
 } from "@/lib/access/anyharness/workspaces";
 import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
-import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
   getCloudWorkspaceConnection,
   updateCloudWorkspaceDisplayName,

--- a/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts
@@ -9,11 +9,13 @@ import {
 } from "@anyharness/sdk-react";
 import {
   buildPublishViewState,
-  defaultPublishPullRequestDraft,
-  type PublishCommitDraft,
-  type PublishIntent,
-  type PublishPullRequestDraft,
 } from "@/lib/domain/workspaces/creation/publish-workflow";
+import { defaultPublishPullRequestDraft } from "@/lib/domain/workspaces/creation/publish-draft";
+import type {
+  PublishCommitDraft,
+  PublishIntent,
+  PublishPullRequestDraft,
+} from "@/lib/domain/workspaces/creation/publish-workflow-model";
 import { runWorkspacePublishWorkflow } from "@/lib/workflows/workspaces/run-workspace-publish-workflow";
 
 export interface UseWorkspacePublishWorkflowOptions {

--- a/desktop/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
@@ -5,7 +5,7 @@ import { APP_ROUTES } from "@/config/app-routes";
 import { useWorkspaceMobilityState } from "@/hooks/workspaces/mobility/use-workspace-mobility-state";
 import { useCreateCloudWorkspace } from "@/hooks/cloud/workflows/use-create-cloud-workspace";
 import type { CloudWorkspaceRepoTarget } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
-import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar/sidebar";
+import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { useAddRepo } from "@/hooks/workspaces/use-add-repo";
 import { useWorkspaceActivationWorkflow } from "@/hooks/workspaces/use-workspace-activation-workflow";
 import { useWorkspaceEntryActions } from "@/hooks/workspaces/use-workspace-entry-actions";

--- a/desktop/src/lib/domain/preferences/workspace-ui/migration.ts
+++ b/desktop/src/lib/domain/preferences/workspace-ui/migration.ts
@@ -1,4 +1,4 @@
-import { resolveSidebarWorkspaceTypes } from "@/lib/domain/workspaces/sidebar/sidebar";
+import { resolveSidebarWorkspaceTypes } from "@/lib/domain/workspaces/sidebar/sidebar-workspace-types";
 import {
   isStringArrayRecord,
   isStringRecord,

--- a/desktop/src/lib/domain/preferences/workspace-ui/model.ts
+++ b/desktop/src/lib/domain/preferences/workspace-ui/model.ts
@@ -1,8 +1,8 @@
-import type { RightPanelDurableState, RightPanelMaterializedState } from "@/lib/domain/workspaces/shell/right-panel";
+import type { RightPanelDurableState, RightPanelMaterializedState } from "@/lib/domain/workspaces/shell/right-panel-model";
 import {
   DEFAULT_SIDEBAR_WORKSPACE_TYPES,
-  type SidebarWorkspaceVariant,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import type { ManualChatGroup } from "@/lib/domain/workspaces/tabs/manual-groups";
 import type { WorkspaceShellIntentKey, WorkspaceShellTabKey } from "@/lib/domain/workspaces/tabs/shell-tabs";
 import { WORKSPACE_SIDEBAR_DEFAULT_WIDTH } from "@/lib/domain/preferences/workspace-ui/sidebar";

--- a/desktop/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts
+++ b/desktop/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts
@@ -1,10 +1,10 @@
 import {
   clampRightPanelWidth,
   normalizeRightPanelDurableState,
-  normalizeRightPanelMaterializedState,
   type RightPanelDurableState,
   type RightPanelMaterializedState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { normalizeRightPanelMaterializedState } from "@/lib/domain/workspaces/shell/right-panel-state";
 import { migrateLegacyRightPanelWorkspaceState } from "@/lib/domain/workspaces/shell/right-panel-migration";
 
 export function migrateLegacyRightPanelPreferences(args: {

--- a/desktop/src/lib/domain/workspaces/changes/git-panel-workspace-context.ts
+++ b/desktop/src/lib/domain/workspaces/changes/git-panel-workspace-context.ts
@@ -2,8 +2,8 @@ import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import type { WorkspaceCollections } from "@/lib/domain/workspaces/cloud/collections";
 import {
   buildLogicalWorkspaces,
-  findLogicalWorkspace,
 } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { findLogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import { sourceRootForGitPanel } from "@/lib/domain/workspaces/changes/git-panel-diff";
 
 export interface GitPanelWorkspaceContext {

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
@@ -1,0 +1,102 @@
+function encodeLogicalSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function decodeLogicalSegment(value: string): string {
+  return decodeURIComponent(value);
+}
+
+export function normalizeLogicalWorkspaceBranchKey(
+  value: string | null | undefined,
+): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : "HEAD";
+}
+
+export type LogicalWorkspaceIdKind = "remote" | "repo-root" | "path";
+
+export interface ParsedLogicalWorkspaceId {
+  kind: LogicalWorkspaceIdKind;
+  segments: string[];
+}
+
+export function buildRemoteLogicalWorkspaceId(
+  provider: string,
+  owner: string,
+  repo: string,
+  branchKey: string,
+): string {
+  return [
+    "remote",
+    encodeLogicalSegment(provider),
+    encodeLogicalSegment(owner),
+    encodeLogicalSegment(repo),
+    encodeLogicalSegment(branchKey),
+  ].join(":");
+}
+
+export function buildRepoRootLogicalWorkspaceId(
+  repoRootId: string,
+  branchKey: string,
+): string {
+  return [
+    "repo-root",
+    encodeLogicalSegment(repoRootId),
+    encodeLogicalSegment(branchKey),
+  ].join(":");
+}
+
+export function buildPathLogicalWorkspaceId(
+  path: string,
+  branchKey: string,
+): string {
+  return [
+    "path",
+    encodeLogicalSegment(path),
+    encodeLogicalSegment(branchKey),
+  ].join(":");
+}
+
+export function parseLogicalWorkspaceId(
+  logicalWorkspaceId: string | null | undefined,
+): ParsedLogicalWorkspaceId | null {
+  if (!logicalWorkspaceId) {
+    return null;
+  }
+
+  const [kind, ...encodedSegments] = logicalWorkspaceId.split(":");
+  if (kind !== "remote" && kind !== "repo-root" && kind !== "path") {
+    return null;
+  }
+
+  return {
+    kind,
+    segments: encodedSegments.map(decodeLogicalSegment),
+  };
+}
+
+export function replaceLogicalWorkspaceBranch(
+  logicalWorkspaceId: string | null | undefined,
+  branchKey: string,
+): string | null {
+  const parsed = parseLogicalWorkspaceId(logicalWorkspaceId);
+  if (!parsed) {
+    return null;
+  }
+
+  const nextBranchKey = normalizeLogicalWorkspaceBranchKey(branchKey);
+  if (parsed.kind === "remote" && parsed.segments.length === 4) {
+    const [provider, owner, repo] = parsed.segments;
+    return buildRemoteLogicalWorkspaceId(provider!, owner!, repo!, nextBranchKey);
+  }
+
+  if (parsed.kind === "repo-root" && parsed.segments.length === 2) {
+    return buildRepoRootLogicalWorkspaceId(parsed.segments[0]!, nextBranchKey);
+  }
+
+  if (parsed.kind === "path" && parsed.segments.length === 2) {
+    return buildPathLogicalWorkspaceId(parsed.segments[0]!, nextBranchKey);
+  }
+
+  return null;
+}

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspace-lookup.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspace-lookup.ts
@@ -1,0 +1,66 @@
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
+import { logicalWorkspaceCloudMaterializationId } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
+
+export function logicalWorkspaceMatchesId(
+  workspace: LogicalWorkspace,
+  candidateId: string | null | undefined,
+): boolean {
+  if (!candidateId) {
+    return false;
+  }
+
+  return candidateId === workspace.id
+    || candidateId === workspace.localWorkspace?.id
+    || candidateId === logicalWorkspaceCloudMaterializationId(workspace);
+}
+
+export function logicalWorkspaceRelatedIds(
+  workspace: Pick<
+    LogicalWorkspace,
+    "id" | "localWorkspace" | "cloudWorkspace" | "mobilityWorkspace" | "preferredMaterializationId"
+  >,
+): string[] {
+  const ids: string[] = [];
+  const pushId = (id: string | null | undefined) => {
+    if (id && !ids.includes(id)) {
+      ids.push(id);
+    }
+  };
+
+  pushId(workspace.id);
+  pushId(workspace.localWorkspace?.id);
+  pushId(logicalWorkspaceCloudMaterializationId(workspace));
+  pushId(workspace.preferredMaterializationId);
+  return ids;
+}
+
+export function latestLogicalWorkspaceTimestamp(
+  timestamps: Record<string, string>,
+  workspace: Pick<
+    LogicalWorkspace,
+    "id" | "localWorkspace" | "cloudWorkspace" | "mobilityWorkspace" | "preferredMaterializationId"
+  >,
+): string | null {
+  let latestTimestamp: string | null = null;
+  for (const id of logicalWorkspaceRelatedIds(workspace)) {
+    const timestamp = timestamps[id];
+    if (!timestamp) {
+      continue;
+    }
+    if (!latestTimestamp || new Date(timestamp).getTime() > new Date(latestTimestamp).getTime()) {
+      latestTimestamp = timestamp;
+    }
+  }
+  return latestTimestamp;
+}
+
+export function findLogicalWorkspace(
+  workspaces: readonly LogicalWorkspace[],
+  candidateId: string | null | undefined,
+): LogicalWorkspace | null {
+  if (!candidateId) {
+    return null;
+  }
+
+  return workspaces.find((workspace) => logicalWorkspaceMatchesId(workspace, candidateId)) ?? null;
+}

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
@@ -1,0 +1,74 @@
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
+
+export function resolvePreferredLogicalWorkspaceMaterialization(
+  localWorkspace: LogicalWorkspace["localWorkspace"],
+  cloudWorkspace: LogicalWorkspace["cloudWorkspace"],
+  mobilityWorkspace: LogicalWorkspace["mobilityWorkspace"],
+  currentSelectionId: string | null,
+  effectiveOwnerHint: "local" | "cloud" | null,
+): { workspaceId: string | null; owner: "local" | "cloud" } {
+  const cloudId = cloudWorkspace
+    ? cloudWorkspaceSyntheticId(cloudWorkspace.id)
+    : mobilityWorkspace?.cloudWorkspaceId
+      ? cloudWorkspaceSyntheticId(mobilityWorkspace.cloudWorkspaceId)
+      : null;
+
+  if (effectiveOwnerHint === "local" && localWorkspace) {
+    return { workspaceId: localWorkspace.id, owner: "local" };
+  }
+
+  if (effectiveOwnerHint === "cloud" && cloudId) {
+    return {
+      workspaceId: cloudId,
+      owner: "cloud",
+    };
+  }
+
+  if (localWorkspace && currentSelectionId === localWorkspace.id) {
+    return { workspaceId: localWorkspace.id, owner: "local" };
+  }
+
+  if (cloudId) {
+    if (currentSelectionId === cloudId) {
+      return { workspaceId: cloudId, owner: "cloud" };
+    }
+  }
+
+  if (localWorkspace) {
+    return { workspaceId: localWorkspace.id, owner: "local" };
+  }
+
+  return {
+    workspaceId: cloudId,
+    owner: "cloud",
+  };
+}
+
+export function resolveLogicalWorkspaceMaterializationId(
+  workspace: LogicalWorkspace,
+  currentSelectionId?: string | null,
+): string | null {
+  const selected = resolvePreferredLogicalWorkspaceMaterialization(
+    workspace.localWorkspace,
+    workspace.cloudWorkspace,
+    workspace.mobilityWorkspace,
+    currentSelectionId ?? null,
+    workspace.mobilityWorkspace?.owner === "local" || workspace.mobilityWorkspace?.owner === "cloud"
+      ? workspace.mobilityWorkspace.owner
+      : null,
+  );
+  return selected.workspaceId;
+}
+
+export function logicalWorkspaceCloudMaterializationId(
+  workspace: Pick<LogicalWorkspace, "cloudWorkspace" | "mobilityWorkspace">,
+): string | null {
+  if (workspace.cloudWorkspace) {
+    return cloudWorkspaceSyntheticId(workspace.cloudWorkspace.id);
+  }
+  if (workspace.mobilityWorkspace?.cloudWorkspaceId) {
+    return cloudWorkspaceSyntheticId(workspace.mobilityWorkspace.cloudWorkspaceId);
+  }
+  return null;
+}

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspace-model.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspace-model.ts
@@ -1,0 +1,31 @@
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import type {
+  CloudMobilityWorkspaceSummary,
+  CloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+export interface LogicalWorkspace {
+  id: string;
+  repoKey: string;
+  sourceRoot: string;
+  repoRoot: RepoRoot | null;
+  provider: string | null;
+  owner: string | null;
+  repoName: string | null;
+  branchKey: string;
+  displayName: string;
+  localWorkspace: Workspace | null;
+  cloudWorkspace: CloudWorkspaceSummary | null;
+  mobilityWorkspace: CloudMobilityWorkspaceSummary | null;
+  preferredMaterializationId: string | null;
+  effectiveOwner: "local" | "cloud";
+  lifecycle:
+    | "local_active"
+    | "moving_to_cloud"
+    | "cloud_active"
+    | "moving_to_local"
+    | "handoff_failed"
+    | "cleanup_failed"
+    | "cloud_lost";
+  updatedAt: string;
+}

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
@@ -3,11 +3,17 @@ import type { CloudMobilityWorkspaceSummary } from "@/lib/domain/workspaces/clou
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import {
   buildLogicalWorkspaces,
+} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import {
   latestLogicalWorkspaceTimestamp,
   logicalWorkspaceRelatedIds,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import {
   replaceLogicalWorkspaceBranch,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-id";
+import {
   resolveLogicalWorkspaceMaterializationId,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
   buildGroups,
   makeCloudWorkspace,

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -7,151 +7,33 @@ import {
   humanizeBranchName,
   workspaceCurrentBranchName,
 } from "@/lib/domain/workspaces/creation/branch-naming";
-import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import {
   cloudWorkspaceGroupKey,
   localWorkspaceGroupKey,
 } from "@/lib/domain/workspaces/cloud/collections";
+import {
+  buildPathLogicalWorkspaceId,
+  buildRemoteLogicalWorkspaceId,
+  buildRepoRootLogicalWorkspaceId,
+  normalizeLogicalWorkspaceBranchKey,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-id";
+import {
+  resolvePreferredLogicalWorkspaceMaterialization,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { workspaceDisplayName } from "@/lib/domain/workspaces/display/workspace-display";
-
-function encodeLogicalSegment(value: string): string {
-  return encodeURIComponent(value);
-}
-
-function decodeLogicalSegment(value: string): string {
-  return decodeURIComponent(value);
-}
-
-function normalizeBranchKey(value: string | null | undefined): string {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : "HEAD";
-}
-
-export type LogicalWorkspaceIdKind = "remote" | "repo-root" | "path";
-
-export interface ParsedLogicalWorkspaceId {
-  kind: LogicalWorkspaceIdKind;
-  segments: string[];
-}
-
-export interface LogicalWorkspace {
-  id: string;
-  repoKey: string;
-  sourceRoot: string;
-  repoRoot: RepoRoot | null;
-  provider: string | null;
-  owner: string | null;
-  repoName: string | null;
-  branchKey: string;
-  displayName: string;
-  localWorkspace: Workspace | null;
-  cloudWorkspace: CloudWorkspaceSummary | null;
-  mobilityWorkspace: CloudMobilityWorkspaceSummary | null;
-  preferredMaterializationId: string | null;
-  effectiveOwner: "local" | "cloud";
-  lifecycle:
-    | "local_active"
-    | "moving_to_cloud"
-    | "cloud_active"
-    | "moving_to_local"
-    | "handoff_failed"
-    | "cleanup_failed"
-    | "cloud_lost";
-  updatedAt: string;
-}
-
-export function buildRemoteLogicalWorkspaceId(
-  provider: string,
-  owner: string,
-  repo: string,
-  branchKey: string,
-): string {
-  return [
-    "remote",
-    encodeLogicalSegment(provider),
-    encodeLogicalSegment(owner),
-    encodeLogicalSegment(repo),
-    encodeLogicalSegment(branchKey),
-  ].join(":");
-}
-
-export function buildRepoRootLogicalWorkspaceId(
-  repoRootId: string,
-  branchKey: string,
-): string {
-  return [
-    "repo-root",
-    encodeLogicalSegment(repoRootId),
-    encodeLogicalSegment(branchKey),
-  ].join(":");
-}
-
-export function buildPathLogicalWorkspaceId(
-  path: string,
-  branchKey: string,
-): string {
-  return [
-    "path",
-    encodeLogicalSegment(path),
-    encodeLogicalSegment(branchKey),
-  ].join(":");
-}
-
-export function parseLogicalWorkspaceId(
-  logicalWorkspaceId: string | null | undefined,
-): ParsedLogicalWorkspaceId | null {
-  if (!logicalWorkspaceId) {
-    return null;
-  }
-
-  const [kind, ...encodedSegments] = logicalWorkspaceId.split(":");
-  if (kind !== "remote" && kind !== "repo-root" && kind !== "path") {
-    return null;
-  }
-
-  return {
-    kind,
-    segments: encodedSegments.map(decodeLogicalSegment),
-  };
-}
-
-export function replaceLogicalWorkspaceBranch(
-  logicalWorkspaceId: string | null | undefined,
-  branchKey: string,
-): string | null {
-  const parsed = parseLogicalWorkspaceId(logicalWorkspaceId);
-  if (!parsed) {
-    return null;
-  }
-
-  const nextBranchKey = normalizeBranchKey(branchKey);
-  if (parsed.kind === "remote" && parsed.segments.length === 4) {
-    const [provider, owner, repo] = parsed.segments;
-    return buildRemoteLogicalWorkspaceId(provider!, owner!, repo!, nextBranchKey);
-  }
-
-  if (parsed.kind === "repo-root" && parsed.segments.length === 2) {
-    return buildRepoRootLogicalWorkspaceId(parsed.segments[0]!, nextBranchKey);
-  }
-
-  if (parsed.kind === "path" && parsed.segments.length === 2) {
-    return buildPathLogicalWorkspaceId(parsed.segments[0]!, nextBranchKey);
-  }
-
-  return null;
-}
 
 function workspaceBranchKey(workspace: Workspace): string {
   const originalBranch = workspace.originalBranch?.trim();
   if (originalBranch) {
-    return normalizeBranchKey(originalBranch);
+    return normalizeLogicalWorkspaceBranchKey(originalBranch);
   }
 
-  return normalizeBranchKey(workspaceCurrentBranchName(workspace));
+  return normalizeLogicalWorkspaceBranchKey(workspaceCurrentBranchName(workspace));
 }
 
 function cloudBranchKey(workspace: CloudWorkspaceSummary): string {
-  return normalizeBranchKey(workspace.repo.branch);
+  return normalizeLogicalWorkspaceBranchKey(workspace.repo.branch);
 }
 
 function buildLogicalWorkspaceIdForLocalWorkspace(workspace: Workspace): string {
@@ -207,50 +89,6 @@ function mobilityDefaultDisplayName(workspace: CloudMobilityWorkspaceSummary): s
   return workspace.repo.branch?.trim()
     ? humanizeBranchName(workspace.repo.branch)
     : workspace.repo.name;
-}
-
-function preferredMaterializationId(
-  localWorkspace: Workspace | null,
-  cloudWorkspace: CloudWorkspaceSummary | null,
-  mobilityWorkspace: CloudMobilityWorkspaceSummary | null,
-  currentSelectionId: string | null,
-  effectiveOwnerHint: "local" | "cloud" | null,
-): { workspaceId: string | null; owner: "local" | "cloud" } {
-  const cloudId = cloudWorkspace
-    ? cloudWorkspaceSyntheticId(cloudWorkspace.id)
-    : mobilityWorkspace?.cloudWorkspaceId
-      ? cloudWorkspaceSyntheticId(mobilityWorkspace.cloudWorkspaceId)
-      : null;
-
-  if (effectiveOwnerHint === "local" && localWorkspace) {
-    return { workspaceId: localWorkspace.id, owner: "local" };
-  }
-
-  if (effectiveOwnerHint === "cloud" && cloudId) {
-    return {
-      workspaceId: cloudId,
-      owner: "cloud",
-    };
-  }
-
-  if (localWorkspace && currentSelectionId === localWorkspace.id) {
-    return { workspaceId: localWorkspace.id, owner: "local" };
-  }
-
-  if (cloudId) {
-    if (currentSelectionId === cloudId) {
-      return { workspaceId: cloudId, owner: "cloud" };
-    }
-  }
-
-  if (localWorkspace) {
-    return { workspaceId: localWorkspace.id, owner: "local" };
-  }
-
-  return {
-    workspaceId: cloudId,
-    owner: "cloud",
-  };
 }
 
 function latestUpdatedAt(
@@ -366,7 +204,7 @@ export function buildLogicalWorkspaces(args: {
       workspace.repo.provider,
       workspace.repo.owner,
       workspace.repo.name,
-      normalizeBranchKey(workspace.repo.branch),
+      normalizeLogicalWorkspaceBranchKey(workspace.repo.branch),
     );
     const current = byId.get(logicalId);
     if (!current) {
@@ -383,7 +221,7 @@ export function buildLogicalWorkspaces(args: {
 
   return Array.from(byId.entries())
     .map(([id, entry]) => {
-      const materialization = preferredMaterializationId(
+      const materialization = resolvePreferredLogicalWorkspaceMaterialization(
         entry.localWorkspace,
         entry.cloudWorkspace,
         entry.mobilityWorkspace,
@@ -452,7 +290,7 @@ export function buildLogicalWorkspaces(args: {
           : entry.cloudWorkspace
             ? cloudBranchKey(entry.cloudWorkspace)
             : entry.mobilityWorkspace
-              ? normalizeBranchKey(entry.mobilityWorkspace.repo.branch)
+              ? normalizeLogicalWorkspaceBranchKey(entry.mobilityWorkspace.repo.branch)
               : "HEAD",
         displayName,
         localWorkspace: entry.localWorkspace,
@@ -474,96 +312,4 @@ export function buildLogicalWorkspaces(args: {
       } satisfies LogicalWorkspace;
     })
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-}
-
-export function logicalWorkspaceMatchesId(
-  workspace: LogicalWorkspace,
-  candidateId: string | null | undefined,
-): boolean {
-  if (!candidateId) {
-    return false;
-  }
-
-  return candidateId === workspace.id
-    || candidateId === workspace.localWorkspace?.id
-    || candidateId === logicalWorkspaceCloudMaterializationId(workspace);
-}
-
-export function logicalWorkspaceRelatedIds(
-  workspace: Pick<
-    LogicalWorkspace,
-    "id" | "localWorkspace" | "cloudWorkspace" | "mobilityWorkspace" | "preferredMaterializationId"
-  >,
-): string[] {
-  const ids: string[] = [];
-  const pushId = (id: string | null | undefined) => {
-    if (id && !ids.includes(id)) {
-      ids.push(id);
-    }
-  };
-
-  pushId(workspace.id);
-  pushId(workspace.localWorkspace?.id);
-  pushId(logicalWorkspaceCloudMaterializationId(workspace));
-  pushId(workspace.preferredMaterializationId);
-  return ids;
-}
-
-export function latestLogicalWorkspaceTimestamp(
-  timestamps: Record<string, string>,
-  workspace: Pick<
-    LogicalWorkspace,
-    "id" | "localWorkspace" | "cloudWorkspace" | "mobilityWorkspace" | "preferredMaterializationId"
-  >,
-): string | null {
-  let latestTimestamp: string | null = null;
-  for (const id of logicalWorkspaceRelatedIds(workspace)) {
-    const timestamp = timestamps[id];
-    if (!timestamp) {
-      continue;
-    }
-    if (!latestTimestamp || new Date(timestamp).getTime() > new Date(latestTimestamp).getTime()) {
-      latestTimestamp = timestamp;
-    }
-  }
-  return latestTimestamp;
-}
-
-export function findLogicalWorkspace(
-  workspaces: readonly LogicalWorkspace[],
-  candidateId: string | null | undefined,
-): LogicalWorkspace | null {
-  if (!candidateId) {
-    return null;
-  }
-
-  return workspaces.find((workspace) => logicalWorkspaceMatchesId(workspace, candidateId)) ?? null;
-}
-
-export function resolveLogicalWorkspaceMaterializationId(
-  workspace: LogicalWorkspace,
-  currentSelectionId?: string | null,
-): string | null {
-  const selected = preferredMaterializationId(
-    workspace.localWorkspace,
-    workspace.cloudWorkspace,
-    workspace.mobilityWorkspace,
-    currentSelectionId ?? null,
-    workspace.mobilityWorkspace?.owner === "local" || workspace.mobilityWorkspace?.owner === "cloud"
-      ? workspace.mobilityWorkspace.owner
-      : null,
-  );
-  return selected.workspaceId;
-}
-
-export function logicalWorkspaceCloudMaterializationId(
-  workspace: Pick<LogicalWorkspace, "cloudWorkspace" | "mobilityWorkspace">,
-): string | null {
-  if (workspace.cloudWorkspace) {
-    return cloudWorkspaceSyntheticId(workspace.cloudWorkspace.id);
-  }
-  if (workspace.mobilityWorkspace?.cloudWorkspaceId) {
-    return cloudWorkspaceSyntheticId(workspace.mobilityWorkspace.cloudWorkspaceId);
-  }
-  return null;
 }

--- a/desktop/src/lib/domain/workspaces/creation/publish-dialog-state.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-dialog-state.ts
@@ -1,4 +1,4 @@
-import type { PublishIntent } from "@/lib/domain/workspaces/creation/publish-workflow";
+import type { PublishIntent } from "@/lib/domain/workspaces/creation/publish-workflow-model";
 
 export interface PublishDialogState {
   open: boolean;

--- a/desktop/src/lib/domain/workspaces/creation/publish-draft.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-draft.ts
@@ -1,0 +1,17 @@
+import type { GitStatusSnapshot } from "@anyharness/sdk";
+import type { PublishPullRequestDraft } from "@/lib/domain/workspaces/creation/publish-workflow-model";
+
+export function defaultPublishPullRequestDraft(input: {
+  gitStatus: GitStatusSnapshot | null | undefined;
+  repoDefaultBranch: string | null;
+}): PublishPullRequestDraft {
+  const baseBranch = input.gitStatus?.suggestedBaseBranch?.trim()
+    || input.repoDefaultBranch?.trim()
+    || "main";
+  return {
+    title: "",
+    body: "",
+    baseBranch,
+    draft: false,
+  };
+}

--- a/desktop/src/lib/domain/workspaces/creation/publish-file-groups.test.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-file-groups.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { GitChangedFile } from "@anyharness/sdk";
+import {
+  groupPublishFiles,
+  partialFileWarning,
+} from "./publish-file-groups";
+
+function file(path: string, includedState: GitChangedFile["includedState"]): GitChangedFile {
+  return {
+    path,
+    oldPath: undefined,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    includedState,
+  };
+}
+
+describe("publish file groups", () => {
+  it("groups publishable files and excludes generated worktree metadata", () => {
+    const groups = groupPublishFiles([
+      file("src/app.ts", "included"),
+      file("src/pending.ts", "partial"),
+      file("src/draft.ts", "excluded"),
+      file(".claude/worktrees/generated.json", "included"),
+      file("", "included"),
+    ]);
+
+    expect(groups.staged.map((entry) => entry.path)).toEqual(["src/app.ts"]);
+    expect(groups.partial.map((entry) => entry.path)).toEqual(["src/pending.ts"]);
+    expect(groups.unstaged.map((entry) => entry.path)).toEqual(["src/draft.ts"]);
+  });
+
+  it("keeps partial-file warnings tied to unstaged inclusion", () => {
+    expect(partialFileWarning(false, true)).toBeNull();
+    expect(partialFileWarning(true, true)).toContain("unstaged hunks");
+    expect(partialFileWarning(true, false)).toContain("only staged hunks");
+  });
+});

--- a/desktop/src/lib/domain/workspaces/creation/publish-file-groups.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-file-groups.ts
@@ -1,0 +1,23 @@
+import type { GitChangedFile } from "@anyharness/sdk";
+import type { PublishFileGroups } from "@/lib/domain/workspaces/creation/publish-workflow-model";
+
+const PARTIAL_WARNING =
+  "Including unstaged changes will also include all unstaged hunks in partially staged files.";
+const PARTIAL_STAGED_ONLY_WARNING =
+  "Partially staged files can show combined file totals; with Include unstaged off, only staged hunks are committed.";
+
+export function partialFileWarning(hasPartialFiles: boolean, includeUnstaged: boolean): string | null {
+  if (!hasPartialFiles) return null;
+  return includeUnstaged ? PARTIAL_WARNING : PARTIAL_STAGED_ONLY_WARNING;
+}
+
+export function groupPublishFiles(files: GitChangedFile[]): PublishFileGroups {
+  const publishable = files.filter((file) =>
+    file.path.length > 0 && !file.path.startsWith(".claude/worktrees/")
+  );
+  return {
+    staged: publishable.filter((file) => file.includedState === "included"),
+    partial: publishable.filter((file) => file.includedState === "partial"),
+    unstaged: publishable.filter((file) => file.includedState === "excluded"),
+  };
+}

--- a/desktop/src/lib/domain/workspaces/creation/publish-workflow-labels.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-workflow-labels.ts
@@ -1,0 +1,137 @@
+import type {
+  CurrentPullRequestResponse,
+  GitStatusSnapshot,
+} from "@anyharness/sdk";
+import type {
+  PublishIntent,
+  PublishWorkflowStep,
+} from "@/lib/domain/workspaces/creation/publish-workflow-model";
+
+export function publishStatusLabel(input: {
+  gitStatus: GitStatusSnapshot | null;
+  wantsPublish: boolean;
+  hasDirtyChanges: boolean;
+}): string | null {
+  if (!input.gitStatus || !input.wantsPublish || input.hasDirtyChanges) return null;
+  const upstream = input.gitStatus.upstreamBranch?.trim() || null;
+  if (input.gitStatus.ahead > 0 && upstream) {
+    return `Push ${input.gitStatus.ahead} local commit${input.gitStatus.ahead === 1 ? "" : "s"} to ${upstream}.`;
+  }
+  if (!upstream && input.gitStatus.actions.canPush) {
+    return "Publish this branch and set its upstream.";
+  }
+  if (upstream) {
+    return `This branch is up to date with ${upstream}.`;
+  }
+  return "This branch has no upstream yet.";
+}
+
+export function publishWorkflowSummary(input: {
+  intent: PublishIntent;
+  gitStatus: GitStatusSnapshot | null;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  publishStatus: string | null;
+  workflowSteps: PublishWorkflowStep[];
+}): string {
+  const hasStageStep = input.workflowSteps.some((step) => step.kind === "stage");
+  const hasCommitStep = input.workflowSteps.some((step) => step.kind === "commit");
+  const hasPushStep = input.workflowSteps.some((step) => step.kind === "push");
+  const hasCreatePrStep = input.workflowSteps.some((step) => step.kind === "create_pull_request");
+  const pushLabel = (input.gitStatus?.actions.pushLabel ?? "Publish").toLowerCase();
+
+  if (input.workflowSteps.length === 0) {
+    if (input.intent === "pull_request" && input.existingPr) {
+      return "A pull request already exists for this branch.";
+    }
+    if (input.publishStatus) {
+      return input.publishStatus;
+    }
+    if (input.intent === "commit") {
+      return "Commit changes in this workspace.";
+    }
+    if (input.intent === "publish") {
+      return "Publish local commits when this branch is ready.";
+    }
+    return "Create a pull request from this branch.";
+  }
+
+  if (input.intent === "commit") {
+    return hasStageStep
+      ? "Stage unstaged changes, then commit them."
+      : "Commit the selected staged changes.";
+  }
+
+  if (input.intent === "publish") {
+    if (hasCommitStep && hasPushStep) {
+      return hasStageStep
+        ? `Stage unstaged changes, commit them, then ${pushLabel}.`
+        : `Commit changes, then ${pushLabel}.`;
+    }
+    if (hasPushStep) {
+      return input.publishStatus ?? "Publish this branch.";
+    }
+    return "Commit changes before publishing this branch.";
+  }
+
+  if (input.existingPr && !hasCreatePrStep) {
+    if (hasCommitStep && hasPushStep) {
+      return hasStageStep
+        ? "Stage unstaged changes, commit them, then update the existing pull request branch."
+        : "Commit changes, then update the existing pull request branch.";
+    }
+    if (hasPushStep) {
+      return "Update the existing pull request branch.";
+    }
+    return "A pull request already exists for this branch.";
+  }
+
+  if (hasCommitStep && hasPushStep && hasCreatePrStep) {
+    return hasStageStep
+      ? "Stage unstaged changes, commit them, publish the branch, then create a pull request."
+      : "Commit changes, publish the branch, then create a pull request.";
+  }
+  if (hasPushStep && hasCreatePrStep) {
+    return "Publish this branch, then create a pull request.";
+  }
+  if (hasCommitStep && hasCreatePrStep) {
+    return hasStageStep
+      ? "Stage unstaged changes, commit them, then create a pull request."
+      : "Commit changes, then create a pull request.";
+  }
+  if (hasCreatePrStep) {
+    return "Create a pull request from this branch.";
+  }
+  if (hasPushStep) {
+    return "Publish this branch.";
+  }
+  return "Prepare this branch for a pull request.";
+}
+
+export function publishPrimaryLabel(input: {
+  intent: PublishIntent;
+  gitStatus: GitStatusSnapshot | null;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  hasDirtyChanges: boolean;
+  workflowSteps: PublishWorkflowStep[];
+}): string {
+  if (input.intent === "pull_request") {
+    if (input.existingPr && input.workflowSteps.length === 0) return "View pull request";
+    const hasCommitStep = input.workflowSteps.some((step) => step.kind === "commit");
+    const hasPushStep = input.workflowSteps.some((step) => step.kind === "push");
+    const hasCreatePrStep = input.workflowSteps.some((step) => step.kind === "create_pull_request");
+    if (hasCommitStep && hasPushStep && hasCreatePrStep) return "Commit, publish, create PR";
+    if (hasPushStep && hasCreatePrStep) return "Publish and create PR";
+    if (hasCreatePrStep) return hasCommitStep ? "Commit and create PR" : "Create PR";
+    if (hasCommitStep && hasPushStep) {
+      const label = input.gitStatus?.actions.pushLabel ?? "Publish";
+      return `Commit and ${label.toLowerCase()}`;
+    }
+    if (hasPushStep) return input.gitStatus?.actions.pushLabel ?? "Publish";
+    return input.existingPr ? "View pull request" : "Create PR";
+  }
+  if (input.intent === "publish") {
+    const label = input.gitStatus?.actions.pushLabel ?? "Publish";
+    return input.hasDirtyChanges ? `Commit and ${label.toLowerCase()}` : label;
+  }
+  return "Commit";
+}

--- a/desktop/src/lib/domain/workspaces/creation/publish-workflow-model.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-workflow-model.ts
@@ -1,0 +1,58 @@
+import type {
+  CreatePullRequestRequest,
+  CurrentPullRequestResponse,
+  GitChangedFile,
+  GitStatusSnapshot,
+} from "@anyharness/sdk";
+
+export type PublishIntent = "commit" | "publish" | "pull_request";
+
+export interface PublishCommitDraft {
+  summary: string;
+  includeUnstaged: boolean;
+}
+
+export interface PublishPullRequestDraft {
+  title: string;
+  body: string;
+  baseBranch: string;
+  draft: boolean;
+}
+
+export type PublishWorkflowStep =
+  | { kind: "stage"; paths: string[] }
+  | { kind: "commit"; summary: string }
+  | { kind: "push" }
+  | { kind: "create_pull_request"; request: CreatePullRequestRequest };
+
+export interface PublishFileGroups {
+  staged: GitChangedFile[];
+  partial: GitChangedFile[];
+  unstaged: GitChangedFile[];
+}
+
+export interface PublishViewState {
+  branchName: string | null;
+  defaultBaseBranch: string;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  fileGroups: PublishFileGroups;
+  hasPartialFiles: boolean;
+  hasStagedChanges: boolean;
+  hasUnstagedChanges: boolean;
+  partialWarning: string | null;
+  publishStatus: string | null;
+  summary: string;
+  primaryLabel: string;
+  disabledReason: string | null;
+  workflowSteps: PublishWorkflowStep[];
+}
+
+export interface BuildPublishViewStateInput {
+  gitStatus: GitStatusSnapshot | null | undefined;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  runtimeBlockedReason: string | null;
+  repoDefaultBranch: string | null;
+  initialIntent: PublishIntent;
+  commitDraft: PublishCommitDraft;
+  pullRequestDraft: PublishPullRequestDraft;
+}

--- a/desktop/src/lib/domain/workspaces/creation/publish-workflow-steps.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-workflow-steps.ts
@@ -1,0 +1,153 @@
+import type {
+  CurrentPullRequestResponse,
+  GitStatusSnapshot,
+} from "@anyharness/sdk";
+import type {
+  PublishFileGroups,
+  PublishPullRequestDraft,
+  PublishWorkflowStep,
+} from "@/lib/domain/workspaces/creation/publish-workflow-model";
+
+export function resolvePublishDisabledReason(input: {
+  gitStatus: GitStatusSnapshot | null;
+  runtimeBlockedReason: string | null;
+  branchName: string | null;
+  summary: string;
+  wantsPublish: boolean;
+  wantsPr: boolean;
+  hasStagedChanges: boolean;
+  hasUnstagedChanges: boolean;
+  includeUnstaged: boolean;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  pullRequestDraft: PublishPullRequestDraft;
+}): string | null {
+  if (input.runtimeBlockedReason) return input.runtimeBlockedReason;
+  if (!input.gitStatus) return "Git status is still loading.";
+  if (input.gitStatus.conflicted || input.gitStatus.actions.reasonIfBlocked) {
+    return input.gitStatus.actions.reasonIfBlocked ?? "Resolve conflicts before publishing.";
+  }
+  if (input.gitStatus.detached || !input.branchName) {
+    return "Switch to a branch before publishing.";
+  }
+  if ((input.wantsPublish || input.wantsPr) && input.gitStatus.behind > 0) {
+    return "Sync this branch before publishing.";
+  }
+
+  const hasDirtyChanges = input.hasStagedChanges || input.hasUnstagedChanges;
+  if (hasDirtyChanges) {
+    if (!input.includeUnstaged && !input.hasStagedChanges) {
+      return "Stage changes or include unstaged changes before committing.";
+    }
+    if (!input.summary) {
+      return "Enter a commit message.";
+    }
+  } else if (!input.wantsPublish && !input.wantsPr) {
+    return "There are no changes to commit.";
+  }
+
+  if (input.wantsPr && !input.existingPr) {
+    const baseBranch = input.pullRequestDraft.baseBranch.trim();
+    if (!baseBranch) return "Choose a base branch.";
+    if (sameBranch(input.branchName, baseBranch)) {
+      return `Switch to a branch other than ${baseBranch} before creating a PR.`;
+    }
+  }
+
+  const needsPush = shouldPush({
+    gitStatus: input.gitStatus,
+    wantsPublish: input.wantsPublish,
+    wantsPr: input.wantsPr,
+    hasDirtyChanges,
+  });
+  const canCreatePrOnly = input.wantsPr
+    && !input.existingPr
+    && !needsPush
+    && input.gitStatus.actions.canCreatePullRequest;
+  const canViewExistingPrOnly = input.wantsPr
+    && input.existingPr
+    && !needsPush;
+
+  if (
+    (input.wantsPublish || input.wantsPr)
+    && !hasDirtyChanges
+    && !needsPush
+    && !canCreatePrOnly
+    && !canViewExistingPrOnly
+  ) {
+    return "There are no local commits ready to publish.";
+  }
+
+  if (input.wantsPr && !input.existingPr) {
+    if (!input.pullRequestDraft.title.trim()) return "Enter a pull request title.";
+  }
+
+  return null;
+}
+
+export function shouldPush(input: {
+  gitStatus: GitStatusSnapshot | null;
+  wantsPublish: boolean;
+  wantsPr: boolean;
+  hasDirtyChanges: boolean;
+}): boolean {
+  if (!input.wantsPublish && !input.wantsPr) return false;
+  if (input.hasDirtyChanges) return true;
+  return input.gitStatus?.actions.canPush ?? false;
+}
+
+export function buildPublishWorkflowSteps(input: {
+  fileGroups: PublishFileGroups;
+  includeUnstaged: boolean;
+  summary: string;
+  wantsPublish: boolean;
+  wantsPr: boolean;
+  needsPush: boolean;
+  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
+  pullRequestDraft: PublishPullRequestDraft;
+  hasStagedChanges: boolean;
+  hasUnstagedChanges: boolean;
+}): PublishWorkflowStep[] {
+  const steps: PublishWorkflowStep[] = [];
+  const hasDirtyChanges = input.hasStagedChanges || input.hasUnstagedChanges;
+  if (hasDirtyChanges) {
+    if (input.includeUnstaged) {
+      const paths = [
+        ...input.fileGroups.unstaged.map((file) => file.path),
+        ...input.fileGroups.partial.map((file) => file.path),
+      ];
+      if (paths.length > 0) steps.push({ kind: "stage", paths });
+    }
+    steps.push({ kind: "commit", summary: input.summary });
+  }
+
+  if (input.needsPush) {
+    steps.push({ kind: "push" });
+  }
+
+  if (input.wantsPr && !input.existingPr) {
+    steps.push({
+      kind: "create_pull_request",
+      request: {
+        title: input.pullRequestDraft.title.trim(),
+        body: input.pullRequestDraft.body.trim() || undefined,
+        baseBranch: input.pullRequestDraft.baseBranch.trim(),
+        draft: input.pullRequestDraft.draft,
+      },
+    });
+  }
+
+  return steps;
+}
+
+function sameBranch(left: string | null, right: string | null): boolean {
+  const normalizedLeft = normalizeBranchName(left);
+  const normalizedRight = normalizeBranchName(right);
+  return normalizedLeft.length > 0 && normalizedLeft === normalizedRight;
+}
+
+function normalizeBranchName(branch: string | null): string {
+  return (branch ?? "")
+    .trim()
+    .replace(/^refs\/heads\//, "")
+    .replace(/^heads\//, "");
+}

--- a/desktop/src/lib/domain/workspaces/creation/publish-workflow.test.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-workflow.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { GitChangedFile, GitStatusSnapshot } from "@anyharness/sdk";
 import {
   buildPublishViewState,
-  defaultPublishPullRequestDraft,
-  type PublishIntent,
 } from "./publish-workflow";
+import { defaultPublishPullRequestDraft } from "./publish-draft";
+import type { PublishIntent } from "./publish-workflow-model";
 
 function file(path: string, includedState: GitChangedFile["includedState"]): GitChangedFile {
   return {

--- a/desktop/src/lib/domain/workspaces/creation/publish-workflow.ts
+++ b/desktop/src/lib/domain/workspaces/creation/publish-workflow.ts
@@ -1,81 +1,21 @@
+import {
+  groupPublishFiles,
+  partialFileWarning,
+} from "@/lib/domain/workspaces/creation/publish-file-groups";
+import {
+  publishPrimaryLabel,
+  publishStatusLabel,
+  publishWorkflowSummary,
+} from "@/lib/domain/workspaces/creation/publish-workflow-labels";
 import type {
-  CreatePullRequestRequest,
-  CurrentPullRequestResponse,
-  GitChangedFile,
-  GitStatusSnapshot,
-} from "@anyharness/sdk";
-
-export type PublishIntent = "commit" | "publish" | "pull_request";
-
-export interface PublishCommitDraft {
-  summary: string;
-  includeUnstaged: boolean;
-}
-
-export interface PublishPullRequestDraft {
-  title: string;
-  body: string;
-  baseBranch: string;
-  draft: boolean;
-}
-
-export type PublishWorkflowStep =
-  | { kind: "stage"; paths: string[] }
-  | { kind: "commit"; summary: string }
-  | { kind: "push" }
-  | { kind: "create_pull_request"; request: CreatePullRequestRequest };
-
-export interface PublishFileGroups {
-  staged: GitChangedFile[];
-  partial: GitChangedFile[];
-  unstaged: GitChangedFile[];
-}
-
-export interface PublishViewState {
-  branchName: string | null;
-  defaultBaseBranch: string;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  fileGroups: PublishFileGroups;
-  hasPartialFiles: boolean;
-  hasStagedChanges: boolean;
-  hasUnstagedChanges: boolean;
-  partialWarning: string | null;
-  publishStatus: string | null;
-  summary: string;
-  primaryLabel: string;
-  disabledReason: string | null;
-  workflowSteps: PublishWorkflowStep[];
-}
-
-export interface BuildPublishViewStateInput {
-  gitStatus: GitStatusSnapshot | null | undefined;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  runtimeBlockedReason: string | null;
-  repoDefaultBranch: string | null;
-  initialIntent: PublishIntent;
-  commitDraft: PublishCommitDraft;
-  pullRequestDraft: PublishPullRequestDraft;
-}
-
-const PARTIAL_WARNING =
-  "Including unstaged changes will also include all unstaged hunks in partially staged files.";
-const PARTIAL_STAGED_ONLY_WARNING =
-  "Partially staged files can show combined file totals; with Include unstaged off, only staged hunks are committed.";
-
-export function defaultPublishPullRequestDraft(input: {
-  gitStatus: GitStatusSnapshot | null | undefined;
-  repoDefaultBranch: string | null;
-}): PublishPullRequestDraft {
-  const baseBranch = input.gitStatus?.suggestedBaseBranch?.trim()
-    || input.repoDefaultBranch?.trim()
-    || "main";
-  return {
-    title: "",
-    body: "",
-    baseBranch,
-    draft: false,
-  };
-}
+  BuildPublishViewStateInput,
+  PublishViewState,
+} from "@/lib/domain/workspaces/creation/publish-workflow-model";
+import {
+  buildPublishWorkflowSteps,
+  resolvePublishDisabledReason,
+  shouldPush,
+} from "@/lib/domain/workspaces/creation/publish-workflow-steps";
 
 export function buildPublishViewState(input: BuildPublishViewStateInput): PublishViewState {
   const gitStatus = input.gitStatus ?? null;
@@ -99,7 +39,7 @@ export function buildPublishViewState(input: BuildPublishViewStateInput): Publis
     hasDirtyChanges,
   });
 
-  const disabledReason = resolveDisabledReason({
+  const disabledReason = resolvePublishDisabledReason({
     gitStatus,
     runtimeBlockedReason: input.runtimeBlockedReason,
     branchName,
@@ -121,7 +61,7 @@ export function buildPublishViewState(input: BuildPublishViewStateInput): Publis
 
   const workflowSteps = disabledReason
     ? []
-    : buildWorkflowSteps({
+    : buildPublishWorkflowSteps({
       fileGroups,
       includeUnstaged: input.commitDraft.includeUnstaged,
       summary,
@@ -144,14 +84,14 @@ export function buildPublishViewState(input: BuildPublishViewStateInput): Publis
     hasUnstagedChanges,
     partialWarning,
     publishStatus,
-    summary: workflowSummary({
+    summary: publishWorkflowSummary({
       intent: input.initialIntent,
       gitStatus,
       existingPr,
       publishStatus,
       workflowSteps,
     }),
-    primaryLabel: primaryLabel({
+    primaryLabel: publishPrimaryLabel({
       intent: input.initialIntent,
       gitStatus,
       existingPr,
@@ -161,293 +101,4 @@ export function buildPublishViewState(input: BuildPublishViewStateInput): Publis
     disabledReason,
     workflowSteps,
   };
-}
-
-function partialFileWarning(hasPartialFiles: boolean, includeUnstaged: boolean): string | null {
-  if (!hasPartialFiles) return null;
-  return includeUnstaged ? PARTIAL_WARNING : PARTIAL_STAGED_ONLY_WARNING;
-}
-
-function publishStatusLabel(input: {
-  gitStatus: GitStatusSnapshot | null;
-  wantsPublish: boolean;
-  hasDirtyChanges: boolean;
-}): string | null {
-  if (!input.gitStatus || !input.wantsPublish || input.hasDirtyChanges) return null;
-  const upstream = input.gitStatus.upstreamBranch?.trim() || null;
-  if (input.gitStatus.ahead > 0 && upstream) {
-    return `Push ${input.gitStatus.ahead} local commit${input.gitStatus.ahead === 1 ? "" : "s"} to ${upstream}.`;
-  }
-  if (!upstream && input.gitStatus.actions.canPush) {
-    return "Publish this branch and set its upstream.";
-  }
-  if (upstream) {
-    return `This branch is up to date with ${upstream}.`;
-  }
-  return "This branch has no upstream yet.";
-}
-
-function groupPublishFiles(files: GitChangedFile[]): PublishFileGroups {
-  const publishable = files.filter((file) =>
-    file.path.length > 0 && !file.path.startsWith(".claude/worktrees/")
-  );
-  return {
-    staged: publishable.filter((file) => file.includedState === "included"),
-    partial: publishable.filter((file) => file.includedState === "partial"),
-    unstaged: publishable.filter((file) => file.includedState === "excluded"),
-  };
-}
-
-function resolveDisabledReason(input: {
-  gitStatus: GitStatusSnapshot | null;
-  runtimeBlockedReason: string | null;
-  branchName: string | null;
-  summary: string;
-  wantsPublish: boolean;
-  wantsPr: boolean;
-  hasStagedChanges: boolean;
-  hasUnstagedChanges: boolean;
-  includeUnstaged: boolean;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  pullRequestDraft: PublishPullRequestDraft;
-}): string | null {
-  if (input.runtimeBlockedReason) return input.runtimeBlockedReason;
-  if (!input.gitStatus) return "Git status is still loading.";
-  if (input.gitStatus.conflicted || input.gitStatus.actions.reasonIfBlocked) {
-    return input.gitStatus.actions.reasonIfBlocked ?? "Resolve conflicts before publishing.";
-  }
-  if (input.gitStatus.detached || !input.branchName) {
-    return "Switch to a branch before publishing.";
-  }
-  if ((input.wantsPublish || input.wantsPr) && input.gitStatus.behind > 0) {
-    return "Sync this branch before publishing.";
-  }
-
-  const hasDirtyChanges = input.hasStagedChanges || input.hasUnstagedChanges;
-  if (hasDirtyChanges) {
-    if (!input.includeUnstaged && !input.hasStagedChanges) {
-      return "Stage changes or include unstaged changes before committing.";
-    }
-    if (!input.summary) {
-      return "Enter a commit message.";
-    }
-  } else if (!input.wantsPublish && !input.wantsPr) {
-    return "There are no changes to commit.";
-  }
-
-  if (input.wantsPr && !input.existingPr) {
-    const baseBranch = input.pullRequestDraft.baseBranch.trim();
-    if (!baseBranch) return "Choose a base branch.";
-    if (sameBranch(input.branchName, baseBranch)) {
-      return `Switch to a branch other than ${baseBranch} before creating a PR.`;
-    }
-  }
-
-  const needsPush = shouldPush({
-    gitStatus: input.gitStatus,
-    wantsPublish: input.wantsPublish,
-    wantsPr: input.wantsPr,
-    hasDirtyChanges,
-  });
-  const canCreatePrOnly = input.wantsPr
-    && !input.existingPr
-    && !needsPush
-    && input.gitStatus.actions.canCreatePullRequest;
-  const canViewExistingPrOnly = input.wantsPr
-    && input.existingPr
-    && !needsPush;
-
-  if (
-    (input.wantsPublish || input.wantsPr)
-    && !hasDirtyChanges
-    && !needsPush
-    && !canCreatePrOnly
-    && !canViewExistingPrOnly
-  ) {
-    return "There are no local commits ready to publish.";
-  }
-
-  if (input.wantsPr && !input.existingPr) {
-    if (!input.pullRequestDraft.title.trim()) return "Enter a pull request title.";
-  }
-
-  return null;
-}
-
-function sameBranch(left: string | null, right: string | null): boolean {
-  const normalizedLeft = normalizeBranchName(left);
-  const normalizedRight = normalizeBranchName(right);
-  return normalizedLeft.length > 0 && normalizedLeft === normalizedRight;
-}
-
-function normalizeBranchName(branch: string | null): string {
-  return (branch ?? "")
-    .trim()
-    .replace(/^refs\/heads\//, "")
-    .replace(/^heads\//, "");
-}
-
-function shouldPush(input: {
-  gitStatus: GitStatusSnapshot | null;
-  wantsPublish: boolean;
-  wantsPr: boolean;
-  hasDirtyChanges: boolean;
-}): boolean {
-  if (!input.wantsPublish && !input.wantsPr) return false;
-  if (input.hasDirtyChanges) return true;
-  return input.gitStatus?.actions.canPush ?? false;
-}
-
-function buildWorkflowSteps(input: {
-  fileGroups: PublishFileGroups;
-  includeUnstaged: boolean;
-  summary: string;
-  wantsPublish: boolean;
-  wantsPr: boolean;
-  needsPush: boolean;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  pullRequestDraft: PublishPullRequestDraft;
-  hasStagedChanges: boolean;
-  hasUnstagedChanges: boolean;
-}): PublishWorkflowStep[] {
-  const steps: PublishWorkflowStep[] = [];
-  const hasDirtyChanges = input.hasStagedChanges || input.hasUnstagedChanges;
-  if (hasDirtyChanges) {
-    if (input.includeUnstaged) {
-      const paths = [
-        ...input.fileGroups.unstaged.map((file) => file.path),
-        ...input.fileGroups.partial.map((file) => file.path),
-      ];
-      if (paths.length > 0) steps.push({ kind: "stage", paths });
-    }
-    steps.push({ kind: "commit", summary: input.summary });
-  }
-
-  if (input.needsPush) {
-    steps.push({ kind: "push" });
-  }
-
-  if (input.wantsPr && !input.existingPr) {
-    steps.push({
-      kind: "create_pull_request",
-      request: {
-        title: input.pullRequestDraft.title.trim(),
-        body: input.pullRequestDraft.body.trim() || undefined,
-        baseBranch: input.pullRequestDraft.baseBranch.trim(),
-        draft: input.pullRequestDraft.draft,
-      },
-    });
-  }
-
-  return steps;
-}
-
-function workflowSummary(input: {
-  intent: PublishIntent;
-  gitStatus: GitStatusSnapshot | null;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  publishStatus: string | null;
-  workflowSteps: PublishWorkflowStep[];
-}): string {
-  const hasStageStep = input.workflowSteps.some((step) => step.kind === "stage");
-  const hasCommitStep = input.workflowSteps.some((step) => step.kind === "commit");
-  const hasPushStep = input.workflowSteps.some((step) => step.kind === "push");
-  const hasCreatePrStep = input.workflowSteps.some((step) => step.kind === "create_pull_request");
-  const pushLabel = (input.gitStatus?.actions.pushLabel ?? "Publish").toLowerCase();
-
-  if (input.workflowSteps.length === 0) {
-    if (input.intent === "pull_request" && input.existingPr) {
-      return "A pull request already exists for this branch.";
-    }
-    if (input.publishStatus) {
-      return input.publishStatus;
-    }
-    if (input.intent === "commit") {
-      return "Commit changes in this workspace.";
-    }
-    if (input.intent === "publish") {
-      return "Publish local commits when this branch is ready.";
-    }
-    return "Create a pull request from this branch.";
-  }
-
-  if (input.intent === "commit") {
-    return hasStageStep
-      ? "Stage unstaged changes, then commit them."
-      : "Commit the selected staged changes.";
-  }
-
-  if (input.intent === "publish") {
-    if (hasCommitStep && hasPushStep) {
-      return hasStageStep
-        ? `Stage unstaged changes, commit them, then ${pushLabel}.`
-        : `Commit changes, then ${pushLabel}.`;
-    }
-    if (hasPushStep) {
-      return input.publishStatus ?? "Publish this branch.";
-    }
-    return "Commit changes before publishing this branch.";
-  }
-
-  if (input.existingPr && !hasCreatePrStep) {
-    if (hasCommitStep && hasPushStep) {
-      return hasStageStep
-        ? "Stage unstaged changes, commit them, then update the existing pull request branch."
-        : "Commit changes, then update the existing pull request branch.";
-    }
-    if (hasPushStep) {
-      return "Update the existing pull request branch.";
-    }
-    return "A pull request already exists for this branch.";
-  }
-
-  if (hasCommitStep && hasPushStep && hasCreatePrStep) {
-    return hasStageStep
-      ? "Stage unstaged changes, commit them, publish the branch, then create a pull request."
-      : "Commit changes, publish the branch, then create a pull request.";
-  }
-  if (hasPushStep && hasCreatePrStep) {
-    return "Publish this branch, then create a pull request.";
-  }
-  if (hasCommitStep && hasCreatePrStep) {
-    return hasStageStep
-      ? "Stage unstaged changes, commit them, then create a pull request."
-      : "Commit changes, then create a pull request.";
-  }
-  if (hasCreatePrStep) {
-    return "Create a pull request from this branch.";
-  }
-  if (hasPushStep) {
-    return "Publish this branch.";
-  }
-  return "Prepare this branch for a pull request.";
-}
-
-function primaryLabel(input: {
-  intent: PublishIntent;
-  gitStatus: GitStatusSnapshot | null;
-  existingPr: NonNullable<CurrentPullRequestResponse["pullRequest"]> | null;
-  hasDirtyChanges: boolean;
-  workflowSteps: PublishWorkflowStep[];
-}): string {
-  if (input.intent === "pull_request") {
-    if (input.existingPr && input.workflowSteps.length === 0) return "View pull request";
-    const hasCommitStep = input.workflowSteps.some((step) => step.kind === "commit");
-    const hasPushStep = input.workflowSteps.some((step) => step.kind === "push");
-    const hasCreatePrStep = input.workflowSteps.some((step) => step.kind === "create_pull_request");
-    if (hasCommitStep && hasPushStep && hasCreatePrStep) return "Commit, publish, create PR";
-    if (hasPushStep && hasCreatePrStep) return "Publish and create PR";
-    if (hasCreatePrStep) return hasCommitStep ? "Commit and create PR" : "Create PR";
-    if (hasCommitStep && hasPushStep) {
-      const label = input.gitStatus?.actions.pushLabel ?? "Publish";
-      return `Commit and ${label.toLowerCase()}`;
-    }
-    if (hasPushStep) return input.gitStatus?.actions.pushLabel ?? "Publish";
-    return input.existingPr ? "View pull request" : "Create PR";
-  }
-  if (input.intent === "publish") {
-    const label = input.gitStatus?.actions.pushLabel ?? "Publish";
-    return input.hasDirtyChanges ? `Commit and ${label.toLowerCase()}` : label;
-  }
-  return "Commit";
 }

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   buildMobilityFooterContext,
   type WorkspaceMobilitySelectedMaterializationKind,

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
@@ -1,4 +1,4 @@
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   isWorkspaceMobilityTransitionPhase,
   mobilityDestinationKind,

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-state-machine.ts
@@ -1,4 +1,4 @@
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { mobilityStatusCopy } from "@/lib/domain/workspaces/mobility/presentation";
 import type { WorkspaceMobilityHandoffSummary } from "@/lib/domain/workspaces/mobility/types";
 

--- a/desktop/src/lib/domain/workspaces/selection/hot-reopen.test.ts
+++ b/desktop/src/lib/domain/workspaces/selection/hot-reopen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   hotReopenWorkspaceLookupIds,
   isHotReopenEligibleSessionSlot,

--- a/desktop/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/desktop/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -1,6 +1,6 @@
 import type { TranscriptState } from "@anyharness/sdk";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
-import { logicalWorkspaceRelatedIds } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
+import { logicalWorkspaceRelatedIds } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 
 export interface HotReopenSessionSlotSnapshot {
   sessionId: string;

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-browser-tabs.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-browser-tabs.ts
@@ -1,0 +1,77 @@
+import { normalizeBrowserUrl } from "@/lib/domain/workspaces/shell/browser-url";
+import {
+  browserIdsFromHeaderOrder,
+  isValidRightPanelBrowserTabId,
+  type RightPanelBrowserTab,
+  type RightPanelBrowserTabsById,
+  type RightPanelHeaderEntryKey,
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+
+export function createRightPanelBrowserTabId(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `browser-${Date.now().toString(36)}-${random}`;
+}
+
+export function browserTabTitle(tab: RightPanelBrowserTab, index: number): string {
+  if (!tab.url) {
+    return `Browser ${index + 1}`;
+  }
+  try {
+    return new URL(tab.url).hostname || `Browser ${index + 1}`;
+  } catch {
+    return `Browser ${index + 1}`;
+  }
+}
+
+export function sanitizeBrowserTabsById(
+  value: unknown,
+  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
+): RightPanelBrowserTabsById {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const headerBrowserIds = new Set(browserIdsFromHeaderOrder(headerOrder));
+  const next: RightPanelBrowserTabsById = {};
+  for (const [browserId, rawTab] of Object.entries(value)) {
+    if (!isValidRightPanelBrowserTabId(browserId) || !isRecord(rawTab)) {
+      continue;
+    }
+    const tabId = rawTab.id;
+    const rawUrl = rawTab.url;
+    if (tabId !== browserId || !headerBrowserIds.has(browserId)) {
+      continue;
+    }
+    if (rawUrl === null) {
+      next[browserId] = { id: browserId, url: null };
+      continue;
+    }
+    if (typeof rawUrl !== "string") {
+      continue;
+    }
+    const normalizedUrl = normalizeBrowserUrl(rawUrl);
+    if (!normalizedUrl) {
+      continue;
+    }
+    next[browserId] = { id: browserId, url: normalizedUrl };
+  }
+  return next;
+}
+
+export function pickBrowserTabsInHeader(
+  browserTabsById: RightPanelBrowserTabsById,
+  headerOrder: readonly RightPanelHeaderEntryKey[],
+): RightPanelBrowserTabsById {
+  const next: RightPanelBrowserTabsById = {};
+  for (const browserId of browserIdsFromHeaderOrder(headerOrder)) {
+    const tab = browserTabsById[browserId];
+    if (tab) {
+      next[browserId] = tab;
+    }
+  }
+  return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-header-entry.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-header-entry.ts
@@ -1,10 +1,10 @@
 import type { TerminalRecord } from "@anyharness/sdk";
 import {
-  browserTabTitle,
   type RightPanelBrowserTab,
   type RightPanelHeaderEntryKey,
   type RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { browserTabTitle } from "@/lib/domain/workspaces/shell/right-panel-browser-tabs";
 
 export type RightPanelHeaderEntry =
   | { kind: "tool"; key: RightPanelHeaderEntryKey; tool: RightPanelTool }

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-migration.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-migration.ts
@@ -3,7 +3,6 @@ import {
   availableRightPanelTools,
   isRightPanelTool,
   normalizeRightPanelDurableState,
-  normalizeRightPanelMaterializedState,
   parseRightPanelHeaderEntryKey,
   rightPanelBrowserHeaderKey,
   rightPanelTerminalHeaderKey,
@@ -14,7 +13,8 @@ import {
   type RightPanelHeaderEntryKey,
   type RightPanelMaterializedState,
   type RightPanelTool,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { normalizeRightPanelMaterializedState } from "@/lib/domain/workspaces/shell/right-panel-state";
 
 export function migrateLegacyRightPanelWorkspaceState(args: {
   state: unknown;

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -1,0 +1,167 @@
+export type RightPanelTool = "files" | "git" | "settings";
+export type RightPanelHeaderEntryKey =
+  | `tool:${RightPanelTool}`
+  | `terminal:${string}`
+  | `browser:${string}`;
+export type RightPanelActiveEntryKey = RightPanelHeaderEntryKey;
+
+export interface RightPanelBrowserTab {
+  id: string;
+  url: string | null;
+}
+
+export type RightPanelBrowserTabsById = Record<string, RightPanelBrowserTab>;
+
+export interface RightPanelDurableState {
+  open: boolean;
+  width: number;
+}
+
+export interface RightPanelMaterializedState {
+  activeEntryKey: RightPanelActiveEntryKey;
+  headerOrder: RightPanelHeaderEntryKey[];
+  browserTabsById: RightPanelBrowserTabsById;
+}
+
+export type RightPanelWorkspaceState = RightPanelMaterializedState;
+
+export interface RightPanelTerminalRecord {
+  id: string;
+  purpose?: string | null;
+}
+
+export const RIGHT_PANEL_DEFAULT_WIDTH = 420;
+export const RIGHT_PANEL_MIN_WIDTH = 260;
+export const RIGHT_PANEL_MAX_WIDTH = 700;
+export const RIGHT_PANEL_BROWSER_TAB_LIMIT = 5;
+
+export const DEFAULT_RIGHT_PANEL_TOOL_ORDER: RightPanelTool[] = [
+  "files",
+  "git",
+  "settings",
+];
+export const DEFAULT_RIGHT_PANEL_HEADER_ORDER: RightPanelHeaderEntryKey[] =
+  DEFAULT_RIGHT_PANEL_TOOL_ORDER.map((tool) => rightPanelToolHeaderKey(tool));
+export const DEFAULT_RIGHT_PANEL_DURABLE_STATE: RightPanelDurableState = {
+  open: false,
+  width: RIGHT_PANEL_DEFAULT_WIDTH,
+};
+export const DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE: RightPanelMaterializedState = {
+  activeEntryKey: "tool:files",
+  headerOrder: DEFAULT_RIGHT_PANEL_HEADER_ORDER,
+  browserTabsById: {},
+};
+export const DEFAULT_RIGHT_PANEL_WORKSPACE_STATE: RightPanelWorkspaceState =
+  DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE;
+
+const RIGHT_PANEL_TOOLS = new Set<RightPanelTool>(DEFAULT_RIGHT_PANEL_TOOL_ORDER);
+const BROWSER_TAB_ID_PATTERN = /^[A-Za-z0-9_-]{1,80}$/;
+
+export function rightPanelToolHeaderKey(tool: RightPanelTool): RightPanelHeaderEntryKey {
+  return `tool:${tool}`;
+}
+
+export function rightPanelTerminalHeaderKey(terminalId: string): RightPanelHeaderEntryKey {
+  return `terminal:${terminalId}`;
+}
+
+export function rightPanelBrowserHeaderKey(browserId: string): RightPanelHeaderEntryKey {
+  return `browser:${browserId}`;
+}
+
+export function parseRightPanelHeaderEntryKey(
+  value: unknown,
+):
+  | { kind: "tool"; tool: RightPanelTool }
+  | { kind: "terminal"; terminalId: string }
+  | { kind: "browser"; browserId: string }
+  | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  if (value.startsWith("tool:")) {
+    const tool = value.slice("tool:".length);
+    if (isRightPanelTool(tool)) {
+      return { kind: "tool", tool };
+    }
+    return null;
+  }
+  if (value.startsWith("terminal:")) {
+    const terminalId = value.slice("terminal:".length);
+    if (terminalId) {
+      return { kind: "terminal", terminalId };
+    }
+    return null;
+  }
+  if (value.startsWith("browser:")) {
+    const browserId = value.slice("browser:".length);
+    if (isValidRightPanelBrowserTabId(browserId)) {
+      return { kind: "browser", browserId };
+    }
+  }
+  return null;
+}
+
+export function availableRightPanelTools(isCloudWorkspaceSelected: boolean): RightPanelTool[] {
+  return DEFAULT_RIGHT_PANEL_TOOL_ORDER.filter(
+    (tool) => tool !== "settings" || isCloudWorkspaceSelected,
+  );
+}
+
+export function clampRightPanelWidth(width: number): number {
+  if (!Number.isFinite(width)) {
+    return RIGHT_PANEL_DEFAULT_WIDTH;
+  }
+  return Math.min(RIGHT_PANEL_MAX_WIDTH, Math.max(RIGHT_PANEL_MIN_WIDTH, width));
+}
+
+export function normalizeRightPanelDurableState(
+  input: Partial<RightPanelDurableState> | undefined,
+): RightPanelDurableState {
+  return {
+    open: typeof input?.open === "boolean" ? input.open : DEFAULT_RIGHT_PANEL_DURABLE_STATE.open,
+    width: clampRightPanelWidth(input?.width ?? DEFAULT_RIGHT_PANEL_DURABLE_STATE.width),
+  };
+}
+
+export function isRightPanelTool(value: unknown): value is RightPanelTool {
+  return typeof value === "string" && RIGHT_PANEL_TOOLS.has(value as RightPanelTool);
+}
+
+export function isBrowserEntryKey(entryKey: RightPanelHeaderEntryKey): boolean {
+  return parseRightPanelHeaderEntryKey(entryKey)?.kind === "browser";
+}
+
+export function isTerminalEntryKey(entryKey: RightPanelHeaderEntryKey): boolean {
+  return parseRightPanelHeaderEntryKey(entryKey)?.kind === "terminal";
+}
+
+export function terminalIdsFromHeaderOrder(
+  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
+): string[] {
+  const terminalIds: string[] = [];
+  for (const key of headerOrder ?? []) {
+    const entry = parseRightPanelHeaderEntryKey(key);
+    if (entry?.kind === "terminal" && !terminalIds.includes(entry.terminalId)) {
+      terminalIds.push(entry.terminalId);
+    }
+  }
+  return terminalIds;
+}
+
+export function browserIdsFromHeaderOrder(
+  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
+): string[] {
+  const browserIds: string[] = [];
+  for (const key of headerOrder ?? []) {
+    const entry = parseRightPanelHeaderEntryKey(key);
+    if (entry?.kind === "browser" && !browserIds.includes(entry.browserId)) {
+      browserIds.push(entry.browserId);
+    }
+  }
+  return browserIds;
+}
+
+export function isValidRightPanelBrowserTabId(value: unknown): value is string {
+  return typeof value === "string" && BROWSER_TAB_ID_PATTERN.test(value);
+}

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-state.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-state.ts
@@ -1,135 +1,25 @@
-import { normalizeBrowserUrl } from "@/lib/domain/workspaces/shell/browser-url";
-
-export type RightPanelTool = "files" | "git" | "settings";
-export type RightPanelHeaderEntryKey =
-  | `tool:${RightPanelTool}`
-  | `terminal:${string}`
-  | `browser:${string}`;
-export type RightPanelActiveEntryKey = RightPanelHeaderEntryKey;
-
-export interface RightPanelBrowserTab {
-  id: string;
-  url: string | null;
-}
-
-export type RightPanelBrowserTabsById = Record<string, RightPanelBrowserTab>;
-
-export interface RightPanelDurableState {
-  open: boolean;
-  width: number;
-}
-
-export interface RightPanelMaterializedState {
-  activeEntryKey: RightPanelActiveEntryKey;
-  headerOrder: RightPanelHeaderEntryKey[];
-  browserTabsById: RightPanelBrowserTabsById;
-}
-
-export type RightPanelWorkspaceState = RightPanelMaterializedState;
-
-export interface RightPanelTerminalRecord {
-  id: string;
-  purpose?: string | null;
-}
-
-export const RIGHT_PANEL_DEFAULT_WIDTH = 420;
-export const RIGHT_PANEL_MIN_WIDTH = 260;
-export const RIGHT_PANEL_MAX_WIDTH = 700;
-export const RIGHT_PANEL_BROWSER_TAB_LIMIT = 5;
-
-export const DEFAULT_RIGHT_PANEL_TOOL_ORDER: RightPanelTool[] = [
-  "files",
-  "git",
-  "settings",
-];
-export const DEFAULT_RIGHT_PANEL_HEADER_ORDER: RightPanelHeaderEntryKey[] =
-  DEFAULT_RIGHT_PANEL_TOOL_ORDER.map((tool) => rightPanelToolHeaderKey(tool));
-export const DEFAULT_RIGHT_PANEL_DURABLE_STATE: RightPanelDurableState = {
-  open: false,
-  width: RIGHT_PANEL_DEFAULT_WIDTH,
-};
-export const DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE: RightPanelMaterializedState = {
-  activeEntryKey: "tool:files",
-  headerOrder: DEFAULT_RIGHT_PANEL_HEADER_ORDER,
-  browserTabsById: {},
-};
-export const DEFAULT_RIGHT_PANEL_WORKSPACE_STATE: RightPanelWorkspaceState =
-  DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE;
-
-const RIGHT_PANEL_TOOLS = new Set<RightPanelTool>(DEFAULT_RIGHT_PANEL_TOOL_ORDER);
-const BROWSER_TAB_ID_PATTERN = /^[A-Za-z0-9_-]{1,80}$/;
-
-export function rightPanelToolHeaderKey(tool: RightPanelTool): RightPanelHeaderEntryKey {
-  return `tool:${tool}`;
-}
-
-export function rightPanelTerminalHeaderKey(terminalId: string): RightPanelHeaderEntryKey {
-  return `terminal:${terminalId}`;
-}
-
-export function rightPanelBrowserHeaderKey(browserId: string): RightPanelHeaderEntryKey {
-  return `browser:${browserId}`;
-}
-
-export function createRightPanelBrowserTabId(): string {
-  const random = Math.random().toString(36).slice(2, 10);
-  return `browser-${Date.now().toString(36)}-${random}`;
-}
-
-export function parseRightPanelHeaderEntryKey(
-  value: unknown,
-):
-  | { kind: "tool"; tool: RightPanelTool }
-  | { kind: "terminal"; terminalId: string }
-  | { kind: "browser"; browserId: string }
-  | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  if (value.startsWith("tool:")) {
-    const tool = value.slice("tool:".length);
-    if (isRightPanelTool(tool)) {
-      return { kind: "tool", tool };
-    }
-    return null;
-  }
-  if (value.startsWith("terminal:")) {
-    const terminalId = value.slice("terminal:".length);
-    if (terminalId) {
-      return { kind: "terminal", terminalId };
-    }
-    return null;
-  }
-  if (value.startsWith("browser:")) {
-    const browserId = value.slice("browser:".length);
-    if (isValidBrowserTabId(browserId)) {
-      return { kind: "browser", browserId };
-    }
-  }
-  return null;
-}
-
-export function availableRightPanelTools(isCloudWorkspaceSelected: boolean): RightPanelTool[] {
-  return DEFAULT_RIGHT_PANEL_TOOL_ORDER.filter(
-    (tool) => tool !== "settings" || isCloudWorkspaceSelected,
-  );
-}
-
-export function clampRightPanelWidth(width: number): number {
-  if (!Number.isFinite(width)) {
-    return RIGHT_PANEL_DEFAULT_WIDTH;
-  }
-  return Math.min(RIGHT_PANEL_MAX_WIDTH, Math.max(RIGHT_PANEL_MIN_WIDTH, width));
-}
-
-export function normalizeRightPanelDurableState(
-  input: Partial<RightPanelDurableState> | undefined,
-): RightPanelDurableState {
-  return {
-    open: typeof input?.open === "boolean" ? input.open : DEFAULT_RIGHT_PANEL_DURABLE_STATE.open,
-    width: clampRightPanelWidth(input?.width ?? DEFAULT_RIGHT_PANEL_DURABLE_STATE.width),
-  };
-}
+import {
+  DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE,
+  RIGHT_PANEL_BROWSER_TAB_LIMIT,
+  availableRightPanelTools,
+  browserIdsFromHeaderOrder,
+  parseRightPanelHeaderEntryKey,
+  rightPanelBrowserHeaderKey,
+  rightPanelTerminalHeaderKey,
+  rightPanelToolHeaderKey,
+  terminalIdsFromHeaderOrder,
+  type RightPanelActiveEntryKey,
+  type RightPanelBrowserTabsById,
+  type RightPanelHeaderEntryKey,
+  type RightPanelMaterializedState,
+  type RightPanelTerminalRecord,
+  type RightPanelTool,
+  type RightPanelWorkspaceState,
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import {
+  pickBrowserTabsInHeader,
+  sanitizeBrowserTabsById,
+} from "@/lib/domain/workspaces/shell/right-panel-browser-tabs";
 
 export function normalizeRightPanelMaterializedState(
   input: Partial<RightPanelMaterializedState> | undefined,
@@ -304,55 +194,6 @@ export function reorderToolInRightPanelState(
   );
 }
 
-export function isRightPanelTool(value: unknown): value is RightPanelTool {
-  return typeof value === "string" && RIGHT_PANEL_TOOLS.has(value as RightPanelTool);
-}
-
-export function isBrowserEntryKey(entryKey: RightPanelHeaderEntryKey): boolean {
-  return parseRightPanelHeaderEntryKey(entryKey)?.kind === "browser";
-}
-
-export function isTerminalEntryKey(entryKey: RightPanelHeaderEntryKey): boolean {
-  return parseRightPanelHeaderEntryKey(entryKey)?.kind === "terminal";
-}
-
-export function terminalIdsFromHeaderOrder(
-  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
-): string[] {
-  const terminalIds: string[] = [];
-  for (const key of headerOrder ?? []) {
-    const entry = parseRightPanelHeaderEntryKey(key);
-    if (entry?.kind === "terminal" && !terminalIds.includes(entry.terminalId)) {
-      terminalIds.push(entry.terminalId);
-    }
-  }
-  return terminalIds;
-}
-
-export function browserIdsFromHeaderOrder(
-  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
-): string[] {
-  const browserIds: string[] = [];
-  for (const key of headerOrder ?? []) {
-    const entry = parseRightPanelHeaderEntryKey(key);
-    if (entry?.kind === "browser" && !browserIds.includes(entry.browserId)) {
-      browserIds.push(entry.browserId);
-    }
-  }
-  return browserIds;
-}
-
-export function browserTabTitle(tab: RightPanelBrowserTab, index: number): string {
-  if (!tab.url) {
-    return `Browser ${index + 1}`;
-  }
-  try {
-    return new URL(tab.url).hostname || `Browser ${index + 1}`;
-  } catch {
-    return `Browser ${index + 1}`;
-  }
-}
-
 function normalizeRightPanelHeaderOrder(
   headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
   options: {
@@ -449,7 +290,7 @@ function resolveFallbackRightPanelActiveEntryKey(
   if (headerOrder.includes("tool:files")) {
     return "tool:files";
   }
-  return headerOrder[0] ?? "tool:files";
+  return headerOrder[0] ?? DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE.activeEntryKey;
 }
 
 function removeHeaderEntryFromState(
@@ -487,61 +328,4 @@ function resolveNearestFallbackEntryKey(
     return next;
   }
   return resolveFallbackRightPanelActiveEntryKey(headerOrder);
-}
-
-function sanitizeBrowserTabsById(
-  value: unknown,
-  headerOrder: readonly RightPanelHeaderEntryKey[] | undefined,
-): RightPanelBrowserTabsById {
-  if (!isRecord(value)) {
-    return {};
-  }
-
-  const headerBrowserIds = new Set(browserIdsFromHeaderOrder(headerOrder));
-  const next: RightPanelBrowserTabsById = {};
-  for (const [browserId, rawTab] of Object.entries(value)) {
-    if (!isValidBrowserTabId(browserId) || !isRecord(rawTab)) {
-      continue;
-    }
-    const tabId = rawTab.id;
-    const rawUrl = rawTab.url;
-    if (tabId !== browserId || !headerBrowserIds.has(browserId)) {
-      continue;
-    }
-    if (rawUrl === null) {
-      next[browserId] = { id: browserId, url: null };
-      continue;
-    }
-    if (typeof rawUrl !== "string") {
-      continue;
-    }
-    const normalizedUrl = normalizeBrowserUrl(rawUrl);
-    if (!normalizedUrl) {
-      continue;
-    }
-    next[browserId] = { id: browserId, url: normalizedUrl };
-  }
-  return next;
-}
-
-function pickBrowserTabsInHeader(
-  browserTabsById: RightPanelBrowserTabsById,
-  headerOrder: readonly RightPanelHeaderEntryKey[],
-): RightPanelBrowserTabsById {
-  const next: RightPanelBrowserTabsById = {};
-  for (const browserId of browserIdsFromHeaderOrder(headerOrder)) {
-    const tab = browserTabsById[browserId];
-    if (tab) {
-      next[browserId] = tab;
-    }
-  }
-  return next;
-}
-
-function isValidBrowserTabId(value: unknown): value is string {
-  return typeof value === "string" && BROWSER_TAB_ID_PATTERN.test(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-view.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-view.ts
@@ -6,7 +6,7 @@ import {
   type RightPanelBrowserTab,
   type RightPanelHeaderEntryKey,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
 
 export function orderTerminals(
   terminals: readonly TerminalRecord[],

--- a/desktop/src/lib/domain/workspaces/shell/right-panel.test.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   RIGHT_PANEL_BROWSER_TAB_LIMIT,
   availableRightPanelTools,
-  canCreateRightPanelBrowserTab,
   clampRightPanelWidth,
-  createBrowserTabInRightPanelState,
   parseRightPanelHeaderEntryKey,
+} from "./right-panel-model";
+import {
+  canCreateRightPanelBrowserTab,
+  createBrowserTabInRightPanelState,
   reconcileRightPanelWorkspaceState,
   removeBrowserTabFromRightPanelState,
   removeTerminalFromRightPanelState,
@@ -13,7 +15,7 @@ import {
   reorderTerminalInRightPanelState,
   reorderToolInRightPanelState,
   updateBrowserTabUrlInRightPanelState,
-} from "./right-panel";
+} from "./right-panel-state";
 
 describe("right panel domain", () => {
   it("gates cloud settings to cloud workspaces", () => {

--- a/desktop/src/lib/domain/workspaces/sidebar/recency.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/recency.ts
@@ -1,7 +1,5 @@
-import {
-  latestLogicalWorkspaceTimestamp,
-  type LogicalWorkspace,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import { latestLogicalWorkspaceTimestamp } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 
 export interface LogicalWorkspaceRecency {
   activityAt: string | null;

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-entries.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-entries.ts
@@ -1,0 +1,134 @@
+import type { Workspace } from "@anyharness/sdk";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import {
+  cloudWorkspaceGroupKey,
+  localWorkspaceGroupKey,
+} from "@/lib/domain/workspaces/cloud/collections";
+import {
+  humanizeBranchName,
+  workspaceCurrentBranchName,
+} from "@/lib/domain/workspaces/creation/branch-naming";
+import { workspaceDisplayName } from "@/lib/domain/workspaces/display/workspace-display";
+import type { SidebarCloudWorkspaceSummary } from "@/lib/domain/workspaces/sidebar/cloud-workspace";
+import type {
+  CloudSidebarWorkspaceEntry,
+  SidebarEntryGitMetadata,
+  SidebarRepoGroupEntry,
+  SidebarWorkspaceEntry,
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
+
+export function buildSidebarWorkspaceEntries(
+  localWorkspaces: Workspace[],
+  cloudWorkspaces: SidebarCloudWorkspaceSummary[],
+): SidebarWorkspaceEntry[] {
+  const entries: SidebarWorkspaceEntry[] = [
+    ...localWorkspaces.map((workspace) => ({
+      source: "local" as const,
+      id: workspace.id,
+      repoKey: localWorkspaceGroupKey(workspace),
+      workspace,
+    })),
+    ...cloudWorkspaces.map((workspace) => ({
+      source: "cloud" as const,
+      id: cloudWorkspaceSyntheticId(workspace.id),
+      cloudWorkspaceId: workspace.id,
+      repoKey: cloudWorkspaceGroupKey(workspace),
+      workspace,
+    })),
+  ];
+
+  return entries.sort((a, b) => {
+    const aTime = new Date(sidebarEntryUpdatedAt(a)).getTime();
+    const bTime = new Date(sidebarEntryUpdatedAt(b)).getTime();
+    return bTime - aTime;
+  });
+}
+
+export function groupSidebarEntries(
+  entries: SidebarWorkspaceEntry[],
+): SidebarRepoGroupEntry[] {
+  const groups = new Map<string, SidebarRepoGroupEntry>();
+
+  for (const entry of entries) {
+    if (!groups.has(entry.repoKey)) {
+      groups.set(entry.repoKey, {
+        repoKey: entry.repoKey,
+        name: sidebarEntryGroupName(entry),
+        entries: [],
+      });
+    }
+
+    groups.get(entry.repoKey)!.entries.push(entry);
+  }
+
+  return Array.from(groups.values());
+}
+
+export function sidebarEntryDisplayName(entry: SidebarWorkspaceEntry): string {
+  if (entry.source === "cloud") {
+    const override = entry.workspace.displayName?.trim();
+    if (override) {
+      return override;
+    }
+    return cloudSidebarEntryDefaultDisplayName(entry);
+  }
+
+  return workspaceDisplayName(entry.workspace);
+}
+
+export function cloudSidebarEntryDefaultDisplayName(
+  entry: CloudSidebarWorkspaceEntry,
+): string {
+  return entry.workspace.repo.branch?.trim()
+    ? humanizeBranchName(entry.workspace.repo.branch)
+    : entry.workspace.repo.name;
+}
+
+export function sidebarEntryUpdatedAt(entry: SidebarWorkspaceEntry): string {
+  if (entry.source === "cloud") {
+    return entry.workspace.updatedAt ?? entry.workspace.createdAt ?? "";
+  }
+
+  return entry.workspace.updatedAt;
+}
+
+export function sidebarEntryGitMetadata(
+  entry: SidebarWorkspaceEntry,
+): SidebarEntryGitMetadata {
+  if (entry.source === "cloud") {
+    return {
+      provider: entry.workspace.repo.provider,
+      owner: entry.workspace.repo.owner,
+      repoName: entry.workspace.repo.name,
+      branchName: entry.workspace.repo.branch,
+    };
+  }
+
+  return {
+    provider: entry.workspace.gitProvider ?? null,
+    owner: entry.workspace.gitOwner ?? null,
+    repoName: entry.workspace.gitRepoName ?? null,
+    branchName: workspaceCurrentBranchName(entry.workspace),
+  };
+}
+
+export function sidebarEntryIsBranchBacked(entry: SidebarWorkspaceEntry): boolean {
+  return entry.source === "cloud" || entry.workspace.kind === "worktree";
+}
+
+export function sidebarEntryIsCloud(
+  entry: SidebarWorkspaceEntry,
+): entry is CloudSidebarWorkspaceEntry {
+  return entry.source === "cloud";
+}
+
+function sidebarEntryGroupName(entry: SidebarWorkspaceEntry): string {
+  if (entry.source === "cloud") {
+    return entry.workspace.repo.name;
+  }
+
+  return entry.workspace.gitRepoName
+    ?? entry.workspace.sourceRepoRootPath?.split("/").pop()
+    ?? entry.workspace.sourceRepoRootPath
+    ?? entry.workspace.path;
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-group-key.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-group-key.test.ts
@@ -3,8 +3,10 @@ import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import { buildLogicalWorkspaces } from "@/lib/domain/workspaces/cloud/logical-workspaces";
 import {
   buildSidebarGroupStates,
+} from "@/lib/domain/workspaces/sidebar/sidebar-groups";
+import {
   DEFAULT_SIDEBAR_WORKSPACE_TYPES,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import {
   sidebarRepoGroupKeyForCloudTarget,
   sidebarRepoGroupKeyForWorkspace,

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
@@ -1,299 +1,36 @@
-import type { GitStatusSnapshot, RepoRoot, Workspace } from "@anyharness/sdk";
+import type { GitStatusSnapshot, RepoRoot } from "@anyharness/sdk";
 import type { SidebarSessionActivityState } from "@/lib/domain/sessions/activity";
-import type { CloudWorkspaceRepoTarget } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import {
   latestLogicalWorkspaceTimestamp,
-  type LogicalWorkspace,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
+import { repoRootGroupKey } from "@/lib/domain/workspaces/cloud/collections";
+import { humanizeBranchName } from "@/lib/domain/workspaces/creation/branch-naming";
+import { workspaceDefaultDisplayName } from "@/lib/domain/workspaces/display/workspace-display";
+import {
+  activeWorkspaceActivity,
+  detailIndicatorsForWorkspace,
+  sidebarStatusIndicatorFromActivity,
+  sidebarWorkspaceVariantForLogicalWorkspace,
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type { SidebarCloudWorkspaceStatus } from "@/lib/domain/workspaces/sidebar/cloud-workspace";
+import { cloudSidebarEntryDefaultDisplayName } from "@/lib/domain/workspaces/sidebar/sidebar-entries";
+import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import {
+  resolveSidebarWorkspaceTypes,
+} from "@/lib/domain/workspaces/sidebar/sidebar-workspace-types";
+import { isWorkspaceNeedsReview } from "@/lib/domain/workspaces/sidebar/sidebar-review";
 import {
   compareLogicalWorkspaceRecency,
   compareResolvedLogicalWorkspaceRecency,
   type LogicalWorkspaceRecency,
   resolveLogicalWorkspaceRecency,
 } from "@/lib/domain/workspaces/sidebar/recency";
-import type {
-  SidebarCloudWorkspaceStatus,
-  SidebarCloudWorkspaceSummary,
-} from "./cloud-workspace";
-import {
-  humanizeBranchName,
-  workspaceCurrentBranchName,
-} from "@/lib/domain/workspaces/creation/branch-naming";
-import {
-  workspaceDefaultDisplayName,
-  workspaceDisplayName,
-} from "@/lib/domain/workspaces/display/workspace-display";
-import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
-import {
-  cloudWorkspaceGroupKey,
-  localWorkspaceGroupKey,
-  repoRootGroupKey,
-} from "@/lib/domain/workspaces/cloud/collections";
-import {
-  activeWorkspaceActivity,
-  detailIndicatorsForWorkspace,
-  sidebarStatusIndicatorFromActivity,
-  sidebarWorkspaceVariantForLogicalWorkspace,
-} from "./sidebar-indicators";
-import type {
-  SidebarDetailIndicator,
-  SidebarStatusIndicator,
-  SidebarWorkspaceVariant,
-} from "./sidebar-indicators";
-
-export {
-  sidebarStatusIndicatorFromActivity,
-  sidebarWorkspaceVariantForLogicalWorkspace,
-} from "./sidebar-indicators";
-export type {
-  SidebarDetailIndicator,
-  SidebarIndicatorAction,
-  SidebarStatusIndicator,
-  SidebarWorkspaceVariant,
-} from "./sidebar-indicators";
-
-export interface LocalSidebarWorkspaceEntry {
-  source: "local";
-  id: string;
-  repoKey: string;
-  workspace: Workspace;
-}
-
-export interface CloudSidebarWorkspaceEntry {
-  source: "cloud";
-  id: string;
-  cloudWorkspaceId: string;
-  repoKey: string;
-  workspace: SidebarCloudWorkspaceSummary;
-}
-
-export type SidebarWorkspaceEntry =
-  | LocalSidebarWorkspaceEntry
-  | CloudSidebarWorkspaceEntry;
-
-export interface SidebarRepoGroupEntry {
-  repoKey: string;
-  name: string;
-  entries: SidebarWorkspaceEntry[];
-}
-
-export interface SidebarEntryGitMetadata {
-  provider: string | null;
-  owner: string | null;
-  repoName: string | null;
-  branchName: string | null;
-}
-
-export type SidebarEmptyState = "noWorkspaces" | "filteredOut" | null;
-
-export const DEFAULT_SIDEBAR_WORKSPACE_TYPES: SidebarWorkspaceVariant[] = [
-  "local",
-  "worktree",
-  "cloud",
-];
-export const SIDEBAR_REPO_GROUP_ITEM_LIMIT = 6;
-
-export interface SidebarWorkspaceItemState {
-  id: string;
-  localWorkspaceId: string | null;
-  name: string;
-  /**
-   * The label we would render if the user had not set a display name override.
-   * Used as the input placeholder in the rename popover. Equal to `name`
-   * when no override is set.
-   */
-  defaultName: string;
-  /**
-   * Whether the local workspace has a user-set display name override. Cloud
-   * entries are always `false` (cloud renaming uses a separate flow).
-   */
-  hasDisplayNameOverride: boolean;
-  /**
-   * Whether this entry supports renaming via the AnyHarness display name
-   * override. False for cloud entries (handled separately).
-   */
-  renameSupported: boolean;
-  subtitle: string | null;
-  active: boolean;
-  archived: boolean;
-  variant: SidebarWorkspaceVariant;
-  statusIndicator: SidebarStatusIndicator | null;
-  detailIndicators: SidebarDetailIndicator[];
-  cloudStatus: SidebarCloudWorkspaceStatus | null;
-  lastInteracted: string | null;
-  needsReview: boolean;
-}
-
-export interface SidebarGroupState {
-  sourceRoot: string;
-  name: string;
-  items: SidebarWorkspaceItemState[];
-  allLogicalWorkspaceIds: string[];
-  repoRootId: string | null;
-  localSourceRoot: string | null;
-  cloudRepoTarget: CloudWorkspaceRepoTarget | null;
-}
 
 function logicalGroupName(workspace: LogicalWorkspace): string {
   return workspace.repoName
     ?? workspace.sourceRoot.split("/").filter(Boolean).pop()
     ?? workspace.sourceRoot;
-}
-
-interface WorkspaceNeedsReviewInput {
-  isArchived: boolean;
-  lastInteracted: string | null | undefined;
-  lastViewedAt: string | null | undefined;
-}
-
-export function buildSidebarWorkspaceEntries(
-  localWorkspaces: Workspace[],
-  cloudWorkspaces: SidebarCloudWorkspaceSummary[],
-): SidebarWorkspaceEntry[] {
-  const entries: SidebarWorkspaceEntry[] = [
-    ...localWorkspaces.map((workspace) => ({
-      source: "local" as const,
-      id: workspace.id,
-      repoKey: localWorkspaceGroupKey(workspace),
-      workspace,
-    })),
-    ...cloudWorkspaces.map((workspace) => ({
-      source: "cloud" as const,
-      id: cloudWorkspaceSyntheticId(workspace.id),
-      cloudWorkspaceId: workspace.id,
-      repoKey: cloudWorkspaceGroupKey(workspace),
-      workspace,
-    })),
-  ];
-
-  return entries.sort((a, b) => {
-    const aTime = new Date(sidebarEntryUpdatedAt(a)).getTime();
-    const bTime = new Date(sidebarEntryUpdatedAt(b)).getTime();
-    return bTime - aTime;
-  });
-}
-
-export function groupSidebarEntries(
-  entries: SidebarWorkspaceEntry[],
-): SidebarRepoGroupEntry[] {
-  const groups = new Map<string, SidebarRepoGroupEntry>();
-
-  for (const entry of entries) {
-    if (!groups.has(entry.repoKey)) {
-      groups.set(entry.repoKey, {
-        repoKey: entry.repoKey,
-        name: sidebarEntryGroupName(entry),
-        entries: [],
-      });
-    }
-
-    groups.get(entry.repoKey)!.entries.push(entry);
-  }
-
-  return Array.from(groups.values());
-}
-
-export function sidebarEntryDisplayName(entry: SidebarWorkspaceEntry): string {
-  if (entry.source === "cloud") {
-    const override = entry.workspace.displayName?.trim();
-    if (override) {
-      return override;
-    }
-    return cloudEntryDefaultDisplayName(entry);
-  }
-
-  return workspaceDisplayName(entry.workspace);
-}
-
-function cloudEntryDefaultDisplayName(entry: CloudSidebarWorkspaceEntry): string {
-  return entry.workspace.repo.branch?.trim()
-    ? humanizeBranchName(entry.workspace.repo.branch)
-    : entry.workspace.repo.name;
-}
-
-export function sidebarEntryUpdatedAt(entry: SidebarWorkspaceEntry): string {
-  if (entry.source === "cloud") {
-    return entry.workspace.updatedAt ?? entry.workspace.createdAt ?? "";
-  }
-
-  return entry.workspace.updatedAt;
-}
-
-export function sidebarEntryGitMetadata(
-  entry: SidebarWorkspaceEntry,
-): SidebarEntryGitMetadata {
-  if (entry.source === "cloud") {
-    return {
-      provider: entry.workspace.repo.provider,
-      owner: entry.workspace.repo.owner,
-      repoName: entry.workspace.repo.name,
-      branchName: entry.workspace.repo.branch,
-    };
-  }
-
-  return {
-    provider: entry.workspace.gitProvider ?? null,
-    owner: entry.workspace.gitOwner ?? null,
-    repoName: entry.workspace.gitRepoName ?? null,
-    branchName: workspaceCurrentBranchName(entry.workspace),
-  };
-}
-
-export function sidebarEntryIsBranchBacked(entry: SidebarWorkspaceEntry): boolean {
-  return entry.source === "cloud" || entry.workspace.kind === "worktree";
-}
-
-export function sidebarEntryIsCloud(
-  entry: SidebarWorkspaceEntry,
-): entry is CloudSidebarWorkspaceEntry {
-  return entry.source === "cloud";
-}
-
-export function isWorkspaceNeedsReview({
-  isArchived,
-  lastInteracted,
-  lastViewedAt,
-}: WorkspaceNeedsReviewInput): boolean {
-  if (isArchived || !lastInteracted) {
-    return false;
-  }
-
-  return !lastViewedAt
-    || new Date(lastInteracted).getTime() > new Date(lastViewedAt).getTime();
-}
-
-export function normalizeSidebarWorkspaceTypes(
-  workspaceTypes: readonly SidebarWorkspaceVariant[],
-): SidebarWorkspaceVariant[] {
-  const typeSet = new Set<SidebarWorkspaceVariant>(workspaceTypes);
-  return DEFAULT_SIDEBAR_WORKSPACE_TYPES.filter((type) => typeSet.has(type));
-}
-
-export function resolveSidebarWorkspaceTypes(
-  workspaceTypes: readonly SidebarWorkspaceVariant[] | null | undefined,
-): SidebarWorkspaceVariant[] {
-  const normalized = normalizeSidebarWorkspaceTypes(workspaceTypes ?? []);
-  return normalized.length > 0 ? normalized : DEFAULT_SIDEBAR_WORKSPACE_TYPES;
-}
-
-export function isDefaultSidebarWorkspaceTypes(
-  workspaceTypes: readonly SidebarWorkspaceVariant[],
-): boolean {
-  return resolveSidebarWorkspaceTypes(workspaceTypes).length === DEFAULT_SIDEBAR_WORKSPACE_TYPES.length;
-}
-
-export function toggleSidebarWorkspaceTypeSelection(
-  workspaceTypes: readonly SidebarWorkspaceVariant[],
-  type: SidebarWorkspaceVariant,
-): SidebarWorkspaceVariant[] {
-  const normalized = resolveSidebarWorkspaceTypes(workspaceTypes);
-  if (normalized.includes(type)) {
-    return normalized.length === 1
-      ? normalized
-      : normalized.filter((selectedType) => selectedType !== type);
-  }
-
-  return normalizeSidebarWorkspaceTypes([...normalized, type]);
 }
 
 export function resolveAutoShowMoreRepoKey(args: {
@@ -325,7 +62,7 @@ export function resolveAutoShowMoreRepoKey(args: {
 export function resolveSidebarEmptyState(
   logicalWorkspaceCount: number,
   groupCount: number,
-): SidebarEmptyState {
+): "noWorkspaces" | "filteredOut" | null {
   if (groupCount > 0) {
     return null;
   }
@@ -341,7 +78,7 @@ export function buildSidebarGroupStates(args: {
   repoRoots: RepoRoot[];
   logicalWorkspaces: LogicalWorkspace[];
   showArchived: boolean;
-  workspaceTypes: SidebarWorkspaceVariant[];
+  workspaceTypes: ReturnType<typeof resolveSidebarWorkspaceTypes>;
   archivedSet: Set<string>;
   hiddenRepoRootIds: Set<string>;
   selectedLogicalWorkspaceId: string | null;
@@ -407,7 +144,7 @@ export function buildSidebarGroupStates(args: {
               : workspaceDefaultDisplayName(preferredLocalWorkspace)
           )
           : preferredCloudWorkspace
-            ? cloudEntryDefaultDisplayName({
+            ? cloudSidebarEntryDefaultDisplayName({
               source: "cloud",
               id: entry.id,
               cloudWorkspaceId: preferredCloudWorkspace.id,
@@ -546,15 +283,4 @@ function groupHasWorkActivity(
   return workspaces.some((workspace) =>
     resolveLogicalWorkspaceRecency(workspace, workspaceActivityAt).activityAt !== null
   );
-}
-
-function sidebarEntryGroupName(entry: SidebarWorkspaceEntry): string {
-  if (entry.source === "cloud") {
-    return entry.workspace.repo.name;
-  }
-
-  return entry.workspace.gitRepoName
-    ?? entry.workspace.sourceRepoRootPath?.split("/").pop()
-    ?? entry.workspace.sourceRepoRootPath
-    ?? entry.workspace.path;
 }

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { WorkspaceExecutionSummary } from "@anyharness/sdk";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import {
   buildGroups,

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
@@ -2,7 +2,7 @@ import type { Workspace } from "@anyharness/sdk";
 import type { SidebarSessionActivityState } from "@/lib/domain/sessions/activity";
 import { resolveWorkspaceExecutionSidebarActivityState } from "@/lib/domain/sessions/activity";
 import { isCloudWorkspacePending } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import { automationWorkspaceDefaultDisplayNameFromBranch } from "@/lib/domain/workspaces/display/workspace-display";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import type { SidebarCloudWorkspaceSummary } from "./cloud-workspace";

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-model.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-model.ts
@@ -1,0 +1,93 @@
+import type { Workspace } from "@anyharness/sdk";
+import type { CloudWorkspaceRepoTarget } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import type {
+  SidebarCloudWorkspaceStatus,
+  SidebarCloudWorkspaceSummary,
+} from "@/lib/domain/workspaces/sidebar/cloud-workspace";
+import type {
+  SidebarDetailIndicator,
+  SidebarStatusIndicator,
+  SidebarWorkspaceVariant,
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
+
+export interface LocalSidebarWorkspaceEntry {
+  source: "local";
+  id: string;
+  repoKey: string;
+  workspace: Workspace;
+}
+
+export interface CloudSidebarWorkspaceEntry {
+  source: "cloud";
+  id: string;
+  cloudWorkspaceId: string;
+  repoKey: string;
+  workspace: SidebarCloudWorkspaceSummary;
+}
+
+export type SidebarWorkspaceEntry =
+  | LocalSidebarWorkspaceEntry
+  | CloudSidebarWorkspaceEntry;
+
+export interface SidebarRepoGroupEntry {
+  repoKey: string;
+  name: string;
+  entries: SidebarWorkspaceEntry[];
+}
+
+export interface SidebarEntryGitMetadata {
+  provider: string | null;
+  owner: string | null;
+  repoName: string | null;
+  branchName: string | null;
+}
+
+export type SidebarEmptyState = "noWorkspaces" | "filteredOut" | null;
+
+export const DEFAULT_SIDEBAR_WORKSPACE_TYPES: SidebarWorkspaceVariant[] = [
+  "local",
+  "worktree",
+  "cloud",
+];
+export const SIDEBAR_REPO_GROUP_ITEM_LIMIT = 6;
+
+export interface SidebarWorkspaceItemState {
+  id: string;
+  localWorkspaceId: string | null;
+  name: string;
+  /**
+   * The label we would render if the user had not set a display name override.
+   * Used as the input placeholder in the rename popover. Equal to `name`
+   * when no override is set.
+   */
+  defaultName: string;
+  /**
+   * Whether the local workspace has a user-set display name override. Cloud
+   * entries are always `false` (cloud renaming uses a separate flow).
+   */
+  hasDisplayNameOverride: boolean;
+  /**
+   * Whether this entry supports renaming via the AnyHarness display name
+   * override. False for cloud entries (handled separately).
+   */
+  renameSupported: boolean;
+  subtitle: string | null;
+  active: boolean;
+  archived: boolean;
+  variant: SidebarWorkspaceVariant;
+  statusIndicator: SidebarStatusIndicator | null;
+  detailIndicators: SidebarDetailIndicator[];
+  cloudStatus: SidebarCloudWorkspaceStatus | null;
+  lastInteracted: string | null;
+  needsReview: boolean;
+}
+
+export interface SidebarGroupState {
+  sourceRoot: string;
+  name: string;
+  items: SidebarWorkspaceItemState[];
+  allLogicalWorkspaceIds: string[];
+  repoRootId: string | null;
+  localSourceRoot: string | null;
+  cloudRepoTarget: CloudWorkspaceRepoTarget | null;
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-review.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-review.ts
@@ -1,0 +1,18 @@
+interface WorkspaceNeedsReviewInput {
+  isArchived: boolean;
+  lastInteracted: string | null | undefined;
+  lastViewedAt: string | null | undefined;
+}
+
+export function isWorkspaceNeedsReview({
+  isArchived,
+  lastInteracted,
+  lastViewedAt,
+}: WorkspaceNeedsReviewInput): boolean {
+  if (isArchived || !lastInteracted) {
+    return false;
+  }
+
+  return !lastViewedAt
+    || new Date(lastInteracted).getTime() > new Date(lastViewedAt).getTime();
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SIDEBAR_REPO_GROUP_ITEM_LIMIT } from "@/lib/domain/workspaces/sidebar/sidebar";
+import { SIDEBAR_REPO_GROUP_ITEM_LIMIT } from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import {
   resolveSidebarShortcutDigitTarget,
   visibleSidebarShortcutTargetIds,

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
@@ -1,5 +1,5 @@
 import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
-import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar/sidebar";
+import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar/sidebar-model";
 
 export function visibleSidebarShortcutTargetIds(args: {
   groups: readonly SidebarGroupState[];

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
@@ -1,12 +1,14 @@
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import type { SidebarSessionActivityState } from "@/lib/domain/sessions/activity";
-import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import type { SidebarCloudWorkspaceSummary } from "./cloud-workspace";
 import {
   buildSidebarGroupStates,
+} from "./sidebar-groups";
+import {
   DEFAULT_SIDEBAR_WORKSPACE_TYPES,
-  type SidebarWorkspaceVariant,
-} from "./sidebar";
+} from "./sidebar-model";
+import type { SidebarWorkspaceVariant } from "./sidebar-indicators";
 
 const DEFAULT_UPDATED_AT = "2026-04-13T10:00:00.000Z";
 

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-types.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-types.ts
@@ -1,0 +1,38 @@
+import {
+  DEFAULT_SIDEBAR_WORKSPACE_TYPES,
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
+
+export function normalizeSidebarWorkspaceTypes(
+  workspaceTypes: readonly SidebarWorkspaceVariant[],
+): SidebarWorkspaceVariant[] {
+  const typeSet = new Set<SidebarWorkspaceVariant>(workspaceTypes);
+  return DEFAULT_SIDEBAR_WORKSPACE_TYPES.filter((type) => typeSet.has(type));
+}
+
+export function resolveSidebarWorkspaceTypes(
+  workspaceTypes: readonly SidebarWorkspaceVariant[] | null | undefined,
+): SidebarWorkspaceVariant[] {
+  const normalized = normalizeSidebarWorkspaceTypes(workspaceTypes ?? []);
+  return normalized.length > 0 ? normalized : DEFAULT_SIDEBAR_WORKSPACE_TYPES;
+}
+
+export function isDefaultSidebarWorkspaceTypes(
+  workspaceTypes: readonly SidebarWorkspaceVariant[],
+): boolean {
+  return resolveSidebarWorkspaceTypes(workspaceTypes).length === DEFAULT_SIDEBAR_WORKSPACE_TYPES.length;
+}
+
+export function toggleSidebarWorkspaceTypeSelection(
+  workspaceTypes: readonly SidebarWorkspaceVariant[],
+  type: SidebarWorkspaceVariant,
+): SidebarWorkspaceVariant[] {
+  const normalized = resolveSidebarWorkspaceTypes(workspaceTypes);
+  if (normalized.includes(type)) {
+    return normalized.length === 1
+      ? normalized
+      : normalized.filter((selectedType) => selectedType !== type);
+  }
+
+  return normalizeSidebarWorkspaceTypes([...normalized, type]);
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SIDEBAR_WORKSPACE_TYPES,
+} from "./sidebar-model";
+import {
   resolveAutoShowMoreRepoKey,
   resolveSidebarEmptyState,
+} from "./sidebar-groups";
+import {
   resolveSidebarWorkspaceTypes,
   toggleSidebarWorkspaceTypeSelection,
-} from "./sidebar";
+} from "./sidebar-workspace-types";
 import {
   buildGroups,
   makeCloudLogicalWorkspace,

--- a/desktop/src/lib/workflows/workspaces/run-workspace-publish-workflow.ts
+++ b/desktop/src/lib/workflows/workspaces/run-workspace-publish-workflow.ts
@@ -1,5 +1,5 @@
 import type { CommitRequest } from "@anyharness/sdk";
-import type { PublishWorkflowStep } from "@/lib/domain/workspaces/creation/publish-workflow";
+import type { PublishWorkflowStep } from "@/lib/domain/workspaces/creation/publish-workflow-model";
 
 export interface WorkspacePublishWorkflowRunner {
   stagePaths: (paths: string[]) => Promise<unknown>;

--- a/desktop/src/providers/AppProviders.tsx
+++ b/desktop/src/providers/AppProviders.tsx
@@ -11,10 +11,14 @@ import { appQueryClient } from "@/lib/infra/query/query-client";
 import { resolveWorkspaceConnection } from "@/lib/access/anyharness/resolve-workspace-connection";
 import {
   buildLogicalWorkspaces,
+} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import {
   findLogicalWorkspace,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import {
   logicalWorkspaceCloudMaterializationId,
   resolveLogicalWorkspaceMaterializationId,
-} from "@/lib/domain/workspaces/cloud/logical-workspaces";
+} from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import { buildStandardRepoProjection } from "@/lib/domain/workspaces/cloud/standard-projection";
 import { cloudMobilityWorkspacesKey } from "@/hooks/access/cloud/query-keys";
 import { cloudWorkspaceConnectionQueryOptions } from "@/hooks/access/cloud/use-cloud-workspace-connection";

--- a/desktop/src/stores/preferences/workspace-ui-store.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store.ts
@@ -3,18 +3,18 @@ import { create } from "zustand";
 import type { ManualChatGroup } from "@/lib/domain/workspaces/tabs/manual-groups";
 import {
   toggleSidebarWorkspaceTypeSelection,
-  type SidebarWorkspaceVariant,
-} from "@/lib/domain/workspaces/sidebar/sidebar";
+} from "@/lib/domain/workspaces/sidebar/sidebar-workspace-types";
+import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import {
   clampRightPanelWidth,
   DEFAULT_RIGHT_PANEL_DURABLE_STATE,
   DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE,
   normalizeRightPanelDurableState,
-  reconcileRightPanelWorkspaceState,
   type RightPanelDurableState,
   type RightPanelMaterializedState,
   type RightPanelWorkspaceState,
-} from "@/lib/domain/workspaces/shell/right-panel";
+} from "@/lib/domain/workspaces/shell/right-panel-model";
+import { reconcileRightPanelWorkspaceState } from "@/lib/domain/workspaces/shell/right-panel-state";
 import type { PendingChatActivation } from "@/lib/domain/workspaces/tabs/shell-activation";
 import {
   type WorkspaceShellIntentKey,


### PR DESCRIPTION
## Summary
- Split logical workspace IDs, lookup, materialization, and model types into focused cloud domain files.
- Split sidebar entries, group state, workspace type filters, review state, and models into direct-import modules.
- Split right-panel model, browser tab, and materialized state helpers, and break publish workflow helpers into focused modules.
- Added focused coverage for publish file grouping while preserving existing behavior.

## Verification
- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check
- git diff --cached --check
- pnpm --dir desktop test -- src/lib/domain/workspaces/cloud/logical-workspaces.test.ts src/lib/domain/workspaces/sidebar/sidebar.test.ts src/lib/domain/workspaces/shell/right-panel.test.ts src/lib/domain/workspaces/creation/publish-workflow.test.ts src/lib/domain/workspaces/creation/publish-file-groups.test.ts
- pnpm --dir desktop exec tsc --noEmit