### PR TITLE
feat(cloud): stream live session projection patches

### DIFF
--- a/server/proliferate/server/cloud/events/api.py
+++ b/server/proliferate/server/cloud/events/api.py
@@ -16,8 +16,8 @@ from proliferate.server.cloud.events.models import CloudSessionSnapshotResponse
 from proliferate.server.cloud.events.service import (
     ensure_visible_session_target,
     get_session_snapshot,
-    stream_session_events,
 )
+from proliferate.server.cloud.live.service import stream_session_events
 
 router = APIRouter(prefix="/sessions", tags=["cloud-sessions"])
 

--- a/server/proliferate/server/cloud/events/models.py
+++ b/server/proliferate/server/cloud/events/models.py
@@ -104,6 +104,22 @@ class CloudSessionEventResponse(BaseModel):
     payload: dict[str, object] | None = None
 
 
+class CloudSessionPatchResponse(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    session_id: str = Field(serialization_alias="sessionId")
+    seq: int
+    event_type: str = Field(serialization_alias="eventType")
+    session: CloudSessionProjectionResponse
+    transcript_item: CloudTranscriptItemResponse | None = Field(
+        default=None,
+        serialization_alias="transcriptItem",
+    )
+    pending_interaction: CloudPendingInteractionResponse | None = Field(
+        default=None,
+        serialization_alias="pendingInteraction",
+    )
+
+
 def session_projection_response(
     value: events_store.CloudSessionProjectionSnapshot,
 ) -> CloudSessionProjectionResponse:
@@ -175,6 +191,33 @@ def session_event_response(
         item_id=value.item_id,
         occurred_at=value.occurred_at,
         payload=_json_dict(value.payload_json),
+    )
+
+
+def session_patch_response(
+    *,
+    target_id: UUID,
+    session_id: str,
+    seq: int,
+    event_type: str,
+    session: events_store.CloudSessionProjectionSnapshot,
+    transcript_item: events_store.CloudTranscriptItemSnapshot | None = None,
+    pending_interaction: events_store.CloudPendingInteractionSnapshot | None = None,
+) -> CloudSessionPatchResponse:
+    return CloudSessionPatchResponse(
+        target_id=str(target_id),
+        session_id=session_id,
+        seq=seq,
+        event_type=event_type,
+        session=session_projection_response(session),
+        transcript_item=(
+            transcript_item_response(transcript_item) if transcript_item is not None else None
+        ),
+        pending_interaction=(
+            pending_interaction_response(pending_interaction)
+            if pending_interaction is not None
+            else None
+        ),
     )
 
 

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from collections import defaultdict
-from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.cloud.errors import CloudApiError
@@ -25,21 +22,23 @@ from proliferate.server.cloud.events.domain.projection import (
     transcript_item_text,
 )
 from proliferate.server.cloud.events.models import (
+    CloudSessionPatchResponse,
     CloudSessionSnapshotResponse,
     WorkerEventBatchRequest,
     WorkerEventBatchResponse,
     WorkerEventSessionAck,
     pending_interaction_response,
-    session_event_response,
     session_projection_response,
     transcript_item_response,
+)
+from proliferate.server.cloud.live.service import (
+    projection_patch_from_event,
+    publish_session_patch,
 )
 from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
 
 SESSION_DURABLE_EVENT_HARD_CAP = 10_000
 SESSION_PAYLOAD_BYTES_HARD_CAP = 25 * 1024 * 1024
-STREAM_POLL_SECONDS = 0.5
-STREAM_EVENT_LIMIT = 100
 
 
 @dataclass(frozen=True)
@@ -66,6 +65,7 @@ async def ingest_worker_event_batch(
     received_by_session: dict[str, list[int]] = defaultdict(list)
     workspace_by_session: dict[str, str | None] = {}
     cloud_workspace_by_session: dict[str, UUID | None] = {}
+    projection_patches: list[CloudSessionPatchResponse] = []
 
     for event in body.events:
         if event.seq <= 0:
@@ -139,13 +139,15 @@ async def ingest_worker_event_batch(
             duplicate_events += 1
             continue
         accepted_events += 1
-        await _apply_projection(
-            db,
-            auth=auth,
-            cloud_workspace_id=cloud_workspace_id,
-            workspace_id=current_workspace_id,
-            envelope=envelope,
-            payload_json=payload_decision.payload_json,
+        projection_patches.append(
+            await _apply_projection(
+                db,
+                auth=auth,
+                cloud_workspace_id=cloud_workspace_id,
+                workspace_id=current_workspace_id,
+                envelope=envelope,
+                payload_json=payload_decision.payload_json,
+            )
         )
 
     session_acks: list[WorkerEventSessionAck] = []
@@ -171,6 +173,9 @@ async def ingest_worker_event_batch(
                 last_contiguous_seq=cursor,
             )
         )
+
+    for patch in projection_patches:
+        await publish_session_patch(patch)
 
     return WorkerEventBatchResponse(
         accepted_events=accepted_events,
@@ -248,53 +253,6 @@ async def ensure_visible_session_target(
     return target_id
 
 
-async def list_session_events_after(
-    db: AsyncSession,
-    *,
-    target_id: UUID,
-    session_id: str,
-    after_seq: int,
-    limit: int = 200,
-) -> list[dict[str, object]]:
-    events = await events_store.list_events_after(
-        db,
-        target_id=target_id,
-        session_id=session_id,
-        after_seq=after_seq,
-        limit=limit,
-    )
-    return [session_event_response(event).model_dump(by_alias=True) for event in events]
-
-
-async def stream_session_events(
-    *,
-    target_id: UUID,
-    session_id: str,
-    after_seq: int,
-) -> AsyncIterator[str]:
-    cursor = max(0, after_seq)
-    while True:
-        async with db_engine.async_session_factory() as stream_db:
-            events = await list_session_events_after(
-                stream_db,
-                target_id=target_id,
-                session_id=session_id,
-                after_seq=cursor,
-                limit=STREAM_EVENT_LIMIT,
-            )
-        for event in events:
-            seq = _int_value(event["seq"])
-            cursor = max(cursor, seq)
-            yield _sse_event(
-                event="session_event",
-                event_id=str(seq),
-                data=event,
-            )
-        if not events:
-            yield ": keepalive\n\n"
-            await asyncio.sleep(STREAM_POLL_SECONDS)
-
-
 async def _apply_projection(
     db: AsyncSession,
     *,
@@ -303,7 +261,7 @@ async def _apply_projection(
     workspace_id: str | None,
     envelope: dict[str, object],
     payload_json: str | None,
-) -> None:
+) -> CloudSessionPatchResponse:
     session_id = str(envelope["sessionId"])
     seq = _int_value(envelope["seq"])
     occurred_at = envelope.get("timestamp")
@@ -312,7 +270,7 @@ async def _apply_projection(
     event_payload = event if isinstance(event, dict) else {}
     current_event_type = event_type(envelope)
     patch = _session_projection_patch(current_event_type, event_payload, timestamp)
-    await events_store.upsert_session_projection(
+    session_projection = await events_store.upsert_session_projection(
         db,
         target_id=auth.target_id,
         cloud_workspace_id=cloud_workspace_id,
@@ -329,12 +287,14 @@ async def _apply_projection(
         started_at=patch.started_at,
         ended_at=patch.ended_at,
     )
+    transcript_item = None
+    pending_interaction = None
 
     if current_event_type in {"item_started", "item_completed"}:
         item_id = transcript_item_id(envelope)
         if item_id is not None:
             item = transcript_item_payload(event_payload)
-            await events_store.upsert_transcript_item(
+            transcript_item = await events_store.upsert_transcript_item(
                 db,
                 target_id=auth.target_id,
                 cloud_workspace_id=cloud_workspace_id,
@@ -355,7 +315,7 @@ async def _apply_projection(
     elif current_event_type == "interaction_requested":
         request_id = _str_or_none(event_payload.get("requestId"))
         if request_id:
-            await events_store.upsert_pending_interaction(
+            pending_interaction = await events_store.upsert_pending_interaction(
                 db,
                 target_id=auth.target_id,
                 cloud_workspace_id=cloud_workspace_id,
@@ -372,7 +332,7 @@ async def _apply_projection(
     elif current_event_type == "interaction_resolved":
         request_id = _str_or_none(event_payload.get("requestId"))
         if request_id:
-            await events_store.resolve_pending_interaction(
+            pending_interaction = await events_store.resolve_pending_interaction(
                 db,
                 target_id=auth.target_id,
                 session_id=session_id,
@@ -381,6 +341,15 @@ async def _apply_projection(
                 occurred_at=timestamp,
                 payload_json=payload_json,
             )
+    return projection_patch_from_event(
+        target_id=auth.target_id,
+        session_id=session_id,
+        seq=seq,
+        event_type=current_event_type,
+        session=session_projection,
+        transcript_item=transcript_item,
+        pending_interaction=pending_interaction,
+    )
 
 
 def _session_projection_patch(
@@ -426,8 +395,3 @@ def _int_value(value: object) -> int:
     if isinstance(value, str):
         return int(value)
     raise TypeError(f"Expected integer-compatible value, got {type(value).__name__}.")
-
-
-def _sse_event(*, event: str, event_id: str, data: object) -> str:
-    encoded = json.dumps(data, separators=(",", ":"), sort_keys=True)
-    return f"id: {event_id}\nevent: {event}\ndata: {encoded}\n\n"

--- a/server/proliferate/server/cloud/live/__init__.py
+++ b/server/proliferate/server/cloud/live/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud live stream service package."""

--- a/server/proliferate/server/cloud/live/domain/__init__.py
+++ b/server/proliferate/server/cloud/live/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure helpers for cloud live stream routing."""

--- a/server/proliferate/server/cloud/live/domain/channels.py
+++ b/server/proliferate/server/cloud/live/domain/channels.py
@@ -1,0 +1,9 @@
+"""Cloud live stream channel names."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+def session_channel(*, target_id: UUID, session_id: str) -> str:
+    return f"session:{target_id}:{session_id}"

--- a/server/proliferate/server/cloud/live/models.py
+++ b/server/proliferate/server/cloud/live/models.py
@@ -1,0 +1,14 @@
+"""Schemas for cloud live stream messages."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CloudStreamHeartbeatResponse(BaseModel):
+    kind: str = "heartbeat"
+
+
+class CloudLivePatchEnvelope(BaseModel):
+    kind: str = "projection_patch"
+    patch: dict[str, object] = Field(serialization_alias="patch")

--- a/server/proliferate/server/cloud/live/service.py
+++ b/server/proliferate/server/cloud/live/service.py
@@ -1,0 +1,206 @@
+"""Cloud live session fanout and SSE stream helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import engine as db_engine
+from proliferate.db.store.cloud_sync import events as events_store
+from proliferate.server.cloud.events.models import (
+    CloudSessionPatchResponse,
+    CloudSessionSnapshotResponse,
+    pending_interaction_response,
+    session_patch_response,
+    session_projection_response,
+    transcript_item_response,
+)
+from proliferate.server.cloud.live.domain.channels import session_channel
+from proliferate.server.cloud.live.models import (
+    CloudLivePatchEnvelope,
+    CloudStreamHeartbeatResponse,
+)
+
+STREAM_HEARTBEAT_SECONDS = 15.0
+SUBSCRIBER_QUEUE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class LiveMessage:
+    event: str
+    event_id: str
+    data: dict[str, object]
+
+
+class InProcessLiveBus:
+    """Process-local live fanout.
+
+    This is intentionally behind a tiny publish/subscribe boundary so Redis,
+    NATS, or an actor implementation can replace it without changing the
+    session/event services.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._subscribers: dict[str, set[asyncio.Queue[LiveMessage]]] = defaultdict(set)
+
+    @asynccontextmanager
+    async def subscribe(self, channel: str) -> AsyncIterator[asyncio.Queue[LiveMessage]]:
+        queue: asyncio.Queue[LiveMessage] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_SIZE)
+        async with self._lock:
+            self._subscribers[channel].add(queue)
+        try:
+            yield queue
+        finally:
+            async with self._lock:
+                subscribers = self._subscribers.get(channel)
+                if subscribers is not None:
+                    subscribers.discard(queue)
+                    if not subscribers:
+                        self._subscribers.pop(channel, None)
+
+    async def publish(self, channel: str, message: LiveMessage) -> None:
+        async with self._lock:
+            subscribers = tuple(self._subscribers.get(channel, ()))
+        for queue in subscribers:
+            try:
+                queue.put_nowait(message)
+            except asyncio.QueueFull:
+                with suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+                with suppress(asyncio.QueueFull):
+                    queue.put_nowait(message)
+
+
+_live_bus = InProcessLiveBus()
+
+
+async def publish_session_patch(patch: CloudSessionPatchResponse) -> None:
+    await _live_bus.publish(
+        session_channel(target_id=UUID(patch.target_id), session_id=patch.session_id),
+        LiveMessage(
+            event="patch",
+            event_id=str(patch.seq),
+            data=CloudLivePatchEnvelope(
+                patch=patch.model_dump(by_alias=True),
+            ).model_dump(by_alias=True),
+        ),
+    )
+
+
+async def stream_session_events(
+    *,
+    target_id: UUID,
+    session_id: str,
+    after_seq: int,
+) -> AsyncIterator[str]:
+    cursor = max(0, after_seq)
+    channel = session_channel(target_id=target_id, session_id=session_id)
+    async with _live_bus.subscribe(channel) as queue:
+        async with db_engine.async_session_factory() as stream_db:
+            snapshot = await _get_session_snapshot(
+                stream_db,
+                target_id=target_id,
+                session_id=session_id,
+            )
+        cursor = max(cursor, snapshot.session.last_event_seq)
+        yield _sse_event(
+            event="snapshot",
+            event_id=str(cursor),
+            data=snapshot.model_dump(by_alias=True),
+        )
+
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    queue.get(),
+                    timeout=STREAM_HEARTBEAT_SECONDS,
+                )
+            except TimeoutError:
+                yield _sse_event(
+                    event="heartbeat",
+                    event_id=str(cursor),
+                    data=CloudStreamHeartbeatResponse().model_dump(by_alias=True),
+                )
+                continue
+            message_seq = _int_or_zero(message.event_id)
+            if message_seq <= cursor:
+                continue
+            cursor = message_seq
+            yield _sse_event(
+                event=message.event,
+                event_id=message.event_id,
+                data=message.data,
+            )
+
+
+async def _get_session_snapshot(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> CloudSessionSnapshotResponse:
+    projection = await events_store.get_session_projection(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    if projection is None:
+        raise LookupError("Synced session not found.")
+    transcript_items = await events_store.list_transcript_items(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    pending_interactions = await events_store.list_pending_interactions(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+    )
+    return CloudSessionSnapshotResponse(
+        session=session_projection_response(projection),
+        transcript_items=[transcript_item_response(item) for item in transcript_items],
+        pending_interactions=[
+            pending_interaction_response(interaction) for interaction in pending_interactions
+        ],
+    )
+
+
+def projection_patch_from_event(
+    *,
+    target_id: UUID,
+    session_id: str,
+    seq: int,
+    event_type: str,
+    session: events_store.CloudSessionProjectionSnapshot,
+    transcript_item: events_store.CloudTranscriptItemSnapshot | None = None,
+    pending_interaction: events_store.CloudPendingInteractionSnapshot | None = None,
+) -> CloudSessionPatchResponse:
+    return session_patch_response(
+        target_id=target_id,
+        session_id=session_id,
+        seq=seq,
+        event_type=event_type,
+        session=session,
+        transcript_item=transcript_item,
+        pending_interaction=pending_interaction,
+    )
+
+
+def _sse_event(*, event: str, event_id: str, data: object) -> str:
+    encoded = json.dumps(data, separators=(",", ":"), sort_keys=True)
+    return f"id: {event_id}\nevent: {event}\ndata: {encoded}\n\n"
+
+
+def _int_or_zero(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return 0

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -101,6 +101,7 @@ module = [
     "proliferate.server.catalogs.models",
     "proliferate.server.cloud.credentials.models",
     "proliferate.server.cloud.events.models",
+    "proliferate.server.cloud.live.models",
     "proliferate.server.cloud.repos.models",
     "proliferate.server.support.models",
     "proliferate.config",

--- a/server/tests/integration/test_cloud_event_sync_api.py
+++ b/server/tests/integration/test_cloud_event_sync_api.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import json
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import cast
+from uuid import UUID
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.server.cloud.live.service import stream_session_events
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.shared import AuthSession
 
@@ -37,6 +44,31 @@ async def _create_enrolled_target(
     assert worker_enroll.status_code == 200
     worker = worker_enroll.json()
     return enrollment["target"]["id"], {"Authorization": f"Bearer {worker['workerToken']}"}
+
+
+def _sse_event(frame: str) -> str:
+    for line in frame.splitlines():
+        if line.startswith("event: "):
+            return line.removeprefix("event: ")
+    raise AssertionError(f"SSE frame has no event line: {frame}")
+
+
+def _sse_data(frame: str) -> dict[str, object]:
+    for line in frame.splitlines():
+        if line.startswith("data: "):
+            value: object = json.loads(line.removeprefix("data: "))
+            assert isinstance(value, dict)
+            return cast("dict[str, object]", value)
+    raise AssertionError(f"SSE frame has no data line: {frame}")
+
+
+async def _next_stream_frame(stream: AsyncIterator[str]) -> str:
+    return await anext(stream)
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return cast("dict[str, object]", value)
 
 
 class TestCloudEventSyncApi:
@@ -182,3 +214,95 @@ class TestCloudEventSyncApi:
         )
         assert duplicate_mismatch.status_code == 409
         assert duplicate_mismatch.json()["detail"]["code"] == "cloud_event_duplicate_mismatch"
+
+    @pytest.mark.asyncio
+    async def test_session_stream_emits_snapshot_and_live_projection_patch(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-event-stream",
+        )
+        target_id, worker_headers = await _create_enrolled_target(
+            client,
+            auth,
+            suffix="stream",
+        )
+        uploaded = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json={
+                "events": [
+                    {
+                        "workspaceId": "workspace-stream",
+                        "sessionId": "session-stream",
+                        "seq": 1,
+                        "timestamp": "2026-05-13T00:00:00Z",
+                        "event": {
+                            "type": "session_started",
+                            "nativeSessionId": "native-stream",
+                            "sourceAgentKind": "codex",
+                        },
+                    }
+                ]
+            },
+        )
+        assert uploaded.status_code == 200
+
+        stream = cast(
+            "AsyncGenerator[str, None]",
+            stream_session_events(
+                target_id=UUID(target_id),
+                session_id="session-stream",
+                after_seq=1,
+            ),
+        )
+        try:
+            snapshot_frame = await asyncio.wait_for(anext(stream), timeout=1)
+            assert _sse_event(snapshot_frame) == "snapshot"
+            snapshot = _sse_data(snapshot_frame)
+            assert _mapping(snapshot["session"])["sessionId"] == "session-stream"
+
+            patch_task: asyncio.Task[str] = asyncio.create_task(_next_stream_frame(stream))
+
+            live_uploaded = await client.post(
+                "/v1/cloud/worker/events/batches",
+                headers=worker_headers,
+                json={
+                    "events": [
+                        {
+                            "workspaceId": "workspace-stream",
+                            "sessionId": "session-stream",
+                            "seq": 2,
+                            "timestamp": "2026-05-13T00:00:01Z",
+                            "turnId": "turn-stream",
+                            "itemId": "item-stream",
+                            "event": {
+                                "type": "item_completed",
+                                "item": {
+                                    "kind": "assistant_message",
+                                    "status": "completed",
+                                    "sourceAgentKind": "codex",
+                                    "contentParts": [
+                                        {"type": "text", "text": "streamed response"}
+                                    ],
+                                },
+                            },
+                        }
+                    ]
+                },
+            )
+            assert live_uploaded.status_code == 200
+
+            patch_frame = await asyncio.wait_for(patch_task, timeout=2)
+            assert _sse_event(patch_frame) == "patch"
+            patch_envelope = _sse_data(patch_frame)
+            assert patch_envelope["kind"] == "projection_patch"
+            patch = _mapping(patch_envelope["patch"])
+            assert patch["eventType"] == "item_completed"
+            assert _mapping(patch["transcriptItem"])["text"] == "streamed response"
+        finally:
+            await stream.aclose()


### PR DESCRIPTION
## Summary
- add a Cloud live fanout boundary for session streams with snapshot, patch, and heartbeat SSE frames
- publish projection patches from worker event ingest after durable session/transcript/interaction projection updates
- switch the cloud session stream route away from DB polling and cover snapshot plus live patch behavior in integration tests

## Verification
- `uv run ruff format proliferate/server/cloud/events proliferate/server/cloud/live tests/integration/test_cloud_event_sync_api.py`
- `uv run ruff check proliferate/server/cloud/events proliferate/server/cloud/live tests/integration/test_cloud_event_sync_api.py`
- `uv run mypy proliferate/server/cloud/events proliferate/server/cloud/live tests/integration/test_cloud_event_sync_api.py`
- `DEBUG=true uv run python -m pytest -q tests/integration/test_cloud_commands_api.py tests/integration/test_cloud_event_sync_api.py`
- `cargo fmt --check --package proliferate-worker && cargo check -p proliferate-worker && cargo test -p proliferate-worker`
- `uv run alembic heads`
- `git diff --check`
