### PR TITLE
docs(anyharness): document runtime architecture and product MCPs

### DIFF
--- a/docs/anyharness/README.md
+++ b/docs/anyharness/README.md
@@ -205,6 +205,9 @@ may own, and which patterns are allowed.
 
 Guides:
 
+- [guides/system-architecture.md](guides/system-architecture.md) for the full
+  AnyHarness source organization model: `api`, `app`, `domains`, `live`,
+  `adapters`, `integrations`, `persistence`, and `observability`.
 - [guides/crates.md](guides/crates.md) for crate ownership:
   `anyharness`, `anyharness-contract`, `anyharness-credential-discovery`, and
   `anyharness-lib`.
@@ -235,8 +238,21 @@ Specs:
 - [specs/session-engine.md](specs/session-engine.md) for the core session
   engine: `SessionRuntime`, live session manager, actor, ACP client, event
   sink, and interaction broker.
+- [specs/session-actor.md](specs/session-actor.md) for the target
+  `live/sessions/actor` state-machine split, actor-owned state, command
+  handling, turn loop, config, notifications, interactions, and shutdown.
+- [specs/agent-catalog-readiness.md](specs/agent-catalog-readiness.md) for
+  the fully migrated agents domain: single catalog input, descriptor
+  projection, install, credentials, readiness, seed artifacts, and launch
+  resolution.
 - [specs/mcp.md](specs/mcp.md) for user MCP bindings, product MCP servers,
   session extensions, capability tokens, and MCP elicitation.
+- [specs/product-mcps.md](specs/product-mcps.md) for the repeatable product
+  MCP server pattern: definition, auth, injection, context, tools, calls, UI
+  exposure, and session MCP selection.
+- [product-mcps/README.md](product-mcps/README.md) for the concrete product
+  MCP definitions currently being standardized: subagents, artifacts, reviews,
+  and workspace naming.
 
 Existing subsystem docs under `docs/anyharness/src/**` remain valid during the
 migration. Treat them as subsystem specs until they are moved or rewritten:
@@ -277,7 +293,7 @@ which guide to read and where the code belongs.
 | Session durable records, event rows, session config, pending prompts | `anyharness-lib/src/sessions/**` | `domains/sessions/**` | [guides/domains.md](guides/domains.md), [specs/session-engine.md](specs/session-engine.md), [src/sessions.md](src/sessions.md) |
 | Live running agent process, session actor loop, ACP client, event sink, interactions | `anyharness-lib/src/acp/**` | `live/sessions/**` plus earned `integrations/acp/**` | [guides/live-runtime.md](guides/live-runtime.md), [specs/session-engine.md](specs/session-engine.md), [src/acp.md](src/acp.md) |
 | Workspace durable lifecycle, materialization, purge/retire, retention policy | `anyharness-lib/src/workspaces/**` | `domains/workspaces/**` | [guides/domains.md](guides/domains.md), [src/workspaces.md](src/workspaces.md) |
-| Agent catalog, readiness, supported-agent meaning | `anyharness-lib/src/domains/agents/**` | `domains/agents/**` | [guides/domains.md](guides/domains.md), [src/agents.md](src/agents.md) |
+| Agent catalog, install, credentials, readiness, supported-agent meaning | `anyharness-lib/src/domains/agents/**` | `domains/agents/**` | [guides/domains.md](guides/domains.md), [specs/agent-catalog-readiness.md](specs/agent-catalog-readiness.md), [src/agents.md](src/agents.md) |
 | Provider CLI install/probe/path/version mechanics | `anyharness-lib/src/integrations/agent_cli/**`, provider-specific ACP code | `integrations/agent_cli/**` | [guides/integrations.md](guides/integrations.md), [guides/harnesses.md](guides/harnesses.md) |
 | Provider-specific behavior such as Claude/Codex extension support or live controls | `anyharness-lib/src/acp/**`, `docs/anyharness/harnesses/**` | harness doc plus owning runtime/integration module | [guides/harnesses.md](guides/harnesses.md), provider doc under `harnesses/**` |
 | File browsing, file reads/writes, workspace file capabilities | `anyharness-lib/src/adapters/files/**` | `adapters/files/**` | [guides/adapters.md](guides/adapters.md), [src/files.md](src/files.md) |
@@ -285,7 +301,7 @@ which guide to read and where the code belongs.
 | Hosting and process helpers around local workspace capabilities | `anyharness-lib/src/adapters/hosting/**`, `anyharness-lib/src/adapters/processes/**` | `adapters/hosting/**`, `adapters/processes/**` | [guides/adapters.md](guides/adapters.md) |
 | Terminal/PTTY lifecycle, terminal stream handles, terminal registry | `anyharness-lib/src/terminals/**` | `live/terminals/**` | [guides/live-runtime.md](guides/live-runtime.md) |
 | MCP user bindings attached to a session | `anyharness-lib/src/sessions/mcp_bindings/**` | current `sessions/mcp_bindings/**`; final `domains/sessions/mcp_bindings/**` | [specs/mcp.md](specs/mcp.md), [guides/domains.md](guides/domains.md) |
-| Product MCP tool servers for cowork, reviews, subagents, workspace naming | `domains/cowork/**`, `domains/reviews/**`, `sessions/subagents/**`, `sessions/workspace_naming/**` | owning product domain | [specs/mcp.md](specs/mcp.md), [guides/domains.md](guides/domains.md) |
+| Product MCP tool servers for artifacts, reviews, subagents, workspace naming | `domains/cowork/**`, `domains/reviews/**`, `sessions/subagents/**`, `sessions/workspace_naming/**` | owning product domain | [specs/product-mcps.md](specs/product-mcps.md), [product-mcps/README.md](product-mcps/README.md), [guides/domains.md](guides/domains.md) |
 | Shared MCP JSON-RPC, capability-token, tool-formatting scaffolding | `anyharness-lib/src/integrations/mcp/**` plus any remaining feature-local wrappers | `integrations/mcp/**` | [guides/integrations.md](guides/integrations.md), [specs/mcp.md](specs/mcp.md) |
 | Cowork artifacts, delegation, or cowork-owned tools | `anyharness-lib/src/domains/cowork/**` | `domains/cowork/**` | [guides/domains.md](guides/domains.md), [src/cowork-artifacts.md](src/cowork-artifacts.md) |
 | Reviews, plans, mobility, or repo-root product behavior | `domains/reviews/**`, `domains/plans/**`, `domains/mobility/**`, `repo_roots/**` | owning `domains/<domain>/**` | [guides/domains.md](guides/domains.md) |

--- a/docs/anyharness/guides/live-runtime.md
+++ b/docs/anyharness/guides/live-runtime.md
@@ -62,24 +62,51 @@ InteractionBroker -> currently acp/permission_broker/**; target live/sessions/in
 
 ## Actor Files
 
-An actor file should not grow into a whole subsystem. Split by actor concern:
+An actor file should not grow into a whole subsystem. The loop owns ordering;
+handlers own behavior. A reader should be able to open the loop file and see
+the live state machine without also reading prompt payload conversion,
+transcript normalization, MCP schemas, or plan ingestion.
+
+Split by actor concern:
 
 ```text
 live/sessions/actor/
   mod.rs
   command.rs
+  state.rs
+  events.rs
+  loop.rs
   startup.rs
-  prompt_queue.rs
-  prompt.rs
-  config.rs
-  interactions.rs
-  fork.rs
-  lifecycle.rs
+  notifications.rs
+  background_work.rs
+  exit.rs
   stderr.rs
+  commands/
+    idle.rs
+    busy.rs
+    prompt.rs
+    config.rs
+    interactions.rs
+    plans.rs
+    fork.rs
+    close.rs
+  turn/
+    start.rs
+    run.rs
+    finish.rs
+    queue.rs
+    diagnostics.rs
+  config/
+    apply.rs
+    restore.rs
+    snapshot.rs
+    selectors.rs
 ```
 
-Keep `mod.rs` focused on the public actor surface and high-level loop. Move
-state transitions and helpers into named files.
+Keep `mod.rs` focused on the public actor surface. Keep `loop.rs` focused on
+selecting the next actor event and dispatching it. Split idle and busy command
+handling because the same command can have different legal behavior while a
+prompt is running.
 
 ## Event Sink Files
 
@@ -90,18 +117,34 @@ normalization by event family:
 live/sessions/event_sink/
   mod.rs
   state.rs
-  emit.rs
+  publish.rs
+  turns.rs
   assistant.rs
+  reasoning.rs
   tools.rs
-  terminals.rs
   plans.rs
+  config.rs
+  interactions.rs
+  pending_prompts.rs
   background_work.rs
-  metadata.rs
-  file_references.rs
+  lifecycle.rs
+  runtime_events.rs
+  normalization/
 ```
 
 The sink may persist and broadcast normalized events. It should not decide
 durable session business rules.
+
+Use the actor/sink boundary strictly:
+
+```text
+actor      decides when something happens
+event_sink decides how that becomes a durable SessionEventEnvelope
+```
+
+The actor may call sink methods such as `begin_turn`, `turn_ended`,
+`interaction_requested`, or `ingest_tool_call`. The sink should not own prompt
+queueing, busy/idle rules, ACP subprocess lifecycle, or interaction waiting.
 
 ## Interaction Broker
 

--- a/docs/anyharness/guides/repo-shape.md
+++ b/docs/anyharness/guides/repo-shape.md
@@ -51,6 +51,32 @@ event_sink/tools.rs
 integrations/mcp/json_rpc.rs
 ```
 
+## Large Subsystems
+
+The top-level boundary is not enough for large subsystems. Once a subsystem has
+multiple responsibility families, define its internal shape before splitting
+files. The target is legibility by path at both levels:
+
+```text
+domains/sessions/runtime/prompt.rs   # session workflow entrypoint
+live/sessions/actor/turn/run.rs      # active prompt turn loop
+live/sessions/event_sink/tools.rs    # transcript event normalization
+```
+
+Do not dump unrelated files into a newly-correct parent folder. A move from
+`acp/session_actor.rs` to `live/sessions/actor/*.rs` is only useful if the
+children also encode responsibility.
+
+Large subsystem splits should name the local architecture explicitly in the
+owning spec or guide. For example:
+
+- durable domains split by `model`, `store`, `service`, `runtime`, and named
+  subdomains.
+- live actors split by command surface, loop, startup, prompt turn, config,
+  notifications, interactions, and shutdown.
+- event sinks split by normalized event family.
+- integrations split by protocol/vendor mechanic.
+
 ## Migration Discipline
 
 - Preserve behavior unless the task explicitly asks for a behavior change.

--- a/docs/anyharness/guides/system-architecture.md
+++ b/docs/anyharness/guides/system-architecture.md
@@ -1,0 +1,997 @@
+# AnyHarness System Architecture
+
+Status: draft architecture reference for AnyHarness source organization.
+
+This document defines where AnyHarness code belongs and how folders should
+grow. It is intentionally about organization and ownership, not current
+implementation completeness. Existing transitional paths should migrate toward
+this shape over time.
+
+## Top-Level Shape
+
+```text
+anyharness-lib/src/
+  api/
+  app/
+  domains/
+  live/
+  adapters/
+  integrations/
+  persistence/
+  observability/
+```
+
+Use these boundaries when placing code:
+
+```text
+api
+  Owns transport only.
+  Parse HTTP/SSE/WS requests, authenticate, acquire route-level leases, call
+  domain/runtime/live APIs, and map results/errors into contract responses.
+  Do not put product workflows, SQL, actor loops, MCP tool behavior, or
+  install policy here.
+
+app
+  Owns composition only.
+  Construct AppState, create stores/services/runtimes/managers, wire session
+  extensions, pass shared config such as runtime_home and auth tokens.
+  Do not implement product behavior here.
+
+domains
+  Owns product concepts.
+  Define product records, durable SQL stores, durable rules, and high-level
+  use cases. Decide what a session/workspace/agent/review/plan means, what
+  state is valid, and when a product action is allowed.
+  Runtime files may command live systems; service files should stay durable.
+
+live
+  Owns currently running state.
+  Manage actors, handles, process clients, PTYs, broadcast channels, pending
+  interactions, startup de-dupe, and stream fanout. Reconstruct from durable
+  domain state after restart. Do not decide product policy.
+
+adapters
+  Owns local machine capabilities.
+  Read/write/list files, run git commands, spawn helper processes, call hosting
+  CLIs, drive browser/computer-use primitives, and parse local command output.
+  Do not own product SQL, session/workspace lifecycle, or UI/API policy.
+
+integrations
+  Owns protocol/vendor mechanics.
+  Encode/decode MCP or ACP messages, normalize provider errors, discover or
+  launch provider CLIs, format tool results, and implement reusable auth/token
+  primitives. Do not know product concepts such as reviews or subagents.
+
+persistence
+  Owns storage infrastructure.
+  Manage SQLite connection setup, migrations, and generic transaction helpers.
+  Do not put domain table queries or product row mapping here.
+
+observability
+  Owns diagnostics infrastructure.
+  Provide tracing, measurements, counters, latency spans, and debug helpers.
+  Do not alter product behavior.
+```
+
+Do not organize code by whichever route happened to call it first. Organize by
+ownership.
+
+## Dependency Direction
+
+Preferred direction:
+
+```text
+api -> domains
+api -> live handles/managers when transport must stream or subscribe
+
+app -> everything
+
+domains/runtime -> domains/service + live + adapters + other domains
+domains/service -> domains/store + domain models
+domains/store -> persistence
+
+live -> domains/store or narrow persistence capabilities
+live -> integrations
+
+domains -> adapters
+domains -> integrations
+
+integrations -> no product domains
+adapters -> no product domains
+```
+
+`app/` is the composition root and may know about everything. Most other code
+should not import `app/`.
+
+## Domains
+
+Domains own product concepts with durable records, rules, and use cases. A
+domain is not created because an HTTP route exists; it is created because the
+product has a concept that must be validated, stored, listed, resumed,
+summarized, or coordinated.
+
+Put code in `domains/<domain>/` when it answers questions like:
+
+```text
+What records represent this product concept?
+Which state transitions are valid?
+What durable data must be read or written?
+Which live/adapters/other domains must be coordinated to perform this use case?
+What should callers receive as the domain-level result or error?
+```
+
+Do not put code in a domain when it only answers:
+
+```text
+How do I parse an HTTP request?
+How do I spawn a process?
+How do I run git?
+How do I format JSON-RPC?
+How do I keep an actor loop alive?
+```
+
+Examples:
+
+```text
+domains/sessions
+domains/workspaces
+domains/agents
+domains/terminals
+domains/plans
+domains/reviews
+domains/cowork
+domains/mobility
+domains/repo_roots
+```
+
+Default small domain:
+
+```text
+domains/<domain>/
+  mod.rs
+  model.rs
+  store.rs
+  service.rs
+```
+
+Add `runtime.rs` only when the domain orchestrates live state, adapters, or
+other domains.
+
+Responsibilities:
+
+```text
+model.rs
+  domain-owned product records, enums, internal data types
+
+store.rs or store/
+  raw domain SQL, row mapping, transactions
+
+service.rs or service/
+  durable product operations over store data
+
+runtime.rs or runtime/
+  high-level use cases that cross durable/live/adapters/domain boundaries
+
+mod.rs
+  module declarations and intentional exports
+```
+
+### Store, Service, Runtime
+
+Use this distinction:
+
+```text
+store
+  DB mechanics for this domain
+
+service
+  durable product rules
+
+runtime
+  running use cases that may command live systems
+```
+
+For sessions:
+
+```text
+SessionStore
+  SQL for sessions, events, config snapshots, pending prompts, attachments
+
+SessionService
+  durable session rules: create, read, list, title, summaries, validation
+
+SessionRuntime
+  session use cases: create-and-start, prompt, resume, fork, config, cancel
+```
+
+### Domain Growth
+
+There are two valid promotions: layer promotion and feature promotion. Pick the
+one that matches the reason the code is growing.
+
+### Layer Promotion
+
+Promote a layer file when the file is large because one layer has many
+operation families. The folder name remains the layer name, and children split
+by operation/data family.
+
+Use layer promotion when the answer is yes:
+
+```text
+Is this still one kind of work?
+Are all children still store operations, service operations, or runtime
+workflows?
+Would moving a child out of this layer hide the fact that it is still SQL,
+durable rules, or live orchestration?
+```
+
+`store/` children are table/query families:
+
+```text
+store.rs -> store/
+  mod.rs
+  sessions.rs
+  events.rs
+  pending_prompts.rs
+  attachments.rs
+  live_config.rs
+```
+
+`service/` children are durable rule/use-case families:
+
+```text
+service.rs -> service/
+  mod.rs
+  creation.rs
+  listing.rs
+  titles.rs
+  config.rs
+```
+
+`runtime/` children are high-level workflow families:
+
+```text
+runtime.rs -> runtime/
+  mod.rs
+  creation.rs
+  prompt.rs
+  config.rs
+  fork.rs
+  interactions.rs
+```
+
+Inside a promoted layer folder:
+
+```text
+mod.rs
+  module declarations and narrow public exports
+
+<operation>.rs
+  one operation family or data family
+
+tests.rs or tests/
+  tests for that layer/folder
+```
+
+Do not name children:
+
+```text
+helpers.rs
+utils.rs
+logic.rs
+misc.rs
+manager.rs     # unless it truly owns live in-memory lifecycle
+processor.rs   # too vague without a narrower qualifier
+```
+
+### Feature Promotion
+
+Promote a named feature folder when a product concept has its own identity
+inside the larger domain.
+
+Use feature promotion when any answer is yes:
+
+```text
+Does this concept have its own model/store/service stack?
+Does it have its own lifecycle or background reconciliation?
+Does it expose an MCP server or session extension?
+Would product docs explain it as a named capability?
+Do its tests naturally group around the concept rather than around store or
+service mechanics?
+```
+
+Feature folder examples:
+
+```text
+domains/sessions/links/
+  mod.rs
+  model.rs
+  store.rs
+  service.rs
+```
+
+```text
+domains/workspaces/retirement/
+  mod.rs
+  policy.rs
+  preflight.rs
+  purge.rs
+```
+
+Inside a feature folder, use the same domain grammar when it applies:
+
+```text
+<feature>/
+  mod.rs
+  model.rs
+  store.rs
+  service.rs
+  runtime.rs     # only if this feature crosses into live/adapters/other domains
+```
+
+### Choosing Between Them
+
+Choose layer promotion when a file is large but still one layer:
+
+```text
+sessions/store.rs is large because it owns sessions, events, attachments,
+pending prompts, and live config SQL.
+
+Promote to:
+  sessions/store/{sessions,events,attachments,pending_prompts,live_config}.rs
+```
+
+Choose feature promotion when the concept has its own product identity:
+
+```text
+sessions/links owns link records, link service behavior, completions, and
+tests.
+
+Promote to:
+  sessions/links/{model,store,service,completions}.rs
+```
+
+Do not create a feature folder just to shrink a file:
+
+```text
+Bad:
+  sessions/title/{store,service}.rs
+
+Better:
+  sessions/service/titles.rs
+  sessions/store/sessions.rs
+```
+
+Do not add:
+
+```text
+rules/
+utils/
+helpers/
+misc/
+common/
+```
+
+Put pure logic next to the concept it serves:
+
+```text
+workspaces/retirement/policy.rs
+sessions/config/selection.rs
+agents/catalog/validation.rs
+```
+
+## Live Runtime
+
+`live/` owns process-lived systems. These systems are reconstructed after an
+AnyHarness restart from domain state, config, and external resources. They are
+not the durable product truth.
+
+Put code in `live/` when it answers questions like:
+
+```text
+Which instances are running right now?
+How do commands reach one running instance?
+How do we subscribe to live events?
+How do we sequence events while an actor is busy?
+How do we manage a subprocess, PTY, sidecar, browser, or long-lived stream?
+How do we hold a pending request until a later API call resolves it?
+```
+
+Examples of live-owned state:
+
+```text
+actor tasks
+command channels
+broadcast channels
+live handles
+PTY handles
+subprocess clients
+pending interaction waiters
+startup de-dupe maps
+watcher tasks
+```
+
+Do not put code in `live/` when it decides product policy, owns product SQL,
+or defines public wire shapes. Those belong to `domains/`, `domains/*/store`,
+and `anyharness-contract`/`api`.
+
+Likely live systems:
+
+```text
+live/sessions/
+live/terminals/
+live/browser/      # future
+live/workers/      # future local worker/dispatch state if owned here
+```
+
+Default live system:
+
+```text
+live/<system>/
+  mod.rs
+  manager.rs
+  handle.rs
+  model.rs
+```
+
+Responsibilities:
+
+```text
+manager.rs
+  registry and lifecycle for many live instances
+
+handle.rs
+  cloneable public command/subscription port for one live instance
+
+model.rs
+  live-only public command outcomes, snapshots, status enums
+
+mod.rs
+  module declarations and intentional exports
+```
+
+Only create a `live/<system>/` folder when there is a real long-lived runtime
+object: a manager, actor, handle, PTY, sidecar, watcher, stream registry, or
+pending interaction broker. A domain workflow that merely starts a session does
+not earn a `live/` folder.
+
+Common live concern folders:
+
+```text
+actor/
+  serialized state machine for one live instance
+
+connection/
+  external process/protocol lifecycle
+
+event_sink/
+  normalized event persistence and broadcast fanout
+
+interactions/
+  pending request/response broker
+
+background_work/
+  long-running tool/background work tracking
+
+pty/
+  terminal PTY lifecycle
+
+streams/
+  SSE/websocket/broadcast mechanics
+
+watchers/
+  long-lived file/git/process watchers
+```
+
+Add these concern folders only after the concern has its own state or contract.
+Do not create empty target trees.
+
+Naming rules:
+
+```text
+manager = many live instances
+handle = one live instance public port
+actor = one serialized decision loop
+connection/process/pty = live resource lifecycle
+event_sink/streams = fanout
+interactions/broker = pending rendezvous
+```
+
+Do not use `service.rs`, `runtime.rs`, or `store.rs` inside `live/` unless
+there is a very specific reason. Those names usually belong to `domains/`.
+
+### Live Sessions
+
+Target shape:
+
+```text
+live/sessions/
+  mod.rs
+  manager.rs
+  handle.rs
+  model.rs
+
+  actor/
+  connection/
+  event_sink/
+  interactions/
+  background_work/
+  replay_actor.rs
+```
+
+Ownership:
+
+```text
+manager.rs
+  live session registry and startup de-dupe
+
+handle.rs
+  command/subscription port used by SessionRuntime and API stream code
+
+actor/
+  idle/busy routing, turn loop, queued prompt/config behavior,
+  notification dispatch, shutdown decisions
+
+connection/
+  ACP process/session lifecycle: spawn, stdio, initialize, authenticate,
+  new/load/fork native session, stderr
+
+event_sink/
+  event normalization, sequence assignment, persistence, broadcast
+
+interactions/
+  permission/user-input/MCP pending request broker
+
+background_work/
+  long-running tool/background task tracking
+```
+
+The actor coordinates these collaborators, but it should not own all their code.
+
+Use this boundary:
+
+```text
+actor/
+  What should this live session do next?
+
+sibling under live/sessions/
+  How does this live session resource/collaborator work?
+```
+
+### Actor Concern Folder Grammar
+
+Inside an actor concern folder, use consistent names:
+
+```text
+actor/<concern>/
+  mod.rs
+  types.rs
+  handle.rs
+```
+
+Add only when needed:
+
+```text
+apply.rs
+  live/protocol state changes
+
+queue.rs
+  deferred work
+
+persist.rs
+  durable/sink writes
+
+finish.rs
+  terminal cleanup for a flow
+
+diagnostics.rs
+  tracing/debug timeout logic
+```
+
+Session actor target:
+
+```text
+live/sessions/actor/
+  mod.rs
+  command.rs
+  state.rs
+  loop.rs
+
+  turn/
+    mod.rs
+    types.rs
+    handle.rs
+    start.rs
+    active.rs
+    queue.rs
+    finish.rs
+    diagnostics.rs
+
+  config/
+    mod.rs
+    types.rs
+    handle.rs
+    apply.rs
+    queue.rs
+    persist.rs
+    selection.rs
+
+  notifications/
+    mod.rs
+    types.rs
+    handle.rs
+    dispatch.rs
+    replay_filter.rs
+    plans.rs
+
+  shutdown/
+    mod.rs
+    types.rs
+    handle.rs
+    cleanup.rs
+    persist.rs
+```
+
+The top loop should read as dispatch:
+
+```text
+command received       -> command/turn/config/interactions/shutdown handler
+ACP notification       -> notification handler
+background work update -> background work handler
+shutdown               -> finalization
+```
+
+## Adapters
+
+Adapters are local machine/workspace capabilities. They know how to perform an
+operation against the local environment, not why the product wants it.
+
+Put code in `adapters/` when it answers questions like:
+
+```text
+How do I safely read this path?
+How do I run this git command and parse the output?
+How do I spawn this process with the right env?
+How do I call this hosting CLI and normalize its output?
+How do I drive a local browser/computer-use primitive?
+```
+
+Do not put code in `adapters/` when it answers:
+
+```text
+Should this workspace be retired?
+Should this session be allowed to read files?
+Should this review run use this diff?
+Which API response should the client see?
+```
+
+Examples:
+
+```text
+adapters/files/
+adapters/git/
+adapters/processes/
+adapters/hosting/
+adapters/browser/      # future
+```
+
+Allowed:
+
+```text
+filesystem access
+path safety checks
+process spawning
+git commands
+hosting CLI calls
+browser automation primitives
+parsing command output
+capability-specific caches
+```
+
+Banned:
+
+```text
+durable product SQL
+session/workspace lifecycle decisions
+calling domain services to decide product policy
+event fanout
+API response shaping
+```
+
+Default adapter:
+
+```text
+adapters/<capability>/
+  mod.rs
+  model.rs
+  service.rs
+```
+
+Use free functions by default. Use a struct only when it holds dependencies,
+cache, config, subprocess state, or test-injectable behavior.
+
+Good as functions:
+
+```text
+read_workspace_file(root, path)
+parse_git_status(output)
+build_safe_path(root, relative_path)
+```
+
+Good as structs:
+
+```text
+WorkspaceFileSearchCache
+ProcessService
+BrowserSessionController
+```
+
+If a struct has no fields, it probably should be a function.
+
+## Integrations
+
+Integrations are reusable protocol/vendor mechanics. They answer:
+
+```text
+How does this protocol/vendor work?
+How do we translate raw external shape into reusable internal capability?
+```
+
+They do not answer:
+
+```text
+Should this be enabled for this workspace/session/team?
+What product object does this create?
+How should this appear in the UI?
+```
+
+Use `integrations/` for reusable mechanics that would still make sense if the
+product feature were removed. If the file name wants a product noun such as
+`reviews`, `cowork`, `subagents`, `sessions`, or `workspace_naming`, it almost
+certainly belongs in a domain.
+
+Default integration:
+
+```text
+integrations/<integration>/
+  mod.rs
+  model.rs
+  client.rs
+```
+
+Add when applicable:
+
+```text
+protocol.rs
+auth.rs
+errors.rs
+config.rs
+```
+
+Examples:
+
+```text
+integrations/mcp/
+  JSON-RPC, tool formatting, capability-token primitive,
+  product MCP dispatcher scaffolding
+
+integrations/acp/
+  reusable ACP protocol helpers and provider error normalization
+
+integrations/agent_cli/
+  executable lookup, launcher scripts, provider CLI command mechanics
+```
+
+Move common protocol/vendor scaffolding here. Do not move product behavior
+here.
+
+Example:
+
+```text
+integrations/mcp
+  knows how MCP JSON-RPC works
+
+domains/reviews/mcp
+  knows what review MCP tools do
+
+domains/sessions/mcp_bindings
+  knows which MCPs are attached to a session
+```
+
+Dependency rule:
+
+```text
+integrations/ may depend on std, protocol crates, HTTP/process/fs helpers,
+and small shared utilities.
+
+integrations/ must not depend on domains/, live/, api/, app/, or product
+stores/services/runtimes.
+```
+
+## API
+
+`api/` is transport.
+
+Allowed:
+
+```text
+parse path/query/body
+authenticate
+authorize at transport boundary
+call domain/runtime/live handle methods
+map errors to HTTP responses
+map domain/live data to contract response types
+build SSE/WS streams from domain/live subscriptions
+```
+
+Banned:
+
+```text
+business workflows
+raw product SQL
+actor loop logic
+product MCP tool logic
+agent install policy
+workspace/session lifecycle policy
+```
+
+If an API handler grows beyond transport work, move the behavior to a domain
+service/runtime or a live system.
+
+API handlers should read in this order:
+
+```text
+extract request
+authenticate/authorize transport-level access
+call one domain/runtime/live capability
+map result/error
+return contract response
+```
+
+If a handler contains multi-step product sequencing, product validation that is
+not transport-specific, or direct SQL, the code is in the wrong layer.
+
+## App
+
+`app/` is the composition root.
+
+It may know about everything because it builds the dependency graph:
+
+```text
+stores
+services
+runtimes
+live managers
+session extensions
+adapters
+catalogs
+auth helpers
+```
+
+It should not implement business behavior. If `AppState::new` becomes too
+large, split wiring by system:
+
+```text
+app/sessions.rs
+app/workspaces.rs
+app/agents.rs
+app/product_extensions.rs
+```
+
+Those files still only wire dependencies.
+
+`app/` code should read as construction:
+
+```text
+create store
+create service
+create runtime
+create live manager
+wire extension implementation
+store in AppState
+```
+
+If `app/` contains a branch that decides product behavior for a session,
+workspace, MCP, review, or agent, move that branch to the owning domain.
+
+## Persistence
+
+`persistence/` owns generic SQLite infrastructure:
+
+```text
+connection/pool
+migration runner
+generic transaction helpers
+custom migration framework
+```
+
+Product SQL belongs in:
+
+```text
+domains/<domain>/store/
+```
+
+Do not put `SELECT * FROM sessions` style queries in `persistence/`.
+
+## Observability
+
+`observability/` owns generic diagnostics:
+
+```text
+tracing helpers
+latency measurement
+debug measurement
+diagnostic classification
+```
+
+It should not change product behavior.
+
+## Structs vs Functions
+
+Use free functions for:
+
+```text
+pure transforms
+local operations with explicit inputs
+stateless parsing/validation
+```
+
+Use structs when they hold stable dependencies:
+
+```text
+stores hold DB handles
+services hold stores/collaborators
+runtimes hold services/live managers/adapters
+managers hold live registries
+actors hold live state machines
+adapters hold caches/config/subprocess state only when needed
+```
+
+This is Rust-style dependency injection:
+
+```text
+AppState wires once
+service/runtime structs narrow the dependency surface
+methods take per-call input
+pure helpers stay free functions
+```
+
+Do not pass `AppState` deep into product logic. That turns it into a service
+locator and erases ownership.
+
+## Banned Generic Buckets
+
+Avoid:
+
+```text
+utils.rs
+helpers.rs
+common.rs
+misc.rs
+logic.rs
+stuff.rs
+```
+
+When a name is hard, stop and identify the owning concept. The path should tell
+a reader what the file is allowed to do.
+
+## Migration Principle
+
+Move one ownership boundary at a time.
+
+Good:
+
+```text
+Split domains/sessions/store.rs into store/{sessions,events,pending_prompts}.rs
+without changing behavior.
+```
+
+Bad:
+
+```text
+Move files, rename types, change session behavior, and alter API responses in
+one PR.
+```
+
+After a split lands, block the old flat path from returning and delete the old
+code path in the same change.

--- a/docs/anyharness/product-mcps/README.md
+++ b/docs/anyharness/product-mcps/README.md
@@ -1,0 +1,28 @@
+# Product MCP Definitions
+
+Status: authoritative index for product MCP definitions.
+
+Read [../specs/product-mcps.md](../specs/product-mcps.md) first. That spec
+defines the source layout and implementation rules. Files in this folder define
+the initial product MCPs we are standardizing.
+
+Each definition answers:
+
+```text
+id
+owner
+visibility
+default injection
+context
+tools
+calls
+UI exposure
+```
+
+Current definitions:
+
+- [subagents.md](subagents.md)
+- [artifacts.md](artifacts.md)
+- [reviews.md](reviews.md)
+- [workspace-naming.md](workspace-naming.md)
+

--- a/docs/anyharness/product-mcps/artifacts.md
+++ b/docs/anyharness/product-mcps/artifacts.md
@@ -1,0 +1,700 @@
+# Artifacts MCP
+
+Status: authoritative target definition for the Artifacts product MCP.
+
+Artifacts are user-visible outputs created by agents and rendered by
+Proliferate. Today they are implemented as **cowork artifacts**. The target is
+to promote the generic artifact lifecycle into an `artifacts` product domain
+and expose it through a reusable product MCP.
+
+## Identity
+
+```text
+id: artifacts
+owner domain: domains/artifacts
+target implementation: anyharness-lib/src/domains/artifacts/mcp/**
+current implementation: anyharness-lib/src/domains/cowork/mcp_server/** artifact tools
+visibility: user_selectable
+route slug: artifacts
+server name: proliferate-artifacts
+default injection: attach when artifact capability is enabled for the session,
+  workspace, automation, cowork thread, or team policy
+```
+
+Current reality:
+
+```text
+Artifacts are file-backed objects inside cowork worktree workspaces.
+The manifest is .proliferate/artifacts.json.
+There is no artifact database table.
+The cowork MCP exposes artifact tools today.
+Desktop reads artifacts through normal HTTP endpoints, not through MCP.
+```
+
+Target reality:
+
+```text
+Artifacts become their own domain.
+Cowork becomes one consumer of artifacts.
+Artifact tools move from cowork MCP to artifacts MCP.
+Artifact lifecycle remains manifest/file-backed unless a separate storage
+change is explicitly designed.
+```
+
+## Current Code Map
+
+Current artifact lifecycle:
+
+```text
+anyharness-lib/src/domains/cowork/manifest.rs
+  Cowork artifact manifest schema
+  .proliferate/artifacts.json constant
+  manifest parse/validate/load
+  artifact path validation
+  artifact type derivation from file extension
+  manifest entry enrichment into contract summaries
+
+anyharness-lib/src/domains/cowork/artifacts.rs
+  CoworkArtifactRuntime
+  create_artifact
+  update_artifact
+  delete_artifact
+  get_manifest
+  get_artifact
+  protected artifact path checks
+  per-workspace artifact locks
+  temp-file commit/rollback helpers
+
+anyharness-lib/src/domains/cowork/mcp_server/protocol.rs
+  artifact MCP tool definitions
+  cowork delegation tool definitions
+  current server instructions
+
+anyharness-lib/src/domains/cowork/mcp_server/tools.rs
+  tools/call implementation for create/update/delete/list/get artifact tools
+  cowork delegation tools in the same file
+
+anyharness-lib/src/domains/cowork/mcp_server/server.rs
+  cowork MCP JSON-RPC dispatch
+  initialize/tools/list/tools/call handling
+  workspace delegation gating
+
+anyharness-lib/src/domains/cowork/mcp_server/auth.rs
+  cowork MCP capability token wrapper
+```
+
+Current injection and prompt text:
+
+```text
+anyharness-lib/src/domains/cowork/runtime.rs
+  CoworkSessionHooks launch extras
+  cowork artifact system prompt append
+  cowork MCP server URL/header construction
+```
+
+Current app wiring:
+
+```text
+anyharness-lib/src/app/mod.rs
+  AppState.cowork_artifact_runtime
+  CoworkArtifactRuntime::new()
+  WorkspaceFilesRuntime receives CoworkArtifactRuntime for write protection
+```
+
+Current HTTP read APIs:
+
+```text
+anyharness-lib/src/api/router.rs
+  GET /v1/workspaces/{workspace_id}/cowork/manifest
+  GET /v1/workspaces/{workspace_id}/cowork/artifacts/{artifact_id}
+  GET/POST /v1/workspaces/{workspace_id}/cowork/sessions/{session_id}/mcp
+
+anyharness-lib/src/api/http/cowork.rs
+  get_cowork_manifest
+  get_cowork_artifact
+  post_cowork_mcp_endpoint
+  cowork artifact error mapping
+```
+
+Current file-write protection:
+
+```text
+anyharness-lib/src/workspaces/files_runtime.rs
+  blocks generic file writes/creates/renames/deletes for cowork artifact
+  manifest paths and artifact-backed paths
+
+anyharness-lib/src/adapters/files/service.rs
+  generic file operations and FileServiceError::ProtectedPath
+```
+
+Current contract types:
+
+```text
+anyharness-contract/src/v1/**
+  CoworkArtifactType
+  CoworkArtifactSummary
+  CoworkArtifactManifestResponse
+  CoworkArtifactDetailResponse
+```
+
+Related current doc:
+
+```text
+docs/anyharness/src/cowork-artifacts.md
+  current cowork artifact behavior
+```
+
+## Target Code Map
+
+Target artifact domain:
+
+```text
+anyharness-lib/src/domains/artifacts/
+  mod.rs
+  model.rs
+  manifest.rs
+  service.rs
+  runtime.rs
+  protection.rs
+  mcp/
+    mod.rs
+    definition.rs
+    auth.rs
+    context.rs
+    tools.rs
+    calls.rs
+```
+
+Target responsibilities:
+
+```text
+model.rs
+  ArtifactId
+  ArtifactNamespace
+  ArtifactAccessMode
+  ArtifactType
+  ArtifactSummary
+  ArtifactDetail
+  create/update/delete input structs
+  domain errors
+
+manifest.rs
+  .proliferate/artifacts.json schema
+  manifest version
+  manifest parse/validate/load/write helpers
+  artifact type derivation
+  relative artifact path validation
+
+service.rs
+  pure durable artifact lifecycle rules over the manifest/file-backed store
+  create/update/delete/list/read operations
+  path immutability
+  id stability
+  read/write permission checks
+
+runtime.rs
+  target/workspace-aware artifact orchestration
+  blocking file IO boundaries
+  per-workspace locks
+  temp-file commit/rollback
+  integration with workspace records
+
+protection.rs
+  checks used by workspace file operations to prevent generic writes to
+  artifact manifests or artifact-backed paths
+
+mcp/definition.rs
+  product MCP metadata and prompt policy
+
+mcp/auth.rs
+  artifacts capability-token scope
+
+mcp/context.rs
+  workspace/session/namespace/access-mode resolution
+
+mcp/tools.rs
+  MCP tools/list definitions
+
+mcp/calls.rs
+  MCP tools/call implementation delegating to artifacts runtime/service
+```
+
+Target API paths:
+
+```text
+GET  /v1/workspaces/{workspace_id}/artifacts/manifest
+GET  /v1/workspaces/{workspace_id}/artifacts/{artifact_id}
+POST /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/artifacts
+GET  /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/artifacts
+```
+
+The old cowork paths may be compatibility aliases during migration, but new
+artifact behavior should not be added to cowork-specific routes.
+
+Target AppState wiring:
+
+```text
+AppState.artifact_runtime: Arc<ArtifactRuntime>
+WorkspaceFilesRuntime receives ArtifactRuntime or ArtifactProtectionService
+CoworkRuntime depends on ArtifactRuntime only when cowork needs artifacts
+```
+
+## Manifest Contract
+
+Path:
+
+```text
+.proliferate/artifacts.json
+```
+
+Current/target shape:
+
+```json
+{
+  "version": 1,
+  "artifacts": {
+    "art_a3f1b2c4": {
+      "id": "art_a3f1b2c4",
+      "path": "reports/plan.md",
+      "type": "text/markdown",
+      "title": "Plan",
+      "description": "Optional description",
+      "createdAt": "2026-04-10T14:23:00Z",
+      "updatedAt": "2026-04-10T14:35:00Z"
+    }
+  }
+}
+```
+
+Rules:
+
+- `version` is required and must be `1`.
+- `artifacts` is keyed by stable artifact id.
+- artifact ids are generated by the artifact lifecycle layer.
+- `path` is workspace-relative.
+- `path` is immutable after create.
+- `path` must not be absolute.
+- `path` must not contain `..` escapes.
+- `path` must not point into `.proliferate/`.
+- `type` is derived from extension, never caller supplied.
+- manifest entries must not duplicate paths.
+- the manifest and artifact file updates must be committed together or rolled
+  back as a unit as much as filesystem semantics allow.
+
+Supported v1 types:
+
+```text
+.md           -> text/markdown
+.html         -> text/html
+.svg          -> image/svg+xml
+.jsx, .tsx    -> application/vnd.proliferate.react
+```
+
+Out of scope unless separately designed:
+
+- binary blobs
+- multi-file artifact bundles
+- artifact rename/move
+- artifact version browsing outside git history
+- artifact publishing/sharing
+- artifact-initiated tool calls
+
+## Auth
+
+Current auth while artifact tools live under cowork:
+
+```text
+header: x-cowork-session-token
+secret file: cowork-mcp-token.key
+ttl: 12 hours
+scope: workspace_id + session_id
+signature: legacy sha256-dot
+```
+
+Target artifact auth:
+
+```text
+header: x-anyharness-product-mcp-token
+secret file: product-mcp-token.key or artifacts-mcp-token.key
+ttl: 12 hours unless the shared product MCP policy changes it
+scope:
+  workspace_id
+  session_id
+  product_mcp_id: artifacts
+  artifact_namespace
+  access_mode: read | read_write
+```
+
+Read-only artifact contexts must be able to list/read but must reject create,
+update, and delete.
+
+## Selection And Injection
+
+Attach when:
+
+- a cowork thread requires artifacts
+- a session explicitly enables artifact tools
+- a workspace/team/org policy enables artifact tools
+- an automation template requests artifact tools
+- the target compute can persist/read artifact files
+
+Do not attach when:
+
+- the session has no artifact namespace
+- artifact writes are disabled and the MCP would expose write tools
+- the workspace cannot support artifact backing files
+- policy disables artifact creation for the session
+
+Injection output:
+
+```text
+url: /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/artifacts
+headers:
+  authorization: Bearer <runtime token> when runtime auth is enabled
+  x-anyharness-product-mcp-token: scoped artifact token
+binding summary:
+  productMcpId: artifacts
+  namespace: <artifact namespace>
+  accessMode: read | read_write
+prompt text:
+  use artifact tools for user-visible artifacts
+  never edit .proliferate/artifacts.json directly
+  do not use generic file writes on artifact-backed paths
+  normal file tools are allowed for supporting non-artifact files
+  JSX/TSX artifacts must follow the rendering contract
+```
+
+Cowork should contribute artifact selection policy when a cowork thread needs
+artifact tools. It should not own the generic artifact MCP implementation.
+
+## Context
+
+`mcp/context.rs` resolves:
+
+- workspace id
+- session id
+- workspace record
+- session record
+- artifact namespace
+- access mode
+- backing workspace root
+- target compute artifact capability
+- optional cowork thread context when selected by cowork
+
+The context type should be explicit:
+
+```text
+ArtifactMcpContext {
+  workspace,
+  session,
+  namespace,
+  access_mode,
+  backing_root,
+  source,
+}
+```
+
+`source` examples:
+
+```text
+cowork_thread
+user_selected_session
+workspace_policy
+team_policy
+automation_policy
+```
+
+The artifact domain may know that a context came from cowork, but generic
+artifact behavior must not depend on cowork-only state unless the context
+explicitly requires it.
+
+## Tools
+
+Initial tools:
+
+```text
+create_artifact
+  path: string
+  content: string
+  title: string
+  description?: string
+
+update_artifact
+  id: string
+  content?: string
+  title?: string
+  description?: string
+
+delete_artifact
+  id: string
+
+list_artifacts
+  no arguments
+
+get_artifact
+  id: string
+```
+
+Read-only contexts expose only:
+
+```text
+list_artifacts
+get_artifact
+```
+
+Read-write contexts expose all tools.
+
+Tool names remain generic because the MCP id scopes them. With MCP namespacing,
+agents should see names like:
+
+```text
+mcp__artifacts__create_artifact
+mcp__artifacts__update_artifact
+```
+
+## Calls
+
+`mcp/calls.rs` delegates to `ArtifactRuntime` / `ArtifactService`.
+
+Required call behavior:
+
+```text
+create_artifact
+  validate read_write access
+  validate path
+  derive type from path
+  reject duplicate manifest path
+  generate stable art_<uuid> id
+  write content temp file
+  write manifest temp file
+  commit both
+  return ArtifactSummary
+
+update_artifact
+  validate read_write access
+  find artifact by id
+  keep path immutable
+  update content/title/description only
+  bump updatedAt
+  commit content/manifest with rollback
+  return ArtifactSummary
+
+delete_artifact
+  validate read_write access
+  remove manifest entry
+  delete file if present
+  commit manifest with rollback
+  return id + deleted true
+
+list_artifacts
+  load manifest or empty
+  validate entries
+  enrich summaries from filesystem metadata
+  sort updatedAt desc
+
+get_artifact
+  load manifest
+  validate id exists
+  validate backing file exists
+  read text content
+  return ArtifactDetail
+```
+
+Required invariants:
+
+- generic file write/edit/delete cannot mutate `.proliferate/artifacts.json`.
+- generic file write/edit/delete cannot mutate artifact-backed paths.
+- artifact paths are immutable in v1.
+- artifact ids remain stable.
+- manifest type is derived from path extension.
+- unsupported file extensions are rejected.
+- all paths stay inside workspace root.
+- read-only contexts cannot call write tools.
+- cowork-specific workflow logic must not be added to generic artifact calls.
+
+## File Protection Integration
+
+Current protection path:
+
+```text
+workspaces/files_runtime.rs
+  calls CoworkArtifactRuntime::is_protected_relative_path
+  calls CoworkArtifactRuntime::is_protected_relative_path_or_ancestor
+  returns FileServiceError::ProtectedPath
+```
+
+Target protection path:
+
+```text
+domains/artifacts/protection.rs
+  ArtifactProtectionService::is_protected_relative_path(...)
+  ArtifactProtectionService::is_protected_relative_path_or_ancestor(...)
+
+workspaces/files_runtime.rs
+  depends on ArtifactProtectionService, not CoworkArtifactRuntime
+```
+
+Protection must cover:
+
+- `.proliferate/artifacts.json`
+- ancestors of the manifest path when deleting/renaming directories
+- artifact-backed files
+- ancestors of artifact-backed files when deleting/renaming directories
+
+## HTTP Read API
+
+Current HTTP read API:
+
+```text
+GET /v1/workspaces/{workspace_id}/cowork/manifest
+GET /v1/workspaces/{workspace_id}/cowork/artifacts/{artifact_id}
+```
+
+Target HTTP read API:
+
+```text
+GET /v1/workspaces/{workspace_id}/artifacts/manifest
+GET /v1/workspaces/{workspace_id}/artifacts/{artifact_id}
+```
+
+These routes are for clients such as desktop/web/mobile. Agents should use the
+MCP tools. Desktop should not call MCP directly for artifact rendering.
+
+## UI Exposure
+
+Artifacts are user-selectable when used outside internal cowork flows.
+
+UI should expose:
+
+- artifact capability enabled/disabled state
+- read vs read-write mode
+- artifact namespace
+- warning that write access lets agents create/update/delete artifact files
+- attached MCP binding summary
+- rendered artifact list/detail through artifact HTTP APIs
+
+UI should not expose:
+
+- capability token values
+- raw MCP headers
+- manifest editing
+
+## Migration Plan
+
+Phase 1: extract artifact domain without changing behavior.
+
+```text
+MOVE/COPY RESPONSIBILITY
+  domains/cowork/manifest.rs      -> domains/artifacts/manifest.rs
+  domains/cowork/artifacts.rs     -> domains/artifacts/runtime.rs + service.rs
+  cowork artifact contract mapping remains behavior-compatible
+
+KEEP TEMPORARILY
+  cowork HTTP routes as aliases
+  cowork MCP routes as aliases
+  CoworkArtifact* contract names if contract rename would create too much churn
+```
+
+Phase 2: split MCP behavior.
+
+```text
+CREATE
+  domains/artifacts/mcp/definition.rs
+  domains/artifacts/mcp/auth.rs
+  domains/artifacts/mcp/context.rs
+  domains/artifacts/mcp/tools.rs
+  domains/artifacts/mcp/calls.rs
+
+MOVE
+  artifact tools from domains/cowork/mcp_server/protocol.rs
+  artifact tool calls from domains/cowork/mcp_server/tools.rs
+
+LEAVE
+  cowork delegation tools in cowork
+```
+
+Phase 3: central session selection/injection.
+
+```text
+ADD
+  domains/sessions/mcp_bindings/product_registry.rs entry for artifacts
+  domains/sessions/mcp_bindings/selection.rs artifact selection policy
+  domains/sessions/mcp_bindings/injection.rs artifact HTTP MCP injection
+
+REMOVE
+  cowork-specific construction of artifact MCP server config where possible
+```
+
+Phase 4: promote API names.
+
+```text
+ADD
+  /v1/workspaces/{workspace_id}/artifacts/manifest
+  /v1/workspaces/{workspace_id}/artifacts/{artifact_id}
+  /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/artifacts
+
+KEEP OR REMOVE
+  cowork aliases based on client migration state
+```
+
+## Tests
+
+Domain tests:
+
+- manifest rejects invalid version
+- manifest rejects absolute paths
+- manifest rejects `..` escapes
+- manifest rejects `.proliferate/**`
+- type derives from `.md`, `.html`, `.svg`, `.jsx`, `.tsx`
+- duplicate paths are rejected
+- create writes file and manifest
+- create rolls back file if manifest commit fails
+- update preserves path and id
+- delete is idempotent
+- list sorts by `updatedAt desc`
+
+Protection tests:
+
+- manifest path is protected
+- manifest ancestor is protected
+- artifact path is protected
+- artifact ancestor is protected
+- sibling prefix is not protected
+
+MCP tests:
+
+- read-only context exposes only list/get
+- read-write context exposes all tools
+- token rejects wrong workspace/session/namespace/access mode
+- create/update/delete reject read-only access
+- tool calls delegate to artifact runtime/service
+- cowork can select artifacts without owning artifact tool calls
+
+API tests:
+
+- artifact manifest route returns manifest response
+- artifact detail route returns content and summary
+- missing artifact maps to 404
+- invalid manifest maps to 409
+
+## Migration Acceptance
+
+Done when:
+
+- generic artifact lifecycle is no longer owned by
+  `domains/cowork/artifacts.rs`.
+- generic artifact manifest logic is no longer owned by
+  `domains/cowork/manifest.rs`.
+- generic artifact MCP tools are no longer owned by
+  `domains/cowork/mcp_server/**`.
+- `domains/artifacts/**` owns artifact model, manifest, service/runtime,
+  protection, and MCP behavior.
+- cowork delegates to artifacts when it needs artifact tools.
+- `WorkspaceFilesRuntime` depends on artifact protection, not cowork artifact
+  runtime.
+- artifact MCP is selectable/injectable through
+  `domains/sessions/mcp_bindings/**`.
+- shared JSON-RPC dispatch lives in `integrations/mcp/product_server/**`.
+- desktop/web/mobile artifact reads can use artifact HTTP routes instead of
+  cowork-specific routes.
+

--- a/docs/anyharness/product-mcps/reviews.md
+++ b/docs/anyharness/product-mcps/reviews.md
@@ -1,0 +1,164 @@
+# Reviews MCP
+
+Status: authoritative target definition for the Reviews product MCP.
+
+## Identity
+
+```text
+id: reviews
+owner domain: domains/reviews
+target implementation: domains/reviews/mcp/**
+current implementation: domains/reviews/mcp_server/**
+visibility: internal
+route slug: reviews
+server name: proliferate-reviews
+default injection: attach to review-created reviewer sessions and to parent
+  sessions that have active review state
+```
+
+This MCP lets review agents submit structured review results and lets parent
+sessions inspect/re-signal review status where the review workflow allows it.
+
+## Auth
+
+Current auth shape:
+
+```text
+header: x-review-session-token
+secret file: review-mcp-token.key
+ttl: 12 hours
+scope: workspace_id + session_id
+signature: HMAC SHA-256
+```
+
+Target scope should include the resolved review role when possible:
+
+```text
+workspace_id
+session_id
+product_mcp_id: reviews
+role: reviewer | parent
+review_run_id when known
+```
+
+The bearer token protects the AnyHarness route. The product MCP token proves
+the MCP call was minted for this review/session capability.
+
+## Selection And Injection
+
+Attach when:
+
+- the session is a reviewer session assigned to a review run
+- the session is a parent session with active review state and allowed parent
+  tools
+
+Do not attach when:
+
+- there is no active review role for the session
+- the session/workspace does not match the review run
+- the review workflow does not allow MCP-signaled revision readiness
+
+Injection output:
+
+```text
+url: /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/reviews
+headers:
+  authorization: Bearer <runtime token> when runtime auth is enabled
+  x-anyharness-product-mcp-token or x-review-session-token: scoped token
+binding summary: review tools attached with role
+prompt text: reviewer sessions must submit a final review result through the
+  MCP; parent sessions may inspect review status
+```
+
+## Context
+
+`context.rs` resolves `ReviewMcpRole`:
+
+```text
+Reviewer
+  session is assigned as reviewer for a review run
+
+Parent { can_signal_revision }
+  session owns an active parent review run
+
+None
+  no review tools should be exposed
+```
+
+Context depends on review store/runtime state and workspace/session matching.
+It belongs in the reviews domain.
+
+## Tools
+
+Reviewer tools:
+
+```text
+submit_review_result
+  pass: boolean
+  summary: string
+  critiqueMarkdown: string
+```
+
+Parent tools:
+
+```text
+get_review_status
+  returns active review status for the parent session
+
+mark_review_revision_ready
+  available only when the review run can accept manual revision-ready signals
+```
+
+Tool list must be role-sensitive. A reviewer should not see parent tools, and
+a parent should not see `submit_review_result`.
+
+## Calls
+
+`calls.rs` delegates to `ReviewRuntime` and review services.
+
+Required call invariants:
+
+- reviewer submission must complete through `submit_review_result`
+- parent status reads use review service/store state
+- revision-ready signal validates run ownership and current review state
+- review MCP does not create sessions, dispatch prompts, or write transcript
+  events directly
+
+## UI Exposure
+
+Internal only.
+
+Review UI/API owns:
+
+- review run status
+- pass/fail result
+- critique presentation
+- revision loop state
+
+MCP binding summaries may show that review tools were attached and which role
+was selected.
+
+## Tests
+
+Required tests:
+
+- reviewer context exposes only `submit_review_result`
+- parent context exposes `get_review_status`
+- `mark_review_revision_ready` appears only when allowed
+- no-role context exposes no tools and rejects calls
+- token rejects wrong workspace/session/review scope
+- review result submission delegates to `ReviewRuntime`
+- endpoint returns JSON-RPC unknown-tool errors by role
+
+## Migration Acceptance
+
+Done when:
+
+- `domains/reviews/mcp_server/**` is replaced by `domains/reviews/mcp/**`.
+- role resolution lives in `context.rs`.
+- tool definitions live in `tools.rs`.
+- review tool calls delegate to `ReviewRuntime` from `calls.rs`.
+- shared JSON-RPC dispatch lives in `integrations/mcp/product_server`.
+- session selection/injection for review roles lives in
+  `domains/sessions/mcp_bindings/**`.
+

--- a/docs/anyharness/product-mcps/subagents.md
+++ b/docs/anyharness/product-mcps/subagents.md
@@ -1,0 +1,176 @@
+# Subagents MCP
+
+Status: authoritative target definition for the Subagents product MCP.
+
+## Identity
+
+```text
+id: subagents
+owner domain: domains/sessions/subagents
+target implementation: domains/sessions/subagents/mcp/**
+current implementation: sessions/subagents/mcp_server/**
+visibility: internal
+route slug: subagents
+server name: proliferate-subagents
+default injection: attach to parent sessions that are allowed to create/manage
+  same-workspace child agent sessions
+```
+
+This MCP lets a parent agent create and supervise same-workspace child sessions.
+It is a product workflow built on the normal session runtime. It must not
+create a parallel session engine.
+
+## Auth
+
+Current auth shape:
+
+```text
+header: x-subagent-session-token
+secret file: subagent-mcp-token.key
+ttl: 12 hours
+scope: workspace_id + parent_session_id
+signature: legacy sha256-dot today; target should use the shared product MCP
+  token envelope from integrations/mcp/product_server
+```
+
+The capability token authorizes only the parent session it was minted for. It
+does not grant access to arbitrary child sessions; child access is checked by
+the subagents domain.
+
+## Selection And Injection
+
+Attach when:
+
+- the session is a standard parent session
+- the product launch policy allows subagents
+- the parent can create same-workspace child sessions
+
+Do not attach when:
+
+- the session is itself a subagent child that cannot create grandchildren
+- workspace/session policy disables subagents
+- the session launch is internal-only and does not include the subagent
+  capability
+
+Injection output:
+
+```text
+url: /v1/workspaces/{workspace_id}/sessions/{parent_session_id}/mcp/subagents
+headers:
+  authorization: Bearer <runtime token> when runtime auth is enabled
+  x-anyharness-product-mcp-token or x-subagent-session-token: scoped token
+binding summary: subagents capability attached
+prompt text: explain same-workspace child sessions, creation limits, and wake
+  behavior
+```
+
+The actor receives the final HTTP MCP server config. It must not evaluate
+subagent policy.
+
+## Context
+
+`context.rs` resolves:
+
+- workspace id
+- parent session id
+- parent session record
+- workspace surface
+- existing child count
+- child ownership validation
+- limits such as max children and depth
+- launch catalog/live config needed to compute defaults
+
+Current invariant:
+
+- subagents are only available in standard workspaces
+- child sessions are normal sessions in the same workspace
+- grandchildren are not allowed
+- child MCP inheritance is currently none
+
+## Tools
+
+Current tools:
+
+```text
+get_subagent_launch_options
+  returns defaults, limits, supported agent/model choices, mode hints, and
+  creation block reason
+
+create_subagent
+  creates a durable child session, links it to the parent, starts it, and sends
+  the initial prompt
+
+list_subagents
+  lists child sessions owned by this parent
+
+send_subagent_message
+  sends another prompt to an owned child session
+
+schedule_subagent_wake
+  schedules a one-shot wake when the child's next newly completed turn lands
+
+get_subagent_status
+  returns execution status for an owned child session
+
+read_subagent_events
+  returns a bounded sanitized event slice from an owned child session
+```
+
+Tool list construction belongs in `tools.rs`. Tool availability should vary by
+typed context, not by ad hoc checks inside JSON-RPC dispatch.
+
+## Calls
+
+`calls.rs` delegates to:
+
+- subagents service for parent/child ownership and links
+- session runtime for durable session creation, live start, and prompt send
+- session event read APIs for sanitized child event slices
+
+Required call invariants:
+
+- trim and validate prompts before creating or sending
+- validate parent can spawn before creating a child
+- rollback child session/link state when startup fails
+- do not bypass `SessionRuntime` for child session creation/start/prompt
+- never expose events for a child not owned by the parent
+- wake scheduling is explicit and not retroactive
+
+## UI Exposure
+
+Internal only.
+
+UI may show:
+
+- attached subagents capability in MCP binding summaries
+- child sessions in the workspace/session UI through normal subagent product
+  state
+
+UI should not show a generic user toggle for this MCP until subagents become a
+separately configurable product capability.
+
+## Tests
+
+Required tests:
+
+- selection attaches subagents only to eligible parent sessions
+- selection does not attach to child sessions/grandchild contexts
+- token rejects wrong workspace/session
+- `tools/list` includes launch options before create
+- `create_subagent` rolls back on failed link/start/prompt
+- child event reads are ownership-scoped and bounded
+- wake scheduling is idempotent and not retroactive
+- actor launch receives final MCP config without policy branches
+
+## Migration Acceptance
+
+Done when:
+
+- `sessions/subagents/mcp_server/**` is replaced by
+  `domains/sessions/subagents/mcp/**`.
+- protocol dispatch uses the shared `integrations/mcp/product_server` kit.
+- selection/injection lives under `domains/sessions/mcp_bindings/**`.
+- product behavior lives in subagents domain service/runtime calls.
+- temporary header/signature names are either migrated to the shared product
+  MCP token envelope or explicitly documented as compatibility aliases.
+

--- a/docs/anyharness/product-mcps/workspace-naming.md
+++ b/docs/anyharness/product-mcps/workspace-naming.md
@@ -1,0 +1,156 @@
+# Workspace Naming MCP
+
+Status: authoritative target definition for the Workspace Naming product MCP.
+
+## Identity
+
+```text
+id: workspace_naming
+owner domain: domains/sessions/workspace_naming
+target implementation: domains/sessions/workspace_naming/mcp/**
+current implementation: sessions/workspace_naming/mcp_server/**
+visibility: internal
+route slug: workspace_naming
+server name: proliferate-workspace-naming
+default injection: attach only to first-turn workspace naming sessions that
+  are eligible to set the workspace display name
+```
+
+This MCP lets a dedicated naming session set a concise display name for a
+workspace before doing any other visible work.
+
+## Auth
+
+Current auth shape:
+
+```text
+header: x-workspace-naming-session-token
+secret file: workspace-naming-mcp-token.key
+ttl: 12 hours
+scope: workspace_id + session_id
+signature: HMAC SHA-256
+```
+
+Target scope:
+
+```text
+workspace_id
+session_id
+product_mcp_id: workspace_naming
+capability: set_workspace_display_name
+```
+
+## Selection And Injection
+
+Attach when:
+
+- the session was created for workspace naming
+- the workspace/session passes naming eligibility checks
+- the session is on the first turn where naming should occur before any other
+  visible output
+
+Do not attach when:
+
+- the workspace already has final naming state that should not be changed
+- the session is not the naming session
+- the workspace is not mutable
+
+Injection output:
+
+```text
+url: /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/workspace_naming
+headers:
+  authorization: Bearer <runtime token> when runtime auth is enabled
+  x-anyharness-product-mcp-token or x-workspace-naming-session-token: scoped token
+binding summary: workspace naming tool attached
+first-prompt-only prompt text: call the naming tool before any visible response
+```
+
+This MCP is intentionally prompt-sensitive. Its prompt text belongs in session
+MCP injection, not inside the actor loop.
+
+## Context
+
+`context.rs` resolves:
+
+- workspace id
+- session id
+- session record
+- workspace record
+- naming eligibility
+- workspace mutability
+
+Context validation must prove the session belongs to the workspace and that the
+naming tool is allowed for this session.
+
+## Tools
+
+Current tool:
+
+```text
+set_workspace_display_name
+  displayName: string
+```
+
+Instructions should make the agent-visible qualified name explicit when tools
+are namespaced:
+
+```text
+mcp__workspace_naming__set_workspace_display_name
+```
+
+The tool description must also state:
+
+- call this before any user-visible response in the naming turn
+- do not use ToolSearch to find it
+- do not use subagents for workspace naming
+- do not rename git branches
+
+## Calls
+
+`calls.rs` delegates to:
+
+- session store to load and validate the session
+- workspace runtime to load and update workspace display name
+- workspace access gate to assert mutability
+- workspace naming eligibility policy
+
+Required call invariants:
+
+- trim and reject empty display names
+- validate session belongs to workspace
+- validate naming eligibility
+- assert workspace mutability before update
+- update only workspace display name; do not rename branches
+
+## UI Exposure
+
+Internal only.
+
+Workspace UI owns visible naming state. The MCP binding summary may show that
+naming tools were attached, but the user should not see a generic toggle for
+this MCP.
+
+## Tests
+
+Required tests:
+
+- selection attaches only for naming-eligible sessions
+- context rejects wrong workspace/session pair
+- tool description includes the exact namespaced tool name
+- tool description forbids ToolSearch/subagents/branch renaming
+- empty display name is rejected
+- workspace mutability is enforced
+- call updates workspace display name through workspace runtime
+
+## Migration Acceptance
+
+Done when:
+
+- `sessions/workspace_naming/mcp_server/**` is replaced by
+  `domains/sessions/workspace_naming/mcp/**`.
+- eligibility/context logic lives in `context.rs`.
+- prompt-sensitive instructions live in injection/definition, not actor code.
+- `calls.rs` delegates to workspace runtime/access gate and naming policy.
+- shared JSON-RPC dispatch lives in `integrations/mcp/product_server`.
+

--- a/docs/anyharness/specs/agent-catalog-readiness.md
+++ b/docs/anyharness/specs/agent-catalog-readiness.md
@@ -1,0 +1,442 @@
+# Agent Catalog And Readiness
+
+Status: authoritative for the fully migrated AnyHarness agent catalog,
+installation, credentials, and readiness architecture.
+
+## Goal
+
+The agents domain answers one product question:
+
+```text
+For this AnyHarness target, which agent families are supported, installable,
+authenticated, ready, and launchable?
+```
+
+It does not answer:
+
+- what the cloud product wants to show optimistically in every UI
+- what an already-running ACP session currently reports as live model/config
+  truth
+- how to speak provider-specific CLI, ACP registry, or MCP protocols
+- how a session actor processes turns
+
+The fully migrated architecture has one supported catalog input, one agents
+domain, and separate modules for catalog, install, credentials, readiness, and
+launch resolution.
+
+## Truth Sources
+
+There are three distinct truths. Do not collapse them.
+
+```text
+Cloud product catalog
+  Product/UI catalog for optimistic rendering in desktop, web, mobile, and
+  automation creation. This can be newer than a target runtime.
+
+AnyHarness agent catalog
+  Target-runtime support manifest. It says what this runtime knows how to
+  install, discover, authenticate, and launch.
+
+Live ACP session config
+  Actual truth for an active session after the agent process starts and reports
+  its live model/config capabilities.
+```
+
+Consequences:
+
+- Desktop may render optimistically from cloud/catalog product data.
+- AnyHarness must still validate and resolve what the target can actually run.
+- A live session's active model/config truth comes from ACP live config, not
+  from the static AnyHarness catalog.
+- AnyHarness catalog endpoints, if exposed, are target capability/readiness
+  endpoints, not the primary product UI catalog.
+
+## Single Catalog Input
+
+The only supported AnyHarness catalog schema is:
+
+```text
+catalogs/agents/v1/catalog.json
+catalogs/agents/v1/schema.json
+```
+
+The catalog document describes supported agent families:
+
+- agent kind and display name
+- install support for native CLI artifacts
+- install support for ACP-facing agent-process artifacts
+- launch executable and default args
+- credential discovery kind and login command
+- fallback session model/control metadata
+- compatibility and status metadata
+
+There must be no split legacy catalog inputs:
+
+```text
+catalogs/launch/**
+ModelCatalogDocument
+LaunchCatalogDocument
+ANYHARNESS_MODEL_CATALOG_URL
+ANYHARNESS_LAUNCH_CATALOG_URL
+old model/launch cache readers
+old model/launch cache writers
+```
+
+If remote catalog refresh is supported, it must use the same
+`AgentCatalogDocument` schema. Remote refresh must not reintroduce separate
+model or launch catalog formats.
+
+## Trust Boundary
+
+Executable behavior is security-sensitive.
+
+The trusted bundled catalog may define:
+
+- install methods
+- binary/package URLs
+- executable names
+- launch args
+- credential discovery kind
+- login command
+
+An unsigned remote catalog may only update non-executable metadata:
+
+- model display names
+- model status
+- launch-remediation text
+- fallback launch controls
+- fallback session default controls
+
+Remote catalog data must not silently change process/install/auth behavior
+unless the remote catalog is signed and verified by an explicitly documented
+trust path.
+
+This boundary should be visible in code. The projection that produces
+`AgentDescriptor` must be sourced from trusted catalog data only.
+
+## Target Source Shape
+
+Final agents domain:
+
+```text
+anyharness-lib/src/domains/agents/
+  model.rs
+  catalog/
+    mod.rs
+    schema.rs
+    bundled.rs
+    validation.rs
+    cache.rs
+    remote.rs
+    projection/
+      descriptors.rs
+      models.rs
+      launch.rs
+    tests/
+  registry/
+    mod.rs
+  credentials/
+    mod.rs
+  readiness/
+    mod.rs
+    artifacts.rs
+    spawn.rs
+    compatibility.rs
+  install/
+    mod.rs
+    native.rs
+    agent_process.rs
+    launcher.rs
+    locks.rs
+  reconcile/
+    mod.rs
+  seed/
+    mod.rs
+```
+
+Use direct imports. Do not add barrel-only convenience files. `mod.rs` may
+define the public surface for that module and re-export intentionally public
+types/functions from its children.
+
+## Module Ownership
+
+### `catalog/`
+
+Owns the static support manifest.
+
+Allowed:
+
+- parse `AgentCatalogDocument`
+- validate schema invariants
+- read bundled catalog JSON
+- refresh/cache same-schema remote catalog metadata, if enabled
+- project trusted catalog data into `AgentDescriptor`
+- project fallback model metadata
+- project fallback launch metadata when an API still needs that response shape
+
+Banned:
+
+- checking local filesystem/PATH readiness
+- checking user credentials
+- executing install/update
+- generating launchers
+- starting ACP sessions
+- treating static model metadata as active-session truth
+- parsing old model/launch catalog formats
+
+### `registry/`
+
+Owns the supported-agent registry exposed to runtime callers.
+
+It should answer:
+
+```text
+Which agent kinds does this runtime know how to support?
+```
+
+It is built from trusted catalog descriptor projection. It should not perform
+readiness checks or installation.
+
+### `credentials/`
+
+Owns runtime credential readiness mapping.
+
+Allowed:
+
+- check required env vars
+- ask `anyharness-credential-discovery` for provider-local auth state
+- map provider-local auth into `CredentialState`
+- report login guidance from the descriptor
+
+Banned:
+
+- storing cloud credential sync policy
+- installing agents
+- changing catalog data
+- starting live sessions
+
+Provider credential file parsing that is reusable across desktop/cloud sync
+belongs in `anyharness-credential-discovery`. The agents domain consumes that
+crate and maps results into runtime readiness.
+
+### `readiness/`
+
+Owns target-local readiness.
+
+Inputs:
+
+- `AgentDescriptor`
+- runtime home
+- platform/architecture
+- managed artifact state
+- PATH-discovered artifact state
+- credential state
+
+Outputs:
+
+- `ResolvedArtifact`
+- `ResolvedAgent`
+- `ResolvedAgentStatus`
+- `SpawnSpec` when launchable
+
+Readiness does not install anything. It reports the current target state.
+
+Dynamic providers such as OpenCode may expose model lists at live ACP runtime.
+Readiness should say whether the provider is launchable; it should not try to
+precompute every live model choice when the provider owns that dynamically.
+
+### `install/`
+
+Owns managed install/update workflows.
+
+Allowed:
+
+- install native CLI artifacts when the descriptor supports managed install
+- install ACP-facing agent-process artifacts
+- generate managed launchers
+- use runtime-home install locks
+- return install results
+- re-run readiness after mutation
+
+Banned:
+
+- defining what agents exist
+- checking credentials except when needed for a provider-specific install step
+- writing static catalog files
+- starting a session actor
+
+Low-level vendor mechanics belong under `integrations/agent_cli/**`.
+`install/` uses those mechanics to implement product install/update behavior.
+
+### `reconcile/`
+
+Owns batch repair/sync.
+
+It can iterate supported agents and call install/readiness flows to make the
+runtime match desired local state.
+
+It should not own per-provider install mechanics.
+
+### `seed/`
+
+Owns prepackaged desktop/runtime artifacts.
+
+Allowed:
+
+- inspect seeded artifacts
+- hydrate runtime-home artifacts from packaged binaries
+- validate seed metadata
+- quarantine or ignore invalid seeds
+- regenerate launchers for seeded artifacts
+
+Banned:
+
+- deciding product launch defaults
+- replacing readiness checks
+- parsing credential files
+
+## External Boundaries
+
+### `integrations/agent_cli/**`
+
+Provider/vendor mechanics:
+
+- ACP registry document fetching
+- provider CLI probe/path/version helpers
+- launcher mechanics that are reusable across install/readiness
+- package manager or binary-distribution mechanics
+
+No product readiness decisions live here.
+
+### `sessions/runtime/**`
+
+Session runtime uses agents as an input:
+
+```text
+agent kind + launch selection
+  -> registry descriptor
+  -> readiness resolution
+  -> spawn spec
+  -> live session startup
+```
+
+It should not parse catalog JSON or inspect credential files directly.
+
+### `live/sessions/**`
+
+Live session code starts and supervises the ACP process from a resolved
+`SpawnSpec`. It should not decide which agents exist or how to install them.
+
+## Runtime Flow
+
+### Listing target agents
+
+```text
+API handler
+  -> agents registry
+  -> readiness resolver for each supported descriptor
+  -> response includes target-local readiness and fallback metadata
+```
+
+### Installing an agent
+
+```text
+API handler
+  -> install service
+    -> descriptor from registry
+    -> install native artifact if supported and needed
+    -> install agent-process artifact if supported and needed
+    -> regenerate launcher if needed
+    -> readiness resolver
+  -> response includes fresh readiness
+```
+
+### Creating a session
+
+```text
+SessionRuntime
+  -> descriptor from registry
+  -> readiness resolver
+  -> reject if not launchable
+  -> build spawn spec
+  -> assemble MCP/session launch extras
+  -> LiveSessionManager starts actor
+  -> live ACP config becomes active-session truth
+```
+
+### Model/config display
+
+```text
+Before live session:
+  client may show cloud product catalog optimism
+
+At target/session creation:
+  AnyHarness validates against target support/readiness
+
+After live session starts:
+  client uses live ACP config/session events as actual truth
+```
+
+## Public API Behavior
+
+AnyHarness may expose target capability endpoints, but their semantics must be
+clear:
+
+- agent list/readiness endpoint: target-local support and readiness
+- install endpoint: mutate target-local managed artifacts
+- session-launch endpoint, if retained: target-local launch metadata projected
+  from the single agents catalog plus readiness filtering
+- model registry endpoint, if retained: fallback metadata projected from the
+  single agents catalog, not active live-session truth
+
+No API should expose or depend on the removed split launch/model catalog files.
+
+## Banned Shapes
+
+Do not add:
+
+- `domains/agents/catalog.rs`
+- `catalog/legacy.rs`
+- `ModelCatalogDocument`
+- `LaunchCatalogDocument`
+- `catalogs/launch/**`
+- `ANYHARNESS_MODEL_CATALOG_URL`
+- `ANYHARNESS_LAUNCH_CATALOG_URL`
+- direct catalog JSON parsing from `sessions/**`, `live/**`, or `api/**`
+- credential detection inside `catalog/**`
+- install/update execution inside `catalog/**`
+- provider CLI mechanics inside `catalog/**`
+
+## Migration Acceptance
+
+A full migration is done only when:
+
+- `domains/agents/catalog.rs` is gone.
+- `domains/agents/catalog/**` exists with focused submodules.
+- `catalogs/launch/**` is gone.
+- old split catalog structs/functions/env vars are gone.
+- all launch/model metadata AnyHarness still exposes is projected from
+  `AgentCatalogDocument`.
+- executable/process/auth descriptor projection is sourced only from trusted
+  catalog data.
+- install, credential detection, readiness, reconcile, and seed behavior live
+  outside `catalog/**`.
+- tests are split by responsibility:
+  - catalog validation
+  - descriptor projection
+  - fallback model projection
+  - fallback launch projection
+  - unified remote/cache behavior, if retained
+  - readiness
+  - install
+  - credentials
+
+Verification examples:
+
+```bash
+rg "ModelCatalogDocument|LaunchCatalogDocument|ANYHARNESS_MODEL_CATALOG_URL|ANYHARNESS_LAUNCH_CATALOG_URL" anyharness catalogs scripts
+rg "catalogs/launch" anyharness catalogs scripts docs
+cargo test -p anyharness-lib domains::agents
+```
+
+The first two commands should return no code references after the migration.

--- a/docs/anyharness/specs/product-mcps.md
+++ b/docs/anyharness/specs/product-mcps.md
@@ -1,0 +1,829 @@
+# Product MCP Servers
+
+Status: authoritative for product-owned MCP servers in AnyHarness.
+
+Product MCP servers are AnyHarness-owned tools exposed to agents through MCP.
+They let an agent call Proliferate product capabilities such as subagents,
+reviews, cowork artifacts, workspace naming, computer use, browser use, or
+artifacts.
+
+This document does not cover arbitrary external/user-supplied MCP servers
+except where those servers are merged into a session launch.
+
+## Core Model
+
+A product MCP has three parts:
+
+```text
+product behavior
+  the domain-owned tool semantics: what tools exist and what they do
+
+session attachment
+  the session-owned decision of whether this session receives that MCP
+
+protocol serving
+  the integration-owned JSON-RPC/MCP transport mechanics
+```
+
+Do not collapse these parts.
+
+```text
+domains/<domain>/mcp
+  What does this product MCP do?
+
+domains/sessions/mcp_bindings
+  Which MCP servers should this session launch with?
+
+integrations/mcp
+  How does MCP JSON-RPC, tool formatting, and capability-token validation work?
+```
+
+The live session actor receives a final concrete MCP server list. It must not
+decide which product MCPs are enabled.
+
+## Current And Future Product MCPs
+
+Current internal product MCPs:
+
+```text
+domains/sessions/subagents/mcp
+domains/reviews/mcp
+domains/sessions/workspace_naming/mcp
+```
+
+Likely future user-selectable product MCPs:
+
+```text
+domains/artifacts/mcp
+domains/computer_use/mcp
+domains/browser/mcp
+domains/workspace_tools/mcp
+```
+
+Current product MCPs are HTTP MCP endpoints exposed by AnyHarness and injected
+into agent sessions as MCP server configs. They are not separate stdio MCP
+processes.
+
+## Target Source Shape
+
+Shared MCP protocol kit:
+
+```text
+anyharness-lib/src/integrations/mcp/
+  capability_token.rs
+  json_rpc.rs
+  tools.rs
+  product_server/
+    mod.rs
+    definition.rs
+    dispatcher.rs
+    endpoint.rs
+    errors.rs
+    request.rs
+    response.rs
+```
+
+Session MCP binding and launch assembly:
+
+```text
+anyharness-lib/src/domains/sessions/mcp_bindings/
+  mod.rs
+  model.rs
+  crypto.rs
+  contract.rs
+  summaries.rs
+  acp.rs
+  assembly.rs
+  product_registry.rs
+  selection.rs
+  injection.rs
+```
+
+Product MCP implementation:
+
+```text
+anyharness-lib/src/domains/<domain>/mcp/
+  mod.rs
+  definition.rs
+  auth.rs
+  context.rs
+  tools.rs
+  calls.rs
+```
+
+Examples:
+
+```text
+domains/reviews/mcp/
+domains/sessions/subagents/mcp/
+domains/sessions/workspace_naming/mcp/
+domains/artifacts/mcp/
+domains/computer_use/mcp/
+domains/browser/mcp/
+```
+
+Current transitional paths may still use `mcp_server/`; target naming is
+`mcp/`.
+
+## Shared Protocol Kit
+
+`integrations/mcp/product_server/**` owns generic MCP serving mechanics.
+
+Allowed:
+
+- parse JSON-RPC requests
+- format JSON-RPC responses
+- implement `initialize`
+- accept `notifications/initialized`
+- dispatch `tools/list`
+- dispatch `tools/call`
+- format MCP tool results and tool errors
+- validate shared capability-token envelopes
+- provide a reusable HTTP endpoint wrapper
+
+Banned:
+
+- product MCP IDs such as `reviews`, `subagents`, or `computer_use`
+- product authorization rules
+- session selection policy
+- domain service calls
+- launch prompt text
+- binding summary semantics
+
+The shared kit should be usable by every product MCP. If a feature needs custom
+JSON-RPC plumbing, first ask whether the shared dispatcher is missing a generic
+MCP behavior.
+
+## Product MCP Definition
+
+Every product MCP must define a static definition.
+
+Required fields:
+
+```text
+id
+  stable product MCP id, such as "reviews" or "computer_use"
+
+display_name
+  user-facing name for summaries/catalogs
+
+description
+  concise capability description
+
+owner_domain
+  owning product domain path/concept
+
+route_slug
+  stable endpoint segment when routed through the generic product MCP endpoint
+
+visibility
+  internal or user_selectable
+
+default_injection_policy
+  when the MCP is attached without explicit user selection
+
+required_capabilities
+  target/runtime capabilities required before launch
+
+binding_summary_kind
+  summary type written into session MCP binding summaries
+
+prompt_policy
+  whether it contributes system prompt or first-prompt-only text
+```
+
+Visibility:
+
+```text
+internal
+  attached by product workflows or session extensions; usually not directly
+  user-toggleable
+
+user_selectable
+  shown in local/cloud/team catalogs and selected by user, team, workspace,
+  automation, or session policy
+```
+
+Default injection policies:
+
+```text
+never
+  only attach when explicitly selected by policy
+
+when_session_role_matches
+  attach for a specific product session role, such as reviewer or subagent
+
+when_product_feature_created_session
+  attach for sessions created by a product workflow
+
+when_capability_enabled
+  attach if user/team/session policy enables the capability
+```
+
+## Product MCP Module Contract
+
+Each `domains/<domain>/mcp/**` folder uses the same file grammar.
+
+```text
+definition.rs
+  static metadata and injection defaults
+
+auth.rs
+  product-specific capability-token scope construction and validation wrapper
+
+context.rs
+  workspace/session/product role resolution
+
+tools.rs
+  data-shaped MCP tools/list definitions
+
+calls.rs
+  tools/call implementation, delegating to domain service/runtime/live handles
+```
+
+### `definition.rs`
+
+Owns static metadata only.
+
+It may reference domain-owned constants and copy. It must not query stores,
+read runtime state, or build session launch config.
+
+### `auth.rs`
+
+Owns product-specific capability scopes.
+
+Minimum scope:
+
+```text
+workspace_id
+session_id
+product_mcp_id
+```
+
+Add fields when the product needs them:
+
+```text
+role
+parent_session_id
+review_run_id
+subagent_id
+computer_use_allowed
+browser_use_allowed
+artifact_namespace
+```
+
+Runtime bearer auth proves the HTTP caller can access protected AnyHarness
+routes. The product MCP capability token proves the MCP call was minted for a
+specific workspace/session/product capability.
+
+### `context.rs`
+
+Owns request-time product context resolution.
+
+Input:
+
+```text
+workspace_id
+session_id
+validated capability scope
+```
+
+Output:
+
+```text
+typed context for tools/list and tools/call
+```
+
+Examples:
+
+```text
+reviews
+  parent session, reviewer session, review run role
+
+subagents
+  parent session allowed to manage child sessions
+
+cowork
+  cowork thread/session/artifact context
+
+artifacts
+  artifact namespace, read/write permissions, target capability availability
+
+computer_use
+  session has computer-use permission and sidecar/runtime capability exists
+
+browser
+  session has browser-use permission and browser sidecar is available
+```
+
+Context resolution belongs in the product domain because it depends on product
+state.
+
+### `tools.rs`
+
+Owns MCP `tools/list` definitions.
+
+Tool definitions must be data-shaped:
+
+```text
+name
+description
+input_schema
+availability by context/role
+```
+
+Tool definitions should be easy to unit test. Do not hide business logic in
+tool-list construction.
+
+### `calls.rs`
+
+Owns MCP `tools/call` behavior.
+
+The call flow is:
+
+```text
+parse tool arguments
+validate context and role
+call product domain service/runtime/live capability
+return structured MCP result
+```
+
+Tool calls should delegate to product services/runtimes. The MCP server must
+not become a second implementation of the product feature.
+
+## Product MCP Trait
+
+Rust should use traits and typed structs, not inheritance or feature-local
+dispatchers copied by hand.
+
+Target shape:
+
+```rust
+pub trait ProductMcpServer {
+    type Context;
+
+    fn definition(&self) -> ProductMcpDefinition;
+
+    fn resolve_context(
+        &self,
+        request: ProductMcpRequestContext,
+    ) -> anyhow::Result<Self::Context>;
+
+    fn tools(&self, ctx: &Self::Context) -> Vec<McpToolDefinition>;
+
+    async fn call_tool(
+        &self,
+        ctx: Self::Context,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> anyhow::Result<McpToolResult>;
+}
+```
+
+Shared code handles JSON-RPC. Product code handles product meaning.
+
+## Session MCP Binding Modules
+
+`domains/sessions/mcp_bindings/**` owns the central session MCP launch
+boundary.
+
+File responsibilities:
+
+```text
+model.rs
+  SessionMcpServer, session binding models, selection records, launch output
+
+crypto.rs
+  external/user MCP binding encryption and decryption
+
+contract.rs
+  contract <-> domain mapping for user MCP binding APIs
+
+summaries.rs
+  binding summary validation, serialization, and merge rules
+
+acp.rs
+  SessionMcpServer -> ACP MCP server config conversion
+
+assembly.rs
+  one launch boundary that produces final MCP servers and prompt additions
+
+product_registry.rs
+  code-defined product MCP definitions and server lookup
+
+selection.rs
+  selection policy for product/user/team/session/workspace MCPs
+
+injection.rs
+  SessionMcpHttpServer URL, headers, capability tokens, summaries, prompt text
+```
+
+`assembly.rs` answers one question:
+
+```text
+Which MCP servers, prompt additions, and binding summaries should this session
+launch with?
+```
+
+It owns:
+
+- applying `InternalOnly` vs user-inherited binding policy
+- decrypting external/user MCP bindings
+- collecting product MCPs selected by policy
+- merging external/user MCP servers and product MCP servers in launch order
+- minting product MCP capability headers
+- producing binding summaries
+- producing system prompt append text
+- producing first-prompt-only prompt append text
+- returning restart-required/missing-data-key errors when persisted bindings
+  cannot be used
+
+It does not own:
+
+- JSON-RPC parsing or response formatting
+- product tool behavior
+- product context resolution
+- live MCP elicitation resolution
+- actor startup policy
+
+## Product MCP Registry
+
+`product_registry.rs` is the session-facing registry of product MCPs available
+to assembly and endpoints.
+
+It should provide:
+
+```text
+lookup by product_mcp_id
+list definitions for UI/catalog/summaries
+server dispatch target for generic MCP endpoint
+injection metadata for session launch
+```
+
+It may be constructed by app composition when concrete servers need runtime
+dependencies. The session MCP assembly still owns selection and injection; app
+composition only wires available implementations.
+
+Do not make each product route manually rediscover its own MCP server. All
+product MCP endpoint dispatch should use the same registry shape.
+
+## Selection Policy
+
+Selection happens before actor startup.
+
+Inputs:
+
+```text
+workspace_id
+session_id
+session kind / role
+session launch source
+agent kind
+external/user MCP binding policy
+explicit session MCP selections
+workspace/team/org MCP selections, when available
+runtime capability availability
+product session extension outputs
+```
+
+Outputs:
+
+```text
+selected product MCP ids
+external/user MCP bindings to include
+binding summaries
+system prompt append
+first-prompt-only prompt append
+final SessionMcpServer list
+```
+
+Internal examples:
+
+```text
+review session
+  receives reviews MCP with reviewer/parent scope
+
+parent session with subagent support
+  receives subagents MCP with parent-session scope
+
+cowork session
+  receives artifacts MCP with cowork thread/artifact scope during the
+  transitional cowork-owned artifact implementation
+
+workspace naming session
+  receives workspace_naming MCP with workspace/session scope
+```
+
+User-selectable examples:
+
+```text
+computer_use enabled for session
+  receives computer_use MCP if target reports computer capability
+
+browser_use enabled for workspace
+  receives browser MCP if target reports browser capability
+
+artifact tools enabled for team automation
+  receives artifacts MCP with org/team/workspace/session scope
+```
+
+The live actor only receives the final launch payload. It must not evaluate
+selection policy.
+
+## Injection Shape
+
+Product MCP injection produces a normal MCP server config.
+
+For local AnyHarness:
+
+```text
+server name: product MCP id or stable display name
+transport: HTTP MCP
+url: /v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/{product_mcp_id}
+headers:
+  authorization: Bearer <runtime token>          # when runtime auth is enabled
+  x-anyharness-product-mcp-token: <capability token>
+```
+
+The capability token is minted at launch and scoped to the selected product
+MCP. It is not durable user config.
+
+The binding summary should make attached product MCPs visible without exposing
+secret headers.
+
+## Endpoint Flow
+
+Preferred generic endpoint:
+
+```text
+/v1/workspaces/{workspace_id}/sessions/{session_id}/mcp/{product_mcp_id}
+```
+
+Migration routes may remain temporarily:
+
+```text
+/v1/workspaces/{workspace_id}/sessions/{session_id}/reviews/mcp
+/v1/workspaces/{workspace_id}/sessions/{session_id}/subagents/mcp
+```
+
+POST flow:
+
+```text
+agent MCP client
+  -> AnyHarness product MCP endpoint
+  -> API validates runtime bearer token when configured
+  -> shared endpoint validates product MCP capability token
+  -> product registry resolves product MCP server
+  -> shared MCP dispatcher parses JSON-RPC
+  -> product MCP resolves context
+  -> product MCP lists/calls tools
+  -> product domain service/runtime/live capability performs behavior
+  -> shared dispatcher formats JSON-RPC result
+  -> agent receives MCP result
+  -> agent emits normal ACP tool call/result notifications
+  -> SessionEventSink persists and broadcasts transcript events
+```
+
+GET may remain `204 No Content` for endpoint liveness unless a future MCP
+transport requires a different handshake.
+
+## Event And Transcript Behavior
+
+Most product MCP calls should not write transcript events directly.
+
+Normal transcript flow:
+
+```text
+agent calls product MCP tool
+product MCP endpoint returns result
+agent emits ACP tool call/result notification
+SessionActor receives notification
+SessionEventSink persists/broadcasts normalized event
+```
+
+If a product MCP changes durable product state independently, the owning domain
+may also expose normal API/UI refresh state. That does not belong in
+`integrations/mcp`.
+
+## Internal vs User-Selectable
+
+Internal product MCPs:
+
+```text
+subagents
+reviews
+workspace_naming
+```
+
+Properties:
+
+- injected by product workflow/session role
+- usually not shown as a user toggle
+- may appear in binding summaries for transparency
+- role/context depends on session relationship
+
+User-selectable product MCPs:
+
+```text
+artifacts
+computer_use
+browser_use
+workspace_tools
+```
+
+Properties:
+
+- shown in local/cloud/team catalogs
+- explicitly enabled by user, workspace, team, automation, or session policy
+- require permission warnings
+- may depend on compute capability availability
+- use the same product MCP server pattern as internal MCPs
+
+Only selection and UI policy differ. The protocol, endpoint, auth, context,
+tools, and calls shape is the same.
+
+## Storage
+
+Code-defined internal product MCPs:
+
+```text
+definition lives in code
+selection is derived from session/product role
+tokens are minted at launch
+no user config is required
+```
+
+User-selectable product MCPs:
+
+```text
+definition lives in code
+selection records are durable product config
+local/session selection first
+workspace/team/org selection later
+resolved at launch into SessionMcpServer configs
+```
+
+External/user MCP server configs:
+
+```text
+stored as encrypted session/workspace/team MCP bindings
+decrypted during session MCP assembly
+merged with product MCP servers before launch
+```
+
+Secrets:
+
+```text
+capability signing secrets live under runtime_home
+tokens are minted per workspace/session/product MCP
+tokens are injected into MCP headers
+tokens are not durable user config
+```
+
+## Cloud And Worker Compatibility
+
+The local structure must support future cloud/worker routing.
+
+Local AnyHarness:
+
+```text
+session launch injects direct local AnyHarness URL and headers
+agent calls local HTTP MCP endpoint
+```
+
+Cloud/worker:
+
+```text
+cloud stores team/org/session MCP selection policy
+worker resolves policy for target compute
+worker launches AnyHarness session with product MCP headers/URLs
+product MCP endpoint is local to the worker/runtime or proxied near it
+cloud receives normal session event sync after agent emits ACP events
+```
+
+Capability token scope may expand:
+
+```text
+org_id
+team_id
+workspace_id
+session_id
+product_mcp_id
+role/capability
+```
+
+The same product MCP definition and call semantics should work locally and in
+cloud. Routing changes; product behavior should not fork.
+
+## Adding A New Product MCP
+
+Concrete definitions for the MCPs currently being standardized live under
+[../product-mcps/](../product-mcps/). Add or update that definition before
+implementing code.
+
+Required steps:
+
+```text
+1. Choose owning domain.
+2. Add domains/<domain>/mcp/definition.rs.
+3. Add domains/<domain>/mcp/auth.rs.
+4. Add domains/<domain>/mcp/context.rs.
+5. Add domains/<domain>/mcp/tools.rs.
+6. Add domains/<domain>/mcp/calls.rs.
+7. Register the product MCP in domains/sessions/mcp_bindings/product_registry.rs.
+8. Add selection policy in domains/sessions/mcp_bindings/selection.rs.
+9. Add injection behavior in domains/sessions/mcp_bindings/injection.rs if the
+   default HTTP injection helper is insufficient.
+10. Add endpoint routing through the generic product MCP endpoint or a temporary
+    explicit route.
+11. Add UI exposure decision: internal-only or user-selectable.
+12. Add tests for definition, auth, context, tools/list, tools/call, selection,
+    injection, and endpoint dispatch.
+```
+
+Do not ship a product MCP until it can answer:
+
+```text
+who owns it?
+who may call it?
+when is it injected?
+what durable state does it read/write?
+what live capabilities can it touch?
+what appears in transcript through normal ACP events?
+what appears in UI outside transcript?
+```
+
+## Tests
+
+Each product MCP needs focused tests:
+
+```text
+definition validates required metadata
+selection attaches it for intended session roles/policies
+selection does not attach it for unrelated sessions
+capability token rejects wrong workspace/session/product MCP
+tools/list varies correctly by context/role
+tools/call validates arguments
+tools/call delegates to owning domain service/runtime
+endpoint returns valid JSON-RPC errors for unknown method/tool
+launch injection adds safe headers and binding summary
+```
+
+Shared integration tests should cover:
+
+```text
+generic endpoint dispatch by product_mcp_id
+shared initialize/tools/list/tools/call behavior
+binding summary merge order
+external/user MCP + product MCP merge order
+actor receives final concrete MCP config only
+```
+
+## Banned Shapes
+
+Do not add:
+
+```text
+integrations/mcp/reviews.rs
+integrations/mcp/computer_use.rs
+integrations/mcp/product_logic.rs
+domains/<domain>/mcp/utils.rs
+api/http/<domain>.rs with embedded tools/call business logic
+live/sessions/actor code that decides which MCPs to attach
+feature-local JSON-RPC dispatcher copies
+durable product state changes inside integrations/mcp
+```
+
+Use:
+
+```text
+integrations/mcp/product_server
+  shared protocol mechanics
+
+domains/sessions/mcp_bindings
+  attachment, selection, summaries, injection
+
+domains/<domain>/mcp
+  product behavior
+```
+
+## Migration Acceptance
+
+The product MCP structure is fully migrated when:
+
+- shared JSON-RPC/product-server scaffolding lives in
+  `integrations/mcp/product_server/**`.
+- product MCP behavior lives in `domains/<domain>/mcp/**`, not
+  feature-local protocol copies.
+- session launch uses one assembly boundary under
+  `domains/sessions/mcp_bindings/assembly.rs`.
+- product MCP selection lives under
+  `domains/sessions/mcp_bindings/selection.rs`.
+- product MCP injection/token/header construction lives under
+  `domains/sessions/mcp_bindings/injection.rs` plus product auth wrappers.
+- the actor receives final concrete MCP server configs and has no product MCP
+  policy branches.
+- endpoint routing can dispatch by product MCP id through one shared path, even
+  if temporary explicit routes still exist.
+- tests prove selection, injection, auth, tools/list, and tools/call behavior
+  for every product MCP.

--- a/docs/anyharness/specs/session-actor.md
+++ b/docs/anyharness/specs/session-actor.md
@@ -1,0 +1,728 @@
+# Session Actor
+
+Status: draft target design for the live session actor rewrite.
+
+This spec is specific to the actor portion of the AnyHarness session engine. It
+assumes the broader architecture in `guides/system-architecture.md` and the
+session engine overview in `specs/session-engine.md`.
+
+Current implementation:
+
+```text
+anyharness-lib/src/acp/session_actor.rs
+```
+
+Target owner:
+
+```text
+anyharness-lib/src/live/sessions/actor/
+```
+
+## Full Cleanup Scope
+
+This is not a helper-extraction task. A completed actor migration means the
+actor implementation is no longer a giant `session_actor.rs` file with support
+modules around it.
+
+Done means:
+
+```text
+live/sessions/actor/ owns the actor command protocol, state, loop, turn,
+config, notification, interaction-command, and shutdown behavior.
+
+live/sessions/connection/ owns ACP process/native-session startup and shutdown
+mechanics currently embedded in actor startup paths.
+
+live/sessions/handle.rs owns the public command/subscription port into one
+actor.
+
+acp/session_actor.rs is deleted, or exists only as a temporary compatibility
+re-export during the same migration PR and is deleted before the PR is done.
+```
+
+Do not stop after moving types, small helpers, or diagnostics out of the old
+file. The top-level actor loop must be readable from
+`live/sessions/actor/loop.rs`.
+
+## Purpose
+
+`SessionActor` is the serialized decision loop for one running ACP-backed
+session.
+
+It owns ordering. It decides how these inputs interleave:
+
+```text
+product/user commands
+ACP notifications
+active prompt execution
+pending prompt edits
+queued config changes
+background work updates
+interaction resolutions
+cancel/close/dismiss/shutdown
+```
+
+It does not own the whole session product. It is one live component inside:
+
+```text
+domains/sessions/runtime
+  -> live/sessions/handle
+    -> live/sessions/actor
+      -> live/sessions/connection
+      -> live/sessions/event_sink
+      -> live/sessions/interactions
+      -> live/sessions/background_work
+```
+
+## Non-Goals
+
+The actor must not own:
+
+```text
+HTTP/SSE request handling
+contract response mapping
+prompt attachment validation
+product MCP selection or injection
+MCP JSON-RPC tool behavior
+agent catalog/install policy
+workspace/session durable business rules
+raw SQL query families
+transcript rendering
+event stream replay
+provider CLI launch policy
+```
+
+Those belong to `api/`, `domains/`, `integrations/`, `adapters/`, or sibling
+`live/sessions/**` collaborators.
+
+## Collaborators
+
+The actor coordinates collaborators; it does not absorb their code.
+
+```text
+live/sessions/handle
+  public command/subscription port used by SessionRuntime and stream code
+
+live/sessions/connection
+  ACP process/session lifecycle: spawn, initialize, authenticate, load/new/fork,
+  stderr, graceful close
+
+live/sessions/acp_client
+  low-level ACP request/notification adapter
+
+live/sessions/event_sink
+  normalized event sequencing, persistence, and broadcast fanout
+
+live/sessions/interactions
+  pending permission, user-input, and MCP elicitation rendezvous
+
+live/sessions/background_work
+  long-running tool/background work tracking
+
+domains/sessions/store
+  narrow durable operations the actor needs, such as raw notification append,
+  pending prompt queue mutation, and config queue mutation
+
+domains/sessions/prompt
+  product prompt payload preparation before the actor receives a command
+
+domains/sessions/mcp_bindings
+  product/user MCP launch assembly before actor startup
+```
+
+Boundary rule:
+
+```text
+actor/
+  What should this one live session do next?
+
+sibling live/sessions folder
+  How does this live resource or collaborator work?
+
+domains/sessions
+  What does this product operation mean durably?
+```
+
+## Owned State
+
+The actor may own state required to serialize one live session:
+
+```text
+native ACP session id
+current ACP connection/client handle
+current phase: starting, idle, busy, closing, closed
+active turn id and active prompt metadata
+current live config snapshot needed for protocol calls
+startup/native-session state
+close/dismiss/cancel intent
+active pending interaction ids that must be cleaned up on shutdown
+diagnostic timers and stuck-turn bookkeeping
+```
+
+The actor should not keep hidden product truth that is not reconstructable from
+domain state or provider state.
+
+## Public Command Surface
+
+Actor commands are the only way product code mutates a live session.
+
+Target command categories:
+
+```text
+Prompt
+  start immediately when idle; durably queue when busy
+
+SetConfigOption
+  apply immediately when idle; durably queue when busy
+
+ResolveInteraction
+  complete a pending permission/user-input/MCP elicitation
+
+Fork
+  allowed only when actor state and provider capability permit
+
+Cancel
+  forward cancellation to ACP and resolve pending waits as cancelled
+
+Close / Dismiss
+  record shutdown intent and finish safely
+
+Snapshot
+  return live execution snapshot without mutating actor state
+```
+
+Command definitions belong in:
+
+```text
+live/sessions/actor/command.rs
+```
+
+Command handlers belong under the concern that owns their behavior, not in one
+giant command file.
+
+## Event Loops
+
+The actor has two important loops.
+
+### Outer Loop
+
+The outer loop runs while the actor is alive:
+
+```text
+startup
+loop:
+  product/user command       -> command handler
+  ACP notification           -> notification handler
+  background work update     -> background_work handler
+  shutdown/error condition   -> shutdown handler
+```
+
+The outer loop file should read as dispatch. It should not contain full prompt
+execution, config application, event normalization, or process startup
+mechanics.
+
+### Active Turn Loop
+
+The active turn loop runs after an idle prompt begins:
+
+```text
+accept prompt
+  -> start turn
+  -> convert already-prepared PromptPayload into ACP blocks
+  -> call ACP prompt
+  -> while prompt is running:
+       ACP notification       -> notification handler
+       product/user command   -> busy command handler
+       background work update -> background_work handler
+       diagnostics timer      -> diagnostics handler
+  -> finish turn
+  -> apply queued config
+  -> drain next pending prompt if one exists
+  -> return to idle or continue next turn
+```
+
+The command response reports acceptance only:
+
+```text
+Started { turn_id }
+Queued { seq }
+Rejected { reason }
+```
+
+Agent output always arrives later through ACP notifications and the event sink.
+
+## Idle vs Busy Rules
+
+The same command may have different behavior depending on actor phase.
+
+Idle:
+
+```text
+Prompt            -> start turn
+SetConfigOption   -> apply to ACP/current config immediately
+Fork              -> attempt fork if supported
+Close/Dismiss     -> shutdown directly
+Snapshot          -> return current snapshot
+```
+
+Busy:
+
+```text
+Prompt            -> durably queue pending prompt
+SetConfigOption   -> durably queue pending config change
+ResolveInteraction -> complete pending interaction
+Cancel            -> forward cancellation to ACP
+Close/Dismiss     -> record shutdown intent; finish/cancel safely
+Fork              -> reject as busy
+Snapshot          -> return current snapshot
+```
+
+This split should be explicit in code. Do not hide busy/idle behavior behind a
+single large command match.
+
+## Target Folder Shape
+
+Top-level actor files:
+
+```text
+live/sessions/actor/
+  mod.rs
+  command.rs
+  state.rs
+  loop.rs
+```
+
+Responsibilities:
+
+```text
+mod.rs
+  public actor surface and module declarations
+
+command.rs
+  command/result types accepted by the actor handle
+
+state.rs
+  actor-owned live state and phase types
+
+loop.rs
+  top-level select loop and dispatch only
+```
+
+No actor-owned file should become the new god module. If one concern file grows
+past the repo-shape hard limit, split it by the concern grammar below before
+the migration is considered complete.
+
+Concern folders:
+
+```text
+turn/
+  prompt turn lifecycle and pending prompt queue drain
+
+config/
+  actor-side config apply/queue/persist behavior
+
+notifications/
+  ACP notification classification and dispatch
+
+shutdown/
+  cancellation, close, dismiss, error finalization
+
+interactions/
+  actor-side interaction resolution commands
+
+diagnostics/
+  stuck-turn and state diagnostics if it outgrows turn/diagnostics.rs
+```
+
+Use the concern grammar from `guides/system-architecture.md`:
+
+```text
+mod.rs
+types.rs
+handle.rs
+apply.rs       # live/protocol mutation
+queue.rs       # deferred durable work
+persist.rs     # durable/sink writes
+finish.rs      # terminal cleanup path
+diagnostics.rs # tracing/debug timeout logic
+```
+
+## Turn Folder
+
+Target:
+
+```text
+actor/turn/
+  mod.rs
+  types.rs
+  handle.rs
+  start.rs
+  active.rs
+  queue.rs
+  finish.rs
+  diagnostics.rs
+```
+
+Responsibilities:
+
+```text
+handle.rs
+  Prompt command entrypoint; choose start-now vs queue
+
+start.rs
+  idle prompt setup: begin turn, convert PromptPayload to ACP blocks, call ACP
+
+active.rs
+  active prompt select loop while provider is running
+
+queue.rs
+  busy prompt queue/edit/delete/drain behavior
+
+finish.rs
+  end turn, clear busy state, apply queued config, drain next prompt
+
+diagnostics.rs
+  stuck turn and long-running prompt diagnostics
+```
+
+The actor receives an already validated `PromptPayload`. Product prompt
+building remains in `domains/sessions/prompt`.
+
+## Config Folder
+
+Target:
+
+```text
+actor/config/
+  mod.rs
+  types.rs
+  handle.rs
+  apply.rs
+  queue.rs
+  persist.rs
+  selection.rs
+```
+
+Responsibilities:
+
+```text
+handle.rs
+  SetConfigOption command entrypoint; choose apply-now vs queue
+
+apply.rs
+  call ACP/native config APIs and mutate actor current config state
+
+queue.rs
+  persist pending config changes while busy
+
+persist.rs
+  update durable requested/current config snapshots through narrow store/sink calls
+
+selection.rs
+  pure helpers for choosing/merging actor-side config values
+```
+
+Config selection that is product-facing or launch-facing belongs in
+`domains/sessions/config`. Actor config code owns only live apply/queue timing.
+
+## Notifications Folder
+
+Target:
+
+```text
+actor/notifications/
+  mod.rs
+  types.rs
+  handle.rs
+  dispatch.rs
+  replay_filter.rs
+  plans.rs
+```
+
+Responsibilities:
+
+```text
+handle.rs
+  ACP notification entrypoint
+
+dispatch.rs
+  route by notification kind: assistant, reasoning, tool, config, session info,
+  usage, permission/input/MCP request, lifecycle
+
+replay_filter.rs
+  suppress provider replay/startup notifications that should not become new
+  product events
+
+plans.rs
+  actor-side plan extraction hooks only while this remains coupled to live
+  notification handling
+```
+
+Notification handlers should persist the raw ACP notification before normalized
+event handling when the current invariant requires it.
+
+Tool calls are not a separate actor subsystem unless they need one. They enter
+as ACP notifications, route through notification dispatch, and are normalized
+by `event_sink/tools.rs`.
+
+## Interactions Folder
+
+Target:
+
+```text
+actor/interactions/
+  mod.rs
+  types.rs
+  handle.rs
+  cleanup.rs
+```
+
+Responsibilities:
+
+```text
+handle.rs
+  ResolveInteraction command entrypoint
+
+cleanup.rs
+  cancel/dismiss/shutdown cleanup for pending waits
+```
+
+The pending request broker itself belongs outside the actor:
+
+```text
+live/sessions/interactions/
+```
+
+Reason: `AcpClient` creates pending requests, API/runtime resolves them through
+commands, and the actor cleans them up. The broker is a collaborator, not an
+actor-internal module.
+
+## Shutdown Folder
+
+Target:
+
+```text
+actor/shutdown/
+  mod.rs
+  types.rs
+  handle.rs
+  cleanup.rs
+  persist.rs
+```
+
+Responsibilities:
+
+```text
+handle.rs
+  Close, Dismiss, Cancel, provider-error, and actor-error entrypoints
+
+cleanup.rs
+  stop/cancel provider work, close connection, resolve pending interactions,
+  clear phase
+
+persist.rs
+  emit terminal session state through event sink and narrow stores
+```
+
+Shutdown code owns finalization ordering. It should not format API errors or
+decide product retention/cleanup policy.
+
+## Connection Boundary
+
+ACP process startup does not belong inside `actor/` concern folders.
+
+Target:
+
+```text
+live/sessions/connection/
+  mod.rs
+  types.rs
+  start.rs
+  process.rs
+  native_session.rs
+  stderr.rs
+  shutdown.rs
+```
+
+Responsibilities:
+
+```text
+start.rs
+  create an initialized ACP connection for this session launch
+
+process.rs
+  spawn and wire the provider process/stdin/stdout/stderr
+
+native_session.rs
+  new/load/fork native ACP session decisions and calls
+
+stderr.rs
+  stderr sanitization/classification
+
+shutdown.rs
+  provider/process close behavior that is not actor state-machine policy
+```
+
+The actor calls connection code during startup and shutdown, but connection code
+owns the process/protocol resource mechanics.
+
+For a full actor cleanup, connection extraction is in scope when the code is
+currently embedded in `session_actor.rs`. The actor may keep policy decisions
+such as "start a new native session vs load an existing native session" only
+when that decision depends on actor phase or ordering. The process/protocol
+mechanics belong in `live/sessions/connection/`.
+
+Reusable ACP protocol or provider mechanics should move lower:
+
+```text
+integrations/acp/
+integrations/agent_cli/
+```
+
+## Event Sink Boundary
+
+The actor decides when something happened. The event sink decides how it becomes
+durable and streamable.
+
+Target:
+
+```text
+live/sessions/event_sink/
+  mod.rs
+  state.rs
+  publish.rs
+  turns.rs
+  assistant.rs
+  reasoning.rs
+  tools.rs
+  plans.rs
+  config.rs
+  interactions.rs
+  pending_prompts.rs
+  background_work.rs
+  lifecycle.rs
+  runtime_events.rs
+  normalization/
+```
+
+Actor may call methods such as:
+
+```text
+begin_turn
+turn_finished
+assistant_chunk
+tool_call
+interaction_requested
+config_updated
+pending_prompt_added/removed
+session_ended
+```
+
+Event sink may:
+
+```text
+assign sequence numbers
+write normalized events
+update open transcript item state
+broadcast envelopes to subscribers
+normalize ACP payload fragments
+```
+
+Event sink must not:
+
+```text
+queue prompts
+decide busy/idle rules
+choose which MCPs are attached
+start/stop ACP process
+wait for interaction resolution
+format API responses
+```
+
+## Required Invariants
+
+Actor rewrite must preserve these:
+
+```text
+one actor owns one live ACP native session
+actor is the only owner of busy/idle phase
+prompt queue handoff is durable before executed pending prompt removal is emitted
+ACP notifications are persisted raw before normalized event handling
+config applies immediately only when idle; otherwise it queues
+interaction cleanup runs on cancel, dismiss, close, and error
+shutdown emits terminal session state exactly once
+event sequence order is stable for SSE replay + live broadcast
+actor never decides product MCP selection
+actor never validates raw HTTP request shapes
+```
+
+## Migration Plan
+
+This rewrite should be behavior-preserving and may be implemented in slices,
+but the final PR state must be the full target shape above. Partial helper
+extraction is not an acceptable endpoint.
+
+Recommended order:
+
+```text
+1. Extract command/state/loop shell.
+2. Extract turn start/active/finish/queue code.
+3. Extract config apply/queue/persist code.
+4. Extract notification dispatch/replay filtering.
+5. Extract interaction resolution/cleanup commands.
+6. Extract shutdown finalization.
+7. Move process startup mechanics to live/sessions/connection.
+8. Rename AcpManager/RuntimeClient paths only after behavior-preserving splits
+   are stable.
+```
+
+Each slice should:
+
+```text
+preserve public command/result behavior
+preserve event ordering
+preserve existing tests or add focused characterization tests
+delete the old code path
+avoid unrelated topology moves
+```
+
+Do not combine actor behavior changes with broad `domains/` or `live/`
+renames. The actor is the core loop; keep the migration reviewable.
+
+## Acceptance Criteria
+
+A full actor migration is accepted only when all of these are true:
+
+```text
+1. Opening live/sessions/actor/loop.rs shows the session engine event loop
+   without reading prompt/config/notification/shutdown implementation details.
+
+2. Idle and busy command behavior are explicit and separated.
+
+3. Active turn handling lives under actor/turn/ and clearly shows start,
+   active loop, finish, queued config application, and pending prompt drain.
+
+4. Config apply-vs-queue behavior lives under actor/config/.
+
+5. ACP notification dispatch lives under actor/notifications/ and delegates
+   normalization to event_sink.
+
+6. Actor-side interaction resolution and cleanup live under actor/interactions/.
+
+7. Cancel/close/dismiss/error finalization lives under actor/shutdown/.
+
+8. ACP process/native-session startup mechanics no longer live in actor
+   concern files; they live under live/sessions/connection/.
+
+9. Product prompt preparation remains in domains/sessions/prompt.
+
+10. Product MCP selection/injection remains in domains/sessions/mcp_bindings.
+
+11. Event normalization, sequence assignment, persistence, and broadcast remain
+    in live/sessions/event_sink.
+
+12. The old acp/session_actor.rs implementation is gone.
+
+13. Existing session behavior and event ordering are preserved by tests or
+    focused characterization coverage.
+```

--- a/docs/anyharness/specs/session-engine.md
+++ b/docs/anyharness/specs/session-engine.md
@@ -36,8 +36,8 @@ Implementation reality after the completed migration phases:
 - `SessionStore` is split under `sessions/store/**`.
 - `SessionRuntime` is split under `sessions/runtime/**`.
 - `SessionEventSink` is split under `acp/event_sink/**`.
-- `acp/session_actor.rs` remains the current actor implementation; the actor
-  loop rewrite is deferred/manual.
+- `acp/session_actor.rs` remains the current actor implementation; the target
+  actor rewrite is specified in `specs/session-actor.md`.
 
 ## Role Map
 
@@ -124,8 +124,7 @@ One running agent session state machine:
 - shutdown/error handling
 
 The current implementation remains a single `acp/session_actor.rs` file. The
-rewrite into an actor folder requires a dedicated actor spec and is explicitly
-deferred.
+rewrite into an actor folder is specified in `specs/session-actor.md`.
 
 ### AcpClient
 
@@ -182,6 +181,24 @@ API handler
     -> SessionEventSink persists and broadcasts events
 ```
 
+Prompt submission and transcript streaming are separate interfaces:
+
+```text
+Command path:
+  client -> HTTP command -> SessionRuntime -> LiveSessionHandle.command_tx -> SessionActor
+
+Event path:
+  SessionEventSink -> SQLite append -> live broadcast channel -> SSE stream
+```
+
+The command response reports acceptance, not the agent response. For prompts,
+the actor returns `Started { turn_id }` when it begins a turn and
+`Queued { seq }` when the session is already busy and the prompt is durably
+queued. The agent response arrives later as ordered `SessionEventEnvelope`
+records over the event stream. Clients reconnect with `after_seq`; the SSE
+handler replays missed SQLite events and then subscribes to the live broadcast
+channel.
+
 ## Create Flow
 
 ```text
@@ -195,6 +212,101 @@ API handler
     -> actor starts ACP client/subprocess
     -> SessionEventSink emits normalized events
 ```
+
+## Session Actor Shape
+
+`SessionActor` is the serialized owner of one live ACP session. Its job is
+ordering: it decides how product commands, ACP notifications, prompt execution,
+background work, pending interactions, config updates, and shutdown interleave.
+
+The actor should not own prompt attachment validation, transcript rendering,
+MCP schemas, plan product semantics, raw SQL query families, or API
+request/response mapping. It should call the modules that own those concerns.
+
+High-level target actor files:
+
+```text
+live/sessions/actor/
+  mod.rs
+  command.rs
+  state.rs
+  loop.rs
+  turn/
+  config/
+  notifications/
+  interactions/
+  shutdown/
+```
+
+See `specs/session-actor.md` for the concern-folder grammar and migration
+plan.
+
+The high-level loop should read as dispatch:
+
+```text
+startup
+loop:
+  command received       -> idle or busy command handler
+  ACP notification       -> notification handler
+  background work update -> background work handler
+  shutdown               -> finalization
+```
+
+The active prompt loop should be equally explicit:
+
+```text
+accept prompt
+  -> start turn
+  -> run ACP prompt while handling notifications, busy commands, and background work
+  -> finish turn
+  -> apply queued config
+  -> drain next pending prompt if one exists
+```
+
+Split idle and busy command handling. While idle, prompt/config/fork/close can
+usually execute immediately. While busy, a prompt is queued, config is queued,
+cancel is forwarded to ACP, interaction resolution is allowed, and close/dismiss
+records intent to finish safely.
+
+Core actor invariants:
+
+- one live actor owns one ACP native session
+- the actor is the only writer of `busy`
+- prompt queue handoff is durable before `PendingPromptRemoved { Executed }`
+- ACP notifications are persisted raw before normalized event handling
+- config changes apply immediately only when idle; otherwise they queue
+- shutdown resolves pending interactions and emits terminal session state
+
+## Event Sink Shape
+
+`SessionEventSink` is the transcript writer. The actor decides when something
+happened; the sink decides how that becomes durable `SessionEventEnvelope`
+records.
+
+Target sink files:
+
+```text
+live/sessions/event_sink/
+  mod.rs
+  state.rs
+  publish.rs
+  turns.rs
+  assistant.rs
+  reasoning.rs
+  tools.rs
+  plans.rs
+  config.rs
+  interactions.rs
+  pending_prompts.rs
+  background_work.rs
+  lifecycle.rs
+  runtime_events.rs
+  normalization/
+```
+
+The sink may assign sequence numbers, persist normalized events, and broadcast
+them. It should not decide actor lifecycle, prompt queueing, config timing, or
+pending interaction waits.
 
 ## Target File Shape
 
@@ -218,6 +330,6 @@ live/sessions/
   actor/
   event_sink/
   interactions/
-  acp_client.rs
+  acp_client/
   replay_actor.rs
 ```


### PR DESCRIPTION
## Summary
- document the AnyHarness runtime architecture, explicit repo boundaries, and live/session organization rules
- add specs for session actor structure, agent catalog/readiness, and product MCPs
- add product MCP reference docs for subagents, artifacts, reviews, and workspace naming

## Verification
- git diff --check