### PR TITLE
refactor(server): close phase 8 wave 2 domain gaps

### DIFF
--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -10,7 +10,6 @@ should remain in that module.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import StrEnum
 from typing import Final, Literal
 
@@ -140,108 +139,6 @@ MAX_SETUP_MONITOR_ERROR_CHARS: Final = 2000
 SETUP_RUN_MISSING_WORKSPACE_ERROR: Final = "Cloud workspace no longer exists."
 SETUP_RUN_SUPERSEDED_ERROR: Final = "Setup run was superseded by a newer apply."
 SETUP_RUN_DEFAULT_FAILURE_ERROR: Final = "Repo setup failed"
-
-
-@dataclass(frozen=True)
-class SetupRunWorkspaceFinalization:
-    phase: WorkspacePostReadyPhase
-    status_detail: str
-    repo_setup_applied_version: int | None = None
-    repo_files_last_error: str | None = None
-
-
-@dataclass(frozen=True)
-class SetupRunFinalizationDecision:
-    run_status: str
-    run_last_error: str | None
-    should_update_workspace: bool
-    set_last_polled_at: bool
-    clear_next_poll_at: bool
-    workspace_update: SetupRunWorkspaceFinalization | None = None
-
-
-def bounded_setup_monitor_error(value: str | None) -> str | None:
-    if value is None:
-        return None
-    return value[:MAX_SETUP_MONITOR_ERROR_CHARS]
-
-
-def setup_run_has_active_workspace_token(
-    *,
-    workspace_apply_token: str | None,
-    workspace_phase: WorkspacePostReadyPhase | str | None,
-    run_apply_token: str,
-    command_run_id: str | None,
-) -> bool:
-    phase_value = (
-        workspace_phase.value if isinstance(workspace_phase, StrEnum) else workspace_phase
-    )
-    return bool(
-        workspace_apply_token == run_apply_token
-        and command_run_id
-        and phase_value == WorkspacePostReadyPhase.starting_setup.value
-    )
-
-
-def classify_setup_run_finalization(
-    *,
-    workspace_exists: bool,
-    workspace_apply_token: str | None,
-    workspace_phase: WorkspacePostReadyPhase | str | None,
-    run_apply_token: str,
-    command_run_id: str | None,
-    final_status: str,
-    success: bool,
-    last_error: str | None,
-    setup_script_version: int,
-) -> SetupRunFinalizationDecision:
-    if not workspace_exists:
-        return SetupRunFinalizationDecision(
-            run_status=SETUP_RUN_STATUS_STALE,
-            run_last_error=SETUP_RUN_MISSING_WORKSPACE_ERROR,
-            should_update_workspace=False,
-            set_last_polled_at=False,
-            clear_next_poll_at=False,
-        )
-
-    if not setup_run_has_active_workspace_token(
-        workspace_apply_token=workspace_apply_token,
-        workspace_phase=workspace_phase,
-        run_apply_token=run_apply_token,
-        command_run_id=command_run_id,
-    ):
-        return SetupRunFinalizationDecision(
-            run_status=SETUP_RUN_STATUS_STALE,
-            run_last_error=SETUP_RUN_SUPERSEDED_ERROR,
-            should_update_workspace=False,
-            set_last_polled_at=False,
-            clear_next_poll_at=False,
-        )
-
-    bounded_last_error = bounded_setup_monitor_error(last_error)
-    if success:
-        workspace_update = SetupRunWorkspaceFinalization(
-            phase=WorkspacePostReadyPhase.completed,
-            repo_setup_applied_version=setup_script_version,
-            repo_files_last_error=None,
-            status_detail="Ready",
-        )
-    else:
-        workspace_update = SetupRunWorkspaceFinalization(
-            phase=WorkspacePostReadyPhase.failed,
-            repo_setup_applied_version=None,
-            repo_files_last_error=bounded_last_error or SETUP_RUN_DEFAULT_FAILURE_ERROR,
-            status_detail="Repo setup failed",
-        )
-
-    return SetupRunFinalizationDecision(
-        run_status=final_status,
-        run_last_error=bounded_last_error,
-        should_update_workspace=True,
-        set_last_polled_at=True,
-        clear_next_poll_at=True,
-        workspace_update=workspace_update,
-    )
 
 
 WORKSPACE_REPO_APPLY_LOCK_SALT: int = 4_203_902

--- a/server/proliferate/db/store/cloud_mobility.py
+++ b/server/proliferate/db/store/cloud_mobility.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Protocol
 from uuid import UUID
 
 from sqlalchemy import select
@@ -14,6 +15,15 @@ from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.mobility import CloudWorkspaceHandoffOp, CloudWorkspaceMobility
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.utils.time import utcnow
+
+
+class RetryableMobilityFailurePredicate(Protocol):
+    def __call__(
+        self,
+        *,
+        lifecycle_state: str,
+        has_active_handoff: bool,
+    ) -> bool: ...
 
 
 @dataclass(frozen=True)
@@ -138,11 +148,11 @@ def _clear_retryable_handoff_failure(
     *,
     owner_hint: str,
     active_lifecycle_state: str,
-    retryable_lifecycle_state: str,
+    is_retryable_failure: RetryableMobilityFailurePredicate,
 ) -> bool:
-    if (
-        record.lifecycle_state != retryable_lifecycle_state
-        or record.active_handoff_op_id is not None
+    if not is_retryable_failure(
+        lifecycle_state=record.lifecycle_state,
+        has_active_handoff=record.active_handoff_op_id is not None,
     ):
         return False
 
@@ -310,7 +320,7 @@ async def ensure_cloud_workspace_mobility(
     git_branch: str,
     owner_hint: str,
     active_lifecycle_state: str,
-    retryable_lifecycle_state: str,
+    is_retryable_failure: RetryableMobilityFailurePredicate,
     display_name: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceMobilityValue:
@@ -352,7 +362,7 @@ async def ensure_cloud_workspace_mobility(
         record,
         owner_hint=owner_hint,
         active_lifecycle_state=active_lifecycle_state,
-        retryable_lifecycle_state=retryable_lifecycle_state,
+        is_retryable_failure=is_retryable_failure,
     )
     if display_name is not None and display_name != record.display_name:
         record.display_name = display_name
@@ -380,7 +390,7 @@ async def backfill_cloud_workspace_mobility_from_workspace(
     *,
     workspace: CloudWorkspace,
     active_lifecycle_state: str,
-    retryable_lifecycle_state: str,
+    is_retryable_failure: RetryableMobilityFailurePredicate,
 ) -> CloudWorkspaceMobilityValue:
     return await ensure_cloud_workspace_mobility(
         db,
@@ -391,7 +401,7 @@ async def backfill_cloud_workspace_mobility_from_workspace(
         git_branch=workspace.git_branch,
         owner_hint="cloud",
         active_lifecycle_state=active_lifecycle_state,
-        retryable_lifecycle_state=retryable_lifecycle_state,
+        is_retryable_failure=is_retryable_failure,
         display_name=workspace.display_name,
         cloud_workspace_id=workspace.id,
     )
@@ -598,7 +608,7 @@ async def ensure_cloud_workspace_mobility_for_user(
     git_branch: str,
     owner_hint: str,
     active_lifecycle_state: str,
-    retryable_lifecycle_state: str,
+    is_retryable_failure: RetryableMobilityFailurePredicate,
     display_name: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceMobilityValue:
@@ -612,7 +622,7 @@ async def ensure_cloud_workspace_mobility_for_user(
             git_branch=git_branch,
             owner_hint=owner_hint,
             active_lifecycle_state=active_lifecycle_state,
-            retryable_lifecycle_state=retryable_lifecycle_state,
+            is_retryable_failure=is_retryable_failure,
             display_name=display_name,
             cloud_workspace_id=cloud_workspace_id,
         )
@@ -622,14 +632,14 @@ async def backfill_cloud_workspace_mobility_for_workspace(
     *,
     workspace: CloudWorkspace,
     active_lifecycle_state: str,
-    retryable_lifecycle_state: str,
+    is_retryable_failure: RetryableMobilityFailurePredicate,
 ) -> CloudWorkspaceMobilityValue:
     async with db_engine.async_session_factory() as db:
         return await backfill_cloud_workspace_mobility_from_workspace(
             db,
             workspace=workspace,
             active_lifecycle_state=active_lifecycle_state,
-            retryable_lifecycle_state=retryable_lifecycle_state,
+            is_retryable_failure=is_retryable_failure,
         )
 
 

--- a/server/proliferate/db/store/cloud_workspace_setup_runs.py
+++ b/server/proliferate/db/store/cloud_workspace_setup_runs.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
+from typing import Protocol
 from uuid import UUID
 
 from sqlalchemy import or_, select
@@ -11,8 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.constants.cloud import (
     SETUP_RUN_ACTIVE_STATUSES,
     SETUP_RUN_STATUS_RUNNING,
-    bounded_setup_monitor_error,
-    classify_setup_run_finalization,
 )
 from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.workspaces import CloudWorkspace, CloudWorkspaceSetupRun
@@ -20,6 +20,43 @@ from proliferate.utils.time import utcnow
 
 SETUP_MONITOR_CLAIM_TTL = timedelta(seconds=45)
 SETUP_MONITOR_POLL_INTERVAL = timedelta(seconds=5)
+SetupMonitorErrorBounder = Callable[[str | None], str | None]
+
+
+class _SetupRunFinalizationPhase(Protocol):
+    value: str
+
+
+class _SetupRunWorkspaceFinalization(Protocol):
+    phase: _SetupRunFinalizationPhase
+    status_detail: str
+    repo_setup_applied_version: int | None
+    repo_files_last_error: str | None
+
+
+class _SetupRunFinalizationDecision(Protocol):
+    run_status: str
+    run_last_error: str | None
+    should_update_workspace: bool
+    set_last_polled_at: bool
+    clear_next_poll_at: bool
+    workspace_update: _SetupRunWorkspaceFinalization | None
+
+
+class SetupRunFinalizationClassifier(Protocol):
+    def __call__(
+        self,
+        *,
+        workspace_exists: bool,
+        workspace_apply_token: str | None,
+        workspace_phase: str | None,
+        run_apply_token: str,
+        command_run_id: str | None,
+        final_status: str,
+        success: bool,
+        last_error: str | None,
+        setup_script_version: int,
+    ) -> _SetupRunFinalizationDecision: ...
 
 
 async def create_cloud_workspace_setup_run(
@@ -109,6 +146,7 @@ async def claim_due_setup_runs(
 async def release_setup_run_claim(
     setup_run_id: UUID,
     *,
+    bound_error: SetupMonitorErrorBounder,
     status: str = SETUP_RUN_STATUS_RUNNING,
     next_poll_at: datetime | None = None,
     last_error: str | None = None,
@@ -123,7 +161,7 @@ async def release_setup_run_claim(
         run.claim_until = None
         run.last_polled_at = now
         run.next_poll_at = next_poll_at or (now + SETUP_MONITOR_POLL_INTERVAL)
-        run.last_error = bounded_setup_monitor_error(last_error)
+        run.last_error = bound_error(last_error)
         run.updated_at = now
         await db.commit()
 
@@ -131,18 +169,27 @@ async def release_setup_run_claim(
 async def finalize_setup_run(
     setup_run_id: UUID,
     *,
+    classify_finalization: SetupRunFinalizationClassifier,
     final_status: str,
     success: bool,
     last_error: str | None = None,
 ) -> None:
     async with db_engine.async_session_factory() as db:
-        await _finalize_setup_run(db, setup_run_id, final_status, success, last_error)
+        await _finalize_setup_run(
+            db,
+            setup_run_id,
+            classify_finalization,
+            final_status,
+            success,
+            last_error,
+        )
         await db.commit()
 
 
 async def _finalize_setup_run(
     db: AsyncSession,
     setup_run_id: UUID,
+    classify_finalization: SetupRunFinalizationClassifier,
     final_status: str,
     success: bool,
     last_error: str | None,
@@ -152,7 +199,7 @@ async def _finalize_setup_run(
         return
     now = utcnow()
     workspace = await db.get(CloudWorkspace, run.workspace_id)
-    decision = classify_setup_run_finalization(
+    decision = classify_finalization(
         workspace_exists=workspace is not None,
         workspace_apply_token=(
             workspace.repo_post_ready_apply_token if workspace is not None else None
@@ -192,9 +239,14 @@ async def _finalize_setup_run(
     workspace.status_detail = workspace_update.status_detail
 
 
-async def mark_setup_run_timed_out(setup_run_id: UUID) -> None:
+async def mark_setup_run_timed_out(
+    setup_run_id: UUID,
+    *,
+    classify_finalization: SetupRunFinalizationClassifier,
+) -> None:
     await finalize_setup_run(
         setup_run_id,
+        classify_finalization=classify_finalization,
         final_status="timed_out",
         success=False,
         last_error="Repo setup monitor timed out.",

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -45,6 +45,7 @@ from proliferate.server.cloud.mobility.domain.lifecycle import (
     OWNER_CLOUD,
     active_lifecycle_state,
     is_local_to_cloud_direction,
+    is_retryable_mobility_failure,
     is_valid_handoff_direction,
     is_valid_handoff_phase,
     is_valid_owner,
@@ -105,7 +106,7 @@ async def list_cloud_workspace_mobility_for_user(
         await backfill_cloud_workspace_mobility_for_workspace(
             workspace=workspace,
             active_lifecycle_state=active_lifecycle_state(OWNER_CLOUD),
-            retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+            is_retryable_failure=is_retryable_mobility_failure,
         )
     return await list_cloud_workspace_mobility_store(user_id=user_id)
 
@@ -147,7 +148,7 @@ async def ensure_cloud_workspace_mobility(
         git_branch=git_branch,
         owner_hint=owner_hint,
         active_lifecycle_state=active_lifecycle_state(owner_hint),
-        retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        is_retryable_failure=is_retryable_mobility_failure,
         display_name=resolved_display_name,
         cloud_workspace_id=cloud_workspace_id,
     )

--- a/server/proliferate/server/cloud/runtime/repo_config_apply.py
+++ b/server/proliferate/server/cloud/runtime/repo_config_apply.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from uuid import UUID, uuid4
 
-from proliferate.constants.cloud import WorkspacePostReadyPhase
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigValue,
@@ -29,14 +28,22 @@ from proliferate.integrations.anyharness import (
 )
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workspaces.domain.post_ready import (
+    WorkspacePostReadyStatusPatch,
+    repo_config_apply_started,
+    repo_config_completed,
+    repo_config_empty_completed,
+    repo_config_file_failed,
+    repo_config_file_progress,
+    repo_config_files_version_applied,
+    repo_setup_start_failed,
+    repo_setup_starting,
+)
 from proliferate.utils.time import duration_ms, utcnow
 
 
 class WorkspaceRepoApplyBusyError(RuntimeError):
     """Raised when a workspace already has an apply or setup operation in flight."""
-
-
-_SKIP = object()
 
 
 @dataclass(frozen=True)
@@ -72,43 +79,37 @@ async def _load_workspace_repo_config(workspace: CloudWorkspace) -> CloudRepoCon
     )
 
 
-async def _set_apply_phase(
+async def _apply_post_ready_patch(
     workspace_id: UUID,
-    *,
-    phase: WorkspacePostReadyPhase,
-    files_total: int | None = None,
-    files_applied: int | None = None,
-    started: bool = False,
-    completed: bool = False,
-    failed_path: str | None | object = _SKIP,
-    failed_error: str | None | object = _SKIP,
-    files_version: int | None = None,
-    applied_now: bool = False,
-    status_detail: str,
-    apply_token: str | None | object = _SKIP,
+    patch: WorkspacePostReadyStatusPatch,
 ) -> None:
-    kwargs: dict[str, object] = {
-        "repo_post_ready_phase": phase.value,
-        "status_detail": status_detail,
-    }
-    if files_total is not None:
-        kwargs["repo_post_ready_files_total"] = files_total
-    if files_applied is not None:
-        kwargs["repo_post_ready_files_applied"] = files_applied
-    if started:
+    kwargs: dict[str, object] = {}
+    if patch.phase is not None:
+        kwargs["repo_post_ready_phase"] = patch.phase.value
+    if patch.status_detail is not None:
+        kwargs["status_detail"] = patch.status_detail
+    if patch.files_total is not None:
+        kwargs["repo_post_ready_files_total"] = patch.files_total
+    if patch.files_applied is not None:
+        kwargs["repo_post_ready_files_applied"] = patch.files_applied
+    if patch.mark_started:
         kwargs["repo_post_ready_started_at"] = utcnow()
-    if completed:
+    if patch.mark_completed:
         kwargs["repo_post_ready_completed_at"] = utcnow()
-    if failed_path is not _SKIP:
-        kwargs["repo_files_last_failed_path"] = failed_path
-    if failed_error is not _SKIP:
-        kwargs["repo_files_last_error"] = failed_error
-    if files_version is not None:
-        kwargs["repo_files_applied_version"] = files_version
-    if applied_now:
+    if patch.clear_completed_at:
+        kwargs["repo_post_ready_completed_at"] = None
+    if patch.set_failed_path:
+        kwargs["repo_files_last_failed_path"] = patch.failed_path
+    if patch.set_failed_error:
+        kwargs["repo_files_last_error"] = patch.failed_error
+    if patch.files_version is not None:
+        kwargs["repo_files_applied_version"] = patch.files_version
+    if patch.mark_applied_now:
         kwargs["repo_files_applied_at"] = utcnow()
-    if apply_token is not _SKIP:
-        kwargs["repo_post_ready_apply_token"] = apply_token
+    if patch.clear_apply_token:
+        kwargs["repo_post_ready_apply_token"] = None
+    elif patch.apply_token is not None:
+        kwargs["repo_post_ready_apply_token"] = patch.apply_token
     await update_workspace_repo_apply_status_by_id(workspace_id, **kwargs)
 
 
@@ -120,16 +121,7 @@ async def _start_workspace_setup_monitor(
     setup_script: str,
 ) -> WorkspaceSetupStartResult:
     apply_token = uuid4().hex
-    await update_workspace_repo_apply_status_by_id(
-        workspace.id,
-        repo_post_ready_phase=WorkspacePostReadyPhase.starting_setup.value,
-        repo_post_ready_started_at=utcnow(),
-        repo_post_ready_completed_at=None,
-        repo_post_ready_apply_token=apply_token,
-        repo_files_last_failed_path=None,
-        repo_files_last_error=None,
-        status_detail="Starting repo setup",
-    )
+    await _apply_post_ready_patch(workspace.id, repo_setup_starting(apply_token))
     try:
         setup_started = time.perf_counter()
         started = await start_remote_workspace_setup(
@@ -160,14 +152,9 @@ async def _start_workspace_setup_monitor(
         )
     except Exception as exc:
         error_message = format_exception_message(exc)
-        await update_workspace_repo_apply_status_by_id(
+        await _apply_post_ready_patch(
             workspace.id,
-            repo_post_ready_phase=WorkspacePostReadyPhase.failed.value,
-            repo_post_ready_completed_at=utcnow(),
-            repo_post_ready_apply_token=None,
-            repo_files_last_failed_path=None,
-            repo_files_last_error=error_message,
-            status_detail="Repo setup failed to start",
+            repo_setup_start_failed(error_message),
         )
         raise CloudRuntimeOperationError(error_message) from exc
 
@@ -186,16 +173,7 @@ async def _apply_repo_files(
     repo_config: CloudRepoConfigValue,
 ) -> None:
     total_files = len(repo_config.tracked_files)
-    await _set_apply_phase(
-        workspace.id,
-        phase=WorkspacePostReadyPhase.applying_files,
-        files_total=total_files,
-        files_applied=0,
-        started=True,
-        failed_path=None,
-        failed_error=None,
-        status_detail="Applying repo config",
-    )
+    await _apply_post_ready_patch(workspace.id, repo_config_apply_started(total_files))
 
     for index, tracked_file in enumerate(repo_config.tracked_files, start=1):
         try:
@@ -233,30 +211,20 @@ async def _apply_repo_files(
             )
         except Exception as exc:
             error_message = format_exception_message(exc)
-            await update_workspace_repo_apply_status_by_id(
+            await _apply_post_ready_patch(
                 workspace.id,
-                repo_post_ready_phase=WorkspacePostReadyPhase.failed.value,
-                repo_post_ready_completed_at=utcnow(),
-                repo_files_last_failed_path=tracked_file.relative_path,
-                repo_files_last_error=error_message,
-                status_detail="Repo config apply failed",
+                repo_config_file_failed(
+                    relative_path=tracked_file.relative_path,
+                    error=error_message,
+                ),
             )
             raise CloudRuntimeOperationError(error_message) from exc
 
-        await update_workspace_repo_apply_status_by_id(
-            workspace.id,
-            repo_post_ready_files_applied=index,
-            repo_files_last_failed_path=None,
-            repo_files_last_error=None,
-            status_detail="Applying repo config",
-        )
+        await _apply_post_ready_patch(workspace.id, repo_config_file_progress(index))
 
-    await update_workspace_repo_apply_status_by_id(
+    await _apply_post_ready_patch(
         workspace.id,
-        repo_files_applied_version=repo_config.files_version,
-        repo_files_applied_at=utcnow(),
-        repo_files_last_failed_path=None,
-        repo_files_last_error=None,
+        repo_config_files_version_applied(repo_config.files_version),
     )
 
 
@@ -269,18 +237,7 @@ async def apply_workspace_repo_config(
     async with _workspace_apply_lock(workspace.id):
         repo_config = await _load_workspace_repo_config(workspace)
         if repo_config is None:
-            await _set_apply_phase(
-                workspace.id,
-                phase=WorkspacePostReadyPhase.completed,
-                files_total=0,
-                files_applied=0,
-                completed=True,
-                files_version=0,
-                applied_now=True,
-                failed_path=None,
-                failed_error=None,
-                status_detail="Ready",
-            )
+            await _apply_post_ready_patch(workspace.id, repo_config_empty_completed())
             return None
 
         await _apply_repo_files(workspace, runtime=runtime, repo_config=repo_config)
@@ -295,18 +252,13 @@ async def apply_workspace_repo_config(
             )
             return repo_config
 
-        await _set_apply_phase(
+        await _apply_post_ready_patch(
             workspace.id,
-            phase=WorkspacePostReadyPhase.completed,
-            files_total=len(repo_config.tracked_files),
-            files_applied=len(repo_config.tracked_files),
-            completed=True,
-            files_version=repo_config.files_version,
-            applied_now=True,
-            failed_path=None,
-            failed_error=None,
-            status_detail="Ready",
-            apply_token=None,
+            repo_config_completed(
+                files_total=len(repo_config.tracked_files),
+                files_version=repo_config.files_version,
+                clear_apply_token=True,
+            ),
         )
         return repo_config
 

--- a/server/proliferate/server/cloud/runtime/setup_monitor.py
+++ b/server/proliferate/server/cloud/runtime/setup_monitor.py
@@ -19,6 +19,10 @@ from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
 from proliferate.integrations.anyharness import get_remote_terminal_command_run
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
 from proliferate.server.cloud.runtime.service import get_workspace_connection
+from proliferate.server.cloud.workspaces.domain.setup_runs import (
+    bounded_setup_monitor_error,
+    classify_setup_run_finalization,
+)
 from proliferate.utils.time import duration_ms, utcnow
 
 _SETUP_MONITOR_POLL_SECONDS = 5
@@ -69,14 +73,14 @@ async def reconcile_cloud_setup_runs() -> None:
         except Exception as exc:
             error_message = format_exception_message(exc)
             if utcnow() >= run.deadline_at:
-                await finalize_setup_run(
+                await _finalize_setup_run(
                     run.id,
                     final_status="failed",
                     success=False,
                     last_error=error_message,
                 )
             else:
-                await release_setup_run_claim(run.id, last_error=error_message)
+                await _release_setup_run_claim(run.id, last_error=error_message)
 
 
 async def _poll_setup_run(setup_run_id: UUID) -> None:
@@ -84,12 +88,12 @@ async def _poll_setup_run(setup_run_id: UUID) -> None:
     if setup_run is None:
         return
     if utcnow() >= setup_run.deadline_at:
-        await mark_setup_run_timed_out(setup_run.id)
+        await _mark_setup_run_timed_out(setup_run.id)
         return
 
     workspace = await load_cloud_workspace_by_id(setup_run.workspace_id)
     if workspace is None:
-        await finalize_setup_run(
+        await _finalize_setup_run(
             setup_run.id,
             final_status="stale",
             success=False,
@@ -99,7 +103,7 @@ async def _poll_setup_run(setup_run_id: UUID) -> None:
 
     target = await get_workspace_connection(workspace)
     if not target.anyharness_workspace_id:
-        await release_setup_run_claim(
+        await _release_setup_run_claim(
             setup_run.id,
             last_error="Cloud workspace runtime is not ready yet.",
         )
@@ -121,15 +125,15 @@ async def _poll_setup_run(setup_run_id: UUID) -> None:
     )
 
     if detail.status in {"queued", "running"}:
-        await release_setup_run_claim(setup_run.id, status="running")
+        await _release_setup_run_claim(setup_run.id, status="running")
         return
 
     if detail.status == "succeeded":
-        await finalize_setup_run(setup_run.id, final_status="succeeded", success=True)
+        await _finalize_setup_run(setup_run.id, final_status="succeeded", success=True)
         return
 
     final_status = "timed_out" if detail.status == "timed_out" else "failed"
-    await finalize_setup_run(
+    await _finalize_setup_run(
         setup_run.id,
         final_status=final_status,
         success=False,
@@ -146,3 +150,40 @@ def _setup_error_message(
         if value and value.strip():
             return value.strip()
     return "Repo setup failed."
+
+
+async def _release_setup_run_claim(
+    setup_run_id: UUID,
+    *,
+    status: str = "running",
+    last_error: str | None = None,
+) -> None:
+    await release_setup_run_claim(
+        setup_run_id,
+        bound_error=bounded_setup_monitor_error,
+        status=status,
+        last_error=last_error,
+    )
+
+
+async def _finalize_setup_run(
+    setup_run_id: UUID,
+    *,
+    final_status: str,
+    success: bool,
+    last_error: str | None = None,
+) -> None:
+    await finalize_setup_run(
+        setup_run_id,
+        classify_finalization=classify_setup_run_finalization,
+        final_status=final_status,
+        success=success,
+        last_error=last_error,
+    )
+
+
+async def _mark_setup_run_timed_out(setup_run_id: UUID) -> None:
+    await mark_setup_run_timed_out(
+        setup_run_id,
+        classify_finalization=classify_setup_run_finalization,
+    )

--- a/server/proliferate/server/cloud/workspaces/domain/post_ready.py
+++ b/server/proliferate/server/cloud/workspaces/domain/post_ready.py
@@ -1,0 +1,126 @@
+"""Pure post-ready repo-apply status decisions for cloud workspaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from proliferate.constants.cloud import WorkspacePostReadyPhase
+
+
+@dataclass(frozen=True)
+class WorkspacePostReadyStatusPatch:
+    phase: WorkspacePostReadyPhase | None = None
+    status_detail: str | None = None
+    files_total: int | None = None
+    files_applied: int | None = None
+    mark_started: bool = False
+    mark_completed: bool = False
+    clear_completed_at: bool = False
+    set_failed_path: bool = False
+    failed_path: str | None = None
+    set_failed_error: bool = False
+    failed_error: str | None = None
+    files_version: int | None = None
+    mark_applied_now: bool = False
+    apply_token: str | None = None
+    clear_apply_token: bool = False
+
+
+def repo_setup_starting(apply_token: str) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        phase=WorkspacePostReadyPhase.starting_setup,
+        status_detail="Starting repo setup",
+        mark_started=True,
+        clear_completed_at=True,
+        set_failed_path=True,
+        set_failed_error=True,
+        apply_token=apply_token,
+    )
+
+
+def repo_setup_start_failed(error: str) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        phase=WorkspacePostReadyPhase.failed,
+        status_detail="Repo setup failed to start",
+        mark_completed=True,
+        set_failed_path=True,
+        set_failed_error=True,
+        failed_error=error,
+        clear_apply_token=True,
+    )
+
+
+def repo_config_apply_started(files_total: int) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        phase=WorkspacePostReadyPhase.applying_files,
+        status_detail="Applying repo config",
+        files_total=files_total,
+        files_applied=0,
+        mark_started=True,
+        set_failed_path=True,
+        set_failed_error=True,
+    )
+
+
+def repo_config_file_progress(files_applied: int) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        status_detail="Applying repo config",
+        files_applied=files_applied,
+        set_failed_path=True,
+        set_failed_error=True,
+    )
+
+
+def repo_config_file_failed(
+    *,
+    relative_path: str,
+    error: str,
+) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        phase=WorkspacePostReadyPhase.failed,
+        status_detail="Repo config apply failed",
+        mark_completed=True,
+        set_failed_path=True,
+        failed_path=relative_path,
+        set_failed_error=True,
+        failed_error=error,
+    )
+
+
+def repo_config_files_version_applied(
+    files_version: int,
+) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        files_version=files_version,
+        mark_applied_now=True,
+        set_failed_path=True,
+        set_failed_error=True,
+    )
+
+
+def repo_config_empty_completed() -> WorkspacePostReadyStatusPatch:
+    return repo_config_completed(
+        files_total=0,
+        files_version=0,
+        clear_apply_token=False,
+    )
+
+
+def repo_config_completed(
+    *,
+    files_total: int,
+    files_version: int,
+    clear_apply_token: bool,
+) -> WorkspacePostReadyStatusPatch:
+    return WorkspacePostReadyStatusPatch(
+        phase=WorkspacePostReadyPhase.completed,
+        status_detail="Ready",
+        files_total=files_total,
+        files_applied=files_total,
+        mark_completed=True,
+        set_failed_path=True,
+        set_failed_error=True,
+        files_version=files_version,
+        mark_applied_now=True,
+        clear_apply_token=clear_apply_token,
+    )

--- a/server/proliferate/server/cloud/workspaces/domain/setup_runs.py
+++ b/server/proliferate/server/cloud/workspaces/domain/setup_runs.py
@@ -1,0 +1,118 @@
+"""Pure setup-run lifecycle decisions for cloud workspaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from proliferate.constants.cloud import (
+    MAX_SETUP_MONITOR_ERROR_CHARS,
+    SETUP_RUN_DEFAULT_FAILURE_ERROR,
+    SETUP_RUN_MISSING_WORKSPACE_ERROR,
+    SETUP_RUN_STATUS_STALE,
+    SETUP_RUN_SUPERSEDED_ERROR,
+    WorkspacePostReadyPhase,
+)
+
+
+@dataclass(frozen=True)
+class SetupRunWorkspaceFinalization:
+    phase: WorkspacePostReadyPhase
+    status_detail: str
+    repo_setup_applied_version: int | None = None
+    repo_files_last_error: str | None = None
+
+
+@dataclass(frozen=True)
+class SetupRunFinalizationDecision:
+    run_status: str
+    run_last_error: str | None
+    should_update_workspace: bool
+    set_last_polled_at: bool
+    clear_next_poll_at: bool
+    workspace_update: SetupRunWorkspaceFinalization | None = None
+
+
+def bounded_setup_monitor_error(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value[:MAX_SETUP_MONITOR_ERROR_CHARS]
+
+
+def setup_run_has_active_workspace_token(
+    *,
+    workspace_apply_token: str | None,
+    workspace_phase: WorkspacePostReadyPhase | str | None,
+    run_apply_token: str,
+    command_run_id: str | None,
+) -> bool:
+    phase_value = (
+        workspace_phase.value
+        if isinstance(workspace_phase, WorkspacePostReadyPhase)
+        else workspace_phase
+    )
+    return bool(
+        workspace_apply_token == run_apply_token
+        and command_run_id
+        and phase_value == WorkspacePostReadyPhase.starting_setup.value
+    )
+
+
+def classify_setup_run_finalization(
+    *,
+    workspace_exists: bool,
+    workspace_apply_token: str | None,
+    workspace_phase: WorkspacePostReadyPhase | str | None,
+    run_apply_token: str,
+    command_run_id: str | None,
+    final_status: str,
+    success: bool,
+    last_error: str | None,
+    setup_script_version: int,
+) -> SetupRunFinalizationDecision:
+    if not workspace_exists:
+        return SetupRunFinalizationDecision(
+            run_status=SETUP_RUN_STATUS_STALE,
+            run_last_error=SETUP_RUN_MISSING_WORKSPACE_ERROR,
+            should_update_workspace=False,
+            set_last_polled_at=False,
+            clear_next_poll_at=False,
+        )
+
+    if not setup_run_has_active_workspace_token(
+        workspace_apply_token=workspace_apply_token,
+        workspace_phase=workspace_phase,
+        run_apply_token=run_apply_token,
+        command_run_id=command_run_id,
+    ):
+        return SetupRunFinalizationDecision(
+            run_status=SETUP_RUN_STATUS_STALE,
+            run_last_error=SETUP_RUN_SUPERSEDED_ERROR,
+            should_update_workspace=False,
+            set_last_polled_at=False,
+            clear_next_poll_at=False,
+        )
+
+    bounded_last_error = bounded_setup_monitor_error(last_error)
+    if success:
+        workspace_update = SetupRunWorkspaceFinalization(
+            phase=WorkspacePostReadyPhase.completed,
+            repo_setup_applied_version=setup_script_version,
+            repo_files_last_error=None,
+            status_detail="Ready",
+        )
+    else:
+        workspace_update = SetupRunWorkspaceFinalization(
+            phase=WorkspacePostReadyPhase.failed,
+            repo_setup_applied_version=None,
+            repo_files_last_error=bounded_last_error or SETUP_RUN_DEFAULT_FAILURE_ERROR,
+            status_detail="Repo setup failed",
+        )
+
+    return SetupRunFinalizationDecision(
+        run_status=final_status,
+        run_last_error=bounded_last_error,
+        should_update_workspace=True,
+        set_last_polled_at=True,
+        clear_next_poll_at=True,
+        workspace_update=workspace_update,
+    )

--- a/server/tests/integration/test_cloud_workspace_lifecycle_store.py
+++ b/server/tests/integration/test_cloud_workspace_lifecycle_store.py
@@ -27,6 +27,10 @@ from proliferate.db.store.cloud_workspaces import (
     reserve_sandbox_slot_for_workspace,
 )
 from proliferate.server.cloud.workspaces import service as workspace_service
+from proliferate.server.cloud.workspaces.domain.setup_runs import (
+    bounded_setup_monitor_error,
+    classify_setup_run_finalization,
+)
 
 
 def _patch_global_session_factory(
@@ -100,7 +104,12 @@ async def test_setup_run_claim_release_and_expired_claim_reclaim(
     assert [run.id for run in next_claim] == [second.id]
 
     next_poll_at = now + timedelta(seconds=30)
-    await release_setup_run_claim(first.id, next_poll_at=next_poll_at, last_error="retry")
+    await release_setup_run_claim(
+        first.id,
+        bound_error=bounded_setup_monitor_error,
+        next_poll_at=next_poll_at,
+        last_error="retry",
+    )
     released = await db_session.get(type(first), first.id)
     assert released is not None
     await db_session.refresh(released)
@@ -146,7 +155,12 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
         apply_token="old-token",
         deadline_at=datetime.now(UTC) + timedelta(minutes=10),
     )
-    await finalize_setup_run(stale_run.id, final_status="succeeded", success=True)
+    await finalize_setup_run(
+        stale_run.id,
+        classify_finalization=classify_setup_run_finalization,
+        final_status="succeeded",
+        success=True,
+    )
 
     await db_session.refresh(stored_workspace)
     stale_record = await db_session.get(type(stale_run), stale_run.id)
@@ -166,7 +180,12 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
         apply_token="current-token",
         deadline_at=datetime.now(UTC) + timedelta(minutes=10),
     )
-    await finalize_setup_run(active_run.id, final_status="succeeded", success=True)
+    await finalize_setup_run(
+        active_run.id,
+        classify_finalization=classify_setup_run_finalization,
+        final_status="succeeded",
+        success=True,
+    )
 
     await db_session.refresh(stored_workspace)
     active_record = await db_session.get(type(active_run), active_run.id)

--- a/server/tests/unit/test_cloud_mobility_store.py
+++ b/server/tests/unit/test_cloud_mobility_store.py
@@ -8,9 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.db.models.cloud.mobility import CloudWorkspaceMobility
 from proliferate.db.store.cloud_mobility import ensure_cloud_workspace_mobility
 from proliferate.server.cloud.mobility.domain.lifecycle import (
-    LIFECYCLE_HANDOFF_FAILED,
     OWNER_LOCAL,
     active_lifecycle_state,
+    is_retryable_mobility_failure,
 )
 
 
@@ -49,7 +49,7 @@ async def test_ensure_clears_retryable_handoff_failure(
         git_branch="gannet",
         owner_hint="local",
         active_lifecycle_state=active_lifecycle_state(OWNER_LOCAL),
-        retryable_lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
+        is_retryable_failure=is_retryable_mobility_failure,
         display_name="Gannet",
         cloud_workspace_id=None,
     )

--- a/server/tests/unit/test_cloud_workspace_lifecycle_domain.py
+++ b/server/tests/unit/test_cloud_workspace_lifecycle_domain.py
@@ -7,8 +7,6 @@ from proliferate.constants.cloud import (
     SETUP_RUN_STATUS_STALE,
     SETUP_RUN_SUPERSEDED_ERROR,
     WorkspacePostReadyPhase,
-    classify_setup_run_finalization,
-    setup_run_has_active_workspace_token,
 )
 from proliferate.server.cloud.workspaces.domain.lifecycle import (
     VALID_STATUS_TRANSITIONS,
@@ -16,6 +14,20 @@ from proliferate.server.cloud.workspaces.domain.lifecycle import (
     decide_workspace_status_transition,
     provider_failure_debug_state,
     start_request_should_return_existing,
+)
+from proliferate.server.cloud.workspaces.domain.post_ready import (
+    repo_config_apply_started,
+    repo_config_completed,
+    repo_config_empty_completed,
+    repo_config_file_failed,
+    repo_config_file_progress,
+    repo_config_files_version_applied,
+    repo_setup_start_failed,
+    repo_setup_starting,
+)
+from proliferate.server.cloud.workspaces.domain.setup_runs import (
+    classify_setup_run_finalization,
+    setup_run_has_active_workspace_token,
 )
 
 
@@ -183,6 +195,62 @@ def test_setup_run_finalization_classifies_stale_and_active_results() -> None:
     assert failed.workspace_update is not None
     assert failed.workspace_update.phase == WorkspacePostReadyPhase.failed
     assert failed.workspace_update.repo_files_last_error == SETUP_RUN_DEFAULT_FAILURE_ERROR
+
+
+def test_post_ready_patch_builders_capture_repo_apply_status_decisions() -> None:
+    started = repo_config_apply_started(3)
+    progress = repo_config_file_progress(2)
+    failed = repo_config_file_failed(relative_path="setup.sh", error="boom")
+    version_applied = repo_config_files_version_applied(7)
+    empty_completed = repo_config_empty_completed()
+    completed = repo_config_completed(
+        files_total=3,
+        files_version=7,
+        clear_apply_token=True,
+    )
+
+    assert started.phase == WorkspacePostReadyPhase.applying_files
+    assert started.files_total == 3
+    assert started.files_applied == 0
+    assert started.mark_started is True
+    assert started.status_detail == "Applying repo config"
+    assert progress.phase is None
+    assert progress.files_applied == 2
+    assert progress.set_failed_path is True
+    assert progress.set_failed_error is True
+    assert failed.phase == WorkspacePostReadyPhase.failed
+    assert failed.failed_path == "setup.sh"
+    assert failed.failed_error == "boom"
+    assert failed.mark_completed is True
+    assert failed.status_detail == "Repo config apply failed"
+    assert version_applied.files_version == 7
+    assert version_applied.mark_applied_now is True
+    assert empty_completed.phase == WorkspacePostReadyPhase.completed
+    assert empty_completed.files_total == 0
+    assert empty_completed.files_version == 0
+    assert empty_completed.clear_apply_token is False
+    assert completed.phase == WorkspacePostReadyPhase.completed
+    assert completed.files_total == 3
+    assert completed.files_applied == 3
+    assert completed.files_version == 7
+    assert completed.clear_apply_token is True
+    assert completed.status_detail == "Ready"
+
+
+def test_post_ready_patch_builders_capture_setup_status_decisions() -> None:
+    starting = repo_setup_starting("apply-token")
+    failed = repo_setup_start_failed("start failed")
+
+    assert starting.phase == WorkspacePostReadyPhase.starting_setup
+    assert starting.apply_token == "apply-token"
+    assert starting.mark_started is True
+    assert starting.clear_completed_at is True
+    assert starting.status_detail == "Starting repo setup"
+    assert failed.phase == WorkspacePostReadyPhase.failed
+    assert failed.failed_error == "start failed"
+    assert failed.clear_apply_token is True
+    assert failed.mark_completed is True
+    assert failed.status_detail == "Repo setup failed to start"
 
 
 def test_provider_failure_debug_state_preserves_stop_but_clears_destroy() -> None:


### PR DESCRIPTION
## Summary

- move cloud workspace setup-run finalization decisions out of shared constants into workspace domain helpers
- move post-ready repo-apply status decisions into pure workspace-domain patch builders and keep runtime code focused on execution
- wire mobility retryable-failure cleanup through the domain predicate without adding store -> product imports

## Verification

- cd server && uv run --extra dev --python /opt/homebrew/bin/python3.12 ruff check proliferate/server/cloud/workspaces/domain/setup_runs.py proliferate/server/cloud/workspaces/domain/post_ready.py proliferate/server/cloud/runtime/repo_config_apply.py proliferate/server/cloud/runtime/setup_monitor.py proliferate/db/store/cloud_workspace_setup_runs.py tests/unit/test_cloud_workspace_lifecycle_domain.py tests/integration/test_cloud_workspace_lifecycle_store.py proliferate/db/store/cloud_mobility.py proliferate/server/cloud/mobility/service.py tests/unit/test_cloud_mobility_store.py
- cd server && DEBUG=true uv run --extra dev --python /opt/homebrew/bin/python3.12 python -m pytest -q tests/unit/test_cloud_workspace_lifecycle_domain.py tests/integration/test_cloud_workspace_lifecycle_store.py tests/unit/test_cloud_workspace_service.py tests/integration/test_cloud_repo_limits.py
- cd server && DEBUG=1 uv run --extra dev --python /opt/homebrew/bin/python3.12 pytest -q tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_service_lifecycle.py tests/unit/test_cloud_mobility_store.py tests/unit/test_cloud_mobility_lifecycle.py tests/unit/test_cloud_mobility_domain.py
- python3.12 scripts/check_server_boundaries.py
- python3.12 scripts/check_max_lines.py
- git diff --check