### PR TITLE
feat(cloud): add live snapshot streams

### DIFF
--- a/cloud/sdk-react/src/hooks/events.ts
+++ b/cloud/sdk-react/src/hooks/events.ts
@@ -6,15 +6,25 @@ import {
 import { cloudRootKey } from "../lib/query-keys.js";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 
-export function cloudSessionEventsKey(sessionId: string | null) {
-  return [...cloudRootKey(), "session-events", sessionId] as const;
+export function cloudSessionEventsKey(targetId: string | null, sessionId: string | null) {
+  return [...cloudRootKey(), "session-events", targetId, sessionId] as const;
 }
 
-export function useCloudSessionEvents(sessionId: string | null, enabled = true) {
+export function useCloudSessionEvents(
+  targetId: string | null,
+  sessionId: string | null,
+  enabled = true,
+) {
   const client = useCloudClient();
+  const canQuery =
+    enabled &&
+    targetId !== null &&
+    targetId !== undefined &&
+    sessionId !== null &&
+    sessionId !== undefined;
   return useQuery<CloudSessionEventsResponse>({
-    queryKey: cloudSessionEventsKey(sessionId),
-    queryFn: () => listSessionEvents(sessionId!, undefined, client),
-    enabled: enabled && sessionId !== null,
+    queryKey: cloudSessionEventsKey(targetId, sessionId),
+    queryFn: () => listSessionEvents(sessionId!, { targetId: targetId! }, client),
+    enabled: canQuery,
   });
 }

--- a/cloud/sdk-react/src/hooks/live.ts
+++ b/cloud/sdk-react/src/hooks/live.ts
@@ -1,9 +1,16 @@
 export type {
+  CloudCommandStatusPatch,
   CloudLivePatch,
   CloudLiveSubscriptionOptions,
+  CloudSessionProjectionPatch,
+  CloudSessionLiveEvent,
+  CloudTargetPatch,
+  CloudTargetLiveEvent,
+  CloudWorkspaceProjectionPatch,
+  CloudWorkspaceLiveEvent,
 } from "@proliferate/cloud-sdk";
 export {
   subscribeSession,
+  subscribeTarget,
   subscribeWorkspace,
 } from "@proliferate/cloud-sdk";
-

--- a/cloud/sdk-react/src/hooks/sessions.ts
+++ b/cloud/sdk-react/src/hooks/sessions.ts
@@ -11,20 +11,40 @@ import {
 } from "../lib/query-keys.js";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 
-export function useCloudSessionSnapshot(sessionId: string | null, enabled = true) {
+export function useCloudSessionSnapshot(
+  targetId: string | null,
+  sessionId: string | null,
+  enabled = true,
+) {
   const client = useCloudClient();
+  const canQuery =
+    enabled &&
+    targetId !== null &&
+    targetId !== undefined &&
+    sessionId !== null &&
+    sessionId !== undefined;
   return useQuery<CloudSessionSnapshot>({
-    queryKey: cloudSessionSnapshotKey(sessionId),
-    queryFn: () => getSessionSnapshot(sessionId!, client),
-    enabled: enabled && sessionId !== null,
+    queryKey: cloudSessionSnapshotKey(targetId, sessionId),
+    queryFn: () => getSessionSnapshot(sessionId!, { targetId: targetId! }, client),
+    enabled: canQuery,
   });
 }
 
-export function useCloudTranscriptSnapshot(sessionId: string | null, enabled = true) {
+export function useCloudTranscriptSnapshot(
+  targetId: string | null,
+  sessionId: string | null,
+  enabled = true,
+) {
   const client = useCloudClient();
+  const canQuery =
+    enabled &&
+    targetId !== null &&
+    targetId !== undefined &&
+    sessionId !== null &&
+    sessionId !== undefined;
   return useQuery<CloudTranscriptSnapshot>({
-    queryKey: cloudTranscriptSnapshotKey(sessionId),
-    queryFn: () => getTranscriptSnapshot(sessionId!, client),
-    enabled: enabled && sessionId !== null,
+    queryKey: cloudTranscriptSnapshotKey(targetId, sessionId),
+    queryFn: () => getTranscriptSnapshot(sessionId!, { targetId: targetId! }, client),
+    enabled: canQuery,
   });
 }

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -149,10 +149,10 @@ export function cloudWorkspaceSnapshotKey(workspaceId: string | null) {
   return [...cloudRootKey(), "workspace-snapshots", workspaceId] as const;
 }
 
-export function cloudSessionSnapshotKey(sessionId: string | null) {
-  return [...cloudRootKey(), "session-snapshots", sessionId] as const;
+export function cloudSessionSnapshotKey(targetId: string | null, sessionId: string | null) {
+  return [...cloudRootKey(), "session-snapshots", targetId, sessionId] as const;
 }
 
-export function cloudTranscriptSnapshotKey(sessionId: string | null) {
-  return [...cloudRootKey(), "transcript-snapshots", sessionId] as const;
+export function cloudTranscriptSnapshotKey(targetId: string | null, sessionId: string | null) {
+  return [...cloudRootKey(), "transcript-snapshots", targetId, sessionId] as const;
 }

--- a/cloud/sdk/src/client/events.ts
+++ b/cloud/sdk/src/client/events.ts
@@ -1,24 +1,21 @@
 import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type { components } from "../generated/openapi.js";
 
-export interface CloudSessionEvent {
-  id: string;
+export type CloudSessionEvent =
+  components["schemas"]["CloudSessionEventResponse"];
+export type CloudSessionEventsResponse =
+  components["schemas"]["CloudSessionEventsResponse"];
+
+export interface ListSessionEventsInput {
   targetId: string;
-  workspaceId: string;
-  sessionId: string;
-  anyharnessSeq: number;
-  type: string;
-  payload: Record<string, unknown>;
-  createdAt?: string | null;
-}
-
-export interface CloudSessionEventsResponse {
-  events: CloudSessionEvent[];
-  nextCursor?: string | null;
+  afterSeq?: number | null;
+  limit?: number | null;
+  signal?: AbortSignal;
 }
 
 export async function listSessionEvents(
   sessionId: string,
-  input?: { cursor?: string | null; limit?: number | null; signal?: AbortSignal },
+  input: ListSessionEventsInput,
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudSessionEventsResponse> {
   return client.requestJson<CloudSessionEventsResponse>({
@@ -26,9 +23,10 @@ export async function listSessionEvents(
     path: "/v1/cloud/sessions/{session_id}/events",
     pathParams: { session_id: sessionId },
     query: {
-      cursor: input?.cursor ?? undefined,
-      limit: input?.limit ?? undefined,
+      targetId: input.targetId,
+      afterSeq: input.afterSeq ?? undefined,
+      limit: input.limit ?? undefined,
     },
-    signal: input?.signal,
+    signal: input.signal,
   });
 }

--- a/cloud/sdk/src/client/live.ts
+++ b/cloud/sdk/src/client/live.ts
@@ -1,34 +1,59 @@
 import { getProliferateClient } from "./core.js";
 import { subscribeCloudSse, type CloudSseSubscription } from "../streams/sse.js";
-import type { CloudLivePatch, CloudLiveSubscriptionOptions } from "../types/index.js";
+import type {
+  CloudCommandStatusPatch,
+  CloudLiveSubscriptionOptions,
+  CloudSessionLiveEvent,
+  CloudSessionProjectionPatch,
+  CloudTargetLiveEvent,
+  CloudTargetPatch,
+  CloudWorkspaceProjectionPatch,
+  CloudWorkspaceLiveEvent,
+} from "../types/index.js";
 
-export interface SubscribeCloudLiveOptions<TPatch> extends CloudLiveSubscriptionOptions {
-  onPatch: (patch: TPatch) => void;
+export interface SubscribeCloudLiveOptions<TEvent, TPatch = TEvent>
+  extends CloudLiveSubscriptionOptions {
+  onEvent?: (event: TEvent) => void;
+  onPatch?: (patch: TPatch) => void;
   onError?: (error: Event) => void;
 }
 
-export function subscribeSession<TPayload = unknown>(
+export interface SubscribeCloudSessionOptions
+  extends SubscribeCloudLiveOptions<
+    CloudSessionLiveEvent,
+    CloudSessionProjectionPatch | CloudCommandStatusPatch
+  > {
+  targetId: string;
+}
+
+export function subscribeSession(
   sessionId: string,
-  options: SubscribeCloudLiveOptions<CloudLivePatch<TPayload>>,
-): CloudSseSubscription<CloudLivePatch<TPayload>> {
+  options: SubscribeCloudSessionOptions,
+): CloudSseSubscription<CloudSessionLiveEvent> {
   const client = getProliferateClient();
+  const onEvent = liveEventHandler(options);
   return subscribeCloudSse({
     url: client.buildUrl(`/v1/cloud/sessions/${encodeURIComponent(sessionId)}/stream`, {
+      targetId: options.targetId,
       afterSeq: options.afterSeq ?? undefined,
     }),
     signal: options.signal,
     fetchResponse: ({ url, headers, signal }) =>
       client.streamRequest({ url, headers, signal }),
-    onEvent: options.onPatch,
+    onEvent,
     onError: options.onError,
   });
 }
 
-export function subscribeWorkspace<TPayload = unknown>(
+export function subscribeWorkspace(
   workspaceId: string,
-  options: SubscribeCloudLiveOptions<CloudLivePatch<TPayload>>,
-): CloudSseSubscription<CloudLivePatch<TPayload>> {
+  options: SubscribeCloudLiveOptions<
+    CloudWorkspaceLiveEvent,
+    CloudWorkspaceProjectionPatch
+  >,
+): CloudSseSubscription<CloudWorkspaceLiveEvent> {
   const client = getProliferateClient();
+  const onEvent = liveEventHandler(options);
   return subscribeCloudSse({
     url: client.buildUrl(`/v1/cloud/workspaces/${encodeURIComponent(workspaceId)}/stream`, {
       afterSeq: options.afterSeq ?? undefined,
@@ -36,7 +61,55 @@ export function subscribeWorkspace<TPayload = unknown>(
     signal: options.signal,
     fetchResponse: ({ url, headers, signal }) =>
       client.streamRequest({ url, headers, signal }),
-    onEvent: options.onPatch,
+    onEvent,
     onError: options.onError,
   });
+}
+
+export function subscribeTarget(
+  targetId: string,
+  options: SubscribeCloudLiveOptions<
+    CloudTargetLiveEvent,
+    CloudTargetPatch | CloudCommandStatusPatch
+  >,
+): CloudSseSubscription<CloudTargetLiveEvent> {
+  const client = getProliferateClient();
+  const onEvent = liveEventHandler(options);
+  return subscribeCloudSse({
+    url: client.buildUrl(`/v1/cloud/targets/${encodeURIComponent(targetId)}/stream`, {
+      afterSeq: options.afterSeq ?? undefined,
+    }),
+    signal: options.signal,
+    fetchResponse: ({ url, headers, signal }) =>
+      client.streamRequest({ url, headers, signal }),
+    onEvent,
+    onError: options.onError,
+  });
+}
+
+function liveEventHandler<TEvent, TPatch>(
+  options: SubscribeCloudLiveOptions<TEvent, TPatch>,
+): (event: TEvent) => void {
+  if (options.onEvent === undefined && options.onPatch === undefined) {
+    throw new Error("Cloud live subscription requires onEvent or onPatch.");
+  }
+  return (event) => {
+    options.onEvent?.(event);
+    if (options.onPatch !== undefined && isCloudPatchEvent(event)) {
+      options.onPatch(event as unknown as TPatch);
+    }
+  };
+}
+
+function isCloudPatchEvent(event: unknown): boolean {
+  if (typeof event !== "object" || event === null) {
+    return false;
+  }
+  const kind = (event as { kind?: unknown }).kind;
+  return (
+    kind === "projection_patch" ||
+    kind === "workspace_projection_patch" ||
+    kind === "target_projection_patch" ||
+    kind === "command_status"
+  );
 }

--- a/cloud/sdk/src/client/sessions.ts
+++ b/cloud/sdk/src/client/sessions.ts
@@ -5,35 +5,79 @@ import type {
   CloudWorkspaceSnapshot,
 } from "../types/index.js";
 
+export interface CloudSnapshotRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface CloudSessionSnapshotInput extends CloudSnapshotRequestOptions {
+  targetId: string;
+}
+
+export function getWorkspaceSnapshot(
+  workspaceId: string,
+  client?: ProliferateCloudClient,
+): Promise<CloudWorkspaceSnapshot>;
+export function getWorkspaceSnapshot(
+  workspaceId: string,
+  input?: CloudSnapshotRequestOptions,
+  client?: ProliferateCloudClient,
+): Promise<CloudWorkspaceSnapshot>;
 export async function getWorkspaceSnapshot(
   workspaceId: string,
-  client: ProliferateCloudClient = getProliferateClient(),
+  inputOrClient?: CloudSnapshotRequestOptions | ProliferateCloudClient,
+  client?: ProliferateCloudClient,
 ): Promise<CloudWorkspaceSnapshot> {
-  return client.requestJson<CloudWorkspaceSnapshot>({
+  const [input, resolvedClient] = resolveSnapshotClient(inputOrClient, client);
+  return resolvedClient.requestJson<CloudWorkspaceSnapshot>({
     method: "GET",
     path: "/v1/cloud/workspaces/{workspace_id}/snapshot",
     pathParams: { workspace_id: workspaceId },
+    signal: input?.signal,
   });
 }
 
 export async function getSessionSnapshot(
   sessionId: string,
+  input: CloudSessionSnapshotInput,
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudSessionSnapshot> {
   return client.requestJson<CloudSessionSnapshot>({
     method: "GET",
     path: "/v1/cloud/sessions/{session_id}/snapshot",
     pathParams: { session_id: sessionId },
+    query: { targetId: input.targetId },
+    signal: input.signal,
   });
 }
 
 export async function getTranscriptSnapshot(
   sessionId: string,
+  input: CloudSessionSnapshotInput,
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudTranscriptSnapshot> {
   return client.requestJson<CloudTranscriptSnapshot>({
     method: "GET",
     path: "/v1/cloud/sessions/{session_id}/transcript",
     pathParams: { session_id: sessionId },
+    query: { targetId: input.targetId },
+    signal: input.signal,
   });
+}
+
+function resolveSnapshotClient(
+  inputOrClient: CloudSnapshotRequestOptions | ProliferateCloudClient | undefined,
+  client: ProliferateCloudClient | undefined,
+): [CloudSnapshotRequestOptions | undefined, ProliferateCloudClient] {
+  if (isProliferateCloudClient(inputOrClient)) {
+    return [undefined, inputOrClient];
+  }
+  return [inputOrClient, client ?? getProliferateClient()];
+}
+
+function isProliferateCloudClient(value: unknown): value is ProliferateCloudClient {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { requestJson?: unknown }).requestJson === "function"
+  );
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1039,6 +1039,176 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Sessions Endpoint */
+        get: operations["list_sessions_endpoint_v1_cloud_sessions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sessions/{session_id}/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Session Snapshot Endpoint */
+        get: operations["get_session_snapshot_endpoint_v1_cloud_sessions__session_id__snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sessions/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Session Snapshot Alias Endpoint */
+        get: operations["get_session_snapshot_alias_endpoint_v1_cloud_sessions__session_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sessions/{session_id}/transcript": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Transcript Snapshot Endpoint */
+        get: operations["get_transcript_snapshot_endpoint_v1_cloud_sessions__session_id__transcript_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Session Events Endpoint */
+        get: operations["list_session_events_endpoint_v1_cloud_sessions__session_id__events_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/workspaces/{workspace_id}/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Workspace Snapshot Endpoint */
+        get: operations["get_workspace_snapshot_endpoint_v1_cloud_workspaces__workspace_id__snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sessions/{session_id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream Session Endpoint */
+        get: operations["stream_session_endpoint_v1_cloud_sessions__session_id__stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/workspaces/{workspace_id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream Workspace Endpoint */
+        get: operations["stream_workspace_endpoint_v1_cloud_workspaces__workspace_id__stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream Target Endpoint */
+        get: operations["stream_target_endpoint_v1_cloud_targets__target_id__stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Backfill Endpoint */
+        post: operations["worker_backfill_endpoint_v1_cloud_worker_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/worker/enroll": {
         parameters: {
             query?: never;
@@ -1135,6 +1305,23 @@ export interface paths {
         put?: never;
         /** Worker Command Result Endpoint */
         post: operations["worker_command_result_endpoint_v1_cloud_worker_commands__command_id__result_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/events/batches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Event Batch Endpoint */
+        post: operations["worker_event_batch_endpoint_v1_cloud_worker_events_batches_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2374,6 +2561,31 @@ export interface components {
             /** Failurecode */
             failureCode?: string | null;
         };
+        /** CloudPendingInteractionResponse */
+        CloudPendingInteractionResponse: {
+            /** Requestid */
+            requestId: string;
+            /** Kind */
+            kind?: string | null;
+            /** Status */
+            status: string;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            } | null;
+            /** Requestedseq */
+            requestedSeq: number;
+            /** Resolvedseq */
+            resolvedSeq?: number | null;
+            /** Requestedat */
+            requestedAt?: string | null;
+            /** Resolvedat */
+            resolvedAt?: string | null;
+        };
         /** CloudPlanInfo */
         CloudPlanInfo: {
             /**
@@ -2495,6 +2707,77 @@ export interface components {
             updatedAt: string;
             /** Lastsyncedat */
             lastSyncedAt: string;
+        };
+        /** CloudSessionEventResponse */
+        CloudSessionEventResponse: {
+            /** Targetid */
+            targetId: string;
+            /** Sessionid */
+            sessionId: string;
+            /** Seq */
+            seq: number;
+            /** Eventtype */
+            eventType: string;
+            /** Sourcekind */
+            sourceKind: string;
+            /** Turnid */
+            turnId?: string | null;
+            /** Itemid */
+            itemId?: string | null;
+            /** Occurredat */
+            occurredAt?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** CloudSessionEventsResponse */
+        CloudSessionEventsResponse: {
+            /** Events */
+            events: components["schemas"]["CloudSessionEventResponse"][];
+            /** Nextcursor */
+            nextCursor?: number | null;
+        };
+        /** CloudSessionProjectionResponse */
+        CloudSessionProjectionResponse: {
+            /** Targetid */
+            targetId: string;
+            /** Cloudworkspaceid */
+            cloudWorkspaceId?: string | null;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Sessionid */
+            sessionId: string;
+            /** Nativesessionid */
+            nativeSessionId?: string | null;
+            /** Sourceagentkind */
+            sourceAgentKind?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Status */
+            status: string;
+            /** Phase */
+            phase?: string | null;
+            /** Liveconfig */
+            liveConfig?: {
+                [key: string]: unknown;
+            } | null;
+            /** Lasteventseq */
+            lastEventSeq: number;
+            /** Lasteventat */
+            lastEventAt?: string | null;
+            /** Startedat */
+            startedAt?: string | null;
+            /** Endedat */
+            endedAt?: string | null;
+        };
+        /** CloudSessionSnapshotResponse */
+        CloudSessionSnapshotResponse: {
+            session: components["schemas"]["CloudSessionProjectionResponse"];
+            /** Transcriptitems */
+            transcriptItems: components["schemas"]["CloudTranscriptItemResponse"][];
+            /** Pendinginteractions */
+            pendingInteractions: components["schemas"]["CloudPendingInteractionResponse"][];
         };
         /** CloudTargetDetail */
         CloudTargetDetail: {
@@ -2636,6 +2919,47 @@ export interface components {
             /** Updatedat */
             updatedAt: string;
         };
+        /** CloudTranscriptItemResponse */
+        CloudTranscriptItemResponse: {
+            /** Itemid */
+            itemId: string;
+            /** Turnid */
+            turnId?: string | null;
+            /** Kind */
+            kind?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Sourceagentkind */
+            sourceAgentKind?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Text */
+            text?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            } | null;
+            /** Firstseq */
+            firstSeq: number;
+            /** Lastseq */
+            lastSeq: number;
+            /** Completedseq */
+            completedSeq?: number | null;
+            /** Firsteventat */
+            firstEventAt?: string | null;
+            /** Lasteventat */
+            lastEventAt?: string | null;
+        };
+        /** CloudTranscriptSnapshotResponse */
+        CloudTranscriptSnapshotResponse: {
+            session: components["schemas"]["CloudSessionProjectionResponse"];
+            /** Transcriptitems */
+            transcriptItems: components["schemas"]["CloudTranscriptItemResponse"][];
+            /** Pendinginteractions */
+            pendingInteractions: components["schemas"]["CloudPendingInteractionResponse"][];
+            /** Lasteventseq */
+            lastEventSeq: number;
+        };
         /** CloudWorkspaceRepoConfigStatusResponse */
         CloudWorkspaceRepoConfigStatusResponse: {
             /** Currentrepofilesversion */
@@ -2664,6 +2988,12 @@ export interface components {
             lastApplyFailedPath: string | null;
             /** Lastapplyerror */
             lastApplyError: string | null;
+        };
+        /** CloudWorkspaceSnapshotResponse */
+        CloudWorkspaceSnapshotResponse: {
+            workspace: components["schemas"]["WorkspaceDetail"];
+            /** Sessions */
+            sessions: components["schemas"]["CloudSessionProjectionResponse"][];
         };
         /** CloudWorktreeRetentionPolicyRequest */
         CloudWorktreeRetentionPolicyRequest: {
@@ -4202,6 +4532,110 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /** WorkerBackfillPendingInteraction */
+        WorkerBackfillPendingInteraction: {
+            /** Requestid */
+            requestId: string;
+            /** Kind */
+            kind?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** WorkerBackfillRepoRef */
+        WorkerBackfillRepoRef: {
+            /** Provider */
+            provider?: string | null;
+            /** Owner */
+            owner?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Branch */
+            branch?: string | null;
+            /** Basebranch */
+            baseBranch?: string | null;
+        };
+        /** WorkerBackfillRequest */
+        WorkerBackfillRequest: {
+            /** Workspaces */
+            workspaces?: components["schemas"]["WorkerBackfillWorkspace"][];
+            /** Sessions */
+            sessions?: components["schemas"]["WorkerBackfillSession"][];
+        };
+        /** WorkerBackfillResponse */
+        WorkerBackfillResponse: {
+            /** Mappedworkspaces */
+            mappedWorkspaces: components["schemas"]["WorkerBackfillWorkspaceMapping"][];
+            /** Mappedsessions */
+            mappedSessions: components["schemas"]["WorkerBackfillSessionMapping"][];
+        };
+        /** WorkerBackfillSession */
+        WorkerBackfillSession: {
+            /** Sessionid */
+            sessionId: string;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Nativesessionid */
+            nativeSessionId?: string | null;
+            /** Sourceagentkind */
+            sourceAgentKind?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Phase */
+            phase?: string | null;
+            /** Liveconfig */
+            liveConfig?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Lasteventseq
+             * @default 0
+             */
+            lastEventSeq: number;
+            /** Lasteventat */
+            lastEventAt?: string | null;
+            /** Startedat */
+            startedAt?: string | null;
+            /** Endedat */
+            endedAt?: string | null;
+            /** Pendinginteractions */
+            pendingInteractions?: components["schemas"]["WorkerBackfillPendingInteraction"][];
+        };
+        /** WorkerBackfillSessionMapping */
+        WorkerBackfillSessionMapping: {
+            /** Sessionid */
+            sessionId: string;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Cloudworkspaceid */
+            cloudWorkspaceId?: string | null;
+        };
+        /** WorkerBackfillWorkspace */
+        WorkerBackfillWorkspace: {
+            /** Workspaceid */
+            workspaceId: string;
+            /** Displayname */
+            displayName?: string | null;
+            /** Path */
+            path?: string | null;
+            repo?: components["schemas"]["WorkerBackfillRepoRef"] | null;
+            /** Updatedat */
+            updatedAt?: string | null;
+        };
+        /** WorkerBackfillWorkspaceMapping */
+        WorkerBackfillWorkspaceMapping: {
+            /** Workspaceid */
+            workspaceId: string;
+            /** Cloudworkspaceid */
+            cloudWorkspaceId: string;
+        };
         /** WorkerCommandDeliveryRequest */
         WorkerCommandDeliveryRequest: {
             /** Leaseid */
@@ -4308,6 +4742,29 @@ export interface components {
             workerToken: string;
             /** Heartbeatintervalseconds */
             heartbeatIntervalSeconds: number;
+        };
+        /** WorkerEventBatchRequest */
+        WorkerEventBatchRequest: {
+            /** Events */
+            events?: components["schemas"]["WorkerSessionEventEnvelope"][];
+        };
+        /** WorkerEventBatchResponse */
+        WorkerEventBatchResponse: {
+            /** Acceptedevents */
+            acceptedEvents: number;
+            /** Duplicateevents */
+            duplicateEvents: number;
+            /** Liveonlyevents */
+            liveOnlyEvents: number;
+            /** Sessionacks */
+            sessionAcks: components["schemas"]["WorkerEventSessionAck"][];
+        };
+        /** WorkerEventSessionAck */
+        WorkerEventSessionAck: {
+            /** Sessionid */
+            sessionId: string;
+            /** Lastcontiguousseq */
+            lastContiguousSeq: number;
         };
         /** WorkerHeartbeatRequest */
         WorkerHeartbeatRequest: {
@@ -4429,6 +4886,25 @@ export interface components {
             workerId: string;
             /** Updated */
             updated: boolean;
+        };
+        /** WorkerSessionEventEnvelope */
+        WorkerSessionEventEnvelope: {
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Sessionid */
+            sessionId: string;
+            /** Seq */
+            seq: number;
+            /** Timestamp */
+            timestamp?: string | null;
+            /** Turnid */
+            turnId?: string | null;
+            /** Itemid */
+            itemId?: string | null;
+            /** Event */
+            event: {
+                [key: string]: unknown;
+            };
         };
         /** WorkspaceConnection */
         WorkspaceConnection: {
@@ -6898,6 +7374,340 @@ export interface operations {
             };
         };
     };
+    list_sessions_endpoint_v1_cloud_sessions_get: {
+        parameters: {
+            query: {
+                targetId: string;
+                cloudWorkspaceId?: string | null;
+                workspaceId?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudSessionProjectionResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_snapshot_endpoint_v1_cloud_sessions__session_id__snapshot_get: {
+        parameters: {
+            query: {
+                targetId: string;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudSessionSnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_snapshot_alias_endpoint_v1_cloud_sessions__session_id__get: {
+        parameters: {
+            query: {
+                targetId: string;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudSessionSnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_transcript_snapshot_endpoint_v1_cloud_sessions__session_id__transcript_get: {
+        parameters: {
+            query: {
+                targetId: string;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTranscriptSnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_session_events_endpoint_v1_cloud_sessions__session_id__events_get: {
+        parameters: {
+            query: {
+                targetId: string;
+                afterSeq?: number;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudSessionEventsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_workspace_snapshot_endpoint_v1_cloud_workspaces__workspace_id__snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudWorkspaceSnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_session_endpoint_v1_cloud_sessions__session_id__stream_get: {
+        parameters: {
+            query: {
+                afterSeq?: number;
+                targetId: string;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_workspace_endpoint_v1_cloud_workspaces__workspace_id__stream_get: {
+        parameters: {
+            query?: {
+                afterSeq?: number;
+            };
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_target_endpoint_v1_cloud_targets__target_id__stream_get: {
+        parameters: {
+            query?: {
+                afterSeq?: number;
+            };
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_backfill_endpoint_v1_cloud_worker_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerBackfillRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerBackfillResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     enroll_worker_endpoint_v1_cloud_worker_enroll_post: {
         parameters: {
             query?: never;
@@ -7097,6 +7907,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkerCommandStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_event_batch_endpoint_v1_cloud_worker_events_batches_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerEventBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerEventBatchResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/live.ts
+++ b/cloud/sdk/src/types/live.ts
@@ -1,20 +1,93 @@
-export type CloudLivePatchKind =
-  | "workspace"
-  | "session"
-  | "transcript"
-  | "command"
-  | "target";
+import type {
+  CloudPendingInteraction,
+  CloudSessionProjection,
+  CloudSessionSnapshot,
+  CloudTranscriptItem,
+  CloudWorkspaceSnapshot,
+} from "./sessions.js";
+import type { CloudTargetDetail } from "./targets.js";
+import type { CloudCommandResponse } from "./commands.js";
 
-export interface CloudLivePatch<TPayload = unknown> {
-  id: string;
-  kind: CloudLivePatchKind;
-  sequence: number;
-  payload: TPayload;
-  createdAt?: string | null;
-}
+export type CloudLiveStreamEventName =
+  | "snapshot"
+  | "patch"
+  | "command_status"
+  | "heartbeat";
 
 export interface CloudLiveSubscriptionOptions {
   afterSeq?: number | null;
   signal?: AbortSignal;
 }
 
+export interface CloudLiveHeartbeat {
+  kind: "heartbeat";
+}
+
+export type CloudProjectionPatchKind =
+  | "projection_patch"
+  | "workspace_projection_patch";
+
+export type CloudLivePatchKind =
+  | CloudProjectionPatchKind
+  | "target_projection_patch"
+  | "command_status";
+
+export interface CloudProjectionPatch<
+  TPatch = Record<string, unknown>,
+  TKind extends CloudProjectionPatchKind = CloudProjectionPatchKind,
+> {
+  kind: TKind;
+  patch: TPatch;
+}
+
+export interface CloudSessionProjectionPatchPayload {
+  targetId: string;
+  sessionId: string;
+  seq: number;
+  eventType: string;
+  session: CloudSessionProjection;
+  transcriptItem?: CloudTranscriptItem | null;
+  pendingInteraction?: CloudPendingInteraction | null;
+}
+
+export type CloudSessionProjectionPatch = CloudProjectionPatch<
+  CloudSessionProjectionPatchPayload,
+  "projection_patch"
+>;
+
+export type CloudWorkspaceProjectionPatch = CloudProjectionPatch<
+  CloudSessionProjectionPatchPayload,
+  "workspace_projection_patch"
+>;
+
+export interface CloudTargetPatch {
+  kind: "target_projection_patch";
+  target: CloudTargetDetail;
+}
+
+export interface CloudCommandStatusPatch {
+  kind: "command_status";
+  command: CloudCommandResponse;
+}
+
+export type CloudLivePatch<TPayload = Record<string, unknown>> =
+  | CloudProjectionPatch<TPayload>
+  | CloudTargetPatch
+  | CloudCommandStatusPatch;
+
+export type CloudSessionLiveEvent =
+  | CloudSessionSnapshot
+  | CloudSessionProjectionPatch
+  | CloudCommandStatusPatch
+  | CloudLiveHeartbeat;
+
+export type CloudWorkspaceLiveEvent =
+  | CloudWorkspaceSnapshot
+  | CloudWorkspaceProjectionPatch
+  | CloudLiveHeartbeat;
+
+export type CloudTargetLiveEvent =
+  | { target: CloudTargetDetail }
+  | CloudTargetPatch
+  | CloudCommandStatusPatch
+  | CloudLiveHeartbeat;

--- a/cloud/sdk/src/types/sessions.ts
+++ b/cloud/sdk/src/types/sessions.ts
@@ -1,12 +1,5 @@
-export type CloudSessionStatus =
-  | "pending"
-  | "starting"
-  | "running"
-  | "idle"
-  | "waiting_for_input"
-  | "completed"
-  | "failed"
-  | "cancelled";
+import type { components } from "../generated/openapi.js";
+import type { CloudWorkspaceDetail } from "./generated.js";
 
 export interface CloudSessionConfigState {
   version: number;
@@ -15,67 +8,19 @@ export interface CloudSessionConfigState {
   updatedAt?: string | null;
 }
 
-export interface CloudRequest {
-  id: string;
-  sessionId: string;
-  type: "permission" | "user_input" | "credential" | "configuration";
-  status: "pending" | "resolved" | "expired" | "cancelled";
-  version: number;
-  title?: string | null;
-  body?: string | null;
-  options?: Record<string, unknown> | null;
-  createdAt?: string | null;
-  resolvedAt?: string | null;
-}
-
-export interface CloudMessage {
-  id: string;
-  sessionId: string;
-  role: "user" | "assistant" | "system";
-  status: "pending" | "streaming" | "completed" | "failed";
-  text: string;
-  createdAt?: string | null;
-  completedAt?: string | null;
-}
-
-export interface CloudToolCallSummary {
-  id: string;
-  sessionId: string;
-  name: string;
-  status: "started" | "completed" | "failed";
-  summary?: string | null;
-  startedAt?: string | null;
-  completedAt?: string | null;
-}
-
-export interface CloudWorkspaceSnapshot {
-  workspaceId: string;
-  targetId: string;
-  displayName?: string | null;
-  repo?: Record<string, unknown> | null;
-  status: string;
-  sessions: CloudSessionSnapshot[];
-  lastActivityAt?: string | null;
-}
-
-export interface CloudSessionSnapshot {
-  sessionId: string;
-  workspaceId: string;
-  targetId: string;
-  status: CloudSessionStatus;
-  agent?: string | null;
-  model?: string | null;
-  config?: CloudSessionConfigState | null;
-  pendingRequests: CloudRequest[];
-  lastEventSeq?: number | null;
-  lastActivityAt?: string | null;
-}
-
-export interface CloudTranscriptSnapshot {
-  sessionId: string;
-  messages: CloudMessage[];
-  toolCalls: CloudToolCallSummary[];
-  pendingRequests: CloudRequest[];
-  lastEventSeq?: number | null;
-}
-
+export type CloudSessionProjection =
+  components["schemas"]["CloudSessionProjectionResponse"];
+export type CloudTranscriptItem =
+  components["schemas"]["CloudTranscriptItemResponse"];
+export type CloudPendingInteraction =
+  components["schemas"]["CloudPendingInteractionResponse"];
+export type CloudSessionSnapshot =
+  components["schemas"]["CloudSessionSnapshotResponse"];
+export type CloudWorkspaceSnapshot = Omit<
+  components["schemas"]["CloudWorkspaceSnapshotResponse"],
+  "workspace"
+> & {
+  workspace: CloudWorkspaceDetail;
+};
+export type CloudTranscriptSnapshot =
+  components["schemas"]["CloudTranscriptSnapshotResponse"];

--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -1,13 +1,22 @@
-from collections.abc import AsyncGenerator
-from typing import Annotated
+import asyncio
+import logging
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import Annotated, cast
 
 from fastapi import Depends
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session
 
 from proliferate.config import settings
 
 engine = create_async_engine(settings.database_url, echo=settings.database_echo)
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+_AFTER_COMMIT_CALLBACKS_KEY = "proliferate_after_commit_callbacks"
+_AFTER_COMMIT_LISTENERS_KEY = "proliferate_after_commit_listeners"
+_logger = logging.getLogger(__name__)
+
+type AfterCommitCallback = Callable[[], Awaitable[None]]
 
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
@@ -21,3 +30,54 @@ async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_session)]
+
+
+async def run_after_commit(db: AsyncSession, callback: AfterCommitCallback) -> None:
+    if not db.in_transaction():
+        await callback()
+        return
+    defer_after_commit(db, callback)
+
+
+def defer_after_commit(db: AsyncSession, callback: AfterCommitCallback) -> None:
+    sync_session = db.sync_session
+    callbacks = cast(
+        list[AfterCommitCallback],
+        sync_session.info.setdefault(_AFTER_COMMIT_CALLBACKS_KEY, []),
+    )
+    callbacks.append(callback)
+    _ensure_after_commit_listeners(sync_session)
+
+
+def _ensure_after_commit_listeners(sync_session: Session) -> None:
+    if sync_session.info.get(_AFTER_COMMIT_LISTENERS_KEY):
+        return
+    sync_session.info[_AFTER_COMMIT_LISTENERS_KEY] = True
+
+    @event.listens_for(sync_session, "after_commit")
+    def _run_after_root_commit(session: Session) -> None:
+        if session.in_nested_transaction():
+            return
+        callbacks = tuple(
+            cast(
+                list[AfterCommitCallback],
+                session.info.pop(_AFTER_COMMIT_CALLBACKS_KEY, []),
+            )
+        )
+        if not callbacks:
+            return
+        loop = asyncio.get_running_loop()
+        loop.create_task(_run_after_commit_callbacks(callbacks))
+
+    @event.listens_for(sync_session, "after_soft_rollback")
+    def _discard_after_root_rollback(session: Session, previous_transaction: object) -> None:
+        if getattr(previous_transaction, "parent", None) is None:
+            session.info.pop(_AFTER_COMMIT_CALLBACKS_KEY, None)
+
+
+async def _run_after_commit_callbacks(callbacks: tuple[AfterCommitCallback, ...]) -> None:
+    for callback in callbacks:
+        try:
+            await callback()
+        except Exception:
+            _logger.exception("Deferred after-commit callback failed.")

--- a/server/proliferate/db/store/cloud_sync/events.py
+++ b/server/proliferate/db/store/cloud_sync/events.py
@@ -691,6 +691,26 @@ async def list_session_projections(
     return tuple(_session_snapshot(row) for row in rows)
 
 
+async def list_session_projections_for_workspace(
+    db: AsyncSession,
+    *,
+    cloud_workspace_id: UUID,
+    limit: int = 100,
+) -> tuple[CloudSessionProjectionSnapshot, ...]:
+    rows = (
+        await db.execute(
+            select(CloudSessionProjection)
+            .where(CloudSessionProjection.cloud_workspace_id == cloud_workspace_id)
+            .order_by(
+                CloudSessionProjection.updated_at.desc(),
+                CloudSessionProjection.last_event_seq.desc(),
+            )
+            .limit(limit)
+        )
+    ).scalars()
+    return tuple(_session_snapshot(row) for row in rows)
+
+
 async def list_transcript_items(
     db: AsyncSession,
     *,

--- a/server/proliferate/integrations/pubsub/__init__.py
+++ b/server/proliferate/integrations/pubsub/__init__.py
@@ -1,0 +1,1 @@
+"""Pub/sub integration boundary for cloud live fanout."""

--- a/server/proliferate/integrations/pubsub/models.py
+++ b/server/proliferate/integrations/pubsub/models.py
@@ -1,0 +1,26 @@
+"""Shared pub/sub integration types."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class PubSubMessage:
+    event: str
+    event_id: str
+    data: dict[str, object]
+
+
+class PubSubBus(Protocol):
+    def subscribe(
+        self,
+        channel: str,
+    ) -> AbstractAsyncContextManager[AsyncIterator[PubSubMessage]]:
+        """Subscribe to a live channel."""
+
+    async def publish(self, channel: str, message: PubSubMessage) -> None:
+        """Publish a live message to a channel."""

--- a/server/proliferate/integrations/pubsub/redis.py
+++ b/server/proliferate/integrations/pubsub/redis.py
@@ -1,0 +1,64 @@
+"""Redis-shaped pub/sub integration.
+
+The launch implementation uses a process-local bus behind the same contract.
+Swapping this module to a real Redis/NATS backend should not change cloud live
+services or endpoint code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+
+from proliferate.integrations.pubsub.models import PubSubBus, PubSubMessage
+
+SUBSCRIBER_QUEUE_SIZE = 100
+
+
+class InProcessPubSubBus:
+    """Process-local live fanout with bounded subscriber queues."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._subscribers: dict[str, set[asyncio.Queue[PubSubMessage]]] = defaultdict(set)
+
+    @asynccontextmanager
+    async def subscribe(self, channel: str) -> AsyncIterator[AsyncIterator[PubSubMessage]]:
+        queue: asyncio.Queue[PubSubMessage] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_SIZE)
+        async with self._lock:
+            self._subscribers[channel].add(queue)
+        try:
+            yield _queue_iterator(queue)
+        finally:
+            async with self._lock:
+                subscribers = self._subscribers.get(channel)
+                if subscribers is not None:
+                    subscribers.discard(queue)
+                    if not subscribers:
+                        self._subscribers.pop(channel, None)
+
+    async def publish(self, channel: str, message: PubSubMessage) -> None:
+        async with self._lock:
+            subscribers = tuple(self._subscribers.get(channel, ()))
+        for queue in subscribers:
+            try:
+                queue.put_nowait(message)
+            except asyncio.QueueFull:
+                with suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+                with suppress(asyncio.QueueFull):
+                    queue.put_nowait(message)
+
+
+async def _queue_iterator(queue: asyncio.Queue[PubSubMessage]) -> AsyncIterator[PubSubMessage]:
+    while True:
+        yield await queue.get()
+
+
+_bus = InProcessPubSubBus()
+
+
+def get_pubsub_bus() -> PubSubBus:
+    return _bus

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -6,6 +6,7 @@ from proliferate.server.cloud.backfill.api import router as backfill_router
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.credentials.api import router as credentials_router
 from proliferate.server.cloud.events.api import router as events_router
+from proliferate.server.cloud.live.api import router as live_router
 from proliferate.server.cloud.mcp_catalog.api import router as mcp_catalog_router
 from proliferate.server.cloud.mcp_connections.api import router as mcp_connections_router
 from proliferate.server.cloud.mcp_materialization.api import router as mcp_materialization_router
@@ -34,5 +35,6 @@ router.include_router(webhooks_router)
 router.include_router(targets_router)
 router.include_router(commands_router)
 router.include_router(events_router)
+router.include_router(live_router)
 router.include_router(backfill_router)
 router.include_router(worker_router)

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -26,6 +26,7 @@ from proliferate.server.cloud.commands.domain.rules import (
 )
 from proliferate.server.cloud.commands.models import CreateCloudCommandRequest
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.live.service import publish_command_status_after_commit
 
 
 def _idempotency_scope_for_command(
@@ -152,6 +153,7 @@ async def enqueue_command(
         idempotency_key=body.idempotency_key,
     )
     if existing is not None:
+        await publish_command_status_after_commit(db, existing)
         return existing
     authorization_context_json = compact_command_json(
         {
@@ -165,7 +167,7 @@ async def enqueue_command(
     )
     try:
         async with db.begin_nested():
-            return await commands_store.create_command(
+            command = await commands_store.create_command(
                 db,
                 idempotency_scope=idempotency_scope,
                 idempotency_key=body.idempotency_key,
@@ -182,6 +184,8 @@ async def enqueue_command(
                 preconditions_json=compact_command_json(body.preconditions),
                 authorization_context_json=authorization_context_json,
             )
+        await publish_command_status_after_commit(db, command)
+        return command
     except IntegrityError:
         duplicate = await commands_store.get_command_by_idempotency(
             db,

--- a/server/proliferate/server/cloud/events/api.py
+++ b/server/proliferate/server/cloud/events/api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
@@ -21,7 +20,14 @@ from proliferate.server.cloud.events.service import (
     get_session_snapshot,
     list_session_summaries,
 )
-from proliferate.server.cloud.live.service import stream_session_events
+from proliferate.server.cloud.live.models import (
+    CloudSessionEventsResponse,
+    CloudTranscriptSnapshotResponse,
+)
+from proliferate.server.cloud.live.service import (
+    get_transcript_snapshot,
+    list_session_events_after,
+)
 
 router = APIRouter(prefix="/sessions", tags=["cloud-sessions"])
 
@@ -71,14 +77,13 @@ async def get_session_snapshot_endpoint(
         raise_cloud_error(error)
 
 
-@router.get("/{session_id}/stream")
-async def stream_session_endpoint(
+@router.get("/{session_id}", response_model=CloudSessionSnapshotResponse)
+async def get_session_snapshot_alias_endpoint(
     session_id: str,
     target_id: UUID = Query(alias="targetId"),
-    after_seq: int = Query(default=0, alias="afterSeq"),
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
-) -> StreamingResponse:
+) -> CloudSessionSnapshotResponse:
     try:
         resolved_target_id = await ensure_visible_session_target(
             db,
@@ -86,14 +91,60 @@ async def stream_session_endpoint(
             session_id=session_id,
             user_id=user.id,
         )
+        return await get_session_snapshot(
+            db,
+            target_id=resolved_target_id,
+            session_id=session_id,
+        )
     except CloudApiError as error:
         raise_cloud_error(error)
 
-    return StreamingResponse(
-        stream_session_events(
+
+@router.get("/{session_id}/transcript", response_model=CloudTranscriptSnapshotResponse)
+async def get_transcript_snapshot_endpoint(
+    session_id: str,
+    target_id: UUID = Query(alias="targetId"),
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudTranscriptSnapshotResponse:
+    try:
+        resolved_target_id = await ensure_visible_session_target(
+            db,
+            target_id=target_id,
+            session_id=session_id,
+            user_id=user.id,
+        )
+        return await get_transcript_snapshot(
+            db,
+            target_id=resolved_target_id,
+            session_id=session_id,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.get("/{session_id}/events", response_model=CloudSessionEventsResponse)
+async def list_session_events_endpoint(
+    session_id: str,
+    target_id: UUID = Query(alias="targetId"),
+    after_seq: int = Query(default=0, alias="afterSeq"),
+    limit: int = Query(default=100, ge=1, le=200),
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudSessionEventsResponse:
+    try:
+        resolved_target_id = await ensure_visible_session_target(
+            db,
+            target_id=target_id,
+            session_id=session_id,
+            user_id=user.id,
+        )
+        return await list_session_events_after(
+            db,
             target_id=resolved_target_id,
             session_id=session_id,
             after_seq=after_seq,
-        ),
-        media_type="text/event-stream",
-    )
+            limit=limit,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/live/access.py
+++ b/server/proliferate/server/cloud/live/access.py
@@ -1,0 +1,81 @@
+"""Short-lived access checks for cloud live streams."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from uuid import UUID
+
+from fastapi import Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.db import engine as db_engine
+from proliferate.db.models.auth import User
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.events.service import ensure_visible_session_target
+from proliferate.server.cloud.targets.service import get_target_detail
+from proliferate.server.cloud.workspaces.models import WorkspaceDetail
+from proliferate.server.cloud.workspaces.service import get_cloud_workspace_detail
+
+
+@dataclass(frozen=True)
+class LiveSessionStreamAccess:
+    target_id: UUID
+    session_id: str
+
+
+async def session_stream_user_can_read(
+    session_id: str,
+    target_id: UUID = Query(alias="targetId"),
+    user: User = Depends(current_active_user),
+) -> LiveSessionStreamAccess:
+    async def read(db: AsyncSession) -> LiveSessionStreamAccess:
+        resolved_target_id = await ensure_visible_session_target(
+            db,
+            target_id=target_id,
+            session_id=session_id,
+            user_id=user.id,
+        )
+        return LiveSessionStreamAccess(
+            target_id=resolved_target_id,
+            session_id=session_id,
+        )
+
+    return await _read_with_short_session(read)
+
+
+async def workspace_stream_user_can_read(
+    workspace_id: UUID,
+    user: User = Depends(current_active_user),
+) -> WorkspaceDetail:
+    async def read(db: AsyncSession) -> WorkspaceDetail:
+        return await get_cloud_workspace_detail(db, user.id, workspace_id)
+
+    return await _read_with_short_session(read)
+
+
+async def target_stream_user_can_read(
+    target_id: UUID,
+    user: User = Depends(current_active_user),
+) -> targets_store.CloudTargetSnapshot:
+    async def read(db: AsyncSession) -> targets_store.CloudTargetSnapshot:
+        return await get_target_detail(db, target_id=target_id, user_id=user.id)
+
+    return await _read_with_short_session(read)
+
+
+async def _read_with_short_session[T](read: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    # Yield dependencies remain open for the lifetime of StreamingResponse.
+    async with db_engine.async_session_factory() as db:
+        try:
+            result = await read(db)
+        except CloudApiError as error:
+            await db.rollback()
+            raise_cloud_error(error)
+        except Exception:
+            await db.rollback()
+            raise
+        await db.rollback()
+        return result

--- a/server/proliferate/server/cloud/live/api.py
+++ b/server/proliferate/server/cloud/live/api.py
@@ -1,0 +1,85 @@
+"""HTTP routes for cloud live snapshots and SSE streams."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.live.access import (
+    LiveSessionStreamAccess,
+    session_stream_user_can_read,
+    target_stream_user_can_read,
+    workspace_stream_user_can_read,
+)
+from proliferate.server.cloud.live.models import CloudWorkspaceSnapshotResponse
+from proliferate.server.cloud.live.service import (
+    get_workspace_snapshot,
+    stream_session_events,
+    stream_target_events,
+    stream_workspace_events,
+)
+from proliferate.server.cloud.workspaces.models import WorkspaceDetail
+from proliferate.server.cloud.workspaces.service import get_cloud_workspace_detail
+
+router = APIRouter(tags=["cloud-live"])
+
+
+@router.get("/workspaces/{workspace_id}/snapshot", response_model=CloudWorkspaceSnapshotResponse)
+async def get_workspace_snapshot_endpoint(
+    workspace_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+) -> CloudWorkspaceSnapshotResponse:
+    try:
+        workspace = await get_cloud_workspace_detail(db, user.id, workspace_id)
+        return await get_workspace_snapshot(db, workspace=workspace)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.get("/sessions/{session_id}/stream")
+async def stream_session_endpoint(
+    after_seq: int = Query(default=0, alias="afterSeq"),
+    access: LiveSessionStreamAccess = Depends(session_stream_user_can_read),
+) -> StreamingResponse:
+    return StreamingResponse(
+        stream_session_events(
+            target_id=access.target_id,
+            session_id=access.session_id,
+            after_seq=after_seq,
+        ),
+        media_type="text/event-stream",
+    )
+
+
+@router.get("/workspaces/{workspace_id}/stream")
+async def stream_workspace_endpoint(
+    after_seq: int = Query(default=0, alias="afterSeq"),
+    workspace: WorkspaceDetail = Depends(workspace_stream_user_can_read),
+) -> StreamingResponse:
+    return StreamingResponse(
+        stream_workspace_events(
+            workspace=workspace,
+            after_seq=after_seq,
+        ),
+        media_type="text/event-stream",
+    )
+
+
+@router.get("/targets/{target_id}/stream")
+async def stream_target_endpoint(
+    after_seq: int = Query(default=0, alias="afterSeq"),
+    target: targets_store.CloudTargetSnapshot = Depends(target_stream_user_can_read),
+) -> StreamingResponse:
+    return StreamingResponse(
+        stream_target_events(target_id=target.id, after_seq=after_seq),
+        media_type="text/event-stream",
+    )

--- a/server/proliferate/server/cloud/live/domain/channels.py
+++ b/server/proliferate/server/cloud/live/domain/channels.py
@@ -7,3 +7,11 @@ from uuid import UUID
 
 def session_channel(*, target_id: UUID, session_id: str) -> str:
     return f"session:{target_id}:{session_id}"
+
+
+def workspace_channel(*, workspace_id: UUID) -> str:
+    return f"workspace:{workspace_id}"
+
+
+def target_channel(*, target_id: UUID) -> str:
+    return f"target:{target_id}"

--- a/server/proliferate/server/cloud/live/domain/rules.py
+++ b/server/proliferate/server/cloud/live/domain/rules.py
@@ -1,0 +1,7 @@
+"""Pure rules for cloud live stream cursors."""
+
+from __future__ import annotations
+
+
+def clamp_live_cursor(value: int) -> int:
+    return max(0, value)

--- a/server/proliferate/server/cloud/live/models.py
+++ b/server/proliferate/server/cloud/live/models.py
@@ -4,6 +4,17 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from proliferate.server.cloud.commands.models import CloudCommandResponse
+from proliferate.server.cloud.events.models import (
+    CloudPendingInteractionResponse,
+    CloudSessionEventResponse,
+    CloudSessionProjectionResponse,
+    CloudSessionSnapshotResponse,
+    CloudTranscriptItemResponse,
+)
+from proliferate.server.cloud.targets.models import CloudTargetDetail
+from proliferate.server.cloud.workspaces.models import WorkspaceDetail
+
 
 class CloudStreamHeartbeatResponse(BaseModel):
     kind: str = "heartbeat"
@@ -12,3 +23,54 @@ class CloudStreamHeartbeatResponse(BaseModel):
 class CloudLivePatchEnvelope(BaseModel):
     kind: str = "projection_patch"
     patch: dict[str, object] = Field(serialization_alias="patch")
+
+
+class CloudWorkspaceSnapshotResponse(BaseModel):
+    workspace: WorkspaceDetail
+    sessions: list[CloudSessionProjectionResponse]
+
+
+class CloudTranscriptSnapshotResponse(BaseModel):
+    session: CloudSessionProjectionResponse
+    transcript_items: list[CloudTranscriptItemResponse] = Field(
+        serialization_alias="transcriptItems",
+    )
+    pending_interactions: list[CloudPendingInteractionResponse] = Field(
+        serialization_alias="pendingInteractions",
+    )
+    last_event_seq: int = Field(serialization_alias="lastEventSeq")
+
+
+class CloudSessionEventsResponse(BaseModel):
+    events: list[CloudSessionEventResponse]
+    next_cursor: int | None = Field(default=None, serialization_alias="nextCursor")
+
+
+class CloudTargetSnapshotResponse(BaseModel):
+    target: CloudTargetDetail
+
+
+class CloudWorkspacePatchEnvelope(BaseModel):
+    kind: str = "workspace_projection_patch"
+    patch: dict[str, object] = Field(serialization_alias="patch")
+
+
+class CloudTargetPatchEnvelope(BaseModel):
+    kind: str = "target_projection_patch"
+    target: CloudTargetDetail
+
+
+class CloudCommandStatusEnvelope(BaseModel):
+    kind: str = "command_status"
+    command: CloudCommandResponse
+
+
+def transcript_snapshot_response(
+    snapshot: CloudSessionSnapshotResponse,
+) -> CloudTranscriptSnapshotResponse:
+    return CloudTranscriptSnapshotResponse(
+        session=snapshot.session,
+        transcript_items=list(snapshot.transcript_items),
+        pending_interactions=list(snapshot.pending_interactions),
+        last_event_seq=snapshot.session.last_event_seq,
+    )

--- a/server/proliferate/server/cloud/live/service.py
+++ b/server/proliferate/server/cloud/live/service.py
@@ -4,88 +4,75 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections import defaultdict
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db import engine as db_engine
+from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import events as events_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.integrations.pubsub.models import PubSubMessage
+from proliferate.integrations.pubsub.redis import get_pubsub_bus
+from proliferate.server.cloud.commands.models import command_response_payload
 from proliferate.server.cloud.events.models import (
+    CloudSessionEventResponse,
     CloudSessionPatchResponse,
     CloudSessionSnapshotResponse,
     pending_interaction_response,
+    session_event_response,
     session_patch_response,
     session_projection_response,
     transcript_item_response,
 )
-from proliferate.server.cloud.live.domain.channels import session_channel
-from proliferate.server.cloud.live.models import (
-    CloudLivePatchEnvelope,
-    CloudStreamHeartbeatResponse,
+from proliferate.server.cloud.live.domain.channels import (
+    session_channel,
+    target_channel,
+    workspace_channel,
 )
+from proliferate.server.cloud.live.domain.rules import clamp_live_cursor
+from proliferate.server.cloud.live.models import (
+    CloudCommandStatusEnvelope,
+    CloudLivePatchEnvelope,
+    CloudSessionEventsResponse,
+    CloudStreamHeartbeatResponse,
+    CloudTargetPatchEnvelope,
+    CloudTargetSnapshotResponse,
+    CloudTranscriptSnapshotResponse,
+    CloudWorkspacePatchEnvelope,
+    CloudWorkspaceSnapshotResponse,
+    transcript_snapshot_response,
+)
+from proliferate.server.cloud.targets.models import target_detail_payload
+from proliferate.server.cloud.workspaces.models import WorkspaceDetail
+from proliferate.utils.time import utcnow
 
 STREAM_HEARTBEAT_SECONDS = 15.0
-SUBSCRIBER_QUEUE_SIZE = 100
+_live_bus = get_pubsub_bus()
+_last_live_event_id = 0
+_live_publish_session: ContextVar[AsyncSession | None] = ContextVar(
+    "cloud_live_publish_session",
+    default=None,
+)
 
-
-@dataclass(frozen=True)
-class LiveMessage:
-    event: str
-    event_id: str
-    data: dict[str, object]
-
-
-class InProcessLiveBus:
-    """Process-local live fanout.
-
-    This is intentionally behind a tiny publish/subscribe boundary so Redis,
-    NATS, or an actor implementation can replace it without changing the
-    session/event services.
-    """
-
-    def __init__(self) -> None:
-        self._lock = asyncio.Lock()
-        self._subscribers: dict[str, set[asyncio.Queue[LiveMessage]]] = defaultdict(set)
-
-    @asynccontextmanager
-    async def subscribe(self, channel: str) -> AsyncIterator[asyncio.Queue[LiveMessage]]:
-        queue: asyncio.Queue[LiveMessage] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_SIZE)
-        async with self._lock:
-            self._subscribers[channel].add(queue)
-        try:
-            yield queue
-        finally:
-            async with self._lock:
-                subscribers = self._subscribers.get(channel)
-                if subscribers is not None:
-                    subscribers.discard(queue)
-                    if not subscribers:
-                        self._subscribers.pop(channel, None)
-
-    async def publish(self, channel: str, message: LiveMessage) -> None:
-        async with self._lock:
-            subscribers = tuple(self._subscribers.get(channel, ()))
-        for queue in subscribers:
-            try:
-                queue.put_nowait(message)
-            except asyncio.QueueFull:
-                with suppress(asyncio.QueueEmpty):
-                    queue.get_nowait()
-                with suppress(asyncio.QueueFull):
-                    queue.put_nowait(message)
-
-
-_live_bus = InProcessLiveBus()
+type LivePublishCallback = Callable[[], Awaitable[None]]
 
 
 async def publish_session_patch(patch: CloudSessionPatchResponse) -> None:
+    db = _live_publish_session.get()
+    if db is not None:
+        await _publish_live_after_commit(db, lambda: _publish_session_patch_now(patch))
+        return
+    await _publish_session_patch_now(patch)
+
+
+async def _publish_session_patch_now(patch: CloudSessionPatchResponse) -> None:
     await _live_bus.publish(
         session_channel(target_id=UUID(patch.target_id), session_id=patch.session_id),
-        LiveMessage(
+        PubSubMessage(
             event="patch",
             event_id=str(patch.seq),
             data=CloudLivePatchEnvelope(
@@ -93,6 +80,76 @@ async def publish_session_patch(patch: CloudSessionPatchResponse) -> None:
             ).model_dump(by_alias=True),
         ),
     )
+    workspace_id = patch.session.cloud_workspace_id
+    if workspace_id is not None:
+        await _live_bus.publish(
+            workspace_channel(workspace_id=UUID(workspace_id)),
+            PubSubMessage(
+                event="patch",
+                event_id=_live_event_id(),
+                data=CloudWorkspacePatchEnvelope(
+                    patch=patch.model_dump(by_alias=True),
+                ).model_dump(by_alias=True),
+            ),
+        )
+
+
+@contextmanager
+def defer_live_publishes_until_commit(db: AsyncSession) -> Iterator[None]:
+    token = _live_publish_session.set(db)
+    try:
+        yield
+    finally:
+        _live_publish_session.reset(token)
+
+
+async def publish_target_patch_after_commit(
+    db: AsyncSession,
+    target: targets_store.CloudTargetSnapshot,
+) -> None:
+    await _publish_live_after_commit(db, lambda: publish_target_patch(target))
+
+
+async def publish_command_status_after_commit(
+    db: AsyncSession,
+    command: commands_store.CloudCommandSnapshot,
+) -> None:
+    await _publish_live_after_commit(db, lambda: publish_command_status(command))
+
+
+async def publish_target_patch(target: targets_store.CloudTargetSnapshot) -> None:
+    detail = target_detail_payload(target)
+    await _live_bus.publish(
+        target_channel(target_id=target.id),
+        PubSubMessage(
+            event="patch",
+            event_id=_live_event_id(),
+            data=CloudTargetPatchEnvelope(target=detail).model_dump(by_alias=True),
+        ),
+    )
+
+
+async def publish_command_status(command: commands_store.CloudCommandSnapshot) -> None:
+    data = CloudCommandStatusEnvelope(
+        command=command_response_payload(command),
+    ).model_dump(by_alias=True)
+    event_id = _live_event_id()
+    await _live_bus.publish(
+        target_channel(target_id=command.target_id),
+        PubSubMessage(event="command_status", event_id=event_id, data=data),
+    )
+    if command.session_id is not None:
+        await _live_bus.publish(
+            session_channel(target_id=command.target_id, session_id=command.session_id),
+            PubSubMessage(event="command_status", event_id=event_id, data=data),
+        )
+
+
+async def _publish_live_after_commit(
+    db: AsyncSession,
+    callback: LivePublishCallback,
+) -> None:
+    await db_engine.run_after_commit(db, callback)
 
 
 async def stream_session_events(
@@ -101,9 +158,9 @@ async def stream_session_events(
     session_id: str,
     after_seq: int,
 ) -> AsyncIterator[str]:
-    cursor = max(0, after_seq)
+    cursor = clamp_live_cursor(after_seq)
     channel = session_channel(target_id=target_id, session_id=session_id)
-    async with _live_bus.subscribe(channel) as queue:
+    async with _live_bus.subscribe(channel) as messages:
         async with db_engine.async_session_factory() as stream_db:
             snapshot = await _get_session_snapshot(
                 stream_db,
@@ -120,7 +177,95 @@ async def stream_session_events(
         while True:
             try:
                 message = await asyncio.wait_for(
-                    queue.get(),
+                    anext(messages),
+                    timeout=STREAM_HEARTBEAT_SECONDS,
+                )
+            except TimeoutError:
+                yield _sse_event(
+                    event="heartbeat",
+                    event_id=str(cursor),
+                    data=CloudStreamHeartbeatResponse().model_dump(by_alias=True),
+                )
+                continue
+            message_seq = _int_or_zero(message.event_id)
+            if message_seq <= cursor:
+                continue
+            cursor = message_seq
+            yield _sse_event(
+                event=message.event,
+                event_id=message.event_id,
+                data=message.data,
+            )
+
+
+async def stream_workspace_events(
+    *,
+    workspace: WorkspaceDetail,
+    after_seq: int,
+) -> AsyncIterator[str]:
+    cursor = clamp_live_cursor(after_seq)
+    workspace_id = UUID(workspace.id)
+    channel = workspace_channel(workspace_id=workspace_id)
+    async with _live_bus.subscribe(channel) as messages:
+        async with db_engine.async_session_factory() as stream_db:
+            snapshot = await _get_workspace_snapshot(
+                stream_db,
+                workspace=workspace,
+            )
+        cursor = max(
+            cursor,
+            max((session.last_event_seq for session in snapshot.sessions), default=0),
+        )
+        yield _sse_event(
+            event="snapshot",
+            event_id=str(cursor),
+            data=snapshot.model_dump(by_alias=True),
+        )
+
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    anext(messages),
+                    timeout=STREAM_HEARTBEAT_SECONDS,
+                )
+            except TimeoutError:
+                yield _sse_event(
+                    event="heartbeat",
+                    event_id=str(cursor),
+                    data=CloudStreamHeartbeatResponse().model_dump(by_alias=True),
+                )
+                continue
+            message_seq = _int_or_zero(message.event_id)
+            if message_seq <= cursor:
+                continue
+            cursor = message_seq
+            yield _sse_event(
+                event=message.event,
+                event_id=message.event_id,
+                data=message.data,
+            )
+
+
+async def stream_target_events(
+    *,
+    target_id: UUID,
+    after_seq: int,
+) -> AsyncIterator[str]:
+    cursor = clamp_live_cursor(after_seq)
+    channel = target_channel(target_id=target_id)
+    async with _live_bus.subscribe(channel) as messages:
+        async with db_engine.async_session_factory() as stream_db:
+            snapshot = await _get_target_snapshot(stream_db, target_id=target_id)
+        yield _sse_event(
+            event="snapshot",
+            event_id=str(cursor),
+            data=snapshot.model_dump(by_alias=True),
+        )
+
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    anext(messages),
                     timeout=STREAM_HEARTBEAT_SECONDS,
                 )
             except TimeoutError:
@@ -173,6 +318,76 @@ async def _get_session_snapshot(
     )
 
 
+async def get_transcript_snapshot(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+) -> CloudTranscriptSnapshotResponse:
+    return transcript_snapshot_response(
+        await _get_session_snapshot(db, target_id=target_id, session_id=session_id)
+    )
+
+
+async def get_workspace_snapshot(
+    db: AsyncSession,
+    *,
+    workspace: WorkspaceDetail,
+) -> CloudWorkspaceSnapshotResponse:
+    return await _get_workspace_snapshot(db, workspace=workspace)
+
+
+async def list_session_events_after(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    session_id: str,
+    after_seq: int,
+    limit: int,
+) -> CloudSessionEventsResponse:
+    events = await events_store.list_events_after(
+        db,
+        target_id=target_id,
+        session_id=session_id,
+        after_seq=clamp_live_cursor(after_seq),
+        limit=min(max(limit, 1), 200),
+    )
+    event_responses: list[CloudSessionEventResponse] = [
+        session_event_response(event) for event in events
+    ]
+    next_cursor = event_responses[-1].seq if event_responses else None
+    return CloudSessionEventsResponse(
+        events=event_responses,
+        next_cursor=next_cursor,
+    )
+
+
+async def _get_workspace_snapshot(
+    db: AsyncSession,
+    *,
+    workspace: WorkspaceDetail,
+) -> CloudWorkspaceSnapshotResponse:
+    sessions = await events_store.list_session_projections_for_workspace(
+        db,
+        cloud_workspace_id=UUID(workspace.id),
+    )
+    return CloudWorkspaceSnapshotResponse(
+        workspace=workspace,
+        sessions=[session_projection_response(session) for session in sessions],
+    )
+
+
+async def _get_target_snapshot(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+) -> CloudTargetSnapshotResponse:
+    target = await targets_store.get_target_by_id(db, target_id)
+    if target is None:
+        raise LookupError("Target not found.")
+    return CloudTargetSnapshotResponse(target=target_detail_payload(target))
+
+
 def projection_patch_from_event(
     *,
     target_id: UUID,
@@ -197,6 +412,13 @@ def projection_patch_from_event(
 def _sse_event(*, event: str, event_id: str, data: object) -> str:
     encoded = json.dumps(data, separators=(",", ":"), sort_keys=True)
     return f"id: {event_id}\nevent: {event}\ndata: {encoded}\n\n"
+
+
+def _live_event_id() -> str:
+    global _last_live_event_id
+    timestamp_ms = int(utcnow().timestamp() * 1000)
+    _last_live_event_id = max(timestamp_ms, _last_live_event_id + 1)
+    return str(_last_live_event_id)
 
 
 def _int_or_zero(value: str) -> int:

--- a/server/proliferate/server/cloud/targets/service.py
+++ b/server/proliferate/server/cloud/targets/service.py
@@ -17,6 +17,7 @@ from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.live.service import publish_target_patch_after_commit
 from proliferate.server.cloud.targets.domain.policy import require_target_admin_membership
 from proliferate.server.cloud.targets.domain.rules import (
     build_install_command,
@@ -173,4 +174,5 @@ async def archive_target(
         target_id=target.id,
         now=utcnow(),
     )
+    await publish_target_patch_after_commit(db, archived)
     return archived

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -30,6 +30,11 @@ from proliferate.server.cloud.events.models import (
     WorkerEventBatchResponse,
 )
 from proliferate.server.cloud.events.service import ingest_worker_event_batch
+from proliferate.server.cloud.live.service import (
+    defer_live_publishes_until_commit,
+    publish_command_status_after_commit,
+    publish_target_patch_after_commit,
+)
 from proliferate.server.cloud.worker.domain.rules import (
     clamp_command_lease_seconds,
     compact_json,
@@ -89,6 +94,12 @@ async def _record_inventory_payload(
         mcp_json=compact_json(payload.mcp),
         raw_json=None,
     )
+
+
+async def _publish_current_target_patch(db: AsyncSession, *, target_id: UUID) -> None:
+    target = await targets_store.get_target_by_id(db, target_id)
+    if target is not None:
+        await publish_target_patch_after_commit(db, target)
 
 
 def _parse_json_dict(value: str | None) -> dict[str, object] | None:
@@ -169,6 +180,7 @@ async def enroll_worker(
             worker_id=worker.id,
             payload=body.inventory,
         )
+    await _publish_current_target_patch(db, target_id=worker.target_id)
     return WorkerEnrollResponse(
         target_id=str(worker.target_id),
         worker_id=str(worker.id),
@@ -258,6 +270,7 @@ async def record_heartbeat(
         status_detail=body.status_detail,
     )
     await targets_store.set_target_status(db, target_id=auth.target_id, status_value=status_value)
+    await _publish_current_target_patch(db, target_id=auth.target_id)
     return WorkerHeartbeatResponse(
         target_id=str(auth.target_id),
         worker_id=str(auth.worker_id),
@@ -287,6 +300,7 @@ async def record_inventory(
         status_detail=body.status_detail,
     )
     await targets_store.set_target_status(db, target_id=auth.target_id, status_value=status_value)
+    await _publish_current_target_patch(db, target_id=auth.target_id)
     return WorkerInventoryResponse(
         target_id=str(auth.target_id),
         worker_id=str(auth.worker_id),
@@ -312,6 +326,8 @@ async def lease_worker_command(
         lease_expires_at=now + timedelta(seconds=lease_seconds),
         now=now,
     )
+    if command is not None:
+        await publish_command_status_after_commit(db, command)
     return WorkerCommandLeaseResponse(
         command=_command_envelope(command) if command is not None else None,
         server_time=now.isoformat(),
@@ -351,6 +367,7 @@ async def record_command_delivery(
             "Command is not leased by this worker.",
             status_code=404,
         )
+    await publish_command_status_after_commit(db, command)
     return WorkerCommandStatusResponse(
         command_id=str(command.id),
         status=command.status,
@@ -383,6 +400,7 @@ async def record_command_result(
             "Command is not leased by this worker.",
             status_code=404,
         )
+    await publish_command_status_after_commit(db, command)
     return WorkerCommandStatusResponse(
         command_id=str(command.id),
         status=command.status,
@@ -396,4 +414,5 @@ async def record_event_batch(
     auth: WorkerAuthContext,
     body: WorkerEventBatchRequest,
 ) -> WorkerEventBatchResponse:
-    return await ingest_worker_event_batch(db, auth=auth, body=body)
+    with defer_live_publishes_until_commit(db):
+        return await ingest_worker_event_batch(db, auth=auth, body=body)

--- a/server/tests/integration/test_cloud_event_sync_api.py
+++ b/server/tests/integration/test_cloud_event_sync_api.py
@@ -10,7 +10,15 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.server.cloud.live.service import stream_session_events
+from proliferate.integrations.pubsub.models import PubSubMessage
+from proliferate.integrations.pubsub.redis import get_pubsub_bus
+from proliferate.server.cloud.live.domain.channels import target_channel
+from proliferate.server.cloud.live.service import (
+    stream_session_events,
+    stream_target_events,
+    stream_workspace_events,
+)
+from proliferate.server.cloud.workspaces.service import get_cloud_workspace_detail
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.shared import AuthSession
 
@@ -51,6 +59,13 @@ def _sse_event(frame: str) -> str:
         if line.startswith("event: "):
             return line.removeprefix("event: ")
     raise AssertionError(f"SSE frame has no event line: {frame}")
+
+
+def _sse_id(frame: str) -> str:
+    for line in frame.splitlines():
+        if line.startswith("id: "):
+            return line.removeprefix("id: ")
+    raise AssertionError(f"SSE frame has no id line: {frame}")
 
 
 def _sse_data(frame: str) -> dict[str, object]:
@@ -197,6 +212,29 @@ class TestCloudEventSyncApi:
         assert body["pendingInteractions"][0]["requestId"] == "interaction-1"
         assert body["pendingInteractions"][0]["title"] == "Approve command"
 
+        snapshot_alias = await client.get(
+            f"/v1/cloud/sessions/session-1?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert snapshot_alias.status_code == 200
+        assert snapshot_alias.json()["session"]["sessionId"] == "session-1"
+
+        transcript = await client.get(
+            f"/v1/cloud/sessions/session-1/transcript?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert transcript.status_code == 200
+        assert transcript.json()["transcriptItems"][0]["text"] == "hello"
+        assert transcript.json()["pendingInteractions"][0]["requestId"] == "interaction-1"
+
+        events = await client.get(
+            f"/v1/cloud/sessions/session-1/events?targetId={target_id}&afterSeq=0",
+            headers=auth.headers,
+        )
+        assert events.status_code == 200
+        assert [event["seq"] for event in events.json()["events"]] == [1, 3, 4, 5]
+        assert events.json()["nextCursor"] == 5
+
         mismatch = dict(batch)
         mismatch_events = list(batch["events"])
         mismatch_first = dict(mismatch_events[0])
@@ -306,3 +344,182 @@ class TestCloudEventSyncApi:
             assert _mapping(patch["transcriptItem"])["text"] == "streamed response"
         finally:
             await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_workspace_and_target_streams_emit_snapshots_and_patches(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-workspace-stream",
+        )
+        target_id, worker_headers = await _create_enrolled_target(
+            client,
+            auth,
+            suffix="workspace-stream",
+        )
+        target_stream = cast(
+            "AsyncGenerator[str, None]",
+            stream_target_events(target_id=UUID(target_id), after_seq=0),
+        )
+        try:
+            target_snapshot_frame = await asyncio.wait_for(anext(target_stream), timeout=1)
+            assert _sse_event(target_snapshot_frame) == "snapshot"
+            assert _mapping(_sse_data(target_snapshot_frame)["target"])["id"] == target_id
+
+            cursor_task: asyncio.Task[str] = asyncio.create_task(
+                _next_stream_frame(target_stream)
+            )
+            bus = get_pubsub_bus()
+            await bus.publish(
+                target_channel(target_id=UUID(target_id)),
+                PubSubMessage(event="patch", event_id="0", data={"kind": "stale_patch"}),
+            )
+            await asyncio.sleep(0.05)
+            assert not cursor_task.done()
+            await bus.publish(
+                target_channel(target_id=UUID(target_id)),
+                PubSubMessage(event="patch", event_id="1", data={"kind": "fresh_patch"}),
+            )
+            cursor_frame = await asyncio.wait_for(cursor_task, timeout=1)
+            assert _sse_event(cursor_frame) == "patch"
+            assert _sse_id(cursor_frame) == "1"
+            assert _sse_data(cursor_frame)["kind"] == "fresh_patch"
+
+            target_patch_task: asyncio.Task[str] = asyncio.create_task(
+                _next_stream_frame(target_stream)
+            )
+            heartbeat = await client.post(
+                "/v1/cloud/worker/heartbeat",
+                headers=worker_headers,
+                json={"status": "online", "statusDetail": "ready"},
+            )
+            assert heartbeat.status_code == 200
+            target_patch_frame = await asyncio.wait_for(target_patch_task, timeout=2)
+            assert _sse_event(target_patch_frame) == "patch"
+            target_patch = _sse_data(target_patch_frame)
+            assert target_patch["kind"] == "target_projection_patch"
+            assert _mapping(target_patch["target"])["status"] == "online"
+
+            command_status_task: asyncio.Task[str] = asyncio.create_task(
+                _next_stream_frame(target_stream)
+            )
+            command = await client.post(
+                "/v1/cloud/commands",
+                headers=auth.headers,
+                json={
+                    "idempotencyKey": "target-stream-command",
+                    "targetId": target_id,
+                    "workspaceId": "workspace-live",
+                    "kind": "sync_existing_workspace",
+                    "payload": {},
+                    "source": "desktop_cloud_view",
+                },
+            )
+            assert command.status_code == 200
+            command_status_frame = await asyncio.wait_for(command_status_task, timeout=2)
+            assert _sse_event(command_status_frame) == "command_status"
+            command_status = _sse_data(command_status_frame)
+            assert command_status["kind"] == "command_status"
+            assert _mapping(command_status["command"])["status"] == "queued"
+        finally:
+            await target_stream.aclose()
+
+        backfill = await client.post(
+            "/v1/cloud/worker/backfill",
+            headers=worker_headers,
+            json={
+                "workspaces": [
+                    {
+                        "workspaceId": "workspace-live",
+                        "displayName": "Live Workspace",
+                        "repo": {
+                            "provider": "github",
+                            "owner": "proliferate-ai",
+                            "name": "proliferate",
+                            "branch": "main",
+                            "baseBranch": "main",
+                        },
+                    }
+                ],
+                "sessions": [],
+            },
+        )
+        assert backfill.status_code == 200
+        cloud_workspace_id = backfill.json()["mappedWorkspaces"][0]["cloudWorkspaceId"]
+
+        uploaded = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json={
+                "events": [
+                    {
+                        "workspaceId": "workspace-live",
+                        "sessionId": "session-live",
+                        "seq": 1,
+                        "timestamp": "2026-05-13T00:00:00Z",
+                        "event": {
+                            "type": "session_started",
+                            "sourceAgentKind": "codex",
+                        },
+                    }
+                ]
+            },
+        )
+        assert uploaded.status_code == 200
+
+        workspace_snapshot_response = await client.get(
+            f"/v1/cloud/workspaces/{cloud_workspace_id}/snapshot",
+            headers=auth.headers,
+        )
+        assert workspace_snapshot_response.status_code == 200
+        workspace_snapshot = workspace_snapshot_response.json()
+        assert workspace_snapshot["workspace"]["id"] == cloud_workspace_id
+        assert workspace_snapshot["sessions"][0]["sessionId"] == "session-live"
+
+        workspace = await get_cloud_workspace_detail(
+            db_session,
+            UUID(auth.user_id),
+            UUID(cloud_workspace_id),
+        )
+        workspace_stream = cast(
+            "AsyncGenerator[str, None]",
+            stream_workspace_events(workspace=workspace, after_seq=1),
+        )
+        try:
+            workspace_snapshot_frame = await asyncio.wait_for(anext(workspace_stream), timeout=1)
+            assert _sse_event(workspace_snapshot_frame) == "snapshot"
+            workspace_snapshot = _sse_data(workspace_snapshot_frame)
+            assert _mapping(workspace_snapshot["workspace"])["id"] == cloud_workspace_id
+            assert _mapping(workspace_snapshot["sessions"][0])["sessionId"] == "session-live"
+
+            workspace_patch_task: asyncio.Task[str] = asyncio.create_task(
+                _next_stream_frame(workspace_stream)
+            )
+            live_uploaded = await client.post(
+                "/v1/cloud/worker/events/batches",
+                headers=worker_headers,
+                json={
+                    "events": [
+                        {
+                            "workspaceId": "workspace-live",
+                            "sessionId": "session-live",
+                            "seq": 2,
+                            "timestamp": "2026-05-13T00:00:01Z",
+                            "event": {"type": "turn_started"},
+                        }
+                    ]
+                },
+            )
+            assert live_uploaded.status_code == 200
+
+            workspace_patch_frame = await asyncio.wait_for(workspace_patch_task, timeout=2)
+            assert _sse_event(workspace_patch_frame) == "patch"
+            patch_envelope = _sse_data(workspace_patch_frame)
+            assert patch_envelope["kind"] == "workspace_projection_patch"
+            assert _mapping(patch_envelope["patch"])["eventType"] == "turn_started"
+        finally:
+            await workspace_stream.aclose()


### PR DESCRIPTION
## Summary

- add cloud live snapshot and SSE stream endpoints for sessions, workspaces, and targets
- add the pub/sub integration boundary plus after-commit live fanout for command, target, and projection patches
- expose cloud snapshot/stream helpers through the cloud SDK and React SDK with regenerated OpenAPI types
- cover event ingest, snapshots, stream cursor behavior, command status fanout, and target/workspace patches in integration tests

## Validation

- `uv run ruff check proliferate/db/engine.py proliferate/integrations/pubsub proliferate/server/cloud/live proliferate/server/cloud/events/api.py proliferate/server/cloud/events/service.py proliferate/server/cloud/commands/service.py proliferate/server/cloud/worker/service.py proliferate/server/cloud/targets/service.py proliferate/db/store/cloud_sync/events.py tests/integration/test_cloud_event_sync_api.py`
- `uv run mypy proliferate/db/engine.py proliferate/integrations/pubsub proliferate/server/cloud/live proliferate/server/cloud/events/api.py proliferate/server/cloud/events/service.py proliferate/server/cloud/commands/service.py proliferate/server/cloud/worker/service.py proliferate/server/cloud/targets/service.py proliferate/db/store/cloud_sync/events.py`
- `DEBUG=true uv run pytest -q tests/integration/test_cloud_event_sync_api.py tests/integration/test_cloud_targets_api.py tests/integration/test_cloud_backfill_api.py`
- `pnpm --filter @proliferate/cloud-sdk typecheck`
- `pnpm --filter @proliferate/cloud-sdk build`
- `pnpm --filter @proliferate/cloud-sdk-react typecheck`
- `git diff --check`

## Notes

- The test run only emitted the existing local JWT HMAC key-length warning.
