### PR TITLE
fix(desktop): respect visible session models

### DIFF
--- a/desktop/src/lib/domain/chat/models/model-selection.test.ts
+++ b/desktop/src/lib/domain/chat/models/model-selection.test.ts
@@ -238,6 +238,180 @@ describe("buildModelSelectorGroups", () => {
       "cursor/auto",
     ]);
   });
+
+  it("applies visibility preferences to active model controls by alias", () => {
+    const groups = buildModelSelectorGroups(
+      [
+        launchAgent(
+          "cursor",
+          [
+            model("cursor/auto", "Auto", true, {
+              aliases: ["auto"],
+              defaultOptIn: true,
+            }),
+            model("cursor/gpt-5.4", "GPT 5.4", false, {
+              aliases: ["gpt-5.4"],
+              defaultOptIn: true,
+            }),
+          ],
+          {
+            displayName: "Cursor",
+          },
+        ),
+      ],
+      { kind: "cursor", modelId: "auto" },
+      { kind: "cursor", modelId: "auto" },
+      {
+        kind: "cursor",
+        values: [
+          { value: "auto", label: "Auto" },
+          { value: "gpt-5.4", label: "GPT 5.4" },
+        ],
+      },
+      {
+        cursor: {
+          "cursor/gpt-5.4": false,
+        },
+      },
+    );
+
+    expect(groups[0]?.models.map((model) => model.modelId)).toEqual([
+      "auto",
+    ]);
+  });
+
+  it("keeps canonical selected models visible when live controls use aliases", () => {
+    const groups = buildModelSelectorGroups(
+      [
+        launchAgent(
+          "cursor",
+          [
+            model("cursor/auto", "Auto", true, {
+              aliases: ["auto"],
+              defaultOptIn: true,
+            }),
+            model("cursor/gpt-5.4", "GPT 5.4", false, {
+              aliases: ["gpt-5.4"],
+              defaultOptIn: true,
+            }),
+          ],
+          {
+            displayName: "Cursor",
+          },
+        ),
+      ],
+      { kind: "cursor", modelId: "cursor/gpt-5.4" },
+      { kind: "cursor", modelId: "cursor/gpt-5.4" },
+      {
+        kind: "cursor",
+        values: [
+          { value: "auto", label: "Auto" },
+          { value: "gpt-5.4", label: "GPT 5.4" },
+        ],
+      },
+      {
+        cursor: {
+          "cursor/gpt-5.4": false,
+        },
+      },
+    );
+
+    expect(groups[0]?.models).toEqual([
+      {
+        kind: "cursor",
+        modelId: "auto",
+        displayName: "Auto",
+        actionKind: "update_current_chat",
+        isSelected: false,
+      },
+      {
+        kind: "cursor",
+        modelId: "gpt-5.4",
+        displayName: "GPT 5.4",
+        actionKind: "select",
+        isSelected: true,
+      },
+    ]);
+  });
+
+  it("hides unknown live control models for dynamic agents unless selected", () => {
+    const groups = buildModelSelectorGroups(
+      [
+        launchAgent(
+          "cursor",
+          [
+            model("cursor/auto", "Auto", true, {
+              aliases: ["auto"],
+              defaultOptIn: true,
+            }),
+          ],
+          {
+            displayName: "Cursor",
+            dynamicModels: true,
+            modelDisplayPolicy: {
+              defaultVisibleModelIds: ["cursor/auto"],
+              allowUserVisibleModelSelection: true,
+              moreModelsSource: "lastKnownLiveSnapshot",
+            },
+          },
+        ),
+      ],
+      { kind: "cursor", modelId: "auto" },
+      { kind: "cursor", modelId: "auto" },
+      {
+        kind: "cursor",
+        values: [
+          { value: "auto", label: "Auto" },
+          { value: "gpt-5.4", label: "GPT 5.4" },
+          { value: "grok-4.3", label: "Grok 4.3" },
+        ],
+      },
+    );
+
+    expect(groups[0]?.models.map((model) => model.modelId)).toEqual([
+      "auto",
+    ]);
+  });
+
+  it("keeps selected unknown live control models visible for dynamic agents", () => {
+    const groups = buildModelSelectorGroups(
+      [
+        launchAgent(
+          "cursor",
+          [
+            model("cursor/auto", "Auto", true, {
+              aliases: ["auto"],
+              defaultOptIn: true,
+            }),
+          ],
+          {
+            displayName: "Cursor",
+            dynamicModels: true,
+            modelDisplayPolicy: {
+              defaultVisibleModelIds: ["cursor/auto"],
+              allowUserVisibleModelSelection: true,
+              moreModelsSource: "lastKnownLiveSnapshot",
+            },
+          },
+        ),
+      ],
+      { kind: "cursor", modelId: "gpt-5.4" },
+      { kind: "cursor", modelId: "gpt-5.4" },
+      {
+        kind: "cursor",
+        values: [
+          { value: "auto", label: "Auto" },
+          { value: "gpt-5.4", label: "GPT 5.4" },
+          { value: "grok-4.3", label: "Grok 4.3" },
+        ],
+      },
+    );
+
+    expect(groups[0]?.models.map((model) => model.modelId)).toEqual([
+      "auto",
+      "gpt-5.4",
+    ]);
+  });
 });
 
 describe("resolveEffectiveLaunchSelection", () => {

--- a/desktop/src/lib/domain/chat/models/model-selection.ts
+++ b/desktop/src/lib/domain/chat/models/model-selection.ts
@@ -205,9 +205,18 @@ export function buildModelSelectorGroups(
       kind: agent.kind,
       modelId: model.id,
       displayName: model.displayName,
-      actionKind: resolveModelSelectionActionKind(activeSelection, agent.kind, model.id),
-      isSelected:
-        selected?.kind === agent.kind && selected?.modelId === model.id,
+      actionKind: resolveModelSelectionActionKindForModel(
+        activeSelection,
+        sourceAgentsByKind.get(agent.kind) ?? agent,
+        agent.kind,
+        model.id,
+      ),
+      isSelected: modelSelectionMatchesModel(
+        selected,
+        sourceAgentsByKind.get(agent.kind) ?? agent,
+        agent.kind,
+        model.id,
+      ),
     })),
   }));
 }
@@ -219,14 +228,24 @@ function resolveSelectorModels(
   sourceAgent: DesktopAgentLaunchAgent,
 ): Array<{ id: string; displayName: string }> {
   if (activeModelControl?.kind === agent.kind && activeModelControl.values.length > 0) {
-    const knownModelIds = new Set(sourceAgent.models.map((model) => model.id));
-    const visibleModelIds = new Set(agent.models.map((model) => model.id));
     return activeModelControl.values.flatMap((value) => {
-      const isSelected = selected?.kind === agent.kind && selected.modelId === value.value;
+      const isSelected = modelSelectionMatchesModel(
+        selected,
+        sourceAgent,
+        agent.kind,
+        value.value,
+      );
+      const knownModel = findLaunchModelByIdOrAlias(sourceAgent, value.value);
+      const visibleModel = findLaunchModelByIdOrAlias(agent, value.value);
       const isFilteredByVisibility =
-        knownModelIds.has(value.value) && !visibleModelIds.has(value.value);
+        Boolean(knownModel) && !visibleModel;
+      const isUnknownDynamicModel =
+        !knownModel && dynamicLaunchAgentAcceptsModel(sourceAgent);
       const isHiddenByProductPolicy = shouldHideSelectorModel(agent.kind, value);
-      if ((isFilteredByVisibility || isHiddenByProductPolicy) && !isSelected) {
+      if (
+        (isFilteredByVisibility || isUnknownDynamicModel || isHiddenByProductPolicy)
+        && !isSelected
+      ) {
         return [];
       }
 
@@ -245,6 +264,55 @@ function resolveSelectorModels(
   }
 
   return agent.models;
+}
+
+function resolveModelSelectionActionKindForModel(
+  activeSelection: ModelSelectorSelection | null | undefined,
+  agent: DesktopAgentLaunchAgent,
+  agentKind: string,
+  modelId: string,
+): ModelSelectionActionKind {
+  if (!activeSelection) {
+    return "select";
+  }
+  if (activeSelection.kind !== agentKind) {
+    return "open_new_chat";
+  }
+  return modelSelectionMatchesModel(activeSelection, agent, agentKind, modelId)
+    ? "select"
+    : "update_current_chat";
+}
+
+function modelSelectionMatchesModel(
+  selection: ModelSelectorSelection | null | undefined,
+  agent: DesktopAgentLaunchAgent,
+  agentKind: string,
+  modelId: string,
+): boolean {
+  if (!selection || selection.kind !== agentKind) {
+    return false;
+  }
+  if (selection.modelId === modelId) {
+    return true;
+  }
+
+  const model = findLaunchModelByIdOrAlias(agent, modelId);
+  return Boolean(
+    model
+    && (
+      model.id === selection.modelId
+      || model.aliases.includes(selection.modelId)
+    ),
+  );
+}
+
+function findLaunchModelByIdOrAlias(
+  agent: DesktopAgentLaunchAgent,
+  modelId: string,
+): DesktopAgentLaunchModel | null {
+  return agent.models.find((model) =>
+    model.id === modelId || model.aliases.includes(modelId)
+  ) ?? null;
 }
 
 function agentsWithVisibleModels(


### PR DESCRIPTION
## Summary

- filters active-session live model controls through the same visible-model policy used by launch/default selection
- matches live model control values by canonical id or alias so Cursor/OpenCode do not show the full live ACP model list after load
- keeps the selected current model visible even when it is hidden by user preference or only known from the live control

## Verification

- pnpm --dir desktop test -- model-selection model-visibility model-display model-options cloud-launch-catalog
- pnpm --dir desktop exec tsc --noEmit
- python3 scripts/check_frontend_boundaries.py
- git diff --check
