### PR TITLE
refactor(server): thread billing request db sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -14,7 +14,7 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_cla
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions own transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 3 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 29 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
@@ -25,7 +25,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspac
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions open DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 4 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/cloud workspace helper still opens isolated DB sessions
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 29 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 9 transitional store opens DB session
@@ -35,7 +35,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_run
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 24 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 4 transitional wrappers used by deferred billing/cloud callers
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 3 transitional wrappers used by deferred organization/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory

--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -568,73 +568,75 @@ def _billing_subject_stripe_state(subject: BillingSubject) -> BillingSubjectStri
     )
 
 
+async def get_or_create_user_stripe_customer_state(
+    db: AsyncSession,
+    user_id: UUID,
+) -> BillingSubjectStripeState:
+    subject = await ensure_personal_billing_subject(db, user_id)
+    await db.flush()
+    return _billing_subject_stripe_state(subject)
+
+
 async def get_or_create_stripe_customer_state_for_user(user_id: UUID) -> BillingSubjectStripeState:
     async with db_engine.async_session_factory() as db:
-        subject = await ensure_personal_billing_subject(db, user_id)
-        state = _billing_subject_stripe_state(subject)
+        state = await get_or_create_user_stripe_customer_state(db, user_id)
         await db.commit()
         return state
 
 
-async def get_or_create_stripe_customer_state_for_organization(
+async def get_or_create_organization_stripe_customer_state(
+    db: AsyncSession,
     organization_id: UUID,
 ) -> BillingSubjectStripeState:
-    async with db_engine.async_session_factory() as db:
-        subject = await ensure_organization_billing_subject(db, organization_id)
-        state = _billing_subject_stripe_state(subject)
-        await db.commit()
-        return state
+    subject = await ensure_organization_billing_subject(db, organization_id)
+    await db.flush()
+    return _billing_subject_stripe_state(subject)
 
 
 async def bind_stripe_customer_to_billing_subject(
+    db: AsyncSession,
     *,
     billing_subject_id: UUID,
     stripe_customer_id: str,
 ) -> BillingSubjectStripeState:
-    async with db_engine.async_session_factory() as db:
-        subject = await set_billing_subject_stripe_customer(
-            db,
-            billing_subject_id=billing_subject_id,
-            stripe_customer_id=stripe_customer_id,
-        )
-        state = _billing_subject_stripe_state(subject)
-        await db.commit()
-        return state
+    subject = await set_billing_subject_stripe_customer(
+        db,
+        billing_subject_id=billing_subject_id,
+        stripe_customer_id=stripe_customer_id,
+    )
+    await db.flush()
+    return _billing_subject_stripe_state(subject)
 
 
 async def set_overage_policy_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     overage_enabled: bool,
     overage_cap_cents_per_seat: int | None = None,
 ) -> BillingSubject:
-    async with db_engine.async_session_factory() as db:
-        subject = await ensure_personal_billing_subject(db, user_id)
-        subject = await set_billing_subject_overage_policy(
-            db,
-            billing_subject_id=subject.id,
-            overage_enabled=overage_enabled,
-            overage_cap_cents_per_seat=overage_cap_cents_per_seat,
-        )
-        await db.commit()
-        return subject
+    subject = await ensure_personal_billing_subject(db, user_id)
+    return await set_billing_subject_overage_policy(
+        db,
+        billing_subject_id=subject.id,
+        overage_enabled=overage_enabled,
+        overage_cap_cents_per_seat=overage_cap_cents_per_seat,
+    )
 
 
 async def set_overage_policy_for_subject(
+    db: AsyncSession,
     *,
     billing_subject_id: UUID,
     overage_enabled: bool,
     overage_cap_cents_per_seat: int | None = None,
 ) -> BillingSubject:
-    async with db_engine.async_session_factory() as db:
-        subject = await set_billing_subject_overage_policy(
-            db,
-            billing_subject_id=billing_subject_id,
-            overage_enabled=overage_enabled,
-            overage_cap_cents_per_seat=overage_cap_cents_per_seat,
-        )
-        await db.commit()
-        return subject
+    return await set_billing_subject_overage_policy(
+        db,
+        billing_subject_id=billing_subject_id,
+        overage_enabled=overage_enabled,
+        overage_cap_cents_per_seat=overage_cap_cents_per_seat,
+    )
 
 
 async def get_billing_subject_for_stripe_reference(
@@ -1315,12 +1317,14 @@ async def count_active_seats_for_billing_subject(
     return 1
 
 
-async def count_active_seats_for_billing_subject_id(billing_subject_id: UUID) -> int:
-    async with db_engine.async_session_factory() as db:
-        subject = await db.get(BillingSubject, billing_subject_id)
-        if subject is None:
-            return 1
-        return await count_active_seats_for_billing_subject(db, subject)
+async def count_active_seats_for_billing_subject_id(
+    db: AsyncSession,
+    billing_subject_id: UUID,
+) -> int:
+    subject = await db.get(BillingSubject, billing_subject_id)
+    if subject is None:
+        return 1
+    return await count_active_seats_for_billing_subject(db, subject)
 
 
 async def prepare_initial_org_seat_reconcile(
@@ -2454,6 +2458,35 @@ async def _build_billing_snapshot_state_for_subject(
             else 0
         ),
     )
+
+
+async def get_billing_snapshot_state_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> BillingSnapshotState:
+    subject = await ensure_personal_billing_subject(db, user_id)
+    if settings.pro_billing_enabled:
+        await ensure_free_trial_v2_grant(db, subject)
+    else:
+        await ensure_free_included_grant(db, user_id)
+    await db.flush()
+    return await _build_billing_snapshot_state_for_subject(db, subject.id)
+
+
+async def get_billing_snapshot_state_for_subject(
+    db: AsyncSession,
+    billing_subject_id: UUID,
+) -> BillingSnapshotState:
+    subject = await db.get(BillingSubject, billing_subject_id)
+    if subject is None:
+        raise RuntimeError("Billing subject not found.")
+    if subject.kind == BILLING_SUBJECT_KIND_PERSONAL and subject.user_id is not None:
+        if settings.pro_billing_enabled:
+            await ensure_free_trial_v2_grant(db, subject)
+        else:
+            await ensure_free_included_grant(db, subject.user_id)
+        await db.flush()
+    return await _build_billing_snapshot_state_for_subject(db, billing_subject_id)
 
 
 async def load_billing_snapshot_state(user_id: UUID) -> BillingSnapshotState:

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -306,17 +306,17 @@ async def ensure_organization_billing_subject_id(organization_id: UUID) -> UUID:
 
 
 async def load_organization_by_billing_subject(
+    db: AsyncSession,
     billing_subject_id: UUID,
 ) -> OrganizationRecord | None:
-    async with db_engine.async_session_factory() as db:
-        row = (
-            await db.execute(
-                select(Organization)
-                .join(BillingSubject, BillingSubject.organization_id == Organization.id)
-                .where(
-                    BillingSubject.id == billing_subject_id,
-                    BillingSubject.kind == BILLING_SUBJECT_KIND_ORGANIZATION,
-                )
+    row = (
+        await db.execute(
+            select(Organization)
+            .join(BillingSubject, BillingSubject.organization_id == Organization.id)
+            .where(
+                BillingSubject.id == billing_subject_id,
+                BillingSubject.kind == BILLING_SUBJECT_KIND_ORGANIZATION,
             )
-        ).scalar_one_or_none()
-        return organization_record(row) if row is not None else None
+        )
+    ).scalar_one_or_none()
+    return organization_record(row) if row is not None else None

--- a/server/proliferate/server/billing/api.py
+++ b/server/proliferate/server/billing/api.py
@@ -4,9 +4,11 @@ from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import OwnerSelection
 from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.billing.models import (
     BillingOverview,
@@ -38,9 +40,10 @@ router = APIRouter(prefix="/billing", tags=["billing"])
 @router.get("/plan", response_model=PlanInfo)
 async def get_plan(
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> PlanInfo:
     try:
-        return await get_current_plan(user.id)
+        return await get_current_plan(db, user.id)
     except BillingServiceError as error:
         raise HTTPException(
             status_code=error.status_code,
@@ -53,11 +56,13 @@ async def get_cloud_plan_endpoint(
     owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
     organization_id: UUID | None = Query(default=None, alias="organizationId"),
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> CloudPlanInfo:
     try:
         if owner_scope == "personal" and organization_id is None:
-            return await get_cloud_plan(user.id)
+            return await get_cloud_plan(db, user.id)
         return await get_cloud_plan_for_owner(
+            db,
             user,
             OwnerSelection(owner_scope=owner_scope, organization_id=organization_id),
         )
@@ -73,11 +78,13 @@ async def get_overview(
     owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
     organization_id: UUID | None = Query(default=None, alias="organizationId"),
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> BillingOverview:
     try:
         if owner_scope == "personal" and organization_id is None:
-            return await get_billing_overview(user.id)
+            return await get_billing_overview(db, user.id)
         return await get_billing_overview_for_owner(
+            db,
             user,
             OwnerSelection(owner_scope=owner_scope, organization_id=organization_id),
         )
@@ -92,9 +99,11 @@ async def get_overview(
 async def create_cloud_checkout(
     request: BillingOwnerSelection | None = None,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session, use_cache=False),
 ) -> BillingUrlResponse:
     try:
         return await create_cloud_checkout_session(
+            db,
             user,
             _owner_selection_from_body(request),
         )
@@ -109,9 +118,11 @@ async def create_cloud_checkout(
 async def create_customer_portal(
     request: BillingOwnerSelection | None = None,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session, use_cache=False),
 ) -> BillingUrlResponse:
     try:
         return await create_customer_portal_session(
+            db,
             user,
             _owner_selection_from_body(request),
         )
@@ -126,9 +137,11 @@ async def create_customer_portal(
 async def create_refill_checkout(
     request: BillingOwnerSelection | None = None,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session, use_cache=False),
 ) -> BillingUrlResponse:
     try:
         return await create_refill_checkout_session(
+            db,
             user,
             _owner_selection_from_body(request),
         )
@@ -143,9 +156,11 @@ async def create_refill_checkout(
 async def update_overage_settings_endpoint(
     request: OverageSettingsRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> OverageSettingsResponse:
     try:
         return await update_overage_settings(
+            db,
             user,
             enabled=request.enabled,
             cap_cents_per_seat=request.cap_cents_per_seat,

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -7,6 +7,8 @@ import math
 from datetime import datetime
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.auth.authorization import OwnerContext, OwnerSelection, require_org_role
 from proliferate.config import settings
 from proliferate.constants.billing import (
@@ -18,6 +20,7 @@ from proliferate.constants.billing import (
     BILLING_MODE_OFF,
     BILLING_PLAN_FREE,
     BILLING_PLAN_PRO,
+    BILLING_SUBJECT_KIND_PERSONAL,
     BILLING_USAGE_EXPORT_STATUS_FAILED_TERMINAL,
     BILLING_USAGE_EXPORT_STATUS_OBSERVED,
     BILLING_USAGE_EXPORT_STATUS_SUCCEEDED,
@@ -50,8 +53,10 @@ from proliferate.db.store.billing import (
     claim_usage_exports_for_sending,
     count_active_seats_for_billing_subject_id,
     ensure_billing_grant_record,
-    get_or_create_stripe_customer_state_for_organization,
-    get_or_create_stripe_customer_state_for_user,
+    get_billing_snapshot_state_for_subject,
+    get_billing_snapshot_state_for_user,
+    get_or_create_organization_stripe_customer_state,
+    get_or_create_user_stripe_customer_state,
     list_billing_subject_ids_for_usage_accounting,
     load_billing_snapshot_state,
     load_billing_snapshot_state_for_subject,
@@ -65,7 +70,10 @@ from proliferate.db.store.billing import (
     set_overage_policy_for_subject,
     set_overage_policy_for_user,
 )
-from proliferate.db.store.organizations import load_organization_by_billing_subject
+from proliferate.db.store.organizations import (
+    get_organization_with_membership,
+    load_organization_by_billing_subject,
+)
 from proliferate.errors import ProliferateError
 from proliferate.integrations.billing import stripe as stripe_billing
 from proliferate.server.billing.domain.accounting import (
@@ -108,10 +116,6 @@ from proliferate.server.billing.pricing import (
 from proliferate.server.billing.seats import (
     prorated_seat_grant_hours,
     seat_proration_grant_source_ref,
-)
-from proliferate.server.organizations.service import (
-    OrganizationServiceError,
-    resolve_owner_context,
 )
 
 logger = logging.getLogger("proliferate.billing.service")
@@ -193,6 +197,22 @@ async def get_billing_snapshot(user_id: UUID) -> BillingSnapshot:
 
 async def get_billing_snapshot_for_subject(billing_subject_id: UUID) -> BillingSnapshot:
     state = await load_billing_snapshot_state_for_subject(billing_subject_id)
+    return _build_billing_snapshot(state)
+
+
+async def _get_billing_snapshot_for_request(
+    db: AsyncSession,
+    user_id: UUID,
+) -> BillingSnapshot:
+    state = await get_billing_snapshot_state_for_user(db, user_id)
+    return _build_billing_snapshot(state)
+
+
+async def _get_billing_snapshot_for_subject_request(
+    db: AsyncSession,
+    billing_subject_id: UUID,
+) -> BillingSnapshot:
+    state = await get_billing_snapshot_state_for_subject(db, billing_subject_id)
     return _build_billing_snapshot(state)
 
 
@@ -421,22 +441,23 @@ async def authorize_sandbox_start(
     )
 
 
-async def get_billing_overview(user_id: UUID) -> BillingOverview:
-    snapshot = await get_billing_snapshot(user_id)
+async def get_billing_overview(db: AsyncSession, user_id: UUID) -> BillingOverview:
+    snapshot = await _get_billing_snapshot_for_request(db, user_id)
     return _billing_overview_from_snapshot(snapshot)
 
 
 async def get_billing_overview_for_owner(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection,
 ) -> BillingOverview:
-    context = await _resolve_billing_owner_context(user, owner_selection)
-    snapshot = await get_billing_snapshot_for_subject(context.billing_subject_id)
+    context = await _resolve_billing_owner_context(db, user, owner_selection)
+    snapshot = await _get_billing_snapshot_for_subject_request(db, context.billing_subject_id)
     return _billing_overview_from_snapshot(snapshot)
 
 
-async def get_current_plan(user_id: UUID) -> PlanInfo:
-    snapshot = await get_billing_snapshot(user_id)
+async def get_current_plan(db: AsyncSession, user_id: UUID) -> PlanInfo:
+    snapshot = await _get_billing_snapshot_for_request(db, user_id)
     return PlanInfo(
         plan=snapshot.plan,
         usage_minutes=int(round(snapshot.used_hours * 60.0)),
@@ -444,17 +465,18 @@ async def get_current_plan(user_id: UUID) -> PlanInfo:
     )
 
 
-async def get_cloud_plan(user_id: UUID) -> CloudPlanInfo:
-    snapshot = await get_billing_snapshot(user_id)
+async def get_cloud_plan(db: AsyncSession, user_id: UUID) -> CloudPlanInfo:
+    snapshot = await _get_billing_snapshot_for_request(db, user_id)
     return _cloud_plan_from_snapshot(snapshot)
 
 
 async def get_cloud_plan_for_owner(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection,
 ) -> CloudPlanInfo:
-    context = await _resolve_billing_owner_context(user, owner_selection)
-    snapshot = await get_billing_snapshot_for_subject(context.billing_subject_id)
+    context = await _resolve_billing_owner_context(db, user, owner_selection)
+    snapshot = await _get_billing_snapshot_for_subject_request(db, context.billing_subject_id)
     return _cloud_plan_from_snapshot(snapshot)
 
 
@@ -579,78 +601,122 @@ def _require_redirect_urls() -> tuple[str, str, str]:
     return success_url, cancel_url, portal_return_url
 
 
-async def _ensure_stripe_customer_for_user(user: User) -> tuple[UUID, str]:
-    state = await get_or_create_stripe_customer_state_for_user(user.id)
-    if state.stripe_customer_id:
-        return state.billing_subject_id, state.stripe_customer_id
-    try:
-        customer = await stripe_billing.create_customer(
-            email=user.email,
-            billing_subject_id=str(state.billing_subject_id),
-            idempotency_key=f"customer:{state.billing_subject_id}",
-        )
-    except stripe_billing.StripeBillingError as error:
-        raise _map_stripe_error(error) from error
-    customer_id = customer.get("id")
-    if not isinstance(customer_id, str):
-        raise BillingServiceError(
-            "stripe_invalid_response",
-            "Stripe did not return a customer id.",
-            status_code=502,
-        )
-    state = await bind_stripe_customer_to_billing_subject(
-        billing_subject_id=state.billing_subject_id,
-        stripe_customer_id=customer_id,
+def _require_owner_selection_uuid(value: str | UUID | None, *, field: str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    if value:
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            raise BillingServiceError(
+                "invalid_organization_id",
+                f"{field} must be a valid UUID.",
+                status_code=400,
+            ) from exc
+    raise BillingServiceError(
+        "missing_organization_id",
+        f"{field} is required for organization scope.",
+        status_code=400,
     )
-    return state.billing_subject_id, customer_id
 
 
 async def _resolve_billing_owner_context(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection,
 ) -> OwnerContext:
-    try:
-        return await resolve_owner_context(user, owner_selection)
-    except OrganizationServiceError as error:
+    selection = owner_selection or OwnerSelection()
+    if selection.owner_scope == "personal":
+        if selection.organization_id is not None:
+            raise BillingServiceError(
+                "invalid_owner_selection",
+                "organizationId is not valid for personal scope.",
+                status_code=400,
+            )
+        state = await get_or_create_user_stripe_customer_state(db, user.id)
+        if state.kind != BILLING_SUBJECT_KIND_PERSONAL:
+            raise BillingServiceError(
+                "invalid_owner_selection",
+                "Personal billing subject could not be resolved.",
+                status_code=500,
+            )
+        return OwnerContext(
+            owner_scope="personal",
+            actor_user_id=user.id,
+            owner_user_id=user.id,
+            organization_id=None,
+            membership_id=None,
+            membership_role=None,
+            billing_subject_id=state.billing_subject_id,
+        )
+
+    organization_id = _require_owner_selection_uuid(
+        selection.organization_id,
+        field="organizationId",
+    )
+    record = await get_organization_with_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user.id,
+    )
+    if record is None:
         raise BillingServiceError(
-            error.code,
-            error.message,
-            status_code=error.status_code,
-        ) from error
+            "organization_not_found",
+            "Organization not found.",
+            status_code=404,
+        )
+    state = await get_or_create_organization_stripe_customer_state(db, organization_id)
+    return OwnerContext(
+        owner_scope="organization",
+        actor_user_id=user.id,
+        owner_user_id=None,
+        organization_id=organization_id,
+        membership_id=record.membership.id,
+        membership_role=record.membership.role,
+        billing_subject_id=state.billing_subject_id,
+    )
 
 
 async def _ensure_stripe_customer_for_owner(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection,
+    *,
+    owner_context: OwnerContext | None = None,
 ) -> tuple[UUID, str]:
-    context = await _resolve_billing_owner_context(user, owner_selection)
-    if context.owner_scope == "organization":
-        try:
-            require_org_role(context, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
-        except ProliferateError as error:
-            raise BillingServiceError(
-                error.code,
-                error.message,
-                status_code=error.status_code,
-            ) from error
-        if context.organization_id is None:
-            raise BillingServiceError(
-                "organization_not_found",
-                "Organization not found.",
-                status_code=404,
+    async with db.begin():
+        context = owner_context or await _resolve_billing_owner_context(db, user, owner_selection)
+        if context.owner_scope == "organization":
+            try:
+                require_org_role(context, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
+            except ProliferateError as error:
+                raise BillingServiceError(
+                    error.code,
+                    error.message,
+                    status_code=error.status_code,
+                ) from error
+            if context.organization_id is None:
+                raise BillingServiceError(
+                    "organization_not_found",
+                    "Organization not found.",
+                    status_code=404,
+                )
+            state = await get_or_create_organization_stripe_customer_state(
+                db,
+                context.organization_id,
             )
-        state = await get_or_create_stripe_customer_state_for_organization(
-            context.organization_id,
-        )
-        organization = await load_organization_by_billing_subject(state.billing_subject_id)
-        customer_name = organization.name if organization is not None else "Organization"
-        organization_id = str(context.organization_id)
-        created_by_user_id = str(user.id)
-    else:
-        state = await get_or_create_stripe_customer_state_for_user(user.id)
-        customer_name = None
-        organization_id = None
-        created_by_user_id = None
+            organization = await load_organization_by_billing_subject(
+                db,
+                state.billing_subject_id,
+            )
+            customer_name = organization.name if organization is not None else "Organization"
+            organization_id = str(context.organization_id)
+            created_by_user_id = str(user.id)
+        else:
+            state = await get_or_create_user_stripe_customer_state(db, user.id)
+            customer_name = None
+            organization_id = None
+            created_by_user_id = None
     if state.stripe_customer_id:
         return state.billing_subject_id, state.stripe_customer_id
     try:
@@ -671,29 +737,33 @@ async def _ensure_stripe_customer_for_owner(
             "Stripe did not return a customer id.",
             status_code=502,
         )
-    state = await bind_stripe_customer_to_billing_subject(
-        billing_subject_id=state.billing_subject_id,
-        stripe_customer_id=customer_id,
-    )
+    async with db.begin():
+        state = await bind_stripe_customer_to_billing_subject(
+            db,
+            billing_subject_id=state.billing_subject_id,
+            stripe_customer_id=customer_id,
+        )
     return state.billing_subject_id, customer_id
 
 
 async def create_cloud_checkout_session(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection | None = None,
 ) -> BillingUrlResponse:
     selection = owner_selection or OwnerSelection()
     org_context: OwnerContext | None = None
     if selection.owner_scope == "organization":
-        org_context = await _resolve_billing_owner_context(user, selection)
-        try:
-            require_org_role(org_context, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
-        except ProliferateError as error:
-            raise BillingServiceError(
-                error.code,
-                error.message,
-                status_code=error.status_code,
-            ) from error
+        async with db.begin():
+            org_context = await _resolve_billing_owner_context(db, user, selection)
+            try:
+                require_org_role(org_context, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
+            except ProliferateError as error:
+                raise BillingServiceError(
+                    error.code,
+                    error.message,
+                    status_code=error.status_code,
+                ) from error
         if not settings.pro_billing_enabled:
             raise BillingServiceError(
                 "org_pro_billing_disabled",
@@ -710,10 +780,18 @@ async def create_cloud_checkout_session(
         raise _map_stripe_error(error) from error
 
     subject_id, stripe_customer_id = await _ensure_stripe_customer_for_owner(
+        db,
         user,
         selection,
+        owner_context=org_context,
     )
-    snapshot = await get_billing_snapshot_for_subject(subject_id)
+    async with db.begin():
+        snapshot = await _get_billing_snapshot_for_subject_request(db, subject_id)
+        seat_quantity = (
+            await count_active_seats_for_billing_subject_id(db, subject_id)
+            if org_context is not None and not snapshot.is_paid_cloud
+            else 1
+        )
     if snapshot.is_paid_cloud:
         try:
             portal = await stripe_billing.create_customer_portal_session(
@@ -730,11 +808,6 @@ async def create_cloud_checkout_session(
             configured_pro_monthly_price_id()
             if settings.pro_billing_enabled
             else settings.stripe_cloud_monthly_price_id
-        )
-        seat_quantity = (
-            await count_active_seats_for_billing_subject_id(subject_id)
-            if org_context is not None
-            else 1
         )
         checkout = await stripe_billing.create_subscription_checkout_session(
             stripe_customer_id=stripe_customer_id,
@@ -766,6 +839,7 @@ async def create_cloud_checkout_session(
 
 
 async def create_refill_checkout_session(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection | None = None,
 ) -> BillingUrlResponse:
@@ -788,6 +862,7 @@ async def create_refill_checkout_session(
     except stripe_billing.StripeBillingError as error:
         raise _map_stripe_error(error) from error
     subject_id, stripe_customer_id = await _ensure_stripe_customer_for_owner(
+        db,
         user,
         selection,
     )
@@ -806,11 +881,13 @@ async def create_refill_checkout_session(
 
 
 async def create_customer_portal_session(
+    db: AsyncSession,
     user: User,
     owner_selection: OwnerSelection | None = None,
 ) -> BillingUrlResponse:
     _success_url, _cancel_url, portal_return_url = _require_redirect_urls()
     subject_id, stripe_customer_id = await _ensure_stripe_customer_for_owner(
+        db,
         user,
         owner_selection or OwnerSelection(),
     )
@@ -826,6 +903,7 @@ async def create_customer_portal_session(
 
 
 async def update_overage_settings(
+    db: AsyncSession,
     user: User,
     *,
     enabled: bool,
@@ -843,12 +921,13 @@ async def update_overage_settings(
     selection = owner_selection or OwnerSelection()
     if selection.owner_scope == "personal":
         subject = await set_overage_policy_for_user(
+            db,
             user_id=user.id,
             overage_enabled=enabled,
             overage_cap_cents_per_seat=cap_cents_per_seat,
         )
     else:
-        context = await _resolve_billing_owner_context(user, selection)
+        context = await _resolve_billing_owner_context(db, user, selection)
         try:
             require_org_role(context, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
         except ProliferateError as error:
@@ -858,6 +937,7 @@ async def update_overage_settings(
                 status_code=error.status_code,
             ) from error
         subject = await set_overage_policy_for_subject(
+            db,
             billing_subject_id=context.billing_subject_id,
             overage_enabled=enabled,
             overage_cap_cents_per_seat=cap_cents_per_seat,

--- a/server/tests/integration/test_billing_store_invariants.py
+++ b/server/tests/integration/test_billing_store_invariants.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -12,7 +11,6 @@ from proliferate.db.store.billing import (
     ensure_organization_billing_subject,
     ensure_personal_billing_subject,
 )
-from tests.integration.billing_accounting_helpers import patch_global_session_factory
 
 
 @pytest.mark.asyncio
@@ -38,15 +36,12 @@ async def test_personal_and_organization_billing_subjects_are_unique(
 @pytest.mark.asyncio
 async def test_stripe_customer_id_binds_to_only_one_billing_subject(
     db_session: AsyncSession,
-    test_engine: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    patch_global_session_factory(test_engine, monkeypatch)
     first = await ensure_personal_billing_subject(db_session, uuid.uuid4())
     second = await ensure_personal_billing_subject(db_session, uuid.uuid4())
-    await db_session.commit()
 
     bound = await bind_stripe_customer_to_billing_subject(
+        db_session,
         billing_subject_id=first.id,
         stripe_customer_id="cus_unique_subject",
     )
@@ -54,6 +49,7 @@ async def test_stripe_customer_id_binds_to_only_one_billing_subject(
 
     with pytest.raises(IntegrityError):
         await bind_stripe_customer_to_billing_subject(
+            db_session,
             billing_subject_id=second.id,
             stripe_customer_id="cus_unique_subject",
         )


### PR DESCRIPTION
## Summary

Phase 8 Wave 3D: Billing request DB threading.

- Inject request `AsyncSession` into billing plan, overview, checkout, portal, refill, and overage settings handlers.
- Thread the session through request-facing billing services into billing/organization store primitives.
- Convert owned request-path store wrappers to injected primitives and ratchet confirmed boundary allowlist counts.

## Invariants

- Preserves billing subject and Stripe customer uniqueness.
- Keeps checkout, customer portal, refill checkout, and overage settings API behavior unchanged.
- Keeps Stripe calls outside the short DB checkpoint transactions used for setup/bind/snapshot reads.
- Does not touch Stripe webhooks, accounting/export paths, reconciler behavior, subscription sync, or provider/runtime checkpointing.

## Verification

- `DEBUG=1 uv run --python 3.12 --extra dev python -m pytest -q tests/unit/test_stripe_billing.py tests/unit/test_billing_service_policy.py tests/unit/test_billing_reconciler.py tests/integration/test_stripe_webhooks.py tests/integration/test_billing_api.py tests/integration/test_billing_accounting.py tests/integration/test_billing_accounting_boundaries.py tests/integration/test_billing_store_invariants.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `/opt/homebrew/bin/python3.12 scripts/check_max_lines.py`
- `git diff --check`