### PR TITLE
refactor(server): thread mobility simple endpoint db sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -15,7 +15,7 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitio
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 3 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 16 transitional store owns transaction commit
@@ -28,7 +28,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/c
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 13 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 9 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environments.py 7 phase 8 runtime lifecycle wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session

--- a/server/proliferate/db/store/cloud_mobility.py
+++ b/server/proliferate/db/store/cloud_mobility.py
@@ -227,6 +227,29 @@ async def list_cloud_workspace_mobility(
     )
 
 
+async def load_cloud_workspace_mobility_value(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+) -> CloudWorkspaceMobilityValue | None:
+    record = await get_cloud_workspace_mobility(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
+    )
+    if record is None:
+        return None
+    active_handoff = None
+    if record.active_handoff_op_id is not None:
+        active_handoff = await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=record.active_handoff_op_id,
+        )
+    return _mobility_value(record, active_handoff=active_handoff)
+
+
 async def get_cloud_workspace_handoff_op(
     db: AsyncSession,
     *,
@@ -441,9 +464,7 @@ async def update_cloud_workspace_handoff_phase(
     if status_detail is not None:
         mobility_workspace.status_detail = status_detail
     mobility_workspace.updated_at = now
-    await db.commit()
-    await db.refresh(handoff_op)
-    await db.refresh(mobility_workspace)
+    await db.flush()
     return _handoff_value(handoff_op)
 
 
@@ -455,8 +476,7 @@ async def heartbeat_cloud_workspace_handoff_op(
     now = utcnow()
     handoff_op.heartbeat_at = now
     handoff_op.updated_at = now
-    await db.commit()
-    await db.refresh(handoff_op)
+    await db.flush()
     return _handoff_value(handoff_op)
 
 
@@ -484,9 +504,7 @@ async def finalize_cloud_workspace_handoff_op(
     mobility_workspace.last_error = None
     mobility_workspace.updated_at = now
 
-    await db.commit()
-    await db.refresh(handoff_op)
-    await db.refresh(mobility_workspace)
+    await db.flush()
     return _handoff_value(handoff_op)
 
 
@@ -506,9 +524,7 @@ async def complete_cloud_workspace_handoff_cleanup(
     mobility_workspace.status_detail = "Ready"
     mobility_workspace.updated_at = now
 
-    await db.commit()
-    await db.refresh(handoff_op)
-    await db.refresh(mobility_workspace)
+    await db.flush()
     return _handoff_value(handoff_op)
 
 
@@ -537,9 +553,7 @@ async def fail_cloud_workspace_handoff_op(
     mobility_workspace.last_error = last_error
     mobility_workspace.updated_at = now
 
-    await db.commit()
-    await db.refresh(handoff_op)
-    await db.refresh(mobility_workspace)
+    await db.flush()
     return _handoff_value(handoff_op)
 
 
@@ -568,21 +582,11 @@ async def load_cloud_workspace_mobility_for_user(
     mobility_workspace_id: UUID,
 ) -> CloudWorkspaceMobilityValue | None:
     async with db_engine.async_session_factory() as db:
-        record = await get_cloud_workspace_mobility(
+        return await load_cloud_workspace_mobility_value(
             db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
         )
-        if record is None:
-            return None
-        active_handoff = None
-        if record.active_handoff_op_id is not None:
-            active_handoff = await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=record.active_handoff_op_id,
-            )
-        return _mobility_value(record, active_handoff=active_handoff)
 
 
 async def ensure_cloud_workspace_mobility_for_user(
@@ -643,20 +647,6 @@ async def load_active_user_handoff_op_for_user(
         return _handoff_value(record) if record is not None else None
 
 
-async def load_cloud_workspace_handoff_op_for_user(
-    *,
-    user_id: UUID,
-    handoff_op_id: UUID,
-) -> CloudWorkspaceHandoffOpValue | None:
-    async with db_engine.async_session_factory() as db:
-        record = await get_cloud_workspace_handoff_op(
-            db,
-            user_id=user_id,
-            handoff_op_id=handoff_op_id,
-        )
-        return _handoff_value(record) if record is not None else None
-
-
 async def create_cloud_workspace_handoff_op_for_user(
     *,
     user_id: UUID,
@@ -699,6 +689,38 @@ async def create_cloud_workspace_handoff_op_for_user(
 
 
 async def update_cloud_workspace_handoff_phase_for_user(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+    handoff_op_id: UUID,
+    phase: str,
+    status_detail: str | None,
+    cloud_workspace_id: UUID | None = None,
+) -> CloudWorkspaceHandoffOpValue:
+    mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
+        await get_cloud_workspace_mobility_for_update(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        ),
+        await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=handoff_op_id,
+        ),
+    )
+    return await update_cloud_workspace_handoff_phase(
+        db,
+        handoff_op=handoff_op,
+        mobility_workspace=mobility_workspace,
+        phase=phase,
+        status_detail=status_detail,
+        cloud_workspace_id=cloud_workspace_id,
+    )
+
+
+async def update_cloud_workspace_handoff_phase_checkpoint_for_user(
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -708,105 +730,134 @@ async def update_cloud_workspace_handoff_phase_for_user(
     cloud_workspace_id: UUID | None = None,
 ) -> CloudWorkspaceHandoffOpValue:
     async with db_engine.async_session_factory() as db:
-        mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
-            await get_cloud_workspace_mobility_for_update(
-                db,
-                user_id=user_id,
-                mobility_workspace_id=mobility_workspace_id,
-            ),
-            await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=handoff_op_id,
-            ),
-        )
-        return await update_cloud_workspace_handoff_phase(
+        value = await update_cloud_workspace_handoff_phase_for_user(
             db,
-            handoff_op=handoff_op,
-            mobility_workspace=mobility_workspace,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+            handoff_op_id=handoff_op_id,
             phase=phase,
             status_detail=status_detail,
             cloud_workspace_id=cloud_workspace_id,
         )
+        await db.commit()
+        return value
 
 
 async def heartbeat_cloud_workspace_handoff_op_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        _, handoff_op = _require_handoff_belongs_to_workspace(
-            await get_cloud_workspace_mobility(
-                db,
-                user_id=user_id,
-                mobility_workspace_id=mobility_workspace_id,
-            ),
-            await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=handoff_op_id,
-            ),
-        )
-        return await heartbeat_cloud_workspace_handoff_op(db, handoff_op=handoff_op)
+    _, handoff_op = _require_handoff_belongs_to_workspace(
+        await get_cloud_workspace_mobility(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        ),
+        await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=handoff_op_id,
+        ),
+    )
+    return await heartbeat_cloud_workspace_handoff_op(db, handoff_op=handoff_op)
 
 
 async def finalize_cloud_workspace_handoff_op_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
-            await get_cloud_workspace_mobility(
-                db,
-                user_id=user_id,
-                mobility_workspace_id=mobility_workspace_id,
-            ),
-            await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=handoff_op_id,
-            ),
-        )
-        return await finalize_cloud_workspace_handoff_op(
+    mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
+        await get_cloud_workspace_mobility(
             db,
-            handoff_op=handoff_op,
-            mobility_workspace=mobility_workspace,
-            cloud_workspace_id=cloud_workspace_id,
-        )
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        ),
+        await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=handoff_op_id,
+        ),
+    )
+    return await finalize_cloud_workspace_handoff_op(
+        db,
+        handoff_op=handoff_op,
+        mobility_workspace=mobility_workspace,
+        cloud_workspace_id=cloud_workspace_id,
+    )
 
 
 async def complete_cloud_workspace_handoff_cleanup_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
-            await get_cloud_workspace_mobility(
-                db,
-                user_id=user_id,
-                mobility_workspace_id=mobility_workspace_id,
-            ),
-            await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=handoff_op_id,
-            ),
-        )
-        return await complete_cloud_workspace_handoff_cleanup(
+    mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
+        await get_cloud_workspace_mobility(
             db,
-            handoff_op=handoff_op,
-            mobility_workspace=mobility_workspace,
-        )
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        ),
+        await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=handoff_op_id,
+        ),
+    )
+    return await complete_cloud_workspace_handoff_cleanup(
+        db,
+        handoff_op=handoff_op,
+        mobility_workspace=mobility_workspace,
+    )
 
 
 async def fail_cloud_workspace_handoff_op_for_user(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+    handoff_op_id: UUID,
+    phase: str,
+    lifecycle_state: str,
+    failure_code: str,
+    failure_detail: str,
+    status_detail: str | None,
+    last_error: str,
+) -> CloudWorkspaceHandoffOpValue:
+    mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
+        await get_cloud_workspace_mobility(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        ),
+        await get_cloud_workspace_handoff_op(
+            db,
+            user_id=user_id,
+            handoff_op_id=handoff_op_id,
+        ),
+    )
+    return await fail_cloud_workspace_handoff_op(
+        db,
+        handoff_op=handoff_op,
+        mobility_workspace=mobility_workspace,
+        phase=phase,
+        lifecycle_state=lifecycle_state,
+        failure_code=failure_code,
+        failure_detail=failure_detail,
+        status_detail=status_detail,
+        last_error=last_error,
+    )
+
+
+async def fail_cloud_workspace_handoff_op_checkpoint_for_user(
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -819,22 +870,11 @@ async def fail_cloud_workspace_handoff_op_for_user(
     last_error: str,
 ) -> CloudWorkspaceHandoffOpValue:
     async with db_engine.async_session_factory() as db:
-        mobility_workspace, handoff_op = _require_handoff_belongs_to_workspace(
-            await get_cloud_workspace_mobility(
-                db,
-                user_id=user_id,
-                mobility_workspace_id=mobility_workspace_id,
-            ),
-            await get_cloud_workspace_handoff_op(
-                db,
-                user_id=user_id,
-                handoff_op_id=handoff_op_id,
-            ),
-        )
-        return await fail_cloud_workspace_handoff_op(
+        value = await fail_cloud_workspace_handoff_op_for_user(
             db,
-            handoff_op=handoff_op,
-            mobility_workspace=mobility_workspace,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+            handoff_op_id=handoff_op_id,
             phase=phase,
             lifecycle_state=lifecycle_state,
             failure_code=failure_code,
@@ -842,6 +882,8 @@ async def fail_cloud_workspace_handoff_op_for_user(
             status_detail=status_detail,
             last_error=last_error,
         )
+        await db.commit()
+        return value
 
 
 async def expire_stale_cloud_workspace_handoff_op_for_user(

--- a/server/proliferate/server/cloud/mobility/api.py
+++ b/server/proliferate/server/cloud/mobility/api.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.mobility.models import (
@@ -70,9 +72,11 @@ async def ensure_mobility_workspace_endpoint(
 async def get_mobility_workspace_endpoint(
     mobility_workspace_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityWorkspaceDetail:
     try:
         value = await get_cloud_workspace_mobility_detail(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
         )
@@ -133,9 +137,11 @@ async def heartbeat_mobility_handoff_endpoint(
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await heartbeat_cloud_workspace_handoff(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -154,9 +160,11 @@ async def update_mobility_handoff_phase_endpoint(
     handoff_op_id: UUID,
     body: UpdateWorkspaceMobilityHandoffPhaseRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await update_cloud_workspace_handoff_phase(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -178,9 +186,11 @@ async def finalize_mobility_handoff_endpoint(
     handoff_op_id: UUID,
     body: FinalizeWorkspaceMobilityHandoffRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await finalize_cloud_workspace_handoff(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -199,9 +209,11 @@ async def cleanup_mobility_handoff_endpoint(
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await complete_cloud_workspace_handoff_cleanup(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -220,9 +232,11 @@ async def fail_mobility_handoff_endpoint(
     handoff_op_id: UUID,
     body: FailWorkspaceMobilityHandoffRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await fail_cloud_workspace_handoff(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -5,6 +5,8 @@ from contextlib import suppress
 from datetime import timedelta
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.db.store.cloud_mobility import (
     CloudWorkspaceHandoffOpValue,
     CloudWorkspaceMobilityValue,
@@ -13,11 +15,14 @@ from proliferate.db.store.cloud_mobility import (
     create_cloud_workspace_handoff_op_for_user,
     ensure_cloud_workspace_mobility_for_user,
     expire_stale_cloud_workspace_handoff_op_for_user,
+    fail_cloud_workspace_handoff_op_checkpoint_for_user,
     fail_cloud_workspace_handoff_op_for_user,
     finalize_cloud_workspace_handoff_op_for_user,
     heartbeat_cloud_workspace_handoff_op_for_user,
     load_active_user_handoff_op_for_user,
     load_cloud_workspace_mobility_for_user,
+    load_cloud_workspace_mobility_value,
+    update_cloud_workspace_handoff_phase_checkpoint_for_user,
     update_cloud_workspace_handoff_phase_for_user,
 )
 from proliferate.db.store.cloud_mobility import (
@@ -149,14 +154,23 @@ async def ensure_cloud_workspace_mobility(
 
 
 async def get_cloud_workspace_mobility_detail(
+    db: AsyncSession | None = None,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
 ) -> CloudWorkspaceMobilityValue:
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
-    record = await load_cloud_workspace_mobility_for_user(
-        user_id=user_id,
-        mobility_workspace_id=mobility_workspace_id,
+    record = (
+        await load_cloud_workspace_mobility_value(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        )
+        if db is not None
+        else await load_cloud_workspace_mobility_for_user(
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+        )
     )
     if record is None:
         raise CloudApiError(
@@ -370,7 +384,7 @@ async def start_cloud_workspace_handoff(
                 else str(error) or "Workspace handoff start failed."
             )
             with suppress(ValueError):
-                await fail_cloud_workspace_handoff_op_for_user(
+                await fail_cloud_workspace_handoff_op_checkpoint_for_user(
                     user_id=user_id,
                     mobility_workspace_id=mobility_workspace_id,
                     handoff_op_id=handoff.id,
@@ -382,7 +396,7 @@ async def start_cloud_workspace_handoff(
                     last_error=visible_failure_last_error(failure_detail),
                 )
             raise
-        return await update_cloud_workspace_handoff_phase_for_user(
+        return await update_cloud_workspace_handoff_phase_checkpoint_for_user(
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff.id,
@@ -394,6 +408,7 @@ async def start_cloud_workspace_handoff(
 
 
 async def heartbeat_cloud_workspace_handoff(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -402,6 +417,7 @@ async def heartbeat_cloud_workspace_handoff(
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
     try:
         return await heartbeat_cloud_workspace_handoff_op_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -411,6 +427,7 @@ async def heartbeat_cloud_workspace_handoff(
 
 
 async def update_cloud_workspace_handoff_phase(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -428,6 +445,7 @@ async def update_cloud_workspace_handoff_phase(
         )
     try:
         return await update_cloud_workspace_handoff_phase_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -440,6 +458,7 @@ async def update_cloud_workspace_handoff_phase(
 
 
 async def finalize_cloud_workspace_handoff(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -449,6 +468,7 @@ async def finalize_cloud_workspace_handoff(
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
     try:
         return await finalize_cloud_workspace_handoff_op_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -459,6 +479,7 @@ async def finalize_cloud_workspace_handoff(
 
 
 async def complete_cloud_workspace_handoff_cleanup(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -467,6 +488,7 @@ async def complete_cloud_workspace_handoff_cleanup(
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
     try:
         return await complete_cloud_workspace_handoff_cleanup_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,
@@ -476,6 +498,7 @@ async def complete_cloud_workspace_handoff_cleanup(
 
 
 async def fail_cloud_workspace_handoff(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -486,6 +509,7 @@ async def fail_cloud_workspace_handoff(
     await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
     try:
         return await fail_cloud_workspace_handoff_op_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff_op_id,

--- a/server/tests/unit/test_cloud_mobility_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_lifecycle.py
@@ -254,6 +254,7 @@ async def test_finalize_flips_owner_before_cleanup_clears_active_handoff(
         mobility_workspace=mobility_record,
         cloud_workspace_id=None,
     )
+    await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
         user_id=user_id,
@@ -295,6 +296,7 @@ async def test_cleanup_completion_clears_active_handoff_and_marks_completed(
         handoff_op=handoff_record,
         mobility_workspace=mobility_record,
     )
+    await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
         user_id=user_id,
@@ -341,6 +343,7 @@ async def test_failure_clears_active_handoff_and_truncates_visible_error(
         status_detail=visible_failure_status_detail(failure_detail),
         last_error=visible_failure_last_error(failure_detail),
     )
+    await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
         user_id=user_id,

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -407,7 +407,7 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     )
     monkeypatch.setattr(
         mobility_service,
-        "fail_cloud_workspace_handoff_op_for_user",
+        "fail_cloud_workspace_handoff_op_checkpoint_for_user",
         _fail_handoff,
     )
     monkeypatch.setattr(

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -254,7 +254,7 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     monkeypatch.setattr(mobility_service, "start_cloud_workspace", _start_cloud_workspace)
     monkeypatch.setattr(
         mobility_service,
-        "update_cloud_workspace_handoff_phase_for_user",
+        "update_cloud_workspace_handoff_phase_checkpoint_for_user",
         _update_phase,
     )
 
@@ -341,6 +341,7 @@ async def test_update_handoff_phase_rejects_unsupported_phase(
 
     with pytest.raises(CloudApiError) as exc_info:
         await mobility_service.update_cloud_workspace_handoff_phase(
+            object(),
             user_id=uuid4(),
             mobility_workspace_id=uuid4(),
             handoff_op_id=uuid4(),


### PR DESCRIPTION
## Summary

Phase 8 Wave 3B, Cloud Mobility simple endpoint DB threading.

- Inject request `AsyncSession` into mobility detail, heartbeat, phase update, finalize, cleanup-complete, and fail routes.
- Thread the request session through mobility services into DB-taking store primitives for those simple paths.
- Keep list/backfill/preflight/start-handoff on the existing isolated wrapper/checkpoint behavior, including durable start/failure checkpoints.
- Ratchet `cloud_mobility.py` boundary allowlist counts only after the checker confirmed lower observed counts.

## Invariants

- Public mobility API payloads are unchanged.
- Handoff start still creates the durable handoff before cloud provisioning.
- Start-handoff success/failure checkpoint updates still use short isolated DB commits outside long provider/runtime operations.
- Finalize still flips visible ownership before cleanup completion, and cleanup completion still clears the active handoff.
- Failure still clears the active handoff and records truncated visible detail/error.

## Verification

- `DEBUG=1 uv run --python 3.12 --extra dev python -m pytest -q tests/unit/test_cloud_mobility_domain.py tests/unit/test_cloud_mobility_store.py tests/unit/test_cloud_mobility_lifecycle.py tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_service_lifecycle.py`
- `uv run --python 3.12 python scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check HEAD~1..HEAD`

Note: local `/usr/bin/python3` is Python 3.9, so the server boundary checker was run with the repo-required Python 3.12 interpreter via `uv`.