### PR TITLE
fix(desktop): repair client session stream materialization

### DIFF
--- a/desktop/src/hooks/chat/lifecycle/use-prompt-outbox-dispatcher.ts
+++ b/desktop/src/hooks/chat/lifecycle/use-prompt-outbox-dispatcher.ts
@@ -3,6 +3,7 @@ import { usePromptSessionMutation } from "@anyharness/sdk-react";
 import {
   selectNextDispatchableOutboxEntry,
 } from "@/lib/domain/chat/outbox/prompt-outbox-selectors";
+import { transcriptHasRenderablePromptEcho } from "@/lib/domain/chat/outbox/prompt-echo";
 import { classifyPromptDispatchFailure } from "@/lib/domain/chat/outbox/prompt-dispatch-failure";
 import type { PromptOutboxEntry } from "@/lib/domain/chat/outbox/prompt-outbox-model";
 import {
@@ -13,18 +14,19 @@ import {
   failLatencyFlow,
   finishLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   getSessionClientAndWorkspace,
 } from "@/lib/workflows/sessions/session-runtime";
 import {
   waitForSessionMaterialization,
-  type SessionMaterializationDeps,
 } from "@/lib/workflows/sessions/session-materialization";
 import {
-  getMaterializedSessionId,
+  sessionMaterializationDeps,
+} from "@/hooks/sessions/workflows/session-materialization-deps";
+import {
   getSessionRecord,
 } from "@/stores/sessions/session-records";
-import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { usePromptOutboxStore } from "@/stores/chat/prompt-outbox-store";
 import { useSessionHistoryHydration } from "@/hooks/sessions/lifecycle/use-session-history-hydration";
 import { useSessionSummaryActions } from "@/hooks/sessions/workflows/use-session-summary-actions";
@@ -36,14 +38,6 @@ const ACCEPTED_RUNNING_RECONCILE_DELAYS_MS = [250, 1_000, 2_500, 5_000, 10_000] 
 const ACCEPTED_RUNNING_RECONCILE_TIMEOUT_MS = 3_000;
 
 let activeDispatcherOwner: symbol | null = null;
-
-const sessionMaterializationDeps: SessionMaterializationDeps = {
-  getMaterializedSessionId,
-  subscribeToMaterializedSessionId: (clientSessionId, onChange) =>
-    useSessionDirectoryStore.subscribe((state) => {
-      onChange(state.entriesById[clientSessionId]?.materializedSessionId ?? null);
-    }),
-};
 
 export function usePromptOutboxDispatcher(): void {
   const dispatchVersion = usePromptOutboxStore((state) => state.dispatchVersion);
@@ -89,12 +83,26 @@ export function usePromptOutboxDispatcher(): void {
         deliveryState: "preparing",
         errorMessage: null,
       });
+      logLatency("prompt.outbox.dispatch.prepare", {
+        clientPromptId: entry.clientPromptId,
+        clientSessionId: entry.clientSessionId,
+        entryWorkspaceId: entry.workspaceId,
+        entryMaterializedSessionId: entry.materializedSessionId,
+        placement: entry.placement,
+        blockTypes: entry.blocks.map((block) => block.type),
+        attachmentCount: entry.attachmentSnapshots.length,
+      });
 
       const materializedSessionId = await waitForSessionMaterialization(
         entry.clientSessionId,
         sessionMaterializationDeps,
         { timeoutMs: CONFIG_READY_TIMEOUT_MS },
       );
+      logLatency("prompt.outbox.dispatch.materialized", {
+        clientPromptId: entry.clientPromptId,
+        clientSessionId: entry.clientSessionId,
+        materializedSessionId,
+      });
       usePromptOutboxStore.getState().bindMaterializedSession(
         entry.clientSessionId,
         materializedSessionId,
@@ -103,6 +111,12 @@ export function usePromptOutboxDispatcher(): void {
         .getState()
         .entriesByPromptId[entry.clientPromptId];
       if (!latestBeforeDispatch || latestBeforeDispatch.deliveryState !== "preparing") {
+        logLatency("prompt.outbox.dispatch.aborted", {
+          reason: "entry_not_preparing_after_materialization",
+          clientPromptId: entry.clientPromptId,
+          clientSessionId: entry.clientSessionId,
+          latestDeliveryState: latestBeforeDispatch?.deliveryState ?? null,
+        });
         return;
       }
 
@@ -113,6 +127,12 @@ export function usePromptOutboxDispatcher(): void {
         .getState()
         .entriesByPromptId[entry.clientPromptId];
       if (!latestAfterPrepare || latestAfterPrepare.deliveryState !== "preparing") {
+        logLatency("prompt.outbox.dispatch.aborted", {
+          reason: "entry_not_preparing_after_block_prepare",
+          clientPromptId: entry.clientPromptId,
+          clientSessionId: entry.clientSessionId,
+          latestDeliveryState: latestAfterPrepare?.deliveryState ?? null,
+        });
         return;
       }
       const {
@@ -129,6 +149,13 @@ export function usePromptOutboxDispatcher(): void {
         dispatchedAt: new Date().toISOString(),
       });
       requestStarted = true;
+      logLatency("prompt.outbox.dispatch.request", {
+        clientPromptId: entry.clientPromptId,
+        clientSessionId: entry.clientSessionId,
+        workspaceId,
+        materializedSessionId: resolvedSessionId,
+        shouldGenerateTitle,
+      });
       const response = await promptSessionMutation.mutateAsync({
         workspaceId,
         sessionId: resolvedSessionId,
@@ -150,6 +177,14 @@ export function usePromptOutboxDispatcher(): void {
         acceptedAt: new Date().toISOString(),
         errorMessage: null,
       });
+      logLatency("prompt.outbox.dispatch.accepted", {
+        clientPromptId: entry.clientPromptId,
+        clientSessionId: entry.clientSessionId,
+        workspaceId,
+        materializedSessionId: response.session.id,
+        responseStatus: response.status,
+        queuedSeq: response.queuedSeq ?? null,
+      });
       finishLatencyFlow(entry.latencyFlowId, "processing_started", {
         keepActive: true,
       });
@@ -170,6 +205,13 @@ export function usePromptOutboxDispatcher(): void {
       }
     } catch (error) {
       const failure = classifyPromptDispatchFailure(error, requestStarted);
+      logLatency("prompt.outbox.dispatch.failed", {
+        clientPromptId: entry.clientPromptId,
+        clientSessionId: entry.clientSessionId,
+        requestStarted,
+        deliveryState: failure.deliveryState,
+        errorMessage: failure.message,
+      });
       usePromptOutboxStore.getState().patchEntry(entry.clientPromptId, {
         deliveryState: failure.deliveryState,
         errorMessage: failure.message,
@@ -212,6 +254,16 @@ export function usePromptOutboxDispatcher(): void {
       }
       const record = getSessionRecord(clientSessionId);
       if (!record?.materializedSessionId) {
+        logLatency("prompt.outbox.dispatch.waiting_unmaterialized", {
+          clientSessionId,
+          nextPromptId: entry.clientPromptId,
+          hasRecord: Boolean(record),
+          workspaceId: record?.workspaceId ?? entry.workspaceId,
+          status: record?.status ?? null,
+          transcriptHydrated: record?.transcriptHydrated ?? null,
+          outboxWorkspaceId: entry.workspaceId,
+          promptCount: state.promptIdsByClientSessionId[clientSessionId]?.length ?? 0,
+        });
         continue;
       }
       inFlightSessionIdsRef.current.add(clientSessionId);
@@ -276,7 +328,5 @@ function transcriptHasPromptId(clientSessionId: string, clientPromptId: string):
   if (!transcript) {
     return false;
   }
-  return Object.values(transcript.itemsById).some((item) =>
-    item.kind === "user_message" && item.promptId === clientPromptId
-  );
+  return transcriptHasRenderablePromptEcho(transcript, clientPromptId);
 }

--- a/desktop/src/hooks/chat/use-cloud-workspace-polling.ts
+++ b/desktop/src/hooks/chat/use-cloud-workspace-polling.ts
@@ -5,6 +5,9 @@ import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-work
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import { buildWorkspaceArrivalEvent } from "@/lib/domain/workspaces/creation/arrival";
 import {
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
+import {
   isCloudWorkspacePostReadyPending,
   shouldPollCloudWorkspaceForUpdates,
   shouldShowCloudWorkspaceStatusScreen,
@@ -27,6 +30,7 @@ export function useCloudWorkspacePolling() {
   const { data: workspaceCollections } = useWorkspaces();
   const { refreshCloudWorkspace } = useCloudWorkspaceActions();
   const { selectWorkspace } = useWorkspaceSelection();
+  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
 
   const cloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
   const cloudWorkspace = workspaceCollections?.cloudWorkspaces.find(
@@ -79,6 +83,11 @@ export function useCloudWorkspacePolling() {
           const pending = useSessionSelectionStore.getState().pendingWorkspaceEntry;
           const shouldPreservePending = pending?.workspaceId === selectedWorkspaceId
             && pending.stage === "awaiting-cloud-ready";
+          logLatency("workspace.cloud_polling.ready_selection.start", {
+            workspaceId: selectedWorkspaceId,
+            pendingAttemptId: pending?.attemptId ?? null,
+            shouldPreservePending,
+          });
 
           try {
             await selectWorkspace(selectedWorkspaceId, {
@@ -100,6 +109,11 @@ export function useCloudWorkspacePolling() {
                   : "Failed to connect the cloud workspace.",
               });
             }
+            logLatency("workspace.cloud_polling.ready_selection.failed", {
+              workspaceId: selectedWorkspaceId,
+              pendingAttemptId: pending?.attemptId ?? null,
+              errorMessage: error instanceof Error ? error.message : String(error),
+            });
             return;
           }
 
@@ -109,6 +123,11 @@ export function useCloudWorkspacePolling() {
             && currentPending.workspaceId === selectedWorkspaceId
             && currentPending.stage === "awaiting-cloud-ready"
           ) {
+            const projectedSessionMaterialization = materializePendingWorkspaceSessions(
+              currentPending,
+              selectedWorkspaceId,
+              { eventPrefix: "workspace.cloud_polling" },
+            );
             setPendingWorkspaceEntry(null);
             setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
               workspaceId: selectedWorkspaceId,
@@ -119,6 +138,8 @@ export function useCloudWorkspacePolling() {
             logLatency("workspace.cloud_polling.ready", {
               workspaceId: selectedWorkspaceId,
               totalElapsedMs: elapsedSince(currentPending.createdAt),
+              projectedSessionCount: projectedSessionMaterialization.projectedSessionCount,
+              projectedSessionIds: projectedSessionMaterialization.projectedSessionIds,
             });
           }
           return;
@@ -148,6 +169,7 @@ export function useCloudWorkspacePolling() {
     };
   }, [
     cloudWorkspaceId,
+    materializePendingWorkspaceSessions,
     pendingWorkspaceEntry,
     refreshCloudWorkspace,
     selectWorkspace,

--- a/desktop/src/hooks/chat/workflows/use-chat-prompt-actions.ts
+++ b/desktop/src/hooks/chat/workflows/use-chat-prompt-actions.ts
@@ -39,6 +39,7 @@ import { hasPromptContent } from "@/lib/domain/chat/composer/prompt-input";
 import type { PromptAttachmentSnapshot } from "@/lib/domain/chat/composer/prompt-attachment-snapshot";
 import { finishOrCancelMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   failLatencyFlow,
   startLatencyFlow,
@@ -143,6 +144,17 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
         });
       } else if (!selectedWorkspaceId && pendingWorkspaceEntry && pendingWorkspaceUiKey && launchSelection) {
         const clientSessionId = createPendingSessionId(launchSelection.kind);
+        logLatency("chat.prompt.projected_session.create", {
+          clientSessionId,
+          pendingWorkspaceUiKey,
+          attemptId: pendingWorkspaceEntry.attemptId,
+          source: pendingWorkspaceEntry.source,
+          stage: pendingWorkspaceEntry.stage,
+          requestKind: pendingWorkspaceEntry.request.kind,
+          agentKind: launchSelection.kind,
+          modelId: launchSelection.modelId,
+          promptId,
+        });
         putSessionRecord({
           ...createEmptySessionRecord(clientSessionId, launchSelection.kind, {
             workspaceId: pendingWorkspaceUiKey,
@@ -168,6 +180,12 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
           optimisticContentParts: input?.optimisticContentParts,
           workspaceId: pendingWorkspaceUiKey,
           measurementOperationId: input?.measurementOperationId,
+          promptId,
+        });
+        logLatency("chat.prompt.projected_session.enqueued", {
+          clientSessionId,
+          pendingWorkspaceUiKey,
+          attemptId: pendingWorkspaceEntry.attemptId,
           promptId,
         });
       } else if (launchSelection) {

--- a/desktop/src/hooks/reviews/derived/use-active-review-run-state.ts
+++ b/desktop/src/hooks/reviews/derived/use-active-review-run-state.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/domain/reviews/review-runs";
 import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
 import type { StartingReviewState } from "@/stores/reviews/review-ui-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
 export interface ActiveReviewRunState {
@@ -23,16 +24,23 @@ export interface ActiveReviewRunState {
 export function useActiveReviewRunState(): ActiveReviewRunState {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
+  const activeMaterializedSessionId = useSessionDirectoryStore((state) =>
+    activeSessionId ? state.entriesById[activeSessionId]?.materializedSessionId ?? null : null
+  );
   const dismissedTerminalNoticeRunIds = useReviewUiStore(
     (state) => state.dismissedTerminalNoticeRunIds,
   );
   const startingReview = useReviewUiStore((state) => state.startingReview);
-  const activeStartingReview = startingReview?.parentSessionId === activeSessionId
+  const activeStartingReview = startingReview
+    && (
+      startingReview.parentSessionId === activeSessionId
+      || startingReview.parentSessionId === activeMaterializedSessionId
+    )
     ? startingReview
     : null;
-  const reviewsQuery = useSessionReviewsQuery(activeSessionId, {
+  const reviewsQuery = useSessionReviewsQuery(activeMaterializedSessionId, {
     workspaceId: selectedWorkspaceId,
-    enabled: !!activeSessionId,
+    enabled: !!activeMaterializedSessionId,
     refetchInterval: 5000,
   });
   const reviews = reviewsQuery.data?.reviews ?? null;

--- a/desktop/src/hooks/reviews/workflows/use-review-actions.ts
+++ b/desktop/src/hooks/reviews/workflows/use-review-actions.ts
@@ -13,6 +13,13 @@ import {
   resolveOneClickReviewRequest,
 } from "@/lib/domain/reviews/review-launch";
 import {
+  materializeReviewParentSession,
+  waitForReviewParentSessionMaterialization,
+} from "@/lib/workflows/reviews/review-parent-materialization";
+import {
+  sessionMaterializationDeps,
+} from "@/hooks/sessions/workflows/session-materialization-deps";
+import {
   type ReviewSetupAnchorRect,
   useReviewUiStore,
 } from "@/stores/reviews/review-ui-store";
@@ -35,7 +42,10 @@ export function useReviewActions() {
   const showToast = useToastStore((state) => state.show);
   const openReviewSetup = useReviewUiStore((state) => state.openSetup);
   const beginStartingReview = useReviewUiStore((state) => state.beginStartingReview);
-  const clearStartingReview = useReviewUiStore((state) => state.clearStartingReview);
+  const clearStartingReviewForToken = useReviewUiStore((state) => state.clearStartingReviewForToken);
+  const patchStartingReviewParentSession = useReviewUiStore(
+    (state) => state.patchStartingReviewParentSession,
+  );
   const startPlanReviewMutation = useStartPlanReviewMutation({ workspaceId: selectedWorkspaceId });
   const startCodeReviewMutation = useStartCodeReviewMutation({ workspaceId: selectedWorkspaceId });
   const stopReviewMutation = useStopReviewMutation({ workspaceId: selectedWorkspaceId });
@@ -97,18 +107,43 @@ export function useReviewActions() {
       openReviewSetup({ kind: "plan", plan }, null);
       return;
     }
-    beginStartingReview(buildStartingReview(plan.sourceSessionId, "plan", request.request));
-    void startPlanReviewMutation.mutateAsync({
-      planId: plan.planId,
-      request: request.request,
-    }).catch((error) => {
-      clearStartingReview();
-      showToast(`Failed to start review: ${errorMessage(error)}`);
+    const reviewRequest = request.request;
+    const startingReview = buildStartingReview(plan.sourceSessionId, "plan", reviewRequest);
+    const startingReviewToken = {
+      kind: startingReview.kind,
+      startedAt: startingReview.startedAt,
+    };
+    beginStartingReview(startingReview);
+    void (async () => {
+      const materializedParentSessionId = await waitForReviewParentSessionMaterialization(
+        plan.sourceSessionId,
+        sessionMaterializationDeps,
+      );
+      const materializedRequest = materializeReviewParentSession(
+        reviewRequest,
+        materializedParentSessionId,
+      );
+      const didPatchStartingReview = patchStartingReviewParentSession(
+        startingReviewToken,
+        materializedParentSessionId,
+      );
+      if (!didPatchStartingReview) {
+        return;
+      }
+      await startPlanReviewMutation.mutateAsync({
+        planId: plan.planId,
+        request: materializedRequest,
+      });
+    })().catch((error) => {
+      if (clearStartingReviewForToken(startingReviewToken)) {
+        showToast(`Failed to start review: ${errorMessage(error)}`);
+      }
     });
   }, [
     beginStartingReview,
-    clearStartingReview,
+    clearStartingReviewForToken,
     openReviewSetup,
+    patchStartingReviewParentSession,
     reviewDefaultsByKind,
     reviewPersonalitiesByKind,
     showToast,
@@ -132,17 +167,42 @@ export function useReviewActions() {
       openReviewSetup({ kind: "code", parentSessionId: activeSessionId }, null);
       return;
     }
-    beginStartingReview(buildStartingReview(activeSessionId, "code", request.request));
-    void startCodeReviewMutation.mutateAsync(request.request).catch((error) => {
-      clearStartingReview();
-      showToast(`Failed to start review: ${errorMessage(error)}`);
+    const reviewRequest = request.request;
+    const startingReview = buildStartingReview(activeSessionId, "code", reviewRequest);
+    const startingReviewToken = {
+      kind: startingReview.kind,
+      startedAt: startingReview.startedAt,
+    };
+    beginStartingReview(startingReview);
+    void (async () => {
+      const materializedParentSessionId = await waitForReviewParentSessionMaterialization(
+        activeSessionId,
+        sessionMaterializationDeps,
+      );
+      const materializedRequest = materializeReviewParentSession(
+        reviewRequest,
+        materializedParentSessionId,
+      );
+      const didPatchStartingReview = patchStartingReviewParentSession(
+        startingReviewToken,
+        materializedParentSessionId,
+      );
+      if (!didPatchStartingReview) {
+        return;
+      }
+      await startCodeReviewMutation.mutateAsync(materializedRequest);
+    })().catch((error) => {
+      if (clearStartingReviewForToken(startingReviewToken)) {
+        showToast(`Failed to start review: ${errorMessage(error)}`);
+      }
     });
   }, [
     activeSessionId,
     activeSlot,
     beginStartingReview,
-    clearStartingReview,
+    clearStartingReviewForToken,
     openReviewSetup,
+    patchStartingReviewParentSession,
     reviewDefaultsByKind,
     reviewPersonalitiesByKind,
     showToast,

--- a/desktop/src/hooks/reviews/workflows/use-review-setup-dialog-state.ts
+++ b/desktop/src/hooks/reviews/workflows/use-review-setup-dialog-state.ts
@@ -18,6 +18,14 @@ import {
   type ReviewSessionDefaults,
   type ReviewSetupDraft,
 } from "@/lib/domain/reviews/review-config";
+import { buildStartingReview } from "@/lib/domain/reviews/review-launch";
+import {
+  materializeReviewParentSession,
+  waitForReviewParentSessionMaterialization,
+} from "@/lib/workflows/reviews/review-parent-materialization";
+import {
+  sessionMaterializationDeps,
+} from "@/hooks/sessions/workflows/session-materialization-deps";
 import { buildSettingsHref } from "@/lib/domain/settings/navigation";
 import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
@@ -36,7 +44,10 @@ export function useReviewSetupDialogState() {
   const setup = useReviewUiStore((state) => state.setup);
   const closeSetup = useReviewUiStore((state) => state.closeSetup);
   const beginStartingReview = useReviewUiStore((state) => state.beginStartingReview);
-  const clearStartingReview = useReviewUiStore((state) => state.clearStartingReview);
+  const clearStartingReviewForToken = useReviewUiStore((state) => state.clearStartingReviewForToken);
+  const patchStartingReviewParentSession = useReviewUiStore(
+    (state) => state.patchStartingReviewParentSession,
+  );
   const reviewDefaultsByKind = useUserPreferencesStore((state) => state.reviewDefaultsByKind);
   const reviewPersonalitiesByKind = useUserPreferencesStore((state) => state.reviewPersonalitiesByKind);
   const setPreference = useUserPreferencesStore((state) => state.set);
@@ -126,37 +137,49 @@ export function useReviewSetupDialogState() {
       };
       setPreference("reviewDefaultsByKind", nextDefaults);
     }
-    beginStartingReview({
-      parentSessionId,
-      kind: draft.kind,
-      maxRounds: draft.maxRounds,
-      autoIterate: draft.autoIterate,
-      reviewers: request.reviewers.map((reviewer) => ({
-        id: reviewer.personaId,
-        label: reviewer.label,
-        agentKind: reviewer.agentKind,
-        modelId: reviewer.modelId ?? "",
-      })),
-      startedAt: Date.now(),
-    });
+    const startingReview = buildStartingReview(parentSessionId, draft.kind, request);
+    const startingReviewToken = {
+      kind: startingReview.kind,
+      startedAt: startingReview.startedAt,
+    };
+    beginStartingReview(startingReview);
     closeSetup();
-    const mutation = setupTarget.kind === "plan"
-      ? startPlanReviewMutation.mutateAsync({
-        planId: setupTarget.plan.planId,
+    void (async () => {
+      const materializedParentSessionId = await waitForReviewParentSessionMaterialization(
+        parentSessionId,
+        sessionMaterializationDeps,
+      );
+      const materializedRequest = materializeReviewParentSession(
         request,
-      })
-      : startCodeReviewMutation.mutateAsync(request);
-
-    void mutation.catch((errorValue) => {
-      clearStartingReview();
-      showToast(`Failed to start review: ${errorMessage(errorValue)}`);
+        materializedParentSessionId,
+      );
+      const didPatchStartingReview = patchStartingReviewParentSession(
+        startingReviewToken,
+        materializedParentSessionId,
+      );
+      if (!didPatchStartingReview) {
+        return;
+      }
+      if (setupTarget.kind === "plan") {
+        await startPlanReviewMutation.mutateAsync({
+          planId: setupTarget.plan.planId,
+          request: materializedRequest,
+        });
+        return;
+      }
+      await startCodeReviewMutation.mutateAsync(materializedRequest);
+    })().catch((errorValue) => {
+      if (clearStartingReviewForToken(startingReviewToken)) {
+        showToast(`Failed to start review: ${errorMessage(errorValue)}`);
+      }
     });
   }, [
     beginStartingReview,
-    clearStartingReview,
+    clearStartingReviewForToken,
     closeSetup,
     draft,
     parentSessionId,
+    patchStartingReviewParentSession,
     personalityTemplates,
     reviewDefaultsByKind,
     saveAsDefault,

--- a/desktop/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
@@ -104,8 +104,8 @@ export function useHotSessionIngest(): void {
       markCold: (clientSessionId) => useSessionIngestStore.getState().markCold(clientSessionId),
       getFreshness: (clientSessionId) =>
         useSessionIngestStore.getState().freshnessByClientSessionId[clientSessionId]?.freshness ?? null,
-      isTargetCurrent: (clientSessionId, generation, materializedSessionId) =>
-        isHotSessionTargetCurrent(clientSessionId, generation, materializedSessionId),
+      isTargetCurrent: (clientSessionId, materializedSessionId) =>
+        isHotSessionTargetCurrent(clientSessionId, materializedSessionId),
       getSessionRecord: (clientSessionId) => {
         const record = getSessionRecord(clientSessionId);
         return record

--- a/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.ts
@@ -5,6 +5,7 @@ import type {
 import { useCallback } from "react";
 import { applyStreamEnvelopeBatch } from "@/lib/domain/sessions/stream/stream-state";
 import { logDevSSEEvent } from "@/lib/infra/debug/session-runtime-dev-sse";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   finishOrCancelMeasurementOperation,
   markOperationForNextCommit,
@@ -217,7 +218,17 @@ export function createSessionStreamFlushController(
     const envelopes = queue;
     queue = [];
 
-    if (!input.isStillCurrent() || !input.isCurrentStream()) {
+    const stillCurrent = input.isStillCurrent();
+    const currentStream = input.isCurrentStream();
+    if (!stillCurrent || !currentStream) {
+      logLatency("session.stream.flush.dropped_stale", {
+        sessionId: input.sessionId,
+        envelopeCount: envelopes.length,
+        firstSeq: envelopes[0]?.seq ?? null,
+        lastSeq: envelopes[envelopes.length - 1]?.seq ?? null,
+        stillCurrent,
+        currentStream,
+      });
       return;
     }
 
@@ -275,6 +286,19 @@ export function createSessionStreamFlushController(
     }
 
     const lastObservedSeq = maxEnvelopeSeq(envelopes, slotState.transcript.lastSeq);
+    logLatency("session.stream.flush.batch", {
+      sessionId: input.sessionId,
+      envelopeCount: envelopes.length,
+      appliedCount: result.appliedEnvelopes.length,
+      duplicateCount: result.duplicateEnvelopes.length,
+      gapSeq: result.gapEnvelope?.seq ?? null,
+      gapType: result.gapEnvelope?.event.type ?? null,
+      lastSeqBefore: slotState.transcript.lastSeq,
+      lastSeqAfter: result.state.transcript.lastSeq,
+      lastObservedSeq,
+      streamConnectionState: slotState.streamConnectionState,
+      transcriptHydrated: slotState.transcriptHydrated,
+    });
     if (result.appliedEnvelopes.length === 0 && !result.gapEnvelope) {
       useSessionIngestStore.getState().applyStreamProgress(input.sessionId, {
         lastAppliedSeq: slotState.transcript.lastSeq,

--- a/desktop/src/hooks/sessions/use-session-creation-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-creation-actions.ts
@@ -68,6 +68,7 @@ import {
   annotateLatencyFlow,
   cancelLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { writeChatShellIntentForSession } from "@/hooks/workspaces/tabs/workspace-shell-intent-writer";
 import { DESKTOP_ORIGIN } from "@/lib/domain/sessions/desktop-origin";
@@ -320,6 +321,19 @@ export function useSessionCreationActions() {
 
     putSessionRecord(optimisticRecord);
     activateSession(pendingSessionId);
+    logLatency("session.create.optimistic_record", {
+      clientSessionId: pendingSessionId,
+      workspaceId,
+      agentKind: options.agentKind,
+      modelId: options.modelId,
+      modeId: resolvedModeId ?? null,
+      hasExistingProjectedRecord: Boolean(existingProjectedRecord),
+      existingProjectedWorkspaceId: existingProjectedRecord?.workspaceId ?? null,
+      hasPrompt,
+      shouldEnqueueInitialPrompt,
+      skipInitialPromptEnqueue: options.skipInitialPromptEnqueue === true,
+      reuseInFlightEmptySession: options.reuseInFlightEmptySession ?? null,
+    });
     let initialShellIntent: WorkspaceShellIntentKey | null | undefined;
     let currentOwnedShellIntent: WorkspaceShellIntentKey | null = null;
     let currentOwnedShellEpoch: number | null = null;
@@ -635,6 +649,18 @@ export function useSessionCreationActions() {
         pendingSessionId,
         launchedSession.id,
       );
+      logLatency("session.create.materialized", {
+        clientSessionId: pendingSessionId,
+        materializedSessionId: launchedSession.id,
+        workspaceId,
+        agentKind: options.agentKind,
+        modelId: launchedSession.modelId ?? options.modelId,
+        modeId: launchedSession.modeId ?? resolvedModeId ?? null,
+        status: realRecord.status,
+        executionPhase: launchedSession.executionSummary?.phase ?? null,
+        pendingInteractionCount: launchedSession.executionSummary?.pendingInteractions?.length ?? 0,
+        activeSessionId: useSessionSelectionStore.getState().activeSessionId,
+      });
       if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
         rememberLastViewedSession(workspaceId, launchedSession.id);
       }
@@ -669,6 +695,15 @@ export function useSessionCreationActions() {
     }
 
     const cleanupCreateFailure = (error: unknown): void => {
+      logLatency("session.create.failed", {
+        clientSessionId: pendingSessionId,
+        workspaceId,
+        agentKind: options.agentKind,
+        modelId: options.modelId,
+        hasPrompt,
+        hasExistingProjectedRecord: Boolean(existingProjectedRecord),
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       if (hasPrompt) {
         markProjectedSessionPromptCreateFailed(pendingSessionId, error);
         if (options.launchIntentId) {

--- a/desktop/src/hooks/sessions/workflows/session-materialization-deps.ts
+++ b/desktop/src/hooks/sessions/workflows/session-materialization-deps.ts
@@ -1,0 +1,23 @@
+import type {
+  SessionMaterializationDeps,
+} from "@/lib/workflows/sessions/session-materialization";
+import {
+  getMaterializedSessionId,
+} from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+export const sessionMaterializationDeps: SessionMaterializationDeps = {
+  getMaterializedSessionId,
+  subscribeToMaterializedSessionId: (clientSessionId, onChange) => {
+    let lastMaterializedSessionId = getMaterializedSessionId(clientSessionId);
+    return useSessionDirectoryStore.subscribe((state) => {
+      const nextMaterializedSessionId =
+        state.entriesById[clientSessionId]?.materializedSessionId ?? null;
+      if (nextMaterializedSessionId === lastMaterializedSessionId) {
+        return;
+      }
+      lastMaterializedSessionId = nextMaterializedSessionId;
+      onChange(nextMaterializedSessionId);
+    });
+  },
+};

--- a/desktop/src/hooks/sessions/workflows/use-session-interaction-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-interaction-actions.ts
@@ -16,15 +16,124 @@ import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspa
 import {
   getSessionClientAndWorkspace,
 } from "@/lib/workflows/sessions/session-runtime";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   getSessionRecord,
 } from "@/stores/sessions/session-records";
+import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+type InteractionAction = "permission" | "user_input" | "mcp_elicitation";
 
 export function useSessionInteractionActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const resolveInteractionMutation = useResolveSessionInteractionMutation();
   const revealMcpElicitationUrlMutation = useRevealMcpElicitationUrlMutation();
+
+  const resolvePendingInteraction = useCallback(async (input: {
+    action: InteractionAction;
+    sessionId: string;
+    selectedWorkspaceId: string | null;
+    slot: SessionRuntimeRecord | null;
+    requestId: string;
+    request: ResolveInteractionRequest;
+    requestExtra?: Record<string, unknown>;
+  }) => {
+    const blockedReason = getWorkspaceRuntimeBlockReason(input.slot?.workspaceId ?? input.selectedWorkspaceId);
+    if (blockedReason) {
+      logInteractionDebug("resolve.blocked", {
+        ...input,
+        extra: { blockedReason },
+      });
+      throw new Error(blockedReason);
+    }
+
+    let materializedSessionId: string | null = null;
+    let workspaceId: string | null = null;
+    try {
+      const resolved = await getSessionClientAndWorkspace(input.sessionId);
+      materializedSessionId = resolved.materializedSessionId;
+      workspaceId = resolved.workspaceId;
+      logInteractionDebug("resolve.request", {
+        ...input,
+        materializedSessionId,
+        workspaceId,
+        extra: input.requestExtra,
+      });
+      await resolveInteractionMutation.mutateAsync({
+        workspaceId,
+        sessionId: materializedSessionId,
+        requestId: input.requestId,
+        request: input.request,
+      });
+      logInteractionDebug("resolve.success", {
+        ...input,
+        materializedSessionId,
+        workspaceId,
+      });
+    } catch (error) {
+      logInteractionDebug("resolve.failed", {
+        ...input,
+        materializedSessionId,
+        workspaceId,
+        extra: { errorMessage: resolveErrorMessage(error) },
+      });
+      throw error;
+    }
+  }, [getWorkspaceRuntimeBlockReason, resolveInteractionMutation]);
+
+  const revealPendingMcpElicitationUrl = useCallback(async (input: {
+    sessionId: string;
+    selectedWorkspaceId: string | null;
+    slot: SessionRuntimeRecord | null;
+    requestId: string;
+  }): Promise<McpElicitationUrlRevealResponse> => {
+    const blockedReason = getWorkspaceRuntimeBlockReason(input.slot?.workspaceId ?? input.selectedWorkspaceId);
+    if (blockedReason) {
+      logInteractionDebug("reveal_url.blocked", {
+        action: "mcp_elicitation",
+        ...input,
+        extra: { blockedReason },
+      });
+      throw new Error(blockedReason);
+    }
+
+    let materializedSessionId: string | null = null;
+    let workspaceId: string | null = null;
+    try {
+      const resolved = await getSessionClientAndWorkspace(input.sessionId);
+      materializedSessionId = resolved.materializedSessionId;
+      workspaceId = resolved.workspaceId;
+      logInteractionDebug("reveal_url.request", {
+        action: "mcp_elicitation",
+        ...input,
+        materializedSessionId,
+        workspaceId,
+      });
+      const response = await revealMcpElicitationUrlMutation.mutateAsync({
+        workspaceId,
+        sessionId: materializedSessionId,
+        requestId: input.requestId,
+      });
+      logInteractionDebug("reveal_url.success", {
+        action: "mcp_elicitation",
+        ...input,
+        materializedSessionId,
+        workspaceId,
+        extra: { hasUrl: Boolean(response.url) },
+      });
+      return response;
+    } catch (error) {
+      logInteractionDebug("reveal_url.failed", {
+        action: "mcp_elicitation",
+        ...input,
+        materializedSessionId,
+        workspaceId,
+        extra: { errorMessage: resolveErrorMessage(error) },
+      });
+      throw error;
+    }
+  }, [getWorkspaceRuntimeBlockReason, revealMcpElicitationUrlMutation]);
 
   const resolvePermission = useCallback(async (
     input: { decision?: "allow" | "deny"; optionId?: string },
@@ -36,27 +145,32 @@ export function useSessionInteractionActions() {
       ? selectPendingApprovalInteraction(slot.transcript)
       : null;
     if (!sessionId || !permission) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "permission",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
       return;
     }
 
-    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
-    if (blockedReason) {
-      throw new Error(blockedReason);
-    }
-
-    const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(sessionId);
     const request: ResolveInteractionRequest = input.optionId
       ? { outcome: "selected", optionId: input.optionId }
       : { outcome: "decision", decision: input.decision ?? "deny" };
-    await resolveInteractionMutation.mutateAsync(
-      {
-        workspaceId,
-        sessionId: materializedSessionId,
-        requestId: permission.requestId,
-        request,
+    await resolvePendingInteraction({
+      action: "permission",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
+      requestId: permission.requestId,
+      request,
+      requestExtra: {
+        outcome: input.optionId ? "selected" : "decision",
+        hasOptionId: Boolean(input.optionId),
+        decision: input.optionId ? null : input.decision ?? "deny",
       },
-    );
-  }, [getWorkspaceRuntimeBlockReason, resolveInteractionMutation]);
+    });
+  }, [resolvePendingInteraction]);
 
   const resolveUserInput = useCallback(async (
     input:
@@ -70,25 +184,31 @@ export function useSessionInteractionActions() {
       ? selectPendingUserInputInteraction(slot.transcript)
       : null;
     if (!sessionId || !userInput) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "user_input",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
       return;
     }
 
-    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
-    if (blockedReason) {
-      throw new Error(blockedReason);
-    }
-
-    const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(sessionId);
     const request: ResolveInteractionRequest = input.outcome === "submitted"
       ? { outcome: "submitted", answers: input.answers }
       : { outcome: "cancelled" };
-    await resolveInteractionMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
+    await resolvePendingInteraction({
+      action: "user_input",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
       requestId: userInput.requestId,
       request,
+      requestExtra: {
+        outcome: input.outcome,
+        answerCount: input.outcome === "submitted" ? input.answers.length : 0,
+      },
     });
-  }, [getWorkspaceRuntimeBlockReason, resolveInteractionMutation]);
+  }, [resolvePendingInteraction]);
 
   const resolveMcpElicitation = useCallback(async (
     input:
@@ -103,25 +223,31 @@ export function useSessionInteractionActions() {
       ? selectPendingMcpElicitationInteraction(slot.transcript)
       : null;
     if (!sessionId || !mcpElicitation) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "mcp_elicitation",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
       return;
     }
 
-    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
-    if (blockedReason) {
-      throw new Error(blockedReason);
-    }
-
-    const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(sessionId);
     const request: ResolveInteractionRequest = input.outcome === "accepted"
       ? { outcome: "accepted", fields: input.fields }
       : { outcome: input.outcome };
-    await resolveInteractionMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
+    await resolvePendingInteraction({
+      action: "mcp_elicitation",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
       requestId: mcpElicitation.requestId,
       request,
+      requestExtra: {
+        outcome: input.outcome,
+        fieldCount: input.outcome === "accepted" ? input.fields.length : 0,
+      },
     });
-  }, [getWorkspaceRuntimeBlockReason, resolveInteractionMutation]);
+  }, [resolvePendingInteraction]);
 
   const revealMcpElicitationUrl = useCallback(async (): Promise<McpElicitationUrlRevealResponse | null> => {
     const state = useSessionSelectionStore.getState();
@@ -131,21 +257,22 @@ export function useSessionInteractionActions() {
       ? selectPendingMcpElicitationInteraction(slot.transcript)
       : null;
     if (!sessionId || !mcpElicitation) {
+      logInteractionDebug("reveal_url.skipped_no_pending", {
+        action: "mcp_elicitation",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
       return null;
     }
 
-    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
-    if (blockedReason) {
-      throw new Error(blockedReason);
-    }
-
-    const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(sessionId);
-    return revealMcpElicitationUrlMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
+    return revealPendingMcpElicitationUrl({
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
       requestId: mcpElicitation.requestId,
     });
-  }, [getWorkspaceRuntimeBlockReason, revealMcpElicitationUrlMutation]);
+  }, [revealPendingMcpElicitationUrl]);
 
   return {
     resolvePermission,
@@ -153,4 +280,46 @@ export function useSessionInteractionActions() {
     resolveUserInput,
     revealMcpElicitationUrl,
   };
+}
+
+function logInteractionDebug(
+  event: string,
+  input: {
+    action: InteractionAction;
+    sessionId: string | null;
+    selectedWorkspaceId: string | null;
+    slot: SessionRuntimeRecord | null;
+    requestId?: string | null;
+    materializedSessionId?: string | null;
+    workspaceId?: string | null;
+    extra?: Record<string, unknown>;
+  },
+): void {
+  logLatency(`session.interaction.${event}`, {
+    action: input.action,
+    sessionId: input.sessionId,
+    selectedWorkspaceId: input.selectedWorkspaceId,
+    requestId: input.requestId ?? null,
+    resolvedWorkspaceId: input.workspaceId ?? null,
+    resolvedMaterializedSessionId: input.materializedSessionId ?? null,
+    slotWorkspaceId: input.slot?.workspaceId ?? null,
+    slotMaterializedSessionId: input.slot?.materializedSessionId ?? null,
+    slotStatus: input.slot?.status ?? null,
+    transcriptHydrated: input.slot?.transcriptHydrated ?? null,
+    streamConnectionState: input.slot?.streamConnectionState ?? null,
+    transcriptLastSeq: input.slot?.transcript.lastSeq ?? null,
+    pendingInteractions: input.slot?.transcript.pendingInteractions.map((interaction) => ({
+      requestId: interaction.requestId,
+      kind: interaction.kind,
+      toolCallId: interaction.toolCallId ?? null,
+      toolKind: interaction.toolKind ?? null,
+      toolStatus: interaction.toolStatus ?? null,
+      linkedPlanId: interaction.linkedPlanId ?? null,
+    })) ?? [],
+    ...(input.extra ?? {}),
+  });
+}
+
+function resolveErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/desktop/src/hooks/sessions/workflows/use-session-prompt-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-prompt-actions.ts
@@ -7,6 +7,8 @@ import {
   isPendingSessionId,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
+import { canPromptSessionSlot } from "@/lib/domain/sessions/prompt-readiness";
 
 export function useSessionPromptActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
@@ -24,10 +26,40 @@ export function useSessionPromptActions() {
 
     const slot = getSessionRecord(sessionId);
     if (!isPendingSessionId(sessionId) && !slot) {
+      logLatency("session.prompt.active.blocked", {
+        reason: "missing_slot",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+      });
       throw new Error("No active session");
     }
-    if (!isPendingSessionId(sessionId) && slot && !slot.transcriptHydrated) {
+    if (!isPendingSessionId(sessionId) && slot && !canPromptSessionSlot(slot)) {
+      logLatency("session.prompt.active.blocked", {
+        reason: "transcript_not_hydrated",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slotWorkspaceId: slot.workspaceId,
+        materializedSessionId: slot.materializedSessionId,
+        status: slot.status,
+        streamConnectionState: slot.streamConnectionState,
+        transcriptLastSeq: slot.transcript.lastSeq,
+        turnCount: slot.transcript.turnOrder.length,
+        pendingInteractionCount: slot.transcript.pendingInteractions.length,
+      });
       throw new Error("Session is still loading. Try again in a moment.");
+    }
+    if (!isPendingSessionId(sessionId) && slot && !slot.transcriptHydrated) {
+      logLatency("session.prompt.active.unhydrated_open_stream_allowed", {
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slotWorkspaceId: slot.workspaceId,
+        materializedSessionId: slot.materializedSessionId,
+        status: slot.status,
+        streamConnectionState: slot.streamConnectionState,
+        transcriptLastSeq: slot.transcript.lastSeq,
+        turnCount: slot.transcript.turnOrder.length,
+        pendingInteractionCount: slot.transcript.pendingInteractions.length,
+      });
     }
 
     const workspaceId = slot?.workspaceId ?? null;

--- a/desktop/src/hooks/sessions/workflows/use-session-prompt-workflow.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-prompt-workflow.ts
@@ -21,6 +21,7 @@ import { outboxEntriesForSession } from "@/lib/domain/chat/outbox/prompt-outbox-
 import type { PromptAttachmentSnapshot } from "@/lib/domain/chat/composer/prompt-attachment-snapshot";
 import { isSessionSlotBusy } from "@/lib/domain/sessions/activity";
 import { usePromptOutboxStore } from "@/stores/chat/prompt-outbox-store";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 
 interface PromptSessionInput {
   sessionId: string;
@@ -65,6 +66,11 @@ export function useSessionPromptWorkflow() {
         PROMPT_SUBMIT_MEASUREMENT_SURFACES,
       );
     }
+    const outboxPlacement = resolvePromptOutboxPlacement({
+      isSessionBusy: isSessionSlotBusy(slot),
+      isSessionMaterialized: Boolean(slot?.materializedSessionId),
+      existingEntries: existingOutboxEntries,
+    });
     flushSync(() => {
       outboxStore.enqueue({
         clientPromptId,
@@ -75,13 +81,25 @@ export function useSessionPromptWorkflow() {
         blocks: blocks ?? [{ type: "text", text }],
         attachmentSnapshots,
         contentParts: optimisticContentParts,
-        placement: resolvePromptOutboxPlacement({
-          isSessionBusy: isSessionSlotBusy(slot),
-          isSessionMaterialized: Boolean(slot?.materializedSessionId),
-          existingEntries: existingOutboxEntries,
-        }),
+        placement: outboxPlacement,
         latencyFlowId,
       });
+    });
+    logLatency("prompt.outbox.enqueue", {
+      clientPromptId,
+      clientSessionId: sessionId,
+      workspaceId: resolvedWorkspaceId,
+      materializedSessionId: slot?.materializedSessionId ?? null,
+      deliveryState: "waiting_for_session",
+      placement: outboxPlacement,
+      hasSlot: Boolean(slot),
+      slotStatus: slot?.status ?? null,
+      transcriptHydrated: slot?.transcriptHydrated ?? null,
+      streamConnectionState: slot?.streamConnectionState ?? null,
+      existingOutboxEntryCount: existingOutboxEntries.length,
+      blockTypes: (blocks ?? [{ type: "text" as const, text }]).map((block) => block.type),
+      attachmentCount: attachmentSnapshots?.length ?? 0,
+      hasOptimisticContentParts: Boolean(optimisticContentParts?.length),
     });
     recordMeasurementWorkflowStep({
       operationId: measurementOperationId,

--- a/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -125,6 +125,12 @@ export function useSessionSelectionWorkflowActions({
       sessionId,
       flowId: options?.latencyFlowId ?? null,
       hasExistingSlot: existingSlot !== null,
+      existingSlotWorkspaceId: existingSlot?.workspaceId ?? null,
+      existingSlotMaterializedSessionId: existingSlot?.materializedSessionId ?? null,
+      existingSlotTranscriptHydrated: existingSlot?.transcriptHydrated ?? null,
+      existingSlotStatus: existingSlot?.status ?? null,
+      existingSlotStreamConnectionState: existingSlot?.streamConnectionState ?? null,
+      existingSlotPendingInteractionCount: existingSlot?.transcript.pendingInteractions.length ?? null,
       selectedWorkspaceId: current.selectedWorkspaceId,
     });
     if (guard && !isSessionActivationCurrent(guard)) {
@@ -197,6 +203,16 @@ export function useSessionSelectionWorkflowActions({
           step: "session.select.hot_slot_activate",
           startedAt: hotStartedAt,
           outcome: existingSlot.transcriptHydrated ? "cache_hit" : "cache_miss",
+        });
+        logLatency("session.select.hot_slot_activate", {
+          sessionId,
+          workspaceId: existingSlot.workspaceId,
+          materializedSessionId: existingSlot.materializedSessionId,
+          transcriptHydrated: existingSlot.transcriptHydrated,
+          status: existingSlot.status,
+          streamConnectionState: existingSlot.streamConnectionState,
+          pendingInteractionCount: existingSlot.transcript.pendingInteractions.length,
+          flowId: options?.latencyFlowId ?? null,
         });
         if (hotOperationId) {
           markOperationForNextCommit(hotOperationId, [
@@ -381,10 +397,16 @@ export function useSessionSelectionWorkflowActions({
       });
     }
 
+    const completedSlot = getSessionRecord(sessionId);
     logLatency("session.select.completed", {
       sessionId,
       workspaceId,
       flowId: options?.latencyFlowId ?? null,
+      materializedSessionId: completedSlot?.materializedSessionId ?? null,
+      transcriptHydrated: completedSlot?.transcriptHydrated ?? null,
+      status: completedSlot?.status ?? null,
+      streamConnectionState: completedSlot?.streamConnectionState ?? null,
+      pendingInteractionCount: completedSlot?.transcript.pendingInteractions.length ?? null,
       totalElapsedMs: elapsedMs(startedAt),
     });
     if (measurementOperationId) {

--- a/desktop/src/hooks/workspaces/use-workspace-entry-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-entry-actions.ts
@@ -11,7 +11,6 @@ import {
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import type { PendingWorkspaceEntry } from "@/lib/domain/workspaces/creation/pending-entry";
 import {
-  buildPendingWorkspaceUiKey,
   buildSubmittingPendingWorkspaceEntry as buildSubmittingPendingEntry,
   createPendingWorkspaceAttemptId as createAttemptId,
 } from "@/lib/domain/workspaces/creation/pending-entry";
@@ -37,10 +36,8 @@ import {
   failLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
 import {
-  getWorkspaceSessionRecords,
-  patchSessionRecord,
-} from "@/stores/sessions/session-records";
-import { useSessionCreationActions } from "@/hooks/sessions/use-session-creation-actions";
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
 
 function resolveDisplayNameFromPath(path: string): string {
   return path.split("/").filter(Boolean).pop() ?? "workspace";
@@ -118,7 +115,7 @@ export function useWorkspaceEntryActions() {
   } = useWorkspaceActions();
   const { selectWorkspaceWithArrival } = useWorkspaceEntryFlow();
   const { selectWorkspace } = useWorkspaceSelection();
-  const { createEmptySessionWithResolvedConfig } = useSessionCreationActions();
+  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
   const enterPendingWorkspaceShell = useSessionSelectionStore(
     (state) => state.enterPendingWorkspaceShell,
   );
@@ -187,12 +184,7 @@ export function useWorkspaceEntryActions() {
       return false;
     }
 
-    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(entry);
-    const projectedSessions = Object.values(getWorkspaceSessionRecords(pendingWorkspaceUiKey))
-      .filter((session) => !session.materializedSessionId);
-    for (const session of projectedSessions) {
-      patchSessionRecord(session.sessionId, { workspaceId });
-    }
+    materializePendingWorkspaceSessions(entry, workspaceId);
 
     setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
       workspaceId,
@@ -201,24 +193,6 @@ export function useWorkspaceEntryActions() {
       baseBranchName: entry.baseBranchName,
     }));
     setPendingWorkspaceEntry(null);
-    for (const session of projectedSessions) {
-      void createEmptySessionWithResolvedConfig({
-        clientSessionId: session.sessionId,
-        workspaceId,
-        agentKind: session.agentKind,
-        modelId: session.modelId ?? session.agentKind,
-        modeId: session.modeId ?? undefined,
-        reuseInFlightEmptySession: false,
-      }).catch((error) => {
-        const message = error instanceof Error ? error.message : "Failed to start projected chat session.";
-        logLatency("workspace.entry.projected_session_create_failed", {
-          attemptId: entry.attemptId,
-          workspaceId,
-          sessionId: session.sessionId,
-          errorMessage: message,
-        });
-      });
-    }
     logLatency("workspace.entry.selection.success", {
       attemptId: entry.attemptId,
       source: entry.source,
@@ -228,7 +202,7 @@ export function useWorkspaceEntryActions() {
     });
     return true;
   }, [
-    createEmptySessionWithResolvedConfig,
+    materializePendingWorkspaceSessions,
     selectWorkspace,
     setPendingWorkspaceEntry,
     setWorkspaceArrivalEvent,

--- a/desktop/src/hooks/workspaces/use-workspace-entry-flow.test.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-entry-flow.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildSubmittingPendingWorkspaceEntry } from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  buildSubmittingPendingWorkspaceEntry,
+  type PendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 
 const mocks = vi.hoisted(() => ({
@@ -9,8 +12,9 @@ const mocks = vi.hoisted(() => ({
   setWorkspaceArrivalEvent: vi.fn(),
   resetWorkspaceFiles: vi.fn(),
   requestChatInputFocus: vi.fn(),
+  materializePendingWorkspaceSessions: vi.fn(),
   harnessState: {
-    pendingWorkspaceEntry: null,
+    pendingWorkspaceEntry: null as PendingWorkspaceEntry | null,
     enterPendingWorkspaceShell: vi.fn(),
     setPendingWorkspaceEntry: vi.fn(),
     setWorkspaceArrivalEvent: vi.fn(),
@@ -50,6 +54,10 @@ vi.mock("@/stores/sessions/session-selection-store", () => {
   return { useSessionSelectionStore };
 });
 
+vi.mock("@/hooks/workspaces/workflows/use-pending-workspace-session-materialization", () => ({
+  usePendingWorkspaceSessionMaterialization: () => mocks.materializePendingWorkspaceSessions,
+}));
+
 vi.mock("@/lib/infra/measurement/debug-latency", () => ({
   elapsedSince: () => 0,
   logLatency: vi.fn(),
@@ -63,6 +71,8 @@ describe("useWorkspaceEntryFlow", () => {
     mocks.setWorkspaceArrivalEvent.mockReset();
     mocks.resetWorkspaceFiles.mockReset();
     mocks.requestChatInputFocus.mockReset();
+    mocks.materializePendingWorkspaceSessions.mockReset();
+    mocks.harnessState.pendingWorkspaceEntry = null;
     mocks.harnessState.enterPendingWorkspaceShell = mocks.enterPendingWorkspaceShell;
     mocks.harnessState.setPendingWorkspaceEntry = mocks.setPendingWorkspaceEntry;
     mocks.harnessState.setWorkspaceArrivalEvent = mocks.setWorkspaceArrivalEvent;
@@ -117,5 +127,35 @@ describe("useWorkspaceEntryFlow", () => {
     expect(mocks.resetWorkspaceFiles).toHaveBeenCalledTimes(1);
     expect(mocks.enterPendingWorkspaceShell).toHaveBeenCalledWith(entry);
     expect(mocks.requestChatInputFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("materializes projected sessions before clearing a finalized pending workspace", async () => {
+    const { useWorkspaceEntryFlow } = await import("./use-workspace-entry-flow");
+    const entry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-1",
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      request: {
+        kind: "select-existing",
+        workspaceId: "cloud-workspace-1",
+      },
+    });
+    mocks.harnessState.pendingWorkspaceEntry = entry;
+
+    const flow = useWorkspaceEntryFlow();
+    await expect(flow.finalizeSelection(entry, "cloud-workspace-1")).resolves.toBe(true);
+
+    expect(mocks.materializePendingWorkspaceSessions).toHaveBeenCalledWith(
+      entry,
+      "cloud-workspace-1",
+    );
+    expect(mocks.setPendingWorkspaceEntry).toHaveBeenLastCalledWith(null);
+    expect(mocks.setWorkspaceArrivalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "cloud-workspace-1",
+        source: "cloud-created",
+      }),
+    );
   });
 });

--- a/desktop/src/hooks/workspaces/use-workspace-entry-flow.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-entry-flow.ts
@@ -3,7 +3,9 @@ import { resetWorkspaceEditorState } from "@/stores/editor/workspace-editor-stat
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
 import { buildWorkspaceArrivalEvent } from "@/lib/domain/workspaces/creation/arrival";
-import type { PendingWorkspaceEntry } from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  type PendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import {
   ensureRepoGroupExpanded,
@@ -12,6 +14,9 @@ import {
   elapsedSince,
   logLatency,
 } from "@/lib/infra/measurement/debug-latency";
+import {
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
 
 interface FinalizeSelectionOptions {
   latencyFlowId?: string | null;
@@ -28,6 +33,7 @@ function requestChatInputFocus(): void {
 
 export function useWorkspaceEntryFlow() {
   const { selectWorkspace } = useWorkspaceSelection();
+  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
   const enterPendingWorkspaceShell = useSessionSelectionStore(
     (state) => state.enterPendingWorkspaceShell,
   );
@@ -91,6 +97,8 @@ export function useWorkspaceEntryFlow() {
       return false;
     }
 
+    materializePendingWorkspaceSessions(entry, workspaceId);
+
     setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
       workspaceId,
       source: entry.source,
@@ -105,7 +113,12 @@ export function useWorkspaceEntryFlow() {
       totalElapsedMs: elapsedSince(entry.createdAt),
     });
     return true;
-  }, [selectWorkspace, setPendingWorkspaceEntry, setWorkspaceArrivalEvent]);
+  }, [
+    materializePendingWorkspaceSessions,
+    selectWorkspace,
+    setPendingWorkspaceEntry,
+    setWorkspaceArrivalEvent,
+  ]);
 
   const failPendingEntry = useCallback((
     entry: PendingWorkspaceEntry,

--- a/desktop/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
@@ -9,6 +9,9 @@ import { useCreateCloudWorkspace } from "@/hooks/cloud/workflows/use-create-clou
 import { useWorkspaceEntryActions } from "@/hooks/workspaces/use-workspace-entry-actions";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
+import {
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
 import {
@@ -35,6 +38,7 @@ export function usePendingWorkspaceEntryActions() {
   } = useWorkspaceEntryActions();
   const { retryCloudWorkspaceAndEnter } = useCreateCloudWorkspace();
   const { selectWorkspace, clearWorkspaceRuntimeState } = useWorkspaceSelection();
+  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
 
   const handleRetry = useCallback(async (entry: PendingWorkspaceEntry) => {
     switch (entry.request.kind) {
@@ -96,6 +100,9 @@ export function usePendingWorkspaceEntryActions() {
               });
               return;
             }
+            materializePendingWorkspaceSessions(current, entry.request.workspaceId, {
+              eventPrefix: "workspace.entry.retry",
+            });
             setPendingWorkspaceEntry(null);
             setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
               workspaceId: entry.request.workspaceId,
@@ -116,6 +123,7 @@ export function usePendingWorkspaceEntryActions() {
   }, [
     createLocalWorkspaceAndEnter,
     createWorktreeAndEnter,
+    materializePendingWorkspaceSessions,
     retryCloudWorkspaceAndEnter,
     selectWorkspace,
     setPendingWorkspaceEntry,

--- a/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
+++ b/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import {
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
+
+const mocks = vi.hoisted(() => ({
+  createEmptySessionWithResolvedConfig: vi.fn(async (options: { clientSessionId: string }) =>
+    options.clientSessionId
+  ),
+}));
+
+vi.mock("react", () => ({
+  useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+}));
+
+vi.mock("@/hooks/sessions/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createEmptySessionWithResolvedConfig: mocks.createEmptySessionWithResolvedConfig,
+  }),
+}));
+
+vi.mock("@/lib/infra/measurement/debug-latency", () => ({
+  logLatency: vi.fn(),
+}));
+
+describe("usePendingWorkspaceSessionMaterialization", () => {
+  beforeEach(() => {
+    mocks.createEmptySessionWithResolvedConfig.mockClear();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it("remaps projected pending-workspace sessions and starts real runtime sessions", async () => {
+    const entry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-1",
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      request: { kind: "select-existing", workspaceId: "cloud-workspace-1" },
+    });
+    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(entry);
+    putSessionRecord(createEmptySessionRecord("client-session:codex:1", "codex", {
+      workspaceId: pendingWorkspaceUiKey,
+      materializedSessionId: null,
+      modelId: "gpt-5.5",
+      modeId: "full-access",
+    }));
+
+    const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
+    const materializationResult = materializePendingWorkspaceSessions(entry, "workspace-real", {
+      eventPrefix: "test",
+    });
+    await Promise.resolve();
+
+    expect(materializationResult).toEqual({
+      pendingWorkspaceUiKey,
+      projectedSessionCount: 1,
+      projectedSessionIds: ["client-session:codex:1"],
+    });
+    expect(getSessionRecord("client-session:codex:1")?.workspaceId).toBe("workspace-real");
+    expect(mocks.createEmptySessionWithResolvedConfig).toHaveBeenCalledWith({
+      clientSessionId: "client-session:codex:1",
+      workspaceId: "workspace-real",
+      agentKind: "codex",
+      modelId: "gpt-5.5",
+      modeId: "full-access",
+      reuseInFlightEmptySession: false,
+    });
+  });
+});

--- a/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
@@ -1,0 +1,94 @@
+import { useCallback } from "react";
+import {
+  buildPendingWorkspaceUiKey,
+  type PendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import { useSessionCreationActions } from "@/hooks/sessions/use-session-creation-actions";
+import {
+  getWorkspaceSessionRecords,
+  patchSessionRecord,
+} from "@/stores/sessions/session-records";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
+
+interface PendingWorkspaceSessionMaterializationOptions {
+  eventPrefix?: string;
+}
+
+export interface PendingWorkspaceSessionMaterializationResult {
+  pendingWorkspaceUiKey: string;
+  projectedSessionCount: number;
+  projectedSessionIds: string[];
+}
+
+export function usePendingWorkspaceSessionMaterialization() {
+  const { createEmptySessionWithResolvedConfig } = useSessionCreationActions();
+
+  return useCallback((
+    entry: PendingWorkspaceEntry,
+    workspaceId: string,
+    options?: PendingWorkspaceSessionMaterializationOptions,
+  ): PendingWorkspaceSessionMaterializationResult => {
+    const eventPrefix = options?.eventPrefix ?? "workspace.entry";
+    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(entry);
+    const projectedSessions = Object.values(getWorkspaceSessionRecords(pendingWorkspaceUiKey))
+      .filter((session) => !session.materializedSessionId);
+    const projectedSessionIds = projectedSessions.map((session) => session.sessionId);
+
+    logLatency(`${eventPrefix}.projected_sessions.detected`, {
+      attemptId: entry.attemptId,
+      source: entry.source,
+      workspaceId,
+      pendingWorkspaceUiKey,
+      projectedSessionCount: projectedSessions.length,
+      projectedSessionIds,
+    });
+
+    for (const session of projectedSessions) {
+      patchSessionRecord(session.sessionId, { workspaceId });
+      logLatency(`${eventPrefix}.projected_session.remapped`, {
+        attemptId: entry.attemptId,
+        workspaceId,
+        pendingWorkspaceUiKey,
+        sessionId: session.sessionId,
+        agentKind: session.agentKind,
+        modelId: session.modelId,
+      });
+    }
+
+    for (const session of projectedSessions) {
+      // The prompt outbox remains the user-visible owner while this background
+      // create binds the projected client session to a real runtime session.
+      void createEmptySessionWithResolvedConfig({
+        clientSessionId: session.sessionId,
+        workspaceId,
+        agentKind: session.agentKind,
+        modelId: session.modelId ?? session.agentKind,
+        modeId: session.modeId ?? undefined,
+        reuseInFlightEmptySession: false,
+      }).then((clientSessionId) => {
+        logLatency(`${eventPrefix}.projected_session_create_completed`, {
+          attemptId: entry.attemptId,
+          workspaceId,
+          sessionId: session.sessionId,
+          returnedClientSessionId: clientSessionId,
+        });
+      }).catch((error) => {
+        const message = error instanceof Error
+          ? error.message
+          : "Failed to start projected chat session.";
+        logLatency(`${eventPrefix}.projected_session_create_failed`, {
+          attemptId: entry.attemptId,
+          workspaceId,
+          sessionId: session.sessionId,
+          errorMessage: message,
+        });
+      });
+    }
+
+    return {
+      pendingWorkspaceUiKey,
+      projectedSessionCount: projectedSessions.length,
+      projectedSessionIds,
+    };
+  }, [createEmptySessionWithResolvedConfig]);
+}

--- a/desktop/src/lib/domain/chat/outbox/pending-prompts.test.ts
+++ b/desktop/src/lib/domain/chat/outbox/pending-prompts.test.ts
@@ -149,6 +149,29 @@ describe("pending prompt visibility", () => {
     ))).toBe(true);
   });
 
+  it("keeps optimistic prompt during an empty started user-message echo", () => {
+    expect(shouldClearOptimisticPendingPromptForEnvelope({
+      sessionId: "session-1",
+      seq: 1,
+      timestamp: "2026-04-13T12:00:01.000Z",
+      turnId: "turn-1",
+      itemId: "item-1",
+      event: {
+        type: "item_started",
+        item: {
+          kind: "user_message",
+          status: "completed",
+          sourceAgentKind: "codex",
+          contentParts: [],
+        },
+      },
+    } satisfies SessionEventEnvelope, createOptimisticPendingPrompt(
+      "Ship it",
+      "prompt-1",
+      "2026-04-13T12:00:00.000Z",
+    ))).toBe(false);
+  });
+
   it("treats plan-only turns as not yet renderable", () => {
     const transcript = createTranscriptState("session-1");
     transcript.turnOrder = ["turn-1"];

--- a/desktop/src/lib/domain/chat/outbox/pending-prompts.ts
+++ b/desktop/src/lib/domain/chat/outbox/pending-prompts.ts
@@ -10,6 +10,7 @@ import type {
   TurnRecord,
 } from "@anyharness/sdk";
 import type { SessionViewState } from "@/lib/domain/sessions/activity";
+import { isRenderableUserMessageEcho } from "@/lib/domain/chat/outbox/prompt-echo";
 
 export function createOptimisticPendingPrompt(
   text: string,
@@ -110,7 +111,7 @@ export function shouldClearOptimisticPendingPromptForEnvelope(
     (event.type === "item_started" || event.type === "item_completed")
     && event.item.kind === "user_message"
   ) {
-    return true;
+    return event.type === "item_completed" || isRenderableUserMessageEcho(event.item);
   }
 
   return false;
@@ -159,6 +160,8 @@ function isTranscriptItemRenderable(item: TranscriptItem | undefined): boolean {
   }
 
   switch (item.kind) {
+    case "user_message":
+      return isRenderableUserMessageEcho(item);
     case "assistant_prose":
       return !!item.text;
     case "plan":

--- a/desktop/src/lib/domain/chat/outbox/prompt-echo.test.ts
+++ b/desktop/src/lib/domain/chat/outbox/prompt-echo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
+import {
+  isRenderableUserMessageEcho,
+  transcriptHasRenderablePromptEcho,
+} from "@/lib/domain/chat/outbox/prompt-echo";
+
+describe("prompt echo", () => {
+  it("does not treat empty user-message echoes as renderable", () => {
+    expect(isRenderableUserMessageEcho({
+      kind: "user_message",
+      contentParts: [],
+      text: "",
+    })).toBe(false);
+  });
+
+  it("finds only renderable prompt echoes in a transcript", () => {
+    const transcript = createTranscriptState("session-1");
+    addUserMessage(transcript, "item-empty", "prompt-empty", "");
+    addUserMessage(transcript, "item-filled", "prompt-filled", "hello");
+
+    expect(transcriptHasRenderablePromptEcho(transcript, "prompt-empty")).toBe(false);
+    expect(transcriptHasRenderablePromptEcho(transcript, "prompt-filled")).toBe(true);
+  });
+});
+
+function addUserMessage(
+  transcript: TranscriptState,
+  itemId: string,
+  promptId: string,
+  text: string,
+) {
+  transcript.itemsById[itemId] = {
+    itemId,
+    turnId: "turn-1",
+    kind: "user_message",
+    text,
+    isStreaming: false,
+    promptId,
+    status: "completed",
+    sourceAgentKind: "codex",
+    messageId: itemId,
+    title: null,
+    nativeToolName: null,
+    parentToolCallId: null,
+    contentParts: text ? [{ type: "text", text }] : [],
+    timestamp: "2026-01-01T00:00:00.000Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: 1,
+    completedAt: "2026-01-01T00:00:00.000Z",
+  };
+}

--- a/desktop/src/lib/domain/chat/outbox/prompt-echo.ts
+++ b/desktop/src/lib/domain/chat/outbox/prompt-echo.ts
@@ -1,0 +1,39 @@
+import type { ContentPart, TranscriptState } from "@anyharness/sdk";
+
+interface UserMessageEchoLike {
+  kind?: string | null;
+  contentParts?: readonly ContentPart[] | null;
+  text?: string | null;
+}
+
+export function isRenderableUserMessageEcho(
+  item: UserMessageEchoLike | null | undefined,
+): boolean {
+  if (!item || item.kind !== "user_message") {
+    return false;
+  }
+
+  if (typeof item.text === "string" && item.text.trim().length > 0) {
+    return true;
+  }
+
+  return item.contentParts?.some(isRenderableContentPart) ?? false;
+}
+
+export function transcriptHasRenderablePromptEcho(
+  transcript: TranscriptState,
+  promptId: string,
+): boolean {
+  return Object.values(transcript.itemsById).some((item) =>
+    item.kind === "user_message"
+    && item.promptId === promptId
+    && isRenderableUserMessageEcho(item)
+  );
+}
+
+function isRenderableContentPart(part: ContentPart): boolean {
+  if (part.type === "text") {
+    return part.text.trim().length > 0;
+  }
+  return true;
+}

--- a/desktop/src/lib/domain/chat/outbox/prompt-outbox-reconciliation.ts
+++ b/desktop/src/lib/domain/chat/outbox/prompt-outbox-reconciliation.ts
@@ -7,6 +7,7 @@ import {
   removePromptOutboxEntry,
   type PromptOutboxStateShape,
 } from "@/lib/domain/chat/outbox/prompt-outbox-state";
+import { isRenderableUserMessageEcho } from "@/lib/domain/chat/outbox/prompt-echo";
 
 export function reconcileOutboxFromEnvelopes(
   state: PromptOutboxStateShape,
@@ -59,7 +60,9 @@ export function reconcileOutboxFromEnvelopes(
       const clientPromptId = event.item.kind === "user_message"
         ? event.item.promptId ?? null
         : null;
-      if (clientPromptId) {
+      const canReplaceOutboxRow = event.type === "item_completed"
+        || isRenderableUserMessageEcho(event.item);
+      if (clientPromptId && canReplaceOutboxRow) {
         nextState = patchPromptOutboxEntry(nextState, clientPromptId, {
           deliveryState: "echoed_tombstone",
           echoedAt: envelope.timestamp,

--- a/desktop/src/lib/domain/chat/outbox/prompt-outbox-selectors.ts
+++ b/desktop/src/lib/domain/chat/outbox/prompt-outbox-selectors.ts
@@ -9,6 +9,7 @@ import {
   type PromptOutboxPlacement,
 } from "@/lib/domain/chat/outbox/prompt-outbox-model";
 import type { PromptOutboxStateShape } from "@/lib/domain/chat/outbox/prompt-outbox-state";
+import { isRenderableUserMessageEcho } from "@/lib/domain/chat/outbox/prompt-echo";
 
 export function selectNextDispatchableOutboxEntry(
   state: PromptOutboxStateShape,
@@ -89,15 +90,16 @@ export function queuedOutboxEntriesForSession(
 
 export function resolvePromptOutboxPlacement(input: {
   isSessionBusy: boolean;
-  isSessionMaterialized?: boolean;
+  isSessionMaterialized: boolean;
   existingEntries: readonly PromptOutboxEntry[];
 }): PromptOutboxPlacement {
-  if (input.isSessionBusy && input.isSessionMaterialized !== false) {
+  if (input.existingEntries.some(isOutboxEntryBlockingNewTranscriptPrompt)) {
     return "queue";
   }
-  return input.existingEntries.some(isOutboxEntryBlockingNewTranscriptPrompt)
-    ? "queue"
-    : "transcript";
+  if (input.isSessionBusy && input.isSessionMaterialized) {
+    return "queue";
+  }
+  return "transcript";
 }
 
 export function outboxEntryToPendingPromptEntry(entry: PromptOutboxEntry): PendingPromptEntry {
@@ -145,6 +147,7 @@ function collectTranscriptPromptIds(
     if (
       item.kind === "user_message"
       && item.promptId
+      && isRenderableUserMessageEcho(item)
       && (!promptIdsToFind || promptIdsToFind.has(item.promptId))
     ) {
       promptIds.add(item.promptId);

--- a/desktop/src/lib/domain/chat/outbox/prompt-outbox.test.ts
+++ b/desktop/src/lib/domain/chat/outbox/prompt-outbox.test.ts
@@ -166,7 +166,15 @@ describe("prompt outbox", () => {
     expect(selectNextDispatchableOutboxEntry(state, "session-1")).toBeNull();
   });
 
-  it("places a new prompt in the composer queue when the session is busy", () => {
+  it("places the first local prompt in the transcript", () => {
+    expect(resolvePromptOutboxPlacement({
+      isSessionBusy: false,
+      isSessionMaterialized: true,
+      existingEntries: [],
+    })).toBe("transcript");
+  });
+
+  it("places a busy materialized session prompt in the composer queue", () => {
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: true,
       isSessionMaterialized: true,
@@ -174,7 +182,7 @@ describe("prompt outbox", () => {
     })).toBe("queue");
   });
 
-  it("places the first prompt for a busy unmaterialized session in the transcript", () => {
+  it("places a busy unmaterialized session prompt in the transcript", () => {
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: true,
       isSessionMaterialized: false,
@@ -209,6 +217,7 @@ describe("prompt outbox", () => {
 
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: false,
+      isSessionMaterialized: true,
       existingEntries: [existing],
     })).toBe("queue");
   });
@@ -227,6 +236,7 @@ describe("prompt outbox", () => {
 
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: false,
+      isSessionMaterialized: true,
       existingEntries: [failed],
     })).toBe("transcript");
   });
@@ -307,6 +317,43 @@ describe("prompt outbox", () => {
     expect(pruned.promptIdsByClientSessionId["session-1"]).toEqual([]);
   });
 
+  it("does not tombstone on an empty started user-message echo", () => {
+    const state = withEntry(emptyState(), createPromptOutboxEntry({
+      clientPromptId: "prompt-1",
+      clientSessionId: "session-1",
+      text: "hello",
+      blocks: [{ type: "text", text: "hello" }],
+      now: NOW,
+    }));
+
+    const next = reconcileOutboxFromEnvelopes(state, "session-1", [
+      envelope({
+        type: "item_started",
+        item: {
+          kind: "user_message",
+          status: "completed",
+          sourceAgentKind: "codex",
+          isTransient: false,
+          messageId: "message-1",
+          promptId: "prompt-1",
+          title: null,
+          toolCallId: null,
+          nativeToolName: null,
+          parentToolCallId: null,
+          rawInput: null,
+          rawOutput: null,
+          contentParts: [],
+          promptProvenance: null,
+        },
+      }),
+    ]);
+
+    expect(next.entriesByPromptId["prompt-1"]).toMatchObject({
+      deliveryState: "waiting_for_session",
+      echoedAt: null,
+    });
+  });
+
   it("keeps echoed tombstones while the matching runtime turn is in progress", () => {
     const echoedAt = "2026-01-01T00:00:01.000Z";
     const echoed = withEntry(emptyState(), {
@@ -354,6 +401,19 @@ describe("prompt outbox", () => {
     const transcript = transcriptWithUserPrompt("session-1", "prompt-1");
 
     expect(renderableOutboxEntriesForTranscript([entry], transcript)).toEqual([]);
+  });
+
+  it("keeps the local row until the runtime user-message echo has renderable content", () => {
+    const entry = createPromptOutboxEntry({
+      clientPromptId: "prompt-1",
+      clientSessionId: "session-1",
+      text: "hello",
+      blocks: [{ type: "text", text: "hello" }],
+      now: NOW,
+    });
+    const transcript = transcriptWithUserPrompt("session-1", "prompt-1", "");
+
+    expect(renderableOutboxEntriesForTranscript([entry], transcript)).toEqual([entry]);
   });
 
   it("does not render local queued prompts in the transcript", () => {
@@ -490,7 +550,11 @@ function envelope(
   };
 }
 
-function transcriptWithUserPrompt(sessionId: string, promptId: string): TranscriptState {
+function transcriptWithUserPrompt(
+  sessionId: string,
+  promptId: string,
+  text = "hello",
+): TranscriptState {
   const transcript = createTranscriptState(sessionId);
   transcript.turnOrder.push("turn-1");
   transcript.turnsById["turn-1"] = {
@@ -505,7 +569,7 @@ function transcriptWithUserPrompt(sessionId: string, promptId: string): Transcri
     itemId: "item-1",
     turnId: "turn-1",
     kind: "user_message",
-    text: "hello",
+    text,
     isStreaming: false,
     promptId,
     status: "completed",
@@ -514,7 +578,7 @@ function transcriptWithUserPrompt(sessionId: string, promptId: string): Transcri
     title: null,
     nativeToolName: null,
     parentToolCallId: null,
-    contentParts: [{ type: "text", text: "hello" }],
+    contentParts: text ? [{ type: "text", text }] : [],
     timestamp: NOW,
     startedSeq: 1,
     lastUpdatedSeq: 1,

--- a/desktop/src/lib/domain/chat/transcript/transcript-row-model.test.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-row-model.test.ts
@@ -67,6 +67,39 @@ describe("buildTranscriptRowModel", () => {
     ]);
   });
 
+  it("hides an empty in-progress latest turn behind the visible outbox prompt", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-complete", true);
+    addTurn(transcript, "turn-live", false);
+
+    const rows = buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript,
+      visibleOptimisticPrompt: null,
+      visibleOutboxEntries: [
+        createPromptOutboxEntry({
+          clientPromptId: "prompt-1",
+          clientSessionId: "session-1",
+          text: "hello",
+          blocks: [{ type: "text", text: "hello" }],
+          now: "2026-01-01T00:00:00.000Z",
+        }),
+      ],
+      latestTurnId: "turn-live",
+      latestTurnHasAssistantRenderableContent: false,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        kind: "turn",
+        key: "turn:turn-complete:block:content",
+        turnId: "turn-complete",
+        blockKey: "content",
+      }),
+      { kind: "outbox_prompt", key: "prompt:prompt-1", clientPromptId: "prompt-1" },
+    ]);
+  });
+
   it("keeps an in-progress latest turn when it already has renderable content", () => {
     const transcript = createTranscriptState("session-1");
     addTurn(transcript, "turn-live", false);

--- a/desktop/src/lib/domain/chat/transcript/transcript-row-model.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-row-model.ts
@@ -82,8 +82,10 @@ export function buildTranscriptRowModel({
 
     const isLatestTurn = turnId === latestTurnId;
     const isLatestTurnInProgress = isLatestTurn && !turn.completedAt;
+    const hasVisibleLocalPrompt =
+      visibleOptimisticPrompt !== null || visibleOutboxEntries.length > 0;
     if (
-      visibleOptimisticPrompt !== null
+      hasVisibleLocalPrompt
       && isLatestTurnInProgress
       && !latestTurnHasAssistantRenderableContent
       && !turnHasRenderableTranscriptContent(turn, transcript)

--- a/desktop/src/lib/domain/sessions/prompt-readiness.test.ts
+++ b/desktop/src/lib/domain/sessions/prompt-readiness.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { canPromptSessionSlot } from "@/lib/domain/sessions/prompt-readiness";
+
+describe("canPromptSessionSlot", () => {
+  it("allows hydrated sessions", () => {
+    expect(canPromptSessionSlot({
+      transcriptHydrated: true,
+      streamConnectionState: "disconnected",
+    })).toBe(true);
+  });
+
+  it("allows unhydrated sessions once their stream is open", () => {
+    expect(canPromptSessionSlot({
+      transcriptHydrated: false,
+      streamConnectionState: "open",
+    })).toBe(true);
+  });
+
+  it("blocks unhydrated sessions before the stream opens", () => {
+    expect(canPromptSessionSlot({
+      transcriptHydrated: false,
+      streamConnectionState: "connecting",
+    })).toBe(false);
+  });
+});

--- a/desktop/src/lib/domain/sessions/prompt-readiness.ts
+++ b/desktop/src/lib/domain/sessions/prompt-readiness.ts
@@ -1,0 +1,10 @@
+import type { SessionStreamConnectionState } from "@/lib/domain/sessions/directory/directory-entry";
+
+export interface PromptableSessionSlotSnapshot {
+  transcriptHydrated: boolean;
+  streamConnectionState: SessionStreamConnectionState;
+}
+
+export function canPromptSessionSlot(slot: PromptableSessionSlotSnapshot): boolean {
+  return slot.transcriptHydrated || slot.streamConnectionState === "open";
+}

--- a/desktop/src/lib/workflows/reviews/review-parent-materialization.test.ts
+++ b/desktop/src/lib/workflows/reviews/review-parent-materialization.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { StartCodeReviewRequest } from "@anyharness/sdk";
+import {
+  materializeReviewParentSession,
+  waitForReviewParentSessionMaterialization,
+} from "@/lib/workflows/reviews/review-parent-materialization";
+
+describe("review parent materialization", () => {
+  it("replaces optimistic parent ids in review requests", () => {
+    const request: StartCodeReviewRequest = {
+      parentSessionId: "client-session:codex:1:abc123",
+      maxRounds: 2,
+      autoIterate: true,
+      reviewers: [{
+        personaId: "correctness",
+        label: "Correctness",
+        prompt: "Find bugs.",
+        agentKind: "codex",
+        modelId: "gpt-5.5",
+        modeId: "full-access",
+      }],
+    };
+
+    expect(materializeReviewParentSession(request, "runtime-session-1")).toEqual({
+      ...request,
+      parentSessionId: "runtime-session-1",
+    });
+  });
+
+  it("waits for parent session materialization through provided deps", async () => {
+    await expect(waitForReviewParentSessionMaterialization("client-session:codex:1", {
+      getMaterializedSessionId: () => "runtime-session-1",
+      subscribeToMaterializedSessionId: () => () => {},
+    })).resolves.toBe("runtime-session-1");
+  });
+});

--- a/desktop/src/lib/workflows/reviews/review-parent-materialization.ts
+++ b/desktop/src/lib/workflows/reviews/review-parent-materialization.ts
@@ -1,0 +1,35 @@
+import type {
+  StartCodeReviewRequest,
+  StartPlanReviewRequest,
+} from "@anyharness/sdk";
+import {
+  waitForSessionMaterialization,
+  type SessionMaterializationDeps,
+} from "@/lib/workflows/sessions/session-materialization";
+
+// Review launch is a user-triggered overlay action; fail quickly so the user
+// can retry instead of leaving the setup dialog in an ambiguous starting state.
+const REVIEW_PARENT_SESSION_MATERIALIZATION_TIMEOUT_MS = 5_000;
+
+export function waitForReviewParentSessionMaterialization(
+  parentSessionId: string,
+  deps: SessionMaterializationDeps,
+): Promise<string> {
+  return waitForSessionMaterialization(
+    parentSessionId,
+    deps,
+    { timeoutMs: REVIEW_PARENT_SESSION_MATERIALIZATION_TIMEOUT_MS },
+  );
+}
+
+export function materializeReviewParentSession<
+  TRequest extends StartPlanReviewRequest | StartCodeReviewRequest,
+>(
+  request: TRequest,
+  materializedParentSessionId: string,
+): TRequest {
+  return {
+    ...request,
+    parentSessionId: materializedParentSessionId,
+  };
+}

--- a/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts
+++ b/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts
@@ -57,6 +57,75 @@ describe("hot-session-ingest-manager", () => {
       .toBe("current");
   });
 
+  it("hydrates a selected hot target before opening its stream", async () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    const deps = depsWithEnsure(async () => {
+      patchSessionRecord("session-a", { streamConnectionState: "open" });
+    });
+
+    reconcileHotSessions([target("session-a", "selected")], deps);
+    await Promise.resolve();
+
+    expect(deps.ensureSessionStreamConnected).toHaveBeenCalledWith(
+      "session-a",
+      expect.objectContaining({
+        awaitOpen: true,
+        hydrateBeforeStream: true,
+        skipInitialRefresh: true,
+      }),
+    );
+  });
+
+  it("keeps an existing stream current when only the hot target reason changes", async () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    const deps = depsWithEnsure(async () => {
+      patchSessionRecord("session-a", { streamConnectionState: "open" });
+    });
+
+    reconcileHotSessions([target("session-a", "selected")], deps);
+    const options = vi.mocked(deps.ensureSessionStreamConnected).mock.calls[0]?.[1];
+    expect(options?.isCurrent?.()).toBe(true);
+
+    reconcileHotSessions([target("session-a", "running")], deps);
+
+    expect(options?.isCurrent?.()).toBe(true);
+    expect(deps.ensureSessionStreamConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates an existing open-tab stream when it becomes selected", async () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    const deps = depsWithEnsure(async () => {
+      patchSessionRecord("session-a", { streamConnectionState: "open" });
+    });
+
+    reconcileHotSessions([target("session-a", "open_tab")], deps);
+    await Promise.resolve();
+    reconcileHotSessions([target("session-a", "selected")], deps);
+    await Promise.resolve();
+
+    expect(deps.ensureSessionStreamConnected).toHaveBeenCalledTimes(2);
+    const firstOptions = vi.mocked(deps.ensureSessionStreamConnected).mock.calls[0]?.[1];
+    const secondOptions = vi.mocked(deps.ensureSessionStreamConnected).mock.calls[1]?.[1];
+    expect(firstOptions?.isCurrent?.()).toBe(true);
+    expect(secondOptions?.isCurrent?.()).toBe(true);
+    expect(deps.ensureSessionStreamConnected).toHaveBeenNthCalledWith(
+      1,
+      "session-a",
+      expect.objectContaining({ hydrateBeforeStream: false }),
+    );
+    expect(deps.ensureSessionStreamConnected).toHaveBeenNthCalledWith(
+      2,
+      "session-a",
+      expect.objectContaining({ hydrateBeforeStream: true }),
+    );
+  });
+
   it("closes and marks cold when a target is demoted", () => {
     putSessionRecord(createEmptySessionRecord("session-b", "codex", {
       workspaceId: "workspace-1",
@@ -71,7 +140,7 @@ describe("hot-session-ingest-manager", () => {
       .toBe("cold");
   });
 
-  it("blocks stale stream callbacks after the hot generation changes", async () => {
+  it("blocks stale stream callbacks after the hot target is removed", async () => {
     putSessionRecord(createEmptySessionRecord("session-b", "codex", {
       workspaceId: "workspace-1",
     }));
@@ -84,6 +153,46 @@ describe("hot-session-ingest-manager", () => {
     reconcileHotSessions([], deps);
 
     expect(options?.isCurrent?.()).toBe(false);
+  });
+
+  it("blocks stale stream callbacks after remove and re-add of the same target", async () => {
+    putSessionRecord(createEmptySessionRecord("session-b", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    let resolveFirstOpen: () => void = () => {
+      throw new Error("first stream open was not started");
+    };
+    let openCallCount = 0;
+    const deps = depsWithEnsure(async () => {
+      openCallCount += 1;
+      if (openCallCount === 1) {
+        return new Promise<void>((resolve) => {
+          resolveFirstOpen = () => {
+            patchSessionRecord("session-b", { streamConnectionState: "open" });
+            resolve();
+          };
+        });
+      }
+      return new Promise<void>(() => {});
+    });
+
+    reconcileHotSessions([target("session-b", "open_tab")], deps);
+    const firstOptions = vi.mocked(deps.ensureSessionStreamConnected).mock.calls[0]?.[1];
+    expect(firstOptions?.isCurrent?.()).toBe(true);
+
+    reconcileHotSessions([], deps);
+    reconcileHotSessions([target("session-b", "open_tab")], deps);
+    const secondOptions = vi.mocked(deps.ensureSessionStreamConnected).mock.calls[1]?.[1];
+    expect(deps.ensureSessionStreamConnected).toHaveBeenCalledTimes(2);
+    expect(firstOptions?.isCurrent?.()).toBe(false);
+    expect(secondOptions?.isCurrent?.()).toBe(true);
+
+    resolveFirstOpen();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-b"]?.freshness)
+      .toBe("warming");
   });
 
   it("routes hot stream reconnects through bounded manager backoff", async () => {
@@ -160,8 +269,8 @@ function depsWithEnsure(
       markCold: (clientSessionId) => useSessionIngestStore.getState().markCold(clientSessionId),
       getFreshness: (clientSessionId) =>
         useSessionIngestStore.getState().freshnessByClientSessionId[clientSessionId]?.freshness ?? null,
-      isTargetCurrent: (clientSessionId, generation, materializedSessionId) =>
-        isHotSessionTargetCurrent(clientSessionId, generation, materializedSessionId),
+      isTargetCurrent: (clientSessionId, materializedSessionId) =>
+        isHotSessionTargetCurrent(clientSessionId, materializedSessionId),
       getSessionRecord: (clientSessionId) => {
         const record = getSessionRecord(clientSessionId);
         return record

--- a/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.ts
+++ b/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.ts
@@ -1,4 +1,5 @@
 import type { HotSessionTarget } from "@/lib/domain/sessions/hot-session-policy";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import { useSessionIngestStore } from "@/stores/sessions/session-ingest-store";
 
 interface EnsureSessionStreamOptions {
@@ -15,7 +16,7 @@ interface EnsureSessionStreamOptions {
 }
 
 interface HotSessionIngestStateDeps {
-  setHotTargets: (targets: readonly HotSessionTarget[]) => number;
+  setHotTargets: (targets: readonly HotSessionTarget[]) => void;
   markWarming: (clientSessionId: string) => void;
   markCurrentIfContiguous: (clientSessionId: string, lastAppliedSeq: number) => void;
   markStale: (
@@ -29,11 +30,7 @@ interface HotSessionIngestStateDeps {
   ) => void;
   markCold: (clientSessionId: string) => void;
   getFreshness: (clientSessionId: string) => "current" | "warming" | "stale" | "cold" | null;
-  isTargetCurrent: (
-    clientSessionId: string,
-    generation: number,
-    materializedSessionId: string | null,
-  ) => boolean;
+  isTargetCurrent: (clientSessionId: string, materializedSessionId: string | null) => boolean;
   getSessionRecord: (clientSessionId: string) => {
     streamConnectionState: string | null;
     lastSeq: number;
@@ -52,7 +49,8 @@ export interface HotSessionIngestManagerDeps {
 interface ActiveHotStream {
   clientSessionId: string;
   materializedSessionId: string;
-  generation: number;
+  openToken: symbol;
+  reason: HotSessionTarget["reason"];
   retryAttempt: number;
   opening: boolean;
   retryTimer: ReturnType<typeof setTimeout> | null;
@@ -66,7 +64,7 @@ export function reconcileHotSessions(
   targets: readonly HotSessionTarget[],
   deps: HotSessionIngestManagerDeps,
 ): void {
-  const generation = deps.state.setHotTargets(targets);
+  deps.state.setHotTargets(targets);
   const nextTargetIds = new Set(targets.map((target) => target.clientSessionId));
 
   for (const clientSessionId of activeStreamsByClientSessionId.keys()) {
@@ -90,25 +88,17 @@ export function reconcileHotSessions(
     if (
       existing
       && existing.materializedSessionId === target.materializedSessionId
-      && existing.generation === generation
-      && (existing.opening || existing.retryTimer)
+      && deps.state.isTargetCurrent(target.clientSessionId, target.materializedSessionId)
     ) {
-      continue;
-    }
-    if (
-      existing
-      && existing.materializedSessionId === target.materializedSessionId
-      && existing.generation === generation
-      && deps.state.isTargetCurrent(
-        target.clientSessionId,
-        generation,
-        target.materializedSessionId,
-      )
-    ) {
+      if (target.reason === "selected" && existing.reason !== "selected") {
+        connectHotTarget(streamableTarget, deps, existing.retryAttempt, existing.openToken);
+        continue;
+      }
+      existing.reason = target.reason;
       continue;
     }
 
-    connectHotTarget(streamableTarget, generation, deps, existing?.retryAttempt ?? 0);
+    connectHotTarget(streamableTarget, deps, existing?.retryAttempt ?? 0);
   }
 }
 
@@ -128,9 +118,9 @@ export function resetHotSessionIngestManagerForTest(): void {
 
 function connectHotTarget(
   target: HotSessionTarget & { materializedSessionId: string },
-  generation: number,
   deps: HotSessionIngestManagerDeps,
   retryAttempt: number,
+  preservedOpenToken?: symbol,
 ): void {
   clearRetry(target.clientSessionId);
   deps.state.markWarming(target.clientSessionId);
@@ -138,37 +128,42 @@ function connectHotTarget(
   const stream: ActiveHotStream = {
     clientSessionId: target.clientSessionId,
     materializedSessionId: target.materializedSessionId,
-    generation,
+    openToken: preservedOpenToken ?? Symbol("hot-session-open"),
+    reason: target.reason,
     retryAttempt,
     opening: true,
     retryTimer: null,
   };
   activeStreamsByClientSessionId.set(target.clientSessionId, stream);
 
+  const shouldHydrateBeforeStream = target.reason === "selected";
+  logLatency("session.hot_stream.connect", {
+    clientSessionId: target.clientSessionId,
+    materializedSessionId: target.materializedSessionId,
+    reason: target.reason,
+    hydrateBeforeStream: shouldHydrateBeforeStream,
+    retryAttempt,
+  });
+
   void deps.ensureSessionStreamConnected(target.clientSessionId, {
     awaitOpen: true,
     openTimeoutMs: 2_500,
     resumeIfActive: true,
-    hydrateBeforeStream: false,
+    hydrateBeforeStream: shouldHydrateBeforeStream,
     skipInitialRefresh: true,
     refreshOnStartupReady: true,
     reconnectOwner: "external",
     onReconnectNeeded: () => {
+      if (!isOpenAttemptCurrent(target, stream.openToken, deps)) {
+        return;
+      }
       const current = activeStreamsByClientSessionId.get(target.clientSessionId);
-      scheduleRetry(target, generation, deps, current?.retryAttempt ?? retryAttempt);
+      scheduleRetry(target, deps, current?.retryAttempt ?? retryAttempt, stream.openToken);
     },
     isCurrent: () =>
-      deps.state.isTargetCurrent(
-        target.clientSessionId,
-        generation,
-        target.materializedSessionId,
-      ),
+      isOpenAttemptCurrent(target, stream.openToken, deps),
   }).then(() => {
-    if (!deps.state.isTargetCurrent(
-      target.clientSessionId,
-      generation,
-      target.materializedSessionId,
-    )) {
+    if (!isOpenAttemptCurrent(target, stream.openToken, deps)) {
       return;
     }
     const current = activeStreamsByClientSessionId.get(target.clientSessionId);
@@ -188,11 +183,7 @@ function connectHotTarget(
       deps.state.markWarming(target.clientSessionId);
     }
   }).catch(() => {
-    if (!deps.state.isTargetCurrent(
-      target.clientSessionId,
-      generation,
-      target.materializedSessionId,
-    )) {
+    if (!isOpenAttemptCurrent(target, stream.openToken, deps)) {
       return;
     }
     const record = deps.state.getSessionRecord(target.clientSessionId);
@@ -202,21 +193,17 @@ function connectHotTarget(
       gapAfterSeq: null,
       lastErrorAt: new Date().toISOString(),
     });
-    scheduleRetry(target, generation, deps, retryAttempt);
+    scheduleRetry(target, deps, retryAttempt, stream.openToken);
   });
 }
 
 function scheduleRetry(
   target: HotSessionTarget & { materializedSessionId: string },
-  generation: number,
   deps: HotSessionIngestManagerDeps,
   retryAttempt: number,
+  openToken: symbol,
 ): void {
-  if (!deps.state.isTargetCurrent(
-    target.clientSessionId,
-    generation,
-    target.materializedSessionId,
-  )) {
+  if (!isOpenAttemptCurrent(target, openToken, deps)) {
     return;
   }
 
@@ -229,18 +216,25 @@ function scheduleRetry(
   stream.retryAttempt = retryAttempt + 1;
   stream.retryTimer = setTimeout(() => {
     const current = activeStreamsByClientSessionId.get(target.clientSessionId);
-    if (current?.retryTimer) {
+    if (current?.openToken === openToken && current.retryTimer) {
       current.retryTimer = null;
     }
-    if (!deps.state.isTargetCurrent(
-      target.clientSessionId,
-      generation,
-      target.materializedSessionId,
-    )) {
+    if (!isOpenAttemptCurrent(target, openToken, deps)) {
       return;
     }
-    connectHotTarget(target, generation, deps, retryAttempt + 1);
+    connectHotTarget(target, deps, retryAttempt + 1);
   }, delayMs);
+}
+
+function isOpenAttemptCurrent(
+  target: HotSessionTarget & { materializedSessionId: string },
+  openToken: symbol,
+  deps: HotSessionIngestManagerDeps,
+): boolean {
+  const current = activeStreamsByClientSessionId.get(target.clientSessionId);
+  return current?.openToken === openToken
+    && current.materializedSessionId === target.materializedSessionId
+    && deps.state.isTargetCurrent(target.clientSessionId, target.materializedSessionId);
 }
 
 function closeHotStream(

--- a/desktop/src/lib/workflows/sessions/session-materialization.ts
+++ b/desktop/src/lib/workflows/sessions/session-materialization.ts
@@ -1,3 +1,5 @@
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
+
 const SESSION_MATERIALIZATION_ERROR = "Session is still starting. Try again in a moment.";
 
 export interface SessionMaterializationDeps {
@@ -21,6 +23,10 @@ export function waitForSessionMaterialization(
   }
 
   const timeoutMs = options?.timeoutMs ?? 15_000;
+  logLatency("session.materialization.wait.start", {
+    clientSessionId,
+    timeoutMs,
+  });
   return new Promise((resolve, reject) => {
     let settled = false;
     let unsubscribe: (() => void) | null = null;
@@ -42,6 +48,10 @@ export function waitForSessionMaterialization(
       }
       settled = true;
       cleanupSubscription();
+      logLatency("session.materialization.wait.timeout", {
+        clientSessionId,
+        timeoutMs,
+      });
       reject(new Error(SESSION_MATERIALIZATION_ERROR));
     }, timeoutMs);
 
@@ -52,6 +62,10 @@ export function waitForSessionMaterialization(
       settled = true;
       globalThis.clearTimeout(timeout);
       cleanupSubscription();
+      logLatency("session.materialization.wait.resolved", {
+        clientSessionId,
+        materializedSessionId,
+      });
       resolve(materializedSessionId);
     };
 

--- a/desktop/src/stores/reviews/review-ui-store.test.ts
+++ b/desktop/src/stores/reviews/review-ui-store.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
+
+describe("review ui store", () => {
+  beforeEach(() => {
+    useReviewUiStore.setState({
+      setup: null,
+      critiqueTarget: null,
+      startingReview: null,
+      dismissedTerminalNoticeRunIds: [],
+    });
+  });
+
+  it("patches and clears a starting review with the same token", () => {
+    useReviewUiStore.getState().beginStartingReview({
+      parentSessionId: "client-session:codex:1",
+      kind: "code",
+      maxRounds: 1,
+      autoIterate: false,
+      reviewers: [],
+      startedAt: 123,
+    });
+
+    expect(useReviewUiStore.getState().patchStartingReviewParentSession(
+      { kind: "code", startedAt: 123 },
+      "runtime-session-1",
+    )).toBe(true);
+    expect(useReviewUiStore.getState().startingReview?.parentSessionId)
+      .toBe("runtime-session-1");
+    expect(useReviewUiStore.getState().clearStartingReviewForToken({
+      kind: "code",
+      startedAt: 123,
+    }))
+      .toBe(true);
+    expect(useReviewUiStore.getState().startingReview).toBeNull();
+  });
+
+  it("ignores stale starting review tokens", () => {
+    useReviewUiStore.getState().beginStartingReview({
+      parentSessionId: "client-session:codex:1",
+      kind: "code",
+      maxRounds: 1,
+      autoIterate: false,
+      reviewers: [],
+      startedAt: 123,
+    });
+
+    expect(useReviewUiStore.getState().patchStartingReviewParentSession(
+      { kind: "code", startedAt: 122 },
+      "runtime-session-1",
+    )).toBe(false);
+    expect(useReviewUiStore.getState().patchStartingReviewParentSession(
+      { kind: "plan", startedAt: 123 },
+      "runtime-session-1",
+    )).toBe(false);
+    expect(useReviewUiStore.getState().startingReview?.parentSessionId)
+      .toBe("client-session:codex:1");
+  });
+});

--- a/desktop/src/stores/reviews/review-ui-store.ts
+++ b/desktop/src/stores/reviews/review-ui-store.ts
@@ -42,6 +42,11 @@ export interface StartingReviewState {
   startedAt: number;
 }
 
+export interface StartingReviewToken {
+  kind: ReviewKind;
+  startedAt: number;
+}
+
 interface ReviewUiState {
   setup: ReviewSetupState | null;
   critiqueTarget: ReviewCritiqueTarget | null;
@@ -51,6 +56,11 @@ interface ReviewUiState {
   closeSetup: () => void;
   beginStartingReview: (startingReview: StartingReviewState) => void;
   clearStartingReview: () => void;
+  clearStartingReviewForToken: (token: StartingReviewToken) => boolean;
+  patchStartingReviewParentSession: (
+    token: StartingReviewToken,
+    parentSessionId: string,
+  ) => boolean;
   openCritique: (target: ReviewCritiqueTarget) => void;
   closeCritique: () => void;
   dismissTerminalNotice: (runId: string) => void;
@@ -67,6 +77,33 @@ export const useReviewUiStore = create<ReviewUiState>((set) => ({
   closeSetup: () => set({ setup: null }),
   beginStartingReview: (startingReview) => set({ startingReview }),
   clearStartingReview: () => set({ startingReview: null }),
+  clearStartingReviewForToken: (token) => {
+    let cleared = false;
+    set((state) => {
+      if (!matchesStartingReviewToken(state.startingReview, token)) {
+        return state;
+      }
+      cleared = true;
+      return { startingReview: null };
+    });
+    return cleared;
+  },
+  patchStartingReviewParentSession: (token, parentSessionId) => {
+    let patched = false;
+    set((state) => {
+      if (!matchesStartingReviewToken(state.startingReview, token)) {
+        return state;
+      }
+      patched = true;
+      return {
+        startingReview: {
+          ...state.startingReview,
+          parentSessionId,
+        },
+      };
+    });
+    return patched;
+  },
   openCritique: (target) => set({ critiqueTarget: target }),
   closeCritique: () => set({ critiqueTarget: null }),
   // Dismissal is intentionally app-lifetime-only; terminal review notices can
@@ -79,3 +116,12 @@ export const useReviewUiStore = create<ReviewUiState>((set) => ({
       ].slice(0, DISMISSED_TERMINAL_NOTICE_RUN_LIMIT),
     })),
 }));
+
+function matchesStartingReviewToken(
+  startingReview: StartingReviewState | null,
+  token: StartingReviewToken,
+): startingReview is StartingReviewState {
+  return !!startingReview
+    && startingReview.kind === token.kind
+    && startingReview.startedAt === token.startedAt;
+}

--- a/desktop/src/stores/sessions/session-ingest-store.test.ts
+++ b/desktop/src/stores/sessions/session-ingest-store.test.ts
@@ -16,22 +16,29 @@ describe("session ingest store invariants", () => {
     vi.useRealTimers();
   });
 
-  it("increments hot set generation only when target identity changes", () => {
+  it("tracks hot targets by client session id", () => {
     const store = useSessionIngestStore.getState();
-    const generation = store.setHotTargets([
+    store.setHotTargets([
       target("session-b", { priority: 4 }),
       target("session-a", { priority: 0 }),
     ]);
 
-    expect(generation).toBe(1);
-    expect(store.setHotTargets([
+    expect(Object.keys(useSessionIngestStore.getState().targetsByClientSessionId).sort())
+      .toEqual(["session-a", "session-b"]);
+
+    store.setHotTargets([
       target("session-a", { priority: 0 }),
       target("session-b", { priority: 4 }),
-    ])).toBe(1);
-    expect(store.setHotTargets([
+    ]);
+    expect(useSessionIngestStore.getState().targetsByClientSessionId["session-b"]?.priority)
+      .toBe(4);
+
+    store.setHotTargets([
       target("session-a", { priority: 0 }),
       target("session-b", { priority: 3, reason: "running" }),
-    ])).toBe(2);
+    ]);
+    expect(useSessionIngestStore.getState().targetsByClientSessionId["session-b"])
+      .toMatchObject({ priority: 3, reason: "running" });
   });
 
   it("keeps removed hot targets cold while preserving their sequence history", () => {
@@ -55,16 +62,29 @@ describe("session ingest store invariants", () => {
       });
   });
 
-  it("guards currentness by generation, materialized id, and streamability", () => {
-    const generation = useSessionIngestStore.getState().setHotTargets([
+  it("keeps currentness across reason-only target changes", () => {
+    useSessionIngestStore.getState().setHotTargets([
       target("session-a", { materializedSessionId: "runtime-a", streamable: true }),
       target("session-b", { materializedSessionId: null, streamable: false }),
     ]);
 
-    expect(isHotSessionTargetCurrent("session-a", generation, "runtime-a")).toBe(true);
-    expect(isHotSessionTargetCurrent("session-a", generation - 1, "runtime-a")).toBe(false);
-    expect(isHotSessionTargetCurrent("session-a", generation, "runtime-old")).toBe(false);
-    expect(isHotSessionTargetCurrent("session-b", generation, null)).toBe(false);
+    expect(isHotSessionTargetCurrent("session-a", "runtime-a")).toBe(true);
+    useSessionIngestStore.getState().setHotTargets([
+      target("session-a", {
+        materializedSessionId: "runtime-a",
+        priority: 3,
+        reason: "running",
+        streamable: true,
+      }),
+      target("session-b", { materializedSessionId: null, streamable: false }),
+    ]);
+
+    expect(isHotSessionTargetCurrent("session-a", "runtime-a")).toBe(true);
+    expect(isHotSessionTargetCurrent("session-a", "runtime-old")).toBe(false);
+    expect(isHotSessionTargetCurrent("session-b", null)).toBe(false);
+
+    useSessionIngestStore.getState().setHotTargets([]);
+    expect(isHotSessionTargetCurrent("session-a", "runtime-a")).toBe(false);
   });
 
   it("does not mark gapped progress current until the gap clears", () => {

--- a/desktop/src/stores/sessions/session-ingest-store.ts
+++ b/desktop/src/stores/sessions/session-ingest-store.ts
@@ -12,10 +12,9 @@ export interface SessionIngestFreshnessState {
 }
 
 interface SessionIngestStoreState {
-  hotSetGeneration: number;
   targetsByClientSessionId: Record<string, HotSessionTarget>;
   freshnessByClientSessionId: Record<string, SessionIngestFreshnessState>;
-  setHotTargets: (targets: readonly HotSessionTarget[]) => number;
+  setHotTargets: (targets: readonly HotSessionTarget[]) => void;
   markWarming: (clientSessionId: string) => void;
   markCurrentIfContiguous: (clientSessionId: string, lastAppliedSeq: number) => void;
   markStale: (
@@ -45,13 +44,11 @@ const COLD_FRESHNESS: SessionIngestFreshnessState = {
   lastErrorAt: null,
 };
 
-export const useSessionIngestStore = create<SessionIngestStoreState>((set, get) => ({
-  hotSetGeneration: 0,
+export const useSessionIngestStore = create<SessionIngestStoreState>((set) => ({
   targetsByClientSessionId: {},
   freshnessByClientSessionId: {},
 
   setHotTargets: (targets) => {
-    let nextGeneration = get().hotSetGeneration;
     set((state) => {
       const targetsByClientSessionId = Object.fromEntries(
         targets.map((target) => [target.clientSessionId, target]),
@@ -60,7 +57,6 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set, get) 
         return state;
       }
 
-      nextGeneration = state.hotSetGeneration + 1;
       const freshnessByClientSessionId = { ...state.freshnessByClientSessionId };
       for (const [sessionId, freshness] of Object.entries(freshnessByClientSessionId)) {
         if (!targetsByClientSessionId[sessionId] && freshness.freshness !== "cold") {
@@ -90,12 +86,10 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set, get) 
       }
 
       return {
-        hotSetGeneration: nextGeneration,
         targetsByClientSessionId,
         freshnessByClientSessionId,
       };
     });
-    return nextGeneration;
   },
 
   markWarming: (clientSessionId) => set((state) => ({
@@ -179,7 +173,6 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set, get) 
   }),
 
   clear: () => set({
-    hotSetGeneration: 0,
     targetsByClientSessionId: {},
     freshnessByClientSessionId: {},
   }),
@@ -187,13 +180,11 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set, get) 
 
 export function isHotSessionTargetCurrent(
   clientSessionId: string,
-  generation: number,
   materializedSessionId: string | null,
 ): boolean {
   const state = useSessionIngestStore.getState();
   const target = state.targetsByClientSessionId[clientSessionId];
-  return state.hotSetGeneration === generation
-    && !!target
+  return !!target
     && target.materializedSessionId === materializedSessionId
     && target.streamable;
 }


### PR DESCRIPTION
## Summary

Fixes the client-side workspace/session materialization and hot-stream path that could leave prompts, assistant replies, or review launches stuck against optimistic `client-session:*` IDs after switching or creating sessions.

## Root Cause

Hot session stream currentness was tied to the hot-set generation. When a selected running session was demoted from `selected` to `running`, the same materialized session stayed hot, but the existing stream callback started reporting stale and dropped later SSE envelopes. Those dropped envelopes prevented the transcript and prompt outbox from reconciling until a later history refresh.

Review launch had the same optimistic-id boundary: code/plan review requests and active review polling could use the client-side session id before the runtime materialized session id was available, which produced `Session not found: client-session:*` errors from AnyHarness.

## Changes

- Keep hot stream currentness valid while the same materialized session remains in the hot set.
- Hydrate selected sessions before opening their hot stream, while preserving stream-first behavior for background/open-tab targets.
- Allow prompt submission when an active session has an open stream even if history hydration is still clearing.
- Resolve review parent sessions to materialized runtime ids before starting code/plan reviews.
- Poll active review runs by materialized session id instead of optimistic client id.
- Add debug latency logs around session/materialization, prompt outbox dispatch, stream flushes, and session selection paths.
- Add focused tests for prompt readiness, materialization wait behavior, review parent id rewriting, hot ingest currentness, and stream flush handling.

## Validation

- `pnpm -C desktop exec vitest run src/lib/workflows/reviews/review-parent-materialization.test.ts src/lib/domain/reviews/review-runs.test.ts src/lib/domain/reviews/review-config.test.ts src/stores/sessions/session-ingest-store.test.ts src/lib/workflows/sessions/hot-session-ingest-manager.test.ts src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts src/lib/domain/sessions/prompt-readiness.test.ts src/lib/workflows/sessions/session-materialization.test.ts`
- `pnpm -C desktop exec tsc --noEmit`
- `git diff --check`