### PR TITLE
feat(cloud): sync worker session events

### DIFF
--- a/anyharness/crates/proliferate-worker/src/anyharness_client/events.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/events.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::WorkerError;
+
+use super::AnyHarnessClient;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEventEnvelope {
+    pub session_id: String,
+    pub seq: i64,
+    pub timestamp: Option<String>,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+    pub event: Value,
+}
+
+impl AnyHarnessClient {
+    pub async fn list_session_events(
+        &self,
+        session_id: &str,
+        after_seq: i64,
+        limit: Option<usize>,
+    ) -> Result<Vec<SessionEventEnvelope>, WorkerError> {
+        let mut request = self
+            .authenticate(self.http().get(format!(
+                "{}/v1/sessions/{}/events",
+                self.base_url(),
+                session_id
+            )))
+            .query(&[("after_seq", after_seq.to_string())]);
+        if let Some(limit) = limit {
+            request = request.query(&[("limit", limit.to_string())]);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        Ok(response.json().await?)
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
@@ -1,3 +1,4 @@
+pub mod events;
 pub mod health;
 pub mod sessions;
 

--- a/anyharness/crates/proliferate-worker/src/cloud_client/events.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/events.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::WorkerError;
+
+use super::{auth, parse_json_response, CloudClient};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerSessionEventEnvelope {
+    pub workspace_id: Option<String>,
+    pub session_id: String,
+    pub seq: i64,
+    pub timestamp: Option<String>,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+    pub event: Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventBatchRequest {
+    pub events: Vec<WorkerSessionEventEnvelope>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventSessionAck {
+    pub session_id: String,
+    pub last_contiguous_seq: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventBatchResponse {
+    pub accepted_events: i64,
+    pub duplicate_events: i64,
+    pub live_only_events: i64,
+    pub session_acks: Vec<EventSessionAck>,
+}
+
+impl CloudClient {
+    pub async fn upload_event_batch(
+        &self,
+        worker_token: &str,
+        request: &EventBatchRequest,
+    ) -> Result<EventBatchResponse, WorkerError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/cloud/worker/events/batches", self.base_url))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            )
+            .json(request)
+            .send()
+            .await?;
+        parse_json_response(response).await
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod commands;
+pub mod events;
 pub mod heartbeat;
 pub mod inventory;
 

--- a/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
@@ -17,6 +17,7 @@ use crate::{
     config::WorkerConfig,
     error::WorkerError,
     identity::credentials::WorkerIdentity,
+    store::WorkerStore,
 };
 
 const EMPTY_LEASE_SLEEP: Duration = Duration::from_secs(2);
@@ -26,6 +27,7 @@ pub async fn run_loop(
     config: WorkerConfig,
     cloud: CloudClient,
     identity: WorkerIdentity,
+    store: WorkerStore,
 ) -> Result<(), WorkerError> {
     let Some(base_url) = config.anyharness_base_url.clone() else {
         warn!("worker command loop disabled because anyharness_base_url is not configured");
@@ -50,7 +52,7 @@ pub async fn run_loop(
             Ok(response) => {
                 if let Some(command) = response.command {
                     if let Err(error) =
-                        process_command(&cloud, &identity, &anyharness, command).await
+                        process_command(&cloud, &identity, &anyharness, &store, command).await
                     {
                         warn!(?error, "worker command processing failed");
                         sleep(ERROR_LEASE_SLEEP).await;
@@ -72,6 +74,7 @@ async fn process_command(
     cloud: &CloudClient,
     identity: &WorkerIdentity,
     anyharness: &AnyHarnessClient,
+    store: &WorkerStore,
     command: CloudCommandEnvelope,
 ) -> Result<(), WorkerError> {
     info!(
@@ -117,6 +120,13 @@ async fn process_command(
         .await?;
 
     let response = dispatch_anyharness(anyharness, &mapped).await;
+    if let Ok(response) = &response {
+        if response.is_success() {
+            if let Err(error) = register_session_for_sync(store, &command, &mapped, response) {
+                warn!(?error, "failed to register session for cloud event sync");
+            }
+        }
+    }
     let result = command_result(&command, &mapped, response);
     cloud
         .report_command_result(&identity.worker_token, &command.command_id, &result)
@@ -222,4 +232,33 @@ fn accepted_status(
         return "accepted_but_queued";
     }
     "accepted"
+}
+
+fn register_session_for_sync(
+    store: &WorkerStore,
+    command: &CloudCommandEnvelope,
+    mapped: &AnyHarnessCommand,
+    response: &AnyHarnessCommandResponse,
+) -> Result<(), WorkerError> {
+    let session_id = match mapped {
+        AnyHarnessCommand::StartSession { .. } => response
+            .body
+            .get("id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        AnyHarnessCommand::SendPrompt { session_id, .. }
+        | AnyHarnessCommand::ResolveInteraction { session_id, .. }
+        | AnyHarnessCommand::UpdateSessionConfig { session_id, .. }
+        | AnyHarnessCommand::UpdateNormalizedSessionConfig { session_id, .. }
+        | AnyHarnessCommand::CancelTurn { session_id }
+        | AnyHarnessCommand::CloseSession { session_id } => Some(session_id.clone()),
+    };
+    let Some(session_id) = session_id else {
+        return Ok(());
+    };
+    let workspace_id = command
+        .workspace_id
+        .as_deref()
+        .or_else(|| response.body.get("workspaceId").and_then(Value::as_str));
+    store.upsert_sync_session(&session_id, workspace_id)
 }

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -8,6 +8,7 @@ mod inventory;
 mod logging;
 mod runtime;
 mod store;
+mod sync;
 
 use std::path::PathBuf;
 

--- a/anyharness/crates/proliferate-worker/src/runtime.rs
+++ b/anyharness/crates/proliferate-worker/src/runtime.rs
@@ -10,6 +10,7 @@ use crate::{
     identity::{credentials::WorkerIdentity, enrollment},
     inventory,
     store::WorkerStore,
+    sync,
 };
 
 pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
@@ -38,11 +39,28 @@ pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
     let command_config = config.clone();
     let command_cloud = cloud.clone();
     let command_identity = identity.clone();
+    let command_store = store.clone();
     tokio::spawn(async move {
-        if let Err(error) =
-            commands::dispatcher::run_loop(command_config, command_cloud, command_identity).await
+        if let Err(error) = commands::dispatcher::run_loop(
+            command_config,
+            command_cloud,
+            command_identity,
+            command_store,
+        )
+        .await
         {
             warn!(?error, "worker command loop exited");
+        }
+    });
+    let sync_config = config.clone();
+    let sync_cloud = cloud.clone();
+    let sync_identity = identity.clone();
+    let sync_store = store.clone();
+    tokio::spawn(async move {
+        if let Err(error) =
+            sync::tailer::run_loop(sync_config, sync_cloud, sync_identity, sync_store).await
+        {
+            warn!(?error, "worker event sync loop exited");
         }
     });
     loop {

--- a/anyharness/crates/proliferate-worker/src/store/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/store/mod.rs
@@ -8,6 +8,21 @@ pub struct WorkerStore {
     path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
+pub struct SyncSession {
+    pub session_id: String,
+    pub workspace_id: Option<String>,
+    pub last_uploaded_seq: i64,
+}
+
+impl Clone for WorkerStore {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+        }
+    }
+}
+
 impl WorkerStore {
     pub fn open(path: PathBuf) -> Result<Self, WorkerError> {
         if let Some(parent) = path.parent() {
@@ -36,6 +51,12 @@ impl WorkerStore {
                 target_id TEXT NOT NULL,
                 worker_id TEXT NOT NULL,
                 worker_token TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS sync_sessions (
+                session_id TEXT PRIMARY KEY,
+                workspace_id TEXT,
+                last_uploaded_seq INTEGER NOT NULL DEFAULT 0,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
             "#,
@@ -78,6 +99,62 @@ impl WorkerStore {
                 identity.worker_id,
                 identity.worker_token
             ],
+        )?;
+        Ok(())
+    }
+
+    pub fn upsert_sync_session(
+        &self,
+        session_id: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        conn.execute(
+            r#"
+            INSERT INTO sync_sessions (session_id, workspace_id, last_uploaded_seq, updated_at)
+            VALUES (?1, ?2, 0, CURRENT_TIMESTAMP)
+            ON CONFLICT(session_id) DO UPDATE SET
+                workspace_id = COALESCE(excluded.workspace_id, sync_sessions.workspace_id),
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+            params![session_id, workspace_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_sync_sessions(&self) -> Result<Vec<SyncSession>, WorkerError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(
+            "SELECT session_id, workspace_id, last_uploaded_seq FROM sync_sessions ORDER BY updated_at DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(SyncSession {
+                session_id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                last_uploaded_seq: row.get(2)?,
+            })
+        })?;
+        let mut sessions = Vec::new();
+        for row in rows {
+            sessions.push(row?);
+        }
+        Ok(sessions)
+    }
+
+    pub fn update_sync_cursor(
+        &self,
+        session_id: &str,
+        last_uploaded_seq: i64,
+    ) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        conn.execute(
+            r#"
+            UPDATE sync_sessions
+            SET last_uploaded_seq = MAX(last_uploaded_seq, ?2),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE session_id = ?1
+            "#,
+            params![session_id, last_uploaded_seq],
         )?;
         Ok(())
     }

--- a/anyharness/crates/proliferate-worker/src/sync/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/mod.rs
@@ -1,0 +1,1 @@
+pub mod tailer;

--- a/anyharness/crates/proliferate-worker/src/sync/tailer.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/tailer.rs
@@ -1,0 +1,113 @@
+use tokio::time::{sleep, Duration};
+use tracing::{debug, warn};
+
+use crate::{
+    anyharness_client::{
+        events::SessionEventEnvelope, health as anyharness_health, AnyHarnessClient,
+    },
+    cloud_client::{
+        events::{EventBatchRequest, WorkerSessionEventEnvelope},
+        CloudClient,
+    },
+    config::WorkerConfig,
+    error::WorkerError,
+    identity::credentials::WorkerIdentity,
+    store::{SyncSession, WorkerStore},
+};
+
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const ERROR_SLEEP: Duration = Duration::from_secs(5);
+const ANYHARNESS_EVENT_LIMIT: usize = 100;
+
+pub async fn run_loop(
+    config: WorkerConfig,
+    cloud: CloudClient,
+    identity: WorkerIdentity,
+    store: WorkerStore,
+) -> Result<(), WorkerError> {
+    let Some(base_url) = config.anyharness_base_url.clone() else {
+        warn!("worker event sync disabled because anyharness_base_url is not configured");
+        return Ok(());
+    };
+    let anyharness = AnyHarnessClient::new(base_url, config.anyharness_bearer_token.clone())?;
+    loop {
+        if !anyharness_health::probe(&anyharness).await {
+            warn!("worker event sync paused because anyharness health check failed");
+            sleep(ERROR_SLEEP).await;
+            continue;
+        }
+        if let Err(error) = sync_once(&store, &anyharness, &cloud, &identity).await {
+            warn!(?error, "worker event sync pass failed");
+            sleep(ERROR_SLEEP).await;
+            continue;
+        }
+        sleep(EVENT_POLL_INTERVAL).await;
+    }
+}
+
+async fn sync_once(
+    store: &WorkerStore,
+    anyharness: &AnyHarnessClient,
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+) -> Result<(), WorkerError> {
+    let sessions = store.list_sync_sessions()?;
+    for session in sessions {
+        if let Err(error) = sync_session(store, anyharness, cloud, identity, &session).await {
+            warn!(
+                ?error,
+                session_id = %session.session_id,
+                "worker event sync failed for session"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn sync_session(
+    store: &WorkerStore,
+    anyharness: &AnyHarnessClient,
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    session: &SyncSession,
+) -> Result<(), WorkerError> {
+    let events = anyharness
+        .list_session_events(&session.session_id, session.last_uploaded_seq, None)
+        .await?;
+    if events.is_empty() {
+        return Ok(());
+    }
+    let request = EventBatchRequest {
+        events: events
+            .into_iter()
+            .take(ANYHARNESS_EVENT_LIMIT)
+            .map(|event| worker_event(session, event))
+            .collect(),
+    };
+    let response = cloud
+        .upload_event_batch(&identity.worker_token, &request)
+        .await?;
+    debug!(
+        accepted_events = response.accepted_events,
+        duplicate_events = response.duplicate_events,
+        live_only_events = response.live_only_events,
+        session_ack_count = response.session_acks.len(),
+        "uploaded worker event batch"
+    );
+    for ack in response.session_acks {
+        store.update_sync_cursor(&ack.session_id, ack.last_contiguous_seq)?;
+    }
+    Ok(())
+}
+
+fn worker_event(session: &SyncSession, event: SessionEventEnvelope) -> WorkerSessionEventEnvelope {
+    WorkerSessionEventEnvelope {
+        workspace_id: session.workspace_id.clone(),
+        session_id: event.session_id,
+        seq: event.seq,
+        timestamp: event.timestamp,
+        turn_id: event.turn_id,
+        item_id: event.item_id,
+        event: event.event,
+    }
+}

--- a/server/alembic/versions/c8d9e0f1a2b3_cloud_event_sync_projections.py
+++ b/server/alembic/versions/c8d9e0f1a2b3_cloud_event_sync_projections.py
@@ -1,0 +1,252 @@
+"""cloud event sync projections
+
+Revision ID: c8d9e0f1a2b3
+Revises: c7d8e9f0a1b2
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9e0f1a2b3"
+down_revision: str | Sequence[str] | None = "c7d8e9f0a1b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "cloud_session_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("worker_id", sa.Uuid(), nullable=True),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("workspace_id", sa.String(length=255), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("anyharness_seq", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=128), nullable=False),
+        sa.Column("schema_version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+        sa.Column("source_kind", sa.String(length=32), nullable=False),
+        sa.Column("turn_id", sa.String(length=255), nullable=True),
+        sa.Column("item_id", sa.String(length=255), nullable=True),
+        sa.Column("occurred_at", sa.String(length=64), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=True),
+        sa.Column("payload_hash", sa.String(length=64), nullable=False),
+        sa.Column("payload_ref", sa.Text(), nullable=True),
+        sa.Column("payload_size_bytes", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("payload_truncated_at_bytes", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "target_id",
+            "session_id",
+            "anyharness_seq",
+            name="uq_cloud_session_events_target_session_seq",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_session_events_cloud_workspace",
+        "cloud_session_events",
+        ["cloud_workspace_id"],
+        unique=False,
+    )
+    op.create_index("ix_cloud_session_events_type", "cloud_session_events", ["event_type"])
+    op.create_index(
+        "ix_cloud_session_events_session_seq",
+        "cloud_session_events",
+        ["session_id", "anyharness_seq"],
+    )
+    op.create_index(
+        "ix_cloud_session_events_target_session",
+        "cloud_session_events",
+        ["target_id", "session_id"],
+    )
+    op.create_index("ix_cloud_session_events_session_id", "cloud_session_events", ["session_id"])
+    op.create_index("ix_cloud_session_events_target_id", "cloud_session_events", ["target_id"])
+
+    op.create_table(
+        "cloud_event_ingest_state",
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("worker_id", sa.Uuid(), nullable=True),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("workspace_id", sa.String(length=255), nullable=True),
+        sa.Column("last_contiguous_seq", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("target_id", "session_id"),
+    )
+
+    op.create_table(
+        "cloud_sessions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("workspace_id", sa.String(length=255), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("native_session_id", sa.String(length=255), nullable=True),
+        sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("phase", sa.String(length=64), nullable=True),
+        sa.Column("live_config_json", sa.Text(), nullable=True),
+        sa.Column("last_event_seq", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("last_event_at", sa.String(length=64), nullable=True),
+        sa.Column("started_at", sa.String(length=64), nullable=True),
+        sa.Column("ended_at", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("target_id", "session_id", name="uq_cloud_sessions_target_session"),
+    )
+    op.create_index("ix_cloud_sessions_cloud_workspace", "cloud_sessions", ["cloud_workspace_id"])
+    op.create_index("ix_cloud_sessions_last_event_seq", "cloud_sessions", ["last_event_seq"])
+    op.create_index("ix_cloud_sessions_session_id", "cloud_sessions", ["session_id"])
+    op.create_index("ix_cloud_sessions_target_id", "cloud_sessions", ["target_id"])
+    op.create_index("ix_cloud_sessions_target_status", "cloud_sessions", ["target_id", "status"])
+
+    op.create_table(
+        "cloud_transcript_items",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("workspace_id", sa.String(length=255), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("item_id", sa.String(length=255), nullable=False),
+        sa.Column("turn_id", sa.String(length=255), nullable=True),
+        sa.Column("kind", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=64), nullable=True),
+        sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("text", sa.Text(), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=True),
+        sa.Column("first_seq", sa.Integer(), nullable=False),
+        sa.Column("last_seq", sa.Integer(), nullable=False),
+        sa.Column("completed_seq", sa.Integer(), nullable=True),
+        sa.Column("first_event_at", sa.String(length=64), nullable=True),
+        sa.Column("last_event_at", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "target_id",
+            "session_id",
+            "item_id",
+            name="uq_cloud_transcript_items_target_session_item",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_transcript_items_cloud_workspace",
+        "cloud_transcript_items",
+        ["cloud_workspace_id"],
+    )
+    op.create_index("ix_cloud_transcript_items_session_id", "cloud_transcript_items", ["session_id"])
+    op.create_index(
+        "ix_cloud_transcript_items_session_seq",
+        "cloud_transcript_items",
+        ["session_id", "last_seq"],
+    )
+    op.create_index("ix_cloud_transcript_items_target_id", "cloud_transcript_items", ["target_id"])
+
+    op.create_table(
+        "cloud_pending_interactions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+        sa.Column("workspace_id", sa.String(length=255), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("request_id", sa.String(length=255), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=True),
+        sa.Column("requested_seq", sa.Integer(), nullable=False),
+        sa.Column("resolved_seq", sa.Integer(), nullable=True),
+        sa.Column("requested_at", sa.String(length=64), nullable=True),
+        sa.Column("resolved_at", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "target_id",
+            "session_id",
+            "request_id",
+            name="uq_cloud_pending_interactions_target_session_request",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_pending_interactions_cloud_workspace",
+        "cloud_pending_interactions",
+        ["cloud_workspace_id"],
+    )
+    op.create_index(
+        "ix_cloud_pending_interactions_session_id",
+        "cloud_pending_interactions",
+        ["session_id"],
+    )
+    op.create_index(
+        "ix_cloud_pending_interactions_session_status",
+        "cloud_pending_interactions",
+        ["session_id", "status"],
+    )
+    op.create_index(
+        "ix_cloud_pending_interactions_target_id",
+        "cloud_pending_interactions",
+        ["target_id"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_cloud_pending_interactions_target_id", table_name="cloud_pending_interactions")
+    op.drop_index(
+        "ix_cloud_pending_interactions_session_status",
+        table_name="cloud_pending_interactions",
+    )
+    op.drop_index("ix_cloud_pending_interactions_session_id", table_name="cloud_pending_interactions")
+    op.drop_index(
+        "ix_cloud_pending_interactions_cloud_workspace",
+        table_name="cloud_pending_interactions",
+    )
+    op.drop_table("cloud_pending_interactions")
+
+    op.drop_index("ix_cloud_transcript_items_target_id", table_name="cloud_transcript_items")
+    op.drop_index("ix_cloud_transcript_items_session_seq", table_name="cloud_transcript_items")
+    op.drop_index("ix_cloud_transcript_items_session_id", table_name="cloud_transcript_items")
+    op.drop_index("ix_cloud_transcript_items_cloud_workspace", table_name="cloud_transcript_items")
+    op.drop_table("cloud_transcript_items")
+
+    op.drop_index("ix_cloud_sessions_target_status", table_name="cloud_sessions")
+    op.drop_index("ix_cloud_sessions_target_id", table_name="cloud_sessions")
+    op.drop_index("ix_cloud_sessions_session_id", table_name="cloud_sessions")
+    op.drop_index("ix_cloud_sessions_last_event_seq", table_name="cloud_sessions")
+    op.drop_index("ix_cloud_sessions_cloud_workspace", table_name="cloud_sessions")
+    op.drop_table("cloud_sessions")
+
+    op.drop_table("cloud_event_ingest_state")
+
+    op.drop_index("ix_cloud_session_events_target_id", table_name="cloud_session_events")
+    op.drop_index("ix_cloud_session_events_session_id", table_name="cloud_session_events")
+    op.drop_index("ix_cloud_session_events_target_session", table_name="cloud_session_events")
+    op.drop_index("ix_cloud_session_events_session_seq", table_name="cloud_session_events")
+    op.drop_index("ix_cloud_session_events_type", table_name="cloud_session_events")
+    op.drop_index("ix_cloud_session_events_cloud_workspace", table_name="cloud_session_events")
+    op.drop_table("cloud_session_events")

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -4,13 +4,14 @@ Importing this package registers all cloud ORM tables with SQLAlchemy metadata.
 Callers should import concrete models from the owning module in this package.
 """
 
-from . import credentials as credentials  # noqa: F401
 from . import commands as commands  # noqa: F401
+from . import credentials as credentials  # noqa: F401
 from . import mcp as mcp  # noqa: F401
 from . import mobility as mobility  # noqa: F401
 from . import repo_config as repo_config  # noqa: F401
 from . import runtime_environments as runtime_environments  # noqa: F401
 from . import sandboxes as sandboxes  # noqa: F401
+from . import sync as sync  # noqa: F401
 from . import targets as targets  # noqa: F401
 from . import workspaces as workspaces  # noqa: F401
 from . import worktree_policy as worktree_policy  # noqa: F401

--- a/server/proliferate/db/models/cloud/sync.py
+++ b/server/proliferate/db/models/cloud/sync.py
@@ -1,0 +1,204 @@
+"""Cloud event-sync and projection ORM models."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.db.models.base import Base, utcnow
+
+
+class CloudSessionEvent(Base):
+    __tablename__ = "cloud_session_events"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_id",
+            "session_id",
+            "anyharness_seq",
+            name="uq_cloud_session_events_target_session_seq",
+        ),
+        Index("ix_cloud_session_events_session_seq", "session_id", "anyharness_seq"),
+        Index("ix_cloud_session_events_target_session", "target_id", "session_id"),
+        Index("ix_cloud_session_events_cloud_workspace", "cloud_workspace_id"),
+        Index("ix_cloud_session_events_type", "event_type"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    worker_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[str] = mapped_column(String(255), index=True)
+    anyharness_seq: Mapped[int] = mapped_column(Integer)
+    event_type: Mapped[str] = mapped_column(String(128), index=True)
+    schema_version: Mapped[int] = mapped_column(Integer, default=1, server_default=text("1"))
+    source_kind: Mapped[str] = mapped_column(String(32), default="system")
+    turn_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    item_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    occurred_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    payload_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_hash: Mapped[str] = mapped_column(String(64))
+    payload_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_size_bytes: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    payload_truncated_at_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class CloudEventIngestState(Base):
+    __tablename__ = "cloud_event_ingest_state"
+
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    session_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    worker_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    last_contiguous_seq: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class CloudSessionProjection(Base):
+    __tablename__ = "cloud_sessions"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_id",
+            "session_id",
+            name="uq_cloud_sessions_target_session",
+        ),
+        Index("ix_cloud_sessions_target_status", "target_id", "status"),
+        Index("ix_cloud_sessions_cloud_workspace", "cloud_workspace_id"),
+        Index("ix_cloud_sessions_last_event_seq", "last_event_seq"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[str] = mapped_column(String(255), index=True)
+    native_session_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    source_agent_kind: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="running", index=True)
+    phase: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    live_config_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_event_seq: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    last_event_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    started_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    ended_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class CloudTranscriptItem(Base):
+    __tablename__ = "cloud_transcript_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_id",
+            "session_id",
+            "item_id",
+            name="uq_cloud_transcript_items_target_session_item",
+        ),
+        Index("ix_cloud_transcript_items_session_seq", "session_id", "last_seq"),
+        Index("ix_cloud_transcript_items_cloud_workspace", "cloud_workspace_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[str] = mapped_column(String(255), index=True)
+    item_id: Mapped[str] = mapped_column(String(255))
+    turn_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    kind: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    status: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    source_agent_kind: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    first_seq: Mapped[int] = mapped_column(Integer)
+    last_seq: Mapped[int] = mapped_column(Integer)
+    completed_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    first_event_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_event_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class CloudPendingInteraction(Base):
+    __tablename__ = "cloud_pending_interactions"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_id",
+            "session_id",
+            "request_id",
+            name="uq_cloud_pending_interactions_target_session_request",
+        ),
+        Index("ix_cloud_pending_interactions_session_status", "session_id", "status"),
+        Index("ix_cloud_pending_interactions_cloud_workspace", "cloud_workspace_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[str] = mapped_column(String(255), index=True)
+    request_id: Mapped[str] = mapped_column(String(255))
+    kind: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    requested_seq: Mapped[int] = mapped_column(Integer)
+    resolved_seq: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    requested_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    resolved_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/cloud_sync/events.py
+++ b/server/proliferate/db/store/cloud_sync/events.py
@@ -1,0 +1,687 @@
+"""Cloud event-sync persistence and projection stores."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.runtime_environments import CloudRuntimeEnvironment
+from proliferate.db.models.cloud.sync import (
+    CloudEventIngestState,
+    CloudPendingInteraction,
+    CloudSessionEvent,
+    CloudSessionProjection,
+    CloudTranscriptItem,
+)
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class InsertSessionEvent:
+    target_id: UUID
+    worker_id: UUID | None
+    cloud_workspace_id: UUID | None
+    workspace_id: str | None
+    session_id: str
+    seq: int
+    event_type: str
+    source_kind: str
+    turn_id: str | None
+    item_id: str | None
+    occurred_at: str | None
+    payload_json: str | None
+    payload_hash: str
+    payload_size_bytes: int
+    payload_truncated_at_bytes: int | None
+
+
+@dataclass(frozen=True)
+class CloudSessionEventSnapshot:
+    id: UUID
+    target_id: UUID
+    worker_id: UUID | None
+    cloud_workspace_id: UUID | None
+    workspace_id: str | None
+    session_id: str
+    seq: int
+    event_type: str
+    source_kind: str
+    turn_id: str | None
+    item_id: str | None
+    occurred_at: str | None
+    payload_json: str | None
+    payload_hash: str
+    payload_size_bytes: int
+    payload_truncated_at_bytes: int | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudSessionProjectionSnapshot:
+    id: UUID
+    target_id: UUID
+    cloud_workspace_id: UUID | None
+    workspace_id: str | None
+    session_id: str
+    native_session_id: str | None
+    source_agent_kind: str | None
+    title: str | None
+    status: str
+    phase: str | None
+    live_config_json: str | None
+    last_event_seq: int
+    last_event_at: str | None
+    started_at: str | None
+    ended_at: str | None
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CloudTranscriptItemSnapshot:
+    id: UUID
+    target_id: UUID
+    cloud_workspace_id: UUID | None
+    workspace_id: str | None
+    session_id: str
+    item_id: str
+    turn_id: str | None
+    kind: str | None
+    status: str | None
+    source_agent_kind: str | None
+    title: str | None
+    text: str | None
+    payload_json: str | None
+    first_seq: int
+    last_seq: int
+    completed_seq: int | None
+    first_event_at: str | None
+    last_event_at: str | None
+
+
+@dataclass(frozen=True)
+class CloudPendingInteractionSnapshot:
+    id: UUID
+    target_id: UUID
+    cloud_workspace_id: UUID | None
+    workspace_id: str | None
+    session_id: str
+    request_id: str
+    kind: str | None
+    status: str
+    title: str | None
+    description: str | None
+    payload_json: str | None
+    requested_seq: int
+    resolved_seq: int | None
+    requested_at: str | None
+    resolved_at: str | None
+
+
+def _event_snapshot(row: CloudSessionEvent) -> CloudSessionEventSnapshot:
+    return CloudSessionEventSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        worker_id=row.worker_id,
+        cloud_workspace_id=row.cloud_workspace_id,
+        workspace_id=row.workspace_id,
+        session_id=row.session_id,
+        seq=row.anyharness_seq,
+        event_type=row.event_type,
+        source_kind=row.source_kind,
+        turn_id=row.turn_id,
+        item_id=row.item_id,
+        occurred_at=row.occurred_at,
+        payload_json=row.payload_json,
+        payload_hash=row.payload_hash,
+        payload_size_bytes=row.payload_size_bytes,
+        payload_truncated_at_bytes=row.payload_truncated_at_bytes,
+        created_at=row.created_at,
+    )
+
+
+def _session_snapshot(row: CloudSessionProjection) -> CloudSessionProjectionSnapshot:
+    return CloudSessionProjectionSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        cloud_workspace_id=row.cloud_workspace_id,
+        workspace_id=row.workspace_id,
+        session_id=row.session_id,
+        native_session_id=row.native_session_id,
+        source_agent_kind=row.source_agent_kind,
+        title=row.title,
+        status=row.status,
+        phase=row.phase,
+        live_config_json=row.live_config_json,
+        last_event_seq=row.last_event_seq,
+        last_event_at=row.last_event_at,
+        started_at=row.started_at,
+        ended_at=row.ended_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _item_snapshot(row: CloudTranscriptItem) -> CloudTranscriptItemSnapshot:
+    return CloudTranscriptItemSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        cloud_workspace_id=row.cloud_workspace_id,
+        workspace_id=row.workspace_id,
+        session_id=row.session_id,
+        item_id=row.item_id,
+        turn_id=row.turn_id,
+        kind=row.kind,
+        status=row.status,
+        source_agent_kind=row.source_agent_kind,
+        title=row.title,
+        text=row.text,
+        payload_json=row.payload_json,
+        first_seq=row.first_seq,
+        last_seq=row.last_seq,
+        completed_seq=row.completed_seq,
+        first_event_at=row.first_event_at,
+        last_event_at=row.last_event_at,
+    )
+
+
+def _interaction_snapshot(row: CloudPendingInteraction) -> CloudPendingInteractionSnapshot:
+    return CloudPendingInteractionSnapshot(
+        id=row.id,
+        target_id=row.target_id,
+        cloud_workspace_id=row.cloud_workspace_id,
+        workspace_id=row.workspace_id,
+        session_id=row.session_id,
+        request_id=row.request_id,
+        kind=row.kind,
+        status=row.status,
+        title=row.title,
+        description=row.description,
+        payload_json=row.payload_json,
+        requested_seq=row.requested_seq,
+        resolved_seq=row.resolved_seq,
+        requested_at=row.requested_at,
+        resolved_at=row.resolved_at,
+    )
+
+
+async def resolve_cloud_workspace_id(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    workspace_id: str | None,
+) -> UUID | None:
+    if not workspace_id:
+        return None
+    row = (
+        await db.execute(
+            select(CloudWorkspace.id)
+            .join(
+                CloudRuntimeEnvironment,
+                CloudRuntimeEnvironment.id == CloudWorkspace.runtime_environment_id,
+            )
+            .where(CloudRuntimeEnvironment.target_id == target_id)
+            .where(CloudWorkspace.anyharness_workspace_id == workspace_id)
+            .where(CloudWorkspace.archived_at.is_(None))
+            .order_by(CloudWorkspace.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+async def get_ingest_cursor(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> int:
+    row = await db.get(CloudEventIngestState, {"target_id": target_id, "session_id": session_id})
+    return int(row.last_contiguous_seq) if row is not None else 0
+
+
+async def upsert_ingest_cursor(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    worker_id: UUID | None,
+    cloud_workspace_id: UUID | None,
+    workspace_id: str | None,
+    last_contiguous_seq: int,
+) -> int:
+    now = utcnow()
+    row = await db.get(CloudEventIngestState, {"target_id": target_id, "session_id": session_id})
+    if row is None:
+        row = CloudEventIngestState(
+            target_id=target_id,
+            session_id=session_id,
+            worker_id=worker_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=workspace_id,
+            last_contiguous_seq=max(0, last_contiguous_seq),
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.worker_id = worker_id
+        row.cloud_workspace_id = cloud_workspace_id or row.cloud_workspace_id
+        row.workspace_id = workspace_id or row.workspace_id
+        row.last_contiguous_seq = max(row.last_contiguous_seq, last_contiguous_seq)
+        row.updated_at = now
+    await db.flush()
+    return int(row.last_contiguous_seq)
+
+
+async def get_session_event_usage(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> tuple[int, int]:
+    count_value, bytes_value = (
+        await db.execute(
+            select(
+                func.count(CloudSessionEvent.id),
+                func.coalesce(func.sum(CloudSessionEvent.payload_size_bytes), 0),
+            )
+            .where(CloudSessionEvent.target_id == target_id)
+            .where(CloudSessionEvent.session_id == session_id)
+        )
+    ).one()
+    return int(count_value or 0), int(bytes_value or 0)
+
+
+async def insert_event_if_new(
+    db: AsyncSession,
+    event: InsertSessionEvent,
+) -> tuple[CloudSessionEventSnapshot | None, bool, bool]:
+    existing = (
+        await db.execute(
+            select(CloudSessionEvent)
+            .where(CloudSessionEvent.target_id == event.target_id)
+            .where(CloudSessionEvent.session_id == event.session_id)
+            .where(CloudSessionEvent.anyharness_seq == event.seq)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return _event_snapshot(existing), False, existing.payload_hash == event.payload_hash
+    row = CloudSessionEvent(
+        target_id=event.target_id,
+        worker_id=event.worker_id,
+        cloud_workspace_id=event.cloud_workspace_id,
+        workspace_id=event.workspace_id,
+        session_id=event.session_id,
+        anyharness_seq=event.seq,
+        event_type=event.event_type,
+        source_kind=event.source_kind,
+        turn_id=event.turn_id,
+        item_id=event.item_id,
+        occurred_at=event.occurred_at,
+        payload_json=event.payload_json,
+        payload_hash=event.payload_hash,
+        payload_ref=None,
+        payload_size_bytes=event.payload_size_bytes,
+        payload_truncated_at_bytes=event.payload_truncated_at_bytes,
+        created_at=utcnow(),
+    )
+    try:
+        async with db.begin_nested():
+            db.add(row)
+            await db.flush()
+    except IntegrityError:
+        existing = (
+            await db.execute(
+                select(CloudSessionEvent)
+                .where(CloudSessionEvent.target_id == event.target_id)
+                .where(CloudSessionEvent.session_id == event.session_id)
+                .where(CloudSessionEvent.anyharness_seq == event.seq)
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            raise
+        return _event_snapshot(existing), False, existing.payload_hash == event.payload_hash
+    return _event_snapshot(row), True, True
+
+
+async def upsert_session_projection(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    cloud_workspace_id: UUID | None,
+    workspace_id: str | None,
+    session_id: str,
+    seq: int,
+    occurred_at: str | None,
+    status: str | None = None,
+    phase: str | None = None,
+    native_session_id: str | None = None,
+    source_agent_kind: str | None = None,
+    title: str | None = None,
+    live_config_json: str | None = None,
+    started_at: str | None = None,
+    ended_at: str | None = None,
+) -> CloudSessionProjectionSnapshot:
+    now = utcnow()
+    row = (
+        await db.execute(
+            select(CloudSessionProjection)
+            .where(CloudSessionProjection.target_id == target_id)
+            .where(CloudSessionProjection.session_id == session_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CloudSessionProjection(
+            target_id=target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            native_session_id=native_session_id,
+            source_agent_kind=source_agent_kind,
+            title=title,
+            status=status or "running",
+            phase=phase,
+            live_config_json=live_config_json,
+            last_event_seq=seq,
+            last_event_at=occurred_at,
+            started_at=started_at,
+            ended_at=ended_at,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        if seq < row.last_event_seq:
+            return _session_snapshot(row)
+        row.cloud_workspace_id = cloud_workspace_id or row.cloud_workspace_id
+        row.workspace_id = workspace_id or row.workspace_id
+        row.native_session_id = native_session_id or row.native_session_id
+        row.source_agent_kind = source_agent_kind or row.source_agent_kind
+        row.title = title if title is not None else row.title
+        row.status = status or row.status
+        row.phase = phase or row.phase
+        row.live_config_json = (
+            live_config_json if live_config_json is not None else row.live_config_json
+        )
+        row.last_event_seq = max(row.last_event_seq, seq)
+        row.last_event_at = occurred_at or row.last_event_at
+        row.started_at = started_at or row.started_at
+        row.ended_at = ended_at or row.ended_at
+        row.updated_at = now
+    await db.flush()
+    return _session_snapshot(row)
+
+
+async def upsert_transcript_item(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    cloud_workspace_id: UUID | None,
+    workspace_id: str | None,
+    session_id: str,
+    item_id: str,
+    turn_id: str | None,
+    seq: int,
+    occurred_at: str | None,
+    kind: str | None,
+    status: str | None,
+    source_agent_kind: str | None,
+    title: str | None,
+    text: str | None,
+    payload_json: str | None,
+    completed: bool,
+) -> CloudTranscriptItemSnapshot:
+    now = utcnow()
+    row = (
+        await db.execute(
+            select(CloudTranscriptItem)
+            .where(CloudTranscriptItem.target_id == target_id)
+            .where(CloudTranscriptItem.session_id == session_id)
+            .where(CloudTranscriptItem.item_id == item_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CloudTranscriptItem(
+            target_id=target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            item_id=item_id,
+            turn_id=turn_id,
+            kind=kind,
+            status=status,
+            source_agent_kind=source_agent_kind,
+            title=title,
+            text=text,
+            payload_json=payload_json,
+            first_seq=seq,
+            last_seq=seq,
+            completed_seq=seq if completed else None,
+            first_event_at=occurred_at,
+            last_event_at=occurred_at,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        if seq < row.last_seq:
+            return _item_snapshot(row)
+        row.cloud_workspace_id = cloud_workspace_id or row.cloud_workspace_id
+        row.workspace_id = workspace_id or row.workspace_id
+        row.turn_id = turn_id or row.turn_id
+        row.kind = kind or row.kind
+        row.status = status or row.status
+        row.source_agent_kind = source_agent_kind or row.source_agent_kind
+        row.title = title if title is not None else row.title
+        row.text = text if text is not None else row.text
+        row.payload_json = payload_json if payload_json is not None else row.payload_json
+        row.last_seq = max(row.last_seq, seq)
+        row.completed_seq = seq if completed else row.completed_seq
+        row.last_event_at = occurred_at or row.last_event_at
+        row.updated_at = now
+    await db.flush()
+    return _item_snapshot(row)
+
+
+async def upsert_pending_interaction(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    cloud_workspace_id: UUID | None,
+    workspace_id: str | None,
+    session_id: str,
+    request_id: str,
+    seq: int,
+    occurred_at: str | None,
+    kind: str | None,
+    title: str | None,
+    description: str | None,
+    payload_json: str | None,
+) -> CloudPendingInteractionSnapshot:
+    now = utcnow()
+    row = (
+        await db.execute(
+            select(CloudPendingInteraction)
+            .where(CloudPendingInteraction.target_id == target_id)
+            .where(CloudPendingInteraction.session_id == session_id)
+            .where(CloudPendingInteraction.request_id == request_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CloudPendingInteraction(
+            target_id=target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            request_id=request_id,
+            kind=kind,
+            status="pending",
+            title=title,
+            description=description,
+            payload_json=payload_json,
+            requested_seq=seq,
+            resolved_seq=None,
+            requested_at=occurred_at,
+            resolved_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        if row.status == "resolved":
+            return _interaction_snapshot(row)
+        row.cloud_workspace_id = cloud_workspace_id or row.cloud_workspace_id
+        row.workspace_id = workspace_id or row.workspace_id
+        row.kind = kind or row.kind
+        row.status = "pending"
+        row.title = title if title is not None else row.title
+        row.description = description if description is not None else row.description
+        row.payload_json = payload_json if payload_json is not None else row.payload_json
+        row.requested_seq = min(row.requested_seq, seq)
+        row.requested_at = row.requested_at or occurred_at
+        row.updated_at = now
+    await db.flush()
+    return _interaction_snapshot(row)
+
+
+async def resolve_pending_interaction(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    request_id: str,
+    seq: int,
+    occurred_at: str | None,
+    payload_json: str | None,
+) -> CloudPendingInteractionSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudPendingInteraction)
+            .where(CloudPendingInteraction.target_id == target_id)
+            .where(CloudPendingInteraction.session_id == session_id)
+            .where(CloudPendingInteraction.request_id == request_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CloudPendingInteraction(
+            target_id=target_id,
+            cloud_workspace_id=None,
+            workspace_id=None,
+            session_id=session_id,
+            request_id=request_id,
+            kind=None,
+            status="resolved",
+            title=None,
+            description=None,
+            payload_json=payload_json,
+            requested_seq=seq,
+            resolved_seq=seq,
+            requested_at=None,
+            resolved_at=occurred_at,
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+        db.add(row)
+        await db.flush()
+        return _interaction_snapshot(row)
+    row.status = "resolved"
+    row.resolved_seq = seq
+    row.resolved_at = occurred_at
+    row.payload_json = payload_json if payload_json is not None else row.payload_json
+    row.updated_at = utcnow()
+    await db.flush()
+    return _interaction_snapshot(row)
+
+
+async def get_session_projection(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> CloudSessionProjectionSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudSessionProjection)
+            .where(CloudSessionProjection.target_id == target_id)
+            .where(CloudSessionProjection.session_id == session_id)
+        )
+    ).scalar_one_or_none()
+    return _session_snapshot(row) if row is not None else None
+
+
+async def get_session_projection_by_session_id(
+    db: AsyncSession,
+    *,
+    session_id: str,
+) -> CloudSessionProjectionSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudSessionProjection)
+            .where(CloudSessionProjection.session_id == session_id)
+            .order_by(CloudSessionProjection.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return _session_snapshot(row) if row is not None else None
+
+
+async def list_transcript_items(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    limit: int = 200,
+) -> tuple[CloudTranscriptItemSnapshot, ...]:
+    rows = (
+        await db.execute(
+            select(CloudTranscriptItem)
+            .where(CloudTranscriptItem.target_id == target_id)
+            .where(CloudTranscriptItem.session_id == session_id)
+            .order_by(CloudTranscriptItem.first_seq.asc())
+            .limit(limit)
+        )
+    ).scalars()
+    return tuple(_item_snapshot(row) for row in rows)
+
+
+async def list_pending_interactions(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> tuple[CloudPendingInteractionSnapshot, ...]:
+    rows = (
+        await db.execute(
+            select(CloudPendingInteraction)
+            .where(CloudPendingInteraction.target_id == target_id)
+            .where(CloudPendingInteraction.session_id == session_id)
+            .where(CloudPendingInteraction.status == "pending")
+            .order_by(CloudPendingInteraction.requested_seq.asc())
+        )
+    ).scalars()
+    return tuple(_interaction_snapshot(row) for row in rows)
+
+
+async def list_events_after(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    after_seq: int,
+    limit: int = 200,
+) -> tuple[CloudSessionEventSnapshot, ...]:
+    rows = (
+        await db.execute(
+            select(CloudSessionEvent)
+            .where(CloudSessionEvent.target_id == target_id)
+            .where(CloudSessionEvent.session_id == session_id)
+            .where(CloudSessionEvent.anyharness_seq > after_seq)
+            .order_by(CloudSessionEvent.anyharness_seq.asc())
+            .limit(limit)
+        )
+    ).scalars()
+    return tuple(_event_snapshot(row) for row in rows)

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.credentials.api import router as credentials_router
+from proliferate.server.cloud.events.api import router as events_router
 from proliferate.server.cloud.mcp_catalog.api import router as mcp_catalog_router
 from proliferate.server.cloud.mcp_connections.api import router as mcp_connections_router
 from proliferate.server.cloud.mcp_materialization.api import router as mcp_materialization_router
@@ -31,4 +32,5 @@ router.include_router(mcp_oauth_router)
 router.include_router(webhooks_router)
 router.include_router(targets_router)
 router.include_router(commands_router)
+router.include_router(events_router)
 router.include_router(worker_router)

--- a/server/proliferate/server/cloud/events/api.py
+++ b/server/proliferate/server/cloud/events/api.py
@@ -1,0 +1,73 @@
+"""HTTP routes for cloud-synced session snapshots and streams."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.events.models import CloudSessionSnapshotResponse
+from proliferate.server.cloud.events.service import (
+    ensure_visible_session_target,
+    get_session_snapshot,
+    stream_session_events,
+)
+
+router = APIRouter(prefix="/sessions", tags=["cloud-sessions"])
+
+
+@router.get("/{session_id}/snapshot", response_model=CloudSessionSnapshotResponse)
+async def get_session_snapshot_endpoint(
+    session_id: str,
+    target_id: UUID = Query(alias="targetId"),
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudSessionSnapshotResponse:
+    try:
+        resolved_target_id = await ensure_visible_session_target(
+            db,
+            target_id=target_id,
+            session_id=session_id,
+            user_id=user.id,
+        )
+        return await get_session_snapshot(
+            db,
+            target_id=resolved_target_id,
+            session_id=session_id,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.get("/{session_id}/stream")
+async def stream_session_endpoint(
+    session_id: str,
+    target_id: UUID = Query(alias="targetId"),
+    after_seq: int = Query(default=0, alias="afterSeq"),
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> StreamingResponse:
+    try:
+        resolved_target_id = await ensure_visible_session_target(
+            db,
+            target_id=target_id,
+            session_id=session_id,
+            user_id=user.id,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+    return StreamingResponse(
+        stream_session_events(
+            target_id=resolved_target_id,
+            session_id=session_id,
+            after_seq=after_seq,
+        ),
+        media_type="text/event-stream",
+    )

--- a/server/proliferate/server/cloud/events/domain/cursors.py
+++ b/server/proliferate/server/cloud/events/domain/cursors.py
@@ -1,0 +1,16 @@
+"""Cloud event-ingest cursor rules."""
+
+from __future__ import annotations
+
+
+def advance_contiguous_cursor(current: int, received_seqs: list[int]) -> int:
+    """Advance across a sorted-or-unsorted batch of received sequence numbers."""
+    cursor = max(0, current)
+    for seq in sorted(set(received_seqs)):
+        if seq <= cursor:
+            continue
+        if seq == cursor + 1:
+            cursor = seq
+            continue
+        break
+    return cursor

--- a/server/proliferate/server/cloud/events/domain/payload_policy.py
+++ b/server/proliferate/server/cloud/events/domain/payload_policy.py
@@ -1,0 +1,100 @@
+"""Cloud event payload retention decisions."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import cast
+
+LIVE_ONLY_EVENT_TYPES = frozenset(
+    {
+        "item_delta",
+        "assistant_message_delta",
+        "tool_call_delta",
+        "token_delta",
+        "terminal_output_delta",
+        "browser_frame_delta",
+        "computer_use_frame_delta",
+    }
+)
+
+INLINE_SOFT_CAP_BYTES = 64 * 1024
+INLINE_HARD_CAP_BYTES = 256 * 1024
+
+RAW_BODY_REPLACEMENT = {
+    "retention": "stripped",
+    "reason": "raw tool bodies are not retained in cloud event sync",
+}
+
+
+@dataclass(frozen=True)
+class PayloadPolicyDecision:
+    durable: bool
+    payload_json: str | None
+    payload_hash: str
+    payload_size_bytes: int
+    payload_truncated_at_bytes: int | None
+
+
+def event_is_durable(event_type: str) -> bool:
+    return event_type not in LIVE_ONLY_EVENT_TYPES
+
+
+def retained_payload(event_type: str, envelope: dict[str, object]) -> PayloadPolicyDecision:
+    if not event_is_durable(event_type):
+        return PayloadPolicyDecision(
+            durable=False,
+            payload_json=None,
+            payload_hash=sha256(b"").hexdigest(),
+            payload_size_bytes=0,
+            payload_truncated_at_bytes=None,
+        )
+    sanitized = _strip_raw_bodies(deepcopy(envelope))
+    encoded = json.dumps(sanitized, separators=(",", ":"), sort_keys=True)
+    size_bytes = len(encoded.encode("utf-8"))
+    if size_bytes <= INLINE_HARD_CAP_BYTES:
+        return PayloadPolicyDecision(
+            durable=True,
+            payload_json=encoded,
+            payload_hash=sha256(encoded.encode("utf-8")).hexdigest(),
+            payload_size_bytes=size_bytes,
+            payload_truncated_at_bytes=None,
+        )
+    truncated = encoded.encode("utf-8")[:INLINE_HARD_CAP_BYTES].decode(
+        "utf-8",
+        errors="ignore",
+    )
+    return PayloadPolicyDecision(
+        durable=True,
+        payload_json=json.dumps(
+            {
+                "type": event_type,
+                "payload": truncated,
+                "payloadTruncated": True,
+                "payloadOriginalBytes": size_bytes,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        payload_hash=sha256(encoded.encode("utf-8")).hexdigest(),
+        payload_size_bytes=size_bytes,
+        payload_truncated_at_bytes=INLINE_HARD_CAP_BYTES,
+    )
+
+
+def _strip_raw_bodies(value: object) -> object:
+    if isinstance(value, dict):
+        sanitized: dict[str, object] = {}
+        for key, child in cast("dict[object, object]", value).items():
+            if not isinstance(key, str):
+                continue
+            if key in {"rawInput", "rawOutput", "raw_input", "raw_output"}:
+                sanitized[key] = RAW_BODY_REPLACEMENT
+            else:
+                sanitized[key] = _strip_raw_bodies(child)
+        return sanitized
+    if isinstance(value, list):
+        return [_strip_raw_bodies(child) for child in value]
+    return value

--- a/server/proliferate/server/cloud/events/domain/projection.py
+++ b/server/proliferate/server/cloud/events/domain/projection.py
@@ -1,0 +1,65 @@
+"""Pure helpers for Cloud session/transcript projections."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+
+def event_type(envelope: Mapping[str, object]) -> str:
+    event = envelope.get("event")
+    if isinstance(event, dict):
+        value = cast("Mapping[str, object]", event).get("type")
+        if isinstance(value, str) and value:
+            return value
+    return "unknown"
+
+
+def source_kind_for_event(event: Mapping[str, object]) -> str:
+    kind = _transcript_item(event).get("kind")
+    if kind == "user_message":
+        return "user"
+    if kind in {"assistant_message", "reasoning", "plan", "proposed_plan"}:
+        return "assistant"
+    if kind == "tool_invocation":
+        return "tool"
+    return "system"
+
+
+def transcript_item_id(envelope: Mapping[str, object]) -> str | None:
+    item_id = envelope.get("itemId")
+    if isinstance(item_id, str) and item_id:
+        return item_id
+    item = _transcript_item(envelope.get("event"))
+    for key in ("messageId", "toolCallId", "promptId"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+    seq = envelope.get("seq")
+    if isinstance(seq, int):
+        return f"seq:{seq}"
+    return None
+
+
+def transcript_item_payload(event: Mapping[str, object]) -> dict[str, object]:
+    return _transcript_item(event)
+
+
+def transcript_item_text(item: Mapping[str, object]) -> str | None:
+    parts = item.get("contentParts")
+    if not isinstance(parts, list):
+        return None
+    text_parts: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") in {"text", "reasoning"} and isinstance(part.get("text"), str):
+            text_parts.append(part["text"])
+    return "".join(text_parts) if text_parts else None
+
+
+def _transcript_item(event: object) -> dict[str, object]:
+    if not isinstance(event, dict):
+        return {}
+    item = cast("Mapping[str, object]", event).get("item")
+    return cast("dict[str, object]", item) if isinstance(item, dict) else {}

--- a/server/proliferate/server/cloud/events/models.py
+++ b/server/proliferate/server/cloud/events/models.py
@@ -1,0 +1,189 @@
+"""Schemas for cloud event ingest, projections, and session streams."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.cloud_sync import events as events_store
+
+
+class WorkerSessionEventEnvelope(BaseModel):
+    workspace_id: str | None = Field(default=None, alias="workspaceId")
+    session_id: str = Field(alias="sessionId")
+    seq: int
+    timestamp: str | None = None
+    turn_id: str | None = Field(default=None, alias="turnId")
+    item_id: str | None = Field(default=None, alias="itemId")
+    event: dict[str, object]
+
+
+class WorkerEventBatchRequest(BaseModel):
+    events: list[WorkerSessionEventEnvelope] = Field(default_factory=list, max_length=200)
+
+
+class WorkerEventSessionAck(BaseModel):
+    session_id: str = Field(serialization_alias="sessionId")
+    last_contiguous_seq: int = Field(serialization_alias="lastContiguousSeq")
+
+
+class WorkerEventBatchResponse(BaseModel):
+    accepted_events: int = Field(serialization_alias="acceptedEvents")
+    duplicate_events: int = Field(serialization_alias="duplicateEvents")
+    live_only_events: int = Field(serialization_alias="liveOnlyEvents")
+    session_acks: list[WorkerEventSessionAck] = Field(serialization_alias="sessionAcks")
+
+
+class CloudSessionProjectionResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    cloud_workspace_id: str | None = Field(default=None, serialization_alias="cloudWorkspaceId")
+    workspace_id: str | None = Field(default=None, serialization_alias="workspaceId")
+    session_id: str = Field(serialization_alias="sessionId")
+    native_session_id: str | None = Field(default=None, serialization_alias="nativeSessionId")
+    source_agent_kind: str | None = Field(default=None, serialization_alias="sourceAgentKind")
+    title: str | None = None
+    status: str
+    phase: str | None = None
+    live_config: dict[str, object] | None = Field(default=None, serialization_alias="liveConfig")
+    last_event_seq: int = Field(serialization_alias="lastEventSeq")
+    last_event_at: str | None = Field(default=None, serialization_alias="lastEventAt")
+    started_at: str | None = Field(default=None, serialization_alias="startedAt")
+    ended_at: str | None = Field(default=None, serialization_alias="endedAt")
+
+
+class CloudTranscriptItemResponse(BaseModel):
+    item_id: str = Field(serialization_alias="itemId")
+    turn_id: str | None = Field(default=None, serialization_alias="turnId")
+    kind: str | None = None
+    status: str | None = None
+    source_agent_kind: str | None = Field(default=None, serialization_alias="sourceAgentKind")
+    title: str | None = None
+    text: str | None = None
+    payload: dict[str, object] | None = None
+    first_seq: int = Field(serialization_alias="firstSeq")
+    last_seq: int = Field(serialization_alias="lastSeq")
+    completed_seq: int | None = Field(default=None, serialization_alias="completedSeq")
+    first_event_at: str | None = Field(default=None, serialization_alias="firstEventAt")
+    last_event_at: str | None = Field(default=None, serialization_alias="lastEventAt")
+
+
+class CloudPendingInteractionResponse(BaseModel):
+    request_id: str = Field(serialization_alias="requestId")
+    kind: str | None = None
+    status: str
+    title: str | None = None
+    description: str | None = None
+    payload: dict[str, object] | None = None
+    requested_seq: int = Field(serialization_alias="requestedSeq")
+    resolved_seq: int | None = Field(default=None, serialization_alias="resolvedSeq")
+    requested_at: str | None = Field(default=None, serialization_alias="requestedAt")
+    resolved_at: str | None = Field(default=None, serialization_alias="resolvedAt")
+
+
+class CloudSessionSnapshotResponse(BaseModel):
+    session: CloudSessionProjectionResponse
+    transcript_items: list[CloudTranscriptItemResponse] = Field(
+        serialization_alias="transcriptItems",
+    )
+    pending_interactions: list[CloudPendingInteractionResponse] = Field(
+        serialization_alias="pendingInteractions",
+    )
+
+
+class CloudSessionEventResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    session_id: str = Field(serialization_alias="sessionId")
+    seq: int
+    event_type: str = Field(serialization_alias="eventType")
+    source_kind: str = Field(serialization_alias="sourceKind")
+    turn_id: str | None = Field(default=None, serialization_alias="turnId")
+    item_id: str | None = Field(default=None, serialization_alias="itemId")
+    occurred_at: str | None = Field(default=None, serialization_alias="occurredAt")
+    payload: dict[str, object] | None = None
+
+
+def session_projection_response(
+    value: events_store.CloudSessionProjectionSnapshot,
+) -> CloudSessionProjectionResponse:
+    return CloudSessionProjectionResponse(
+        target_id=str(value.target_id),
+        cloud_workspace_id=_uuid_str(value.cloud_workspace_id),
+        workspace_id=value.workspace_id,
+        session_id=value.session_id,
+        native_session_id=value.native_session_id,
+        source_agent_kind=value.source_agent_kind,
+        title=value.title,
+        status=value.status,
+        phase=value.phase,
+        live_config=_json_dict(value.live_config_json),
+        last_event_seq=value.last_event_seq,
+        last_event_at=value.last_event_at,
+        started_at=value.started_at,
+        ended_at=value.ended_at,
+    )
+
+
+def transcript_item_response(
+    value: events_store.CloudTranscriptItemSnapshot,
+) -> CloudTranscriptItemResponse:
+    return CloudTranscriptItemResponse(
+        item_id=value.item_id,
+        turn_id=value.turn_id,
+        kind=value.kind,
+        status=value.status,
+        source_agent_kind=value.source_agent_kind,
+        title=value.title,
+        text=value.text,
+        payload=_json_dict(value.payload_json),
+        first_seq=value.first_seq,
+        last_seq=value.last_seq,
+        completed_seq=value.completed_seq,
+        first_event_at=value.first_event_at,
+        last_event_at=value.last_event_at,
+    )
+
+
+def pending_interaction_response(
+    value: events_store.CloudPendingInteractionSnapshot,
+) -> CloudPendingInteractionResponse:
+    return CloudPendingInteractionResponse(
+        request_id=value.request_id,
+        kind=value.kind,
+        status=value.status,
+        title=value.title,
+        description=value.description,
+        payload=_json_dict(value.payload_json),
+        requested_seq=value.requested_seq,
+        resolved_seq=value.resolved_seq,
+        requested_at=value.requested_at,
+        resolved_at=value.resolved_at,
+    )
+
+
+def session_event_response(
+    value: events_store.CloudSessionEventSnapshot,
+) -> CloudSessionEventResponse:
+    return CloudSessionEventResponse(
+        target_id=str(value.target_id),
+        session_id=value.session_id,
+        seq=value.seq,
+        event_type=value.event_type,
+        source_kind=value.source_kind,
+        turn_id=value.turn_id,
+        item_id=value.item_id,
+        occurred_at=value.occurred_at,
+        payload=_json_dict(value.payload_json),
+    )
+
+
+def _json_dict(value: str | None) -> dict[str, object] | None:
+    if value is None:
+        return None
+    parsed = json.loads(value)
+    return parsed if isinstance(parsed, dict) else {"value": parsed}
+
+
+def _uuid_str(value: UUID | None) -> str | None:
+    return str(value) if value is not None else None

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -1,0 +1,433 @@
+"""Application service for worker event ingest and cloud session projections."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import engine as db_engine
+from proliferate.db.store.cloud_sync import events as events_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.events.domain.cursors import advance_contiguous_cursor
+from proliferate.server.cloud.events.domain.payload_policy import retained_payload
+from proliferate.server.cloud.events.domain.projection import (
+    event_type,
+    source_kind_for_event,
+    transcript_item_id,
+    transcript_item_payload,
+    transcript_item_text,
+)
+from proliferate.server.cloud.events.models import (
+    CloudSessionSnapshotResponse,
+    WorkerEventBatchRequest,
+    WorkerEventBatchResponse,
+    WorkerEventSessionAck,
+    pending_interaction_response,
+    session_event_response,
+    session_projection_response,
+    transcript_item_response,
+)
+from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
+
+SESSION_DURABLE_EVENT_HARD_CAP = 10_000
+SESSION_PAYLOAD_BYTES_HARD_CAP = 25 * 1024 * 1024
+STREAM_POLL_SECONDS = 0.5
+STREAM_EVENT_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class SessionProjectionPatch:
+    status: str | None = None
+    phase: str | None = None
+    native_session_id: str | None = None
+    source_agent_kind: str | None = None
+    title: str | None = None
+    live_config_json: str | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
+
+
+async def ingest_worker_event_batch(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerEventBatchRequest,
+) -> WorkerEventBatchResponse:
+    accepted_events = 0
+    duplicate_events = 0
+    live_only_events = 0
+    received_by_session: dict[str, list[int]] = defaultdict(list)
+    workspace_by_session: dict[str, str | None] = {}
+    cloud_workspace_by_session: dict[str, UUID | None] = {}
+
+    for event in body.events:
+        if event.seq <= 0:
+            raise CloudApiError(
+                "cloud_event_invalid_sequence",
+                "Event sequence must be positive.",
+                status_code=400,
+            )
+        envelope = event.model_dump(by_alias=True)
+        current_event_type = event_type(envelope)
+        current_workspace_id = event.workspace_id
+        workspace_by_session.setdefault(event.session_id, current_workspace_id)
+        cloud_workspace_id = cloud_workspace_by_session.get(event.session_id)
+        if event.session_id not in cloud_workspace_by_session:
+            cloud_workspace_id = await events_store.resolve_cloud_workspace_id(
+                db,
+                target_id=auth.target_id,
+                workspace_id=current_workspace_id,
+            )
+            cloud_workspace_by_session[event.session_id] = cloud_workspace_id
+
+        received_by_session[event.session_id].append(event.seq)
+        payload_decision = retained_payload(current_event_type, envelope)
+        if not payload_decision.durable:
+            live_only_events += 1
+            continue
+        event_count, payload_bytes = await events_store.get_session_event_usage(
+            db,
+            target_id=auth.target_id,
+            session_id=event.session_id,
+        )
+        if event_count >= SESSION_DURABLE_EVENT_HARD_CAP:
+            raise CloudApiError(
+                "cloud_event_session_cap_exceeded",
+                "Session cloud event retention cap exceeded.",
+                status_code=413,
+            )
+        if payload_bytes + payload_decision.payload_size_bytes > SESSION_PAYLOAD_BYTES_HARD_CAP:
+            raise CloudApiError(
+                "cloud_event_session_payload_cap_exceeded",
+                "Session cloud payload retention cap exceeded.",
+                status_code=413,
+            )
+        inserted, is_new, duplicate_matches = await events_store.insert_event_if_new(
+            db,
+            events_store.InsertSessionEvent(
+                target_id=auth.target_id,
+                worker_id=auth.worker_id,
+                cloud_workspace_id=cloud_workspace_id,
+                workspace_id=current_workspace_id,
+                session_id=event.session_id,
+                seq=event.seq,
+                event_type=current_event_type,
+                source_kind=source_kind_for_event(event.event),
+                turn_id=event.turn_id,
+                item_id=event.item_id,
+                occurred_at=event.timestamp,
+                payload_json=payload_decision.payload_json,
+                payload_hash=payload_decision.payload_hash,
+                payload_size_bytes=payload_decision.payload_size_bytes,
+                payload_truncated_at_bytes=payload_decision.payload_truncated_at_bytes,
+            ),
+        )
+        if not duplicate_matches:
+            raise CloudApiError(
+                "cloud_event_duplicate_mismatch",
+                "Duplicate event sequence has a different payload hash.",
+                status_code=409,
+            )
+        if inserted is None or not is_new:
+            duplicate_events += 1
+            continue
+        accepted_events += 1
+        await _apply_projection(
+            db,
+            auth=auth,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=current_workspace_id,
+            envelope=envelope,
+            payload_json=payload_decision.payload_json,
+        )
+
+    session_acks: list[WorkerEventSessionAck] = []
+    for session_id, seqs in received_by_session.items():
+        current = await events_store.get_ingest_cursor(
+            db,
+            target_id=auth.target_id,
+            session_id=session_id,
+        )
+        last_contiguous_seq = advance_contiguous_cursor(current, seqs)
+        cursor = await events_store.upsert_ingest_cursor(
+            db,
+            target_id=auth.target_id,
+            session_id=session_id,
+            worker_id=auth.worker_id,
+            cloud_workspace_id=cloud_workspace_by_session.get(session_id),
+            workspace_id=workspace_by_session.get(session_id),
+            last_contiguous_seq=last_contiguous_seq,
+        )
+        session_acks.append(
+            WorkerEventSessionAck(
+                session_id=session_id,
+                last_contiguous_seq=cursor,
+            )
+        )
+
+    return WorkerEventBatchResponse(
+        accepted_events=accepted_events,
+        duplicate_events=duplicate_events,
+        live_only_events=live_only_events,
+        session_acks=session_acks,
+    )
+
+
+async def get_session_snapshot(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> CloudSessionSnapshotResponse:
+    projection = await events_store.get_session_projection(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    if projection is None:
+        raise CloudApiError(
+            "cloud_session_not_found",
+            "Synced session not found.",
+            status_code=404,
+        )
+    transcript_items = await events_store.list_transcript_items(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    pending_interactions = await events_store.list_pending_interactions(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    return CloudSessionSnapshotResponse(
+        session=session_projection_response(projection),
+        transcript_items=[transcript_item_response(item) for item in transcript_items],
+        pending_interactions=[
+            pending_interaction_response(interaction) for interaction in pending_interactions
+        ],
+    )
+
+
+async def ensure_visible_session_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    user_id: UUID,
+) -> UUID:
+    target = await targets_store.get_visible_target_by_id(
+        db,
+        target_id=target_id,
+        user_id=user_id,
+    )
+    if target is None:
+        raise CloudApiError(
+            "cloud_session_not_found",
+            "Synced session not found.",
+            status_code=404,
+        )
+    projection = await events_store.get_session_projection(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    if projection is None:
+        raise CloudApiError(
+            "cloud_session_not_found",
+            "Synced session not found.",
+            status_code=404,
+        )
+    return target_id
+
+
+async def list_session_events_after(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    after_seq: int,
+    limit: int = 200,
+) -> list[dict[str, object]]:
+    events = await events_store.list_events_after(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+        after_seq=after_seq,
+        limit=limit,
+    )
+    return [session_event_response(event).model_dump(by_alias=True) for event in events]
+
+
+async def stream_session_events(
+    *,
+    target_id: UUID,
+    session_id: str,
+    after_seq: int,
+) -> AsyncIterator[str]:
+    cursor = max(0, after_seq)
+    while True:
+        async with db_engine.async_session_factory() as stream_db:
+            events = await list_session_events_after(
+                stream_db,
+                target_id=target_id,
+                session_id=session_id,
+                after_seq=cursor,
+                limit=STREAM_EVENT_LIMIT,
+            )
+        for event in events:
+            seq = _int_value(event["seq"])
+            cursor = max(cursor, seq)
+            yield _sse_event(
+                event="session_event",
+                event_id=str(seq),
+                data=event,
+            )
+        if not events:
+            yield ": keepalive\n\n"
+            await asyncio.sleep(STREAM_POLL_SECONDS)
+
+
+async def _apply_projection(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    cloud_workspace_id: UUID | None,
+    workspace_id: str | None,
+    envelope: dict[str, object],
+    payload_json: str | None,
+) -> None:
+    session_id = str(envelope["sessionId"])
+    seq = _int_value(envelope["seq"])
+    occurred_at = envelope.get("timestamp")
+    timestamp = occurred_at if isinstance(occurred_at, str) else None
+    event = envelope.get("event")
+    event_payload = event if isinstance(event, dict) else {}
+    current_event_type = event_type(envelope)
+    patch = _session_projection_patch(current_event_type, event_payload, timestamp)
+    await events_store.upsert_session_projection(
+        db,
+        target_id=auth.target_id,
+        cloud_workspace_id=cloud_workspace_id,
+        workspace_id=workspace_id,
+        session_id=session_id,
+        seq=seq,
+        occurred_at=timestamp,
+        status=patch.status,
+        phase=patch.phase,
+        native_session_id=patch.native_session_id,
+        source_agent_kind=patch.source_agent_kind,
+        title=patch.title,
+        live_config_json=patch.live_config_json,
+        started_at=patch.started_at,
+        ended_at=patch.ended_at,
+    )
+
+    if current_event_type in {"item_started", "item_completed"}:
+        item_id = transcript_item_id(envelope)
+        if item_id is not None:
+            item = transcript_item_payload(event_payload)
+            await events_store.upsert_transcript_item(
+                db,
+                target_id=auth.target_id,
+                cloud_workspace_id=cloud_workspace_id,
+                workspace_id=workspace_id,
+                session_id=session_id,
+                item_id=item_id,
+                turn_id=_str_or_none(envelope.get("turnId")),
+                seq=seq,
+                occurred_at=timestamp,
+                kind=_str_or_none(item.get("kind")),
+                status=_str_or_none(item.get("status")),
+                source_agent_kind=_str_or_none(item.get("sourceAgentKind")),
+                title=_str_or_none(item.get("title")),
+                text=transcript_item_text(item),
+                payload_json=payload_json,
+                completed=current_event_type == "item_completed",
+            )
+    elif current_event_type == "interaction_requested":
+        request_id = _str_or_none(event_payload.get("requestId"))
+        if request_id:
+            await events_store.upsert_pending_interaction(
+                db,
+                target_id=auth.target_id,
+                cloud_workspace_id=cloud_workspace_id,
+                workspace_id=workspace_id,
+                session_id=session_id,
+                request_id=request_id,
+                seq=seq,
+                occurred_at=timestamp,
+                kind=_str_or_none(event_payload.get("kind")),
+                title=_str_or_none(event_payload.get("title")),
+                description=_str_or_none(event_payload.get("description")),
+                payload_json=payload_json,
+            )
+    elif current_event_type == "interaction_resolved":
+        request_id = _str_or_none(event_payload.get("requestId"))
+        if request_id:
+            await events_store.resolve_pending_interaction(
+                db,
+                target_id=auth.target_id,
+                session_id=session_id,
+                request_id=request_id,
+                seq=seq,
+                occurred_at=timestamp,
+                payload_json=payload_json,
+            )
+
+
+def _session_projection_patch(
+    event_type_value: str,
+    event: dict[str, object],
+    timestamp: str | None,
+) -> SessionProjectionPatch:
+    if event_type_value == "session_started":
+        return SessionProjectionPatch(
+            status="running",
+            phase="running",
+            native_session_id=_str_or_none(event.get("nativeSessionId")),
+            source_agent_kind=_str_or_none(event.get("sourceAgentKind")),
+            started_at=timestamp,
+        )
+    if event_type_value == "session_ended":
+        return SessionProjectionPatch(status="ended", phase="ended", ended_at=timestamp)
+    if event_type_value == "turn_started":
+        return SessionProjectionPatch(status="running", phase="turn_running")
+    if event_type_value == "turn_ended":
+        return SessionProjectionPatch(status="idle", phase="idle")
+    if event_type_value == "session_info_update":
+        return SessionProjectionPatch(title=_str_or_none(event.get("title")))
+    if event_type_value == "config_option_update":
+        live_config = event.get("liveConfig")
+        return SessionProjectionPatch(
+            live_config_json=json.dumps(
+                live_config if isinstance(live_config, dict) else event,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    return SessionProjectionPatch()
+
+
+def _str_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_value(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    raise TypeError(f"Expected integer-compatible value, got {type(value).__name__}.")
+
+
+def _sse_event(*, event: str, event_id: str, data: object) -> str:
+    encoded = json.dumps(data, separators=(",", ":"), sort_keys=True)
+    return f"id: {event_id}\nevent: {event}\ndata: {encoded}\n\n"

--- a/server/proliferate/server/cloud/worker/api.py
+++ b/server/proliferate/server/cloud/worker/api.py
@@ -9,6 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.engine import get_async_session
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.events.models import (
+    WorkerEventBatchRequest,
+    WorkerEventBatchResponse,
+)
 from proliferate.server.cloud.worker.models import (
     WorkerCommandDeliveryRequest,
     WorkerCommandLeaseRequest,
@@ -28,6 +32,7 @@ from proliferate.server.cloud.worker.service import (
     lease_worker_command,
     record_command_delivery,
     record_command_result,
+    record_event_batch,
     record_heartbeat,
     record_inventory,
 )
@@ -119,5 +124,18 @@ async def worker_command_result_endpoint(
             command_id=command_id,
             body=body,
         )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.post("/events/batches", response_model=WorkerEventBatchResponse)
+async def worker_event_batch_endpoint(
+    body: WorkerEventBatchRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerEventBatchResponse:
+    try:
+        auth = await authenticate_worker(db, authorization=authorization)
+        return await record_event_batch(db, auth=auth, body=body)
     except CloudApiError as error:
         raise_cloud_error(error)

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -25,6 +25,11 @@ from proliferate.db.store.cloud_sync import inventory as inventory_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.events.models import (
+    WorkerEventBatchRequest,
+    WorkerEventBatchResponse,
+)
+from proliferate.server.cloud.events.service import ingest_worker_event_batch
 from proliferate.server.cloud.worker.domain.rules import (
     clamp_command_lease_seconds,
     compact_json,
@@ -109,9 +114,7 @@ def _command_envelope(
         observed_event_seq=command.observed_event_seq,
         preconditions=_parse_json_dict(command.preconditions_json),
         lease_id=command.lease_id or "",
-        lease_expires_at=command.lease_expires_at.isoformat()
-        if command.lease_expires_at
-        else "",
+        lease_expires_at=command.lease_expires_at.isoformat() if command.lease_expires_at else "",
     )
 
 
@@ -385,3 +388,12 @@ async def record_command_result(
         status=command.status,
         updated=True,
     )
+
+
+async def record_event_batch(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerEventBatchRequest,
+) -> WorkerEventBatchResponse:
+    return await ingest_worker_event_batch(db, auth=auth, body=body)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -100,6 +100,7 @@ module = [
     "proliferate.server.cloud.workspaces.models",
     "proliferate.server.catalogs.models",
     "proliferate.server.cloud.credentials.models",
+    "proliferate.server.cloud.events.models",
     "proliferate.server.cloud.repos.models",
     "proliferate.server.support.models",
     "proliferate.config",

--- a/server/tests/integration/test_cloud_event_sync_api.py
+++ b/server/tests/integration/test_cloud_event_sync_api.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+from tests.e2e.cloud.helpers.shared import AuthSession
+
+
+async def _create_enrolled_target(
+    client: AsyncClient,
+    auth: AuthSession,
+    *,
+    suffix: str = "events",
+) -> tuple[str, dict[str, str]]:
+    create = await client.post(
+        "/v1/cloud/targets/enrollments",
+        headers=auth.headers,
+        json={
+            "displayName": f"Event Target {suffix}",
+            "kind": "ssh",
+            "ownerScope": "personal",
+        },
+    )
+    assert create.status_code == 200
+    enrollment = create.json()
+    worker_enroll = await client.post(
+        "/v1/cloud/worker/enroll",
+        json={
+            "enrollmentToken": enrollment["enrollmentToken"],
+            "machineFingerprint": f"{suffix}-machine",
+            "hostname": f"{suffix}-target",
+            "workerVersion": "0.1.0",
+        },
+    )
+    assert worker_enroll.status_code == 200
+    worker = worker_enroll.json()
+    return enrollment["target"]["id"], {"Authorization": f"Bearer {worker['workerToken']}"}
+
+
+class TestCloudEventSyncApi:
+    @pytest.mark.asyncio
+    async def test_worker_event_batch_dedupes_and_updates_session_snapshot(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-event-sync",
+        )
+        target_id, worker_headers = await _create_enrolled_target(client, auth)
+
+        batch = {
+            "events": [
+                {
+                    "workspaceId": "workspace-1",
+                    "sessionId": "session-1",
+                    "seq": 1,
+                    "timestamp": "2026-05-13T00:00:00Z",
+                    "event": {
+                        "type": "session_started",
+                        "nativeSessionId": "native-1",
+                        "sourceAgentKind": "codex",
+                    },
+                },
+                {
+                    "workspaceId": "workspace-1",
+                    "sessionId": "session-1",
+                    "seq": 2,
+                    "timestamp": "2026-05-13T00:00:01Z",
+                    "itemId": "item-1",
+                    "event": {"type": "item_delta", "delta": {"appendText": "hel"}},
+                },
+                {
+                    "workspaceId": "workspace-1",
+                    "sessionId": "session-1",
+                    "seq": 3,
+                    "timestamp": "2026-05-13T00:00:02Z",
+                    "event": {"type": "turn_started"},
+                },
+                {
+                    "workspaceId": "workspace-1",
+                    "sessionId": "session-1",
+                    "seq": 4,
+                    "timestamp": "2026-05-13T00:00:03Z",
+                    "turnId": "turn-1",
+                    "itemId": "item-1",
+                    "event": {
+                        "type": "item_completed",
+                        "item": {
+                            "kind": "assistant_message",
+                            "status": "completed",
+                            "sourceAgentKind": "codex",
+                            "rawInput": {"secret": "do-not-store"},
+                            "contentParts": [{"type": "text", "text": "hello"}],
+                        },
+                    },
+                },
+                {
+                    "workspaceId": "workspace-1",
+                    "sessionId": "session-1",
+                    "seq": 5,
+                    "timestamp": "2026-05-13T00:00:04Z",
+                    "event": {
+                        "type": "interaction_requested",
+                        "requestId": "interaction-1",
+                        "kind": "permission",
+                        "title": "Approve command",
+                        "description": "Agent wants to run tests.",
+                        "source": {},
+                        "payload": {
+                            "type": "permission",
+                            "options": [
+                                {
+                                    "optionId": "allow_once",
+                                    "label": "Allow",
+                                    "kind": "allow_once",
+                                }
+                            ],
+                        },
+                    },
+                },
+            ]
+        }
+        uploaded = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json=batch,
+        )
+        assert uploaded.status_code == 200
+        assert uploaded.json()["acceptedEvents"] == 4
+        assert uploaded.json()["liveOnlyEvents"] == 1
+        assert uploaded.json()["sessionAcks"] == [
+            {"sessionId": "session-1", "lastContiguousSeq": 5}
+        ]
+
+        duplicate = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json=batch,
+        )
+        assert duplicate.status_code == 200
+        assert duplicate.json()["acceptedEvents"] == 0
+        assert duplicate.json()["duplicateEvents"] == 4
+        assert duplicate.json()["sessionAcks"] == [
+            {"sessionId": "session-1", "lastContiguousSeq": 5}
+        ]
+
+        snapshot = await client.get(
+            f"/v1/cloud/sessions/session-1/snapshot?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert snapshot.status_code == 200
+        body = snapshot.json()
+        assert body["session"]["sessionId"] == "session-1"
+        assert body["session"]["sourceAgentKind"] == "codex"
+        assert body["session"]["lastEventSeq"] == 5
+        assert body["transcriptItems"][0]["text"] == "hello"
+        assert body["transcriptItems"][0]["payload"]["event"]["item"]["rawInput"]["retention"] == (
+            "stripped"
+        )
+        assert body["pendingInteractions"][0]["requestId"] == "interaction-1"
+        assert body["pendingInteractions"][0]["title"] == "Approve command"
+
+        mismatch = dict(batch)
+        mismatch_events = list(batch["events"])
+        mismatch_first = dict(mismatch_events[0])
+        mismatch_first["event"] = {
+            "type": "session_started",
+            "nativeSessionId": "different-native",
+            "sourceAgentKind": "codex",
+        }
+        mismatch_events[0] = mismatch_first
+        mismatch["events"] = mismatch_events
+        duplicate_mismatch = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json=mismatch,
+        )
+        assert duplicate_mismatch.status_code == 409
+        assert duplicate_mismatch.json()["detail"]["code"] == "cloud_event_duplicate_mismatch"


### PR DESCRIPTION
## Summary
- add cloud event ingest/projection tables and worker event batch API
- add worker-side AnyHarness event tailing and cloud event upload
- expose cloud session snapshot/stream routes backed by target-scoped projections
- harden ingest with payload retention, duplicate hash checks, projection ordering guards, and cursor acks

## Verification
- uv run ruff check proliferate/db/models/cloud proliferate/db/store/cloud_sync proliferate/server/cloud/events proliferate/server/cloud/worker tests/integration/test_cloud_event_sync_api.py
- uv run mypy proliferate/db/store/cloud_sync proliferate/server/cloud/events proliferate/server/cloud/worker tests/integration/test_cloud_event_sync_api.py
- cargo fmt --check --package proliferate-worker
- cargo check -p proliferate-worker
- cargo test -p proliferate-worker
- DEBUG=true uv run python -m pytest -q tests/integration/test_cloud_commands_api.py tests/integration/test_cloud_event_sync_api.py
- uv run alembic heads
- git diff --check

Stacked on #216.