### PR TITLE
feat(cloud): sync existing workspaces through workers

### DIFF
--- a/anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::error::WorkerError;
+
+use super::AnyHarnessClient;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyHarnessRepoRoot {
+    pub id: String,
+    pub display_name: Option<String>,
+    pub default_branch: Option<String>,
+    pub remote_provider: Option<String>,
+    pub remote_owner: Option<String>,
+    pub remote_repo_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyHarnessWorkspace {
+    pub id: String,
+    pub repo_root_id: String,
+    pub path: String,
+    pub original_branch: Option<String>,
+    pub current_branch: Option<String>,
+    pub display_name: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyHarnessSession {
+    pub id: String,
+    pub workspace_id: String,
+    pub agent_kind: String,
+    pub native_session_id: Option<String>,
+    pub title: Option<String>,
+    pub live_config: Option<Value>,
+    pub execution_summary: Option<AnyHarnessSessionExecutionSummary>,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyHarnessSessionExecutionSummary {
+    pub phase: String,
+    #[serde(default)]
+    pub pending_interactions: Vec<AnyHarnessPendingInteraction>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnyHarnessPendingInteraction {
+    pub request_id: String,
+    pub kind: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnyHarnessBackfillSnapshot {
+    pub workspaces: Vec<AnyHarnessWorkspace>,
+    pub repo_roots_by_id: HashMap<String, AnyHarnessRepoRoot>,
+    pub sessions: Vec<AnyHarnessSession>,
+}
+
+impl AnyHarnessClient {
+    pub async fn backfill_snapshot(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> Result<AnyHarnessBackfillSnapshot, WorkerError> {
+        let repo_roots = self.list_repo_roots().await?;
+        let repo_roots_by_id = repo_roots
+            .into_iter()
+            .map(|repo_root| (repo_root.id.clone(), repo_root))
+            .collect::<HashMap<_, _>>();
+        let mut workspaces = self.list_workspaces().await?;
+        if let Some(workspace_id) = workspace_id {
+            workspaces.retain(|workspace| workspace.id == workspace_id);
+        }
+        let mut sessions = self.list_sessions(workspace_id).await?;
+        if workspace_id.is_none() {
+            let workspace_ids = workspaces
+                .iter()
+                .map(|workspace| workspace.id.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            sessions.retain(|session| workspace_ids.contains(session.workspace_id.as_str()));
+        }
+        Ok(AnyHarnessBackfillSnapshot {
+            workspaces,
+            repo_roots_by_id,
+            sessions,
+        })
+    }
+
+    async fn list_repo_roots(&self) -> Result<Vec<AnyHarnessRepoRoot>, WorkerError> {
+        self.get_json("/v1/repo-roots").await
+    }
+
+    async fn list_workspaces(&self) -> Result<Vec<AnyHarnessWorkspace>, WorkerError> {
+        self.get_json("/v1/workspaces").await
+    }
+
+    async fn list_sessions(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> Result<Vec<AnyHarnessSession>, WorkerError> {
+        let mut request =
+            self.authenticate(self.http().get(format!("{}/v1/sessions", self.base_url())));
+        if let Some(workspace_id) = workspace_id {
+            request = request.query(&[("workspace_id", workspace_id)]);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        Ok(response.json().await?)
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, WorkerError> {
+        let response = self
+            .authenticate(self.http().get(format!("{}{}", self.base_url(), path)))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        Ok(response.json().await?)
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
@@ -1,3 +1,4 @@
+pub mod backfill;
 pub mod events;
 pub mod health;
 pub mod sessions;

--- a/anyharness/crates/proliferate-worker/src/cloud_client/backfill.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/backfill.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::WorkerError;
+
+use super::{auth, parse_json_response, CloudClient};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillRepoRef {
+    pub provider: Option<String>,
+    pub owner: Option<String>,
+    pub name: Option<String>,
+    pub branch: Option<String>,
+    pub base_branch: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillWorkspace {
+    pub workspace_id: String,
+    pub display_name: Option<String>,
+    pub path: Option<String>,
+    pub repo: Option<WorkerBackfillRepoRef>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillPendingInteraction {
+    pub request_id: String,
+    pub kind: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillSession {
+    pub session_id: String,
+    pub workspace_id: Option<String>,
+    pub native_session_id: Option<String>,
+    pub source_agent_kind: Option<String>,
+    pub title: Option<String>,
+    pub status: Option<String>,
+    pub phase: Option<String>,
+    pub live_config: Option<Value>,
+    pub last_event_seq: i64,
+    pub last_event_at: Option<String>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub pending_interactions: Vec<WorkerBackfillPendingInteraction>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillRequest {
+    pub workspaces: Vec<WorkerBackfillWorkspace>,
+    pub sessions: Vec<WorkerBackfillSession>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillWorkspaceMapping {
+    pub workspace_id: String,
+    pub cloud_workspace_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillSessionMapping {
+    pub session_id: String,
+    pub workspace_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerBackfillResponse {
+    pub mapped_workspaces: Vec<WorkerBackfillWorkspaceMapping>,
+    pub mapped_sessions: Vec<WorkerBackfillSessionMapping>,
+}
+
+impl CloudClient {
+    pub async fn upload_backfill(
+        &self,
+        worker_token: &str,
+        request: &WorkerBackfillRequest,
+    ) -> Result<WorkerBackfillResponse, WorkerError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/cloud/worker/backfill", self.base_url))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            )
+            .json(request)
+            .send()
+            .await?;
+        parse_json_response(response).await
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
@@ -61,6 +61,7 @@ pub const SUPPORTED_COMMAND_KINDS: &[&str] = &[
     "update_session_config",
     "cancel_turn",
     "close_session",
+    "sync_existing_workspace",
 ];
 
 impl CloudClient {

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod backfill;
 pub mod commands;
 pub mod events;
 pub mod heartbeat;

--- a/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
@@ -17,7 +17,8 @@ use crate::{
     config::WorkerConfig,
     error::WorkerError,
     identity::credentials::WorkerIdentity,
-    store::WorkerStore,
+    store::{PendingCommandResult, WorkerStore},
+    sync,
 };
 
 const EMPTY_LEASE_SLEEP: Duration = Duration::from_secs(2);
@@ -39,6 +40,9 @@ pub async fn run_loop(
         .map(|kind| (*kind).to_string())
         .collect::<Vec<_>>();
     loop {
+        if let Err(error) = flush_pending_command_results(&cloud, &identity, &store).await {
+            warn!(?error, "failed to flush pending command results");
+        }
         if !anyharness_health::probe(&anyharness).await {
             warn!("worker command loop paused because anyharness health check failed");
             sleep(ERROR_LEASE_SLEEP).await;
@@ -89,6 +93,12 @@ async fn process_command(
         lease_expires_at = %command.lease_expires_at,
         "processing cloud command"
     );
+    if command.kind == "sync_existing_workspace" {
+        return process_sync_existing_workspace_command(
+            cloud, identity, anyharness, store, command,
+        )
+        .await;
+    }
     let mapped = match map_cloud_command(&command) {
         Ok(mapped) => mapped,
         Err(error) => {
@@ -99,9 +109,7 @@ async fn process_command(
                 error_message: Some(error.message),
                 result: None,
             };
-            cloud
-                .report_command_result(&identity.worker_token, &command.command_id, &result)
-                .await?;
+            report_command_result(cloud, identity, store, &command.command_id, &result).await?;
             return Ok(());
         }
     };
@@ -128,9 +136,100 @@ async fn process_command(
         }
     }
     let result = command_result(&command, &mapped, response);
+    report_command_result(cloud, identity, store, &command.command_id, &result).await
+}
+
+async fn process_sync_existing_workspace_command(
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    anyharness: &AnyHarnessClient,
+    store: &WorkerStore,
+    command: CloudCommandEnvelope,
+) -> Result<(), WorkerError> {
     cloud
-        .report_command_result(&identity.worker_token, &command.command_id, &result)
-        .await
+        .report_command_delivery(
+            &identity.worker_token,
+            &command.command_id,
+            &CommandDeliveryRequest {
+                lease_id: command.lease_id.clone(),
+                status: "delivered".to_string(),
+                error_code: None,
+                error_message: None,
+            },
+        )
+        .await?;
+    let response = sync::backfill::sync_existing_workspace(
+        store,
+        anyharness,
+        cloud,
+        identity,
+        command.workspace_id.as_deref(),
+    )
+    .await;
+    let result = match response {
+        Ok(result) => CommandResultRequest {
+            lease_id: command.lease_id.clone(),
+            status: "accepted".to_string(),
+            error_code: None,
+            error_message: None,
+            result: Some(json!({
+                "mappedWorkspaceCount": result.mapped_workspace_count,
+                "mappedSessionCount": result.mapped_session_count,
+            })),
+        },
+        Err(error) => CommandResultRequest {
+            lease_id: command.lease_id.clone(),
+            status: "failed_delivery".to_string(),
+            error_code: Some("backfill_failed".to_string()),
+            error_message: Some(error.to_string()),
+            result: None,
+        },
+    };
+    report_command_result(cloud, identity, store, &command.command_id, &result).await
+}
+
+async fn flush_pending_command_results(
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    store: &WorkerStore,
+) -> Result<(), WorkerError> {
+    for pending in store.list_pending_command_results()? {
+        let request = CommandResultRequest {
+            lease_id: pending.lease_id,
+            status: pending.status,
+            error_code: pending.error_code,
+            error_message: pending.error_message,
+            result: pending.result,
+        };
+        cloud
+            .report_command_result(&identity.worker_token, &pending.command_id, &request)
+            .await?;
+        store.delete_pending_command_result(&pending.command_id)?;
+    }
+    Ok(())
+}
+
+async fn report_command_result(
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    store: &WorkerStore,
+    command_id: &str,
+    result: &CommandResultRequest,
+) -> Result<(), WorkerError> {
+    let pending = PendingCommandResult {
+        command_id: command_id.to_string(),
+        lease_id: result.lease_id.clone(),
+        status: result.status.clone(),
+        error_code: result.error_code.clone(),
+        error_message: result.error_message.clone(),
+        result: result.result.clone(),
+    };
+    store.save_pending_command_result(&pending)?;
+    cloud
+        .report_command_result(&identity.worker_token, command_id, result)
+        .await?;
+    store.delete_pending_command_result(command_id)?;
+    Ok(())
 }
 
 async fn dispatch_anyharness(
@@ -187,12 +286,18 @@ fn command_result(
             })),
         },
         Ok(response) => {
-            let (status, error_code) =
-                if response.status.as_u16() == 401 || response.status.as_u16() == 403 {
-                    ("failed_delivery", "anyharness_auth_failed")
-                } else {
-                    ("rejected", "anyharness_rejected")
-                };
+            let status_code = response.status.as_u16();
+            let (status, error_code) = if status_code == 401 || status_code == 403 {
+                ("failed_delivery", "anyharness_auth_failed")
+            } else if response.status.is_server_error()
+                || status_code == 408
+                || status_code == 409
+                || status_code == 429
+            {
+                ("failed_delivery", "anyharness_temporarily_unavailable")
+            } else {
+                ("rejected", "anyharness_rejected")
+            };
             CommandResultRequest {
                 lease_id: command.lease_id.clone(),
                 status: status.to_string(),

--- a/anyharness/crates/proliferate-worker/src/error.rs
+++ b/anyharness/crates/proliferate-worker/src/error.rs
@@ -18,6 +18,8 @@ pub enum WorkerError {
     },
     #[error("worker database error")]
     Store(#[from] rusqlite::Error),
+    #[error("worker JSON serialization error")]
+    Json(#[from] serde_json::Error),
     #[error("cloud request failed")]
     Http(#[from] reqwest::Error),
     #[error("failed to build http client")]

--- a/anyharness/crates/proliferate-worker/src/store/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/store/mod.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::Value;
 
 use crate::{error::WorkerError, identity::credentials::WorkerIdentity};
 
@@ -13,6 +14,16 @@ pub struct SyncSession {
     pub session_id: String,
     pub workspace_id: Option<String>,
     pub last_uploaded_seq: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingCommandResult {
+    pub command_id: String,
+    pub lease_id: String,
+    pub status: String,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub result: Option<Value>,
 }
 
 impl Clone for WorkerStore {
@@ -39,7 +50,15 @@ impl WorkerStore {
     }
 
     fn connection(&self) -> Result<Connection, WorkerError> {
-        Ok(Connection::open(&self.path)?)
+        let conn = Connection::open(&self.path)?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        conn.execute_batch(
+            r#"
+            PRAGMA foreign_keys = ON;
+            PRAGMA journal_mode = WAL;
+            "#,
+        )?;
+        Ok(conn)
     }
 
     fn migrate(&self) -> Result<(), WorkerError> {
@@ -57,6 +76,20 @@ impl WorkerStore {
                 session_id TEXT PRIMARY KEY,
                 workspace_id TEXT,
                 last_uploaded_seq INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS sync_workspaces (
+                workspace_id TEXT PRIMARY KEY,
+                cloud_workspace_id TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS pending_command_results (
+                command_id TEXT PRIMARY KEY,
+                lease_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                error_code TEXT,
+                error_message TEXT,
+                result_json TEXT,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
             "#,
@@ -122,6 +155,41 @@ impl WorkerStore {
         Ok(())
     }
 
+    pub fn upsert_sync_mappings(
+        &self,
+        workspace_mappings: &[(String, String)],
+        session_mappings: &[(String, Option<String>)],
+    ) -> Result<(), WorkerError> {
+        let mut conn = self.connection()?;
+        let tx = conn.transaction()?;
+        for (workspace_id, cloud_workspace_id) in workspace_mappings {
+            tx.execute(
+                r#"
+                INSERT INTO sync_workspaces (workspace_id, cloud_workspace_id, updated_at)
+                VALUES (?1, ?2, CURRENT_TIMESTAMP)
+                ON CONFLICT(workspace_id) DO UPDATE SET
+                    cloud_workspace_id = excluded.cloud_workspace_id,
+                    updated_at = CURRENT_TIMESTAMP
+                "#,
+                params![workspace_id, cloud_workspace_id],
+            )?;
+        }
+        for (session_id, workspace_id) in session_mappings {
+            tx.execute(
+                r#"
+                INSERT INTO sync_sessions (session_id, workspace_id, last_uploaded_seq, updated_at)
+                VALUES (?1, ?2, 0, CURRENT_TIMESTAMP)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    workspace_id = COALESCE(excluded.workspace_id, sync_sessions.workspace_id),
+                    updated_at = CURRENT_TIMESTAMP
+                "#,
+                params![session_id, workspace_id],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     pub fn list_sync_sessions(&self) -> Result<Vec<SyncSession>, WorkerError> {
         let conn = self.connection()?;
         let mut stmt = conn.prepare(
@@ -155,6 +223,93 @@ impl WorkerStore {
             WHERE session_id = ?1
             "#,
             params![session_id, last_uploaded_seq],
+        )?;
+        Ok(())
+    }
+
+    pub fn save_pending_command_result(
+        &self,
+        result: &PendingCommandResult,
+    ) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        let result_json = match &result.result {
+            Some(value) => Some(serde_json::to_string(value)?),
+            None => None,
+        };
+        conn.execute(
+            r#"
+            INSERT INTO pending_command_results (
+                command_id,
+                lease_id,
+                status,
+                error_code,
+                error_message,
+                result_json,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)
+            ON CONFLICT(command_id) DO UPDATE SET
+                lease_id = excluded.lease_id,
+                status = excluded.status,
+                error_code = excluded.error_code,
+                error_message = excluded.error_message,
+                result_json = excluded.result_json,
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+            params![
+                result.command_id,
+                result.lease_id,
+                result.status,
+                result.error_code,
+                result.error_message,
+                result_json
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_pending_command_results(&self) -> Result<Vec<PendingCommandResult>, WorkerError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT command_id, lease_id, status, error_code, error_message, result_json
+            FROM pending_command_results
+            ORDER BY updated_at ASC
+            "#,
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let result_json: Option<String> = row.get(5)?;
+            let result = match result_json {
+                Some(value) => Some(serde_json::from_str(&value).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        5,
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?),
+                None => None,
+            };
+            Ok(PendingCommandResult {
+                command_id: row.get(0)?,
+                lease_id: row.get(1)?,
+                status: row.get(2)?,
+                error_code: row.get(3)?,
+                error_message: row.get(4)?,
+                result,
+            })
+        })?;
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
+    }
+
+    pub fn delete_pending_command_result(&self, command_id: &str) -> Result<(), WorkerError> {
+        let conn = self.connection()?;
+        conn.execute(
+            "DELETE FROM pending_command_results WHERE command_id = ?1",
+            params![command_id],
         )?;
         Ok(())
     }

--- a/anyharness/crates/proliferate-worker/src/sync/backfill.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/backfill.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+use tracing::info;
+
+use crate::{
+    anyharness_client::{
+        backfill::{
+            AnyHarnessBackfillSnapshot, AnyHarnessPendingInteraction, AnyHarnessRepoRoot,
+            AnyHarnessSession, AnyHarnessWorkspace,
+        },
+        AnyHarnessClient,
+    },
+    cloud_client::{
+        backfill::{
+            WorkerBackfillPendingInteraction, WorkerBackfillRepoRef, WorkerBackfillRequest,
+            WorkerBackfillSession, WorkerBackfillWorkspace,
+        },
+        CloudClient,
+    },
+    error::WorkerError,
+    identity::credentials::WorkerIdentity,
+    store::WorkerStore,
+};
+
+#[derive(Debug, Clone)]
+pub struct BackfillResult {
+    pub mapped_workspace_count: usize,
+    pub mapped_session_count: usize,
+}
+
+const MAX_WORKSPACES_PER_BACKFILL: usize = 200;
+const MAX_SESSIONS_PER_BACKFILL: usize = 500;
+const MAX_PENDING_INTERACTIONS_PER_SESSION: usize = 100;
+
+pub async fn sync_existing_workspace(
+    store: &WorkerStore,
+    anyharness: &AnyHarnessClient,
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    workspace_id: Option<&str>,
+) -> Result<BackfillResult, WorkerError> {
+    let snapshot = anyharness.backfill_snapshot(workspace_id).await?;
+    let request = backfill_request(&snapshot);
+    let mut mapped_workspace_count = 0;
+    let mut mapped_session_count = 0;
+    for chunk in backfill_chunks(request) {
+        let response = cloud
+            .upload_backfill(&identity.worker_token, &chunk)
+            .await?;
+        let workspace_mappings = response
+            .mapped_workspaces
+            .iter()
+            .map(|mapping| {
+                (
+                    mapping.workspace_id.clone(),
+                    mapping.cloud_workspace_id.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let session_mappings = response
+            .mapped_sessions
+            .iter()
+            .map(|mapping| (mapping.session_id.clone(), mapping.workspace_id.clone()))
+            .collect::<Vec<_>>();
+        store.upsert_sync_mappings(&workspace_mappings, &session_mappings)?;
+        mapped_workspace_count += response.mapped_workspaces.len();
+        mapped_session_count += response.mapped_sessions.len();
+    }
+    info!(
+        mapped_workspace_count,
+        mapped_session_count, "worker backfill completed"
+    );
+    Ok(BackfillResult {
+        mapped_workspace_count,
+        mapped_session_count,
+    })
+}
+
+fn backfill_chunks(request: WorkerBackfillRequest) -> Vec<WorkerBackfillRequest> {
+    let mut chunks = Vec::new();
+    for workspaces in request.workspaces.chunks(MAX_WORKSPACES_PER_BACKFILL) {
+        chunks.push(WorkerBackfillRequest {
+            workspaces: workspaces.to_vec(),
+            sessions: Vec::new(),
+        });
+    }
+    for sessions in request.sessions.chunks(MAX_SESSIONS_PER_BACKFILL) {
+        chunks.push(WorkerBackfillRequest {
+            workspaces: Vec::new(),
+            sessions: sessions.to_vec(),
+        });
+    }
+    if chunks.is_empty() {
+        chunks.push(WorkerBackfillRequest {
+            workspaces: Vec::new(),
+            sessions: Vec::new(),
+        });
+    }
+    chunks
+}
+
+fn backfill_request(snapshot: &AnyHarnessBackfillSnapshot) -> WorkerBackfillRequest {
+    let workspaces = snapshot
+        .workspaces
+        .iter()
+        .map(|workspace| workspace_payload(workspace, &snapshot.repo_roots_by_id))
+        .collect();
+    let workspace_ids = snapshot
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let sessions = snapshot
+        .sessions
+        .iter()
+        .filter(|session| workspace_ids.contains(session.workspace_id.as_str()))
+        .map(session_payload)
+        .collect();
+    WorkerBackfillRequest {
+        workspaces,
+        sessions,
+    }
+}
+
+fn workspace_payload(
+    workspace: &AnyHarnessWorkspace,
+    repo_roots_by_id: &HashMap<String, AnyHarnessRepoRoot>,
+) -> WorkerBackfillWorkspace {
+    let repo_root = repo_roots_by_id.get(&workspace.repo_root_id);
+    WorkerBackfillWorkspace {
+        workspace_id: workspace.id.clone(),
+        display_name: workspace.display_name.clone().or_else(|| {
+            repo_root
+                .and_then(|repo| repo.display_name.clone())
+                .or_else(|| Some(workspace.id.clone()))
+        }),
+        path: Some(workspace.path.clone()),
+        repo: Some(WorkerBackfillRepoRef {
+            provider: repo_root.and_then(|repo| repo.remote_provider.clone()),
+            owner: repo_root.and_then(|repo| repo.remote_owner.clone()),
+            name: repo_root.and_then(|repo| repo.remote_repo_name.clone()),
+            branch: workspace
+                .current_branch
+                .clone()
+                .or_else(|| workspace.original_branch.clone())
+                .or_else(|| repo_root.and_then(|repo| repo.default_branch.clone())),
+            base_branch: workspace
+                .original_branch
+                .clone()
+                .or_else(|| repo_root.and_then(|repo| repo.default_branch.clone())),
+        }),
+        updated_at: Some(workspace.updated_at.clone()),
+    }
+}
+
+fn session_payload(session: &AnyHarnessSession) -> WorkerBackfillSession {
+    let phase = session
+        .execution_summary
+        .as_ref()
+        .map(|summary| summary.phase.clone());
+    let pending_interactions = session
+        .execution_summary
+        .as_ref()
+        .map(|summary| {
+            summary
+                .pending_interactions
+                .iter()
+                .take(MAX_PENDING_INTERACTIONS_PER_SESSION)
+                .map(pending_interaction_payload)
+                .collect()
+        })
+        .unwrap_or_default();
+    WorkerBackfillSession {
+        session_id: session.id.clone(),
+        workspace_id: Some(session.workspace_id.clone()),
+        native_session_id: session.native_session_id.clone(),
+        source_agent_kind: Some(session.agent_kind.clone()),
+        title: session.title.clone(),
+        status: Some(session.status.clone()),
+        phase,
+        live_config: session.live_config.clone(),
+        last_event_seq: 0,
+        last_event_at: Some(session.updated_at.clone()),
+        started_at: Some(session.created_at.clone()),
+        ended_at: session.closed_at.clone(),
+        pending_interactions,
+    }
+}
+
+fn pending_interaction_payload(
+    interaction: &AnyHarnessPendingInteraction,
+) -> WorkerBackfillPendingInteraction {
+    WorkerBackfillPendingInteraction {
+        request_id: interaction.request_id.clone(),
+        kind: Some(interaction.kind.clone()),
+        title: Some(interaction.title.clone()),
+        description: interaction.description.clone(),
+        payload: object_or_wrapped(interaction.payload.clone()),
+    }
+}
+
+fn object_or_wrapped(value: Value) -> Option<Value> {
+    match value {
+        Value::Null => None,
+        Value::Object(_) => Some(value),
+        other => Some(serde_json::json!({ "value": other })),
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/sync/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/mod.rs
@@ -1,1 +1,2 @@
+pub mod backfill;
 pub mod tailer;

--- a/server/alembic/versions/c9d0e1f2a3b4_cloud_synced_workspace_mappings.py
+++ b/server/alembic/versions/c9d0e1f2a3b4_cloud_synced_workspace_mappings.py
@@ -1,0 +1,64 @@
+"""cloud synced workspace mappings
+
+Revision ID: c9d0e1f2a3b4
+Revises: c8d9e0f1a2b3
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: str | Sequence[str] | None = "c8d9e0f1a2b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "cloud_synced_workspaces",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "target_id",
+            "workspace_id",
+            name="uq_cloud_synced_workspaces_target_workspace",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_synced_workspaces_cloud_workspace",
+        "cloud_synced_workspaces",
+        ["cloud_workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cloud_synced_workspaces_target_id",
+        "cloud_synced_workspaces",
+        ["target_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_cloud_synced_workspaces_target_id", table_name="cloud_synced_workspaces")
+    op.drop_index(
+        "ix_cloud_synced_workspaces_cloud_workspace",
+        table_name="cloud_synced_workspaces",
+    )
+    op.drop_table("cloud_synced_workspaces")

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -282,8 +282,17 @@ ACTIVE_CLOUD_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.update_session_config.value,
     CloudCommandKind.cancel_turn.value,
     CloudCommandKind.close_session.value,
+    CloudCommandKind.sync_existing_workspace.value,
 )
-PHASE3_CLOUD_COMMAND_KINDS: tuple[str, ...] = ACTIVE_CLOUD_COMMAND_KINDS
+DEFAULT_CLOUD_WORKER_COMMAND_KINDS: tuple[str, ...] = (
+    CloudCommandKind.start_session.value,
+    CloudCommandKind.send_prompt.value,
+    CloudCommandKind.resolve_interaction.value,
+    CloudCommandKind.update_session_config.value,
+    CloudCommandKind.cancel_turn.value,
+    CloudCommandKind.close_session.value,
+)
+PHASE3_CLOUD_COMMAND_KINDS: tuple[str, ...] = DEFAULT_CLOUD_WORKER_COMMAND_KINDS
 SUPPORTED_CLOUD_COMMAND_STATUSES: tuple[str, ...] = tuple(
     status.value for status in CloudCommandStatus
 )

--- a/server/proliferate/db/models/cloud/sync.py
+++ b/server/proliferate/db/models/cloud/sync.py
@@ -75,6 +75,35 @@ class CloudEventIngestState(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
 
+class CloudSyncedWorkspace(Base):
+    __tablename__ = "cloud_synced_workspaces"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_id",
+            "workspace_id",
+            name="uq_cloud_synced_workspaces_target_workspace",
+        ),
+        Index("ix_cloud_synced_workspaces_cloud_workspace", "cloud_workspace_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    cloud_workspace_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_workspace.id", ondelete="CASCADE"),
+        index=True,
+    )
+    workspace_id: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
 class CloudSessionProjection(Base):
     __tablename__ = "cloud_sessions"
     __table_args__ = (

--- a/server/proliferate/db/store/cloud_sync/backfill.py
+++ b/server/proliferate/db/store/cloud_sync/backfill.py
@@ -1,0 +1,205 @@
+"""Cloud backfill persistence for worker-synced local workspaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import (
+    CloudWorkspaceCleanupState,
+    CloudWorkspaceStatus,
+    WorkspacePostReadyPhase,
+)
+from proliferate.db.models.cloud.sync import CloudSyncedWorkspace
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class SyncedCloudWorkspaceSnapshot:
+    id: UUID
+    target_id: UUID
+    anyharness_workspace_id: str
+    display_name: str | None
+    git_provider: str
+    git_owner: str
+    git_repo_name: str
+    git_branch: str
+    git_base_branch: str | None
+    status: str
+    updated_at: datetime
+
+
+def _workspace_snapshot(
+    *,
+    target_id: UUID,
+    workspace: CloudWorkspace,
+) -> SyncedCloudWorkspaceSnapshot:
+    return SyncedCloudWorkspaceSnapshot(
+        id=workspace.id,
+        target_id=target_id,
+        anyharness_workspace_id=workspace.anyharness_workspace_id or "",
+        display_name=workspace.display_name,
+        git_provider=workspace.git_provider,
+        git_owner=workspace.git_owner,
+        git_repo_name=workspace.git_repo_name,
+        git_branch=workspace.git_branch,
+        git_base_branch=workspace.git_base_branch,
+        status=workspace.status,
+        updated_at=workspace.updated_at,
+    )
+
+
+async def upsert_synced_workspace(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    anyharness_workspace_id: str,
+    billing_subject_id: UUID,
+    owner_scope: str,
+    owner_user_id: UUID,
+    organization_id: UUID | None,
+    created_by_user_id: UUID,
+    display_name: str | None,
+    git_provider: str,
+    git_owner: str,
+    git_repo_name: str,
+    git_branch: str,
+    git_base_branch: str | None,
+    origin_json: str | None,
+    template_version: str,
+) -> SyncedCloudWorkspaceSnapshot:
+    workspace = await _find_workspace_by_anyharness_id(
+        db,
+        target_id=target_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+    )
+    now = utcnow()
+    if workspace is None:
+        workspace = CloudWorkspace(
+            user_id=owner_user_id,
+            owner_scope=owner_scope,
+            owner_user_id=owner_user_id if owner_scope == "personal" else None,
+            organization_id=organization_id if owner_scope == "organization" else None,
+            created_by_user_id=created_by_user_id,
+            billing_subject_id=billing_subject_id,
+            runtime_environment_id=None,
+            display_name=display_name,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            git_branch=git_branch,
+            git_base_branch=git_base_branch,
+            origin_json=origin_json,
+            status=CloudWorkspaceStatus.ready.value,
+            status_detail="Synced from target.",
+            last_error=None,
+            template_version=template_version,
+            runtime_generation=0,
+            anyharness_workspace_id=anyharness_workspace_id,
+            repo_env_vars_ciphertext=None,
+            repo_files_applied_version=0,
+            repo_setup_applied_version=0,
+            repo_post_ready_phase=WorkspacePostReadyPhase.idle.value,
+            repo_post_ready_files_total=0,
+            repo_post_ready_files_applied=0,
+            repo_post_ready_apply_token=None,
+            repo_files_last_failed_path=None,
+            repo_files_last_error=None,
+            cleanup_state=CloudWorkspaceCleanupState.none.value,
+            created_at=now,
+            updated_at=now,
+            ready_at=now,
+        )
+        db.add(workspace)
+        await db.flush()
+        mapping = CloudSyncedWorkspace(
+            target_id=target_id,
+            cloud_workspace_id=workspace.id,
+            workspace_id=anyharness_workspace_id,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(mapping)
+    else:
+        workspace.billing_subject_id = billing_subject_id
+        workspace.display_name = (
+            display_name if display_name is not None else workspace.display_name
+        )
+        workspace.git_provider = git_provider
+        workspace.git_owner = git_owner
+        workspace.git_repo_name = git_repo_name
+        workspace.git_branch = git_branch
+        workspace.git_base_branch = git_base_branch or workspace.git_base_branch
+        workspace.origin_json = origin_json if origin_json is not None else workspace.origin_json
+        workspace.status = CloudWorkspaceStatus.ready.value
+        workspace.status_detail = "Synced from target."
+        workspace.last_error = None
+        workspace.template_version = template_version
+        workspace.anyharness_workspace_id = anyharness_workspace_id
+        workspace.updated_at = now
+        workspace.ready_at = workspace.ready_at or now
+        await _upsert_workspace_mapping(
+            db,
+            target_id=target_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+            cloud_workspace_id=workspace.id,
+            now=now,
+        )
+    await db.flush()
+    return _workspace_snapshot(target_id=target_id, workspace=workspace)
+
+
+async def _upsert_workspace_mapping(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    anyharness_workspace_id: str,
+    cloud_workspace_id: UUID,
+    now: datetime,
+) -> None:
+    row = (
+        await db.execute(
+            select(CloudSyncedWorkspace)
+            .where(CloudSyncedWorkspace.target_id == target_id)
+            .where(CloudSyncedWorkspace.workspace_id == anyharness_workspace_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CloudSyncedWorkspace(
+            target_id=target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=anyharness_workspace_id,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+        return
+    row.cloud_workspace_id = cloud_workspace_id
+    row.updated_at = now
+
+
+async def _find_workspace_by_anyharness_id(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    anyharness_workspace_id: str,
+) -> CloudWorkspace | None:
+    return (
+        await db.execute(
+            select(CloudWorkspace)
+            .join(
+                CloudSyncedWorkspace,
+                CloudSyncedWorkspace.cloud_workspace_id == CloudWorkspace.id,
+            )
+            .where(CloudSyncedWorkspace.target_id == target_id)
+            .where(CloudSyncedWorkspace.workspace_id == anyharness_workspace_id)
+            .where(CloudWorkspace.archived_at.is_(None))
+            .order_by(CloudWorkspace.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()

--- a/server/proliferate/db/store/cloud_sync/events.py
+++ b/server/proliferate/db/store/cloud_sync/events.py
@@ -16,6 +16,7 @@ from proliferate.db.models.cloud.sync import (
     CloudPendingInteraction,
     CloudSessionEvent,
     CloudSessionProjection,
+    CloudSyncedWorkspace,
     CloudTranscriptItem,
 )
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
@@ -217,6 +218,16 @@ async def resolve_cloud_workspace_id(
 ) -> UUID | None:
     if not workspace_id:
         return None
+    synced_row = (
+        await db.execute(
+            select(CloudSyncedWorkspace.cloud_workspace_id)
+            .where(CloudSyncedWorkspace.target_id == target_id)
+            .where(CloudSyncedWorkspace.workspace_id == workspace_id)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if synced_row is not None:
+        return synced_row
     row = (
         await db.execute(
             select(CloudWorkspace.id)
@@ -597,6 +608,33 @@ async def resolve_pending_interaction(
     return _interaction_snapshot(row)
 
 
+async def resolve_missing_pending_interactions(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    active_request_ids: tuple[str, ...],
+    seq: int,
+    occurred_at: str | None,
+) -> None:
+    query = (
+        select(CloudPendingInteraction)
+        .where(CloudPendingInteraction.target_id == target_id)
+        .where(CloudPendingInteraction.session_id == session_id)
+        .where(CloudPendingInteraction.status == "pending")
+    )
+    if active_request_ids:
+        query = query.where(CloudPendingInteraction.request_id.not_in(active_request_ids))
+    rows = (await db.execute(query)).scalars()
+    now = utcnow()
+    for row in rows:
+        row.status = "resolved"
+        row.resolved_seq = seq
+        row.resolved_at = occurred_at
+        row.updated_at = now
+    await db.flush()
+
+
 async def get_session_projection(
     db: AsyncSession,
     *,
@@ -627,6 +665,30 @@ async def get_session_projection_by_session_id(
         )
     ).scalar_one_or_none()
     return _session_snapshot(row) if row is not None else None
+
+
+async def list_session_projections(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    cloud_workspace_id: UUID | None = None,
+    workspace_id: str | None = None,
+    limit: int = 100,
+) -> tuple[CloudSessionProjectionSnapshot, ...]:
+    query = select(CloudSessionProjection).where(CloudSessionProjection.target_id == target_id)
+    if cloud_workspace_id is not None:
+        query = query.where(CloudSessionProjection.cloud_workspace_id == cloud_workspace_id)
+    if workspace_id is not None:
+        query = query.where(CloudSessionProjection.workspace_id == workspace_id)
+    rows = (
+        await db.execute(
+            query.order_by(
+                CloudSessionProjection.updated_at.desc(),
+                CloudSessionProjection.last_event_seq.desc(),
+            ).limit(limit)
+        )
+    ).scalars()
+    return tuple(_session_snapshot(row) for row in rows)
 
 
 async def list_transcript_items(

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from proliferate.server.cloud.backfill.api import router as backfill_router
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.credentials.api import router as credentials_router
 from proliferate.server.cloud.events.api import router as events_router
@@ -33,4 +34,5 @@ router.include_router(webhooks_router)
 router.include_router(targets_router)
 router.include_router(commands_router)
 router.include_router(events_router)
+router.include_router(backfill_router)
 router.include_router(worker_router)

--- a/server/proliferate/server/cloud/backfill/__init__.py
+++ b/server/proliferate/server/cloud/backfill/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud worker backfill domain."""

--- a/server/proliferate/server/cloud/backfill/api.py
+++ b/server/proliferate/server/cloud/backfill/api.py
@@ -1,0 +1,30 @@
+"""Worker-facing backfill routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.backfill.models import (
+    WorkerBackfillRequest,
+    WorkerBackfillResponse,
+)
+from proliferate.server.cloud.backfill.service import record_worker_backfill
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.worker.service import authenticate_worker
+
+router = APIRouter(prefix="/worker/backfill", tags=["cloud-worker-backfill"])
+
+
+@router.post("", response_model=WorkerBackfillResponse)
+async def worker_backfill_endpoint(
+    body: WorkerBackfillRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerBackfillResponse:
+    try:
+        auth = await authenticate_worker(db, authorization=authorization)
+        return await record_worker_backfill(db, auth=auth, body=body)
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/backfill/models.py
+++ b/server/proliferate/server/cloud/backfill/models.py
@@ -1,0 +1,78 @@
+"""Request and response models for worker backfill."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class WorkerBackfillRepoRef(BaseModel):
+    provider: str | None = Field(default=None, max_length=32)
+    owner: str | None = Field(default=None, max_length=255)
+    name: str | None = Field(default=None, max_length=255)
+    branch: str | None = Field(default=None, max_length=255)
+    base_branch: str | None = Field(default=None, alias="baseBranch", max_length=255)
+
+
+class WorkerBackfillWorkspace(BaseModel):
+    workspace_id: str = Field(alias="workspaceId", max_length=255)
+    display_name: str | None = Field(default=None, alias="displayName", max_length=255)
+    path: str | None = Field(default=None, max_length=4096)
+    repo: WorkerBackfillRepoRef | None = None
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+
+
+class WorkerBackfillPendingInteraction(BaseModel):
+    request_id: str = Field(alias="requestId", max_length=255)
+    kind: str | None = Field(default=None, max_length=64)
+    title: str | None = None
+    description: str | None = None
+    payload: dict[str, object] | None = None
+
+
+class WorkerBackfillSession(BaseModel):
+    session_id: str = Field(alias="sessionId", max_length=255)
+    workspace_id: str | None = Field(default=None, alias="workspaceId", max_length=255)
+    native_session_id: str | None = Field(default=None, alias="nativeSessionId", max_length=255)
+    source_agent_kind: str | None = Field(
+        default=None,
+        alias="sourceAgentKind",
+        max_length=64,
+    )
+    title: str | None = None
+    status: str | None = Field(default=None, max_length=32)
+    phase: str | None = Field(default=None, max_length=64)
+    live_config: dict[str, object] | None = Field(default=None, alias="liveConfig")
+    last_event_seq: int = Field(default=0, alias="lastEventSeq", ge=0)
+    last_event_at: str | None = Field(default=None, alias="lastEventAt")
+    started_at: str | None = Field(default=None, alias="startedAt")
+    ended_at: str | None = Field(default=None, alias="endedAt")
+    pending_interactions: list[WorkerBackfillPendingInteraction] = Field(
+        default_factory=list,
+        alias="pendingInteractions",
+        max_length=100,
+    )
+
+
+class WorkerBackfillRequest(BaseModel):
+    workspaces: list[WorkerBackfillWorkspace] = Field(default_factory=list, max_length=200)
+    sessions: list[WorkerBackfillSession] = Field(default_factory=list, max_length=500)
+
+
+class WorkerBackfillWorkspaceMapping(BaseModel):
+    workspace_id: str = Field(serialization_alias="workspaceId")
+    cloud_workspace_id: str = Field(serialization_alias="cloudWorkspaceId")
+
+
+class WorkerBackfillSessionMapping(BaseModel):
+    session_id: str = Field(serialization_alias="sessionId")
+    workspace_id: str | None = Field(default=None, serialization_alias="workspaceId")
+    cloud_workspace_id: str | None = Field(default=None, serialization_alias="cloudWorkspaceId")
+
+
+class WorkerBackfillResponse(BaseModel):
+    mapped_workspaces: list[WorkerBackfillWorkspaceMapping] = Field(
+        serialization_alias="mappedWorkspaces",
+    )
+    mapped_sessions: list[WorkerBackfillSessionMapping] = Field(
+        serialization_alias="mappedSessions",
+    )

--- a/server/proliferate/server/cloud/backfill/service.py
+++ b/server/proliferate/server/cloud/backfill/service.py
@@ -1,0 +1,189 @@
+"""Application service for worker backfill."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.billing import (
+    ensure_organization_billing_subject,
+    ensure_personal_billing_subject,
+)
+from proliferate.db.store.cloud_sync import backfill as backfill_store
+from proliferate.db.store.cloud_sync import events as events_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud.backfill.models import (
+    WorkerBackfillRequest,
+    WorkerBackfillResponse,
+    WorkerBackfillSessionMapping,
+    WorkerBackfillWorkspace,
+    WorkerBackfillWorkspaceMapping,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.worker.domain.rules import compact_json
+from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
+
+CLOUD_BACKFILL_TEMPLATE_VERSION = "worker-backfill-v1"
+CLOUD_BACKFILL_ORIGIN_JSON = '{"kind":"system","entrypoint":"cloud"}'
+
+
+@dataclass(frozen=True)
+class NormalizedBackfillRepo:
+    provider: str
+    owner: str
+    name: str
+    branch: str
+    base_branch: str
+
+
+async def record_worker_backfill(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerBackfillRequest,
+) -> WorkerBackfillResponse:
+    target = await targets_store.get_target_by_id(db, auth.target_id)
+    if target is None:
+        raise CloudApiError(
+            "cloud_worker_target_missing",
+            "Worker target no longer exists.",
+            status_code=401,
+        )
+    billing_subject = (
+        await ensure_organization_billing_subject(db, target.organization_id)
+        if target.owner_scope == "organization" and target.organization_id is not None
+        else await ensure_personal_billing_subject(db, target.owner_user_id)
+    )
+    workspace_mappings: dict[str, UUID] = {}
+    mapped_workspaces: list[WorkerBackfillWorkspaceMapping] = []
+    for workspace in body.workspaces:
+        repo = _normalize_repo(workspace)
+        mapped = await backfill_store.upsert_synced_workspace(
+            db,
+            target_id=auth.target_id,
+            anyharness_workspace_id=workspace.workspace_id,
+            billing_subject_id=billing_subject.id,
+            owner_scope=target.owner_scope,
+            owner_user_id=target.owner_user_id,
+            organization_id=target.organization_id,
+            created_by_user_id=target.created_by_user_id,
+            display_name=workspace.display_name,
+            git_provider=repo.provider,
+            git_owner=repo.owner,
+            git_repo_name=repo.name,
+            git_branch=repo.branch,
+            git_base_branch=repo.base_branch,
+            origin_json=CLOUD_BACKFILL_ORIGIN_JSON,
+            template_version=CLOUD_BACKFILL_TEMPLATE_VERSION,
+        )
+        workspace_mappings[workspace.workspace_id] = mapped.id
+        mapped_workspaces.append(
+            WorkerBackfillWorkspaceMapping(
+                workspace_id=workspace.workspace_id,
+                cloud_workspace_id=str(mapped.id),
+            )
+        )
+
+    mapped_sessions: list[WorkerBackfillSessionMapping] = []
+    for session in body.sessions:
+        cloud_workspace_id = workspace_mappings.get(session.workspace_id or "")
+        if cloud_workspace_id is None:
+            cloud_workspace_id = await events_store.resolve_cloud_workspace_id(
+                db,
+                target_id=auth.target_id,
+                workspace_id=session.workspace_id,
+            )
+        projection = await events_store.upsert_session_projection(
+            db,
+            target_id=auth.target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=session.workspace_id,
+            session_id=session.session_id,
+            seq=max(0, session.last_event_seq),
+            occurred_at=session.last_event_at,
+            status=session.status,
+            phase=session.phase,
+            native_session_id=session.native_session_id,
+            source_agent_kind=session.source_agent_kind,
+            title=session.title,
+            live_config_json=compact_json(session.live_config),
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+        )
+        for interaction in session.pending_interactions:
+            await events_store.upsert_pending_interaction(
+                db,
+                target_id=auth.target_id,
+                cloud_workspace_id=cloud_workspace_id,
+                workspace_id=session.workspace_id,
+                session_id=session.session_id,
+                request_id=interaction.request_id,
+                seq=max(0, session.last_event_seq),
+                occurred_at=session.last_event_at,
+                kind=interaction.kind,
+                title=interaction.title,
+                description=interaction.description,
+                payload_json=compact_json(interaction.payload),
+            )
+        await events_store.resolve_missing_pending_interactions(
+            db,
+            target_id=auth.target_id,
+            session_id=session.session_id,
+            active_request_ids=tuple(
+                interaction.request_id for interaction in session.pending_interactions
+            ),
+            seq=max(0, session.last_event_seq),
+            occurred_at=session.last_event_at,
+        )
+        mapped_sessions.append(
+            WorkerBackfillSessionMapping(
+                session_id=session.session_id,
+                workspace_id=session.workspace_id,
+                cloud_workspace_id=(
+                    str(projection.cloud_workspace_id)
+                    if projection.cloud_workspace_id is not None
+                    else None
+                ),
+            )
+        )
+    return WorkerBackfillResponse(
+        mapped_workspaces=mapped_workspaces,
+        mapped_sessions=mapped_sessions,
+    )
+
+
+def _normalize_repo(workspace: WorkerBackfillWorkspace) -> NormalizedBackfillRepo:
+    repo = workspace.repo
+    provider = _clean(repo.provider if repo is not None else None) or "local"
+    owner = _clean(repo.owner if repo is not None else None) or "target"
+    name = (
+        _clean(repo.name if repo is not None else None)
+        or _clean(workspace.display_name)
+        or _last_path_segment(workspace.path)
+        or workspace.workspace_id
+    )
+    branch = _clean(repo.branch if repo is not None else None) or "default"
+    base_branch = _clean(repo.base_branch if repo is not None else None) or branch
+    return NormalizedBackfillRepo(
+        provider=provider[:32],
+        owner=owner[:255],
+        name=name[:255],
+        branch=branch[:255],
+        base_branch=base_branch[:255],
+    )
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _last_path_segment(value: str | None) -> str | None:
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    return cleaned.rstrip("/").rsplit("/", 1)[-1] or None

--- a/server/proliferate/server/cloud/commands/domain/rules.py
+++ b/server/proliferate/server/cloud/commands/domain/rules.py
@@ -43,7 +43,10 @@ def validate_command_shape(
     session_id: str | None,
     preconditions: dict[str, object] | None,
 ) -> None:
-    if kind == CloudCommandKind.start_session.value and not workspace_id:
+    if kind in {
+        CloudCommandKind.start_session.value,
+        CloudCommandKind.sync_existing_workspace.value,
+    } and not workspace_id:
         raise CloudApiError(
             "cloud_command_workspace_required",
             f"Cloud command kind requires workspaceId: {kind}",

--- a/server/proliferate/server/cloud/events/api.py
+++ b/server/proliferate/server/cloud/events/api.py
@@ -12,14 +12,40 @@ from proliferate.auth.dependencies import current_active_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
-from proliferate.server.cloud.events.models import CloudSessionSnapshotResponse
+from proliferate.server.cloud.events.models import (
+    CloudSessionProjectionResponse,
+    CloudSessionSnapshotResponse,
+)
 from proliferate.server.cloud.events.service import (
     ensure_visible_session_target,
     get_session_snapshot,
+    list_session_summaries,
 )
 from proliferate.server.cloud.live.service import stream_session_events
 
 router = APIRouter(prefix="/sessions", tags=["cloud-sessions"])
+
+
+@router.get("", response_model=list[CloudSessionProjectionResponse])
+async def list_sessions_endpoint(
+    target_id: UUID = Query(alias="targetId"),
+    cloud_workspace_id: UUID | None = Query(default=None, alias="cloudWorkspaceId"),
+    workspace_id: str | None = Query(default=None, alias="workspaceId"),
+    limit: int = Query(default=100, ge=1, le=200),
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> list[CloudSessionProjectionResponse]:
+    try:
+        return await list_session_summaries(
+            db,
+            target_id=target_id,
+            user_id=user.id,
+            cloud_workspace_id=cloud_workspace_id,
+            workspace_id=workspace_id,
+            limit=limit,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
 
 
 @router.get("/{session_id}/snapshot", response_model=CloudSessionSnapshotResponse)

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -23,6 +23,7 @@ from proliferate.server.cloud.events.domain.projection import (
 )
 from proliferate.server.cloud.events.models import (
     CloudSessionPatchResponse,
+    CloudSessionProjectionResponse,
     CloudSessionSnapshotResponse,
     WorkerEventBatchRequest,
     WorkerEventBatchResponse,
@@ -221,6 +222,26 @@ async def get_session_snapshot(
     )
 
 
+async def list_session_summaries(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+    cloud_workspace_id: UUID | None = None,
+    workspace_id: str | None = None,
+    limit: int = 100,
+) -> list[CloudSessionProjectionResponse]:
+    await ensure_visible_target(db, target_id=target_id, user_id=user_id)
+    sessions = await events_store.list_session_projections(
+        db,
+        target_id=target_id,
+        cloud_workspace_id=cloud_workspace_id,
+        workspace_id=workspace_id,
+        limit=min(max(limit, 1), 200),
+    )
+    return [session_projection_response(session) for session in sessions]
+
+
 async def ensure_visible_session_target(
     db: AsyncSession,
     *,
@@ -251,6 +272,26 @@ async def ensure_visible_session_target(
             status_code=404,
         )
     return target_id
+
+
+async def ensure_visible_target(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+) -> targets_store.CloudTargetSnapshot:
+    target = await targets_store.get_visible_target_by_id(
+        db,
+        target_id=target_id,
+        user_id=user_id,
+    )
+    if target is None:
+        raise CloudApiError(
+            "cloud_target_not_found",
+            "Target not found.",
+            status_code=404,
+        )
+    return target
 
 
 async def _apply_projection(

--- a/server/proliferate/server/cloud/worker/domain/rules.py
+++ b/server/proliferate/server/cloud/worker/domain/rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from proliferate.constants.cloud import (
+    ACTIVE_CLOUD_COMMAND_KINDS,
     CLOUD_COMMAND_DEFAULT_LEASE_SECONDS,
     CLOUD_COMMAND_MAX_LEASE_SECONDS,
     PHASE3_CLOUD_COMMAND_KINDS,
@@ -49,7 +50,7 @@ def compact_json(value: dict[str, object] | None) -> str | None:
 def normalize_supported_command_kinds(supported_kinds: list[str]) -> tuple[str, ...]:
     if not supported_kinds:
         return PHASE3_CLOUD_COMMAND_KINDS
-    filtered = tuple(kind for kind in supported_kinds if kind in PHASE3_CLOUD_COMMAND_KINDS)
+    filtered = tuple(kind for kind in supported_kinds if kind in ACTIVE_CLOUD_COMMAND_KINDS)
     if not filtered:
         raise CloudApiError(
             "cloud_worker_command_kinds_unsupported",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -89,6 +89,7 @@ module = [
     "proliferate.server.health",
     "proliferate.auth.models",
     "proliferate.auth.desktop.models",
+    "proliferate.server.cloud.backfill.models",
     "proliferate.server.cloud.commands.models",
     "proliferate.server.cloud.mcp_catalog.models",
     "proliferate.server.cloud.mcp_connections.models",

--- a/server/tests/integration/test_cloud_backfill_api.py
+++ b/server/tests/integration/test_cloud_backfill_api.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+from tests.e2e.cloud.helpers.shared import AuthSession
+
+
+async def _create_enrolled_target(
+    client: AsyncClient,
+    auth: AuthSession,
+    *,
+    suffix: str = "backfill",
+) -> tuple[str, dict[str, str]]:
+    create = await client.post(
+        "/v1/cloud/targets/enrollments",
+        headers=auth.headers,
+        json={
+            "displayName": f"Backfill Target {suffix}",
+            "kind": "desktop_dispatch",
+            "ownerScope": "personal",
+        },
+    )
+    assert create.status_code == 200
+    enrollment = create.json()
+    worker_enroll = await client.post(
+        "/v1/cloud/worker/enroll",
+        json={
+            "enrollmentToken": enrollment["enrollmentToken"],
+            "machineFingerprint": f"{suffix}-machine",
+            "hostname": f"{suffix}-target",
+            "workerVersion": "0.1.0",
+        },
+    )
+    assert worker_enroll.status_code == 200
+    worker = worker_enroll.json()
+    return enrollment["target"]["id"], {"Authorization": f"Bearer {worker['workerToken']}"}
+
+
+class TestCloudBackfillApi:
+    @pytest.mark.asyncio
+    async def test_worker_backfill_maps_workspace_and_session_read_models(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-backfill",
+        )
+        target_id, worker_headers = await _create_enrolled_target(client, auth)
+
+        backfill = await client.post(
+            "/v1/cloud/worker/backfill",
+            headers=worker_headers,
+            json={
+                "workspaces": [
+                    {
+                        "workspaceId": "local-workspace-1",
+                        "displayName": "Local Workspace",
+                        "path": "/tmp/proliferate",
+                        "repo": {
+                            "provider": "github",
+                            "owner": "proliferate-ai",
+                            "name": "proliferate",
+                            "branch": "worker-sync",
+                            "baseBranch": "main",
+                        },
+                        "updatedAt": "2026-05-14T00:00:00Z",
+                    }
+                ],
+                "sessions": [
+                    {
+                        "sessionId": "local-session-1",
+                        "workspaceId": "local-workspace-1",
+                        "nativeSessionId": "native-session-1",
+                        "sourceAgentKind": "codex",
+                        "title": "Synced session",
+                        "status": "idle",
+                        "phase": "awaiting_interaction",
+                        "liveConfig": {"model": "gpt-5.4"},
+                        "lastEventSeq": 0,
+                        "lastEventAt": "2026-05-14T00:00:00Z",
+                        "startedAt": "2026-05-14T00:00:00Z",
+                        "pendingInteractions": [
+                            {
+                                "requestId": "interaction-1",
+                                "kind": "permission",
+                                "title": "Approve tests",
+                                "description": "Agent wants to run tests.",
+                                "payload": {"type": "permission"},
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        assert backfill.status_code == 200
+        body = backfill.json()
+        assert body["mappedWorkspaces"][0]["workspaceId"] == "local-workspace-1"
+        cloud_workspace_id = body["mappedWorkspaces"][0]["cloudWorkspaceId"]
+        assert body["mappedSessions"][0]["cloudWorkspaceId"] == cloud_workspace_id
+
+        workspaces = await client.get("/v1/cloud/workspaces", headers=auth.headers)
+        assert workspaces.status_code == 200
+        workspace = workspaces.json()[0]
+        assert workspace["id"] == cloud_workspace_id
+        assert workspace["displayName"] == "Local Workspace"
+        assert workspace["repo"]["branch"] == "worker-sync"
+
+        sessions = await client.get(
+            f"/v1/cloud/sessions?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert sessions.status_code == 200
+        session = sessions.json()[0]
+        assert session["sessionId"] == "local-session-1"
+        assert session["cloudWorkspaceId"] == cloud_workspace_id
+        assert session["liveConfig"] == {"model": "gpt-5.4"}
+
+        snapshot = await client.get(
+            f"/v1/cloud/sessions/local-session-1/snapshot?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert snapshot.status_code == 200
+        assert snapshot.json()["pendingInteractions"][0]["requestId"] == "interaction-1"
+
+        cleared = await client.post(
+            "/v1/cloud/worker/backfill",
+            headers=worker_headers,
+            json={
+                "workspaces": [],
+                "sessions": [
+                    {
+                        "sessionId": "local-session-1",
+                        "workspaceId": "local-workspace-1",
+                        "status": "idle",
+                        "lastEventSeq": 1,
+                        "lastEventAt": "2026-05-14T00:01:00Z",
+                        "pendingInteractions": [],
+                    }
+                ],
+            },
+        )
+        assert cleared.status_code == 200
+        cleared_snapshot = await client.get(
+            f"/v1/cloud/sessions/local-session-1/snapshot?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert cleared_snapshot.status_code == 200
+        assert cleared_snapshot.json()["pendingInteractions"] == []
+
+    @pytest.mark.asyncio
+    async def test_backfill_keeps_same_repo_branch_distinct_per_target(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-backfill-target-scope",
+        )
+        first_target_id, first_worker_headers = await _create_enrolled_target(
+            client,
+            auth,
+            suffix="target-scope-1",
+        )
+        second_target_id, second_worker_headers = await _create_enrolled_target(
+            client,
+            auth,
+            suffix="target-scope-2",
+        )
+
+        payload = {
+            "workspaces": [
+                {
+                    "workspaceId": "same-local-id",
+                    "displayName": "Local Workspace",
+                    "repo": {
+                        "provider": "github",
+                        "owner": "proliferate-ai",
+                        "name": "proliferate",
+                        "branch": "main",
+                        "baseBranch": "main",
+                    },
+                }
+            ],
+            "sessions": [],
+        }
+        first = await client.post(
+            "/v1/cloud/worker/backfill",
+            headers=first_worker_headers,
+            json=payload,
+        )
+        assert first.status_code == 200
+        second = await client.post(
+            "/v1/cloud/worker/backfill",
+            headers=second_worker_headers,
+            json=payload,
+        )
+        assert second.status_code == 200
+        first_workspace_id = first.json()["mappedWorkspaces"][0]["cloudWorkspaceId"]
+        second_workspace_id = second.json()["mappedWorkspaces"][0]["cloudWorkspaceId"]
+        assert first_workspace_id != second_workspace_id
+
+        first_sessions = await client.get(
+            f"/v1/cloud/sessions?targetId={first_target_id}",
+            headers=auth.headers,
+        )
+        assert first_sessions.status_code == 200
+        second_sessions = await client.get(
+            f"/v1/cloud/sessions?targetId={second_target_id}",
+            headers=auth.headers,
+        )
+        assert second_sessions.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_sync_existing_workspace_command_can_be_queued(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-backfill-command",
+        )
+        target_id, worker_headers = await _create_enrolled_target(
+            client,
+            auth,
+            suffix="backfill-command",
+        )
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "sync-local-workspace",
+                "targetId": target_id,
+                "workspaceId": "local-workspace-1",
+                "kind": "sync_existing_workspace",
+                "payload": {},
+                "source": "desktop_cloud_view",
+            },
+        )
+        assert created.status_code == 200
+        command_id = created.json()["commandId"]
+
+        legacy_lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={"leaseTimeoutSeconds": 30},
+        )
+        assert legacy_lease.status_code == 200
+        assert legacy_lease.json()["command"] is None
+
+        lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["sync_existing_workspace"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert lease.status_code == 200
+        command = lease.json()["command"]
+        assert command["commandId"] == command_id
+        assert command["workspaceId"] == "local-workspace-1"


### PR DESCRIPTION
## Summary

- Add worker backfill APIs so cloud-visible targets can map existing AnyHarness workspaces and sessions into Cloud read models.
- Add `sync_existing_workspace` command dispatch in proliferate-worker, including typed AnyHarness/cloud payloads, chunked uploads, local sync mappings, and pending command result retry storage.
- Add target-scoped synced workspace mappings, pending interaction cleanup, session list reads, and integration coverage for backfill + command leasing.

## Verification

- `cd server && uv run ruff check proliferate/server/cloud/backfill proliferate/server/cloud/worker/domain/rules.py proliferate/server/cloud/events proliferate/db/store/cloud_sync/backfill.py proliferate/db/store/cloud_sync/events.py proliferate/db/models/cloud/sync.py proliferate/constants/cloud.py tests/integration/test_cloud_backfill_api.py alembic/versions/c9d0e1f2a3b4_cloud_synced_workspace_mappings.py`
- `cd server && uv run mypy proliferate/server/cloud/backfill proliferate/server/cloud/events proliferate/db/store/cloud_sync/backfill.py proliferate/db/store/cloud_sync/events.py proliferate/db/models/cloud/sync.py tests/integration/test_cloud_backfill_api.py`
- `cargo fmt --check --package proliferate-worker && cargo check -p proliferate-worker && cargo test -p proliferate-worker`
- `cd server && DEBUG=true uv run python -m pytest -q tests/integration/test_cloud_backfill_api.py tests/integration/test_cloud_commands_api.py tests/integration/test_cloud_event_sync_api.py tests/integration/test_cloud_targets_api.py`
- `cd server && uv run alembic heads && git diff --check`

## Notes

Stacked on `proliferate/cloud-live-session-fanout`.
