### PR TITLE
feat(cloud): add compute targets and worker enrollment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,6 +4208,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "proliferate-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "proliferate-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "dirs",
+ "reqwest 0.12.28",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ zip = { version = "4.6.1", default-features = false, features = ["deflate"] }
 tar = "0.4"
 zstd = "0.13"
 fs2 = "0.4"
+toml = "0.8"
 
 # ACP SDK
 agent-client-protocol = { version = "0.10.2", features = ["unstable"] }

--- a/anyharness/crates/proliferate-supervisor/Cargo.toml
+++ b/anyharness/crates/proliferate-supervisor/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "proliferate-supervisor"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "Supervisor for AnyHarness and Proliferate Worker"
+
+[[bin]]
+name = "proliferate-supervisor"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/anyharness/crates/proliferate-supervisor/src/config.rs
+++ b/anyharness/crates/proliferate-supervisor/src/config.rs
@@ -1,0 +1,48 @@
+use std::{fs, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::SupervisorError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SupervisorConfig {
+    pub anyharness_binary: PathBuf,
+    pub worker_binary: PathBuf,
+    pub worker_config: PathBuf,
+    #[serde(default = "default_anyharness_args")]
+    pub anyharness_args: Vec<String>,
+    #[serde(default = "default_restart_delay_seconds")]
+    pub restart_delay_seconds: u64,
+}
+
+fn default_anyharness_args() -> Vec<String> {
+    vec!["serve".to_string()]
+}
+
+fn default_restart_delay_seconds() -> u64 {
+    5
+}
+
+impl SupervisorConfig {
+    pub fn load(path: Option<PathBuf>) -> Result<Self, SupervisorError> {
+        let path = path.unwrap_or_else(default_config_path);
+        let contents = fs::read_to_string(&path).map_err(|source| SupervisorError::ReadConfig {
+            path: path.clone(),
+            source,
+        })?;
+        toml::from_str(&contents).map_err(|source| SupervisorError::ParseConfig { path, source })
+    }
+}
+
+fn default_config_path() -> PathBuf {
+    dirs_fallback_home()
+        .join(".proliferate")
+        .join("supervisor")
+        .join("config.toml")
+}
+
+fn dirs_fallback_home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}

--- a/anyharness/crates/proliferate-supervisor/src/error.rs
+++ b/anyharness/crates/proliferate-supervisor/src/error.rs
@@ -1,0 +1,16 @@
+use std::{io, path::PathBuf};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SupervisorError {
+    #[error("failed to read supervisor config at {path}")]
+    ReadConfig { path: PathBuf, source: io::Error },
+    #[error("failed to parse supervisor config at {path}")]
+    ParseConfig {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+    #[error("failed to spawn {program}")]
+    Spawn { program: String, source: io::Error },
+}

--- a/anyharness/crates/proliferate-supervisor/src/install/layout.rs
+++ b/anyharness/crates/proliferate-supervisor/src/install/layout.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+pub fn default_home() -> PathBuf {
+    std::env::var_os("PROLIFERATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".proliferate")))
+        .unwrap_or_else(|| PathBuf::from(".proliferate"))
+}

--- a/anyharness/crates/proliferate-supervisor/src/install/mod.rs
+++ b/anyharness/crates/proliferate-supervisor/src/install/mod.rs
@@ -1,0 +1,2 @@
+pub mod layout;
+pub mod service;

--- a/anyharness/crates/proliferate-supervisor/src/install/service.rs
+++ b/anyharness/crates/proliferate-supervisor/src/install/service.rs
@@ -1,0 +1,32 @@
+use crate::{config::SupervisorConfig, install::layout};
+
+pub fn systemd_user_unit(config: &SupervisorConfig) -> String {
+    let fallback_bin_dir = layout::default_home().join("bin");
+    format!(
+        r#"[Unit]
+Description=Proliferate target supervisor
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart={} --config {} run
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"#,
+        config
+            .anyharness_binary
+            .parent()
+            .unwrap_or(fallback_bin_dir.as_path())
+            .join("proliferate-supervisor")
+            .display(),
+        config
+            .worker_config
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join("../supervisor/config.toml")
+            .display()
+    )
+}

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -1,0 +1,8 @@
+pub fn init() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "proliferate_supervisor=info,info".into()),
+        )
+        .try_init();
+}

--- a/anyharness/crates/proliferate-supervisor/src/main.rs
+++ b/anyharness/crates/proliferate-supervisor/src/main.rs
@@ -1,0 +1,36 @@
+mod config;
+mod error;
+mod install;
+mod logging;
+mod process;
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "proliferate-supervisor")]
+struct Args {
+    #[arg(long)]
+    config: Option<PathBuf>,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Run,
+    PrintService,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    logging::init();
+    let args = Args::parse();
+    let config = config::SupervisorConfig::load(args.config)?;
+    match args.command {
+        Command::Run => process::run(config).await?,
+        Command::PrintService => println!("{}", install::service::systemd_user_unit(&config)),
+    }
+    Ok(())
+}

--- a/anyharness/crates/proliferate-supervisor/src/process/child.rs
+++ b/anyharness/crates/proliferate-supervisor/src/process/child.rs
@@ -1,0 +1,13 @@
+use tokio::process::{Child, Command};
+
+use crate::error::SupervisorError;
+
+pub fn spawn(program: &str, args: &[String]) -> Result<Child, SupervisorError> {
+    let mut command = Command::new(program);
+    command.args(args);
+    command.kill_on_drop(true);
+    command.spawn().map_err(|source| SupervisorError::Spawn {
+        program: program.to_string(),
+        source,
+    })
+}

--- a/anyharness/crates/proliferate-supervisor/src/process/health.rs
+++ b/anyharness/crates/proliferate-supervisor/src/process/health.rs
@@ -1,0 +1,3 @@
+pub fn is_upgrade_window() -> bool {
+    true
+}

--- a/anyharness/crates/proliferate-supervisor/src/process/mod.rs
+++ b/anyharness/crates/proliferate-supervisor/src/process/mod.rs
@@ -1,0 +1,60 @@
+pub mod child;
+pub mod health;
+pub mod restart;
+
+use tokio::time::{sleep, Duration};
+use tracing::{info, warn};
+
+use crate::{config::SupervisorConfig, error::SupervisorError};
+
+pub async fn run(config: SupervisorConfig) -> Result<(), SupervisorError> {
+    loop {
+        let mut anyharness = match child::spawn(
+            config.anyharness_binary.to_string_lossy().as_ref(),
+            &config.anyharness_args,
+        ) {
+            Ok(child) => child,
+            Err(error) => {
+                warn!(?error, "failed to start anyharness");
+                sleep(restart::backoff(config.restart_delay_seconds)).await;
+                continue;
+            }
+        };
+        info!("anyharness started");
+        loop {
+            let worker_args = [
+                "--config".to_string(),
+                config.worker_config.to_string_lossy().to_string(),
+            ];
+            let mut worker = match child::spawn(
+                config.worker_binary.to_string_lossy().as_ref(),
+                &worker_args,
+            ) {
+                Ok(child) => child,
+                Err(error) => {
+                    warn!(?error, "failed to start proliferate-worker");
+                    sleep(restart::backoff(config.restart_delay_seconds)).await;
+                    continue;
+                }
+            };
+            info!("proliferate-worker started");
+            tokio::select! {
+                result = anyharness.wait() => {
+                    warn!(?result, "anyharness exited");
+                    let _ = worker.kill().await;
+                    let _ = worker.wait().await;
+                    break;
+                }
+                result = worker.wait() => {
+                    warn!(?result, "proliferate-worker exited");
+                    sleep(restart::backoff(config.restart_delay_seconds)).await;
+                }
+            }
+        }
+        if health::is_upgrade_window() {
+            sleep(restart::backoff(config.restart_delay_seconds)).await;
+        } else {
+            sleep(Duration::from_secs(config.restart_delay_seconds.max(1))).await;
+        }
+    }
+}

--- a/anyharness/crates/proliferate-supervisor/src/process/restart.rs
+++ b/anyharness/crates/proliferate-supervisor/src/process/restart.rs
@@ -1,0 +1,5 @@
+use std::time::Duration;
+
+pub fn backoff(seconds: u64) -> Duration {
+    Duration::from_secs(seconds.max(1))
+}

--- a/anyharness/crates/proliferate-worker/Cargo.toml
+++ b/anyharness/crates/proliferate-worker/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "proliferate-worker"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "Target-side Proliferate cloud bridge"
+
+[[bin]]
+name = "proliferate-worker"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+dirs.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/health.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/health.rs
@@ -1,0 +1,12 @@
+use crate::anyharness_client::AnyHarnessClient;
+
+pub async fn probe(client: &AnyHarnessClient) -> bool {
+    let url = format!("{}/v1/health", client.base_url());
+    client
+        .http()
+        .get(url)
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false)
+}

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
@@ -1,0 +1,35 @@
+pub mod health;
+
+use std::time::Duration;
+
+use reqwest::Client;
+
+use crate::error::WorkerError;
+
+#[derive(Debug, Clone)]
+pub struct AnyHarnessClient {
+    http: Client,
+    base_url: String,
+}
+
+impl AnyHarnessClient {
+    pub fn new(base_url: String) -> Result<Self, WorkerError> {
+        let http = Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(WorkerError::BuildHttpClient)?;
+        Ok(Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn http(&self) -> &Client {
+        &self.http
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/auth.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/auth.rs
@@ -1,0 +1,3 @@
+pub fn bearer_header(token: &str) -> String {
+    format!("Bearer {token}")
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/heartbeat.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/heartbeat.rs
@@ -1,0 +1,15 @@
+use super::HeartbeatRequest;
+
+pub fn online(
+    worker_version: Option<String>,
+    anyharness_version: Option<String>,
+    supervisor_version: Option<String>,
+) -> HeartbeatRequest {
+    HeartbeatRequest {
+        status: "online".to_string(),
+        status_detail: None,
+        worker_version,
+        anyharness_version,
+        supervisor_version,
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/inventory.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/inventory.rs
@@ -1,0 +1,9 @@
+use super::{InventoryPayload, InventoryRequest};
+
+pub fn report(payload: InventoryPayload) -> InventoryRequest {
+    InventoryRequest {
+        inventory: payload,
+        status: "online".to_string(),
+        status_detail: None,
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -1,0 +1,152 @@
+pub mod auth;
+pub mod heartbeat;
+pub mod inventory;
+
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{config::WorkerConfig, error::WorkerError};
+
+#[derive(Clone)]
+pub struct CloudClient {
+    http: Client,
+    base_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrollRequest {
+    pub enrollment_token: String,
+    pub machine_fingerprint: String,
+    pub hostname: Option<String>,
+    pub worker_version: Option<String>,
+    pub anyharness_version: Option<String>,
+    pub supervisor_version: Option<String>,
+    pub inventory: InventoryPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrollResponse {
+    pub target_id: String,
+    pub worker_id: String,
+    pub worker_token: String,
+    pub heartbeat_interval_seconds: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatRequest {
+    pub status: String,
+    pub status_detail: Option<String>,
+    pub worker_version: Option<String>,
+    pub anyharness_version: Option<String>,
+    pub supervisor_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct InventoryPayload {
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub distro: Option<String>,
+    pub shell: Option<String>,
+    pub git: Option<Value>,
+    pub node: Option<Value>,
+    pub python: Option<Value>,
+    pub browser: Option<Value>,
+    pub capabilities: Option<Value>,
+    pub providers: Option<Value>,
+    pub mcp: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InventoryRequest {
+    #[serde(flatten)]
+    pub inventory: InventoryPayload,
+    pub status: String,
+    pub status_detail: Option<String>,
+}
+
+impl CloudClient {
+    pub fn new(config: &WorkerConfig) -> Result<Self, WorkerError> {
+        let http = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(WorkerError::BuildHttpClient)?;
+        Ok(Self {
+            http,
+            base_url: config.cloud_base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    pub async fn enroll(&self, request: &EnrollRequest) -> Result<EnrollResponse, WorkerError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/cloud/worker/enroll", self.base_url))
+            .json(request)
+            .send()
+            .await?;
+        parse_json_response(response).await
+    }
+
+    pub async fn heartbeat(
+        &self,
+        worker_token: &str,
+        request: &HeartbeatRequest,
+    ) -> Result<(), WorkerError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/cloud/worker/heartbeat", self.base_url))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            )
+            .json(request)
+            .send()
+            .await?;
+        parse_empty_response(response).await
+    }
+
+    pub async fn upload_inventory(
+        &self,
+        worker_token: &str,
+        request: &InventoryRequest,
+    ) -> Result<(), WorkerError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/cloud/worker/inventory", self.base_url))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            )
+            .json(request)
+            .send()
+            .await?;
+        parse_empty_response(response).await
+    }
+}
+
+async fn parse_json_response<T: for<'de> Deserialize<'de>>(
+    response: reqwest::Response,
+) -> Result<T, WorkerError> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    Ok(response.json().await?)
+}
+
+async fn parse_empty_response(response: reqwest::Response) -> Result<(), WorkerError> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    Ok(())
+}

--- a/anyharness/crates/proliferate-worker/src/config.rs
+++ b/anyharness/crates/proliferate-worker/src/config.rs
@@ -1,0 +1,85 @@
+use std::{fs, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::WorkerError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerConfig {
+    pub cloud_base_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrollment_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anyharness_base_url: Option<String>,
+    pub worker_db_path: PathBuf,
+    #[serde(default = "default_heartbeat_interval_seconds")]
+    pub heartbeat_interval_seconds: u64,
+    #[serde(skip)]
+    pub config_path: Option<PathBuf>,
+}
+
+fn default_heartbeat_interval_seconds() -> u64 {
+    60
+}
+
+impl WorkerConfig {
+    pub fn load(path: Option<PathBuf>) -> Result<Self, WorkerError> {
+        let path = path.unwrap_or_else(default_config_path);
+        let contents = fs::read_to_string(&path).map_err(|source| WorkerError::ReadConfig {
+            path: path.clone(),
+            source,
+        })?;
+        let mut config: Self =
+            toml::from_str(&contents).map_err(|source| WorkerError::ParseConfig {
+                path: path.clone(),
+                source,
+            })?;
+        config.config_path = Some(path);
+        Ok(config)
+    }
+
+    pub fn clear_enrollment_token(&self) -> Result<(), WorkerError> {
+        let Some(path) = self.config_path.clone() else {
+            return Ok(());
+        };
+        if self.enrollment_token.is_none() {
+            return Ok(());
+        }
+        let mut sanitized = self.clone();
+        sanitized.enrollment_token = None;
+        let contents =
+            toml::to_string_pretty(&sanitized).map_err(|source| WorkerError::SerializeConfig {
+                path: path.clone(),
+                source,
+            })?;
+        fs::write(&path, contents).map_err(|source| WorkerError::WriteConfig {
+            path: path.clone(),
+            source,
+        })?;
+        set_private_file_permissions(&path)
+    }
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &PathBuf) -> Result<(), WorkerError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = fs::Permissions::from_mode(0o600);
+    fs::set_permissions(path, permissions).map_err(|source| WorkerError::SetPrivatePermissions {
+        path: path.clone(),
+        source,
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &PathBuf) -> Result<(), WorkerError> {
+    Ok(())
+}
+
+fn default_config_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".proliferate")
+        .join("worker")
+        .join("config.toml")
+}

--- a/anyharness/crates/proliferate-worker/src/error.rs
+++ b/anyharness/crates/proliferate-worker/src/error.rs
@@ -1,0 +1,38 @@
+use std::{io, path::PathBuf};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum WorkerError {
+    #[error("failed to read worker config at {path}")]
+    ReadConfig { path: PathBuf, source: io::Error },
+    #[error("failed to parse worker config at {path}")]
+    ParseConfig {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+    #[error("failed to serialize worker config at {path}")]
+    SerializeConfig {
+        path: PathBuf,
+        source: toml::ser::Error,
+    },
+    #[error("worker database error")]
+    Store(#[from] rusqlite::Error),
+    #[error("cloud request failed")]
+    Http(#[from] reqwest::Error),
+    #[error("failed to build http client")]
+    BuildHttpClient(reqwest::Error),
+    #[error("cloud rejected request: {status} {body}")]
+    Cloud {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    #[error("worker enrollment token is missing")]
+    MissingEnrollmentToken,
+    #[error("failed to create parent directory for {path}")]
+    CreateParent { path: PathBuf, source: io::Error },
+    #[error("failed to write worker config at {path}")]
+    WriteConfig { path: PathBuf, source: io::Error },
+    #[error("failed to set private permissions on {path}")]
+    SetPrivatePermissions { path: PathBuf, source: io::Error },
+}

--- a/anyharness/crates/proliferate-worker/src/identity/credentials.rs
+++ b/anyharness/crates/proliferate-worker/src/identity/credentials.rs
@@ -1,0 +1,18 @@
+use crate::{error::WorkerError, store::WorkerStore};
+
+#[derive(Debug, Clone)]
+pub struct WorkerIdentity {
+    pub target_id: String,
+    pub worker_id: String,
+    pub worker_token: String,
+}
+
+impl WorkerIdentity {
+    pub fn load(store: &WorkerStore) -> Result<Option<Self>, WorkerError> {
+        store.load_identity()
+    }
+
+    pub fn save(&self, store: &WorkerStore) -> Result<(), WorkerError> {
+        store.save_identity(self)
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/identity/enrollment.rs
+++ b/anyharness/crates/proliferate-worker/src/identity/enrollment.rs
@@ -1,0 +1,34 @@
+use crate::{
+    cloud_client::{EnrollRequest, InventoryPayload},
+    config::WorkerConfig,
+    error::WorkerError,
+    identity::{credentials::WorkerIdentity, fingerprint},
+};
+
+pub fn build_enroll_request(
+    config: &WorkerConfig,
+    inventory: InventoryPayload,
+) -> Result<EnrollRequest, WorkerError> {
+    let enrollment_token = config
+        .enrollment_token
+        .clone()
+        .ok_or(WorkerError::MissingEnrollmentToken)?;
+    Ok(EnrollRequest {
+        enrollment_token,
+        machine_fingerprint: fingerprint::machine_fingerprint(),
+        hostname: fingerprint::hostname(),
+        worker_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        anyharness_version: None,
+        supervisor_version: None,
+        inventory,
+    })
+}
+
+pub fn identity_from_response(response: crate::cloud_client::EnrollResponse) -> WorkerIdentity {
+    let _cloud_heartbeat_interval_seconds = response.heartbeat_interval_seconds;
+    WorkerIdentity {
+        target_id: response.target_id,
+        worker_id: response.worker_id,
+        worker_token: response.worker_token,
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/identity/fingerprint.rs
+++ b/anyharness/crates/proliferate-worker/src/identity/fingerprint.rs
@@ -1,0 +1,21 @@
+use sha2::{Digest, Sha256};
+
+pub fn machine_fingerprint() -> String {
+    let host = std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_else(|_| "unknown-host".to_string());
+    let raw = format!(
+        "{}:{}:{}",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        host
+    );
+    format!("{:x}", Sha256::digest(raw.as_bytes()))
+}
+
+pub fn hostname() -> Option<String> {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}

--- a/anyharness/crates/proliferate-worker/src/identity/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/identity/mod.rs
@@ -1,0 +1,3 @@
+pub mod credentials;
+pub mod enrollment;
+pub mod fingerprint;

--- a/anyharness/crates/proliferate-worker/src/inventory/capabilities.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/capabilities.rs
@@ -1,0 +1,12 @@
+use serde_json::{json, Value};
+
+use crate::inventory::versions::command_version;
+
+pub fn browser_inventory() -> Option<Value> {
+    Some(json!({
+        "chromium": command_version("chromium", &["--version"]),
+        "chromiumBrowser": command_version("chromium-browser", &["--version"]),
+        "googleChrome": command_version("google-chrome", &["--version"]),
+        "playwright": command_version("playwright", &["--version"])
+    }))
+}

--- a/anyharness/crates/proliferate-worker/src/inventory/mcp.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/mcp.rs
@@ -1,0 +1,8 @@
+use serde_json::{json, Value};
+
+pub fn collect() -> Option<Value> {
+    Some(json!({
+        "cacheWritable": true,
+        "defaultPackageManager": "npm"
+    }))
+}

--- a/anyharness/crates/proliferate-worker/src/inventory/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/mod.rs
@@ -1,0 +1,30 @@
+pub mod capabilities;
+pub mod mcp;
+pub mod platform;
+pub mod providers;
+pub mod versions;
+
+use serde_json::json;
+
+use crate::cloud_client::InventoryPayload;
+
+pub fn collect() -> InventoryPayload {
+    InventoryPayload {
+        os: Some(std::env::consts::OS.to_string()),
+        arch: Some(std::env::consts::ARCH.to_string()),
+        distro: platform::distro(),
+        shell: platform::shell(),
+        git: versions::command_version("git", &["--version"]),
+        node: versions::node_inventory(),
+        python: versions::python_inventory(),
+        browser: capabilities::browser_inventory(),
+        capabilities: Some(json!({
+            "processSpawn": true,
+            "filesystem": true,
+            "networkEgress": true,
+            "pty": true
+        })),
+        providers: providers::collect(),
+        mcp: mcp::collect(),
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/inventory/platform.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/platform.rs
@@ -1,0 +1,19 @@
+use std::{fs, path::Path};
+
+pub fn shell() -> Option<String> {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+pub fn distro() -> Option<String> {
+    let os_release = Path::new("/etc/os-release");
+    if !os_release.exists() {
+        return None;
+    }
+    let contents = fs::read_to_string(os_release).ok()?;
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("PRETTY_NAME="))
+        .map(|value| value.trim_matches('"').to_string())
+}

--- a/anyharness/crates/proliferate-worker/src/inventory/providers.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/providers.rs
@@ -1,0 +1,12 @@
+use serde_json::{json, Value};
+
+use crate::inventory::versions::command_version;
+
+pub fn collect() -> Option<Value> {
+    Some(json!({
+        "claude": command_version("claude", &["--version"]),
+        "codex": command_version("codex", &["--version"]),
+        "gemini": command_version("gemini", &["--version"]),
+        "opencode": command_version("opencode", &["--version"])
+    }))
+}

--- a/anyharness/crates/proliferate-worker/src/inventory/versions.rs
+++ b/anyharness/crates/proliferate-worker/src/inventory/versions.rs
@@ -1,0 +1,54 @@
+use std::{
+    io::Read,
+    process::{Command, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use serde_json::{json, Value};
+
+pub fn command_version(command: &str, args: &[&str]) -> Option<Value> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match child.try_wait().ok()? {
+            Some(status) if status.success() => {
+                let mut stdout = String::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    let _ = pipe.read_to_string(&mut stdout);
+                }
+                return Some(json!({ "available": true, "version": stdout.trim() }));
+            }
+            Some(_) => {
+                return Some(json!({ "available": false }));
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Some(json!({ "available": false, "timedOut": true }));
+            }
+            None => sleep(Duration::from_millis(25)),
+        }
+    }
+}
+
+pub fn node_inventory() -> Option<Value> {
+    Some(json!({
+        "node": command_version("node", &["--version"]),
+        "npm": command_version("npm", &["--version"]),
+        "npx": command_version("npx", &["--version"])
+    }))
+}
+
+pub fn python_inventory() -> Option<Value> {
+    Some(json!({
+        "python3": command_version("python3", &["--version"]),
+        "python": command_version("python", &["--version"]),
+        "uv": command_version("uv", &["--version"])
+    }))
+}

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -1,0 +1,8 @@
+pub fn init() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "proliferate_worker=info,info".into()),
+        )
+        .try_init();
+}

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -1,0 +1,31 @@
+mod anyharness_client;
+mod cloud_client;
+mod config;
+mod error;
+mod identity;
+mod inventory;
+mod logging;
+mod runtime;
+mod store;
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(name = "proliferate-worker")]
+struct Args {
+    #[arg(long)]
+    config: Option<PathBuf>,
+    #[arg(long)]
+    once: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    logging::init();
+    let args = Args::parse();
+    let config = config::WorkerConfig::load(args.config)?;
+    runtime::run(config, args.once).await?;
+    Ok(())
+}

--- a/anyharness/crates/proliferate-worker/src/runtime.rs
+++ b/anyharness/crates/proliferate-worker/src/runtime.rs
@@ -1,0 +1,83 @@
+use tokio::time::{sleep, Duration};
+use tracing::{info, warn};
+
+use crate::{
+    anyharness_client::{health as anyharness_health, AnyHarnessClient},
+    cloud_client::{heartbeat, inventory as cloud_inventory, CloudClient},
+    config::WorkerConfig,
+    error::WorkerError,
+    identity::{credentials::WorkerIdentity, enrollment},
+    inventory,
+    store::WorkerStore,
+};
+
+pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
+    let store = WorkerStore::open(config.worker_db_path.clone())?;
+    let cloud = CloudClient::new(&config)?;
+    let identity = ensure_identity(&config, &store, &cloud).await?;
+    if let Some(base_url) = config.anyharness_base_url.clone() {
+        let client = AnyHarnessClient::new(base_url)?;
+        let healthy = anyharness_health::probe(&client).await;
+        info!(healthy, "anyharness health probe completed");
+    }
+    info!(
+        target_id = %identity.target_id,
+        worker_id = %identity.worker_id,
+        "proliferate worker started"
+    );
+    if let Err(error) = upload_inventory(&cloud, &identity).await {
+        warn!(?error, "worker inventory upload failed");
+    }
+    if let Err(error) = send_heartbeat(&cloud, &identity).await {
+        warn!(?error, "worker heartbeat failed");
+    }
+    if once {
+        return Ok(());
+    }
+    loop {
+        sleep(Duration::from_secs(
+            config.heartbeat_interval_seconds.max(10),
+        ))
+        .await;
+        if let Err(error) = send_heartbeat(&cloud, &identity).await {
+            warn!(?error, "worker heartbeat failed");
+        }
+    }
+}
+
+async fn ensure_identity(
+    config: &WorkerConfig,
+    store: &WorkerStore,
+    cloud: &CloudClient,
+) -> Result<WorkerIdentity, WorkerError> {
+    if let Some(identity) = WorkerIdentity::load(store)? {
+        return Ok(identity);
+    }
+    let local_inventory = inventory::collect();
+    let request = enrollment::build_enroll_request(config, local_inventory)?;
+    let response = cloud.enroll(&request).await?;
+    let identity = enrollment::identity_from_response(response);
+    identity.save(store)?;
+    if let Err(error) = config.clear_enrollment_token() {
+        warn!(
+            ?error,
+            "failed to clear enrollment token from worker config"
+        );
+    }
+    Ok(identity)
+}
+
+async fn upload_inventory(
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+) -> Result<(), WorkerError> {
+    let request = cloud_inventory::report(inventory::collect());
+    cloud
+        .upload_inventory(&identity.worker_token, &request)
+        .await
+}
+
+async fn send_heartbeat(cloud: &CloudClient, identity: &WorkerIdentity) -> Result<(), WorkerError> {
+    let request = heartbeat::online(Some(env!("CARGO_PKG_VERSION").to_string()), None, None);
+    cloud.heartbeat(&identity.worker_token, &request).await
+}

--- a/anyharness/crates/proliferate-worker/src/store/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/store/mod.rs
@@ -1,0 +1,120 @@
+use std::path::PathBuf;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::{error::WorkerError, identity::credentials::WorkerIdentity};
+
+pub struct WorkerStore {
+    path: PathBuf,
+}
+
+impl WorkerStore {
+    pub fn open(path: PathBuf) -> Result<Self, WorkerError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| WorkerError::CreateParent {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+            set_private_dir_permissions(&parent.to_path_buf())?;
+        }
+        let store = Self { path };
+        store.migrate()?;
+        set_private_file_permissions(&store.path)?;
+        Ok(store)
+    }
+
+    fn connection(&self) -> Result<Connection, WorkerError> {
+        Ok(Connection::open(&self.path)?)
+    }
+
+    fn migrate(&self) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS identity (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                target_id TEXT NOT NULL,
+                worker_id TEXT NOT NULL,
+                worker_token TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            "#,
+        )?;
+        Ok(())
+    }
+
+    pub fn load_identity(&self) -> Result<Option<WorkerIdentity>, WorkerError> {
+        let conn = self.connection()?;
+        let value = conn
+            .query_row(
+                "SELECT target_id, worker_id, worker_token FROM identity WHERE id = 1",
+                [],
+                |row| {
+                    Ok(WorkerIdentity {
+                        target_id: row.get(0)?,
+                        worker_id: row.get(1)?,
+                        worker_token: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(value)
+    }
+
+    pub fn save_identity(&self, identity: &WorkerIdentity) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        conn.execute(
+            r#"
+            INSERT INTO identity (id, target_id, worker_id, worker_token, updated_at)
+            VALUES (1, ?1, ?2, ?3, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                target_id = excluded.target_id,
+                worker_id = excluded.worker_id,
+                worker_token = excluded.worker_token,
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+            params![
+                identity.target_id,
+                identity.worker_id,
+                identity.worker_token
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &PathBuf) -> Result<(), WorkerError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = std::fs::Permissions::from_mode(0o700);
+    std::fs::set_permissions(path, permissions).map_err(|source| {
+        WorkerError::SetPrivatePermissions {
+            path: path.clone(),
+            source,
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_dir_permissions(_path: &PathBuf) -> Result<(), WorkerError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &PathBuf) -> Result<(), WorkerError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, permissions).map_err(|source| {
+        WorkerError::SetPrivatePermissions {
+            path: path.clone(),
+            source,
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &PathBuf) -> Result<(), WorkerError> {
+    Ok(())
+}

--- a/cloud/sdk/src/client/targets.ts
+++ b/cloud/sdk/src/client/targets.ts
@@ -1,5 +1,6 @@
 import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
 import type {
+  ArchiveCloudTargetResponse,
   CloudTargetDetail,
   CloudTargetEnrollmentRequest,
   CloudTargetEnrollmentResponse,
@@ -33,6 +34,17 @@ export async function getTarget(
   return client.requestJson<CloudTargetDetail>({
     method: "GET",
     path: "/v1/cloud/targets/{target_id}",
+    pathParams: { target_id: targetId },
+  });
+}
+
+export async function archiveTarget(
+  targetId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<ArchiveCloudTargetResponse> {
+  return client.requestJson<ArchiveCloudTargetResponse>({
+    method: "POST",
+    path: "/v1/cloud/targets/{target_id}/archive",
     pathParams: { target_id: targetId },
   });
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -937,6 +937,125 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/targets/enrollments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Target Enrollment Endpoint */
+        post: operations["create_target_enrollment_endpoint_v1_cloud_targets_enrollments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Targets Endpoint */
+        get: operations["list_targets_endpoint_v1_cloud_targets_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Target Endpoint */
+        get: operations["get_target_endpoint_v1_cloud_targets__target_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Archive Target Endpoint */
+        post: operations["archive_target_endpoint_v1_cloud_targets__target_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/enroll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Enroll Worker Endpoint */
+        post: operations["enroll_worker_endpoint_v1_cloud_worker_enroll_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Heartbeat Endpoint */
+        post: operations["worker_heartbeat_endpoint_v1_cloud_worker_heartbeat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/inventory": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Inventory Endpoint */
+        post: operations["worker_inventory_endpoint_v1_cloud_worker_inventory_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/catalogs/agents": {
         parameters: {
             query?: never;
@@ -1793,6 +1912,10 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** ArchiveCloudTargetResponse */
+        ArchiveCloudTargetResponse: {
+            target: components["schemas"]["CloudTargetDetail"];
+        };
         /**
          * AuthCodeCreated
          * @description Returned when the server has created an auth code (internal use / testing).
@@ -2250,6 +2373,146 @@ export interface components {
             updatedAt: string;
             /** Lastsyncedat */
             lastSyncedAt: string;
+        };
+        /** CloudTargetDetail */
+        CloudTargetDetail: {
+            /** Id */
+            id: string;
+            /** Displayname */
+            displayName: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Defaultworkspaceroot */
+            defaultWorkspaceRoot?: string | null;
+            inventory?: components["schemas"]["CloudTargetInventoryModel"] | null;
+            statusDetail?: components["schemas"]["CloudTargetStatusModel"] | null;
+            /** Archivedat */
+            archivedAt?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+            /** Owneruserid */
+            ownerUserId: string;
+            /** Createdbyuserid */
+            createdByUserId: string;
+        };
+        /** CloudTargetEnrollmentRequest */
+        CloudTargetEnrollmentRequest: {
+            /** Displayname */
+            displayName: string;
+            /**
+             * Kind
+             * @default ssh
+             */
+            kind: string;
+            /**
+             * Ownerscope
+             * @default personal
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Defaultworkspaceroot */
+            defaultWorkspaceRoot?: string | null;
+            /** Ttlseconds */
+            ttlSeconds?: number | null;
+        };
+        /** CloudTargetEnrollmentResponse */
+        CloudTargetEnrollmentResponse: {
+            target: components["schemas"]["CloudTargetDetail"];
+            /** Enrollmenttoken */
+            enrollmentToken: string;
+            /** Installcommand */
+            installCommand: string;
+            /** Expiresat */
+            expiresAt: string;
+        };
+        /** CloudTargetInventoryModel */
+        CloudTargetInventoryModel: {
+            /** Os */
+            os?: string | null;
+            /** Arch */
+            arch?: string | null;
+            /** Distro */
+            distro?: string | null;
+            /** Shell */
+            shell?: string | null;
+            /** Git */
+            git?: {
+                [key: string]: unknown;
+            } | null;
+            /** Node */
+            node?: {
+                [key: string]: unknown;
+            } | null;
+            /** Python */
+            python?: {
+                [key: string]: unknown;
+            } | null;
+            /** Browser */
+            browser?: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: unknown;
+            } | null;
+            /** Providers */
+            providers?: {
+                [key: string]: unknown;
+            } | null;
+            /** Mcp */
+            mcp?: {
+                [key: string]: unknown;
+            } | null;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** CloudTargetStatusModel */
+        CloudTargetStatusModel: {
+            /** Status */
+            status: string;
+            /** Statusdetail */
+            statusDetail?: string | null;
+            /** Lastseenat */
+            lastSeenAt?: string | null;
+            /** Lastheartbeatat */
+            lastHeartbeatAt?: string | null;
+            /** Updatedat */
+            updatedAt?: string | null;
+        };
+        /** CloudTargetSummary */
+        CloudTargetSummary: {
+            /** Id */
+            id: string;
+            /** Displayname */
+            displayName: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Defaultworkspaceroot */
+            defaultWorkspaceRoot?: string | null;
+            inventory?: components["schemas"]["CloudTargetInventoryModel"] | null;
+            statusDetail?: components["schemas"]["CloudTargetStatusModel"] | null;
+            /** Archivedat */
+            archivedAt?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
         };
         /** CloudWorkspaceRepoConfigStatusResponse */
         CloudWorkspaceRepoConfigStatusResponse: {
@@ -3788,6 +4051,154 @@ export interface components {
             input?: unknown;
             /** Context */
             ctx?: Record<string, never>;
+        };
+        /** WorkerEnrollRequest */
+        WorkerEnrollRequest: {
+            /** Enrollmenttoken */
+            enrollmentToken: string;
+            /** Machinefingerprint */
+            machineFingerprint?: string | null;
+            /** Hostname */
+            hostname?: string | null;
+            /** Workerversion */
+            workerVersion?: string | null;
+            /** Anyharnessversion */
+            anyharnessVersion?: string | null;
+            /** Supervisorversion */
+            supervisorVersion?: string | null;
+            inventory?: components["schemas"]["WorkerInventoryPayload"] | null;
+        };
+        /** WorkerEnrollResponse */
+        WorkerEnrollResponse: {
+            /** Targetid */
+            targetId: string;
+            /** Workerid */
+            workerId: string;
+            /** Workertoken */
+            workerToken: string;
+            /** Heartbeatintervalseconds */
+            heartbeatIntervalSeconds: number;
+        };
+        /** WorkerHeartbeatRequest */
+        WorkerHeartbeatRequest: {
+            /**
+             * Status
+             * @default online
+             */
+            status: string;
+            /** Statusdetail */
+            statusDetail?: string | null;
+            /** Workerversion */
+            workerVersion?: string | null;
+            /** Anyharnessversion */
+            anyharnessVersion?: string | null;
+            /** Supervisorversion */
+            supervisorVersion?: string | null;
+        };
+        /** WorkerHeartbeatResponse */
+        WorkerHeartbeatResponse: {
+            /** Targetid */
+            targetId: string;
+            /** Workerid */
+            workerId: string;
+            /** Status */
+            status: string;
+            /** Servertime */
+            serverTime: string;
+        };
+        /** WorkerInventoryPayload */
+        WorkerInventoryPayload: {
+            /** Os */
+            os?: string | null;
+            /** Arch */
+            arch?: string | null;
+            /** Distro */
+            distro?: string | null;
+            /** Shell */
+            shell?: string | null;
+            /** Git */
+            git?: {
+                [key: string]: unknown;
+            } | null;
+            /** Node */
+            node?: {
+                [key: string]: unknown;
+            } | null;
+            /** Python */
+            python?: {
+                [key: string]: unknown;
+            } | null;
+            /** Browser */
+            browser?: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: unknown;
+            } | null;
+            /** Providers */
+            providers?: {
+                [key: string]: unknown;
+            } | null;
+            /** Mcp */
+            mcp?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** WorkerInventoryRequest */
+        WorkerInventoryRequest: {
+            /** Os */
+            os?: string | null;
+            /** Arch */
+            arch?: string | null;
+            /** Distro */
+            distro?: string | null;
+            /** Shell */
+            shell?: string | null;
+            /** Git */
+            git?: {
+                [key: string]: unknown;
+            } | null;
+            /** Node */
+            node?: {
+                [key: string]: unknown;
+            } | null;
+            /** Python */
+            python?: {
+                [key: string]: unknown;
+            } | null;
+            /** Browser */
+            browser?: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: unknown;
+            } | null;
+            /** Providers */
+            providers?: {
+                [key: string]: unknown;
+            } | null;
+            /** Mcp */
+            mcp?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Status
+             * @default online
+             */
+            status: string;
+            /** Statusdetail */
+            statusDetail?: string | null;
+        };
+        /** WorkerInventoryResponse */
+        WorkerInventoryResponse: {
+            /** Targetid */
+            targetId: string;
+            /** Workerid */
+            workerId: string;
+            /** Updated */
+            updated: boolean;
         };
         /** WorkspaceConnection */
         WorkspaceConnection: {
@@ -6065,6 +6476,224 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["E2BWebhookReceipt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_target_enrollment_endpoint_v1_cloud_targets_enrollments_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CloudTargetEnrollmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetEnrollmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_targets_endpoint_v1_cloud_targets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetSummary"][];
+                };
+            };
+        };
+    };
+    get_target_endpoint_v1_cloud_targets__target_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_target_endpoint_v1_cloud_targets__target_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchiveCloudTargetResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enroll_worker_endpoint_v1_cloud_worker_enroll_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerEnrollRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerEnrollResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_heartbeat_endpoint_v1_cloud_worker_heartbeat_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerHeartbeatRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerHeartbeatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_inventory_endpoint_v1_cloud_worker_inventory_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerInventoryRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerInventoryResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/targets.ts
+++ b/cloud/sdk/src/types/targets.ts
@@ -1,3 +1,5 @@
+import type { components } from "../generated/openapi.js";
+
 export type CloudTargetKind =
   | "managed_cloud"
   | "ssh"
@@ -5,62 +7,46 @@ export type CloudTargetKind =
   | "local_direct"
   | "self_hosted_cloud";
 
-export type CloudTargetStatus = "online" | "offline" | "degraded" | "enrolling";
+export type CloudTargetStatus = "online" | "offline" | "degraded" | "enrolling" | "archived";
 
-export interface CloudTargetCapability {
-  key: string;
-  available: boolean;
-  detail?: string | null;
-}
+export type CloudTargetInventory = components["schemas"]["CloudTargetInventoryModel"];
 
-export interface CloudTargetInventory {
-  os?: string | null;
-  arch?: string | null;
-  distro?: string | null;
-  shell?: string | null;
-  git?: CloudTargetCapability | null;
-  node?: CloudTargetCapability | null;
-  python?: CloudTargetCapability | null;
-  browser?: CloudTargetCapability | null;
-  capabilities?: CloudTargetCapability[];
-}
+export type CloudTargetStatusDetail = Omit<
+  components["schemas"]["CloudTargetStatusModel"],
+  "status"
+> & {
+  status: CloudTargetStatus;
+};
 
-export interface CloudTargetSummary {
-  id: string;
-  displayName: string;
+export type CloudTargetSummary = Omit<
+  components["schemas"]["CloudTargetSummary"],
+  "kind" | "status" | "ownerScope" | "statusDetail"
+> & {
   kind: CloudTargetKind;
   status: CloudTargetStatus;
   ownerScope: "personal" | "organization";
-  organizationId?: string | null;
-  lastSeenAt?: string | null;
-  anyharnessVersion?: string | null;
-  workerVersion?: string | null;
-  inventory?: CloudTargetInventory | null;
-}
+  statusDetail?: CloudTargetStatusDetail | null;
+};
 
-export interface CloudTargetDetail extends CloudTargetSummary {
-  createdAt?: string | null;
-  updatedAt?: string | null;
-  access?: {
-    canUse: boolean;
-    canOpenDirectly: boolean;
-    reason?: string | null;
-  } | null;
-}
+export type CloudTargetDetail = Omit<
+  components["schemas"]["CloudTargetDetail"],
+  "kind" | "status" | "ownerScope" | "statusDetail"
+> & {
+  kind: CloudTargetKind;
+  status: CloudTargetStatus;
+  ownerScope: "personal" | "organization";
+  statusDetail?: CloudTargetStatusDetail | null;
+};
 
-export interface CloudTargetEnrollmentRequest {
-  displayName: string;
+export type CloudTargetEnrollmentRequest = Omit<
+  components["schemas"]["CloudTargetEnrollmentRequest"],
+  "kind"
+> & {
   kind: Exclude<CloudTargetKind, "local_direct">;
-  ownerScope?: "personal" | "organization";
-  organizationId?: string | null;
-  expiresInSeconds?: number | null;
-}
+};
 
-export interface CloudTargetEnrollmentResponse {
-  enrollmentId: string;
-  targetId: string;
-  token: string;
-  installCommand?: string | null;
-  expiresAt: string;
-}
+export type CloudTargetEnrollmentResponse =
+  components["schemas"]["CloudTargetEnrollmentResponse"];
 
+export type ArchiveCloudTargetResponse =
+  components["schemas"]["ArchiveCloudTargetResponse"];

--- a/desktop/src/components/settings/panes/ComputePane.tsx
+++ b/desktop/src/components/settings/panes/ComputePane.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from "react";
+import { SettingsPageHeader } from "@/components/settings/shared/SettingsPageHeader";
+import { AddSshTargetDialog } from "@/components/settings/panes/compute/AddSshTargetDialog";
+import { ComputeTargetDetails } from "@/components/settings/panes/compute/ComputeTargetDetails";
+import { ComputeTargetList } from "@/components/settings/panes/compute/ComputeTargetList";
+import { Button } from "@/components/ui/Button";
+import { COMPUTE_COPY } from "@/copy/settings/compute";
+import { useCloudTargetMutations } from "@/hooks/access/cloud/targets/use-cloud-target-mutations";
+import {
+  useCloudTarget,
+  useCloudTargets,
+} from "@/hooks/access/cloud/targets/use-cloud-targets";
+import type { ComputeTargetSummary } from "@/lib/domain/compute/target-types";
+
+const EMPTY_TARGETS: ComputeTargetSummary[] = [];
+
+export function ComputePane() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [archiveError, setArchiveError] = useState<string | null>(null);
+  const { data, isLoading } = useCloudTargets();
+  const targets: ComputeTargetSummary[] = data ?? EMPTY_TARGETS;
+  const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null);
+  const effectiveTargetId = selectedTargetId ?? targets[0]?.id ?? null;
+  const selectedSummary = useMemo(
+    () => targets.find((target) => target.id === effectiveTargetId) ?? null,
+    [effectiveTargetId, targets],
+  );
+  const { data: selectedDetail, isLoading: detailLoading } = useCloudTarget(
+    effectiveTargetId,
+    Boolean(effectiveTargetId),
+  );
+  const { archiveTarget, isArchivingTarget } = useCloudTargetMutations();
+
+  return (
+    <section className="space-y-6">
+      <SettingsPageHeader
+        title={COMPUTE_COPY.title}
+        description={COMPUTE_COPY.description}
+        action={(
+          <Button type="button" variant="secondary" onClick={() => setDialogOpen(true)}>
+            {COMPUTE_COPY.addSshTarget}
+          </Button>
+        )}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <ComputeTargetList
+          targets={targets}
+          loading={isLoading}
+          selectedTargetId={effectiveTargetId}
+          onSelectTarget={setSelectedTargetId}
+          onAddSshTarget={() => setDialogOpen(true)}
+        />
+        <ComputeTargetDetails
+          target={selectedDetail ?? selectedSummary}
+          loading={detailLoading && Boolean(effectiveTargetId)}
+          archiving={isArchivingTarget}
+          onArchive={(targetId) => {
+            setArchiveError(null);
+            void archiveTarget(targetId).catch((error) => {
+              setArchiveError(
+                error instanceof Error ? error.message : COMPUTE_COPY.archiveError,
+              );
+            });
+          }}
+        />
+      </div>
+
+      {archiveError && (
+        <p className="text-sm text-destructive">{archiveError}</p>
+      )}
+
+      <AddSshTargetDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
+    </section>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/AddSshTargetDialog.tsx
+++ b/desktop/src/components/settings/panes/compute/AddSshTargetDialog.tsx
@@ -1,0 +1,86 @@
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { ModalShell } from "@/components/ui/ModalShell";
+import { useComputeTargetEnrollment } from "@/hooks/settings/workflows/use-compute-target-enrollment";
+import { EnrollmentCommandBlock } from "./EnrollmentCommandBlock";
+
+interface AddSshTargetDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function AddSshTargetDialog({ open, onClose }: AddSshTargetDialogProps) {
+  const [displayName, setDisplayName] = useState("");
+  const [workspaceRoot, setWorkspaceRoot] = useState("~/proliferate-workspaces");
+  const [error, setError] = useState<string | null>(null);
+  const {
+    enrollment,
+    isCreating,
+    clearEnrollment,
+    startSshEnrollment,
+  } = useComputeTargetEnrollment();
+
+  const close = () => {
+    clearEnrollment();
+    setError(null);
+    onClose();
+  };
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    void startSshEnrollment({
+      displayName,
+      defaultWorkspaceRoot: workspaceRoot,
+    }).catch((nextError) => {
+      setError(nextError instanceof Error ? nextError.message : "Could not create enrollment.");
+    });
+  };
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={close}
+      title="Add SSH target"
+      description="Create a one-time enrollment command for a machine you can SSH into."
+      sizeClassName="max-w-2xl"
+      footer={(
+        <Button type="button" variant="outline" onClick={close}>
+          Done
+        </Button>
+      )}
+    >
+      <form className="space-y-4" onSubmit={submit}>
+        <div>
+          <Label htmlFor="compute-target-name">Display name</Label>
+          <Input
+            id="compute-target-name"
+            value={displayName}
+            placeholder="Staging SSH Box"
+            onChange={(event) => setDisplayName(event.target.value)}
+            disabled={isCreating || Boolean(enrollment)}
+            required
+          />
+        </div>
+        <div>
+          <Label htmlFor="compute-target-root">Default workspace root</Label>
+          <Input
+            id="compute-target-root"
+            value={workspaceRoot}
+            onChange={(event) => setWorkspaceRoot(event.target.value)}
+            disabled={isCreating || Boolean(enrollment)}
+          />
+        </div>
+        {!enrollment && (
+          <Button type="submit" loading={isCreating} disabled={!displayName.trim()}>
+            Create enrollment command
+          </Button>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {enrollment && <EnrollmentCommandBlock command={enrollment.installCommand} />}
+      </form>
+    </ModalShell>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
@@ -1,0 +1,96 @@
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import { COMPUTE_COPY } from "@/copy/settings/compute";
+import {
+  computeTargetKindLabel,
+  computeTargetStatusLabel,
+  computeTargetStatusTone,
+} from "@/lib/domain/compute/target-presentation";
+import type {
+  ComputeTargetDetail,
+  ComputeTargetSummary,
+} from "@/lib/domain/compute/target-types";
+import { ComputeTargetReadiness } from "./ComputeTargetReadiness";
+
+interface ComputeTargetDetailsProps {
+  target: ComputeTargetDetail | ComputeTargetSummary | null;
+  loading: boolean;
+  onArchive: (targetId: string) => void;
+  archiving: boolean;
+}
+
+export function ComputeTargetDetails({
+  target,
+  loading,
+  onArchive,
+  archiving,
+}: ComputeTargetDetailsProps) {
+  if (loading) {
+    return (
+      <SettingsCard>
+        <div className="p-3 text-sm text-muted-foreground">Loading target details...</div>
+      </SettingsCard>
+    );
+  }
+  if (!target) {
+    return (
+      <SettingsCard>
+        <div className="p-3 text-sm text-muted-foreground">
+          Select a compute target to view its worker, inventory, and readiness.
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  return (
+    <SettingsCard>
+      <div className="space-y-4 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-medium text-foreground">{target.displayName}</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {computeTargetKindLabel(target.kind)}
+              {target.inventory?.os ? ` · ${target.inventory.os}/${target.inventory.arch ?? "unknown"}` : ""}
+            </p>
+          </div>
+          <Badge tone={computeTargetStatusTone(target.status)}>
+            {computeTargetStatusLabel(target.status)}
+          </Badge>
+        </div>
+
+        <dl className="grid grid-cols-2 gap-3 text-xs">
+          <div>
+            <dt className="text-muted-foreground">Workspace root</dt>
+            <dd className="mt-1 truncate text-foreground">{target.defaultWorkspaceRoot ?? "Not set"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Last heartbeat</dt>
+            <dd className="mt-1 truncate text-foreground">
+              {target.statusDetail?.lastHeartbeatAt ?? "Not seen yet"}
+            </dd>
+          </div>
+        </dl>
+
+        <ComputeTargetReadiness inventory={target.inventory} />
+
+        {target.status !== "archived" && (
+          <div className="flex justify-end border-t border-border/40 pt-3">
+            <Button
+              type="button"
+              variant="outline"
+              loading={archiving}
+              onClick={() => {
+                if (window.confirm(COMPUTE_COPY.archiveConfirm)) {
+                  onArchive(target.id);
+                }
+              }}
+            >
+              Archive target
+            </Button>
+          </div>
+        )}
+      </div>
+    </SettingsCard>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
@@ -1,0 +1,72 @@
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import {
+  computeTargetKindLabel,
+  computeTargetStatusLabel,
+  computeTargetStatusTone,
+} from "@/lib/domain/compute/target-presentation";
+import type { ComputeTargetSummary } from "@/lib/domain/compute/target-types";
+import { COMPUTE_COPY } from "@/copy/settings/compute";
+
+interface ComputeTargetListProps {
+  targets: ComputeTargetSummary[];
+  selectedTargetId: string | null;
+  loading: boolean;
+  onSelectTarget: (targetId: string) => void;
+  onAddSshTarget: () => void;
+}
+
+export function ComputeTargetList({
+  targets,
+  selectedTargetId,
+  loading,
+  onSelectTarget,
+  onAddSshTarget,
+}: ComputeTargetListProps) {
+  return (
+    <SettingsCard>
+      <div className="flex items-center justify-between gap-3 p-3">
+        <div>
+          <h3 className="text-sm font-medium text-foreground">Targets</h3>
+          <p className="text-xs text-muted-foreground">Cloud-dispatchable machines and runtimes.</p>
+        </div>
+        <Button type="button" variant="secondary" onClick={onAddSshTarget}>
+          {COMPUTE_COPY.addSshTarget}
+        </Button>
+      </div>
+      {loading ? (
+        <div className="p-3 text-sm text-muted-foreground">Loading targets...</div>
+      ) : targets.length === 0 ? (
+        <div className="space-y-2 p-3">
+          <div className="text-sm font-medium text-foreground">{COMPUTE_COPY.emptyTitle}</div>
+          <p className="text-sm text-muted-foreground">{COMPUTE_COPY.emptyDescription}</p>
+        </div>
+      ) : (
+        targets.map((target) => (
+          <button
+            key={target.id}
+            type="button"
+            className={`flex w-full items-center justify-between gap-3 px-3 py-3 text-left transition-colors hover:bg-accent/50 ${
+              selectedTargetId === target.id ? "bg-accent/40" : ""
+            }`}
+            onClick={() => onSelectTarget(target.id)}
+          >
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {target.displayName}
+              </span>
+              <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                {computeTargetKindLabel(target.kind)}
+                {target.defaultWorkspaceRoot ? ` · ${target.defaultWorkspaceRoot}` : ""}
+              </span>
+            </span>
+            <Badge tone={computeTargetStatusTone(target.status)}>
+              {computeTargetStatusLabel(target.status)}
+            </Badge>
+          </button>
+        ))
+      )}
+    </SettingsCard>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/ComputeTargetReadiness.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetReadiness.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "@/components/ui/Badge";
+import { computeTargetReadiness } from "@/lib/domain/compute/target-readiness";
+import type { ComputeTargetInventory } from "@/lib/domain/compute/target-types";
+
+interface ComputeTargetReadinessProps {
+  inventory: ComputeTargetInventory | null | undefined;
+}
+
+export function ComputeTargetReadiness({ inventory }: ComputeTargetReadinessProps) {
+  const items = computeTargetReadiness(inventory);
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Readiness
+      </h4>
+      <div className="divide-y divide-border/40 rounded-md border border-border/60">
+        {items.map((item) => (
+          <div key={item.key} className="flex items-center justify-between gap-3 p-3">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-foreground">{item.label}</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">{item.detail}</div>
+            </div>
+            <Badge tone={item.ready ? "success" : "warning"}>
+              {item.ready ? "Ready" : "Missing"}
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/EnrollmentCommandBlock.tsx
+++ b/desktop/src/components/settings/panes/compute/EnrollmentCommandBlock.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Copy } from "@/components/ui/icons";
+import { COMPUTE_COPY } from "@/copy/settings/compute";
+
+interface EnrollmentCommandBlockProps {
+  command: string;
+}
+
+export function EnrollmentCommandBlock({ command }: EnrollmentCommandBlockProps) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs font-medium text-muted-foreground">
+          {COMPUTE_COPY.installCommandLabel}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            void navigator.clipboard.writeText(command).then(() => {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1500);
+            });
+          }}
+        >
+          <Copy className="size-3.5" />
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <pre className="max-h-44 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-foreground whitespace-pre-wrap">
+        {command}
+      </pre>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import { CloudAuthUnavailablePane } from "@/components/settings/panes/CloudAuthU
 import { CloudPane } from "@/components/settings/panes/CloudPane";
 import { CloudSignInRequiredPane } from "@/components/settings/panes/CloudSignInRequiredPane";
 import { CloudUnavailablePane } from "@/components/settings/panes/CloudUnavailablePane";
+import { ComputePane } from "@/components/settings/panes/ComputePane";
 import { EnvironmentsPane } from "@/components/settings/panes/EnvironmentsPane";
 import { WorktreesPane } from "@/components/settings/panes/WorktreesPane";
 import {
@@ -89,6 +90,21 @@ function renderSettingsSection(
 
     return cloudSignInAvailable ? <CloudSignInRequiredPane /> : <CloudAuthUnavailablePane />;
   }
+  if (activeSection === "compute") {
+    if (!cloudEnabled) {
+      return <CloudUnavailablePane />;
+    }
+
+    if (cloudActive) {
+      return <ComputePane />;
+    }
+
+    if (cloudSignInChecking) {
+      return <CloudSignInRequiredPane />;
+    }
+
+    return cloudSignInAvailable ? <CloudSignInRequiredPane /> : <CloudAuthUnavailablePane />;
+  }
   return (
     <EnvironmentsPane
       repositories={repositories}
@@ -131,7 +147,7 @@ export function SettingsScreen({
         activeSection={activeSection}
         onNavigateHome={onNavigateHome}
         onSelectSection={onSelectSection}
-        disabledSections={{ cloud: !cloudEnabled }}
+        disabledSections={{ cloud: !cloudEnabled, compute: !cloudEnabled }}
         onCheckForUpdates={() => { void checkNow(); }}
         updateActionState={{
           availableVersion,

--- a/desktop/src/components/settings/settings-navigation.ts
+++ b/desktop/src/components/settings/settings-navigation.ts
@@ -51,6 +51,7 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
     items: [
       { kind: "section", id: "repo", label: "Environments", icon: FolderList },
       { kind: "section", id: "worktrees", label: "Worktrees", icon: GitBranch },
+      { kind: "section", id: "compute", label: "Compute", icon: CloudIcon },
       { kind: "section", id: "cloud", label: "Cloud", icon: CloudIcon },
     ],
   },

--- a/desktop/src/config/settings.ts
+++ b/desktop/src/config/settings.ts
@@ -11,6 +11,7 @@ export const SETTINGS_CONTENT_SECTIONS = [
   "organization",
   "repo",
   "worktrees",
+  "compute",
 ] as const;
 
 export type SettingsSection = (typeof SETTINGS_CONTENT_SECTIONS)[number];

--- a/desktop/src/copy/settings/compute.ts
+++ b/desktop/src/copy/settings/compute.ts
@@ -1,0 +1,10 @@
+export const COMPUTE_COPY = {
+  title: "Compute",
+  description: "Connect machines that can run cloud-dispatchable agent work.",
+  addSshTarget: "Add SSH target",
+  emptyTitle: "No cloud compute targets yet",
+  emptyDescription: "Connect an SSH machine or enable a managed cloud target to run work remotely.",
+  installCommandLabel: "Run this on the target machine",
+  archiveConfirm: "Archive this compute target?",
+  archiveError: "Could not archive target.",
+} as const;

--- a/desktop/src/hooks/access/cloud/query-keys.ts
+++ b/desktop/src/hooks/access/cloud/query-keys.ts
@@ -13,6 +13,8 @@ export {
   cloudRepoConfigKey,
   cloudWorkspaceRepoConfigStatusKey,
   cloudWorkspaceConnectionKey,
+  cloudTargetKey,
+  cloudTargetsKey,
   isCloudWorkspaceConnectionQueryKey,
   isCloudWorkspaceRepoConfigStatusQueryKey,
 } from "@proliferate/cloud-sdk-react/lib/query-keys";

--- a/desktop/src/hooks/access/cloud/targets/query-keys.ts
+++ b/desktop/src/hooks/access/cloud/targets/query-keys.ts
@@ -1,0 +1,4 @@
+export {
+  cloudTargetKey,
+  cloudTargetsKey,
+} from "@/hooks/access/cloud/query-keys";

--- a/desktop/src/hooks/access/cloud/targets/use-cloud-target-mutations.ts
+++ b/desktop/src/hooks/access/cloud/targets/use-cloud-target-mutations.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  archiveTarget,
+  createTargetEnrollment,
+  type ArchiveCloudTargetResponse,
+  type CloudTargetEnrollmentRequest,
+  type CloudTargetEnrollmentResponse,
+} from "@proliferate/cloud-sdk";
+import "@/lib/access/cloud/client";
+import { cloudTargetKey, cloudTargetsKey } from "./query-keys";
+
+export function useCloudTargetMutations() {
+  const queryClient = useQueryClient();
+  const createEnrollment = useMutation<
+    CloudTargetEnrollmentResponse,
+    Error,
+    CloudTargetEnrollmentRequest
+  >({
+    mutationFn: (body) => createTargetEnrollment(body),
+    onSuccess: async (result) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: cloudTargetsKey() }),
+        queryClient.invalidateQueries({ queryKey: cloudTargetKey(result.target.id) }),
+      ]);
+    },
+  });
+  const archive = useMutation<ArchiveCloudTargetResponse, Error, string>({
+    mutationFn: (targetId) => archiveTarget(targetId),
+    onSuccess: async (_result, targetId) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: cloudTargetsKey() }),
+        queryClient.invalidateQueries({ queryKey: cloudTargetKey(targetId) }),
+      ]);
+    },
+  });
+  return {
+    createTargetEnrollment: createEnrollment.mutateAsync,
+    isCreatingTargetEnrollment: createEnrollment.isPending,
+    archiveTarget: archive.mutateAsync,
+    isArchivingTarget: archive.isPending,
+  };
+}

--- a/desktop/src/hooks/access/cloud/targets/use-cloud-targets.ts
+++ b/desktop/src/hooks/access/cloud/targets/use-cloud-targets.ts
@@ -1,0 +1,6 @@
+import "@/lib/access/cloud/client";
+
+export {
+  useCloudTarget,
+  useCloudTargets,
+} from "@proliferate/cloud-sdk-react";

--- a/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
+++ b/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { useCloudTargetMutations } from "@/hooks/access/cloud/targets/use-cloud-target-mutations";
+
+interface StartSshEnrollmentInput {
+  displayName: string;
+  defaultWorkspaceRoot?: string | null;
+}
+
+interface ComputeTargetEnrollmentResult {
+  installCommand: string;
+}
+
+export function useComputeTargetEnrollment() {
+  const { createTargetEnrollment, isCreatingTargetEnrollment } = useCloudTargetMutations();
+  const [result, setResult] = useState<ComputeTargetEnrollmentResult | null>(null);
+
+  return {
+    enrollment: result,
+    isCreating: isCreatingTargetEnrollment,
+    clearEnrollment: () => setResult(null),
+    startSshEnrollment: async (input: StartSshEnrollmentInput) => {
+      const next = await createTargetEnrollment({
+        displayName: input.displayName,
+        kind: "ssh",
+        ownerScope: "personal",
+        defaultWorkspaceRoot: input.defaultWorkspaceRoot ?? null,
+      });
+      setResult(next);
+      return next;
+    },
+  };
+}

--- a/desktop/src/lib/domain/compute/target-presentation.ts
+++ b/desktop/src/lib/domain/compute/target-presentation.ts
@@ -1,0 +1,47 @@
+import type { ComputeTargetKind, ComputeTargetStatus } from "@/lib/domain/compute/target-types";
+
+export function computeTargetKindLabel(kind: ComputeTargetKind): string {
+  switch (kind) {
+    case "managed_cloud":
+      return "Managed cloud";
+    case "ssh":
+      return "SSH target";
+    case "desktop_dispatch":
+      return "Desktop dispatch";
+    case "local_direct":
+      return "Local direct";
+    case "self_hosted_cloud":
+      return "Self-hosted cloud";
+  }
+}
+
+export function computeTargetStatusTone(
+  status: ComputeTargetStatus,
+): "success" | "warning" | "neutral" | "destructive" {
+  switch (status) {
+    case "online":
+      return "success";
+    case "enrolling":
+      return "warning";
+    case "offline":
+    case "archived":
+      return "neutral";
+    case "degraded":
+      return "destructive";
+  }
+}
+
+export function computeTargetStatusLabel(status: ComputeTargetStatus): string {
+  switch (status) {
+    case "online":
+      return "Online";
+    case "enrolling":
+      return "Waiting for enrollment";
+    case "offline":
+      return "Offline";
+    case "degraded":
+      return "Degraded";
+    case "archived":
+      return "Archived";
+  }
+}

--- a/desktop/src/lib/domain/compute/target-readiness.ts
+++ b/desktop/src/lib/domain/compute/target-readiness.ts
@@ -1,0 +1,48 @@
+import type { ComputeTargetInventory } from "@/lib/domain/compute/target-types";
+
+export interface ComputeReadinessItem {
+  key: "git" | "node" | "python";
+  label: string;
+  ready: boolean;
+  detail: string;
+}
+
+function hasAvailableFlag(value: Record<string, unknown> | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  if (typeof value.available === "boolean") {
+    return value.available;
+  }
+  return Object.values(value).some((entry) => (
+    typeof entry === "object"
+    && entry !== null
+    && "available" in entry
+    && (entry as { available?: unknown }).available === true
+  ));
+}
+
+export function computeTargetReadiness(
+  inventory: ComputeTargetInventory | null | undefined,
+): ComputeReadinessItem[] {
+  return [
+    {
+      key: "git",
+      label: "Git",
+      ready: hasAvailableFlag(inventory?.git),
+      detail: "Required for repository checkout and worktree operations.",
+    },
+    {
+      key: "node",
+      label: "Node / npm",
+      ready: hasAvailableFlag(inventory?.node),
+      detail: "Required for most product MCP servers and plugin materialization.",
+    },
+    {
+      key: "python",
+      label: "Python / uv",
+      ready: hasAvailableFlag(inventory?.python),
+      detail: "Used by Python-based setup scripts and some future MCP bundles.",
+    },
+  ];
+}

--- a/desktop/src/lib/domain/compute/target-types.ts
+++ b/desktop/src/lib/domain/compute/target-types.ts
@@ -1,0 +1,51 @@
+export type ComputeTargetKind =
+  | "managed_cloud"
+  | "ssh"
+  | "desktop_dispatch"
+  | "local_direct"
+  | "self_hosted_cloud";
+
+export type ComputeTargetStatus = "online" | "offline" | "degraded" | "enrolling" | "archived";
+
+export interface ComputeTargetInventory {
+  os?: string | null;
+  arch?: string | null;
+  distro?: string | null;
+  shell?: string | null;
+  git?: Record<string, unknown> | null;
+  node?: Record<string, unknown> | null;
+  python?: Record<string, unknown> | null;
+  browser?: Record<string, unknown> | null;
+  capabilities?: Record<string, unknown> | null;
+  providers?: Record<string, unknown> | null;
+  mcp?: Record<string, unknown> | null;
+  updatedAt: string;
+}
+
+export interface ComputeTargetStatusDetail {
+  status: ComputeTargetStatus;
+  statusDetail?: string | null;
+  lastSeenAt?: string | null;
+  lastHeartbeatAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface ComputeTargetSummary {
+  id: string;
+  displayName: string;
+  kind: ComputeTargetKind;
+  status: ComputeTargetStatus;
+  ownerScope: "personal" | "organization";
+  organizationId?: string | null;
+  defaultWorkspaceRoot?: string | null;
+  inventory?: ComputeTargetInventory | null;
+  statusDetail?: ComputeTargetStatusDetail | null;
+  archivedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ComputeTargetDetail extends ComputeTargetSummary {
+  ownerUserId: string;
+  createdByUserId: string;
+}

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,30 @@
+# Proliferate Target Installer
+
+`proliferate-target-install.sh` installs the three target-side binaries:
+
+- `anyharness`: local runtime source of truth
+- `proliferate-worker`: outbound cloud bridge for enrollment, heartbeat, and inventory
+- `proliferate-supervisor`: restart wrapper for the runtime and worker
+
+The cloud target enrollment API emits a command in this shape:
+
+```sh
+curl -fsSL "$INSTALLER_URL" | \
+  PROLIFERATE_CLOUD_URL="$CLOUD_URL" \
+  PROLIFERATE_ENROLLMENT_TOKEN="$TOKEN" \
+  sh
+```
+
+If the binaries are already on `PATH`, the installer copies them into
+`~/.proliferate/bin`. Otherwise it downloads platform-specific artifacts from
+`PROLIFERATE_ARTIFACT_BASE_URL/<target>/<binary>`.
+
+The installer writes:
+
+- `~/.proliferate/worker/config.toml`
+- `~/.proliferate/supervisor/config.toml`
+- `~/.config/systemd/user/proliferate-target.service` when `systemctl` exists
+
+Managed cloud images can use the same installer with a one-time enrollment
+token at boot. SSH onboarding uses the same command surfaced in the Desktop
+Compute settings page.

--- a/install/proliferate-target-install.sh
+++ b/install/proliferate-target-install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+set -eu
+umask 077
+
+if [ -z "${PROLIFERATE_CLOUD_URL:-}" ]; then
+  echo "PROLIFERATE_CLOUD_URL is required" >&2
+  exit 1
+fi
+
+if [ -z "${PROLIFERATE_ENROLLMENT_TOKEN:-}" ]; then
+  echo "PROLIFERATE_ENROLLMENT_TOKEN is required" >&2
+  exit 1
+fi
+
+PROLIFERATE_HOME="${PROLIFERATE_HOME:-$HOME/.proliferate}"
+BIN_DIR="$PROLIFERATE_HOME/bin"
+WORKER_DIR="$PROLIFERATE_HOME/worker"
+SUPERVISOR_DIR="$PROLIFERATE_HOME/supervisor"
+mkdir -p "$BIN_DIR" "$WORKER_DIR" "$SUPERVISOR_DIR"
+chmod 700 "$PROLIFERATE_HOME" "$BIN_DIR" "$WORKER_DIR" "$SUPERVISOR_DIR"
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s:$uname_m" in
+  Linux:x86_64) target="linux-x86_64" ;;
+  Linux:aarch64|Linux:arm64) target="linux-aarch64" ;;
+  Darwin:arm64) target="macos-aarch64" ;;
+  Darwin:x86_64) target="macos-x86_64" ;;
+  *) echo "Unsupported platform: $uname_s $uname_m" >&2; exit 1 ;;
+esac
+
+download_binary() {
+  name="$1"
+  if command -v "$name" >/dev/null 2>&1; then
+    cp "$(command -v "$name")" "$BIN_DIR/$name"
+    chmod +x "$BIN_DIR/$name"
+    return
+  fi
+  if [ -n "${PROLIFERATE_ARTIFACT_BASE_URL:-}" ]; then
+    url="${PROLIFERATE_ARTIFACT_BASE_URL%/}/$target/$name"
+    curl -fsSL "$url" -o "$BIN_DIR/$name"
+    chmod +x "$BIN_DIR/$name"
+    return
+  fi
+  echo "Could not find $name and PROLIFERATE_ARTIFACT_BASE_URL is unset" >&2
+  exit 1
+}
+
+download_binary anyharness
+download_binary proliferate-worker
+download_binary proliferate-supervisor
+
+cat > "$WORKER_DIR/config.toml" <<EOF
+cloud_base_url = "$PROLIFERATE_CLOUD_URL"
+enrollment_token = "$PROLIFERATE_ENROLLMENT_TOKEN"
+worker_db_path = "$WORKER_DIR/worker.sqlite3"
+heartbeat_interval_seconds = 60
+EOF
+chmod 600 "$WORKER_DIR/config.toml"
+
+cat > "$SUPERVISOR_DIR/config.toml" <<EOF
+anyharness_binary = "$BIN_DIR/anyharness"
+worker_binary = "$BIN_DIR/proliferate-worker"
+worker_config = "$WORKER_DIR/config.toml"
+anyharness_args = ["serve"]
+restart_delay_seconds = 5
+EOF
+chmod 600 "$SUPERVISOR_DIR/config.toml"
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemd_dir="$HOME/.config/systemd/user"
+  mkdir -p "$systemd_dir"
+  cat > "$systemd_dir/proliferate-target.service" <<EOF
+[Unit]
+Description=Proliferate target supervisor
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$BIN_DIR/proliferate-supervisor --config $SUPERVISOR_DIR/config.toml run
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+  if systemctl --user daemon-reload \
+    && systemctl --user enable --now proliferate-target.service \
+    && systemctl --user is-active --quiet proliferate-target.service; then
+    echo "Proliferate target installed. Check status with: systemctl --user status proliferate-target.service"
+  else
+    echo "Proliferate target files installed, but the user systemd service did not start." >&2
+    echo "Start manually with:" >&2
+    echo "  $BIN_DIR/proliferate-supervisor --config $SUPERVISOR_DIR/config.toml run" >&2
+    exit 1
+  fi
+else
+  echo "Proliferate target installed."
+  echo "Start it with:"
+  echo "  $BIN_DIR/proliferate-supervisor --config $SUPERVISOR_DIR/config.toml run"
+fi

--- a/server/alembic/versions/c4d5e6f7a8b9_cloud_targets_workers.py
+++ b/server/alembic/versions/c4d5e6f7a8b9_cloud_targets_workers.py
@@ -1,0 +1,231 @@
+"""cloud targets and workers
+
+Revision ID: c4d5e6f7a8b9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | Sequence[str] | None = "c3d4e5f6a7b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_index_once(index_name: str, table_name: str, columns: list[str]) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=False)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if not _has_table("cloud_targets"):
+        op.create_table(
+            "cloud_targets",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("display_name", sa.String(length=255), nullable=False),
+            sa.Column("kind", sa.String(length=32), nullable=False),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("owner_scope", sa.String(length=32), nullable=False),
+            sa.Column("owner_user_id", sa.Uuid(), nullable=False),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("created_by_user_id", sa.Uuid(), nullable=False),
+            sa.Column("default_workspace_root", sa.Text(), nullable=True),
+            sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "kind IN ('managed_cloud', 'ssh', 'desktop_dispatch', 'local_direct', "
+                "'self_hosted_cloud')",
+                name="ck_cloud_targets_kind",
+            ),
+            sa.CheckConstraint(
+                "owner_scope IN ('personal', 'organization')",
+                name="ck_cloud_targets_owner_scope",
+            ),
+            sa.CheckConstraint(
+                "status IN ('enrolling', 'online', 'offline', 'degraded', 'archived')",
+                name="ck_cloud_targets_status",
+            ),
+            sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once("ix_cloud_targets_status", "cloud_targets", ["status"])
+    _create_index_once("ix_cloud_targets_owner_user_id", "cloud_targets", ["owner_user_id"])
+    _create_index_once("ix_cloud_targets_organization_id", "cloud_targets", ["organization_id"])
+    _create_index_once(
+        "ix_cloud_targets_owner_user_status",
+        "cloud_targets",
+        ["owner_user_id", "status"],
+    )
+    _create_index_once(
+        "ix_cloud_targets_organization_status",
+        "cloud_targets",
+        ["organization_id", "status"],
+    )
+    _create_index_once(
+        "ix_cloud_targets_created_by_user_id",
+        "cloud_targets",
+        ["created_by_user_id"],
+    )
+
+    if not _has_table("cloud_workers"):
+        op.create_table(
+            "cloud_workers",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("token_hash", sa.String(length=64), nullable=False),
+            sa.Column("machine_fingerprint", sa.String(length=255), nullable=True),
+            sa.Column("hostname", sa.String(length=255), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("worker_version", sa.String(length=128), nullable=True),
+            sa.Column("anyharness_version", sa.String(length=128), nullable=True),
+            sa.Column("supervisor_version", sa.String(length=128), nullable=True),
+            sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('enrolling', 'online', 'offline', 'degraded', 'archived')",
+                name="ck_cloud_workers_status",
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("token_hash"),
+        )
+    _create_index_once("ix_cloud_workers_target_id", "cloud_workers", ["target_id"])
+    _create_index_once("ix_cloud_workers_token_hash", "cloud_workers", ["token_hash"])
+    _create_index_once("ix_cloud_workers_status", "cloud_workers", ["status"])
+    _create_index_once(
+        "ix_cloud_workers_target_status",
+        "cloud_workers",
+        ["target_id", "status"],
+    )
+    _create_index_once("ix_cloud_workers_last_seen_at", "cloud_workers", ["last_seen_at"])
+
+    if not _has_table("cloud_target_enrollments"):
+        op.create_table(
+            "cloud_target_enrollments",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("token_hash", sa.String(length=64), nullable=False),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("created_by_user_id", sa.Uuid(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('pending', 'consumed', 'expired', 'revoked')",
+                name="ck_cloud_target_enrollments_status",
+            ),
+            sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("token_hash"),
+        )
+    _create_index_once(
+        "ix_cloud_target_enrollments_target_id",
+        "cloud_target_enrollments",
+        ["target_id"],
+    )
+    _create_index_once(
+        "ix_cloud_target_enrollments_token_hash",
+        "cloud_target_enrollments",
+        ["token_hash"],
+    )
+    _create_index_once(
+        "ix_cloud_target_enrollments_status",
+        "cloud_target_enrollments",
+        ["status"],
+    )
+    _create_index_once(
+        "ix_cloud_target_enrollments_target_status",
+        "cloud_target_enrollments",
+        ["target_id", "status"],
+    )
+    _create_index_once(
+        "ix_cloud_target_enrollments_expires_at",
+        "cloud_target_enrollments",
+        ["expires_at"],
+    )
+    _create_index_once(
+        "ix_cloud_target_enrollments_created_by_user_id",
+        "cloud_target_enrollments",
+        ["created_by_user_id"],
+    )
+
+    if not _has_table("cloud_target_inventory"):
+        op.create_table(
+            "cloud_target_inventory",
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("worker_id", sa.Uuid(), nullable=True),
+            sa.Column("os", sa.String(length=64), nullable=True),
+            sa.Column("arch", sa.String(length=64), nullable=True),
+            sa.Column("distro", sa.String(length=128), nullable=True),
+            sa.Column("shell", sa.String(length=255), nullable=True),
+            sa.Column("git_json", sa.Text(), nullable=True),
+            sa.Column("node_json", sa.Text(), nullable=True),
+            sa.Column("python_json", sa.Text(), nullable=True),
+            sa.Column("browser_json", sa.Text(), nullable=True),
+            sa.Column("capabilities_json", sa.Text(), nullable=True),
+            sa.Column("providers_json", sa.Text(), nullable=True),
+            sa.Column("mcp_json", sa.Text(), nullable=True),
+            sa.Column("raw_json", sa.Text(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("target_id"),
+        )
+    _create_index_once(
+        "ix_cloud_target_inventory_worker_id",
+        "cloud_target_inventory",
+        ["worker_id"],
+    )
+
+    if not _has_table("cloud_target_status"):
+        op.create_table(
+            "cloud_target_status",
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("worker_id", sa.Uuid(), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("status_detail", sa.Text(), nullable=True),
+            sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("target_id"),
+        )
+    _create_index_once("ix_cloud_target_status_status", "cloud_target_status", ["status"])
+    _create_index_once("ix_cloud_target_status_worker_id", "cloud_target_status", ["worker_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("cloud_target_status")
+    op.drop_table("cloud_target_inventory")
+    op.drop_table("cloud_target_enrollments")
+    op.drop_table("cloud_workers")
+    op.drop_table("cloud_targets")

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -129,6 +129,11 @@ class Settings(BaseSettings):
     daytona_api_key: str = ""
     daytona_server_url: str = "https://app.daytona.io/api"
     daytona_target: str = "us"
+    proliferate_target_installer_url: str = (
+        "https://raw.githubusercontent.com/proliferate-ai/proliferate/main/"
+        "install/proliferate-target-install.sh"
+    )
+    proliferate_target_artifact_base_url: str = ""
 
     @model_validator(mode="after")
     def validate_secrets_in_production(self) -> "Settings":

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -161,3 +161,63 @@ DEFAULT_WORKTREE_POLICY_UPDATED_AT = "1970-01-01T00:00:00+00:00"
 # ---------------------------------------------------------------------------
 
 SUPPORTED_GIT_PROVIDER: str = "github"
+
+
+# ---------------------------------------------------------------------------
+# Cloud compute targets and Proliferate Worker lifecycle
+# ---------------------------------------------------------------------------
+
+
+class CloudTargetKind(StrEnum):
+    managed_cloud = "managed_cloud"
+    ssh = "ssh"
+    desktop_dispatch = "desktop_dispatch"
+    local_direct = "local_direct"
+    self_hosted_cloud = "self_hosted_cloud"
+
+
+class CloudTargetStatus(StrEnum):
+    enrolling = "enrolling"
+    online = "online"
+    offline = "offline"
+    degraded = "degraded"
+    archived = "archived"
+
+
+class CloudWorkerStatus(StrEnum):
+    enrolling = "enrolling"
+    online = "online"
+    offline = "offline"
+    degraded = "degraded"
+    archived = "archived"
+
+
+class CloudTargetEnrollmentStatus(StrEnum):
+    pending = "pending"
+    consumed = "consumed"
+    expired = "expired"
+    revoked = "revoked"
+
+
+SUPPORTED_CLOUD_TARGET_KINDS: tuple[str, ...] = tuple(kind.value for kind in CloudTargetKind)
+SUPPORTED_ENROLLABLE_CLOUD_TARGET_KINDS: tuple[str, ...] = (
+    CloudTargetKind.managed_cloud.value,
+    CloudTargetKind.ssh.value,
+    CloudTargetKind.desktop_dispatch.value,
+    CloudTargetKind.self_hosted_cloud.value,
+)
+SUPPORTED_CLOUD_TARGET_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in CloudTargetStatus
+)
+SUPPORTED_CLOUD_WORKER_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in CloudWorkerStatus
+)
+SUPPORTED_CLOUD_TARGET_ENROLLMENT_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in CloudTargetEnrollmentStatus
+)
+
+CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN: Final = "cloud-target-enrollment"
+CLOUD_WORKER_TOKEN_DOMAIN: Final = "cloud-worker"
+CLOUD_TARGET_DEFAULT_ENROLLMENT_TTL_SECONDS: Final = 3600
+CLOUD_TARGET_MAX_ENROLLMENT_TTL_SECONDS: Final = 86_400
+CLOUD_TARGET_HEARTBEAT_STALE_SECONDS: Final = 180

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -10,5 +10,6 @@ from . import mobility as mobility  # noqa: F401
 from . import repo_config as repo_config  # noqa: F401
 from . import runtime_environments as runtime_environments  # noqa: F401
 from . import sandboxes as sandboxes  # noqa: F401
+from . import targets as targets  # noqa: F401
 from . import workspaces as workspaces  # noqa: F401
 from . import worktree_policy as worktree_policy  # noqa: F401

--- a/server/proliferate/db/models/cloud/targets.py
+++ b/server/proliferate/db/models/cloud/targets.py
@@ -1,0 +1,179 @@
+"""Cloud compute target and worker ORM models."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.constants.cloud import (
+    SUPPORTED_CLOUD_TARGET_ENROLLMENT_STATUSES,
+    SUPPORTED_CLOUD_TARGET_KINDS,
+    SUPPORTED_CLOUD_TARGET_STATUSES,
+    SUPPORTED_CLOUD_WORKER_STATUSES,
+)
+from proliferate.db.models.base import Base, utcnow
+
+
+class CloudTarget(Base):
+    __tablename__ = "cloud_targets"
+    __table_args__ = (
+        CheckConstraint(
+            f"kind IN {SUPPORTED_CLOUD_TARGET_KINDS}",
+            name="ck_cloud_targets_kind",
+        ),
+        CheckConstraint(
+            "owner_scope IN ('personal', 'organization')",
+            name="ck_cloud_targets_owner_scope",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_CLOUD_TARGET_STATUSES}",
+            name="ck_cloud_targets_status",
+        ),
+        Index("ix_cloud_targets_owner_user_status", "owner_user_id", "status"),
+        Index("ix_cloud_targets_organization_status", "organization_id", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    display_name: Mapped[str] = mapped_column(String(255))
+    kind: Mapped[str] = mapped_column(String(32))
+    status: Mapped[str] = mapped_column(String(32), default="enrolling", index=True)
+    owner_scope: Mapped[str] = mapped_column(String(32), default="personal")
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    created_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    default_workspace_root: Mapped[str | None] = mapped_column(Text, nullable=True)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class CloudWorker(Base):
+    __tablename__ = "cloud_workers"
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN {SUPPORTED_CLOUD_WORKER_STATUSES}",
+            name="ck_cloud_workers_status",
+        ),
+        Index("ix_cloud_workers_target_status", "target_id", "status"),
+        Index("ix_cloud_workers_last_seen_at", "last_seen_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    machine_fingerprint: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    hostname: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="online", index=True)
+    worker_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    anyharness_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    supervisor_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class CloudTargetEnrollment(Base):
+    __tablename__ = "cloud_target_enrollments"
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN {SUPPORTED_CLOUD_TARGET_ENROLLMENT_STATUSES}",
+            name="ck_cloud_target_enrollments_status",
+        ),
+        Index("ix_cloud_target_enrollments_target_status", "target_id", "status"),
+        Index("ix_cloud_target_enrollments_expires_at", "expires_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    created_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class CloudTargetInventory(Base):
+    __tablename__ = "cloud_target_inventory"
+
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    worker_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workers.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    os: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    arch: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    distro: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    shell: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    git_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    node_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    python_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    browser_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    capabilities_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    providers_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mcp_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    raw_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class CloudTargetStatus(Base):
+    __tablename__ = "cloud_target_status"
+
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    worker_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workers.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(String(32), default="enrolling", index=True)
+    status_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/server/proliferate/db/store/cloud_sync/__init__.py
+++ b/server/proliferate/db/store/cloud_sync/__init__.py
@@ -1,0 +1,2 @@
+"""Persistence helpers for Cloud Worker sync and target registry state."""
+

--- a/server/proliferate/db/store/cloud_sync/inventory.py
+++ b/server/proliferate/db/store/cloud_sync/inventory.py
@@ -1,0 +1,103 @@
+"""Proliferate Worker heartbeat and inventory persistence."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.targets import (
+    CloudTargetInventory,
+)
+from proliferate.db.models.cloud.targets import (
+    CloudTargetStatus as CloudTargetStatusRow,
+)
+from proliferate.utils.time import utcnow
+
+
+async def upsert_target_status(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    worker_id: UUID | None,
+    status_value: str,
+    status_detail: str | None,
+) -> None:
+    now = utcnow()
+    row = await db.get(CloudTargetStatusRow, target_id)
+    if row is None:
+        row = CloudTargetStatusRow(
+            target_id=target_id,
+            worker_id=worker_id,
+            status=status_value,
+            status_detail=status_detail,
+            last_seen_at=now,
+            last_heartbeat_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.worker_id = worker_id
+        row.status = status_value
+        row.status_detail = status_detail
+        row.last_seen_at = now
+        row.last_heartbeat_at = now
+        row.updated_at = now
+    await db.flush()
+
+
+async def upsert_inventory(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    worker_id: UUID | None,
+    os: str | None,
+    arch: str | None,
+    distro: str | None,
+    shell: str | None,
+    git_json: str | None,
+    node_json: str | None,
+    python_json: str | None,
+    browser_json: str | None,
+    capabilities_json: str | None,
+    providers_json: str | None,
+    mcp_json: str | None,
+    raw_json: str | None,
+) -> None:
+    now = utcnow()
+    row = await db.get(CloudTargetInventory, target_id)
+    if row is None:
+        row = CloudTargetInventory(
+            target_id=target_id,
+            worker_id=worker_id,
+            os=os,
+            arch=arch,
+            distro=distro,
+            shell=shell,
+            git_json=git_json,
+            node_json=node_json,
+            python_json=python_json,
+            browser_json=browser_json,
+            capabilities_json=capabilities_json,
+            providers_json=providers_json,
+            mcp_json=mcp_json,
+            raw_json=raw_json,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.worker_id = worker_id
+        row.os = os
+        row.arch = arch
+        row.distro = distro
+        row.shell = shell
+        row.git_json = git_json
+        row.node_json = node_json
+        row.python_json = python_json
+        row.browser_json = browser_json
+        row.capabilities_json = capabilities_json
+        row.providers_json = providers_json
+        row.mcp_json = mcp_json
+        row.raw_json = raw_json
+        row.updated_at = now
+    await db.flush()

--- a/server/proliferate/db/store/cloud_sync/targets.py
+++ b/server/proliferate/db/store/cloud_sync/targets.py
@@ -1,0 +1,286 @@
+"""Cloud target registry persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, exists, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from proliferate.constants.cloud import CloudTargetStatus
+from proliferate.constants.organizations import ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE
+from proliferate.db.models.cloud.targets import (
+    CloudTarget,
+    CloudTargetInventory,
+)
+from proliferate.db.models.cloud.targets import (
+    CloudTargetStatus as CloudTargetStatusRow,
+)
+from proliferate.db.models.organizations import OrganizationMembership
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class CloudTargetInventorySnapshot:
+    target_id: UUID
+    worker_id: UUID | None
+    os: str | None
+    arch: str | None
+    distro: str | None
+    shell: str | None
+    git_json: str | None
+    node_json: str | None
+    python_json: str | None
+    browser_json: str | None
+    capabilities_json: str | None
+    providers_json: str | None
+    mcp_json: str | None
+    raw_json: str | None
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudTargetStatusSnapshot:
+    target_id: UUID
+    worker_id: UUID | None
+    status: str
+    status_detail: str | None
+    last_seen_at: datetime | None
+    last_heartbeat_at: datetime | None
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudTargetSnapshot:
+    id: UUID
+    display_name: str
+    kind: str
+    status: str
+    owner_scope: str
+    owner_user_id: UUID
+    organization_id: UUID | None
+    created_by_user_id: UUID
+    default_workspace_root: str | None
+    archived_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    status_record: CloudTargetStatusSnapshot | None
+    inventory: CloudTargetInventorySnapshot | None
+
+
+def _status_snapshot(row: CloudTargetStatusRow | None) -> CloudTargetStatusSnapshot | None:
+    if row is None:
+        return None
+    return CloudTargetStatusSnapshot(
+        target_id=row.target_id,
+        worker_id=row.worker_id,
+        status=row.status,
+        status_detail=row.status_detail,
+        last_seen_at=row.last_seen_at,
+        last_heartbeat_at=row.last_heartbeat_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _inventory_snapshot(row: CloudTargetInventory | None) -> CloudTargetInventorySnapshot | None:
+    if row is None:
+        return None
+    return CloudTargetInventorySnapshot(
+        target_id=row.target_id,
+        worker_id=row.worker_id,
+        os=row.os,
+        arch=row.arch,
+        distro=row.distro,
+        shell=row.shell,
+        git_json=row.git_json,
+        node_json=row.node_json,
+        python_json=row.python_json,
+        browser_json=row.browser_json,
+        capabilities_json=row.capabilities_json,
+        providers_json=row.providers_json,
+        mcp_json=row.mcp_json,
+        raw_json=row.raw_json,
+        updated_at=row.updated_at,
+    )
+
+
+def _target_snapshot(
+    target: CloudTarget,
+    status: CloudTargetStatusRow | None,
+    inventory: CloudTargetInventory | None,
+) -> CloudTargetSnapshot:
+    return CloudTargetSnapshot(
+        id=target.id,
+        display_name=target.display_name,
+        kind=target.kind,
+        status=status.status if status is not None else target.status,
+        owner_scope=target.owner_scope,
+        owner_user_id=target.owner_user_id,
+        organization_id=target.organization_id,
+        created_by_user_id=target.created_by_user_id,
+        default_workspace_root=target.default_workspace_root,
+        archived_at=target.archived_at,
+        created_at=target.created_at,
+        updated_at=target.updated_at,
+        status_record=_status_snapshot(status),
+        inventory=_inventory_snapshot(inventory),
+    )
+
+
+def _visible_target_filter(user_id: UUID) -> ColumnElement[bool]:
+    active_org_membership = exists().where(
+        OrganizationMembership.organization_id == CloudTarget.organization_id,
+        OrganizationMembership.user_id == user_id,
+        OrganizationMembership.status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    )
+    return or_(
+        and_(
+            CloudTarget.owner_scope == "personal",
+            or_(
+                CloudTarget.owner_user_id == user_id,
+                CloudTarget.created_by_user_id == user_id,
+            ),
+        ),
+        and_(
+            CloudTarget.owner_scope == "organization",
+            CloudTarget.organization_id.is_not(None),
+            active_org_membership,
+        ),
+    )
+
+
+async def create_target(
+    db: AsyncSession,
+    *,
+    display_name: str,
+    kind: str,
+    owner_scope: str,
+    owner_user_id: UUID,
+    organization_id: UUID | None,
+    created_by_user_id: UUID,
+    default_workspace_root: str | None,
+) -> CloudTargetSnapshot:
+    now = utcnow()
+    target = CloudTarget(
+        display_name=display_name,
+        kind=kind,
+        status=CloudTargetStatus.enrolling.value,
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+        default_workspace_root=default_workspace_root,
+        archived_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(target)
+    await db.flush()
+    status = CloudTargetStatusRow(
+        target_id=target.id,
+        worker_id=None,
+        status=CloudTargetStatus.enrolling.value,
+        status_detail="Waiting for worker enrollment.",
+        last_seen_at=None,
+        last_heartbeat_at=None,
+        updated_at=now,
+    )
+    db.add(status)
+    await db.flush()
+    return _target_snapshot(target, status, None)
+
+
+async def get_target_by_id(
+    db: AsyncSession,
+    target_id: UUID,
+) -> CloudTargetSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudTarget, CloudTargetStatusRow, CloudTargetInventory)
+            .outerjoin(CloudTargetStatusRow, CloudTargetStatusRow.target_id == CloudTarget.id)
+            .outerjoin(CloudTargetInventory, CloudTargetInventory.target_id == CloudTarget.id)
+            .where(CloudTarget.id == target_id)
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    target, status, inventory = row
+    return _target_snapshot(target, status, inventory)
+
+
+async def get_visible_target_by_id(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+) -> CloudTargetSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudTarget, CloudTargetStatusRow, CloudTargetInventory)
+            .outerjoin(CloudTargetStatusRow, CloudTargetStatusRow.target_id == CloudTarget.id)
+            .outerjoin(CloudTargetInventory, CloudTargetInventory.target_id == CloudTarget.id)
+            .where(CloudTarget.id == target_id)
+            .where(_visible_target_filter(user_id))
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    target, status, inventory = row
+    return _target_snapshot(target, status, inventory)
+
+
+async def list_visible_targets(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> tuple[CloudTargetSnapshot, ...]:
+    rows = (
+        await db.execute(
+            select(CloudTarget, CloudTargetStatusRow, CloudTargetInventory)
+            .outerjoin(CloudTargetStatusRow, CloudTargetStatusRow.target_id == CloudTarget.id)
+            .outerjoin(CloudTargetInventory, CloudTargetInventory.target_id == CloudTarget.id)
+            .where(CloudTarget.status != CloudTargetStatus.archived.value)
+            .where(_visible_target_filter(user_id))
+            .order_by(CloudTarget.updated_at.desc(), CloudTarget.created_at.desc())
+        )
+    ).all()
+    return tuple(_target_snapshot(target, status, inventory) for target, status, inventory in rows)
+
+
+async def archive_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+) -> CloudTargetSnapshot | None:
+    target = await db.get(CloudTarget, target_id)
+    if target is None:
+        return None
+    now = utcnow()
+    target.status = CloudTargetStatus.archived.value
+    target.archived_at = now
+    target.updated_at = now
+    status = await db.get(CloudTargetStatusRow, target_id)
+    if status is not None:
+        status.status = CloudTargetStatus.archived.value
+        status.status_detail = "Target archived."
+        status.updated_at = now
+    await db.flush()
+    inventory = await db.get(CloudTargetInventory, target_id)
+    return _target_snapshot(target, status, inventory)
+
+
+async def set_target_status(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    status_value: str,
+) -> None:
+    target = await db.get(CloudTarget, target_id)
+    if target is None:
+        return
+    target.status = status_value
+    target.updated_at = utcnow()
+    await db.flush()

--- a/server/proliferate/db/store/cloud_sync/worker_auth.py
+++ b/server/proliferate/db/store/cloud_sync/worker_auth.py
@@ -1,0 +1,213 @@
+"""Proliferate Worker enrollment and auth persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import (
+    CloudTargetEnrollmentStatus,
+    CloudWorkerStatus,
+)
+from proliferate.db.models.cloud.targets import CloudTargetEnrollment, CloudWorker
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class CloudTargetEnrollmentSnapshot:
+    id: UUID
+    target_id: UUID
+    token_hash: str
+    status: str
+    created_by_user_id: UUID
+    expires_at: datetime
+    consumed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudWorkerSnapshot:
+    id: UUID
+    target_id: UUID
+    token_hash: str
+    machine_fingerprint: str | None
+    hostname: str | None
+    status: str
+    worker_version: str | None
+    anyharness_version: str | None
+    supervisor_version: str | None
+    last_seen_at: datetime | None
+    last_heartbeat_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _enrollment_snapshot(row: CloudTargetEnrollment) -> CloudTargetEnrollmentSnapshot:
+    return CloudTargetEnrollmentSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        token_hash=row.token_hash,
+        status=row.status,
+        created_by_user_id=row.created_by_user_id,
+        expires_at=row.expires_at,
+        consumed_at=row.consumed_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _worker_snapshot(row: CloudWorker) -> CloudWorkerSnapshot:
+    return CloudWorkerSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        token_hash=row.token_hash,
+        machine_fingerprint=row.machine_fingerprint,
+        hostname=row.hostname,
+        status=row.status,
+        worker_version=row.worker_version,
+        anyharness_version=row.anyharness_version,
+        supervisor_version=row.supervisor_version,
+        last_seen_at=row.last_seen_at,
+        last_heartbeat_at=row.last_heartbeat_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def create_enrollment(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    token_hash: str,
+    created_by_user_id: UUID,
+    expires_at: datetime,
+) -> CloudTargetEnrollmentSnapshot:
+    now = utcnow()
+    row = CloudTargetEnrollment(
+        target_id=target_id,
+        token_hash=token_hash,
+        status=CloudTargetEnrollmentStatus.pending.value,
+        created_by_user_id=created_by_user_id,
+        expires_at=expires_at,
+        consumed_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    return _enrollment_snapshot(row)
+
+
+async def consume_pending_enrollment_by_hash(
+    db: AsyncSession,
+    *,
+    token_hash: str,
+    now: datetime,
+) -> CloudTargetEnrollmentSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudTargetEnrollment)
+            .where(CloudTargetEnrollment.token_hash == token_hash)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    if row.status != CloudTargetEnrollmentStatus.pending.value:
+        return None
+    if row.expires_at <= now:
+        row.status = CloudTargetEnrollmentStatus.expired.value
+        row.updated_at = now
+        await db.flush()
+        return None
+    row.status = CloudTargetEnrollmentStatus.consumed.value
+    row.consumed_at = now
+    row.updated_at = now
+    await db.flush()
+    return _enrollment_snapshot(row)
+
+
+async def create_worker(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    token_hash: str,
+    machine_fingerprint: str | None,
+    hostname: str | None,
+    worker_version: str | None,
+    anyharness_version: str | None,
+    supervisor_version: str | None,
+    now: datetime,
+) -> CloudWorkerSnapshot:
+    row = CloudWorker(
+        target_id=target_id,
+        token_hash=token_hash,
+        machine_fingerprint=machine_fingerprint,
+        hostname=hostname,
+        status=CloudWorkerStatus.online.value,
+        worker_version=worker_version,
+        anyharness_version=anyharness_version,
+        supervisor_version=supervisor_version,
+        last_seen_at=now,
+        last_heartbeat_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    return _worker_snapshot(row)
+
+
+async def get_worker_by_token_hash(
+    db: AsyncSession,
+    *,
+    token_hash: str,
+) -> CloudWorkerSnapshot | None:
+    row = (
+        await db.execute(select(CloudWorker).where(CloudWorker.token_hash == token_hash))
+    ).scalar_one_or_none()
+    return _worker_snapshot(row) if row is not None else None
+
+
+async def record_worker_heartbeat(
+    db: AsyncSession,
+    *,
+    worker_id: UUID,
+    status_value: str,
+    worker_version: str | None,
+    anyharness_version: str | None,
+    supervisor_version: str | None,
+    now: datetime,
+) -> CloudWorkerSnapshot | None:
+    row = await db.get(CloudWorker, worker_id)
+    if row is None:
+        return None
+    row.status = status_value
+    row.worker_version = worker_version
+    row.anyharness_version = anyharness_version
+    row.supervisor_version = supervisor_version
+    row.last_seen_at = now
+    row.last_heartbeat_at = now
+    row.updated_at = now
+    await db.flush()
+    return _worker_snapshot(row)
+
+
+async def archive_workers_for_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    now: datetime,
+) -> None:
+    await db.execute(
+        update(CloudWorker)
+        .where(CloudWorker.target_id == target_id)
+        .where(CloudWorker.status != CloudWorkerStatus.archived.value)
+        .values(status=CloudWorkerStatus.archived.value, updated_at=now)
+    )
+    await db.flush()

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -10,7 +10,9 @@ from proliferate.server.cloud.mcp_oauth.api import router as mcp_oauth_router
 from proliferate.server.cloud.mobility.api import router as mobility_router
 from proliferate.server.cloud.repo_config.api import router as repo_config_router
 from proliferate.server.cloud.repos.api import router as repos_router
+from proliferate.server.cloud.targets.api import router as targets_router
 from proliferate.server.cloud.webhooks.api import router as webhooks_router
+from proliferate.server.cloud.worker.api import router as worker_router
 from proliferate.server.cloud.workspaces.api import router as workspaces_router
 from proliferate.server.cloud.worktree_policy.api import router as worktree_policy_router
 
@@ -26,3 +28,5 @@ router.include_router(mcp_connections_router)
 router.include_router(mcp_materialization_router)
 router.include_router(mcp_oauth_router)
 router.include_router(webhooks_router)
+router.include_router(targets_router)
+router.include_router(worker_router)

--- a/server/proliferate/server/cloud/targets/__init__.py
+++ b/server/proliferate/server/cloud/targets/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud compute target API package."""

--- a/server/proliferate/server/cloud/targets/access.py
+++ b/server/proliferate/server/cloud/targets/access.py
@@ -1,0 +1,30 @@
+"""Access helpers for cloud compute targets."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud.errors import CloudApiError
+
+
+async def require_visible_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+) -> targets_store.CloudTargetSnapshot:
+    target = await targets_store.get_visible_target_by_id(
+        db,
+        target_id=target_id,
+        user_id=user_id,
+    )
+    if target is None:
+        raise CloudApiError(
+            "cloud_target_not_found",
+            "Target not found.",
+            status_code=404,
+        )
+    return target

--- a/server/proliferate/server/cloud/targets/api.py
+++ b/server/proliferate/server/cloud/targets/api.py
@@ -1,0 +1,77 @@
+"""HTTP routes for cloud compute targets."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.targets.models import (
+    ArchiveCloudTargetResponse,
+    CloudTargetDetail,
+    CloudTargetEnrollmentRequest,
+    CloudTargetEnrollmentResponse,
+    CloudTargetSummary,
+    target_detail_payload,
+    target_summary_payload,
+)
+from proliferate.server.cloud.targets.service import (
+    archive_target,
+    create_target_enrollment,
+    get_target_detail,
+    list_targets,
+)
+
+router = APIRouter(prefix="/targets", tags=["cloud-targets"])
+
+
+@router.post("/enrollments", response_model=CloudTargetEnrollmentResponse)
+async def create_target_enrollment_endpoint(
+    body: CloudTargetEnrollmentRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudTargetEnrollmentResponse:
+    try:
+        return await create_target_enrollment(db, user=user, body=body)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.get("", response_model=list[CloudTargetSummary])
+async def list_targets_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> list[CloudTargetSummary]:
+    values = await list_targets(db, user_id=user.id)
+    return [target_summary_payload(value) for value in values]
+
+
+@router.get("/{target_id}", response_model=CloudTargetDetail)
+async def get_target_endpoint(
+    target_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudTargetDetail:
+    try:
+        value = await get_target_detail(db, target_id=target_id, user_id=user.id)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return target_detail_payload(value)
+
+
+@router.post("/{target_id}/archive", response_model=ArchiveCloudTargetResponse)
+async def archive_target_endpoint(
+    target_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> ArchiveCloudTargetResponse:
+    try:
+        value = await archive_target(db, target_id=target_id, user=user)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return ArchiveCloudTargetResponse(target=target_detail_payload(value))

--- a/server/proliferate/server/cloud/targets/domain/__init__.py
+++ b/server/proliferate/server/cloud/targets/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure cloud target domain helpers."""

--- a/server/proliferate/server/cloud/targets/domain/policy.py
+++ b/server/proliferate/server/cloud/targets/domain/policy.py
@@ -1,0 +1,24 @@
+"""Policy decisions for cloud compute target management."""
+
+from __future__ import annotations
+
+from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
+from proliferate.db.store.organization_records import MembershipRecord
+from proliferate.server.cloud.errors import CloudApiError
+
+
+def require_target_admin_membership(
+    membership: MembershipRecord | None,
+) -> None:
+    if membership is None:
+        raise CloudApiError(
+            "cloud_target_organization_not_found",
+            "Organization not found.",
+            status_code=404,
+        )
+    if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
+        raise CloudApiError(
+            "cloud_target_organization_permission_denied",
+            "You do not have permission to manage targets for this organization.",
+            status_code=403,
+        )

--- a/server/proliferate/server/cloud/targets/domain/rules.py
+++ b/server/proliferate/server/cloud/targets/domain/rules.py
@@ -1,0 +1,105 @@
+"""Pure validation and formatting rules for cloud compute targets."""
+
+from __future__ import annotations
+
+import shlex
+from uuid import UUID
+
+from proliferate.constants.cloud import (
+    CLOUD_TARGET_DEFAULT_ENROLLMENT_TTL_SECONDS,
+    CLOUD_TARGET_MAX_ENROLLMENT_TTL_SECONDS,
+    SUPPORTED_ENROLLABLE_CLOUD_TARGET_KINDS,
+    CloudTargetKind,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.targets.domain.types import CloudTargetOwnerScope
+
+_DISPLAY_NAME_MAX_LENGTH = 255
+
+
+def normalize_target_display_name(display_name: str) -> str:
+    normalized = " ".join(display_name.strip().split())
+    if not normalized:
+        raise CloudApiError(
+            "cloud_target_display_name_required",
+            "Target display name is required.",
+            status_code=400,
+        )
+    return normalized[:_DISPLAY_NAME_MAX_LENGTH]
+
+
+def validate_enrollable_kind(kind: str) -> str:
+    if kind not in SUPPORTED_ENROLLABLE_CLOUD_TARGET_KINDS:
+        raise CloudApiError(
+            "cloud_target_kind_unsupported",
+            "This target kind cannot be enrolled with Proliferate Worker.",
+            status_code=400,
+        )
+    return kind
+
+
+def validate_owner_scope(
+    *,
+    owner_scope: str,
+    organization_id: UUID | None,
+) -> CloudTargetOwnerScope:
+    if owner_scope == "personal":
+        if organization_id is not None:
+            raise CloudApiError(
+                "cloud_target_personal_org_forbidden",
+                "Personal targets cannot include an organization id.",
+                status_code=400,
+            )
+        return "personal"
+    if owner_scope == "organization":
+        if organization_id is None:
+            raise CloudApiError(
+                "cloud_target_organization_required",
+                "Organization targets require an organization id.",
+                status_code=400,
+            )
+        return "organization"
+    raise CloudApiError(
+        "cloud_target_owner_scope_invalid",
+        "Target owner scope must be personal or organization.",
+        status_code=400,
+    )
+
+
+def clamp_enrollment_ttl_seconds(value: int | None) -> int:
+    if value is None:
+        return CLOUD_TARGET_DEFAULT_ENROLLMENT_TTL_SECONDS
+    if value <= 0:
+        raise CloudApiError(
+            "cloud_target_enrollment_ttl_invalid",
+            "Enrollment token TTL must be positive.",
+            status_code=400,
+        )
+    return min(value, CLOUD_TARGET_MAX_ENROLLMENT_TTL_SECONDS)
+
+
+def default_workspace_root_for_kind(kind: str, supplied_root: str | None) -> str | None:
+    root = supplied_root.strip() if supplied_root is not None else ""
+    if root:
+        return root
+    if kind == CloudTargetKind.ssh.value:
+        return "~/proliferate-workspaces"
+    if kind == CloudTargetKind.desktop_dispatch.value:
+        return "~/Proliferate/workspaces"
+    return None
+
+
+def build_install_command(
+    *,
+    installer_url: str,
+    cloud_base_url: str,
+    enrollment_token: str,
+    artifact_base_url: str | None,
+) -> str:
+    env_parts = [
+        f"PROLIFERATE_CLOUD_URL={shlex.quote(cloud_base_url)}",
+        f"PROLIFERATE_ENROLLMENT_TOKEN={shlex.quote(enrollment_token)}",
+    ]
+    if artifact_base_url:
+        env_parts.append(f"PROLIFERATE_ARTIFACT_BASE_URL={shlex.quote(artifact_base_url)}")
+    return f"curl -fsSL {shlex.quote(installer_url)} | {' '.join(env_parts)} sh"

--- a/server/proliferate/server/cloud/targets/domain/types.py
+++ b/server/proliferate/server/cloud/targets/domain/types.py
@@ -1,0 +1,7 @@
+"""Pure type aliases for cloud compute targets."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+CloudTargetOwnerScope = Literal["personal", "organization"]

--- a/server/proliferate/server/cloud/targets/models.py
+++ b/server/proliferate/server/cloud/targets/models.py
@@ -1,0 +1,159 @@
+"""Request and response models for cloud compute targets."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Literal, cast
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.cloud_sync.targets import (
+    CloudTargetInventorySnapshot,
+    CloudTargetSnapshot,
+    CloudTargetStatusSnapshot,
+)
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _parse_json(value: str | None) -> dict[str, object] | None:
+    if value is None:
+        return None
+    parsed = cast(object, json.loads(value))
+    return parsed if isinstance(parsed, dict) else {"value": parsed}
+
+
+class CloudTargetInventoryModel(BaseModel):
+    os: str | None = None
+    arch: str | None = None
+    distro: str | None = None
+    shell: str | None = None
+    git: dict[str, object] | None = None
+    node: dict[str, object] | None = None
+    python: dict[str, object] | None = None
+    browser: dict[str, object] | None = None
+    capabilities: dict[str, object] | None = None
+    providers: dict[str, object] | None = None
+    mcp: dict[str, object] | None = None
+    updated_at: str = Field(serialization_alias="updatedAt")
+
+
+class CloudTargetStatusModel(BaseModel):
+    status: str
+    status_detail: str | None = Field(default=None, serialization_alias="statusDetail")
+    last_seen_at: str | None = Field(default=None, serialization_alias="lastSeenAt")
+    last_heartbeat_at: str | None = Field(default=None, serialization_alias="lastHeartbeatAt")
+    updated_at: str | None = Field(default=None, serialization_alias="updatedAt")
+
+
+class CloudTargetSummary(BaseModel):
+    id: str
+    display_name: str = Field(serialization_alias="displayName")
+    kind: str
+    status: str
+    owner_scope: str = Field(serialization_alias="ownerScope")
+    organization_id: str | None = Field(default=None, serialization_alias="organizationId")
+    default_workspace_root: str | None = Field(
+        default=None,
+        serialization_alias="defaultWorkspaceRoot",
+    )
+    inventory: CloudTargetInventoryModel | None = None
+    status_detail: CloudTargetStatusModel | None = Field(
+        default=None,
+        serialization_alias="statusDetail",
+    )
+    archived_at: str | None = Field(default=None, serialization_alias="archivedAt")
+    created_at: str = Field(serialization_alias="createdAt")
+    updated_at: str = Field(serialization_alias="updatedAt")
+
+
+class CloudTargetDetail(CloudTargetSummary):
+    owner_user_id: str = Field(serialization_alias="ownerUserId")
+    created_by_user_id: str = Field(serialization_alias="createdByUserId")
+
+
+class CloudTargetEnrollmentRequest(BaseModel):
+    display_name: str = Field(alias="displayName")
+    kind: str = "ssh"
+    owner_scope: Literal["personal", "organization"] = Field(
+        default="personal",
+        alias="ownerScope",
+    )
+    organization_id: UUID | None = Field(default=None, alias="organizationId")
+    default_workspace_root: str | None = Field(default=None, alias="defaultWorkspaceRoot")
+    ttl_seconds: int | None = Field(default=None, alias="ttlSeconds")
+
+
+class CloudTargetEnrollmentResponse(BaseModel):
+    target: CloudTargetDetail
+    enrollment_token: str = Field(serialization_alias="enrollmentToken")
+    install_command: str = Field(serialization_alias="installCommand")
+    expires_at: str = Field(serialization_alias="expiresAt")
+
+
+class ArchiveCloudTargetResponse(BaseModel):
+    target: CloudTargetDetail
+
+
+def inventory_payload(
+    value: CloudTargetInventorySnapshot | None,
+) -> CloudTargetInventoryModel | None:
+    if value is None:
+        return None
+    return CloudTargetInventoryModel(
+        os=value.os,
+        arch=value.arch,
+        distro=value.distro,
+        shell=value.shell,
+        git=_parse_json(value.git_json),
+        node=_parse_json(value.node_json),
+        python=_parse_json(value.python_json),
+        browser=_parse_json(value.browser_json),
+        capabilities=_parse_json(value.capabilities_json),
+        providers=_parse_json(value.providers_json),
+        mcp=_parse_json(value.mcp_json),
+        updated_at=_to_iso(value.updated_at),
+    )
+
+
+def status_payload(
+    value: CloudTargetStatusSnapshot | None,
+) -> CloudTargetStatusModel | None:
+    if value is None:
+        return None
+    return CloudTargetStatusModel(
+        status=value.status,
+        status_detail=value.status_detail,
+        last_seen_at=_to_iso(value.last_seen_at),
+        last_heartbeat_at=_to_iso(value.last_heartbeat_at),
+        updated_at=_to_iso(value.updated_at),
+    )
+
+
+def target_summary_payload(value: CloudTargetSnapshot) -> CloudTargetSummary:
+    return CloudTargetSummary(
+        id=str(value.id),
+        display_name=value.display_name,
+        kind=value.kind,
+        status=value.status,
+        owner_scope=value.owner_scope,
+        organization_id=str(value.organization_id) if value.organization_id else None,
+        default_workspace_root=value.default_workspace_root,
+        inventory=inventory_payload(value.inventory),
+        status_detail=status_payload(value.status_record),
+        archived_at=_to_iso(value.archived_at),
+        created_at=_to_iso(value.created_at),
+        updated_at=_to_iso(value.updated_at),
+    )
+
+
+def target_detail_payload(value: CloudTargetSnapshot) -> CloudTargetDetail:
+    return CloudTargetDetail(
+        **target_summary_payload(value).model_dump(),
+        owner_user_id=str(value.owner_user_id),
+        created_by_user_id=str(value.created_by_user_id),
+    )

--- a/server/proliferate/server/cloud/targets/service.py
+++ b/server/proliferate/server/cloud/targets/service.py
@@ -1,0 +1,176 @@
+"""Application service for cloud compute targets."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from datetime import timedelta
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.cloud import CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN
+from proliferate.db.models.auth import User
+from proliferate.db.store import organizations as organizations_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.targets.domain.policy import require_target_admin_membership
+from proliferate.server.cloud.targets.domain.rules import (
+    build_install_command,
+    clamp_enrollment_ttl_seconds,
+    default_workspace_root_for_kind,
+    normalize_target_display_name,
+    validate_enrollable_kind,
+    validate_owner_scope,
+)
+from proliferate.server.cloud.targets.models import (
+    CloudTargetEnrollmentRequest,
+    CloudTargetEnrollmentResponse,
+    target_detail_payload,
+)
+from proliferate.utils.time import utcnow
+
+
+def _hash_token(*, domain: str, token: str) -> str:
+    return hmac.new(
+        settings.cloud_secret_key.encode("utf-8"),
+        f"{domain}:{token}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _cloud_base_url() -> str:
+    for candidate in (
+        settings.api_base_url,
+        settings.cloud_mcp_oauth_callback_base_url,
+        settings.cloud_mcp_oauth_callback_fallback_base_url,
+    ):
+        normalized = candidate.strip().rstrip("/")
+        if normalized:
+            return normalized
+    return "http://localhost:8000"
+
+
+async def create_target_enrollment(
+    db: AsyncSession,
+    *,
+    user: User,
+    body: CloudTargetEnrollmentRequest,
+) -> CloudTargetEnrollmentResponse:
+    kind = validate_enrollable_kind(body.kind)
+    owner_scope = validate_owner_scope(
+        owner_scope=body.owner_scope,
+        organization_id=body.organization_id,
+    )
+    display_name = normalize_target_display_name(body.display_name)
+    owner_user_id = user.id
+    organization_id = body.organization_id if owner_scope == "organization" else None
+    if organization_id is not None:
+        membership = await organizations_store.get_active_membership(
+            db,
+            organization_id=organization_id,
+            user_id=user.id,
+        )
+        require_target_admin_membership(membership)
+    target = await targets_store.create_target(
+        db,
+        display_name=display_name,
+        kind=kind,
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        created_by_user_id=user.id,
+        default_workspace_root=default_workspace_root_for_kind(
+            kind,
+            body.default_workspace_root,
+        ),
+    )
+    token = secrets.token_urlsafe(48)
+    ttl_seconds = clamp_enrollment_ttl_seconds(body.ttl_seconds)
+    expires_at = utcnow() + timedelta(seconds=ttl_seconds)
+    await worker_auth_store.create_enrollment(
+        db,
+        target_id=target.id,
+        token_hash=_hash_token(domain=CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN, token=token),
+        created_by_user_id=user.id,
+        expires_at=expires_at,
+    )
+    install_command = build_install_command(
+        installer_url=settings.proliferate_target_installer_url,
+        cloud_base_url=_cloud_base_url(),
+        enrollment_token=token,
+        artifact_base_url=settings.proliferate_target_artifact_base_url or None,
+    )
+    refreshed = await targets_store.get_target_by_id(db, target.id)
+    if refreshed is None:
+        raise CloudApiError(
+            "cloud_target_not_found",
+            "Target was not created.",
+            status_code=500,
+        )
+    return CloudTargetEnrollmentResponse(
+        target=target_detail_payload(refreshed),
+        enrollment_token=token,
+        install_command=install_command,
+        expires_at=expires_at.isoformat(),
+    )
+
+
+async def list_targets(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> list[targets_store.CloudTargetSnapshot]:
+    return list(await targets_store.list_visible_targets(db, user_id=user_id))
+
+
+async def get_target_detail(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+) -> targets_store.CloudTargetSnapshot:
+    target = await targets_store.get_visible_target_by_id(
+        db,
+        target_id=target_id,
+        user_id=user_id,
+    )
+    if target is None:
+        raise CloudApiError(
+            "cloud_target_not_found",
+            "Target not found.",
+            status_code=404,
+        )
+    return target
+
+
+async def archive_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user: User,
+) -> targets_store.CloudTargetSnapshot:
+    target = await get_target_detail(db, target_id=target_id, user_id=user.id)
+    if target.organization_id is not None:
+        membership = await organizations_store.get_active_membership(
+            db,
+            organization_id=target.organization_id,
+            user_id=user.id,
+        )
+        require_target_admin_membership(membership)
+    archived = await targets_store.archive_target(db, target_id=target.id)
+    if archived is None:
+        raise CloudApiError(
+            "cloud_target_not_found",
+            "Target not found.",
+            status_code=404,
+        )
+    await worker_auth_store.archive_workers_for_target(
+        db,
+        target_id=target.id,
+        now=utcnow(),
+    )
+    return archived

--- a/server/proliferate/server/cloud/worker/__init__.py
+++ b/server/proliferate/server/cloud/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Proliferate Worker cloud API package."""

--- a/server/proliferate/server/cloud/worker/api.py
+++ b/server/proliferate/server/cloud/worker/api.py
@@ -1,0 +1,62 @@
+"""Worker-facing cloud control-plane routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.worker.models import (
+    WorkerEnrollRequest,
+    WorkerEnrollResponse,
+    WorkerHeartbeatRequest,
+    WorkerHeartbeatResponse,
+    WorkerInventoryRequest,
+    WorkerInventoryResponse,
+)
+from proliferate.server.cloud.worker.service import (
+    authenticate_worker,
+    enroll_worker,
+    record_heartbeat,
+    record_inventory,
+)
+
+router = APIRouter(prefix="/worker", tags=["cloud-worker"])
+
+
+@router.post("/enroll", response_model=WorkerEnrollResponse)
+async def enroll_worker_endpoint(
+    body: WorkerEnrollRequest,
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerEnrollResponse:
+    try:
+        return await enroll_worker(db, body=body)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.post("/heartbeat", response_model=WorkerHeartbeatResponse)
+async def worker_heartbeat_endpoint(
+    body: WorkerHeartbeatRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerHeartbeatResponse:
+    try:
+        auth = await authenticate_worker(db, authorization=authorization)
+        return await record_heartbeat(db, auth=auth, body=body)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.post("/inventory", response_model=WorkerInventoryResponse)
+async def worker_inventory_endpoint(
+    body: WorkerInventoryRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerInventoryResponse:
+    try:
+        auth = await authenticate_worker(db, authorization=authorization)
+        return await record_inventory(db, auth=auth, body=body)
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/worker/domain/__init__.py
+++ b/server/proliferate/server/cloud/worker/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure Proliferate Worker domain helpers."""

--- a/server/proliferate/server/cloud/worker/domain/rules.py
+++ b/server/proliferate/server/cloud/worker/domain/rules.py
@@ -1,0 +1,39 @@
+"""Pure validation and normalization rules for worker payloads."""
+
+from __future__ import annotations
+
+import json
+
+from proliferate.constants.cloud import SUPPORTED_CLOUD_WORKER_STATUSES, CloudWorkerStatus
+from proliferate.server.cloud.errors import CloudApiError
+
+_JSON_FIELD_MAX_BYTES = 256 * 1024
+
+
+def validate_worker_status(status: str) -> str:
+    if status not in SUPPORTED_CLOUD_WORKER_STATUSES:
+        raise CloudApiError(
+            "cloud_worker_status_invalid",
+            "Worker status is invalid.",
+            status_code=400,
+        )
+    if status == CloudWorkerStatus.archived.value:
+        raise CloudApiError(
+            "cloud_worker_status_reserved",
+            "Worker archived status is controlled by the cloud service.",
+            status_code=400,
+        )
+    return status
+
+
+def compact_json(value: dict[str, object] | None) -> str | None:
+    if value is None:
+        return None
+    serialized = json.dumps(value, separators=(",", ":"), sort_keys=True)
+    if len(serialized.encode("utf-8")) > _JSON_FIELD_MAX_BYTES:
+        raise CloudApiError(
+            "cloud_worker_inventory_too_large",
+            "Worker inventory payload is too large.",
+            status_code=413,
+        )
+    return serialized

--- a/server/proliferate/server/cloud/worker/domain/types.py
+++ b/server/proliferate/server/cloud/worker/domain/types.py
@@ -1,0 +1,12 @@
+"""Pure worker domain types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class WorkerAuthContext:
+    worker_id: UUID
+    target_id: UUID

--- a/server/proliferate/server/cloud/worker/models.py
+++ b/server/proliferate/server/cloud/worker/models.py
@@ -1,0 +1,62 @@
+"""Request and response models for Proliferate Worker endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class WorkerInventoryPayload(BaseModel):
+    os: str | None = None
+    arch: str | None = None
+    distro: str | None = None
+    shell: str | None = None
+    git: dict[str, object] | None = None
+    node: dict[str, object] | None = None
+    python: dict[str, object] | None = None
+    browser: dict[str, object] | None = None
+    capabilities: dict[str, object] | None = None
+    providers: dict[str, object] | None = None
+    mcp: dict[str, object] | None = None
+
+
+class WorkerEnrollRequest(BaseModel):
+    enrollment_token: str = Field(alias="enrollmentToken")
+    machine_fingerprint: str | None = Field(default=None, alias="machineFingerprint")
+    hostname: str | None = None
+    worker_version: str | None = Field(default=None, alias="workerVersion")
+    anyharness_version: str | None = Field(default=None, alias="anyharnessVersion")
+    supervisor_version: str | None = Field(default=None, alias="supervisorVersion")
+    inventory: WorkerInventoryPayload | None = None
+
+
+class WorkerEnrollResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    worker_id: str = Field(serialization_alias="workerId")
+    worker_token: str = Field(serialization_alias="workerToken")
+    heartbeat_interval_seconds: int = Field(serialization_alias="heartbeatIntervalSeconds")
+
+
+class WorkerHeartbeatRequest(BaseModel):
+    status: str = "online"
+    status_detail: str | None = Field(default=None, alias="statusDetail")
+    worker_version: str | None = Field(default=None, alias="workerVersion")
+    anyharness_version: str | None = Field(default=None, alias="anyharnessVersion")
+    supervisor_version: str | None = Field(default=None, alias="supervisorVersion")
+
+
+class WorkerHeartbeatResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    worker_id: str = Field(serialization_alias="workerId")
+    status: str
+    server_time: str = Field(serialization_alias="serverTime")
+
+
+class WorkerInventoryRequest(WorkerInventoryPayload):
+    status: str = "online"
+    status_detail: str | None = Field(default=None, alias="statusDetail")
+
+
+class WorkerInventoryResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    worker_id: str = Field(serialization_alias="workerId")
+    updated: bool

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -1,0 +1,245 @@
+"""Application service for Proliferate Worker registration and heartbeats."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.cloud import (
+    CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN,
+    CLOUD_TARGET_HEARTBEAT_STALE_SECONDS,
+    CLOUD_WORKER_TOKEN_DOMAIN,
+    CloudTargetStatus,
+    CloudWorkerStatus,
+)
+from proliferate.db.store.cloud_sync import inventory as inventory_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.worker.domain.rules import compact_json, validate_worker_status
+from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
+from proliferate.server.cloud.worker.models import (
+    WorkerEnrollRequest,
+    WorkerEnrollResponse,
+    WorkerHeartbeatRequest,
+    WorkerHeartbeatResponse,
+    WorkerInventoryPayload,
+    WorkerInventoryRequest,
+    WorkerInventoryResponse,
+)
+from proliferate.utils.time import utcnow
+
+
+def _hash_token(*, domain: str, token: str) -> str:
+    return hmac.new(
+        settings.cloud_secret_key.encode("utf-8"),
+        f"{domain}:{token}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+async def _record_inventory_payload(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    worker_id: UUID,
+    payload: WorkerInventoryPayload,
+) -> None:
+    await inventory_store.upsert_inventory(
+        db,
+        target_id=target_id,
+        worker_id=worker_id,
+        os=payload.os,
+        arch=payload.arch,
+        distro=payload.distro,
+        shell=payload.shell,
+        git_json=compact_json(payload.git),
+        node_json=compact_json(payload.node),
+        python_json=compact_json(payload.python),
+        browser_json=compact_json(payload.browser),
+        capabilities_json=compact_json(payload.capabilities),
+        providers_json=compact_json(payload.providers),
+        mcp_json=compact_json(payload.mcp),
+        raw_json=None,
+    )
+
+
+async def enroll_worker(
+    db: AsyncSession,
+    *,
+    body: WorkerEnrollRequest,
+) -> WorkerEnrollResponse:
+    now = utcnow()
+    enrollment = await worker_auth_store.consume_pending_enrollment_by_hash(
+        db,
+        token_hash=_hash_token(
+            domain=CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN,
+            token=body.enrollment_token,
+        ),
+        now=now,
+    )
+    if enrollment is None:
+        raise CloudApiError(
+            "cloud_worker_enrollment_invalid",
+            "Enrollment token is invalid or expired.",
+            status_code=401,
+        )
+    worker_token = secrets.token_urlsafe(48)
+    worker = await worker_auth_store.create_worker(
+        db,
+        target_id=enrollment.target_id,
+        token_hash=_hash_token(domain=CLOUD_WORKER_TOKEN_DOMAIN, token=worker_token),
+        machine_fingerprint=body.machine_fingerprint,
+        hostname=body.hostname,
+        worker_version=body.worker_version,
+        anyharness_version=body.anyharness_version,
+        supervisor_version=body.supervisor_version,
+        now=now,
+    )
+    await inventory_store.upsert_target_status(
+        db,
+        target_id=worker.target_id,
+        worker_id=worker.id,
+        status_value=CloudTargetStatus.online.value,
+        status_detail="Worker enrolled.",
+    )
+    await targets_store.set_target_status(
+        db,
+        target_id=worker.target_id,
+        status_value=CloudTargetStatus.online.value,
+    )
+    if body.inventory is not None:
+        await _record_inventory_payload(
+            db,
+            target_id=worker.target_id,
+            worker_id=worker.id,
+            payload=body.inventory,
+        )
+    return WorkerEnrollResponse(
+        target_id=str(worker.target_id),
+        worker_id=str(worker.id),
+        worker_token=worker_token,
+        heartbeat_interval_seconds=CLOUD_TARGET_HEARTBEAT_STALE_SECONDS // 3,
+    )
+
+
+async def authenticate_worker(
+    db: AsyncSession,
+    *,
+    authorization: str | None,
+) -> WorkerAuthContext:
+    if authorization is None or not authorization.startswith("Bearer "):
+        raise CloudApiError(
+            "cloud_worker_auth_required",
+            "Worker authentication is required.",
+            status_code=401,
+        )
+    token = authorization.removeprefix("Bearer ").strip()
+    if not token:
+        raise CloudApiError(
+            "cloud_worker_auth_required",
+            "Worker authentication is required.",
+            status_code=401,
+        )
+    worker = await worker_auth_store.get_worker_by_token_hash(
+        db,
+        token_hash=_hash_token(domain=CLOUD_WORKER_TOKEN_DOMAIN, token=token),
+    )
+    if worker is None:
+        raise CloudApiError(
+            "cloud_worker_auth_invalid",
+            "Worker token is invalid.",
+            status_code=401,
+        )
+    if worker.status == CloudWorkerStatus.archived.value:
+        raise CloudApiError(
+            "cloud_worker_archived",
+            "Worker token is archived.",
+            status_code=401,
+        )
+    target = await targets_store.get_target_by_id(db, worker.target_id)
+    if target is None:
+        raise CloudApiError(
+            "cloud_worker_target_missing",
+            "Worker target no longer exists.",
+            status_code=401,
+        )
+    if target.status == CloudTargetStatus.archived.value:
+        raise CloudApiError(
+            "cloud_worker_target_archived",
+            "Worker target is archived.",
+            status_code=409,
+        )
+    return WorkerAuthContext(worker_id=worker.id, target_id=worker.target_id)
+
+
+async def record_heartbeat(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerHeartbeatRequest,
+) -> WorkerHeartbeatResponse:
+    status_value = validate_worker_status(body.status)
+    now = utcnow()
+    worker = await worker_auth_store.record_worker_heartbeat(
+        db,
+        worker_id=auth.worker_id,
+        status_value=status_value,
+        worker_version=body.worker_version,
+        anyharness_version=body.anyharness_version,
+        supervisor_version=body.supervisor_version,
+        now=now,
+    )
+    if worker is None:
+        raise CloudApiError(
+            "cloud_worker_not_found",
+            "Worker not found.",
+            status_code=404,
+        )
+    await inventory_store.upsert_target_status(
+        db,
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        status_value=status_value,
+        status_detail=body.status_detail,
+    )
+    await targets_store.set_target_status(db, target_id=auth.target_id, status_value=status_value)
+    return WorkerHeartbeatResponse(
+        target_id=str(auth.target_id),
+        worker_id=str(auth.worker_id),
+        status=status_value,
+        server_time=now.isoformat(),
+    )
+
+
+async def record_inventory(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerInventoryRequest,
+) -> WorkerInventoryResponse:
+    status_value = validate_worker_status(body.status)
+    await _record_inventory_payload(
+        db,
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        payload=body,
+    )
+    await inventory_store.upsert_target_status(
+        db,
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        status_value=status_value,
+        status_detail=body.status_detail,
+    )
+    await targets_store.set_target_status(db, target_id=auth.target_id, status_value=status_value)
+    return WorkerInventoryResponse(
+        target_id=str(auth.target_id),
+        worker_id=str(auth.worker_id),
+        updated=True,
+    )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -94,6 +94,8 @@ module = [
     "proliferate.server.cloud.mcp_materialization.models",
     "proliferate.server.cloud.mcp_oauth.models",
     "proliferate.server.cloud.plugins.catalog.models",
+    "proliferate.server.cloud.targets.models",
+    "proliferate.server.cloud.worker.models",
     "proliferate.server.cloud.workspaces.models",
     "proliferate.server.catalogs.models",
     "proliferate.server.cloud.credentials.models",

--- a/server/tests/integration/test_cloud_targets_api.py
+++ b/server/tests/integration/test_cloud_targets_api.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+)
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+
+
+class TestCloudTargetsApi:
+    @pytest.mark.asyncio
+    async def test_ssh_target_enrollment_and_worker_inventory(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-targets",
+        )
+
+        create = await client.post(
+            "/v1/cloud/targets/enrollments",
+            headers=auth.headers,
+            json={
+                "displayName": "Staging SSH Box",
+                "kind": "ssh",
+                "ownerScope": "personal",
+                "defaultWorkspaceRoot": "~/proliferate-workspaces",
+            },
+        )
+        assert create.status_code == 200
+        enrollment = create.json()
+        target_id = enrollment["target"]["id"]
+        assert enrollment["target"]["status"] == "enrolling"
+        assert "PROLIFERATE_ENROLLMENT_TOKEN" in enrollment["installCommand"]
+
+        worker_enroll = await client.post(
+            "/v1/cloud/worker/enroll",
+            json={
+                "enrollmentToken": enrollment["enrollmentToken"],
+                "machineFingerprint": "test-machine",
+                "hostname": "staging-ssh",
+                "workerVersion": "0.1.0",
+                "inventory": {
+                    "os": "linux",
+                    "arch": "x86_64",
+                    "git": {"available": True, "version": "git version 2.44.0"},
+                    "node": {"node": {"available": True, "version": "v22.0.0"}},
+                    "python": {"python3": {"available": True, "version": "Python 3.12"}},
+                },
+            },
+        )
+        assert worker_enroll.status_code == 200
+        worker = worker_enroll.json()
+        assert worker["targetId"] == target_id
+        worker_headers = {"Authorization": f"Bearer {worker['workerToken']}"}
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers=worker_headers,
+            json={"status": "online", "statusDetail": "ready"},
+        )
+        assert heartbeat.status_code == 200
+
+        inventory = await client.post(
+            "/v1/cloud/worker/inventory",
+            headers=worker_headers,
+            json={
+                "status": "online",
+                "os": "linux",
+                "arch": "x86_64",
+                "git": {"available": True, "version": "git version 2.45.0"},
+                "node": {"node": {"available": True, "version": "v22.1.0"}},
+                "python": {"python3": {"available": True, "version": "Python 3.12"}},
+                "capabilities": {"processSpawn": True, "filesystem": True},
+                "raw": {"secret": "do-not-expose"},
+            },
+        )
+        assert inventory.status_code == 200
+
+        detail = await client.get(f"/v1/cloud/targets/{target_id}", headers=auth.headers)
+        assert detail.status_code == 200
+        payload = detail.json()
+        assert payload["status"] == "online"
+        assert payload["inventory"]["git"]["version"] == "git version 2.45.0"
+        assert "raw" not in payload["inventory"]
+
+        listed = await client.get("/v1/cloud/targets", headers=auth.headers)
+        assert listed.status_code == 200
+        assert [target["id"] for target in listed.json()] == [target_id]
+
+        archived = await client.post(
+            f"/v1/cloud/targets/{target_id}/archive",
+            headers=auth.headers,
+        )
+        assert archived.status_code == 200
+        assert archived.json()["target"]["status"] == "archived"
+
+        stale_heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers=worker_headers,
+            json={"status": "online"},
+        )
+        assert stale_heartbeat.status_code == 401
+        assert stale_heartbeat.json()["detail"]["code"] == "cloud_worker_archived"
+
+    @pytest.mark.asyncio
+    async def test_org_member_can_view_but_not_archive_target(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        owner = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-target-owner",
+        )
+        member = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-target-member",
+        )
+        organization = Organization(name="Cloud Target Org")
+        db_session.add(organization)
+        await db_session.flush()
+        db_session.add_all(
+            [
+                OrganizationMembership(
+                    organization_id=organization.id,
+                    user_id=uuid.UUID(owner.user_id),
+                    role=ORGANIZATION_ROLE_OWNER,
+                    status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+                ),
+                OrganizationMembership(
+                    organization_id=organization.id,
+                    user_id=uuid.UUID(member.user_id),
+                    role=ORGANIZATION_ROLE_MEMBER,
+                    status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        create = await client.post(
+            "/v1/cloud/targets/enrollments",
+            headers=owner.headers,
+            json={
+                "displayName": "Team SSH Box",
+                "kind": "ssh",
+                "ownerScope": "organization",
+                "organizationId": str(organization.id),
+            },
+        )
+        assert create.status_code == 200
+        target_id = create.json()["target"]["id"]
+
+        detail = await client.get(f"/v1/cloud/targets/{target_id}", headers=member.headers)
+        assert detail.status_code == 200
+
+        denied = await client.post(
+            f"/v1/cloud/targets/{target_id}/archive",
+            headers=member.headers,
+        )
+        assert denied.status_code == 403
+        assert denied.json()["detail"]["code"] == "cloud_target_organization_permission_denied"
+
+        archived = await client.post(
+            f"/v1/cloud/targets/{target_id}/archive",
+            headers=owner.headers,
+        )
+        assert archived.status_code == 200
+        assert archived.json()["target"]["status"] == "archived"


### PR DESCRIPTION
## Summary
- add cloud target/worker registry, enrollment, heartbeat, inventory APIs and persistence
- add `proliferate-worker` and `proliferate-supervisor` runtime crates plus the SSH target installer
- add the Desktop Compute settings surface and shared cloud SDK target client/types
- harden reviewer findings around org target permissions, archived worker tokens, raw inventory exposure, worker/supervisor failure behavior, and frontend boundaries

## Validation
- `cd server && uv run ruff check proliferate/server/cloud/targets proliferate/server/cloud/worker proliferate/db/store/cloud_sync proliferate/db/models/cloud/targets.py alembic/versions/c4d5e6f7a8b9_cloud_targets_workers.py tests/integration/test_cloud_targets_api.py`
- `cd server && uv run --extra dev --python 3.12 mypy proliferate/server/cloud/targets proliferate/server/cloud/worker proliferate/db/store/cloud_sync proliferate/db/models/cloud/targets.py`
- `cd server && DEBUG=true uv run --extra dev --python 3.12 pytest -q tests/integration/test_cloud_targets_api.py`
- `cargo fmt --package proliferate-worker --package proliferate-supervisor && cargo check -p proliferate-worker -p proliferate-supervisor`
- `make cloud-client-generate`
- `python3 scripts/check_frontend_boundaries.py`
- `pnpm --dir cloud/sdk build && pnpm --dir cloud/sdk-react build && pnpm --dir desktop exec tsc --noEmit --pretty false`

## Follow-up
- Worker enrollment is safer now because secrets are private and enrollment tokens are cleared after identity persistence, but fully retry/idempotency-safe lost-response enrollment should be handled in the next worker protocol iteration with a stable install id / enrollment retry contract.