### PR TITLE
refactor(server): thread workspace simple request db sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -18,7 +18,7 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional sto
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 16 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 14 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 1 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
@@ -32,7 +32,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 13 tran
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environments.py 7 phase 8 runtime lifecycle wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 26 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 24 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 4 transitional wrappers used by deferred billing/cloud callers

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -144,6 +144,28 @@ async def get_existing_cloud_workspace(
     ).scalar_one_or_none()
 
 
+async def update_workspace_branch(
+    db: AsyncSession,
+    workspace: CloudWorkspace,
+    branch_name: str,
+) -> CloudWorkspace:
+    workspace.git_branch = branch_name
+    workspace.updated_at = utcnow()
+    await db.flush()
+    return workspace
+
+
+async def update_workspace_display_name(
+    db: AsyncSession,
+    workspace: CloudWorkspace,
+    display_name: str | None,
+) -> CloudWorkspace:
+    workspace.display_name = display_name
+    workspace.updated_at = utcnow()
+    await db.flush()
+    return workspace
+
+
 async def create_cloud_workspace_record(
     db: AsyncSession,
     *,
@@ -759,40 +781,6 @@ async def save_workspace(
     async with db_engine.async_session_factory() as db:
         merged = await db.merge(workspace)
         return await persist_workspace_record(db, merged)
-
-
-async def save_workspace_branch_for_user(
-    *,
-    user_id: UUID,
-    workspace_id: UUID,
-    branch_name: str,
-) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        workspace = await get_cloud_workspace_for_user(db, user_id, workspace_id)
-        if workspace is None:
-            return None
-        workspace.git_branch = branch_name
-        workspace.updated_at = utcnow()
-        await db.commit()
-        await db.refresh(workspace)
-        return workspace
-
-
-async def save_workspace_display_name_for_user(
-    *,
-    user_id: UUID,
-    workspace_id: UUID,
-    display_name: str | None,
-) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        workspace = await get_cloud_workspace_for_user(db, user_id, workspace_id)
-        if workspace is None:
-            return None
-        workspace.display_name = display_name
-        workspace.updated_at = utcnow()
-        await db.commit()
-        await db.refresh(workspace)
-        return workspace
 
 
 async def reserve_and_attach_sandbox_for_workspace(

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -177,16 +177,29 @@ async def load_active_membership(
     user_id: UUID,
 ) -> MembershipRecord | None:
     async with db_engine.async_session_factory() as db:
-        membership = (
-            await db.execute(
-                select(OrganizationMembership).where(
-                    OrganizationMembership.organization_id == organization_id,
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-                )
+        return await get_active_membership(
+            db,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+
+
+async def get_active_membership(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    user_id: UUID,
+) -> MembershipRecord | None:
+    membership = (
+        await db.execute(
+            select(OrganizationMembership).where(
+                OrganizationMembership.organization_id == organization_id,
+                OrganizationMembership.user_id == user_id,
+                OrganizationMembership.status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
             )
-        ).scalar_one_or_none()
-        return membership_record(membership) if membership is not None else None
+        )
+    ).scalar_one_or_none()
+    return membership_record(membership) if membership is not None else None
 
 
 async def update_organization_settings(

--- a/server/proliferate/server/cloud/workspaces/access.py
+++ b/server/proliferate/server/cloud/workspaces/access.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NoReturn
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.auth.authorization import PolicyDenied
-from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
-from proliferate.db.store.organizations import load_active_membership
+from proliferate.db.store.cloud_workspaces import (
+    get_cloud_workspace_by_id,
+    load_cloud_workspace_by_id,
+)
+from proliferate.db.store.organizations import get_active_membership, load_active_membership
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.workspaces.domain.policy import can_read_cloud_workspace
 
@@ -40,6 +45,38 @@ async def cloud_workspace_user_can_read(
     has_active_organization_membership = False
     if workspace.owner_scope == "organization" and workspace.organization_id is not None:
         membership = await load_active_membership(
+            organization_id=workspace.organization_id,
+            user_id=user_id,
+        )
+        has_active_organization_membership = membership is not None
+
+    verdict = can_read_cloud_workspace(
+        actor_user_id=user_id,
+        owner_scope=workspace.owner_scope,
+        owner_user_id=workspace.owner_user_id,
+        organization_id=workspace.organization_id,
+        has_active_organization_membership=has_active_organization_membership,
+    )
+    if isinstance(verdict, PolicyDenied):
+        _raise_policy_denied(verdict)
+    return workspace
+
+
+async def cloud_workspace_user_can_read_with_db(
+    db: AsyncSession,
+    user_id: UUID,
+    workspace_id: UUID,
+) -> CloudWorkspace:
+    # Transitional: the cloud workspace service still consumes ORM objects.
+    # Keep lookup/policy ownership here until the store returns snapshots.
+    workspace = await get_cloud_workspace_by_id(db, workspace_id)
+    if workspace is None:
+        _raise_workspace_not_found()
+
+    has_active_organization_membership = False
+    if workspace.owner_scope == "organization" and workspace.organization_id is not None:
+        membership = await get_active_membership(
+            db,
             organization_id=workspace.organization_id,
             user_id=user_id,
         )

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -4,9 +4,11 @@ from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import OwnerSelection
 from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.workspaces.models import (
@@ -38,9 +40,11 @@ async def list_cloud_workspaces_endpoint(
     owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
     organization_id: UUID | None = Query(default=None, alias="organizationId"),
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> list[WorkspaceSummary]:
     try:
         return await list_cloud_workspaces_for_user(
+            db,
             user.id,
             user=user,
             owner_selection=OwnerSelection(
@@ -80,9 +84,10 @@ async def create_cloud_workspace_endpoint(
 async def get_cloud_workspace_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
-        return await get_cloud_workspace_detail(user.id, workspace_id)
+        return await get_cloud_workspace_detail(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
 
@@ -127,9 +132,11 @@ async def update_cloud_workspace_branch_endpoint(
     workspace_id: UUID,
     body: UpdateCloudWorkspaceBranchRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
         payload = await sync_cloud_workspace_branch(
+            db,
             user.id,
             workspace_id,
             branch_name=body.branch_name,
@@ -144,9 +151,11 @@ async def update_cloud_workspace_display_name_endpoint(
     workspace_id: UUID,
     body: UpdateCloudWorkspaceDisplayNameRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
         payload = await sync_cloud_workspace_display_name(
+            db,
             user.id,
             workspace_id,
             display_name=body.display_name,
@@ -160,9 +169,10 @@ async def update_cloud_workspace_display_name_endpoint(
 async def sync_cloud_workspace_credentials_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
-        payload = await sync_cloud_workspace_credentials(user.id, workspace_id)
+        payload = await sync_cloud_workspace_credentials(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
     return payload

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import NoReturn
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.auth.authorization import OwnerSelection
 from proliferate.constants.billing import (
     BILLING_MODE_ENFORCE,
@@ -33,7 +35,11 @@ from proliferate.db.store.automations import (
 from proliferate.db.store.billing import (
     close_usage_segment_for_sandbox,
 )
-from proliferate.db.store.cloud_runtime_environments import load_runtime_environment_for_workspace
+from proliferate.db.store.cloud_credentials import get_user_cloud_credentials
+from proliferate.db.store.cloud_runtime_environments import (
+    get_runtime_environment_for_workspace,
+    load_runtime_environment_for_workspace,
+)
 from proliferate.db.store.cloud_workspaces import (
     CloudRepoLimitExceededError,
     create_cloud_workspace_for_user,
@@ -47,9 +53,11 @@ from proliferate.db.store.cloud_workspaces import (
     persist_workspace_stop_state,
     save_workspace,
     update_sandbox_status,
+    update_workspace_branch,
+    update_workspace_display_name,
 )
 from proliferate.db.store.cloud_workspaces import (
-    list_cloud_workspaces_for_user as list_cloud_workspaces_store,
+    list_cloud_workspaces as list_cloud_workspaces_store,
 )
 from proliferate.integrations.anyharness import CloudRuntimeReconnectError
 from proliferate.integrations.sandbox import get_configured_sandbox_provider, get_sandbox_provider
@@ -64,9 +72,11 @@ from proliferate.server.billing.service import (
     repo_limit_for_billing_snapshot,
 )
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
-from proliferate.server.cloud.credentials.domain.status import allowed_agent_kinds
+from proliferate.server.cloud.credentials.domain.status import (
+    allowed_agent_kinds,
+    build_credential_statuses,
+)
 from proliferate.server.cloud.credentials.service import load_cloud_credential_statuses
-from proliferate.server.cloud.credentials.session_loader import load_cloud_credentials_for_user
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.repo_config.service import (
     bootstrap_repo_config,
@@ -88,7 +98,10 @@ from proliferate.server.cloud.runtime.service import (
     get_workspace_connection,
     sync_workspace_credentials,
 )
-from proliferate.server.cloud.workspaces.access import cloud_workspace_user_can_read
+from proliferate.server.cloud.workspaces.access import (
+    cloud_workspace_user_can_read,
+    cloud_workspace_user_can_read_with_db,
+)
 from proliferate.server.cloud.workspaces.domain.lifecycle import (
     decide_workspace_start_after_validation,
     decide_workspace_status_transition,
@@ -182,6 +195,7 @@ def transition_workspace_status(
 
 
 async def list_cloud_workspaces_for_user(
+    db: AsyncSession,
     user_id: UUID,
     *,
     user: User | None = None,
@@ -199,17 +213,17 @@ async def list_cloud_workspaces_for_user(
         except OrganizationServiceError as error:
             _map_owner_context_error(error)
         return []
-    workspaces = await list_cloud_workspaces_store(user_id)
+    workspaces = await list_cloud_workspaces_store(db, user_id)
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
         user_id=user_id,
         cloud_workspace_ids=[workspace.id for workspace in workspaces],
     )
-    credential_records = await load_cloud_credentials_for_user(user_id)
+    credential_records = await get_user_cloud_credentials(db, user_id)
     credential_revisions = build_credential_revision_state(credential_records)
     snapshots_by_subject: dict[UUID, BillingSnapshot] = {}
     summaries: list[WorkspaceSummary] = []
     for workspace in workspaces:
-        runtime_environment = await load_runtime_environment_for_workspace(workspace)
+        runtime_environment = await get_runtime_environment_for_workspace(db, workspace)
         credential_freshness = (
             build_credential_freshness_snapshot(runtime_environment, credential_revisions)
             if runtime_environment is not None
@@ -308,11 +322,48 @@ def _provider_state_is_running(state: str | None) -> bool:
 
 
 async def get_cloud_workspace_detail(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> WorkspaceDetail:
-    workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
-    return await _build_workspace_detail(workspace)
+    workspace = await cloud_workspace_user_can_read_with_db(db, user_id, workspace_id)
+    return await _build_workspace_detail_for_request(db, workspace)
+
+
+async def _build_workspace_detail_for_request(
+    db: AsyncSession,
+    workspace: CloudWorkspace,
+) -> WorkspaceDetail:
+    runtime_environment = await get_runtime_environment_for_workspace(db, workspace)
+    credential_records = await get_user_cloud_credentials(db, workspace.user_id)
+    credential_revisions = build_credential_revision_state(credential_records)
+    credential_freshness = (
+        build_credential_freshness_snapshot(runtime_environment, credential_revisions)
+        if runtime_environment is not None
+        else None
+    )
+    statuses = build_credential_statuses(credential_records)
+    billing = await get_billing_snapshot_for_subject(
+        runtime_environment.billing_subject_id
+        if runtime_environment is not None
+        else workspace.billing_subject_id
+    )
+    action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
+    automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
+        user_id=workspace.user_id,
+        cloud_workspace_ids=[workspace.id],
+    )
+    return workspace_detail_payload(
+        workspace,
+        statuses,
+        runtime_environment=runtime_environment,
+        credential_freshness=credential_freshness,
+        action_block_kind=action_block_kind,
+        action_block_reason=action_block_reason,
+        creator_context=_creator_context_for_automation_run(
+            automation_runs_by_workspace.get(workspace.id)
+        ),
+    )
 
 
 async def _build_workspace_detail(
@@ -847,6 +898,7 @@ async def start_cloud_workspace(
 
 
 async def sync_cloud_workspace_branch(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
     *,
@@ -860,13 +912,13 @@ async def sync_cloud_workspace_branch(
             status_code=400,
         )
 
-    workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
-    workspace.git_branch = cleaned_branch_name
-    workspace = await save_workspace(workspace)
-    return await _build_workspace_detail(workspace)
+    workspace = await cloud_workspace_user_can_read_with_db(db, user_id, workspace_id)
+    workspace = await update_workspace_branch(db, workspace, cleaned_branch_name)
+    return await _build_workspace_detail_for_request(db, workspace)
 
 
 async def sync_cloud_workspace_display_name(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
     *,
@@ -893,20 +945,20 @@ async def sync_cloud_workspace_display_name(
                 status_code=400,
             )
 
-    workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
-    workspace.display_name = cleaned
-    workspace = await save_workspace(workspace)
-    return await _build_workspace_detail(workspace)
+    workspace = await cloud_workspace_user_can_read_with_db(db, user_id, workspace_id)
+    workspace = await update_workspace_display_name(db, workspace, cleaned)
+    return await _build_workspace_detail_for_request(db, workspace)
 
 
 async def sync_cloud_workspace_credentials(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> WorkspaceDetail:
     workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
     await sync_workspace_credentials(workspace)
-    reloaded_workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
-    return await _build_workspace_detail(reloaded_workspace)
+    reloaded_workspace = await cloud_workspace_user_can_read_with_db(db, user_id, workspace_id)
+    return await _build_workspace_detail_for_request(db, reloaded_workspace)
 
 
 async def stop_cloud_workspace(


### PR DESCRIPTION
## Summary

Phase 8 Wave 3C: Cloud Workspace simple HTTP DB threading.

- Inject request `AsyncSession` into workspace list, detail, branch update, display-name update, and credential-sync routes.
- Thread the request DB through workspace service/access/store reads and branch/display update primitives.
- Keep provisioning, setup monitor, stop/delete, runtime provisioning, sandbox reservation, and automation workspace-claim boundaries on their existing wrappers.
- Ratchet Cloud Workspace boundary allowlist counts after the checker confirmed the drop.

## Invariants

- Public API shapes and response payloads are preserved.
- Branch/display updates commit through the request session instead of self-opening store wrappers.
- Credential sync still performs the external runtime credential reconciliation before the injected-session detail reload, avoiding a new request DB transaction across that AnyHarness path.
- No provisioning/materialization, setup monitor, stop/delete, runtime provisioning, sandbox reservation, or automation workspace-claim atomicity code was changed.

## Validation

- `DEBUG=true uv run --extra dev pytest -q tests/unit/test_cloud_workspace_service.py tests/unit/test_cloud_workspace_access_policy.py tests/unit/test_cloud_workspace_lifecycle_domain.py tests/integration/test_cloud_api.py::TestCloudWorkspaces tests/integration/test_cloud_repo_limits.py`
- `PATH=/opt/homebrew/bin:$PATH python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `DEBUG=true uv run --extra dev ruff check proliferate/server/cloud/workspaces/api.py proliferate/server/cloud/workspaces/service.py proliferate/server/cloud/workspaces/access.py proliferate/db/store/cloud_workspaces.py proliferate/db/store/organizations.py`