### PR TITLE
docs(anyharness): align migration docs with runtime split

### DIFF
--- a/docs/anyharness/README.md
+++ b/docs/anyharness/README.md
@@ -284,9 +284,9 @@ which guide to read and where the code belongs.
 | Git status/diff/branch operations and git command parsing | `anyharness-lib/src/adapters/git/**` | `adapters/git/**` | [guides/adapters.md](guides/adapters.md), [src/git.md](src/git.md) |
 | Hosting and process helpers around local workspace capabilities | `anyharness-lib/src/adapters/hosting/**`, `anyharness-lib/src/adapters/processes/**` | `adapters/hosting/**`, `adapters/processes/**` | [guides/adapters.md](guides/adapters.md) |
 | Terminal/PTTY lifecycle, terminal stream handles, terminal registry | `anyharness-lib/src/terminals/**` | `live/terminals/**` | [guides/live-runtime.md](guides/live-runtime.md) |
-| MCP user bindings attached to a session | `anyharness-lib/src/sessions/mcp.rs` | `domains/sessions/mcp_bindings/**` | [specs/mcp.md](specs/mcp.md), [guides/domains.md](guides/domains.md) |
+| MCP user bindings attached to a session | `anyharness-lib/src/sessions/mcp_bindings/**` | current `sessions/mcp_bindings/**`; final `domains/sessions/mcp_bindings/**` | [specs/mcp.md](specs/mcp.md), [guides/domains.md](guides/domains.md) |
 | Product MCP tool servers for cowork, reviews, subagents, workspace naming | `domains/cowork/**`, `domains/reviews/**`, `sessions/subagents/**`, `sessions/workspace_naming/**` | owning product domain | [specs/mcp.md](specs/mcp.md), [guides/domains.md](guides/domains.md) |
-| Shared MCP JSON-RPC, capability-token, tool-formatting scaffolding | scattered MCP helpers | `integrations/mcp/**` | [guides/integrations.md](guides/integrations.md), [specs/mcp.md](specs/mcp.md) |
+| Shared MCP JSON-RPC, capability-token, tool-formatting scaffolding | `anyharness-lib/src/integrations/mcp/**` plus any remaining feature-local wrappers | `integrations/mcp/**` | [guides/integrations.md](guides/integrations.md), [specs/mcp.md](specs/mcp.md) |
 | Cowork artifacts, delegation, or cowork-owned tools | `anyharness-lib/src/domains/cowork/**` | `domains/cowork/**` | [guides/domains.md](guides/domains.md), [src/cowork-artifacts.md](src/cowork-artifacts.md) |
 | Reviews, plans, mobility, or repo-root product behavior | `domains/reviews/**`, `domains/plans/**`, `domains/mobility/**`, `repo_roots/**` | owning `domains/<domain>/**` | [guides/domains.md](guides/domains.md) |
 | Latency tracing, request measurement, diagnostic ids | `api/http/latency.rs` and scattered measurement helpers | `observability/**` | [guides/observability.md](guides/observability.md) |
@@ -372,19 +372,35 @@ current api/http/latency.rs -> target observability/latency.rs
 
 Known transitional issues:
 
+- Phase 1 topology moves are present: local file/git/hosting/process
+  capabilities live under `adapters/**`, shared MCP helpers live under
+  `integrations/mcp/**`, and provider CLI mechanics live under
+  `integrations/agent_cli/**`.
+- Product domain cleanup is partially present: agents, cowork, reviews, plans,
+  and mobility live under `domains/**`; sessions, workspaces, repo roots, and
+  terminals still use transitional top-level paths until the final topology
+  rename phase.
+- Session MCP assembly is split under `sessions/mcp_bindings/**`, including
+  `assembly.rs`. The final `domains/sessions/**` path is still a target.
+- `SessionRuntime` is split under `sessions/runtime/**`. The public
+  `SessionRuntime` type remains the API-facing use-case surface.
+- `SessionStore` is split under `sessions/store/**`. The public `SessionStore`
+  type remains the caller-facing store surface.
+- `SessionEventSink` is split under `acp/event_sink/**`. It has not moved to
+  final `live/sessions/event_sink/**` topology yet.
 - Some runtime/domain modules import `crate::api::http::latency`; latency
   helpers should move to `observability/`.
 - Contract request/response types leak below `api/`. Contract event payloads
   may be a deliberate durable event-log type, but other contract types should
   be mapped at the API boundary.
-- Core session files are too large and mix multiple roles:
-  `acp/session_actor.rs`, `acp/event_sink.rs`, and `sessions/store.rs`.
-- Product MCP servers duplicate JSON-RPC helpers and capability-token logic.
-  Common protocol/auth scaffolding should move to `integrations/mcp/`; product
-  tool semantics stay with their owning domain.
-- Agent/provider CLI mechanics are mixed with agent catalog/readiness logic.
-  Provider-specific process/install/probe behavior should move toward
-  `integrations/agent_cli/`.
+- Core live/session cleanup still remaining is centered on
+  `acp/session_actor.rs`; the actor loop rewrite is deferred/manual.
+- Some product MCP endpoint scaffolding may still be feature-local. Common
+  protocol/auth scaffolding should use `integrations/mcp/`; product tool
+  semantics stay with their owning domain.
+- Some agent/provider CLI mechanics may still be mixed with agent
+  catalog/readiness logic. Provider-specific process/install/probe behavior
+  should move toward `integrations/agent_cli/`.
 
 Cleanup work should preserve behavior, then move code to the target owner.
 Do not leave duplicate old and new code paths after a migration.

--- a/docs/anyharness/guides/domains.md
+++ b/docs/anyharness/guides/domains.md
@@ -12,8 +12,8 @@ Current session-domain reality:
 - user MCP bindings and session MCP launch assembly live under
   `sessions/mcp_bindings/**`.
 - session persistence is split under `sessions/store/**`.
-- `sessions/runtime.rs` remains the current runtime bridge; the runtime split
-  is in progress/planned on this base.
+- session runtime orchestration is split under `sessions/runtime/**`, while the
+  final `domains/sessions/**` topology remains deferred.
 
 ## Purpose
 

--- a/docs/anyharness/guides/domains.md
+++ b/docs/anyharness/guides/domains.md
@@ -2,9 +2,18 @@
 
 Status: authoritative for durable/product code under `anyharness-lib/src/domains/**`.
 
-The current code is transitional and still has top-level folders such as
-`sessions/`, `workspaces/`, `agents`, and `cowork`. Those folders map to the
-target `domains/**` layer.
+The current code is transitional. Product domains such as `agents`, `cowork`,
+`reviews`, `plans`, and `mobility` live under `domains/**`. Core session,
+workspace, repo-root, and terminal paths still use top-level transitional
+folders until the final topology rename.
+
+Current session-domain reality:
+
+- user MCP bindings and session MCP launch assembly live under
+  `sessions/mcp_bindings/**`.
+- session persistence is split under `sessions/store/**`.
+- `sessions/runtime.rs` remains the current runtime bridge; the runtime split
+  is in progress/planned on this base.
 
 ## Purpose
 
@@ -97,7 +106,7 @@ Expected shape:
   store/          # product-specific queries
   service/        # durable product rules
   runtime/        # only if it coordinates cross-domain or live work
-  mcp_server.rs   # when the product exposes MCP tools
+  mcp_server/     # when the product exposes MCP tools
   session_extension.rs  # when the product plugs into session launch/prompt
 ```
 
@@ -280,6 +289,10 @@ domains/reviews/session_extension.rs
 domains/sessions/subagents/session_extension.rs
 domains/sessions/workspace_naming/session_extension.rs
 ```
+
+Current implementations are still transitional in places:
+`domains/cowork/runtime.rs`, `domains/reviews/hooks.rs`,
+`sessions/subagents/hooks.rs`, and `sessions/workspace_naming/hooks.rs`.
 
 `app/` wires implementations into the core. The core domain depends only on the
 trait.

--- a/docs/anyharness/guides/integrations.md
+++ b/docs/anyharness/guides/integrations.md
@@ -7,7 +7,7 @@ Status: authoritative for external protocol/vendor mechanics.
 `integrations/**` owns how AnyHarness speaks external protocols and vendor
 surfaces. It does not own product semantics.
 
-Target examples:
+Current and target examples:
 
 ```text
 integrations/mcp/
@@ -19,6 +19,11 @@ integrations/agent_cli/
 integrations/acp/
   low-level ACP protocol helpers if they become reusable outside live sessions
 ```
+
+`integrations/mcp/**` and `integrations/agent_cli/**` are present in the
+current code. Reusable ACP protocol helpers have not earned a separate
+`integrations/acp/**` folder yet; live ACP execution remains under the
+transitional `acp/**` path.
 
 ## MCP
 
@@ -33,7 +38,8 @@ Generic MCP code belongs here:
 Product tool behavior does not belong here.
 Session MCP launch assembly also does not belong here; that is session-domain
 composition because it decides which user and product MCP servers a session
-launches with.
+launches with. The current implementation is `sessions/mcp_bindings/**`; the
+final topology target is `domains/sessions/mcp_bindings/**`.
 
 Examples:
 

--- a/docs/anyharness/guides/live-runtime.md
+++ b/docs/anyharness/guides/live-runtime.md
@@ -5,6 +5,9 @@ Status: authoritative for long-lived in-memory runtime systems under
 
 The current code is transitional. Today `acp/**` maps mostly to target
 `live/sessions/**`, and `terminals/**` maps to target `live/terminals/**`.
+`SessionEventSink` has been split under `acp/event_sink/**`; the final move to
+`live/sessions/event_sink/**` is still a topology step. `SessionActor` remains
+in `acp/session_actor.rs`; the actor loop rewrite is deferred/manual.
 
 ## Purpose
 
@@ -53,8 +56,8 @@ Current name mapping:
 ```text
 AcpManager       -> LiveSessionManager
 RuntimeClient    -> AcpClient
-SessionEventSink -> keep or split under event_sink/
-InteractionBroker -> live/sessions/interactions/
+SessionEventSink -> currently acp/event_sink/**; target live/sessions/event_sink/
+InteractionBroker -> currently acp/permission_broker/**; target live/sessions/interactions/
 ```
 
 ## Actor Files

--- a/docs/anyharness/guides/repo-shape.md
+++ b/docs/anyharness/guides/repo-shape.md
@@ -20,6 +20,16 @@ Use these thresholds for Rust source under `anyharness/crates/**`:
 
 Existing files above these limits are migration debt, not precedent.
 
+Current migration reality:
+
+- `sessions/store/**` is the current split session store shape.
+- `sessions/mcp_bindings/**` is the current split session MCP binding and
+  launch assembly shape.
+- `acp/event_sink/**` is the current split session event sink shape.
+- `sessions/runtime.rs` remains unsplit on this base; treat a runtime folder as
+  planned until the runtime split lands.
+- `acp/session_actor.rs` remains a manual deferred rewrite target.
+
 ## Module Style
 
 Prefer explicit concern files over giant `mod.rs` files.

--- a/docs/anyharness/guides/repo-shape.md
+++ b/docs/anyharness/guides/repo-shape.md
@@ -26,8 +26,7 @@ Current migration reality:
 - `sessions/mcp_bindings/**` is the current split session MCP binding and
   launch assembly shape.
 - `acp/event_sink/**` is the current split session event sink shape.
-- `sessions/runtime.rs` remains unsplit on this base; treat a runtime folder as
-  planned until the runtime split lands.
+- `sessions/runtime/**` is the current split session runtime shape.
 - `acp/session_actor.rs` remains a manual deferred rewrite target.
 
 ## Module Style

--- a/docs/anyharness/specs/mcp.md
+++ b/docs/anyharness/specs/mcp.md
@@ -11,7 +11,11 @@ thing.
 
 MCP servers explicitly attached to a session by a client/user.
 
-Current owner: `sessions/mcp.rs`.
+Current implementation owner:
+
+```text
+sessions/mcp_bindings/
+```
 
 Target owner:
 
@@ -28,12 +32,14 @@ Responsibilities:
 - conversion to ACP MCP server config
 
 This folder also owns the central session MCP assembly path described below.
+The current path is still under transitional `sessions/**` topology; the final
+`domains/sessions/**` rename is a later topology phase.
 
 ### 2. Session Extensions
 
 Product features can inject MCP servers into a session launch.
 
-Current trait: `SessionExtension`.
+Current trait: `sessions/extensions.rs::SessionExtension`.
 
 Target owner:
 
@@ -41,13 +47,13 @@ Target owner:
 domains/sessions/extensions/
 ```
 
-Implementations:
+Current implementations:
 
 ```text
-domains/cowork/session_extension.rs
-domains/reviews/session_extension.rs
-domains/sessions/subagents/session_extension.rs
-domains/sessions/workspace_naming/session_extension.rs
+domains/cowork/runtime.rs
+domains/reviews/hooks.rs
+sessions/subagents/hooks.rs
+sessions/workspace_naming/hooks.rs
 ```
 
 The extension returns launch extras:
@@ -68,13 +74,13 @@ Examples:
 - review tools
 - workspace naming tool
 
-Target shape:
+Current implementation shape:
 
 ```text
-domains/cowork/mcp_server.rs
-domains/reviews/mcp_server.rs
-domains/sessions/subagents/mcp_server.rs
-domains/sessions/workspace_naming/mcp_server.rs
+domains/cowork/mcp_server/
+domains/reviews/mcp_server/
+sessions/subagents/mcp_server/
+sessions/workspace_naming/mcp_server/
 ```
 
 Product tool behavior stays with the product domain.
@@ -82,6 +88,12 @@ Product tool behavior stays with the product domain.
 ### 4. MCP Elicitation
 
 Live ACP interaction type where an agent asks for an MCP form or URL reveal.
+
+Current implementation owner:
+
+```text
+acp/mcp_elicitation/
+```
 
 Target owner:
 
@@ -108,6 +120,12 @@ SessionRuntime starts a session
 Session launch needs one central assembly boundary. Do not spread MCP launch
 composition across session runtime, product domains, and actor startup.
 
+Current implementation owner:
+
+```text
+sessions/mcp_bindings/assembly.rs
+```
+
 Target owner:
 
 ```text
@@ -121,10 +139,10 @@ Which MCP servers, prompt additions, and binding summaries should this session
 launch with?
 ```
 
-Expected shape:
+Current transitional shape:
 
 ```text
-domains/sessions/mcp_bindings/
+sessions/mcp_bindings/
   model.rs       # SessionMcpServer, headers/env, policies, summaries
   crypto.rs      # binding encryption/decryption and data-key loading
   contract.rs    # contract <-> domain mapping
@@ -132,6 +150,9 @@ domains/sessions/mcp_bindings/
   acp.rs         # SessionMcpServer -> ACP MCP server config
   assembly.rs    # assemble_session_mcp_launch(...)
 ```
+
+The final topology target keeps the same files under
+`domains/sessions/mcp_bindings/`.
 
 The assembly function owns:
 
@@ -228,6 +249,10 @@ integrations/mcp/
   json_rpc.rs
   tools.rs
 ```
+
+The shared `integrations/mcp/**` helpers are present. Per-feature HTTP endpoint
+wrappers may remain until a focused transport cleanup moves common endpoint
+scaffolding behind one wrapper.
 
 ## Consolidation Rule
 

--- a/docs/anyharness/specs/session-engine.md
+++ b/docs/anyharness/specs/session-engine.md
@@ -34,9 +34,8 @@ Implementation reality after the completed migration phases:
 
 - session MCP assembly lives under `sessions/mcp_bindings/**`.
 - `SessionStore` is split under `sessions/store/**`.
+- `SessionRuntime` is split under `sessions/runtime/**`.
 - `SessionEventSink` is split under `acp/event_sink/**`.
-- `sessions/runtime.rs` remains the current `SessionRuntime` implementation;
-  the runtime split is in progress/planned on this base.
 - `acp/session_actor.rs` remains the current actor implementation; the actor
   loop rewrite is deferred/manual.
 
@@ -83,11 +82,9 @@ High-level session use cases:
 - edit/remove pending prompts
 - inject/replay events
 
-This is the bridge between durable sessions and live execution.
-
-The current implementation remains in `sessions/runtime.rs` until the Phase 6
-runtime split lands. Do not document or assume a completed `sessions/runtime/**`
-split on this base.
+This is the bridge between durable sessions and live execution. The
+implementation is split under `sessions/runtime/**` by API-facing operation
+family; callers should continue to use the public `SessionRuntime` type.
 
 ### LiveSessionManager
 

--- a/docs/anyharness/specs/session-engine.md
+++ b/docs/anyharness/specs/session-engine.md
@@ -21,14 +21,24 @@ Current names:
 ```text
 SessionRuntime      anyharness-lib/src/sessions/runtime/
 SessionService      anyharness-lib/src/sessions/service.rs
-SessionStore        anyharness-lib/src/sessions/store.rs
+SessionStore        anyharness-lib/src/sessions/store/**
 AcpManager          target name: LiveSessionManager
 LiveSessionHandle   currently inside acp/session_actor.rs
 SessionActor        currently acp/session_actor.rs
 RuntimeClient       target name: AcpClient
-SessionEventSink    currently acp/event_sink.rs
-InteractionBroker   currently acp/permission_broker.rs
+SessionEventSink    currently acp/event_sink/**
+InteractionBroker   currently acp/permission_broker/**
 ```
+
+Implementation reality after the completed migration phases:
+
+- session MCP assembly lives under `sessions/mcp_bindings/**`.
+- `SessionStore` is split under `sessions/store/**`.
+- `SessionEventSink` is split under `acp/event_sink/**`.
+- `sessions/runtime.rs` remains the current `SessionRuntime` implementation;
+  the runtime split is in progress/planned on this base.
+- `acp/session_actor.rs` remains the current actor implementation; the actor
+  loop rewrite is deferred/manual.
 
 ## Role Map
 
@@ -75,6 +85,10 @@ High-level session use cases:
 
 This is the bridge between durable sessions and live execution.
 
+The current implementation remains in `sessions/runtime.rs` until the Phase 6
+runtime split lands. Do not document or assume a completed `sessions/runtime/**`
+split on this base.
+
 ### LiveSessionManager
 
 Live registry:
@@ -111,6 +125,10 @@ One running agent session state machine:
 - interaction registration
 - event sink calls
 - shutdown/error handling
+
+The current implementation remains a single `acp/session_actor.rs` file. The
+rewrite into an actor folder requires a dedicated actor spec and is explicitly
+deferred.
 
 ### AcpClient
 

--- a/docs/anyharness/src/acp.md
+++ b/docs/anyharness/src/acp.md
@@ -2,6 +2,10 @@
 
 `anyharness-lib/src/acp/**` owns live ACP-backed session execution.
 
+This is a legacy subsystem doc updated for current implementation paths. The
+event sink is already split under `acp/event_sink/**`; the actor remains in
+`acp/session_actor.rs` and its rewrite is deferred/manual.
+
 ## Core Concepts
 
 The ACP runtime starts after the session domain has already decided that a
@@ -92,7 +96,7 @@ It does not own the actor loop. It translates ACP protocol callbacks into:
 - internal notification messages
 - normalized runtime events through the event sink
 
-### `SessionEventSink` (`anyharness/crates/anyharness-lib/src/acp/event_sink.rs`)
+### `SessionEventSink` (`anyharness/crates/anyharness-lib/src/acp/event_sink/**`)
 
 `SessionEventSink` is the canonical normalization layer from ACP updates into
 AnyHarness `SessionEventEnvelope`.

--- a/docs/anyharness/src/persistence.md
+++ b/docs/anyharness/src/persistence.md
@@ -15,7 +15,7 @@ It owns:
 - exposing the shared `Db` handle used by stores
 
 It does not own domain-specific SQL. That stays in the owning domain store such
-as `sessions/store.rs` or `workspaces/store.rs`.
+as `sessions/store/**` or `workspaces/store.rs`.
 
 ## Core Models
 
@@ -75,12 +75,12 @@ Persistence should be thought of as a two-layer boundary:
 
 - `persistence/**`
   - DB bootstrap and shared DB access
-- domain `store.rs`
+- domain `store.rs` or `store/**`
   - actual SQL for that domain
 
 That means:
 
-- `sessions/store.rs` owns session/event/config SQL
+- `sessions/store/**` owns session/event/config SQL
 - `workspaces/store.rs` owns workspace SQL
 - `persistence/**` does not become a giant shared query bucket
 

--- a/docs/anyharness/src/sessions.md
+++ b/docs/anyharness/src/sessions.md
@@ -6,8 +6,8 @@ orchestration that bridges durable sessions into live ACP execution.
 
 This is a legacy subsystem doc updated for current implementation paths.
 Session MCP binding assembly lives under `sessions/mcp_bindings/**`, and the
-session store is split under `sessions/store/**`. `sessions/runtime.rs` remains
-the current runtime implementation until the runtime split lands.
+session store is split under `sessions/store/**`. The runtime implementation is
+split under `sessions/runtime/**`.
 
 ## Core Concepts
 
@@ -343,8 +343,8 @@ merging live events.
 
 ## Runtime Flow
 
-`sessions/runtime.rs` is still the current implementation on this base. Treat
-a split `sessions/runtime/**` layout as in progress/planned, not completed.
+The runtime flow is implemented across `sessions/runtime/**`, split by
+API-facing session operation family.
 
 ### Create and Start
 

--- a/docs/anyharness/src/sessions.md
+++ b/docs/anyharness/src/sessions.md
@@ -4,14 +4,20 @@
 validation, event persistence, live-config persistence, and the runtime-level
 orchestration that bridges durable sessions into live ACP execution.
 
+This is a legacy subsystem doc updated for current implementation paths.
+Session MCP binding assembly lives under `sessions/mcp_bindings/**`, and the
+session store is split under `sessions/store/**`. `sessions/runtime.rs` remains
+the current runtime implementation until the runtime split lands.
+
 ## Core Concepts
 
 The sessions area has two layers:
 
 - durable session domain
   - `anyharness/crates/anyharness-lib/src/sessions/model.rs`
-  - `anyharness/crates/anyharness-lib/src/sessions/store.rs`
+  - `anyharness/crates/anyharness-lib/src/sessions/store/**`
   - `anyharness/crates/anyharness-lib/src/sessions/service.rs`
+  - `anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/**`
   - `anyharness/crates/anyharness-lib/src/sessions/links/**`
 - live orchestration bridge
   - `anyharness/crates/anyharness-lib/src/sessions/runtime/**`
@@ -336,6 +342,9 @@ SSE replay and history endpoints read from these durable records first before
 merging live events.
 
 ## Runtime Flow
+
+`sessions/runtime.rs` is still the current implementation on this base. Treat
+a split `sessions/runtime/**` layout as in progress/planned, not completed.
 
 ### Create and Start
 

--- a/reference/anyharness_cleanup_migration_sequence.md
+++ b/reference/anyharness_cleanup_migration_sequence.md
@@ -1,7 +1,8 @@
 # AnyHarness Cleanup Migration Sequence
 
 Status: current migration tracker after the completed AnyHarness cleanup
-phases and the Phase 10a docs reality pass.
+phases and the Phase 10a docs, ratchet, focused-test, and boundary-rails
+passes.
 
 Authoritative docs:
 
@@ -18,7 +19,7 @@ planned or manual cleanup only.
 
 | Phase | Status | Reality |
 | --- | --- | --- |
-| 0 | Complete | Repo-shape rails and allowlist discipline were established before the structural passes. |
+| 0 | Complete | Repo-shape rails and allowlist discipline are established, including CI-enforced AnyHarness boundary checks. |
 | 1 | Complete | Local file/git/hosting/process capabilities are under `adapters/**`; shared MCP helpers are under `integrations/mcp/**`; provider CLI mechanics are under `integrations/agent_cli/**`. |
 | 2 | Complete | Product-domain cleanup landed for the completed lanes. Agents, cowork, reviews, plans, and mobility live under `domains/**`. Core sessions, workspaces, repo roots, and terminals remain transitional until Phase 9. |
 | 3 | Complete | Product MCP servers follow feature-owned `mcp_server/**` modules and use shared `integrations/mcp/**` helpers where common protocol/auth scaffolding has landed. |
@@ -28,8 +29,8 @@ planned or manual cleanup only.
 | 7 | Complete | `SessionEventSink` is split under `acp/event_sink/**`, while the final `live/sessions/event_sink/**` topology remains future work. |
 | 8 | Deferred/manual | The `SessionActor` loop rewrite remains deferred until a dedicated actor spec exists. Current actor implementation stays in `acp/session_actor.rs`. |
 | 9 | Remaining | Final topology/naming moves remain: live session manager/client/broker naming, `sessions/**` to `domains/sessions/**`, `workspaces/**` to `domains/workspaces/**`, terminal live topology, and related import cleanup. |
-| 10 | Remaining | Ratchet tightening, allowlist shrinkage, and additional tests remain after the implementation phases settle. |
-| 10a | Complete | Docs describe completed Phases 1-7, while keeping Phase 8 actor work, Phase 9 final topology, and Phase 10 ratchet tightening deferred. |
+| 10 | Remaining | Further ratchet tightening, allowlist shrinkage, and additional tests remain after the implementation phases settle. |
+| 10a | Complete | Docs describe completed Phases 1-7, old-path ratchets block retired split files, focused invariant tests landed, and boundary rails run in CI. Phase 8 actor work and Phase 9 final topology stay deferred/manual. |
 
 ## North Star
 
@@ -294,14 +295,21 @@ Acceptance:
 
 Status: remaining.
 
+Already landed through Phase 10a:
+
+- Old-path ratchets block retired flat files for completed session/runtime
+  splits from being reintroduced.
+- Focused invariant tests cover session MCP assembly behavior and event-sink
+  publish/normalization behavior.
+- AnyHarness boundary rails run in CI with count-based allowlist discipline for
+  current transitional debt.
+
 Work:
 
-- Shrink boundary allowlists.
+- Shrink boundary allowlists beyond the current seeded counts.
 - Shrink file-size allowlists.
 - Add or strengthen tests around:
-  - session MCP assembly
   - prompt input to ACP blocks
-  - event sink publish paths
   - actor prompt queue invariants
   - product MCP endpoint compatibility
 - Update docs when implementation differs from the initial target.
@@ -310,6 +318,29 @@ Acceptance:
 
 - New target-shape code is CI-enforced.
 - Remaining exceptions are documented with owner and reason.
+
+## Phase 10a: Docs Reality Lane
+
+Status: complete.
+
+Landed reality:
+
+- Authoritative docs and the migration reference now describe the current
+  split runtime shape: session MCP bindings, session store, session runtime,
+  and ACP event sink are split, while their public caller-facing types remain
+  stable.
+- The old-path ratchet is wired into the repo-shape CI lane for completed
+  splits, so retired flat implementation files stay retired.
+- Focused invariant coverage landed for session MCP assembly and event-sink
+  behavior.
+- AnyHarness boundary rails and the seeded allowlist landed in CI; new
+  violations, increased counts, and stale allowlist rows fail the check.
+
+Still deferred:
+
+- `SessionActor` spec and loop rewrite.
+- Final Phase 9 topology and naming moves.
+- Further Phase 10 allowlist shrinkage and expanded focused coverage.
 
 ## Explicitly Leave For Later
 

--- a/reference/anyharness_cleanup_migration_sequence.md
+++ b/reference/anyharness_cleanup_migration_sequence.md
@@ -24,12 +24,12 @@ planned or manual cleanup only.
 | 3 | Complete | Product MCP servers follow feature-owned `mcp_server/**` modules and use shared `integrations/mcp/**` helpers where common protocol/auth scaffolding has landed. |
 | 4 | Complete | Session MCP binding models, crypto, contract mapping, summaries, ACP conversion, and launch assembly live under `sessions/mcp_bindings/**`. |
 | 5 | Complete | `SessionStore` is split under `sessions/store/**`, while the public `SessionStore` type remains caller-facing. |
-| 6 | In progress/planned | `SessionRuntime` still lives in `sessions/runtime.rs` on this base. Do not document a completed runtime folder split until it lands. |
+| 6 | Complete | `SessionRuntime` is split under `sessions/runtime/**`, while the public `SessionRuntime` type remains caller-facing. |
 | 7 | Complete | `SessionEventSink` is split under `acp/event_sink/**`, while the final `live/sessions/event_sink/**` topology remains future work. |
 | 8 | Deferred/manual | The `SessionActor` loop rewrite remains deferred until a dedicated actor spec exists. Current actor implementation stays in `acp/session_actor.rs`. |
 | 9 | Remaining | Final topology/naming moves remain: live session manager/client/broker naming, `sessions/**` to `domains/sessions/**`, `workspaces/**` to `domains/workspaces/**`, terminal live topology, and related import cleanup. |
 | 10 | Remaining | Ratchet tightening, allowlist shrinkage, and additional tests remain after the implementation phases settle. |
-| 10a | Current docs lane | Update docs to describe completed Phases 1-5 and 7 without overstating Phase 6, 8, 9, or 10. |
+| 10a | Complete | Docs describe completed Phases 1-7, while keeping Phase 8 actor work, Phase 9 final topology, and Phase 10 ratchet tightening deferred. |
 
 ## North Star
 
@@ -183,22 +183,15 @@ Still deferred:
 
 ## Phase 6: Session Runtime Split
 
-Status: in progress/planned on this base.
+Status: complete.
 
 Current implementation:
-
-```text
-sessions/runtime.rs
-```
-
-Target after the split:
 
 ```text
 sessions/runtime/
   mod.rs
   contract.rs
   creation.rs
-  live_session.rs
   prompt.rs
   pending_prompts.rs
   config.rs
@@ -207,9 +200,8 @@ sessions/runtime/
   interactions.rs
   replay.rs
   plans.rs
-  extensions.rs
   startup.rs
-  errors.rs
+  tests.rs
 ```
 
 Rules:

--- a/reference/anyharness_cleanup_migration_sequence.md
+++ b/reference/anyharness_cleanup_migration_sequence.md
@@ -1,0 +1,361 @@
+# AnyHarness Cleanup Migration Sequence
+
+Status: current migration tracker after the completed AnyHarness cleanup
+phases and the Phase 10a docs reality pass.
+
+Authoritative docs:
+
+- `docs/anyharness/README.md`
+- `docs/anyharness/guides/**`
+- `docs/anyharness/specs/session-engine.md`
+- `docs/anyharness/specs/mcp.md`
+
+This plan is behavior-preserving unless a phase explicitly says otherwise.
+Completed phases document landed ownership and shape; remaining phases document
+planned or manual cleanup only.
+
+## Current Status
+
+| Phase | Status | Reality |
+| --- | --- | --- |
+| 0 | Complete | Repo-shape rails and allowlist discipline were established before the structural passes. |
+| 1 | Complete | Local file/git/hosting/process capabilities are under `adapters/**`; shared MCP helpers are under `integrations/mcp/**`; provider CLI mechanics are under `integrations/agent_cli/**`. |
+| 2 | Complete | Product-domain cleanup landed for the completed lanes. Agents, cowork, reviews, plans, and mobility live under `domains/**`. Core sessions, workspaces, repo roots, and terminals remain transitional until Phase 9. |
+| 3 | Complete | Product MCP servers follow feature-owned `mcp_server/**` modules and use shared `integrations/mcp/**` helpers where common protocol/auth scaffolding has landed. |
+| 4 | Complete | Session MCP binding models, crypto, contract mapping, summaries, ACP conversion, and launch assembly live under `sessions/mcp_bindings/**`. |
+| 5 | Complete | `SessionStore` is split under `sessions/store/**`, while the public `SessionStore` type remains caller-facing. |
+| 6 | In progress/planned | `SessionRuntime` still lives in `sessions/runtime.rs` on this base. Do not document a completed runtime folder split until it lands. |
+| 7 | Complete | `SessionEventSink` is split under `acp/event_sink/**`, while the final `live/sessions/event_sink/**` topology remains future work. |
+| 8 | Deferred/manual | The `SessionActor` loop rewrite remains deferred until a dedicated actor spec exists. Current actor implementation stays in `acp/session_actor.rs`. |
+| 9 | Remaining | Final topology/naming moves remain: live session manager/client/broker naming, `sessions/**` to `domains/sessions/**`, `workspaces/**` to `domains/workspaces/**`, terminal live topology, and related import cleanup. |
+| 10 | Remaining | Ratchet tightening, allowlist shrinkage, and additional tests remain after the implementation phases settle. |
+| 10a | Current docs lane | Update docs to describe completed Phases 1-5 and 7 without overstating Phase 6, 8, 9, or 10. |
+
+## North Star
+
+Make AnyHarness readable by path.
+
+When a developer sees a file path, they should know whether the file owns:
+
+- transport
+- durable product truth
+- live runtime state
+- local workspace/machine capability
+- protocol/vendor mechanics
+- app composition
+- process startup
+
+The migration goal is not to redesign the session engine during structural
+passes. The goal is to expose existing ownership clearly enough that deeper
+changes become safe.
+
+## Global Rules For Every Phase
+
+- Preserve public API unless the phase explicitly says otherwise.
+- Prefer moving one symbol once over leaving old and new copies behind.
+- Use direct imports. Do not add compatibility barrels.
+- Split by responsibility, not by line count alone.
+- Run targeted tests/checks for the touched crate/module when feasible.
+- Keep `app/mod.rs`, route registration, and core session files single-owned
+  during a PR.
+- If a file is too complex to reason about safely, stop and mark it manual
+  instead of doing a broad mechanical rewrite.
+
+## Phase 1: Low-Risk Topology Moves
+
+Status: complete.
+
+Landed reality:
+
+- local capability folders moved toward `adapters/**`:
+  - files
+  - git
+  - hosting
+  - processes
+- generic protocol/vendor helpers moved toward `integrations/**`:
+  - MCP JSON-RPC helpers
+  - capability-token primitives
+  - agent CLI executable/probe/launcher mechanics
+
+Still true:
+
+- Product tool behavior belongs in owning product domains.
+- Core session behavior was intentionally not part of this phase.
+
+## Phase 2: Product Domains In Parallel
+
+Status: complete for the scoped lanes that landed.
+
+Landed reality:
+
+- `domains/agents/**`
+- `domains/cowork/**`
+- `domains/reviews/**`
+- `domains/plans/**`
+- `domains/mobility/**`
+
+Still transitional:
+
+- `sessions/**` remains the session-domain path until Phase 9.
+- `workspaces/**` remains the workspace-domain path until Phase 9.
+- `repo_roots/**` remains transitional until Phase 9 decides final ownership.
+
+Do not treat Phase 2 completion as final topology completion.
+
+## Phase 3: Product MCP Consolidation
+
+Status: complete.
+
+Landed reality:
+
+- Shared MCP protocol/auth helpers live under `integrations/mcp/**`.
+- Product MCP servers live with their product domains:
+  - `domains/cowork/mcp_server/**`
+  - `domains/reviews/mcp_server/**`
+  - `sessions/subagents/mcp_server/**`
+  - `sessions/workspace_naming/mcp_server/**`
+
+Still true:
+
+- Product tool behavior stays in product domains.
+- HTTP endpoint wrappers may remain feature-local until a focused transport
+  cleanup.
+- MCP elicitation remains a live interaction concern, not product MCP server
+  behavior.
+
+## Phase 4: Session MCP Assembly
+
+Status: complete.
+
+Current implementation:
+
+```text
+sessions/mcp_bindings/
+  model.rs
+  crypto.rs
+  contract.rs
+  summaries.rs
+  acp.rs
+  assembly.rs
+```
+
+The assembly boundary owns:
+
+- applying internal-only versus inherited user-binding policy
+- decrypting user-supplied MCP bindings
+- collecting launch extras from registered session extensions
+- merging user and product MCP servers in launch order
+- merging and validating binding summaries
+- producing system prompt additions
+- returning restart-required or missing-data-key errors when persisted
+  bindings cannot be used
+
+The final topology target keeps this ownership under
+`domains/sessions/mcp_bindings/**`.
+
+## Phase 5: Session Store Split
+
+Status: complete.
+
+Current implementation:
+
+```text
+sessions/store/
+  mod.rs
+  sessions.rs
+  events.rs
+  notifications.rs
+  live_config.rs
+  pending_prompts.rs
+  attachments.rs
+  background_work.rs
+  links.rs
+  tests/
+```
+
+The public type remains `SessionStore`. Callers should not depend on internal
+store module boundaries.
+
+Still deferred:
+
+- Cross-domain deletion redesign.
+- Schema-level cascade changes unless covered by a focused persistence task.
+
+## Phase 6: Session Runtime Split
+
+Status: in progress/planned on this base.
+
+Current implementation:
+
+```text
+sessions/runtime.rs
+```
+
+Target after the split:
+
+```text
+sessions/runtime/
+  mod.rs
+  contract.rs
+  creation.rs
+  live_session.rs
+  prompt.rs
+  pending_prompts.rs
+  config.rs
+  fork.rs
+  lifecycle.rs
+  interactions.rs
+  replay.rs
+  plans.rs
+  extensions.rs
+  startup.rs
+  errors.rs
+```
+
+Rules:
+
+- Preserve `SessionRuntime` as the public type.
+- Split by API-facing session operation family.
+- Keep live bridging in runtime; stores/services should not call live actors.
+- Do not combine this with the actor loop rewrite.
+
+## Phase 7: Session Event Sink Split
+
+Status: complete.
+
+Current implementation:
+
+```text
+acp/event_sink/
+  mod.rs
+  state.rs
+  publish.rs
+  turns.rs
+  assistant.rs
+  reasoning.rs
+  tools.rs
+  plans.rs
+  interactions.rs
+  config.rs
+  pending_prompts.rs
+  runtime_events.rs
+  metadata.rs
+  background_work.rs
+  lifecycle.rs
+  normalization/
+  tests/
+```
+
+The public actor-facing type remains `SessionEventSink`.
+
+Still future:
+
+- Moving the sink to `live/sessions/event_sink/**` belongs to Phase 9.
+- Transcript schema redesign is out of scope.
+- Plan entity ingestion should only move in a focused plan-ingestion pass.
+
+## Phase 8: Session Actor Spec And Loop Rewrite
+
+Status: deferred/manual.
+
+Before implementation:
+
+- Write `docs/anyharness/specs/session-actor.md`.
+- Spell out loop invariants:
+  - actor owns one live ACP-backed session.
+  - actor owns the busy interval.
+  - prompt loop remains responsive to commands, notifications, and background
+    work.
+  - durable pending prompt queue is drained without releasing busy between
+    turns.
+  - actor receives final MCP launch payload; it does not assemble product MCPs.
+
+Current implementation remains:
+
+```text
+acp/session_actor.rs
+```
+
+Do not delegate this broadly until the spec exists.
+
+## Phase 9: Naming And Final Topology
+
+Status: remaining.
+
+Candidate moves:
+
+- `acp/manager` live-session manager ownership and naming.
+- `acp/runtime_client` ACP client ownership and naming.
+- `acp/permission_broker/**` to live session interactions.
+- `sessions/**` to `domains/sessions/**`.
+- `workspaces/**` to `domains/workspaces/**`.
+- `terminals/**` to `live/terminals/**`.
+- `acp/event_sink/**` to `live/sessions/event_sink/**`.
+
+Acceptance:
+
+- Rename PRs are mostly mechanical.
+- Import churn is isolated.
+- Old paths are deleted, not re-exported.
+
+## Phase 10: Ratchet Tightening
+
+Status: remaining.
+
+Work:
+
+- Shrink boundary allowlists.
+- Shrink file-size allowlists.
+- Add or strengthen tests around:
+  - session MCP assembly
+  - prompt input to ACP blocks
+  - event sink publish paths
+  - actor prompt queue invariants
+  - product MCP endpoint compatibility
+- Update docs when implementation differs from the initial target.
+
+Acceptance:
+
+- New target-shape code is CI-enforced.
+- Remaining exceptions are documented with owner and reason.
+
+## Explicitly Leave For Later
+
+Do not mix these into broad structural migration PRs:
+
+- Full `SessionActor` loop rewrite before `session-actor.md` exists.
+- Cross-domain delete/cascade redesign.
+- Transcript event schema redesign.
+- MCP elicitation interaction redesign.
+- Public contract shape changes.
+- Agent/provider behavior changes.
+- Workspace materialization lifecycle redesign.
+- Review/cowork product workflow behavior changes.
+- Large `AppState` dependency graph redesign.
+- Renaming core live/session types before code ownership is split.
+
+## Handoff Template
+
+```text
+Read:
+- docs/anyharness/README.md
+- the relevant docs/anyharness/guides/*.md
+- docs/anyharness/specs/session-engine.md or specs/mcp.md if applicable
+- reference/anyharness_cleanup_migration_sequence.md
+
+Task:
+Implement Phase <N>, lane <lane name>.
+
+Rules:
+- Preserve behavior.
+- Do not touch core session files unless assigned.
+- Do not add compatibility barrels.
+- Delete old paths when moved.
+- Keep public APIs stable unless explicitly assigned.
+
+Output:
+- List changed files.
+- Explain ownership changes.
+- List tests/checks run.
+- Call out skipped/manual follow-up.
+```


### PR DESCRIPTION
## Summary

- Align AnyHarness docs with the current split session runtime/store/MCP/event-sink implementation.
- Mark Phase 6 and Phase 10a reality-lane items complete while keeping SessionActor and final topology work deferred/manual.
- Document landed old-path ratchets, focused invariant coverage, and boundary rails.

## Verification

- `rg -n "sessions/mcp\\.rs|sessions/store\\.rs|sessions/runtime\\.rs|acp/event_sink\\.rs" docs reference`
- `git diff --check`