### PR TITLE
refactor(server): align non-deferred ownership cleanup

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -47,6 +47,14 @@ step is design clarity before code movement:
 - [audits/phase6-cloud-runtime-background-loops.md](audits/phase6-cloud-runtime-background-loops.md)
   for the cloud runtime setup monitor and provisioning scheduler audit.
 
+The [Phase 8 server tracker](../../reference/server_phase8_tracker.md)
+coordinates the remaining deferred complex systems. Normal server code follows
+this README and the focused guides now; the tracker only names lanes whose
+lifecycle, transaction, retry, or external-I/O semantics still need staged
+cleanup. Deferred lanes are not exemptions: when touching them, preserve the
+listed invariants and take invariant-pinned opportunistic cleanup toward the
+guide shape.
+
 Specs (when added) define product/surface contracts: lifecycle invariants,
 edge cases, and focused verification for a specific cross-cutting flow such as
 billing, runtime provisioning, or MCP. None are written yet.

--- a/reference/server_phase8_tracker.md
+++ b/reference/server_phase8_tracker.md
@@ -10,6 +10,18 @@ Source note: `reference/server_cleanup_migration_sequence.md` was requested as
 an input, but it is not present on current `origin/main`. This tracker uses the
 Phase 8 audit docs present on main plus the post-Wave-3 audit context.
 
+## How to use this tracker
+
+- Start from `docs/server/README.md` and the focused server guides for normal
+  code. They are the current rules.
+- Use this tracker only for the deferred complex lanes below: systems whose
+  lifecycle, transaction, retry, or external-I/O semantics need staged cleanup.
+- Deferred does not mean exempt. Touch these lanes only when preserving the
+  lane invariants, reducing debt opportunistically, and keeping public behavior
+  plus durable checkpoints intact.
+- Stop when a change hits a lane stop condition, changes another lane's
+  lifecycle contract, or needs broad design before code movement.
+
 ## Baseline
 
 - Post-Wave-3 green anchor: `be58fe84dc9eb3a346d30b12014d3e1c4e2a1797`.
@@ -22,8 +34,8 @@ Remaining server boundary debt:
 
 | Rule | Count | Notes |
 | --- | ---: | --- |
-| `STORE_SESSION_FACTORY_CALL` | 93 | Remaining self-opening store entrypoints. |
-| `STORE_COMMIT_ROLLBACK` | 61 | Remaining store-owned transaction boundaries. |
+| `STORE_SESSION_FACTORY_CALL` | 90 | Remaining self-opening store entrypoints. |
+| `STORE_COMMIT_ROLLBACK` | 59 | Remaining store-owned transaction boundaries. |
 | `STORE_SESSION_FACTORY_IMPORT` | 16 | Remaining store imports of the session factory. |
 | `STORE_FORBIDDEN_IMPORT` | 4 | All in the billing store. |
 | `SERVICE_ORM_IMPORT` | 5 | Billing, cloud runtime, and cloud workspaces services. |
@@ -200,7 +212,57 @@ Stop conditions:
   lifecycle boundary is explicit.
 - Billing repo-limit or concurrency semantics cannot be preserved locally.
 
-### 5. MCP Materialization
+### 5. Cloud Mobility
+
+Owned paths:
+
+- `server/proliferate/server/cloud/mobility/**`
+- `server/proliferate/db/store/cloud_mobility.py`
+- `server/proliferate/db/models/cloud/mobility.py`
+- Mobility-specific callsites in
+  `server/proliferate/server/cloud/workspaces/service.py`,
+  `server/proliferate/server/cloud/runtime/provision.py`, and
+  `server/proliferate/server/cloud/runtime/anyharness_api.py` by coordination
+  with the workspace and runtime lanes
+
+Invariants:
+
+- Logical mobility workspace identity remains unique per user, provider,
+  owner, repository, and branch.
+- Only one active handoff exists per mobility workspace; preflight also blocks
+  another active handoff for the same user.
+- Handoff creation remains a durable checkpoint before local-to-cloud
+  provisioning continues.
+- Local-to-cloud provisioning failure after handoff creation records an
+  observable failed handoff before surfacing the original error.
+- Finalization flips the visible owner and lifecycle state to the target owner
+  but leaves the active handoff until source cleanup completes.
+- Cleanup completion clears the active handoff; `cleanup_failed` remains active
+  under current semantics until a product decision changes that model.
+- Stale expiry distinguishes pre-finalization handoff failure from
+  post-finalization cleanup failure.
+- Branch and repository preflight remains strict about access, branch presence,
+  branch match, and requested base SHA.
+- Read paths that expire stale handoffs or backfill cloud-owned rows preserve
+  that behavior until a tested replacement exists.
+- Public API payloads and the desktop/runtime handoff protocol remain stable.
+
+Stop conditions:
+
+- Handoff start would become one broad request transaction that can roll back
+  durable handoff creation after provisioning failure.
+- GitHub, provider, AnyHarness, or workspace provisioning I/O would be held
+  inside a broad DB transaction.
+- Active-handoff, retryability, or `cleanup_failed` semantics are unclear or
+  changed without a product decision.
+- Mobility cleanup needs workspace or runtime lifecycle changes before those
+  lane boundaries are explicit.
+- The store split becomes mechanical before lifecycle rules and checkpoint
+  ownership are explicit.
+- Stale expiry or backfill behavior would be removed without a tested
+  replacement.
+
+### 6. MCP Materialization
 
 Owned paths:
 

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -18,7 +18,6 @@ STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transition
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 14 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/organizations.py 1 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions open DB sessions
@@ -34,7 +33,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_run
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 24 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 2 transitional wrappers used by deferred organization/cloud callers
+STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 1 transitional wrapper used by deferred organization/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -115,6 +115,7 @@ class Settings(BaseSettings):
     automation_cloud_executor_branch_prefix: str = "automation"
     automation_cloud_executor_branch_slug_chars: int = 48
     cloud_mcp_oauth_callback_base_url: str = ""
+    cloud_mcp_oauth_callback_fallback_base_url: str = "http://localhost:8000"
     cloud_mcp_slack_enabled: bool = False
     cloud_mcp_slack_client_id: str = ""
     cloud_mcp_slack_client_secret: str = ""

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -39,6 +39,8 @@ RESERVED_CLOUD_REPO_ENV_VARS: frozenset[str] = frozenset(
     }
 )
 
+CLOUD_REPO_CONFIG_FILE_MAX_BYTES: Final = 1_048_576
+
 # ---------------------------------------------------------------------------
 # Allowed credential auth files
 # ---------------------------------------------------------------------------

--- a/server/proliferate/db/store/organization_invitations.py
+++ b/server/proliferate/db/store/organization_invitations.py
@@ -26,7 +26,6 @@ from proliferate.db.models.organizations import (
     OrganizationInvitation,
     OrganizationMembership,
 )
-from proliferate.db.store.billing import maybe_create_org_seat_adjustment
 from proliferate.db.store.organization_records import (
     InvitationAcceptRecord,
     InvitationCreateRecord,
@@ -393,11 +392,6 @@ async def accept_invitation_handoff(
     invitation.handoff_token_hash = None
     invitation.handoff_expires_at = None
     invitation.updated_at = now
-    await maybe_create_org_seat_adjustment(
-        db,
-        organization_id=invitation.organization_id,
-        membership_id=membership.id,
-    )
     return (
         InvitationAcceptRecord(
             organization=organization_record(organization),

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -17,10 +17,6 @@ from proliferate.db import engine as db_engine
 from proliferate.db.models.auth import User
 from proliferate.db.models.billing import BillingSubject
 from proliferate.db.models.organizations import Organization, OrganizationMembership
-from proliferate.db.store.billing import (
-    ensure_organization_billing_subject,
-    maybe_create_org_seat_adjustment,
-)
 from proliferate.db.store.organization_records import (
     MemberRecord,
     MembershipRecord,
@@ -119,7 +115,6 @@ async def ensure_default_organization_for_user(
         updated_at=now,
     )
     db.add(membership)
-    await ensure_organization_billing_subject(db, organization.id)
     await db.flush()
     return [
         OrganizationWithMembershipRecord(
@@ -276,20 +271,7 @@ async def update_organization_membership(
             membership.joined_at = now
     membership.updated_at = now
     await db.flush()
-    if status is not None:
-        await maybe_create_org_seat_adjustment(
-            db,
-            organization_id=organization_id,
-            membership_id=membership.id,
-        )
     return membership_record(membership), None
-
-
-async def ensure_organization_billing_subject_id(organization_id: UUID) -> UUID:
-    async with db_engine.async_session_factory() as db:
-        subject = await ensure_organization_billing_subject(db, organization_id)
-        await db.commit()
-        return subject.id
 
 
 async def load_organization_by_billing_subject(

--- a/server/proliferate/server/automations/api.py
+++ b/server/proliferate/server/automations/api.py
@@ -41,6 +41,8 @@ from proliferate.server.automations.models import (
     LocalAutomationFailRequest,
     LocalAutomationMutationResponse,
     UpdateAutomationRequest,
+    automation_payload,
+    automation_run_payload,
 )
 from proliferate.server.automations.service import (
     create_automation,
@@ -61,7 +63,8 @@ async def list_automations_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationListResponse:
-    return await list_automations(db, user.id)
+    values = await list_automations(db, user.id)
+    return AutomationListResponse(automations=[automation_payload(value) for value in values])
 
 
 @router.post("", response_model=AutomationResponse)
@@ -70,7 +73,7 @@ async def create_automation_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await create_automation(db, user.id, body)
+    return automation_payload(await create_automation(db, user.id, body))
 
 
 @router.post("/executor/local/claims", response_model=LocalAutomationClaimListResponse)
@@ -205,7 +208,7 @@ async def get_automation_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await get_automation(db, user.id, automation_id)
+    return automation_payload(await get_automation(db, user.id, automation_id))
 
 
 @router.patch("/{automation_id}", response_model=AutomationResponse)
@@ -215,7 +218,7 @@ async def update_automation_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await update_automation(db, user.id, automation_id, body)
+    return automation_payload(await update_automation(db, user.id, automation_id, body))
 
 
 @router.post("/{automation_id}/pause", response_model=AutomationResponse)
@@ -224,7 +227,7 @@ async def pause_automation_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await pause_automation(db, user.id, automation_id)
+    return automation_payload(await pause_automation(db, user.id, automation_id))
 
 
 @router.post("/{automation_id}/resume", response_model=AutomationResponse)
@@ -233,7 +236,7 @@ async def resume_automation_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationResponse:
-    return await resume_automation(db, user.id, automation_id)
+    return automation_payload(await resume_automation(db, user.id, automation_id))
 
 
 @router.post("/{automation_id}/run-now", response_model=AutomationRunResponse)
@@ -242,7 +245,7 @@ async def run_automation_now_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationRunResponse:
-    return await run_automation_now(db, user.id, automation_id)
+    return automation_run_payload(await run_automation_now(db, user.id, automation_id))
 
 
 @router.get("/{automation_id}/runs", response_model=AutomationRunListResponse)
@@ -254,4 +257,5 @@ async def list_automation_runs_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> AutomationRunListResponse:
-    return await list_automation_runs(db, user.id, automation_id, limit=limit)
+    values = await list_automation_runs(db, user.id, automation_id, limit=limit)
+    return AutomationRunListResponse(runs=[automation_run_payload(value) for value in values])

--- a/server/proliferate/server/automations/service.py
+++ b/server/proliferate/server/automations/service.py
@@ -10,6 +10,7 @@ from proliferate.constants.automations import (
     AUTOMATION_RUN_LIST_DEFAULT_LIMIT,
 )
 from proliferate.db.store.automations import (
+    AutomationRunValue,
     AutomationValue,
     create_automation_for_user,
     create_manual_run_for_user,
@@ -20,7 +21,7 @@ from proliferate.db.store.automations import (
 )
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigLimitExceededError,
-    bootstrap_cloud_repo_config_for_user,
+    bootstrap_cloud_repo_config,
 )
 from proliferate.server.automations.domain.schedule import (
     next_future_occurrence,
@@ -45,23 +46,18 @@ from proliferate.server.automations.errors import (
     AutomationRepoLimitExceeded,
 )
 from proliferate.server.automations.models import (
-    AutomationListResponse,
-    AutomationResponse,
-    AutomationRunListResponse,
-    AutomationRunResponse,
     CreateAutomationRequest,
     UpdateAutomationRequest,
-    automation_payload,
-    automation_run_payload,
 )
 from proliferate.server.billing.service import (
-    get_billing_snapshot,
+    get_billing_snapshot_for_request,
     repo_limit_for_billing_snapshot,
 )
 from proliferate.utils.time import utcnow
 
 
 async def _ensure_repo_config_id(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
@@ -69,10 +65,11 @@ async def _ensure_repo_config_id(
 ) -> UUID:
     # Automations point at a repo identity. Runtime-input config for that repo can still
     # be empty; the executor PR will decide when to apply env/files/setup.
-    billing_snapshot = await get_billing_snapshot(user_id)
+    billing_snapshot = await get_billing_snapshot_for_request(db, user_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
     try:
-        repo_config = await bootstrap_cloud_repo_config_for_user(
+        repo_config = await bootstrap_cloud_repo_config(
+            db,
             user_id=user_id,
             git_owner=git_owner,
             git_repo_name=git_repo_name,
@@ -86,31 +83,31 @@ async def _ensure_repo_config_id(
     return repo_config.id
 
 
-async def list_automations(db: AsyncSession, user_id: UUID) -> AutomationListResponse:
-    values = await list_automations_for_user(db, user_id)
-    return AutomationListResponse(automations=[automation_payload(value) for value in values])
+async def list_automations(db: AsyncSession, user_id: UUID) -> list[AutomationValue]:
+    return await list_automations_for_user(db, user_id)
 
 
 async def get_automation(
     db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
-) -> AutomationResponse:
+) -> AutomationValue:
     value = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if value is None:
         raise AutomationNotFound()
-    return automation_payload(value)
+    return value
 
 
 async def create_automation(
     db: AsyncSession,
     user_id: UUID,
     body: CreateAutomationRequest,
-) -> AutomationResponse:
+) -> AutomationValue:
     now = utcnow()
     git_owner = normalize_repo_part(body.git_owner, field_name="gitOwner")
     git_repo_name = normalize_repo_part(body.git_repo_name, field_name="gitRepoName")
     repo_config_id = await _ensure_repo_config_id(
+        db,
         user_id=user_id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
@@ -139,7 +136,7 @@ async def create_automation(
         reasoning_effort=normalize_reasoning_effort(body.reasoning_effort),
         next_run_at=schedule.next_run_at,
     )
-    return automation_payload(value)
+    return value
 
 
 async def update_automation(
@@ -147,7 +144,7 @@ async def update_automation(
     user_id: UUID,
     automation_id: UUID,
     body: UpdateAutomationRequest,
-) -> AutomationResponse:
+) -> AutomationValue:
     existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
@@ -204,14 +201,14 @@ async def update_automation(
     )
     if value is None:
         raise AutomationNotFound()
-    return automation_payload(value)
+    return value
 
 
 async def pause_automation(
     db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
-) -> AutomationResponse:
+) -> AutomationValue:
     value = await update_automation_for_user(
         db,
         user_id=user_id,
@@ -222,14 +219,14 @@ async def pause_automation(
     )
     if value is None:
         raise AutomationNotFound()
-    return automation_payload(value)
+    return value
 
 
 async def resume_automation(
     db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
-) -> AutomationResponse:
+) -> AutomationValue:
     existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
@@ -249,14 +246,14 @@ async def resume_automation(
     )
     if value is None:
         raise AutomationNotFound()
-    return automation_payload(value)
+    return value
 
 
 async def run_automation_now(
     db: AsyncSession,
     user_id: UUID,
     automation_id: UUID,
-) -> AutomationRunResponse:
+) -> AutomationRunValue:
     existing = await load_automation_for_user(db, user_id=user_id, automation_id=automation_id)
     if existing is None:
         raise AutomationNotFound()
@@ -264,6 +261,7 @@ async def run_automation_now(
         raise AutomationPaused()
     require_agent_kind(existing.execution_target, existing.agent_kind)
     await _ensure_repo_config_id(
+        db,
         user_id=user_id,
         git_owner=existing.git_owner,
         git_repo_name=existing.git_repo_name,
@@ -271,7 +269,7 @@ async def run_automation_now(
     value = await create_manual_run_for_user(db, user_id=user_id, automation_id=automation_id)
     if value is None:
         raise AutomationNotFound()
-    return automation_run_payload(value)
+    return value
 
 
 async def list_automation_runs(
@@ -280,7 +278,7 @@ async def list_automation_runs(
     automation_id: UUID,
     *,
     limit: int = AUTOMATION_RUN_LIST_DEFAULT_LIMIT,
-) -> AutomationRunListResponse:
+) -> list[AutomationRunValue]:
     bounded_limit = bounded_run_list_limit(limit)
     values = await list_runs_for_automation_for_user(
         db,
@@ -290,8 +288,4 @@ async def list_automation_runs(
     )
     if values is None:
         raise AutomationNotFound()
-    return AutomationRunListResponse(runs=[automation_run_payload(value) for value in values])
-
-
-def automation_for_tests(value: AutomationValue) -> AutomationResponse:
-    return automation_payload(value)
+    return values

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -47,6 +47,7 @@ from proliferate.db.models.billing import (
 from proliferate.db.store.billing import (
     BillingAccountingResult,
     BillingSnapshotState,
+    BillingSubjectStripeState,
     account_usage_for_billing_subject,
     bind_stripe_customer_to_billing_subject,
     claim_pending_seat_adjustments,
@@ -65,6 +66,7 @@ from proliferate.db.store.billing import (
     mark_seat_adjustment_stripe_confirmed,
     mark_usage_export_failed,
     mark_usage_export_succeeded,
+    maybe_create_org_seat_adjustment,
     record_billing_decision_event,
     resolve_billing_subject_id_for_workspace,
     set_overage_policy_for_subject,
@@ -174,6 +176,33 @@ def repo_limit_for_billing_snapshot(snapshot: BillingSnapshot) -> int | None:
     )
 
 
+async def ensure_personal_billing_subject_state(
+    db: AsyncSession,
+    user_id: UUID,
+) -> BillingSubjectStripeState:
+    return await get_or_create_user_stripe_customer_state(db, user_id)
+
+
+async def ensure_organization_billing_subject_state(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> BillingSubjectStripeState:
+    return await get_or_create_organization_stripe_customer_state(db, organization_id)
+
+
+async def maybe_create_organization_seat_adjustment(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    membership_id: UUID | None,
+) -> bool:
+    return await maybe_create_org_seat_adjustment(
+        db,
+        organization_id=organization_id,
+        membership_id=membership_id,
+    )
+
+
 def _grant_applies_to_paid_state(grant: BillingGrant, *, is_paid_cloud: bool) -> bool:
     return grant_applies_to_paid_state(
         grant.grant_type,
@@ -193,6 +222,13 @@ def _segment_seconds(segment: UsageSegment, now: datetime) -> float:
 async def get_billing_snapshot(user_id: UUID) -> BillingSnapshot:
     state = await load_billing_snapshot_state(user_id)
     return _build_billing_snapshot(state)
+
+
+async def get_billing_snapshot_for_request(
+    db: AsyncSession,
+    user_id: UUID,
+) -> BillingSnapshot:
+    return await _get_billing_snapshot_for_request(db, user_id)
 
 
 async def get_billing_snapshot_for_subject(billing_subject_id: UUID) -> BillingSnapshot:

--- a/server/proliferate/server/cloud/credentials/api.py
+++ b/server/proliferate/server/cloud/credentials/api.py
@@ -11,6 +11,7 @@ from proliferate.server.cloud.credentials.models import (
     CloudCredentialMutationResponse,
     CredentialStatus,
     SyncCloudCredentialRequest,
+    credential_status_payload,
 )
 from proliferate.server.cloud.credentials.service import (
     delete_cloud_credential_for_user,
@@ -26,7 +27,9 @@ async def list_cloud_credentials_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> list[CredentialStatus]:
-    return await list_cloud_credentials(db, user.id)
+    return [
+        credential_status_payload(status) for status in await list_cloud_credentials(db, user.id)
+    ]
 
 
 @router.put("/credentials/{provider}")

--- a/server/proliferate/server/cloud/credentials/service.py
+++ b/server/proliferate/server/cloud/credentials/service.py
@@ -25,9 +25,7 @@ from proliferate.server.cloud.credentials.domain.types import (
     CloudCredentialAuthMode,
 )
 from proliferate.server.cloud.credentials.models import (
-    CredentialStatus,
     SyncCloudCredentialRequest,
-    credential_status_payload,
 )
 from proliferate.server.cloud.credentials.session_loader import (
     load_cloud_credentials_for_user,
@@ -38,9 +36,8 @@ from proliferate.utils.crypto import decrypt_json, encrypt_json
 async def list_cloud_credentials(
     db: AsyncSession,
     user_id: UUID,
-) -> list[CredentialStatus]:
-    statuses = await load_cloud_credential_statuses_for_request(db, user_id)
-    return [credential_status_payload(status) for status in statuses]
+) -> list[CredentialStatusRecord]:
+    return await load_cloud_credential_statuses_for_request(db, user_id)
 
 
 async def load_cloud_credential_statuses_for_request(

--- a/server/proliferate/server/cloud/mcp_connections/api.py
+++ b/server/proliferate/server/cloud/mcp_connections/api.py
@@ -16,8 +16,11 @@ from proliferate.server.cloud.mcp_connections.models import (
     PatchCloudMcpConnectionRequest,
     PutCloudMcpSecretAuthRequest,
     SyncCloudMcpConnectionRequest,
+    cloud_mcp_connection_payload,
+    cloud_mcp_connection_status_payload,
 )
 from proliferate.server.cloud.mcp_connections.service import (
+    CloudMcpConnectionPayload,
     create_cloud_mcp_connection,
     delete_cloud_mcp_connection_for_user,
     delete_legacy_cloud_mcp_connection_for_user,
@@ -31,12 +34,28 @@ from proliferate.server.cloud.mcp_connections.service import (
 router = APIRouter()
 
 
+def _connection_response(
+    payload: CloudMcpConnectionPayload,
+) -> CloudMcpConnectionResponse:
+    return cloud_mcp_connection_payload(
+        payload.record,
+        payload.settings,
+        payload.auth_kind,
+        payload.auth_status,
+    )
+
+
 @router.get("/mcp/connections", response_model=CloudMcpConnectionsResponse)
 async def list_cloud_mcp_connections_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpConnectionsResponse:
-    return await list_cloud_mcp_connections(db, user.id)
+    return CloudMcpConnectionsResponse(
+        connections=[
+            _connection_response(payload)
+            for payload in await list_cloud_mcp_connections(db, user.id)
+        ]
+    )
 
 
 @router.post("/mcp/connections", response_model=CloudMcpConnectionResponse)
@@ -45,7 +64,7 @@ async def create_cloud_mcp_connection_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpConnectionResponse:
-    return await create_cloud_mcp_connection(db, user.id, body)
+    return _connection_response(await create_cloud_mcp_connection(db, user.id, body))
 
 
 @router.patch("/mcp/connections/{connection_id}", response_model=CloudMcpConnectionResponse)
@@ -54,7 +73,7 @@ async def patch_cloud_mcp_connection_endpoint(
     connection: McpConnectionManageDependency,
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpConnectionResponse:
-    return await patch_cloud_mcp_connection(db, connection, body)
+    return _connection_response(await patch_cloud_mcp_connection(db, connection, body))
 
 
 @router.delete("/mcp/connections/{connection_id}", response_model=OkResponse)
@@ -75,7 +94,7 @@ async def put_cloud_mcp_connection_secret_auth_endpoint(
     connection: McpConnectionManageDependency,
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpConnectionResponse:
-    return await put_cloud_mcp_connection_secret_auth(db, connection, body)
+    return _connection_response(await put_cloud_mcp_connection_secret_auth(db, connection, body))
 
 
 @router.get("/mcp-connections/statuses", response_model=list[CloudMcpConnectionSyncStatus])
@@ -83,7 +102,10 @@ async def list_cloud_mcp_connection_statuses_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> list[CloudMcpConnectionSyncStatus]:
-    return await list_cloud_mcp_connection_statuses(db, user.id)
+    return [
+        cloud_mcp_connection_status_payload(record)
+        for record in await list_cloud_mcp_connection_statuses(db, user.id)
+    ]
 
 
 @router.put("/mcp-connections/{connection_id}", response_model=OkResponse)

--- a/server/proliferate/server/cloud/mcp_connections/service.py
+++ b/server/proliferate/server/cloud/mcp_connections/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import NoReturn
 from uuid import UUID
 
@@ -42,17 +43,20 @@ from proliferate.server.cloud.mcp_connections.domain.connection_rules import (
 from proliferate.server.cloud.mcp_connections.models import (
     CloudMcpAuthKind,
     CloudMcpAuthStatus,
-    CloudMcpConnectionResponse,
-    CloudMcpConnectionsResponse,
-    CloudMcpConnectionSyncStatus,
     CreateCloudMcpConnectionRequest,
     PatchCloudMcpConnectionRequest,
     PutCloudMcpSecretAuthRequest,
     SyncCloudMcpConnectionRequest,
-    cloud_mcp_connection_payload,
-    cloud_mcp_connection_status_payload,
 )
 from proliferate.utils.crypto import encrypt_json
+
+
+@dataclass(frozen=True)
+class CloudMcpConnectionPayload:
+    record: CloudMcpConnectionRecord
+    settings: dict[str, object]
+    auth_kind: CloudMcpAuthKind
+    auth_status: CloudMcpAuthStatus
 
 
 def _invalid_payload(message: str) -> NoReturn:
@@ -121,36 +125,34 @@ def _auth_state(
     return state.auth_kind, state.auth_status
 
 
-def _connection_payload(record: CloudMcpConnectionRecord) -> CloudMcpConnectionResponse:
+def _connection_payload(record: CloudMcpConnectionRecord) -> CloudMcpConnectionPayload:
     auth_kind, auth_status = _auth_state(record)
     entry = get_catalog_entry(record.catalog_entry_id)
     parsed_settings = parse_connection_settings(record.settings_json)
     if entry is not None:
         with suppress(McpConnectionRuleViolation):
             parsed_settings = validate_connection_settings(entry, parsed_settings)
-    return cloud_mcp_connection_payload(
-        record,
-        parsed_settings,
-        auth_kind,
-        auth_status,
+    return CloudMcpConnectionPayload(
+        record=record,
+        settings=parsed_settings,
+        auth_kind=auth_kind,
+        auth_status=auth_status,
     )
 
 
 async def list_cloud_mcp_connections(
     db: AsyncSession,
     user_id: UUID,
-) -> CloudMcpConnectionsResponse:
+) -> list[CloudMcpConnectionPayload]:
     records = await list_user_connections(db, user_id)
-    return CloudMcpConnectionsResponse(
-        connections=[_connection_payload(record) for record in records]
-    )
+    return [_connection_payload(record) for record in records]
 
 
 async def create_cloud_mcp_connection(
     db: AsyncSession,
     user_id: UUID,
     body: CreateCloudMcpConnectionRequest,
-) -> CloudMcpConnectionResponse:
+) -> CloudMcpConnectionPayload:
     catalog_entry_id = body.catalog_entry_id.strip()
     entry = get_catalog_entry(catalog_entry_id)
     if entry is None:
@@ -196,7 +198,7 @@ async def patch_cloud_mcp_connection(
     db: AsyncSession,
     existing: CloudMcpConnectionRecord,
     body: PatchCloudMcpConnectionRequest,
-) -> CloudMcpConnectionResponse:
+) -> CloudMcpConnectionPayload:
     entry = get_catalog_entry(existing.catalog_entry_id)
     if entry is None:
         _invalid_payload("Connector catalog entry was not found.")
@@ -233,7 +235,7 @@ async def put_cloud_mcp_connection_secret_auth(
     db: AsyncSession,
     record: CloudMcpConnectionRecord,
     body: PutCloudMcpSecretAuthRequest,
-) -> CloudMcpConnectionResponse:
+) -> CloudMcpConnectionPayload:
     entry = get_catalog_entry(record.catalog_entry_id)
     if entry is None:
         _invalid_payload("Connector catalog entry was not found.")
@@ -262,11 +264,8 @@ async def delete_cloud_mcp_connection_for_user(
 async def list_cloud_mcp_connection_statuses(
     db: AsyncSession,
     user_id: UUID,
-) -> list[CloudMcpConnectionSyncStatus]:
-    return [
-        cloud_mcp_connection_status_payload(record)
-        for record in await legacy_list_connections(db, user_id)
-    ]
+) -> list[CloudMcpConnectionRecord]:
+    return await legacy_list_connections(db, user_id)
 
 
 async def sync_cloud_mcp_connection_for_user(

--- a/server/proliferate/server/cloud/mcp_materialization/oauth_tokens.py
+++ b/server/proliferate/server/cloud/mcp_materialization/oauth_tokens.py
@@ -25,6 +25,7 @@ def _redirect_uri() -> str:
     return oauth_redirect_uri(
         configured_callback_base_url=settings.cloud_mcp_oauth_callback_base_url,
         api_base_url=settings.api_base_url,
+        fallback_callback_base_url=settings.cloud_mcp_oauth_callback_fallback_base_url,
     )
 
 

--- a/server/proliferate/server/cloud/mcp_oauth/api.py
+++ b/server/proliferate/server/cloud/mcp_oauth/api.py
@@ -14,6 +14,8 @@ from proliferate.server.cloud.mcp_connections.access import McpConnectionManageD
 from proliferate.server.cloud.mcp_oauth.models import (
     CloudMcpOAuthFlowStatusResponse,
     StartCloudMcpOAuthFlowResponse,
+    oauth_flow_start_payload,
+    oauth_flow_status_payload,
 )
 from proliferate.server.cloud.mcp_oauth.pages import make_mcp_oauth_callback_page
 from proliferate.server.cloud.mcp_oauth.service import (
@@ -34,7 +36,7 @@ async def start_cloud_mcp_oauth_flow_endpoint(
     connection: McpConnectionManageDependency,
     db: AsyncSession = Depends(get_async_session),
 ) -> StartCloudMcpOAuthFlowResponse:
-    return await start_cloud_mcp_oauth_flow(db, connection=connection)
+    return oauth_flow_start_payload(await start_cloud_mcp_oauth_flow(db, connection=connection))
 
 
 @router.get("/oauth/flows/{flow_id}", response_model=CloudMcpOAuthFlowStatusResponse)
@@ -43,7 +45,11 @@ async def get_cloud_mcp_oauth_flow_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpOAuthFlowStatusResponse:
-    return await get_cloud_mcp_oauth_flow_status(db, user_id=user.id, flow_id=flow_id)
+    status = await get_cloud_mcp_oauth_flow_status(db, user_id=user.id, flow_id=flow_id)
+    return oauth_flow_status_payload(
+        status.flow,
+        include_authorization_url=status.include_authorization_url,
+    )
 
 
 @router.post("/oauth/flows/{flow_id}/cancel", response_model=CloudMcpOAuthFlowStatusResponse)
@@ -52,7 +58,11 @@ async def cancel_cloud_mcp_oauth_flow_endpoint(
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudMcpOAuthFlowStatusResponse:
-    return await cancel_cloud_mcp_oauth_flow(db, user_id=user.id, flow_id=flow_id)
+    status = await cancel_cloud_mcp_oauth_flow(db, user_id=user.id, flow_id=flow_id)
+    return oauth_flow_status_payload(
+        status.flow,
+        include_authorization_url=status.include_authorization_url,
+    )
 
 
 @router.get("/oauth/callback", response_class=HTMLResponse)

--- a/server/proliferate/server/cloud/mcp_oauth/domain/flow_rules.py
+++ b/server/proliferate/server/cloud/mcp_oauth/domain/flow_rules.py
@@ -15,10 +15,11 @@ def resolve_callback_base_url(
     *,
     configured_callback_base_url: str,
     api_base_url: str,
+    fallback_callback_base_url: str = "",
 ) -> str:
     base = configured_callback_base_url.strip() or api_base_url.strip()
     if not base:
-        base = "http://localhost:8000"
+        base = fallback_callback_base_url.strip()
     return base.rstrip("/")
 
 
@@ -26,10 +27,12 @@ def oauth_redirect_uri(
     *,
     configured_callback_base_url: str,
     api_base_url: str,
+    fallback_callback_base_url: str = "",
 ) -> str:
     base_url = resolve_callback_base_url(
         configured_callback_base_url=configured_callback_base_url,
         api_base_url=api_base_url,
+        fallback_callback_base_url=fallback_callback_base_url,
     )
     return f"{base_url}{CLOUD_MCP_OAUTH_CALLBACK_PATH}"
 

--- a/server/proliferate/server/cloud/mcp_oauth/models.py
+++ b/server/proliferate/server/cloud/mcp_oauth/models.py
@@ -25,11 +25,6 @@ class CloudMcpOAuthFlowStatusResponse(BaseModel):
     failure_code: str | None = Field(default=None, serialization_alias="failureCode")
 
 
-class CloudMcpOAuthCallbackResponse(BaseModel):
-    ok: bool
-    status: str
-
-
 def oauth_flow_start_payload(flow: CloudMcpOAuthFlowRecord) -> StartCloudMcpOAuthFlowResponse:
     return StartCloudMcpOAuthFlowResponse(
         flow_id=flow.id,

--- a/server/proliferate/server/cloud/mcp_oauth/service.py
+++ b/server/proliferate/server/cloud/mcp_oauth/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -27,6 +28,7 @@ from proliferate.db.store.cloud_mcp.oauth_flows import (
 from proliferate.db.store.cloud_mcp.types import (
     CloudMcpConnectionRecord,
     CloudMcpOAuthClientRecord,
+    CloudMcpOAuthFlowRecord,
 )
 from proliferate.integrations.mcp_oauth import (
     McpOAuthProviderError,
@@ -62,17 +64,22 @@ from proliferate.server.cloud.mcp_oauth.domain.flow_rules import (
 from proliferate.server.cloud.mcp_oauth.domain.static_client_rules import (
     cached_static_client_matches,
 )
-from proliferate.server.cloud.mcp_oauth.models import (
-    CloudMcpOAuthCallbackResponse,
-    CloudMcpOAuthFlowStatusResponse,
-    StartCloudMcpOAuthFlowResponse,
-    oauth_flow_start_payload,
-    oauth_flow_status_payload,
-)
 from proliferate.server.cloud.mcp_oauth.static_clients import (
     get_static_oauth_client_config,
 )
 from proliferate.utils.crypto import decrypt_text, encrypt_json, encrypt_text
+
+
+@dataclass(frozen=True)
+class CloudMcpOAuthFlowStatus:
+    flow: CloudMcpOAuthFlowRecord
+    include_authorization_url: bool
+
+
+@dataclass(frozen=True)
+class CloudMcpOAuthCallbackResult:
+    ok: bool
+    status: str
 
 
 def _cloud_mcp_enabled_or_raise() -> None:
@@ -84,6 +91,7 @@ def _redirect_uri() -> str:
     return oauth_redirect_uri(
         configured_callback_base_url=settings.cloud_mcp_oauth_callback_base_url,
         api_base_url=settings.api_base_url,
+        fallback_callback_base_url=settings.cloud_mcp_oauth_callback_fallback_base_url,
     )
 
 
@@ -214,7 +222,7 @@ async def start_cloud_mcp_oauth_flow(
     db: AsyncSession,
     *,
     connection: CloudMcpConnectionRecord,
-) -> StartCloudMcpOAuthFlowResponse:
+) -> CloudMcpOAuthFlowRecord:
     _cloud_mcp_enabled_or_raise()
     entry = get_catalog_entry(connection.catalog_entry_id)
     if entry is None or entry.auth_kind != "oauth":
@@ -286,7 +294,7 @@ async def start_cloud_mcp_oauth_flow(
         authorization_url=authorization_url,
         expires_at=datetime.now(UTC) + CLOUD_MCP_OAUTH_FLOW_TTL,
     )
-    return oauth_flow_start_payload(flow)
+    return flow
 
 
 async def get_cloud_mcp_oauth_flow_status(
@@ -294,7 +302,7 @@ async def get_cloud_mcp_oauth_flow_status(
     *,
     user_id: UUID,
     flow_id: UUID,
-) -> CloudMcpOAuthFlowStatusResponse:
+) -> CloudMcpOAuthFlowStatus:
     flow = await get_oauth_flow_for_user(db, user_id=user_id, flow_id=flow_id)
     if flow is None:
         raise CloudApiError("not_found", "OAuth flow was not found.", status_code=404)
@@ -304,8 +312,8 @@ async def get_cloud_mcp_oauth_flow_status(
         now=datetime.now(UTC),
     ):
         status = await fail_oauth_flow(db, flow_id=flow.id, failure_code="expired") or flow
-    return oauth_flow_status_payload(
-        status,
+    return CloudMcpOAuthFlowStatus(
+        flow=status,
         include_authorization_url=oauth_status_includes_authorization_url(status.status),
     )
 
@@ -315,11 +323,11 @@ async def cancel_cloud_mcp_oauth_flow(
     *,
     user_id: UUID,
     flow_id: UUID,
-) -> CloudMcpOAuthFlowStatusResponse:
+) -> CloudMcpOAuthFlowStatus:
     flow = await cancel_oauth_flow_for_user(db, user_id=user_id, flow_id=flow_id)
     if flow is None:
         raise CloudApiError("not_found", "OAuth flow was not found.", status_code=404)
-    return oauth_flow_status_payload(flow, include_authorization_url=False)
+    return CloudMcpOAuthFlowStatus(flow=flow, include_authorization_url=False)
 
 
 async def complete_cloud_mcp_oauth_callback(
@@ -327,22 +335,22 @@ async def complete_cloud_mcp_oauth_callback(
     *,
     state: str,
     code: str,
-) -> CloudMcpOAuthCallbackResponse:
+) -> CloudMcpOAuthCallbackResult:
     _cloud_mcp_enabled_or_raise()
     hashed = oauth_state_hash(state)
     flow = await claim_active_oauth_flow_by_state_hash(db, hashed)
     if flow is None:
-        return CloudMcpOAuthCallbackResponse(ok=False, status="failed")
+        return CloudMcpOAuthCallbackResult(ok=False, status="failed")
     if oauth_flow_is_expired(expires_at=flow.expires_at, now=datetime.now(UTC)):
         await fail_oauth_flow(db, flow_id=flow.id, failure_code="expired")
-        return CloudMcpOAuthCallbackResponse(ok=False, status="expired")
+        return CloudMcpOAuthCallbackResult(ok=False, status="expired")
     if not flow.token_endpoint or not flow.resource:
         await fail_oauth_flow(db, flow_id=flow.id, failure_code="invalid_flow")
-        return CloudMcpOAuthCallbackResponse(ok=False, status="failed")
+        return CloudMcpOAuthCallbackResult(ok=False, status="failed")
     connection = await get_user_connection_by_db_id(db, flow.user_id, flow.connection_db_id)
     if connection is None:
         await fail_oauth_flow(db, flow_id=flow.id, failure_code="invalid_flow")
-        return CloudMcpOAuthCallbackResponse(ok=False, status="failed")
+        return CloudMcpOAuthCallbackResult(ok=False, status="failed")
     oauth_client = await get_oauth_client(
         db,
         issuer=flow.issuer or "",
@@ -377,7 +385,7 @@ async def complete_cloud_mcp_oauth_callback(
                 catalog_entry_id=connection.catalog_entry_id if connection else "",
             )
         await fail_oauth_flow(db, flow_id=flow.id, failure_code=exc.code)
-        return CloudMcpOAuthCallbackResponse(ok=False, status="failed")
+        return CloudMcpOAuthCallbackResult(ok=False, status="failed")
 
     await upsert_connection_auth(
         db,
@@ -401,4 +409,4 @@ async def complete_cloud_mcp_oauth_callback(
         token_expires_at=token.expires_at,
     )
     await complete_oauth_flow(db, flow_id=flow.id)
-    return CloudMcpOAuthCallbackResponse(ok=True, status="completed")
+    return CloudMcpOAuthCallbackResult(ok=True, status="completed")

--- a/server/proliferate/server/cloud/repo_config/api.py
+++ b/server/proliferate/server/cloud/repo_config/api.py
@@ -17,6 +17,11 @@ from proliferate.server.cloud.repo_config.models import (
     ResyncCloudWorkspaceFilesResponse,
     RunCloudWorkspaceSetupResponse,
     SaveCloudRepoConfigRequest,
+    repo_config_payload,
+    repo_config_summary_payload,
+    resync_cloud_workspace_files_payload,
+    run_cloud_workspace_setup_payload,
+    workspace_repo_config_status_payload,
 )
 from proliferate.server.cloud.repo_config.service import (
     get_repo_config,
@@ -31,12 +36,29 @@ from proliferate.server.cloud.repo_config.service import (
 router = APIRouter()
 
 
+def _default_repo_config_response() -> CloudRepoConfigResponse:
+    return CloudRepoConfigResponse(
+        configured=False,
+        configured_at=None,
+        default_branch=None,
+        env_vars={},
+        setup_script="",
+        run_command="",
+        files_version=0,
+        tracked_files=[],
+    )
+
+
 @router.get("/repos/configs", response_model=CloudRepoConfigsListResponse)
 async def list_cloud_repo_configs_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> CloudRepoConfigsListResponse:
-    return await list_repo_configs(db, user.id)
+    return CloudRepoConfigsListResponse(
+        configs=[
+            repo_config_summary_payload(value) for value in await list_repo_configs(db, user.id)
+        ]
+    )
 
 
 @router.get("/repos/{git_owner}/{git_repo_name}/config", response_model=CloudRepoConfigResponse)
@@ -46,12 +68,13 @@ async def get_cloud_repo_config_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> CloudRepoConfigResponse:
-    return await get_repo_config(
+    value = await get_repo_config(
         db,
         user.id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
     )
+    return _default_repo_config_response() if value is None else repo_config_payload(value)
 
 
 @router.put("/repos/{git_owner}/{git_repo_name}/config", response_model=CloudRepoConfigResponse)
@@ -63,7 +86,7 @@ async def save_cloud_repo_config_endpoint(
     user: User = Depends(current_active_user),
 ) -> CloudRepoConfigResponse:
     try:
-        return await save_repo_config(
+        value = await save_repo_config(
             db,
             user.id,
             git_owner=git_owner,
@@ -72,6 +95,7 @@ async def save_cloud_repo_config_endpoint(
         )
     except CloudApiError as error:
         raise_cloud_error(error)
+    return repo_config_payload(value)
 
 
 @router.put("/repos/{git_owner}/{git_repo_name}/files", response_model=CloudRepoConfigResponse)
@@ -83,7 +107,7 @@ async def save_cloud_repo_file_endpoint(
     user: User = Depends(current_active_user),
 ) -> CloudRepoConfigResponse:
     try:
-        return await save_repo_file(
+        value = await save_repo_file(
             db,
             user.id,
             git_owner=git_owner,
@@ -92,6 +116,7 @@ async def save_cloud_repo_file_endpoint(
         )
     except CloudApiError as error:
         raise_cloud_error(error)
+    return repo_config_payload(value)
 
 
 @router.get(
@@ -104,9 +129,10 @@ async def get_cloud_workspace_repo_config_status_endpoint(
     user: User = Depends(current_active_user),
 ) -> CloudWorkspaceRepoConfigStatusResponse:
     try:
-        return await get_workspace_repo_config_status(db, user.id, workspace_id)
+        status = await get_workspace_repo_config_status(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
+    return workspace_repo_config_status_payload(status)
 
 
 @router.post(
@@ -119,9 +145,10 @@ async def resync_cloud_workspace_files_endpoint(
     user: User = Depends(current_active_user),
 ) -> ResyncCloudWorkspaceFilesResponse:
     try:
-        return await resync_workspace_files(db, user.id, workspace_id)
+        status = await resync_workspace_files(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
+    return resync_cloud_workspace_files_payload(status)
 
 
 @router.post(
@@ -134,6 +161,7 @@ async def run_cloud_workspace_setup_endpoint(
     user: User = Depends(current_active_user),
 ) -> RunCloudWorkspaceSetupResponse:
     try:
-        return await run_workspace_setup(db, user.id, workspace_id)
+        status = await run_workspace_setup(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
+    return run_cloud_workspace_setup_payload(status)

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigLimitExceededError,
+    CloudRepoConfigSummaryValue,
     CloudRepoConfigValue,
     CloudRepoFileInput,
     bootstrap_cloud_repo_config_for_user,
@@ -23,6 +24,7 @@ from proliferate.db.store.users import get_user_with_oauth_accounts_by_id
 from proliferate.integrations.anyharness import CloudRuntimeOperationError
 from proliferate.server.billing.service import (
     get_billing_snapshot,
+    get_billing_snapshot_for_request,
     repo_limit_for_billing_snapshot,
 )
 from proliferate.server.cloud.errors import CloudApiError
@@ -33,18 +35,8 @@ from proliferate.server.cloud.repo_config.domain.workspace_status import (
     WorkspaceRepoConfigStatus,
 )
 from proliferate.server.cloud.repo_config.models import (
-    CloudRepoConfigResponse,
-    CloudRepoConfigsListResponse,
-    CloudWorkspaceRepoConfigStatusResponse,
     PutCloudRepoFileRequest,
-    ResyncCloudWorkspaceFilesResponse,
-    RunCloudWorkspaceSetupResponse,
     SaveCloudRepoConfigRequest,
-    repo_config_payload,
-    repo_config_summary_payload,
-    resync_cloud_workspace_files_payload,
-    run_cloud_workspace_setup_payload,
-    workspace_repo_config_status_payload,
 )
 from proliferate.server.cloud.repo_config.validation import (
     normalize_env_vars,
@@ -78,19 +70,6 @@ class _WorkspaceRepoConfigRecord(Protocol):
     repo_post_ready_completed_at: datetime | None
     repo_files_last_failed_path: str | None
     repo_files_last_error: str | None
-
-
-def _default_repo_config_response() -> CloudRepoConfigResponse:
-    return CloudRepoConfigResponse(
-        configured=False,
-        configured_at=None,
-        default_branch=None,
-        env_vars={},
-        setup_script="",
-        run_command="",
-        files_version=0,
-        tracked_files=[],
-    )
 
 
 def _raise_workspace_not_found() -> NoReturn:
@@ -180,11 +159,8 @@ def _resync_workspace_repo_config_status(
 async def list_repo_configs(
     db: AsyncSession,
     user_id: UUID,
-) -> CloudRepoConfigsListResponse:
-    values = await list_cloud_repo_configs(db, user_id)
-    return CloudRepoConfigsListResponse(
-        configs=[repo_config_summary_payload(value) for value in values]
-    )
+) -> list[CloudRepoConfigSummaryValue]:
+    return await list_cloud_repo_configs(db, user_id)
 
 
 async def get_repo_config(
@@ -193,14 +169,13 @@ async def get_repo_config(
     *,
     git_owner: str,
     git_repo_name: str,
-) -> CloudRepoConfigResponse:
-    value = await get_cloud_repo_config(
+) -> CloudRepoConfigValue | None:
+    return await get_cloud_repo_config(
         db,
         user_id=user_id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
     )
-    return _default_repo_config_response() if value is None else repo_config_payload(value)
 
 
 def _normalize_files(files: list[CloudRepoFileInput]) -> list[CloudRepoFileInput]:
@@ -262,7 +237,7 @@ async def save_repo_config(
     git_owner: str,
     git_repo_name: str,
     body: SaveCloudRepoConfigRequest,
-) -> CloudRepoConfigResponse:
+) -> CloudRepoConfigValue:
     env_vars = normalize_env_vars(body.env_vars)
     default_branch = await _validate_default_branch(
         db,
@@ -277,7 +252,7 @@ async def save_repo_config(
             for item in body.files
         ]
     )
-    billing_snapshot = await get_billing_snapshot(user_id)
+    billing_snapshot = await get_billing_snapshot_for_request(db, user_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
     try:
         value = await save_cloud_repo_config(
@@ -303,7 +278,7 @@ async def save_repo_config(
             ),
             status_code=409,
         ) from error
-    return repo_config_payload(value)
+    return value
 
 
 async def save_repo_file(
@@ -313,7 +288,7 @@ async def save_repo_file(
     git_owner: str,
     git_repo_name: str,
     body: PutCloudRepoFileRequest,
-) -> CloudRepoConfigResponse:
+) -> CloudRepoConfigValue:
     relative_path = normalize_repo_file_path(body.relative_path)
     validate_tracked_file_content(body.content)
     value = await save_cloud_repo_file(
@@ -324,7 +299,7 @@ async def save_repo_file(
         relative_path=relative_path,
         content=body.content,
     )
-    return repo_config_payload(value)
+    return value
 
 
 async def load_repo_config_value(
@@ -371,7 +346,7 @@ async def get_workspace_repo_config_status(
     db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
-) -> CloudWorkspaceRepoConfigStatusResponse:
+) -> WorkspaceRepoConfigStatus:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
     repo_config = await get_cloud_repo_config(
         db,
@@ -379,16 +354,14 @@ async def get_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return workspace_repo_config_status_payload(
-        _workspace_repo_config_status(workspace, repo_config)
-    )
+    return _workspace_repo_config_status(workspace, repo_config)
 
 
 async def build_resync_workspace_repo_config_status(
     db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
-) -> ResyncCloudWorkspaceFilesResponse:
+) -> ResyncWorkspaceRepoConfigStatus:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
     repo_config = await get_cloud_repo_config(
         db,
@@ -396,9 +369,7 @@ async def build_resync_workspace_repo_config_status(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(
-        _resync_workspace_repo_config_status(workspace, repo_config)
-    )
+    return _resync_workspace_repo_config_status(workspace, repo_config)
 
 
 def _runtime_access_from_target(
@@ -421,7 +392,7 @@ async def resync_workspace_files(
     db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
-) -> ResyncCloudWorkspaceFilesResponse:
+) -> ResyncWorkspaceRepoConfigStatus:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
@@ -452,16 +423,14 @@ async def resync_workspace_files(
         git_owner=workspace.git_owner,
         git_repo_name=workspace.git_repo_name,
     )
-    return resync_cloud_workspace_files_payload(
-        _resync_workspace_repo_config_status(workspace, repo_config)
-    )
+    return _resync_workspace_repo_config_status(workspace, repo_config)
 
 
 async def run_workspace_setup(
     db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
-) -> RunCloudWorkspaceSetupResponse:
+) -> RunWorkspaceSetupStatus:
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
@@ -485,12 +454,10 @@ async def run_workspace_setup(
         ) from error
 
     workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
-    return run_cloud_workspace_setup_payload(
-        RunWorkspaceSetupStatus(
-            workspace_id=workspace.id,
-            command=started.command,
-            terminal_id=started.terminal_id,
-            command_run_id=started.command_run_id,
-            status=started.status,
-        )
+    return RunWorkspaceSetupStatus(
+        workspace_id=workspace.id,
+        command=started.command,
+        terminal_id=started.terminal_id,
+        command_run_id=started.command_run_id,
+        status=started.status,
     )

--- a/server/proliferate/server/cloud/repo_config/validation.py
+++ b/server/proliferate/server/cloud/repo_config/validation.py
@@ -6,12 +6,12 @@ import re
 
 from proliferate.constants.cloud import (
     ANYHARNESS_RESERVED_ENV_PREFIX,
+    CLOUD_REPO_CONFIG_FILE_MAX_BYTES,
     PROLIFERATE_RESERVED_ENV_PREFIX,
     RESERVED_CLOUD_REPO_ENV_VARS,
 )
 from proliferate.server.cloud.errors import CloudApiError
 
-_MAX_TRACKED_FILE_BYTES = 1_048_576
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -55,7 +55,7 @@ def normalize_repo_file_path(value: str) -> str:
 
 
 def validate_tracked_file_content(content: str) -> None:
-    if len(content.encode("utf-8")) > _MAX_TRACKED_FILE_BYTES:
+    if len(content.encode("utf-8")) > CLOUD_REPO_CONFIG_FILE_MAX_BYTES:
         raise CloudApiError(
             "repo_file_too_large",
             "Tracked files must be 1 MiB or smaller.",

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -60,10 +60,12 @@ async def list_cloud_workspaces_endpoint(
 async def create_cloud_workspace_endpoint(
     body: CreateCloudWorkspaceRequest,
     user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
         payload = await create_cloud_workspace(
             user,
+            db=db,
             git_provider=body.git_provider,
             git_owner=body.git_owner,
             git_repo_name=body.git_repo_name,

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -209,7 +209,7 @@ async def list_cloud_workspaces_for_user(
                 status_code=404,
             )
         try:
-            await resolve_owner_context(user, owner_selection)
+            await resolve_owner_context(user, owner_selection, db=db)
         except OrganizationServiceError as error:
             _map_owner_context_error(error)
         return []
@@ -568,6 +568,7 @@ async def _resolve_new_cloud_workspace_create(
 async def create_cloud_workspace(
     user: User,
     *,
+    db: AsyncSession | None = None,
     git_provider: str,
     git_owner: str,
     git_repo_name: str,
@@ -577,8 +578,14 @@ async def create_cloud_workspace(
     owner_selection: OwnerSelection | None = None,
 ) -> WorkspaceDetail:
     if owner_selection is not None and owner_selection.owner_scope == "organization":
+        if db is None:
+            raise CloudApiError(
+                "organization_not_found",
+                "Organization not found.",
+                status_code=404,
+            )
         try:
-            await resolve_owner_context(user, owner_selection)
+            await resolve_owner_context(user, owner_selection, db=db)
         except OrganizationServiceError as error:
             _map_owner_context_error(error)
         _raise_org_cloud_not_ready()

--- a/server/proliferate/server/cloud/worktree_policy/api.py
+++ b/server/proliferate/server/cloud/worktree_policy/api.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
+from proliferate.constants.cloud import DEFAULT_WORKTREE_POLICY_UPDATED_AT
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.worktree_policy.models import (
@@ -11,11 +12,26 @@ from proliferate.server.cloud.worktree_policy.models import (
     CloudWorktreeRetentionPolicyResponse,
 )
 from proliferate.server.cloud.worktree_policy.service import (
+    CloudWorktreeRetentionPolicy,
     get_worktree_retention_policy,
     set_worktree_retention_policy,
 )
 
 router = APIRouter()
+
+
+def _worktree_policy_response(
+    policy: CloudWorktreeRetentionPolicy,
+) -> CloudWorktreeRetentionPolicyResponse:
+    return CloudWorktreeRetentionPolicyResponse(
+        max_materialized_worktrees_per_repo=policy.max_materialized_worktrees_per_repo,
+        updated_at=(
+            DEFAULT_WORKTREE_POLICY_UPDATED_AT
+            if policy.updated_at is None
+            else policy.updated_at.isoformat()
+        ),
+        source=policy.source,
+    )
 
 
 @router.get(
@@ -26,7 +42,7 @@ async def get_cloud_worktree_retention_policy_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> CloudWorktreeRetentionPolicyResponse:
-    return await get_worktree_retention_policy(db, user.id)
+    return _worktree_policy_response(await get_worktree_retention_policy(db, user.id))
 
 
 @router.put(
@@ -38,8 +54,10 @@ async def put_cloud_worktree_retention_policy_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ) -> CloudWorktreeRetentionPolicyResponse:
-    return await set_worktree_retention_policy(
-        db,
-        user.id,
-        max_materialized_worktrees_per_repo=body.max_materialized_worktrees_per_repo,
+    return _worktree_policy_response(
+        await set_worktree_retention_policy(
+            db,
+            user.id,
+            max_materialized_worktrees_per_repo=body.max_materialized_worktrees_per_repo,
+        )
     )

--- a/server/proliferate/server/cloud/worktree_policy/models.py
+++ b/server/proliferate/server/cloud/worktree_policy/models.py
@@ -6,8 +6,6 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from proliferate.db.store.cloud_worktree_policy import CloudWorktreePolicyValue
-
 CloudWorktreePolicySource = Literal["persisted", "default"]
 
 
@@ -21,13 +19,3 @@ class CloudWorktreeRetentionPolicyResponse(BaseModel):
     )
     updated_at: str = Field(serialization_alias="updatedAt")
     source: CloudWorktreePolicySource
-
-
-def cloud_worktree_policy_payload(
-    value: CloudWorktreePolicyValue,
-) -> CloudWorktreeRetentionPolicyResponse:
-    return CloudWorktreeRetentionPolicyResponse(
-        max_materialized_worktrees_per_repo=value.max_materialized_worktrees_per_repo,
-        updated_at=value.updated_at.isoformat(),
-        source="persisted",
-    )

--- a/server/proliferate/server/cloud/worktree_policy/service.py
+++ b/server/proliferate/server/cloud/worktree_policy/service.py
@@ -1,25 +1,49 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import (
     DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
-    DEFAULT_WORKTREE_POLICY_UPDATED_AT,
     MAX_MAX_MATERIALIZED_WORKTREES_PER_REPO,
     MIN_MAX_MATERIALIZED_WORKTREES_PER_REPO,
 )
 from proliferate.db.store.cloud_worktree_policy import (
+    CloudWorktreePolicyValue,
     get_cloud_worktree_policy,
     load_cloud_worktree_policy_for_user,
     save_cloud_worktree_policy,
 )
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.worktree_policy.models import (
-    CloudWorktreeRetentionPolicyResponse,
-    cloud_worktree_policy_payload,
-)
+
+CloudWorktreePolicySource = Literal["persisted", "default"]
+
+
+@dataclass(frozen=True)
+class CloudWorktreeRetentionPolicy:
+    max_materialized_worktrees_per_repo: int
+    updated_at: datetime | None
+    source: CloudWorktreePolicySource
+
+
+def _default_worktree_policy() -> CloudWorktreeRetentionPolicy:
+    return CloudWorktreeRetentionPolicy(
+        max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
+        updated_at=None,
+        source="default",
+    )
+
+
+def _worktree_policy_result(value: CloudWorktreePolicyValue) -> CloudWorktreeRetentionPolicy:
+    return CloudWorktreeRetentionPolicy(
+        max_materialized_worktrees_per_repo=value.max_materialized_worktrees_per_repo,
+        updated_at=value.updated_at,
+        source="persisted",
+    )
 
 
 def validate_worktree_policy_limit(value: int) -> int:
@@ -43,15 +67,11 @@ def validate_worktree_policy_limit(value: int) -> int:
 async def get_worktree_retention_policy(
     db: AsyncSession,
     user_id: UUID,
-) -> CloudWorktreeRetentionPolicyResponse:
+) -> CloudWorktreeRetentionPolicy:
     value = await get_cloud_worktree_policy(db, user_id)
     if value is None:
-        return CloudWorktreeRetentionPolicyResponse(
-            max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
-            updated_at=DEFAULT_WORKTREE_POLICY_UPDATED_AT,
-            source="default",
-        )
-    return cloud_worktree_policy_payload(value)
+        return _default_worktree_policy()
+    return _worktree_policy_result(value)
 
 
 async def set_worktree_retention_policy(
@@ -59,7 +79,7 @@ async def set_worktree_retention_policy(
     user_id: UUID,
     *,
     max_materialized_worktrees_per_repo: int,
-) -> CloudWorktreeRetentionPolicyResponse:
+) -> CloudWorktreeRetentionPolicy:
     value = await save_cloud_worktree_policy(
         db,
         user_id=user_id,
@@ -67,17 +87,13 @@ async def set_worktree_retention_policy(
             max_materialized_worktrees_per_repo,
         ),
     )
-    return cloud_worktree_policy_payload(value)
+    return _worktree_policy_result(value)
 
 
 async def load_worktree_retention_policy_for_runtime(
     user_id: UUID,
-) -> CloudWorktreeRetentionPolicyResponse:
+) -> CloudWorktreeRetentionPolicy:
     value = await load_cloud_worktree_policy_for_user(user_id)
     if value is None:
-        return CloudWorktreeRetentionPolicyResponse(
-            max_materialized_worktrees_per_repo=DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO,
-            updated_at=DEFAULT_WORKTREE_POLICY_UPDATED_AT,
-            source="default",
-        )
-    return cloud_worktree_policy_payload(value)
+        return _default_worktree_policy()
+    return _worktree_policy_result(value)

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -31,11 +31,6 @@ from proliferate.constants.organizations import (
 )
 from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import organizations as organization_store
-from proliferate.db.store.billing import (
-    ensure_organization_billing_subject,
-    get_or_create_stripe_customer_state_for_user,
-    get_or_create_user_stripe_customer_state,
-)
 from proliferate.db.store.organization_records import (
     InvitationCreateRecord,
     InvitationRecord,
@@ -45,6 +40,11 @@ from proliferate.db.store.organization_records import (
     normalize_invitation_email,
 )
 from proliferate.integrations import resend
+from proliferate.server.billing.service import (
+    ensure_organization_billing_subject_state,
+    ensure_personal_billing_subject_state,
+    maybe_create_organization_seat_adjustment,
+)
 from proliferate.server.organizations.domain.policy import (
     can_modify_membership,
     can_modify_owner_memberships,
@@ -175,7 +175,7 @@ async def resolve_owner_context(
     actor_user: OrganizationActor,
     owner_selection: OwnerSelection | None = None,
     *,
-    db: AsyncSession | None = None,
+    db: AsyncSession,
 ) -> OwnerContext:
     selection = owner_selection or OwnerSelection()
     if selection.owner_scope == "personal":
@@ -185,11 +185,7 @@ async def resolve_owner_context(
                 "organizationId is not valid for personal scope.",
                 status_code=400,
             )
-        state = (
-            await get_or_create_user_stripe_customer_state(db, actor_user.id)
-            if db is not None
-            else await get_or_create_stripe_customer_state_for_user(actor_user.id)
-        )
+        state = await ensure_personal_billing_subject_state(db, actor_user.id)
         if state.kind != BILLING_SUBJECT_KIND_PERSONAL:
             raise OrganizationServiceError(
                 "invalid_owner_selection",
@@ -207,27 +203,16 @@ async def resolve_owner_context(
         )
 
     organization_id = _require_uuid(selection.organization_id, field="organizationId")
-    if db is not None:
-        record = await organization_store.get_organization_with_membership(
-            db,
-            organization_id=organization_id,
-            user_id=actor_user.id,
-        )
-        if record is None:
-            raise _org_not_found()
-        subject = await ensure_organization_billing_subject(db, organization_id)
-        membership = record.membership
-        billing_subject_id = subject.id
-    else:
-        membership = await organization_store.load_active_membership(
-            organization_id=organization_id,
-            user_id=actor_user.id,
-        )
-        if membership is None:
-            raise _org_not_found()
-        billing_subject_id = await organization_store.ensure_organization_billing_subject_id(
-            organization_id,
-        )
+    record = await organization_store.get_organization_with_membership(
+        db,
+        organization_id=organization_id,
+        user_id=actor_user.id,
+    )
+    if record is None:
+        raise _org_not_found()
+    subject = await ensure_organization_billing_subject_state(db, organization_id)
+    membership = record.membership
+    billing_subject_id = subject.billing_subject_id
     return OwnerContext(
         owner_scope="organization",
         actor_user_id=actor_user.id,
@@ -251,7 +236,7 @@ async def _resolve_organization_owner_context(
     )
     if record is None:
         raise _org_not_found()
-    subject = await ensure_organization_billing_subject(db, organization_id)
+    subject = await ensure_organization_billing_subject_state(db, organization_id)
     return OwnerContext(
         owner_scope="organization",
         actor_user_id=actor_user.id,
@@ -259,7 +244,7 @@ async def _resolve_organization_owner_context(
         organization_id=organization_id,
         membership_id=record.membership.id,
         membership_role=record.membership.role,
-        billing_subject_id=subject.id,
+        billing_subject_id=subject.billing_subject_id,
     )
 
 
@@ -270,12 +255,15 @@ async def list_organizations(
     records = await organization_store.list_organizations_for_user(db, actor_user.id)
     if records:
         return records
-    return await organization_store.ensure_default_organization_for_user(
+    records = await organization_store.ensure_default_organization_for_user(
         db,
         user_id=actor_user.id,
         name=_default_organization_name(actor_user),
         logo_domain=derive_logo_domain_from_email(actor_user.email),
     )
+    if records:
+        await ensure_organization_billing_subject_state(db, records[0].organization.id)
+    return records
 
 
 async def get_organization(
@@ -375,6 +363,12 @@ async def update_membership(
         )
     if membership is None:
         raise _org_not_found()
+    if status is not None:
+        await maybe_create_organization_seat_adjustment(
+            db,
+            organization_id=organization_id,
+            membership_id=membership.id,
+        )
     return membership
 
 
@@ -581,6 +575,11 @@ async def accept_invitation(
             message,
             status_code=status_code,
         )
+    await maybe_create_organization_seat_adjustment(
+        db,
+        organization_id=accepted.organization.id,
+        membership_id=accepted.membership.id,
+    )
     return OrganizationWithMembershipRecord(
         organization=accepted.organization,
         membership=accepted.membership,

--- a/server/tests/unit/test_automation_service.py
+++ b/server/tests/unit/test_automation_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from proliferate.db import engine as engine_module
 from proliferate.db.models.automations import Automation
+from proliferate.db.models.billing import BillingSubject
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
 from proliferate.errors import ProliferateError
 from proliferate.server.automations import service as automation_service
@@ -79,6 +80,62 @@ async def test_create_automation_bootstraps_repo_config(
         assert response.git_owner == "proliferate-ai"
         assert response.git_repo_name == "proliferate"
         assert repo_config.configured is True
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
+async def test_create_automation_repo_bootstrap_uses_request_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    monkeypatch.setattr(
+        automation_service,
+        "utcnow",
+        lambda: datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+    )
+    user_id = uuid.uuid4()
+
+    try:
+        async with engine_module.async_session_factory() as session:
+            await automation_service.create_automation(
+                session,
+                user_id,
+                CreateAutomationRequest(
+                    title="Daily check",
+                    prompt="Check the repo.",
+                    gitOwner="proliferate-ai",
+                    gitRepoName="proliferate",
+                    schedule=AutomationScheduleRequest(
+                        rrule="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                        timezone="UTC",
+                    ),
+                    executionTarget="cloud",
+                    agentKind="codex",
+                ),
+            )
+            await session.rollback()
+
+        async with engine_module.async_session_factory() as session:
+            repo_config = (
+                await session.execute(
+                    select(CloudRepoConfig).where(
+                        CloudRepoConfig.user_id == user_id,
+                        CloudRepoConfig.git_owner == "proliferate-ai",
+                        CloudRepoConfig.git_repo_name == "proliferate",
+                    )
+                )
+            ).scalar_one_or_none()
+            billing_subject = (
+                await session.execute(
+                    select(BillingSubject).where(BillingSubject.user_id == user_id)
+                )
+            ).scalar_one_or_none()
+
+        assert repo_config is None
+        assert billing_subject is None
     finally:
         engine_module.async_session_factory = original_factory
 

--- a/server/tests/unit/test_cloud_mcp_oauth_domain.py
+++ b/server/tests/unit/test_cloud_mcp_oauth_domain.py
@@ -22,6 +22,7 @@ def test_oauth_redirect_uri_prefers_configured_callback_base() -> None:
         oauth_redirect_uri(
             configured_callback_base_url=" https://callbacks.example.com/ ",
             api_base_url="https://api.example.com",
+            fallback_callback_base_url="http://localhost:8000",
         )
         == "https://callbacks.example.com/v1/cloud/mcp/oauth/callback"
     )
@@ -32,6 +33,7 @@ def test_oauth_redirect_uri_falls_back_to_api_base_and_localhost() -> None:
         oauth_redirect_uri(
             configured_callback_base_url="",
             api_base_url=" https://api.example.com/ ",
+            fallback_callback_base_url="http://localhost:8000",
         )
         == "https://api.example.com/v1/cloud/mcp/oauth/callback"
     )
@@ -39,6 +41,7 @@ def test_oauth_redirect_uri_falls_back_to_api_base_and_localhost() -> None:
         oauth_redirect_uri(
             configured_callback_base_url="",
             api_base_url="",
+            fallback_callback_base_url="http://localhost:8000",
         )
         == "http://localhost:8000/v1/cloud/mcp/oauth/callback"
     )

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -62,7 +62,8 @@ async def test_org_cloud_workspace_create_fails_before_personal_helpers(
     user = SimpleNamespace(id=uuid4())
     organization_id = uuid4()
 
-    async def _resolve_owner_context(_user, owner_selection):
+    async def _resolve_owner_context(_user, owner_selection, *, db):
+        assert db is not None
         assert owner_selection.owner_scope == "organization"
         assert owner_selection.organization_id == organization_id
         return OwnerContext(
@@ -88,6 +89,7 @@ async def test_org_cloud_workspace_create_fails_before_personal_helpers(
     with pytest.raises(CloudApiError) as exc_info:
         await workspace_service.create_cloud_workspace(
             user,
+            db=object(),  # type: ignore[arg-type]
             git_provider="github",
             git_owner="acme",
             git_repo_name="rocket",


### PR DESCRIPTION
## Summary
- thread non-deferred automation/repo-config CRUD through request DB sessions
- route organization billing side effects through billing service helpers instead of organization stores
- move small cloud service DTO construction to API layers and relocate config/constants drift
- clarify the Phase 8 tracker, add cloud mobility, and ratchet server boundary debt to 90/59

## Verification
- `uv run --project server python scripts/check_server_boundaries.py`
- `uv run --project server python scripts/check_max_lines.py`
- `uv run --project server ruff check ...changed server paths...`
- `DEBUG=true uv run --project server --extra dev python -m pytest -q server/tests/integration/test_organizations_api.py server/tests/unit/test_cloud_workspace_service.py server/tests/unit/test_billing_service_policy.py server/tests/unit/test_automation_service.py server/tests/unit/test_cloud_mcp_oauth_domain.py server/tests/unit/test_mcp_oauth.py server/tests/integration/test_cloud_credentials_api.py server/tests/integration/test_cloud_api.py`

## Notes
- Broad `server/tests/unit server/tests/integration` was also attempted by a verification subagent: 566 passed, 1 xfailed, 2 schema-migration tests failed due local DB superuser privilege on `pg_terminate_backend`, unrelated to this patch.
- Full `ruff check` still reports pre-existing issues in `scripts/check_max_lines.py` and alembic migration line lengths; changed-path ruff passes.
