### PR TITLE
refactor(desktop): decouple session runtime records

### DIFF
--- a/desktop/src/hooks/chat/use-prompt-outbox-dispatcher.ts
+++ b/desktop/src/hooks/chat/use-prompt-outbox-dispatcher.ts
@@ -16,9 +16,14 @@ import {
   getSessionClientAndWorkspace,
 } from "@/lib/workflows/sessions/session-runtime";
 import {
-  getSessionRecord,
   waitForSessionMaterialization,
+  type SessionMaterializationDeps,
+} from "@/lib/workflows/sessions/session-materialization";
+import {
+  getMaterializedSessionId,
+  getSessionRecord,
 } from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { usePromptOutboxStore } from "@/stores/chat/prompt-outbox-store";
 import { useSessionHistoryHydration } from "@/hooks/sessions/lifecycle/use-session-history-hydration";
 import { useSessionSummaryActions } from "@/hooks/sessions/workflows/use-session-summary-actions";
@@ -30,6 +35,14 @@ const ACCEPTED_RUNNING_RECONCILE_DELAYS_MS = [250, 1_000, 2_500, 5_000, 10_000] 
 const ACCEPTED_RUNNING_RECONCILE_TIMEOUT_MS = 3_000;
 
 let activeDispatcherOwner: symbol | null = null;
+
+const sessionMaterializationDeps: SessionMaterializationDeps = {
+  getMaterializedSessionId,
+  subscribeToMaterializedSessionId: (clientSessionId, onChange) =>
+    useSessionDirectoryStore.subscribe((state) => {
+      onChange(state.entriesById[clientSessionId]?.materializedSessionId ?? null);
+    }),
+};
 
 export function usePromptOutboxDispatcher(): void {
   const dispatchVersion = usePromptOutboxStore((state) => state.dispatchVersion);
@@ -78,7 +91,8 @@ export function usePromptOutboxDispatcher(): void {
 
       const materializedSessionId = await waitForSessionMaterialization(
         entry.clientSessionId,
-        CONFIG_READY_TIMEOUT_MS,
+        sessionMaterializationDeps,
+        { timeoutMs: CONFIG_READY_TIMEOUT_MS },
       );
       usePromptOutboxStore.getState().bindMaterializedSession(
         entry.clientSessionId,

--- a/desktop/src/hooks/sessions/session-runtime-helpers.ts
+++ b/desktop/src/hooks/sessions/session-runtime-helpers.ts
@@ -1,8 +1,8 @@
 import type { SessionStreamHandle } from "@anyharness/sdk";
 import { resolveSessionViewState } from "@/lib/domain/sessions/activity";
 import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
-import { isPendingSessionId } from "@/lib/workflows/sessions/session-runtime";
 import { isCurrentSessionStreamHandle } from "@/lib/access/anyharness/session-stream-handles";
+import { isPendingSessionId } from "@/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 export function shouldReconnectStream(sessionId: string): boolean {

--- a/desktop/src/hooks/sessions/use-session-creation-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-creation-actions.ts
@@ -28,7 +28,11 @@ import { useToastStore } from "@/stores/toast/toast-store";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
   createEmptySessionRecord,
+  findClientSessionIdByMaterializedSessionId,
+  getMaterializedSessionId,
   getSessionRecord,
+  getSessionRecords,
+  isPendingSessionId,
   patchSessionRecord,
   putSessionRecord,
 } from "@/stores/sessions/session-records";
@@ -49,7 +53,14 @@ import { useSessionPromptWorkflow } from "@/hooks/sessions/use-session-prompt-wo
 import {
   createPendingSessionId,
   pruneInactiveSessionStreams,
+  type FlushAwareSessionStreamHandle,
+  type SessionStreamPruningDeps,
 } from "@/lib/workflows/sessions/session-runtime";
+import {
+  closeSessionStreamHandle,
+  flushAllSessionStreamHandles,
+  getSessionStreamHandle,
+} from "@/lib/access/anyharness/session-stream-handles";
 import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap";
 import { useSessionRuntimeActions } from "@/hooks/sessions/use-session-runtime-actions";
 import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
@@ -119,6 +130,28 @@ interface CreateEmptySessionWithResolvedConfigOptions {
   clientSessionId?: string | null;
   reuseInFlightEmptySession?: boolean;
 }
+
+const sessionStreamPruningDeps: SessionStreamPruningDeps = {
+  getSessionRecords,
+  getSessionStreamHandle: (sessionId: string) =>
+    getSessionStreamHandle(sessionId) as FlushAwareSessionStreamHandle | null,
+  closeSessionStreamHandle: (
+    sessionId: string,
+    handle: FlushAwareSessionStreamHandle,
+  ) => {
+    closeSessionStreamHandle(sessionId, handle);
+  },
+  flushAllSessionStreamHandles,
+  getMaterializedSessionId,
+  findClientSessionIdByMaterializedSessionId,
+  patchSessionStreamConnectionState: (
+    clientSessionId: string,
+    streamConnectionState,
+  ) => {
+    patchSessionRecord(clientSessionId, { streamConnectionState });
+  },
+  isPendingSessionId,
+};
 
 async function ensureRuntimeReadyForSessions(): Promise<string> {
   const state = useHarnessConnectionStore.getState();
@@ -317,7 +350,7 @@ export function useSessionCreationActions() {
       }).rolledBack;
     };
     writeOwnedShellIntent(pendingSessionId);
-    pruneInactiveSessionStreams();
+    pruneInactiveSessionStreams(sessionStreamPruningDeps);
     if (shouldEnqueueInitialPrompt) {
       await promptSession({
         sessionId: pendingSessionId,

--- a/desktop/src/hooks/sessions/workflows/use-session-config-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-config-actions.ts
@@ -16,13 +16,13 @@ import {
 } from "@/lib/domain/sessions/pending-config";
 import {
   getSessionRecord,
+  isPendingSessionId,
   patchSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import {
   getSessionClientAndWorkspace,
-  isPendingSessionId,
 } from "@/lib/workflows/sessions/session-runtime";
 
 let nextPendingConfigMutationId = 0;

--- a/desktop/src/hooks/sessions/workflows/use-session-prompt-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-prompt-actions.ts
@@ -4,11 +4,9 @@ import type { ActiveSessionPromptOptions } from "@/hooks/sessions/workflows/sess
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/use-workspace-runtime-block";
 import {
   getSessionRecord,
+  isPendingSessionId,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import {
-  isPendingSessionId,
-} from "@/lib/workflows/sessions/session-runtime";
 
 export function useSessionPromptActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();

--- a/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -27,12 +27,12 @@ import {
 import { HOT_PAINT_MEASUREMENT_SUMMARY_BUDGET } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { annotateLatencyFlow } from "@/lib/infra/measurement/latency-flow";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
-import { isPendingSessionId } from "@/lib/workflows/sessions/session-runtime";
 import { rememberLastViewedSession } from "@/stores/preferences/workspace-ui-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import {
   createEmptySessionRecord,
   getSessionRecord,
+  isPendingSessionId,
   patchSessionRecord,
   putSessionRecord,
 } from "@/stores/sessions/session-records";

--- a/desktop/src/hooks/workspaces/selection/clear-runtime-state.ts
+++ b/desktop/src/hooks/workspaces/selection/clear-runtime-state.ts
@@ -1,11 +1,43 @@
 import { resetWorkspaceEditorState } from "@/stores/editor/workspace-editor-state";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
 import { useChatPlanAttachmentStore } from "@/stores/chat/chat-plan-attachment-store";
-import { detachAndCloseSessionStreams } from "@/lib/workflows/sessions/session-runtime";
-import { getWorkspaceSessionRecords } from "@/stores/sessions/session-records";
+import {
+  detachAndCloseSessionStreams,
+  type FlushAwareSessionStreamHandle,
+  type SessionStreamDetachDeps,
+} from "@/lib/workflows/sessions/session-runtime";
+import {
+  findClientSessionIdByMaterializedSessionId,
+  getMaterializedSessionId,
+  getWorkspaceSessionRecords,
+  patchSessionRecord,
+} from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import {
+  closeSessionStreamHandle,
+  getSessionStreamHandle,
+} from "@/lib/access/anyharness/session-stream-handles";
 import { clearWorkspaceBootstrappedInSession } from "../workspace-bootstrap-memory";
 import type { WorkspaceSelectionDeps } from "./types";
+
+const sessionStreamDetachDeps: SessionStreamDetachDeps = {
+  getMaterializedSessionId,
+  getSessionStreamHandle: (sessionId: string) =>
+    getSessionStreamHandle(sessionId) as FlushAwareSessionStreamHandle | null,
+  closeSessionStreamHandle: (
+    sessionId: string,
+    handle: FlushAwareSessionStreamHandle,
+  ) => {
+    closeSessionStreamHandle(sessionId, handle);
+  },
+  findClientSessionIdByMaterializedSessionId,
+  patchSessionStreamConnectionState: (
+    clientSessionId: string,
+    streamConnectionState,
+  ) => {
+    patchSessionRecord(clientSessionId, { streamConnectionState });
+  },
+};
 
 export function clearWorkspaceRuntimeState(
   deps: Pick<WorkspaceSelectionDeps, "removeWorkspaceSlots" | "clearSelection">,
@@ -15,7 +47,7 @@ export function clearWorkspaceRuntimeState(
   const selectedWorkspaceId = useSessionSelectionStore.getState().selectedWorkspaceId;
   const workspaceSlots = getWorkspaceSessionRecords(workspaceId);
 
-  detachAndCloseSessionStreams(Object.keys(workspaceSlots));
+  detachAndCloseSessionStreams(Object.keys(workspaceSlots), sessionStreamDetachDeps);
   deps.removeWorkspaceSlots(workspaceId);
   if (options?.clearDraftUiKey) {
     useChatInputStore.getState().clearDraft(options.clearDraftUiKey);

--- a/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
+++ b/desktop/src/hooks/workspaces/selection/run-hot-workspace-reopen.ts
@@ -11,11 +11,11 @@ import {
 import {
   getMaterializedSessionId,
   getSessionRecords,
+  isPendingSessionId,
   removeSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import { isPendingSessionId } from "@/lib/workflows/sessions/session-runtime";
 import {
   finishMeasurementOperation,
   finishOrCancelMeasurementOperation,

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
@@ -32,8 +32,10 @@ import {
 } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import { isHotReopenEligibleSessionSlot } from "@/lib/domain/workspaces/selection/hot-reopen";
-import { isPendingSessionId } from "@/lib/workflows/sessions/session-runtime";
-import { getSessionRecord } from "@/stores/sessions/session-records";
+import {
+  getSessionRecord,
+  isPendingSessionId,
+} from "@/stores/sessions/session-records";
 
 const HOT_SWITCH_SURFACES = [
   "workspace-shell",

--- a/desktop/src/lib/workflows/sessions/session-materialization.test.ts
+++ b/desktop/src/lib/workflows/sessions/session-materialization.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  waitForSessionMaterialization,
+  type SessionMaterializationDeps,
+} from "./session-materialization";
+
+describe("waitForSessionMaterialization", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when a materialized id already exists", async () => {
+    const deps: SessionMaterializationDeps = {
+      getMaterializedSessionId: () => "runtime-a",
+      subscribeToMaterializedSessionId: vi.fn(),
+    };
+
+    await expect(waitForSessionMaterialization("client-a", deps))
+      .resolves
+      .toBe("runtime-a");
+    expect(deps.subscribeToMaterializedSessionId).not.toHaveBeenCalled();
+  });
+
+  it("resolves from the injected subscription", async () => {
+    vi.useFakeTimers();
+    const listenerRef: {
+      current: ((materializedSessionId: string | null) => void) | null;
+    } = { current: null };
+    const unsubscribe = vi.fn();
+    const deps: SessionMaterializationDeps = {
+      getMaterializedSessionId: () => null,
+      subscribeToMaterializedSessionId: (_clientSessionId, onChange) => {
+        listenerRef.current = onChange;
+        return unsubscribe;
+      },
+    };
+
+    const pending = waitForSessionMaterialization("client-a", deps, {
+      timeoutMs: 1_000,
+    });
+    listenerRef.current?.("runtime-a");
+
+    await expect(pending).resolves.toBe("runtime-a");
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("rechecks after subscribing to cover materialization races", async () => {
+    vi.useFakeTimers();
+    let current: string | null = null;
+    const unsubscribe = vi.fn();
+    const deps: SessionMaterializationDeps = {
+      getMaterializedSessionId: () => current,
+      subscribeToMaterializedSessionId: () => {
+        current = "runtime-a";
+        return unsubscribe;
+      },
+    };
+
+    await expect(waitForSessionMaterialization("client-a", deps, {
+      timeoutMs: 1_000,
+    })).resolves.toBe("runtime-a");
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects and unsubscribes on timeout", async () => {
+    vi.useFakeTimers();
+    const unsubscribe = vi.fn();
+    const deps: SessionMaterializationDeps = {
+      getMaterializedSessionId: () => null,
+      subscribeToMaterializedSessionId: () => unsubscribe,
+    };
+
+    const pending = expect(waitForSessionMaterialization("client-a", deps, {
+      timeoutMs: 1_000,
+    })).rejects.toThrow("Session is still starting. Try again in a moment.");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await pending;
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/lib/workflows/sessions/session-materialization.ts
+++ b/desktop/src/lib/workflows/sessions/session-materialization.ts
@@ -1,0 +1,68 @@
+const SESSION_MATERIALIZATION_ERROR = "Session is still starting. Try again in a moment.";
+
+export interface SessionMaterializationDeps {
+  getMaterializedSessionId(clientSessionId: string): string | null;
+  subscribeToMaterializedSessionId(
+    clientSessionId: string,
+    onChange: (materializedSessionId: string | null) => void,
+  ): () => void;
+}
+
+export function waitForSessionMaterialization(
+  clientSessionId: string,
+  deps: SessionMaterializationDeps,
+  options?: {
+    timeoutMs?: number;
+  },
+): Promise<string> {
+  const existing = deps.getMaterializedSessionId(clientSessionId);
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let unsubscribe: (() => void) | null = null;
+    let needsUnsubscribeAfterSubscribe = false;
+
+    const cleanupSubscription = () => {
+      if (!unsubscribe) {
+        needsUnsubscribeAfterSubscribe = true;
+        return;
+      }
+      const unsubscribeNow = unsubscribe;
+      unsubscribe = null;
+      unsubscribeNow();
+    };
+
+    const timeout = globalThis.setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupSubscription();
+      reject(new Error(SESSION_MATERIALIZATION_ERROR));
+    }, timeoutMs);
+
+    const resolveMaterialized = (materializedSessionId: string | null) => {
+      if (settled || !materializedSessionId) {
+        return;
+      }
+      settled = true;
+      globalThis.clearTimeout(timeout);
+      cleanupSubscription();
+      resolve(materializedSessionId);
+    };
+
+    unsubscribe = deps.subscribeToMaterializedSessionId(
+      clientSessionId,
+      resolveMaterialized,
+    );
+    if (needsUnsubscribeAfterSubscribe) {
+      cleanupSubscription();
+      return;
+    }
+    resolveMaterialized(deps.getMaterializedSessionId(clientSessionId));
+  });
+}

--- a/desktop/src/lib/workflows/sessions/session-runtime.test.ts
+++ b/desktop/src/lib/workflows/sessions/session-runtime.test.ts
@@ -1,18 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   collectInactiveSessionStreamIds,
-  createEmptySessionRuntimeRecord,
-  createSessionRuntimeRecordFromSummary,
   detachAndCloseSessionStreams,
   fetchSessionHistory,
   pruneInactiveSessionStreams,
   resumeSession,
+  type FlushAwareSessionStreamHandle,
+  type SessionStreamPruningDeps,
 } from "./session-runtime";
-import type { Session, SessionStreamHandle } from "@anyharness/sdk";
-import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
+import type { SessionStreamHandle } from "@anyharness/sdk";
 import {
   createEmptySessionRecord,
+  findClientSessionIdByMaterializedSessionId,
+  getMaterializedSessionId,
   getSessionRecord,
+  getSessionRecords,
+  isPendingSessionId,
   patchSessionRecord,
   putSessionRecord,
 } from "@/stores/sessions/session-records";
@@ -21,10 +24,34 @@ import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-st
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import {
+  closeSessionStreamHandle,
+  flushAllSessionStreamHandles,
   getSessionStreamHandle,
   setSessionStreamHandle,
   resetSessionStreamHandlesForTest,
 } from "@/lib/access/anyharness/session-stream-handles";
+
+const sessionStreamPruningDeps: SessionStreamPruningDeps = {
+  getSessionRecords,
+  getSessionStreamHandle: (sessionId: string) =>
+    getSessionStreamHandle(sessionId) as FlushAwareSessionStreamHandle | null,
+  closeSessionStreamHandle: (
+    sessionId: string,
+    handle: FlushAwareSessionStreamHandle,
+  ) => {
+    closeSessionStreamHandle(sessionId, handle);
+  },
+  flushAllSessionStreamHandles,
+  getMaterializedSessionId,
+  findClientSessionIdByMaterializedSessionId,
+  patchSessionStreamConnectionState: (
+    clientSessionId: string,
+    streamConnectionState,
+  ) => {
+    patchSessionRecord(clientSessionId, { streamConnectionState });
+  },
+  isPendingSessionId,
+};
 
 const mocks = vi.hoisted(() => ({
   listEvents: vi.fn(),
@@ -130,57 +157,21 @@ describe("fetchSessionHistory", () => {
 });
 
 describe("collectInactiveSessionStreamIds", () => {
-  it("initializes empty pending config changes on new slots", () => {
-    expect(createEmptySessionRuntimeRecord("session-1", "codex").pendingConfigChanges).toEqual({});
-  });
-
-  it("defaults generic slots to pending relationships", () => {
-    expect(createEmptySessionRuntimeRecord("session-1", "codex").sessionRelationship)
-      .toEqual({ kind: "pending" });
-  });
-
-  it("applies and prunes relationship hints when slots mount later", () => {
-    useSessionDirectoryStore.getState().recordRelationshipHint("child-session", {
-      kind: "subagent_child",
-      parentSessionId: "parent-session",
-      sessionLinkId: "link-1",
-      relation: "subagent",
-      workspaceId: "workspace-1",
-    });
-
-    putSessionRecord(
-      createEmptySessionRecord("child-session", "codex", {
-        workspaceId: "workspace-1",
-      }),
-    );
-
-    expect(useSessionDirectoryStore.getState().entriesById["child-session"]?.sessionRelationship)
-      .toEqual({
-        kind: "subagent_child",
-        parentSessionId: "parent-session",
-        sessionLinkId: "link-1",
-        relation: "subagent",
-        workspaceId: "workspace-1",
-      });
-    expect(useSessionDirectoryStore.getState().relationshipHintsBySessionId["child-session"])
-      .toBeUndefined();
-  });
-
   it("prunes only idle, non-pending sessions with open stream handles", () => {
     const idleSlot = {
-      ...createEmptySessionRuntimeRecord("session-idle", "codex"),
+      ...createEmptySessionRecord("session-idle", "codex"),
       streamConnectionState: "open" as const,
       transcriptHydrated: true,
       status: "idle" as const,
     };
     const workingSlot = {
-      ...createEmptySessionRuntimeRecord("session-working", "codex"),
+      ...createEmptySessionRecord("session-working", "codex"),
       streamConnectionState: "open" as const,
       transcriptHydrated: true,
       status: "running" as const,
     };
     const pendingSlot = {
-      ...createEmptySessionRuntimeRecord("pending-session:codex:1:abc123", "codex"),
+      ...createEmptySessionRecord("pending-session:codex:1:abc123", "codex"),
       streamConnectionState: "open" as const,
       transcriptHydrated: true,
       status: "idle" as const,
@@ -202,7 +193,7 @@ describe("collectInactiveSessionStreamIds", () => {
       "session-idle": idleSlot,
       "session-working": workingSlot,
       "pending-session:codex:1:abc123": pendingSlot,
-    }, {
+    }, sessionStreamPruningDeps, {
       preserveSessionIds: ["session-working"],
     });
 
@@ -231,7 +222,7 @@ describe("detachAndCloseSessionStreams", () => {
       title: "initial title",
     });
 
-    expect(detachAndCloseSessionStreams(["session-1"])).toBe(1);
+    expect(detachAndCloseSessionStreams(["session-1"], sessionStreamPruningDeps)).toBe(1);
 
     const slot = getSessionRecord("session-1")!;
     expect(close).toHaveBeenCalledTimes(1);
@@ -265,77 +256,13 @@ describe("pruneInactiveSessionStreams", () => {
       status: "idle",
     });
 
-    expect(pruneInactiveSessionStreams()).toEqual([]);
+    expect(pruneInactiveSessionStreams(sessionStreamPruningDeps)).toEqual([]);
 
     const slot = getSessionRecord("session-1")!;
     expect(flushPendingEvents).toHaveBeenCalledTimes(1);
     expect(close).not.toHaveBeenCalled();
     expect(getSessionStreamHandle("session-1")).toBe(handle);
     expect(slot.status).toBe("running");
-  });
-});
-
-describe("createSessionRuntimeRecordFromSummary", () => {
-  it("uses the subagent label as a fallback title for untitled runtime-created sessions", () => {
-    const session = {
-      id: "child-session",
-      agentKind: "claude",
-      modelId: "opus",
-      modeId: "default",
-      title: null,
-      status: "idle",
-      liveConfig: null,
-      executionSummary: null,
-      mcpBindingSummaries: null,
-      lastPromptAt: null,
-    } as Session;
-
-    const slot = createSessionRuntimeRecordFromSummary(session, "workspace-1", {
-      titleFallback: "haiku-test",
-    });
-
-    expect(slot.sessionId).toBe("child-session");
-    expect(slot.workspaceId).toBe("workspace-1");
-    expect(slot.title).toBe("haiku-test");
-    expect(slot.transcript.sessionMeta.title).toBe("haiku-test");
-    expect(slot.transcriptHydrated).toBe(false);
-    expect(slot.status).toBe("idle");
-  });
-
-  it("preserves existing relationship metadata across summary patches", () => {
-    const relationship = {
-      kind: "review_child" as const,
-      parentSessionId: "parent-session",
-      sessionLinkId: "review-link-1",
-      relation: "review",
-      workspaceId: "workspace-1",
-    };
-    const slot = createEmptySessionRuntimeRecord("review-session", "codex", {
-      workspaceId: "workspace-1",
-      sessionRelationship: relationship,
-    });
-    putSessionRecord(slot);
-
-    const patch = buildSessionSlotPatchFromSummary(
-      {
-        id: "review-session",
-        agentKind: "codex",
-        modelId: "gpt-5.4",
-        modeId: "default",
-        title: "Reviewer",
-        status: "idle",
-        liveConfig: null,
-        executionSummary: null,
-        mcpBindingSummaries: null,
-        lastPromptAt: null,
-      } as Session,
-      "workspace-1",
-      slot.transcript,
-    );
-    patchSessionRecord("review-session", patch);
-
-    expect(useSessionDirectoryStore.getState().entriesById["review-session"]?.sessionRelationship)
-      .toEqual(relationship);
   });
 });
 

--- a/desktop/src/lib/workflows/sessions/session-runtime.ts
+++ b/desktop/src/lib/workflows/sessions/session-runtime.ts
@@ -1,14 +1,9 @@
 import {
-  type PendingPromptEntry,
   streamSession,
 } from "@anyharness/sdk";
 import type {
   Session,
-  SessionActionCapabilities,
   SessionEventEnvelope,
-  SessionExecutionSummary,
-  SessionLiveConfigSnapshot,
-  SessionMcpBindingSummary,
   SessionStreamHandle,
 } from "@anyharness/sdk";
 import {
@@ -39,20 +34,11 @@ import { resolveSessionMcpServersForLaunch } from "@/lib/workflows/sessions/sess
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import {
-  createEmptySessionRecord,
-  createSessionRecordFromSummary,
-  getMaterializedSessionId,
-  getSessionRecords,
-  isSessionMaterialized,
   requireMaterializedSessionId,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
-import type { SessionRelationship } from "@/lib/domain/sessions/directory/relationship";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
 import {
-  closeSessionStreamHandle,
-  flushAllSessionStreamHandles,
-  getSessionStreamHandle,
   type ManagedSessionStreamHandle,
 } from "@/lib/access/anyharness/session-stream-handles";
 
@@ -66,6 +52,29 @@ interface SessionStreamCallbacks {
 }
 
 export type FlushAwareSessionStreamHandle = ManagedSessionStreamHandle;
+
+export interface SessionStreamStatusDeps {
+  getSessionStreamHandle(sessionId: string): FlushAwareSessionStreamHandle | null;
+  isPendingSessionId(sessionId: string): boolean;
+}
+
+export interface SessionStreamDetachDeps {
+  getMaterializedSessionId(clientSessionId: string): string | null;
+  getSessionStreamHandle(sessionId: string): FlushAwareSessionStreamHandle | null;
+  closeSessionStreamHandle(sessionId: string, handle: FlushAwareSessionStreamHandle): void;
+  findClientSessionIdByMaterializedSessionId(materializedSessionId: string): string | null;
+  patchSessionStreamConnectionState(
+    clientSessionId: string,
+    streamConnectionState: SessionRuntimeRecord["streamConnectionState"],
+  ): void;
+}
+
+export interface SessionStreamPruningDeps
+  extends SessionStreamDetachDeps,
+    SessionStreamStatusDeps {
+  getSessionRecords(): Record<string, SessionRuntimeRecord>;
+  flushAllSessionStreamHandles(): void;
+}
 
 const SESSION_HISTORY_FETCH_TIMEOUT_MS = 10_000;
 function buildConnection(target: RuntimeTarget): AnyHarnessWorkspaceSessionConnection {
@@ -104,46 +113,6 @@ async function measureSessionWorkflowStep<T>(
 
 export function createPendingSessionId(agentKind: string): string {
   return `client-session:${agentKind}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
-}
-
-export function isPendingSessionId(sessionId: string): boolean {
-  if (sessionId.startsWith("pending-session:") || sessionId.startsWith("client-session:")) {
-    return !isSessionMaterialized(sessionId);
-  }
-  const entry = useSessionDirectoryStore.getState().entriesById[sessionId];
-  return !!entry && !entry.materializedSessionId;
-}
-
-export function createEmptySessionRuntimeRecord(
-  sessionId: string,
-  agentKind: string,
-  config?: {
-    workspaceId?: string | null;
-    modelId?: string | null;
-    modeId?: string | null;
-    title?: string | null;
-    actionCapabilities?: SessionActionCapabilities | null;
-    liveConfig?: SessionLiveConfigSnapshot | null;
-    executionSummary?: SessionExecutionSummary | null;
-    mcpBindingSummaries?: SessionMcpBindingSummary[] | null;
-    lastPromptAt?: string | null;
-    optimisticPrompt?: PendingPromptEntry | null;
-    sessionRelationship?: SessionRelationship;
-  },
-): SessionRuntimeRecord {
-  return createEmptySessionRecord(sessionId, agentKind, config);
-}
-
-export function createSessionRuntimeRecordFromSummary(
-  session: Session,
-  workspaceId: string,
-  options?: {
-    titleFallback?: string | null;
-    transcriptHydrated?: boolean;
-    sessionRelationship?: SessionRelationship;
-  },
-): SessionRuntimeRecord {
-  return createSessionRecordFromSummary(session, workspaceId, options);
 }
 
 export function getWorkspaceClientAndId(
@@ -363,6 +332,7 @@ export async function resumeSession(
 
 export function collectInactiveSessionStreamIds(
   sessions: Record<string, SessionRuntimeRecord>,
+  deps: SessionStreamStatusDeps,
   options?: {
     preserveSessionIds?: Iterable<string>;
   },
@@ -373,8 +343,8 @@ export function collectInactiveSessionStreamIds(
   for (const [sessionId, record] of Object.entries(sessions)) {
     if (
       !record.materializedSessionId
-      || !getSessionStreamHandle(record.materializedSessionId)
-      || isPendingSessionId(sessionId)
+      || !deps.getSessionStreamHandle(record.materializedSessionId)
+      || deps.isPendingSessionId(sessionId)
       || preservedSessionIds.has(sessionId)
     ) {
       continue;
@@ -393,6 +363,7 @@ export function collectInactiveSessionStreamIds(
 
 export function detachAndCloseSessionStreams(
   sessionIds: Iterable<string>,
+  deps: SessionStreamDetachDeps,
 ): number {
   const uniqueSessionIds = Array.from(new Set(sessionIds));
   if (uniqueSessionIds.length === 0) {
@@ -401,9 +372,9 @@ export function detachAndCloseSessionStreams(
 
   const streams: { sessionId: string; handle: FlushAwareSessionStreamHandle }[] = [];
   for (const sessionId of uniqueSessionIds) {
-    const materializedSessionId = getMaterializedSessionId(sessionId);
+    const materializedSessionId = deps.getMaterializedSessionId(sessionId);
     const handle = materializedSessionId
-      ? getSessionStreamHandle(materializedSessionId)
+      ? deps.getSessionStreamHandle(materializedSessionId)
       : null;
     if (!materializedSessionId || !handle) {
       continue;
@@ -416,32 +387,31 @@ export function detachAndCloseSessionStreams(
   }
 
   for (const { sessionId, handle } of streams) {
-    closeSessionStreamHandle(sessionId, handle);
-    const clientSessionId =
-      useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId[sessionId]
+    deps.closeSessionStreamHandle(sessionId, handle);
+    const clientSessionId = deps.findClientSessionIdByMaterializedSessionId(sessionId)
       ?? sessionId;
-    useSessionDirectoryStore.getState().patchEntry(clientSessionId, {
-      streamConnectionState: "disconnected",
-    });
+    deps.patchSessionStreamConnectionState(clientSessionId, "disconnected");
   }
   return streams.length;
 }
 
 export function pruneInactiveSessionStreams(
+  deps: SessionStreamPruningDeps,
   options?: {
     preserveSessionIds?: Iterable<string>;
   },
 ): string[] {
-  flushAllSessionStreamHandles();
+  deps.flushAllSessionStreamHandles();
   const prunableSessionIds = collectInactiveSessionStreamIds(
-    getSessionRecords(),
+    deps.getSessionRecords(),
+    deps,
     options,
   );
   if (prunableSessionIds.length === 0) {
     return [];
   }
 
-  detachAndCloseSessionStreams(prunableSessionIds);
+  detachAndCloseSessionStreams(prunableSessionIds, deps);
   logLatency("session.stream.pruned", {
     closedSessionCount: prunableSessionIds.length,
   });

--- a/desktop/src/stores/sessions/session-records.test.ts
+++ b/desktop/src/stores/sessions/session-records.test.ts
@@ -1,20 +1,22 @@
-import { createTranscriptState } from "@anyharness/sdk";
+import { createTranscriptState, type Session } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSessionSlotPatchFromSummary } from "@/lib/domain/sessions/summary";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionIngestStore } from "@/stores/sessions/session-ingest-store";
 import {
   createEmptySessionRecord,
+  createSessionRecordFromSummary,
   findClientSessionIdByMaterializedSessionId,
   getMaterializedSessionId,
   getSessionRecord,
   getSessionRecordByMaterializedSessionId,
   getWorkspaceSessionRecords,
+  isPendingSessionId,
   isSessionMaterialized,
   patchSessionRecord,
   putSessionRecord,
   removeSessionRecord,
   requireMaterializedSessionId,
-  waitForSessionMaterialization,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
@@ -61,6 +63,23 @@ describe("session records facade invariants", () => {
     expect(findClientSessionIdByMaterializedSessionId("runtime-a")).toBe("client-a");
     expect(getSessionRecordByMaterializedSessionId("runtime-a")?.sessionId).toBe("client-a");
     expect(getSessionRecord("client-a")?.transcript).toBe(transcript);
+  });
+
+  it("classifies pending client ids from synchronous directory state", () => {
+    putSessionRecord(createEmptySessionRecord("client-a", "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-a",
+    }));
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+    }));
+
+    expect(isPendingSessionId("client-a")).toBe(true);
+    expect(isPendingSessionId("session-a")).toBe(false);
+
+    patchSessionRecord("client-a", { materializedSessionId: "runtime-a" });
+
+    expect(isPendingSessionId("client-a")).toBe(false);
   });
 
   it("returns only complete records from workspace-indexed facade reads", () => {
@@ -119,21 +138,99 @@ describe("session records facade invariants", () => {
     expect(useSessionIngestStore.getState()).toBe(ingestBefore);
   });
 
-  it("waits for materialization and rejects with the same guard error on timeout", async () => {
-    vi.useFakeTimers();
-    putSessionRecord(createEmptySessionRecord("client-a", "codex", {
-      materializedSessionId: null,
-      workspaceId: "workspace-a",
-    }));
+  it("initializes empty pending config changes and pending relationships on new records", () => {
+    const record = createEmptySessionRecord("session-1", "codex");
 
-    const pending = waitForSessionMaterialization("client-a", 1_000);
-    patchSessionRecord("client-a", { materializedSessionId: "runtime-a" });
-    await expect(pending).resolves.toBe("runtime-a");
+    expect(record.pendingConfigChanges).toEqual({});
+    expect(record.sessionRelationship).toEqual({ kind: "pending" });
+  });
 
-    const timedOut = expect(waitForSessionMaterialization("missing-client", 1_000))
-      .rejects
-      .toThrow("Session is still starting. Try again in a moment.");
-    await vi.advanceTimersByTimeAsync(1_000);
-    await timedOut;
+  it("applies and prunes relationship hints when records mount later", () => {
+    useSessionDirectoryStore.getState().recordRelationshipHint("child-session", {
+      kind: "subagent_child",
+      parentSessionId: "parent-session",
+      sessionLinkId: "link-1",
+      relation: "subagent",
+      workspaceId: "workspace-1",
+    });
+
+    putSessionRecord(
+      createEmptySessionRecord("child-session", "codex", {
+        workspaceId: "workspace-1",
+      }),
+    );
+
+    expect(useSessionDirectoryStore.getState().entriesById["child-session"]?.sessionRelationship)
+      .toEqual({
+        kind: "subagent_child",
+        parentSessionId: "parent-session",
+        sessionLinkId: "link-1",
+        relation: "subagent",
+        workspaceId: "workspace-1",
+      });
+    expect(useSessionDirectoryStore.getState().relationshipHintsBySessionId["child-session"])
+      .toBeUndefined();
+  });
+
+  it("uses the subagent label as a fallback title for untitled runtime-created sessions", () => {
+    const session = {
+      id: "child-session",
+      agentKind: "claude",
+      modelId: "opus",
+      modeId: "default",
+      title: null,
+      status: "idle",
+      liveConfig: null,
+      executionSummary: null,
+      mcpBindingSummaries: null,
+      lastPromptAt: null,
+    } as Session;
+
+    const record = createSessionRecordFromSummary(session, "workspace-1", {
+      titleFallback: "haiku-test",
+    });
+
+    expect(record.sessionId).toBe("child-session");
+    expect(record.workspaceId).toBe("workspace-1");
+    expect(record.title).toBe("haiku-test");
+    expect(record.transcript.sessionMeta.title).toBe("haiku-test");
+    expect(record.transcriptHydrated).toBe(false);
+    expect(record.status).toBe("idle");
+  });
+
+  it("preserves existing relationship metadata across summary patches", () => {
+    const relationship = {
+      kind: "review_child" as const,
+      parentSessionId: "parent-session",
+      sessionLinkId: "review-link-1",
+      relation: "review",
+      workspaceId: "workspace-1",
+    };
+    const record = createEmptySessionRecord("review-session", "codex", {
+      workspaceId: "workspace-1",
+      sessionRelationship: relationship,
+    });
+    putSessionRecord(record);
+
+    const patch = buildSessionSlotPatchFromSummary(
+      {
+        id: "review-session",
+        agentKind: "codex",
+        modelId: "gpt-5.4",
+        modeId: "default",
+        title: "Reviewer",
+        status: "idle",
+        liveConfig: null,
+        executionSummary: null,
+        mcpBindingSummaries: null,
+        lastPromptAt: null,
+      } as Session,
+      "workspace-1",
+      record.transcript,
+    );
+    patchSessionRecord("review-session", patch);
+
+    expect(useSessionDirectoryStore.getState().entriesById["review-session"]?.sessionRelationship)
+      .toEqual(relationship);
   });
 });

--- a/desktop/src/stores/sessions/session-records.ts
+++ b/desktop/src/stores/sessions/session-records.ts
@@ -247,32 +247,12 @@ export function isSessionMaterialized(clientSessionId: string | null | undefined
   return !!getMaterializedSessionId(clientSessionId);
 }
 
-export function waitForSessionMaterialization(
-  clientSessionId: string,
-  timeoutMs = 15_000,
-): Promise<string> {
-  const existing = getMaterializedSessionId(clientSessionId);
-  if (existing) {
-    return Promise.resolve(existing);
+export function isPendingSessionId(sessionId: string): boolean {
+  if (sessionId.startsWith("pending-session:") || sessionId.startsWith("client-session:")) {
+    return !isSessionMaterialized(sessionId);
   }
-
-  return new Promise((resolve, reject) => {
-    let unsubscribe: () => void = () => {};
-    const timeout = globalThis.setTimeout(() => {
-      unsubscribe();
-      reject(new Error("Session is still starting. Try again in a moment."));
-    }, timeoutMs);
-    unsubscribe = useSessionDirectoryStore.subscribe((state) => {
-      const materializedSessionId = state.entriesById[clientSessionId]?.materializedSessionId
-        ?? null;
-      if (!materializedSessionId) {
-        return;
-      }
-      globalThis.clearTimeout(timeout);
-      unsubscribe();
-      resolve(materializedSessionId);
-    });
-  });
+  const entry = useSessionDirectoryStore.getState().entriesById[sessionId];
+  return !!entry && !entry.materializedSessionId;
 }
 
 export function getSessionRecordByMaterializedSessionId(


### PR DESCRIPTION
## Summary\n- move session materialization waiting out of the session records store facade\n- make selected session runtime pruning/detach behavior use explicit deps\n- keep session record store behavior synchronous and add focused coverage\n\n## Verification\n- python3 scripts/check_frontend_boundaries.py\n- python3 scripts/check_max_lines.py\n- git diff --check origin/main...HEAD\n- pnpm --dir desktop exec vitest run src/lib/workflows/sessions/session-materialization.test.ts src/stores/sessions/session-records.test.ts src/lib/workflows/sessions/session-runtime.test.ts\n- pnpm --dir desktop exec tsc --noEmit