### PR TITLE
feat(cloud): add worker workspace materialization command

### DIFF
--- a/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
@@ -2,6 +2,7 @@ pub mod backfill;
 pub mod events;
 pub mod health;
 pub mod sessions;
+pub mod workspaces;
 
 use std::time::Duration;
 

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/sessions.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/sessions.rs
@@ -256,7 +256,7 @@ fn normalized_control_unavailable_response(control_id: &str) -> AnyHarnessComman
     }
 }
 
-async fn parse_anyharness_response(
+pub(crate) async fn parse_anyharness_response(
     response: reqwest::Response,
 ) -> Result<AnyHarnessCommandResponse, WorkerError> {
     let status = response.status();

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
@@ -1,0 +1,469 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tracing::warn;
+
+use crate::error::WorkerError;
+
+use super::{
+    sessions::{parse_anyharness_response, AnyHarnessCommandResponse},
+    AnyHarnessClient,
+};
+
+const WORKSPACE_MATERIALIZE_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MaterializeWorkspaceRequest {
+    ExistingPath {
+        path: String,
+        #[serde(rename = "displayName")]
+        display_name: Option<String>,
+        origin: Option<Value>,
+        #[serde(rename = "creatorContext")]
+        creator_context: Option<Value>,
+    },
+    Worktree {
+        #[serde(rename = "repoRootId")]
+        repo_root_id: String,
+        #[serde(rename = "targetPath")]
+        target_path: String,
+        #[serde(rename = "newBranchName")]
+        new_branch_name: String,
+        #[serde(rename = "baseBranch")]
+        base_branch: Option<String>,
+        #[serde(rename = "setupScript")]
+        setup_script: Option<String>,
+        origin: Option<Value>,
+        #[serde(rename = "creatorContext")]
+        creator_context: Option<Value>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterializedWorkspaceResult {
+    pub mode: String,
+    pub anyharness_workspace_id: String,
+    pub repo_root_id: String,
+    pub path: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+impl MaterializeWorkspaceRequest {
+    pub fn mode(&self) -> &'static str {
+        match self {
+            Self::ExistingPath { .. } => "existing_path",
+            Self::Worktree { .. } => "worktree",
+        }
+    }
+
+    fn repo_root_id_hint(&self) -> Option<&str> {
+        match self {
+            Self::ExistingPath { .. } => None,
+            Self::Worktree { repo_root_id, .. } => Some(repo_root_id.as_str()),
+        }
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        match self {
+            Self::ExistingPath { display_name, .. } => display_name.as_deref(),
+            Self::Worktree { .. } => None,
+        }
+    }
+
+    fn anyharness_body(&self) -> Value {
+        match self {
+            Self::ExistingPath {
+                path,
+                origin,
+                creator_context,
+                ..
+            } => compact_object(json!({
+                "path": path,
+                "origin": origin,
+                "creatorContext": creator_context,
+            })),
+            Self::Worktree {
+                repo_root_id,
+                target_path,
+                new_branch_name,
+                base_branch,
+                setup_script,
+                origin,
+                creator_context,
+            } => compact_object(json!({
+                "repoRootId": repo_root_id,
+                "targetPath": target_path,
+                "newBranchName": new_branch_name,
+                "baseBranch": base_branch,
+                "setupScript": setup_script,
+                "origin": origin,
+                "creatorContext": creator_context,
+            })),
+        }
+    }
+
+    fn resolve_body(&self) -> Value {
+        match self {
+            Self::ExistingPath {
+                path,
+                origin,
+                creator_context,
+                ..
+            } => compact_object(json!({
+                "path": path,
+                "origin": origin,
+                "creatorContext": creator_context,
+            })),
+            Self::Worktree {
+                target_path,
+                origin,
+                creator_context,
+                ..
+            } => compact_object(json!({
+                "path": target_path,
+                "origin": origin,
+                "creatorContext": creator_context,
+            })),
+        }
+    }
+
+    pub fn materialized_result(
+        &self,
+        response_body: &Value,
+    ) -> Result<MaterializedWorkspaceResult, String> {
+        let workspace = response_body
+            .get("workspace")
+            .ok_or_else(|| "AnyHarness response must contain workspace.".to_string())?;
+        let anyharness_workspace_id = required_string(workspace, "id")?;
+        let repo_root_id = string_field(workspace, "repoRootId")
+            .or_else(|| {
+                response_body
+                    .get("repoRoot")
+                    .and_then(|repo_root| string_field(repo_root, "id"))
+            })
+            .or_else(|| self.repo_root_id_hint().map(ToOwned::to_owned))
+            .ok_or_else(|| {
+                "AnyHarness response must contain workspace.repoRootId or repoRoot.id.".to_string()
+            })?;
+        Ok(MaterializedWorkspaceResult {
+            mode: self.mode().to_string(),
+            anyharness_workspace_id,
+            repo_root_id,
+            path: required_string(workspace, "path")?,
+            kind: required_string(workspace, "kind")?,
+            current_branch: string_field(workspace, "currentBranch"),
+            original_branch: string_field(workspace, "originalBranch"),
+            display_name: string_field(workspace, "displayName"),
+        })
+    }
+
+    fn recovered_worktree_is_expected(&self, response_body: &Value) -> bool {
+        let Self::Worktree {
+            repo_root_id,
+            new_branch_name,
+            ..
+        } = self
+        else {
+            return false;
+        };
+        let Ok(result) = self.materialized_result(response_body) else {
+            return false;
+        };
+        if result.kind != "worktree" || result.repo_root_id != *repo_root_id {
+            return false;
+        }
+        match result.current_branch.as_deref() {
+            Some(current_branch) => current_branch == new_branch_name,
+            None => true,
+        }
+    }
+}
+
+impl AnyHarnessClient {
+    pub async fn materialize_workspace(
+        &self,
+        request: &MaterializeWorkspaceRequest,
+    ) -> Result<AnyHarnessCommandResponse, WorkerError> {
+        let path = match request {
+            MaterializeWorkspaceRequest::ExistingPath { .. } => "/v1/workspaces/resolve",
+            MaterializeWorkspaceRequest::Worktree { .. } => "/v1/workspaces/worktrees",
+        };
+        let response = self
+            .authenticate(self.http().post(format!("{}{}", self.base_url(), path)))
+            .timeout(WORKSPACE_MATERIALIZE_TIMEOUT)
+            .json(&request.anyharness_body())
+            .send()
+            .await?;
+        let mut response = parse_anyharness_response(response).await?;
+        if !response.is_success() {
+            if let Some(recovered) = self.recover_materialized_workspace(request).await? {
+                response = recovered;
+            }
+        }
+        if response.is_success() {
+            self.apply_display_name_if_requested(request, &mut response)
+                .await?;
+        }
+        Ok(response)
+    }
+
+    async fn recover_materialized_workspace(
+        &self,
+        request: &MaterializeWorkspaceRequest,
+    ) -> Result<Option<AnyHarnessCommandResponse>, WorkerError> {
+        if !matches!(request, MaterializeWorkspaceRequest::Worktree { .. }) {
+            return Ok(None);
+        }
+        let response = self
+            .authenticate(
+                self.http()
+                    .post(format!("{}/v1/workspaces/resolve", self.base_url())),
+            )
+            .timeout(WORKSPACE_MATERIALIZE_TIMEOUT)
+            .json(&request.resolve_body())
+            .send()
+            .await?;
+        let response = parse_anyharness_response(response).await?;
+        if response.is_success() && request.recovered_worktree_is_expected(&response.body) {
+            return Ok(Some(response));
+        }
+        Ok(None)
+    }
+
+    async fn apply_display_name_if_requested(
+        &self,
+        request: &MaterializeWorkspaceRequest,
+        response: &mut AnyHarnessCommandResponse,
+    ) -> Result<(), WorkerError> {
+        let Some(display_name) = request
+            .display_name()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(());
+        };
+        let Some(workspace_id) = response
+            .body
+            .get("workspace")
+            .and_then(|workspace| string_field(workspace, "id"))
+        else {
+            return Ok(());
+        };
+        let display_response = match self
+            .update_workspace_display_name(&workspace_id, display_name)
+            .await
+        {
+            Ok(display_response) => display_response,
+            Err(error) => {
+                warn!(?error, workspace_id, "failed to set workspace display name");
+                return Ok(());
+            }
+        };
+        if display_response.is_success() {
+            if let Value::Object(object) = &mut response.body {
+                object.insert("workspace".to_string(), display_response.body);
+            }
+        } else if let Value::Object(object) = &mut response.body {
+            object.insert(
+                "displayNameUpdate".to_string(),
+                json!({
+                    "statusCode": display_response.status.as_u16(),
+                    "body": display_response.body,
+                }),
+            );
+        }
+        Ok(())
+    }
+
+    async fn update_workspace_display_name(
+        &self,
+        workspace_id: &str,
+        display_name: &str,
+    ) -> Result<AnyHarnessCommandResponse, WorkerError> {
+        let response = self
+            .authenticate(self.http().patch(format!(
+                "{}/v1/workspaces/{}/display-name",
+                self.base_url(),
+                workspace_id
+            )))
+            .json(&json!({ "displayName": display_name }))
+            .send()
+            .await?;
+        parse_anyharness_response(response).await
+    }
+}
+
+fn compact_object(value: Value) -> Value {
+    let Value::Object(object) = value else {
+        return value;
+    };
+    Value::Object(
+        object
+            .into_iter()
+            .filter(|(_key, value)| !value.is_null())
+            .collect(),
+    )
+}
+
+fn required_string(value: &Value, field: &str) -> Result<String, String> {
+    string_field(value, field).ok_or_else(|| format!("AnyHarness response must contain {field}."))
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::MaterializeWorkspaceRequest;
+
+    #[test]
+    fn materialized_result_extracts_existing_path_fields() {
+        let request = MaterializeWorkspaceRequest::ExistingPath {
+            path: "/workspace/proliferate".to_string(),
+            display_name: Some("Proliferate".to_string()),
+            origin: None,
+            creator_context: None,
+        };
+        let result = request
+            .materialized_result(&json!({
+                "repoRoot": { "id": "repo-root-1" },
+                "workspace": {
+                    "id": "workspace-1",
+                    "repoRootId": "repo-root-1",
+                    "path": "/workspace/proliferate",
+                    "kind": "local",
+                    "currentBranch": "main",
+                    "displayName": "Proliferate"
+                }
+            }))
+            .expect("result");
+        assert_eq!(result.mode, "existing_path");
+        assert_eq!(result.anyharness_workspace_id, "workspace-1");
+        assert_eq!(result.repo_root_id, "repo-root-1");
+        assert_eq!(result.display_name.as_deref(), Some("Proliferate"));
+    }
+
+    #[test]
+    fn existing_path_body_does_not_pass_display_name_to_anyharness_create_body() {
+        let request = MaterializeWorkspaceRequest::ExistingPath {
+            path: "/workspace/proliferate".to_string(),
+            display_name: Some("Proliferate".to_string()),
+            origin: Some(json!({ "kind": "api", "entrypoint": "cloud" })),
+            creator_context: Some(json!({ "kind": "human" })),
+        };
+        assert_eq!(
+            request.anyharness_body(),
+            json!({
+                "path": "/workspace/proliferate",
+                "origin": { "kind": "api", "entrypoint": "cloud" },
+                "creatorContext": { "kind": "human" }
+            })
+        );
+    }
+
+    #[test]
+    fn materialized_result_uses_worktree_repo_root_hint() {
+        let request = MaterializeWorkspaceRequest::Worktree {
+            repo_root_id: "repo-root-1".to_string(),
+            target_path: "/workspace/feature".to_string(),
+            new_branch_name: "feature".to_string(),
+            base_branch: Some("main".to_string()),
+            setup_script: None,
+            origin: None,
+            creator_context: None,
+        };
+        let result = request
+            .materialized_result(&json!({
+                "workspace": {
+                    "id": "workspace-2",
+                    "path": "/workspace/feature",
+                    "kind": "worktree",
+                    "currentBranch": "feature",
+                    "originalBranch": "main"
+                }
+            }))
+            .expect("result");
+        assert_eq!(result.mode, "worktree");
+        assert_eq!(result.repo_root_id, "repo-root-1");
+    }
+
+    #[test]
+    fn worktree_body_uses_anyharness_camel_case_fields() {
+        let request = MaterializeWorkspaceRequest::Worktree {
+            repo_root_id: "repo-root-1".to_string(),
+            target_path: "/workspace/feature".to_string(),
+            new_branch_name: "feature".to_string(),
+            base_branch: Some("main".to_string()),
+            setup_script: Some("pnpm install".to_string()),
+            origin: None,
+            creator_context: None,
+        };
+        assert_eq!(
+            request.anyharness_body(),
+            json!({
+                "repoRootId": "repo-root-1",
+                "targetPath": "/workspace/feature",
+                "newBranchName": "feature",
+                "baseBranch": "main",
+                "setupScript": "pnpm install"
+            })
+        );
+    }
+
+    #[test]
+    fn worktree_recovery_requires_expected_workspace_shape() {
+        let request = MaterializeWorkspaceRequest::Worktree {
+            repo_root_id: "repo-root-1".to_string(),
+            target_path: "/workspace/feature".to_string(),
+            new_branch_name: "feature".to_string(),
+            base_branch: Some("main".to_string()),
+            setup_script: None,
+            origin: None,
+            creator_context: None,
+        };
+        assert!(request.recovered_worktree_is_expected(&json!({
+            "workspace": {
+                "id": "workspace-2",
+                "repoRootId": "repo-root-1",
+                "path": "/workspace/feature",
+                "kind": "worktree",
+                "currentBranch": "feature"
+            }
+        })));
+        assert!(!request.recovered_worktree_is_expected(&json!({
+            "workspace": {
+                "id": "workspace-2",
+                "repoRootId": "repo-root-1",
+                "path": "/workspace/feature",
+                "kind": "worktree",
+                "currentBranch": "other"
+            }
+        })));
+        assert!(!request.recovered_worktree_is_expected(&json!({
+            "workspace": {
+                "id": "workspace-2",
+                "repoRootId": "other-root",
+                "path": "/workspace/feature",
+                "kind": "worktree",
+                "currentBranch": "feature"
+            }
+        })));
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
@@ -56,6 +56,7 @@ pub struct CommandResultRequest {
 
 pub const SUPPORTED_COMMAND_KINDS: &[&str] = &[
     "start_session",
+    "materialize_workspace",
     "materialize_environment",
     "send_prompt",
     "resolve_interaction",

--- a/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
@@ -382,6 +382,9 @@ async fn dispatch_anyharness(
 ) -> Result<AnyHarnessCommandResponse, WorkerError> {
     match command {
         AnyHarnessCommand::StartSession { body } => anyharness.start_session(body).await,
+        AnyHarnessCommand::MaterializeWorkspace { request } => {
+            anyharness.materialize_workspace(request).await
+        }
         AnyHarnessCommand::SendPrompt { session_id, body } => {
             anyharness.send_prompt(session_id, body).await
         }
@@ -419,15 +422,21 @@ fn command_result(
     response: Result<AnyHarnessCommandResponse, WorkerError>,
 ) -> CommandResultRequest {
     match response {
-        Ok(response) if response.is_success() => CommandResultRequest {
-            lease_id: command.lease_id.clone(),
-            status: accepted_status(mapped, &response).to_string(),
-            error_code: None,
-            error_message: None,
-            result: Some(json!({
-                "anyharnessStatusCode": response.status.as_u16(),
-                "body": response.body,
-            })),
+        Ok(response) if response.is_success() => match success_result(mapped, &response) {
+            Ok(result) => CommandResultRequest {
+                lease_id: command.lease_id.clone(),
+                status: accepted_status(mapped, &response).to_string(),
+                error_code: None,
+                error_message: None,
+                result: Some(result),
+            },
+            Err(error) => CommandResultRequest {
+                lease_id: command.lease_id.clone(),
+                status: "rejected".to_string(),
+                error_code: Some(error.code),
+                error_message: Some(error.message),
+                result: Some(error.result),
+            },
         },
         Ok(response) => {
             let status_code = response.status.as_u16();
@@ -463,6 +472,48 @@ fn command_result(
     }
 }
 
+struct SuccessResultError {
+    code: String,
+    message: String,
+    result: Value,
+}
+
+fn success_result(
+    command: &AnyHarnessCommand,
+    response: &AnyHarnessCommandResponse,
+) -> Result<Value, SuccessResultError> {
+    match command {
+        AnyHarnessCommand::MaterializeWorkspace { request } => {
+            match request.materialized_result(&response.body) {
+                Ok(result) => {
+                    let mut value = serde_json::to_value(result).unwrap_or_else(|_| json!({}));
+                    if let Value::Object(object) = &mut value {
+                        object.insert(
+                            "anyharnessStatusCode".to_string(),
+                            Value::from(response.status.as_u16()),
+                        );
+                        object.insert("body".to_string(), response.body.clone());
+                    }
+                    Ok(value)
+                }
+                Err(message) => Err(SuccessResultError {
+                    code: "invalid_anyharness_workspace_response".to_string(),
+                    message: message.clone(),
+                    result: json!({
+                        "anyharnessStatusCode": response.status.as_u16(),
+                        "resultExtractionError": message,
+                        "body": response.body.clone(),
+                    }),
+                }),
+            }
+        }
+        _ => Ok(json!({
+            "anyharnessStatusCode": response.status.as_u16(),
+            "body": response.body.clone(),
+        })),
+    }
+}
+
 fn accepted_status(
     command: &AnyHarnessCommand,
     response: &AnyHarnessCommandResponse,
@@ -495,6 +546,7 @@ fn register_session_for_sync(
             .get("id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
+        AnyHarnessCommand::MaterializeWorkspace { .. } => None,
         AnyHarnessCommand::SendPrompt { session_id, .. }
         | AnyHarnessCommand::ResolveInteraction { session_id, .. }
         | AnyHarnessCommand::UpdateSessionConfig { session_id, .. }
@@ -510,4 +562,75 @@ fn register_session_for_sync(
         .as_deref()
         .or_else(|| response.body.get("workspaceId").and_then(Value::as_str));
     store.upsert_sync_session(&session_id, workspace_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::StatusCode;
+    use serde_json::json;
+
+    use crate::{
+        anyharness_client::{
+            sessions::AnyHarnessCommandResponse, workspaces::MaterializeWorkspaceRequest,
+        },
+        cloud_client::commands::CloudCommandEnvelope,
+        commands::mapping::AnyHarnessCommand,
+    };
+
+    use super::command_result;
+
+    #[test]
+    fn materialize_workspace_result_extraction_failure_rejects_command() {
+        let command = test_command();
+        let mapped = AnyHarnessCommand::MaterializeWorkspace {
+            request: MaterializeWorkspaceRequest::ExistingPath {
+                path: "/workspace/proliferate".to_string(),
+                display_name: None,
+                origin: None,
+                creator_context: None,
+            },
+        };
+        let result = command_result(
+            &command,
+            &mapped,
+            Ok(AnyHarnessCommandResponse {
+                status: StatusCode::OK,
+                body: json!({
+                    "workspace": {
+                        "path": "/workspace/proliferate",
+                        "kind": "local"
+                    }
+                }),
+            }),
+        );
+        assert_eq!(result.status, "rejected");
+        assert_eq!(
+            result.error_code.as_deref(),
+            Some("invalid_anyharness_workspace_response")
+        );
+        assert_eq!(
+            result
+                .result
+                .as_ref()
+                .and_then(|value| value.get("resultExtractionError"))
+                .and_then(serde_json::Value::as_str),
+            Some("AnyHarness response must contain id.")
+        );
+    }
+
+    fn test_command() -> CloudCommandEnvelope {
+        CloudCommandEnvelope {
+            command_id: "command-1".to_string(),
+            idempotency_key: "key-1".to_string(),
+            target_id: "target-1".to_string(),
+            workspace_id: None,
+            session_id: None,
+            kind: "materialize_workspace".to_string(),
+            payload: json!({}),
+            observed_event_seq: None,
+            preconditions: None,
+            lease_id: "lease-1".to_string(),
+            lease_expires_at: "2026-05-14T00:00:00Z".to_string(),
+        }
+    }
 }

--- a/anyharness/crates/proliferate-worker/src/commands/mapping.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/mapping.rs
@@ -1,11 +1,17 @@
 use serde_json::{json, Map, Value};
 
-use crate::cloud_client::commands::CloudCommandEnvelope;
+use crate::{
+    anyharness_client::workspaces::MaterializeWorkspaceRequest,
+    cloud_client::commands::CloudCommandEnvelope,
+};
 
 #[derive(Debug)]
 pub enum AnyHarnessCommand {
     StartSession {
         body: Value,
+    },
+    MaterializeWorkspace {
+        request: MaterializeWorkspaceRequest,
     },
     SendPrompt {
         session_id: String,
@@ -54,6 +60,9 @@ pub fn map_cloud_command(
     match command.kind.as_str() {
         "start_session" => Ok(AnyHarnessCommand::StartSession {
             body: start_session_body(command)?,
+        }),
+        "materialize_workspace" => Ok(AnyHarnessCommand::MaterializeWorkspace {
+            request: materialize_workspace_request(&command.payload)?,
         }),
         "send_prompt" => Ok(AnyHarnessCommand::SendPrompt {
             session_id: require_session_id(command)?,
@@ -128,6 +137,46 @@ fn start_session_body(command: &CloudCommandEnvelope) -> Result<Value, CommandMa
     body.entry("origin".to_string())
         .or_insert_with(|| json!({ "kind": "system", "entrypoint": "cloud" }));
     Ok(Value::Object(body))
+}
+
+fn materialize_workspace_request(
+    payload: &Value,
+) -> Result<MaterializeWorkspaceRequest, CommandMappingError> {
+    let request: MaterializeWorkspaceRequest =
+        serde_json::from_value(payload.clone()).map_err(|error| {
+            CommandMappingError::new(
+                "invalid_materialize_workspace_payload",
+                format!("materialize_workspace payload is invalid: {error}"),
+            )
+        })?;
+    match &request {
+        MaterializeWorkspaceRequest::ExistingPath { path, .. } => {
+            require_non_empty(path, "path", "invalid_materialize_workspace_payload")?;
+        }
+        MaterializeWorkspaceRequest::Worktree {
+            repo_root_id,
+            target_path,
+            new_branch_name,
+            ..
+        } => {
+            require_non_empty(
+                repo_root_id,
+                "repoRootId",
+                "invalid_materialize_workspace_payload",
+            )?;
+            require_non_empty(
+                target_path,
+                "targetPath",
+                "invalid_materialize_workspace_payload",
+            )?;
+            require_non_empty(
+                new_branch_name,
+                "newBranchName",
+                "invalid_materialize_workspace_payload",
+            )?;
+        }
+    }
+    Ok(request)
 }
 
 fn require_session_id(command: &CloudCommandEnvelope) -> Result<String, CommandMappingError> {
@@ -241,4 +290,110 @@ fn string_field(object: &Map<String, Value>, primary: &str, fallback: &str) -> O
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn require_non_empty(
+    value: &str,
+    field: &str,
+    code: &'static str,
+) -> Result<(), CommandMappingError> {
+    if value.trim().is_empty() {
+        return Err(CommandMappingError::new(
+            code,
+            format!("materialize_workspace payload must contain non-empty {field}."),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::cloud_client::commands::CloudCommandEnvelope;
+
+    use super::{map_cloud_command, AnyHarnessCommand};
+
+    #[test]
+    fn maps_existing_path_workspace_materialization() {
+        let command = test_command(json!({
+            "mode": "existing_path",
+            "path": "/workspace/proliferate",
+            "displayName": "Proliferate",
+            "origin": { "kind": "api", "entrypoint": "cloud" },
+            "creatorContext": { "kind": "human", "label": "Pablo" }
+        }));
+        let mapped = map_cloud_command(&command).expect("mapped");
+        let AnyHarnessCommand::MaterializeWorkspace { request } = mapped else {
+            panic!("expected materialize workspace");
+        };
+        assert_eq!(request.mode(), "existing_path");
+        let result = request
+            .materialized_result(&json!({
+                "repoRoot": { "id": "repo-root-1" },
+                "workspace": {
+                    "id": "workspace-1",
+                    "repoRootId": "repo-root-1",
+                    "path": "/workspace/proliferate",
+                    "kind": "local",
+                    "displayName": "Proliferate"
+                }
+            }))
+            .expect("result");
+        assert_eq!(result.display_name.as_deref(), Some("Proliferate"));
+    }
+
+    #[test]
+    fn maps_worktree_workspace_materialization() {
+        let command = test_command(json!({
+            "mode": "worktree",
+            "repoRootId": "repo-root-1",
+            "targetPath": "/workspace/feature",
+            "newBranchName": "feature",
+            "baseBranch": "main",
+            "setupScript": "pnpm install"
+        }));
+        let mapped = map_cloud_command(&command).expect("mapped");
+        let AnyHarnessCommand::MaterializeWorkspace { request } = mapped else {
+            panic!("expected materialize workspace");
+        };
+        assert_eq!(request.mode(), "worktree");
+        let result = request
+            .materialized_result(&json!({
+                "workspace": {
+                    "id": "workspace-2",
+                    "path": "/workspace/feature",
+                    "kind": "worktree"
+                }
+            }))
+            .expect("result");
+        assert_eq!(result.repo_root_id, "repo-root-1");
+    }
+
+    #[test]
+    fn rejects_invalid_workspace_materialization_payload() {
+        let command = test_command(json!({
+            "mode": "worktree",
+            "repoRootId": "repo-root-1",
+            "targetPath": "/workspace/feature"
+        }));
+        let error = map_cloud_command(&command).expect_err("error");
+        assert_eq!(error.code, "invalid_materialize_workspace_payload");
+    }
+
+    fn test_command(payload: serde_json::Value) -> CloudCommandEnvelope {
+        CloudCommandEnvelope {
+            command_id: "command-1".to_string(),
+            idempotency_key: "key-1".to_string(),
+            target_id: "target-1".to_string(),
+            workspace_id: None,
+            session_id: None,
+            kind: "materialize_workspace".to_string(),
+            payload,
+            observed_event_seq: None,
+            preconditions: None,
+            lease_id: "lease-1".to_string(),
+            lease_expires_at: "2026-05-14T00:00:00Z".to_string(),
+        }
+    }
 }

--- a/server/alembic/versions/d3e4f5a6b7c8_cloud_materialize_workspace_command.py
+++ b/server/alembic/versions/d3e4f5a6b7c8_cloud_materialize_workspace_command.py
@@ -1,0 +1,89 @@
+"""cloud materialize workspace command
+
+Revision ID: d3e4f5a6b7c8
+Revises: d2e3f4a5b6c7
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3e4f5a6b7c8"
+down_revision: str | Sequence[str] | None = "d2e3f4a5b6c7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_OLD_COMMAND_KINDS = (
+    "start_session",
+    "materialize_environment",
+    "resume_session",
+    "send_prompt",
+    "resolve_interaction",
+    "update_session_config",
+    "cancel_turn",
+    "close_session",
+    "cancel_session",
+    "stop_workspace",
+    "hibernate_workspace",
+    "resume_workspace",
+    "prune_workspace",
+    "extend_workspace_ttl",
+    "sync_existing_workspace",
+)
+
+_NEW_COMMAND_KINDS = (
+    "start_session",
+    "materialize_workspace",
+    "materialize_environment",
+    "resume_session",
+    "send_prompt",
+    "resolve_interaction",
+    "update_session_config",
+    "cancel_turn",
+    "close_session",
+    "cancel_session",
+    "stop_workspace",
+    "hibernate_workspace",
+    "resume_workspace",
+    "prune_workspace",
+    "extend_workspace_ttl",
+    "sync_existing_workspace",
+)
+
+
+def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
+    return f"{column_name} IN {values}"
+
+
+def _has_check_constraint(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_check_constraints(table_name)
+    }
+
+
+def _replace_command_kind_constraint(values: tuple[str, ...]) -> None:
+    if _has_check_constraint("cloud_commands", "ck_cloud_commands_kind"):
+        op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
+    op.create_check_constraint(
+        "ck_cloud_commands_kind",
+        "cloud_commands",
+        _in_constraint("kind", values),
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _replace_command_kind_constraint(_NEW_COMMAND_KINDS)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DELETE FROM cloud_commands WHERE kind = 'materialize_workspace'")
+    _replace_command_kind_constraint(_OLD_COMMAND_KINDS)

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -252,6 +252,7 @@ CLOUD_TARGET_HEARTBEAT_STALE_SECONDS: Final = 180
 
 class CloudCommandKind(StrEnum):
     start_session = "start_session"
+    materialize_workspace = "materialize_workspace"
     materialize_environment = "materialize_environment"
     resume_session = "resume_session"
     send_prompt = "send_prompt"
@@ -300,6 +301,7 @@ class CloudCommandSource(StrEnum):
 SUPPORTED_CLOUD_COMMAND_KINDS: tuple[str, ...] = tuple(kind.value for kind in CloudCommandKind)
 ACTIVE_CLOUD_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.start_session.value,
+    CloudCommandKind.materialize_workspace.value,
     CloudCommandKind.materialize_environment.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.resolve_interaction.value,
@@ -310,6 +312,7 @@ ACTIVE_CLOUD_COMMAND_KINDS: tuple[str, ...] = (
 )
 DEFAULT_CLOUD_WORKER_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.start_session.value,
+    CloudCommandKind.materialize_workspace.value,
     CloudCommandKind.materialize_environment.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.resolve_interaction.value,

--- a/server/proliferate/db/store/cloud_sync/commands.py
+++ b/server/proliferate/db/store/cloud_sync/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
@@ -9,7 +10,7 @@ from uuid import UUID
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.cloud import CloudCommandStatus
+from proliferate.constants.cloud import CloudCommandKind, CloudCommandStatus
 from proliferate.db.models.cloud.commands import CloudCommand
 from proliferate.utils.time import utcnow
 
@@ -182,9 +183,7 @@ async def expire_command_if_not_terminal(
 ) -> CloudCommandSnapshot | None:
     row = (
         await db.execute(
-            select(CloudCommand)
-            .where(CloudCommand.id == command_id)
-            .with_for_update()
+            select(CloudCommand).where(CloudCommand.id == command_id).with_for_update()
         )
     ).scalar_one_or_none()
     if row is None:
@@ -332,21 +331,76 @@ async def record_command_result(
         CloudCommandStatus.delivered.value,
     }:
         return None
-    row.status = status
-    row.error_code = error_code
-    row.error_message = error_message
+    effective_status = status
+    effective_error_code = error_code
+    effective_error_message = error_message
+    materialized_workspace_id = _materialized_workspace_id(
+        kind=row.kind,
+        status=status,
+        result_json=result_json,
+    )
+    if (
+        row.kind == CloudCommandKind.materialize_workspace.value
+        and status
+        in {
+            CloudCommandStatus.accepted.value,
+            CloudCommandStatus.accepted_but_queued.value,
+        }
+        and materialized_workspace_id is None
+    ):
+        effective_status = CloudCommandStatus.rejected.value
+        effective_error_code = "invalid_materialize_workspace_result"
+        effective_error_message = "materialize_workspace result is missing required stable fields."
+    row.status = effective_status
+    row.error_code = effective_error_code
+    row.error_message = effective_error_message
     row.result_json = result_json
+    if materialized_workspace_id is not None:
+        row.workspace_id = materialized_workspace_id
     row.updated_at = now
-    if status in {
+    if effective_status in {
         CloudCommandStatus.accepted.value,
         CloudCommandStatus.accepted_but_queued.value,
     }:
         row.accepted_at = now
         row.rejected_at = None
-    elif status in {CloudCommandStatus.rejected.value, CloudCommandStatus.failed_delivery.value}:
+    elif effective_status in {
+        CloudCommandStatus.rejected.value,
+        CloudCommandStatus.failed_delivery.value,
+    }:
         row.rejected_at = now
     await db.flush()
     return _snapshot(row)
+
+
+def _materialized_workspace_id(
+    *,
+    kind: str,
+    status: str,
+    result_json: str | None,
+) -> str | None:
+    if kind != CloudCommandKind.materialize_workspace.value or status not in {
+        CloudCommandStatus.accepted.value,
+        CloudCommandStatus.accepted_but_queued.value,
+    }:
+        return None
+    try:
+        result = json.loads(result_json or "{}")
+    except ValueError:
+        return None
+    if not isinstance(result, dict):
+        return None
+    mode = result.get("mode")
+    if mode not in {"existing_path", "worktree"}:
+        return None
+    for field in ("repoRootId", "path", "kind"):
+        value = result.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return None
+    workspace_id = result.get("anyharnessWorkspaceId")
+    if not isinstance(workspace_id, str) or not workspace_id.strip():
+        return None
+    return workspace_id.strip()
 
 
 def _is_terminal_status(status: str) -> bool:

--- a/server/proliferate/server/cloud/commands/domain/rules.py
+++ b/server/proliferate/server/cloud/commands/domain/rules.py
@@ -13,6 +13,25 @@ from proliferate.constants.cloud import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 
+_MATERIALIZE_EXISTING_PATH_FIELDS = {
+    "mode",
+    "path",
+    "displayName",
+    "origin",
+    "creatorContext",
+}
+_MATERIALIZE_WORKTREE_FIELDS = {
+    "mode",
+    "repoRootId",
+    "targetPath",
+    "newBranchName",
+    "baseBranch",
+    "setupScript",
+    "origin",
+    "creatorContext",
+}
+_MAX_MATERIALIZE_WORKSPACE_DISPLAY_NAME_CHARS = 160
+
 
 def validate_active_command_kind(kind: str) -> str:
     if kind not in ACTIVE_CLOUD_COMMAND_KINDS:
@@ -43,10 +62,14 @@ def validate_command_shape(
     session_id: str | None,
     preconditions: dict[str, object] | None,
 ) -> None:
-    if kind in {
-        CloudCommandKind.start_session.value,
-        CloudCommandKind.sync_existing_workspace.value,
-    } and not workspace_id:
+    if (
+        kind
+        in {
+            CloudCommandKind.start_session.value,
+            CloudCommandKind.sync_existing_workspace.value,
+        }
+        and not workspace_id
+    ):
         raise CloudApiError(
             "cloud_command_workspace_required",
             f"Cloud command kind requires workspaceId: {kind}",
@@ -58,13 +81,23 @@ def validate_command_shape(
             "materialize_environment commands must be scoped only to a target.",
             status_code=400,
         )
-    if kind in {
-        CloudCommandKind.send_prompt.value,
-        CloudCommandKind.resolve_interaction.value,
-        CloudCommandKind.update_session_config.value,
-        CloudCommandKind.cancel_turn.value,
-        CloudCommandKind.close_session.value,
-    } and not session_id:
+    if kind == CloudCommandKind.materialize_workspace.value and (workspace_id or session_id):
+        raise CloudApiError(
+            "cloud_command_target_only",
+            "materialize_workspace commands must be scoped only to a target.",
+            status_code=400,
+        )
+    if (
+        kind
+        in {
+            CloudCommandKind.send_prompt.value,
+            CloudCommandKind.resolve_interaction.value,
+            CloudCommandKind.update_session_config.value,
+            CloudCommandKind.cancel_turn.value,
+            CloudCommandKind.close_session.value,
+        }
+        and not session_id
+    ):
         raise CloudApiError(
             "cloud_command_session_required",
             f"Cloud command kind requires sessionId: {kind}",
@@ -74,6 +107,115 @@ def validate_command_shape(
         raise CloudApiError(
             "cloud_command_preconditions_unsupported",
             "Cloud command preconditions are not supported in phase 3.",
+            status_code=400,
+        )
+
+
+def validate_command_payload(*, kind: str, payload: dict[str, object]) -> None:
+    if kind != CloudCommandKind.materialize_workspace.value:
+        return
+    mode = _required_string(
+        payload,
+        "mode",
+        code="cloud_command_materialize_workspace_mode_required",
+        message="materialize_workspace payload must contain mode.",
+    )
+    if mode == "existing_path":
+        _reject_unknown_fields(payload, _MATERIALIZE_EXISTING_PATH_FIELDS)
+        _required_string(
+            payload,
+            "path",
+            code="cloud_command_materialize_workspace_path_required",
+            message="existing_path workspace materialization requires path.",
+        )
+        _optional_string(payload, "displayName")
+        _optional_object(payload, "origin")
+        _optional_object(payload, "creatorContext")
+        return
+    if mode == "worktree":
+        _reject_unknown_fields(payload, _MATERIALIZE_WORKTREE_FIELDS)
+        _required_string(
+            payload,
+            "repoRootId",
+            code="cloud_command_materialize_workspace_repo_root_required",
+            message="worktree workspace materialization requires repoRootId.",
+        )
+        _required_string(
+            payload,
+            "targetPath",
+            code="cloud_command_materialize_workspace_target_path_required",
+            message="worktree workspace materialization requires targetPath.",
+        )
+        _required_string(
+            payload,
+            "newBranchName",
+            code="cloud_command_materialize_workspace_branch_required",
+            message="worktree workspace materialization requires newBranchName.",
+        )
+        _optional_string(payload, "baseBranch")
+        _optional_string(payload, "setupScript")
+        _optional_object(payload, "origin")
+        _optional_object(payload, "creatorContext")
+        return
+    raise CloudApiError(
+        "cloud_command_materialize_workspace_mode_invalid",
+        "materialize_workspace mode must be existing_path or worktree.",
+        status_code=400,
+    )
+
+
+def _required_string(
+    payload: dict[str, object],
+    field: str,
+    *,
+    code: str,
+    message: str,
+) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise CloudApiError(code, message, status_code=400)
+    return value.strip()
+
+
+def _reject_unknown_fields(payload: dict[str, object], allowed_fields: set[str]) -> None:
+    unknown_fields = sorted(set(payload) - allowed_fields)
+    if unknown_fields:
+        raise CloudApiError(
+            "cloud_command_materialize_workspace_payload_unknown",
+            "materialize_workspace payload contains unsupported field(s): "
+            + ", ".join(unknown_fields),
+            status_code=400,
+        )
+
+
+def _optional_string(payload: dict[str, object], field: str) -> None:
+    if field not in payload or payload[field] is None:
+        return
+    if not isinstance(payload[field], str):
+        raise CloudApiError(
+            "cloud_command_materialize_workspace_payload_invalid",
+            f"materialize_workspace payload field must be a string: {field}",
+            status_code=400,
+        )
+    if (
+        field == "displayName"
+        and len(payload[field].strip()) > _MAX_MATERIALIZE_WORKSPACE_DISPLAY_NAME_CHARS
+    ):
+        raise CloudApiError(
+            "cloud_command_materialize_workspace_payload_invalid",
+            "materialize_workspace displayName cannot exceed "
+            f"{_MAX_MATERIALIZE_WORKSPACE_DISPLAY_NAME_CHARS} characters.",
+            status_code=400,
+        )
+
+
+def _optional_object(payload: dict[str, object], field: str) -> None:
+    if field not in payload or payload[field] is None:
+        return
+    if not isinstance(payload[field], dict):
+        raise CloudApiError(
+            "cloud_command_materialize_workspace_payload_invalid",
+            f"materialize_workspace payload field must be an object: {field}",
             status_code=400,
         )
 

--- a/server/proliferate/server/cloud/commands/models.py
+++ b/server/proliferate/server/cloud/commands/models.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
+from proliferate.constants.cloud import CloudCommandKind
 from proliferate.db.store.cloud_sync.commands import CloudCommandSnapshot
 
 
@@ -24,6 +27,34 @@ class CreateCloudCommandRequest(BaseModel):
     observed_event_seq: int | None = Field(default=None, alias="observedEventSeq")
     preconditions: dict[str, object] | None = None
     source: str | None = None
+
+
+class MaterializeWorkspaceExistingPathPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["existing_path"]
+    path: str = Field(min_length=1)
+    display_name: str | None = Field(default=None, alias="displayName")
+    origin: dict[str, object] | None = None
+    creator_context: dict[str, object] | None = Field(default=None, alias="creatorContext")
+
+
+class MaterializeWorkspaceWorktreePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["worktree"]
+    repo_root_id: str = Field(alias="repoRootId", min_length=1)
+    target_path: str = Field(alias="targetPath", min_length=1)
+    new_branch_name: str = Field(alias="newBranchName", min_length=1)
+    base_branch: str | None = Field(default=None, alias="baseBranch")
+    setup_script: str | None = Field(default=None, alias="setupScript")
+    origin: dict[str, object] | None = None
+    creator_context: dict[str, object] | None = Field(default=None, alias="creatorContext")
+
+
+MaterializeWorkspacePayload = (
+    MaterializeWorkspaceExistingPathPayload | MaterializeWorkspaceWorktreePayload
+)
 
 
 class CloudCommandResponse(BaseModel):
@@ -44,6 +75,7 @@ class CloudCommandResponse(BaseModel):
     rejected_at: str | None = Field(default=None, serialization_alias="rejectedAt")
     error_code: str | None = Field(default=None, serialization_alias="errorCode")
     error_message: str | None = Field(default=None, serialization_alias="errorMessage")
+    result: dict[str, object] | None = None
 
 
 def command_response_payload(value: CloudCommandSnapshot) -> CloudCommandResponse:
@@ -65,4 +97,17 @@ def command_response_payload(value: CloudCommandSnapshot) -> CloudCommandRespons
         rejected_at=_to_iso(value.rejected_at),
         error_code=value.error_code,
         error_message=value.error_message,
+        result=_parse_result_json(value.kind, value.result_json),
     )
+
+
+def _parse_result_json(kind: str, value: str | None) -> dict[str, object] | None:
+    if kind != CloudCommandKind.materialize_workspace.value:
+        return None
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -21,6 +21,7 @@ from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.cloud.commands.domain.rules import (
     compact_command_json,
     validate_active_command_kind,
+    validate_command_payload,
     validate_command_shape,
     validate_command_source,
 )
@@ -59,6 +60,13 @@ async def _resolve_command_workspace(
 ) -> tuple[str | None, dict[str, object], str | None]:
     if kind != CloudCommandKind.start_session.value:
         return body.workspace_id, body.payload, None
+    if not body.workspace_id:
+        workspace_id = _direct_start_session_workspace_id(body.payload)
+        if workspace_id is None:
+            return None, body.payload, None
+        payload = dict(body.payload)
+        payload["workspaceId"] = workspace_id
+        return workspace_id, payload, None
     try:
         cloud_workspace_id = UUID(body.workspace_id or "")
     except ValueError as exc:
@@ -103,6 +111,13 @@ async def _resolve_command_workspace(
     return workspace.anyharness_workspace_id, payload, str(workspace.id)
 
 
+def _direct_start_session_workspace_id(payload: dict[str, object]) -> str | None:
+    value = payload.get("workspaceId")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
 async def enqueue_command(
     db: AsyncSession,
     *,
@@ -130,10 +145,11 @@ async def enqueue_command(
     source = validate_command_source(body.source)
     validate_command_shape(
         kind=kind,
-        workspace_id=body.workspace_id,
+        workspace_id=body.workspace_id or _direct_start_session_workspace_id(body.payload),
         session_id=body.session_id,
         preconditions=body.preconditions,
     )
+    validate_command_payload(kind=kind, payload=body.payload)
     resolved_workspace_id, payload, cloud_workspace_id = await _resolve_command_workspace(
         db,
         user=user,

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -250,6 +250,342 @@ class TestCloudCommandsApi:
         assert arbitrary_workspace.status_code == 404
         assert arbitrary_workspace.json()["detail"]["code"] == "cloud_command_workspace_not_found"
 
+        first_result = await client.post(
+            f"/v1/cloud/worker/commands/{command_id}/result",
+            headers=worker_headers,
+            json={"leaseId": leased_command["leaseId"], "status": "accepted"},
+        )
+        assert first_result.status_code == 200
+
+        direct_materialized_workspace = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "start-session-materialized-workspace",
+                "targetId": target_id,
+                "kind": "start_session",
+                "payload": {"workspaceId": "anyharness-workspace-1", "agentKind": "codex"},
+            },
+        )
+        assert direct_materialized_workspace.status_code == 200
+        direct_command_id = direct_materialized_workspace.json()["commandId"]
+
+        direct_lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={"supportedKinds": ["start_session"], "leaseTimeoutSeconds": 30},
+        )
+        assert direct_lease.status_code == 200
+        direct_command = direct_lease.json()["command"]
+        assert direct_command["commandId"] == direct_command_id
+        assert direct_command["workspaceId"] == "anyharness-workspace-1"
+        assert direct_command["payload"]["workspaceId"] == "anyharness-workspace-1"
+
+    @pytest.mark.asyncio
+    async def test_materialize_workspace_command_is_target_scoped(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-materialize-workspace",
+        )
+        target_id, worker_headers = await _create_enrolled_target(client, auth)
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-worktree-1",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "worktree",
+                    "repoRootId": "repo-root-1",
+                    "targetPath": "/workspace/feature",
+                    "newBranchName": "proliferate/cloud-workspace",
+                    "baseBranch": "main",
+                },
+                "source": "automation",
+            },
+        )
+        assert created.status_code == 200
+        command_id = created.json()["commandId"]
+        assert created.json()["workspaceId"] is None
+        assert created.json()["sessionId"] is None
+
+        lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["materialize_workspace"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert lease.status_code == 200
+        command = lease.json()["command"]
+        assert command["commandId"] == command_id
+        assert command["workspaceId"] is None
+        assert command["sessionId"] is None
+        assert command["payload"]["repoRootId"] == "repo-root-1"
+
+        accepted = await client.post(
+            f"/v1/cloud/worker/commands/{command_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": command["leaseId"],
+                "status": "accepted",
+                "result": {
+                    "mode": "worktree",
+                    "anyharnessWorkspaceId": "workspace-1",
+                    "repoRootId": "repo-root-1",
+                    "path": "/workspace/feature",
+                    "kind": "worktree",
+                    "currentBranch": "proliferate/cloud-workspace",
+                    "originalBranch": "main",
+                },
+            },
+        )
+        assert accepted.status_code == 200
+
+        status = await client.get(
+            f"/v1/cloud/commands/{command_id}",
+            headers=auth.headers,
+        )
+        assert status.status_code == 200
+        assert status.json()["workspaceId"] == "workspace-1"
+        assert status.json()["result"]["anyharnessWorkspaceId"] == "workspace-1"
+
+        malformed = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-malformed-result",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {"mode": "existing_path", "path": "/workspace/proliferate"},
+            },
+        )
+        assert malformed.status_code == 200
+        malformed_id = malformed.json()["commandId"]
+        malformed_lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["materialize_workspace"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert malformed_lease.status_code == 200
+        malformed_command = malformed_lease.json()["command"]
+        assert malformed_command["commandId"] == malformed_id
+
+        malformed_result = await client.post(
+            f"/v1/cloud/worker/commands/{malformed_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": malformed_command["leaseId"],
+                "status": "accepted",
+                "result": {
+                    "mode": "existing_path",
+                    "repoRootId": "repo-root-1",
+                    "path": "/workspace/proliferate",
+                    "kind": "local",
+                },
+            },
+        )
+        assert malformed_result.status_code == 200
+        assert malformed_result.json()["status"] == "rejected"
+
+        malformed_status = await client.get(
+            f"/v1/cloud/commands/{malformed_id}",
+            headers=auth.headers,
+        )
+        assert malformed_status.status_code == 200
+        assert malformed_status.json()["status"] == "rejected"
+        assert malformed_status.json()["errorCode"] == "invalid_materialize_workspace_result"
+        assert malformed_status.json()["workspaceId"] is None
+
+        existing_path = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-existing-path-1",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "existing_path",
+                    "path": "/workspace/proliferate",
+                    "displayName": "Proliferate",
+                },
+            },
+        )
+        assert existing_path.status_code == 200
+
+        session_scoped = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-session-scoped",
+                "targetId": target_id,
+                "sessionId": "session-1",
+                "kind": "materialize_workspace",
+                "payload": {"mode": "existing_path", "path": "/workspace/proliferate"},
+            },
+        )
+        assert session_scoped.status_code == 400
+        assert session_scoped.json()["detail"]["code"] == "cloud_command_target_only"
+
+        workspace_scoped = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-workspace-scoped",
+                "targetId": target_id,
+                "workspaceId": "workspace-1",
+                "kind": "materialize_workspace",
+                "payload": {"mode": "existing_path", "path": "/workspace/proliferate"},
+            },
+        )
+        assert workspace_scoped.status_code == 400
+        assert workspace_scoped.json()["detail"]["code"] == "cloud_command_target_only"
+
+        missing_path = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-missing-path",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {"mode": "existing_path"},
+            },
+        )
+        assert missing_path.status_code == 400
+        assert (
+            missing_path.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_path_required"
+        )
+
+        missing_worktree_branch = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-missing-branch",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "worktree",
+                    "repoRootId": "repo-root-1",
+                    "targetPath": "/workspace/feature",
+                },
+            },
+        )
+        assert missing_worktree_branch.status_code == 400
+        assert (
+            missing_worktree_branch.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_branch_required"
+        )
+
+        missing_repo_root = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-missing-repo-root",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "worktree",
+                    "targetPath": "/workspace/feature",
+                    "newBranchName": "feature",
+                },
+            },
+        )
+        assert missing_repo_root.status_code == 400
+        assert (
+            missing_repo_root.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_repo_root_required"
+        )
+
+        missing_target_path = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-missing-target-path",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "worktree",
+                    "repoRootId": "repo-root-1",
+                    "newBranchName": "feature",
+                },
+            },
+        )
+        assert missing_target_path.status_code == 400
+        assert (
+            missing_target_path.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_target_path_required"
+        )
+
+        unknown_mode = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-unknown-mode",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {"mode": "archive", "path": "/workspace/proliferate"},
+            },
+        )
+        assert unknown_mode.status_code == 400
+        assert (
+            unknown_mode.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_mode_invalid"
+        )
+
+        unknown_field = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-unknown-field",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "existing_path",
+                    "path": "/workspace/proliferate",
+                    "unexpected": True,
+                },
+            },
+        )
+        assert unknown_field.status_code == 400
+        assert (
+            unknown_field.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_payload_unknown"
+        )
+
+        invalid_optional_type = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "materialize-invalid-optional",
+                "targetId": target_id,
+                "kind": "materialize_workspace",
+                "payload": {
+                    "mode": "worktree",
+                    "repoRootId": "repo-root-1",
+                    "targetPath": "/workspace/feature",
+                    "newBranchName": "feature",
+                    "baseBranch": 42,
+                },
+            },
+        )
+        assert invalid_optional_type.status_code == 400
+        assert (
+            invalid_optional_type.json()["detail"]["code"]
+            == "cloud_command_materialize_workspace_payload_invalid"
+        )
+
     @pytest.mark.asyncio
     async def test_close_session_command_requires_session(
         self,


### PR DESCRIPTION
## Summary
- add active `materialize_workspace` CloudCommand support for target-side AnyHarness workspace/worktree creation
- add strict server payload validation, DB constraint migration, and stable result exposure/promotion
- add worker AnyHarness workspace client, typed payload mapping, display-name application, and invalid-result rejection
- tighten review findings: idempotent existing-path resolve, worktree recovery after create retries, direct start-session handoff from materialized workspace ids, and malformed materialize-result rejection

## Validation
- `cargo test -p proliferate-worker`
- `DEBUG=1 uv run pytest tests/integration/test_cloud_commands_api.py::TestCloudCommandsApi::test_start_session_command_requires_workspace_not_session tests/integration/test_cloud_commands_api.py::TestCloudCommandsApi::test_materialize_workspace_command_is_target_scoped -q`
- `DEBUG=1 uv run ruff format --check proliferate/db/store/cloud_sync/commands.py proliferate/server/cloud/commands/domain/rules.py proliferate/server/cloud/commands/service.py tests/integration/test_cloud_commands_api.py`
- `DEBUG=1 uv run ruff check proliferate/db/store/cloud_sync/commands.py proliferate/server/cloud/commands/domain/rules.py proliferate/server/cloud/commands/service.py tests/integration/test_cloud_commands_api.py`
- `DEBUG=1 uv run alembic heads`
- `git diff --check`

## Notes
- stacked on `proliferate/cloud-runtime-bundle-supervisor-impl`
- review-agent passes tightened result promotion/exposure, strict validation, malformed AnyHarness response handling, idempotency/recovery, and start-session handoff semantics
