### PR TITLE
refactor(server): remove org membership DB wrapper

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -35,7 +35,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_run
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 24 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 3 transitional wrappers used by deferred organization/cloud callers
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 2 transitional wrappers used by deferred organization/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -158,19 +158,6 @@ async def get_organization_with_membership(
     )
 
 
-async def load_organization_with_membership(
-    *,
-    organization_id: UUID,
-    user_id: UUID,
-) -> OrganizationWithMembershipRecord | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_organization_with_membership(
-            db,
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-
-
 async def load_active_membership(
     *,
     organization_id: UUID,

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -34,6 +34,7 @@ from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.billing import (
     ensure_organization_billing_subject,
     get_or_create_stripe_customer_state_for_user,
+    get_or_create_user_stripe_customer_state,
 )
 from proliferate.db.store.organization_records import (
     InvitationCreateRecord,
@@ -173,6 +174,8 @@ def _org_not_found() -> OrganizationServiceError:
 async def resolve_owner_context(
     actor_user: OrganizationActor,
     owner_selection: OwnerSelection | None = None,
+    *,
+    db: AsyncSession | None = None,
 ) -> OwnerContext:
     selection = owner_selection or OwnerSelection()
     if selection.owner_scope == "personal":
@@ -182,7 +185,11 @@ async def resolve_owner_context(
                 "organizationId is not valid for personal scope.",
                 status_code=400,
             )
-        state = await get_or_create_stripe_customer_state_for_user(actor_user.id)
+        state = (
+            await get_or_create_user_stripe_customer_state(db, actor_user.id)
+            if db is not None
+            else await get_or_create_stripe_customer_state_for_user(actor_user.id)
+        )
         if state.kind != BILLING_SUBJECT_KIND_PERSONAL:
             raise OrganizationServiceError(
                 "invalid_owner_selection",
@@ -200,22 +207,34 @@ async def resolve_owner_context(
         )
 
     organization_id = _require_uuid(selection.organization_id, field="organizationId")
-    record = await organization_store.load_organization_with_membership(
-        organization_id=organization_id,
-        user_id=actor_user.id,
-    )
-    if record is None:
-        raise _org_not_found()
-    billing_subject_id = await organization_store.ensure_organization_billing_subject_id(
-        organization_id,
-    )
+    if db is not None:
+        record = await organization_store.get_organization_with_membership(
+            db,
+            organization_id=organization_id,
+            user_id=actor_user.id,
+        )
+        if record is None:
+            raise _org_not_found()
+        subject = await ensure_organization_billing_subject(db, organization_id)
+        membership = record.membership
+        billing_subject_id = subject.id
+    else:
+        membership = await organization_store.load_active_membership(
+            organization_id=organization_id,
+            user_id=actor_user.id,
+        )
+        if membership is None:
+            raise _org_not_found()
+        billing_subject_id = await organization_store.ensure_organization_billing_subject_id(
+            organization_id,
+        )
     return OwnerContext(
         owner_scope="organization",
         actor_user_id=actor_user.id,
         owner_user_id=None,
         organization_id=organization_id,
-        membership_id=record.membership.id,
-        membership_role=record.membership.role,
+        membership_id=membership.id,
+        membership_role=membership.role,
         billing_subject_id=billing_subject_id,
     )
 

--- a/server/tests/integration/test_organizations_api.py
+++ b/server/tests/integration/test_organizations_api.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 import pytest
 from httpx import AsyncClient
 
+from proliferate.auth.authorization import OwnerSelection
 from proliferate.server.organizations import service as organization_service
 
 TINY_PNG_DATA_URL = (
@@ -138,6 +139,38 @@ async def test_default_organization_member_list_and_last_owner_protection(
     )
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "cannot_modify_own_membership"
+
+
+@pytest.mark.asyncio
+async def test_resolve_owner_context_uses_threaded_db(
+    client: AsyncClient,
+) -> None:
+    owner = await _create_user_and_get_tokens(
+        client,
+        email="owner@acme.dev",
+        display_name="Owner User",
+    )
+    organization = await _default_organization(client, owner)
+    organization_id = uuid.UUID(str(organization["id"]))
+
+    from proliferate.db import engine as engine_module
+    from proliferate.db.models.auth import User
+
+    async with engine_module.async_session_factory() as session:
+        user = await session.get(User, uuid.UUID(owner["user_id"]))
+        assert user is not None
+        context = await organization_service.resolve_owner_context(
+            user,
+            OwnerSelection(
+                owner_scope="organization",
+                organization_id=organization_id,
+            ),
+            db=session,
+        )
+
+    assert context.owner_scope == "organization"
+    assert context.organization_id == organization_id
+    assert context.membership_role == "owner"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Remove the self-opening `load_organization_with_membership` organization store wrapper.
- Let `resolve_owner_context` use threaded DB store calls when a request session is provided, while preserving existing no-session callers.
- Add focused integration coverage for threaded organization owner-context resolution.
- Lower `STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py` from 3 to 2.

## Verification
- `DEBUG=1 uv run --python 3.12 --project server --extra dev python -m pytest -q server/tests/integration/test_organizations_api.py server/tests/unit/test_organization_domain.py server/tests/unit/test_organization_errors.py`
- `uv run --project server python scripts/check_server_boundaries.py`
- `uv run --project server python scripts/check_max_lines.py`
- `git diff --check`