### PR TITLE
fix(desktop): seed agent catalog for first paint

### DIFF
--- a/desktop/src/assets.d.ts
+++ b/desktop/src/assets.d.ts
@@ -38,6 +38,11 @@ declare module "*.svg?raw" {
   export default src;
 }
 
+declare module "*.json?raw" {
+  const src: string;
+  export default src;
+}
+
 declare module "*.jpg" {
   const src: string;
   export default src;

--- a/desktop/src/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog.ts
+++ b/desktop/src/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog.ts
@@ -6,6 +6,7 @@ import {
   projectCloudAgentCatalogToDesktopLaunchCatalog,
   type DesktopAgentLaunchCatalog,
 } from "@/lib/domain/agents/cloud-launch-catalog";
+import { getBundledDesktopAgentLaunchCatalog } from "@/lib/domain/agents/bundled-agent-catalog";
 import { cloudAgentCatalogKey } from "./query-keys";
 
 async function fetchCloudAgentCatalogProjection(): Promise<DesktopAgentLaunchCatalog> {
@@ -17,6 +18,8 @@ export function useCloudAgentCatalog(enabled = true) {
     queryKey: cloudAgentCatalogKey(),
     queryFn: fetchCloudAgentCatalogProjection,
     enabled,
+    initialData: getBundledDesktopAgentLaunchCatalog,
+    initialDataUpdatedAt: 0,
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });
@@ -43,6 +46,8 @@ export function useCloudAgentCatalogCache() {
       queryClient.ensureQueryData({
         queryKey: cloudAgentCatalogKey(),
         queryFn: fetchCloudAgentCatalogProjection,
+        initialData: getBundledDesktopAgentLaunchCatalog,
+        initialDataUpdatedAt: 0,
         staleTime: 5 * 60 * 1000,
       }),
   };

--- a/desktop/src/lib/domain/agents/bundled-agent-catalog.ts
+++ b/desktop/src/lib/domain/agents/bundled-agent-catalog.ts
@@ -1,0 +1,13 @@
+import bundledAgentCatalogJson from "../../../../../catalogs/agents/v1/catalog.json?raw";
+import {
+  projectCloudAgentCatalogToDesktopLaunchCatalog,
+  type DesktopAgentLaunchCatalog,
+} from "./cloud-launch-catalog";
+
+const BUNDLED_DESKTOP_AGENT_LAUNCH_CATALOG = projectCloudAgentCatalogToDesktopLaunchCatalog(
+  JSON.parse(bundledAgentCatalogJson),
+);
+
+export function getBundledDesktopAgentLaunchCatalog(): DesktopAgentLaunchCatalog {
+  return BUNDLED_DESKTOP_AGENT_LAUNCH_CATALOG;
+}


### PR DESCRIPTION
## Summary

- seed the desktop cloud agent catalog query from the bundled agents catalog
- keep the bundled catalog stale so the cloud catalog still refreshes in the background
- add raw JSON asset typing for the bundled catalog import

## Root cause

The agent catalog migration moved first-paint launch controls behind the cloud catalog query. When that query was not ready yet, new sessions/workspaces could show a model label but not the rest of the composer controls until live session config arrived.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/agents/cloud-launch-catalog.test.ts src/hooks/chat/derived/use-chat-launch-catalog.test.tsx src/hooks/chat/derived/use-configured-launch-readiness.test.tsx src/lib/domain/chat/models/launch-control-descriptors.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- `git diff --check`
