### PR TITLE
refactor(server): standardize redirect pages

### DIFF
--- a/server/proliferate/auth/desktop/pages.py
+++ b/server/proliferate/auth/desktop/pages.py
@@ -1,231 +1,46 @@
-"""HTML handoff pages for the desktop browser auth flow.
-
-These minimal pages are rendered server-side during the OAuth callback to hand
-control back to the desktop app via deep-link or recovery polling.
-"""
-
-import json
-from html import escape
+"""HTML handoff pages for the desktop browser auth flow."""
 
 from fastapi.responses import HTMLResponse
 
+from proliferate.utils.redirect_pages import make_redirect_page
+
 
 def make_browser_flow_page(*, title: str, message: str) -> HTMLResponse:
-    return HTMLResponse(
-        f"""<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <style>
-      :root {{
-        color-scheme: dark;
-        font-family: Geist, system-ui, sans-serif;
-        background: #151210;
-        color: #f0ebe6;
-      }}
-      body {{
-        margin: 0;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
-        background:
-          radial-gradient(circle at top, rgba(222, 186, 147, 0.16), transparent 42%),
-          #151210;
-      }}
-      main {{
-        width: min(28rem, calc(100vw - 2rem));
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        border-radius: 24px;
-        background: rgba(31, 26, 24, 0.88);
-        padding: 2rem;
-        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-        text-align: center;
-      }}
-      h1 {{
-        margin: 0 0 0.75rem;
-        font-size: 1.5rem;
-      }}
-      p {{
-        margin: 0;
-        color: rgba(240, 235, 230, 0.72);
-        line-height: 1.6;
-      }}
-    </style>
-    <script>
-      window.addEventListener("load", () => {{
-        setTimeout(() => window.close(), 250);
-      }});
-    </script>
-  </head>
-  <body>
-    <main>
-      <h1>{title}</h1>
-      <p>{message}</p>
-    </main>
-  </body>
-</html>"""
+    return make_redirect_page(
+        title=title,
+        eyebrow="Desktop sign-in",
+        message=message,
+        close_after_ms=250,
     )
 
 
 def make_desktop_handoff_page(*, deep_link_url: str, launch_deep_link: bool) -> HTMLResponse:
-    escaped_href = escape(deep_link_url, quote=True)
-    deep_link_json = json.dumps(deep_link_url)
     title = "Opening Proliferate..." if launch_deep_link else "Return to Proliferate"
-    status_text = (
+    message = (
         "Your GitHub session is verified. Proliferate should take over from here."
         if launch_deep_link
         else "Your GitHub session is verified. Return to Proliferate and it will unlock shortly."
     )
-    recovery_block = (
-        f"""
-      <div class="recovery" id="recovery" data-visible="false">
-        <a class="action" href="{escaped_href}">Open Proliferate again</a>
-        <p class="hint">
-          Keep this tab open if you want Proliferate's recovery polling to finish the sign-in instead.
-        </p>
-      </div>"""
+    hint = (
+        "Keep this tab open if you want Proliferate's recovery polling to finish the sign-in."
         if launch_deep_link
-        else """
-      <div class="recovery" id="recovery" data-visible="true">
-        <p class="hint">
-          Native deep-link launch is disabled in this environment, so Proliferate will
-          finish the sign-in from its recovery polling instead.
-        </p>
-      </div>"""
+        else (
+            "Native deep-link launch is disabled in this environment, so Proliferate will "
+            "finish the sign-in from its recovery polling instead."
+        )
     )
-    launch_script = (
-        f"""
-    <script>
-      window.addEventListener("load", () => {{
-        const deepLinkUrl = {deep_link_json};
-        const recovery = document.getElementById("recovery");
-        const statusText = document.getElementById("status-text");
-
-        window.location.replace(deepLinkUrl);
-
-        window.setTimeout(() => {{
-          if (recovery) {{
-            recovery.dataset.visible = "true";
-          }}
-          if (statusText) {{
-            statusText.textContent =
-              "If Proliferate did not open automatically, use the button below or " +
-              "return to the app. Proliferate can still finish the sign-in from " +
-              "this browser callback.";
-          }}
-        }}, 1500);
-      }});
-    </script>"""
-        if launch_deep_link
-        else ""
-    )
-    return HTMLResponse(
-        f"""<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <style>
-      :root {{
-        color-scheme: dark;
-        font-family: Inter, "Geist", system-ui, sans-serif;
-        background: hsl(24 10% 7%);
-        color: hsl(30 8% 91%);
-      }}
-      body {{
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: 2rem;
-        background: hsl(24 10% 7%);
-      }}
-      main {{
-        width: min(28rem, 100%);
-      }}
-      .brand {{
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        margin-bottom: 2.5rem;
-        color: hsl(30 8% 91%);
-      }}
-      .brand-name {{
-        font-family: Inter, "Geist", system-ui, sans-serif;
-        font-size: 2.75rem;
-        font-weight: 500;
-        letter-spacing: 0.025em;
-      }}
-      h1 {{
-        margin: 0 0 0.75rem;
-        font-size: 1.125rem;
-        font-weight: 500;
-      }}
-      p {{
-        margin: 0;
-        color: hsl(23 5% 63%);
-        font-size: 0.8125rem;
-        line-height: 1.5;
-      }}
-      .recovery {{
-        display: none;
-        margin-top: 1.5rem;
-      }}
-      .recovery[data-visible="true"] {{
-        display: block;
-      }}
-      .action {{
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        margin-top: 1rem;
-        border-radius: 0.375rem;
-        padding: 0.75rem;
-        background: hsl(30 8% 91%);
-        color: hsl(25 8% 16%);
-        font-size: 0.8125rem;
-        font-weight: 500;
-        text-decoration: none;
-        transition: opacity 0.15s;
-      }}
-      .action:hover {{
-        opacity: 0.9;
-      }}
-      .hint {{
-        margin-top: 0.75rem;
-        font-size: 0.8125rem;
-      }}
-    </style>
-{launch_script}
-  </head>
-  <body>
-    <main>
-      <div class="brand">
-        <svg viewBox="300 300 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" width="44" height="44">
-          <rect x="375" y="375" width="50" height="50" fill="currentColor" />
-          <rect x="387.67" y="305" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="429" y="346.33" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="470.33" y="387.67" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="429" y="429" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="387.67" y="470.33" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="346.33" y="429" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="305" y="387.67" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="346.33" y="346.33" width="24.67" height="24.67" fill="currentColor" />
-        </svg>
-        <span class="brand-name">PROLIFERATE</span>
-      </div>
-      <h1>{title}</h1>
-      <p id="status-text">
-        {status_text}
-      </p>
-{recovery_block}
-    </main>
-  </body>
-</html>"""
+    return make_redirect_page(
+        title=title,
+        eyebrow="Desktop sign-in",
+        message=message,
+        action_url=deep_link_url if launch_deep_link else None,
+        action_label="Open Proliferate again",
+        action_visible=False,
+        launch_action_on_load=launch_deep_link,
+        delayed_status_message=(
+            "If Proliferate did not open automatically, use the button below "
+            "or return to the app. Proliferate can still finish the sign-in "
+            "from this browser callback."
+        ),
+        hint=hint,
     )

--- a/server/proliferate/auth/desktop/service.py
+++ b/server/proliferate/auth/desktop/service.py
@@ -263,10 +263,9 @@ async def finish_github_desktop_callback(
         )
 
     if error is not None:
-        detail = error_description or error
         return make_browser_flow_page(
             title="GitHub sign-in failed",
-            message=f"The browser flow returned: {detail}",
+            message="The browser flow could not be completed. Start again from Proliferate.",
         )
 
     if code is None or state is None:

--- a/server/proliferate/server/cloud/mcp_oauth/pages.py
+++ b/server/proliferate/server/cloud/mcp_oauth/pages.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import json
-from html import escape
-
 from fastapi.responses import HTMLResponse
 
 from proliferate.constants.auth import (
     DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
     DESKTOP_REDIRECT_SCHEME,
 )
+from proliferate.utils.redirect_pages import make_redirect_page
 
 
 def make_mcp_oauth_callback_page(*, ok: bool) -> HTMLResponse:
@@ -16,8 +14,6 @@ def make_mcp_oauth_callback_page(*, ok: bool) -> HTMLResponse:
     deep_link_url = (
         f"{DESKTOP_REDIRECT_SCHEME}://plugins?source=mcp_oauth_callback&status={status}"
     )
-    escaped_href = escape(deep_link_url, quote=True)
-    deep_link_json = json.dumps(deep_link_url)
     title = "Authorization complete" if ok else "Authorization failed"
     message = (
         "Return to Proliferate to finish using this plugin."
@@ -32,144 +28,14 @@ def make_mcp_oauth_callback_page(*, ok: bool) -> HTMLResponse:
             "the latest connection state."
         )
     )
-    recovery_visible = "false" if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else "true"
-    launch_script = (
-        f"""
-    <script>
-      window.addEventListener("load", () => {{
-        const deepLinkUrl = {deep_link_json};
-        const recovery = document.getElementById("recovery");
-        const statusText = document.getElementById("status-text");
-
-        window.location.replace(deepLinkUrl);
-
-        window.setTimeout(() => {{
-          if (recovery) {{
-            recovery.dataset.visible = "true";
-          }}
-          if (statusText) {{
-            statusText.textContent =
-              "If Proliferate did not open automatically, use the button below.";
-          }}
-        }}, 1500);
-      }});
-    </script>"""
-        if DESKTOP_DEEP_LINK_LAUNCH_ENABLED
-        else ""
-    )
-    return HTMLResponse(
-        f"""<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <style>
-      :root {{
-        color-scheme: dark;
-        font-family: Inter, "Geist", system-ui, sans-serif;
-        background: hsl(24 10% 7%);
-        color: hsl(30 8% 91%);
-      }}
-      body {{
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 2rem;
-        background: hsl(24 10% 7%);
-      }}
-      main {{
-        width: min(30rem, 100%);
-      }}
-      .brand {{
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        margin-bottom: 2.5rem;
-        color: hsl(30 8% 91%);
-      }}
-      .brand-name {{
-        font-size: 2.75rem;
-        font-weight: 500;
-        letter-spacing: 0.025em;
-      }}
-      .eyebrow {{
-        margin: 0 0 0.625rem;
-        color: hsl(23 5% 63%);
-        font-size: 0.75rem;
-        font-weight: 500;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-      }}
-      h1 {{
-        margin: 0 0 0.75rem;
-        font-size: 1.25rem;
-        font-weight: 500;
-      }}
-      p {{
-        margin: 0;
-        color: hsl(23 5% 63%);
-        font-size: 0.875rem;
-        line-height: 1.55;
-      }}
-      .detail {{
-        margin-top: 0.75rem;
-      }}
-      .recovery {{
-        display: none;
-        margin-top: 1.5rem;
-      }}
-      .recovery[data-visible="true"] {{
-        display: block;
-      }}
-      .action {{
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        border-radius: 0.375rem;
-        padding: 0.75rem;
-        background: hsl(30 8% 91%);
-        color: hsl(25 8% 16%);
-        font-size: 0.875rem;
-        font-weight: 500;
-        text-decoration: none;
-        transition: opacity 0.15s;
-      }}
-      .action:hover {{
-        opacity: 0.9;
-      }}
-    </style>
-{launch_script}
-  </head>
-  <body>
-    <main>
-      <div class="brand" aria-label="Proliferate">
-        <svg viewBox="300 300 200 200" fill="none"
-          xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
-          width="44" height="44">
-          <rect x="375" y="375" width="50" height="50" fill="currentColor" />
-          <rect x="387.67" y="305" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="429" y="346.33" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="470.33" y="387.67" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="429" y="429" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="387.67" y="470.33" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="346.33" y="429" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="305" y="387.67" width="24.67" height="24.67" fill="currentColor" />
-          <rect x="346.33" y="346.33" width="24.67" height="24.67" fill="currentColor" />
-        </svg>
-        <span class="brand-name">PROLIFERATE</span>
-      </div>
-      <p class="eyebrow">Plugins</p>
-      <h1>{title}</h1>
-      <p id="status-text">{message}</p>
-      <p class="detail">{detail}</p>
-      <div class="recovery" id="recovery" data-visible="{recovery_visible}">
-        <a class="action" href="{escaped_href}">Open Proliferate</a>
-      </div>
-    </main>
-  </body>
-</html>"""
+    return make_redirect_page(
+        title=title,
+        eyebrow="Plugins",
+        message=message,
+        detail=detail,
+        action_url=deep_link_url,
+        action_label="Open Proliferate",
+        action_visible=not DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
+        launch_action_on_load=DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
+        delayed_status_message="If Proliferate did not open automatically, use the button below.",
     )

--- a/server/proliferate/utils/redirect_pages.py
+++ b/server/proliferate/utils/redirect_pages.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from html import escape
+
+from fastapi.responses import HTMLResponse
+
+PROLIFERATE_MARK = """
+        <svg viewBox="300 300 200 200" fill="none"
+          xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
+          width="42" height="42" aria-hidden="true">
+          <rect x="375" y="375" width="50" height="50" fill="currentColor" />
+          <rect x="387.67" y="305" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="429" y="346.33" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="470.33" y="387.67" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="429" y="429" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="387.67" y="470.33" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="346.33" y="429" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="305" y="387.67" width="24.67" height="24.67" fill="currentColor" />
+          <rect x="346.33" y="346.33" width="24.67" height="24.67" fill="currentColor" />
+        </svg>"""
+
+
+def make_redirect_page(
+    *,
+    title: str,
+    message: str,
+    eyebrow: str | None = None,
+    detail: str | None = None,
+    action_url: str | None = None,
+    action_label: str = "Open Proliferate",
+    action_visible: bool = True,
+    launch_action_on_load: bool = False,
+    delayed_status_message: str | None = None,
+    hint: str | None = None,
+    close_after_ms: int | None = None,
+) -> HTMLResponse:
+    safe_title = escape(title)
+    safe_message = escape(message)
+    safe_eyebrow = escape(eyebrow) if eyebrow else ""
+    safe_detail = escape(detail) if detail else ""
+    safe_action_label = escape(action_label)
+    safe_hint = escape(hint) if hint else ""
+    safe_action_href = escape(action_url, quote=True) if action_url else ""
+    action_json = _json_for_script(action_url) if action_url else "null"
+    delayed_status_json = (
+        _json_for_script(delayed_status_message) if delayed_status_message else "null"
+    )
+    recovery_visible = "true" if action_url and action_visible else "false"
+    action_block = _action_block(
+        href=safe_action_href,
+        label=safe_action_label,
+        visible=recovery_visible,
+        hint=safe_hint,
+    ) if action_url else _hint_block(safe_hint)
+    launch_script = _launch_script(
+        action_json=action_json,
+        delayed_status_json=delayed_status_json,
+    ) if action_url and launch_action_on_load else ""
+    close_script = _close_script(close_after_ms) if close_after_ms is not None else ""
+    eyebrow_block = f'<p class="eyebrow">{safe_eyebrow}</p>' if eyebrow else ""
+    detail_block = f'<p class="detail">{safe_detail}</p>' if detail else ""
+
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{safe_title}</title>
+    <style>
+      :root {{
+        color-scheme: light dark;
+        font-family: Inter, "Geist", ui-sans-serif, system-ui, -apple-system,
+          BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f7f6f3;
+        color: #24211f;
+        --page-bg: #f7f6f3;
+        --page-bg-soft: #ffffff;
+        --text: #24211f;
+        --muted: #706a64;
+        --border: rgba(36, 33, 31, 0.12);
+        --button-bg: #24211f;
+        --button-text: #ffffff;
+        --line: rgba(36, 33, 31, 0.08);
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root {{
+          background: #14110f;
+          color: #f2eee9;
+          --page-bg: #14110f;
+          --page-bg-soft: #1c1815;
+          --text: #f2eee9;
+          --muted: #a49b93;
+          --border: rgba(242, 238, 233, 0.12);
+          --button-bg: #f2eee9;
+          --button-text: #211d1a;
+          --line: rgba(242, 238, 233, 0.08);
+        }}
+      }}
+      * {{
+        box-sizing: border-box;
+      }}
+      body {{
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        background:
+          linear-gradient(180deg, transparent 0, var(--line) 1px, transparent 1px) 0 0 / 100% 4rem,
+          var(--page-bg);
+      }}
+      main {{
+        width: min(31rem, 100%);
+      }}
+      .brand {{
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 2.25rem;
+        color: var(--text);
+      }}
+      .brand-name {{
+        font-size: clamp(1.8rem, 9vw, 2.75rem);
+        font-weight: 520;
+        letter-spacing: 0.025em;
+        line-height: 1;
+      }}
+      .panel {{
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        background: color-mix(in oklab, var(--page-bg-soft) 92%, transparent);
+        padding: 1.25rem;
+      }}
+      .eyebrow {{
+        margin: 0 0 0.625rem;
+        color: var(--muted);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }}
+      h1 {{
+        margin: 0 0 0.75rem;
+        color: var(--text);
+        font-size: 1.25rem;
+        font-weight: 560;
+        letter-spacing: 0;
+      }}
+      p {{
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }}
+      .detail,
+      .hint {{
+        margin-top: 0.75rem;
+      }}
+      .recovery {{
+        display: none;
+        margin-top: 1.25rem;
+      }}
+      .recovery[data-visible="true"] {{
+        display: block;
+      }}
+      .action {{
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        min-height: 2.5rem;
+        border-radius: 0.5rem;
+        padding: 0.625rem 0.875rem;
+        background: var(--button-bg);
+        color: var(--button-text);
+        font-size: 0.875rem;
+        font-weight: 560;
+        text-decoration: none;
+      }}
+      .action:hover {{
+        opacity: 0.9;
+      }}
+      .action:focus-visible {{
+        outline: 2px solid color-mix(in oklab, var(--button-bg) 45%, transparent);
+        outline-offset: 3px;
+      }}
+    </style>
+{launch_script}
+{close_script}
+  </head>
+  <body>
+    <main>
+      <div class="brand" aria-label="Proliferate">
+{PROLIFERATE_MARK}
+        <span class="brand-name">PROLIFERATE</span>
+      </div>
+      <section class="panel" aria-labelledby="redirect-title">
+        {eyebrow_block}
+        <h1 id="redirect-title">{safe_title}</h1>
+        <p id="status-text">{safe_message}</p>
+        {detail_block}
+{action_block}
+      </section>
+    </main>
+  </body>
+</html>"""
+    )
+
+
+def _json_for_script(value: str | None) -> str:
+    return (
+        json.dumps(value)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _action_block(*, href: str, label: str, visible: str, hint: str) -> str:
+    hint_block = f'\n        <p class="hint">{hint}</p>' if hint else ""
+    return f"""
+        <div class="recovery" id="recovery" data-visible="{visible}">
+          <a class="action" href="{href}">{label}</a>{hint_block}
+        </div>"""
+
+
+def _hint_block(hint: str) -> str:
+    if not hint:
+        return ""
+    return f"""
+        <div class="recovery" id="recovery" data-visible="true">
+          <p class="hint">{hint}</p>
+        </div>"""
+
+
+def _launch_script(*, action_json: str, delayed_status_json: str) -> str:
+    return f"""
+    <script>
+      window.addEventListener("load", () => {{
+        const deepLinkUrl = {action_json};
+        const delayedStatusText = {delayed_status_json};
+        const recovery = document.getElementById("recovery");
+        const statusText = document.getElementById("status-text");
+
+        window.location.replace(deepLinkUrl);
+
+        window.setTimeout(() => {{
+          if (recovery) {{
+            recovery.dataset.visible = "true";
+          }}
+          if (statusText && delayedStatusText) {{
+            statusText.textContent = delayedStatusText;
+          }}
+        }}, 1500);
+      }});
+    </script>"""
+
+
+def _close_script(delay_ms: int) -> str:
+    return f"""
+    <script>
+      window.addEventListener("load", () => {{
+        window.setTimeout(() => window.close(), {delay_ms});
+      }});
+    </script>"""

--- a/server/tests/unit/auth/test_desktop_customerio.py
+++ b/server/tests/unit/auth/test_desktop_customerio.py
@@ -228,6 +228,36 @@ async def test_finish_github_desktop_callback_skips_customerio_when_oauth_fails(
 
 
 @pytest.mark.asyncio
+async def test_finish_github_desktop_callback_sanitizes_provider_error_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    request = _make_request()
+    user_manager = SimpleNamespace(oauth_callback=AsyncMock())
+
+    monkeypatch.setattr(settings, "github_oauth_client_id", "github-client-id")
+    monkeypatch.setattr(settings, "github_oauth_client_secret", "github-client-secret")
+
+    response = await desktop_service.finish_github_desktop_callback(
+        db,  # type: ignore[arg-type]
+        request,
+        code=None,
+        state=None,
+        error="invalid_request_<raw-oauth-error>",
+        error_description="refresh-token leaked from provider",
+        desktop_github_csrf=None,
+        user_manager=user_manager,
+    )
+
+    html = response.body.decode()
+    assert response.status_code == 200
+    assert "The browser flow could not be completed" in html
+    assert "raw-oauth-error" not in html
+    assert "refresh-token" not in html
+    user_manager.oauth_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_finish_github_desktop_callback_skips_customerio_when_auth_code_creation_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/server/tests/unit/test_redirect_pages.py
+++ b/server/tests/unit/test_redirect_pages.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from fastapi.responses import HTMLResponse
+
+from proliferate.auth.desktop.pages import make_desktop_handoff_page
+from proliferate.server.cloud.mcp_oauth.pages import make_mcp_oauth_callback_page
+from proliferate.utils.redirect_pages import make_redirect_page
+
+
+def _html(response: HTMLResponse) -> str:
+    return response.body.decode("utf-8")
+
+
+def test_redirect_page_escapes_html_content_and_action_href() -> None:
+    html = _html(
+        make_redirect_page(
+            title='<script>alert("title")</script>',
+            eyebrow="<provider>",
+            message='<img src=x onerror="alert(1)">',
+            detail="token=<secret>",
+            action_url='proliferate://auth/callback?code="abc"&state=<bad>',
+            action_label="<Open>",
+            hint="Use <fallback>.",
+        )
+    )
+
+    assert '<script>alert("title")</script>' not in html
+    assert '<img src=x onerror="alert(1)">' not in html
+    assert "&lt;script&gt;alert(&quot;title&quot;)&lt;/script&gt;" in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+    assert "token=&lt;secret&gt;" in html
+    assert (
+        'href="proliferate://auth/callback?code=&quot;abc&quot;&amp;state=&lt;bad&gt;"'
+        in html
+    )
+    assert "&lt;Open&gt;" in html
+    assert "Use &lt;fallback&gt;." in html
+
+
+def test_redirect_page_escapes_deep_link_script_data() -> None:
+    html = _html(
+        make_redirect_page(
+            title="Opening Proliferate...",
+            message="Launching...",
+            action_url="proliferate://open?next=</script><script>alert(1)</script>&ok=1",
+            launch_action_on_load=True,
+            delayed_status_message="Use <the button>.",
+        )
+    )
+
+    assert "window.location.replace(deepLinkUrl)" in html
+    assert "proliferate://open?next=</script><script>alert(1)</script>&ok=1" not in html
+    assert "\\u003c/script\\u003e\\u003cscript\\u003ealert(1)" in html
+    assert "\\u0026ok=1" in html
+    assert "Use \\u003cthe button\\u003e." in html
+
+
+def test_desktop_handoff_page_preserves_deep_link_recovery() -> None:
+    html = _html(
+        make_desktop_handoff_page(
+            deep_link_url="proliferate://auth/callback?code=auth-code&state=desktop-state",
+            launch_deep_link=True,
+        )
+    )
+
+    assert "Opening Proliferate..." in html
+    assert "Open Proliferate again" in html
+    assert "window.location.replace(deepLinkUrl)" in html
+    assert "proliferate://auth/callback?code=auth-code&amp;state=desktop-state" in html
+    assert "proliferate://auth/callback?code=auth-code\\u0026state=desktop-state" in html
+
+
+def test_mcp_oauth_callback_page_uses_generic_success_and_failure_copy() -> None:
+    success_html = _html(make_mcp_oauth_callback_page(ok=True))
+    failure_html = _html(make_mcp_oauth_callback_page(ok=False))
+
+    assert "Authorization complete" in success_html
+    assert "finish using this plugin" in success_html
+    assert "Plugins list" in success_html
+    assert "Open Proliferate" in success_html
+    assert "proliferate://plugins?source=mcp_oauth_callback&amp;status=completed" in success_html
+
+    assert "Authorization failed" in failure_html
+    assert "No tokens were exposed in this browser page" in failure_html
+    assert "proliferate://plugins?source=mcp_oauth_callback&amp;status=failed" in failure_html
+    assert "access-token" not in failure_html
+    assert "refresh-token" not in failure_html
+    assert "invalid_grant" not in failure_html


### PR DESCRIPTION
## Summary
- add a shared server-side redirect page renderer for desktop auth and MCP OAuth callbacks
- preserve existing desktop handoff/deep-link behavior while improving light/dark styling and recovery copy
- sanitize desktop GitHub provider errors so raw OAuth error text is not reflected into callback HTML

## Tests
- DEBUG=1 uv run --extra dev pytest -q tests/unit/test_redirect_pages.py tests/unit/auth/test_desktop_customerio.py::test_finish_github_desktop_callback_sanitizes_provider_error_page
- DEBUG=1 uv run --extra dev pytest -q tests/integration/test_auth_flow.py::TestDesktopGitHubBrowserFlow::test_github_browser_flow_stages_and_exchanges_desktop_session tests/integration/test_auth_flow.py::TestDesktopGitHubBrowserFlow::test_github_browser_flow_associates_existing_user tests/integration/test_cloud_api.py::TestCloudMcpConnections::test_oauth_callback_uses_cached_dcr_client_secret tests/integration/test_cloud_api.py::TestCloudMcpConnections::test_oauth_callback_failure_uses_safe_handoff_page
- DEBUG=1 uv run --extra dev ruff check proliferate/auth/desktop/pages.py proliferate/auth/desktop/service.py proliferate/server/cloud/mcp_oauth/pages.py proliferate/utils/redirect_pages.py tests/unit/test_redirect_pages.py tests/unit/auth/test_desktop_customerio.py
- uv run python ../scripts/check_server_boundaries.py