### PR TITLE
perf(desktop): reduce chat typing and tab-switch latency

### DIFF
--- a/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/desktop/src-tauri/src/commands/diagnostics.rs
@@ -1,5 +1,6 @@
 use rfd::FileDialog;
 use serde::Deserialize;
+use std::path::PathBuf;
 use tauri::State;
 
 use crate::{
@@ -28,6 +29,13 @@ pub struct RendererEventInput {
     pub message: String,
     pub route: Option<String>,
     pub elapsed_ms: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveDiagnosticJsonToPathInput {
+    pub output_path: String,
+    pub contents: String,
 }
 
 fn runtime_status_label(status: &RuntimeStatus) -> &'static str {
@@ -111,4 +119,40 @@ pub async fn save_diagnostic_json(
         contents,
     })
     .map(Some)
+}
+
+#[tauri::command]
+pub fn save_diagnostic_json_to_absolute_path(
+    input: SaveDiagnosticJsonToPathInput,
+) -> Result<SaveDiagnosticJsonResult, String> {
+    if !cfg!(debug_assertions) {
+        return Err("save_diagnostic_json_to_absolute_path is dev-only".to_string());
+    }
+
+    let output_path = expand_home_path(&input.output_path)?;
+    if !output_path.is_absolute() {
+        return Err("output_path must be absolute".to_string());
+    }
+
+    save_diagnostic_json_to_path(SaveDiagnosticJsonOptions {
+        output_path,
+        contents: input.contents,
+    })
+}
+
+fn expand_home_path(path: &str) -> Result<PathBuf, String> {
+    if path == "~" {
+        return std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME is not set".to_string());
+    }
+
+    if let Some(rest) = path.strip_prefix("~/") {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME is not set".to_string())?;
+        return Ok(home.join(rest));
+    }
+
+    Ok(PathBuf::from(path))
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run() {
             diagnostics_commands::log_renderer_diagnostic,
             diagnostics_commands::log_renderer_event,
             diagnostics_commands::save_diagnostic_json,
+            diagnostics_commands::save_diagnostic_json_to_absolute_path,
             runtime::get_runtime_info,
             runtime::restart_runtime,
             quit_flow::set_running_agent_count,

--- a/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/desktop/src/components/workspace/chat/ChatView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useState, type DragEvent, type JSX } from "react";
+import {
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+  type DragEvent,
+  type JSX,
+} from "react";
 import { ChatInput } from "@/components/workspace/chat/input/ChatInput";
 import { ChatComposerDock } from "@/components/workspace/chat/input/ChatComposerDock";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
@@ -22,6 +29,7 @@ import { useCloudWorkspacePolling } from "@/hooks/chat/use-cloud-workspace-polli
 import { useComposerDockSlots } from "@/hooks/chat/ui/use-composer-dock-slots";
 import { useQueuedPromptEditStatus } from "@/hooks/chat/use-queued-prompt-edit";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
 import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { useSessionErrorAcknowledgement } from "@/hooks/sessions/lifecycle/use-session-error-acknowledgement";
 import { useSelectedCloudRuntimeRehydration } from "@/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration";
@@ -34,14 +42,17 @@ import {
   readFileDragInput,
 } from "@/lib/domain/chat/composer/prompt-attachment-drag";
 import type { WorkspaceRenderSurface } from "@/lib/domain/workspaces/tabs/shell-activation";
+import { useProliferatePerfFlag } from "@/hooks/ui/use-proliferate-perf-flag";
 
 function ChatContent({
   dockSafeAreaPx,
+  freezeTranscriptPane,
   mode,
   scrollBottomInsetPx,
   stickyBottomInsetPx,
 }: {
   dockSafeAreaPx: number;
+  freezeTranscriptPane: boolean;
   mode: ChatSurfaceState;
   scrollBottomInsetPx: number;
   stickyBottomInsetPx: number;
@@ -59,7 +70,9 @@ function ChatContent({
         </ChatPreMessageCanvas>
       );
     case "session-hydrating":
-      return <SessionTranscriptPane bottomInsetPx={stickyBottomInsetPx} />;
+      return freezeTranscriptPane
+        ? <PerfFrozenChatSurface label="Transcript pane frozen" />
+        : <SessionTranscriptPane bottomInsetPx={stickyBottomInsetPx} />;
     case "session-switching":
       return <TranscriptSwitchingPlaceholder />;
     case "session-empty":
@@ -69,7 +82,9 @@ function ChatContent({
         </ChatPreMessageCanvas>
       );
     case "session-transcript":
-      return <SessionTranscriptPane bottomInsetPx={stickyBottomInsetPx} />;
+      return freezeTranscriptPane
+        ? <PerfFrozenChatSurface label="Transcript pane frozen" />
+        : <SessionTranscriptPane bottomInsetPx={stickyBottomInsetPx} />;
   }
 }
 
@@ -89,7 +104,7 @@ function shouldShowSessionInputChrome(mode: ChatSurfaceState): boolean {
   }
 }
 
-export function ChatView({
+export const ChatView = memo(function ChatView({
   shellRenderSurface = null,
 }: {
   shellRenderSurface?: WorkspaceRenderSurface | null;
@@ -104,6 +119,8 @@ export function ChatView({
   const availability = useChatAvailabilityState();
   const queuedPromptEditStatus = useQueuedPromptEditStatus();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
+  const freezeComposerDock = useProliferatePerfFlag("freezeComposerDock");
+  const freezeTranscriptPane = useProliferatePerfFlag("freezeTranscriptPane");
   const isSessionMode = shouldShowSessionInputChrome(mode);
   const composerDockSlots = useComposerDockSlots({
     suppressSessionSlots,
@@ -138,6 +155,14 @@ export function ChatView({
   useSessionErrorAcknowledgement();
   useWorkspaceMobilityLifecycle();
 
+  const chatInput = useMemo(() => (
+    <ChatInput
+      attachments={promptAttachments}
+      suppressActiveSessionState={suppressComposerActiveSessionState}
+    />
+  ), [promptAttachments, suppressComposerActiveSessionState]);
+  const footerSlot = useMemo(() => <WorkspaceMobilityFooterRow />, []);
+
   useDebugValueChange("chat_surface.inputs", "chat_view_refs", {
     modeKind: mode.kind,
     activeSessionId,
@@ -148,6 +173,28 @@ export function ChatView({
     composerDockSlots,
     promptAttachments,
     canAcceptFileDrop,
+    dockSafeAreaPx,
+    lowerBackdropTopPx,
+    scrollBottomInsetPx,
+    stickyBottomInsetPx,
+  });
+  useDebugRenderReason("ChatView", {
+    shellRenderSurface,
+    mode,
+    suppressSessionSlots,
+    suppressComposerActiveSessionState,
+    activeSessionId,
+    activePromptCapabilities,
+    availability,
+    queuedPromptEditStatus,
+    selectedCloudRuntimeState: selectedCloudRuntime.state,
+    isSessionMode,
+    composerDockSlots,
+    promptCapabilities,
+    supportsAttachments,
+    canAcceptFileDrop,
+    promptAttachments,
+    fileDragOver,
     dockSafeAreaPx,
     lowerBackdropTopPx,
     scrollBottomInsetPx,
@@ -186,17 +233,6 @@ export function ChatView({
     setFileDragOver(false);
   }, []);
 
-  useEffect(() => {
-    if (!import.meta.env.DEV) {
-      return;
-    }
-
-    console.debug("[chat-view] surface mode", {
-      kind: mode.kind,
-      composerChrome: isSessionMode,
-    });
-  }, [isSessionMode, mode.kind]);
-
   return (
     <DebugProfiler id="chat-surface">
       <div
@@ -209,6 +245,7 @@ export function ChatView({
       <div className="flex flex-1 min-h-0 flex-col">
         <ChatContent
           dockSafeAreaPx={dockSafeAreaPx}
+          freezeTranscriptPane={freezeTranscriptPane}
           mode={mode}
           scrollBottomInsetPx={scrollBottomInsetPx}
           stickyBottomInsetPx={stickyBottomInsetPx}
@@ -221,24 +258,43 @@ export function ChatView({
         />
       )}
       <WorkspaceMobilityOverlay />
-      <ChatComposerDock
-        ref={dockRef}
-        backdrop={isSessionMode}
-        outboundSlot={composerDockSlots.outboundSlot}
-        activeSlot={composerDockSlots.activeSlot}
-        attachedSlot={composerDockSlots.attachedSlot}
-        footerSlot={<WorkspaceMobilityFooterRow />}
-        lowerBackdropTopPx={lowerBackdropTopPx}
-        shellClassName="pointer-events-none absolute inset-x-0 bottom-0"
-        data-telemetry-block
-        data-focus-zone="chat"
-      >
-        <ChatInput
-          attachments={promptAttachments}
-          suppressActiveSessionState={suppressComposerActiveSessionState}
-        />
-      </ChatComposerDock>
+      {freezeComposerDock ? (
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-6 pb-4"
+          data-perf-frozen="composer-dock"
+        >
+          <div className="mx-auto max-w-3xl rounded-md border border-dashed border-border/70 bg-background/90 px-3 py-2 text-xs text-muted-foreground">
+            Composer dock frozen
+          </div>
+        </div>
+      ) : (
+        <ChatComposerDock
+          ref={dockRef}
+          backdrop={isSessionMode}
+          outboundSlot={composerDockSlots.outboundSlot}
+          activeSlot={composerDockSlots.activeSlot}
+          attachedSlot={composerDockSlots.attachedSlot}
+          footerSlot={footerSlot}
+          lowerBackdropTopPx={lowerBackdropTopPx}
+          shellClassName="pointer-events-none absolute inset-x-0 bottom-0"
+          data-telemetry-block
+          data-focus-zone="chat"
+        >
+          {chatInput}
+        </ChatComposerDock>
+      )}
       </div>
     </DebugProfiler>
+  );
+});
+
+function PerfFrozenChatSurface({ label }: { label: string }) {
+  return (
+    <div
+      className="flex h-full min-h-0 w-full items-center justify-center border border-dashed border-border/70 bg-muted/20 p-3 text-xs text-muted-foreground"
+      data-perf-frozen="transcript-pane"
+    >
+      {label}
+    </div>
   );
 }

--- a/desktop/src/components/workspace/chat/input/ChatComposerDock.tsx
+++ b/desktop/src/components/workspace/chat/input/ChatComposerDock.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+import { forwardRef, memo, type HTMLAttributes, type ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import {
@@ -7,6 +7,7 @@ import {
   CHAT_SURFACE_GUTTER_CLASSNAME,
 } from "@/config/chat-layout";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
 
 interface ChatComposerDockProps extends HTMLAttributes<HTMLDivElement> {
   backdrop?: boolean;
@@ -31,7 +32,7 @@ interface ChatComposerDockProps extends HTMLAttributes<HTMLDivElement> {
  * Consumed by `ChatView` (production) and `ChatPlaygroundPage` (dev) so
  * both surfaces stay in sync automatically.
  */
-export const ChatComposerDock = forwardRef<HTMLDivElement, ChatComposerDockProps>(
+export const ChatComposerDock = memo(forwardRef<HTMLDivElement, ChatComposerDockProps>(
   function ChatComposerDock({
     backdrop = true,
     outboundSlot,
@@ -45,6 +46,17 @@ export const ChatComposerDock = forwardRef<HTMLDivElement, ChatComposerDockProps
     ...rest
   }, ref) {
     useDebugRenderCount("chat-composer-dock");
+    useDebugRenderReason("ChatComposerDock", {
+      backdrop,
+      outboundSlot,
+      activeSlot,
+      attachedSlot,
+      footerSlot,
+      lowerBackdropTopPx,
+      shellClassName,
+      children,
+      className,
+    });
     const baseShellClassName = shellClassName
       ? "z-10 shrink-0"
       : "relative z-10 mt-auto shrink-0";
@@ -111,4 +123,4 @@ export const ChatComposerDock = forwardRef<HTMLDivElement, ChatComposerDockProps
       </DebugProfiler>
     );
   },
-);
+));

--- a/desktop/src/components/workspace/chat/input/ComposerMentionEditor.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerMentionEditor.tsx
@@ -85,11 +85,11 @@ export function ComposerMentionEditor({
 
   const updateSelection = useCallback(() => {
     const next = textareaRef.current?.selectionStart ?? text.length;
-    setSelectionOffset(next);
-    setSearchSuppressed(false);
+    setSelectionOffset((current) => current === next ? current : next);
+    setSearchSuppressed((current) => current ? false : current);
     return next;
   }, [text.length]);
-  const { resizeTextarea } = useComposerTextareaAutosize({
+  useComposerTextareaAutosize({
     textareaRef,
     value: text,
     lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
@@ -145,9 +145,8 @@ export function ComposerMentionEditor({
     setSearchSuppressed(false);
     window.requestAnimationFrame(() => {
       updateSelection();
-      resizeTextarea();
     });
-  }, [onDraftChange, resizeTextarea, updateSelection]);
+  }, [onDraftChange, updateSelection]);
 
   useEffect(() => () => {
     finishOrCancelMeasurementOperation(typingOperationRef.current, "unmount");

--- a/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -217,11 +217,15 @@ export function SessionTranscriptPane({ bottomInsetPx }: SessionTranscriptPanePr
   ]);
 
   if (transcriptDeferred) {
-    return <TranscriptSwitchingPlaceholder />;
+    return <TranscriptSwitchingPlaceholder label="Switching chat" />;
   }
 
-  if (!activeSessionId || !transcript) {
+  if (!activeSessionId) {
     return null;
+  }
+
+  if (!transcript) {
+    return <TranscriptSwitchingPlaceholder label="Loading chat" />;
   }
 
   return (

--- a/desktop/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx
+++ b/desktop/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx
@@ -1,19 +1,48 @@
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
 
-export function TranscriptSwitchingPlaceholder() {
+function AssistantMessageSkeleton() {
+  return (
+    <div className="flex max-w-[88%] flex-col gap-2">
+      <div className="h-3 w-24 rounded-md bg-muted/60" />
+      <div className="h-3 w-full rounded-md bg-muted/45" />
+      <div className="h-3 w-[92%] rounded-md bg-muted/45" />
+      <div className="h-3 w-[68%] rounded-md bg-muted/45" />
+    </div>
+  );
+}
+
+function UserMessageSkeleton() {
+  return (
+    <div className="flex justify-end">
+      <div className="flex w-[min(22rem,72%)] flex-col items-end gap-2">
+        <div className="h-3 w-20 rounded-md bg-muted/60" />
+        <div className="h-10 w-full rounded-md bg-muted/45" />
+      </div>
+    </div>
+  );
+}
+
+export function TranscriptSwitchingPlaceholder({
+  label = "Loading chat",
+}: {
+  label?: string;
+}) {
   return (
     <DebugProfiler id="session-transcript-pane">
       <div
-        className="flex h-full min-h-0 items-center justify-center text-muted-foreground"
+        className="flex h-full min-h-0 overflow-hidden px-5 py-4"
         role="status"
-        aria-label="Switching chat"
+        aria-label={label}
         data-chat-switching-placeholder
       >
-        <div className="flex w-full max-w-[14rem] flex-col items-center gap-2 px-6">
-          <div className="h-px w-full bg-border" aria-hidden="true" />
-        <span className="text-[11px] font-medium uppercase text-muted-foreground/70">
-            Switching chat
-          </span>
+        <div
+          className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 motion-safe:animate-pulse"
+          aria-hidden="true"
+        >
+          <UserMessageSkeleton />
+          <AssistantMessageSkeleton />
+          <UserMessageSkeleton />
+          <AssistantMessageSkeleton />
         </div>
       </div>
     </DebugProfiler>

--- a/desktop/src/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext.tsx
+++ b/desktop/src/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext.tsx
@@ -1,14 +1,30 @@
 import {
   createContext,
   useContext,
+  useMemo,
   type ReactNode,
 } from "react";
 import { useWorkspaceHeaderTabsViewModel } from "@/hooks/workspaces/tabs/use-workspace-header-tabs-view-model";
 
 type WorkspaceHeaderTabsViewModel = ReturnType<typeof useWorkspaceHeaderTabsViewModel>;
+type WorkspaceContentTabsViewModel = Pick<
+  WorkspaceHeaderTabsViewModel,
+  | "activeShellTab"
+  | "activeShellTabKey"
+  | "activation"
+  | "selectedWorkspaceId"
+  | "workspaceUiKey"
+  | "materializedWorkspaceId"
+  | "visibleChatSessionIds"
+  | "liveChatSessionIds"
+  | "childToParent"
+  | "orderedTabs"
+>;
 
 const WorkspaceHeaderTabsViewModelContext =
   createContext<WorkspaceHeaderTabsViewModel | null>(null);
+const WorkspaceContentTabsViewModelContext =
+  createContext<WorkspaceContentTabsViewModel | null>(null);
 
 interface WorkspaceHeaderTabsViewModelProviderProps {
   children: ReactNode;
@@ -36,10 +52,35 @@ function EnabledWorkspaceHeaderTabsViewModelProvider({
   children: ReactNode;
 }) {
   const viewModel = useWorkspaceHeaderTabsViewModel();
+  const contentViewModel = useMemo<WorkspaceContentTabsViewModel>(() => ({
+    activeShellTab: viewModel.activeShellTab,
+    activeShellTabKey: viewModel.activeShellTabKey,
+    activation: viewModel.activation,
+    selectedWorkspaceId: viewModel.selectedWorkspaceId,
+    workspaceUiKey: viewModel.workspaceUiKey,
+    materializedWorkspaceId: viewModel.materializedWorkspaceId,
+    visibleChatSessionIds: viewModel.visibleChatSessionIds,
+    liveChatSessionIds: viewModel.liveChatSessionIds,
+    childToParent: viewModel.childToParent,
+    orderedTabs: viewModel.orderedTabs,
+  }), [
+    viewModel.activeShellTab,
+    viewModel.activeShellTabKey,
+    viewModel.activation,
+    viewModel.childToParent,
+    viewModel.liveChatSessionIds,
+    viewModel.materializedWorkspaceId,
+    viewModel.orderedTabs,
+    viewModel.selectedWorkspaceId,
+    viewModel.visibleChatSessionIds,
+    viewModel.workspaceUiKey,
+  ]);
 
   return (
     <WorkspaceHeaderTabsViewModelContext.Provider value={viewModel}>
-      {children}
+      <WorkspaceContentTabsViewModelContext.Provider value={contentViewModel}>
+        {children}
+      </WorkspaceContentTabsViewModelContext.Provider>
     </WorkspaceHeaderTabsViewModelContext.Provider>
   );
 }
@@ -49,6 +90,16 @@ export function useWorkspaceHeaderTabsViewModelContext(): WorkspaceHeaderTabsVie
   if (!viewModel) {
     throw new Error(
       "useWorkspaceHeaderTabsViewModelContext must be used inside WorkspaceHeaderTabsViewModelProvider",
+    );
+  }
+  return viewModel;
+}
+
+export function useWorkspaceContentTabsViewModelContext(): WorkspaceContentTabsViewModel {
+  const viewModel = useContext(WorkspaceContentTabsViewModelContext);
+  if (!viewModel) {
+    throw new Error(
+      "useWorkspaceContentTabsViewModelContext must be used inside WorkspaceHeaderTabsViewModelProvider",
     );
   }
   return viewModel;

--- a/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -23,12 +23,14 @@ import { useMainScreenActions } from "@/hooks/main/workflows/use-main-screen-act
 import { useTransparentChromeEnabled } from "@/hooks/theme/derived/use-transparent-chrome";
 import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
 import { useNativeOverlayOpen } from "@/hooks/ui/use-native-overlay-presence";
 import { useUpdater } from "@/hooks/access/tauri/use-updater";
 import { useRunWorkspaceCommand } from "@/hooks/workspaces/workflows/use-run-workspace-command";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
 import { useWorkspaceActivityAcknowledgement } from "@/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement";
 import { resolveStandardWorkspaceChromeClasses } from "@/lib/domain/preferences/workspace-chrome";
+import { useProliferatePerfFlag } from "@/hooks/ui/use-proliferate-perf-flag";
 import { WorkspacePathProvider } from "@/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
@@ -36,6 +38,9 @@ import {
   buildCloudRepoSettingsHref,
   buildSettingsHref,
 } from "@/lib/domain/settings/navigation";
+import type { WorkspaceRenderSurface } from "@/lib/domain/workspaces/tabs/shell-activation";
+
+const CHAT_SHELL_RENDER_SURFACE: WorkspaceRenderSurface = { kind: "chat-shell" };
 
 export function StandardWorkspaceShell() {
   useDebugRenderCount("workspace-shell");
@@ -79,10 +84,13 @@ export function StandardWorkspaceShell() {
     onRightSeparatorDown,
   } = layout;
   const transparentChromeEnabled = useTransparentChromeEnabled();
-  const chromeClasses = resolveStandardWorkspaceChromeClasses({
-    transparent: transparentChromeEnabled,
-    sidebarOpen,
-  });
+  const chromeClasses = useMemo(
+    () => resolveStandardWorkspaceChromeClasses({
+      transparent: transparentChromeEnabled,
+      sidebarOpen,
+    }),
+    [sidebarOpen, transparentChromeEnabled],
+  );
   const activePublishWorkspaceId = selectedWorkspaceId;
   const publishSourceRootPath = publishDialog.open
     ? selectedWorkspace?.sourceRepoRootPath?.trim() || null
@@ -135,6 +143,10 @@ export function StandardWorkspaceShell() {
   const nativeWorkspaceOverlaysHidden = commandPaletteOpen
     || publishDialog.open
     || nativePortalOverlayOpen;
+  const freezeSidebar = useProliferatePerfFlag("freezeSidebar");
+  const freezeRightPanel = useProliferatePerfFlag("freezeRightPanel");
+  const freezeWorkspaceContent = useProliferatePerfFlag("freezeWorkspaceContent");
+  const freezeHeaderTabsViewModel = useProliferatePerfFlag("freezeHeaderTabsViewModel");
   useDebugValueChange("workspace_shell.inputs", "shell_refs", {
     selectedWorkspaceId,
     selectedWorkspace,
@@ -163,6 +175,34 @@ export function StandardWorkspaceShell() {
     runtimeBlockedReason,
     repoSettingsHref,
     canOpenRepositorySettings,
+    nativeWorkspaceOverlaysHidden,
+  });
+  useDebugRenderReason("StandardWorkspaceShell", {
+    pendingWorkspaceEntry,
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+    selectedWorkspace,
+    selectedCloudWorkspace,
+    gitStatus,
+    existingPr,
+    hasRuntimeReadyWorkspace,
+    shouldKeepRuntimePanelsVisible,
+    hasWorkspaceShell,
+    hasLaunchIntentOnlyShell,
+    isCloudWorkspaceSelected,
+    sidebarOpen,
+    sidebarWidth,
+    rightPanelOpen,
+    rightPanelState,
+    rightPanelWidth,
+    terminalActivationRequest,
+    publishDialog,
+    commandPaletteOpen,
+    chromeClasses,
+    runCanRun: runCommand.canRun,
+    runIsLaunching: runCommand.isLaunching,
+    runtimeBlockedReason,
+    repoSettingsHref,
     nativeWorkspaceOverlaysHidden,
   });
   const handleTerminalActivationRequestHandled = useCallback(
@@ -209,7 +249,7 @@ export function StandardWorkspaceShell() {
       <WorkspaceShellActionsProvider value={shellActions}>
         <WorkspacePathProvider workspacePath={selectedWorkspace?.path ?? null}>
           <WorkspaceHeaderTabsViewModelProvider
-            enabled={hasWorkspaceShell && !hasLaunchIntentOnlyShell}
+            enabled={hasWorkspaceShell && !hasLaunchIntentOnlyShell && !freezeHeaderTabsViewModel}
           >
             <div
               className={`h-screen flex overflow-hidden ${chromeClasses.root}`}
@@ -224,28 +264,36 @@ export function StandardWorkspaceShell() {
                 className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
                 style={{ width: sidebarOpen ? sidebarWidth : 0 }}
               >
-                <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">
-                  <div className="flex h-full items-center gap-2 pl-[82px]">
-                    <IconButton
-                      tone="sidebar"
-                      size="sm"
-                      onClick={actions.onToggleSidebar}
-                      title="Hide sidebar"
-                      className="rounded-md"
-                    >
-                      <SplitPanel className="size-4" />
-                    </IconButton>
-                    <SidebarUpdatePill
-                      phase={updaterPhase}
-                      downloadProgress={downloadProgress}
-                      onDownloadUpdate={downloadUpdate}
-                      onOpenRestartPrompt={openRestartPrompt}
-                    />
+                <DebugProfiler id="workspace-sidebar-frame">
+                  <div className="flex h-full min-h-0 flex-col">
+                    <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">
+                      <div className="flex h-full items-center gap-2 pl-[82px]">
+                        <IconButton
+                          tone="sidebar"
+                          size="sm"
+                          onClick={actions.onToggleSidebar}
+                          title="Hide sidebar"
+                          className="rounded-md"
+                        >
+                          <SplitPanel className="size-4" />
+                        </IconButton>
+                        <SidebarUpdatePill
+                          phase={updaterPhase}
+                          downloadProgress={downloadProgress}
+                          onDownloadUpdate={downloadUpdate}
+                          onOpenRestartPrompt={openRestartPrompt}
+                        />
+                      </div>
+                    </div>
+                    <div className="flex-1 min-h-0 overflow-hidden">
+                      {freezeSidebar ? (
+                        <PerfFrozenPanel label="Sidebar frozen" surface="sidebar" />
+                      ) : (
+                        <MainSidebar />
+                      )}
+                    </div>
                   </div>
-                </div>
-                <div className="flex-1 min-h-0 overflow-hidden">
-                  <MainSidebar />
-                </div>
+                </DebugProfiler>
               </div>
               {sidebarOpen && (
                 <div
@@ -264,56 +312,72 @@ export function StandardWorkspaceShell() {
                   className={chromeClasses.header}
                   data-tauri-drag-region="true"
                 >
-                  {!sidebarOpen && (
-                    <div className="flex items-center gap-2 pl-[82px] pr-2">
-                      <IconButton
-                        size="sm"
-                        onClick={actions.onToggleSidebar}
-                        title="Show sidebar"
-                        className="rounded-md"
-                      >
-                        <SplitPanel className="size-4" />
-                      </IconButton>
-                      <SidebarUpdatePill
-                        phase={updaterPhase}
-                        downloadProgress={downloadProgress}
-                        onDownloadUpdate={downloadUpdate}
-                        onOpenRestartPrompt={openRestartPrompt}
-                      />
-                    </div>
-                  )}
-                  {hasWorkspaceShell && !hasLaunchIntentOnlyShell && (
-                    <GlobalHeader
-                      existingPr={existingPr}
-                      selectedWorkspace={selectedWorkspace}
-                      rightPanelOpen={rightPanelOpen}
-                      disableGitActions={!hasRuntimeReadyWorkspace}
-                      runDisabled={!runCommand.canRun}
-                      runLoading={runCommand.isLaunching}
-                      runLabel={runCommand.runLabel}
-                      runTitle={runCommand.runTitle}
-                      onRun={runCommand.onRun}
-                      onTogglePanel={actions.toggleRightPanel}
-                      onCommit={actions.handleCommitOpen}
-                      onPush={actions.handlePushOpen}
-                      onCreatePr={actions.handlePrOpen}
-                      onViewPr={actions.handleViewPr}
-                      onRenameBranch={hasRuntimeReadyWorkspace ? actions.renameBranch : undefined}
-                      gitStatus={gitStatus ?? null}
-                    />
-                  )}
+                  <DebugProfiler id="workspace-header-frame">
+                    <>
+                      {!sidebarOpen && (
+                        <div className="flex items-center gap-2 pl-[82px] pr-2">
+                          <IconButton
+                            size="sm"
+                            onClick={actions.onToggleSidebar}
+                            title="Show sidebar"
+                            className="rounded-md"
+                          >
+                            <SplitPanel className="size-4" />
+                          </IconButton>
+                          <SidebarUpdatePill
+                            phase={updaterPhase}
+                            downloadProgress={downloadProgress}
+                            onDownloadUpdate={downloadUpdate}
+                            onOpenRestartPrompt={openRestartPrompt}
+                          />
+                        </div>
+                      )}
+                      {hasWorkspaceShell && !hasLaunchIntentOnlyShell && (
+                        <GlobalHeader
+                          existingPr={existingPr}
+                          selectedWorkspace={selectedWorkspace}
+                          rightPanelOpen={rightPanelOpen}
+                          disableGitActions={!hasRuntimeReadyWorkspace}
+                          runDisabled={!runCommand.canRun}
+                          runLoading={runCommand.isLaunching}
+                          runLabel={runCommand.runLabel}
+                          runTitle={runCommand.runTitle}
+                          onRun={runCommand.onRun}
+                          onTogglePanel={actions.toggleRightPanel}
+                          onCommit={actions.handleCommitOpen}
+                          onPush={actions.handlePushOpen}
+                          onCreatePr={actions.handlePrOpen}
+                          onViewPr={actions.handleViewPr}
+                          onRenameBranch={hasRuntimeReadyWorkspace ? actions.renameBranch : undefined}
+                          gitStatus={gitStatus ?? null}
+                        />
+                      )}
+                    </>
+                  </DebugProfiler>
                 </div>
 
                 <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
                   {hasLaunchIntentOnlyShell ? (
-                    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-                      <ChatView shellRenderSurface={{ kind: "chat-shell" }} />
-                    </div>
+                    <DebugProfiler id="workspace-content-frame">
+                      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                        {freezeWorkspaceContent ? (
+                          <PerfFrozenPanel label="Workspace content frozen" surface="workspace-content" />
+                        ) : (
+                          <ChatView shellRenderSurface={CHAT_SHELL_RENDER_SURFACE} />
+                        )}
+                      </div>
+                    </DebugProfiler>
                   ) : hasWorkspaceShell ? (
                     <>
-                      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-                        <WorkspaceContentView />
-                      </div>
+                      <DebugProfiler id="workspace-content-frame">
+                        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                        {freezeWorkspaceContent || freezeHeaderTabsViewModel ? (
+                          <PerfFrozenPanel label="Workspace content frozen" surface="workspace-content" />
+                        ) : (
+                          <WorkspaceContentView />
+                          )}
+                        </div>
+                      </DebugProfiler>
 
                       {rightPanelOpen && (
                         <div
@@ -327,42 +391,50 @@ export function StandardWorkspaceShell() {
                         className="shrink-0 overflow-hidden transition-[width] duration-150 ease-in-out"
                         style={{ width: rightPanelOpen ? rightPanelWidth : 0 }}
                       >
-                        <div className="h-full" style={{ minWidth: 260 }}>
-                          <RightPanel
-                            workspaceId={selectedWorkspaceId}
-                            isWorkspaceReady={hasRuntimeReadyWorkspace}
-                            isOpen={rightPanelOpen}
-                            shouldKeepContentVisible={shouldKeepRuntimePanelsVisible}
-                            isCloudWorkspaceSelected={isCloudWorkspaceSelected}
-                            state={rightPanelState}
-                            repoSettingsHref={repoSettingsHref ?? buildSettingsHref({
-                              section: "repo",
-                              repo: null,
-                            })}
-                            onStateChange={layout.setRightPanelState}
-                            terminalActivationRequest={terminalActivationRequest}
-                            focusRequestToken={rightPanelFocusRequestToken}
-                            nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
-                            onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
-                          />
-                        </div>
+                        <DebugProfiler id="workspace-right-panel">
+                          <div className="h-full" style={{ minWidth: 260 }}>
+                            {freezeRightPanel ? (
+                              <PerfFrozenPanel label="Right panel frozen" surface="right-panel" />
+                            ) : (
+                              <RightPanel
+                                workspaceId={selectedWorkspaceId}
+                                isWorkspaceReady={hasRuntimeReadyWorkspace}
+                                isOpen={rightPanelOpen}
+                                shouldKeepContentVisible={shouldKeepRuntimePanelsVisible}
+                                isCloudWorkspaceSelected={isCloudWorkspaceSelected}
+                                state={rightPanelState}
+                                repoSettingsHref={repoSettingsHref ?? buildSettingsHref({
+                                  section: "repo",
+                                  repo: null,
+                                })}
+                                onStateChange={layout.setRightPanelState}
+                                terminalActivationRequest={terminalActivationRequest}
+                                focusRequestToken={rightPanelFocusRequestToken}
+                                nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
+                                onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
+                              />
+                            )}
+                          </div>
+                        </DebugProfiler>
                       </div>
 
-                      <WorkspaceCommandPalette
-                        open={commandPaletteOpen}
-                        onClose={actions.onCommandPaletteClose}
-                        hasWorkspaceShell={hasWorkspaceShell}
-                        selectedWorkspaceId={selectedWorkspaceId}
-                        hasRuntimeReadyWorkspace={hasRuntimeReadyWorkspace}
-                        runtimeBlockedReason={runtimeBlockedReason}
-                        repoSettingsHref={repoSettingsHref}
-                        canOpenRepositorySettings={canOpenRepositorySettings}
-                        repositorySettingsDisabledReason={repositorySettingsDisabledReason}
-                        runCommand={runCommand}
-                        openTerminalPanel={actions.openTerminalPanel}
-                        onToggleLeftSidebar={actions.onToggleSidebar}
-                        onToggleRightPanel={actions.toggleRightPanel}
-                      />
+                      <DebugProfiler id="workspace-command-palette">
+                        <WorkspaceCommandPalette
+                          open={commandPaletteOpen}
+                          onClose={actions.onCommandPaletteClose}
+                          hasWorkspaceShell={hasWorkspaceShell}
+                          selectedWorkspaceId={selectedWorkspaceId}
+                          hasRuntimeReadyWorkspace={hasRuntimeReadyWorkspace}
+                          runtimeBlockedReason={runtimeBlockedReason}
+                          repoSettingsHref={repoSettingsHref}
+                          canOpenRepositorySettings={canOpenRepositorySettings}
+                          repositorySettingsDisabledReason={repositorySettingsDisabledReason}
+                          runCommand={runCommand}
+                          openTerminalPanel={actions.openTerminalPanel}
+                          onToggleLeftSidebar={actions.onToggleSidebar}
+                          onToggleRightPanel={actions.toggleRightPanel}
+                        />
+                      </DebugProfiler>
 
                       {hasRuntimeReadyWorkspace && (
                         <>
@@ -390,5 +462,22 @@ export function StandardWorkspaceShell() {
         </WorkspacePathProvider>
       </WorkspaceShellActionsProvider>
     </DebugProfiler>
+  );
+}
+
+function PerfFrozenPanel({
+  label,
+  surface,
+}: {
+  label: string;
+  surface: string;
+}) {
+  return (
+    <div
+      className="flex h-full min-h-0 w-full items-center justify-center border border-dashed border-border/70 bg-muted/20 p-3 text-xs text-muted-foreground"
+      data-perf-frozen={surface}
+    >
+      {label}
+    </div>
   );
 }

--- a/desktop/src/components/workspace/shell/screen/WorkspaceContentView.tsx
+++ b/desktop/src/components/workspace/shell/screen/WorkspaceContentView.tsx
@@ -2,46 +2,58 @@ import { memo } from "react";
 import { ChatView } from "@/components/workspace/chat/ChatView";
 import { useWorkspaceContentShortcuts } from "@/hooks/workspaces/ui/use-workspace-content-shortcuts";
 import { useWorkspaceTabActions } from "@/hooks/workspaces/tabs/use-workspace-tab-actions";
-import { useWorkspaceHeaderTabsViewModelContext } from "@/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext";
+import { useWorkspaceContentTabsViewModelContext } from "@/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext";
 import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
+import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
+import { DebugProfiler } from "@/components/ui/DebugProfiler";
 import { FileEditorView } from "@/components/workspace/files/FileEditorView";
 import { AllChangesFrame } from "@/components/workspace/changes/AllChangesFrame";
 import { viewerTargetKey } from "@/lib/domain/workspaces/viewer/viewer-target";
 
 export const WorkspaceContentView = memo(function WorkspaceContentView() {
-  const headerTabs = useWorkspaceHeaderTabsViewModelContext();
-  const tabActions = useWorkspaceTabActions(headerTabs);
+  useDebugRenderCount("workspace-content-view");
+  const contentTabs = useWorkspaceContentTabsViewModelContext();
+  const tabActions = useWorkspaceTabActions(contentTabs);
   useWorkspaceContentShortcuts(tabActions);
-  const renderSurface = headerTabs.activation.renderSurface;
+  const renderSurface = contentTabs.activation.renderSurface;
   useDebugValueChange("workspace_content.inputs", "active_surface_refs", {
-    activeShellTab: headerTabs.activeShellTab,
-    activeShellTabKey: headerTabs.activeShellTabKey,
-    activation: headerTabs.activation,
+    activeShellTab: contentTabs.activeShellTab,
+    activeShellTabKey: contentTabs.activeShellTabKey,
+    activation: contentTabs.activation,
     renderSurfaceKind: renderSurface.kind,
     renderSurfaceSessionId: "sessionId" in renderSurface ? renderSurface.sessionId : null,
     renderSurfaceTargetKey: "targetKey" in renderSurface ? renderSurface.targetKey : null,
   });
+  useDebugRenderReason("WorkspaceContentView", {
+    activeShellTab: contentTabs.activeShellTab,
+    activeShellTabKey: contentTabs.activeShellTabKey,
+    activation: contentTabs.activation,
+    renderSurface,
+  });
 
   return (
-    <div className="h-full flex flex-col">
+    <DebugProfiler id="workspace-content-view">
+      <div className="h-full flex flex-col">
       <div className="flex-1 min-h-0 flex flex-col">
-        {headerTabs.activeShellTab?.kind !== "viewer" ? (
-          <ChatView shellRenderSurface={headerTabs.activation.renderSurface} />
-        ) : headerTabs.activeShellTab.target.kind === "fileDiff" ? (
+        {contentTabs.activeShellTab?.kind !== "viewer" ? (
+          <ChatView shellRenderSurface={contentTabs.activation.renderSurface} />
+        ) : contentTabs.activeShellTab.target.kind === "fileDiff" ? (
           <FileEditorView
-            filePath={headerTabs.activeShellTab.target.path}
-            targetKey={viewerTargetKey(headerTabs.activeShellTab.target)}
-            diffTarget={headerTabs.activeShellTab.target}
+            filePath={contentTabs.activeShellTab.target.path}
+            targetKey={viewerTargetKey(contentTabs.activeShellTab.target)}
+            diffTarget={contentTabs.activeShellTab.target}
           />
-        ) : headerTabs.activeShellTab.target.kind === "allChanges" ? (
-          <AllChangesFrame target={headerTabs.activeShellTab.target} />
+        ) : contentTabs.activeShellTab.target.kind === "allChanges" ? (
+          <AllChangesFrame target={contentTabs.activeShellTab.target} />
         ) : (
           <FileEditorView
-            filePath={headerTabs.activeShellTab.target.path}
-            targetKey={viewerTargetKey(headerTabs.activeShellTab.target)}
+            filePath={contentTabs.activeShellTab.target.path}
+            targetKey={viewerTargetKey(contentTabs.activeShellTab.target)}
           />
         )}
       </div>
-    </div>
+      </div>
+    </DebugProfiler>
   );
 });

--- a/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 import { SupportDialog } from "@/components/support/SupportDialog";
@@ -23,6 +23,7 @@ import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-avail
 import { useCloudBilling } from "@/hooks/cloud/facade/use-cloud-billing";
 import { useCloudRepoConfigs } from "@/hooks/access/cloud/use-cloud-repo-configs";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
 import { useSidebarSupportContext } from "@/hooks/support/derived/use-sidebar-support-context";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
@@ -36,7 +37,7 @@ import {
 } from "@/lib/domain/settings/navigation";
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
 
-export function MainSidebar() {
+export const MainSidebar = memo(function MainSidebar() {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
   const actions = useWorkspaceSidebarActions();
@@ -71,9 +72,28 @@ export function MainSidebar() {
     emptyState,
     isLoading,
   } = useWorkspaceSidebarState({ showArchived });
-
   const navigate = useNavigate();
   const location = useLocation();
+  useDebugRenderReason("MainSidebar", {
+    groups,
+    selectedWorkspaceId,
+    selectedLogicalWorkspaceId,
+    cleanupAttentionWorkspaces,
+    emptyState,
+    isLoading,
+    pendingWorkspaceEntry,
+    showArchived,
+    workspaceTypes,
+    cloudActive,
+    cloudUnavailable,
+    billingPlan,
+    cloudRepoConfigs,
+    isCloudRepoConfigsPending,
+    supportContext,
+    supportOpen,
+    pathname: location.pathname,
+  });
+
   const isOnPlugins = location.pathname === APP_ROUTES.plugins;
   const isOnAutomations = location.pathname.startsWith(APP_ROUTES.automations);
   const isOnHome = location.pathname === APP_ROUTES.home;
@@ -226,4 +246,4 @@ export function MainSidebar() {
       </div>
     </DebugProfiler>
   );
-}
+});

--- a/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useState,
   useCallback,
   useEffect,
@@ -21,6 +22,8 @@ import {
 import type { GitStatusSnapshot, Workspace } from "@anyharness/sdk";
 import type { CurrentPullRequestResponse } from "@anyharness/sdk";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
+import { useProliferatePerfFlag } from "@/hooks/ui/use-proliferate-perf-flag";
 
 interface GlobalHeaderProps {
   gitStatus: GitStatusSnapshot | null;
@@ -41,7 +44,7 @@ interface GlobalHeaderProps {
   onRenameBranch?: (newName: string) => Promise<void>;
 }
 
-export function GlobalHeader({
+export const GlobalHeader = memo(function GlobalHeader({
   gitStatus,
   existingPr,
   selectedWorkspace,
@@ -60,6 +63,8 @@ export function GlobalHeader({
   onRenameBranch: _onRenameBranch,
 }: GlobalHeaderProps) {
   useDebugRenderCount("global-header");
+  const freezeHeaderTabs = useProliferatePerfFlag("freezeHeaderTabs");
+  const freezeHeaderTabsViewModel = useProliferatePerfFlag("freezeHeaderTabsViewModel");
 
   const [targets, setTargets] = useState<OpenTarget[]>([]);
   const {
@@ -69,6 +74,21 @@ export function GlobalHeader({
   const defaultOpenInTargetId = useUserPreferencesStore((s) => s.defaultOpenInTargetId);
   const preferredTarget = resolvePreferredOpenTarget(targets, { defaultOpenInTargetId });
   const workspacePath = selectedWorkspace?.path;
+  useDebugRenderReason("GlobalHeader", {
+    gitStatus,
+    existingPr,
+    selectedWorkspace,
+    workspacePath,
+    rightPanelOpen,
+    disableGitActions,
+    runDisabled,
+    runLoading,
+    runLabel,
+    runTitle,
+    targets,
+    defaultOpenInTargetId,
+    preferredTarget,
+  });
 
   useEffect(() => {
     void listOpenTargets("directory").then(setTargets);
@@ -93,7 +113,16 @@ export function GlobalHeader({
       <div className="flex h-full min-w-0 flex-1 items-stretch gap-2 px-2">
       {/* Tabs */}
       <div className="flex min-w-0 flex-1 items-center overflow-hidden">
-        <HeaderTabs />
+        {freezeHeaderTabs || freezeHeaderTabsViewModel ? (
+          <div
+            className="h-9 min-w-0 flex-1 rounded-md border border-dashed border-border/70 px-2 text-xs text-muted-foreground flex items-center"
+            data-perf-frozen="header-tabs"
+          >
+            Header tabs frozen
+          </div>
+        ) : (
+          <HeaderTabs />
+        )}
       </div>
 
       {/* Right side - branch + open-in + git + panel toggle */}
@@ -143,4 +172,4 @@ export function GlobalHeader({
       </div>
     </DebugProfiler>
   );
-}
+});

--- a/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
+++ b/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useState,
 } from "react";
@@ -15,6 +16,7 @@ import { useSessionDismissActions } from "@/hooks/sessions/workflows/use-session
 import { useSessionForkActions } from "@/hooks/sessions/workflows/use-session-fork-actions";
 import { useSessionTitleActions } from "@/hooks/sessions/workflows/use-session-title-actions";
 import { useDebugRenderCount } from "@/hooks/ui/use-debug-render-count";
+import { useDebugRenderReason } from "@/hooks/ui/use-debug-render-reason";
 import { useResizeObserverWidth } from "@/hooks/ui/use-resize-observer-width";
 import { useHeaderTabsCloseActions } from "@/hooks/workspaces/tabs/use-header-tabs-close-actions";
 import { useHeaderTabsGroupEditor } from "@/hooks/workspaces/tabs/use-header-tabs-group-editor";
@@ -37,9 +39,31 @@ import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-ta
 import { useToastStore } from "@/stores/toast/toast-store";
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
 
-export function HeaderTabs() {
+export const HeaderTabs = memo(function HeaderTabs() {
   useDebugRenderCount("header-tabs");
   const viewModel = useWorkspaceHeaderTabsViewModelContext();
+  useDebugRenderReason("HeaderTabs", {
+    activeSessionId: viewModel.activeSessionId,
+    activeShellTab: viewModel.activeShellTab,
+    activeShellTabKey: viewModel.activeShellTabKey,
+    activation: viewModel.activation,
+    selectedWorkspaceId: viewModel.selectedWorkspaceId,
+    workspaceUiKey: viewModel.workspaceUiKey,
+    materializedWorkspaceId: viewModel.materializedWorkspaceId,
+    openTargets: viewModel.openTargets,
+    chatTabs: viewModel.chatTabs,
+    stripRows: viewModel.stripRows,
+    shellRows: viewModel.shellRows,
+    orderedTabs: viewModel.orderedTabs,
+    orderedShellTabKeys: viewModel.orderedShellTabKeys,
+    stripChatSessionIds: viewModel.stripChatSessionIds,
+    menuChatTabs: viewModel.menuChatTabs,
+    visibleChatSessionIds: viewModel.visibleChatSessionIds,
+    liveChatSessionIds: viewModel.liveChatSessionIds,
+    childToParent: viewModel.childToParent,
+    childrenByParentSessionId: viewModel.childrenByParentSessionId,
+    displayManualGroups: viewModel.displayManualGroups,
+  });
   const chatVisibilityActions = useChatTabVisibilityActions({
     workspaceUiKey: viewModel.workspaceUiKey,
     materializedWorkspaceId: viewModel.materializedWorkspaceId,
@@ -344,4 +368,4 @@ export function HeaderTabs() {
       </div>
     </DebugProfiler>
   );
-}
+});

--- a/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.ts
+++ b/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.ts
@@ -125,6 +125,7 @@ export function useActiveTranscriptPaneState(): {
 export function useActiveSessionSurfaceSnapshot(): {
   activeSessionId: string | null;
   hasContent: boolean;
+  hasTranscriptEntry: boolean;
   hasSlot: boolean;
   transcriptHydrated: boolean;
   isEmpty: boolean;
@@ -153,6 +154,7 @@ export function useActiveSessionSurfaceSnapshot(): {
     return {
       activeSessionId,
       hasContent,
+      hasTranscriptEntry: transcriptEntry !== null,
       transcript,
     };
   }));
@@ -169,6 +171,7 @@ export function useActiveSessionSurfaceSnapshot(): {
   return {
     activeSessionId: transcriptState.activeSessionId,
     hasContent,
+    hasTranscriptEntry: transcriptState.hasTranscriptEntry,
     ...directoryState,
     isEmpty: transcriptState.activeSessionId !== null
       && directoryState.hasSlot

--- a/desktop/src/hooks/chat/derived/use-chat-surface-state.ts
+++ b/desktop/src/hooks/chat/derived/use-chat-surface-state.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
 import {
@@ -28,6 +29,7 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
   const {
     activeSessionId,
     hasContent,
+    hasTranscriptEntry,
     hasSlot,
     transcriptHydrated,
     isEmpty,
@@ -36,38 +38,72 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
   } = useActiveSessionSurfaceSnapshot();
 
   const selectedCloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
-  const selectedCloudWorkspace =
-    workspaceCollections?.cloudWorkspaces.find((workspace) => workspace.id === selectedCloudWorkspaceId)
-    ?? null;
-  const selectedLocalWorkspace = selectedWorkspaceId
-    ? workspaceCollections?.localWorkspaces?.find((w) => w.id === selectedWorkspaceId)
-    : null;
-
-  return {
-    mode: resolveChatSurfaceState({
-      selectedWorkspaceId,
-      hasPendingWorkspaceEntry: pendingWorkspaceEntry !== null,
-      activeLaunchIntentId: activeLaunchIntent?.id ?? null,
-      launchIntentSessionId: activeLaunchIntent?.materializedSessionId ?? null,
-      selectedLocalWorkspace: selectedLocalWorkspace ?? null,
-      isArrivalWorkspace: workspaceArrivalEvent?.workspaceId === selectedWorkspaceId,
-      shouldShowSelectedCloudWorkspaceStatus: selectedCloudWorkspace
-        ? shouldShowCloudWorkspaceStatusScreen(selectedCloudWorkspace)
-        : false,
-      shouldPreserveVisibleCloudContent: selectedCloudRuntime.state?.preserveVisibleContent === true,
-      shellRenderScope: shellRenderSurface
-        ? shellRenderSurface.kind === "chat-session-pending"
-          ? { kind: "chat-session-pending", sessionId: shellRenderSurface.sessionId }
-          : { kind: shellRenderSurface.kind === "chat-shell" ? "chat-shell" : "other" }
-        : null,
-      activeSessionId,
-      hasContent,
-      hasSlot,
-      transcriptHydrated,
-      isEmpty,
-      isRunning,
-      streamConnectionState,
-    }),
+  const selectedCloudWorkspace = useMemo(() => (
+    workspaceCollections?.cloudWorkspaces.find((workspace) =>
+      workspace.id === selectedCloudWorkspaceId
+    ) ?? null
+  ), [selectedCloudWorkspaceId, workspaceCollections?.cloudWorkspaces]);
+  const selectedLocalWorkspace = useMemo(() => (
+    selectedWorkspaceId
+      ? workspaceCollections?.localWorkspaces?.find((workspace) =>
+          workspace.id === selectedWorkspaceId
+        ) ?? null
+      : null
+  ), [selectedWorkspaceId, workspaceCollections?.localWorkspaces]);
+  const shellRenderScope = useMemo(() => {
+    if (!shellRenderSurface) {
+      return null;
+    }
+    if (shellRenderSurface.kind === "chat-session-pending") {
+      return { kind: "chat-session-pending" as const, sessionId: shellRenderSurface.sessionId };
+    }
+    if (shellRenderSurface.kind === "chat-session") {
+      return {
+        kind: "chat-session" as const,
+        sessionId: shellRenderSurface.sessionId,
+      };
+    }
+    return { kind: shellRenderSurface.kind === "chat-shell" ? "chat-shell" as const : "other" as const };
+  }, [shellRenderSurface]);
+  const mode = useMemo(() => resolveChatSurfaceState({
     selectedWorkspaceId,
-  };
+    hasPendingWorkspaceEntry: pendingWorkspaceEntry !== null,
+    activeLaunchIntentId: activeLaunchIntent?.id ?? null,
+    launchIntentSessionId: activeLaunchIntent?.materializedSessionId ?? null,
+    selectedLocalWorkspace,
+    isArrivalWorkspace: workspaceArrivalEvent?.workspaceId === selectedWorkspaceId,
+    shouldShowSelectedCloudWorkspaceStatus: selectedCloudWorkspace
+      ? shouldShowCloudWorkspaceStatusScreen(selectedCloudWorkspace)
+      : false,
+    shouldPreserveVisibleCloudContent: selectedCloudRuntime.state?.preserveVisibleContent === true,
+    shellRenderScope,
+    activeSessionId,
+    hasContent,
+    hasTranscriptEntry,
+    hasSlot,
+    transcriptHydrated,
+    isEmpty,
+    isRunning,
+    streamConnectionState,
+  }), [
+    activeLaunchIntent?.id,
+    activeLaunchIntent?.materializedSessionId,
+    activeSessionId,
+    hasContent,
+    hasTranscriptEntry,
+    hasSlot,
+    isEmpty,
+    isRunning,
+    pendingWorkspaceEntry,
+    selectedCloudRuntime.state?.preserveVisibleContent,
+    selectedCloudWorkspace,
+    selectedLocalWorkspace,
+    selectedWorkspaceId,
+    shellRenderScope,
+    streamConnectionState,
+    transcriptHydrated,
+    workspaceArrivalEvent?.workspaceId,
+  ]);
+
+  return useMemo(() => ({ mode, selectedWorkspaceId }), [mode, selectedWorkspaceId]);
 }

--- a/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -5,6 +5,8 @@ import {
   computeChatSurfaceBottomInsetPx,
 } from "@/config/chat-layout";
 
+const CHAT_DOCK_RESIZE_SETTLE_MS = 90;
+
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   const [metrics, setMetrics] = useState({
@@ -29,12 +31,12 @@ export function useChatDockInset() {
       const surfaceRect = composerSurface?.getBoundingClientRect() ?? null;
       const footerRect = composerFooter?.getBoundingClientRect() ?? null;
       const nextMetrics = {
-        composerSurfaceHeightPx: surfaceRect ? Math.max(0, surfaceRect.height) : 0,
+        composerSurfaceHeightPx: surfaceRect ? Math.max(0, Math.ceil(surfaceRect.height)) : 0,
         composerSurfaceOffsetTopPx: surfaceRect
-          ? Math.max(0, surfaceRect.top - dockRect.top)
+          ? Math.max(0, Math.ceil(surfaceRect.top - dockRect.top))
           : 0,
-        composerFooterHeightPx: footerRect ? Math.max(0, footerRect.height) : 0,
-        dockHeightPx: Math.max(0, dockRect.height),
+        composerFooterHeightPx: footerRect ? Math.max(0, Math.ceil(footerRect.height)) : 0,
+        dockHeightPx: Math.max(0, Math.ceil(dockRect.height)),
       };
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
@@ -52,14 +54,25 @@ export function useChatDockInset() {
       return;
     }
 
-    const observer = new ResizeObserver(() => {
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
+    let settleTimer: number | null = null;
+    const scheduleMeasure = () => {
+      if (settleTimer !== null) {
+        window.clearTimeout(settleTimer);
       }
-      frameId = window.requestAnimationFrame(() => {
-        frameId = null;
-        measure();
-      });
+      settleTimer = window.setTimeout(() => {
+        settleTimer = null;
+        if (frameId !== null) {
+          window.cancelAnimationFrame(frameId);
+        }
+        frameId = window.requestAnimationFrame(() => {
+          frameId = null;
+          measure();
+        });
+      }, CHAT_DOCK_RESIZE_SETTLE_MS);
+    };
+
+    const observer = new ResizeObserver(() => {
+      scheduleMeasure();
     });
 
     observer.observe(dock);
@@ -74,6 +87,9 @@ export function useChatDockInset() {
 
     return () => {
       observer.disconnect();
+      if (settleTimer !== null) {
+        window.clearTimeout(settleTimer);
+      }
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }

--- a/desktop/src/hooks/chat/ui/use-chat-prompt-attachments.ts
+++ b/desktop/src/hooks/chat/ui/use-chat-prompt-attachments.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { PromptCapabilities } from "@anyharness/sdk";
 import { canAttachPromptContent } from "@/lib/domain/chat/composer/prompt-attachment-rules";
 import { usePromptAttachments } from "@/hooks/chat/ui/use-prompt-attachments";
@@ -34,11 +34,17 @@ export function useChatPromptAttachments({
     return attachments.addTextPaste(text);
   }, [attachments.addTextPaste, canAttachFiles, pasteAttachmentsEnabled]);
 
-  return {
+  return useMemo(() => ({
     ...attachments,
     addFiles,
     addTextPaste,
     canAttachFiles,
     supportsAttachments,
-  };
+  }), [
+    addFiles,
+    addTextPaste,
+    attachments,
+    canAttachFiles,
+    supportsAttachments,
+  ]);
 }

--- a/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
+++ b/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { CloudRuntimeAttachedPanel } from "@/components/workspace/chat/surface/CloudRuntimeAttachedPanel";
 import { WorkspaceArrivalAttachedPanel } from "@/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel";
 import { TodoTrackerPanel } from "@/components/workspace/chat/input/TodoTrackerPanel";
@@ -45,46 +45,61 @@ export function useComposerDockSlots(options?: {
     selectedCloudRuntimeState: selectedCloudRuntime.state,
   });
 
-  const interactionPanel: ReactNode | null = primaryPendingInteraction?.kind === "permission"
-    ? <ConnectedApprovalCard />
-    : primaryPendingInteraction?.kind === "user_input"
-      ? <ConnectedUserInputCard />
-      : primaryPendingInteraction?.kind === "mcp_elicitation"
-        ? <ConnectedMcpElicitationCard />
-        : null;
+  const interactionPanel = useMemo<ReactNode | null>(() => (
+    primaryPendingInteraction?.kind === "permission"
+      ? <ConnectedApprovalCard />
+      : primaryPendingInteraction?.kind === "user_input"
+        ? <ConnectedUserInputCard />
+        : primaryPendingInteraction?.kind === "mcp_elicitation"
+          ? <ConnectedMcpElicitationCard />
+          : null
+  ), [primaryPendingInteraction?.kind]);
 
-  const ambientContextSlot: ReactNode | null = workspaceStatusPanel
-    ? <WorkspaceArrivalAttachedPanel />
-    : selectedCloudRuntime.state && selectedCloudRuntime.state.phase !== "ready"
-      ? <CloudRuntimeAttachedPanel />
-      : null;
-  const activeAgentSlot: ReactNode | null = suppressSessionSlots
-    ? null
-    : interactionPanel || (activeTodoTracker
-      ? <TodoTrackerPanel entries={activeTodoTracker.entries} />
-      : null);
-  const delegatedWorkSlot: ReactNode | null = delegatedWorkComposer
-    ? (
+  const ambientContextSlot = useMemo<ReactNode | null>(() => (
+    workspaceStatusPanel
+      ? <WorkspaceArrivalAttachedPanel />
+      : selectedCloudRuntime.state && selectedCloudRuntime.state.phase !== "ready"
+        ? <CloudRuntimeAttachedPanel />
+        : null
+  ), [selectedCloudRuntime.state, workspaceStatusPanel]);
+  const activeAgentSlot = useMemo<ReactNode | null>(() => (
+    suppressSessionSlots
+      ? null
+      : interactionPanel || (activeTodoTracker
+        ? <TodoTrackerPanel entries={activeTodoTracker.entries} />
+        : null)
+  ), [activeTodoTracker, interactionPanel, suppressSessionSlots]);
+  const delegatedWorkSlot = useMemo<ReactNode | null>(() => (
+    delegatedWorkComposer
+      ? (
       <DelegatedWorkComposerPanel>
         <DelegatedWorkComposerControl viewModel={delegatedWorkComposer} />
       </DelegatedWorkComposerPanel>
-    )
-    : null;
+      )
+      : null
+  ), [delegatedWorkComposer]);
   const attachedDelegatedWorkSlot = suppressSessionSlots ? null : delegatedWorkSlot;
-  const attachedSlot: ReactNode | null = ambientContextSlot || attachedDelegatedWorkSlot
-    ? (
+  const attachedSlot = useMemo<ReactNode | null>(() => (
+    ambientContextSlot || attachedDelegatedWorkSlot
+      ? (
       <>
         {ambientContextSlot}
         {attachedDelegatedWorkSlot}
       </>
-    )
-    : null;
+      )
+      : null
+  ), [ambientContextSlot, attachedDelegatedWorkSlot]);
 
-  return {
+  return useMemo(() => ({
     outboundSlot: !suppressSessionSlots && pendingPrompts.length > 0
       ? <ConnectedPendingPromptList />
       : null,
     activeSlot: activeAgentSlot,
     attachedSlot,
-  };
+  }), [
+    activeAgentSlot,
+    attachedSlot,
+    pendingPrompts.length,
+    suppressSessionSlots,
+  ]);
 }

--- a/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts
+++ b/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, type RefObject } from "react";
+import { useCallback, useLayoutEffect, useRef, type RefObject } from "react";
 import { computeComposerTextareaAutosize } from "@/lib/domain/chat/composer/composer-textarea-sizing";
 
 interface UseComposerTextareaAutosizeArgs {
@@ -20,15 +20,30 @@ export function useComposerTextareaAutosize({
 }: UseComposerTextareaAutosizeArgs): {
   resizeTextarea: () => void;
 } {
+  const cachedSizingRef = useRef<{
+    lineHeightPx: number;
+    rootFontSizePx: number;
+  } | null>(null);
+  const previousValueLengthRef = useRef(0);
+
   const resizeTextarea = useCallback(() => {
     const el = textareaRef.current;
     if (!el) {
       return;
     }
 
-    const lineHeightPx = parseFloat(getComputedStyle(el).lineHeight);
-    const rootFontSizePx = parseFloat(getComputedStyle(document.documentElement).fontSize);
-    el.style.height = "auto";
+    const cachedSizing = cachedSizingRef.current;
+    const lineHeightPx = cachedSizing?.lineHeightPx
+      ?? parseFloat(getComputedStyle(el).lineHeight);
+    const rootFontSizePx = cachedSizing?.rootFontSizePx
+      ?? parseFloat(getComputedStyle(document.documentElement).fontSize);
+    cachedSizingRef.current = {
+      lineHeightPx,
+      rootFontSizePx,
+    };
+    if (value.length < previousValueLengthRef.current) {
+      el.style.height = "auto";
+    }
     const { heightPx, overflowY } = computeComposerTextareaAutosize({
       scrollHeightPx: el.scrollHeight,
       lineHeightPx,
@@ -38,14 +53,21 @@ export function useComposerTextareaAutosize({
       maxRows,
       minHeightRem,
     });
-    el.style.height = `${heightPx}px`;
-    el.style.overflowY = overflowY;
+    const nextHeight = `${heightPx}px`;
+    if (el.style.height !== nextHeight) {
+      el.style.height = nextHeight;
+    }
+    if (el.style.overflowY !== overflowY) {
+      el.style.overflowY = overflowY;
+    }
+    previousValueLengthRef.current = value.length;
   }, [
     lineHeightRem,
     maxRows,
     minHeightRem,
     minRows,
     textareaRef,
+    value.length,
   ]);
 
   useLayoutEffect(() => {

--- a/desktop/src/hooks/chat/ui/use-prompt-attachments.ts
+++ b/desktop/src/hooks/chat/ui/use-prompt-attachments.ts
@@ -168,7 +168,7 @@ export function usePromptAttachments(
     );
   }, []);
 
-  return {
+  return useMemo(() => ({
     attachments: descriptors,
     addFiles,
     addTextPaste,
@@ -176,5 +176,13 @@ export function usePromptAttachments(
     clearAttachments,
     snapshotForSubmit,
     hasAttachments: entries.length > 0,
-  };
+  }), [
+    addFiles,
+    addTextPaste,
+    clearAttachments,
+    descriptors,
+    entries.length,
+    removeAttachment,
+    snapshotForSubmit,
+  ]);
 }

--- a/desktop/src/hooks/chat/use-queued-prompt-edit.ts
+++ b/desktop/src/hooks/chat/use-queued-prompt-edit.ts
@@ -77,7 +77,8 @@ export function useQueuedPromptEditStatus(): {
   isEditing: boolean;
 } {
   const { editingSeq } = useDerivedEditingState();
-  return { isEditing: editingSeq != null };
+  const isEditing = editingSeq != null;
+  return useMemo(() => ({ isEditing }), [isEditing]);
 }
 
 /**

--- a/desktop/src/hooks/main/facade/use-main-screen-state.ts
+++ b/desktop/src/hooks/main/facade/use-main-screen-state.ts
@@ -17,6 +17,7 @@ import {
   type SetStateAction,
 } from "react";
 import { useResize } from "@/hooks/ui/layout/use-resize";
+import { useProliferatePerfFlag } from "@/hooks/ui/use-proliferate-perf-flag";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
 import { useIsHotPaintGatePendingForWorkspace } from "@/hooks/workspaces/derived/use-hot-paint-gate";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
@@ -101,6 +102,7 @@ export interface MainScreenState {
 // Owns the Main screen view-model: local layout state plus selected workspace
 // data needed by the shell. User actions live in main/workflows.
 export function useMainScreenState(): MainScreenState {
+  const freezeMainScreenDataQueries = useProliferatePerfFlag("freezeMainScreenDataQueries");
   const [rightPanelUserOpenOverride, setRightPanelUserOpenOverride] = useState<{
     materializedWorkspaceId: string;
     nonce: number;
@@ -143,13 +145,19 @@ export function useMainScreenState(): MainScreenState {
   const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelMaterializedForWorkspace,
   );
-  const rightPanelDurableFallback = resolveWithWorkspaceFallback(
-    rightPanelDurableByWorkspace,
-    workspaceUiKey,
-    materializedWorkspaceId,
+  const rightPanelDurableFallback = useMemo(
+    () => resolveWithWorkspaceFallback(
+      rightPanelDurableByWorkspace,
+      workspaceUiKey,
+      materializedWorkspaceId,
+    ),
+    [materializedWorkspaceId, rightPanelDurableByWorkspace, workspaceUiKey],
   );
-  const persistedRightPanelDurableState = normalizeRightPanelDurableState(
-    rightPanelDurableFallback.value ?? DEFAULT_RIGHT_PANEL_DURABLE_STATE,
+  const persistedRightPanelDurableState = useMemo(
+    () => normalizeRightPanelDurableState(
+      rightPanelDurableFallback.value ?? DEFAULT_RIGHT_PANEL_DURABLE_STATE,
+    ),
+    [rightPanelDurableFallback.value],
   );
   const rightPanelDurableState = rightPanelSessionDurableState
     ?? persistedRightPanelDurableState;
@@ -279,7 +287,9 @@ export function useMainScreenState(): MainScreenState {
 
   const activeLaunchIntent = useChatLaunchIntentStore((state) => state.activeIntent);
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
-  const { data: workspaceCollections } = useWorkspaces();
+  const { data: workspaceCollections } = useWorkspaces({
+    enabled: !freezeMainScreenDataQueries,
+  });
   const workspaces = workspaceCollections?.workspaces ?? EMPTY_WORKSPACES;
   const hasLaunchIntentOnlyShell = Boolean(
     activeLaunchIntent
@@ -303,10 +313,13 @@ export function useMainScreenState(): MainScreenState {
   );
   const { data: gitStatus } = useGitStatusQuery({
     workspaceId: materializedWorkspaceId,
-    enabled: hasRuntimeReadyWorkspace && !hotPaintPending,
+    enabled: hasRuntimeReadyWorkspace && !hotPaintPending && !freezeMainScreenDataQueries,
   });
   const shouldQueryCurrentPullRequest =
-    hasRuntimeReadyWorkspace && !hotPaintPending && Boolean(gitStatus?.currentBranch?.trim());
+    hasRuntimeReadyWorkspace
+    && !hotPaintPending
+    && !freezeMainScreenDataQueries
+    && Boolean(gitStatus?.currentBranch?.trim());
   const { data: currentPullRequest } = useCurrentPullRequestQuery({
     workspaceId: materializedWorkspaceId,
     enabled: shouldQueryCurrentPullRequest,

--- a/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -35,6 +35,7 @@ import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-st
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 
 const SESSION_APPLY_MEASUREMENT_SURFACES: readonly MeasurementSurface[] = [
   "session-transcript-pane",
@@ -71,6 +72,15 @@ export function useSessionHistoryHydration() {
     options?: SessionHistoryHydrationOptions,
   ): Promise<boolean> => {
     const startedAt = performance.now();
+    if (isProliferatePerfFlagEnabled("pauseSessionHistoryHydration")) {
+      logLatency("session.history.rehydrate.paused_by_perf_flag", {
+        sessionId,
+        afterSeq: options?.afterSeq ?? null,
+        beforeSeq: options?.beforeSeq ?? null,
+        replace: options?.replace ?? false,
+      });
+      return false;
+    }
     let standaloneMeasurementOperationId: MeasurementOperationId | null = null;
     try {
       if (options?.isCurrent && !options.isCurrent()) {

--- a/desktop/src/hooks/sessions/use-session-runtime-actions.ts
+++ b/desktop/src/hooks/sessions/use-session-runtime-actions.ts
@@ -58,6 +58,7 @@ import {
   closeSessionStreamHandle,
   setSessionStreamHandle,
 } from "@/lib/access/anyharness/session-stream-handles";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 
 const ACTIVE_SUMMARY_REFRESH_DELAY_MS = 8_000;
 
@@ -534,6 +535,9 @@ export function useSessionRuntimeActions() {
         finishStreamConnectMeasurement("completed");
       },
       onEvent: (envelope) => {
+        if (isProliferatePerfFlagEnabled("pauseSessionStreamUi")) {
+          return;
+        }
         const materializedSessionId = getMaterializedSessionId(sessionId);
         if (!isStillCurrent() || !handle || !materializedSessionId || !isCurrentStreamHandle(materializedSessionId, handle)) {
           return;

--- a/desktop/src/hooks/sessions/workflows/use-session-prompt-workflow.ts
+++ b/desktop/src/hooks/sessions/workflows/use-session-prompt-workflow.ts
@@ -22,6 +22,7 @@ import type { PromptAttachmentSnapshot } from "@/lib/domain/chat/composer/prompt
 import { isSessionSlotBusy } from "@/lib/domain/sessions/activity";
 import { usePromptOutboxStore } from "@/stores/chat/prompt-outbox-store";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 
 interface PromptSessionInput {
   sessionId: string;
@@ -60,6 +61,24 @@ export function useSessionPromptWorkflow() {
     const outboxStore = usePromptOutboxStore.getState();
     const existingOutboxEntries = outboxEntriesForSession(outboxStore, sessionId);
     const enqueueStartedAt = performance.now();
+    if (isProliferatePerfFlagEnabled("pausePromptOutboxUi")) {
+      logLatency("prompt.outbox.enqueue.paused_by_perf_flag", {
+        clientPromptId,
+        clientSessionId: sessionId,
+        workspaceId: resolvedWorkspaceId,
+      });
+      recordMeasurementWorkflowStep({
+        operationId: measurementOperationId,
+        step: "prompt.submit.enqueue",
+        startedAt: enqueueStartedAt,
+        outcome: "skipped",
+        count: existingOutboxEntries.length,
+      });
+      finishLatencyFlow(latencyFlowId, "optimistic_visible", {
+        keepActive: true,
+      });
+      return;
+    }
     if (measurementOperationId) {
       markOperationForNextCommit(
         measurementOperationId,
@@ -71,7 +90,7 @@ export function useSessionPromptWorkflow() {
       isSessionMaterialized: Boolean(slot?.materializedSessionId),
       existingEntries: existingOutboxEntries,
     });
-    flushSync(() => {
+    const enqueuePrompt = () => {
       outboxStore.enqueue({
         clientPromptId,
         clientSessionId: sessionId,
@@ -84,7 +103,12 @@ export function useSessionPromptWorkflow() {
         placement: outboxPlacement,
         latencyFlowId,
       });
-    });
+    };
+    if (isProliferatePerfFlagEnabled("disablePromptFlushSync")) {
+      enqueuePrompt();
+    } else {
+      flushSync(enqueuePrompt);
+    }
     logLatency("prompt.outbox.enqueue", {
       clientPromptId,
       clientSessionId: sessionId,

--- a/desktop/src/hooks/ui/use-debug-render-reason.ts
+++ b/desktop/src/hooks/ui/use-debug-render-reason.ts
@@ -1,0 +1,10 @@
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
+
+type DebugRenderReasonValues = Record<string, unknown>;
+
+export function useDebugRenderReason(
+  component: string,
+  values: DebugRenderReasonValues,
+): void {
+  useDebugValueChange("render_reason", component, values);
+}

--- a/desktop/src/hooks/ui/use-proliferate-perf-flag.ts
+++ b/desktop/src/hooks/ui/use-proliferate-perf-flag.ts
@@ -1,0 +1,14 @@
+import { useSyncExternalStore } from "react";
+import {
+  isProliferatePerfFlagEnabled,
+  subscribeProliferatePerfFlags,
+  type ProliferatePerfFlagName,
+} from "@/lib/infra/perf/perf-isolation-flags";
+
+export function useProliferatePerfFlag(flag: ProliferatePerfFlagName): boolean {
+  return useSyncExternalStore(
+    subscribeProliferatePerfFlags,
+    () => isProliferatePerfFlagEnabled(flag),
+    () => false,
+  );
+}

--- a/desktop/src/hooks/workspaces/cache/use-workspaces.ts
+++ b/desktop/src/hooks/workspaces/cache/use-workspaces.ts
@@ -32,6 +32,10 @@ import { hashMeasurementScope } from "@/lib/infra/measurement/debug-measurement-
 const WORKSPACE_ACTIVITY_REFRESH_INTERVAL_MS = 5_000;
 const WORKSPACE_COLLECTIONS_STALE_MS = 30_000;
 
+interface UseWorkspacesOptions {
+  enabled?: boolean;
+}
+
 function requestOptionsWithSignal(
   requestOptions: AnyHarnessRequestOptions | undefined,
   signal: AbortSignal,
@@ -74,10 +78,12 @@ async function fallbackOnNonAbort<T>(
   }
 }
 
-export function useWorkspaces() {
+export function useWorkspaces(options?: UseWorkspacesOptions) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const { cloudActive } = useCloudAvailabilityState();
-  const canQuery = runtimeUrl.trim().length > 0 || cloudActive;
+  const canQuery = (options?.enabled ?? true) && (
+    runtimeUrl.trim().length > 0 || cloudActive
+  );
   const {
     getWorkspaceCollectionsCacheState,
     queryKey,

--- a/desktop/src/hooks/workspaces/derived/use-workspace-finish-suggestions.ts
+++ b/desktop/src/hooks/workspaces/derived/use-workspace-finish-suggestions.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceRetirePreflightResponse } from "@anyharness/sdk";
+import { useMemo } from "react";
 import type { WorkspaceCollections } from "@/lib/domain/workspaces/cloud/collections";
 import { useWorkspaceRetirePreflightQueries } from "@/hooks/access/anyharness/workspaces/use-workspace-retire-preflights";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
@@ -9,33 +10,65 @@ export interface WorkspaceFinishSuggestion {
   preflight: WorkspaceRetirePreflightResponse;
 }
 
+const EMPTY_FINISH_SUGGESTIONS: Record<string, WorkspaceFinishSuggestion> = {};
+
 // Owns read-only finish-suggestion state for standard worktree workspaces.
 // AnyHarness retire-preflight query shape lives in the access hook.
 export function useWorkspaceFinishSuggestions(
   collections: WorkspaceCollections | undefined,
 ): Record<string, WorkspaceFinishSuggestion> {
   const dismissals = useWorkspaceUiStore((state) => state.finishSuggestionDismissalsByWorkspaceId);
-  const workspaces = collections?.localWorkspaces.filter((workspace) =>
-    workspace.kind === "worktree"
-    && (workspace.surface ?? "standard") === "standard"
-    && workspace.lifecycleState !== "retired"
-  ) ?? [];
-  const queries = useWorkspaceRetirePreflightQueries(workspaces.map((workspace) => workspace.id));
-
-  const suggestions: Record<string, WorkspaceFinishSuggestion> = {};
-  queries.forEach((query, index) => {
+  const workspaces = useMemo(
+    () => collections?.localWorkspaces.filter((workspace) =>
+      workspace.kind === "worktree"
+      && (workspace.surface ?? "standard") === "standard"
+      && workspace.lifecycleState !== "retired"
+    ) ?? [],
+    [collections?.localWorkspaces],
+  );
+  const workspaceIds = useMemo(
+    () => workspaces.map((workspace) => workspace.id),
+    [workspaces],
+  );
+  const queries = useWorkspaceRetirePreflightQueries(workspaceIds);
+  const signature = queries.map((query, index) => {
     const preflight = query.data;
-    if (!preflight?.canRetire || !preflight.mergedIntoBase || preflight.headMatchesBase) {
-      return;
-    }
-    if (dismissals[preflight.workspaceId] === preflight.readinessFingerprint) {
-      return;
-    }
-    suggestions[preflight.workspaceId] = {
-      workspaceId: workspaces[index].id,
-      readinessFingerprint: preflight.readinessFingerprint,
-      preflight,
-    };
-  });
-  return suggestions;
+    return [
+      workspaceIds[index] ?? "",
+      preflight?.workspaceId ?? "",
+      preflight?.canRetire ? "can" : "no",
+      preflight?.mergedIntoBase ? "merged" : "unmerged",
+      preflight?.headMatchesBase ? "same" : "different",
+      preflight?.readinessFingerprint ?? "",
+      preflight ? dismissals[preflight.workspaceId] ?? "" : "",
+    ].join("\u001f");
+  }).join("\u001e");
+
+  return useMemo(() => {
+    const suggestions: Record<string, WorkspaceFinishSuggestion> = {};
+    queries.forEach((query, index) => {
+      const preflight = query.data;
+      if (!preflight?.canRetire || !preflight.mergedIntoBase || preflight.headMatchesBase) {
+        return;
+      }
+      if (dismissals[preflight.workspaceId] === preflight.readinessFingerprint) {
+        return;
+      }
+      const workspace = workspaces[index];
+      if (!workspace) {
+        return;
+      }
+      suggestions[preflight.workspaceId] = {
+        workspaceId: workspace.id,
+        readinessFingerprint: preflight.readinessFingerprint,
+        preflight,
+      };
+    });
+    return Object.keys(suggestions).length === 0
+      ? EMPTY_FINISH_SUGGESTIONS
+      : suggestions;
+    // useQueries returns a new wrapper array each render. The signature above
+    // captures the fields that affect sidebar finish suggestion rendering.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature, workspaces]);
 }

--- a/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
+++ b/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
@@ -20,9 +20,9 @@ import { useWorkspaceFinishSuggestions } from "@/hooks/workspaces/derived/use-wo
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import { useWorkspaceSidebarActivityStatesWithErrorAttention } from "@/hooks/workspaces/derived/use-workspace-sidebar-activities";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
-import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
+import { useDebugValueChange } from "@/hooks/ui/use-debug-value-change";
 
 interface UseWorkspaceSidebarStateArgs {
   showArchived: boolean;
@@ -35,7 +35,6 @@ interface WorkspaceSidebarState {
   selectedWorkspaceId: string | null;
   selectedLogicalWorkspaceId: string | null;
   gitStatus: GitStatusSnapshot | undefined;
-  transcriptTitle: string | null;
   emptyState: SidebarEmptyState;
   cleanupAttentionWorkspaces: Workspace[];
   isLoading: boolean;
@@ -50,7 +49,6 @@ export function useWorkspaceSidebarState({
 }: UseWorkspaceSidebarStateArgs): WorkspaceSidebarState {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore((state) => state.selectedLogicalWorkspaceId);
-  const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
   const lastViewedSessionErrorAtBySession = useWorkspaceUiStore((state) =>
     state.lastViewedSessionErrorAtBySession
     ?? EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION
@@ -59,12 +57,6 @@ export function useWorkspaceSidebarState({
     lastViewedSessionErrorAtBySession,
   );
   const deferredLaunchesById = useDeferredHomeLaunchStore((state) => state.launches);
-  const activeSessionTitle = useSessionDirectoryStore((state) => {
-    const entry = activeSessionId ? state.entriesById[activeSessionId] : null;
-    return entry
-      ? entry.title?.trim() || entry.activity.transcriptTitle?.trim() || null
-      : null;
-  });
 
   const {
     archivedWorkspaceIds,
@@ -121,12 +113,11 @@ export function useWorkspaceSidebarState({
     workspaceActivities,
     pendingPromptCounts,
     gitStatus,
-    activeSessionTitle,
+    activeSessionTitle: null,
     lastViewedAt,
     workspaceLastInteracted,
     finishSuggestionsByWorkspaceId,
   }), [
-    activeSessionTitle,
     archivedSet,
     gitStatus,
     hiddenRepoRootSet,
@@ -143,6 +134,31 @@ export function useWorkspaceSidebarState({
     finishSuggestionsByWorkspaceId,
   ]);
   const emptyState = resolveSidebarEmptyState(logicalWorkspaces.length, groups.length);
+  useDebugValueChange("workspace_sidebar_state.inputs", "state_refs", {
+    selectedWorkspaceId,
+    selectedLogicalWorkspaceId,
+    lastViewedSessionErrorAtBySession,
+    workspaceActivities,
+    deferredLaunchesById,
+    archivedWorkspaceIds,
+    hiddenRepoRootIds,
+    lastViewedAt,
+    workspaceLastInteracted,
+    workspaceTypes,
+    logicalWorkspaces,
+    workspaceCollections,
+    cleanupAttentionWorkspaces,
+    finishSuggestionsByWorkspaceId,
+    repoRoots,
+    gitStatus,
+    archivedSet,
+    hiddenRepoRootSet,
+    pendingPromptCounts,
+    groups,
+    emptyState,
+    showArchived,
+    workspacesLoading,
+  });
 
   return {
     groups,
@@ -151,7 +167,6 @@ export function useWorkspaceSidebarState({
     selectedWorkspaceId,
     selectedLogicalWorkspaceId,
     gitStatus,
-    transcriptTitle: activeSessionTitle,
     emptyState,
     cleanupAttentionWorkspaces,
     isLoading: workspacesLoading,

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -67,7 +67,6 @@ export interface WorkspaceHeaderSubagentHierarchy {
 export function useWorkspaceHeaderSubagentHierarchy(args: {
   workspaceId: string | null;
   sessionIds: string[];
-  activeSessionId: string | null;
 }): WorkspaceHeaderSubagentHierarchy {
   const workspace = useAnyHarnessWorkspaceContext();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
@@ -172,6 +171,24 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [reviewRelationshipHintSignature],
   );
+  const hierarchyQuerySignature = buildHierarchyQuerySignature({
+    sessionIds: uniqueSessionIds,
+    subagentQueries,
+    reviewQueries,
+  });
+  const hierarchyQueryRows = useMemo(
+    () => uniqueSessionIds.map((sessionId, index) => ({
+      sessionId,
+      subagentSuccess: subagentQueries[index]?.isSuccess === true,
+      subagentData: subagentQueries[index]?.data ?? null,
+      reviewSuccess: reviewQueries[index]?.isSuccess === true,
+      reviewData: reviewQueries[index]?.data ?? null,
+    })),
+    // useQueries returns new wrapper arrays every render. The signature captures
+    // the response fields that affect the header hierarchy model.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hierarchyQuerySignature, uniqueSessionIds],
+  );
 
   useEffect(() => {
     for (const hint of subagentRelationshipHints) {
@@ -199,10 +216,8 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
 
   useDebugValueChange("header_subagent_hierarchy.inputs", "query_refs", {
     workspaceId: args.workspaceId,
-    activeSessionId: args.activeSessionId,
     uniqueSessionIds,
-    subagentQueries,
-    reviewQueries,
+    hierarchyQuerySignature,
   });
 
   return useMemo(() => measureDebugComputation({
@@ -216,11 +231,10 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     const childrenByParentSessionId = new Map<string, HeaderSubagentChildRow[]>();
     const resolvedSessionIds = new Set<string>();
 
-    for (let index = 0; index < uniqueSessionIds.length; index += 1) {
-      const sessionId = uniqueSessionIds[index];
-      const query = subagentQueries[index];
-      const data = query?.data;
-      if (query?.isSuccess) {
+    for (const row of hierarchyQueryRows) {
+      const { sessionId } = row;
+      const data = row.subagentData;
+      if (row.subagentSuccess) {
         resolvedSessionIds.add(sessionId);
       }
       if (!data) {
@@ -245,7 +259,6 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
               parentSessionId: sessionId,
               childSessionId: resolveClientSessionId(child.childSessionId),
               ordinal: childIndex + 1,
-              activeSessionId: args.activeSessionId,
             })
           ),
         );
@@ -254,13 +267,12 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
         }
       }
 
-      const reviewQuery = reviewQueries[index];
-      const reviewData = reviewQuery?.data;
-      if (reviewQuery?.isSuccess) {
+      const reviewData = row.reviewData;
+      if (row.reviewSuccess) {
         resolvedSessionIds.add(sessionId);
       }
       const reviewChildren = reviewData
-        ? buildReviewChildRows(reviewData.reviews, args.activeSessionId, resolveClientSessionId)
+        ? buildReviewChildRows(reviewData.reviews, resolveClientSessionId)
         : [];
       if (reviewChildren.length > 0) {
         const existing = childrenByParentSessionId.get(sessionId) ?? [];
@@ -278,12 +290,85 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       resolvedSessionIds,
     };
   }), [
-    args.activeSessionId,
+    hierarchyQueryRows,
     resolveClientSessionId,
-    reviewQueries,
-    subagentQueries,
-    uniqueSessionIds,
   ]);
+}
+
+function buildHierarchyQuerySignature({
+  sessionIds,
+  subagentQueries,
+  reviewQueries,
+}: {
+  sessionIds: readonly string[];
+  subagentQueries: readonly {
+    data?: SessionSubagentsResponse;
+    isSuccess: boolean;
+  }[];
+  reviewQueries: readonly {
+    data?: SessionReviewsResponse;
+    isSuccess: boolean;
+  }[];
+}): string {
+  return sessionIds.map((sessionId, index) => [
+    sessionId,
+    subagentQueries[index]?.isSuccess ? "subagents:ok" : "subagents:pending",
+    subagentResponseSignature(subagentQueries[index]?.data),
+    reviewQueries[index]?.isSuccess ? "reviews:ok" : "reviews:pending",
+    reviewResponseSignature(reviewQueries[index]?.data),
+  ].join("\u001f")).join("\u001e");
+}
+
+function subagentResponseSignature(
+  response: SessionSubagentsResponse | null | undefined,
+): string {
+  if (!response) {
+    return "";
+  }
+  return [
+    response.parent
+      ? [
+        response.parent.parentSessionId,
+        response.parent.parentTitle ?? "",
+        response.parent.label ?? "",
+        response.parent.parentAgentKind,
+      ].join(":")
+      : "",
+    response.children.map((child) => [
+      child.sessionLinkId,
+      child.childSessionId,
+      child.title ?? "",
+      child.label ?? "",
+      child.agentKind,
+      child.status,
+      child.wakeScheduled ? "wake" : "",
+    ].join(":")).join("|"),
+  ].join("\u001f");
+}
+
+function reviewResponseSignature(
+  response: SessionReviewsResponse | null | undefined,
+): string {
+  if (!response) {
+    return "";
+  }
+  return response.reviews.map((run) => [
+    run.id,
+    run.kind,
+    run.parentSessionId,
+    run.rounds.map((round) => [
+      round.id,
+      round.status,
+      round.assignments.map((assignment) => [
+        assignment.id,
+        assignment.sessionLinkId ?? "",
+        assignment.reviewerSessionId ?? "",
+        assignment.personaLabel,
+        assignment.agentKind,
+        assignment.status,
+      ].join(":")).join(","),
+    ].join(":")).join("|"),
+  ].join("\u001f")).join("\u001e");
 }
 
 function buildParentRow(
@@ -305,13 +390,11 @@ function buildChildRow({
   parentSessionId,
   childSessionId,
   ordinal,
-  activeSessionId,
 }: {
   child: ChildSubagentSummary;
   parentSessionId: string;
   childSessionId: string;
   ordinal: number;
-  activeSessionId: string | null;
 }): HeaderSubagentChildRow {
   return {
     sessionLinkId: child.sessionLinkId,
@@ -323,13 +406,12 @@ function buildChildRow({
     meta: null,
     statusLabel: formatSessionStatus(child.status),
     wakeScheduled: child.wakeScheduled,
-    isActive: childSessionId === activeSessionId,
+    isActive: false,
   };
 }
 
 function buildReviewChildRows(
   reviews: readonly ReviewRunDetail[],
-  activeSessionId: string | null,
   resolveClientSessionId: (sessionId: string) => string,
 ): HeaderSubagentChildRow[] {
   const rowsBySessionId = new Map<string, HeaderSubagentChildRow>();
@@ -349,7 +431,7 @@ function buildReviewChildRows(
           meta: reviewKindLabel(run.kind),
           statusLabel: reviewAssignmentHeaderStatusLabel(assignment),
           wakeScheduled: false,
-          isActive: clientSessionId === activeSessionId,
+          isActive: false,
         });
       }
     }

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
@@ -33,7 +33,6 @@ import {
   type ChatVisibilityCandidate,
 } from "@/lib/domain/workspaces/tabs/visibility";
 import {
-  useWorkspaceActiveChatTabId,
   useWorkspaceShellTabsState,
 } from "@/hooks/workspaces/tabs/use-workspace-shell-tabs-state";
 import type {
@@ -107,6 +106,17 @@ export function useWorkspaceHeaderTabsViewModel() {
     workspaceId: selectedWorkspaceId,
     enabled: !!selectedWorkspaceId && !hotPaintPending,
   });
+  useDebugValueChange("header_tabs.query_state", "workspace_sessions_query", {
+    selectedWorkspaceId,
+    enabled: !!selectedWorkspaceId && !hotPaintPending,
+    status: workspaceSessionsQuery.status,
+    fetchStatus: workspaceSessionsQuery.fetchStatus,
+    isFetching: workspaceSessionsQuery.isFetching,
+    isPending: workspaceSessionsQuery.isPending,
+    data: workspaceSessionsQuery.data,
+    dataUpdatedAt: workspaceSessionsQuery.dataUpdatedAt,
+    errorUpdatedAt: workspaceSessionsQuery.errorUpdatedAt,
+  });
 
   const knownSessions = useMemo<Map<string, KnownHeaderSession>>(() =>
     measureDebugComputation({
@@ -131,7 +141,6 @@ export function useWorkspaceHeaderTabsViewModel() {
   const hierarchy = useWorkspaceHeaderSubagentHierarchy({
     workspaceId: selectedWorkspaceId,
     sessionIds: knownSessionIds,
-    activeSessionId,
   });
   const hierarchyChildren = useMemo(
     () => measureDebugComputation({
@@ -185,11 +194,6 @@ export function useWorkspaceHeaderTabsViewModel() {
   const recentlyHiddenIds = recentlyHiddenFallback.value ?? [];
   const collapsedParentIds = collapsedParentFallback.value ?? [];
   const persistedManualGroups = manualGroupsFallback.value ?? [];
-  const activeChatSessionIdForTabs = useWorkspaceActiveChatTabId({
-    workspaceUiKey,
-    materializedWorkspaceId,
-    fallbackSessionId: activeSessionId,
-  });
   const persistedVisibleIdsForResolution = useMemo(
     () => persistedVisibleIds?.filter((sessionId) =>
       sessionId === activeSessionId || !hierarchyChildren.rowsBySessionId.has(sessionId)
@@ -256,7 +260,6 @@ export function useWorkspaceHeaderTabsViewModel() {
       category: "header_tabs.derive",
       label: "chat_tabs",
       keys: [
-        "activeChatSessionIdForTabs",
         "groupedTabs",
         "hierarchy",
         "knownSessions",
@@ -264,7 +267,6 @@ export function useWorkspaceHeaderTabsViewModel() {
       ],
       count: (tabs) => tabs.length,
     }, () => buildHeaderChatTabs({
-      activeChatSessionIdForTabs,
       groupedTabs,
       rowsBySessionId: hierarchyChildren.rowsBySessionId,
       childrenByParentSessionId: hierarchy.childrenByParentSessionId,
@@ -273,7 +275,6 @@ export function useWorkspaceHeaderTabsViewModel() {
       manualGroupByTopLevelSessionId,
     })),
     [
-      activeChatSessionIdForTabs,
       groupedTabs,
       hierarchyChildren.rowsBySessionId,
       hierarchy.childrenByParentSessionId,
@@ -283,11 +284,13 @@ export function useWorkspaceHeaderTabsViewModel() {
     ],
   );
 
+  const activeSessionIdForStripRows =
+    collapsedParentIds.length > 0 ? activeSessionId : null;
   const stripRows = useMemo(
     () => measureDebugComputation({
       category: "header_tabs.derive",
       label: "strip_rows",
-      keys: ["activeSessionId", "chatTabs", "collapsedParentIds", "displayManualGroups"],
+      keys: ["activeSessionIdForStripRows", "chatTabs", "collapsedParentIds", "displayManualGroups"],
       count: (rows) => rows.length,
     }, () => buildHeaderStripRows({
       groupedTabs: chatTabs,
@@ -295,11 +298,11 @@ export function useWorkspaceHeaderTabsViewModel() {
       collapsedGroupIds: collapsedParentIds,
       resolveManualGroupColor: (group) => resolveManualChatGroupColor(group.colorId),
       manualGroups: displayManualGroups,
-      activeSessionId,
+      activeSessionId: activeSessionIdForStripRows,
       subagentLabel: "Agents",
     })),
     [
-      activeSessionId,
+      activeSessionIdForStripRows,
       chatTabs,
       collapsedParentIds,
       displayManualGroups,

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.test.tsx
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmptySessionRecord,
   putSessionRecord,
@@ -60,6 +60,7 @@ vi.mock("@/lib/infra/measurement/debug-measurement", () => ({
 }));
 
 beforeEach(() => {
+  vi.useFakeTimers();
   vi.clearAllMocks();
   measurementMocks.nextOperation = 0;
   hookMocks.scheduledCallbacks = [];
@@ -98,6 +99,10 @@ beforeEach(() => {
   }));
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("useWorkspaceShellActivation", () => {
   it("sets pending chat activation before durable shell intent or real selection", async () => {
     const { result } = renderHook(() => useWorkspaceShellActivation());
@@ -120,6 +125,11 @@ describe("useWorkspaceShellActivation", () => {
     expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
       .toBeUndefined();
     expect(hookMocks.selectSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+    });
+
     expect(hookMocks.scheduledCallbacks).toHaveLength(1);
     expect(measurementMocks.recordMeasurementWorkflowStep).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -159,6 +169,7 @@ describe("useWorkspaceShellActivation", () => {
 
     let outcome: any;
     await act(async () => {
+      vi.advanceTimersByTime(180);
       hookMocks.scheduledCallbacks.shift()?.();
       outcome = await activationPromise;
     });
@@ -198,8 +209,11 @@ describe("useWorkspaceShellActivation", () => {
       intent: "chat:session-2",
     });
 
+    expect(hookMocks.scheduledCallbacks).toHaveLength(0);
+
     await act(async () => {
-      hookMocks.scheduledCallbacks.shift()?.();
+      vi.advanceTimersByTime(180);
+      expect(hookMocks.scheduledCallbacks).toHaveLength(1);
       hookMocks.scheduledCallbacks.shift()?.();
       await Promise.all([firstPromise, secondPromise]);
     });
@@ -227,6 +241,7 @@ describe("useWorkspaceShellActivation", () => {
     });
 
     await act(async () => {
+      vi.advanceTimersByTime(180);
       hookMocks.scheduledCallbacks.shift()?.();
       await activationPromise;
     });

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
@@ -25,6 +25,7 @@ import {
   recordMeasurementWorkflowStep,
   startMeasurementOperation,
 } from "@/lib/infra/measurement/debug-measurement";
+import { recordDebugActionDiagnostic } from "@/lib/infra/measurement/debug-action-diagnostic";
 import {
   HOT_PAINT_MEASUREMENT_SUMMARY_BUDGET,
   type MeasurementOperationId,
@@ -36,6 +37,7 @@ import {
   getSessionRecord,
   isPendingSessionId,
 } from "@/stores/sessions/session-records";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 
 const HOT_SWITCH_SURFACES = [
   "workspace-shell",
@@ -53,6 +55,17 @@ const pendingHotSwitchMeasurementsByShellKey = new Map<
     operationId: MeasurementOperationId;
   }
 >();
+const pendingDeferredChatActivationsByShellKey = new Map<
+  string,
+  {
+    attemptId: string;
+    cancel: () => void;
+    guard: SessionActivationGuard;
+    sessionId: string;
+    resolve: (outcome: SessionActivationOutcome) => void;
+  }
+>();
+const CHAT_TAB_ACTIVATION_COALESCE_MS = 180;
 
 export type ShellActivationOutcome =
   | { result: "completed"; surface: "viewer" | "chat-shell"; shellActivationEpoch: number }
@@ -85,6 +98,17 @@ export function useWorkspaceShellActivation() {
     mode?: "focus-existing" | "open-or-focus";
   }): ShellActivationOutcome => {
     const shellStateKey = resolveCurrentShellStateKey(workspaceId, shellWorkspaceId);
+    recordDebugActionDiagnostic({
+      category: "workspace_shell_activation",
+      label: "activate_viewer_target",
+      keys: [workspaceId, shellStateKey],
+      detail: {
+        workspaceId,
+        shellWorkspaceId: shellWorkspaceId ?? null,
+        shellStateKey,
+        targetKind: target.kind,
+      },
+    });
     invalidateSessionActivationIntent(workspaceId);
     const targetKey = viewerWorkspaceShellTabKey(target);
     setActiveViewerTarget(targetKey);
@@ -92,6 +116,7 @@ export function useWorkspaceShellActivation() {
       workspaceId: shellStateKey,
       intent: targetKey,
     });
+    cancelPendingDeferredChatActivation(shellStateKey, "intent-replaced");
     clearCurrentPendingForWorkspace(shellStateKey);
     return {
       result: "completed",
@@ -129,12 +154,23 @@ export function useWorkspaceShellActivation() {
     reason?: string;
   }): ShellActivationOutcome => {
     const shellStateKey = resolveCurrentShellStateKey(workspaceId, shellWorkspaceId);
+    recordDebugActionDiagnostic({
+      category: "workspace_shell_activation",
+      label: "activate_chat_shell",
+      keys: [workspaceId, shellStateKey],
+      detail: {
+        workspaceId,
+        shellWorkspaceId: shellWorkspaceId ?? null,
+        shellStateKey,
+      },
+    });
     invalidateSessionActivationIntent(workspaceId);
     const write = writeShellIntent({
       workspaceId: shellStateKey,
       intent: chatShellWorkspaceIntentKey(),
     });
     clearActiveSession(workspaceId);
+    cancelPendingDeferredChatActivation(shellStateKey, "intent-replaced");
     clearCurrentPendingForWorkspace(shellStateKey);
     return {
       result: "completed",
@@ -147,6 +183,7 @@ export function useWorkspaceShellActivation() {
     workspaceId,
     shellWorkspaceId,
     sessionId,
+    source,
     selection,
   }: {
     workspaceId: string;
@@ -156,7 +193,35 @@ export function useWorkspaceShellActivation() {
     source?: string;
     selection?: SelectSessionOptionsWithoutGuard;
   }): Promise<SessionActivationOutcome> => {
+    if (isProliferatePerfFlagEnabled("freezeShellActivation")) {
+      const state = useSessionSelectionStore.getState();
+      return Promise.resolve({
+        result: "completed",
+        sessionId,
+        guard: {
+          workspaceId,
+          workspaceSelectionNonce: state.workspaceSelectionNonce,
+          token: state.sessionActivationIntentEpochByWorkspace[workspaceId] ?? 0,
+        },
+        activeSessionVersion: state.activeSessionVersion,
+      });
+    }
     const shellStateKey = resolveCurrentShellStateKey(workspaceId, shellWorkspaceId);
+    recordDebugActionDiagnostic({
+      category: "workspace_shell_activation",
+      label: "activate_chat_tab",
+      keys: [source ?? "unknown", workspaceId, sessionId],
+      detail: {
+        source: source ?? null,
+        workspaceId,
+        shellWorkspaceId: shellWorkspaceId ?? null,
+        shellStateKey,
+        sessionId,
+        hasSelection: selection !== undefined,
+        allowColdIdleNoStream: selection?.allowColdIdleNoStream ?? false,
+        forceCold: selection?.forceCold ?? false,
+      },
+    });
     const guard = beginSessionActivationIntent(workspaceId);
     const intent = chatWorkspaceShellTabKey(sessionId);
     const shellEpochAtWrite =
@@ -197,8 +262,14 @@ export function useWorkspaceShellActivation() {
     }
 
     return new Promise<SessionActivationOutcome>((resolve, reject) => {
+      cancelPendingDeferredChatActivation(shellStateKey, "intent-replaced");
       const scheduledAt = performance.now();
-      scheduleAfterNextPaint(() => {
+      const cancel = scheduleCoalescedChatActivation(() => {
+        const currentScheduled =
+          pendingDeferredChatActivationsByShellKey.get(shellStateKey);
+        if (currentScheduled?.attemptId === pending.attemptId) {
+          pendingDeferredChatActivationsByShellKey.delete(shellStateKey);
+        }
         recordMeasurementWorkflowStep({
           operationId: hotOperationId,
           step: "workspace.shell.after_paint",
@@ -216,10 +287,16 @@ export function useWorkspaceShellActivation() {
           selectSession,
           selection,
           sessionId,
-          setPendingChatActivation,
           shellStateKey,
           writeShellIntent,
         }).then(resolve, reject);
+      });
+      pendingDeferredChatActivationsByShellKey.set(shellStateKey, {
+        attemptId: pending.attemptId,
+        cancel,
+        guard,
+        sessionId,
+        resolve,
       });
     });
   }, [
@@ -235,6 +312,27 @@ export function useWorkspaceShellActivation() {
     activateChatTab,
     activateFileTab,
     activateViewerTarget,
+  };
+}
+
+function scheduleCoalescedChatActivation(callback: () => void): () => void {
+  let cancelled = false;
+  let cancelAfterPaint: (() => void) | null = null;
+  const timeoutId = window.setTimeout(() => {
+    if (cancelled) {
+      return;
+    }
+    cancelAfterPaint = scheduleAfterNextPaint(() => {
+      if (!cancelled) {
+        callback();
+      }
+    });
+  }, CHAT_TAB_ACTIVATION_COALESCE_MS);
+
+  return () => {
+    cancelled = true;
+    window.clearTimeout(timeoutId);
+    cancelAfterPaint?.();
   };
 }
 
@@ -345,6 +443,24 @@ function clearPendingHotSwitchMeasurement({
   }
 }
 
+function cancelPendingDeferredChatActivation(
+  shellStateKey: string,
+  reason: Extract<SessionActivationOutcome, { result: "stale" }>["reason"],
+): void {
+  const scheduled = pendingDeferredChatActivationsByShellKey.get(shellStateKey);
+  if (!scheduled) {
+    return;
+  }
+  scheduled.cancel();
+  pendingDeferredChatActivationsByShellKey.delete(shellStateKey);
+  scheduled.resolve({
+    result: "stale",
+    sessionId: scheduled.sessionId,
+    guard: scheduled.guard,
+    reason,
+  });
+}
+
 async function runDeferredChatTabActivation({
   clearPendingChatActivation,
   guard,
@@ -356,7 +472,6 @@ async function runDeferredChatTabActivation({
   selectSession,
   selection,
   sessionId,
-  setPendingChatActivation,
   shellStateKey,
   writeShellIntent,
 }: {
@@ -370,7 +485,6 @@ async function runDeferredChatTabActivation({
   selectSession: ReturnType<typeof useSessionSelectionActions>["selectSession"];
   selection?: SelectSessionOptionsWithoutGuard;
   sessionId: string;
-  setPendingChatActivation: WorkspaceUiStoreState["setPendingChatActivation"];
   shellStateKey: string;
   writeShellIntent: WorkspaceUiStoreState["writeShellIntent"];
 }): Promise<SessionActivationOutcome> {
@@ -402,15 +516,6 @@ async function runDeferredChatTabActivation({
     startedAt: durableStartedAt,
     outcome: previousWrite.changed ? "completed" : "skipped",
   });
-  const durablePending = pending.shellEpochAtWrite === previousWrite.epoch
-    ? pending
-    : { ...pending, shellEpochAtWrite: previousWrite.epoch };
-  if (durablePending !== pending) {
-    setPendingChatActivation({
-      workspaceId: shellStateKey,
-      pending: durablePending,
-    });
-  }
 
   try {
     const guardedSelectSession = selectSession as (
@@ -435,7 +540,7 @@ async function runDeferredChatTabActivation({
       rollbackPendingDurableIntent({
         hotOperationId,
         intent,
-        pending: durablePending,
+        pending,
         previousWrite,
         rollbackShellIntent,
         shellStateKey,
@@ -443,7 +548,7 @@ async function runDeferredChatTabActivation({
       clearMatchingPending({
         clearPendingChatActivation,
         hotOperationId,
-        pending: durablePending,
+        pending,
         shellStateKey,
         step: "workspace.shell.pending_clear",
       });
@@ -453,7 +558,7 @@ async function runDeferredChatTabActivation({
     clearMatchingPending({
       clearPendingChatActivation,
       hotOperationId,
-      pending: durablePending,
+      pending,
       shellStateKey,
       step: "workspace.shell.pending_clear",
     });
@@ -467,7 +572,7 @@ async function runDeferredChatTabActivation({
     rollbackPendingDurableIntent({
       hotOperationId,
       intent,
-      pending: durablePending,
+      pending,
       previousWrite,
       rollbackShellIntent,
       shellStateKey,
@@ -475,7 +580,7 @@ async function runDeferredChatTabActivation({
     clearMatchingPending({
       clearPendingChatActivation,
       hotOperationId,
-      pending: durablePending,
+      pending,
       shellStateKey,
       step: "workspace.shell.pending_clear",
     });

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-shell-tabs-state.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-shell-tabs-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { HeaderStripRow } from "@/lib/domain/workspaces/tabs/group-rows";
 import type { DisplayManualChatGroup } from "@/lib/domain/workspaces/tabs/manual-groups";
 import {
@@ -17,6 +17,7 @@ import { viewerTargetKey, type ViewerTarget } from "@/lib/domain/workspaces/view
 import {
   resolveWorkspaceShellActivation,
   type WorkspaceShellActivation,
+  type WorkspaceRenderSurface,
 } from "@/lib/domain/workspaces/tabs/shell-activation";
 import {
   resolveWithWorkspaceFallback,
@@ -176,7 +177,7 @@ export function useWorkspaceShellTabsState<TTab extends ShellChatTab>({
     () => orderedTabs.map(getWorkspaceShellTabKey),
     [orderedTabs],
   );
-  const activation = useMemo<WorkspaceShellActivation>(() => resolveWorkspaceShellActivation({
+  const resolvedActivation = useMemo<WorkspaceShellActivation>(() => resolveWorkspaceShellActivation({
     workspaceId: materializedWorkspaceId ?? "",
     storedIntent: storedActiveShellTabKey,
     orderedTabs: orderedShellTabKeys,
@@ -201,6 +202,7 @@ export function useWorkspaceShellTabsState<TTab extends ShellChatTab>({
     storedActiveShellTabKey,
     workspaceSelectionNonce,
   ]);
+  const activation = useStableWorkspaceShellActivation(resolvedActivation);
   const activeShellTab = useMemo<WorkspaceShellTab | null>(() => {
     switch (activation.renderSurface.kind) {
       case "chat-session":
@@ -269,4 +271,38 @@ export function useWorkspaceShellTabsState<TTab extends ShellChatTab>({
     orderedTabs,
     orderedShellTabKeys,
   };
+}
+
+function useStableWorkspaceShellActivation(
+  activation: WorkspaceShellActivation,
+): WorkspaceShellActivation {
+  const previousRef = useRef<WorkspaceShellActivation | null>(null);
+  const previous = previousRef.current;
+  if (
+    previous
+    && previous.highlightedTabKey === activation.highlightedTabKey
+    && sameRenderSurface(previous.renderSurface, activation.renderSurface)
+  ) {
+    return previous;
+  }
+  previousRef.current = activation;
+  return activation;
+}
+
+function sameRenderSurface(
+  left: WorkspaceRenderSurface,
+  right: WorkspaceRenderSurface,
+): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  switch (left.kind) {
+    case "chat-shell":
+      return true;
+    case "chat-session":
+    case "chat-session-pending":
+      return left.sessionId === (right as typeof left).sessionId;
+    case "viewer":
+      return left.targetKey === (right as typeof left).targetKey;
+  }
 }

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-tab-actions.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-tab-actions.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
-import { flushSync } from "react-dom";
+import { useCallback } from "react";
 import { useActiveSessionLaunchState } from "@/hooks/chat/derived/use-active-chat-session-selectors";
 import { useConfiguredLaunchReadiness } from "@/hooks/chat/derived/use-configured-launch-readiness";
 import { useCloseActiveWorkspaceTab } from "@/hooks/workspaces/tabs/use-close-active-workspace-tab";
@@ -21,8 +20,6 @@ import {
   startLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
 
-const URGENT_CHAT_HIGHLIGHT_FALLBACK_TIMEOUT_MS = 1_500;
-
 export interface WorkspaceTabActionsContext {
   workspaceUiKey: string | null;
   materializedWorkspaceId: string | null;
@@ -38,12 +35,6 @@ export function useWorkspaceTabActions(headerTabs: WorkspaceTabActionsContext) {
   const { activateViewerTarget } = useWorkspaceShellActivation();
   const showToast = useToastStore((state) => state.show);
   const closeActiveWorkspaceTab = useCloseActiveWorkspaceTab(headerTabs);
-  const setUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
-    (state) => state.setUrgentHighlightedChatSessionForWorkspace,
-  );
-  const clearUrgentHighlightedChatSessionForWorkspace = useWorkspaceUiStore(
-    (state) => state.clearUrgentHighlightedChatSessionForWorkspace,
-  );
   const chatVisibilityActions = useChatTabVisibilityActions({
     workspaceUiKey: headerTabs.workspaceUiKey,
     materializedWorkspaceId: headerTabs.materializedWorkspaceId,
@@ -58,61 +49,8 @@ export function useWorkspaceTabActions(headerTabs: WorkspaceTabActionsContext) {
 
   const orderedTabs = headerTabs.orderedTabs;
   const activeTab = headerTabs.activeShellTab;
-  const urgentHighlightTimeoutRef = useRef<number | null>(null);
-  const clearUrgentHighlightTimeout = useCallback(() => {
-    if (urgentHighlightTimeoutRef.current === null) {
-      return;
-    }
-    window.clearTimeout(urgentHighlightTimeoutRef.current);
-    urgentHighlightTimeoutRef.current = null;
-  }, []);
-  const scheduleUrgentHighlightClear = useCallback((
-    workspaceUiKey: string,
-    sessionId: string,
-  ) => {
-    clearUrgentHighlightTimeout();
-    urgentHighlightTimeoutRef.current = window.setTimeout(() => {
-      urgentHighlightTimeoutRef.current = null;
-      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey, sessionId);
-    }, URGENT_CHAT_HIGHLIGHT_FALLBACK_TIMEOUT_MS);
-  }, [
-    clearUrgentHighlightTimeout,
-    clearUrgentHighlightedChatSessionForWorkspace,
-  ]);
-
-  const previewWorkspaceTab = useCallback((tab: WorkspaceShellTab) => {
-    const workspaceUiKey = headerTabs.workspaceUiKey;
-    if (!workspaceUiKey) {
-      return;
-    }
-    clearUrgentHighlightTimeout();
-    flushSync(() => {
-      if (tab.kind === "chat") {
-        setUrgentHighlightedChatSessionForWorkspace(
-          workspaceUiKey,
-          tab.sessionId,
-        );
-        return;
-      }
-      clearUrgentHighlightedChatSessionForWorkspace(workspaceUiKey);
-    });
-    if (tab.kind === "chat") {
-      scheduleUrgentHighlightClear(workspaceUiKey, tab.sessionId);
-    }
-  }, [
-    clearUrgentHighlightedChatSessionForWorkspace,
-    clearUrgentHighlightTimeout,
-    headerTabs.workspaceUiKey,
-    scheduleUrgentHighlightClear,
-    setUrgentHighlightedChatSessionForWorkspace,
-  ]);
-
-  useEffect(() => () => {
-    clearUrgentHighlightTimeout();
-  }, [clearUrgentHighlightTimeout]);
 
   const activateWorkspaceTab = useCallback((tab: WorkspaceShellTab) => {
-    previewWorkspaceTab(tab);
     if (tab.kind === "chat") {
       return chatVisibilityActions.showChatSessionTab(tab.sessionId, { select: true });
     }
@@ -131,7 +69,6 @@ export function useWorkspaceTabActions(headerTabs: WorkspaceTabActionsContext) {
     chatVisibilityActions,
     headerTabs.workspaceUiKey,
     headerTabs.selectedWorkspaceId,
-    previewWorkspaceTab,
   ]);
 
   const activateRelativeTab = useCallback((delta: number) => {

--- a/desktop/src/lib/access/tauri/diagnostics.ts
+++ b/desktop/src/lib/access/tauri/diagnostics.ts
@@ -61,3 +61,23 @@ export async function saveDiagnosticJson(
   );
   return result?.outputPath ?? null;
 }
+
+export async function saveDiagnosticJsonToPath(
+  outputPath: string,
+  contents: string,
+): Promise<string | null> {
+  if (!isTauriDesktop()) {
+    return null;
+  }
+
+  const result = await invoke<{ outputPath: string }>(
+    "save_diagnostic_json_to_absolute_path",
+    {
+      input: {
+        outputPath,
+        contents,
+      },
+    },
+  );
+  return result.outputPath;
+}

--- a/desktop/src/lib/domain/chat/surface/chat-surface.test.ts
+++ b/desktop/src/lib/domain/chat/surface/chat-surface.test.ts
@@ -39,6 +39,7 @@ function surfaceInput(
     shellRenderScope: null,
     activeSessionId: "session-1",
     hasContent: true,
+    hasTranscriptEntry: true,
     hasSlot: true,
     transcriptHydrated: true,
     isEmpty: false,
@@ -164,6 +165,28 @@ describe("chat surface", () => {
     expect(resolveChatSurfaceState(surfaceInput({
       shellRenderScope: { kind: "chat-session-pending", sessionId: "session-2" },
     }))).toEqual({ kind: "session-switching", sessionId: "session-2" });
+  });
+
+  it("keeps a selected chat tab on the switching skeleton until its transcript entry exists", () => {
+    expect(resolveChatSurfaceState(surfaceInput({
+      shellRenderScope: { kind: "chat-session", sessionId: "session-1" },
+      hasContent: false,
+      hasTranscriptEntry: false,
+      transcriptHydrated: true,
+      isEmpty: true,
+      streamConnectionState: "open",
+    }))).toEqual({ kind: "session-switching", sessionId: "session-1" });
+  });
+
+  it("shows the empty session state once a selected chat tab has an empty transcript entry", () => {
+    expect(resolveChatSurfaceState(surfaceInput({
+      shellRenderScope: { kind: "chat-session", sessionId: "session-1" },
+      hasContent: false,
+      hasTranscriptEntry: true,
+      transcriptHydrated: true,
+      isEmpty: true,
+      streamConnectionState: "open",
+    }))).toEqual({ kind: "session-empty", sessionId: "session-1" });
   });
 
   it("keeps existing content visible during an unhydrated loading window", () => {

--- a/desktop/src/lib/domain/chat/surface/chat-surface.ts
+++ b/desktop/src/lib/domain/chat/surface/chat-surface.ts
@@ -16,7 +16,8 @@ export type LaunchIntentSurfaceOverride =
   | { kind: "session-transcript"; sessionId: string };
 
 export interface ChatSurfaceRenderScope {
-  kind: "chat-shell" | "other";
+  kind: "chat-shell" | "chat-session" | "other";
+  sessionId?: string;
 }
 
 export interface ChatSessionPendingRenderScope {
@@ -36,6 +37,7 @@ export interface ResolveChatSurfaceStateInput {
   shellRenderScope: ChatSurfaceRenderScope | ChatSessionPendingRenderScope | null;
   activeSessionId: string | null;
   hasContent: boolean;
+  hasTranscriptEntry: boolean;
   hasSlot: boolean;
   transcriptHydrated: boolean;
   isEmpty: boolean;
@@ -140,6 +142,14 @@ export function resolveChatSurfaceState(input: ResolveChatSurfaceStateInput): Ch
       kind: "session-switching",
       sessionId: input.shellRenderScope.sessionId,
     };
+  }
+
+  if (
+    input.shellRenderScope?.kind === "chat-session"
+    && input.shellRenderScope.sessionId === scopedActiveSessionId
+    && !input.hasTranscriptEntry
+  ) {
+    return { kind: "session-switching", sessionId: input.shellRenderScope.sessionId };
   }
 
   if (!scopedActiveSessionId) {

--- a/desktop/src/lib/domain/telemetry/debug-measurement-catalog.ts
+++ b/desktop/src/lib/domain/telemetry/debug-measurement-catalog.ts
@@ -32,7 +32,13 @@ export type MeasurementOperationKind =
 
 export type MeasurementSurface =
   | "workspace-shell"
+  | "workspace-sidebar-frame"
   | "workspace-sidebar"
+  | "workspace-header-frame"
+  | "workspace-content-frame"
+  | "workspace-content-view"
+  | "workspace-right-panel"
+  | "workspace-command-palette"
   | "global-header"
   | "header-tabs"
   | "chat-surface"

--- a/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.ts
+++ b/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.ts
@@ -34,7 +34,6 @@ export function buildManualGroupByTopLevelSessionId(
 }
 
 export function buildHeaderChatTabs(args: {
-  activeChatSessionIdForTabs: string | null;
   groupedTabs: readonly GroupedChatTab[];
   rowsBySessionId: ReadonlyMap<string, HeaderHierarchyChildRow>;
   childrenByParentSessionId: ReadonlyMap<string, readonly HeaderHierarchyChildRow[]>;
@@ -67,7 +66,7 @@ export function buildHeaderChatTabs(args: {
           : getLinkedChildViewState(hierarchyChild!),
         canFork: known ? getKnownSessionCanFork(known) : false,
         isReviewAgentChild: hierarchyChild?.source === "review",
-        isActive: grouped.sessionId === args.activeChatSessionIdForTabs,
+        isActive: false as boolean,
         groupColor,
         visualGroupId: manualGroup?.id ?? (isSubagentGrouped ? grouped.groupRootSessionId : null),
         manualGroupId: manualGroup?.id ?? null,

--- a/desktop/src/lib/infra/measurement/debug-action-diagnostic.ts
+++ b/desktop/src/lib/infra/measurement/debug-action-diagnostic.ts
@@ -1,0 +1,46 @@
+import { recordMeasurementDiagnostic } from "@/lib/infra/measurement/debug-measurement";
+import { isDebugMeasurementEnabled } from "@/lib/infra/measurement/debug-measurement-env";
+
+export function recordDebugActionDiagnostic({
+  category,
+  label,
+  keys,
+  detail,
+}: {
+  category: string;
+  label: string;
+  keys?: readonly string[];
+  detail?: Record<string, unknown>;
+}): void {
+  if (!isDebugMeasurementEnabled()) {
+    return;
+  }
+
+  recordMeasurementDiagnostic({
+    category,
+    label,
+    keys,
+    count: keys?.length,
+    detail: JSON.stringify({
+      ...detail,
+      stack: captureActionStack(),
+    }),
+  });
+}
+
+function captureActionStack(): string[] {
+  const stack = new Error().stack;
+  if (!stack) {
+    return [];
+  }
+  return stack
+    .split("\n")
+    .slice(2)
+    .map((line) => line.trim())
+    .filter((line) =>
+      line.length > 0
+      && !line.includes("debug-action-diagnostic")
+      && !line.includes("debug-measurement")
+    )
+    .slice(0, 8);
+}

--- a/desktop/src/lib/infra/measurement/debug-measurement-dump.ts
+++ b/desktop/src/lib/infra/measurement/debug-measurement-dump.ts
@@ -15,6 +15,8 @@ import {
 } from "./debug-measurement-events";
 import { isAnyHarnessTimingEnabled, isMainThreadMeasurementEnabled } from "./debug-measurement-env";
 import { getLongTaskObserverSupportedForMeasurement } from "./debug-measurement-observer";
+import { getProliferatePerfFlags } from "@/lib/infra/perf/perf-isolation-flags";
+import { saveDiagnosticJsonToPath } from "@/lib/access/tauri/diagnostics";
 import type {
   MeasurementDebugApi,
   MeasurementDebugDump,
@@ -37,6 +39,7 @@ export function getDebugMeasurementDump(): MeasurementDebugDump {
       mainThread: isMainThreadMeasurementEnabled(),
       anyHarnessTiming: isAnyHarnessTimingEnabled(),
     },
+    perfFlags: getProliferatePerfFlags(),
     longTaskObserverSupported: getLongTaskObserverSupportedForMeasurement(),
     memory: getMeasurementMemorySnapshot(),
     counts: getDebugMeasurementStatus().counts,
@@ -56,6 +59,7 @@ export function installDebugMeasurementExport(): () => void {
   const api: MeasurementDebugApi = {
     dump: getDebugMeasurementDump,
     export: exportDebugMeasurementDump,
+    save: saveDebugMeasurementDump,
     clear: clearDebugMeasurementBuffer,
     status: () => getDebugMeasurementStatus(),
   };
@@ -112,4 +116,14 @@ function exportDebugMeasurementDump(fileName?: string): MeasurementDebugDump {
   link.remove();
   URL.revokeObjectURL(url);
   return dump;
+}
+
+async function saveDebugMeasurementDump(outputPath: string): Promise<string | null> {
+  const dump = getDebugMeasurementDump();
+  const body = JSON.stringify(dump, null, 2);
+  const writtenPath = await saveDiagnosticJsonToPath(outputPath, body);
+  if (typeof console !== "undefined") {
+    console.info("[measurement_dump] saved", writtenPath ?? "(not running in Tauri)");
+  }
+  return writtenPath;
 }

--- a/desktop/src/lib/infra/measurement/debug-measurement-env.ts
+++ b/desktop/src/lib/infra/measurement/debug-measurement-env.ts
@@ -1,17 +1,27 @@
 import { hashTimingScope } from "@anyharness/sdk";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 import { envFlagEnabled } from "./debug-measurement-utils";
 
 export function isMainThreadMeasurementEnabled(): boolean {
+  if (isProliferatePerfFlagEnabled("disableDebugMeasurement")) {
+    return false;
+  }
   return import.meta.env.DEV
     && envFlagEnabled(import.meta.env.VITE_PROLIFERATE_DEBUG_MAIN_THREAD, false);
 }
 
 export function isAnyHarnessTimingEnabled(): boolean {
+  if (isProliferatePerfFlagEnabled("disableDebugMeasurement")) {
+    return false;
+  }
   return import.meta.env.DEV
     && envFlagEnabled(import.meta.env.VITE_PROLIFERATE_DEBUG_ANYHARNESS_TIMING, false);
 }
 
 export function isDebugMeasurementEnabled(): boolean {
+  if (isProliferatePerfFlagEnabled("disableDebugMeasurement")) {
+    return false;
+  }
   return isMainThreadMeasurementEnabled() || isAnyHarnessTimingEnabled();
 }
 

--- a/desktop/src/lib/infra/measurement/debug-measurement-install.ts
+++ b/desktop/src/lib/infra/measurement/debug-measurement-install.ts
@@ -5,6 +5,7 @@ import { installDebugMainThreadDetectors } from "@/lib/infra/measurement/debug-m
 import { recordMeasurementMetric } from "@/lib/infra/measurement/debug-measurement";
 import { installDebugMeasurementExport } from "@/lib/infra/measurement/debug-measurement-dump";
 import { isAnyHarnessTimingEnabled } from "@/lib/infra/measurement/debug-measurement-env";
+import { isProliferatePerfFlagEnabled } from "@/lib/infra/perf/perf-isolation-flags";
 import type { MeasurementOperationId } from "./debug-measurement-catalog-types";
 
 let uninstallMeasurement: (() => void) | null = null;
@@ -32,6 +33,9 @@ export function installDebugMeasurement(): () => void {
         return;
       }
 
+      if (isProliferatePerfFlagEnabled("suppressAnyHarnessStreamMetrics")) {
+        return;
+      }
       recordMeasurementMetric({
         type: "stream",
         category: event.category,

--- a/desktop/src/lib/infra/measurement/debug-measurement-report-types.ts
+++ b/desktop/src/lib/infra/measurement/debug-measurement-report-types.ts
@@ -6,6 +6,7 @@ import type {
   MeasurementSurface,
 } from "./debug-measurement-catalog-types";
 import type { MeasurementMetricSnapshot } from "./debug-measurement-metric-types";
+import type { ProliferatePerfFlags } from "@/lib/infra/perf/perf-isolation-flags";
 
 export type MeasurementSummaryValue = string | number | boolean | null;
 export type MeasurementSummaryRow = Record<string, MeasurementSummaryValue>;
@@ -111,6 +112,7 @@ export interface MeasurementDebugDump {
     mainThread: boolean;
     anyHarnessTiming: boolean;
   };
+  perfFlags: ProliferatePerfFlags;
   longTaskObserverSupported: boolean;
   memory: MeasurementMemorySnapshot;
   counts: {
@@ -137,6 +139,7 @@ export interface MeasurementDebugStatus {
 export interface MeasurementDebugApi {
   dump: () => MeasurementDebugDump;
   export: (fileName?: string) => MeasurementDebugDump;
+  save: (outputPath: string) => Promise<string | null>;
   clear: () => void;
   status: () => MeasurementDebugStatus;
 }

--- a/desktop/src/lib/infra/perf/perf-isolation-flags.ts
+++ b/desktop/src/lib/infra/perf/perf-isolation-flags.ts
@@ -1,0 +1,115 @@
+export interface ProliferatePerfFlags {
+  disableDebugMeasurement?: boolean;
+  disablePromptFlushSync?: boolean;
+  freezeHeaderTabsViewModel?: boolean;
+  freezeComposerDock?: boolean;
+  freezeMainScreenDataQueries?: boolean;
+  freezeHeaderTabs?: boolean;
+  freezeRightPanel?: boolean;
+  freezeShellActivation?: boolean;
+  freezeSidebar?: boolean;
+  freezeTranscriptPane?: boolean;
+  freezeWorkspaceContent?: boolean;
+  pausePromptOutboxUi?: boolean;
+  pauseSessionHistoryHydration?: boolean;
+  pauseSessionStreamUi?: boolean;
+  suppressAnyHarnessStreamMetrics?: boolean;
+}
+
+declare global {
+  interface Window {
+    proliferatePerfFlags?: ProliferatePerfFlags;
+    proliferateSetPerfFlags?: (
+      next:
+        | ProliferatePerfFlags
+        | ((current: ProliferatePerfFlags) => ProliferatePerfFlags),
+    ) => ProliferatePerfFlags;
+  }
+}
+
+export type ProliferatePerfFlagName = keyof ProliferatePerfFlags;
+
+const listeners = new Set<() => void>();
+const KNOWN_PERF_FLAGS = [
+  "disableDebugMeasurement",
+  "disablePromptFlushSync",
+  "freezeComposerDock",
+  "freezeHeaderTabs",
+  "freezeHeaderTabsViewModel",
+  "freezeMainScreenDataQueries",
+  "freezeRightPanel",
+  "freezeShellActivation",
+  "freezeSidebar",
+  "freezeTranscriptPane",
+  "freezeWorkspaceContent",
+  "pausePromptOutboxUi",
+  "pauseSessionHistoryHydration",
+  "pauseSessionStreamUi",
+  "suppressAnyHarnessStreamMetrics",
+] satisfies readonly ProliferatePerfFlagName[];
+const KNOWN_PERF_FLAG_SET = new Set<string>(KNOWN_PERF_FLAGS);
+
+export function getProliferatePerfFlags(): ProliferatePerfFlags {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return {};
+  }
+  installProliferatePerfFlagSetter();
+  return window.proliferatePerfFlags ?? {};
+}
+
+export function isProliferatePerfFlagEnabled(
+  flag: ProliferatePerfFlagName,
+): boolean {
+  return getProliferatePerfFlags()[flag] === true;
+}
+
+export function setProliferatePerfFlags(
+  next:
+    | ProliferatePerfFlags
+    | ((current: ProliferatePerfFlags) => ProliferatePerfFlags),
+): ProliferatePerfFlags {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return {};
+  }
+  const current = window.proliferatePerfFlags ?? {};
+  const resolved = typeof next === "function" ? next(current) : next;
+  window.proliferatePerfFlags = resolved;
+  logPerfFlagUpdate(resolved);
+  for (const listener of listeners) {
+    listener();
+  }
+  return resolved;
+}
+
+export function subscribeProliferatePerfFlags(listener: () => void): () => void {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return () => undefined;
+  }
+  installProliferatePerfFlagSetter();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function installProliferatePerfFlagSetter(): void {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return;
+  }
+  window.proliferateSetPerfFlags = setProliferatePerfFlags;
+}
+
+function logPerfFlagUpdate(flags: ProliferatePerfFlags): void {
+  if (!import.meta.env.DEV || typeof console === "undefined") {
+    return;
+  }
+  const keys = Object.keys(flags);
+  const unknown = keys.filter((key) => !KNOWN_PERF_FLAG_SET.has(key));
+  const active = KNOWN_PERF_FLAGS.filter((flag) => flags[flag] === true);
+  if (unknown.length > 0) {
+    console.warn("[proliferate-perf] Unknown perf flag(s):", unknown, {
+      knownFlags: KNOWN_PERF_FLAGS,
+    });
+  }
+  console.info("[proliferate-perf] Active perf flags:", active.length > 0 ? active : "(none)");
+}

--- a/desktop/src/stores/preferences/workspace-ui-chat-tab-actions.ts
+++ b/desktop/src/stores/preferences/workspace-ui-chat-tab-actions.ts
@@ -10,6 +10,7 @@ import {
   uniqueIds,
 } from "@/lib/domain/workspaces/tabs/visibility";
 import { sameStringArray } from "@/lib/domain/workspaces/selection/workspace-keyed-preferences";
+import { recordDebugActionDiagnostic } from "@/lib/infra/measurement/debug-action-diagnostic";
 import type { WorkspaceUiGet, WorkspaceUiSet, WorkspaceUiState } from "@/stores/preferences/workspace-ui-store-types";
 
 type WorkspaceUiChatTabActions = Pick<
@@ -35,6 +36,25 @@ export function createWorkspaceUiChatTabActions(
 ): WorkspaceUiChatTabActions {
   return {
     setUrgentHighlightedChatSessionForWorkspace: (workspaceId, sessionId) => {
+      if (get().urgentHighlightedChatSessionByWorkspace[workspaceId] === sessionId) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "set_urgent_highlight_skipped",
+          keys: [workspaceId, sessionId],
+          detail: { workspaceId, sessionId },
+        });
+        return;
+      }
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "set_urgent_highlight",
+        keys: [workspaceId, sessionId],
+        detail: {
+          workspaceId,
+          sessionId,
+          previousSessionId: get().urgentHighlightedChatSessionByWorkspace[workspaceId] ?? null,
+        },
+      });
       set({
         urgentHighlightedChatSessionByWorkspace: {
           ...get().urgentHighlightedChatSessionByWorkspace,
@@ -46,8 +66,28 @@ export function createWorkspaceUiChatTabActions(
     clearUrgentHighlightedChatSessionForWorkspace: (workspaceId, sessionId) => {
       const current = get().urgentHighlightedChatSessionByWorkspace[workspaceId] ?? null;
       if (!current || (sessionId !== undefined && current !== sessionId)) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "clear_urgent_highlight_skipped",
+          keys: [workspaceId, sessionId ?? "any"],
+          detail: {
+            workspaceId,
+            sessionId: sessionId ?? null,
+            current,
+          },
+        });
         return;
       }
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "clear_urgent_highlight",
+        keys: [workspaceId, current],
+        detail: {
+          workspaceId,
+          sessionId: current,
+          requestedSessionId: sessionId ?? null,
+        },
+      });
       set({
         urgentHighlightedChatSessionByWorkspace: {
           ...get().urgentHighlightedChatSessionByWorkspace,
@@ -67,6 +107,16 @@ export function createWorkspaceUiChatTabActions(
         if (hasCurrent && sameStringArray(current, nextSessionIds)) {
           return state;
         }
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "set_visible_chat_session_ids",
+          keys: [workspaceId],
+          detail: {
+            workspaceId,
+            previousCount: current.length,
+            nextCount: nextSessionIds.length,
+          },
+        });
         return {
           visibleChatSessionIdsByWorkspace: {
             ...state.visibleChatSessionIdsByWorkspace,

--- a/desktop/src/stores/preferences/workspace-ui-shell-actions.ts
+++ b/desktop/src/stores/preferences/workspace-ui-shell-actions.ts
@@ -1,4 +1,5 @@
 import { sameStringArray } from "@/lib/domain/workspaces/selection/workspace-keyed-preferences";
+import { recordDebugActionDiagnostic } from "@/lib/infra/measurement/debug-action-diagnostic";
 import type { WorkspaceUiGet, WorkspaceUiSet, WorkspaceUiState } from "@/stores/preferences/workspace-ui-store-types";
 
 type WorkspaceUiShellActions = Pick<
@@ -19,6 +20,12 @@ export function createWorkspaceUiShellActions(
 ): WorkspaceUiShellActions {
   return {
     setActiveShellTabKeyForWorkspace: (workspaceId, key) => {
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "set_active_shell_tab_key",
+        keys: [workspaceId, key ?? "null"],
+        detail: { workspaceId, key },
+      });
       get().writeShellIntent({ workspaceId, intent: key });
     },
 
@@ -31,6 +38,16 @@ export function createWorkspaceUiShellActions(
       if (hasCurrent && sameStringArray(current, order)) {
         return;
       }
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "set_shell_tab_order",
+        keys: [workspaceId],
+        detail: {
+          workspaceId,
+          count: order.length,
+          previousCount: current.length,
+        },
+      });
       set({
         shellTabOrderByWorkspace: {
           ...get().shellTabOrderByWorkspace,
@@ -47,6 +64,16 @@ export function createWorkspaceUiShellActions(
       const current = hasCurrent ? get().activeShellTabKeyByWorkspace[workspaceId] : null;
       const previousEpoch = get().shellActivationEpochByWorkspace[workspaceId] ?? 0;
       if (hasCurrent && current === intent) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "write_shell_intent_skipped",
+          keys: [workspaceId, intent ?? "null"],
+          detail: {
+            workspaceId,
+            intent,
+            previousEpoch,
+          },
+        });
         return {
           changed: false,
           previousIntent: current,
@@ -55,6 +82,18 @@ export function createWorkspaceUiShellActions(
         };
       }
       const nextEpoch = previousEpoch + 1;
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "write_shell_intent",
+        keys: [workspaceId, intent ?? "null"],
+        detail: {
+          workspaceId,
+          previousIntent: current,
+          intent,
+          previousEpoch,
+          nextEpoch,
+        },
+      });
       set({
         activeShellTabKeyByWorkspace: {
           ...get().activeShellTabKeyByWorkspace,
@@ -80,6 +119,19 @@ export function createWorkspaceUiShellActions(
         previousIntent !== expectedIntent
         || (expectedEpoch !== undefined && previousEpoch !== expectedEpoch)
       ) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "replace_shell_intent_rejected",
+          keys: [workspaceId, nextIntent ?? "null"],
+          detail: {
+            workspaceId,
+            expectedIntent,
+            nextIntent,
+            expectedEpoch,
+            previousIntent,
+            previousEpoch,
+          },
+        });
         return {
           changed: false,
           replaced: false,
@@ -110,6 +162,21 @@ export function createWorkspaceUiShellActions(
           && pending?.attemptId !== expectedPendingAttemptId
         )
       ) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "rollback_shell_intent_rejected",
+          keys: [workspaceId, rollbackIntent ?? "null"],
+          detail: {
+            workspaceId,
+            expectedIntent,
+            expectedEpoch,
+            expectedPendingAttemptId,
+            previousIntent,
+            previousEpoch,
+            pendingAttemptId: pending?.attemptId ?? null,
+            rollbackIntent,
+          },
+        });
         return {
           changed: false,
           rolledBack: false,
@@ -123,6 +190,43 @@ export function createWorkspaceUiShellActions(
     },
 
     setPendingChatActivation: ({ workspaceId, pending }) => {
+      const current = get().pendingChatActivationByWorkspace[workspaceId] ?? null;
+      if (
+        current?.attemptId === pending.attemptId
+        && current.sessionId === pending.sessionId
+        && current.intent === pending.intent
+        && current.guardToken === pending.guardToken
+        && current.workspaceSelectionNonce === pending.workspaceSelectionNonce
+        && current.shellEpochAtWrite === pending.shellEpochAtWrite
+        && current.sessionActivationEpochAtWrite === pending.sessionActivationEpochAtWrite
+      ) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "set_pending_chat_activation_skipped",
+          keys: [workspaceId, pending.sessionId],
+          detail: {
+            workspaceId,
+            sessionId: pending.sessionId,
+            attemptId: pending.attemptId,
+            intent: pending.intent,
+          },
+        });
+        return { set: false };
+      }
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "set_pending_chat_activation",
+        keys: [workspaceId, pending.sessionId],
+        detail: {
+          workspaceId,
+          sessionId: pending.sessionId,
+          attemptId: pending.attemptId,
+          previousAttemptId: current?.attemptId ?? null,
+          intent: pending.intent,
+          shellEpochAtWrite: pending.shellEpochAtWrite,
+          guardToken: pending.guardToken,
+        },
+      });
       set({
         pendingChatActivationByWorkspace: {
           ...get().pendingChatActivationByWorkspace,
@@ -136,9 +240,34 @@ export function createWorkspaceUiShellActions(
       const pending = get().pendingChatActivationByWorkspace[workspaceId] ?? null;
       const epoch = get().shellActivationEpochByWorkspace[workspaceId] ?? 0;
       if (!pending || pending.attemptId !== attemptId) {
+        recordDebugActionDiagnostic({
+          category: "workspace_ui_store.action",
+          label: "clear_pending_chat_activation_skipped",
+          keys: [workspaceId],
+          detail: {
+            workspaceId,
+            attemptId,
+            currentAttemptId: pending?.attemptId ?? null,
+            bumpIfCurrent,
+            epoch,
+          },
+        });
         return { cleared: false, bumped: false, epoch };
       }
       const nextEpoch = bumpIfCurrent ? epoch + 1 : epoch;
+      recordDebugActionDiagnostic({
+        category: "workspace_ui_store.action",
+        label: "clear_pending_chat_activation",
+        keys: [workspaceId, pending.sessionId],
+        detail: {
+          workspaceId,
+          sessionId: pending.sessionId,
+          attemptId,
+          bumpIfCurrent,
+          epoch,
+          nextEpoch,
+        },
+      });
       set({
         pendingChatActivationByWorkspace: {
           ...get().pendingChatActivationByWorkspace,

--- a/desktop/src/stores/preferences/workspace-ui-store-types.ts
+++ b/desktop/src/stores/preferences/workspace-ui-store-types.ts
@@ -92,7 +92,7 @@ export interface WorkspaceUiState {
   setPendingChatActivation: (input: {
     workspaceId: string;
     pending: PendingChatActivation;
-  }) => { set: true };
+  }) => { set: boolean };
   clearPendingChatActivation: (input: {
     workspaceId: string;
     attemptId: string;


### PR DESCRIPTION
## Summary

- Add dev-only render/diagnostic instrumentation for chat, workspace shell, sidebar, header tabs, prompt dispatch, and Tauri diagnostic export.
- Reduce chat-tab switching churn by coalescing deferred chat activations and narrowing content/header view-model subscriptions.
- Reduce typing-time chat surface churn by debouncing composer dock geometry updates and avoiding redundant textarea resize work.
- Keep switching UI in a transcript-shaped skeleton until the target transcript entry is available.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/chat/surface/chat-surface.test.ts src/hooks/workspaces/tabs/use-workspace-shell-activation.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check`

Note: validation was run in `/Users/pablo/proliferate`, where desktop dependencies are installed. The clean PR worktree intentionally only contains the staged desktop/Tauri diff.
