### PR TITLE
refactor(desktop): extract session directory helpers

### DIFF
--- a/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.ts
+++ b/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.ts
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
 import { isSessionSlotBusy } from "@/lib/domain/sessions/activity";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
 import { useTauriWindowActions } from "@/hooks/access/tauri/use-window-actions";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 type SessionEntries = ReturnType<typeof useSessionDirectoryStore.getState>["entriesById"];
 

--- a/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.ts
+++ b/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.ts
@@ -24,10 +24,11 @@ import {
 } from "@/lib/domain/chat/outbox/prompt-outbox-selectors";
 import type { PromptOutboxEntry } from "@/lib/domain/chat/outbox/prompt-outbox-model";
 import { outboxEntriesForSession } from "@/lib/domain/chat/outbox/prompt-outbox-state";
-import { activitySnapshotFromDirectoryEntry, useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import type { SessionStreamConnectionState } from "@/lib/domain/sessions/directory/directory-entry";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
-import type { SessionStreamConnectionState } from "@/stores/sessions/session-types";
 import { usePromptOutboxStore } from "@/stores/chat/prompt-outbox-store";
 
 const EMPTY_PENDING_PROMPTS: readonly PendingPromptEntry[] = [];

--- a/desktop/src/hooks/chat/subagents/use-linked-session-mounting.ts
+++ b/desktop/src/hooks/chat/subagents/use-linked-session-mounting.ts
@@ -6,7 +6,7 @@ import {
   getSessionRecord,
   putSessionRecord,
 } from "@/stores/sessions/session-records";
-import type { SessionRelationship } from "@/stores/sessions/session-types";
+import type { SessionRelationship } from "@/lib/domain/sessions/directory/relationship";
 
 interface MountLinkedSessionInput {
   sessionId: string;

--- a/desktop/src/hooks/sessions/lifecycle/use-session-activity-reconciler.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-session-activity-reconciler.ts
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { resolveSessionSidebarActivityState } from "@/lib/domain/sessions/activity";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionRuntimeActions } from "@/hooks/sessions/use-session-runtime-actions";
 import { isHotSessionClientId } from "@/lib/workflows/sessions/hot-session-ingest-manager";

--- a/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -29,11 +29,9 @@ import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import { fetchSessionHistory } from "@/lib/workflows/sessions/session-runtime";
+import { activityFromTranscript } from "@/lib/domain/sessions/directory/directory-activity";
 import { useLinkedSessionMounting } from "@/hooks/chat/subagents/use-linked-session-mounting";
-import {
-  activityFromTranscript,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";

--- a/desktop/src/hooks/sessions/session-runtime-helpers.ts
+++ b/desktop/src/hooks/sessions/session-runtime-helpers.ts
@@ -1,11 +1,9 @@
 import type { SessionStreamHandle } from "@anyharness/sdk";
 import { resolveSessionViewState } from "@/lib/domain/sessions/activity";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
 import { isPendingSessionId } from "@/lib/workflows/sessions/session-runtime";
 import { isCurrentSessionStreamHandle } from "@/lib/access/anyharness/session-stream-handles";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 export function shouldReconnectStream(sessionId: string): boolean {
   const entry = useSessionDirectoryStore.getState().entriesById[sessionId];

--- a/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.test.ts
@@ -12,7 +12,7 @@ import {
 import { applyBatchedStreamSideEffects } from "@/hooks/sessions/session-stream-side-effects";
 import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
-import type { SessionRelationship } from "@/stores/sessions/session-types";
+import type { SessionRelationship } from "@/lib/domain/sessions/directory/relationship";
 
 const mocks = vi.hoisted(() => ({
   effectOrder: [] as string[],

--- a/desktop/src/hooks/sessions/session-stream-side-effects.ts
+++ b/desktop/src/hooks/sessions/session-stream-side-effects.ts
@@ -19,7 +19,7 @@ import {
 import type {
   SessionChildRelationship,
   SessionRelationship,
-} from "@/stores/sessions/session-types";
+} from "@/lib/domain/sessions/directory/relationship";
 import {
   clearPendingConfigRollbackCheck,
   schedulePendingConfigRollbackCheck,

--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -24,6 +24,7 @@ import {
   resolveSessionStatus,
   shouldSkipColdIdleSessionStream,
 } from "@/lib/domain/sessions/activity";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
 import {
   clearSessionReconnectTimer,
   scheduleSessionReconnectTimer,
@@ -45,10 +46,7 @@ import { useSessionStreamCache } from "@/hooks/sessions/cache/use-session-stream
 import { useSessionHistoryHydration } from "@/hooks/sessions/lifecycle/use-session-history-hydration";
 import { useSessionSummaryActions } from "@/hooks/sessions/workflows/use-session-summary-actions";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import {
   getMaterializedSessionId,
   getSessionRecord,

--- a/desktop/src/hooks/sessions/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/use-session-stream-flush.ts
@@ -19,7 +19,7 @@ import { uniqueMeasurementOperationIds } from "@/lib/infra/measurement/operation
 import type {
   SessionChildRelationship,
   SessionRelationship,
-} from "@/stores/sessions/session-types";
+} from "@/lib/domain/sessions/directory/relationship";
 import { markWorkspaceViewedAt } from "@/stores/preferences/workspace-ui-store";
 import { isDocumentVisibleAndFocused } from "@/hooks/ui/use-document-focus-visibility";
 import {
@@ -39,11 +39,9 @@ import {
 import type { ReconciledStreamConfigIntent } from "@/lib/domain/sessions/stream/stream-side-effect-plan";
 import type { SessionStreamCache } from "@/hooks/sessions/cache/use-session-stream-cache";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
+import { activityFromTranscript } from "@/lib/domain/sessions/directory/directory-activity";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
-import {
-  activityFromTranscript,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionIngestStore } from "@/stores/sessions/session-ingest-store";

--- a/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -40,7 +40,7 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 import type {
   SessionChildRelationship,
   SessionRelationship,
-} from "@/stores/sessions/session-types";
+} from "@/lib/domain/sessions/directory/relationship";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/use-workspace-runtime-block";
 
 interface UseSessionSelectionWorkflowActionsOptions {

--- a/desktop/src/hooks/sessions/workflows/use-session-summary-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-summary-actions.ts
@@ -15,14 +15,12 @@ import {
   type PendingSessionConfigChange,
 } from "@/lib/domain/sessions/pending-config";
 import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
+import { activityFromTranscript } from "@/lib/domain/sessions/directory/directory-activity";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 import { persistDefaultSessionModePreference } from "@/hooks/sessions/session-mode-preferences";
 import { clearPendingConfigRollbackCheck } from "@/hooks/sessions/session-runtime-pending-config";
 import { useWorkspaceSurfaceLookup } from "@/hooks/workspaces/use-workspace-surface-lookup";
-import {
-  activityFromTranscript,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import { trackWorkspaceInteraction } from "@/stores/preferences/workspace-ui-store";

--- a/desktop/src/hooks/support/workflows/use-session-debug-actions.ts
+++ b/desktop/src/hooks/support/workflows/use-session-debug-actions.ts
@@ -32,7 +32,7 @@ import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { createSessionDebugClient } from "@/lib/access/anyharness/debug-client";
 

--- a/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
+++ b/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
@@ -4,11 +4,9 @@ import {
   collectWorkspaceSidebarActivityStatesWithErrorAttention,
   type SidebarSessionActivityState,
 } from "@/lib/domain/sessions/activity";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 const EMPTY_ACTIVITY_STATES: Record<string, SidebarSessionActivityState> = {};
 const EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION: Record<string, string> = {};

--- a/desktop/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
+++ b/desktop/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
@@ -24,10 +24,8 @@ import { isCloudDisplayNameBackfillSuppressed } from "./cloud-display-name-backf
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { getWorkspace } from "@/lib/access/anyharness/workspaces";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useIsHotPaintGatePendingForWorkspace } from "@/hooks/workspaces/use-hot-paint-gate";
 import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-model.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-model.ts
@@ -29,12 +29,10 @@ import type { ViewerTarget } from "@/lib/domain/workspaces/viewer/viewer-target"
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useIsHotPaintGatePendingForWorkspace } from "@/hooks/workspaces/use-hot-paint-gate";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
 import { resolveSelectedWorkspaceIdentity } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 import { resolveWithWorkspaceFallback } from "@/lib/domain/workspaces/selection/workspace-keyed-preferences";
 

--- a/desktop/src/hooks/workspaces/tabs/workspace-header-live-slots-selector.ts
+++ b/desktop/src/hooks/workspaces/tabs/workspace-header-live-slots-selector.ts
@@ -1,4 +1,4 @@
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
 
 type SessionDirectoryStoreSnapshot = {
   entriesById: Record<string, SessionDirectoryEntry>;

--- a/desktop/src/hooks/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts
+++ b/desktop/src/hooks/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts
@@ -6,7 +6,7 @@ import {
   getKnownSessionId,
   getKnownSessionViewState,
 } from "@/hooks/workspaces/tabs/workspace-header-tabs-model-helpers";
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
 
 function idleSlot(canFork: boolean): SessionDirectoryEntry {
   return {

--- a/desktop/src/hooks/workspaces/tabs/workspace-header-tabs-model-helpers.ts
+++ b/desktop/src/hooks/workspaces/tabs/workspace-header-tabs-model-helpers.ts
@@ -6,10 +6,8 @@ import {
   type SessionViewState,
 } from "@/lib/domain/sessions/activity";
 import type { ChatVisibilityCandidate } from "@/lib/domain/workspaces/tabs/visibility";
-import {
-  activitySnapshotFromDirectoryEntry,
-} from "@/stores/sessions/session-directory-store";
-import type { SessionDirectoryEntry } from "@/stores/sessions/session-types";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
 
 export type KnownHeaderSession =
   | { kind: "slot"; slot: SessionDirectoryEntry; session?: Session }

--- a/desktop/src/lib/domain/sessions/directory/directory-activity.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-activity.ts
@@ -1,0 +1,48 @@
+import type {
+  SessionExecutionSummary,
+  SessionStatus,
+  TranscriptState,
+} from "@anyharness/sdk";
+import { resolveSessionErrorAttentionKey } from "@/lib/domain/sessions/activity";
+import type {
+  SessionDirectoryActivitySummary,
+  SessionDirectoryEntry,
+} from "@/lib/domain/sessions/directory/directory-entry";
+
+export function activityFromTranscript(
+  transcript: TranscriptState,
+  context?: {
+    status?: SessionStatus | null;
+    executionSummary?: SessionExecutionSummary | null;
+  },
+): SessionDirectoryActivitySummary {
+  return {
+    isStreaming: transcript.isStreaming,
+    pendingInteractions: transcript.pendingInteractions,
+    transcriptTitle: transcript.sessionMeta.title ?? null,
+    errorAttentionKey: resolveSessionErrorAttentionKey({
+      sessionId: transcript.sessionMeta.sessionId,
+      status: context?.status ?? null,
+      executionSummary: context?.executionSummary ?? null,
+      transcript: {
+        itemsById: transcript.itemsById,
+      },
+    }),
+  };
+}
+
+export function activitySnapshotFromDirectoryEntry(
+  entry: SessionDirectoryEntry | null | undefined,
+) {
+  return entry
+    ? {
+      status: entry.status,
+      executionSummary: entry.executionSummary,
+      streamConnectionState: entry.streamConnectionState,
+      transcript: {
+        isStreaming: entry.activity.isStreaming,
+        pendingInteractions: entry.activity.pendingInteractions,
+      },
+    }
+    : null;
+}

--- a/desktop/src/lib/domain/sessions/directory/directory-entry.test.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-entry.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SESSION_ACTION_CAPABILITIES,
+  createDirectoryEntry,
+  directoryEntryEqual,
+  normalizeDirectoryEntryInput,
+  normalizePatchedDirectoryEntry,
+} from "@/lib/domain/sessions/directory/directory-entry";
+
+describe("session directory entry model", () => {
+  it("normalizes defaults, existing values, activity overlays, and relationship hints", () => {
+    const existing = createDirectoryEntry({
+      sessionId: "session-a",
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+      modelId: "model-a",
+      title: "Existing title",
+      activity: {
+        isStreaming: true,
+        transcriptTitle: "Transcript title",
+      },
+    });
+
+    const entry = normalizeDirectoryEntryInput(
+      {
+        sessionId: "session-a",
+        agentKind: "proliferate",
+        title: null,
+        activity: {
+          errorAttentionKey: "session-a:error",
+        },
+      },
+      existing,
+      {
+        kind: "linked_child",
+        parentSessionId: "parent-a",
+        workspaceId: "workspace-a",
+      },
+    );
+
+    expect(entry).toMatchObject({
+      sessionId: "session-a",
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+      modelId: "model-a",
+      title: "Existing title",
+      actionCapabilities: DEFAULT_SESSION_ACTION_CAPABILITIES,
+      streamConnectionState: "disconnected",
+      transcriptHydrated: false,
+      sessionRelationship: {
+        kind: "linked_child",
+        parentSessionId: "parent-a",
+        workspaceId: "workspace-a",
+      },
+      activity: {
+        isStreaming: true,
+        pendingInteractions: [],
+        transcriptTitle: "Transcript title",
+        errorAttentionKey: "session-a:error",
+      },
+    });
+  });
+
+  it("merges activity patches and compares relationship values structurally", () => {
+    const entry = createDirectoryEntry({
+      sessionId: "session-a",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+      sessionRelationship: {
+        kind: "subagent_child",
+        parentSessionId: "parent-a",
+        sessionLinkId: "link-a",
+        workspaceId: "workspace-a",
+      },
+      activity: {
+        isStreaming: true,
+        transcriptTitle: "Old title",
+      },
+    });
+
+    const patched = normalizePatchedDirectoryEntry(entry, {
+      activity: {
+        transcriptTitle: "New title",
+      },
+    });
+
+    expect(patched.activity).toEqual({
+      ...entry.activity,
+      transcriptTitle: "New title",
+    });
+    expect(directoryEntryEqual(entry, {
+      ...entry,
+      sessionRelationship: {
+        kind: "subagent_child",
+        parentSessionId: "parent-a",
+        sessionLinkId: "link-a",
+        workspaceId: "workspace-a",
+      },
+    })).toBe(true);
+  });
+});

--- a/desktop/src/lib/domain/sessions/directory/directory-entry.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-entry.ts
@@ -1,0 +1,189 @@
+import type {
+  PendingInteraction,
+  SessionActionCapabilities,
+  SessionExecutionSummary,
+  SessionLiveConfigSnapshot,
+  SessionMcpBindingSummary,
+  SessionStatus,
+} from "@anyharness/sdk";
+import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import {
+  sessionRelationshipEqual,
+  type SessionChildRelationship,
+  type SessionRelationship,
+} from "@/lib/domain/sessions/directory/relationship";
+
+export type ClientSessionId = string;
+export type MaterializedSessionId = string;
+
+export type SessionStreamConnectionState =
+  | "disconnected"
+  | "connecting"
+  | "open"
+  | "ended";
+
+export interface SessionDirectoryActivitySummary {
+  isStreaming: boolean;
+  pendingInteractions: PendingInteraction[];
+  transcriptTitle: string | null;
+  errorAttentionKey: string | null;
+}
+
+export interface SessionDirectoryEntry {
+  sessionId: ClientSessionId;
+  materializedSessionId: MaterializedSessionId | null;
+  workspaceId: string | null;
+  agentKind: string;
+  modelId: string | null;
+  modeId: string | null;
+  title: string | null;
+  actionCapabilities: SessionActionCapabilities;
+  liveConfig: SessionLiveConfigSnapshot | null;
+  executionSummary: SessionExecutionSummary | null;
+  mcpBindingSummaries: SessionMcpBindingSummary[] | null;
+  pendingConfigChanges: PendingSessionConfigChanges;
+  status: SessionStatus | null;
+  lastPromptAt: string | null;
+  streamConnectionState: SessionStreamConnectionState;
+  transcriptHydrated: boolean;
+  sessionRelationship: SessionRelationship;
+  activity: SessionDirectoryActivitySummary;
+}
+
+export interface DirectoryEntryInput {
+  sessionId: string;
+  materializedSessionId?: string | null;
+  workspaceId?: string | null;
+  agentKind: string;
+  modelId?: string | null;
+  modeId?: string | null;
+  title?: string | null;
+  actionCapabilities?: SessionActionCapabilities | null;
+  liveConfig?: SessionLiveConfigSnapshot | null;
+  executionSummary?: SessionExecutionSummary | null;
+  mcpBindingSummaries?: SessionMcpBindingSummary[] | null;
+  pendingConfigChanges?: PendingSessionConfigChanges;
+  status?: SessionStatus | null;
+  lastPromptAt?: string | null;
+  streamConnectionState?: SessionStreamConnectionState;
+  transcriptHydrated?: boolean;
+  sessionRelationship?: SessionRelationship;
+  activity?: Partial<SessionDirectoryActivitySummary>;
+}
+
+export type DirectoryEntryPatch =
+  Partial<Omit<SessionDirectoryEntry, "activity" | "sessionId">>
+  & { activity?: Partial<SessionDirectoryActivitySummary> };
+
+export const DEFAULT_SESSION_ACTION_CAPABILITIES: SessionActionCapabilities = {
+  fork: false,
+  targetedFork: false,
+};
+
+export const EMPTY_DIRECTORY_ACTIVITY: SessionDirectoryActivitySummary = {
+  isStreaming: false,
+  pendingInteractions: [],
+  transcriptTitle: null,
+  errorAttentionKey: null,
+};
+
+export function createDirectoryEntry(input: DirectoryEntryInput): SessionDirectoryEntry {
+  return normalizeDirectoryEntryInput(input, undefined, undefined);
+}
+
+export function normalizeDirectoryEntryInput(
+  input: DirectoryEntryInput,
+  existing?: SessionDirectoryEntry,
+  hint?: SessionChildRelationship,
+): SessionDirectoryEntry {
+  return {
+    sessionId: input.sessionId,
+    materializedSessionId:
+      input.materializedSessionId !== undefined
+        ? input.materializedSessionId
+        : existing?.materializedSessionId ?? input.sessionId,
+    workspaceId: input.workspaceId ?? existing?.workspaceId ?? null,
+    agentKind: input.agentKind,
+    modelId: input.modelId ?? existing?.modelId ?? null,
+    modeId: input.modeId ?? existing?.modeId ?? null,
+    title: input.title ?? existing?.title ?? null,
+    actionCapabilities:
+      input.actionCapabilities
+      ?? existing?.actionCapabilities
+      ?? DEFAULT_SESSION_ACTION_CAPABILITIES,
+    liveConfig: input.liveConfig ?? existing?.liveConfig ?? null,
+    executionSummary: input.executionSummary ?? existing?.executionSummary ?? null,
+    mcpBindingSummaries:
+      input.mcpBindingSummaries
+      ?? existing?.mcpBindingSummaries
+      ?? null,
+    pendingConfigChanges: input.pendingConfigChanges ?? existing?.pendingConfigChanges ?? {},
+    status: input.status ?? existing?.status ?? null,
+    lastPromptAt: input.lastPromptAt ?? existing?.lastPromptAt ?? null,
+    streamConnectionState:
+      input.streamConnectionState
+      ?? existing?.streamConnectionState
+      ?? "disconnected",
+    transcriptHydrated: input.transcriptHydrated ?? existing?.transcriptHydrated ?? false,
+    sessionRelationship:
+      input.sessionRelationship
+      ?? hint
+      ?? existing?.sessionRelationship
+      ?? { kind: "pending" },
+    activity: {
+      ...EMPTY_DIRECTORY_ACTIVITY,
+      ...existing?.activity,
+      ...input.activity,
+    },
+  };
+}
+
+export function normalizePatchedDirectoryEntry(
+  entry: SessionDirectoryEntry,
+  patch: DirectoryEntryPatch,
+): SessionDirectoryEntry {
+  return {
+    ...entry,
+    ...patch,
+    activity: patch.activity
+      ? {
+        ...entry.activity,
+        ...patch.activity,
+      }
+      : entry.activity,
+  };
+}
+
+export function directoryEntryEqual(
+  a: SessionDirectoryEntry,
+  b: SessionDirectoryEntry,
+): boolean {
+  return a.sessionId === b.sessionId
+    && a.materializedSessionId === b.materializedSessionId
+    && a.workspaceId === b.workspaceId
+    && a.agentKind === b.agentKind
+    && a.modelId === b.modelId
+    && a.modeId === b.modeId
+    && a.title === b.title
+    && a.actionCapabilities === b.actionCapabilities
+    && a.liveConfig === b.liveConfig
+    && a.executionSummary === b.executionSummary
+    && a.mcpBindingSummaries === b.mcpBindingSummaries
+    && a.pendingConfigChanges === b.pendingConfigChanges
+    && a.status === b.status
+    && a.lastPromptAt === b.lastPromptAt
+    && a.streamConnectionState === b.streamConnectionState
+    && a.transcriptHydrated === b.transcriptHydrated
+    && sessionRelationshipEqual(a.sessionRelationship, b.sessionRelationship)
+    && activitySummaryEqual(a.activity, b.activity);
+}
+
+export function activitySummaryEqual(
+  a: SessionDirectoryActivitySummary,
+  b: SessionDirectoryActivitySummary,
+): boolean {
+  return a.isStreaming === b.isStreaming
+    && a.pendingInteractions === b.pendingInteractions
+    && a.transcriptTitle === b.transcriptTitle
+    && a.errorAttentionKey === b.errorAttentionKey;
+}

--- a/desktop/src/lib/domain/sessions/directory/directory-indexes.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-indexes.ts
@@ -1,0 +1,82 @@
+export function updateMaterializedIndex(
+  index: Record<string, string>,
+  previousMaterializedSessionId: string | null,
+  nextMaterializedSessionId: string | null,
+  clientSessionId: string,
+): Record<string, string> {
+  let next = index;
+  if (previousMaterializedSessionId && previousMaterializedSessionId !== nextMaterializedSessionId) {
+    next = removeMaterializedIndexEntry(next, previousMaterializedSessionId);
+  }
+  if (!nextMaterializedSessionId) {
+    return next;
+  }
+  if (next[nextMaterializedSessionId] === clientSessionId) {
+    return next;
+  }
+  return {
+    ...next,
+    [nextMaterializedSessionId]: clientSessionId,
+  };
+}
+
+export function removeMaterializedIndexEntry(
+  index: Record<string, string>,
+  materializedSessionId: string | null,
+): Record<string, string> {
+  if (!materializedSessionId || !(materializedSessionId in index)) {
+    return index;
+  }
+  const { [materializedSessionId]: _removed, ...rest } = index;
+  return rest;
+}
+
+export function updateWorkspaceIndex(
+  index: Record<string, readonly string[]>,
+  previousWorkspaceId: string | null,
+  nextWorkspaceId: string | null,
+  sessionId: string,
+): Record<string, readonly string[]> {
+  if (previousWorkspaceId === nextWorkspaceId) {
+    if (!nextWorkspaceId || index[nextWorkspaceId]?.includes(sessionId)) {
+      return index;
+    }
+    return {
+      ...index,
+      [nextWorkspaceId]: [...(index[nextWorkspaceId] ?? []), sessionId].sort(),
+    };
+  }
+  let next = index;
+  if (previousWorkspaceId) {
+    next = removeSessionFromWorkspaceIndex(next, previousWorkspaceId, sessionId);
+  }
+  if (nextWorkspaceId) {
+    const currentIds = next[nextWorkspaceId] ?? [];
+    if (!currentIds.includes(sessionId)) {
+      next = {
+        ...next,
+        [nextWorkspaceId]: [...currentIds, sessionId].sort(),
+      };
+    }
+  }
+  return next;
+}
+
+export function removeSessionFromWorkspaceIndex(
+  index: Record<string, readonly string[]>,
+  workspaceId: string | null,
+  sessionId: string,
+): Record<string, readonly string[]> {
+  if (!workspaceId || !index[workspaceId]?.includes(sessionId)) {
+    return index;
+  }
+  const nextIds = index[workspaceId].filter((id) => id !== sessionId);
+  if (nextIds.length === 0) {
+    const { [workspaceId]: _removed, ...rest } = index;
+    return rest;
+  }
+  return {
+    ...index,
+    [workspaceId]: nextIds,
+  };
+}

--- a/desktop/src/lib/domain/sessions/directory/directory-reducer.test.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-reducer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { createDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
+import {
+  applyPendingRelationshipHint,
+  putDirectoryEntry,
+  removeWorkspaceDirectoryEntries,
+  type SessionDirectoryReducerState,
+} from "@/lib/domain/sessions/directory/directory-reducer";
+
+function emptyState(): SessionDirectoryReducerState {
+  return {
+    entriesById: {},
+    clientSessionIdByMaterializedSessionId: {},
+    sessionIdsByWorkspaceId: {},
+    relationshipHintsBySessionId: {},
+  };
+}
+
+describe("session directory reducer", () => {
+  it("puts entries, applies pending hints, updates indexes, and preserves no-op identity", () => {
+    const hintedState: SessionDirectoryReducerState = {
+      ...emptyState(),
+      relationshipHintsBySessionId: {
+        "session-b": {
+          kind: "linked_child",
+          parentSessionId: "session-a",
+          workspaceId: "workspace-a",
+        },
+      },
+    };
+    const entry = createDirectoryEntry({
+      sessionId: "session-b",
+      materializedSessionId: "runtime-b",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+    });
+
+    const next = putDirectoryEntry(
+      hintedState,
+      applyPendingRelationshipHint(entry, hintedState.relationshipHintsBySessionId["session-b"]),
+    );
+
+    expect(next.entriesById["session-b"]?.sessionRelationship).toEqual({
+      kind: "linked_child",
+      parentSessionId: "session-a",
+      workspaceId: "workspace-a",
+    });
+    expect(next.clientSessionIdByMaterializedSessionId).toEqual({
+      "runtime-b": "session-b",
+    });
+    expect(next.sessionIdsByWorkspaceId).toEqual({
+      "workspace-a": ["session-b"],
+    });
+    expect(next.relationshipHintsBySessionId).toEqual({});
+    expect(putDirectoryEntry(next, next.entriesById["session-b"]!)).toBe(next);
+  });
+
+  it("removes workspace entries, materialized indexes, and stale workspace hints together", () => {
+    const sessionA = createDirectoryEntry({
+      sessionId: "session-a",
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+    });
+    const sessionB = createDirectoryEntry({
+      sessionId: "session-b",
+      materializedSessionId: "runtime-b",
+      workspaceId: "workspace-b",
+      agentKind: "proliferate",
+    });
+    const state: SessionDirectoryReducerState = {
+      entriesById: {
+        "session-a": sessionA,
+        "session-b": sessionB,
+      },
+      clientSessionIdByMaterializedSessionId: {
+        "runtime-a": "session-a",
+        "runtime-b": "session-b",
+      },
+      sessionIdsByWorkspaceId: {
+        "workspace-a": ["session-a"],
+        "workspace-b": ["session-b"],
+      },
+      relationshipHintsBySessionId: {
+        "missing-a": {
+          kind: "linked_child",
+          parentSessionId: "parent-a",
+          workspaceId: "workspace-a",
+        },
+        "missing-b": {
+          kind: "linked_child",
+          parentSessionId: "parent-b",
+          workspaceId: "workspace-b",
+        },
+      },
+    };
+
+    const result = removeWorkspaceDirectoryEntries(state, "workspace-a");
+
+    expect(result.removedSessionIds).toEqual(["session-a"]);
+    expect(result.state.entriesById).toEqual({ "session-b": sessionB });
+    expect(result.state.clientSessionIdByMaterializedSessionId).toEqual({
+      "runtime-b": "session-b",
+    });
+    expect(result.state.sessionIdsByWorkspaceId).toEqual({
+      "workspace-b": ["session-b"],
+    });
+    expect(result.state.relationshipHintsBySessionId).toEqual({
+      "missing-b": {
+        kind: "linked_child",
+        parentSessionId: "parent-b",
+        workspaceId: "workspace-b",
+      },
+    });
+  });
+});

--- a/desktop/src/lib/domain/sessions/directory/directory-reducer.ts
+++ b/desktop/src/lib/domain/sessions/directory/directory-reducer.ts
@@ -1,0 +1,203 @@
+import {
+  directoryEntryEqual,
+  type SessionDirectoryEntry,
+} from "@/lib/domain/sessions/directory/directory-entry";
+import {
+  removeMaterializedIndexEntry,
+  removeSessionFromWorkspaceIndex,
+  updateMaterializedIndex,
+  updateWorkspaceIndex,
+} from "@/lib/domain/sessions/directory/directory-indexes";
+import {
+  sessionChildRelationshipEqual,
+  sessionRelationshipEqual,
+  type SessionChildRelationship,
+  type SessionRelationship,
+} from "@/lib/domain/sessions/directory/relationship";
+
+export interface SessionDirectoryReducerState {
+  entriesById: Record<string, SessionDirectoryEntry>;
+  clientSessionIdByMaterializedSessionId: Record<string, string>;
+  sessionIdsByWorkspaceId: Record<string, readonly string[]>;
+  relationshipHintsBySessionId: Record<string, SessionChildRelationship>;
+}
+
+export function applyPendingRelationshipHint(
+  entry: SessionDirectoryEntry,
+  hint: SessionChildRelationship | undefined,
+): SessionDirectoryEntry {
+  return hint && entry.sessionRelationship.kind === "pending"
+    ? { ...entry, sessionRelationship: hint }
+    : entry;
+}
+
+export function putDirectoryEntry<TState extends SessionDirectoryReducerState>(
+  state: TState,
+  entry: SessionDirectoryEntry,
+): TState | SessionDirectoryReducerState {
+  const previous = state.entriesById[entry.sessionId];
+  const entriesById = previous && directoryEntryEqual(previous, entry)
+    ? state.entriesById
+    : {
+      ...state.entriesById,
+      [entry.sessionId]: entry,
+    };
+  const relationshipHintsBySessionId = state.relationshipHintsBySessionId[entry.sessionId]
+    ? removeRecordKey(state.relationshipHintsBySessionId, entry.sessionId)
+    : state.relationshipHintsBySessionId;
+  const clientSessionIdByMaterializedSessionId = updateMaterializedIndex(
+    state.clientSessionIdByMaterializedSessionId,
+    previous?.materializedSessionId ?? null,
+    entry.materializedSessionId,
+    entry.sessionId,
+  );
+  const sessionIdsByWorkspaceId = updateWorkspaceIndex(
+    state.sessionIdsByWorkspaceId,
+    previous?.workspaceId ?? null,
+    entry.workspaceId,
+    entry.sessionId,
+  );
+
+  if (
+    entriesById === state.entriesById
+    && clientSessionIdByMaterializedSessionId === state.clientSessionIdByMaterializedSessionId
+    && relationshipHintsBySessionId === state.relationshipHintsBySessionId
+    && sessionIdsByWorkspaceId === state.sessionIdsByWorkspaceId
+  ) {
+    return state;
+  }
+  return {
+    entriesById,
+    clientSessionIdByMaterializedSessionId,
+    relationshipHintsBySessionId,
+    sessionIdsByWorkspaceId,
+  };
+}
+
+export function removeDirectoryEntry<TState extends SessionDirectoryReducerState>(
+  state: TState,
+  sessionId: string,
+): TState | SessionDirectoryReducerState {
+  const entry = state.entriesById[sessionId];
+  if (!entry) {
+    return state;
+  }
+  const { [sessionId]: _removed, ...entriesById } = state.entriesById;
+  const clientSessionIdByMaterializedSessionId = removeMaterializedIndexEntry(
+    state.clientSessionIdByMaterializedSessionId,
+    entry.materializedSessionId,
+  );
+  const { [sessionId]: _removedHint, ...relationshipHintsBySessionId } =
+    state.relationshipHintsBySessionId;
+  return {
+    entriesById,
+    clientSessionIdByMaterializedSessionId,
+    relationshipHintsBySessionId,
+    sessionIdsByWorkspaceId: removeSessionFromWorkspaceIndex(
+      state.sessionIdsByWorkspaceId,
+      entry.workspaceId,
+      sessionId,
+    ),
+  };
+}
+
+export function removeWorkspaceDirectoryEntries<TState extends SessionDirectoryReducerState>(
+  state: TState,
+  workspaceId: string,
+): {
+  state: TState | SessionDirectoryReducerState;
+  removedSessionIds: string[];
+} {
+  const removedSessionIds = Object.values(state.entriesById)
+    .filter((entry) => entry.workspaceId === workspaceId)
+    .map((entry) => entry.sessionId);
+  if (removedSessionIds.length === 0) {
+    return { state, removedSessionIds };
+  }
+  const removed = new Set(removedSessionIds);
+  const entriesById: Record<string, SessionDirectoryEntry> = Object.fromEntries(
+    Object.entries(state.entriesById).filter(([sessionId]) => !removed.has(sessionId)),
+  );
+  const clientSessionIdByMaterializedSessionId: Record<string, string> = Object.fromEntries(
+    Object.entries(state.clientSessionIdByMaterializedSessionId).filter(([, clientSessionId]) =>
+      !removed.has(clientSessionId)
+    ),
+  );
+  const relationshipHintsBySessionId: Record<string, SessionChildRelationship> = Object.fromEntries(
+    Object.entries(state.relationshipHintsBySessionId).filter(([sessionId, hint]) =>
+      !removed.has(sessionId) && hint.workspaceId !== workspaceId
+    ),
+  );
+  const { [workspaceId]: _removedWorkspace, ...sessionIdsByWorkspaceId } =
+    state.sessionIdsByWorkspaceId;
+  return {
+    state: {
+      entriesById,
+      clientSessionIdByMaterializedSessionId,
+      relationshipHintsBySessionId,
+      sessionIdsByWorkspaceId,
+    },
+    removedSessionIds,
+  };
+}
+
+export function recordDirectoryRelationshipHint<TState extends SessionDirectoryReducerState>(
+  state: TState,
+  sessionId: string,
+  relationship: SessionChildRelationship,
+): TState | SessionDirectoryReducerState {
+  const entry = state.entriesById[sessionId];
+  if (entry) {
+    const relationshipHintsBySessionId = removeRecordKey(
+      state.relationshipHintsBySessionId,
+      sessionId,
+    );
+    if (sessionRelationshipEqual(entry.sessionRelationship, relationship)) {
+      return relationshipHintsBySessionId === state.relationshipHintsBySessionId
+        ? state
+        : { ...state, relationshipHintsBySessionId };
+    }
+    return {
+      ...putDirectoryEntry(state, {
+        ...entry,
+        sessionRelationship: relationship,
+      }),
+      relationshipHintsBySessionId,
+    };
+  }
+
+  const existing = state.relationshipHintsBySessionId[sessionId];
+  if (sessionChildRelationshipEqual(existing, relationship)) {
+    return state;
+  }
+  return {
+    ...state,
+    relationshipHintsBySessionId: {
+      ...state.relationshipHintsBySessionId,
+      [sessionId]: relationship,
+    },
+  };
+}
+
+export function setDirectoryEntryRelationship<TState extends SessionDirectoryReducerState>(
+  state: TState,
+  sessionId: string,
+  relationship: SessionRelationship,
+): TState | SessionDirectoryReducerState {
+  const entry = state.entriesById[sessionId];
+  if (!entry || sessionRelationshipEqual(entry.sessionRelationship, relationship)) {
+    return state;
+  }
+  return putDirectoryEntry(state, {
+    ...entry,
+    sessionRelationship: relationship,
+  });
+}
+
+export function removeRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in record)) {
+    return record;
+  }
+  const { [key]: _removed, ...rest } = record;
+  return rest;
+}

--- a/desktop/src/lib/domain/sessions/directory/relationship.ts
+++ b/desktop/src/lib/domain/sessions/directory/relationship.ts
@@ -1,0 +1,60 @@
+export type SessionRelationship =
+  | { kind: "root" }
+  | { kind: "pending" }
+  | SessionChildRelationship;
+
+export type SessionChildRelationship =
+  | {
+    kind: "subagent_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "cowork_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "review_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  }
+  | {
+    kind: "linked_child";
+    parentSessionId: string | null;
+    sessionLinkId?: string | null;
+    relation?: string | null;
+    workspaceId?: string | null;
+  };
+
+export function sessionRelationshipEqual(
+  a: SessionRelationship | undefined,
+  b: SessionRelationship | undefined,
+): boolean {
+  if (!a || !b || a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "root" || a.kind === "pending") {
+    return true;
+  }
+  return sessionChildRelationshipEqual(a, b as SessionChildRelationship);
+}
+
+export function sessionChildRelationshipEqual(
+  a: SessionChildRelationship | undefined,
+  b: SessionChildRelationship | undefined,
+): boolean {
+  return !!a
+    && !!b
+    && a.kind === b.kind
+    && a.parentSessionId === b.parentSessionId
+    && (a.sessionLinkId ?? null) === (b.sessionLinkId ?? null)
+    && (a.relation ?? null) === (b.relation ?? null)
+    && (a.workspaceId ?? null) === (b.workspaceId ?? null);
+}

--- a/desktop/src/lib/workflows/sessions/session-runtime.ts
+++ b/desktop/src/lib/workflows/sessions/session-runtime.ts
@@ -47,7 +47,8 @@ import {
   requireMaterializedSessionId,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import type { SessionRelationship, SessionRuntimeRecord } from "@/stores/sessions/session-types";
+import type { SessionRelationship } from "@/lib/domain/sessions/directory/relationship";
+import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
 import {
   closeSessionStreamHandle,
   flushAllSessionStreamHandles,

--- a/desktop/src/stores/sessions/session-directory-store.test.ts
+++ b/desktop/src/stores/sessions/session-directory-store.test.ts
@@ -1,9 +1,7 @@
 import { createTranscriptState, type PendingInteraction } from "@anyharness/sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  activitySnapshotFromDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 describe("session directory store invariants", () => {
   beforeEach(() => {

--- a/desktop/src/stores/sessions/session-directory-store.ts
+++ b/desktop/src/stores/sessions/session-directory-store.ts
@@ -1,49 +1,27 @@
 import { create } from "zustand";
-import type {
-  SessionActionCapabilities,
-  SessionExecutionSummary,
-  SessionLiveConfigSnapshot,
-  SessionMcpBindingSummary,
-  SessionStatus,
-  TranscriptState,
-} from "@anyharness/sdk";
-import { resolveSessionErrorAttentionKey } from "@/lib/domain/sessions/activity";
-import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import type { TranscriptState } from "@anyharness/sdk";
+import { activityFromTranscript } from "@/lib/domain/sessions/directory/directory-activity";
 import {
-  DEFAULT_SESSION_ACTION_CAPABILITIES,
-  sessionChildRelationshipEqual,
-  sessionRelationshipEqual,
-  type SessionChildRelationship,
-  type SessionDirectoryActivitySummary,
+  activitySummaryEqual,
+  directoryEntryEqual,
+  normalizeDirectoryEntryInput,
+  normalizePatchedDirectoryEntry,
+  type DirectoryEntryInput,
+  type DirectoryEntryPatch,
   type SessionDirectoryEntry,
-  type SessionRelationship,
-  type SessionStreamConnectionState,
-} from "@/stores/sessions/session-types";
-
-interface DirectoryEntryInput {
-  sessionId: string;
-  materializedSessionId?: string | null;
-  workspaceId?: string | null;
-  agentKind: string;
-  modelId?: string | null;
-  modeId?: string | null;
-  title?: string | null;
-  actionCapabilities?: SessionActionCapabilities | null;
-  liveConfig?: SessionLiveConfigSnapshot | null;
-  executionSummary?: SessionExecutionSummary | null;
-  mcpBindingSummaries?: SessionMcpBindingSummary[] | null;
-  pendingConfigChanges?: PendingSessionConfigChanges;
-  status?: SessionStatus | null;
-  lastPromptAt?: string | null;
-  streamConnectionState?: SessionStreamConnectionState;
-  transcriptHydrated?: boolean;
-  sessionRelationship?: SessionRelationship;
-  activity?: Partial<SessionDirectoryActivitySummary>;
-}
-
-type DirectoryEntryPatch =
-  Partial<Omit<SessionDirectoryEntry, "activity" | "sessionId">>
-  & { activity?: Partial<SessionDirectoryActivitySummary> };
+} from "@/lib/domain/sessions/directory/directory-entry";
+import {
+  applyPendingRelationshipHint,
+  putDirectoryEntry,
+  recordDirectoryRelationshipHint,
+  removeDirectoryEntry,
+  removeWorkspaceDirectoryEntries,
+  setDirectoryEntryRelationship,
+} from "@/lib/domain/sessions/directory/directory-reducer";
+import type {
+  SessionChildRelationship,
+  SessionRelationship,
+} from "@/lib/domain/sessions/directory/relationship";
 
 interface SessionDirectoryState {
   entriesById: Record<string, SessionDirectoryEntry>;
@@ -61,13 +39,6 @@ interface SessionDirectoryState {
   setSessionRelationship: (sessionId: string, relationship: SessionRelationship) => void;
 }
 
-const EMPTY_ACTIVITY: SessionDirectoryActivitySummary = {
-  isStreaming: false,
-  pendingInteractions: [],
-  transcriptTitle: null,
-  errorAttentionKey: null,
-};
-
 export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => ({
   entriesById: {},
   clientSessionIdByMaterializedSessionId: {},
@@ -76,17 +47,15 @@ export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => (
 
   putEntry: (entry) => set((state) => {
     const hint = state.relationshipHintsBySessionId[entry.sessionId];
-    const nextEntry = hint && entry.sessionRelationship.kind === "pending"
-      ? { ...entry, sessionRelationship: hint }
-      : entry;
-    return applyPutEntry(state, nextEntry);
+    const nextEntry = applyPendingRelationshipHint(entry, hint);
+    return putDirectoryEntry(state, nextEntry);
   }),
 
   upsertEntry: (input) => set((state) => {
     const existing = state.entriesById[input.sessionId];
     const hint = state.relationshipHintsBySessionId[input.sessionId];
-    const entry = normalizeEntryInput(input, existing, hint);
-    return applyPutEntry(state, entry);
+    const entry = normalizeDirectoryEntryInput(input, existing, hint);
+    return putDirectoryEntry(state, entry);
   }),
 
   patchEntry: (sessionId, patch) => set((state) => {
@@ -94,11 +63,11 @@ export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => (
     if (!entry) {
       return state;
     }
-    const nextEntry = normalizePatchedEntry(entry, patch);
+    const nextEntry = normalizePatchedDirectoryEntry(entry, patch);
     if (directoryEntryEqual(entry, nextEntry)) {
       return state;
     }
-    return applyPutEntry(state, nextEntry);
+    return putDirectoryEntry(state, nextEntry);
   }),
 
   patchActivityFromTranscript: (sessionId, transcript) => set((state) => {
@@ -113,7 +82,7 @@ export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => (
     if (activitySummaryEqual(entry.activity, activity)) {
       return state;
     }
-    return applyPutEntry(state, {
+    return putDirectoryEntry(state, {
       ...entry,
       modeId: transcript.currentModeId ?? entry.modeId,
       title: entry.title ?? transcript.sessionMeta.title ?? null,
@@ -121,60 +90,14 @@ export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => (
     });
   }),
 
-  removeEntry: (sessionId) => set((state) => {
-    if (!state.entriesById[sessionId]) {
-      return state;
-    }
-    const { [sessionId]: _removed, ...entriesById } = state.entriesById;
-    const clientSessionIdByMaterializedSessionId = removeMaterializedIndexEntry(
-      state.clientSessionIdByMaterializedSessionId,
-      state.entriesById[sessionId].materializedSessionId,
-    );
-    const { [sessionId]: _removedHint, ...relationshipHintsBySessionId } =
-      state.relationshipHintsBySessionId;
-    return {
-      entriesById,
-      clientSessionIdByMaterializedSessionId,
-      relationshipHintsBySessionId,
-      sessionIdsByWorkspaceId: removeSessionFromWorkspaceIndex(
-        state.sessionIdsByWorkspaceId,
-        state.entriesById[sessionId].workspaceId,
-        sessionId,
-      ),
-    };
-  }),
+  removeEntry: (sessionId) => set((state) => removeDirectoryEntry(state, sessionId)),
 
   removeWorkspaceEntries: (workspaceId) => {
     let removedSessionIds: string[] = [];
     set((state) => {
-      removedSessionIds = Object.values(state.entriesById)
-        .filter((entry) => entry.workspaceId === workspaceId)
-        .map((entry) => entry.sessionId);
-      if (removedSessionIds.length === 0) {
-        return state;
-      }
-      const removed = new Set(removedSessionIds);
-      const entriesById = Object.fromEntries(
-        Object.entries(state.entriesById).filter(([sessionId]) => !removed.has(sessionId)),
-      );
-      const clientSessionIdByMaterializedSessionId = Object.fromEntries(
-        Object.entries(state.clientSessionIdByMaterializedSessionId).filter(([, clientSessionId]) =>
-          !removed.has(clientSessionId)
-        ),
-      );
-      const relationshipHintsBySessionId = Object.fromEntries(
-        Object.entries(state.relationshipHintsBySessionId).filter(([sessionId, hint]) =>
-          !removed.has(sessionId) && hint.workspaceId !== workspaceId
-        ),
-      );
-      const { [workspaceId]: _removedWorkspace, ...sessionIdsByWorkspaceId } =
-        state.sessionIdsByWorkspaceId;
-      return {
-        entriesById,
-        clientSessionIdByMaterializedSessionId,
-        relationshipHintsBySessionId,
-        sessionIdsByWorkspaceId,
-      };
+      const result = removeWorkspaceDirectoryEntries(state, workspaceId);
+      removedSessionIds = result.removedSessionIds;
+      return result.state;
     });
     return removedSessionIds;
   },
@@ -186,326 +109,11 @@ export const useSessionDirectoryStore = create<SessionDirectoryState>((set) => (
     relationshipHintsBySessionId: {},
   }),
 
-  recordRelationshipHint: (sessionId, relationship) => set((state) => {
-    const entry = state.entriesById[sessionId];
-    if (entry) {
-      const relationshipHintsBySessionId = removeRecordKey(
-        state.relationshipHintsBySessionId,
-        sessionId,
-      );
-      if (sessionRelationshipEqual(entry.sessionRelationship, relationship)) {
-        return relationshipHintsBySessionId === state.relationshipHintsBySessionId
-          ? state
-          : { ...state, relationshipHintsBySessionId };
-      }
-      return {
-        ...applyPutEntry(state, {
-          ...entry,
-          sessionRelationship: relationship,
-        }),
-        relationshipHintsBySessionId,
-      };
-    }
+  recordRelationshipHint: (sessionId, relationship) => set((state) =>
+    recordDirectoryRelationshipHint(state, sessionId, relationship)
+  ),
 
-    const existing = state.relationshipHintsBySessionId[sessionId];
-    if (sessionChildRelationshipEqual(existing, relationship)) {
-      return state;
-    }
-    return {
-      relationshipHintsBySessionId: {
-        ...state.relationshipHintsBySessionId,
-        [sessionId]: relationship,
-      },
-    };
-  }),
-
-  setSessionRelationship: (sessionId, relationship) => set((state) => {
-    const entry = state.entriesById[sessionId];
-    if (!entry || sessionRelationshipEqual(entry.sessionRelationship, relationship)) {
-      return state;
-    }
-    return applyPutEntry(state, {
-      ...entry,
-      sessionRelationship: relationship,
-    });
-  }),
+  setSessionRelationship: (sessionId, relationship) => set((state) =>
+    setDirectoryEntryRelationship(state, sessionId, relationship)
+  ),
 }));
-
-export function createDirectoryEntry(input: DirectoryEntryInput): SessionDirectoryEntry {
-  return normalizeEntryInput(input, undefined, undefined);
-}
-
-export function activityFromTranscript(
-  transcript: TranscriptState,
-  context?: {
-    status?: SessionStatus | null;
-    executionSummary?: SessionExecutionSummary | null;
-  },
-): SessionDirectoryActivitySummary {
-  return {
-    isStreaming: transcript.isStreaming,
-    pendingInteractions: transcript.pendingInteractions,
-    transcriptTitle: transcript.sessionMeta.title ?? null,
-    errorAttentionKey: resolveSessionErrorAttentionKey({
-      sessionId: transcript.sessionMeta.sessionId,
-      status: context?.status ?? null,
-      executionSummary: context?.executionSummary ?? null,
-      transcript: {
-        itemsById: transcript.itemsById,
-      },
-    }),
-  };
-}
-
-export function activitySnapshotFromDirectoryEntry(
-  entry: SessionDirectoryEntry | null | undefined,
-) {
-  return entry
-    ? {
-      status: entry.status,
-      executionSummary: entry.executionSummary,
-      streamConnectionState: entry.streamConnectionState,
-      transcript: {
-        isStreaming: entry.activity.isStreaming,
-        pendingInteractions: entry.activity.pendingInteractions,
-      },
-    }
-    : null;
-}
-
-function normalizeEntryInput(
-  input: DirectoryEntryInput,
-  existing?: SessionDirectoryEntry,
-  hint?: SessionChildRelationship,
-): SessionDirectoryEntry {
-  return {
-    sessionId: input.sessionId,
-    materializedSessionId:
-      input.materializedSessionId !== undefined
-        ? input.materializedSessionId
-        : existing?.materializedSessionId ?? input.sessionId,
-    workspaceId: input.workspaceId ?? existing?.workspaceId ?? null,
-    agentKind: input.agentKind,
-    modelId: input.modelId ?? existing?.modelId ?? null,
-    modeId: input.modeId ?? existing?.modeId ?? null,
-    title: input.title ?? existing?.title ?? null,
-    actionCapabilities:
-      input.actionCapabilities
-      ?? existing?.actionCapabilities
-      ?? DEFAULT_SESSION_ACTION_CAPABILITIES,
-    liveConfig: input.liveConfig ?? existing?.liveConfig ?? null,
-    executionSummary: input.executionSummary ?? existing?.executionSummary ?? null,
-    mcpBindingSummaries:
-      input.mcpBindingSummaries
-      ?? existing?.mcpBindingSummaries
-      ?? null,
-    pendingConfigChanges: input.pendingConfigChanges ?? existing?.pendingConfigChanges ?? {},
-    status: input.status ?? existing?.status ?? null,
-    lastPromptAt: input.lastPromptAt ?? existing?.lastPromptAt ?? null,
-    streamConnectionState:
-      input.streamConnectionState
-      ?? existing?.streamConnectionState
-      ?? "disconnected",
-    transcriptHydrated: input.transcriptHydrated ?? existing?.transcriptHydrated ?? false,
-    sessionRelationship:
-      input.sessionRelationship
-      ?? hint
-      ?? existing?.sessionRelationship
-      ?? { kind: "pending" },
-    activity: {
-      ...EMPTY_ACTIVITY,
-      ...existing?.activity,
-      ...input.activity,
-    },
-  };
-}
-
-function normalizePatchedEntry(
-  entry: SessionDirectoryEntry,
-  patch: DirectoryEntryPatch,
-): SessionDirectoryEntry {
-  return {
-    ...entry,
-    ...patch,
-    activity: patch.activity
-      ? {
-        ...entry.activity,
-        ...patch.activity,
-      }
-      : entry.activity,
-  };
-}
-
-function applyPutEntry(
-  state: Pick<
-    SessionDirectoryState,
-    | "entriesById"
-    | "clientSessionIdByMaterializedSessionId"
-    | "sessionIdsByWorkspaceId"
-    | "relationshipHintsBySessionId"
-  >,
-  entry: SessionDirectoryEntry,
-) {
-  const previous = state.entriesById[entry.sessionId];
-  const entriesById = previous && directoryEntryEqual(previous, entry)
-    ? state.entriesById
-    : {
-      ...state.entriesById,
-      [entry.sessionId]: entry,
-    };
-  const relationshipHintsBySessionId = state.relationshipHintsBySessionId[entry.sessionId]
-    ? removeRecordKey(state.relationshipHintsBySessionId, entry.sessionId)
-    : state.relationshipHintsBySessionId;
-  const clientSessionIdByMaterializedSessionId = updateMaterializedIndex(
-    state.clientSessionIdByMaterializedSessionId,
-    previous?.materializedSessionId ?? null,
-    entry.materializedSessionId,
-    entry.sessionId,
-  );
-  const sessionIdsByWorkspaceId = updateWorkspaceIndex(
-    state.sessionIdsByWorkspaceId,
-    previous?.workspaceId ?? null,
-    entry.workspaceId,
-    entry.sessionId,
-  );
-
-  if (
-    entriesById === state.entriesById
-    && clientSessionIdByMaterializedSessionId === state.clientSessionIdByMaterializedSessionId
-    && relationshipHintsBySessionId === state.relationshipHintsBySessionId
-    && sessionIdsByWorkspaceId === state.sessionIdsByWorkspaceId
-  ) {
-    return state;
-  }
-  return {
-    entriesById,
-    clientSessionIdByMaterializedSessionId,
-    relationshipHintsBySessionId,
-    sessionIdsByWorkspaceId,
-  };
-}
-
-function updateMaterializedIndex(
-  index: Record<string, string>,
-  previousMaterializedSessionId: string | null,
-  nextMaterializedSessionId: string | null,
-  clientSessionId: string,
-): Record<string, string> {
-  let next = index;
-  if (previousMaterializedSessionId && previousMaterializedSessionId !== nextMaterializedSessionId) {
-    next = removeMaterializedIndexEntry(next, previousMaterializedSessionId);
-  }
-  if (!nextMaterializedSessionId) {
-    return next;
-  }
-  if (next[nextMaterializedSessionId] === clientSessionId) {
-    return next;
-  }
-  return {
-    ...next,
-    [nextMaterializedSessionId]: clientSessionId,
-  };
-}
-
-function removeMaterializedIndexEntry(
-  index: Record<string, string>,
-  materializedSessionId: string | null,
-): Record<string, string> {
-  if (!materializedSessionId || !(materializedSessionId in index)) {
-    return index;
-  }
-  const { [materializedSessionId]: _removed, ...rest } = index;
-  return rest;
-}
-
-function updateWorkspaceIndex(
-  index: Record<string, readonly string[]>,
-  previousWorkspaceId: string | null,
-  nextWorkspaceId: string | null,
-  sessionId: string,
-): Record<string, readonly string[]> {
-  if (previousWorkspaceId === nextWorkspaceId) {
-    if (!nextWorkspaceId || index[nextWorkspaceId]?.includes(sessionId)) {
-      return index;
-    }
-    return {
-      ...index,
-      [nextWorkspaceId]: [...(index[nextWorkspaceId] ?? []), sessionId].sort(),
-    };
-  }
-  let next = index;
-  if (previousWorkspaceId) {
-    next = removeSessionFromWorkspaceIndex(next, previousWorkspaceId, sessionId);
-  }
-  if (nextWorkspaceId) {
-    const currentIds = next[nextWorkspaceId] ?? [];
-    if (!currentIds.includes(sessionId)) {
-      next = {
-        ...next,
-        [nextWorkspaceId]: [...currentIds, sessionId].sort(),
-      };
-    }
-  }
-  return next;
-}
-
-function removeSessionFromWorkspaceIndex(
-  index: Record<string, readonly string[]>,
-  workspaceId: string | null,
-  sessionId: string,
-): Record<string, readonly string[]> {
-  if (!workspaceId || !index[workspaceId]?.includes(sessionId)) {
-    return index;
-  }
-  const nextIds = index[workspaceId].filter((id) => id !== sessionId);
-  if (nextIds.length === 0) {
-    const { [workspaceId]: _removed, ...rest } = index;
-    return rest;
-  }
-  return {
-    ...index,
-    [workspaceId]: nextIds,
-  };
-}
-
-function directoryEntryEqual(
-  a: SessionDirectoryEntry,
-  b: SessionDirectoryEntry,
-): boolean {
-  return a.sessionId === b.sessionId
-    && a.materializedSessionId === b.materializedSessionId
-    && a.workspaceId === b.workspaceId
-    && a.agentKind === b.agentKind
-    && a.modelId === b.modelId
-    && a.modeId === b.modeId
-    && a.title === b.title
-    && a.actionCapabilities === b.actionCapabilities
-    && a.liveConfig === b.liveConfig
-    && a.executionSummary === b.executionSummary
-    && a.mcpBindingSummaries === b.mcpBindingSummaries
-    && a.pendingConfigChanges === b.pendingConfigChanges
-    && a.status === b.status
-    && a.lastPromptAt === b.lastPromptAt
-    && a.streamConnectionState === b.streamConnectionState
-    && a.transcriptHydrated === b.transcriptHydrated
-    && sessionRelationshipEqual(a.sessionRelationship, b.sessionRelationship)
-    && activitySummaryEqual(a.activity, b.activity);
-}
-
-function activitySummaryEqual(
-  a: SessionDirectoryActivitySummary,
-  b: SessionDirectoryActivitySummary,
-): boolean {
-  return a.isStreaming === b.isStreaming
-    && a.pendingInteractions === b.pendingInteractions
-    && a.transcriptTitle === b.transcriptTitle
-    && a.errorAttentionKey === b.errorAttentionKey;
-}
-
-function removeRecordKey<T>(record: Record<string, T>, key: string): Record<string, T> {
-  if (!(key in record)) {
-    return record;
-  }
-  const { [key]: _removed, ...rest } = record;
-  return rest;
-}

--- a/desktop/src/stores/sessions/session-records.ts
+++ b/desktop/src/stores/sessions/session-records.ts
@@ -9,22 +9,18 @@ import {
 } from "@anyharness/sdk";
 import { resolveStatusFromExecutionSummary } from "@/lib/domain/sessions/activity";
 import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import { activityFromTranscript } from "@/lib/domain/sessions/directory/directory-activity";
 import {
-  activityFromTranscript,
   createDirectoryEntry,
-  useSessionDirectoryStore,
-} from "@/stores/sessions/session-directory-store";
-import {
-  useSessionTranscriptStore,
-} from "@/stores/sessions/session-transcript-store";
+  DEFAULT_SESSION_ACTION_CAPABILITIES,
+  type SessionDirectoryEntry,
+} from "@/lib/domain/sessions/directory/directory-entry";
+import type { SessionRelationship } from "@/lib/domain/sessions/directory/relationship";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import type {
-  SessionDirectoryEntry,
-  SessionRelationship,
   SessionRuntimeRecord,
   SessionTranscriptEntry,
-} from "@/stores/sessions/session-types";
-import {
-  DEFAULT_SESSION_ACTION_CAPABILITIES,
 } from "@/stores/sessions/session-types";
 import { batchSessionStoreWrites } from "@/lib/infra/scheduling/react-batching";
 

--- a/desktop/src/stores/sessions/session-types.ts
+++ b/desktop/src/stores/sessions/session-types.ts
@@ -1,89 +1,12 @@
 import type {
-  PendingInteraction,
   PendingPromptEntry,
-  SessionActionCapabilities,
   SessionEventEnvelope,
-  SessionExecutionSummary,
-  SessionLiveConfigSnapshot,
-  SessionMcpBindingSummary,
-  SessionStatus,
   TranscriptState,
 } from "@anyharness/sdk";
-import type { PendingSessionConfigChanges } from "@/lib/domain/sessions/pending-config";
+import type { SessionDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
 export type { HotPaintGate } from "@/lib/domain/sessions/hot-paint-gate";
 
 export type HarnessConnectionState = "connecting" | "healthy" | "failed";
-export type ClientSessionId = string;
-export type MaterializedSessionId = string;
-
-export type SessionStreamConnectionState =
-  | "disconnected"
-  | "connecting"
-  | "open"
-  | "ended";
-
-export type SessionRelationship =
-  | { kind: "root" }
-  | { kind: "pending" }
-  | SessionChildRelationship;
-
-export type SessionChildRelationship =
-  | {
-    kind: "subagent_child";
-    parentSessionId: string | null;
-    sessionLinkId?: string | null;
-    relation?: string | null;
-    workspaceId?: string | null;
-  }
-  | {
-    kind: "cowork_child";
-    parentSessionId: string | null;
-    sessionLinkId?: string | null;
-    relation?: string | null;
-    workspaceId?: string | null;
-  }
-  | {
-    kind: "review_child";
-    parentSessionId: string | null;
-    sessionLinkId?: string | null;
-    relation?: string | null;
-    workspaceId?: string | null;
-  }
-  | {
-    kind: "linked_child";
-    parentSessionId: string | null;
-    sessionLinkId?: string | null;
-    relation?: string | null;
-    workspaceId?: string | null;
-  };
-
-export interface SessionDirectoryActivitySummary {
-  isStreaming: boolean;
-  pendingInteractions: PendingInteraction[];
-  transcriptTitle: string | null;
-  errorAttentionKey: string | null;
-}
-
-export interface SessionDirectoryEntry {
-  sessionId: ClientSessionId;
-  materializedSessionId: MaterializedSessionId | null;
-  workspaceId: string | null;
-  agentKind: string;
-  modelId: string | null;
-  modeId: string | null;
-  title: string | null;
-  actionCapabilities: SessionActionCapabilities;
-  liveConfig: SessionLiveConfigSnapshot | null;
-  executionSummary: SessionExecutionSummary | null;
-  mcpBindingSummaries: SessionMcpBindingSummary[] | null;
-  pendingConfigChanges: PendingSessionConfigChanges;
-  status: SessionStatus | null;
-  lastPromptAt: string | null;
-  streamConnectionState: SessionStreamConnectionState;
-  transcriptHydrated: boolean;
-  sessionRelationship: SessionRelationship;
-  activity: SessionDirectoryActivitySummary;
-}
 
 export interface SessionTranscriptEntry {
   sessionId: string;
@@ -96,35 +19,4 @@ export interface SessionRuntimeRecord extends SessionDirectoryEntry {
   events: SessionEventEnvelope[];
   transcript: TranscriptState;
   optimisticPrompt: PendingPromptEntry | null;
-}
-
-export const DEFAULT_SESSION_ACTION_CAPABILITIES: SessionActionCapabilities = {
-  fork: false,
-  targetedFork: false,
-};
-
-export function sessionRelationshipEqual(
-  a: SessionRelationship | undefined,
-  b: SessionRelationship | undefined,
-): boolean {
-  if (!a || !b || a.kind !== b.kind) {
-    return false;
-  }
-  if (a.kind === "root" || a.kind === "pending") {
-    return true;
-  }
-  return sessionChildRelationshipEqual(a, b as SessionChildRelationship);
-}
-
-export function sessionChildRelationshipEqual(
-  a: SessionChildRelationship | undefined,
-  b: SessionChildRelationship | undefined,
-): boolean {
-  return !!a
-    && !!b
-    && a.kind === b.kind
-    && a.parentSessionId === b.parentSessionId
-    && (a.sessionLinkId ?? null) === (b.sessionLinkId ?? null)
-    && (a.relation ?? null) === (b.relation ?? null)
-    && (a.workspaceId ?? null) === (b.workspaceId ?? null);
 }


### PR DESCRIPTION
## Summary

- Move session directory relationship, entry normalization/equality, activity projection, index, and reducer helpers into `lib/domain/sessions/directory`.
- Keep `session-directory-store.ts` focused on Zustand state and synchronous setters.
- Update direct imports for moved directory helpers/types and add focused domain reducer/model tests.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
- `pnpm --dir desktop exec vitest run src/lib/domain/sessions/directory/directory-entry.test.ts src/lib/domain/sessions/directory/directory-reducer.test.ts src/stores/sessions/session-directory-store.test.ts src/stores/sessions/session-store-isolation.test.ts src/stores/sessions/session-records.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
