### PR TITLE
feat(desktop): add workspace scratch pad

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod process;
 pub mod runtime;
 pub mod shell;
 pub mod window_chrome;
+pub mod workspace_scratch;

--- a/desktop/src-tauri/src/commands/workspace_scratch.rs
+++ b/desktop/src-tauri/src/commands/workspace_scratch.rs
@@ -1,0 +1,138 @@
+use crate::app_config::{app_dir_path, write_string_file_atomic};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceScratchPadRecord {
+    pub content: String,
+    pub updated_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceScratchPadWriteResult {
+    pub updated_at_ms: Option<u64>,
+}
+
+#[tauri::command]
+pub fn read_workspace_scratch_pad(
+    workspace_key: String,
+) -> Result<WorkspaceScratchPadRecord, String> {
+    let path = workspace_scratch_pad_path_for_key(&workspace_key)?;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(WorkspaceScratchPadRecord {
+                content: String::new(),
+                updated_at_ms: None,
+            });
+        }
+        Err(error) => return Err(format!("Failed to read {}: {error}", path.display())),
+    };
+
+    Ok(WorkspaceScratchPadRecord {
+        content,
+        updated_at_ms: modified_at_ms(&path)?,
+    })
+}
+
+#[tauri::command]
+pub fn write_workspace_scratch_pad(
+    workspace_key: String,
+    content: String,
+) -> Result<WorkspaceScratchPadWriteResult, String> {
+    let path = workspace_scratch_pad_path_for_key(&workspace_key)?;
+    write_string_file_atomic(&path, &content)?;
+    Ok(WorkspaceScratchPadWriteResult {
+        updated_at_ms: modified_at_ms(&path)?,
+    })
+}
+
+fn workspace_scratch_pad_path_for_key(workspace_key: &str) -> Result<PathBuf, String> {
+    Ok(workspace_scratch_pad_path(app_dir_path()?, workspace_key)?)
+}
+
+fn workspace_scratch_pad_path(app_dir: PathBuf, workspace_key: &str) -> Result<PathBuf, String> {
+    let normalized = workspace_key.trim();
+    if normalized.is_empty() {
+        return Err("workspace_key_required".to_string());
+    }
+    Ok(app_dir
+        .join("workspace-scratch")
+        .join(format!("{}.md", sha256_hex(normalized))))
+}
+
+fn sha256_hex(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn modified_at_ms(path: &Path) -> Result<Option<u64>, String> {
+    let modified = std::fs::metadata(path)
+        .map_err(|error| format!("Failed to stat {}: {error}", path.display()))?
+        .modified()
+        .map_err(|error| {
+            format!(
+                "Failed to read modified time for {}: {error}",
+                path.display()
+            )
+        })?;
+    let duration = modified
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("Invalid modified time for {}: {error}", path.display()))?;
+    Ok(Some(duration.as_millis() as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_app_dir() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("proliferate-scratch-test-{unique}"))
+    }
+
+    #[test]
+    fn scratch_path_hashes_workspace_key() {
+        let path = workspace_scratch_pad_path(PathBuf::from("/tmp/app"), " workspace://one ")
+            .expect("path should be valid");
+
+        assert!(path.starts_with("/tmp/app/workspace-scratch"));
+        assert_eq!(
+            path.extension().and_then(|value| value.to_str()),
+            Some("md")
+        );
+        assert!(!path.to_string_lossy().contains("workspace://one"));
+    }
+
+    #[test]
+    fn scratch_path_rejects_empty_workspace_key() {
+        let error = workspace_scratch_pad_path(PathBuf::from("/tmp/app"), "  ")
+            .expect_err("empty key should be rejected");
+
+        assert_eq!(error, "workspace_key_required");
+    }
+
+    #[test]
+    fn scratch_record_round_trips() {
+        let app_dir = temp_app_dir();
+        let path = workspace_scratch_pad_path(app_dir.clone(), "workspace-a")
+            .expect("path should be valid");
+
+        write_string_file_atomic(&path, "- [ ] first\n").expect("write should succeed");
+        let content = std::fs::read_to_string(&path).expect("read should succeed");
+        let updated_at_ms = modified_at_ms(&path).expect("modified time should be available");
+
+        assert_eq!(content, "- [ ] first\n");
+        assert!(updated_at_ms.is_some());
+
+        std::fs::remove_dir_all(app_dir).expect("temp dir cleanup should succeed");
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ mod telemetry_file_logging;
 
 use commands::{
     anonymous_telemetry, config, diagnostics as diagnostics_commands, google_workspace_mcp,
-    keychain, process, runtime, shell, window_chrome,
+    keychain, process, runtime, shell, window_chrome, workspace_scratch,
 };
 use quit_flow::QuitFlowState;
 use tauri::Manager;
@@ -213,6 +213,8 @@ pub fn run() {
             diagnostics_commands::save_diagnostic_json_to_absolute_path,
             runtime::get_runtime_info,
             runtime::restart_runtime,
+            workspace_scratch::read_workspace_scratch_pad,
+            workspace_scratch::write_workspace_scratch_pad,
             quit_flow::set_running_agent_count,
             shell::pick_folder,
             shell::copy_text,

--- a/desktop/src/components/ui/icons.tsx
+++ b/desktop/src/components/ui/icons.tsx
@@ -734,6 +734,16 @@ export function StickyNote({ className, ...props }: IconProps) {
   );
 }
 
+export function ScratchPadIcon({ className, ...props }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <rect x="4" y="3" width="16" height="18" rx="2" />
+      <path d="M8 9c1-1.5 2-1.5 3 0s2 1.5 3 0 2-1.5 3 0" />
+      <path d="M8 15c1-1.5 2-1.5 3 0s2 1.5 3 0" />
+    </svg>
+  );
+}
+
 export function Link2({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>

--- a/desktop/src/components/workspace/files/viewer/WorkspaceFilesPanel.tsx
+++ b/desktop/src/components/workspace/files/viewer/WorkspaceFilesPanel.tsx
@@ -1,0 +1,41 @@
+import {
+  useEffect,
+  useState,
+} from "react";
+import { PaneHeader } from "@/components/workspace/pane/PaneHeader";
+import { useWorkspaceFileContext } from "@/hooks/workspaces/files/derived/use-workspace-file-context";
+import { useWorkspaceFileTargetActions } from "@/hooks/workspaces/files/workflows/use-workspace-file-target-actions";
+import { WorkspaceFileBrowserPane } from "./WorkspaceFileBrowserPane";
+
+export function WorkspaceFilesPanel() {
+  const fileContext = useWorkspaceFileContext();
+  const { openFile } = useWorkspaceFileTargetActions(fileContext);
+  const [pathPrefix, setPathPrefix] = useState("");
+
+  useEffect(() => {
+    setPathPrefix("");
+  }, [fileContext.workspaceUiKey]);
+
+  return (
+    <div className="flex h-full min-w-0 flex-col overflow-hidden bg-background text-sidebar-foreground">
+      <PaneHeader
+        left={(
+          <div className="flex min-w-0 items-center px-1">
+            <span className="truncate text-xs font-medium text-sidebar-foreground">
+              Files
+            </span>
+          </div>
+        )}
+      />
+      <WorkspaceFileBrowserPane
+        workspaceId={fileContext.materializedWorkspaceId}
+        selectedPath=""
+        pathPrefix={pathPrefix}
+        onPathPrefixChange={setPathPrefix}
+        onOpenFile={(path) => {
+          void openFile(path);
+        }}
+      />
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/pane/PaneOptionsMenu.tsx
+++ b/desktop/src/components/workspace/pane/PaneOptionsMenu.tsx
@@ -19,7 +19,7 @@ export function PaneOptionsMenu({
   return (
     <PopoverButton
       trigger={(
-        <PaneIconButton label={label}>
+        <PaneIconButton label={label} tooltip={label}>
           <MoreHorizontal className="size-3.5" />
         </PaneIconButton>
       )}

--- a/desktop/src/components/workspace/scratch/ScratchPadPanel.test.tsx
+++ b/desktop/src/components/workspace/scratch/ScratchPadPanel.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScratchPadPanel } from "@/components/workspace/scratch/ScratchPadPanel";
+
+const scratchQueryMocks = vi.hoisted(() => ({
+  record: {
+    content: "",
+    updatedAtMs: 1,
+  } as { content: string; updatedAtMs: number | null } | undefined,
+  isLoading: false,
+  writeScratchPad: vi.fn(async () => ({ updatedAtMs: 1 })),
+  setScratchPadCache: vi.fn(),
+}));
+
+const shellMocks = vi.hoisted(() => ({
+  copyText: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad", () => ({
+  useWorkspaceScratchPad: () => ({
+    data: scratchQueryMocks.record,
+    isLoading: scratchQueryMocks.isLoading,
+  }),
+}));
+
+vi.mock("@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations", () => ({
+  useWorkspaceScratchPadMutations: () => ({
+    writeScratchPad: scratchQueryMocks.writeScratchPad,
+    writeScratchPadState: {
+      isPending: false,
+      isError: false,
+    },
+    setScratchPadCache: scratchQueryMocks.setScratchPadCache,
+  }),
+}));
+
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => ({
+    copyText: shellMocks.copyText,
+  }),
+}));
+
+beforeEach(() => {
+  scratchQueryMocks.record = {
+    content: "",
+    updatedAtMs: 1,
+  };
+  scratchQueryMocks.writeScratchPad = vi.fn(async () => ({ updatedAtMs: 1 }));
+  scratchQueryMocks.setScratchPadCache = vi.fn();
+  scratchQueryMocks.isLoading = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("ScratchPadPanel", () => {
+  it("renders loaded scratch content and debounces writes", async () => {
+    vi.useFakeTimers();
+    scratchQueryMocks.record = {
+      content: "- [ ] keep this",
+      updatedAtMs: 1,
+    };
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    expect(editor.value).toBe("- [ ] keep this");
+
+    fireEvent.change(editor, { target: { value: "- [ ] updated" } });
+    expect(scratchQueryMocks.writeScratchPad).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenCalledWith(
+      "- [ ] updated",
+      "workspace-1",
+    );
+    expect(scratchQueryMocks.setScratchPadCache).toHaveBeenCalledWith(
+      "- [ ] updated",
+      1,
+      "workspace-1",
+    );
+  });
+
+  it("keeps newer local edits when stale cache data arrives", () => {
+    scratchQueryMocks.record = {
+      content: "",
+      updatedAtMs: 1,
+    };
+    const { rerender } = render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "newer local draft" } });
+
+    scratchQueryMocks.record = {
+      content: "older saved draft",
+      updatedAtMs: 2,
+    };
+    rerender(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    expect(editor.value).toBe("newer local draft");
+  });
+
+  it("serializes saves so newer edits are written after stale in-flight writes", async () => {
+    vi.useFakeTimers();
+    scratchQueryMocks.record = {
+      content: "",
+      updatedAtMs: 1,
+    };
+    const resolvers: Array<(result: { updatedAtMs: number }) => void> = [];
+    scratchQueryMocks.writeScratchPad = vi.fn(
+      () => new Promise<{ updatedAtMs: number }>((resolve) => {
+        resolvers.push(resolve);
+      }),
+    );
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "first draft" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenCalledWith(
+      "first draft",
+      "workspace-1",
+    );
+
+    fireEvent.change(editor, { target: { value: "second draft" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvers[0]?.({ updatedAtMs: 10 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenCalledTimes(2);
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenLastCalledWith(
+      "second draft",
+      "workspace-1",
+    );
+    expect(scratchQueryMocks.setScratchPadCache).not.toHaveBeenCalledWith(
+      "first draft",
+      10,
+      "workspace-1",
+    );
+
+    await act(async () => {
+      resolvers[1]?.({ updatedAtMs: 11 });
+      await Promise.resolve();
+    });
+
+    expect(scratchQueryMocks.setScratchPadCache).toHaveBeenCalledWith(
+      "second draft",
+      11,
+      "workspace-1",
+    );
+  });
+
+  it("clears visible scratch content while a new workspace read is loading", () => {
+    scratchQueryMocks.record = {
+      content: "workspace one note",
+      updatedAtMs: 1,
+    };
+    const { rerender } = render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    expect((screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement).value)
+      .toBe("workspace one note");
+
+    scratchQueryMocks.record = undefined;
+    scratchQueryMocks.isLoading = true;
+    rerender(<ScratchPadPanel workspaceKey="workspace-2" />);
+
+    expect((screen.getByPlaceholderText(/Loading scratch/) as HTMLTextAreaElement).value)
+      .toBe("");
+  });
+
+  it("inserts checklist items and clears completed tasks from the options menu", async () => {
+    scratchQueryMocks.record = {
+      content: "- [ ] open\n- [x] done\n",
+      updatedAtMs: 1,
+    };
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    fireEvent.click(screen.getByRole("button", { name: "Scratch options" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear completed" }));
+
+    expect(editor.value).toBe("- [ ] open\n");
+
+    fireEvent.click(screen.getByRole("button", { name: "Scratch options" }));
+    fireEvent.click(screen.getByRole("button", { name: "Insert checklist item" }));
+
+    expect(editor.value).toContain("- [ ] ");
+  });
+
+  it("copies scratch content through the shell access boundary", async () => {
+    scratchQueryMocks.record = {
+      content: "durable note",
+      updatedAtMs: 1,
+    };
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Scratch options" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy content" }));
+
+    await waitFor(() => expect(shellMocks.copyText).toHaveBeenCalledWith("durable note"));
+  });
+});

--- a/desktop/src/components/workspace/scratch/ScratchPadPanel.tsx
+++ b/desktop/src/components/workspace/scratch/ScratchPadPanel.tsx
@@ -1,0 +1,310 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { Textarea } from "@/components/ui/Textarea";
+import {
+  Check,
+  Copy,
+  Plus,
+  Trash,
+} from "@/components/ui/icons";
+import { PaneHeader } from "@/components/workspace/pane/PaneHeader";
+import {
+  PaneOptionsMenu,
+  PaneOptionsMenuItem,
+  PaneOptionsMenuSeparator,
+} from "@/components/workspace/pane/PaneOptionsMenu";
+import { useWorkspaceScratchPad } from "@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad";
+import { useWorkspaceScratchPadMutations } from "@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+
+const SAVE_DEBOUNCE_MS = 500;
+const SCRATCH_PLACEHOLDER = "- [ ] Capture follow-ups\n- [ ] Keep durable workspace notes here";
+const COMPLETED_TASK_PATTERN = /^\s*[-*]\s+\[[xX]\]\s+.*(?:\r?\n|$)/gm;
+const COMPLETED_TASK_DETECT_PATTERN = /^\s*[-*]\s+\[[xX]\]\s+/m;
+
+interface ScratchPadPanelProps {
+  workspaceKey: string | null;
+}
+
+export function ScratchPadPanel({ workspaceKey }: ScratchPadPanelProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const saveInFlightRef = useRef(false);
+  const pendingSaveRef = useRef<string | null>(null);
+  const saveSequenceRef = useRef(0);
+  const workspaceKeyRef = useRef<string | null>(workspaceKey ?? null);
+  const previousWorkspaceKeyRef = useRef<string | null>(workspaceKey ?? null);
+  const latestDraftRef = useRef("");
+  const lastSavedRef = useRef("");
+  const scratchQuery = useWorkspaceScratchPad(workspaceKey);
+  const {
+    writeScratchPad,
+    writeScratchPadState,
+    setScratchPadCache,
+  } = useWorkspaceScratchPadMutations(workspaceKey);
+  const { copyText } = useTauriShellActions();
+  const [draft, setDraft] = useState("");
+  const [wordWrap, setWordWrap] = useState(true);
+  const [copied, setCopied] = useState(false);
+  const hasWorkspace = Boolean(workspaceKey);
+  const loading = hasWorkspace && scratchQuery.isLoading;
+  const dirty = draft !== lastSavedRef.current;
+  const saveStatus = !hasWorkspace
+    ? "No workspace"
+    : writeScratchPadState.isPending
+      ? "Saving"
+      : writeScratchPadState.isError
+        ? "Save failed"
+        : dirty
+          ? "Unsaved"
+          : "Saved";
+
+  const flushSave = useCallback(async (content: string) => {
+    const targetWorkspaceKey = workspaceKeyRef.current;
+    if (!targetWorkspaceKey || content === lastSavedRef.current) {
+      return;
+    }
+    if (saveInFlightRef.current) {
+      pendingSaveRef.current = content;
+      return;
+    }
+
+    saveInFlightRef.current = true;
+    const sequence = saveSequenceRef.current + 1;
+    saveSequenceRef.current = sequence;
+    try {
+      const result = await writeScratchPad(content, targetWorkspaceKey);
+      if (
+        workspaceKeyRef.current === targetWorkspaceKey
+        && sequence === saveSequenceRef.current
+        && content === latestDraftRef.current
+      ) {
+        lastSavedRef.current = content;
+        setScratchPadCache(content, result.updatedAtMs, targetWorkspaceKey);
+      }
+    } finally {
+      saveInFlightRef.current = false;
+      const pendingContent = pendingSaveRef.current;
+      pendingSaveRef.current = null;
+      if (pendingContent !== null) {
+        void flushSave(pendingContent).catch(() => undefined);
+      }
+    }
+  }, [setScratchPadCache, writeScratchPad]);
+
+  const queueSave = useCallback((content: string) => {
+    latestDraftRef.current = content;
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+    }
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null;
+      void flushSave(latestDraftRef.current).catch(() => undefined);
+    }, SAVE_DEBOUNCE_MS);
+  }, [flushSave]);
+
+  useEffect(() => {
+    const nextWorkspaceKey = workspaceKey ?? null;
+    if (previousWorkspaceKeyRef.current === nextWorkspaceKey) {
+      workspaceKeyRef.current = nextWorkspaceKey;
+      return;
+    }
+    previousWorkspaceKeyRef.current = nextWorkspaceKey;
+    workspaceKeyRef.current = nextWorkspaceKey;
+    saveSequenceRef.current += 1;
+    pendingSaveRef.current = null;
+    setDraft("");
+    latestDraftRef.current = "";
+    lastSavedRef.current = "";
+  }, [workspaceKey]);
+
+  useEffect(() => {
+    if (!scratchQuery.data) {
+      return;
+    }
+    if (
+      latestDraftRef.current !== lastSavedRef.current
+      && scratchQuery.data.content !== latestDraftRef.current
+    ) {
+      return;
+    }
+    setDraft(scratchQuery.data.content);
+    latestDraftRef.current = scratchQuery.data.content;
+    lastSavedRef.current = scratchQuery.data.content;
+  }, [scratchQuery.data]);
+
+  useEffect(() => () => {
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    void flushSave(latestDraftRef.current).catch(() => undefined);
+  }, [flushSave]);
+
+  const handleChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    const next = event.currentTarget.value;
+    setDraft(next);
+    queueSave(next);
+  }, [queueSave]);
+
+  const updateDraft = useCallback((next: string) => {
+    setDraft(next);
+    queueSave(next);
+  }, [queueSave]);
+
+  const handleInsertChecklistItem = useCallback(() => {
+    const textarea = textareaRef.current;
+    const insertion = "- [ ] ";
+    if (!textarea) {
+      updateDraft(draft ? `${draft}\n${insertion}` : insertion);
+      return;
+    }
+
+    const start = textarea.selectionStart ?? draft.length;
+    const end = textarea.selectionEnd ?? start;
+    const prefix = draft.slice(0, start);
+    const suffix = draft.slice(end);
+    const needsLeadingNewline = prefix.length > 0 && !prefix.endsWith("\n");
+    const next = `${prefix}${needsLeadingNewline ? "\n" : ""}${insertion}${suffix}`;
+    const caret = prefix.length + (needsLeadingNewline ? 1 : 0) + insertion.length;
+    updateDraft(next);
+    window.requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(caret, caret);
+    });
+  }, [draft, updateDraft]);
+
+  const handleClearCompleted = useCallback(() => {
+    updateDraft(draft.replace(COMPLETED_TASK_PATTERN, ""));
+  }, [draft, updateDraft]);
+
+  const handleCopyContent = useCallback(async () => {
+    await copyText(draft);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  }, [copyText, draft]);
+
+  const handleBlur = useCallback(() => {
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    void flushSave(latestDraftRef.current).catch(() => undefined);
+  }, [flushSave]);
+
+  return (
+    <div className="flex h-full min-w-0 flex-col overflow-hidden bg-background text-sidebar-foreground">
+      <PaneHeader
+        left={(
+          <div className="flex min-w-0 items-center px-1">
+            <span className="truncate text-xs font-medium text-sidebar-foreground">
+              Scratch
+            </span>
+          </div>
+        )}
+        right={(
+          <>
+            <span className="max-w-20 truncate text-[11px] leading-4 text-sidebar-muted-foreground">
+              {saveStatus}
+            </span>
+            <ScratchPadOptionsMenu
+              canCopy={draft.length > 0}
+              canClearCompleted={COMPLETED_TASK_DETECT_PATTERN.test(draft)}
+              copied={copied}
+              wordWrap={wordWrap}
+              onCopyContent={handleCopyContent}
+              onInsertChecklistItem={handleInsertChecklistItem}
+              onClearCompleted={handleClearCompleted}
+              onToggleWordWrap={() => setWordWrap((current) => !current)}
+            />
+          </>
+        )}
+      />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <Textarea
+          ref={textareaRef}
+          variant="ghost"
+          value={draft}
+          placeholder={loading ? "Loading scratch..." : SCRATCH_PLACEHOLDER}
+          disabled={!hasWorkspace || loading}
+          wrap={wordWrap ? "soft" : "off"}
+          spellCheck
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className={`h-full overflow-auto px-4 py-3 font-[family:var(--diffs-font-family)] text-[length:var(--diffs-font-size)] leading-[var(--diffs-line-height)] text-foreground placeholder:text-sidebar-muted-foreground/65 disabled:cursor-not-allowed ${wordWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ScratchPadOptionsMenu({
+  canCopy,
+  canClearCompleted,
+  copied,
+  wordWrap,
+  onCopyContent,
+  onInsertChecklistItem,
+  onClearCompleted,
+  onToggleWordWrap,
+}: {
+  canCopy: boolean;
+  canClearCompleted: boolean;
+  copied: boolean;
+  wordWrap: boolean;
+  onCopyContent: () => void;
+  onInsertChecklistItem: () => void;
+  onClearCompleted: () => void;
+  onToggleWordWrap: () => void;
+}) {
+  return (
+    <PaneOptionsMenu label="Scratch options" className="min-w-[220px]">
+      {(close) => (
+        <div className="flex flex-col gap-px">
+          <PaneOptionsMenuItem
+            icon={copied ? <Check /> : <Copy />}
+            label={copied ? "Copied content" : "Copy content"}
+            disabled={!canCopy}
+            onClick={() => {
+              void onCopyContent();
+              close();
+            }}
+          />
+          <PaneOptionsMenuItem
+            icon={<Plus />}
+            label="Insert checklist item"
+            onClick={() => {
+              onInsertChecklistItem();
+              close();
+            }}
+          />
+          <PaneOptionsMenuItem
+            icon={<Trash />}
+            label="Clear completed"
+            disabled={!canClearCompleted}
+            onClick={() => {
+              onClearCompleted();
+              close();
+            }}
+          />
+          <PaneOptionsMenuSeparator />
+          <PaneOptionsMenuItem
+            reserveIconSlot
+            icon={wordWrap ? <Check /> : null}
+            label="Word wrap"
+            trailing={wordWrap ? "On" : "Off"}
+            onClick={() => {
+              onToggleWordWrap();
+              close();
+            }}
+          />
+        </div>
+      )}
+    </PaneOptionsMenu>
+  );
+}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -71,12 +71,20 @@ vi.mock("@/components/workspace/browser/WorkspaceBrowserPanel", () => ({
   },
 }));
 
-vi.mock("@/components/workspace/git/GitPanel", () => ({
-  GitPanel: () => (
-    <div data-testid="git-panel">
-      <input data-testid="git-panel-input" />
+vi.mock("@/components/workspace/files/viewer/WorkspaceFilesPanel", () => ({
+  WorkspaceFilesPanel: () => (
+    <div data-testid="files-panel">
+      <input data-testid="files-panel-input" />
     </div>
   ),
+}));
+
+vi.mock("@/components/workspace/git/GitPanel", () => ({
+  GitPanel: () => <div data-testid="git-panel" />,
+}));
+
+vi.mock("@/components/workspace/scratch/ScratchPadPanel", () => ({
+  ScratchPadPanel: () => <div data-testid="scratch-panel" />,
 }));
 
 vi.mock("@/components/workspace/files/FileEditorView", () => ({
@@ -125,11 +133,11 @@ afterEach(() => {
 });
 
 describe("RightPanel terminal activation", () => {
-  it("creates one default terminal lazily without leaving the Changes panel", async () => {
+  it("creates one default terminal lazily without leaving the Scratch panel", async () => {
     render(<RightPanelHarness isWorkspaceReady />);
 
     await waitFor(() => expect(terminalActionsMocks.createTab).toHaveBeenCalledTimes(1));
-    expect(screen.getByTestId("git-panel")).toBeTruthy();
+    expect(screen.getByTestId("scratch-panel")).toBeTruthy();
   });
 
   it("opens the new tab menu with Terminal focused from a right-panel request", async () => {
@@ -363,19 +371,20 @@ describe("RightPanel tab shortcuts", () => {
     fireEvent.pointerDown(root);
     expect(document.activeElement).toBe(root);
 
-    fireEvent.keyDown(window, primaryDigitEvent(1));
+    fireEvent.keyDown(window, primaryDigitEvent(3));
 
     await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
   });
 
   it("uses primary-number shortcuts from right-panel text inputs", async () => {
     render(<RightPanelHarness isWorkspaceReady />);
-    const input = screen.getByTestId("git-panel-input");
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    const input = screen.getByTestId("files-panel-input");
 
     input.focus();
     expect(document.activeElement).toBe(input);
 
-    fireEvent.keyDown(window, primaryDigitEvent(1));
+    fireEvent.keyDown(window, primaryDigitEvent(3));
 
     await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
   });
@@ -434,6 +443,7 @@ function RightPanelHarness({
   return (
     <RightPanel
       workspaceId={workspaceId}
+      workspaceUiKey={workspaceId}
       isWorkspaceReady={isWorkspaceReady}
       isOpen={isOpen}
       isCloudWorkspaceSelected
@@ -475,6 +485,7 @@ function RemountingRightPanelHarness({
   return (
     <RightPanel
       workspaceId="workspace-1"
+      workspaceUiKey="workspace-1"
       isWorkspaceReady
       isOpen
       isCloudWorkspaceSelected

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -63,6 +63,7 @@ interface TerminalActivationRequest {
 
 interface RightPanelProps {
   workspaceId: string | null;
+  workspaceUiKey: string | null;
   isWorkspaceReady: boolean;
   isOpen: boolean;
   shouldKeepContentVisible?: boolean;
@@ -79,6 +80,7 @@ interface RightPanelProps {
 
 export const RightPanel = memo(function RightPanel({
   workspaceId,
+  workspaceUiKey,
   isWorkspaceReady,
   isOpen,
   shouldKeepContentVisible = false,
@@ -538,6 +540,7 @@ export const RightPanel = memo(function RightPanel({
       rootRef={rootRef}
       onPointerDownCapture={handleRootPointerDownCapture}
       workspaceId={workspaceId}
+      workspaceUiKey={workspaceUiKey}
       activeEntryKey={state.activeEntryKey}
       activeTool={activeTool}
       activeBrowserId={activeBrowserId}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
@@ -1,7 +1,9 @@
 import { WorkspaceBrowserPanel } from "@/components/workspace/browser/WorkspaceBrowserPanel";
 import { CloudWorkspaceSettingsPanel } from "@/components/cloud/workspace-settings/CloudWorkspaceSettingsPanel";
 import { FileEditorView } from "@/components/workspace/files/FileEditorView";
+import { WorkspaceFilesPanel } from "@/components/workspace/files/viewer/WorkspaceFilesPanel";
 import { GitPanel } from "@/components/workspace/git/GitPanel";
+import { ScratchPadPanel } from "@/components/workspace/scratch/ScratchPadPanel";
 import { RightPanelPlaceholder } from "@/components/workspace/shell/right-panel/RightPanelPlaceholder";
 import { TerminalPanel } from "@/components/workspace/terminals/TerminalPanel";
 import type { TerminalRecord } from "@anyharness/sdk";
@@ -17,6 +19,7 @@ import {
 
 interface RightPanelContentProps {
   workspaceId: string | null;
+  workspaceUiKey: string | null;
   activeEntryKey: RightPanelActiveEntryKey;
   activeTool: RightPanelTool | null;
   activeBrowserId: string | null;
@@ -44,6 +47,7 @@ interface RightPanelContentProps {
 
 export function RightPanelContent({
   workspaceId,
+  workspaceUiKey,
   activeEntryKey,
   activeTool,
   activeBrowserId,
@@ -78,6 +82,19 @@ export function RightPanelContent({
         <RightPanelPlaceholder activeEntryKey={activeEntryKey} />
       ) : (
         <>
+          {activeTool === "scratch" && (
+            <div className="absolute inset-0">
+              <ScratchPadPanel
+                key={workspaceUiKey ?? "no-workspace"}
+                workspaceKey={workspaceUiKey}
+              />
+            </div>
+          )}
+          {activeTool === "files" && (
+            <div className="absolute inset-0">
+              <WorkspaceFilesPanel />
+            </div>
+          )}
           {activeTool === "settings" && (
             <div className="absolute inset-0">
               <CloudWorkspaceSettingsPanel />

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -23,6 +23,7 @@ interface RightPanelFrameProps {
   rootRef: RefObject<HTMLDivElement | null>;
   onPointerDownCapture: PointerEventHandler<HTMLDivElement>;
   workspaceId: string | null;
+  workspaceUiKey: string | null;
   activeEntryKey: RightPanelActiveEntryKey;
   activeTool: RightPanelTool | null;
   activeBrowserId: string | null;
@@ -70,6 +71,7 @@ export function RightPanelFrame({
   rootRef,
   onPointerDownCapture,
   workspaceId,
+  workspaceUiKey,
   activeEntryKey,
   activeTool,
   activeBrowserId,
@@ -145,6 +147,7 @@ export function RightPanelFrame({
 
       <RightPanelContent
         workspaceId={workspaceId}
+        workspaceUiKey={workspaceUiKey}
         activeEntryKey={activeEntryKey}
         activeTool={activeTool}
         activeBrowserId={activeBrowserId}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx
@@ -6,20 +6,28 @@ import {
 export function RightPanelPlaceholder({ activeEntryKey }: { activeEntryKey: RightPanelActiveEntryKey }) {
   const entry = parseRightPanelHeaderEntryKey(activeEntryKey);
   const kind = entry?.kind === "tool" ? entry.tool : entry?.kind ?? "git";
-  const title = kind === "terminal"
-    ? "Terminals are getting ready"
-    : kind === "browser"
-      ? "Browser is getting ready"
-      : kind === "settings"
-        ? "Cloud settings are getting ready"
-        : "Git view is getting ready";
-  const description = kind === "terminal"
-    ? "Terminals will connect once the workspace runtime is ready."
-    : kind === "browser"
-      ? "Browser tabs will appear once the workspace is ready."
-      : kind === "settings"
-        ? "Repo sync status and setup controls will appear once the cloud workspace finishes loading."
-        : "Changes and diffs will appear here as soon as the workspace finishes loading.";
+  const title = kind === "scratch"
+    ? "Scratch is getting ready"
+    : kind === "files"
+    ? "Files are getting ready"
+    : kind === "terminal"
+      ? "Terminals are getting ready"
+      : kind === "browser"
+        ? "Browser is getting ready"
+        : kind === "settings"
+          ? "Cloud settings are getting ready"
+          : "Git view is getting ready";
+  const description = kind === "scratch"
+    ? "Your workspace notes will appear here as soon as the workspace finishes loading."
+    : kind === "files"
+    ? "The file tree will appear here as soon as the workspace finishes loading."
+    : kind === "terminal"
+      ? "Terminals will connect once the workspace runtime is ready."
+      : kind === "browser"
+        ? "Browser tabs will appear once the workspace is ready."
+        : kind === "settings"
+          ? "Repo sync status and setup controls will appear once the cloud workspace finishes loading."
+          : "Changes and diffs will appear here as soon as the workspace finishes loading.";
 
   return (
     <div className="flex h-full items-center justify-center px-6 text-center">

--- a/desktop/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx
@@ -1,8 +1,11 @@
 import type { ComponentType } from "react";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import {
   CloudIcon,
   AppShellReviewIcon,
+  FileIcon,
+  ScratchPadIcon,
   type IconProps,
 } from "@/components/ui/icons";
 import type { RightPanelTool } from "@/lib/domain/workspaces/shell/right-panel-model";
@@ -23,6 +26,8 @@ interface ToolConfig {
 }
 
 const PANEL_TOOLS: Record<RightPanelTool, ToolConfig> = {
+  scratch: { label: "Scratch", icon: ScratchPadIcon },
+  files: { label: "Files", icon: FileIcon },
   git: { label: "Changes", icon: AppShellReviewIcon },
   settings: { label: "Cloud environment", icon: CloudIcon },
 };
@@ -38,36 +43,41 @@ export function ToolHeaderButton({
   const Icon = panelTool.icon;
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      role="tab"
-      aria-selected={isActive}
-      aria-controls={`tabpanel-workspace-right-panel-${tool}`}
-      tabIndex={isActive ? 0 : -1}
-      data-reorderable="true"
-      data-active={isActive ? true : undefined}
-      aria-grabbed={isDragging}
-      aria-label={panelTool.label}
-      onClick={() => {
-        if (shouldSuppressClick()) {
-          return;
-        }
-        onSelect();
-      }}
-      className={HEADER_TOOL_TAB_CLASS}
+    <Tooltip
+      content={panelTool.label}
+      className="right-panel-tab-tooltip"
     >
-      <span className="ui-tab-system-tab__content">
-        <Icon className="ui-tab-system-tab__icon" />
-        <span className="ui-tab-system-tab__label">
-          <span className="ui-tab-system-tab__label-primary">{panelTool.label}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        role="tab"
+        aria-selected={isActive}
+        aria-controls={`tabpanel-workspace-right-panel-${tool}`}
+        tabIndex={isActive ? 0 : -1}
+        data-reorderable="true"
+        data-active={isActive ? true : undefined}
+        aria-grabbed={isDragging}
+        aria-label={panelTool.label}
+        onClick={() => {
+          if (shouldSuppressClick()) {
+            return;
+          }
+          onSelect();
+        }}
+        className={HEADER_TOOL_TAB_CLASS}
+      >
+        <span className="ui-tab-system-tab__content">
+          <Icon className="ui-tab-system-tab__icon" />
+          <span className="ui-tab-system-tab__label">
+            <span className="ui-tab-system-tab__label-primary">{panelTool.label}</span>
+          </span>
+          <span
+            className="ui-tab-system-tab__dirty-indicator"
+            aria-hidden="true"
+          />
         </span>
-        <span
-          className="ui-tab-system-tab__dirty-indicator"
-          aria-hidden="true"
-        />
-      </span>
-    </Button>
+      </Button>
+    </Tooltip>
   );
 }

--- a/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -67,6 +67,7 @@ export function StandardWorkspaceShell() {
     hasWorkspaceShell,
     hasLaunchIntentOnlyShell,
     isCloudWorkspaceSelected,
+    workspaceUiKey,
     selectedWorkspaceId,
     selectedWorkspace,
     selectedCloudWorkspace,
@@ -359,6 +360,7 @@ export function StandardWorkspaceShell() {
                       <div className="h-full" style={{ minWidth: 260 }}>
                         <RightPanel
                           workspaceId={selectedWorkspaceId}
+                          workspaceUiKey={workspaceUiKey}
                           isWorkspaceReady={hasRuntimeReadyWorkspace}
                           isOpen={rightPanelOpen}
                           shouldKeepContentVisible={shouldKeepRuntimePanelsVisible}

--- a/desktop/src/hooks/access/tauri/workspace-scratch/query-keys.ts
+++ b/desktop/src/hooks/access/tauri/workspace-scratch/query-keys.ts
@@ -1,0 +1,3 @@
+export function workspaceScratchPadKey(workspaceKey: string | null | undefined) {
+  return ["tauri", "workspace-scratch-pad", workspaceKey ?? null] as const;
+}

--- a/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations.ts
+++ b/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations.ts
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  writeWorkspaceScratchPad,
+  type WorkspaceScratchPadRecord,
+  type WorkspaceScratchPadWriteResult,
+} from "@/lib/access/tauri/workspace-scratch";
+import { workspaceScratchPadKey } from "@/hooks/access/tauri/workspace-scratch/query-keys";
+
+interface WorkspaceScratchPadWriteInput {
+  workspaceKey: string;
+  content: string;
+}
+
+export function useWorkspaceScratchPadMutations(workspaceKey: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  const writeMutation = useMutation<
+    WorkspaceScratchPadWriteResult,
+    Error,
+    WorkspaceScratchPadWriteInput
+  >({
+    mutationFn: ({ workspaceKey: key, content }) => writeWorkspaceScratchPad(key, content),
+  });
+  const { mutateAsync } = writeMutation;
+
+  const writeScratchPad = useCallback((content: string, keyOverride?: string | null) => {
+    const key = keyOverride ?? workspaceKey;
+    if (!key) {
+      throw new Error("workspace_key_required");
+    }
+    return mutateAsync({ workspaceKey: key, content });
+  }, [mutateAsync, workspaceKey]);
+
+  const setScratchPadCache = useCallback((
+    content: string,
+    updatedAtMs: number | null,
+    keyOverride?: string | null,
+  ) => {
+    const key = keyOverride ?? workspaceKey;
+    if (!key) {
+      return;
+    }
+    queryClient.setQueryData<WorkspaceScratchPadRecord>(
+      workspaceScratchPadKey(key),
+      {
+        content,
+        updatedAtMs,
+      },
+    );
+  }, [queryClient, workspaceKey]);
+
+  return {
+    writeScratchPad,
+    writeScratchPadState: writeMutation,
+    setScratchPadCache,
+  };
+}

--- a/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.ts
+++ b/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  readWorkspaceScratchPad,
+  type WorkspaceScratchPadRecord,
+} from "@/lib/access/tauri/workspace-scratch";
+import { workspaceScratchPadKey } from "@/hooks/access/tauri/workspace-scratch/query-keys";
+
+export function useWorkspaceScratchPad(workspaceKey: string | null | undefined) {
+  return useQuery<WorkspaceScratchPadRecord>({
+    queryKey: workspaceScratchPadKey(workspaceKey),
+    queryFn: () => readWorkspaceScratchPad(workspaceKey!),
+    enabled: Boolean(workspaceKey),
+    staleTime: Infinity,
+  });
+}

--- a/desktop/src/hooks/main/facade/use-main-screen-state.ts
+++ b/desktop/src/hooks/main/facade/use-main-screen-state.ts
@@ -85,6 +85,7 @@ export interface MainScreenDataState {
   hasWorkspaceShell: boolean;
   hasLaunchIntentOnlyShell: boolean;
   isCloudWorkspaceSelected: boolean;
+  workspaceUiKey: string | null;
   selectedWorkspaceId: string | null;
   selectedWorkspace: Workspace | undefined;
   selectedCloudWorkspace: CloudWorkspaceSummary | undefined;
@@ -382,6 +383,7 @@ export function useMainScreenState(): MainScreenState {
       hasWorkspaceShell,
       hasLaunchIntentOnlyShell,
       isCloudWorkspaceSelected: selectedCloudWorkspaceId !== null,
+      workspaceUiKey,
       selectedWorkspaceId,
       selectedWorkspace,
       selectedCloudWorkspace,

--- a/desktop/src/hooks/main/workflows/use-main-screen-actions.test.tsx
+++ b/desktop/src/hooks/main/workflows/use-main-screen-actions.test.tsx
@@ -153,7 +153,7 @@ describe("useMainScreenActions right panel actions", () => {
     expect(spies.requestRightPanelFocus).not.toHaveBeenCalled();
   });
 
-  it("toggles a closed right panel to Changes when a singleton tool is active", () => {
+  it("toggles a closed right panel to scratch when a singleton tool is active", () => {
     const { result, spies } = renderActions({
       rightPanelState: {
         ...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
@@ -168,7 +168,7 @@ describe("useMainScreenActions right panel actions", () => {
       DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
       lastCallArg(spies.setRightPanelState),
     );
-    expect(nextState.activeEntryKey).toBe("tool:git");
+    expect(nextState.activeEntryKey).toBe("tool:scratch");
     expect(spies.setRightPanelOpen).toHaveBeenCalledWith(true);
     expect(spies.requestRightPanelFocus).toHaveBeenCalledTimes(1);
   });

--- a/desktop/src/hooks/main/workflows/use-main-screen-actions.ts
+++ b/desktop/src/hooks/main/workflows/use-main-screen-actions.ts
@@ -108,7 +108,7 @@ export function useMainScreenActions({
         requestRightPanelFocus();
         return;
       }
-      openRightPanelTool("git");
+      openRightPanelTool("scratch");
     }
   }, [
     openRightPanelTool,

--- a/desktop/src/lib/access/tauri/workspace-scratch.ts
+++ b/desktop/src/lib/access/tauri/workspace-scratch.ts
@@ -1,0 +1,26 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WorkspaceScratchPadRecord {
+  content: string;
+  updatedAtMs: number | null;
+}
+
+export interface WorkspaceScratchPadWriteResult {
+  updatedAtMs: number | null;
+}
+
+export async function readWorkspaceScratchPad(
+  workspaceKey: string,
+): Promise<WorkspaceScratchPadRecord> {
+  return invoke<WorkspaceScratchPadRecord>("read_workspace_scratch_pad", { workspaceKey });
+}
+
+export async function writeWorkspaceScratchPad(
+  workspaceKey: string,
+  content: string,
+): Promise<WorkspaceScratchPadWriteResult> {
+  return invoke<WorkspaceScratchPadWriteResult>("write_workspace_scratch_pad", {
+    workspaceKey,
+    content,
+  });
+}

--- a/desktop/src/lib/domain/preferences/workspace-ui/migration.test.ts
+++ b/desktop/src/lib/domain/preferences/workspace-ui/migration.test.ts
@@ -308,6 +308,8 @@ describe("workspace UI state migration", () => {
       w1: {
         activeEntryKey: "tool:git",
         headerOrder: [
+          "tool:files",
+          "tool:scratch",
           "tool:git",
           "tool:settings",
           "terminal:t1",
@@ -347,7 +349,9 @@ describe("workspace UI state migration", () => {
       headerOrder: [
         "tool:git",
         "terminal:terminal-b",
+        "tool:files",
         "terminal:terminal-a",
+        "tool:scratch",
         "tool:settings",
       ],
       browserTabsById: {},
@@ -385,6 +389,8 @@ describe("workspace UI state migration", () => {
       headerOrder: [
         "terminal:t1",
         "tool:git",
+        "tool:scratch",
+        "tool:files",
         "tool:settings",
       ],
       browserTabsById: {},

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -5,7 +5,7 @@ import {
   type ViewerTargetKey,
 } from "@/lib/domain/workspaces/viewer/viewer-target";
 
-export type RightPanelTool = "git" | "settings";
+export type RightPanelTool = "scratch" | "files" | "git" | "settings";
 export type RightPanelHeaderEntryKey =
   | `tool:${RightPanelTool}`
   | `terminal:${string}`
@@ -44,6 +44,8 @@ export const RIGHT_PANEL_MAX_WIDTH = 700;
 export const RIGHT_PANEL_BROWSER_TAB_LIMIT = 5;
 
 export const DEFAULT_RIGHT_PANEL_TOOL_ORDER: RightPanelTool[] = [
+  "scratch",
+  "files",
   "git",
   "settings",
 ];
@@ -54,7 +56,7 @@ export const DEFAULT_RIGHT_PANEL_DURABLE_STATE: RightPanelDurableState = {
   width: RIGHT_PANEL_DEFAULT_WIDTH,
 };
 export const DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE: RightPanelMaterializedState = {
-  activeEntryKey: "tool:git",
+  activeEntryKey: "tool:scratch",
   headerOrder: DEFAULT_RIGHT_PANEL_HEADER_ORDER,
   browserTabsById: {},
 };

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-state.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-state.ts
@@ -344,6 +344,12 @@ function resolveRightPanelActiveEntryKey(
 function resolveFallbackRightPanelActiveEntryKey(
   headerOrder: readonly RightPanelHeaderEntryKey[],
 ): RightPanelActiveEntryKey {
+  if (headerOrder.includes("tool:scratch")) {
+    return "tool:scratch";
+  }
+  if (headerOrder.includes("tool:files")) {
+    return "tool:files";
+  }
   return headerOrder[0] ?? DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE.activeEntryKey;
 }
 

--- a/desktop/src/lib/domain/workspaces/shell/right-panel.test.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel.test.ts
@@ -21,8 +21,19 @@ import { fileViewerTarget } from "@/lib/domain/workspaces/viewer/viewer-target";
 
 describe("right panel domain", () => {
   it("gates cloud settings to cloud workspaces", () => {
-    expect(availableRightPanelTools(false)).toEqual(["git"]);
-    expect(availableRightPanelTools(true)).toEqual(["git", "settings"]);
+    expect(availableRightPanelTools(false)).toEqual(["scratch", "files", "git"]);
+    expect(availableRightPanelTools(true)).toEqual(["scratch", "files", "git", "settings"]);
+  });
+
+  it("defaults to scratch for new right-panel state", () => {
+    const state = reconcileRightPanelWorkspaceState(undefined, { isCloudWorkspaceSelected: false });
+
+    expect(state.activeEntryKey).toBe("tool:scratch");
+    expect(state.headerOrder).toEqual([
+      "tool:scratch",
+      "tool:files",
+      "tool:git",
+    ]);
   });
 
   it("parses browser entry keys", () => {
@@ -43,7 +54,7 @@ describe("right panel domain", () => {
     });
   });
 
-  it("drops cloud settings and legacy Files entries for local workspaces", () => {
+  it("drops cloud settings for local workspaces and falls back to scratch", () => {
     const state = reconcileRightPanelWorkspaceState(
       {
         activeEntryKey: "tool:settings",
@@ -52,8 +63,12 @@ describe("right panel domain", () => {
       { isCloudWorkspaceSelected: false },
     );
 
-    expect(state.activeEntryKey).toBe("tool:git");
-    expect(state.headerOrder).toEqual(["tool:git"]);
+    expect(state.activeEntryKey).toBe("tool:scratch");
+    expect(state.headerOrder).toEqual([
+      "tool:files",
+      "tool:scratch",
+      "tool:git",
+    ]);
   });
 
   it("routes legacy Review tool state to Changes", () => {
@@ -66,7 +81,7 @@ describe("right panel domain", () => {
     );
 
     expect(state.activeEntryKey).toBe("tool:git");
-    expect(state.headerOrder).toEqual(["tool:git"]);
+    expect(state.headerOrder).toEqual(["tool:files", "tool:scratch", "tool:git"]);
   });
 
   it("keeps a terminal active when no live terminal list is available", () => {
@@ -82,6 +97,8 @@ describe("right panel domain", () => {
     expect(state.headerOrder).toEqual([
       "terminal:t1",
       "tool:git",
+      "tool:scratch",
+      "tool:files",
     ]);
   });
 
@@ -100,9 +117,11 @@ describe("right panel domain", () => {
     expect(state.headerOrder).toEqual([
       "tool:git",
       "terminal:t2",
+      "tool:scratch",
+      "tool:files",
       "terminal:t1",
     ]);
-    expect(state.activeEntryKey).toBe("tool:git");
+    expect(state.activeEntryKey).toBe("tool:scratch");
   });
 
   it("does not append setup terminals unless already in the header", () => {
@@ -117,7 +136,12 @@ describe("right panel domain", () => {
       },
     );
 
-    expect(state.headerOrder).toEqual(["tool:git", "terminal:run"]);
+    expect(state.headerOrder).toEqual([
+      "tool:git",
+      "tool:scratch",
+      "tool:files",
+      "terminal:run",
+    ]);
   });
 
   it("reconciles one mixed header order for tools, terminals, and browsers", () => {
@@ -139,6 +163,8 @@ describe("right panel domain", () => {
       "browser:b1",
       "terminal:t2",
       "tool:git",
+      "tool:files",
+      "tool:scratch",
       "terminal:t1",
     ]);
     expect(state.activeEntryKey).toBe("browser:b1");
@@ -158,6 +184,8 @@ describe("right panel domain", () => {
       "tool:git",
       "terminal:t1",
       "terminal:t3",
+      "tool:scratch",
+      "tool:files",
     ]);
     expect(state.activeEntryKey).toBe("terminal:t1");
   });
@@ -205,6 +233,8 @@ describe("right panel domain", () => {
       "terminal:t3",
       "terminal:t1",
       "terminal:t2",
+      "tool:scratch",
+      "tool:files",
       "tool:git",
     ]);
     expect(state.activeEntryKey).toBe("terminal:t1");
@@ -222,9 +252,11 @@ describe("right panel domain", () => {
     );
 
     expect(state.headerOrder).toEqual([
+      "tool:files",
       "terminal:t1",
       "terminal:t2",
       "tool:git",
+      "tool:scratch",
     ]);
   });
 
@@ -242,6 +274,8 @@ describe("right panel domain", () => {
     expect(state.headerOrder).toEqual([
       "tool:settings",
       "tool:git",
+      "tool:scratch",
+      "tool:files",
     ]);
     expect(state.activeEntryKey).toBe("tool:git");
   });
@@ -260,7 +294,12 @@ describe("right panel domain", () => {
       },
     );
 
-    expect(state.headerOrder).toEqual([targetKey, "tool:git"]);
+    expect(state.headerOrder).toEqual([
+      "tool:files",
+      targetKey,
+      "tool:scratch",
+      "tool:git",
+    ]);
     expect(state.activeEntryKey).toBe(targetKey);
   });
 

--- a/docs/frontend/specs/workspace-files.md
+++ b/docs/frontend/specs/workspace-files.md
@@ -23,6 +23,12 @@ Changes is changed-file workflow:
 - review the latest completed turn as a transcript-backed file filter over
   current git diffs
 
+Scratch is local workspace notes:
+
+- store one plain Markdown scratch pad per workspace in Proliferate app data
+- keep scratch content out of the workspace repository
+- render as the default right-panel tool without forcing the panel open
+
 The durable right-panel tool id remains `git`; “Changes” is a display label.
 
 ## Viewer Targets
@@ -74,6 +80,22 @@ Zustand stores only local UI/editor state:
 
 Closing a viewer target deletes its mode/layout entries. File buffers are not a
 server read cache; they exist only for local editing and conflict metadata.
+
+Scratch content belongs to Tauri app-data access hooks. It is a local external
+resource, not Zustand state and not an AnyHarness file resource.
+
+## Right Panel Tools
+
+The durable Scratch tool id is `scratch`. New right-panel state defaults to
+Scratch first, followed by Files, Changes, and cloud Settings when available.
+Persisted selections should be normalized without opening the panel
+automatically.
+
+Workspace companion tools should use the shared pane primitives under
+`components/workspace/pane/**` for fixed-height headers, icon buttons, and
+options menus. Editable Scratch text uses the same source-view typography tokens
+as file and diff views. Shiki remains owned by shared Markdown/code renderers;
+the editable Scratch textarea is not syntax-highlighted.
 
 ## File Viewing
 


### PR DESCRIPTION
## Summary
- Adds a right-panel Scratch tool backed by Tauri app-data read/write commands, React Query hooks, and debounced serialized saves so stale writes cannot overwrite newer drafts.
- Makes Scratch the default right-panel tool ahead of Files and Changes, preserves legacy `allChanges` state by routing it to Changes, and keys Scratch storage by the stable workspace UI key.
- Wires the Files tool to the current workspace file browser surface and updates the workspace-files spec for the new panel order.

## Validation
- `git diff --check origin/main..HEAD`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir desktop test ScratchPadPanel.test.tsx RightPanel.test.tsx right-panel.test.ts migration.test.ts use-main-screen-actions.test.tsx` (61 tests)
- `python3 scripts/check_max_lines.py`