### PR TITLE
refactor(desktop): untangle auth orchestration effects

### DIFF
--- a/desktop/src/hooks/auth/lifecycle/use-auth-bootstrap.ts
+++ b/desktop/src/hooks/auth/lifecycle/use-auth-bootstrap.ts
@@ -1,18 +1,20 @@
 import { useCallback, useEffect } from "react";
 import { registerCurrentAuthSessionProvider } from "@/lib/domain/auth/current-auth-session";
 import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
-import { useAuthStore } from "@/stores/auth/auth-store";
 import { bootstrapAuth } from "@/lib/integrations/auth/orchestration";
+import { useAuthOrchestrationEffects } from "@/hooks/auth/workflows/use-auth-orchestration-effects";
 
 // Owns app-mounted auth bootstrap wiring. Does not own sign-in/sign-out actions.
 export function useAuthBootstrap() {
+  const authEffects = useAuthOrchestrationEffects();
+
   useEffect(() => {
-    registerCurrentAuthSessionProvider(() => useAuthStore.getState().session);
-  }, []);
+    registerCurrentAuthSessionProvider(() => authEffects.getAuthState().session);
+  }, [authEffects]);
 
   return useCallback(async () => {
     try {
-      await bootstrapAuth();
+      await bootstrapAuth(authEffects);
     } catch (error) {
       captureTelemetryException(error, {
         tags: {
@@ -21,5 +23,5 @@ export function useAuthBootstrap() {
         },
       });
     }
-  }, []);
+  }, [authEffects]);
 }

--- a/desktop/src/hooks/auth/workflows/use-auth-actions.ts
+++ b/desktop/src/hooks/auth/workflows/use-auth-actions.ts
@@ -10,13 +10,16 @@ import {
   signOut,
 } from "@/lib/integrations/auth/orchestration";
 import type { GitHubDesktopSignInOptions } from "@/lib/integrations/auth/proliferate-auth";
+import { useAuthOrchestrationEffects } from "@/hooks/auth/workflows/use-auth-orchestration-effects";
 
 // Owns user-triggered auth actions and their telemetry. Does not own auth bootstrap.
 export function useAuthActions() {
+  const authEffects = useAuthOrchestrationEffects();
+
   return {
     signInWithGitHub: useCallback(async (options?: GitHubDesktopSignInOptions) => {
       try {
-        const result = await signInWithGitHub(options);
+        const result = await signInWithGitHub(options, authEffects);
         trackProductEvent("auth_signed_in", {
           provider: result.provider,
           source: result.source,
@@ -38,10 +41,10 @@ export function useAuthActions() {
         });
         throw error;
       }
-    }, []),
+    }, [authEffects]),
     signOut: useCallback(async () => {
       try {
-        const result = await signOut();
+        const result = await signOut(authEffects);
         trackProductEvent("auth_signed_out", {
           provider: result.provider,
         });
@@ -55,6 +58,6 @@ export function useAuthActions() {
         });
         throw error;
       }
-    }, []),
+    }, [authEffects]),
   };
 }

--- a/desktop/src/hooks/auth/workflows/use-auth-orchestration-effects.ts
+++ b/desktop/src/hooks/auth/workflows/use-auth-orchestration-effects.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { closeAllSessionStreamHandles } from "@/lib/access/anyharness/session-stream-handles";
+import type { AuthClientStatePatch } from "@/lib/domain/auth/auth-state-mapping";
+import type { AuthOrchestrationDeps } from "@/lib/integrations/auth/orchestration";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import { useToastStore } from "@/stores/toast/toast-store";
+import { useRepoSetupModalStore } from "@/stores/ui/repo-setup-modal-store";
+
+// Owns auth orchestration's store/runtime effect wiring. Does not own the auth network flow.
+export function useAuthOrchestrationEffects(): AuthOrchestrationDeps {
+  return useMemo(() => ({
+    getAuthState: () => useAuthStore.getState(),
+    setAuthState: (state: AuthClientStatePatch) => {
+      useAuthStore.setState(state);
+    },
+    clearSessionRuntimeState: () => {
+      closeAllSessionStreamHandles();
+      useSessionDirectoryStore.getState().clearEntries();
+      useSessionTranscriptStore.getState().clearEntries();
+      useSessionSelectionStore.getState().clearSelection();
+    },
+    closeRepoSetupModal: () => {
+      useRepoSetupModalStore.getState().close();
+    },
+    showToast: (message: string) => {
+      useToastStore.getState().show(message);
+    },
+  }), []);
+}

--- a/desktop/src/lib/domain/auth/auth-state-mapping.test.ts
+++ b/desktop/src/lib/domain/auth/auth-state-mapping.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+import {
+  anonymousAuthState,
+  authenticatedAuthState,
+  authErrorStatePatch,
+  bootstrappingAuthStatePatch,
+} from "./auth-state-mapping";
+
+const storedSession: StoredAuthSession = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  expires_at: "2026-05-09T12:00:00.000Z",
+  user_id: "user-session",
+  email: "session@example.com",
+  display_name: "Session User",
+  github_login: "session-login",
+};
+
+describe("auth state mapping", () => {
+  it("builds bootstrapping and anonymous state without requiring store access", () => {
+    expect(bootstrappingAuthStatePatch()).toEqual({
+      status: "bootstrapping",
+      error: null,
+    });
+
+    expect(anonymousAuthState()).toEqual({
+      status: "anonymous",
+      session: null,
+      user: null,
+      error: null,
+    });
+  });
+
+  it("builds authenticated state from either the session or a validated user", () => {
+    expect(authenticatedAuthState(storedSession).user).toEqual({
+      id: "user-session",
+      email: "session@example.com",
+      display_name: "Session User",
+      github_login: "session-login",
+      avatar_url: null,
+    });
+
+    const validatedUser: AuthUser = {
+      id: "user-current",
+      email: "current@example.com",
+      display_name: "Current User",
+      github_login: null,
+      avatar_url: null,
+    };
+
+    expect(authenticatedAuthState(storedSession, validatedUser)).toEqual({
+      status: "authenticated",
+      session: storedSession,
+      user: validatedUser,
+      error: null,
+    });
+  });
+
+  it("builds an error-only patch for background callback failures", () => {
+    expect(authErrorStatePatch("Sign-in failed")).toEqual({
+      error: "Sign-in failed",
+    });
+  });
+});

--- a/desktop/src/lib/domain/auth/auth-state-mapping.ts
+++ b/desktop/src/lib/domain/auth/auth-state-mapping.ts
@@ -1,0 +1,46 @@
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import { authUserFromStoredSession } from "@/lib/domain/auth/session-mapping";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+
+export type AuthClientStatus = "bootstrapping" | "anonymous" | "authenticated";
+
+export interface AuthClientState {
+  status: AuthClientStatus;
+  session: StoredAuthSession | null;
+  user: AuthUser | null;
+  error: string | null;
+}
+
+export type AuthClientStatePatch = Partial<AuthClientState>;
+
+export function bootstrappingAuthStatePatch(): Pick<AuthClientState, "status" | "error"> {
+  return {
+    status: "bootstrapping",
+    error: null,
+  };
+}
+
+export function anonymousAuthState(): AuthClientState {
+  return {
+    status: "anonymous",
+    session: null,
+    user: null,
+    error: null,
+  };
+}
+
+export function authenticatedAuthState(
+  session: StoredAuthSession,
+  user: AuthUser = authUserFromStoredSession(session),
+): AuthClientState {
+  return {
+    status: "authenticated",
+    session,
+    user,
+    error: null,
+  };
+}
+
+export function authErrorStatePatch(error: string): Pick<AuthClientState, "error"> {
+  return { error };
+}

--- a/desktop/src/lib/domain/auth/session-mapping.test.ts
+++ b/desktop/src/lib/domain/auth/session-mapping.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+import {
+  authUserFromStoredSession,
+  storedSessionWithValidatedUser,
+} from "./session-mapping";
+
+const storedSession: StoredAuthSession = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  expires_at: "2026-05-09T12:00:00.000Z",
+  user_id: "user-session",
+  email: "session@example.com",
+  display_name: "Session User",
+};
+
+describe("authUserFromStoredSession", () => {
+  it("maps persisted session identity into the auth user model", () => {
+    expect(authUserFromStoredSession(storedSession)).toEqual({
+      id: "user-session",
+      email: "session@example.com",
+      display_name: "Session User",
+      github_login: null,
+      avatar_url: null,
+    });
+  });
+});
+
+describe("storedSessionWithValidatedUser", () => {
+  it("keeps tokens while replacing stale persisted identity fields", () => {
+    const user: AuthUser = {
+      id: "user-current",
+      email: "current@example.com",
+      display_name: null,
+      github_login: "current-login",
+      avatar_url: "https://example.com/avatar.png",
+    };
+
+    expect(storedSessionWithValidatedUser(storedSession, user)).toEqual({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_at: "2026-05-09T12:00:00.000Z",
+      user_id: "user-current",
+      email: "current@example.com",
+      display_name: null,
+      github_login: "current-login",
+      avatar_url: "https://example.com/avatar.png",
+    });
+  });
+});

--- a/desktop/src/lib/domain/auth/session-mapping.ts
+++ b/desktop/src/lib/domain/auth/session-mapping.ts
@@ -1,0 +1,26 @@
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+
+export function authUserFromStoredSession(session: StoredAuthSession): AuthUser {
+  return {
+    id: session.user_id,
+    email: session.email,
+    display_name: session.display_name,
+    github_login: session.github_login ?? null,
+    avatar_url: session.avatar_url ?? null,
+  };
+}
+
+export function storedSessionWithValidatedUser(
+  session: StoredAuthSession,
+  user: AuthUser,
+): StoredAuthSession {
+  return {
+    ...session,
+    user_id: user.id,
+    email: user.email,
+    display_name: user.display_name,
+    github_login: user.github_login ?? null,
+    avatar_url: user.avatar_url ?? null,
+  };
+}

--- a/desktop/src/lib/integrations/auth/orchestration.ts
+++ b/desktop/src/lib/integrations/auth/orchestration.ts
@@ -6,18 +6,10 @@ import {
   getStoredPendingAuthSession,
   setStoredAuthSession,
   setStoredPendingAuthSession,
-  type StoredAuthSession,
   type StoredPendingAuthSession,
 } from "@/lib/access/tauri/auth";
 import { desktopNavigationTarget } from "@/lib/domain/auth/desktop-navigation";
-import { closeAllSessionStreamHandles } from "@/lib/access/anyharness/session-stream-handles";
 import { markTelemetryHandled } from "@/lib/domain/telemetry/errors";
-import { useAuthStore } from "@/stores/auth/auth-store";
-import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
-import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
-import { useRepoSetupModalStore } from "@/stores/ui/repo-setup-modal-store";
-import { useToastStore } from "@/stores/toast/toast-store";
 import {
   cancelGitHubSignIn,
   getActiveGitHubSignIn,
@@ -26,7 +18,18 @@ import {
   startGitHubSignIn,
 } from "@/lib/domain/auth/github-signin-state";
 import { createDevBypassSession, isDevAuthBypassed } from "@/lib/domain/auth/auth-mode";
+import {
+  anonymousAuthState,
+  authErrorStatePatch,
+  bootstrappingAuthStatePatch,
+  type AuthClientState,
+  type AuthClientStatePatch,
+} from "@/lib/domain/auth/auth-state-mapping";
+import {
+  storedSessionWithValidatedUser,
+} from "@/lib/domain/auth/session-mapping";
 import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
 import type { GitHubDesktopSignInOptions } from "@/lib/integrations/auth/proliferate-auth";
 import type { AuthSignInSource, AuthTelemetryProvider } from "@/lib/domain/telemetry/events";
 import {
@@ -41,7 +44,6 @@ import {
   parseDesktopAuthCallback,
   pollGitHubDesktopSession,
   refreshDesktopUserSession,
-  sessionUser,
 } from "@/lib/integrations/auth/proliferate-auth";
 import {
   captureTelemetryException,
@@ -53,16 +55,23 @@ import {
   startStartupTimer,
   summarizeStartupError,
 } from "@/lib/infra/measurement/debug-startup";
+import {
+  applyAnonymousAuthState,
+  applyPersistedAuthenticatedAuthState,
+  applyVolatileAuthenticatedAuthState,
+} from "@/lib/workflows/auth/apply-auth-state";
 
-function applyDevBypassState(): void {
+export interface AuthOrchestrationDeps {
+  getAuthState(): AuthClientState;
+  setAuthState(state: AuthClientStatePatch): void;
+  clearSessionRuntimeState(): void;
+  closeRepoSetupModal(): void;
+  showToast(message: string): void;
+}
+
+function applyDevBypassState(deps: AuthOrchestrationDeps): void {
   const session = createDevBypassSession();
-
-  useAuthStore.setState({
-    status: "authenticated",
-    session,
-    user: sessionUser(session),
-    error: null,
-  });
+  applyVolatileAuthenticatedAuthState({ session }, deps);
 }
 
 function isTransientBootstrapError(error: unknown): boolean {
@@ -71,20 +80,6 @@ function isTransientBootstrapError(error: unknown): boolean {
   }
 
   return error instanceof Error;
-}
-
-function persistValidatedSession(
-  session: StoredAuthSession,
-  user: AuthUser,
-): StoredAuthSession {
-  return {
-    ...session,
-    user_id: user.id,
-    email: user.email,
-    display_name: user.display_name,
-    github_login: user.github_login ?? null,
-    avatar_url: user.avatar_url ?? null,
-  };
 }
 
 function wait(ms: number): Promise<void> {
@@ -112,43 +107,39 @@ async function validateSession(
 
 async function recoverValidatedSessionAfterTransientFailure(
   storedSession: StoredAuthSession,
+  deps: AuthOrchestrationDeps,
 ): Promise<void> {
   const expectedRefreshToken = storedSession.refresh_token;
 
   for (let attempt = 0; attempt < 10; attempt += 1) {
     await wait(1000);
 
-    const currentSession = useAuthStore.getState().session;
+    const currentSession = deps.getAuthState().session;
     if (currentSession?.refresh_token !== expectedRefreshToken) {
       return;
     }
 
     try {
       const { session, user } = await validateSession(storedSession);
-      const persistedSession = persistValidatedSession(session, user);
+      const persistedSession = storedSessionWithValidatedUser(session, user);
       await setStoredAuthSession(persistedSession);
 
-      if (useAuthStore.getState().session?.refresh_token !== expectedRefreshToken) {
+      if (deps.getAuthState().session?.refresh_token !== expectedRefreshToken) {
         return;
       }
 
-      useAuthStore.setState({
-        status: "authenticated",
-        session: persistedSession,
-        user,
-        error: null,
-      });
+      applyVolatileAuthenticatedAuthState({ session: persistedSession, user }, deps);
       return;
     } catch (error) {
       if (isTransientBootstrapError(error)) {
         continue;
       }
 
-      if (useAuthStore.getState().session?.refresh_token !== expectedRefreshToken) {
+      if (deps.getAuthState().session?.refresh_token !== expectedRefreshToken) {
         return;
       }
 
-      await applyAnonymousState();
+      await applyAnonymousState(deps);
       return;
     }
   }
@@ -162,37 +153,38 @@ function toError(error: unknown, fallback: string): Error {
   return new Error(fallback);
 }
 
-async function applyAnonymousState(options?: {
-  clearPendingAuth?: boolean;
-}): Promise<void> {
-  await clearStoredAuthSession();
-  if (options?.clearPendingAuth) {
-    await clearStoredPendingAuthSession();
-  }
-  clearSessionRuntimeStateForAuth();
-  useRepoSetupModalStore.getState().close();
-  useAuthStore.setState({
-    status: "anonymous",
-    session: null,
-    user: null,
-    error: null,
+async function applyAnonymousState(
+  deps: AuthOrchestrationDeps,
+  options?: {
+    clearPendingAuth?: boolean;
+  },
+): Promise<void> {
+  await applyAnonymousAuthState(options ?? {}, {
+    clearStoredAuthSession,
+    clearStoredPendingAuthSession,
+    clearSessionRuntimeState: deps.clearSessionRuntimeState,
+    closeRepoSetupModal: deps.closeRepoSetupModal,
+    setAuthState: deps.setAuthState,
   });
 }
 
-async function applyAuthenticatedState(session: StoredAuthSession): Promise<void> {
-  await setStoredAuthSession(session);
-  useAuthStore.setState({
-    status: "authenticated",
-    session,
-    user: sessionUser(session),
-    error: null,
+async function applyAuthenticatedState(
+  deps: AuthOrchestrationDeps,
+  session: StoredAuthSession,
+): Promise<void> {
+  await applyPersistedAuthenticatedAuthState({ session }, {
+    setStoredAuthSession,
+    setAuthState: deps.setAuthState,
   });
 }
 
-function reportBackgroundAuthError(message: string): void {
-  useToastStore.getState().show(message);
-  if (useAuthStore.getState().status !== "authenticated") {
-    useAuthStore.setState({ error: message });
+function reportBackgroundAuthError(
+  message: string,
+  deps: AuthOrchestrationDeps,
+): void {
+  deps.showToast(message);
+  if (deps.getAuthState().status !== "authenticated") {
+    deps.setAuthState(authErrorStatePatch(message));
   }
   captureTelemetryException(new Error(message), {
     level: "warning",
@@ -241,14 +233,14 @@ async function restorePendingCallbackMarker(
   });
 }
 
-export async function bootstrapAuth(): Promise<void> {
+export async function bootstrapAuth(deps: AuthOrchestrationDeps): Promise<void> {
   const startedAt = startStartupTimer();
-  useAuthStore.setState({ status: "bootstrapping", error: null });
+  deps.setAuthState(bootstrappingAuthStatePatch());
   logStartupDebug("auth.bootstrap.start");
 
   if (isDevAuthBypassed()) {
     await clearStoredPendingAuthSession();
-    applyDevBypassState();
+    applyDevBypassState(deps);
     logStartupDebug("auth.bootstrap.dev_bypass", {
       elapsedMs: elapsedStartupMs(startedAt),
     });
@@ -259,34 +251,24 @@ export async function bootstrapAuth(): Promise<void> {
   const controlPlaneReachable = await checkControlPlaneReachable();
   if (!controlPlaneReachable) {
     await clearStoredPendingAuthSession();
-    clearSessionRuntimeStateForAuth();
+    deps.clearSessionRuntimeState();
 
     if (storedSession) {
-      useAuthStore.setState({
-        status: "authenticated",
-        session: storedSession,
-        user: sessionUser(storedSession),
-        error: null,
-      });
+      applyVolatileAuthenticatedAuthState({ session: storedSession }, deps);
       logStartupDebug("auth.bootstrap.control_plane_unreachable.cached_session", {
         elapsedMs: elapsedStartupMs(startedAt),
       });
       return;
     }
 
-    useAuthStore.setState({
-      status: "anonymous",
-      session: null,
-      user: null,
-      error: null,
-    });
+    deps.setAuthState(anonymousAuthState());
     logStartupDebug("auth.bootstrap.control_plane_unreachable.anonymous", {
       elapsedMs: elapsedStartupMs(startedAt),
     });
     return;
   }
 
-  await ensureDeepLinkBridge(handleDesktopCallbackUrl);
+  await ensureDeepLinkBridge((url) => handleDesktopCallbackUrl(url, deps));
 
   const pending = await getStoredPendingAuthSession();
   if (pending && isPendingDesktopAuthExpired(pending)) {
@@ -297,12 +279,7 @@ export async function bootstrapAuth(): Promise<void> {
   }
 
   if (!storedSession) {
-    useAuthStore.setState({
-      status: "anonymous",
-      session: null,
-      user: null,
-      error: null,
-    });
+    deps.setAuthState(anonymousAuthState());
     logStartupDebug("auth.bootstrap.no_stored_session", {
       elapsedMs: elapsedStartupMs(startedAt),
     });
@@ -312,34 +289,29 @@ export async function bootstrapAuth(): Promise<void> {
   try {
     logStartupDebug("auth.bootstrap.validate_stored_session.start");
     const { session, user } = await validateSession(storedSession);
-    const persistedSession = persistValidatedSession(session, user);
-    await setStoredAuthSession(persistedSession);
-    useAuthStore.setState({
-      status: "authenticated",
-      session: persistedSession,
-      user,
-      error: null,
-    });
+    const persistedSession = storedSessionWithValidatedUser(session, user);
+    await applyPersistedAuthenticatedAuthState(
+      { session: persistedSession, user },
+      {
+        setStoredAuthSession,
+        setAuthState: deps.setAuthState,
+      },
+    );
     logStartupDebug("auth.bootstrap.validate_stored_session.completed", {
       elapsedMs: elapsedStartupMs(startedAt),
     });
   } catch (error) {
     if (isTransientBootstrapError(error)) {
-      useAuthStore.setState({
-        status: "authenticated",
-        session: storedSession,
-        user: sessionUser(storedSession),
-        error: null,
-      });
+      applyVolatileAuthenticatedAuthState({ session: storedSession }, deps);
       logStartupDebug("auth.bootstrap.transient_failure_background_recovery", {
         elapsedMs: elapsedStartupMs(startedAt),
         ...summarizeStartupError(error),
       });
-      void recoverValidatedSessionAfterTransientFailure(storedSession);
+      void recoverValidatedSessionAfterTransientFailure(storedSession, deps);
       return;
     }
 
-    await applyAnonymousState();
+    await applyAnonymousState(deps);
     logStartupDebug("auth.bootstrap.failed_anonymous", {
       elapsedMs: elapsedStartupMs(startedAt),
       ...summarizeStartupError(error),
@@ -348,19 +320,15 @@ export async function bootstrapAuth(): Promise<void> {
   }
 }
 
-function clearSessionRuntimeStateForAuth(): void {
-  closeAllSessionStreamHandles();
-  useSessionDirectoryStore.getState().clearEntries();
-  useSessionTranscriptStore.getState().clearEntries();
-  useSessionSelectionStore.getState().clearSelection();
-}
-
-export async function signInWithGitHub(options?: GitHubDesktopSignInOptions): Promise<{
+export async function signInWithGitHub(
+  options: GitHubDesktopSignInOptions | undefined,
+  deps: AuthOrchestrationDeps,
+): Promise<{
   provider: AuthTelemetryProvider;
   source: AuthSignInSource;
 }> {
   if (isDevAuthBypassed()) {
-    applyDevBypassState();
+    applyDevBypassState(deps);
     return {
       provider: "dev_bypass",
       source: "dev_bypass",
@@ -429,7 +397,7 @@ export async function signInWithGitHub(options?: GitHubDesktopSignInOptions): Pr
     }
 
     await clearStoredPendingAuthSession();
-    await applyAuthenticatedState(session);
+    await applyAuthenticatedState(deps, session);
     return {
       provider: "github",
       source,
@@ -438,7 +406,7 @@ export async function signInWithGitHub(options?: GitHubDesktopSignInOptions): Pr
     if (
       error instanceof Error
       && error.name === "AbortError"
-      && useAuthStore.getState().status === "authenticated"
+      && deps.getAuthState().status === "authenticated"
     ) {
       return {
         provider: "github",
@@ -454,25 +422,28 @@ export async function signInWithGitHub(options?: GitHubDesktopSignInOptions): Pr
   }
 }
 
-export async function signOut(): Promise<{
+export async function signOut(deps: AuthOrchestrationDeps): Promise<{
   provider: AuthTelemetryProvider;
 }> {
   if (isDevAuthBypassed()) {
     await clearPendingGitHubAuth();
-    applyDevBypassState();
+    applyDevBypassState(deps);
     return {
       provider: "dev_bypass",
     };
   }
 
   await clearPendingGitHubAuth();
-  await applyAnonymousState({ clearPendingAuth: true });
+  await applyAnonymousState(deps, { clearPendingAuth: true });
   return {
     provider: "github",
   };
 }
 
-export async function handleDesktopCallbackUrl(url: string): Promise<boolean> {
+export async function handleDesktopCallbackUrl(
+  url: string,
+  deps: AuthOrchestrationDeps,
+): Promise<boolean> {
   if (handleDesktopNavigationUrl(url)) {
     return true;
   }
@@ -494,13 +465,14 @@ export async function handleDesktopCallbackUrl(url: string): Promise<boolean> {
   if (isPendingDesktopAuthExpired(pending)) {
     const message = "GitHub sign-in expired. Start again from Proliferate.";
     await clearPendingGitHubAuth(pending.state, new Error(message));
-    reportBackgroundAuthError(message);
+    reportBackgroundAuthError(message, deps);
     return false;
   }
 
   if (pending.state !== callback.state) {
     reportBackgroundAuthError(
       "Proliferate ignored a stale browser callback because it did not match the active sign-in.",
+      deps,
     );
     return false;
   }
@@ -519,7 +491,7 @@ export async function handleDesktopCallbackUrl(url: string): Promise<boolean> {
 
     resolveGitHubSignIn(pending.state, session);
     await clearStoredPendingAuthSession();
-    await applyAuthenticatedState(session);
+    await applyAuthenticatedState(deps, session);
     return true;
   } catch (error) {
     const latestPending = await getStoredPendingAuthSession();
@@ -546,6 +518,7 @@ export async function handleDesktopCallbackUrl(url: string): Promise<boolean> {
 
     reportBackgroundAuthError(
       error instanceof Error ? error.message : "GitHub sign-in failed",
+      deps,
     );
     return false;
   }

--- a/desktop/src/lib/integrations/auth/proliferate-auth.ts
+++ b/desktop/src/lib/integrations/auth/proliferate-auth.ts
@@ -237,16 +237,6 @@ export function isSessionExpiring(session: StoredAuthSession, skewSeconds = 60):
   return expiresAt - Date.now() <= skewSeconds * 1000
 }
 
-export function sessionUser(session: StoredAuthSession): AuthUser {
-  return {
-    id: session.user_id,
-    email: session.email,
-    display_name: session.display_name,
-    github_login: session.github_login ?? null,
-    avatar_url: session.avatar_url ?? null,
-  }
-}
-
 export function buildGitHubOAuthAppSettingsUrl(clientId?: string | null): string {
   if (!clientId) {
     return GITHUB_APP_SETTINGS_FALLBACK_URL

--- a/desktop/src/lib/workflows/auth/apply-auth-state.test.ts
+++ b/desktop/src/lib/workflows/auth/apply-auth-state.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthClientStatePatch } from "@/lib/domain/auth/auth-state-mapping";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+import {
+  applyAnonymousAuthState,
+  applyPersistedAuthenticatedAuthState,
+  applyVolatileAuthenticatedAuthState,
+} from "./apply-auth-state";
+
+const storedSession: StoredAuthSession = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  expires_at: "2026-05-09T12:00:00.000Z",
+  user_id: "user-session",
+  email: "session@example.com",
+  display_name: "Session User",
+};
+
+describe("applyAnonymousAuthState", () => {
+  it("clears persisted auth before resetting runtime and client auth state", async () => {
+    const calls: string[] = [];
+    const setAuthState = vi.fn((_: AuthClientStatePatch) => calls.push("setAuthState"));
+
+    await applyAnonymousAuthState({ clearPendingAuth: true }, {
+      clearStoredAuthSession: vi.fn(async () => {
+        calls.push("clearStoredAuthSession");
+      }),
+      clearStoredPendingAuthSession: vi.fn(async () => {
+        calls.push("clearStoredPendingAuthSession");
+      }),
+      clearSessionRuntimeState: vi.fn(() => {
+        calls.push("clearSessionRuntimeState");
+      }),
+      closeRepoSetupModal: vi.fn(() => {
+        calls.push("closeRepoSetupModal");
+      }),
+      setAuthState,
+    });
+
+    expect(calls).toEqual([
+      "clearStoredAuthSession",
+      "clearStoredPendingAuthSession",
+      "clearSessionRuntimeState",
+      "closeRepoSetupModal",
+      "setAuthState",
+    ]);
+    expect(setAuthState).toHaveBeenCalledWith({
+      status: "anonymous",
+      session: null,
+      user: null,
+      error: null,
+    });
+  });
+});
+
+describe("applyPersistedAuthenticatedAuthState", () => {
+  it("persists the session before applying authenticated client state", async () => {
+    const calls: string[] = [];
+    const setAuthState = vi.fn((_: AuthClientStatePatch) => calls.push("setAuthState"));
+
+    await applyPersistedAuthenticatedAuthState({ session: storedSession }, {
+      setStoredAuthSession: vi.fn(async () => {
+        calls.push("setStoredAuthSession");
+      }),
+      setAuthState,
+    });
+
+    expect(calls).toEqual(["setStoredAuthSession", "setAuthState"]);
+    expect(setAuthState).toHaveBeenCalledWith({
+      status: "authenticated",
+      session: storedSession,
+      user: {
+        id: "user-session",
+        email: "session@example.com",
+        display_name: "Session User",
+        github_login: null,
+        avatar_url: null,
+      },
+      error: null,
+    });
+  });
+});
+
+describe("applyVolatileAuthenticatedAuthState", () => {
+  it("applies cached authenticated state without requiring persistence deps", () => {
+    const setAuthState = vi.fn();
+
+    applyVolatileAuthenticatedAuthState({ session: storedSession }, { setAuthState });
+
+    expect(setAuthState).toHaveBeenCalledWith({
+      status: "authenticated",
+      session: storedSession,
+      user: {
+        id: "user-session",
+        email: "session@example.com",
+        display_name: "Session User",
+        github_login: null,
+        avatar_url: null,
+      },
+      error: null,
+    });
+  });
+});

--- a/desktop/src/lib/workflows/auth/apply-auth-state.ts
+++ b/desktop/src/lib/workflows/auth/apply-auth-state.ts
@@ -1,0 +1,59 @@
+import {
+  anonymousAuthState,
+  authenticatedAuthState,
+  type AuthClientStatePatch,
+} from "@/lib/domain/auth/auth-state-mapping";
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { StoredAuthSession } from "@/lib/domain/auth/stored-auth-session";
+
+export interface AuthStateWriterDeps {
+  setAuthState(state: AuthClientStatePatch): void;
+}
+
+export interface ApplyAnonymousAuthStateDeps extends AuthStateWriterDeps {
+  clearStoredAuthSession(): Promise<void>;
+  clearStoredPendingAuthSession(): Promise<void>;
+  clearSessionRuntimeState(): void;
+  closeRepoSetupModal(): void;
+}
+
+export interface ApplyAnonymousAuthStateInput {
+  clearPendingAuth?: boolean;
+}
+
+export async function applyAnonymousAuthState(
+  input: ApplyAnonymousAuthStateInput,
+  deps: ApplyAnonymousAuthStateDeps,
+): Promise<void> {
+  await deps.clearStoredAuthSession();
+  if (input.clearPendingAuth) {
+    await deps.clearStoredPendingAuthSession();
+  }
+  deps.clearSessionRuntimeState();
+  deps.closeRepoSetupModal();
+  deps.setAuthState(anonymousAuthState());
+}
+
+export interface ApplyPersistedAuthenticatedAuthStateDeps extends AuthStateWriterDeps {
+  setStoredAuthSession(session: StoredAuthSession): Promise<void>;
+}
+
+export interface ApplyAuthenticatedAuthStateInput {
+  session: StoredAuthSession;
+  user?: AuthUser;
+}
+
+export async function applyPersistedAuthenticatedAuthState(
+  input: ApplyAuthenticatedAuthStateInput,
+  deps: ApplyPersistedAuthenticatedAuthStateDeps,
+): Promise<void> {
+  await deps.setStoredAuthSession(input.session);
+  applyVolatileAuthenticatedAuthState(input, deps);
+}
+
+export function applyVolatileAuthenticatedAuthState(
+  input: ApplyAuthenticatedAuthStateInput,
+  deps: AuthStateWriterDeps,
+): void {
+  deps.setAuthState(authenticatedAuthState(input.session, input.user));
+}


### PR DESCRIPTION
## Summary
- Move pure auth session and auth-state mapping into `lib/domain/auth` with focused tests.
- Move auth state apply/reset sequencing into `lib/workflows/auth` with explicit dependencies.
- Wire auth hooks to provide store/runtime effects so `orchestration.ts` no longer imports stores directly.

## Verification
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
- `pnpm --dir desktop exec vitest run src/lib/domain/auth/session-mapping.test.ts src/lib/domain/auth/auth-state-mapping.test.ts src/lib/workflows/auth/apply-auth-state.test.ts src/lib/domain/auth/auth-mode.test.ts src/lib/domain/auth/desktop-navigation.test.ts src/lib/domain/auth/account-profile-presentation.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`