### PR TITLE
docs(cloud): add cloud worker implementation specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,22 @@ start of the task, not after implementation has already started.
     and launch-time model resolution boundaries
 - `docs/architecture/cloud-worker-control-plane.md`
   - reference architecture for target workers, Cloud-mediated session control,
-    command delivery, event ingestion, and projections
+    command delivery, event ingestion, and snapshots
+- `docs/architecture/cloud-worker-implementation-phases.md`
+  - concrete implementation phases, file paths, ownership boundaries, and
+    acceptance criteria for the Cloud Worker migration
+- `docs/architecture/cloud-worker-pr-stack-review-guide.md`
+  - synthesized reviewer map for the worker/control-plane PR stack
+- `docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md`
+  - concrete implementation spec for supervised runtime bundle packaging,
+    SSH installation, managed cloud boot, version reporting, and smoke tests
+- `docs/architecture/cloud-worker-workspace-command-spec.md`
+  - concrete implementation spec for the `materialize_workspace`
+    CloudCommand that creates/resolves target-side AnyHarness workspaces and
+    worktrees
+- `docs/architecture/cloud-worker-automation-migration-spec.md`
+  - concrete implementation spec for migrating automations to a target-agnostic
+    staged CloudCommand pipeline
 - `docs/architecture/plugins-and-skills.md`
   - reference architecture for plugin packages, skill bundles, plugin-owned
     MCP servers, the plugins UI, and the session bundle boundary

--- a/docs/architecture/cloud-worker-automation-migration-spec.md
+++ b/docs/architecture/cloud-worker-automation-migration-spec.md
@@ -1,0 +1,1457 @@
+# Cloud Worker Automation Migration Spec
+
+Status: concrete follow-up PR spec.
+
+Scope: PR C in the Cloud Worker migration sequence.
+
+This spec defines the migration that makes automations run against any
+registered target through CloudCommands.
+
+It depends on:
+
+- `docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md`
+- `docs/architecture/cloud-worker-workspace-command-spec.md`
+
+## Goal
+
+Automations should not be a special server-to-AnyHarness execution path.
+
+Automation execution should become a target-agnostic command pipeline:
+
+```text
+automation run
+  -> resolve target_id
+  -> materialize_workspace command
+  -> materialize_environment command if needed
+  -> start_session command
+  -> update_session_config command if needed
+  -> send_prompt command
+  -> worker event sync updates Cloud session/message/request state
+```
+
+The same pipeline must work for:
+
+```text
+managed_cloud
+ssh
+future desktop_dispatch / self_hosted / vpc targets
+```
+
+The executor should not know how to call E2B or SSH directly for execution
+mutations. It should resolve a target and enqueue commands for that target.
+
+## Non-Goals
+
+Do not implement the supervised runtime bundle in this PR.
+
+Do not add `materialize_workspace` in this PR.
+
+Do not build the final Web/Mobile automation UX in this PR.
+
+Do not redesign automation scheduling.
+
+Do not fully solve retention/pruning. The PR should keep enough IDs to allow
+future cleanup and should not make pruning harder.
+
+Do not remove all Cloud runtime bootstrap code. Managed cloud may still need
+server-owned provisioning before a target exists.
+
+## Current Target Model
+
+The target model already has the correct core shape.
+
+`cloud_targets` is the durable target identity:
+
+```text
+id
+display_name
+kind
+status
+owner_scope
+owner_user_id
+organization_id
+created_by_user_id
+default_workspace_root
+desired_anyharness_version
+desired_worker_version
+desired_supervisor_version
+update state
+timestamps
+```
+
+`cloud_workers` is the enrolled process attached to a target:
+
+```text
+id
+target_id
+token_hash
+machine_fingerprint
+hostname
+status
+worker_version
+anyharness_version
+supervisor_version
+last_seen_at
+last_heartbeat_at
+```
+
+`cloud_commands.target_id` is the routing key.
+
+Worker authentication flow:
+
+```text
+worker token -> cloud_workers row -> target_id
+```
+
+Command leasing flow:
+
+```text
+CloudCommand(target_id = T)
+worker for target T long-polls
+Cloud leases command to that worker
+worker calls local AnyHarness
+worker reports result
+```
+
+The automation executor must use this routing model.
+
+## Current Automation Model
+
+Current automation data already stores enough execution lifecycle state for a
+first migration:
+
+```text
+automation.execution_target
+automation_run.execution_target
+automation_run.status
+automation_run.cloud_workspace_id
+automation_run.anyharness_workspace_id
+automation_run.anyharness_session_id
+automation_run.claim_id
+automation_run.dispatch_started_at
+automation_run.dispatched_at
+automation_run.last_error_*
+```
+
+Existing run statuses can be retained initially:
+
+```text
+queued
+claimed
+creating_workspace
+provisioning_workspace
+creating_session
+dispatching
+dispatched
+failed
+cancelled
+```
+
+For PR C, interpret them as:
+
+```text
+creating_workspace
+  materialize_workspace command in progress
+
+provisioning_workspace
+  materialize_environment command in progress
+
+creating_session
+  start_session command in progress
+
+dispatching
+  send_prompt command in progress
+```
+
+Avoid a status migration unless it is necessary.
+
+## Required Data Model Changes
+
+Automations need to snapshot the selected target.
+
+Add to `automation`:
+
+```text
+cloud_target_id UUID NULL REFERENCES cloud_targets(id) ON DELETE SET NULL
+cloud_target_kind_snapshot VARCHAR(32) NULL
+```
+
+Add to `automation_run`:
+
+```text
+cloud_target_id_snapshot UUID NULL REFERENCES cloud_targets(id) ON DELETE SET NULL
+cloud_target_kind_snapshot VARCHAR(32) NULL
+```
+
+The run snapshot is required because a target can be renamed, archived, or
+changed after the run is created.
+
+Naming notes:
+
+- Keep `execution_target` temporarily if removing it causes too much migration
+  churn.
+- Prefer using `cloud_target_id_snapshot` as the actual command-routing source
+  once a run is queued.
+- `cloud_target_kind_snapshot` is for debugging/UI and not for routing.
+- Use `targetId` in API request/response JSON. Do not expose the internal
+  `cloud_target_id` column name on the wire.
+
+If the existing `execution_target` check constraint only allows `cloud` and
+`local`, do not force SSH into `execution_target` unless needed. The cleaner
+short-term model is:
+
+```text
+execution_target = cloud
+cloud_target_id_snapshot = selected managed_cloud or ssh target
+```
+
+Longer term, rename `execution_target` to a more precise execution mode.
+
+Do not add separate automation columns for SSH host, E2B sandbox id, runtime
+URL, worker id, or direct AnyHarness URL. Those are target/worker/runtime
+concerns. Automation only selects a registered Cloud target.
+
+## Target Selection Rules
+
+Automation target selection has three moments, each with a different purpose:
+
+```text
+automation create/update
+  store the user's preferred target for future runs
+
+automation run creation
+  snapshot the preferred target onto the run
+
+automation run execution
+  load the snapshotted target and enqueue commands for it
+```
+
+Rules:
+
+- If `automation.cloud_target_id` is set, every new run snapshots it into
+  `automation_run.cloud_target_id_snapshot`.
+- If `automation.cloud_target_id` is null and `execution_target = cloud`,
+  service may resolve the user's default managed-cloud target. If none exists,
+  return a clear `target_required` error.
+- If `execution_target = local`, do not set a cloud target snapshot.
+- A manual run may override the automation's default target only if the API
+  explicitly accepts that override and snapshots it onto the run.
+- Once a run exists, execution uses the run snapshot. It does not reread the
+  automation's current target preference.
+
+The resolver may queue work for a temporarily offline target only if product
+policy explicitly allows queued execution for that target kind. For the first
+implementation, prefer a strict rule:
+
+```text
+ssh
+  require worker online and target not archived
+
+managed_cloud
+  if no target exists, provision/register one first
+  then require worker online before command execution
+```
+
+This keeps first-run failure modes obvious.
+
+## File Ownership Map
+
+### Automation ORM And Store
+
+```text
+server/proliferate/db/models/automations.py
+server/proliferate/db/store/automations.py
+server/proliferate/db/store/automation_run_claim_values.py
+server/proliferate/db/store/automation_run_claims.py
+server/proliferate/db/store/automation_run_claim_transitions.py
+server/alembic/versions/<new_revision>_automation_target_snapshots.py
+```
+
+Expected work:
+
+- add automation target fields
+- snapshot target fields when creating automation runs
+- thread target fields through `AutomationValue` and `AutomationRunValue`
+- ensure claim values include target snapshot fields
+- preserve existing claim and heartbeat semantics
+
+Dataclasses must include the new fields:
+
+```text
+AutomationValue.cloud_target_id
+AutomationValue.cloud_target_kind
+
+AutomationRunValue.cloud_target_id_snapshot
+AutomationRunValue.cloud_target_kind_snapshot
+
+AutomationRunClaimValue.cloud_target_id_snapshot
+AutomationRunClaimValue.cloud_target_kind_snapshot
+```
+
+Store functions that create or claim runs must never infer target selection
+from `execution_target` alone after this migration. `execution_target = cloud`
+only means "the Cloud executor owns this run"; it does not identify the
+specific machine/sandbox.
+
+### Automation API And Models
+
+```text
+server/proliferate/server/automations/api.py
+server/proliferate/server/automations/models.py
+server/proliferate/server/automations/service.py
+server/proliferate/server/automations/domain/validation.py
+```
+
+Expected work:
+
+- create/update automation can accept target selection
+- list/detail responses include target selection and target snapshot
+- validate selected target is visible and usable by the actor
+- keep existing local automation behavior intact
+
+Request shape:
+
+```json
+{
+  "executionTarget": "cloud",
+  "targetId": "a602..."
+}
+```
+
+Response shape:
+
+```json
+{
+  "executionTarget": "cloud",
+  "targetId": "a602...",
+  "targetKind": "ssh"
+}
+```
+
+If `targetId` is omitted for a cloud automation, service may pick the user's
+default managed cloud target if that exists. If no target exists, fail with a
+clear `target_required` error.
+
+Validation must happen in `service.py` or `domain/validation.py`, not in
+`api.py`.
+
+Validation inputs:
+
+```text
+actor user id
+organization/team scope when present
+executionTarget
+targetId
+agentKind/model/mode
+repo config
+```
+
+Validation output should be a resolved target preference:
+
+```text
+cloud_target_id: UUID | None
+cloud_target_kind_snapshot: str | None
+```
+
+The API should not accept raw worker ids. Workers rotate and reconnect; target
+ids are the durable product identity.
+
+## Automation Run Snapshot Timing
+
+Snapshot target fields at run creation whenever possible:
+
+```text
+create_automation_run
+scheduled run insert
+manual run trigger
+```
+
+If a legacy run has no target snapshot, the cloud executor's target stage may
+perform a compatibility resolution, write the snapshot back to the run, and
+continue. This compatibility path is allowed only for rows created before this
+migration.
+
+The executor should not silently switch targets on retry. If a snapshotted
+target is archived or unavailable, fail with a target-specific error unless
+the user manually reruns against a different target.
+
+Expected failure codes:
+
+```text
+target_required
+target_not_found
+target_archived
+target_offline
+target_not_authorized
+target_missing_capability
+target_agent_not_ready
+```
+
+Use these as internal failure codes first; user-facing copy can map them later.
+
+### Automation Cloud Execution Structure
+
+Promote cloud automation execution into a legible stage subfolder.
+
+Target structure:
+
+```text
+server/proliferate/server/automations/worker/
+  cloud_executor.py
+    loop only:
+      claim runs
+      spawn process task
+      heartbeat cleanup
+
+  cloud_execution/
+    __init__.py
+    context.py
+      AutomationExecutionContext
+      TargetExecutionContext
+      WorkspaceExecutionContext
+      SessionExecutionContext
+
+    pipeline.py
+      run_automation_pipeline(ctx)
+      ordered stage calls
+
+    commands.py
+      enqueue_cloud_command()
+      wait_for_cloud_command()
+      parse command result helpers
+      idempotency helpers
+
+    stages/
+      __init__.py
+      target.py
+        resolve_target_stage()
+
+      workspace.py
+        materialize_workspace_stage()
+
+      environment.py
+        materialize_environment_stage()
+
+      session.py
+        start_session_stage()
+        apply_session_config_stage()
+
+      prompt.py
+        dispatch_prompt_stage()
+
+      cleanup.py
+        close_orphan_session()
+        fail_current_claim()
+```
+
+Do not keep substantial new logic in the older flat files if this PR rewrites
+the executor. Existing files can become shims temporarily only inside the same
+PR while moving tests; do not leave duplicate production paths.
+
+## Execution Context
+
+Use explicit context objects so stages do not pass large positional argument
+lists or reload the same facts repeatedly.
+
+Suggested dataclasses:
+
+```python
+@dataclass(frozen=True)
+class AutomationExecutionContext:
+    claim: AutomationRunClaimValue
+    target: TargetExecutionContext | None = None
+    workspace: WorkspaceExecutionContext | None = None
+    session: SessionExecutionContext | None = None
+```
+
+```python
+@dataclass(frozen=True)
+class TargetExecutionContext:
+    target_id: UUID
+    target_kind: str
+    default_workspace_root: str | None
+    status: str
+    ready_agent_kinds: tuple[str, ...]
+```
+
+```python
+@dataclass(frozen=True)
+class WorkspaceExecutionContext:
+    cloud_workspace_id: UUID
+    anyharness_workspace_id: str
+    anyharness_repo_root_id: str | None
+    path: str
+    branch: str | None
+    target_config_id: UUID | None
+    target_config_version: int | None
+```
+
+```python
+@dataclass(frozen=True)
+class SessionExecutionContext:
+    anyharness_session_id: str
+```
+
+Each stage should return a new context with additional fields populated.
+
+## Pipeline
+
+`pipeline.py` should make the sequence obvious:
+
+```python
+async def run_automation_pipeline(ctx: AutomationExecutionContext) -> None:
+    ctx = await resolve_target_stage(ctx)
+    ctx = await materialize_workspace_stage(ctx)
+    ctx = await materialize_environment_stage(ctx)
+    ctx = await start_session_stage(ctx)
+    ctx = await apply_session_config_stage(ctx)
+    await dispatch_prompt_stage(ctx)
+```
+
+`cloud_executor.py` should not contain this sequence inline. It should:
+
+- claim runs
+- start heartbeat loop
+- build initial context
+- call `run_automation_pipeline`
+- handle final exception-to-failure conversion
+
+`cloud_executor.py` may own concurrency, loop timing, task cancellation, and
+heartbeat lifecycle. It must not own command payload construction, target
+resolution, workspace materialization, or session config details.
+
+## Claim And Retry Semantics
+
+The current claim model is good enough and should be preserved:
+
+```text
+run status
+claim_id
+claim_expires_at
+last_heartbeat_at
+executor_kind
+executor_id
+```
+
+The staged pipeline must be retry-safe. Each stage should be written so a
+reclaimed run can continue from persisted state:
+
+```text
+cloud_workspace_id exists
+  workspace stage loads it instead of creating another CloudWorkspace
+
+anyharness_workspace_id exists
+  workspace stage skips materialize_workspace unless a repair is required
+
+anyharness_session_id exists
+  session stage skips start_session and only applies missing config if needed
+
+dispatched_at exists
+  prompt stage is complete
+```
+
+Do not rely on in-memory context to survive executor restart. Context is only a
+readability layer over persisted run/command/target state.
+
+When a command times out, the stage must distinguish:
+
+```text
+definitely not delivered
+  command expired before worker lease/delivery
+
+uncertain
+  command was delivered/leased but no terminal result arrived before timeout
+
+terminal failure
+  worker/AnyHarness reported rejected or failed_delivery
+```
+
+For uncertain prompt dispatch, keep using the existing
+`dispatch_uncertain`-style failure behavior so the UI and future repair logic
+do not claim the prompt was safely absent.
+
+## Stage Responsibilities
+
+### Target Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/target.py
+```
+
+Responsibilities:
+
+- read `cloud_target_id_snapshot` from claim
+- if missing, resolve default target according to current product rule
+- load target snapshot
+- verify target is visible/usable for the run owner or org
+- verify target is online or command-addressable
+- verify required agent kind is available or at least not explicitly missing
+- verify basic target readiness needed by automations:
+  - `git`
+  - configured agent provider
+  - Node/npm/npx if MCP bundles are requested
+  - writable workspace root
+- write compatibility snapshot fields back to the run if this is a legacy run
+  missing them
+
+Do not inspect SSH credentials. Command execution happens through worker
+long-polling, not by direct SSH.
+
+Target stage output:
+
+```text
+TargetExecutionContext
+  target_id
+  target_kind
+  default_workspace_root
+  status
+  ready_agent_kinds
+```
+
+This stage is the only automation stage allowed to choose or provision a
+target.
+
+### Workspace Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
+```
+
+Responsibilities:
+
+- create/load `CloudWorkspace` record for the run
+- enqueue `materialize_workspace`
+- wait for result
+- attach `anyharness_workspace_id` and cloud workspace id to the run
+- attach `anyharness_repo_root_id` if the worker returns one and the schema has
+  a place for it; otherwise record it in command result metadata until a later
+  migration adds a first-class column
+- build `WorkspaceExecutionContext`
+
+Command stage key:
+
+```text
+materialize-workspace
+```
+
+Expected payload:
+
+```json
+{
+  "mode": "worktree",
+  "repoRootId": "... if known ...",
+  "targetPath": "...",
+  "newBranchName": "...",
+  "baseBranch": "...",
+  "origin": {
+    "kind": "system",
+    "entrypoint": "automation"
+  },
+  "creatorContext": {
+    "kind": "automation",
+    "automationId": "...",
+    "automationRunId": "..."
+  }
+}
+```
+
+If repo root id is unknown for a fresh target, PR C may need a pre-step that
+uses `existing_path` to register the cloned repo root before creating a
+worktree. Keep this explicit rather than hiding it in the worker.
+
+Workspace path policy:
+
+```text
+base:
+  target.default_workspace_root
+
+path:
+  <base>/<repo-owner>/<repo-name>/<automation-run-id-or-branch-slug>
+
+branch:
+  <automation_cloud_executor_branch_prefix>/<run-specific-slug>
+```
+
+Do not derive target paths inside the worker. The server chooses the desired
+path/branch, the worker validates and materializes it.
+
+### Environment Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/environment.py
+```
+
+Responsibilities:
+
+- decide whether a target config exists for this target/repo
+- create or update the target config record if needed
+- enqueue `materialize_environment`
+- wait for result
+- fail run if target config cannot be applied
+
+Command stage key:
+
+```text
+materialize-environment:{target_config_version}
+```
+
+This stage owns durable filesystem materialization:
+
+```text
+git credentials
+repo env vars
+tracked files
+agent auth files when required by harness
+MCP/skill filesystem config when required
+target config manifest
+```
+
+It does not start sessions.
+
+It should use the Cloud target config subsystem as the source of the material
+to apply. If target config does not exist for this target/repo/user, create it
+from the same synced credential/environment model used by the existing Cloud
+syncing UI.
+
+The stage must be idempotent by target config version. Reapplying the same
+version should be a no-op or safe overwrite on the target.
+
+### Session Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/session.py
+```
+
+Responsibilities:
+
+- enqueue `start_session`
+- wait for session id
+- attach `anyharness_session_id` to run
+- apply session config commands that must happen after creation
+
+Command stage keys:
+
+```text
+start-session
+update-reasoning-effort
+update-model
+update-mode
+```
+
+The `start_session` payload should carry session-scoped bundle data where
+AnyHarness can consume it directly:
+
+```text
+agentKind
+modelId
+modeId
+origin
+credential grant refs
+MCP bundle refs/config
+skill refs
+```
+
+Do not move workspace path creation into this stage.
+
+Session result parsing must accept the worker's typed command result, not raw
+AnyHarness JSON guessing in the pipeline. The helper may translate compatible
+legacy bodies for one migration, but the target result is:
+
+```json
+{
+  "sessionId": "sess_...",
+  "workspaceId": "ws_...",
+  "acceptedConfig": {
+    "agentKind": "claude",
+    "modelId": "...",
+    "modeId": "..."
+  }
+}
+```
+
+### Prompt Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/prompt.py
+```
+
+Responsibilities:
+
+- mark run `dispatching`
+- enqueue `send_prompt`
+- wait for accepted or accepted_but_queued
+- mark run `dispatched`
+
+Command stage key:
+
+```text
+send-prompt
+```
+
+Payload:
+
+```json
+{
+  "idempotencyKey": "automation_run:<run_id>:send-prompt",
+  "blocks": [
+    { "type": "text", "text": "..." }
+  ]
+}
+```
+
+Do not write the final Cloud message row here. The accepted user message and
+assistant output should arrive through worker event sync. The executor only
+records command status and automation-run dispatch state.
+
+### Cleanup Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/cleanup.py
+```
+
+Responsibilities:
+
+- close orphan sessions when a claim is lost after session creation
+- translate stage failures into automation failure codes
+- avoid best-effort cleanup blocking command result persistence
+
+Cleanup is deliberately best-effort. If a close command cannot be enqueued,
+record a warning and fail the run with the original stage error. Do not mask
+the original failure with cleanup failure.
+
+## Command Helper Layer
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/commands.py
+```
+
+This file should be intentionally boring.
+
+Responsibilities:
+
+- create command rows with stable idempotency scope/key
+- wait for command status
+- expire timed-out commands
+- parse command result body
+- provide typed helpers for known stage results
+
+It should not know business semantics such as "an automation is creating a
+workspace" or "this claim is stale."
+
+Idempotency scope:
+
+```text
+automation_run:{run_id}:target:{target_id}
+```
+
+Stage keys:
+
+```text
+materialize-workspace
+materialize-environment:{config_version}
+start-session
+update-reasoning-effort
+send-prompt
+close-orphan-session:{session_id}
+```
+
+## CloudCommand Contracts Used By Automations
+
+The automation executor should use the normal Cloud command store/service, not
+private worker endpoints.
+
+Every command row should include:
+
+```text
+target_id
+kind
+workspace_id when known
+session_id when known
+actor_kind = automation
+actor_id = automation id or run id
+source = automation
+idempotency_scope = automation_run:<run_id>:target:<target_id>
+idempotency_key = stage key
+payload
+expires_at
+```
+
+Command statuses are interpreted as:
+
+```text
+queued
+  Cloud accepted the command but no worker has leased it yet.
+
+leased
+  A worker has reserved the command. Execution may not have started.
+
+delivered
+  Worker received the command and started local handling.
+
+accepted
+  AnyHarness accepted/applied the command.
+
+accepted_but_queued
+  AnyHarness accepted the command but queued it behind existing runtime work.
+
+rejected
+  AnyHarness rejected the command with a structured reason.
+
+failed_delivery
+  Worker could not deliver/apply the command to local AnyHarness.
+
+expired / superseded
+  Cloud terminal states. Treat as failure unless the stage has already been
+  satisfied through persisted run state.
+```
+
+Stage success rules:
+
+```text
+materialize_workspace
+  accepted or accepted_but_queued, with workspace result body
+
+materialize_environment
+  accepted or accepted_but_queued, with materialization status applied
+
+start_session
+  accepted or accepted_but_queued, with session id
+
+update_session_config
+  accepted or accepted_but_queued
+
+send_prompt
+  accepted or accepted_but_queued
+```
+
+Do not treat `delivered` as success. It only means the worker saw the command.
+
+## Typed Payload And Result Shapes
+
+PR C should avoid new `dict[str, object]` spread across stages. It is fine for
+the store to persist JSON, but stage code should use small Pydantic/dataclass
+payload builders before serializing.
+
+Suggested files:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/command_models.py
+```
+
+Suggested types:
+
+```text
+MaterializeWorkspacePayload
+MaterializeWorkspaceResult
+MaterializeEnvironmentPayload
+MaterializeEnvironmentResult
+StartSessionPayload
+StartSessionResult
+UpdateSessionConfigPayload
+SendPromptPayload
+```
+
+The command helper should expose methods like:
+
+```python
+await enqueue_materialize_workspace(ctx, payload)
+await wait_for_materialize_workspace(command)
+await enqueue_start_session(ctx, payload)
+await wait_for_start_session(command)
+```
+
+Those helpers may internally call a generic `enqueue_cloud_command`, but call
+sites should read like domain stages, not raw JSON assembly.
+
+Result parsing must be strict:
+
+- required ids must be present and non-empty
+- unexpected terminal command statuses fail the stage
+- raw worker result JSON is translated once at the command helper boundary
+- stages receive typed result objects
+
+## Cloud Workspace And Session Projections
+
+PR C should not poll AnyHarness directly to find transcript/session state.
+
+After `start_session` and `send_prompt`, visibility comes from the existing
+Cloud sync path:
+
+```text
+AnyHarness emits normalized events
+worker uploads event batches
+Cloud ingest dedupes/stores semantic rows
+Cloud updates CloudSession/CloudMessage/PendingInteraction snapshots
+SSE/Web clients observe patches
+```
+
+The automation executor may persist:
+
+```text
+automation_run.cloud_workspace_id
+automation_run.anyharness_workspace_id
+automation_run.anyharness_session_id
+automation_run.dispatched_at
+```
+
+It should not persist assistant messages, tool summaries, pending
+interactions, or completion summaries directly. Those belong to the event
+ingest/projection path.
+
+## Existing File Migration Map
+
+Current files:
+
+```text
+server/proliferate/server/automations/worker/cloud_executor.py
+server/proliferate/server/automations/worker/cloud_executor_claims.py
+server/proliferate/server/automations/worker/cloud_executor_commands.py
+server/proliferate/server/automations/worker/cloud_executor_config.py
+server/proliferate/server/automations/worker/cloud_executor_session.py
+server/proliferate/server/automations/worker/cloud_executor_target.py
+server/proliferate/server/automations/worker/cloud_executor_workspace.py
+```
+
+Target movement:
+
+```text
+cloud_executor.py
+  keep as loop and task lifecycle entrypoint
+
+cloud_executor_config.py
+  keep if config is only used by the loop; otherwise move to
+  cloud_execution/context.py or cloud_execution/config.py
+
+cloud_executor_claims.py
+  keep claim heartbeat/failure helpers if they are general worker lifecycle
+  plumbing
+
+cloud_executor_commands.py
+  move into cloud_execution/commands.py
+
+cloud_executor_target.py
+  move into cloud_execution/stages/target.py
+
+cloud_executor_workspace.py
+  split into cloud_execution/stages/workspace.py and
+  cloud_execution/stages/environment.py
+
+cloud_executor_session.py
+  split into cloud_execution/stages/session.py and
+  cloud_execution/stages/prompt.py
+```
+
+Do not leave both old and new production implementations active. Compatibility
+shims are acceptable only if they import and delegate to the new module.
+
+## Database Migration Details
+
+Migration should:
+
+```text
+automation:
+  add cloud_target_id nullable FK cloud_targets(id) ON DELETE SET NULL
+  add cloud_target_kind_snapshot nullable string(32)
+  add index on cloud_target_id
+
+automation_run:
+  add cloud_target_id_snapshot nullable FK cloud_targets(id) ON DELETE SET NULL
+  add cloud_target_kind_snapshot nullable string(32)
+  add index on cloud_target_id_snapshot
+  consider partial index for cloud claimable runs with cloud_target_id_snapshot
+```
+
+Backfill:
+
+```text
+existing cloud automations/runs:
+  leave target null
+  compatibility resolver can select default managed-cloud target
+
+existing local automations/runs:
+  leave target null
+```
+
+Do not attempt to infer SSH targets from repo URLs, hostnames, or previous
+workspace paths.
+
+## Product/API Behavior
+
+Automation create/update:
+
+```text
+executionTarget = local
+  targetId must be null
+
+executionTarget = cloud
+  targetId optional only if product policy can resolve a default managed target
+```
+
+Manual trigger:
+
+```text
+uses automation target by default
+may accept target override if implemented in this PR
+snapshot override onto run
+```
+
+List/detail:
+
+```text
+automation.target
+  id
+  kind
+  displayName if available
+
+automationRun.targetSnapshot
+  id
+  kind
+```
+
+If the target was deleted/archived after the run:
+
+```text
+show snapshotted id/kind
+target display name may be null
+do not hide the run
+```
+
+## Managed Cloud And SSH Exact Flow
+
+Managed cloud:
+
+```text
+1. Automation has executionTarget=cloud and no explicit SSH target.
+2. Target stage resolves or provisions the user's/team's managed cloud target.
+3. Runtime bundle boots under supervisor.
+4. Worker enrolls and reports online.
+5. Target stage snapshots cloud_target_id_snapshot.
+6. Later stages enqueue CloudCommands to that target id.
+```
+
+SSH:
+
+```text
+1. User/admin enrolls SSH target through compute settings.
+2. Automation is created with executionTarget=cloud and targetId=<ssh target>.
+3. Run snapshots that target id/kind.
+4. Target stage requires the worker to be online.
+5. Later stages enqueue the same CloudCommands to that target id.
+```
+
+No automation executor code should branch on SSH credentials. The only target
+kind branches allowed are:
+
+```text
+target resolution/provisioning
+readiness policy
+workspace root/path defaults
+error copy/code
+```
+
+## Implementation Order
+
+Implement PR C in this order to keep reviewable:
+
+1. Add DB columns and dataclass/Pydantic fields.
+2. Add service validation for automation target selection.
+3. Snapshot target fields when creating manual and scheduled runs.
+4. Add `cloud_execution/context.py`, `commands.py`, and typed command models.
+5. Move target resolution into `cloud_execution/stages/target.py`.
+6. Move workspace/environment/session/prompt logic into explicit stages.
+7. Replace `process_cloud_automation_run` with a call to
+   `run_automation_pipeline`.
+8. Remove direct AnyHarness mutation imports from automation worker code.
+9. Add unit tests for target selection, snapshotting, command order, and
+   idempotency.
+10. Run manual SSH smoke.
+
+Do not begin by deleting old files. First introduce the staged shape, migrate
+call sites, then delete or turn old modules into thin import shims in the same
+PR.
+
+## Acceptance Criteria
+
+The PR is done only when all of these are true:
+
+- A cloud automation can target an enrolled SSH target by target id.
+- A cloud automation can target the managed-cloud path after the target is
+  provisioned/enrolled.
+- The executor never needs a runtime URL or runtime token to mutate a session.
+- The executor does not create transcript/message rows directly.
+- Retrying a claimed run does not create duplicate workspaces, sessions, or
+  prompts when prior command results were already persisted.
+- Every CloudCommand created by the executor has stable idempotency scope/key.
+- A reviewer can understand the full execution order from `pipeline.py` without
+  opening worker loop code.
+
+## Direct AnyHarness Call Removal
+
+Automation execution must not call direct AnyHarness mutation helpers.
+
+Disallowed in automation execution code after this PR:
+
+```text
+create_runtime_session
+send_runtime_prompt
+apply_runtime_config
+close_runtime_session
+resolve_remote_workspace
+prepare_runtime_mobility_destination
+```
+
+These may still exist in managed cloud provisioning/bootstrap until the broader
+runtime provisioning migration removes them.
+
+The test gate should scan automation worker code for imports from:
+
+```text
+proliferate.integrations.anyharness.sessions
+proliferate.server.cloud.runtime.anyharness_api
+```
+
+unless the import is in an explicitly allowed bootstrap-only file.
+
+## Managed Cloud Targeting
+
+Managed cloud is still allowed to provision a sandbox before a target exists.
+
+After the sandbox worker enrolls, automation execution should use:
+
+```text
+target_id
+```
+
+not:
+
+```text
+runtime_url
+runtime_token
+```
+
+If an automation has no selected target and product policy allows default
+managed cloud, the target stage may provision or select a managed cloud target.
+Once selected, later stages must be command-based.
+
+## SSH Targeting
+
+SSH automations require an already enrolled SSH target.
+
+The executor should not open SSH connections.
+
+The executor should not require the user running the server to have SSH keys.
+
+All execution happens by:
+
+```text
+CloudCommand.target_id
+worker long poll
+local AnyHarness
+```
+
+## Tests
+
+### Unit Tests
+
+Add or update:
+
+```text
+server/tests/unit/test_automation_cloud_execution_pipeline.py
+server/tests/unit/test_cloud_executor_worker_commands.py
+server/tests/unit/test_automations_service.py
+```
+
+Suggested cases:
+
+- pipeline calls stages in order
+- target stage loads selected SSH target
+- target stage loads selected managed cloud target
+- target stage rejects archived/offline target where policy requires online
+- workspace stage enqueues `materialize_workspace`
+- environment stage enqueues `materialize_environment`
+- session stage enqueues `start_session`
+- prompt stage enqueues `send_prompt`
+- idempotency keys are stable across retries
+- automation run snapshots selected cloud target id/kind
+- automation responses include selected target id/kind
+- legacy cloud runs without a target snapshot resolve a default managed-cloud
+  target or fail with `target_required`
+- automation worker path has no direct AnyHarness mutation imports
+
+### Integration Smoke
+
+The migration should be validated as a smoke ladder. Each rung proves one spec,
+and the final rung proves the full Cloud Worker architecture.
+
+Runtime bundle / supervisor smoke:
+
+```text
+1. fresh SSH machine or freshly cleaned test target
+2. run install/proliferate-target-install.sh with:
+     PROLIFERATE_CLOUD_URL
+     PROLIFERATE_ENROLLMENT_TOKEN
+3. verify proliferate-supervisor is running
+4. verify anyharness is running under supervisor
+5. verify proliferate-worker is running under supervisor
+6. verify target appears online in Cloud
+7. verify inventory reports:
+     git
+     node/npm/npx
+     AnyHarness version
+     worker version
+     supervisor version
+```
+
+Workspace command smoke:
+
+```text
+1. use the enrolled target from the runtime smoke
+2. enqueue one materialize_workspace CloudCommand for that target
+3. verify worker leases the command
+4. verify worker calls local AnyHarness
+5. verify target has the expected workspace/worktree path
+6. verify command reaches accepted or accepted_but_queued
+7. verify Cloud stores the returned AnyHarness workspace id/path
+```
+
+The workspace command smoke must include a `mode = worktree` case, not only an
+`existing_path` case, because automation runs are expected to create isolated
+worktrees under the target's default workspace root.
+
+Automation command pipeline smoke:
+
+```text
+1. local Cloud server
+2. enrolled SSH target from the runtime smoke
+3. automation targeting SSH target
+4. manual automation trigger
+5. CloudCommands appear:
+     materialize_workspace
+     materialize_environment
+     start_session
+     update_session_config if configured
+     send_prompt
+6. worker leases and accepts them
+7. AnyHarness session exists
+8. automation_run stores cloud_workspace_id and anyharness_workspace_id
+9. CloudWorkspace records target id, repo identity, requested worktree path,
+   and returned AnyHarness workspace id
+10. target filesystem contains the expected automation worktree path
+11. worker event sync creates Cloud session/message/projection rows
+12. automation run is dispatched or failed with a specific stage error
+```
+
+Managed cloud smoke should prove the same command sequence after the managed
+target is ready.
+
+The PR stack is not architecturally complete until the final smoke proves:
+
+```text
+local Cloud server
+  -> ngrok or reverse tunnel
+  -> fresh SSH target enrollment
+  -> target online with supervisor/AnyHarness/worker
+  -> automation targeting SSH target
+  -> manual trigger
+  -> CloudCommands leased by worker
+  -> AnyHarness worktree workspace/session/prompt accepted
+  -> automation run linked to CloudWorkspace + AnyHarness workspace id
+  -> target filesystem has expected worktree path
+  -> worker event upload
+  -> Cloud session/message/projection rows visible
+  -> Cloud web view can render the run
+```
+
+Eventually this should become one repeatable command:
+
+```bash
+make smoke-cloud-worker-ssh PROFILE=worker \
+  CLOUD_URL=https://example.ngrok-free.app \
+  SSH_HOST=ubuntu@example \
+  SSH_KEY=/path/to/key
+```
+
+The make target may start as a thin wrapper over the existing local dev server,
+ngrok/reverse tunnel setup, enrollment token creation, SSH installer execution,
+manual automation trigger, and database/API assertions. It should not rely on
+private local state beyond the explicit arguments.
+
+### Static Checks
+
+Add a cheap regression check, either as a unit test or script invoked by the
+server test target:
+
+```text
+rg "proliferate\\.integrations\\.anyharness\\.sessions|server\\.cloud\\.runtime\\.anyharness_api" \
+  server/proliferate/server/automations/worker
+```
+
+The check should fail if automation worker code imports direct AnyHarness
+mutation adapters.
+
+### Manual Local Smoke
+
+Expected manual loop after PR A and PR B:
+
+```text
+1. make dev PROFILE=worker
+2. expose local server to SSH target with ngrok or reverse tunnel
+3. enroll SSH target with install/proliferate-target-install.sh
+4. create automation with executionTarget=cloud and targetId=<ssh target id>
+5. trigger manual run
+6. inspect cloud_commands for ordered stage commands
+7. inspect automation_run for cloud_target_id_snapshot, cloud_workspace_id,
+   anyharness_workspace_id, and anyharness_session_id
+8. inspect CloudWorkspace for target id, repo identity, requested worktree path,
+   and returned AnyHarness workspace id
+9. SSH into target and confirm the expected worktree path exists under the
+   target default workspace root
+10. open Cloud session view and confirm transcript/event sync appears
+```
+
+This smoke is intentionally end-to-end. Unit tests prove stage logic; this
+proves target registration, command leasing, worker dispatch, AnyHarness
+execution, event upload, and Cloud projections are connected.
+
+## Completion Checklist
+
+- [ ] automations can store selected cloud target id
+- [ ] automation runs snapshot selected cloud target id/kind
+- [ ] cloud executor is organized as a stage pipeline
+- [ ] workspace stage uses `materialize_workspace`
+- [ ] environment stage uses `materialize_environment`
+- [ ] session/prompt stages use existing command kinds
+- [ ] managed cloud automations use target id after provisioning/enrollment
+- [ ] SSH automations use the same command path
+- [ ] automation execution code has no direct AnyHarness mutation calls
+- [ ] event sync, not direct executor polling, updates Cloud session/message
+      visibility
+
+## Review Questions
+
+Reviewers should be able to answer:
+
+1. Where is the target selected?
+2. Where is `cloud_target_id_snapshot` written?
+3. Which file shows the ordered automation execution pipeline?
+4. Which stage creates the AnyHarness workspace?
+5. Which stage applies target environment config?
+6. Which stage starts the session?
+7. Can the same code run on SSH and managed cloud?
+8. What direct AnyHarness calls remain, and are they bootstrap-only?
+
+If any answer is unclear, the PR is not finished.

--- a/docs/architecture/cloud-worker-implementation-phases.md
+++ b/docs/architecture/cloud-worker-implementation-phases.md
@@ -1,0 +1,2371 @@
+# Cloud Worker Implementation Phases
+
+Status: implementation plan for the Cloud Worker migration.
+
+This document turns `docs/architecture/cloud-worker-control-plane.md` into
+direct implementation phases with concrete file paths and ownership rules.
+
+Use this when assigning implementation work. The architecture spec remains the
+source of truth for the overall model; this file is the execution plan.
+
+## Goal
+
+Move Cloud-mediated runtime control to:
+
+```text
+Cloud client or automation
+  -> CloudCommand in Proliferate Cloud
+  -> Proliferate Worker on the target
+  -> local AnyHarness API
+  -> AnyHarness normalized events
+  -> Worker event upload
+  -> Cloud durable rows, snapshots, and live patches
+```
+
+The migration must preserve Desktop direct mode:
+
+```text
+Desktop rich local mode -> AnyHarness directly
+```
+
+The migration must remove production Cloud runtime control that directly calls
+AnyHarness from the server. Server code may still provision compute, manage
+policy, enqueue commands, ingest events, publish live patches, and store
+snapshots.
+
+## Non-Negotiable Boundaries
+
+AnyHarness owns execution truth:
+
+- session actor loop
+- prompt queue semantics
+- config application semantics
+- interaction acceptance/rejection
+- event sequence numbers
+- local SQLite runtime state
+- local files/git/terminal/process capabilities
+
+Proliferate Worker owns target transport:
+
+- enrollment
+- heartbeat
+- inventory and readiness
+- command leasing
+- local AnyHarness API calls
+- event tailing
+- event upload
+- local retry/outbox state
+- supervisor/update coordination
+
+Cloud owns control plane state:
+
+- org/user/team auth
+- target registry
+- command queue
+- event ingest and dedupe
+- durable semantic transcript/config/request rows
+- snapshots and live patches
+- credential grants
+- MCP/plugin launch input
+- audit/billing/retention
+
+Desktop owns rich direct UX:
+
+- direct local AnyHarness SDK usage
+- local workspace UI
+- terminal/files/git/browser/computer-use rich surfaces
+- local auth/storage/Tauri wiring
+
+Cloud-mediated clients own thin remote UX:
+
+- fetch snapshots
+- subscribe to Cloud streams
+- send Cloud commands
+- render command status, transcript, config, requests, targets
+
+## Product Objects Cloud Stores
+
+Cloud should store concrete product rows, not an abstract UI-only event feed.
+
+Durable Cloud rows:
+
+```text
+CloudTarget
+CloudWorker
+CloudWorkspace
+CloudSession
+CloudMessage
+CloudToolCallSummary
+CloudRequest
+CloudSessionConfigState
+CloudCommand
+CloudSessionEvent
+CloudEventIngestState
+CloudArtifactRef
+```
+
+Where:
+
+- `CloudWorkspace` is repo/root/workspace identity, target, owner/team,
+  lifecycle, retention, and last activity.
+- `CloudSession` is the cloud-visible session record: workspace, target,
+  agent/model/mode, status, current turn, config version, last event sequence.
+- `CloudMessage` is a completed user/assistant transcript item suitable for
+  fast web/mobile/Slack rendering.
+- `CloudToolCallSummary` is lightweight metadata only: tool name, status,
+  timing, short summary, artifact refs. It is not raw tool input/output by
+  default. ORM rows live in `db/models/cloud/sessions.py`; DB access lives in
+  `db/store/cloud_sync/tool_calls.py`.
+- `CloudRequest` is pending/resolved interaction state: permissions,
+  elicitations, user-input requests, stale/expired requests.
+- `CloudSessionConfigState` stores available config options plus current config
+  for the session, as reported by AnyHarness events.
+- `CloudCommand` is the durable queue and status record for a requested
+  mutation.
+- `CloudSessionEvent` is the bounded semantic event log used for replay,
+  debugging, and snapshot rebuilds.
+- `CloudEventIngestState` tracks per target/session cursors and gaps.
+- `CloudArtifactRef` points at object-storage payloads when data is too large
+  to store inline.
+
+`projection` may still appear as an implementation term, but it is not a
+user-facing product object or a default server folder. The server may keep
+snapshot cache rows for fast reads, but the client-facing model should be
+workspaces, sessions, transcript/messages, requests, config, targets, and
+command status.
+
+Live deltas are separate:
+
+```text
+live delta patches -> Redis/NATS/pubsub -> SSE/WebSocket clients
+semantic facts     -> Postgres rows       -> snapshots and replay
+large payloads     -> object storage      -> CloudArtifactRef
+```
+
+If no client is connected, live deltas may disappear. Durable semantic rows and
+snapshots must still be written.
+
+## Server Cloud Module Contract
+
+Cloud server areas must use a predictable folder shape. Do not create a large
+set of area-specific filenames up front. Each Cloud area starts with the same
+module contract:
+
+```text
+server/proliferate/server/cloud/<area>/
+  api.py          # HTTP/SSE transport only
+  models.py       # Pydantic request/response schemas only
+  service.py      # orchestration, transactions, store calls, integrations
+  access.py       # optional resource-access route deps
+  errors.py       # optional area-specific errors
+  domain/
+    types.py      # optional frozen dataclasses/enums used by pure rules
+    rules.py      # optional pure validators, reducers, status transitions
+    policy.py     # optional pure access/control policy verdicts
+```
+
+Initial Cloud areas for this migration:
+
+```text
+server/proliferate/server/cloud/
+  targets/        compute target registry, enrollment, inventory, readiness
+  worker/         worker-only auth, heartbeat, command lease, event upload
+  commands/       CloudCommand enqueue, status, routing, idempotency
+  events/         ingest, dedupe, cursor, payload policy, event log
+  sessions/       CloudSession, messages, requests, config, transcript reads
+  live/           Redis/NATS pubsub, SSE streams, replay
+  compute/        stop/prune/extend/provider lifecycle policy
+  target_config/  env, credentials, files, git, MCP materialization model
+  runtime/        managed compute provisioning; direct-AnyHarness mutation paths transitional
+```
+
+Promotion rule:
+
+- Start with `domain/types.py`, `domain/rules.py`, and `domain/policy.py`.
+- Promote a more specific `domain/<concern>.py` only when one of those files is
+  clearly too large or owns multiple unrelated rule families.
+- Do not create `capabilities.py`, `enrollment.py`, `readiness.py`,
+  `versions.py`, `routing.py`, `payload_policy.py`, etc. as default files.
+  Those names are allowed only after promotion is earned.
+
+DB files should also be predictable:
+
+```text
+server/proliferate/db/models/cloud/
+  targets.py
+  commands.py
+  events.py
+  sessions.py
+  artifacts.py
+  target_config.py
+
+server/proliferate/db/store/cloud_sync/
+  targets.py
+  worker_auth.py
+  inventory.py
+  commands.py
+  leases.py
+  events.py
+  cursors.py
+  sessions.py
+  messages.py
+  tool_calls.py
+  requests.py
+  config.py
+  artifacts.py
+  target_config.py
+```
+
+Store files may be split into `db/store/cloud_sync/<area>/` only after a single
+store file becomes too large or mixes unrelated DB ownership. The split should
+be by table/resource, not by caller.
+
+`db/models/cloud/sessions.py` owns `CloudSession`, `CloudMessage`,
+`CloudToolCallSummary`, `CloudRequest`, and `CloudSessionConfigState`.
+`db/store/cloud_sync/{sessions,messages,tool_calls,requests,config}.py` own
+the corresponding read/write paths.
+
+Existing cloud DB layout is transitional and must not be silently duplicated.
+Phase 0 must add one disposition row per existing file before Phase 2 creates
+or moves DB stores:
+
+```text
+server/proliferate/db/models/cloud/workspaces.py          keep; existing CloudWorkspace/CloudWorkspaceSetupRun owner
+server/proliferate/db/models/cloud/repo_config.py         keep; repo config owner
+server/proliferate/db/models/cloud/credentials.py         keep; credential owner
+server/proliferate/db/models/cloud/mcp.py                 keep; MCP owner
+server/proliferate/db/models/cloud/runtime_environments.py keep; managed runtime owner
+server/proliferate/db/models/cloud/sandboxes.py           keep; managed sandbox owner
+server/proliferate/db/models/cloud/worktree_policy.py     keep; worktree policy owner
+server/proliferate/db/models/cloud/mobility.py            keep; mobility/handoff owner
+
+server/proliferate/db/store/cloud_workspaces.py           decide: keep as owner or move whole resource, no duplicate
+server/proliferate/db/store/cloud_workspace_setup_runs.py decide: keep as owner or merge with workspace store, no duplicate
+server/proliferate/db/store/cloud_repo_config.py          keep unless target_config migration moves whole resource
+server/proliferate/db/store/cloud_credentials.py          keep; credential owner
+server/proliferate/db/store/cloud_mcp/**                  keep; MCP owner
+server/proliferate/db/store/cloud_runtime_environments.py keep; runtime owner
+server/proliferate/db/store/cloud_worktree_policy.py      keep; policy owner
+server/proliferate/db/store/cloud_mobility.py             keep; mobility/handoff owner
+```
+
+## Phase 0: Contract Freeze And Direct-Path Audit
+
+### Goal
+
+Freeze the command/event/snapshot shapes and produce an exact inventory of
+direct server-to-AnyHarness calls before migration starts.
+
+This phase prevents a hidden second runtime path from surviving the worker
+migration.
+
+### Files
+
+Specs and audit output:
+
+```text
+docs/architecture/cloud-worker-control-plane.md
+docs/architecture/cloud-worker-implementation-phases.md
+docs/audits/cloud-worker-direct-anyharness-inventory.md
+```
+
+Existing direct server AnyHarness integration to audit:
+
+```text
+server/proliferate/integrations/anyharness/
+  client.py
+  runtime.py
+  sessions.py
+  workspaces.py
+  workspace_ops.py
+  worktrees.py
+
+server/proliferate/server/automations/worker/
+  cloud_executor_workspace.py
+  cloud_executor_session.py
+
+server/proliferate/server/cloud/runtime/
+  anyharness_api.py
+  provision.py
+  service.py
+  setup_monitor.py
+  workspace_operations.py
+  git_operations.py
+  repo_config_apply.py
+  worktree_policy_sync.py
+```
+
+AnyHarness contract files to stabilize:
+
+```text
+anyharness/crates/anyharness-contract/src/v1/commands.rs
+anyharness/crates/anyharness-contract/src/v1/events.rs
+anyharness/crates/anyharness-contract/src/v1/runtime.rs
+```
+
+Cloud schema and API shape specs:
+
+```text
+server/proliferate/server/cloud/commands/models.py
+server/proliferate/server/cloud/events/models.py
+server/proliferate/server/cloud/sessions/models.py
+server/proliferate/server/cloud/targets/models.py
+server/proliferate/server/cloud/worker/models.py
+```
+
+### Decisions
+
+Production Cloud-mediated runtime commands must migrate:
+
+- create session
+- resume session
+- send prompt
+- update config
+- resolve permission/user-input/MCP elicitation
+- cancel turn/session
+- sync existing workspace/session
+- stop/prune/hibernate/extend when implemented through target runtime state
+
+These direct server calls are transitional and should be removed or bypassed
+for production Cloud sessions:
+
+- `create_runtime_session`
+- `prompt_runtime_session`
+- `apply_runtime_reasoning_effort`
+- `close_runtime_session`
+- workspace setup calls that mutate AnyHarness directly
+- worktree policy sync calls that mutate AnyHarness directly
+
+These may remain temporarily while migration is staged:
+
+- managed sandbox provisioning code in `server/proliferate/server/cloud/runtime/**`
+- runtime setup monitor code needed to keep current cloud workspaces working
+- direct AnyHarness integration tests
+- local diagnostics and explicit developer tools
+
+Final target:
+
+- server does not directly mutate AnyHarness for Cloud-mediated sessions.
+- `server/proliferate/integrations/anyharness/**` is either deleted or
+  limited to tests, local diagnostics, or transitional code with an explicit
+  audit allowlist.
+- Desktop direct AnyHarness usage remains because it is not server-mediated
+  Cloud runtime control.
+
+### Required Audit Commands
+
+Use these to create the inventory:
+
+```bash
+rg "integrations.anyharness|create_runtime_session|prompt_runtime_session|runtime_url|anyharness_workspace_id|anyharness_session_id" server/proliferate -g '*.py'
+rg "AnyHarness|anyharness" server/proliferate/server/automations server/proliferate/server/cloud -g '*.py'
+rg "integrations.anyharness|AnyHarness|anyharness" server/proliferate/server -g '*.py'
+rg --files server/proliferate/db/models/cloud server/proliferate/db/store | rg 'cloud'
+```
+
+### Acceptance
+
+- `docs/audits/cloud-worker-direct-anyharness-inventory.md` exists.
+- Every direct AnyHarness server callsite is classified as:
+  - `migrate-to-command`
+  - `temporary-provisioning`
+  - `test-or-diagnostic`
+  - `delete`
+- The audit groups every direct AnyHarness callsite by server consumer
+  (`cloud`, `automations`, `billing`, `webhooks`, diagnostics, tests, etc.)
+  and explicitly says whether any non-cloud production consumer remains.
+- The audit includes the DB layout disposition table for every existing
+  `db/models/cloud/**`, `db/store/cloud_*.py`, and `db/store/cloud_mcp/**`
+  file, with no duplicate owner allowed for one ORM resource.
+- No phase after Phase 4 can add a new production server-to-AnyHarness command
+  path.
+
+## Phase 1: Shared Cloud SDK Foundation
+
+### Goal
+
+Extract reusable Cloud API access from Desktop so Desktop, Web, Mobile, and
+future developer SDKs do not each hand-roll Cloud clients.
+
+This phase is allowed before the worker is complete because it mostly moves the
+client access boundary.
+
+### New Packages
+
+Add two workspace packages:
+
+These packages live under top-level `cloud/` because they are Proliferate
+Cloud API clients, not AnyHarness runtime SDKs. Add exact workspace entries for
+`cloud/sdk` and `cloud/sdk-react` to `pnpm-workspace.yaml`.
+
+```text
+cloud/sdk/
+  package.json
+  tsconfig.json
+  src/
+    index.ts
+    client/
+      core.ts
+      auth.ts
+      automations.ts
+      commands.ts
+      config.ts
+      credentials.ts
+      events.ts
+      live.ts
+      mcp.ts
+      organizations.ts
+      repos.ts
+      sessions.ts
+      targets.ts
+      workspaces.ts
+    streams/
+      sse.ts
+    types/
+      automations.ts
+      commands.ts
+      config.ts
+      credentials.ts
+      events.ts
+      live.ts
+      organizations.ts
+      sessions.ts
+      targets.ts
+      workspaces.ts
+    generated/
+      openapi.ts
+
+cloud/sdk-react/
+  package.json
+  tsconfig.json
+  src/
+    index.ts
+    context/
+      CloudClientProvider.tsx
+    hooks/
+      automations.ts
+      commands.ts
+      config.ts
+      credentials.ts
+      live.ts
+      organizations.ts
+      sessions.ts
+      targets.ts
+      workspaces.ts
+    lib/
+      query-keys.ts
+      client-cache.ts
+```
+
+Update workspace config:
+
+```text
+pnpm-workspace.yaml
+desktop/package.json
+```
+
+Package names:
+
+```text
+@proliferate/cloud-sdk
+@proliferate/cloud-sdk-react
+```
+
+The tree above is the end-state shape, not permission to pre-create empty
+resource modules. Phase 1 should create the package skeleton, `client/core.ts`,
+generated OpenAPI output, the React provider, and only the resource
+client/hook files that are backed by an existing Desktop migration in the same
+phase. Every later Desktop migration adds its SDK module in the same change.
+
+### Desktop Migration Paths
+
+Existing Desktop cloud access:
+
+```text
+desktop/src/lib/access/cloud/
+desktop/src/hooks/access/cloud/
+```
+
+Target after migration:
+
+```text
+desktop/src/lib/access/cloud/
+  client.ts                 # desktop auth/base-url/session wiring only
+  timing.ts                 # desktop-local telemetry/timing if still needed
+
+desktop/src/hooks/access/cloud/
+  <resource>/query-keys.ts  # may delegate to cloud-sdk-react key helpers
+  use-*.ts                  # desktop-specific auth/error/telemetry wrappers only
+```
+
+Move reusable raw endpoint logic from:
+
+```text
+desktop/src/lib/access/cloud/*.ts
+```
+
+into:
+
+```text
+cloud/sdk/src/client/*.ts
+cloud/sdk/src/types/*.ts
+```
+
+Create each resource file only when its Desktop source module is moved.
+
+Move reusable React Query logic from:
+
+```text
+desktop/src/hooks/access/cloud/**/*.ts
+```
+
+into:
+
+```text
+cloud/sdk-react/src/hooks/*.ts
+cloud/sdk-react/src/lib/query-keys.ts
+```
+
+Create each hook file only when its Desktop hook migration lands.
+
+Keep in Desktop:
+
+- desktop auth/session storage
+- Tauri/browser sign-in bridge
+- product-specific workflow hooks
+- Desktop-only telemetry decoration
+- Desktop-only selected organization/user context if not generic
+
+Do not keep duplicate low-level endpoint helpers in both Desktop and
+`@proliferate/cloud-sdk`.
+
+### Generated Types
+
+The server OpenAPI schema remains the source for generated Cloud API types.
+
+Generated output:
+
+```text
+cloud/sdk/src/generated/openapi.ts
+```
+
+Existing generated Desktop output:
+
+```text
+desktop/src/lib/access/cloud/generated/openapi.ts
+```
+
+is removed or replaced with a shim only during the migration. End state:
+Desktop imports generated Cloud types through `@proliferate/cloud-sdk`.
+
+### Acceptance
+
+- Desktop builds using `@proliferate/cloud-sdk`.
+- No product component calls raw `client.GET`/`client.POST` directly.
+- SDK package skeleton, auth/base URL wiring, generated OpenAPI output, and
+  the methods needed by Phase 1 Desktop migrations exist.
+- New worker/cloud endpoints progressively gain typed SDK methods in the phase
+  that introduces or migrates that endpoint:
+  - `createTargetEnrollment`
+  - `listTargets`
+  - `getTarget`
+  - `enqueueCommand`
+  - `getCommandStatus`
+  - `getWorkspaceSnapshot`
+  - `getSessionSnapshot`
+  - `getTranscriptSnapshot`
+  - `subscribeSession`
+  - `subscribeWorkspace`
+- Existing Desktop Cloud functionality still works.
+
+## Phase 2: Compute Targets, SSH Enrollment, And Supervisor MVP
+
+### Goal
+
+Let users register compute targets, especially SSH targets, and see them in
+Desktop. SSH onboarding, installer, worker enrollment, target registry, and
+supervisor MVP are one vertical.
+
+### Server Domains
+
+Add:
+
+```text
+server/proliferate/server/cloud/targets/
+  api.py
+  access.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+    policy.py
+
+server/proliferate/server/cloud/worker/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+```
+
+Register routers in:
+
+```text
+server/proliferate/server/cloud/api.py
+```
+
+### Server DB
+
+Add or update:
+
+```text
+server/proliferate/db/models/cloud/targets.py
+server/proliferate/db/models/cloud/__init__.py  # directory already exists; export new models
+
+server/proliferate/db/store/cloud_sync/
+  __init__.py
+  targets.py
+  worker_auth.py
+  inventory.py
+
+server/alembic/versions/<revision>_cloud_targets_workers.py
+```
+
+Core tables:
+
+```text
+cloud_targets
+cloud_workers
+cloud_target_enrollments
+cloud_target_inventory
+cloud_target_status
+```
+
+### API Endpoints
+
+Client/admin:
+
+```text
+POST /api/v1/cloud/targets/enrollments
+GET  /api/v1/cloud/targets
+GET  /api/v1/cloud/targets/{target_id}
+POST /api/v1/cloud/targets/{target_id}/archive
+```
+
+Worker-only:
+
+```text
+POST /api/v1/cloud/worker/enroll
+POST /api/v1/cloud/worker/heartbeat
+POST /api/v1/cloud/worker/inventory
+```
+
+### Worker Crate
+
+Add:
+
+```text
+anyharness/crates/proliferate-worker/
+  Cargo.toml
+  src/
+    main.rs
+    config.rs
+    error.rs
+    logging.rs
+    runtime.rs
+    identity/
+      mod.rs
+      enrollment.rs
+      credentials.rs
+      fingerprint.rs
+    cloud_client/
+      mod.rs
+      auth.rs
+      heartbeat.rs
+      inventory.rs
+    anyharness_client/
+      mod.rs
+      health.rs
+      runtime.rs
+    inventory/
+      mod.rs
+      platform.rs
+      capabilities.rs
+      mcp.rs
+      providers.rs
+      versions.rs
+    store/
+      mod.rs
+      schema.rs
+      migrations.rs
+      identity.rs
+      inventory.rs
+```
+
+Update:
+
+```text
+Cargo.toml
+```
+
+because the root workspace uses `anyharness/crates/*`.
+
+### Supervisor Crate
+
+Add a minimal supervisor from day one:
+
+```text
+anyharness/crates/proliferate-supervisor/
+  Cargo.toml
+  src/
+    main.rs
+    config.rs
+    error.rs
+    logging.rs
+    process/
+      mod.rs
+      child.rs
+      health.rs
+      restart.rs
+    install/
+      mod.rs
+      layout.rs
+      service.rs
+```
+
+MVP responsibilities:
+
+- start AnyHarness
+- start Proliferate Worker
+- restart either process if it exits unexpectedly
+- write local logs
+- expose installed version facts for worker inventory
+
+Not MVP:
+
+- signed artifact updates
+- rollback
+- staged upgrades
+- idle-aware binary swap
+
+Those move to Phase 8.
+
+### Installer
+
+Add:
+
+```text
+install/
+  proliferate-target-install.sh
+  README.md
+
+server/proliferate/server/cloud/targets/domain/rules.py
+```
+
+Installer behavior:
+
+- detect OS and arch
+- create `~/.proliferate`
+- download supervisor, AnyHarness, and worker artifacts
+- write worker config with Cloud base URL and one-time enrollment token
+- install systemd user service when available
+- otherwise print foreground/manual fallback command
+- start supervisor
+
+Target layout:
+
+```text
+~/.proliferate/bin/anyharness
+~/.proliferate/bin/proliferate-worker
+~/.proliferate/bin/proliferate-supervisor
+~/.proliferate/worker/config.toml
+~/.proliferate/worker/worker.sqlite
+~/.proliferate/logs/
+```
+
+Managed cloud images may use `$PROLIFERATE_HOME`, but the logical layout is
+the same.
+
+### Desktop Compute UX
+
+Add:
+
+```text
+desktop/src/components/settings/panes/ComputePane.tsx
+desktop/src/components/settings/panes/compute/
+  AddSshTargetDialog.tsx
+  ComputeTargetDetails.tsx
+  ComputeTargetList.tsx
+  ComputeTargetReadiness.tsx
+  EnrollmentCommandBlock.tsx
+
+desktop/src/hooks/access/cloud/targets/
+  query-keys.ts
+  use-cloud-targets.ts
+  use-cloud-target-mutations.ts
+
+desktop/src/hooks/settings/workflows/
+  use-compute-target-enrollment.ts
+
+desktop/src/lib/domain/compute/
+  target-presentation.ts
+  target-readiness.ts
+
+desktop/src/copy/settings/
+  compute.ts
+```
+
+Update:
+
+```text
+desktop/src/config/settings.ts
+desktop/src/components/settings/settings-navigation.ts
+desktop/src/components/settings/screen/SettingsScreen.tsx
+```
+
+UX:
+
+- Settings has a distinct `Compute` section.
+- User can click `Add SSH target`.
+- UI asks for display name and optional default workspace root.
+- UI creates enrollment token and shows an install command.
+- After the command runs, the target appears as online/degraded/offline.
+- Target details show worker version, AnyHarness version, supervisor version,
+  git, node/npm/npx, python/uv, writable roots, provider readiness, MCP
+  readiness, last heartbeat, and access scope.
+
+### E2B Managed Cloud
+
+Managed cloud target enrollment is not SSH onboarding.
+
+Managed cloud flow:
+
+- Cloud provisions sandbox through existing sandbox provider integration.
+- Sandbox template starts supervisor, AnyHarness, and worker.
+- Worker reads bootstrap token from env or metadata.
+- Worker calls the same `/api/v1/cloud/worker/enroll` endpoint.
+- Cloud creates or attaches a `managed_cloud` target.
+
+Existing managed runtime provisioning remains under:
+
+```text
+server/proliferate/server/cloud/runtime/
+server/proliferate/integrations/sandbox/
+```
+
+but its goal shifts from "server controls AnyHarness directly" to "server
+provisions compute where worker controls AnyHarness".
+
+### Acceptance
+
+- Desktop can create an SSH enrollment token.
+- SSH install command installs supervisor, AnyHarness, and worker.
+- Worker enrolls successfully.
+- Worker heartbeat updates target status.
+- Inventory appears in target details.
+- Target is selectable in UI once online.
+- Managed cloud can enroll through the same worker endpoint.
+
+## Phase 3: Worker Command Path
+
+### Goal
+
+Make Cloud commands reach AnyHarness through the worker with strong typed
+payloads.
+
+### Server Domains
+
+Add:
+
+```text
+server/proliferate/server/cloud/commands/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+    policy.py
+```
+
+Extend:
+
+```text
+server/proliferate/server/cloud/worker/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+```
+
+### Server DB
+
+Add:
+
+```text
+server/proliferate/db/models/cloud/commands.py
+server/proliferate/db/models/cloud/sessions.py
+server/proliferate/db/store/cloud_sync/commands.py
+server/proliferate/db/store/cloud_sync/leases.py
+server/proliferate/db/store/cloud_sync/sessions.py
+server/alembic/versions/<revision>_cloud_commands.py
+```
+
+Tables:
+
+```text
+cloud_commands
+cloud_command_leases
+cloud_sessions
+```
+
+Constraints:
+
+```text
+unique(org_id, idempotency_key)
+index(target_id, status, created_at)
+index(session_id, status, created_at)
+index(lease_expires_at) where status = 'leased'
+unique(target_id, anyharness_session_id)
+```
+
+Phase 3 creates only the minimal `CloudSession` identity/status row needed for
+command routing before full event ingest exists:
+
+```text
+cloud_session_id
+org_id
+target_id
+workspace_id nullable
+anyharness_session_id nullable until start_session is accepted
+status: starting | running | rejected | failed | cancelled | unknown
+last_command_id nullable
+last_command_status
+last_command_result_at nullable
+last_observed_event_seq nullable
+```
+
+`start_session` command results create or update this row with the
+AnyHarness session id. Later `send_prompt`, `resolve_interaction`,
+`update_session_config`, and `cancel_turn` commands address the Cloud session
+row and carry the AnyHarness session id to the Worker. This row is
+command-backed until Phase 5 begins event ingest; Phase 5 extends the same ORM
+and store ownership with message, request, config, tool-call, and
+event-derived status fields.
+
+### API Endpoints
+
+Client/admin:
+
+```text
+POST /api/v1/cloud/commands
+GET  /api/v1/cloud/commands/{command_id}
+```
+
+Worker:
+
+```text
+POST /api/v1/cloud/worker/commands/lease
+POST /api/v1/cloud/worker/commands/{command_id}/delivery
+POST /api/v1/cloud/worker/commands/{command_id}/result
+```
+
+### Command Kinds
+
+V1 command kinds:
+
+```text
+start_session
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+sync_existing_workspace
+```
+
+V1.1 command kinds:
+
+```text
+stop_session
+close_session
+stop_target
+prune_workspace
+materialize_environment
+refresh_inventory
+```
+
+### Cloud Command Envelope
+
+Every command must include:
+
+```text
+command_id
+idempotency_key
+org_id
+actor_user_id nullable
+source: web | mobile | slack | api | automation | desktop_cloud
+target_id
+workspace_id nullable
+session_id nullable
+kind
+payload
+observed_event_seq nullable
+preconditions
+created_at
+expires_at nullable
+```
+
+Command payloads must be typed Pydantic models on the server and typed Rust
+enums in the worker. Do not pass arbitrary `serde_json::Value` past the edge of
+the parser. If a provider-specific field is unavoidable, wrap it in a named
+typed extension object with validation and size limits.
+
+### Worker Implementation
+
+Add:
+
+```text
+anyharness/crates/proliferate-worker/src/cloud_client/
+  commands.rs
+
+anyharness/crates/proliferate-worker/src/commands/
+  mod.rs
+  dispatcher.rs
+  mapping.rs
+  preconditions.rs
+  result.rs
+
+anyharness/crates/proliferate-worker/src/anyharness_client/
+  sessions.rs
+  workspaces.rs
+```
+
+Responsibility split:
+
+- `dispatcher.rs` chooses the local AnyHarness client method for the command
+  kind.
+- `mapping.rs` converts typed Cloud payloads into typed AnyHarness request
+  payloads.
+- `preconditions.rs` checks cheap local freshness before making the request.
+- `result.rs` maps local accepted/rejected/error states back to Cloud command
+  status.
+
+### AnyHarness Contract Additions
+
+Add optional command metadata to existing requests:
+
+```text
+PromptSessionRequest.command_metadata
+SetSessionConfigOptionRequest.command_metadata
+SetSessionConfigOptionRequest.expected_config_version
+ResolveInteractionRequest.command_metadata
+ResolveInteractionRequest.expected_interaction_version
+CreateSessionRequest.command_metadata
+CreateSessionRequest.target_context
+CancelSessionRequest.command_metadata
+```
+
+Place types in:
+
+```text
+anyharness/crates/anyharness-contract/src/v1/commands.rs
+```
+
+Do not create parallel worker-only AnyHarness routes when an existing route can
+accept optional command metadata.
+
+### Acceptance
+
+- Worker long-polls and leases commands.
+- `start_session` creates or updates a minimal CloudSession identity row from
+  the worker delivery/result path.
+- `send_prompt` reaches a local AnyHarness session through the worker.
+- `resolve_interaction` reaches AnyHarness through the worker.
+- `update_session_config` reaches AnyHarness through the worker.
+- Duplicate idempotency keys return the same Cloud command.
+- Expired/stale leases recover and can be re-leased.
+- AnyHarness rejection updates Cloud command status as rejected.
+
+## Phase 4: Direct Server-To-AnyHarness Migration
+
+### Goal
+
+Move production Cloud and automation runtime mutations from direct server
+AnyHarness calls to Cloud commands.
+
+This is the semantic migration. Phase 3 gives us the path; Phase 4 uses it.
+
+### Must Migrate
+
+Current automation direct runtime files:
+
+```text
+server/proliferate/server/automations/worker/cloud_executor_workspace.py
+server/proliferate/server/automations/worker/cloud_executor_session.py
+```
+
+Current direct runtime integration:
+
+```text
+server/proliferate/integrations/anyharness/sessions.py
+server/proliferate/integrations/anyharness/workspaces.py
+server/proliferate/integrations/anyharness/workspace_ops.py
+server/proliferate/integrations/anyharness/worktrees.py
+```
+
+Current cloud runtime direct setup code:
+
+```text
+server/proliferate/server/cloud/runtime/provision.py
+server/proliferate/server/cloud/runtime/service.py
+server/proliferate/server/cloud/runtime/repo_config_apply.py
+server/proliferate/server/cloud/runtime/worktree_policy_sync.py
+```
+
+### Target Automation Shape
+
+Add command-oriented executor helpers:
+
+```text
+server/proliferate/server/automations/worker/
+  cloud_executor_commands.py
+  cloud_executor_target.py
+```
+
+Migration:
+
+- `cloud_executor_workspace.py` creates/selects a `CloudWorkspace` and target.
+- It enqueues worker commands instead of directly preparing AnyHarness
+  workspace state.
+- `cloud_executor_session.py` enqueues:
+  - `start_session`
+  - `update_session_config`
+  - `send_prompt`
+- Automation run state advances from Cloud command status and the minimal
+  command-backed CloudSession identity/status row introduced in Phase 3.
+  Event-derived transcript, request, config, and turn-detail state starts in
+  Phase 5.
+
+Automation can still own:
+
+- schedule/claim lifecycle
+- run state
+- deciding which target/workspace to use
+- recording automation-specific failure codes
+
+Automation must not own:
+
+- direct prompt delivery to AnyHarness
+- direct session creation in AnyHarness
+- direct config mutation in AnyHarness
+
+### Target Cloud Runtime Shape
+
+Keep:
+
+```text
+server/proliferate/server/cloud/runtime/
+```
+
+for managed compute lifecycle:
+
+- provision sandbox
+- attach existing sandbox
+- create runtime environment record
+- create enrollment token/bootstrap material
+- wait for worker enrollment and readiness
+- retire/stop/prune sandbox according to policy
+
+Remove or make transitional:
+
+- direct session creation
+- direct prompt sending
+- direct config application
+- direct AnyHarness workspace mutation once worker commands exist
+
+### Integration Boundary End State
+
+By the end of this phase:
+
+```bash
+rg "proliferate.integrations.anyharness" server/proliferate/server -g '*.py'
+```
+
+should only return:
+
+- explicit transitional allowlist entries
+- tests
+- diagnostics
+- provisioning code with an issue/todo pointing to the exact worker command
+  that will replace it
+
+### Acceptance
+
+- A cloud automation can start a session and send its prompt through
+  `CloudCommand -> Worker -> AnyHarness`.
+- Automation progression in this phase relies on Cloud command status and the
+  minimal CloudSession row, not on Phase 5 event-ingest rows.
+- The old automation path no longer imports `create_runtime_session`,
+  `prompt_runtime_session`, or `apply_runtime_reasoning_effort`.
+- Managed cloud provisioning still works.
+- Desktop direct AnyHarness usage still works.
+- There is a short allowlist for any remaining server direct AnyHarness usage.
+
+## Phase 5: Worker Event Sync And Cloud Ingest
+
+### Goal
+
+Upload AnyHarness session facts to Cloud and store durable semantic rows.
+
+This is not token-level database replication. Live deltas can be chatty;
+durable Cloud storage must be bounded and semantic.
+
+### AnyHarness Requirements
+
+Ensure session event envelopes carry:
+
+```text
+session_id
+seq
+event_id
+event_type
+schema_version
+actor/source metadata
+created_at
+payload
+payload_size/truncation/blob metadata where relevant
+```
+
+Contract file:
+
+```text
+anyharness/crates/anyharness-contract/src/v1/events.rs
+```
+
+Worker reads:
+
+```text
+GET /v1/sessions/{session_id}/events?after_seq=...
+GET /v1/sessions/{session_id}/stream?after_seq=...
+```
+
+### Worker Implementation
+
+Add:
+
+```text
+anyharness/crates/proliferate-worker/src/sync/
+  mod.rs
+  backfill.rs
+  cursor.rs
+  event_batch.rs
+  mapper.rs
+  outbox.rs
+  tailer.rs
+
+anyharness/crates/proliferate-worker/src/cloud_client/
+  events.rs
+
+anyharness/crates/proliferate-worker/src/store/
+  cursors.rs
+  outbox.rs
+```
+
+Loop split:
+
+- `tailer.rs` talks to local AnyHarness and local worker SQLite.
+- `outbox.rs` uploads retryable batches to Cloud.
+
+The tailer exists even though AnyHarness has its own SQLite because the worker
+needs an independent retry/outbox cursor for Cloud upload. It should not
+interpret transcript meaning.
+
+Batch defaults:
+
+```text
+flush after 100 ms
+or 100 events
+or 512 KB payload
+or boundary event
+```
+
+Boundary events:
+
+```text
+message_completed
+tool_call_started
+tool_call_completed
+interaction_requested
+interaction_resolved
+turn_completed
+session_failed
+config_updated
+```
+
+### Server Domains
+
+Add:
+
+```text
+server/proliferate/server/cloud/events/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+
+server/proliferate/server/cloud/sessions/
+  api.py
+  models.py
+  access.py
+  service.py
+  domain/
+    types.py
+    rules.py
+    policy.py
+```
+
+### Server DB
+
+Add or extend:
+
+```text
+server/proliferate/db/models/cloud/events.py
+server/proliferate/db/models/cloud/sessions.py
+server/proliferate/db/models/cloud/artifacts.py
+
+server/proliferate/db/store/cloud_sync/
+  events.py
+  cursors.py
+  sessions.py
+  messages.py
+  tool_calls.py
+  requests.py
+  config.py
+  artifacts.py
+
+server/alembic/versions/<revision>_cloud_event_ingest.py
+```
+
+Tables:
+
+```text
+cloud_session_events
+cloud_event_ingest_cursors
+cloud_sessions (extend the Phase 3 command-backed row with event-derived state)
+cloud_messages
+cloud_tool_call_summaries
+cloud_requests
+cloud_session_config_state
+cloud_artifact_refs
+```
+
+`db/models/cloud/sessions.py` owns `CloudSession`, `CloudMessage`,
+`CloudToolCallSummary`, `CloudRequest`, and `CloudSessionConfigState`.
+`db/store/cloud_sync/tool_calls.py` is the only store for
+`CloudToolCallSummary` rows.
+
+### Ingest Endpoint
+
+Worker endpoint:
+
+```text
+POST /api/v1/cloud/worker/events/batches
+```
+
+Ingest order:
+
+```text
+1. authenticate worker
+2. validate target/session ownership
+3. parse typed event batch
+4. dedupe by target_id + session_id + anyharness_seq
+5. apply payload policy
+6. write durable semantic event rows
+7. update product rows:
+   - CloudWorkspace
+   - CloudSession
+   - CloudMessage
+   - CloudToolCallSummary
+   - CloudRequest
+   - CloudSessionConfigState
+8. update ingest cursor
+9. publish patches to live fanout
+10. ack accepted contiguous cursor to worker
+```
+
+Do not publish durable patches as final unless the durable write succeeded.
+Live-only deltas may publish before completion only if marked ephemeral.
+
+### Payload Policy
+
+Default durable policy:
+
+```text
+store:
+  workspace/session lifecycle
+  turn lifecycle
+  user message accepted/completed
+  assistant message completed
+  tool call started/completed metadata
+  interaction requested/resolved
+  config changed
+  session status changed
+  artifact/blob references
+
+do not store by default:
+  per-token deltas
+  raw item_delta rows
+  raw tool input/output bodies
+  terminal byte streams
+  browser/computer-use frames
+  screenshots inline
+  full file contents
+  raw ACP internals
+```
+
+Caps:
+
+```text
+inline payload soft cap: 64 KB
+inline payload hard cap: 256 KB
+durable session soft cap: 5k semantic events or 15 MB
+durable session hard cap: 10k semantic events or 25 MB
+```
+
+Oversized data becomes:
+
+- truncated
+- summarized
+- stored as `CloudArtifactRef`
+- or excluded by policy
+
+Durable session hard-cap behavior is deterministic. On the write that would
+cross the hard cap, Cloud first compacts eligible older semantic events in the
+same transaction. If the session still exceeds the hard cap, Cloud writes a
+bounded `retention_exceeded` marker, marks the session sync state degraded,
+stores only lifecycle/command/request-critical facts and artifact references,
+excludes low-value transcript or tool metadata according to policy, and
+advances the ingest cursor only for events whose storage/exclusion decision was
+recorded. The Worker uploads events; Cloud alone decides compaction,
+exclusion, and degraded-state transitions.
+
+### Acceptance
+
+- Worker tails local AnyHarness events.
+- Worker uploads event batches.
+- Duplicate uploads are harmless.
+- Payload hash mismatch for same seq marks sync degraded.
+- Cloud stores messages, sessions, config, requests, and tool summaries.
+- Cloud does not durably store token-level deltas by default.
+- If no SSE clients are connected, durable rows and snapshots still update.
+
+## Phase 6: Cloud Snapshots, Redis Pubsub, And SSE
+
+### Goal
+
+Expose fast Cloud reads and live streams to Desktop cloud views, Web, Mobile,
+Slack, and future API clients.
+
+### Server Domains
+
+Continue:
+
+```text
+server/proliferate/server/cloud/sessions/
+server/proliferate/server/cloud/live/
+```
+
+Add:
+
+```text
+server/proliferate/server/cloud/live/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+
+server/proliferate/integrations/pubsub/
+  __init__.py
+  redis.py
+  models.py
+```
+
+`integrations/pubsub` owns Redis/NATS mechanics. `cloud/live` owns product
+stream authorization, channel naming, replay, and patch shape.
+
+### API Endpoints
+
+Snapshot reads:
+
+```text
+GET /api/v1/cloud/workspaces
+GET /api/v1/cloud/workspaces/{workspace_id}
+GET /api/v1/cloud/sessions/{session_id}
+GET /api/v1/cloud/sessions/{session_id}/transcript
+GET /api/v1/cloud/targets/{target_id}
+GET /api/v1/cloud/commands/{command_id}
+```
+
+Live streams:
+
+```text
+GET /api/v1/cloud/workspaces/{workspace_id}/stream
+GET /api/v1/cloud/sessions/{session_id}/stream
+GET /api/v1/cloud/targets/{target_id}/stream
+```
+
+SSE events:
+
+```text
+snapshot
+patch
+command_status
+heartbeat
+```
+
+Stream clients should consume snapshots and patches. They should not rebuild
+transcript state from raw AnyHarness events.
+
+### Shared SDK
+
+Add to:
+
+```text
+cloud/sdk/src/client/live.ts
+cloud/sdk/src/streams/sse.ts
+cloud/sdk/src/types/live.ts
+cloud/sdk-react/src/hooks/live.ts
+```
+
+Required SDK functions:
+
+```text
+getWorkspaceSnapshot()
+getSessionSnapshot()
+getTranscriptSnapshot()
+subscribeWorkspace()
+subscribeSession()
+subscribeTarget()
+```
+
+### Desktop Cloud Views
+
+Add or migrate access hooks:
+
+```text
+desktop/src/hooks/access/cloud/workspaces/
+desktop/src/hooks/access/cloud/sessions/
+desktop/src/hooks/access/cloud/live/
+desktop/src/hooks/access/cloud/targets/
+```
+
+Product surfaces can initially be minimal. The key requirement is that Desktop
+can inspect the same Cloud snapshots that Web/Mobile will consume.
+
+### Web Smoke Client
+
+If the web app exists in this repo by this phase, it should depend on the
+shared SDK packages instead of copying Desktop access code.
+
+Expected future paths:
+
+```text
+web/package.json
+web/src/app/
+web/src/components/sessions/
+web/src/hooks/access/cloud/
+web/src/routes/workspaces.tsx
+web/src/routes/sessions.$sessionId.tsx
+```
+
+If the web app is not yet in this repo, create only a minimal internal smoke
+page or test client after confirming the intended app location.
+
+### Acceptance
+
+- Session stream returns initial snapshot and live patches.
+- Workspace stream returns session/status changes.
+- Redis/NATS failure does not corrupt durable rows.
+- Reconnecting with cursor replays durable patches after cursor.
+- Desktop cloud view can render target/session/transcript snapshots.
+- Shared SDK exposes stream helpers.
+
+## Phase 7: Credential And Environment Sync For Targets
+
+### Goal
+
+Make local, SSH, and managed cloud targets receive the same environment,
+credential, git, and MCP launch configuration model.
+
+This extends the existing Cloud environment configuration page rather than
+creating a separate ad hoc SSH secrets flow.
+
+### Existing Code To Reuse
+
+Server:
+
+```text
+server/proliferate/server/cloud/credentials/
+server/proliferate/server/cloud/repo_config/
+server/proliferate/server/cloud/mcp_catalog/
+server/proliferate/server/cloud/mcp_connections/
+server/proliferate/server/cloud/mcp_materialization/
+```
+
+Desktop:
+
+```text
+desktop/src/components/settings/panes/EnvironmentsPane.tsx
+desktop/src/components/settings/panes/repo/CloudRepoSection.tsx
+desktop/src/lib/domain/settings/environment-draft.ts
+desktop/src/hooks/access/cloud/use-cloud-credentials.ts
+desktop/src/hooks/access/cloud/use-cloud-repo-config.ts
+desktop/src/hooks/access/cloud/use-resync-cloud-workspace-credentials.ts
+desktop/src/hooks/access/cloud/use-resync-cloud-workspace-files.ts
+```
+
+### New Target Config Domain
+
+Add:
+
+```text
+server/proliferate/server/cloud/target_config/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+    policy.py
+```
+
+DB:
+
+```text
+server/proliferate/db/models/cloud/target_config.py
+server/proliferate/db/store/cloud_sync/target_config.py
+server/alembic/versions/<revision>_cloud_target_config.py
+```
+
+Worker:
+
+```text
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+anyharness/crates/proliferate-worker/src/materialization/
+  mod.rs
+  env.rs
+  files.rs
+  git.rs
+  mcp.rs
+  skills.rs
+```
+
+Command kind:
+
+```text
+materialize_environment
+```
+
+### Config Model
+
+Target config contains:
+
+```text
+env vars
+tracked files
+git credential grant
+git author/committer identity
+MCP bundle materialization plan
+skill bundle refs
+package/runtime readiness requirements
+target-specific install/cache paths
+```
+
+It must not contain broad permanent raw secrets unless explicitly required and
+approved by policy. Prefer session-scoped or target-scoped grants.
+
+### Readiness Checks
+
+Worker inventory reports:
+
+```text
+git
+node
+npm
+npx
+python
+uv
+network egress
+writable plugin cache
+browser/playwright support when relevant
+```
+
+Most first-party MCPs can assume Node once target readiness reports it. If a
+tool needs Python/uv/browser/docker, its bundle declares that requirement and
+Cloud/Worker mark the target degraded for that bundle until ready.
+
+### Desktop UX
+
+Extend the existing Cloud environment section so target choice is explicit.
+
+Paths:
+
+```text
+desktop/src/components/settings/panes/repo/CloudRepoSection.tsx
+desktop/src/components/settings/panes/repo/TargetEnvironmentSection.tsx
+desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
+
+desktop/src/hooks/settings/workflows/use-target-environment-settings.ts
+desktop/src/hooks/cloud/workflows/use-sync-target-environment.ts
+desktop/src/lib/domain/settings/environment-draft.ts
+```
+
+UX:
+
+- Repo environment page can show local, managed cloud, and SSH target sync.
+- Target details show whether credentials/env are synced.
+- User can resync selected files/credentials to a target.
+- Workspace/automation creation can select an eligible target.
+
+### Acceptance
+
+- SSH target can receive repo env vars and tracked files.
+- Managed cloud target can receive the same config model.
+- Git credentials are present where required for repo operations.
+- MCP readiness and materialization state are visible.
+- Worker does not decide credential policy; it materializes resolved grants.
+
+## Phase 8: Supervisor Updates, Retention, Observability, And Hardening
+
+### Goal
+
+Make targets operationally reliable: updateable, observable, revocable,
+retention-aware, and safe to run at scale.
+
+### Supervisor Update System
+
+Extend:
+
+```text
+anyharness/crates/proliferate-supervisor/src/
+  update/
+    mod.rs
+    artifacts.rs
+    download.rs
+    manifest.rs
+    rollback.rs
+    staging.rs
+    swap.rs
+  process/
+    idle.rs
+    health.rs
+```
+
+Worker:
+
+```text
+anyharness/crates/proliferate-worker/src/updates/
+  mod.rs
+  desired.rs
+  supervisor.rs
+  status.rs
+
+anyharness/crates/proliferate-worker/src/cloud_client/updates.rs
+anyharness/crates/proliferate-worker/src/store/updates.rs
+```
+
+Server:
+
+```text
+server/proliferate/server/cloud/targets/domain/rules.py
+server/proliferate/server/cloud/worker/api.py
+server/proliferate/server/cloud/worker/models.py
+server/proliferate/server/cloud/worker/service.py
+```
+
+Optional if updates grow large:
+
+```text
+server/proliferate/server/cloud/updates/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+```
+
+Update flow:
+
+```text
+1. worker reports installed versions
+2. cloud returns desired versions/update instructions
+3. worker asks supervisor to stage update
+4. supervisor downloads signed artifact for OS/arch
+5. supervisor verifies signature/checksum
+6. supervisor waits for safe point or pause
+7. supervisor swaps binary atomically
+8. supervisor restarts process
+9. worker reports applied/failed/rolled_back status
+```
+
+### Retention And Safe Stop
+
+Server:
+
+```text
+server/proliferate/server/cloud/compute/
+  api.py
+  models.py
+  service.py
+  domain/
+    types.py
+    rules.py
+    policy.py
+
+server/proliferate/server/cloud/runtime/
+  scheduler.py
+  setup_monitor.py
+```
+
+AnyHarness:
+
+```text
+anyharness/crates/anyharness-contract/src/v1/runtime.rs
+anyharness/crates/anyharness-lib/src/api/http/runtime.rs
+anyharness/crates/anyharness-lib/src/domains/runtime_inventory/
+```
+
+Worker:
+
+```text
+anyharness/crates/proliferate-worker/src/lifecycle/
+  activity.rs
+  safe_stop.rs
+  shutdown.rs
+```
+
+Cloud should decide policy. Worker/AnyHarness report whether stopping is safe.
+
+### Observability
+
+Server logs/metrics:
+
+- command queued/leased/delivered/accepted/rejected/expired
+- worker heartbeat age
+- event ingest lag
+- snapshot update lag
+- SSE subscriber count
+- target online/degraded/offline
+- payload truncation/blob decisions
+- update status
+
+Worker logs/metrics:
+
+- enrollment result
+- heartbeat failures
+- lease loop status
+- command dispatch latency
+- AnyHarness request failures
+- event tail lag
+- outbox size/retry count
+- inventory hash changes
+- update stage/apply/rollback
+
+Suggested files:
+
+```text
+server/proliferate/server/cloud/observability.py
+anyharness/crates/proliferate-worker/src/observability.rs
+anyharness/crates/proliferate-supervisor/src/observability.rs
+```
+
+### Security Hardening
+
+Must support:
+
+- worker token rotation
+- worker revocation
+- enrollment token expiry
+- command idempotency
+- command expiry
+- signed update artifacts
+- artifact checksum verification
+- target access policy
+- audit rows for commands and credential grants
+
+### Acceptance
+
+- Target versions are visible in Cloud.
+- Worker/supervisor/AnyHarness update status is visible.
+- Revoked worker cannot lease commands or upload events.
+- Idle managed workspace can stop/prune after final sync.
+- Active session/turn blocks unsafe stop.
+- Large payloads are truncated or blobbed by policy.
+- Event ingest and command latency are observable.
+
+## Parallelization Plan
+
+These workstreams can run mostly in parallel once Phase 0 is complete:
+
+```text
+A. Shared Cloud SDK
+   Owns cloud/sdk, cloud/sdk-react, Desktop cloud access migration.
+
+B. Compute Targets + SSH Enrollment
+   Owns server targets/worker enrollment, Desktop Compute UX, installer,
+   worker enrollment/heartbeat/inventory, supervisor MVP.
+
+C. Command Path
+   Owns server commands, worker command leasing/dispatch, AnyHarness command
+   metadata.
+
+D. Event Ingest + Sessions/Live
+   Owns worker tail/outbox/upload, server events/sessions/live fanout.
+
+E. Direct Runtime Migration
+   Starts after C has a working command path. Owns automations/cloud runtime
+   callsite migration and direct AnyHarness allowlist deletion.
+
+F. Credential/Env Sync
+   Starts after B and C. Owns target config, materialization command, SSH and
+   managed cloud environment sync.
+
+G. Hardening
+   Starts after B. Owns update staging, retention, observability, revocation.
+```
+
+Do not start E before C has a tested worker command path. Otherwise the
+migration will replace one unstable path with another.
+
+## Implementation Guardrails
+
+- Do not put all worker/cloud sync code in `server/proliferate/server/cloud/runtime`.
+- Do not make Worker own business policy.
+- Do not make Cloud store token-level transcript rows durably by default.
+- Do not create surface-specific command semantics for Web, Slack, Mobile, API,
+  and automations. They all enqueue `CloudCommand`.
+- Do not let Desktop direct access bypass team policy for team/cloud sessions.
+- Do not keep old and new direct runtime command paths after a phase declares
+  migration complete.
+- Do not introduce untyped `serde_json::Value` command payloads beyond edge
+  parsing.
+- Do not make Redis/NATS the durable source of truth.
+- Do not make update logic depend on a single managed sandbox provider.
+
+## Phase Completion Checklist
+
+Before marking a phase complete:
+
+- update or add tests named in the phase acceptance section
+- update generated OpenAPI/SDK artifacts if endpoint contracts changed
+- run the narrowest relevant checks
+- run `rg` for disallowed imports/calls named in the phase
+- remove transitional duplicate code unless explicitly allowlisted
+- update this doc if implementation discovered a better file boundary
+
+## Mechanical Phase Verification
+
+Each phase should have a mechanical verifier. The verifier is not a replacement
+for tests; it is a cheap, repeatable gate that checks repo shape, forbidden
+imports, required files, generated artifacts, and the narrow smoke path for the
+phase.
+
+Add one script:
+
+```text
+scripts/check-cloud-worker-phase.mjs
+```
+
+Usage:
+
+```bash
+node scripts/check-cloud-worker-phase.mjs phase-0
+node scripts/check-cloud-worker-phase.mjs phase-1
+node scripts/check-cloud-worker-phase.mjs phase-2
+node scripts/check-cloud-worker-phase.mjs phase-3
+node scripts/check-cloud-worker-phase.mjs phase-4
+node scripts/check-cloud-worker-phase.mjs phase-5
+node scripts/check-cloud-worker-phase.mjs phase-6
+node scripts/check-cloud-worker-phase.mjs phase-7
+node scripts/check-cloud-worker-phase.mjs phase-8
+```
+
+The script should be intentionally boring:
+
+- use Node built-ins only where possible
+- shell out to `rg`, `cargo`, `pnpm`, and `uv` for focused checks
+- fail fast with a clear list of missing files or forbidden references
+- print the exact follow-up command when a generated artifact is stale
+- support `--json` for CI summaries later
+
+### Phase 0 Verifier
+
+Checks:
+
+```text
+required files:
+  docs/audits/cloud-worker-direct-anyharness-inventory.md
+
+required audit sections:
+  migrate-to-command
+  temporary-provisioning
+  test-or-diagnostic
+  delete
+  non-cloud consumers
+  DB layout disposition
+
+scan:
+  rg "integrations.anyharness|create_runtime_session|prompt_runtime_session|runtime_url|anyharness_workspace_id|anyharness_session_id" server/proliferate -g "*.py"
+  rg "integrations.anyharness|AnyHarness|anyharness" server/proliferate/server -g "*.py"
+  rg --files server/proliferate/db/models/cloud server/proliferate/db/store | rg "cloud"
+```
+
+The scan may return results in Phase 0, but every result must appear in the
+audit file. This can be checked mechanically by requiring each file path from
+the `rg` output to be mentioned in the audit. The DB scan must also appear in
+the audit with one disposition per existing cloud model/store file.
+
+### Phase 1 Verifier
+
+Checks:
+
+```text
+required files:
+  cloud/sdk/package.json
+  cloud/sdk/src/index.ts
+  cloud/sdk/src/client/core.ts
+  cloud/sdk/src/generated/openapi.ts
+  cloud/sdk-react/package.json
+  cloud/sdk-react/src/index.ts
+  cloud/sdk-react/src/context/CloudClientProvider.tsx
+
+workspace config:
+  pnpm-workspace.yaml includes cloud/sdk and cloud/sdk-react
+  desktop/package.json depends on @proliferate/cloud-sdk
+
+forbidden:
+  desktop product components outside desktop/src/lib/access/cloud and
+  desktop/src/hooks/access/cloud do not call raw cloud client.GET/POST/PUT/PATCH/DELETE
+  no duplicate generated Cloud OpenAPI truth remains in desktop after migration
+```
+
+Suggested raw-client scan:
+
+```bash
+rg "client\\.(GET|POST|PUT|PATCH|DELETE)\\(" desktop/src/components desktop/src/lib/domain desktop/src/hooks -g "*.ts" -g "*.tsx" -g "!desktop/src/hooks/access/cloud/**"
+```
+
+Focused commands:
+
+```bash
+pnpm --filter @proliferate/cloud-sdk build
+pnpm --filter @proliferate/cloud-sdk-react build
+pnpm --filter proliferate build
+```
+
+### Phase 2 Verifier
+
+Checks:
+
+```text
+required server files:
+  server/proliferate/server/cloud/targets/api.py
+  server/proliferate/server/cloud/targets/service.py
+  server/proliferate/server/cloud/worker/api.py
+  server/proliferate/server/cloud/worker/service.py
+  server/proliferate/db/models/cloud/targets.py
+  server/proliferate/db/store/cloud_sync/targets.py
+  server/proliferate/db/store/cloud_sync/worker_auth.py
+
+required Rust crates:
+  anyharness/crates/proliferate-worker/Cargo.toml
+  anyharness/crates/proliferate-supervisor/Cargo.toml
+
+required installer files:
+  install/proliferate-target-install.sh
+  install/README.md
+
+required desktop files:
+  desktop/src/components/settings/panes/ComputePane.tsx
+  desktop/src/components/settings/panes/compute/AddSshTargetDialog.tsx
+  desktop/src/hooks/access/cloud/targets/use-cloud-targets.ts
+```
+
+Smoke path:
+
+```text
+1. create enrollment token through server test client
+2. worker enrolls with token against local server
+3. worker heartbeat updates target status
+4. inventory appears in target snapshot
+```
+
+Focused commands:
+
+```bash
+cargo check -p proliferate-worker
+cargo check -p proliferate-supervisor
+cd server && uv run pytest -q tests/cloud/test_targets.py tests/cloud/test_worker_enrollment.py
+cd desktop && pnpm test -- Compute
+```
+
+### Phase 3 Verifier
+
+Checks:
+
+```text
+required files:
+  server/proliferate/server/cloud/commands/api.py
+  server/proliferate/server/cloud/commands/service.py
+  server/proliferate/db/models/cloud/commands.py
+  server/proliferate/db/models/cloud/sessions.py
+  server/proliferate/db/store/cloud_sync/commands.py
+  server/proliferate/db/store/cloud_sync/sessions.py
+  anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+  anyharness/crates/proliferate-worker/src/commands/mapping.rs
+  anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+  anyharness/crates/anyharness-contract/src/v1/commands.rs
+
+forbidden:
+  command dispatch does not pass arbitrary serde_json::Value past edge parsing
+  server command service does not call integrations.anyharness
+```
+
+Shape checks:
+
+```bash
+rg "serde_json::Value" anyharness/crates/proliferate-worker/src/commands -g '!mod.rs'
+```
+
+Expected result: no untyped command payloads outside edge parsing/mapping
+files.
+
+Smoke path:
+
+```text
+1. enqueue start_session command
+2. worker leases command
+3. worker dispatches local AnyHarness create-session request
+4. worker reports delivered/result
+5. Cloud creates or updates minimal CloudSession identity row
+6. enqueue send_prompt against the CloudSession row
+7. worker dispatches local AnyHarness prompt request
+8. duplicate idempotency key returns same command
+```
+
+Focused commands:
+
+```bash
+cargo test -p proliferate-worker commands
+cd server && uv run pytest -q tests/cloud/test_commands.py tests/cloud/test_worker_leases.py tests/cloud/test_command_sessions.py
+```
+
+### Phase 4 Verifier
+
+Checks:
+
+```text
+scan:
+  rg "create_runtime_session|prompt_runtime_session|apply_runtime_reasoning_effort|close_runtime_session" server/proliferate/server/automations server/proliferate/server/cloud -g "*.py"
+```
+
+Expected result:
+
+- no hits in production automation execution paths
+- remaining hits only in an explicit allowlist file:
+
+```text
+docs/audits/cloud-worker-direct-anyharness-allowlist.md
+```
+
+Smoke path:
+
+```text
+1. automation run chooses target/workspace
+2. automation enqueues start_session/update_config/send_prompt commands
+3. worker delivers commands
+4. automation run advances from Cloud command status and minimal CloudSession state
+```
+
+Focused commands:
+
+```bash
+cd server && uv run pytest -q tests/automations/test_cloud_executor_worker_commands.py
+```
+
+### Phase 5 Verifier
+
+Checks:
+
+```text
+required files:
+  server/proliferate/server/cloud/events/service.py
+  server/proliferate/server/cloud/events/domain/rules.py
+  server/proliferate/server/cloud/sessions/service.py
+  server/proliferate/server/cloud/sessions/domain/rules.py
+  server/proliferate/db/models/cloud/events.py
+  server/proliferate/db/models/cloud/sessions.py
+  server/proliferate/db/store/cloud_sync/tool_calls.py
+  anyharness/crates/proliferate-worker/src/sync/tailer.rs
+  anyharness/crates/proliferate-worker/src/sync/outbox.rs
+  anyharness/crates/proliferate-worker/src/sync/mapper.rs
+```
+
+Forbidden durable storage:
+
+```text
+per-token deltas
+raw item_delta rows
+raw terminal byte streams
+raw browser/computer-use frames
+large tool bodies inline by default
+```
+
+Smoke path:
+
+```text
+1. feed synthetic AnyHarness event batch to ingest
+2. duplicate upload is accepted idempotently
+3. cursor advances only over contiguous seq
+4. completed message creates CloudMessage
+5. interaction requested creates CloudRequest
+6. config update creates CloudSessionConfigState
+7. tool call started/completed creates or updates CloudToolCallSummary
+```
+
+Focused commands:
+
+```bash
+cargo test -p proliferate-worker sync
+cd server && uv run pytest -q tests/cloud/test_event_ingest.py tests/cloud/test_session_rows.py
+```
+
+### Phase 6 Verifier
+
+Checks:
+
+```text
+required files:
+  server/proliferate/server/cloud/live/api.py
+  server/proliferate/server/cloud/live/service.py
+  server/proliferate/server/cloud/live/domain/rules.py
+  server/proliferate/integrations/pubsub/redis.py
+  cloud/sdk/src/client/live.ts
+  cloud/sdk/src/streams/sse.ts
+  cloud/sdk-react/src/hooks/live.ts
+```
+
+Smoke path:
+
+```text
+1. client opens session stream
+2. server sends snapshot
+3. event ingest updates durable rows
+4. live service publishes patch
+5. stream receives patch
+6. reconnect with cursor replays missed durable patches
+```
+
+Focused commands:
+
+```bash
+cd server && uv run pytest -q tests/cloud/test_live_streams.py
+pnpm --filter @proliferate/cloud-sdk test
+```
+
+### Phase 7 Verifier
+
+Checks:
+
+```text
+required files:
+  server/proliferate/server/cloud/target_config/api.py
+  server/proliferate/server/cloud/target_config/service.py
+  server/proliferate/server/cloud/target_config/domain/rules.py
+  anyharness/crates/proliferate-worker/src/materialization/env.rs
+  anyharness/crates/proliferate-worker/src/materialization/files.rs
+  anyharness/crates/proliferate-worker/src/materialization/git.rs
+  anyharness/crates/proliferate-worker/src/materialization/mcp.rs
+```
+
+Smoke path:
+
+```text
+1. create target config for SSH target
+2. enqueue materialize_environment command
+3. worker writes env/tracked files to target location
+4. git credential grant is present for repo operation
+5. MCP readiness/materialization status is visible
+```
+
+Focused commands:
+
+```bash
+cargo test -p proliferate-worker materialization
+cd server && uv run pytest -q tests/cloud/test_target_config.py
+```
+
+### Phase 8 Verifier
+
+Checks:
+
+```text
+required files:
+  anyharness/crates/proliferate-supervisor/src/update/manifest.rs
+  anyharness/crates/proliferate-supervisor/src/update/staging.rs
+  anyharness/crates/proliferate-supervisor/src/update/rollback.rs
+  anyharness/crates/proliferate-worker/src/updates/desired.rs
+  anyharness/crates/proliferate-worker/src/cloud_client/updates.rs
+  server/proliferate/server/cloud/compute/service.py
+  server/proliferate/server/cloud/compute/domain/rules.py
+```
+
+Smoke path:
+
+```text
+1. worker reports installed versions
+2. cloud returns desired version
+3. worker asks supervisor to stage update
+4. supervisor verifies artifact metadata/checksum in test mode
+5. active session blocks unsafe update/stop
+6. idle target allows update/stop
+7. revoked worker cannot lease/upload
+```
+
+Focused commands:
+
+```bash
+cargo test -p proliferate-supervisor update
+cargo test -p proliferate-worker updates
+cd server && uv run pytest -q tests/cloud/test_updates.py tests/cloud/test_compute_safe_stop.py
+```
+
+## CI Shape
+
+Each implementation PR should run only the phase gates it claims to complete.
+The eventual CI jobs can be:
+
+```text
+cloud-worker-phase-0
+cloud-worker-phase-1
+cloud-worker-phase-2
+cloud-worker-phase-3
+cloud-worker-phase-4
+cloud-worker-phase-5
+cloud-worker-phase-6
+cloud-worker-phase-7
+cloud-worker-phase-8
+```
+
+Early PRs can run the verifier manually. Once a phase is complete, add its
+verifier to CI so regressions fail mechanically.

--- a/docs/architecture/cloud-worker-pr-stack-review-guide.md
+++ b/docs/architecture/cloud-worker-pr-stack-review-guide.md
@@ -1,0 +1,1127 @@
+# Cloud Worker PR Stack Review Guide
+
+Status: synthesized reviewer guide for the Cloud worker/control-plane PR stack.
+
+Purpose: give reviewers a single map for understanding the PRs that implement
+the Cloud-mediated worker model. This document is intentionally not the source
+of truth for the architecture itself. The architecture source of truth remains
+`docs/architecture/cloud-worker-control-plane.md`.
+
+Use this guide when reviewing:
+
+- broad worker/control-plane baseline PR #207
+- implementation stack PRs #212, #214, #216, #217, #218, #219, #221, #222,
+  and #223
+
+## Core Mental Model
+
+The product architecture is:
+
+```text
+Commands flow down:
+  Cloud client / automation / Slack / API
+    -> Cloud command API
+    -> durable CloudCommand
+    -> Proliferate Worker
+    -> local AnyHarness API
+
+Events flow up:
+  AnyHarness normalized events
+    -> Proliferate Worker
+    -> Cloud ingest
+    -> durable semantic rows + projections
+    -> live fanout
+    -> web / mobile / Slack / API / desktop cloud views
+```
+
+The ownership split must stay sharp:
+
+```text
+AnyHarness:
+  execution truth, local SQLite, command acceptance/order, session loop,
+  provider/MCP launch, local files/git/terminal/runtime capabilities.
+
+Proliferate Worker:
+  target-side bridge, enrollment, heartbeat, inventory, command delivery,
+  event upload, cursor/outbox behavior, config materialization, update
+  participation.
+
+Cloud:
+  auth, team/org policy, target registry, durable commands, event ingest,
+  projections, live fanout, credentials/config grants, audit, billing,
+  compute/update policy.
+
+Clients:
+  read Cloud snapshots/patches or direct AnyHarness state. They do not create
+  durable runtime truth.
+```
+
+## Recommended Review Order
+
+Review the implementation stack in this order:
+
+1. #212 shared Cloud SDK foundation
+2. #214 compute targets and worker enrollment
+3. #216 command delivery through workers
+4. #217 worker session event sync
+5. #218 live session projection fanout
+6. #219 existing workspace backfill
+7. #221 live snapshot streams
+8. #222 target config materialization
+9. #223 worker update supervision
+
+Review #207 as a broad baseline/reference PR. It is useful for understanding
+the original system shape, but the sliced stack above contains the more specific
+implementation path.
+
+## Stack Map
+
+| PR | Role | What It Enables |
+| --- | --- | --- |
+| #207 | Broad baseline | First worker/control-plane spine from main |
+| #212 | SDK foundation | Shared typed Cloud API surface for Desktop/Web/Mobile |
+| #214 | Targets/enrollment | Machines become registered Cloud targets through workers |
+| #216 | Commands | Cloud routes runtime mutations through worker commands |
+| #217 | Events/projections | Worker uploads AnyHarness session events into Cloud |
+| #218 | Live fanout | Session projection patches fan out to live subscribers |
+| #219 | Backfill | Existing target workspaces/sessions become Cloud-visible |
+| #221 | Snapshot streams | Snapshot-first session/workspace/target streams |
+| #222 | Target config | Env/git/MCP/skills/credentials materialize on targets |
+| #223 | Updates | Desired versions, safe-stop checks, worker revocation |
+
+## Cross-Stack Invariants
+
+These checks apply to every PR in the stack:
+
+- Worker tokens are target-scoped and do not authorize cross-target access.
+- User-facing Cloud APIs enforce org/user/team ownership before returning
+  target, workspace, session, event, command, config, or update state.
+- Every runtime mutation is represented as a command and eventually accepted or
+  rejected by AnyHarness.
+- Worker command handling is idempotent or retry-safe at every network boundary.
+- Cloud dedupes worker uploads by stable IDs, not by trusting retries to be
+  rare.
+- Cloud stores bounded semantic session history and projections, not raw
+  token-level or ACP-internal runtime truth.
+- Live fanout is derived from durable/projection writes and is safe to miss or
+  replay from snapshots.
+- Config and credential materialization does not leak secret payloads through
+  user-facing responses, logs, SDK types, or live patches.
+- Updates are generation-fenced so stale workers cannot report success for a
+  newer desired version.
+
+## PR #207: Worker Sync Control Plane
+
+Link: https://github.com/proliferate-ai/proliferate/pull/207
+
+### Purpose
+
+Establishes the broad V1 Cloud worker/control-plane spine from `main`:
+
+- target enrollment
+- worker auth, heartbeat, and inventory
+- command leasing
+- event upload
+- projection storage
+- minimal live replay
+- AnyHarness runtime inventory/activity/safe-stop APIs
+
+Treat this as the broad baseline/reference PR rather than the final sliced
+implementation.
+
+### User-Visible Behavior
+
+Cloud clients can:
+
+- create and list targets
+- enqueue and read commands
+- read synced session events/projections
+- open a basic session SSE replay
+
+Target workers can enroll and start reporting target state.
+
+### Architecture Flow
+
+```text
+Cloud:
+  stores target, worker, command, event, projection, and artifact state
+
+Worker:
+  enrolls, heartbeats, leases commands, uploads events
+
+AnyHarness:
+  exposes runtime inventory/activity/safe-stop state
+```
+
+### Important Files
+
+- `docs/architecture/cloud-worker-control-plane.md`
+- `anyharness/crates/proliferate-worker/src/**`
+- `anyharness/crates/anyharness-contract/src/v1/runtime.rs`
+- `anyharness/crates/anyharness-lib/src/api/http/runtime.rs`
+- `server/proliferate/db/models/cloud/{targets,commands,events,projections,artifacts}.py`
+- `server/proliferate/db/store/cloud_sync/**`
+- `server/proliferate/server/cloud/{targets,worker,commands,events,projections,live,compute}/**`
+
+### Contracts And Tables
+
+AnyHarness APIs:
+
+- `GET /v1/runtime/inventory`
+- `GET /v1/runtime/activity`
+- `POST /v1/runtime/prepare-stop`
+
+Worker APIs:
+
+- `POST /v1/cloud/worker/enroll`
+- `POST /v1/cloud/worker/heartbeat`
+- `POST /v1/cloud/worker/inventory`
+- `POST /v1/cloud/worker/commands/lease`
+- `POST /v1/cloud/worker/commands/{id}/delivery`
+- `POST /v1/cloud/worker/commands/{id}/result`
+- `POST /v1/cloud/worker/events/batches`
+- `POST /v1/cloud/worker/update-status`
+
+Core tables:
+
+- `cloud_targets`
+- `cloud_workers`
+- `cloud_commands`
+- `cloud_command_leases`
+- `cloud_session_events`
+- `cloud_event_ingest_cursors`
+- `cloud_projection_snapshots`
+- `cloud_artifact_refs`
+
+### Review Checklist
+
+- Target and worker auth scopes every API path.
+- Command leases recover after worker death.
+- Duplicate event uploads are harmless.
+- Cursor gaps do not corrupt projection state.
+- Migration constraints/indexes match query shape.
+- Worker token storage is private and not logged.
+- Contract types do not leak AnyHarness runtime internals.
+
+### Relationship And Risk
+
+#207 is broad. Later PRs implement narrower hardened pieces of the same
+architecture. It intentionally leaves live fanout, rich projections, backfill,
+update trust, and full compute lifecycle incomplete.
+
+## PR #212: Shared Cloud SDK Foundation
+
+Link: https://github.com/proliferate-ai/proliferate/pull/212
+
+### Purpose
+
+Adds shared Cloud client packages:
+
+- `@proliferate/cloud-sdk`
+- `@proliferate/cloud-sdk-react`
+
+It moves generated Cloud OpenAPI types out of Desktop and keeps Desktop-specific
+auth, base URL, session refresh, and metrics in Desktop.
+
+### User-Visible Behavior
+
+This should be behavior-preserving for existing Desktop Cloud flows. The point
+is to make Desktop, Web, Mobile, and future API surfaces consume the same typed
+Cloud client primitives.
+
+### Architecture Flow
+
+```text
+OpenAPI schema
+  -> cloud/sdk generated types
+  -> ProliferateCloudClient
+  -> cloud-sdk-react hooks/query keys
+  -> Desktop/Web/Mobile configure auth and storage separately
+```
+
+Desktop should configure the shared client, not fork endpoint logic.
+
+### Important Files
+
+- `cloud/sdk/src/client/core.ts`
+- `cloud/sdk/src/client/{commands,targets,sessions,live,workspaces}.ts`
+- `cloud/sdk/src/types/{commands,targets,sessions,live}.ts`
+- `cloud/sdk/src/streams/sse.ts`
+- `cloud/sdk-react/src/context/CloudClientProvider.tsx`
+- `cloud/sdk-react/src/lib/query-keys.ts`
+- `desktop/src/lib/access/cloud/client.ts`
+- `Makefile`
+- `pnpm-workspace.yaml`
+
+### Key Contracts
+
+- `ProliferateCloudClient`
+- `ProliferateClientError`
+- SDK global client config helpers
+- typed command/target/session snapshot/live-patch types
+- SSE helper primitives
+
+The SDK adds client surfaces for phase-forward endpoints such as:
+
+- `/v1/cloud/commands`
+- `/v1/cloud/targets`
+- `/v1/cloud/workspaces/{id}/snapshot`
+- `/v1/cloud/sessions/{id}/snapshot`
+- `/v1/cloud/sessions/{id}/transcript`
+- live stream endpoints
+
+### Review Checklist
+
+- SDK package has no Desktop or Tauri imports.
+- Generated OpenAPI output is not hand-edited.
+- Desktop auth refresh remains Desktop-owned.
+- SSE helper handles auth, abort, and reconnect call sites cleanly.
+- React Query keys are stable and compatible with existing Desktop invalidation.
+- Package-global client config is reset or overridden safely in tests.
+
+### Relationship And Risk
+
+This is the foundation for every later Cloud client change. The biggest risk is
+that the SDK defines phase-forward contracts before the server routes fully
+exist. Treat those contracts as intentional only when they are consumed by later
+stack PRs.
+
+## PR #214: Compute Targets And Worker Enrollment
+
+Link: https://github.com/proliferate-ai/proliferate/pull/214
+
+### Purpose
+
+Adds the target registry and first target-side install/enrollment loop:
+
+- Cloud target records
+- one-time enrollment tokens
+- worker heartbeat and inventory persistence
+- Rust `proliferate-worker`
+- Rust `proliferate-supervisor`
+- SSH installer
+- Desktop Compute settings pane
+
+### User-Visible Behavior
+
+Desktop gets a Compute pane where users can:
+
+- list targets
+- inspect readiness/inventory
+- create an SSH enrollment command
+- archive targets
+
+Running the installer on a remote machine turns it into a Cloud-visible target.
+
+### Architecture Flow
+
+```text
+User creates enrollment
+  -> Cloud creates cloud_targets row and hashed single-use token
+  -> installer writes worker/supervisor config
+  -> worker POST /v1/cloud/worker/enroll
+  -> Cloud returns worker token
+  -> worker stores identity in local SQLite
+  -> worker sends inventory and heartbeats
+  -> Cloud updates target status and inventory
+```
+
+### Important Files
+
+- `server/proliferate/server/cloud/targets/{api,models,service}.py`
+- `server/proliferate/server/cloud/worker/{api,models,service}.py`
+- `server/proliferate/db/models/cloud/targets.py`
+- `server/proliferate/db/store/cloud_sync/{targets,worker_auth,inventory}.py`
+- `server/alembic/versions/c4d5e6f7a8b9_cloud_targets_workers.py`
+- `anyharness/crates/proliferate-worker/**`
+- `anyharness/crates/proliferate-supervisor/**`
+- `install/proliferate-target-install.sh`
+- `desktop/src/components/settings/panes/ComputePane.tsx`
+
+### Key Endpoints And Tables
+
+User APIs:
+
+- `POST /v1/cloud/targets/enrollments`
+- `GET /v1/cloud/targets`
+- `GET /v1/cloud/targets/{target_id}`
+- `POST /v1/cloud/targets/{target_id}/archive`
+
+Worker APIs:
+
+- `POST /v1/cloud/worker/enroll`
+- `POST /v1/cloud/worker/heartbeat`
+- `POST /v1/cloud/worker/inventory`
+
+Tables:
+
+- `cloud_targets`
+- `cloud_workers`
+- `cloud_target_enrollments`
+- `cloud_target_inventory`
+- `cloud_target_status`
+
+### Review Checklist
+
+- Enrollment tokens are hashed, single-use, and expire.
+- Archived target tokens are rejected.
+- Target list/get/archive are org/user scoped.
+- Worker inventory does not expose raw secrets.
+- Worker config and DB files are created with private permissions.
+- Installer handles artifact URLs, install paths, and systemd launch safely.
+- Desktop invalidates target queries after enrollment/archive.
+
+### Relationship And Risk
+
+This PR makes targets real. Later PRs depend on its target IDs, worker tokens,
+heartbeat path, and inventory shape. Watch the lost-response enrollment case:
+if a worker consumes a one-time token but crashes before persisting its returned
+identity, retry behavior must be understood.
+
+## PR #216: Cloud Command Delivery Through Workers
+
+Link: https://github.com/proliferate-ai/proliferate/pull/216
+
+### Purpose
+
+Routes Cloud runtime mutations through durable worker commands instead of direct
+server-to-AnyHarness calls.
+
+It is the first major step toward:
+
+```text
+Cloud -> Worker -> AnyHarness
+```
+
+for automation and cloud-mediated session control.
+
+### User-Visible Behavior
+
+Automations still create workspaces, start sessions, apply config, send prompts,
+and cancel/close sessions. The difference is that the work is now delivered
+through a worker polling/lease loop.
+
+Command status becomes Cloud-readable.
+
+### Architecture Flow
+
+```text
+Cloud API / automation
+  -> validate target/workspace/command kind
+  -> create cloud_commands row
+  -> worker leases command
+  -> worker reports delivered
+  -> worker calls local AnyHarness API
+  -> worker reports accepted/rejected/failed_delivery
+  -> Cloud marks command terminal or retryable
+```
+
+Managed Cloud provisions a worker sidecar next to AnyHarness.
+
+### Important Files
+
+- `server/proliferate/server/cloud/commands/{api,models,service}.py`
+- `server/proliferate/db/models/cloud/commands.py`
+- `server/proliferate/db/store/cloud_sync/commands.py`
+- `server/proliferate/server/cloud/worker/{api,models,service}.py`
+- `server/proliferate/server/automations/worker/cloud_executor_{commands,session,target,workspace}.py`
+- `server/proliferate/server/cloud/runtime/{target_registration,bootstrap,provision}.py`
+- `anyharness/crates/proliferate-worker/src/commands/{dispatcher,mapping}.rs`
+- `anyharness/crates/proliferate-worker/src/anyharness_client/sessions.rs`
+- `docs/audits/cloud-worker-direct-anyharness-allowlist.md`
+
+### Key Endpoints, Kinds, And Statuses
+
+User APIs:
+
+- `POST /v1/cloud/commands`
+- `GET /v1/cloud/commands/{command_id}`
+
+Worker APIs:
+
+- `POST /v1/cloud/worker/commands/lease`
+- `POST /v1/cloud/worker/commands/{command_id}/delivery`
+- `POST /v1/cloud/worker/commands/{command_id}/result`
+
+Command kinds:
+
+- `start_session`
+- `send_prompt`
+- `resolve_interaction`
+- `update_session_config`
+- `cancel_turn`
+- `close_session`
+
+Command statuses:
+
+- `queued`
+- `leased`
+- `delivered`
+- `accepted`
+- `accepted_but_queued`
+- `rejected`
+- `expired`
+- `superseded`
+- `failed_delivery`
+
+### Review Checklist
+
+- Idempotency is scoped to actor/org/target/workspace/command shape.
+- Lease locking prevents two workers from delivering the same command.
+- Delivered-but-not-resulted commands recover or expire predictably.
+- Worker result reporting is idempotent.
+- Command payload mapping is explicit and typed where possible.
+- Automation waits on command status without reintroducing direct AnyHarness
+  calls outside the allowlist.
+- Managed Cloud bootstraps worker config alongside AnyHarness.
+
+### Relationship And Risk
+
+This PR makes the command path real. Later event and live-sync PRs make command
+effects observable. Highest-risk review points are lease recovery, command
+idempotency, and any remaining direct server-to-AnyHarness path.
+
+## PR #217: Worker Session Event Sync
+
+Link: https://github.com/proliferate-ai/proliferate/pull/217
+
+### Purpose
+
+Adds worker-uploaded AnyHarness session event sync and derives Cloud session
+read models from those events.
+
+### User-Visible Behavior
+
+Cloud users can read:
+
+- `GET /v1/cloud/sessions/{sessionId}/snapshot?targetId=...`
+- `GET /v1/cloud/sessions/{sessionId}/stream?targetId=...&afterSeq=...`
+
+Snapshots expose:
+
+- session status
+- transcript items
+- pending interactions
+
+Worker upload responses report accepted, duplicate, live-only events, and cursor
+acknowledgements per session.
+
+### Architecture Flow
+
+```text
+Worker command succeeds
+  -> worker seeds local sync session
+  -> worker polls AnyHarness session events
+  -> worker uploads event batches
+  -> Cloud dedupes by target/session/seq
+  -> Cloud applies retention/redaction policy
+  -> Cloud writes durable semantic rows
+  -> Cloud advances ingest cursors
+  -> Cloud updates session/transcript/interaction projections
+```
+
+### Important Files
+
+- `server/proliferate/server/cloud/events/**`
+- `server/proliferate/db/store/cloud_sync/events.py`
+- `server/proliferate/db/models/cloud/sync.py`
+- `server/alembic/versions/c8d9e0f1a2b3_*.py`
+- `anyharness/crates/proliferate-worker/src/sync/tailer.rs`
+- `anyharness/crates/proliferate-worker/src/cloud_client/events.rs`
+- `anyharness/crates/proliferate-worker/src/anyharness_client/events.rs`
+- `anyharness/crates/proliferate-worker/src/store/mod.rs`
+- `anyharness/crates/proliferate-worker/src/commands/dispatcher.rs`
+
+### Key Contracts And Tables
+
+Tables:
+
+- `cloud_session_events`
+- `cloud_event_ingest_state`
+- `cloud_sessions`
+- `cloud_transcript_items`
+- `cloud_pending_interactions`
+
+Types/responses:
+
+- `WorkerSessionEventEnvelope`
+- `WorkerEventBatchRequest`
+- `WorkerEventBatchResponse`
+- `CloudSessionSnapshotResponse`
+- `CloudSessionEventResponse`
+
+### Review Checklist
+
+- Worker event upload auth is target-scoped.
+- Duplicate event with same seq and different hash is rejected or surfaced.
+- Out-of-order seqs do not advance contiguous ack cursors incorrectly.
+- Live-only events are acknowledged without becoming durable history.
+- Raw tool bodies and oversized payloads are stripped or capped.
+- Session hard caps are enforced.
+- AnyHarness event pagination and limits are respected.
+- Command success seeds enough target/session/workspace IDs for event sync.
+
+### Relationship And Risk
+
+This PR makes command effects visible in Cloud. It is intentionally more
+important than live fanout: durable semantic rows and projections are what web,
+mobile, Slack, and API read after reconnect.
+
+Risk: projection logic relies on event type strings and dict payloads. Review
+for places that should become stricter typed contracts.
+
+## PR #218: Live Session Projection Fanout
+
+Link: https://github.com/proliferate-ai/proliferate/pull/218
+
+### Purpose
+
+Replaces raw/polling session stream behavior with Cloud live fanout for session
+projection patches.
+
+### User-Visible Behavior
+
+Session streams emit SSE frames:
+
+- `snapshot`
+- `patch`
+- `heartbeat`
+
+The client gets an initial full snapshot and then applies projection patches.
+
+### Architecture Flow
+
+```text
+Cloud event ingest
+  -> projection apply returns CloudSessionPatchResponse
+  -> live service publishes projection_patch
+  -> subscribers receive patch
+```
+
+The live layer uses a bounded subscriber queue keyed by:
+
+```text
+session:{targetId}:{sessionId}
+```
+
+### Important Files
+
+- `server/proliferate/server/cloud/live/service.py`
+- `server/proliferate/server/cloud/live/models.py`
+- `server/proliferate/server/cloud/live/domain/channels.py`
+- `server/proliferate/server/cloud/events/service.py`
+- `server/proliferate/server/cloud/events/models.py`
+- `server/proliferate/server/cloud/events/api.py`
+
+### Key Contracts
+
+- `CloudSessionPatchResponse`
+- `CloudLivePatchEnvelope`
+- `CloudStreamHeartbeatResponse`
+
+### Review Checklist
+
+- Clients tolerate new SSE event names and payload shape.
+- Snapshot includes enough cursor information for reconnect.
+- Heartbeats avoid silent dead streams.
+- Subscriber queue overflow behavior is explicit.
+- Patch ordering is stable when one batch produces multiple projection changes.
+- Patches are scoped by target/session, not only session ID.
+
+### Relationship And Risk
+
+This builds on #217 projections. #221 later generalizes live streams across
+sessions, workspaces, and targets with a clearer pub/sub boundary.
+
+Risk: the live bus in this phase is process-local and cannot fan out across
+multi-process or serverless deployments.
+
+## PR #219: Existing Workspace Backfill Through Workers
+
+Link: https://github.com/proliferate-ai/proliferate/pull/219
+
+### Purpose
+
+Lets workers map existing AnyHarness workspaces and sessions into Cloud read
+models, not only sessions created through new Cloud commands.
+
+### User-Visible Behavior
+
+Existing target workspaces appear in:
+
+- `GET /v1/cloud/workspaces`
+- `GET /v1/cloud/sessions?targetId=...`
+
+Existing sessions become readable through snapshot and stream APIs.
+
+Users can enqueue `sync_existing_workspace`. Only workers advertising that
+capability should lease it.
+
+### Architecture Flow
+
+```text
+Cloud queues sync_existing_workspace
+  -> worker leases special command
+  -> worker fetches AnyHarness repo roots/workspaces/sessions
+  -> worker uploads chunks to /worker/backfill
+  -> Cloud creates/updates CloudWorkspace and mappings
+  -> Cloud creates/updates session projections
+  -> worker stores local workspace/session mappings
+```
+
+### Important Files
+
+- `server/proliferate/server/cloud/backfill/**`
+- `server/proliferate/db/store/cloud_sync/backfill.py`
+- `server/proliferate/db/models/cloud/sync.py`
+- `server/alembic/versions/c9d0e1f2a3b4_*.py`
+- `server/proliferate/server/cloud/events/{api,service}.py`
+- `server/proliferate/constants/cloud.py`
+- `anyharness/crates/proliferate-worker/src/sync/backfill.rs`
+- `anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs`
+- `anyharness/crates/proliferate-worker/src/cloud_client/backfill.rs`
+- `anyharness/crates/proliferate-worker/src/store/mod.rs`
+- `anyharness/crates/proliferate-worker/src/commands/dispatcher.rs`
+
+### Key Contracts And Tables
+
+Endpoint:
+
+- `POST /v1/cloud/worker/backfill`
+
+Command kind:
+
+- `sync_existing_workspace`
+
+Tables/local worker tables:
+
+- `cloud_synced_workspaces`
+- worker `sync_workspaces`
+- worker `pending_command_results`
+
+AnyHarness dependencies:
+
+- `GET /v1/repo-roots`
+- `GET /v1/workspaces`
+- `GET /v1/sessions?workspace_id=...`
+
+### Review Checklist
+
+- Workspace/session mapping is target-scoped.
+- Backfill does not over-resolve active pending interactions.
+- Only capable workers lease `sync_existing_workspace`.
+- Pending command results survive worker restart and stale leases.
+- Chunk ordering and retries are harmless.
+- Backfilled workspaces with `runtime_environment_id = None` do not break
+  assumptions elsewhere.
+
+### Relationship And Risk
+
+This closes the gap where only Cloud-created sessions were synced. It sits
+between event sync and the later snapshot/live stream surface.
+
+Risk: the worker can backfill all workspaces if no workspace ID is supplied,
+while Cloud validation may require `workspaceId` for user-queued commands.
+Review whether sync-all is internal-only.
+
+## PR #221: Live Snapshot Streams
+
+Link: https://github.com/proliferate-ai/proliferate/pull/221
+
+### Purpose
+
+Adds snapshot-first live stream endpoints for sessions, workspaces, and targets.
+It also introduces a pub/sub integration boundary and after-commit live fanout.
+
+### User-Visible Behavior
+
+Clients can:
+
+- fetch session, transcript, event, workspace, and target snapshots
+- subscribe to session streams
+- subscribe to workspace streams
+- subscribe to target streams
+- receive command status patches
+- receive target status/update patches
+
+### Architecture Flow
+
+```text
+DB mutation
+  -> projection/status write
+  -> register after-commit live publish
+  -> commit succeeds
+  -> PubSubBus publish
+  -> SSE stream emits patch
+```
+
+This avoids publishing a live patch for a DB transaction that later rolls back.
+
+### Important Files
+
+- `server/proliferate/db/engine.py`
+- `server/proliferate/integrations/pubsub/{models,redis}.py`
+- `server/proliferate/server/cloud/live/{access,api,domain/rules,service,models}.py`
+- `server/proliferate/server/cloud/events/api.py`
+- `server/proliferate/server/cloud/events/service.py`
+- `server/proliferate/server/cloud/commands/service.py`
+- `server/proliferate/server/cloud/worker/service.py`
+- `server/proliferate/server/cloud/targets/service.py`
+- `cloud/sdk/src/client/live.ts`
+- `cloud/sdk/src/client/sessions.ts`
+- `cloud/sdk-react/src/hooks/{live,events,sessions}.ts`
+- `cloud/sdk/src/types/live.ts`
+
+### Key Endpoints And Events
+
+Endpoints:
+
+- `GET /v1/cloud/workspaces/{workspaceId}/snapshot`
+- `GET /v1/cloud/sessions/{sessionId}/stream?targetId=&afterSeq=`
+- `GET /v1/cloud/workspaces/{workspaceId}/stream?afterSeq=`
+- `GET /v1/cloud/targets/{targetId}/stream?afterSeq=`
+- `GET /v1/cloud/sessions/{sessionId}`
+- `GET /v1/cloud/sessions/{sessionId}/snapshot`
+- `GET /v1/cloud/sessions/{sessionId}/transcript`
+- `GET /v1/cloud/sessions/{sessionId}/events`
+
+Live event types include:
+
+- `snapshot`
+- `projection_patch`
+- `workspace_projection_patch`
+- `target_projection_patch`
+- `command_status`
+- `heartbeat`
+
+### Review Checklist
+
+- Stream access checks match snapshot access checks.
+- Snapshot-then-subscribe race is handled by cursor semantics.
+- After-commit hooks discard rolled-back patches.
+- Reconnect with `afterSeq` does not miss durable events.
+- Command and target patches publish after status mutation commit.
+- SDK query/path names exactly match FastAPI routes.
+
+### Relationship And Risk
+
+This is the general live substrate that #222 and #223 build on for config and
+update visibility.
+
+Risk: the pub/sub abstraction is present, but production Redis/NATS/multi-node
+fanout needs explicit deployment and testing. Stream IDs combine persisted event
+seqs with generated live IDs, so reviewers should check reconnect semantics.
+
+## PR #222: Target Config Materialization
+
+Link: https://github.com/proliferate-ai/proliferate/pull/222
+
+### Purpose
+
+Adds target-scoped materialization for environment/config state needed before a
+session runs on SSH, managed Cloud, or desktop-dispatch targets.
+
+Materialization can include:
+
+- env files
+- repo files
+- Git credentials
+- MCP package/config data
+- skills
+- agent credential files
+
+### User-Visible Behavior
+
+Users can request materialization for a target/repo and inspect target config
+records/status. Worker-owned secret plans are not exposed in user-facing
+responses.
+
+### Architecture Flow
+
+```text
+User requests materialization
+  -> Cloud validates target/repo/config
+  -> Cloud stores encrypted plan in cloud_target_configs
+  -> Cloud queues materialize_environment command
+  -> worker leases command
+  -> worker fetches materialization plan with command_id/config_version/lease_id
+  -> worker writes local files/config
+  -> worker reports status
+```
+
+The worker should not decide which credentials or bundles are allowed. Cloud
+resolves that policy and sends a narrow plan.
+
+### Important Files
+
+- `server/proliferate/server/cloud/target_config/{api,models,service}.py`
+- `server/proliferate/server/cloud/target_config/domain/**`
+- `server/proliferate/db/models/cloud/target_config.py`
+- `server/proliferate/db/store/cloud_sync/target_config.py`
+- `server/alembic/versions/d0*.py`
+- `anyharness/crates/proliferate-worker/src/materialization/{env,files,git,mcp,skills,mod}.rs`
+- `anyharness/crates/proliferate-worker/src/cloud_client/target_config.rs`
+- `anyharness/crates/proliferate-worker/src/commands/dispatcher.rs`
+- `cloud/sdk/src/client/target-configs.ts`
+
+### Key Endpoints, Command, And Table
+
+User APIs:
+
+- `GET /v1/cloud/targets/{targetId}/configs`
+- `GET /v1/cloud/targets/{targetId}/configs/{configId}`
+- `POST /v1/cloud/targets/{targetId}/configs/materialize`
+
+Worker APIs:
+
+- `GET /v1/cloud/worker/target-configs/{configId}/materialization?command_id=&config_version=&lease_id=`
+- `POST /v1/cloud/worker/target-configs/{configId}/status`
+
+Command kind:
+
+- `materialize_environment`
+
+Table:
+
+- `cloud_target_configs`
+
+### Review Checklist
+
+- Encrypted plan contents never leak through user responses.
+- Worker plan fetch requires the matching command ID, worker ID, lease ID, and
+  config version.
+- Stale commands cannot apply newer config materialization plans.
+- Workspace-root validation matches worker-side canonicalization.
+- Path traversal, symlink, absolute path, and parent-dir escapes are blocked.
+- Files are written with private permissions where appropriate.
+- Git config rejects control characters and unsafe keys.
+- Agent credential file materialization is provider-keyed and allowlisted.
+- Idempotency accounts for config version changes.
+
+### Relationship And Risk
+
+This PR depends on durable commands and live target streams. It supplies the
+target-preparation path needed for SSH/BYO targets, managed Cloud, MCP bundles,
+skills, and agent credentials.
+
+Risk: secret breadth is high. Review secret handling, file writes, and plan
+fetch authorization more carefully than normal CRUD code.
+
+## PR #223: Worker Update Supervision
+
+Link: https://github.com/proliferate-ai/proliferate/pull/223
+
+### Purpose
+
+Adds update coordination and conservative compute safety controls:
+
+- desired AnyHarness/worker/supervisor versions
+- target update generation
+- worker heartbeat desired-version handling
+- worker update-status reporting
+- supervisor update manifest/staging/rollback primitives
+- safe-stop checks
+- worker revocation
+
+### User-Visible Behavior
+
+Cloud target payloads expose current/desired versions and update status.
+
+Admins can:
+
+- set desired runtime versions
+- check whether a target can stop safely
+- revoke workers for a target
+
+### Architecture Flow
+
+```text
+Admin sets desired versions
+  -> Cloud increments updateGeneration
+  -> worker heartbeat receives desiredVersions + generation
+  -> worker compares desired with installed versions
+  -> worker writes supervisor mailbox / update request
+  -> supervisor stages/verifies update artifacts
+  -> worker reports update status
+  -> Cloud generation-fences status update
+  -> target live stream publishes status patch
+```
+
+Safe-stop is intentionally conservative until target-side safety signals are
+fully trusted.
+
+### Important Files
+
+- `server/proliferate/server/cloud/compute/{api,models,service}.py`
+- `server/proliferate/server/cloud/worker/domain/updates.py`
+- `server/proliferate/db/store/cloud_sync/targets.py`
+- `server/proliferate/db/models/cloud/targets.py`
+- `server/alembic/versions/*target_update*.py`
+- `anyharness/crates/proliferate-worker/src/updates/**`
+- `anyharness/crates/proliferate-supervisor/src/update/**`
+- `cloud/sdk/src/client/compute.ts`
+- `cloud/sdk/src/types/targets.ts`
+
+### Key Endpoints And Fields
+
+Compute APIs:
+
+- `POST /v1/cloud/compute/targets/{targetId}/desired-versions`
+- `POST /v1/cloud/compute/targets/{targetId}/safe-stop-check`
+- `POST /v1/cloud/compute/targets/{targetId}/revoke-workers`
+
+Worker API:
+
+- `POST /v1/cloud/worker/update-status`
+
+Target response adds:
+
+- `update.channel`
+- `update.generation`
+- `update.desiredVersions`
+- `update.currentVersions`
+- `update.status`
+- `update.component`
+- `update.version`
+- `update.reportedAt`
+
+DB target update fields include:
+
+- `update_channel`
+- `update_generation`
+- desired AnyHarness/worker/supervisor versions
+- update status/detail/component/version/report time
+
+### Review Checklist
+
+- Desired-version updates are patch-style, not accidental full overwrites.
+- `updateGeneration` fences worker status reports.
+- Worker cannot report `applied` unless current versions match desired versions.
+- Heartbeat response parsing is strict but backward compatible.
+- Revoked workers cannot lease commands, upload events, fetch configs, or report
+  update status.
+- Safe-stop blocks active commands, active sessions, and idle-but-open sessions.
+- Revocation is blocked while target update is in progress.
+- Target streams publish update/revocation patches after commit.
+- Supervisor staging validates checksums and does not follow unsafe paths.
+- Stale supervisor mailbox entries are cleared before new desired versions.
+
+### Relationship And Risk
+
+This completes the update placeholder from the worker/control-plane architecture.
+
+Risk: supervisor update support is not a full updater yet. Signed manifests,
+trust root, artifact fetching, durable apply loop, rollback policy, and richer
+machine-readable failure codes are deferred.
+
+## Review By System Boundary
+
+Use this section when reviewing the code by folder instead of by PR.
+
+### `cloud/sdk/**`
+
+Owns shared typed Cloud access:
+
+- generated OpenAPI types
+- low-level Cloud client
+- stream/SSE helpers
+- Cloud React hooks
+
+It must not own Desktop auth storage, Tauri access, product-specific UI state,
+or worker runtime behavior.
+
+### `desktop/src/**`
+
+Owns Desktop-specific Cloud wiring and UX:
+
+- auth/session storage
+- base URL configuration
+- Desktop Compute settings surface
+- Desktop query invalidation and local UI orchestration
+
+It should not construct raw Cloud endpoint paths in product components when a
+shared SDK method exists.
+
+### `server/proliferate/server/cloud/**`
+
+Owns Cloud product/control-plane behavior:
+
+- target registry
+- command queue
+- worker APIs
+- event ingest
+- projections
+- live streams
+- backfill
+- target config materialization
+- compute/update policy
+
+Domain folders should keep the same predictable shape where possible:
+
+```text
+api.py       HTTP boundary
+models.py    Pydantic request/response models
+service.py   orchestration and transaction shape
+domain/      pure validation/mapping/rules when logic gets large
+```
+
+### `server/proliferate/db/**`
+
+Owns persistence:
+
+- SQLAlchemy models
+- store classes/functions
+- Alembic migrations
+
+Stores should not decide product policy. They should provide precise persistence
+operations used by Cloud services.
+
+### `anyharness/crates/proliferate-worker/**`
+
+Owns the target-side bridge:
+
+- enrollment identity
+- heartbeat/inventory
+- command polling/dispatch
+- local AnyHarness HTTP client
+- event tailing and upload
+- local cursor/outbox state
+- backfill
+- target config materialization
+- update status/supervisor mailbox integration
+
+It should not decide org/team authorization, credential grants, prompt queue
+semantics, or transcript reconstruction.
+
+### `anyharness/crates/proliferate-supervisor/**`
+
+Owns process/update supervision primitives:
+
+- start/restart worker/AnyHarness where applicable
+- update manifest parsing
+- staging and validation
+- rollback metadata
+
+It should not know Cloud org policy or session semantics.
+
+## Open Questions To Keep Visible During Review
+
+These are not necessarily blockers, but they are the questions most likely to
+create future drift:
+
+- Which direct server-to-AnyHarness paths remain, and are they explicitly
+  allowed?
+- Is every Cloud mutation either a durable command or a Cloud-owned metadata
+  mutation?
+- Do event payload caps keep Cloud storage bounded for large sessions?
+- Are live patches always reconstructable from snapshots/projections?
+- Does target config materialization have a clean path for GitHub/Git token
+  rotation and credential revocation?
+- Do worker retries preserve command result and materialization status across
+  process restarts?
+- Is `sync_existing_workspace` supposed to support sync-all as a product path,
+  or only as an internal maintenance operation?
+- What exact production pub/sub backend will replace or back the current
+  process-local live fanout?
+- What is the signed update artifact/trust-root plan after supervisor staging?
+

--- a/docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md
+++ b/docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md
@@ -1,0 +1,719 @@
+# Cloud Worker Runtime Bundle And Supervisor Spec
+
+Status: concrete follow-up PR spec.
+
+Scope: PR A in the Cloud Worker migration sequence.
+
+This spec defines the implementation work required to make every
+cloud-addressable target boot the same supervised runtime bundle:
+
+```text
+proliferate-supervisor
+  starts and restarts:
+    anyharness
+    proliferate-worker
+```
+
+The target may be a managed cloud sandbox, an SSH machine, or a future
+self-hosted/VPC target. The process shape must be the same even when the
+onboarding flow differs.
+
+This spec intentionally does not cover the next two PRs:
+
+- adding missing command kinds such as workspace/worktree materialization
+- migrating automations fully to target-agnostic CloudCommand orchestration
+
+Those PRs should assume the runtime bundle and process lifecycle in this file
+are already correct.
+
+## Goal
+
+Answer this operational question:
+
+```text
+When Cloud says "this machine is a Proliferate target," exactly which binaries
+exist on that machine, who starts them, who restarts them, how versions are
+reported, and how can we prove the target is alive?
+```
+
+By the end of this PR:
+
+- runtime artifacts contain `anyharness`, `proliferate-worker`, and
+  `proliferate-supervisor`
+- SSH installation creates a supervisor-managed target, not a worker-only
+  process
+- managed cloud/E2B provisioning starts `proliferate-supervisor`, not detached
+  `anyharness` and detached `proliferate-worker` independently
+- `proliferate-worker` enrolls and heartbeats through the existing worker APIs
+- target inventory reports all runtime component versions
+- local development and CI/template smoke tests verify the bundle and process
+  shape
+
+## Non-Goals
+
+Do not add or change automation execution semantics in this PR.
+
+Do not add missing CloudCommand kinds such as `materialize_workspace` in this
+PR.
+
+Do not delete all direct server-to-AnyHarness runtime calls in this PR. Direct
+execution mutation removal belongs to the automation migration PR. This PR may
+move managed cloud process launch away from direct detached process scripts.
+
+Do not build a full update rollout product in this PR. The PR should make
+component version reporting and supervisor update hooks structurally correct.
+The production rollout policy can remain basic.
+
+## Invariants
+
+All target kinds use the same process role model:
+
+```text
+supervisor owns process lifecycle
+worker owns cloud transport
+AnyHarness owns runtime execution
+Cloud owns target registry and desired state
+```
+
+Cloud may provision infrastructure and write launch config, but Cloud must not
+be the long-running process supervisor for target-local runtime components.
+
+The worker should never be the only long-lived process installed as the target
+service. If the worker dies, the supervisor restarts it. If AnyHarness dies,
+the supervisor restarts it.
+
+The supervisor should not own Cloud command semantics, session semantics,
+credential policy, or transcript/event interpretation.
+
+## Current State On Stack Tip
+
+The stack already includes these pieces:
+
+- `anyharness/crates/proliferate-worker/**`
+- `anyharness/crates/proliferate-supervisor/**`
+- worker enrollment, heartbeat, inventory, command leasing, event upload, and
+  update status endpoints
+- SSH installer that downloads/copies all three binaries and creates a
+  supervisor systemd user service
+- managed cloud bootstrap that can stage `anyharness` and `proliferate-worker`
+  and launch them directly
+
+The main gap is managed cloud process ownership:
+
+```text
+current managed cloud shape:
+  server writes AnyHarness launch script
+  server starts AnyHarness with nohup
+  server writes worker config
+  server starts worker with nohup
+
+target managed cloud shape:
+  server writes worker config
+  server writes supervisor config
+  server starts supervisor with nohup or template entrypoint
+  supervisor starts AnyHarness and worker
+```
+
+SSH is closer to target state than managed cloud. It still needs test hardening
+and possibly bundle download cleanup.
+
+## Branching
+
+Implement this PR on top of the current worker stack tip, not on the first SDK
+branch:
+
+```text
+base: origin/proliferate/cloud-worker-phase8-hardening
+branch: proliferate/cloud-worker-runtime-supervisor
+```
+
+If the stack tip changes, rebase this PR onto the latest tip before opening.
+
+## File Ownership Map
+
+### Runtime Crates
+
+```text
+anyharness/crates/anyharness/**
+anyharness/crates/proliferate-worker/**
+anyharness/crates/proliferate-supervisor/**
+Cargo.toml
+Cargo.lock
+```
+
+Expected work:
+
+- confirm all three crates are workspace members
+- confirm release builds produce all three binaries
+- add missing `--version` support if any component cannot report a version
+- keep worker and supervisor responsibilities separate
+
+### SSH Installer
+
+```text
+install/proliferate-target-install.sh
+install/README.md
+```
+
+Expected work:
+
+- keep the installer installing all three binaries
+- keep the installed systemd user service pointing at
+  `proliferate-supervisor`
+- make the generated supervisor config match managed cloud config shape where
+  possible
+- document `PROLIFERATE_ARTIFACT_BASE_URL`, `PROLIFERATE_HOME`,
+  `PROLIFERATE_CLOUD_URL`, `PROLIFERATE_ENROLLMENT_TOKEN`,
+  `PROLIFERATE_ANYHARNESS_BASE_URL`, and `PROLIFERATE_SERVICE_NAME`
+- add or preserve clear dev testing instructions for piping a local installer
+  over SSH
+
+Current target service shape:
+
+```text
+ExecStart=$PROLIFERATE_HOME/bin/proliferate-supervisor \
+  --config $PROLIFERATE_HOME/supervisor/config.toml run
+```
+
+That shape should remain.
+
+### Managed Cloud Bootstrap
+
+```text
+server/proliferate/server/cloud/runtime/bootstrap.py
+server/proliferate/server/cloud/runtime/provision.py
+server/proliferate/server/cloud/runtime/sandbox_exec.py
+server/proliferate/integrations/sandbox/e2b.py
+server/proliferate/constants/sandbox/e2b.py
+server/proliferate/config.py
+```
+
+Expected work:
+
+- replace managed cloud direct detached AnyHarness launch with supervisor launch
+- replace managed cloud direct detached worker launch with supervisor launch
+- stage or verify all three binaries on the sandbox
+- write worker config before supervisor start
+- write supervisor config before supervisor start
+- keep existing AnyHarness health verification, but treat worker enrollment as
+  the target availability signal
+- persist the worker-created `target_id` on the runtime environment as today
+- make reusable helper names describe runtime bundle concepts, not only
+  AnyHarness
+
+### Cloud Worker Registration
+
+```text
+server/proliferate/server/cloud/worker/api.py
+server/proliferate/server/cloud/worker/service.py
+server/proliferate/db/store/cloud_sync/worker_auth.py
+server/proliferate/db/store/cloud_sync/targets.py
+server/proliferate/db/store/cloud_sync/inventory.py
+```
+
+Expected work:
+
+- no large API redesign
+- ensure heartbeat/inventory response continues to carry desired versions
+- ensure managed cloud enrollment flow produces a visible online target
+- add tests if managed cloud provisioning now depends on a stronger
+  target-online wait condition
+
+### Release And Template Workflows
+
+```text
+.github/workflows/release-runtime.yml
+.github/workflows/release-cloud-template.yml
+.github/workflows/promote-cloud-template.yml
+scripts/build-template.mjs
+scripts/promote-cloud-template.mjs
+scripts/smoke-cloud-template.mjs
+scripts/smoke-e2b-runtime.mjs
+server/infra/self-hosted-aws/template.yaml
+server/infra/self-hosted-aws/README.md
+```
+
+Expected work:
+
+- build and publish all three runtime binaries for supported Linux targets
+- ensure cloud template build includes or downloads all three binaries
+- ensure local template build uses the same binary names and install layout as
+  production template build
+- ensure self-hosted runtime asset references do not assume only `anyharness`
+- smoke template should fail if any of the three binaries is missing or
+  non-executable
+
+## Runtime Bundle Model
+
+The release artifact should be thought of as a runtime bundle even if the first
+implementation still downloads individual binaries.
+
+Logical bundle contents:
+
+```text
+runtime-bundle/
+  bin/
+    anyharness
+    proliferate-worker
+    proliferate-supervisor
+```
+
+Preferred installed layout:
+
+```text
+$PROLIFERATE_HOME/
+  bin/
+    anyharness
+    proliferate-worker
+    proliferate-supervisor
+  worker/
+    config.toml
+    worker.sqlite3
+  supervisor/
+    config.toml
+    update/
+      staging/
+      rollback/
+  logs/
+    anyharness.log
+    proliferate-worker.log
+    proliferate-supervisor.log
+```
+
+The first PR does not have to migrate every log path if that creates churn, but
+the spec target should be represented in helper names and tests.
+
+## Supervisor Config
+
+The config should be sufficient to start both child processes:
+
+```toml
+anyharness_binary = "/home/user/.proliferate/bin/anyharness"
+worker_binary = "/home/user/.proliferate/bin/proliferate-worker"
+worker_config = "/home/user/.proliferate/worker/config.toml"
+anyharness_args = [
+  "serve",
+  "--require-bearer-auth",
+  "--host",
+  "127.0.0.1",
+  "--port",
+  "8457"
+]
+restart_delay_seconds = 5
+```
+
+For SSH, binding AnyHarness to `127.0.0.1` is preferred. The worker talks to
+AnyHarness locally. Direct remote access should be explicit, not the default.
+
+For managed cloud, the runtime endpoint behavior depends on E2B/provider
+networking. If a provider endpoint requires `0.0.0.0`, the config may use that
+for managed cloud, but the reason must live in the bootstrap helper and tests.
+
+## Worker Config
+
+Worker config continues to contain Cloud and local AnyHarness details:
+
+```toml
+cloud_base_url = "https://api.proliferate.dev"
+enrollment_token = "..."
+anyharness_base_url = "http://127.0.0.1:8457"
+anyharness_bearer_token = "..."
+worker_db_path = "/home/user/.proliferate/worker/worker.sqlite3"
+heartbeat_interval_seconds = 30
+```
+
+The worker remains responsible for enrollment, heartbeat, inventory,
+commands, event upload, and update status. The supervisor only starts and
+restarts it.
+
+## Managed Cloud Boot Flow
+
+Target flow:
+
+```text
+1. Cloud provisions or reconnects sandbox.
+2. Cloud ensures runtime bundle exists on sandbox:
+     anyharness
+     proliferate-worker
+     proliferate-supervisor
+3. Cloud writes worker config with enrollment token and local AnyHarness URL.
+4. Cloud writes supervisor config.
+5. Cloud launches supervisor.
+6. Supervisor starts AnyHarness.
+7. Supervisor starts worker.
+8. Cloud waits for AnyHarness health for backwards-compatible workspace
+   preparation.
+9. Cloud waits for worker enrollment/heartbeat and target online.
+10. Cloud stores runtime_environment.target_id.
+11. Provisioning continues with workspace preparation until PR C moves that
+    work behind commands.
+```
+
+This PR may keep the existing direct workspace preparation calls after
+supervisor boot. The automation migration PR will remove execution mutation
+calls.
+
+## SSH Boot Flow
+
+Target flow:
+
+```text
+1. User creates target enrollment token from Cloud/Desktop UI.
+2. UI shows install command.
+3. Installer downloads or copies all three binaries.
+4. Installer writes worker config.
+5. Installer writes supervisor config.
+6. Installer creates systemd user service for supervisor.
+7. Supervisor starts AnyHarness and worker.
+8. Worker enrolls and reports inventory.
+9. Cloud/Desktop shows target online.
+```
+
+The SSH install command should not require a direct inbound route to
+AnyHarness. It should require only outbound access to Cloud.
+
+## Version And Update Shape
+
+Worker heartbeat already reports:
+
+```text
+anyharness_version
+worker_version
+supervisor_version
+```
+
+Cloud target desired versions already model:
+
+```text
+desired_anyharness_version
+desired_worker_version
+desired_supervisor_version
+update_generation
+update_channel
+```
+
+This PR should ensure every process can produce real version values and that
+managed cloud and SSH both report them.
+
+Minimum update flow for this PR:
+
+```text
+1. Worker heartbeat receives desired versions.
+2. Worker determines whether desired versions differ from current versions.
+3. Worker calls or signals supervisor update hook.
+4. Supervisor can verify/stage artifacts with existing update commands.
+5. Worker reports update status to Cloud.
+```
+
+If the final swap/restart path is not production-ready, document it as pending
+and make tests cover only verify/stage/status paths. Do not fake applied
+updates.
+
+## Exact Implementation Tasks
+
+### Task 1: Normalize Runtime Binary Resolution
+
+Files:
+
+```text
+server/proliferate/server/cloud/runtime/bootstrap.py
+server/proliferate/config.py
+```
+
+Add or confirm helpers:
+
+```python
+resolve_local_runtime_binary_path()      # anyharness
+resolve_local_worker_binary_path()       # proliferate-worker
+resolve_local_supervisor_binary_path()   # proliferate-supervisor
+```
+
+Add config if missing:
+
+```text
+CLOUD_RUNTIME_SOURCE_BINARY_PATH
+CLOUD_WORKER_SOURCE_BINARY_PATH
+CLOUD_SUPERVISOR_SOURCE_BINARY_PATH
+```
+
+Acceptance:
+
+- unit test can override each binary path
+- missing binary error names the missing component
+- managed cloud staging code never silently skips supervisor
+
+### Task 2: Stage Or Verify Runtime Bundle
+
+Files:
+
+```text
+server/proliferate/server/cloud/runtime/bootstrap.py
+server/tests/unit/test_e2b_runtime.py
+```
+
+Add helpers:
+
+```python
+runtime_bundle_paths(runtime_context)
+check_runtime_bundle_preinstalled(...)
+stage_runtime_bundle(...)
+```
+
+or equivalent explicit helpers for all three binaries.
+
+Acceptance:
+
+- template preinstall check verifies all required binaries
+- local upload path writes all required binaries
+- smoke/unit tests fail if supervisor is absent
+
+### Task 3: Build Managed Cloud Supervisor Config
+
+Files:
+
+```text
+server/proliferate/server/cloud/runtime/bootstrap.py
+```
+
+Add helpers:
+
+```python
+supervisor_config_path(runtime_context)
+supervisor_log_path(runtime_context)
+build_supervisor_config(...)
+build_detached_supervisor_launch_command(...)
+```
+
+The generated config must include:
+
+- anyharness binary path
+- worker binary path
+- worker config path
+- AnyHarness serve args
+- restart delay
+
+Acceptance:
+
+- unit test snapshots or asserts config fields
+- config uses the same local AnyHarness URL the worker config uses
+- config can express provider-specific bind host/port
+
+### Task 4: Replace Managed Cloud Direct Process Launch
+
+Files:
+
+```text
+server/proliferate/server/cloud/runtime/provision.py
+server/proliferate/server/cloud/runtime/bootstrap.py
+```
+
+Replace:
+
+```text
+build_runtime_launch_script(...)
+build_detached_runtime_launch_command(...)
+build_detached_worker_launch_command(...)
+```
+
+for managed cloud launch with:
+
+```text
+write worker config
+write supervisor config
+launch supervisor
+```
+
+Keep health checks:
+
+```text
+wait_for_runtime_health(...)
+verify_runtime_auth_enforced(...)
+```
+
+Add target readiness check:
+
+```text
+wait_for_worker_target_online(runtime_environment_id or target_id)
+```
+
+Acceptance:
+
+- managed cloud path starts only one long-lived root process:
+  `proliferate-supervisor`
+- worker still enrolls and target becomes online
+- runtime environment records target id
+
+### Task 5: Harden SSH Installer Around Supervisor
+
+Files:
+
+```text
+install/proliferate-target-install.sh
+install/README.md
+scripts/cloud-ssh-worker-smoke.py
+Makefile
+```
+
+Keep or add assertions:
+
+- all three binaries are installed
+- supervisor config exists
+- worker config exists
+- systemd user service points at `proliferate-supervisor`
+- service starts successfully
+- AnyHarness health succeeds locally
+- worker target is online in Cloud
+
+Acceptance:
+
+```bash
+make test-cloud-ssh-worker ...
+```
+
+should prove the supervisor service, not only worker enrollment.
+
+### Task 6: Template And Release Packaging
+
+Files:
+
+```text
+.github/workflows/release-runtime.yml
+.github/workflows/release-cloud-template.yml
+.github/workflows/promote-cloud-template.yml
+scripts/build-template.mjs
+scripts/smoke-cloud-template.mjs
+scripts/smoke-e2b-runtime.mjs
+server/infra/self-hosted-aws/template.yaml
+```
+
+Acceptance:
+
+- release workflow builds all three binaries
+- cloud template build includes all three or downloads all three
+- smoke test checks `anyharness --version`,
+  `proliferate-worker --version`, and `proliferate-supervisor --version`
+- no workflow still treats `anyharness` as the only runtime artifact
+
+### Task 7: Observability
+
+Files:
+
+```text
+anyharness/crates/proliferate-supervisor/src/observability.rs
+anyharness/crates/proliferate-supervisor/src/process/*
+server/proliferate/server/cloud/worker/service.py
+```
+
+Acceptance:
+
+- supervisor logs child start/stop/restart
+- worker heartbeat exposes all component versions
+- Cloud target patch includes enough version/status detail to debug target boot
+
+## Tests
+
+### Unit Tests
+
+Add or update:
+
+```text
+server/tests/unit/test_e2b_runtime.py
+server/tests/unit/test_cloud_worker_runtime_bundle.py
+```
+
+Suggested cases:
+
+- runtime bundle path resolution finds all three binaries
+- runtime bundle path resolution fails with component-specific error
+- supervisor config includes AnyHarness and worker commands
+- managed cloud launch command invokes supervisor
+- template preinstall check requires supervisor
+
+### Rust Tests
+
+Add tests where practical:
+
+```text
+anyharness/crates/proliferate-supervisor/src/config.rs
+anyharness/crates/proliferate-supervisor/src/install/service.rs
+anyharness/crates/proliferate-supervisor/src/update/*
+```
+
+Suggested cases:
+
+- config parses expected TOML
+- generated service starts supervisor command
+- update verify rejects bad sha256
+- update stage writes artifact to expected staging path
+
+### Smoke Tests
+
+SSH smoke:
+
+```bash
+make test-cloud-ssh-worker PROFILE=worker ...
+```
+
+Must assert:
+
+- remote service unit exists
+- unit `ExecStart` references `proliferate-supervisor`
+- supervisor process is running
+- AnyHarness child is running
+- worker child is running
+- Cloud target is online
+- target inventory includes `default_workspace_root`
+- `default_workspace_root` exists on the target and is writable by the
+  supervised runtime user
+- killing AnyHarness results in restart
+- killing worker results in restart
+
+Managed cloud smoke:
+
+```bash
+node scripts/smoke-e2b-runtime.mjs
+```
+
+Must assert:
+
+- template has all three binaries
+- supervisor starts
+- worker enrolls
+- target online appears in Cloud
+- AnyHarness health succeeds through provider endpoint
+- target inventory includes a writable default workspace root for future
+  repo/worktree materialization commands
+
+This PR does not need to create an automation worktree. It only proves the
+target has a stable writable root that later `materialize_workspace(mode =
+worktree)` commands can use.
+
+## Completion Checklist
+
+Before opening the PR:
+
+- [ ] all three binaries build locally for the target Linux release profile
+- [ ] SSH installer still works against a clean target
+- [ ] managed cloud starts supervisor instead of direct detached AnyHarness and
+      worker processes
+- [ ] Cloud target online is driven by worker heartbeat/enrollment
+- [ ] runtime environment stores `target_id`
+- [ ] template build/smoke checks all three binaries
+- [ ] docs mention supervised runtime bundle, not only AnyHarness binary
+- [ ] `rg "launch_worker_nohup|launch_runtime_nohup|build_detached_worker_launch_command"` has
+      no managed cloud production process-launch usage left, or each remaining
+      hit is a backwards-compatible helper marked for deletion
+
+## Review Questions
+
+Reviewers should be able to answer:
+
+1. If AnyHarness crashes on an SSH target, who restarts it?
+2. If the worker crashes on managed cloud, who restarts it?
+3. How does Cloud know the target is alive?
+4. Which version of each component is running?
+5. Does managed cloud boot use the same runtime bundle as SSH?
+6. Can template CI fail if `proliferate-supervisor` is missing?
+7. Is any server code still acting as a long-running process supervisor?
+
+If any answer is unclear, the PR is not finished.

--- a/docs/architecture/cloud-worker-workspace-command-spec.md
+++ b/docs/architecture/cloud-worker-workspace-command-spec.md
@@ -1,0 +1,695 @@
+# Cloud Worker Workspace Command Spec
+
+Status: concrete follow-up PR spec.
+
+Scope: PR B in the Cloud Worker migration sequence.
+
+This spec defines the missing CloudCommand primitive for target-side workspace
+creation and worktree creation.
+
+It assumes the supervised runtime bundle from
+`docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md` exists:
+
+```text
+proliferate-supervisor
+  -> anyharness
+  -> proliferate-worker
+```
+
+## Goal
+
+Cloud must be able to ask any registered target to create or resolve the
+AnyHarness workspace needed before a session can start.
+
+The command sequence after this PR should be:
+
+```text
+materialize_workspace
+  -> returns anyharnessWorkspaceId, repoRootId, path, branch
+
+start_session
+  -> starts selected harness/model/mode in that workspace
+
+send_prompt / update_session_config / resolve_interaction / cancel_turn
+  -> normal live session control
+```
+
+This PR answers one question:
+
+```text
+How does Cloud create the target-side AnyHarness workspace/worktree without
+directly calling AnyHarness from the server?
+```
+
+## Non-Goals
+
+Do not migrate automations in this PR.
+
+Do not add session MCP bundle launch semantics in this PR.
+
+Do not move model/mode/reasoning/session config into this command.
+
+Do not make this command responsible for all target environment files. Target
+environment materialization remains separate.
+
+Do not remove server direct AnyHarness calls in this PR except where they are
+trivially unused. Full deletion belongs to the automation migration PR.
+
+## Current Command Coverage
+
+Already present on the worker stack:
+
+```text
+start_session
+materialize_environment
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+close_session
+sync_existing_workspace
+```
+
+These cover live session control and target config application. They do not
+create the target-side AnyHarness workspace/worktree.
+
+`materialize_environment` currently applies configuration files to a filesystem
+root:
+
+```text
+env vars
+tracked config files
+git credential config
+agent credential files
+MCP config
+skill refs
+target-config manifest
+```
+
+It does not call:
+
+```text
+POST /v1/workspaces
+POST /v1/workspaces/worktrees
+```
+
+It therefore does not produce:
+
+```text
+anyharnessWorkspaceId
+repoRootId
+workspace path registered in AnyHarness SQLite
+```
+
+## Command Name
+
+Add one active command kind:
+
+```text
+materialize_workspace
+```
+
+This name is intentionally broader than `create_workspace` because the worker
+may either:
+
+- resolve/register an existing path as an AnyHarness workspace
+- create a new worktree workspace from an existing repo root
+
+The command is still narrowly scoped: it materializes the AnyHarness workspace
+identity, not the full session environment.
+
+## Data Model
+
+### CloudCommand Row
+
+The command is stored in `cloud_commands` like other worker commands:
+
+```text
+target_id       required
+workspace_id    optional on enqueue; set to AnyHarness workspace id only after result
+session_id      null
+kind            materialize_workspace
+payload_json    typed command payload
+result_json     typed worker result
+```
+
+The command must be target-scoped. It is not session-scoped because the session
+does not exist yet.
+
+### Command Kind Constants
+
+Files:
+
+```text
+server/proliferate/constants/cloud.py
+anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+```
+
+Add:
+
+```python
+CloudCommandKind.materialize_workspace = "materialize_workspace"
+```
+
+Add to:
+
+```text
+ACTIVE_CLOUD_COMMAND_KINDS
+DEFAULT_CLOUD_WORKER_COMMAND_KINDS
+SUPPORTED_COMMAND_KINDS in worker
+```
+
+## Payload Schema
+
+The payload is a discriminated union.
+
+### Existing Path Mode
+
+Use this when a repo/workspace path already exists on the target and should be
+registered or resolved as an AnyHarness workspace.
+
+```json
+{
+  "mode": "existing_path",
+  "path": "/home/ubuntu/proliferate/workspaces/acme-api",
+  "displayName": "acme-api",
+  "origin": {
+    "kind": "system",
+    "entrypoint": "cloud"
+  },
+  "creatorContext": {
+    "kind": "automation",
+    "automationRunId": "6bf8..."
+  }
+}
+```
+
+Required:
+
+```text
+mode = existing_path
+path
+```
+
+Optional:
+
+```text
+displayName
+origin
+creatorContext
+```
+
+Worker behavior:
+
+```text
+POST /v1/workspaces
+{
+  "path": payload.path,
+  "origin": payload.origin,
+  "creatorContext": payload.creatorContext
+}
+```
+
+If `displayName` is present, either:
+
+- call the existing AnyHarness display-name endpoint if available, or
+- defer display-name support and return the natural AnyHarness display name
+
+Do not invent a worker-side display-name store.
+
+### Worktree Mode
+
+Use this when Cloud wants a new worktree workspace for an automation/new run.
+
+```json
+{
+  "mode": "worktree",
+  "repoRootId": "rr_123",
+  "targetPath": "/home/ubuntu/proliferate/workspaces/acme-api-run-6bf8",
+  "newBranchName": "proliferate/automation-6bf8",
+  "baseBranch": "main",
+  "setupScript": null,
+  "origin": {
+    "kind": "system",
+    "entrypoint": "cloud"
+  },
+  "creatorContext": {
+    "kind": "automation",
+    "automationRunId": "6bf8..."
+  }
+}
+```
+
+Required:
+
+```text
+mode = worktree
+repoRootId
+targetPath
+newBranchName
+```
+
+Optional:
+
+```text
+baseBranch
+setupScript
+origin
+creatorContext
+```
+
+Worker behavior:
+
+```text
+POST /v1/workspaces/worktrees
+{
+  "repoRootId": payload.repoRootId,
+  "targetPath": payload.targetPath,
+  "newBranchName": payload.newBranchName,
+  "baseBranch": payload.baseBranch,
+  "setupScript": payload.setupScript,
+  "origin": payload.origin,
+  "creatorContext": payload.creatorContext
+}
+```
+
+For this PR, `setupScript` may be passed through to AnyHarness if the endpoint
+already supports it. Do not add worker-side setup-script execution.
+
+## Result Schema
+
+The worker command result should be stable and independent of raw AnyHarness
+response details:
+
+```json
+{
+  "mode": "worktree",
+  "anyharnessWorkspaceId": "workspace_abc",
+  "repoRootId": "repo_root_abc",
+  "path": "/home/ubuntu/proliferate/workspaces/acme-api-run-6bf8",
+  "kind": "worktree",
+  "currentBranch": "proliferate/automation-6bf8",
+  "originalBranch": "main",
+  "displayName": "acme-api-run-6bf8"
+}
+```
+
+Required:
+
+```text
+mode
+anyharnessWorkspaceId
+repoRootId
+path
+kind
+```
+
+Optional:
+
+```text
+currentBranch
+originalBranch
+displayName
+```
+
+The command result may still include the raw AnyHarness response under the
+existing `body` wrapper used by worker command reporting, but consumers should
+read the stable result fields.
+
+## Server Changes
+
+### Constants
+
+File:
+
+```text
+server/proliferate/constants/cloud.py
+```
+
+Changes:
+
+- add `CloudCommandKind.materialize_workspace`
+- add to `ACTIVE_CLOUD_COMMAND_KINDS`
+- add to `DEFAULT_CLOUD_WORKER_COMMAND_KINDS`
+- keep `materialize_environment` separate
+
+### Validation
+
+File:
+
+```text
+server/proliferate/server/cloud/commands/domain/rules.py
+```
+
+Changes:
+
+- `materialize_workspace` must require `target_id`
+- `materialize_workspace` must reject `session_id`
+- `materialize_workspace` must accept absent `workspace_id`
+- validate payload shape:
+  - `mode` is `existing_path` or `worktree`
+  - required fields for each mode are present and non-empty strings
+  - reject unknown mode
+  - reject payload over existing command size cap
+
+Keep validation pure. Do not query the database from this file.
+
+### API Models
+
+File:
+
+```text
+server/proliferate/server/cloud/commands/models.py
+```
+
+Changes:
+
+- add Pydantic models for `MaterializeWorkspacePayload`
+- add Pydantic response helper for typed command result if command responses
+  expose parsed payload/result
+- preserve generic command API compatibility
+
+### Database Migration
+
+Files:
+
+```text
+server/proliferate/db/models/cloud/commands.py
+server/alembic/versions/<new_revision>_cloud_materialize_workspace_command.py
+```
+
+If command kind is enforced by a check constraint, update it to include:
+
+```text
+materialize_workspace
+```
+
+The migration should be idempotent in the style of existing migrations.
+
+## Worker Changes
+
+### Cloud Client Command List
+
+File:
+
+```text
+anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+```
+
+Changes:
+
+- add `"materialize_workspace"` to `SUPPORTED_COMMAND_KINDS`
+
+### AnyHarness Workspace Client
+
+New file:
+
+```text
+anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
+```
+
+Changes:
+
+- add `AnyHarnessClient::create_workspace`
+- add `AnyHarnessClient::create_worktree_workspace`
+- parse response into a typed Rust struct, not loose `serde_json::Value`
+  where practical
+
+Expected structs:
+
+```rust
+pub struct AnyHarnessWorkspaceCommandResponse {
+    pub status: StatusCode,
+    pub body: serde_json::Value,
+}
+
+pub struct MaterializedWorkspaceResult {
+    pub mode: String,
+    pub anyharness_workspace_id: String,
+    pub repo_root_id: String,
+    pub path: String,
+    pub kind: String,
+    pub current_branch: Option<String>,
+    pub original_branch: Option<String>,
+    pub display_name: Option<String>,
+}
+```
+
+If sharing `AnyHarnessCommandResponse` is simpler, keep the response type
+shared but extract the typed result before reporting the command result.
+
+Update:
+
+```text
+anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+```
+
+to expose the new module.
+
+### Payload Mapping
+
+File:
+
+```text
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
+```
+
+Changes:
+
+- add `AnyHarnessCommand::MaterializeWorkspace`
+- parse a typed `MaterializeWorkspacePayload`
+- reject invalid mode or missing fields with stable error codes
+- map `existing_path` to AnyHarness create-workspace request
+- map `worktree` to AnyHarness create-worktree request
+
+Suggested worker-side enum:
+
+```rust
+#[derive(Debug, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+enum MaterializeWorkspacePayload {
+    ExistingPath {
+        path: String,
+        #[serde(default)]
+        display_name: Option<String>,
+        #[serde(default)]
+        origin: Option<Value>,
+        #[serde(default)]
+        creator_context: Option<Value>,
+    },
+    Worktree {
+        repo_root_id: String,
+        target_path: String,
+        new_branch_name: String,
+        #[serde(default)]
+        base_branch: Option<String>,
+        #[serde(default)]
+        setup_script: Option<String>,
+        #[serde(default)]
+        origin: Option<Value>,
+        #[serde(default)]
+        creator_context: Option<Value>,
+    },
+}
+```
+
+Use `deny_unknown_fields` unless existing command payload compatibility makes
+that risky. Prefer strict parsing for this new command.
+
+### Dispatcher
+
+File:
+
+```text
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+```
+
+Changes:
+
+- advertise `materialize_workspace`
+- dispatch it only when AnyHarness is healthy
+- call the new AnyHarness workspace client method
+- report stable result fields
+- register the new workspace for sync if the command succeeds
+
+Registration detail:
+
+```text
+store.upsert_sync_session(...) is session-scoped and should not be reused for
+workspace-only commands unless the store already has a workspace sync table.
+```
+
+If no workspace-sync store exists yet, PR B should not invent a large sync
+store. Return the workspace id in command result and let PR C decide how to
+wire automation run state to Cloud workspace/session rows.
+
+## AnyHarness API Dependency
+
+This PR should use existing AnyHarness APIs:
+
+```text
+POST /v1/workspaces
+POST /v1/workspaces/worktrees
+```
+
+Do not change AnyHarness APIs unless the current contract lacks a required
+field. If a field is missing:
+
+- add it to `anyharness-contract`
+- update the HTTP handler
+- regenerate or update OpenAPI as the repo expects
+- add focused AnyHarness tests
+
+Known existing request types:
+
+```text
+CreateWorkspaceRequest
+CreateWorktreeWorkspaceRequest
+WorkspaceCreatorContext
+OriginContext
+```
+
+## Command Sequencing After PR B
+
+Existing path session:
+
+```text
+CloudCommand materialize_workspace(mode=existing_path)
+  -> worker returns anyharnessWorkspaceId
+
+CloudCommand start_session(workspaceId=anyharnessWorkspaceId)
+  -> worker returns session id
+```
+
+Automation worktree session:
+
+```text
+CloudCommand materialize_workspace(mode=worktree)
+  -> worker returns anyharnessWorkspaceId
+
+CloudCommand materialize_environment(targetConfigId, configVersion)
+  -> worker applies env/credentials/MCP/skills to workspace path
+
+CloudCommand start_session(workspaceId=anyharnessWorkspaceId, session bundle)
+  -> worker starts agent
+
+CloudCommand send_prompt
+  -> worker sends automation prompt
+```
+
+PR C may choose to reorder `materialize_environment` before or after
+`materialize_workspace` if the target config plan already contains a final path.
+The preferred order is workspace first, environment second.
+
+## Tests
+
+### Server Unit Tests
+
+Files:
+
+```text
+server/tests/unit/test_cloud_commands.py
+server/tests/unit/test_cloud_worker_commands.py
+```
+
+Add tests:
+
+- accepts valid `materialize_workspace` `existing_path` payload
+- accepts valid `materialize_workspace` `worktree` payload
+- rejects missing path in `existing_path`
+- rejects missing `repoRootId`, `targetPath`, or `newBranchName` in `worktree`
+- rejects `session_id` on `materialize_workspace`
+- allows absent `workspace_id` on `materialize_workspace`
+- check constraint/migration includes command kind
+
+### Worker Rust Tests
+
+Files:
+
+```text
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
+```
+
+Add tests:
+
+- parses `existing_path` payload
+- parses `worktree` payload
+- rejects unknown mode
+- rejects missing required fields
+- maps request body to AnyHarness camelCase fields
+- extracts stable result fields from AnyHarness response
+
+### Integration/Smoke
+
+No full automation smoke is required in this PR.
+
+Minimal existing-path smoke:
+
+```text
+1. start local AnyHarness
+2. enqueue materialize_workspace existing_path command for local/SSH target
+3. worker leases command
+4. AnyHarness workspace appears in /v1/workspaces
+5. command result includes anyharnessWorkspaceId
+```
+
+Minimal worktree smoke:
+
+```text
+1. start local AnyHarness with a repo root registered or resolvable
+2. enqueue materialize_workspace worktree command with:
+     repoRootId
+     targetPath under the target default workspace root
+     newBranchName
+     baseBranch
+3. worker leases command
+4. target filesystem contains the expected worktree path
+5. AnyHarness workspace appears in /v1/workspaces with kind=worktree
+6. command result includes:
+     anyharnessWorkspaceId
+     anyharnessRepoRootId when available
+     path
+     kind=worktree
+     branch/newBranchName
+```
+
+The worktree smoke is the important handoff to PR C. Automations should be
+able to take the returned workspace id/path and attach them to
+`automation_run.cloud_workspace_id` and
+`automation_run.anyharness_workspace_id` without any direct Cloud ->
+AnyHarness workspace call.
+
+If this is too expensive for CI, keep it as a local smoke command and cover
+server/worker mapping in unit tests.
+
+## Completion Checklist
+
+- [ ] `materialize_workspace` is an active CloudCommand kind
+- [ ] worker advertises `materialize_workspace`
+- [ ] server validates payload shape
+- [ ] worker strictly parses payload shape
+- [ ] worker calls AnyHarness workspace and worktree APIs
+- [ ] command result exposes stable workspace fields
+- [ ] worktree command returns enough path/branch/repo-root data for automation
+      run attachment
+- [ ] no MCP/session bundle logic is added to this command
+- [ ] no automation migration occurs in this PR
+- [ ] docs explain the difference between `materialize_workspace` and
+      `materialize_environment`
+
+## Review Questions
+
+Reviewers should be able to answer:
+
+1. Which command creates an AnyHarness workspace?
+2. Which command applies env/credentials/MCP/skills files?
+3. Does `start_session` require an existing AnyHarness workspace id?
+4. Can an SSH target and managed cloud target use the same command?
+5. Does the command result give PR C enough data to attach automation runs to
+   the workspace?
+6. For automation worktrees, which path and branch did Cloud request, and which
+   workspace id did AnyHarness return?
+
+If any answer is unclear, the PR is not finished.


### PR DESCRIPTION
## Summary

- Adds the Cloud Worker implementation phase plan and PR stack review guide.
- Adds concrete specs for the supervised runtime bundle, `materialize_workspace` command, and target-agnostic automation command pipeline.
- Links the Cloud Worker implementation specs from the docs index so follow-up implementation PRs have stable references.

## Validation

- `git diff --check`
- searched docs for forbidden `codex` naming
