### PR TITLE
refactor(server): move scheduler DB boundaries to worker service

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -13,7 +13,6 @@ SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 trans
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions own transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 1 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automations.py 1 worker scheduler batch owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 29 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
@@ -24,7 +23,7 @@ STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional sto
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions open DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 2 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 2 worker/cloud workspace helper still opens isolated DB sessions
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 1 cloud workspace helper still opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 29 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
@@ -40,7 +39,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runti
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 worker/cloud workspace helper still imports DB session factory
+STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 cloud workspace helper still imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/billing.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/auth.py 1 materialization refresh wrappers import DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper imports DB session factory

--- a/server/proliferate/db/store/automation_run_claims.py
+++ b/server/proliferate/db/store/automation_run_claims.py
@@ -338,6 +338,7 @@ async def _heartbeat_run_claim(
 
 
 async def sweep_expired_dispatching_runs(
+    db: AsyncSession,
     *,
     now: datetime,
     dispatching_status: str,
@@ -347,31 +348,28 @@ async def sweep_expired_dispatching_runs(
     if limit <= 0:
         return 0
 
-    async def operation(db: AsyncSession) -> int:
-        runs = list(
-            (
-                await db.execute(
-                    select(AutomationRun)
-                    .where(
-                        AutomationRun.status == dispatching_status,
-                        AutomationRun.claim_expires_at.is_not(None),
-                        AutomationRun.claim_expires_at <= now,
-                    )
-                    .order_by(AutomationRun.claim_expires_at.asc(), AutomationRun.id.asc())
-                    .limit(limit)
-                    .with_for_update(skip_locked=True)
+    runs = list(
+        (
+            await db.execute(
+                select(AutomationRun)
+                .where(
+                    AutomationRun.status == dispatching_status,
+                    AutomationRun.claim_expires_at.is_not(None),
+                    AutomationRun.claim_expires_at <= now,
                 )
+                .order_by(AutomationRun.claim_expires_at.asc(), AutomationRun.id.asc())
+                .limit(limit)
+                .with_for_update(skip_locked=True)
             )
-            .scalars()
-            .all()
         )
-        for run in runs:
-            run.status = AUTOMATION_RUN_STATUS_FAILED
-            run.failed_at = now
-            run.last_error_code = dispatch_uncertain_failure.code
-            run.last_error_message = dispatch_uncertain_failure.message
-            clear_claim_metadata(run)
-            run.updated_at = now
-        return len(runs)
-
-    return await _run_self_committing(operation)
+        .scalars()
+        .all()
+    )
+    for run in runs:
+        run.status = AUTOMATION_RUN_STATUS_FAILED
+        run.failed_at = now
+        run.last_error_code = dispatch_uncertain_failure.code
+        run.last_error_message = dispatch_uncertain_failure.message
+        clear_claim_metadata(run)
+        run.updated_at = now
+    return len(runs)

--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -451,113 +451,112 @@ async def list_latest_runs_by_cloud_workspace_ids_for_user(
 
 
 async def create_due_scheduled_runs_batch(
+    db: AsyncSession,
     *,
     now: datetime,
     limit: int,
     schedule_advance_resolver: ScheduleAdvanceResolver,
 ) -> int:
-    async with db_engine.async_session_factory() as db:
-        rows = list(
-            (
-                await db.execute(
-                    select(Automation, CloudRepoConfig)
-                    .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
-                    .where(
-                        Automation.enabled.is_(True),
-                        Automation.next_run_at.is_not(None),
-                        Automation.next_run_at <= now,
-                        or_(
-                            Automation.execution_target == AUTOMATION_EXECUTION_TARGET_LOCAL,
-                            CloudRepoConfig.configured.is_(True),
-                        ),
-                    )
-                    .order_by(Automation.next_run_at.asc())
-                    .limit(limit)
-                    .with_for_update(skip_locked=True)
-                )
-            ).all()
-        )
-        inserted_count = 0
-        for record, repo_config in rows:
-            try:
-                advance = schedule_advance_resolver(
-                    AutomationScheduleFields(
-                        schedule_rrule=record.schedule_rrule,
-                        schedule_timezone=record.schedule_timezone,
-                        next_run_at=record.next_run_at,
+    rows = list(
+        (
+            await db.execute(
+                select(Automation, CloudRepoConfig)
+                .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
+                .where(
+                    Automation.enabled.is_(True),
+                    Automation.next_run_at.is_not(None),
+                    Automation.next_run_at <= now,
+                    or_(
+                        Automation.execution_target == AUTOMATION_EXECUTION_TARGET_LOCAL,
+                        CloudRepoConfig.configured.is_(True),
                     ),
-                    now,
                 )
-            except Exception:
-                logger.exception(
-                    "automation schedule advance failed; disabling automation automation_id=%s",
-                    record.id,
-                )
-                record.enabled = False
-                record.paused_at = now
-                record.next_run_at = None
-                record.updated_at = now
-                continue
-            if advance.scheduled_for is not None:
-                result = await db.execute(
-                    pg_insert(AutomationRun)
-                    .values(
-                        automation_id=record.id,
-                        user_id=record.user_id,
-                        trigger_kind=AUTOMATION_RUN_TRIGGER_SCHEDULED,
-                        scheduled_for=advance.scheduled_for,
-                        execution_target=record.execution_target,
-                        status=AUTOMATION_RUN_STATUS_QUEUED,
-                        title_snapshot=record.title,
-                        prompt_snapshot=record.prompt,
-                        git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
-                        git_owner_snapshot=repo_config.git_owner,
-                        git_repo_name_snapshot=repo_config.git_repo_name,
-                        cloud_repo_config_id_snapshot=record.cloud_repo_config_id,
-                        agent_kind_snapshot=record.agent_kind,
-                        model_id_snapshot=record.model_id,
-                        mode_id_snapshot=record.mode_id,
-                        reasoning_effort_snapshot=record.reasoning_effort,
-                        executor_kind=None,
-                        executor_id=None,
-                        claim_id=None,
-                        claimed_at=None,
-                        claim_expires_at=None,
-                        last_heartbeat_at=None,
-                        dispatch_started_at=None,
-                        dispatched_at=None,
-                        failed_at=None,
-                        cloud_workspace_id=None,
-                        anyharness_workspace_id=None,
-                        anyharness_session_id=None,
-                        cancelled_at=None,
-                        last_error_code=None,
-                        last_error_message=None,
-                        created_at=now,
-                        updated_at=now,
-                    )
-                    .on_conflict_do_nothing(
-                        index_elements=[
-                            AutomationRun.automation_id,
-                            AutomationRun.scheduled_for,
-                        ],
-                        index_where=AutomationRun.trigger_kind == AUTOMATION_RUN_TRIGGER_SCHEDULED,
-                    )
-                    .returning(AutomationRun.id)
-                )
-                if result.scalar_one_or_none() is not None:
-                    inserted_count += 1
-                    record.last_scheduled_at = advance.scheduled_for
-                else:
-                    logger.debug(
-                        "automation scheduled slot already existed "
-                        "automation_id=%s scheduled_for=%s",
-                        record.id,
-                        advance.scheduled_for,
-                    )
-                    # Another scheduler already created this slot; still advance next_run_at so
-                    # the automation does not keep retrying an idempotent duplicate forever.
-            record.next_run_at = advance.next_run_at
+                .order_by(Automation.next_run_at.asc())
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            )
+        ).all()
+    )
+    inserted_count = 0
+    for record, repo_config in rows:
+        try:
+            advance = schedule_advance_resolver(
+                AutomationScheduleFields(
+                    schedule_rrule=record.schedule_rrule,
+                    schedule_timezone=record.schedule_timezone,
+                    next_run_at=record.next_run_at,
+                ),
+                now,
+            )
+        except Exception:
+            logger.exception(
+                "automation schedule advance failed; disabling automation automation_id=%s",
+                record.id,
+            )
+            record.enabled = False
+            record.paused_at = now
+            record.next_run_at = None
             record.updated_at = now
-        await db.commit()
-        return inserted_count
+            continue
+        if advance.scheduled_for is not None:
+            result = await db.execute(
+                pg_insert(AutomationRun)
+                .values(
+                    automation_id=record.id,
+                    user_id=record.user_id,
+                    trigger_kind=AUTOMATION_RUN_TRIGGER_SCHEDULED,
+                    scheduled_for=advance.scheduled_for,
+                    execution_target=record.execution_target,
+                    status=AUTOMATION_RUN_STATUS_QUEUED,
+                    title_snapshot=record.title,
+                    prompt_snapshot=record.prompt,
+                    git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
+                    git_owner_snapshot=repo_config.git_owner,
+                    git_repo_name_snapshot=repo_config.git_repo_name,
+                    cloud_repo_config_id_snapshot=record.cloud_repo_config_id,
+                    agent_kind_snapshot=record.agent_kind,
+                    model_id_snapshot=record.model_id,
+                    mode_id_snapshot=record.mode_id,
+                    reasoning_effort_snapshot=record.reasoning_effort,
+                    executor_kind=None,
+                    executor_id=None,
+                    claim_id=None,
+                    claimed_at=None,
+                    claim_expires_at=None,
+                    last_heartbeat_at=None,
+                    dispatch_started_at=None,
+                    dispatched_at=None,
+                    failed_at=None,
+                    cloud_workspace_id=None,
+                    anyharness_workspace_id=None,
+                    anyharness_session_id=None,
+                    cancelled_at=None,
+                    last_error_code=None,
+                    last_error_message=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=[
+                        AutomationRun.automation_id,
+                        AutomationRun.scheduled_for,
+                    ],
+                    index_where=AutomationRun.trigger_kind == AUTOMATION_RUN_TRIGGER_SCHEDULED,
+                )
+                .returning(AutomationRun.id)
+            )
+            if result.scalar_one_or_none() is not None:
+                inserted_count += 1
+                record.last_scheduled_at = advance.scheduled_for
+            else:
+                logger.debug(
+                    "automation scheduled slot already existed "
+                    "automation_id=%s scheduled_for=%s",
+                    record.id,
+                    advance.scheduled_for,
+                )
+                # Another scheduler already created this slot; still advance next_run_at so
+                # the automation does not keep retrying an idempotent duplicate forever.
+        record.next_run_at = advance.next_run_at
+        record.updated_at = now
+    return inserted_count

--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -550,8 +550,7 @@ async def create_due_scheduled_runs_batch(
                 record.last_scheduled_at = advance.scheduled_for
             else:
                 logger.debug(
-                    "automation scheduled slot already existed "
-                    "automation_id=%s scheduled_for=%s",
+                    "automation scheduled slot already existed automation_id=%s scheduled_for=%s",
                     record.id,
                     advance.scheduled_for,
                 )

--- a/server/proliferate/server/automations/worker/scheduler.py
+++ b/server/proliferate/server/automations/worker/scheduler.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 
+from proliferate.db import engine as db_engine
 from proliferate.integrations.sentry import capture_server_sentry_exception
 from proliferate.server.automations.worker.service import run_scheduler_tick
 
@@ -33,7 +34,10 @@ async def run_scheduler_loop(
             if not schema_validated:
                 await validate_schema()
                 schema_validated = True
-            result = await run_scheduler_tick(batch_size=batch_size)
+            result = await run_scheduler_tick(
+                session_factory=db_engine.async_session_factory,
+                batch_size=batch_size,
+            )
             consecutive_failures = 0
             if result.created_runs:
                 logger.info("Automation scheduler created runs count=%s", result.created_runs)

--- a/server/proliferate/server/automations/worker/service.py
+++ b/server/proliferate/server/automations/worker/service.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store.automation_run_claims import (
     sweep_expired_dispatching_runs,
@@ -27,6 +31,9 @@ class SchedulerTickResult:
     swept_dispatching_runs: int = 0
 
 
+SchedulerSessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+
+
 def _resolve_due_schedule(
     fields: AutomationScheduleFields,
     now: datetime,
@@ -40,16 +47,41 @@ def _resolve_due_schedule(
     return AutomationScheduleAdvance(scheduled_for=scheduled_for, next_run_at=next_run_at)
 
 
-async def run_scheduler_tick(*, batch_size: int = 100) -> SchedulerTickResult:
-    swept_dispatching_runs = await sweep_expired_dispatching_runs(
-        now=utcnow(),
-        dispatching_status=AUTOMATION_RUN_STATUS_DISPATCHING,
-        dispatch_uncertain_failure=dispatch_uncertain_failure(),
-    )
-    created_runs = await create_due_scheduled_runs_batch(
-        now=utcnow(),
-        limit=max(1, batch_size),
-        schedule_advance_resolver=_resolve_due_schedule,
+async def _sweep_expired_dispatching_runs(
+    session_factory: SchedulerSessionFactory,
+) -> int:
+    async with session_factory() as db, db.begin():
+        return await sweep_expired_dispatching_runs(
+            db,
+            now=utcnow(),
+            dispatching_status=AUTOMATION_RUN_STATUS_DISPATCHING,
+            dispatch_uncertain_failure=dispatch_uncertain_failure(),
+        )
+
+
+async def _create_due_scheduled_runs_batch(
+    session_factory: SchedulerSessionFactory,
+    *,
+    batch_size: int,
+) -> int:
+    async with session_factory() as db, db.begin():
+        return await create_due_scheduled_runs_batch(
+            db,
+            now=utcnow(),
+            limit=max(1, batch_size),
+            schedule_advance_resolver=_resolve_due_schedule,
+        )
+
+
+async def run_scheduler_tick(
+    *,
+    session_factory: SchedulerSessionFactory,
+    batch_size: int = 100,
+) -> SchedulerTickResult:
+    swept_dispatching_runs = await _sweep_expired_dispatching_runs(session_factory)
+    created_runs = await _create_due_scheduled_runs_batch(
+        session_factory,
+        batch_size=batch_size,
     )
     return SchedulerTickResult(
         created_runs=created_runs,

--- a/server/tests/unit/test_automation_executor.py
+++ b/server/tests/unit/test_automation_executor.py
@@ -499,7 +499,8 @@ async def test_expired_dispatching_run_is_swept_to_failed(
             record.claim_expires_at = now - timedelta(seconds=1)
             await session.commit()
 
-        swept = await sweep_expired_dispatching_runs(now=now)
+        async with engine_module.async_session_factory() as session, session.begin():
+            swept = await sweep_expired_dispatching_runs(db=session, now=now)
 
         async with engine_module.async_session_factory() as session:
             record = (
@@ -558,7 +559,8 @@ async def test_expired_dispatching_sweep_is_bounded_and_ordered(
             second_record.claim_expires_at = now - timedelta(minutes=1)
             await session.commit()
 
-        swept = await sweep_expired_dispatching_runs(now=now, limit=1)
+        async with engine_module.async_session_factory() as session, session.begin():
+            swept = await sweep_expired_dispatching_runs(db=session, now=now, limit=1)
 
         async with engine_module.async_session_factory() as session:
             first_record = await session.get(AutomationRun, first_claim.id)

--- a/server/tests/unit/test_automation_store.py
+++ b/server/tests/unit/test_automation_store.py
@@ -113,11 +113,13 @@ async def test_due_scheduler_disables_bad_schedule_and_continues_batch(
                 next_run_at=now + timedelta(hours=1),
             )
 
-        created = await create_due_scheduled_runs_batch(
-            now=now,
-            limit=10,
-            schedule_advance_resolver=_advance,
-        )
+        async with engine_module.async_session_factory() as session, session.begin():
+            created = await create_due_scheduled_runs_batch(
+                session,
+                now=now,
+                limit=10,
+                schedule_advance_resolver=_advance,
+            )
 
         async with engine_module.async_session_factory() as session:
             good = await session.get(Automation, good_id)
@@ -245,11 +247,13 @@ async def test_due_scheduler_advances_after_duplicate_scheduled_slot(
                 next_run_at=now + timedelta(hours=1),
             )
 
-        created = await create_due_scheduled_runs_batch(
-            now=now,
-            limit=10,
-            schedule_advance_resolver=_advance,
-        )
+        async with engine_module.async_session_factory() as session, session.begin():
+            created = await create_due_scheduled_runs_batch(
+                session,
+                now=now,
+                limit=10,
+                schedule_advance_resolver=_advance,
+            )
 
         async with engine_module.async_session_factory() as session:
             automation = await session.get(Automation, automation_id)

--- a/server/tests/unit/test_automation_worker_scheduler.py
+++ b/server/tests/unit/test_automation_worker_scheduler.py
@@ -1,0 +1,133 @@
+from datetime import UTC, datetime, timedelta
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_RUN_STATUS_DISPATCHING,
+    AUTOMATION_RUN_TRIGGER_MANUAL,
+)
+from proliferate.db import engine as engine_module
+from proliferate.db.models.automations import Automation, AutomationRun
+from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.server.automations.domain.claim_lifecycle import (
+    AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
+)
+from proliferate.server.automations.worker import service as worker_service
+
+
+@pytest.mark.asyncio
+async def test_scheduler_tick_commits_sweep_before_due_batch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    async def _fail_due_batch(*args, **kwargs) -> int:  # type: ignore[no-untyped-def]
+        raise RuntimeError("due batch failed")
+
+    monkeypatch.setattr(worker_service, "utcnow", lambda: now)
+    monkeypatch.setattr(worker_service, "create_due_scheduled_runs_batch", _fail_due_batch)
+
+    try:
+        async with engine_module.async_session_factory() as session:
+            repo = CloudRepoConfig(
+                user_id=user_id,
+                git_owner="proliferate-ai",
+                git_repo_name="proliferate",
+                configured=True,
+                configured_at=now,
+                default_branch="main",
+                env_vars_ciphertext="",
+                env_vars_version=0,
+                setup_script="",
+                setup_script_version=0,
+                files_version=0,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(repo)
+            await session.flush()
+            automation = Automation(
+                user_id=user_id,
+                cloud_repo_config_id=repo.id,
+                title="Daily check",
+                prompt="Original prompt",
+                schedule_rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                schedule_timezone="UTC",
+                schedule_summary="Daily at 09:00 in UTC",
+                execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+                agent_kind="codex",
+                model_id=None,
+                mode_id=None,
+                reasoning_effort=None,
+                enabled=True,
+                paused_at=None,
+                next_run_at=now,
+                last_scheduled_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(automation)
+            await session.flush()
+            run = AutomationRun(
+                automation_id=automation.id,
+                user_id=user_id,
+                trigger_kind=AUTOMATION_RUN_TRIGGER_MANUAL,
+                scheduled_for=None,
+                execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+                status=AUTOMATION_RUN_STATUS_DISPATCHING,
+                title_snapshot=automation.title,
+                prompt_snapshot=automation.prompt,
+                git_provider_snapshot="github",
+                git_owner_snapshot=repo.git_owner,
+                git_repo_name_snapshot=repo.git_repo_name,
+                cloud_repo_config_id_snapshot=repo.id,
+                agent_kind_snapshot=automation.agent_kind,
+                model_id_snapshot=automation.model_id,
+                mode_id_snapshot=automation.mode_id,
+                reasoning_effort_snapshot=automation.reasoning_effort,
+                executor_kind="cloud",
+                executor_id="executor-1",
+                claim_id=uuid.uuid4(),
+                claimed_at=now - timedelta(minutes=10),
+                claim_expires_at=now - timedelta(seconds=1),
+                last_heartbeat_at=now - timedelta(minutes=10),
+                dispatch_started_at=now - timedelta(minutes=5),
+                dispatched_at=None,
+                failed_at=None,
+                cloud_workspace_id=None,
+                anyharness_workspace_id=None,
+                anyharness_session_id=None,
+                cancelled_at=None,
+                last_error_code=None,
+                last_error_message=None,
+                created_at=now - timedelta(minutes=10),
+                updated_at=now - timedelta(minutes=10),
+            )
+            session.add(run)
+            await session.commit()
+            run_id = run.id
+
+        with pytest.raises(RuntimeError, match="due batch failed"):
+            await worker_service.run_scheduler_tick(
+                session_factory=engine_module.async_session_factory,
+                batch_size=1,
+            )
+
+        async with engine_module.async_session_factory() as session:
+            record = await session.get(AutomationRun, run_id)
+
+        assert record is not None
+        assert record.status == "failed"
+        assert record.failed_at == now
+        assert record.last_error_code == AUTOMATION_ERROR_DISPATCH_UNCERTAIN
+        assert record.claim_id is None
+        assert record.executor_id is None
+    finally:
+        engine_module.async_session_factory = original_factory


### PR DESCRIPTION
## Summary
- Thread the automation scheduler store calls through caller-provided `AsyncSession` instances instead of store-owned commits.
- Keep the scheduler tick's expired-dispatching sweep and due-run creation as two independent transaction scopes.
- Update scheduler/store tests and reduce the server boundary allowlist for the removed store commit/session-factory debt.

## Verification
- `DEBUG=true uv run --project server --extra dev pytest server/tests/unit/test_automation_store.py server/tests/unit/test_automation_executor.py server/tests/unit/test_automation_worker_scheduler.py -q`
- `uv run --project server python scripts/check_server_boundaries.py`
- `uv run --project server python scripts/check_max_lines.py`
- `git diff --check`
- `uv run --project server --extra dev ruff check server/proliferate/db/store/automation_run_claims.py server/proliferate/db/store/automations.py server/proliferate/server/automations/worker/scheduler.py server/proliferate/server/automations/worker/service.py server/tests/unit/test_automation_executor.py server/tests/unit/test_automation_store.py server/tests/unit/test_automation_worker_scheduler.py`