### PR TITLE
feat(desktop): improve loading and review receipts

### DIFF
--- a/desktop/src/components/playground/UpdateUiPlayground.tsx
+++ b/desktop/src/components/playground/UpdateUiPlayground.tsx
@@ -6,9 +6,8 @@ import {
   ArrowUp,
   Check,
   CircleAlert,
-  LoaderCircle,
   RefreshCw,
-  type IconProps,
+  Spinner,
 } from "@/components/ui/icons";
 import {
   UPDATE_PREVIEW_STATES,
@@ -24,10 +23,10 @@ const PHASE_LABELS: Record<UpdatePreviewPhase, string> = {
   error: "Error",
 };
 
-const PHASE_ICONS: Record<UpdatePreviewPhase, ComponentType<IconProps>> = {
+const PHASE_ICONS: Record<UpdatePreviewPhase, ComponentType<{ className?: string }>> = {
   checking: RefreshCw,
   available: ArrowUp,
-  downloading: LoaderCircle,
+  downloading: Spinner,
   ready: Check,
   error: CircleAlert,
 };
@@ -118,6 +117,7 @@ function PreviewSection({
 function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
   const Icon = PHASE_ICONS[state.phase];
   const isBusy = state.phase === "checking" || state.phase === "downloading";
+  const iconClassName = `size-4 ${state.phase === "checking" ? "animate-spin" : ""}`;
   const primaryDisabled = isBusy;
 
   return (
@@ -126,7 +126,7 @@ function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
         <div
           className={`flex size-8 shrink-0 items-center justify-center rounded-md bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
         >
-          <Icon className={`size-4 ${isBusy ? "animate-spin" : ""}`} />
+          <Icon className={iconClassName} />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
@@ -169,6 +169,7 @@ function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
 function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
   const Icon = PHASE_ICONS[state.phase];
   const isBusy = state.phase === "checking" || state.phase === "downloading";
+  const iconClassName = `size-5 ${state.phase === "checking" ? "animate-spin" : ""}`;
   const primaryDisabled = isBusy;
 
   return (
@@ -178,7 +179,7 @@ function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
           <div
             className={`flex size-10 shrink-0 items-center justify-center rounded-lg bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
           >
-            <Icon className={`size-5 ${isBusy ? "animate-spin" : ""}`} />
+            <Icon className={iconClassName} />
           </div>
           <Badge tone={PHASE_BADGE_TONES[state.phase]}>
             {PHASE_LABELS[state.phase]}

--- a/desktop/src/components/playground/UpdateUiPlayground.tsx
+++ b/desktop/src/components/playground/UpdateUiPlayground.tsx
@@ -6,7 +6,6 @@ import {
   ArrowUp,
   Check,
   CircleAlert,
-  RefreshCw,
   Spinner,
 } from "@/components/ui/icons";
 import {
@@ -24,7 +23,7 @@ const PHASE_LABELS: Record<UpdatePreviewPhase, string> = {
 };
 
 const PHASE_ICONS: Record<UpdatePreviewPhase, ComponentType<{ className?: string }>> = {
-  checking: RefreshCw,
+  checking: Spinner,
   available: ArrowUp,
   downloading: Spinner,
   ready: Check,
@@ -117,7 +116,6 @@ function PreviewSection({
 function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
   const Icon = PHASE_ICONS[state.phase];
   const isBusy = state.phase === "checking" || state.phase === "downloading";
-  const iconClassName = `size-4 ${state.phase === "checking" ? "animate-spin" : ""}`;
   const primaryDisabled = isBusy;
 
   return (
@@ -126,7 +124,7 @@ function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
         <div
           className={`flex size-8 shrink-0 items-center justify-center rounded-md bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
         >
-          <Icon className={iconClassName} />
+          <Icon className="size-4" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
@@ -169,7 +167,6 @@ function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
 function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
   const Icon = PHASE_ICONS[state.phase];
   const isBusy = state.phase === "checking" || state.phase === "downloading";
-  const iconClassName = `size-5 ${state.phase === "checking" ? "animate-spin" : ""}`;
   const primaryDisabled = isBusy;
 
   return (
@@ -179,7 +176,7 @@ function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
           <div
             className={`flex size-10 shrink-0 items-center justify-center rounded-lg bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
           >
-            <Icon className={iconClassName} />
+            <Icon className="size-5" />
           </div>
           <Badge tone={PHASE_BADGE_TONES[state.phase]}>
             {PHASE_LABELS[state.phase]}

--- a/desktop/src/components/ui/Button.test.tsx
+++ b/desktop/src/components/ui/Button.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Button } from "@/components/ui/Button";
+
+afterEach(cleanup);
+
+describe("Button", () => {
+  it("uses the shared compact spinner while loading", () => {
+    render(<Button loading>Save</Button>);
+
+    const button = screen.getByRole("button", { name: "Save" });
+    expect(button.querySelector("[data-loading-spinner]")).toBeTruthy();
+    expect(button.querySelector("svg.animate-spin")).toBeNull();
+  });
+});

--- a/desktop/src/components/ui/Button.tsx
+++ b/desktop/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
+import { Spinner } from "@/components/ui/icons";
 
 type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "destructive" | "inverted" | "unstyled";
 type ButtonSize = "sm" | "md" | "pill" | "icon" | "icon-sm" | "unstyled";
@@ -55,19 +56,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={twMerge(base, variantClasses[variant], sizeClasses[size], className)}
         {...props}
       >
-        {loading && (
-          <svg
-            className="size-3 animate-spin"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M21 12a9 9 0 1 1-6.22-8.56" />
-          </svg>
-        )}
+        {loading && <Spinner className="size-3" />}
         {children}
       </button>
     );

--- a/desktop/src/components/ui/icons.tsx
+++ b/desktop/src/components/ui/icons.tsx
@@ -901,16 +901,26 @@ export function ExpandAll({ className, ...props }: IconProps) {
 /** Spinning ring indicator — 3/4 arc that rotates. */
 export function Spinner({ className }: { className?: string }) {
   return (
-    <div className={`inline-flex animate-spin ${className ?? ""}`} style={{ animationDuration: "2s" }}>
-      <svg className="size-full" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <div
+      className={`proliferate-spinner inline-flex shrink-0 ${className ?? ""}`}
+      data-loading-spinner
+    >
+      <svg
+        aria-hidden="true"
+        className="size-full overflow-visible"
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <circle
           cx="10"
           cy="10"
-          r="7.5"
+          r="7.25"
           stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
-          strokeDasharray="28 19"
+          strokeDasharray="30 18"
+          opacity="0.72"
         />
       </svg>
     </div>

--- a/desktop/src/components/ui/icons.tsx
+++ b/desktop/src/components/ui/icons.tsx
@@ -570,14 +570,6 @@ export function CircleAlert({ className, ...props }: IconProps) {
   );
 }
 
-export function LoaderCircle({ className, ...props }: IconProps) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
-      <path d="M21 12a9 9 0 1 1-6.22-8.56" />
-    </svg>
-  );
-}
-
 export function StopSquare({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" {...props}>

--- a/desktop/src/components/workspace/browser/BrowserToolbar.tsx
+++ b/desktop/src/components/workspace/browser/BrowserToolbar.tsx
@@ -7,6 +7,7 @@ import {
   ExternalLink,
   Globe,
   RefreshCw,
+  Spinner,
 } from "@/components/ui/icons";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import type { RightPanelBrowserTab } from "@/lib/domain/workspaces/shell/right-panel-model";
@@ -47,7 +48,9 @@ export function BrowserToolbar({
               }
             }}
           >
-            <RefreshCw className={`size-3.5 ${activeStatus === "loading" ? "animate-spin" : ""}`} />
+            {activeStatus === "loading"
+              ? <Spinner className="size-3.5" />
+              : <RefreshCw className="size-3.5" />}
           </IconButton>
         </Tooltip>
         <div className="mx-0.5 h-4 w-px shrink-0 bg-sidebar-border" aria-hidden="true" />

--- a/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import type { ContentPart } from "@anyharness/sdk";
-import { FileIcon, Link2, LoaderCircle, X } from "@/components/ui/icons";
+import { FileIcon, Link2, Spinner, X } from "@/components/ui/icons";
 import { Button } from "@/components/ui/Button";
 import { FilePathLink } from "@/components/ui/content/FilePathLink";
 import { FileTreeEntryIcon } from "@/components/ui/file-icons";
@@ -277,7 +277,7 @@ function PromptImagePreview({
   return (
     <div className={previewFrameClassName(variant)} title={image.isError ? "Image unavailable" : "Loading image"}>
       {image.isLoading ? (
-        <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+        <Spinner className="size-4 text-muted-foreground" />
       ) : (
         <FileIcon className="size-4 text-muted-foreground" />
       )}

--- a/desktop/src/components/workspace/chat/input/ComposerFileMentionSearch.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerFileMentionSearch.tsx
@@ -3,7 +3,7 @@ import type { RefObject } from "react";
 import { twMerge } from "tailwind-merge";
 import { Button } from "@/components/ui/Button";
 import { FileTreeEntryIcon } from "@/components/ui/file-icons";
-import { LoaderCircle, Search } from "@/components/ui/icons";
+import { Search, Spinner } from "@/components/ui/icons";
 
 type FileSearchResult = SearchWorkspaceFilesResponse["results"][number];
 
@@ -46,7 +46,7 @@ export function ComposerFileMentionSearch({
     >
       <div className="flex h-8 items-center gap-2 border-b border-border/60 px-2.5 text-[0.5rem] text-muted-foreground">
         {isLoading ? (
-          <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+          <Spinner className="size-3.5" />
         ) : (
           <Search className="size-3.5 shrink-0" />
         )}

--- a/desktop/src/components/workspace/chat/input/PendingConfigIndicator.tsx
+++ b/desktop/src/components/workspace/chat/input/PendingConfigIndicator.tsx
@@ -1,5 +1,5 @@
 import type { PendingSessionConfigChangeStatus } from "@/lib/domain/sessions/pending-config";
-import { Clock, LoaderCircle } from "@/components/ui/icons";
+import { Clock, Spinner } from "@/components/ui/icons";
 
 interface PendingConfigIndicatorProps {
   pendingState: PendingSessionConfigChangeStatus | null;
@@ -11,7 +11,7 @@ export function PendingConfigIndicator({
   className = "size-3 shrink-0 text-muted-foreground/70",
 }: PendingConfigIndicatorProps) {
   if (pendingState === "submitting") {
-    return <LoaderCircle className={`${className} animate-spin`} />;
+    return <Spinner className={className} />;
   }
 
   if (pendingState === "queued") {

--- a/desktop/src/components/workspace/chat/input/PlanPickerPopover.tsx
+++ b/desktop/src/components/workspace/chat/input/PlanPickerPopover.tsx
@@ -1,7 +1,7 @@
 import { PopoverButton } from "@/components/ui/PopoverButton";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import { AddPlan, ClipboardList, LoaderCircle } from "@/components/ui/icons";
+import { AddPlan, ClipboardList, Spinner } from "@/components/ui/icons";
 import { ComposerControlButton } from "@/components/workspace/chat/input/ComposerControlButton";
 import { ComposerPopoverSurface } from "@/components/workspace/chat/input/ComposerPopoverSurface";
 import { usePlanPicker } from "@/hooks/plans/ui/use-plan-picker";
@@ -95,7 +95,7 @@ export function PlanPickerContentBody({
       <div className="max-h-80 overflow-y-auto p-1">
         {picker.isLoading && (
           <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
-            <LoaderCircle className="size-4 animate-spin" />
+            <Spinner className="size-4" />
             Loading plans...
           </div>
         )}

--- a/desktop/src/components/workspace/chat/input/WorkspaceMobilityFooterRow.tsx
+++ b/desktop/src/components/workspace/chat/input/WorkspaceMobilityFooterRow.tsx
@@ -9,7 +9,7 @@ import {
   Folder,
   FolderOpen,
   GitBranch,
-  LoaderCircle,
+  Spinner,
 } from "@/components/ui/icons";
 import { ComposerControlButton } from "./ComposerControlButton";
 import { WorkspaceMobilityLocationPopover } from "./WorkspaceMobilityLocationPopover";
@@ -43,7 +43,7 @@ export function WorkspaceMobilityFooterProgressStatus({
 }) {
   return (
     <div className="flex h-7 min-w-0 max-w-[34rem] shrink items-center gap-1.5 rounded-full bg-[var(--color-composer-control-hover)] px-2 text-sm text-foreground">
-      <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground" />
+      <Spinner className="size-3 text-muted-foreground" />
       <span className="min-w-0 truncate font-medium">{title}</span>
       <span className="h-3 w-px shrink-0 bg-border/80" aria-hidden="true" />
       <span className="min-w-0 truncate text-muted-foreground">{statusLabel}</span>

--- a/desktop/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/Button";
 import { ComposerAttachedPanel } from "@/components/workspace/chat/input/ComposerAttachedPanel";
 import { CloudStatusCompactHeader } from "@/components/workspace/chat/surface/CloudStatusCompactHeader";
-import { CircleAlert, LoaderCircle } from "@/components/ui/icons";
+import { CircleAlert, Spinner } from "@/components/ui/icons";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/use-selected-cloud-runtime-state";
 import type { SelectedCloudRuntimeViewModel } from "@/lib/domain/workspaces/cloud/cloud-runtime-state";
 
@@ -73,7 +73,7 @@ export function CloudRuntimeAttachedPanelView({
           phaseLabel={state.subtitle ?? "Reconnecting runtime"}
           tone={tone}
           statusIcon={state.phase === "resuming"
-            ? <LoaderCircle className="size-3 animate-spin" />
+            ? <Spinner className="size-3" />
             : <CircleAlert className="size-3" />}
           primaryAction={primaryAction}
           expanded={expanded}

--- a/desktop/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx
@@ -11,7 +11,7 @@ import { useCloudWorkspaceStatusScreenActions } from "@/hooks/cloud/workflows/us
 import { useRerunSetupMutation } from "@anyharness/sdk-react";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
-import { ArrowUpRight, LoaderCircle, X } from "@/components/ui/icons";
+import { ArrowUpRight, Spinner, X } from "@/components/ui/icons";
 import type { WorkspaceArrivalViewModel } from "@/lib/domain/workspaces/creation/arrival";
 import { useWorkspaceShellActions } from "@/components/workspace/shell/providers/WorkspaceShellActionsContext";
 
@@ -83,7 +83,7 @@ export function WorkspaceArrivalAttachedPanelView({
         <SectionRow label="Setup">
           <div className="flex items-center gap-2 text-base">
             {isSetupRunning && (
-              <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground" />
+              <Spinner className="size-3 text-muted-foreground" />
             )}
             <span className={`shrink-0 whitespace-nowrap ${setupToneColor}`}>{viewModel.setupStatusLabel}</span>
             <span className="text-muted-foreground/40">·</span>
@@ -256,7 +256,7 @@ export function WorkspaceArrivalAttachedPanel() {
           <>
             <Badge className="shrink-0 rounded-full px-2 py-0.5 text-base">
               <span className="inline-flex items-center gap-1">
-                {isBusy && <LoaderCircle className="size-3 animate-spin" />}
+                {isBusy && <Spinner className="size-3" />}
                 <span>{panelState.badgeLabel}</span>
               </span>
             </Badge>

--- a/desktop/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx
+++ b/desktop/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx
@@ -7,7 +7,7 @@ import {
   type CloudWorkspaceStatusScreenMode,
   type CloudWorkspaceStatusScreenModel,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
-import { CircleAlert, LoaderCircle } from "@/components/ui/icons";
+import { CircleAlert, Spinner } from "@/components/ui/icons";
 
 function SectionRow({
   label,
@@ -32,7 +32,7 @@ function shouldExpandByDefault(mode: CloudWorkspaceStatusScreenMode): boolean {
 
 function cloudStatusIcon(model: CloudWorkspaceStatusScreenModel) {
   if (model.mode === "pending") {
-    return <LoaderCircle className="size-3 animate-spin" />;
+    return <Spinner className="size-3" />;
   }
   return <CircleAlert className="size-3" />;
 }

--- a/desktop/src/components/workspace/chat/transcript/DelegatedAgentReceiptName.tsx
+++ b/desktop/src/components/workspace/chat/transcript/DelegatedAgentReceiptName.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/Button";
+import { buildDelegatedAgentIdentity } from "@/lib/domain/delegated-work/identity";
+
+interface DelegatedAgentReceiptNameProps {
+  id: string;
+  title?: string | null;
+  sessionId?: string | null;
+  sessionLinkId?: string | null;
+  onOpenSession?: (sessionId: string) => void;
+  className?: string;
+}
+
+export function DelegatedAgentReceiptName({
+  id,
+  title,
+  sessionId,
+  sessionLinkId,
+  onOpenSession,
+  className = "",
+}: DelegatedAgentReceiptNameProps) {
+  const identity = buildDelegatedAgentIdentity({
+    id,
+    title,
+    sessionId,
+    sessionLinkId,
+  });
+  const visibleLabel = identity.generatedName;
+  const fullLabel = identity.displayName;
+  const targetSessionId = sessionId?.trim() || null;
+  const textClassName = `font-medium ${identity.textColorClassName} ${className}`.trim();
+
+  if (targetSessionId && onOpenSession) {
+    return (
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        data-chat-transcript-ignore
+        aria-label={`Open ${fullLabel}`}
+        title={fullLabel}
+        className={`inline h-auto p-0 align-baseline leading-[inherit] hover:underline focus-visible:underline ${textClassName}`}
+        onClick={() => onOpenSession(targetSessionId)}
+      >
+        {visibleLabel}
+      </Button>
+    );
+  }
+
+  return (
+    <span className={textClassName} title={fullLabel}>
+      {visibleLabel}
+    </span>
+  );
+}

--- a/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SubagentWakeBadge } from "./SubagentWakeBadge";
 
 describe("SubagentWakeBadge", () => {
@@ -9,7 +9,7 @@ describe("SubagentWakeBadge", () => {
     cleanup();
   });
 
-  it("keeps the wake receipt at chat text size when rendered as a button", () => {
+  it("renders wake receipts as sentence-style transcript text", () => {
     const { container } = render(
       <SubagentWakeBadge
         label="explore-dotfiles"
@@ -19,26 +19,31 @@ describe("SubagentWakeBadge", () => {
       />,
     );
 
-    const chip = container.querySelector("button");
-    expect(chip?.className).toContain("text-[length:var(--text-chat)]");
+    const receipt = container.querySelector("p");
+    expect(receipt?.className).toContain("text-chat");
+    expect(receipt?.className).toContain("text-muted-foreground");
+    expect(receipt?.textContent).toContain("finished a turn.");
   });
 
-  it("does not render a visible Open suffix for clickable wake receipts", () => {
+  it("renders the delegated identity as the only clickable target", () => {
+    const onOpenChild = vi.fn();
     const { container } = render(
       <SubagentWakeBadge
         label="explore-dotfiles"
         childSessionId="child-session"
         sessionLinkId="session-link"
-        onOpenChild={() => {}}
+        onOpenChild={onOpenChild}
       />,
     );
 
-    const chip = container.querySelector("button");
-    expect(chip?.textContent).toContain("finished a turn");
-    expect(chip?.textContent).not.toContain("Open");
+    const openButton = screen.getByRole("button", { name: /Open .*explore-dotfiles/ });
+    expect(openButton.textContent).not.toContain("finished a turn");
+    fireEvent.click(openButton);
+    expect(onOpenChild).toHaveBeenCalledWith("child-session");
+    expect(container.querySelectorAll("button")).toHaveLength(1);
   });
 
-  it("renders clickable wake receipts directly without a hover-card wrapper", () => {
+  it("renders receipts without a chip shell", () => {
     const { container } = render(
       <SubagentWakeBadge
         label="explore-dotfiles"
@@ -48,7 +53,9 @@ describe("SubagentWakeBadge", () => {
       />,
     );
 
-    expect(container.firstElementChild?.tagName).toBe("BUTTON");
-    expect(container.querySelector("button")?.className).toContain("max-w-[77%]");
+    expect(container.firstElementChild?.tagName).toBe("P");
+    expect(container.firstElementChild?.className).toContain("max-w-[77%]");
+    expect(container.firstElementChild?.className).not.toContain("rounded-2xl");
+    expect(container.firstElementChild?.className).not.toContain("bg-foreground/5");
   });
 });

--- a/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx
+++ b/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx
@@ -1,6 +1,4 @@
-import { Button } from "@/components/ui/Button";
-import { Robot } from "@/components/ui/icons";
-import { buildDelegatedAgentIdentity } from "@/lib/domain/delegated-work/identity";
+import { DelegatedAgentReceiptName } from "@/components/workspace/chat/transcript/DelegatedAgentReceiptName";
 
 interface SubagentWakeBadgeProps {
   label?: string | null;
@@ -22,63 +20,37 @@ export function SubagentWakeBadge({
   onOpenChild,
 }: SubagentWakeBadgeProps) {
   const title = label?.trim() || titleFallback;
-  const identity = buildDelegatedAgentIdentity({
-    id: sessionLinkId ?? childSessionId ?? title,
-    title,
-    sessionId: childSessionId ?? null,
-    sessionLinkId: sessionLinkId ?? null,
-  });
-  const receiptText = formatWakeReceipt(identity.displayName, outcome);
-  const canOpenChild = !!childSessionId && !!onOpenChild;
-  const openChild = () => {
-    if (canOpenChild) {
-      onOpenChild(childSessionId!);
-    }
-  };
-  const content = (
-    <>
-      <Robot className={`size-3.5 shrink-0 ${identity.textColorClassName}`} />
-      <span className="min-w-0 truncate">{receiptText}</span>
-    </>
-  );
-  const chip = canOpenChild ? (
-    <Button
-      type="button"
-      variant="unstyled"
-      size="unstyled"
-      data-telemetry-mask
-      data-chat-transcript-ignore
-      title={`Open ${identity.displayName}`}
-      aria-label={`Open ${identity.displayName}`}
-      onClick={openChild}
-      className="inline-flex max-w-[77%] items-center gap-1.5 rounded-2xl bg-foreground/5 px-3 py-1.5 text-[length:var(--text-chat)] font-normal leading-[var(--text-chat--line-height)] text-foreground hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      {content}
-    </Button>
-  ) : (
-    <div
-      className="inline-flex max-w-[77%] items-center gap-1.5 rounded-2xl bg-foreground/5 px-3 py-1.5 text-[length:var(--text-chat)] leading-[var(--text-chat--line-height)] text-foreground"
-      data-telemetry-mask
-    >
-      {content}
-    </div>
-  );
+  const receiptText = formatWakeReceipt(outcome);
 
-  return chip;
+  return (
+    <p
+      className="max-w-[77%] text-right text-chat leading-[var(--text-chat--line-height)] text-muted-foreground"
+      data-telemetry-mask
+    >
+      <DelegatedAgentReceiptName
+        id={sessionLinkId ?? childSessionId ?? title}
+        title={title}
+        sessionId={childSessionId ?? null}
+        sessionLinkId={sessionLinkId ?? null}
+        onOpenSession={onOpenChild}
+      />
+      <span> {receiptText}.</span>
+    </p>
+  );
 }
 
-function formatWakeReceipt(title: string, outcome: string | null | undefined): string {
+function formatWakeReceipt(outcome: string | null | undefined): string {
   const normalized = normalizeOutcome(outcome);
   if (!normalized || normalized === "completed") {
-    return `${title} finished a turn`;
+    return "finished a turn";
   }
   if (normalized === "failed") {
-    return `${title} failed a turn`;
+    return "failed a turn";
   }
   if (normalized === "cancelled" || normalized === "canceled") {
-    return `${title} cancelled a turn`;
+    return "cancelled a turn";
   }
-  return `${title} ${normalized} a turn`;
+  return `${normalized} a turn`;
 }
 
 function normalizeOutcome(outcome: string | null | undefined): string | null {

--- a/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -114,10 +114,19 @@ export function TranscriptItemBlock({
         item.text,
       );
       if (reviewFeedbackReference) {
+        const canOpenReviewSession = (reviewerSessionId: string) =>
+          !!openSession && (canOpenSession?.(reviewerSessionId, "linked-child") ?? true);
         return (
           <ReviewFeedbackSummary
             reference={reviewFeedbackReference}
             sessionId={sessionId}
+            onOpenReviewerSession={openSession
+              ? (reviewerSessionId) => {
+                if (canOpenReviewSession(reviewerSessionId)) {
+                  openSession(reviewerSessionId, "linked-child");
+                }
+              }
+              : undefined}
           />
         );
       }

--- a/desktop/src/components/workspace/chat/transcript/TranscriptRowListShared.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptRowListShared.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, RefObject } from "react";
-import { LoaderCircle } from "@/components/ui/icons";
+import { Spinner } from "@/components/ui/icons";
 import type { TranscriptVirtualRow } from "@/lib/domain/chat/transcript/transcript-virtual-rows";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 
@@ -162,7 +162,7 @@ export function estimateRenderableRowHeight(
 export function TranscriptHistoryLoadingRow() {
   return (
     <div className="flex justify-center pb-3 text-muted-foreground" role="status">
-      <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+      <Spinner className="size-4" />
       <span className="sr-only">Loading earlier messages</span>
     </div>
   );

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
@@ -180,6 +180,35 @@ describe("ReviewFeedbackSummaryView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open UX reviewer critique" }));
     expect(onOpenCritique).toHaveBeenCalledTimes(1);
   });
+
+  it("shows cancelled queued reviewers as cancelled instead of reviewing", () => {
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "security",
+            personaLabel: "Security reviewer",
+            pass: true,
+          }),
+          assignment({
+            id: "offline",
+            personaLabel: "Offline reviewer",
+            pass: false,
+            status: "cancelled",
+          }),
+        ]}
+        reviewRunId="review-run"
+        state="queued"
+        target="PR"
+        onOpenCritique={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2 reviewers · 1 cancelled · 1 approved · PR")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open review feedback details" }));
+    expect(screen.getByText("Cancelled")).toBeTruthy();
+    expect(screen.queryByText("Reviewing")).toBeNull();
+  });
 });
 
 function assignment(

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
@@ -8,79 +8,24 @@ import { ReviewFeedbackSummaryView } from "./ReviewFeedbackSummary";
 afterEach(cleanup);
 
 describe("ReviewFeedbackSummaryView", () => {
-  it("renders a collapsed receipt before details are requested", () => {
+  it("renders all-approved terminal results as a sentence receipt", () => {
     render(
       <ReviewFeedbackSummaryView
         assignments={[
           assignment({
-            id: "security",
-            personaLabel: "Security reviewer",
+            id: "architecture",
+            personaLabel: "Architecture reviewer",
             pass: true,
-            summary: "Looks safe.",
+            reviewerSessionId: "reviewer-session-architecture",
+            sessionLinkId: "session-link-architecture",
           }),
           assignment({
-            id: "ux",
-            personaLabel: "UX reviewer",
-            pass: false,
-            summary: "Needs clearer approval copy.",
-          }),
-        ]}
-        reviewRunId="review-run"
-        target="PR"
-        onOpenCritique={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Review feedback")).toBeTruthy();
-    expect(screen.getByText("2 reviewers · 1 requested change · 1 approved · PR")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open review feedback details" })).toBeTruthy();
-    expect(screen.queryByText("Security reviewer")).toBeNull();
-    expect(screen.queryByText("UX reviewer")).toBeNull();
-    expect(screen.queryByText("codex")).toBeNull();
-    expect(screen.queryByText("gpt-5.4")).toBeNull();
-  });
-
-  it("opens reviewer rows in the details popover", () => {
-    const onOpenCritique = vi.fn();
-    render(
-      <ReviewFeedbackSummaryView
-        assignments={[
-          assignment({
-            id: "security",
-            personaLabel: "Security reviewer",
+            id: "risk",
+            personaLabel: "Risk reviewer",
             pass: true,
-            summary: "Looks safe.",
+            reviewerSessionId: "reviewer-session-risk",
+            sessionLinkId: "session-link-risk",
           }),
-          assignment({
-            id: "ux",
-            personaLabel: "UX reviewer",
-            pass: false,
-            summary: "Needs clearer approval copy.",
-          }),
-        ]}
-        reviewRunId="review-run"
-        target="PR"
-        onOpenCritique={onOpenCritique}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Open review feedback details" }));
-
-    expect(screen.getByText("Security reviewer")).toBeTruthy();
-    expect(screen.getByText("UX reviewer")).toBeTruthy();
-    expect(screen.getByText("Approved")).toBeTruthy();
-    expect(screen.getByText("Requests changes")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Open UX reviewer critique" }));
-    expect(onOpenCritique).toHaveBeenCalledTimes(1);
-  });
-
-  it("summarizes fully approved reviews as complete", () => {
-    render(
-      <ReviewFeedbackSummaryView
-        assignments={[
-          assignment({ id: "architecture", personaLabel: "Architecture reviewer", pass: true }),
-          assignment({ id: "risk", personaLabel: "Risk reviewer", pass: true }),
         ]}
         reviewRunId="review-run"
         target="plan"
@@ -88,8 +33,121 @@ describe("ReviewFeedbackSummaryView", () => {
       />,
     );
 
-    expect(screen.getByText("Review complete")).toBeTruthy();
-    expect(screen.getByText("2 reviewers approved · plan")).toBeTruthy();
+    expect(screen.getByTestId("review-terminal-receipt").textContent).toContain(
+      "finished reviewing your plan.",
+    );
+    expect(screen.queryByText(/approved · plan/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open review feedback details" })).toBeNull();
+    expect(screen.queryByText("codex")).toBeNull();
+    expect(screen.queryByText("gpt-5.4")).toBeNull();
+  });
+
+  it("renders mixed terminal results with concise counts", () => {
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "security",
+            personaLabel: "Security reviewer",
+            pass: true,
+            summary: "Looks safe.",
+            reviewerSessionId: "reviewer-session-security",
+            sessionLinkId: "session-link-security",
+          }),
+          assignment({
+            id: "ux",
+            personaLabel: "UX reviewer",
+            pass: false,
+            summary: "Needs clearer approval copy.",
+            reviewerSessionId: "reviewer-session-ux",
+            sessionLinkId: "session-link-ux",
+          }),
+        ]}
+        reviewRunId="review-run"
+        target="PR"
+        onOpenCritique={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("review-terminal-receipt").textContent).toContain(
+      "finished reviewing your PR: 1 requested change, 1 approved.",
+    );
+    expect(screen.queryByText("Review feedback")).toBeNull();
+  });
+
+  it("opens reviewer sessions from reviewer-name links", () => {
+    const onOpenReviewerSession = vi.fn();
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "ux",
+            personaLabel: "UX reviewer",
+            pass: false,
+            reviewerSessionId: "reviewer-session-ux",
+            sessionLinkId: "session-link-ux",
+          }),
+        ]}
+        reviewRunId="review-run"
+        target="PR"
+        onOpenCritique={vi.fn()}
+        onOpenReviewerSession={onOpenReviewerSession}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Open .*UX reviewer/ }));
+    expect(onOpenReviewerSession).toHaveBeenCalledWith("reviewer-session-ux");
+  });
+
+  it("renders reviewers without session ids as non-clickable colored text", () => {
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "offline",
+            personaLabel: "Offline reviewer",
+            pass: true,
+            reviewerSessionId: null,
+            sessionLinkId: "session-link-offline",
+          }),
+        ]}
+        reviewRunId="review-run"
+        target="PR"
+        onOpenCritique={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("review-terminal-receipt").textContent).toContain(
+      "finished reviewing your PR.",
+    );
+    expect(screen.queryByRole("button", { name: /Offline reviewer/ })).toBeNull();
+  });
+
+  it("keeps queued review feedback in the details-capable queue card", () => {
+    const onOpenCritique = vi.fn();
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "ux",
+            personaLabel: "UX reviewer",
+            pass: false,
+            summary: "Needs clearer approval copy.",
+          }),
+        ]}
+        reviewRunId="review-run"
+        state="queued"
+        target="PR"
+        onOpenCritique={onOpenCritique}
+      />,
+    );
+
+    expect(screen.getByText("Review feedback")).toBeTruthy();
+    expect(screen.getByText("1 reviewer · 1 requested change · PR")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open review feedback details" }));
+    expect(screen.getByText("UX reviewer")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open UX reviewer critique" }));
+    expect(onOpenCritique).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.test.tsx
@@ -75,6 +75,37 @@ describe("ReviewFeedbackSummaryView", () => {
     expect(screen.queryByText("Review feedback")).toBeNull();
   });
 
+  it("renders cancelled terminal reviewers without treating them as still reviewing", () => {
+    render(
+      <ReviewFeedbackSummaryView
+        assignments={[
+          assignment({
+            id: "security",
+            personaLabel: "Security reviewer",
+            pass: true,
+            reviewerSessionId: "reviewer-session-security",
+            sessionLinkId: "session-link-security",
+          }),
+          assignment({
+            id: "offline",
+            personaLabel: "Offline reviewer",
+            pass: false,
+            reviewerSessionId: null,
+            sessionLinkId: "session-link-offline",
+            status: "cancelled",
+          }),
+        ]}
+        reviewRunId="review-run"
+        target="PR"
+        onOpenCritique={vi.fn()}
+      />,
+    );
+
+    const receiptText = screen.getByTestId("review-terminal-receipt").textContent;
+    expect(receiptText).toContain("finished reviewing your PR: 1 cancelled, 1 approved.");
+    expect(receiptText).not.toContain("still reviewing");
+  });
+
   it("opens reviewer sessions from reviewer-name links", () => {
     const onOpenReviewerSession = vi.fn();
     render(

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
@@ -4,8 +4,8 @@ import type { ReactNode } from "react";
 import { Button } from "@/components/ui/Button";
 import { FileText } from "@/components/ui/icons";
 import { PopoverButton } from "@/components/ui/PopoverButton";
+import { DelegatedAgentReceiptName } from "@/components/workspace/chat/transcript/DelegatedAgentReceiptName";
 import type { ReviewFeedbackPromptReference } from "@/lib/domain/chat/subagents/provenance";
-import { buildDelegatedAgentIdentity } from "@/lib/domain/delegated-work/identity";
 import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
@@ -200,37 +200,14 @@ function ReviewerReceiptName({
   assignment: ReviewAssignmentDetail;
   onOpenReviewerSession?: (sessionId: string) => void;
 }) {
-  const identity = buildDelegatedAgentIdentity({
-    id: assignment.id,
-    title: assignment.personaLabel,
-    sessionId: assignment.reviewerSessionId,
-    sessionLinkId: assignment.sessionLinkId,
-  });
-  const label = identity.generatedName;
-  const className = `font-medium ${identity.textColorClassName}`;
-  const sessionId = assignment.reviewerSessionId?.trim() || null;
-
-  if (sessionId && onOpenReviewerSession) {
-    return (
-      <Button
-        type="button"
-        variant="unstyled"
-        size="unstyled"
-        data-chat-transcript-ignore
-        aria-label={`Open ${identity.displayName}`}
-        title={identity.displayName}
-        className={`inline h-auto p-0 align-baseline leading-[inherit] hover:underline focus-visible:underline ${className}`}
-        onClick={() => onOpenReviewerSession(sessionId)}
-      >
-        {label}
-      </Button>
-    );
-  }
-
   return (
-    <span className={className} title={identity.displayName}>
-      {label}
-    </span>
+    <DelegatedAgentReceiptName
+      id={assignment.id}
+      title={assignment.personaLabel}
+      sessionId={assignment.reviewerSessionId}
+      sessionLinkId={assignment.sessionLinkId}
+      onOpenSession={onOpenReviewerSession}
+    />
   );
 }
 

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
@@ -222,12 +222,15 @@ function reviewTerminalSummary(assignments: ReviewAssignmentDetail[]): string | 
   const timedOutCount = assignments.filter((assignment) =>
     assignment.status === "timed_out"
   ).length;
+  const cancelledCount = assignments.filter((assignment) =>
+    assignment.status === "cancelled"
+  ).length;
   const failedCount = assignments.filter((assignment) =>
     assignment.status === "system_failed" || assignment.status === "retryable_failed"
   ).length;
   const pendingCount = Math.max(
     0,
-    reviewerCount - approvedCount - changesCount - timedOutCount - failedCount,
+    reviewerCount - approvedCount - changesCount - timedOutCount - cancelledCount - failedCount,
   );
 
   if (reviewerCount > 0 && approvedCount === reviewerCount) {
@@ -240,6 +243,7 @@ function reviewTerminalSummary(assignments: ReviewAssignmentDetail[]): string | 
       : null,
     failedCount > 0 ? `${failedCount} failed` : null,
     timedOutCount > 0 ? `${timedOutCount} timed out` : null,
+    cancelledCount > 0 ? `${cancelledCount} cancelled` : null,
     approvedCount > 0 ? `${approvedCount} approved` : null,
     pendingCount > 0 ? `${pendingCount} still reviewing` : null,
   ].filter((part): part is string => part !== null);

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
@@ -367,7 +367,11 @@ function reviewFeedbackReceipt(
     || assignment.status === "timed_out"
     || assignment.status === "retryable_failed"
   ).length;
-  const pendingCount = Math.max(0, reviewerCount - approvedCount - changesCount - failedCount);
+  const cancelledCount = assignments.filter((assignment) => assignment.status === "cancelled").length;
+  const pendingCount = Math.max(
+    0,
+    reviewerCount - approvedCount - changesCount - failedCount - cancelledCount,
+  );
   const reviewerLabel = `${reviewerCount} ${reviewerCount === 1 ? "reviewer" : "reviewers"}`;
 
   if (approvedCount === reviewerCount) {
@@ -380,6 +384,7 @@ function reviewFeedbackReceipt(
   const detailParts = [
     changesCount > 0 ? `${changesCount} requested ${changesCount === 1 ? "change" : "changes"}` : null,
     failedCount > 0 ? `${failedCount} failed` : null,
+    cancelledCount > 0 ? `${cancelledCount} cancelled` : null,
     pendingCount > 0 ? `${pendingCount} reviewing` : null,
     approvedCount > 0 ? `${approvedCount} approved` : null,
   ].filter((part): part is string => part !== null);
@@ -407,6 +412,9 @@ function reviewAssignmentVerdict(assignment: ReviewAssignmentDetail): {
   }
   if (assignment.status === "retryable_failed") {
     return { label: "Needs retry", tone: "changes" };
+  }
+  if (assignment.status === "cancelled") {
+    return { label: "Cancelled", tone: "pending" };
   }
   return { label: "Reviewing", tone: "pending" };
 }

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
@@ -1,9 +1,11 @@
 import type { ReviewAssignmentDetail } from "@anyharness/sdk";
 import { useSessionReviewsQuery } from "@anyharness/sdk-react";
+import type { ReactNode } from "react";
 import { Button } from "@/components/ui/Button";
 import { FileText } from "@/components/ui/icons";
 import { PopoverButton } from "@/components/ui/PopoverButton";
 import type { ReviewFeedbackPromptReference } from "@/lib/domain/chat/subagents/provenance";
+import { buildDelegatedAgentIdentity } from "@/lib/domain/delegated-work/identity";
 import { useReviewUiStore } from "@/stores/reviews/review-ui-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 
@@ -11,12 +13,14 @@ interface ReviewFeedbackSummaryProps {
   reference: ReviewFeedbackPromptReference;
   sessionId: string | null;
   state?: "queued" | "completed";
+  onOpenReviewerSession?: (sessionId: string) => void;
 }
 
 export function ReviewFeedbackSummary({
   reference,
   sessionId,
   state = "completed",
+  onOpenReviewerSession,
 }: ReviewFeedbackSummaryProps) {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const openCritique = useReviewUiStore((state) => state.openCritique);
@@ -43,6 +47,7 @@ export function ReviewFeedbackSummary({
       reviewRunId={reference.reviewRunId}
       state={state}
       target={target}
+      onOpenReviewerSession={onOpenReviewerSession}
       onOpenCritique={(assignment) => {
         openCritique({
           reviewRunId: reference.reviewRunId,
@@ -60,6 +65,7 @@ export function ReviewFeedbackSummaryView({
   reviewRunId,
   state = "completed",
   target,
+  onOpenReviewerSession,
   onOpenCritique,
 }: {
   assignments: ReviewAssignmentDetail[];
@@ -67,9 +73,21 @@ export function ReviewFeedbackSummaryView({
   reviewRunId: string;
   state?: "queued" | "completed";
   target: "plan" | "PR";
+  onOpenReviewerSession?: (sessionId: string) => void;
   onOpenCritique: (assignment: ReviewAssignmentDetail) => void;
 }) {
   const receipt = reviewFeedbackReceipt(assignments, target, state, referenceLabel);
+
+  if (state === "completed" && assignments.length > 0) {
+    return (
+      <ReviewTerminalReceipt
+        assignments={assignments}
+        target={target}
+        onOpenReviewerSession={onOpenReviewerSession}
+      />
+    );
+  }
+
   return (
     <div className="flex justify-end">
       <div
@@ -114,6 +132,142 @@ export function ReviewFeedbackSummaryView({
       </div>
     </div>
   );
+}
+
+function ReviewTerminalReceipt({
+  assignments,
+  target,
+  onOpenReviewerSession,
+}: {
+  assignments: ReviewAssignmentDetail[];
+  target: "plan" | "PR";
+  onOpenReviewerSession?: (sessionId: string) => void;
+}) {
+  const summary = reviewTerminalSummary(assignments);
+  return (
+    <div className="flex justify-end" data-telemetry-mask>
+      <p
+        data-testid="review-terminal-receipt"
+        className="max-w-[77%] text-right text-chat leading-[var(--text-chat--line-height)] text-muted-foreground"
+      >
+        {reviewerNameList(assignments, onOpenReviewerSession)}
+        <span> finished reviewing {target === "PR" ? "your PR" : "your plan"}</span>
+        {summary ? <span>: {summary}</span> : null}
+        <span>.</span>
+      </p>
+    </div>
+  );
+}
+
+function reviewerNameList(
+  assignments: ReviewAssignmentDetail[],
+  onOpenReviewerSession: ((sessionId: string) => void) | undefined,
+): ReactNode[] {
+  const names = assignments.map((assignment) => (
+    <ReviewerReceiptName
+      key={assignment.id}
+      assignment={assignment}
+      onOpenReviewerSession={onOpenReviewerSession}
+    />
+  ));
+
+  if (names.length <= 1) {
+    return names;
+  }
+
+  if (names.length === 2) {
+    return [names[0], <span key="separator-and"> and </span>, names[1]];
+  }
+
+  const result: ReactNode[] = [];
+  names.forEach((name, index) => {
+    if (index > 0) {
+      result.push(
+        <span key={`separator-${index}`}>
+          {index === names.length - 1 ? ", and " : ", "}
+        </span>,
+      );
+    }
+    result.push(name);
+  });
+  return result;
+}
+
+function ReviewerReceiptName({
+  assignment,
+  onOpenReviewerSession,
+}: {
+  assignment: ReviewAssignmentDetail;
+  onOpenReviewerSession?: (sessionId: string) => void;
+}) {
+  const identity = buildDelegatedAgentIdentity({
+    id: assignment.id,
+    title: assignment.personaLabel,
+    sessionId: assignment.reviewerSessionId,
+    sessionLinkId: assignment.sessionLinkId,
+  });
+  const label = identity.generatedName;
+  const className = `font-medium ${identity.textColorClassName}`;
+  const sessionId = assignment.reviewerSessionId?.trim() || null;
+
+  if (sessionId && onOpenReviewerSession) {
+    return (
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        data-chat-transcript-ignore
+        aria-label={`Open ${identity.displayName}`}
+        title={identity.displayName}
+        className={`inline h-auto p-0 align-baseline leading-[inherit] hover:underline focus-visible:underline ${className}`}
+        onClick={() => onOpenReviewerSession(sessionId)}
+      >
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <span className={className} title={identity.displayName}>
+      {label}
+    </span>
+  );
+}
+
+function reviewTerminalSummary(assignments: ReviewAssignmentDetail[]): string | null {
+  const reviewerCount = assignments.length;
+  const approvedCount = assignments.filter((assignment) =>
+    assignment.status === "submitted" && assignment.pass
+  ).length;
+  const changesCount = assignments.filter((assignment) =>
+    assignment.status === "submitted" && !assignment.pass
+  ).length;
+  const timedOutCount = assignments.filter((assignment) =>
+    assignment.status === "timed_out"
+  ).length;
+  const failedCount = assignments.filter((assignment) =>
+    assignment.status === "system_failed" || assignment.status === "retryable_failed"
+  ).length;
+  const pendingCount = Math.max(
+    0,
+    reviewerCount - approvedCount - changesCount - timedOutCount - failedCount,
+  );
+
+  if (reviewerCount > 0 && approvedCount === reviewerCount) {
+    return null;
+  }
+
+  const parts = [
+    changesCount > 0
+      ? `${changesCount} requested ${changesCount === 1 ? "change" : "changes"}`
+      : null,
+    failedCount > 0 ? `${failedCount} failed` : null,
+    timedOutCount > 0 ? `${timedOutCount} timed out` : null,
+    approvedCount > 0 ? `${approvedCount} approved` : null,
+    pendingCount > 0 ? `${pendingCount} still reviewing` : null,
+  ].filter((part): part is string => part !== null);
+
+  return parts.join(", ") || null;
 }
 
 function ReviewFeedbackDetails({

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -377,6 +377,24 @@ describe("RightPanel tab shortcuts", () => {
     expect(screen.queryByTestId("git-panel")).toBeNull();
   });
 
+  it("does not intercept angle tab-cycle shell shortcuts after clicking panel content", async () => {
+    const { container } = render(<RightPanelHarness isWorkspaceReady />);
+    const root = container.querySelector("[data-right-panel-root='true']");
+    if (!(root instanceof HTMLElement)) {
+      throw new Error("Expected right panel root");
+    }
+
+    fireEvent.pointerDown(root);
+    expect(document.activeElement).toBe(root);
+
+    fireEvent.keyDown(window, angleTabEvent("next"));
+    fireEvent.keyDown(window, angleTabEvent("previous"));
+
+    await Promise.resolve();
+
+    expect(screen.queryByTestId("git-panel")).toBeNull();
+  });
+
   it("does not intercept primary-number shell shortcuts from right-panel text inputs", async () => {
     render(<RightPanelHarness isWorkspaceReady />);
     const input = screen.getByTestId("scratch-panel-input");
@@ -385,6 +403,22 @@ describe("RightPanel tab shortcuts", () => {
     expect(document.activeElement).toBe(input);
 
     fireEvent.keyDown(window, primaryDigitEvent(3));
+
+    await Promise.resolve();
+
+    expect(screen.queryByTestId("git-panel")).toBeNull();
+  });
+
+  it("does not intercept angle tab-cycle shell shortcuts from right-panel text inputs", async () => {
+    render(<RightPanelHarness isWorkspaceReady />);
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    const input = screen.getByTestId("files-panel-input");
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.keyDown(window, angleTabEvent("next"));
+    fireEvent.keyDown(window, angleTabEvent("previous"));
 
     await Promise.resolve();
 
@@ -526,6 +560,16 @@ function primaryDigitEvent(digit: number) {
   return {
     key: String(digit),
     code: `Digit${digit}`,
+    ...(isApplePlatform() ? { metaKey: true } : { ctrlKey: true }),
+  };
+}
+
+function angleTabEvent(direction: "next" | "previous") {
+  return {
+    key: direction === "next" ? ">" : "<",
+    code: direction === "next" ? "Period" : "Comma",
+    shiftKey: true,
+    altKey: true,
     ...(isApplePlatform() ? { metaKey: true } : { ctrlKey: true }),
   };
 }

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -411,8 +411,7 @@ describe("RightPanel tab shortcuts", () => {
 
   it("does not intercept angle tab-cycle shell shortcuts from right-panel text inputs", async () => {
     render(<RightPanelHarness isWorkspaceReady />);
-    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
-    const input = screen.getByTestId("files-panel-input");
+    const input = screen.getByTestId("scratch-panel-input");
 
     input.focus();
     expect(document.activeElement).toBe(input);

--- a/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/Button";
-import { Check, LoaderCircle } from "@/components/ui/icons";
+import { Check, Spinner } from "@/components/ui/icons";
 import type { UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 
 interface SidebarUpdatePillProps {
@@ -40,7 +40,7 @@ export function SidebarUpdatePill({
 
   const indicator =
     phase === "downloading"
-      ? <LoaderCircle className="size-3 animate-spin text-sidebar-muted-foreground" />
+      ? <Spinner className="size-3 text-sidebar-muted-foreground" />
       : phase === "ready"
         ? <Check className="size-3 text-info-foreground" />
         : null;

--- a/desktop/src/config/playground.test.ts
+++ b/desktop/src/config/playground.test.ts
@@ -8,6 +8,7 @@ import { renderMobilityOverlayPreview } from "@/components/playground/Playground
 import { renderActiveSlot } from "@/components/playground/composer-slots/PlaygroundActiveSlotFixtures";
 import { renderAttachedSlot } from "@/components/playground/composer-slots/PlaygroundAttachedSlotFixtures";
 import { renderOutboundSlot } from "@/components/playground/composer-slots/PlaygroundOutboundSlotFixtures";
+import { renderPlaygroundReviewTranscript } from "@/components/playground/transcript/PlaygroundReviewTranscript";
 import { renderComposerSurfaceForScenario } from "@/components/playground/PlaygroundComposerSurfaces";
 import { FILE_MENTION_SEARCH_RESULTS } from "@/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures";
 import {
@@ -178,6 +179,16 @@ describe("playground scenarios", () => {
 
   it("includes collapsed review feedback transcript message scenarios", () => {
     expect(Object.keys(SCENARIOS)).toEqual(expect.arrayContaining(REVIEW_TRANSCRIPT_SCENARIOS));
+
+    const completeHtml = renderToStaticMarkup(renderPlaygroundReviewTranscript("review-complete-message"));
+    expect(completeHtml).toContain("finished reviewing your plan");
+    expect(completeHtml).not.toContain("Open review feedback details");
+
+    const feedbackHtml = renderToStaticMarkup(renderPlaygroundReviewTranscript("review-feedback-message"));
+    expect(feedbackHtml).toContain("finished reviewing your PR");
+    expect(feedbackHtml).toContain("requested change");
+    expect(feedbackHtml).toContain("approved");
+    expect(feedbackHtml).not.toContain("Open review feedback details");
   });
 
   it("keeps queued rows single-line and hides edit on the active edit row", () => {

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -1679,6 +1679,29 @@ body {
   animation: brand-mark-fade-out 0.22s ease-out forwards;
 }
 
+/* ---- Compact spinner ----
+   Shared current-color spinner for small controls. Keep this separate from
+   the braille/session loading vocabulary below. */
+@keyframes proliferate-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.proliferate-spinner {
+  animation: proliferate-spinner-rotate 1.1s linear infinite;
+  transform-origin: center;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proliferate-spinner {
+    animation: none;
+    transform: rotate(45deg);
+    will-change: auto;
+  }
+}
+
 /* ---- Braille sweep loading text ----
    This must stay CSS-driven. The previous React ticker updated every 60ms and
    forced the chat shell to commit continuously while a loader was visible. */

--- a/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -341,4 +341,92 @@ describe("shortcut dispatch policy", () => {
       target: null,
     } as KeyboardEvent)).toBe(true);
   });
+
+  it("allows tab index shortcuts from right-panel text inputs even when handled locally", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.tabByIndex, {
+      key: "3",
+      code: "Digit3",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: true,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+  });
+
+  it("allows angle tab cycling from right-panel text inputs even when handled locally", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.previousTabAngle, {
+      key: "<",
+      code: "Comma",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: true,
+      defaultPrevented: true,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.nextTabAngle, {
+      key: ">",
+      code: "Period",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: true,
+      defaultPrevented: true,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+  });
+
+  it("allows tab index shortcuts from terminal focus zones", () => {
+    vi.stubGlobal("document", {
+      activeElement: {
+        closest: () => ({
+          getAttribute: () => "terminal",
+        }),
+      },
+    });
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.tabByIndex, {
+      key: "4",
+      code: "Digit4",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: true,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+  });
+
+  it("allows tab cycling from browser focus zones", () => {
+    vi.stubGlobal("document", {
+      activeElement: {
+        closest: () => ({
+          getAttribute: () => "browser",
+        }),
+      },
+    });
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.nextTabAngle, {
+      key: ">",
+      code: "Period",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: true,
+      defaultPrevented: true,
+      target: null,
+    } as KeyboardEvent)).toBe(true);
+  });
 });

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -56,5 +56,8 @@ server/proliferate/server/cloud/runtime/credential_freshness.py
 server/proliferate/db/store/cloud_workspaces.py
 server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/runtime/bootstrap.py
+server/proliferate/server/cloud/runtime/credential_freshness.py
+server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/runtime/provision.py
 server/proliferate/server/cloud/workspaces/service.py
+server/tests/integration/test_cloud_commands_api.py


### PR DESCRIPTION
## Summary
- Use the shared compact Spinner for small loading states and tune its reduced-motion behavior.
- Render completed review results as inline transcript receipts with colored reviewer session links.
- Add right-pane shortcut regressions for tab index and tab-cycle shortcuts from focused panel, input, terminal, and browser-like contexts.

## Verification
- `pnpm --filter proliferate exec tsc --noEmit`
- `pnpm --filter proliferate test`
- `git diff --check`