### PR TITLE
refactor(server): thread local automation executor DB sessions

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,8 +11,8 @@ SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional s
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions own transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 3 transitional store owns transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions own transaction commit
+STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 33 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 9 transitional store owns transaction commit
@@ -22,8 +22,8 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 16 transit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 1 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 6 transitional automation claim transitions open DB sessions
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 4 transitional store opens DB session
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions open DB sessions
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 2 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/cloud workspace helper still opens isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 34 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions

--- a/server/proliferate/db/store/automation_run_claim_transitions.py
+++ b/server/proliferate/db/store/automation_run_claim_transitions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from uuid import UUID
 
@@ -31,6 +32,13 @@ from proliferate.db.store.automation_run_claims import (
     clear_claim_metadata,
     load_claimed_run_for_update,
 )
+
+
+async def _run_self_committing[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    async with db_engine.async_session_factory() as db:
+        result = await operation(db)
+        await db.commit()
+        return result
 
 
 def _transition_requirements_satisfied(
@@ -73,6 +81,7 @@ async def _load_run_for_transition(
 
 
 async def _mark_claim_status(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -86,31 +95,30 @@ async def _mark_claim_status(
     anyharness_workspace_id: str | None = None,
     dispatch_started_at: datetime | None = None,
 ) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        run.status = status
-        if anyharness_workspace_id is not None:
-            run.anyharness_workspace_id = anyharness_workspace_id
-        if dispatch_started_at is not None:
-            run.dispatch_started_at = dispatch_started_at
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return None
+    run.status = status
+    if anyharness_workspace_id is not None:
+        run.anyharness_workspace_id = anyharness_workspace_id
+    if dispatch_started_at is not None:
+        run.dispatch_started_at = dispatch_started_at
+    run.updated_at = now
+    return claim_value(run)
 
 
 async def mark_run_creating_workspace(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -121,17 +129,21 @@ async def mark_run_creating_workspace(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    return await _mark_claim_status(
-        run_id=run_id,
-        claim_id=claim_id,
-        now=now,
-        status=AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-        transition=transition,
-        claim_is_active=claim_is_active,
-        execution_target=execution_target,
-        executor_kind=executor_kind,
-        user_id=user_id,
-    )
+    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
+        return await _mark_claim_status(
+            session,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            status=AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+            transition=transition,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+        )
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def attach_cloud_workspace_to_run(
@@ -143,7 +155,7 @@ async def attach_cloud_workspace_to_run(
     transition: ClaimTransitionRule,
     claim_is_active: ClaimActivePredicate,
 ) -> bool:
-    async with db_engine.async_session_factory() as db:
+    async def operation(db: AsyncSession) -> bool:
         run = await _load_run_for_transition(
             db,
             run_id=run_id,
@@ -158,11 +170,13 @@ async def attach_cloud_workspace_to_run(
             return False
         run.cloud_workspace_id = cloud_workspace_id
         run.updated_at = now
-        await db.commit()
         return True
+
+    return await _run_self_committing(operation)
 
 
 async def attach_anyharness_workspace_to_run(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -174,7 +188,7 @@ async def attach_anyharness_workspace_to_run(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_DESKTOP,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
         run = await _load_run_for_transition(
             db,
             run_id=run_id,
@@ -190,11 +204,13 @@ async def attach_anyharness_workspace_to_run(
             return None
         run.anyharness_workspace_id = anyharness_workspace_id
         run.updated_at = now
-        await db.commit()
         return claim_value(run)
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def mark_run_provisioning_workspace(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -205,20 +221,25 @@ async def mark_run_provisioning_workspace(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    return await _mark_claim_status(
-        run_id=run_id,
-        claim_id=claim_id,
-        now=now,
-        status=AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-        transition=transition,
-        claim_is_active=claim_is_active,
-        execution_target=execution_target,
-        executor_kind=executor_kind,
-        user_id=user_id,
-    )
+    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
+        return await _mark_claim_status(
+            session,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            status=AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+            transition=transition,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+        )
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def mark_run_creating_session(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -230,21 +251,26 @@ async def mark_run_creating_session(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    return await _mark_claim_status(
-        run_id=run_id,
-        claim_id=claim_id,
-        now=now,
-        status=AUTOMATION_RUN_STATUS_CREATING_SESSION,
-        transition=transition,
-        claim_is_active=claim_is_active,
-        execution_target=execution_target,
-        executor_kind=executor_kind,
-        user_id=user_id,
-        anyharness_workspace_id=anyharness_workspace_id,
-    )
+    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
+        return await _mark_claim_status(
+            session,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            status=AUTOMATION_RUN_STATUS_CREATING_SESSION,
+            transition=transition,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+        )
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def attach_anyharness_session_to_run(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -257,7 +283,7 @@ async def attach_anyharness_session_to_run(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async with db_engine.async_session_factory() as db:
+    async def operation(db: AsyncSession) -> bool:
         run = await _load_run_for_transition(
             db,
             run_id=run_id,
@@ -274,11 +300,13 @@ async def attach_anyharness_session_to_run(
         run.anyharness_workspace_id = anyharness_workspace_id
         run.anyharness_session_id = anyharness_session_id
         run.updated_at = now
-        await db.commit()
         return True
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def mark_run_dispatching(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -289,21 +317,26 @@ async def mark_run_dispatching(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    return await _mark_claim_status(
-        run_id=run_id,
-        claim_id=claim_id,
-        now=now,
-        status=AUTOMATION_RUN_STATUS_DISPATCHING,
-        transition=transition,
-        claim_is_active=claim_is_active,
-        execution_target=execution_target,
-        executor_kind=executor_kind,
-        user_id=user_id,
-        dispatch_started_at=now,
-    )
+    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
+        return await _mark_claim_status(
+            session,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            status=AUTOMATION_RUN_STATUS_DISPATCHING,
+            transition=transition,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+            dispatch_started_at=now,
+        )
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def mark_run_dispatched(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -316,7 +349,7 @@ async def mark_run_dispatched(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async with db_engine.async_session_factory() as db:
+    async def operation(db: AsyncSession) -> bool:
         run = await _load_run_for_transition(
             db,
             run_id=run_id,
@@ -336,11 +369,13 @@ async def mark_run_dispatched(
         run.anyharness_session_id = anyharness_session_id
         clear_claim_metadata(run)
         run.updated_at = now
-        await db.commit()
         return True
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def mark_run_failed(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -353,7 +388,7 @@ async def mark_run_failed(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async with db_engine.async_session_factory() as db:
+    async def operation(db: AsyncSession) -> bool:
         run = await load_claimed_run_for_update(
             db,
             run_id=run_id,
@@ -373,5 +408,6 @@ async def mark_run_failed(
         run.last_error_message = message
         clear_claim_metadata(run)
         run.updated_at = now
-        await db.commit()
         return True
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)

--- a/server/proliferate/db/store/automation_run_claims.py
+++ b/server/proliferate/db/store/automation_run_claims.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Protocol
 from uuid import UUID, uuid4
@@ -46,6 +47,13 @@ class LocalAutomationRepoIdentity(Protocol):
 
 class ClaimActivePredicate(Protocol):
     def __call__(self, claim_expires_at: datetime | None, now: datetime) -> bool: ...
+
+
+async def _run_self_committing[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    async with db_engine.async_session_factory() as db:
+        result = await operation(db)
+        await db.commit()
+        return result
 
 
 async def load_claimed_run_for_update(
@@ -107,21 +115,26 @@ async def claim_cloud_automation_runs(
     reclaimable_statuses: frozenset[str],
     unconfigured_agent_failure: ClaimFailure,
 ) -> list[AutomationRunClaimValue]:
-    return await _claim_automation_runs(
-        executor_id=executor_id,
-        executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-        claim_ttl=claim_ttl,
-        limit=limit,
-        now=now,
-        reclaimable_statuses=reclaimable_statuses,
-        unconfigured_agent_failure=unconfigured_agent_failure,
-        user_id=None,
-        repo_identities=None,
-    )
+    async def operation(db: AsyncSession) -> list[AutomationRunClaimValue]:
+        return await _claim_automation_runs(
+            db,
+            executor_id=executor_id,
+            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+            claim_ttl=claim_ttl,
+            limit=limit,
+            now=now,
+            reclaimable_statuses=reclaimable_statuses,
+            unconfigured_agent_failure=unconfigured_agent_failure,
+            user_id=None,
+            repo_identities=None,
+        )
+
+    return await _run_self_committing(operation)
 
 
 async def claim_local_automation_runs(
+    db: AsyncSession | None = None,
     *,
     user_id: UUID,
     executor_id: str,
@@ -139,21 +152,28 @@ async def claim_local_automation_runs(
     }
     if not identities:
         return []
-    return await _claim_automation_runs(
-        executor_id=executor_id,
-        executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
-        execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
-        claim_ttl=claim_ttl,
-        limit=limit,
-        now=now,
-        reclaimable_statuses=reclaimable_statuses,
-        unconfigured_agent_failure=unconfigured_agent_failure,
-        user_id=user_id,
-        repo_identities=sorted(identities),
-    )
+    repo_identities = sorted(identities)
+
+    async def operation(session: AsyncSession) -> list[AutomationRunClaimValue]:
+        return await _claim_automation_runs(
+            session,
+            executor_id=executor_id,
+            executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
+            execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+            claim_ttl=claim_ttl,
+            limit=limit,
+            now=now,
+            reclaimable_statuses=reclaimable_statuses,
+            unconfigured_agent_failure=unconfigured_agent_failure,
+            user_id=user_id,
+            repo_identities=repo_identities,
+        )
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
 
 
 async def _claim_automation_runs(
+    db: AsyncSession,
     *,
     executor_id: str,
     executor_kind: str,
@@ -193,40 +213,38 @@ async def _claim_automation_runs(
             )
         )
 
-    async with db_engine.async_session_factory() as db:
-        rows = list(
-            (
-                await db.execute(
-                    select(AutomationRun)
-                    .where(*predicates)
-                    .order_by(AutomationRun.created_at.asc(), AutomationRun.id.asc())
-                    .limit(max(1, limit))
-                    .with_for_update(skip_locked=True)
-                )
+    rows = list(
+        (
+            await db.execute(
+                select(AutomationRun)
+                .where(*predicates)
+                .order_by(AutomationRun.created_at.asc(), AutomationRun.id.asc())
+                .limit(max(1, limit))
+                .with_for_update(skip_locked=True)
             )
-            .scalars()
-            .all()
         )
-        expires_at = now + claim_ttl
-        values: list[AutomationRunClaimValue] = []
-        for run in rows:
-            if run.agent_kind_snapshot is None:
-                _fail_unconfigured_agent(run, now, unconfigured_agent_failure)
-                continue
-            run.status = AUTOMATION_RUN_STATUS_CLAIMED
-            run.executor_kind = executor_kind
-            run.executor_id = executor_id
-            run.claim_id = uuid4()
-            run.claimed_at = now
-            run.claim_expires_at = expires_at
-            run.last_heartbeat_at = now
-            run.failed_at = None
-            run.last_error_code = None
-            run.last_error_message = None
-            run.updated_at = now
-            values.append(claim_value(run))
-        await db.commit()
-        return values
+        .scalars()
+        .all()
+    )
+    expires_at = now + claim_ttl
+    values: list[AutomationRunClaimValue] = []
+    for run in rows:
+        if run.agent_kind_snapshot is None:
+            _fail_unconfigured_agent(run, now, unconfigured_agent_failure)
+            continue
+        run.status = AUTOMATION_RUN_STATUS_CLAIMED
+        run.executor_kind = executor_kind
+        run.executor_id = executor_id
+        run.claim_id = uuid4()
+        run.claimed_at = now
+        run.claim_expires_at = expires_at
+        run.last_heartbeat_at = now
+        run.failed_at = None
+        run.last_error_code = None
+        run.last_error_message = None
+        run.updated_at = now
+        values.append(claim_value(run))
+    return values
 
 
 async def load_current_run_claim(
@@ -258,6 +276,7 @@ async def load_current_run_claim(
 
 
 async def heartbeat_run_claim(
+    db: AsyncSession | None = None,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -269,25 +288,53 @@ async def heartbeat_run_claim(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
+    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
+        return await _heartbeat_run_claim(
+            session,
             run_id=run_id,
             claim_id=claim_id,
+            claim_ttl=claim_ttl,
             now=now,
-            allowed_statuses=active_statuses,
+            active_statuses=active_statuses,
+            claim_is_active=claim_is_active,
             execution_target=execution_target,
             executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
             user_id=user_id,
         )
-        if run is None:
-            return None
-        run.claim_expires_at = now + claim_ttl
-        run.last_heartbeat_at = now
-        run.updated_at = now
-        await db.commit()
-        return claim_value(run)
+
+    return await operation(db) if db is not None else await _run_self_committing(operation)
+
+
+async def _heartbeat_run_claim(
+    db: AsyncSession,
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    claim_ttl: timedelta,
+    now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str,
+    executor_kind: str,
+    user_id: UUID | None,
+) -> AutomationRunClaimValue | None:
+    run = await load_claimed_run_for_update(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        allowed_statuses=active_statuses,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return None
+    run.claim_expires_at = now + claim_ttl
+    run.last_heartbeat_at = now
+    run.updated_at = now
+    return claim_value(run)
 
 
 async def sweep_expired_dispatching_runs(
@@ -299,7 +346,8 @@ async def sweep_expired_dispatching_runs(
 ) -> int:
     if limit <= 0:
         return 0
-    async with db_engine.async_session_factory() as db:
+
+    async def operation(db: AsyncSession) -> int:
         runs = list(
             (
                 await db.execute(
@@ -324,5 +372,6 @@ async def sweep_expired_dispatching_runs(
             run.last_error_message = dispatch_uncertain_failure.message
             clear_claim_metadata(run)
             run.updated_at = now
-        await db.commit()
         return len(runs)
+
+    return await _run_self_committing(operation)

--- a/server/proliferate/server/automations/api.py
+++ b/server/proliferate/server/automations/api.py
@@ -76,9 +76,10 @@ async def create_automation_endpoint(
 @router.post("/executor/local/claims", response_model=LocalAutomationClaimListResponse)
 async def claim_local_runs_endpoint(
     body: LocalAutomationClaimRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationClaimListResponse:
-    return await claim_local_runs(user.id, body)
+    return await claim_local_runs(db, user.id, body)
 
 
 @router.post(
@@ -88,9 +89,10 @@ async def claim_local_runs_endpoint(
 async def heartbeat_local_run_endpoint(
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await heartbeat_local_run(user.id, run_id, body)
+    return await heartbeat_local_run(db, user.id, run_id, body)
 
 
 @router.post(
@@ -100,9 +102,10 @@ async def heartbeat_local_run_endpoint(
 async def mark_local_run_creating_workspace_endpoint(
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_creating_workspace(user.id, run_id, body)
+    return await mark_local_run_creating_workspace(db, user.id, run_id, body)
 
 
 @router.post(
@@ -112,9 +115,10 @@ async def mark_local_run_creating_workspace_endpoint(
 async def attach_local_run_workspace_endpoint(
     run_id: UUID,
     body: LocalAutomationAttachWorkspaceRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await attach_local_run_workspace(user.id, run_id, body)
+    return await attach_local_run_workspace(db, user.id, run_id, body)
 
 
 @router.post(
@@ -124,9 +128,10 @@ async def attach_local_run_workspace_endpoint(
 async def mark_local_run_provisioning_workspace_endpoint(
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_provisioning_workspace(user.id, run_id, body)
+    return await mark_local_run_provisioning_workspace(db, user.id, run_id, body)
 
 
 @router.post(
@@ -136,9 +141,10 @@ async def mark_local_run_provisioning_workspace_endpoint(
 async def mark_local_run_creating_session_endpoint(
     run_id: UUID,
     body: LocalAutomationAttachWorkspaceRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_creating_session(user.id, run_id, body)
+    return await mark_local_run_creating_session(db, user.id, run_id, body)
 
 
 @router.post(
@@ -148,9 +154,10 @@ async def mark_local_run_creating_session_endpoint(
 async def attach_local_run_session_endpoint(
     run_id: UUID,
     body: LocalAutomationAttachSessionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await attach_local_run_session(user.id, run_id, body)
+    return await attach_local_run_session(db, user.id, run_id, body)
 
 
 @router.post(
@@ -160,9 +167,10 @@ async def attach_local_run_session_endpoint(
 async def mark_local_run_dispatching_endpoint(
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_dispatching(user.id, run_id, body)
+    return await mark_local_run_dispatching(db, user.id, run_id, body)
 
 
 @router.post(
@@ -172,9 +180,10 @@ async def mark_local_run_dispatching_endpoint(
 async def mark_local_run_dispatched_endpoint(
     run_id: UUID,
     body: LocalAutomationAttachSessionRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_dispatched(user.id, run_id, body)
+    return await mark_local_run_dispatched(db, user.id, run_id, body)
 
 
 @router.post(
@@ -184,9 +193,10 @@ async def mark_local_run_dispatched_endpoint(
 async def mark_local_run_failed_endpoint(
     run_id: UUID,
     body: LocalAutomationFailRequest,
+    db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> LocalAutomationMutationResponse:
-    return await mark_local_run_failed(user.id, run_id, body)
+    return await mark_local_run_failed(db, user.id, run_id, body)
 
 
 @router.get("/{automation_id}", response_model=AutomationResponse)

--- a/server/proliferate/server/automations/local_executor_service.py
+++ b/server/proliferate/server/automations/local_executor_service.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.constants.automations import (
     AUTOMATION_EXECUTION_TARGET_LOCAL,
     AUTOMATION_EXECUTOR_KIND_DESKTOP,
@@ -99,6 +101,7 @@ def _normalize_local_error_code(value: str) -> str:
 
 
 async def claim_local_runs(
+    db: AsyncSession,
     user_id: UUID,
     body: LocalAutomationClaimRequest,
 ) -> LocalAutomationClaimListResponse:
@@ -111,6 +114,7 @@ async def claim_local_runs(
             repositories.append(identity)
 
     values = await claim_local_automation_runs(
+        db,
         user_id=user_id,
         executor_id=executor_id,
         available_repositories=repositories,
@@ -124,12 +128,14 @@ async def claim_local_runs(
 
 
 async def heartbeat_local_run(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await heartbeat_run_claim(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         claim_ttl=_local_claim_ttl(),
@@ -144,12 +150,14 @@ async def heartbeat_local_run(
 
 
 async def mark_local_run_creating_workspace(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await mark_run_creating_workspace(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
@@ -163,12 +171,14 @@ async def mark_local_run_creating_workspace(
 
 
 async def attach_local_run_workspace(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationAttachWorkspaceRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await attach_anyharness_workspace_to_run(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         anyharness_workspace_id=normalize_required_text(
@@ -187,12 +197,14 @@ async def attach_local_run_workspace(
 
 
 async def mark_local_run_provisioning_workspace(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await mark_run_provisioning_workspace(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
@@ -206,12 +218,14 @@ async def mark_local_run_provisioning_workspace(
 
 
 async def mark_local_run_creating_session(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationAttachWorkspaceRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await mark_run_creating_session(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         anyharness_workspace_id=normalize_required_text(
@@ -230,12 +244,14 @@ async def mark_local_run_creating_session(
 
 
 async def attach_local_run_session(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationAttachSessionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     attached = await attach_anyharness_session_to_run(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         anyharness_workspace_id=normalize_required_text(
@@ -259,12 +275,14 @@ async def attach_local_run_session(
 
 
 async def mark_local_run_dispatching(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationClaimActionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     value = await mark_run_dispatching(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         now=utcnow(),
@@ -278,12 +296,14 @@ async def mark_local_run_dispatching(
 
 
 async def mark_local_run_dispatched(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationAttachSessionRequest,
 ) -> LocalAutomationMutationResponse:
     _normalize_executor_id(body.executor_id)
     dispatched = await mark_run_dispatched(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         anyharness_workspace_id=normalize_required_text(
@@ -307,6 +327,7 @@ async def mark_local_run_dispatched(
 
 
 async def mark_local_run_failed(
+    db: AsyncSession,
     user_id: UUID,
     run_id: UUID,
     body: LocalAutomationFailRequest,
@@ -314,6 +335,7 @@ async def mark_local_run_failed(
     _normalize_executor_id(body.executor_id)
     error_code = _normalize_local_error_code(body.error_code)
     failed = await mark_run_failed(
+        db,
         run_id=run_id,
         claim_id=body.claim_id,
         error_code=error_code,

--- a/server/tests/unit/test_automation_local_executor_db_threading.py
+++ b/server/tests/unit/test_automation_local_executor_db_threading.py
@@ -1,0 +1,123 @@
+from datetime import UTC, datetime
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_LOCAL,
+    AUTOMATION_RUN_STATUS_CLAIMED,
+    AUTOMATION_RUN_STATUS_QUEUED,
+)
+from proliferate.db import engine as engine_module
+from proliferate.db.models.automations import Automation, AutomationRun
+from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.store.automations import create_manual_run_for_user
+from proliferate.server.automations.local_executor_service import (
+    claim_local_runs as claim_local_runs_service,
+)
+from proliferate.server.automations.models import (
+    LocalAutomationClaimRequest,
+    LocalExecutorRepositoryIdentity,
+)
+
+
+async def _create_local_automation(user_id: uuid.UUID, now: datetime) -> uuid.UUID:
+    async with engine_module.async_session_factory() as session:
+        repo = CloudRepoConfig(
+            user_id=user_id,
+            git_owner="Proliferate-AI",
+            git_repo_name="Proliferate",
+            configured=False,
+            configured_at=None,
+            default_branch="main",
+            env_vars_ciphertext="",
+            env_vars_version=0,
+            setup_script="",
+            setup_script_version=0,
+            files_version=0,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(repo)
+        await session.flush()
+        automation = Automation(
+            user_id=user_id,
+            cloud_repo_config_id=repo.id,
+            title="Local check",
+            prompt="Check locally",
+            schedule_rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+            schedule_timezone="UTC",
+            schedule_summary="Daily at 09:00 in UTC",
+            execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+            agent_kind="codex",
+            model_id=None,
+            mode_id=None,
+            reasoning_effort=None,
+            enabled=True,
+            paused_at=None,
+            next_run_at=now,
+            last_scheduled_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(automation)
+        await session.commit()
+        return automation.id
+
+
+async def _create_manual_run(user_id: uuid.UUID, automation_id: uuid.UUID):
+    async with engine_module.async_session_factory() as session:
+        run = await create_manual_run_for_user(
+            session,
+            user_id=user_id,
+            automation_id=automation_id,
+        )
+        await session.commit()
+        return run
+
+
+@pytest.mark.asyncio
+async def test_local_claim_service_uses_request_scoped_db_session(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        automation_id = await _create_local_automation(user_id, now)
+        run = await _create_manual_run(user_id=user_id, automation_id=automation_id)
+        assert run is not None
+
+        request = LocalAutomationClaimRequest(
+            executor_id="desktop-1",
+            available_repositories=[
+                LocalExecutorRepositoryIdentity(
+                    provider="github",
+                    owner="proliferate-ai",
+                    name="proliferate",
+                )
+            ],
+            limit=1,
+        )
+        async with engine_module.async_session_factory() as request_db:
+            response = await claim_local_runs_service(request_db, user_id, request)
+            assert len(response.runs) == 1
+
+            async with engine_module.async_session_factory() as observer:
+                uncommitted_record = await observer.get(AutomationRun, run.id)
+                assert uncommitted_record is not None
+                assert uncommitted_record.status == AUTOMATION_RUN_STATUS_QUEUED
+                assert uncommitted_record.claim_id is None
+
+            await request_db.commit()
+
+        async with engine_module.async_session_factory() as observer:
+            committed_record = await observer.get(AutomationRun, run.id)
+            assert committed_record is not None
+            assert committed_record.status == AUTOMATION_RUN_STATUS_CLAIMED
+            assert committed_record.claim_id == uuid.UUID(response.runs[0].claim_id)
+    finally:
+        engine_module.async_session_factory = original_factory


### PR DESCRIPTION
## Summary
- Phase 8 Wave 3A: thread request-scoped `AsyncSession` through Automation local executor endpoints and service/store claim paths.
- Keep existing cloud executor and scheduler compatibility wrappers on their current short self-committing transaction boundaries.
- Ratchet automation claim boundary allowlist counts only where the checker confirmed lower counts.

## Invariants
- One local executor HTTP request maps to one request DB transaction.
- Local claim acquisition, heartbeat, transition, dispatched, and failed mutations still use claim identity, status, target, executor kind, and user/repo scoping gates.
- Public local executor request/response shapes are unchanged.
- Cloud executor worker loops, scheduler tick behavior, and long AnyHarness/provider operations are not moved into request transactions.

## Verification
- `DEBUG=true uv run --python /opt/homebrew/opt/python@3.12/bin/python3.12 --extra dev python -m pytest -q tests/unit/test_automation_executor.py tests/unit/test_automation_local_executor_db_threading.py tests/unit/test_automation_store.py tests/unit/test_automation_service.py tests/unit/test_automation_claim_contracts.py tests/integration/test_automations_api.py`
- `/opt/homebrew/bin/python3.12 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `git diff --check HEAD~1 HEAD`