### PR TITLE
docs(cloud): update worker supervisor specs

### DIFF
--- a/docs/anyharness/contract.md
+++ b/docs/anyharness/contract.md
@@ -142,6 +142,30 @@ keeps the clear self-contained after a runtime process restart.
 Omitted values default to enabled for compatibility. Resume requests do not
 carry this flag; resumed sessions use their persisted policy.
 
+### Worker-Facing HTTP Contract
+
+`proliferate-worker` is a first-class AnyHarness API client. These routes are
+the current worker-facing contract used by Cloud-mediated targets:
+
+| Worker command / loop | AnyHarness route | Notes |
+| --- | --- | --- |
+| `materialize_workspace` `existing_path` | `POST /v1/workspaces/resolve` | Idempotently resolves or registers a repo/workspace path. |
+| `materialize_workspace` `worktree` | `POST /v1/workspaces/worktrees` | Creates a worktree workspace from an existing repo root id. |
+| worktree recovery | `POST /v1/workspaces/resolve` | Used only when a failed worktree create may correspond to an existing compatible worktree. |
+| display-name patch | `PATCH /v1/workspaces/{workspace_id}/display-name` | Best-effort after workspace materialization. |
+| `start_session` | `POST /v1/sessions` | Uses the normal session create contract. |
+| `send_prompt` | `POST /v1/sessions/{session_id}/prompt` | Worker maps legacy text/prompt payloads into prompt blocks for compatibility. |
+| `update_session_config` | `POST /v1/sessions/{session_id}/config-options` | Raw config ids are applied directly; normalized controls are resolved from live config before apply. |
+| `resolve_interaction` | `POST /v1/sessions/{session_id}/interactions/{interaction_id}/resolve` | Covers permission, user-input, and MCP elicitation outcomes. |
+| `cancel_turn` | `POST /v1/sessions/{session_id}/cancel` | AnyHarness owns canonical cancel semantics. |
+| `close_session` | `POST /v1/sessions/{session_id}/close` | AnyHarness owns session close state. |
+| event tailing | `GET /v1/sessions/{session_id}/events?after_seq=...` | Worker polls by sequence and uploads Cloud event batches. |
+
+Cloud command ids, actor metadata, and target routing context are Cloud/worker
+concerns today. The worker currently sends ordinary AnyHarness request bodies;
+there is no AnyHarness `command_metadata` envelope or precondition contract on
+these routes yet.
+
 ### `files.rs`
 
 Owns workspace file listing, read, write, and stat wire formats.

--- a/docs/anyharness/src/agents.md
+++ b/docs/anyharness/src/agents.md
@@ -188,6 +188,23 @@ Important install cases:
   `agents/<kind>/.install.lock` so desktop, CLI, and seed hydration do not
   write the same agent at the same time
 
+Public HTTP routes include:
+
+- `GET /v1/agents`
+- `GET /v1/agents/launch-options`
+- `GET /v1/agents/reconcile`
+- `POST /v1/agents/reconcile`
+- `GET /v1/agents/{kind}`
+- `POST /v1/agents/{kind}/install`
+- `POST /v1/agents/{kind}/login/start`
+- `GET /v1/agents/{kind}/model-registry`
+- `POST /v1/agents/{kind}/model-registry/refresh`
+
+Cloud target enrollment, Git bootstrap, and workspace materialization do not
+install agents. A fresh cloud/SSH target may report worker and AnyHarness
+online while `start_session` still fails with an install/readiness error until
+the requested agent is installed through this API.
+
 ### ACP Registry Flow
 
 `integrations/agent_cli/acp_registry.rs`

--- a/docs/anyharness/src/sessions.md
+++ b/docs/anyharness/src/sessions.md
@@ -232,8 +232,8 @@ Current tools:
 before choosing non-default `agentKind`, `modelId`, or `modeId` values. It
 reports current parent-derived defaults, launchable agents/models, subagent
 limits, and live parent mode options when AnyHarness has observed them. Mode ids
-remain launch hints in this PR; agent/model choices are validated against the
-launch catalog.
+remain launch hints; agent/model choices are validated against the launch
+catalog.
 
 `read_subagent_events` is deliberately bounded. It accepts `sinceSeq` plus a
 limit capped at 100, strips streaming deltas, and removes raw tool input/output
@@ -390,12 +390,21 @@ The runtime layer:
 
 Cancel and close follow the same pattern.
 
-### Permission Resolution
+### Interaction Resolution
 
-Permission resolution also goes through `SessionRuntime`.
+Interaction resolution also goes through `SessionRuntime`.
 
-It does not persist permissions itself. It finds the live session handle and
-delegates to ACP’s permission broker via the live runtime.
+It does not persist interaction decisions itself. It finds the live session
+handle and delegates to the live runtime. Current interaction kinds include:
+
+- permission decisions
+- requested user input
+- MCP elicitation responses
+
+The public resolution path is
+`POST /v1/sessions/{session_id}/interactions/{interaction_id}/resolve`.
+`proliferate-worker` uses the same route for Cloud-mediated web/mobile/Slack
+approval and input commands.
 
 ## Configuring Flow
 

--- a/docs/anyharness/src/workspaces.md
+++ b/docs/anyharness/src/workspaces.md
@@ -94,6 +94,8 @@ It:
 6. otherwise creates or returns a `kind=local` workspace for that repo root
 
 This is the main registration path when a client points AnyHarness at a repo.
+It is also the endpoint used by `proliferate-worker` for
+`materialize_workspace(mode=existing_path)`.
 
 ### Create Workspace
 
@@ -111,10 +113,17 @@ local-vs-worktree logic without the early return for an existing record.
 2. runs `git worktree add -b ...`
 3. resolves git context for the new path
 4. inserts a new durable worktree workspace record
-5. optionally runs a setup script inside the new worktree
+5. schedules setup script execution for the new worktree when requested
 
-The returned result includes both the new workspace and optional setup-script
-execution output.
+The HTTP worktree creation response returns the new workspace identity. Setup
+script execution is asynchronous in the current API surface; callers should not
+expect synchronous setup-script output in the creation response.
+
+`proliferate-worker` uses this endpoint for
+`materialize_workspace(mode=worktree)`. If worktree creation returns a
+non-success response that could represent a compatible existing worktree, the
+worker may recover by calling `/v1/workspaces/resolve` for the requested target
+path and accepting only matching worktree identity.
 
 ### Workspace Environment
 

--- a/docs/architecture/cloud-worker-automation-migration-spec.md
+++ b/docs/architecture/cloud-worker-automation-migration-spec.md
@@ -1,10 +1,10 @@
 # Cloud Worker Automation Migration Spec
 
-Status: concrete follow-up PR spec.
+Status: current implementation spec, verified against `main` on 2026-05-15.
 
-Scope: PR C in the Cloud Worker migration sequence.
+Scope: command-backed automation execution through Proliferate Worker.
 
-This spec defines the migration that makes automations run against any
+This spec describes the current automation execution path that runs against any
 registered target through CloudCommands.
 
 It depends on:
@@ -21,8 +21,11 @@ Automation execution should become a target-agnostic command pipeline:
 ```text
 automation run
   -> resolve target_id
-  -> materialize_workspace command
-  -> materialize_environment command if needed
+  -> configure_git_identity command
+  -> ensure_repo_checkout command
+  -> materialize_workspace existing_path command for repo root
+  -> materialize_workspace worktree command for the run workspace
+  -> materialize_environment command
   -> start_session command
   -> update_session_config command if needed
   -> send_prompt command
@@ -40,13 +43,60 @@ future desktop_dispatch / self_hosted / vpc targets
 The executor should not know how to call E2B or SSH directly for execution
 mutations. It should resolve a target and enqueue commands for that target.
 
+## Current Main State
+
+`main` implements the staged automation pipeline under:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/
+```
+
+The ordered stage calls are:
+
+```text
+resolve_target_stage
+ensure_git_identity_stage
+materialize_workspace_stage
+materialize_environment_stage
+start_session_stage
+apply_session_config_stage
+dispatch_prompt_stage
+```
+
+Stage responsibilities on `main`:
+
+- target stage resolves/snapshots the registered target and checks online
+  readiness.
+- Git identity stage enqueues `configure_git_identity` using target-scoped
+  encrypted Git material. Raw GitHub tokens are not placed in command payloads.
+- workspace stage creates/loads the CloudWorkspace, enqueues
+  `ensure_repo_checkout`, resolves the repo root with
+  `materialize_workspace(mode=existing_path)`, creates the automation worktree
+  with `materialize_workspace(mode=worktree)`, and attaches AnyHarness ids to
+  the run.
+- environment stage enqueues `materialize_environment` for env vars, tracked
+  files, MCP config, skills, agent credential files, and manifests.
+- session stage enqueues `start_session` and optional `update_session_config`.
+- prompt stage enqueues `send_prompt` and marks the run `dispatched` after the
+  command is accepted or accepted-but-queued.
+
+Current caveats:
+
+- Worker compatibility/min-version gating is not implemented; there are no
+  pre-launch deployed old workers, so failures are currently command-level
+  instead of immediate "target worker too old" errors.
+- Fresh targets still need the requested agent installed/readied before
+  `start_session`; Git checkout and workspace materialization do not install
+  Claude/Codex/Gemini/OpenCode.
+- Cloud projections/session visibility are event-ingest driven. The automation
+  executor records run ids and command status, not assistant transcript rows.
+
 ## Non-Goals
 
-Do not implement the supervised runtime bundle in this PR.
+Do not implement target bootstrap or supervisor behavior here. That belongs to
+`docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md`.
 
-Do not add `materialize_workspace` in this PR.
-
-Do not build the final Web/Mobile automation UX in this PR.
+Do not build the final Web/Mobile automation UX in this migration layer.
 
 Do not redesign automation scheduling.
 
@@ -147,11 +197,12 @@ failed
 cancelled
 ```
 
-For PR C, interpret them as:
+Current command-backed interpretation:
 
 ```text
 creating_workspace
-  materialize_workspace command in progress
+  configure_git_identity, ensure_repo_checkout, or materialize_workspace command
+  in progress
 
 provisioning_workspace
   materialize_environment command in progress
@@ -444,7 +495,7 @@ server/proliferate/server/automations/worker/
         fail_current_claim()
 ```
 
-Do not keep substantial new logic in the older flat files if this PR rewrites
+Do not keep substantial new logic in the older flat files if this migration rewrites
 the executor. Existing files can become shims temporarily only inside the same
 PR while moving tests; do not leave duplicate production paths.
 
@@ -501,6 +552,7 @@ Each stage should return a new context with additional fields populated.
 ```python
 async def run_automation_pipeline(ctx: AutomationExecutionContext) -> None:
     ctx = await resolve_target_stage(ctx)
+    ctx = await ensure_git_identity_stage(ctx)
     ctx = await materialize_workspace_stage(ctx)
     ctx = await materialize_environment_stage(ctx)
     ctx = await start_session_stage(ctx)
@@ -613,6 +665,34 @@ TargetExecutionContext
 This stage is the only automation stage allowed to choose or provision a
 target.
 
+### Git Identity Stage
+
+File:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/git_identity.py
+```
+
+Responsibilities:
+
+- resolve the target creator/user GitHub OAuth account and Git identity used
+  for v1 target Git access
+- create or load the target Git identity record
+- enqueue `configure_git_identity`
+- wait for result
+- fail explicitly if the user has no GitHub auth or Cloud cannot materialize
+  the target Git identity
+
+The command payload contains only the target Git identity id and config
+version. It must never contain the raw GitHub OAuth token. The worker fetches
+encrypted material through a worker-authenticated Cloud endpoint.
+
+Command stage key:
+
+```text
+configure-git-identity:{config_version}
+```
+
 ### Workspace Stage
 
 File:
@@ -624,8 +704,13 @@ server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
 Responsibilities:
 
 - create/load `CloudWorkspace` record for the run
-- enqueue `materialize_workspace`
-- wait for result
+- enqueue `ensure_repo_checkout`
+- wait for repo checkout result
+- enqueue `materialize_workspace(mode=existing_path)` to resolve the repo root
+- wait for repo-root workspace result
+- enqueue `materialize_workspace(mode=worktree)` to create/resolve the run
+  worktree
+- wait for worktree result
 - attach `anyharness_workspace_id` and cloud workspace id to the run
 - attach `anyharness_repo_root_id` if the worker returns one and the schema has
   a place for it; otherwise record it in command result metadata until a later
@@ -635,10 +720,26 @@ Responsibilities:
 Command stage key:
 
 ```text
-materialize-workspace
+ensure-repo-checkout
+materialize-workspace:repo-root
+materialize-workspace:worktree
 ```
 
-Expected payload:
+Expected `ensure_repo_checkout` payload:
+
+```json
+{
+  "repo": {
+    "provider": "github",
+    "owner": "proliferate-ai",
+    "name": "proliferate"
+  },
+  "checkoutPath": "/home/ubuntu/proliferate-workspaces/proliferate-ai/proliferate",
+  "baseBranch": "main"
+}
+```
+
+Expected worktree `materialize_workspace` payload:
 
 ```json
 {
@@ -659,9 +760,9 @@ Expected payload:
 }
 ```
 
-If repo root id is unknown for a fresh target, PR C may need a pre-step that
-uses `existing_path` to register the cloned repo root before creating a
-worktree. Keep this explicit rather than hiding it in the worker.
+Fresh targets use `ensure_repo_checkout` followed by
+`materialize_workspace(mode=existing_path)` to get the repo root id before
+creating the worktree. Keep this explicit rather than hiding it in the worker.
 
 Workspace path policy:
 
@@ -861,7 +962,10 @@ automation_run:{run_id}:target:{target_id}
 Stage keys:
 
 ```text
-materialize-workspace
+configure-git-identity:{config_version}
+ensure-repo-checkout
+materialize-workspace:repo-root
+materialize-workspace:worktree
 materialize-environment:{config_version}
 start-session
 update-reasoning-effort
@@ -942,9 +1046,9 @@ Do not treat `delivered` as success. It only means the worker saw the command.
 
 ## Typed Payload And Result Shapes
 
-PR C should avoid new `dict[str, object]` spread across stages. It is fine for
-the store to persist JSON, but stage code should use small Pydantic/dataclass
-payload builders before serializing.
+Stage code should avoid new `dict[str, object]` spread across stages. It is
+fine for the store to persist JSON, but stage code should use small
+Pydantic/dataclass payload builders before serializing.
 
 Suggested files:
 
@@ -955,6 +1059,10 @@ server/proliferate/server/automations/worker/cloud_execution/command_models.py
 Suggested types:
 
 ```text
+ConfigureGitIdentityPayload
+ConfigureGitIdentityResult
+EnsureRepoCheckoutPayload
+EnsureRepoCheckoutResult
 MaterializeWorkspacePayload
 MaterializeWorkspaceResult
 MaterializeEnvironmentPayload
@@ -986,7 +1094,8 @@ Result parsing must be strict:
 
 ## Cloud Workspace And Session Projections
 
-PR C should not poll AnyHarness directly to find transcript/session state.
+The automation executor should not poll AnyHarness directly to find
+transcript/session state.
 
 After `start_session` and `send_prompt`, visibility comes from the existing
 Cloud sync path:
@@ -1105,7 +1214,7 @@ Manual trigger:
 
 ```text
 uses automation target by default
-may accept target override if implemented in this PR
+may accept target override if implemented
 snapshot override onto run
 ```
 
@@ -1165,28 +1274,31 @@ error copy/code
 
 ## Implementation Order
 
-Implement PR C in this order to keep reviewable:
+The implementation on `main` has already completed the core migration order:
 
-1. Add DB columns and dataclass/Pydantic fields.
-2. Add service validation for automation target selection.
-3. Snapshot target fields when creating manual and scheduled runs.
-4. Add `cloud_execution/context.py`, `commands.py`, and typed command models.
-5. Move target resolution into `cloud_execution/stages/target.py`.
-6. Move workspace/environment/session/prompt logic into explicit stages.
-7. Replace `process_cloud_automation_run` with a call to
-   `run_automation_pipeline`.
-8. Remove direct AnyHarness mutation imports from automation worker code.
-9. Add unit tests for target selection, snapshotting, command order, and
-   idempotency.
-10. Run manual SSH smoke.
+1. DB columns and dataclass/Pydantic fields were added for target snapshots.
+2. Automation target selection is validated through the automation service.
+3. Manual and scheduled runs snapshot target fields.
+4. `cloud_execution/context.py`, `commands.py`, and typed command models exist.
+5. Target resolution lives in `cloud_execution/stages/target.py`.
+6. Git identity, workspace, environment, session, and prompt logic live in
+   explicit stages.
+7. `cloud_executor.py` calls `run_automation_pipeline`.
+8. Direct AnyHarness mutation imports are removed from automation execution.
+9. Unit coverage exists for the staged pieces.
 
-Do not begin by deleting old files. First introduce the staged shape, migrate
-call sites, then delete or turn old modules into thin import shims in the same
-PR.
+Remaining implementation hardening:
+
+1. Make fresh-target agent install/readiness part of the repeatable smoke path.
+2. Add worker command-kind/min-version gating before enqueue.
+3. Keep managed-cloud legacy direct launch fallbacks isolated to provisioning
+   and reconnect compatibility.
+4. Expand smoke scripts so SSH and managed cloud automations are both tested
+   from `main` without manual setup.
 
 ## Acceptance Criteria
 
-The PR is done only when all of these are true:
+The migration is considered healthy only when all of these are true:
 
 - A cloud automation can target an enrolled SSH target by target id.
 - A cloud automation can target the managed-cloud path after the target is
@@ -1198,12 +1310,14 @@ The PR is done only when all of these are true:
 - Every CloudCommand created by the executor has stable idempotency scope/key.
 - A reviewer can understand the full execution order from `pipeline.py` without
   opening worker loop code.
+- A fresh SSH smoke either installs/readies the requested agent automatically
+  or fails before `start_session` with a clear agent-readiness error.
 
 ## Direct AnyHarness Call Removal
 
 Automation execution must not call direct AnyHarness mutation helpers.
 
-Disallowed in automation execution code after this PR:
+Disallowed in automation execution code:
 
 ```text
 create_runtime_session
@@ -1281,7 +1395,9 @@ Suggested cases:
 - target stage loads selected SSH target
 - target stage loads selected managed cloud target
 - target stage rejects archived/offline target where policy requires online
-- workspace stage enqueues `materialize_workspace`
+- Git identity stage enqueues `configure_git_identity`
+- workspace stage enqueues `ensure_repo_checkout`
+- workspace stage enqueues `materialize_workspace` for repo root and worktree
 - environment stage enqueues `materialize_environment`
 - session stage enqueues `start_session`
 - prompt stage enqueues `send_prompt`
@@ -1340,7 +1456,10 @@ Automation command pipeline smoke:
 3. automation targeting SSH target
 4. manual automation trigger
 5. CloudCommands appear:
-     materialize_workspace
+     configure_git_identity
+     ensure_repo_checkout
+     materialize_workspace existing_path
+     materialize_workspace worktree
      materialize_environment
      start_session
      update_session_config if configured
@@ -1405,7 +1524,7 @@ mutation adapters.
 
 ### Manual Local Smoke
 
-Expected manual loop after PR A and PR B:
+Expected manual loop:
 
 ```text
 1. make dev PROFILE=worker
@@ -1429,17 +1548,22 @@ execution, event upload, and Cloud projections are connected.
 
 ## Completion Checklist
 
-- [ ] automations can store selected cloud target id
-- [ ] automation runs snapshot selected cloud target id/kind
-- [ ] cloud executor is organized as a stage pipeline
-- [ ] workspace stage uses `materialize_workspace`
-- [ ] environment stage uses `materialize_environment`
-- [ ] session/prompt stages use existing command kinds
-- [ ] managed cloud automations use target id after provisioning/enrollment
-- [ ] SSH automations use the same command path
-- [ ] automation execution code has no direct AnyHarness mutation calls
-- [ ] event sync, not direct executor polling, updates Cloud session/message
+- [x] automations can store selected cloud target id
+- [x] automation runs snapshot selected cloud target id/kind
+- [x] cloud executor is organized as a stage pipeline
+- [x] Git identity stage uses `configure_git_identity`
+- [x] workspace stage uses `ensure_repo_checkout`
+- [x] workspace stage uses `materialize_workspace`
+- [x] environment stage uses `materialize_environment`
+- [x] session/prompt stages use existing command kinds
+- [x] managed cloud automations use target id after provisioning/enrollment
+- [x] SSH automations use the same command path
+- [x] automation execution code has no direct AnyHarness mutation calls
+- [x] event sync, not direct executor polling, updates Cloud session/message
       visibility
+- [ ] fresh-target automation smoke installs/readies requested agent before
+      `start_session`
+- [ ] Cloud rejects enqueue for command kinds unsupported by the target worker
 
 ## Review Questions
 

--- a/docs/architecture/cloud-worker-control-plane.md
+++ b/docs/architecture/cloud-worker-control-plane.md
@@ -2,7 +2,8 @@
 
 Status: implementation spec for Cloud-mediated session control, Proliferate
 Worker, target enrollment, command delivery, event ingestion, snapshots,
-compute lifecycle, and cloud sync.
+compute lifecycle, and cloud sync. Current implementation notes were verified
+against `main` on 2026-05-15.
 
 Scope:
 
@@ -59,6 +60,33 @@ AnyHarness remains the execution source of truth. Cloud stores command history,
 normalized events, snapshots/read models, policy, audit, billing, target state,
 and artifact references. Cloud does not become a second AnyHarness runtime
 database.
+
+## Current Main Implementation Notes
+
+The architecture below is the target model. Current `main` implements the
+worker spine with a few pragmatic differences that reviewers should keep in
+mind:
+
+- active worker command kinds are `configure_git_identity`,
+  `ensure_repo_checkout`, `materialize_workspace`,
+  `materialize_environment`, `start_session`, `send_prompt`,
+  `resolve_interaction`, `update_session_config`, `cancel_turn`,
+  `close_session`, and `sync_existing_workspace`.
+- command leases are stored inline on `cloud_commands`; there is no separate
+  lease table.
+- worker command polling currently returns immediately from the server and the
+  worker sleeps on empty responses. It is not server-held long polling yet.
+- command `preconditions` are not accepted by the current Cloud command
+  validator.
+- the worker sends ordinary AnyHarness request bodies. There is not yet an
+  AnyHarness `command_metadata` envelope.
+- event sync polls
+  `GET /v1/sessions/{session_id}/events?after_seq=...` and uploads batches
+  directly. The worker has local command-result retry state, but no durable
+  event outbox table.
+- event ingest currently enforces caps by rejecting oversized batches and
+  truncating retained payloads through payload policy; it does not yet emit all
+  degraded/compacted marker variants described as future target behavior.
 
 ## Non-Goals For V1
 
@@ -451,20 +479,23 @@ error_message nullable
 V1 command kinds:
 
 ```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
+materialize_environment
 start_session
-resume_session
 send_prompt
 resolve_interaction
 update_session_config
 cancel_turn
-cancel_session
-stop_workspace
-hibernate_workspace
-resume_workspace
-prune_workspace
-extend_workspace_ttl
+close_session
 sync_existing_workspace
 ```
+
+Additional lifecycle commands such as `stop_workspace`,
+`hibernate_workspace`, `resume_workspace`, `prune_workspace`, and
+`extend_workspace_ttl` remain target architecture, not active worker command
+kinds on current `main`.
 
 Command status:
 
@@ -876,6 +907,12 @@ cloud_artifact_refs:
 The worker is a separate binary crate. Do not put worker code inside
 `anyharness-lib`; the worker talks to AnyHarness over the local HTTP/SSE API.
 
+The tree below is the intended ownership shape. Current `main` has the core
+modules but not every target submodule: event sync uses polling in `sync/tailer`
+rather than a local SSE stream tailer plus durable event outbox, command
+preconditions are not implemented, and some inventory/readiness logic is still
+coarser than the final split.
+
 ```text
 anyharness/crates/proliferate-worker/
   Cargo.toml
@@ -1020,12 +1057,12 @@ runtime main
 Loop defaults:
 
 ```text
-heartbeat interval: 15 seconds when active, 60 seconds when idle
+heartbeat interval: implementation-configured; current worker config default is 30 seconds
 inventory interval: 5 minutes or when hash changes
-command long-poll timeout: 25 seconds
-event batch flush: 100 ms or 100 events or 512 KB, whichever comes first
-outbox retry: exponential backoff with jitter
-lease timeout: 60 seconds for normal commands, shorter for stale-safe commands
+command poll: server returns immediately; worker sleeps briefly on empty responses
+lease timeout: current worker requests a 300 second lease
+event upload: worker polls AnyHarness events by seq and uploads batches directly
+event outbox retry: not implemented as a separate durable local event outbox yet
 ```
 
 ## AnyHarness Contract Additions
@@ -1033,6 +1070,12 @@ lease timeout: 60 seconds for normal commands, shorter for stale-safe commands
 Prefer using existing AnyHarness endpoints where they already express the
 operation. Add contract fields only where worker/cloud correctness requires
 canonical command identity, actor metadata, or target inventory.
+
+Current `main` uses existing AnyHarness HTTP contracts for worker dispatch:
+workspace resolve/worktree creation, session create/prompt/config/interaction
+resolution/cancel/close, and session event listing. The `commands.rs`
+metadata/precondition contract below remains target architecture and is not
+accepted by current AnyHarness request bodies.
 
 New/extended contract files:
 
@@ -1306,7 +1349,7 @@ Desktop dispatch should be opt-in per machine and preferably per workspace.
    target is cloud-sync addressable
    command kind is allowed
    idempotency key is unique or returns existing command
-   preconditions are well formed
+   preconditions are absent until the precondition contract is implemented
 
 4. commands.store inserts queued command.
 
@@ -1319,7 +1362,7 @@ Desktop dispatch should be opt-in per machine and preferably per workspace.
    lease_expires_at = now + timeout
 
 8. Worker dispatcher maps Cloud command to AnyHarness request:
-   POST /v1/sessions/{S}/prompt with command_metadata.
+   POST /v1/sessions/{S}/prompt.
 
 9. AnyHarness accepts/rejects/queues and emits canonical events.
 
@@ -1340,6 +1383,11 @@ from AnyHarness events.
 ## Event Upload And Backfill Flow
 
 Backfill is required when enabling sync for an existing workspace/session.
+
+Current implementation note: worker event sync polls AnyHarness session events
+by sequence and uploads batches directly to Cloud. The explicit local event
+outbox steps below describe the target reliability model; they are not a
+separate table in current `main`.
 
 ```text
 1. Cloud enqueues sync_existing_workspace command or worker observes sync flag.

--- a/docs/architecture/cloud-worker-implementation-phases.md
+++ b/docs/architecture/cloud-worker-implementation-phases.md
@@ -1,6 +1,7 @@
 # Cloud Worker Implementation Phases
 
-Status: implementation plan for the Cloud Worker migration.
+Status: implementation plan plus current implementation snapshot, verified
+against `main` on 2026-05-15.
 
 This document turns `docs/architecture/cloud-worker-control-plane.md` into
 direct implementation phases with concrete file paths and ownership rules.
@@ -32,6 +33,76 @@ The migration must remove production Cloud runtime control that directly calls
 AnyHarness from the server. Server code may still provision compute, manage
 policy, enqueue commands, ingest events, publish live patches, and store
 snapshots.
+
+## Current Main Snapshot
+
+The original phase list below is still useful as the implementation map, but
+the stack has moved beyond several "to build" statements. Current `main`
+state for the AnyHarness / Proliferate Worker / supervisor path:
+
+Implemented:
+
+- `cloud/sdk` and `cloud/sdk-react` exist; generated OpenAPI output is tracked.
+- Compute targets, SSH enrollment, worker heartbeat, target inventory, and
+  direct SSH access metadata exist.
+- `proliferate-supervisor` exists and is the target service entrypoint for SSH
+  installs.
+- Managed cloud bootstrap stages AnyHarness, Proliferate Worker, and
+  Proliferate Supervisor, then launches the supervisor for fresh supervised
+  runtimes.
+- Worker command leasing/result reporting exists over `cloud_commands` using
+  inline lease fields, not a separate lease table.
+- Active worker command kinds are:
+
+```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
+materialize_environment
+start_session
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+close_session
+sync_existing_workspace
+```
+
+- Automation execution is staged through
+  `server/proliferate/server/automations/worker/cloud_execution/`:
+
+```text
+resolve_target_stage
+ensure_git_identity_stage
+materialize_workspace_stage
+materialize_environment_stage
+start_session_stage
+apply_session_config_stage
+dispatch_prompt_stage
+```
+
+- Worker event sync polls AnyHarness session events by sequence and uploads
+  batches directly to Cloud ingest. There is not yet a durable local event
+  outbox table.
+- Cloud event ingest stores bounded semantic rows, applies payload policy, and
+  updates session/message/request/config state from events.
+- A main-branch SSH automation smoke has verified command dispatch through
+  `configure_git_identity`, `ensure_repo_checkout`, workspace materialization,
+  environment materialization, session start, and prompt dispatch.
+
+Important remaining gaps:
+
+- Fresh target agent install/readiness is not automated in the worker
+  automation smoke path. A target can be online but fail `start_session` with
+  `InstallRequired` until the requested agent is installed through AnyHarness.
+- Worker command-kind/min-version gating is not implemented.
+- Supervisor update flow can stage/verify update requests, but no daemon path
+  downloads, swaps binaries, restarts into a desired version, or rolls back.
+- Some managed-cloud reconnect/credential-refresh paths still contain legacy
+  direct launch fallbacks for old sandboxes.
+- The worker sync path does not yet persist a separate event outbox before
+  upload; command result retry state exists locally, event replay relies on
+  AnyHarness event history and Cloud ingest cursors.
 
 ## Non-Negotiable Boundaries
 
@@ -250,6 +321,15 @@ server/proliferate/db/store/cloud_mobility.py             keep; mobility/handoff
 ```
 
 ## Phase 0: Contract Freeze And Direct-Path Audit
+
+The phase sections below preserve the original implementation plan and file
+ownership map. When a lower section describes future-looking pieces that differ
+from `main`, the "Current Main Snapshot" above and the focused current specs
+take precedence:
+
+- `docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md`
+- `docs/architecture/cloud-worker-workspace-command-spec.md`
+- `docs/architecture/cloud-worker-automation-migration-spec.md`
 
 ### Goal
 
@@ -919,9 +999,11 @@ Tables:
 
 ```text
 cloud_commands
-cloud_command_leases
 cloud_sessions
 ```
+
+Current `main` stores lease fields inline on `cloud_commands`; there is no
+separate `cloud_command_leases` table.
 
 Constraints:
 
@@ -1057,6 +1139,10 @@ Responsibility split:
 ### AnyHarness Contract Additions
 
 Add optional command metadata to existing requests:
+
+Current `main` has not added these fields. Worker dispatch uses existing
+AnyHarness request bodies, and Cloud command ids/preconditions remain
+Cloud/worker concerns.
 
 ```text
 PromptSessionRequest.command_metadata

--- a/docs/architecture/cloud-worker-pr-stack-review-guide.md
+++ b/docs/architecture/cloud-worker-pr-stack-review-guide.md
@@ -1,6 +1,7 @@
 # Cloud Worker PR Stack Review Guide
 
 Status: synthesized reviewer guide for the Cloud worker/control-plane PR stack.
+Current implementation notes were verified against `main` on 2026-05-15.
 
 Purpose: give reviewers a single map for understanding the PRs that implement
 the Cloud-mediated worker model. This document is intentionally not the source
@@ -12,6 +13,42 @@ Use this guide when reviewing:
 - broad worker/control-plane baseline PR #207
 - implementation stack PRs #212, #214, #216, #217, #218, #219, #221, #222,
   and #223
+
+Current `main` has since folded in additional follow-up work beyond the PR list
+above:
+
+- supervised target runtime bundle for SSH and managed cloud
+- active worker commands for Git bootstrap, repo checkout, workspace
+  materialization, environment materialization, session control, and sync
+- staged automation execution through
+  `server/proliferate/server/automations/worker/cloud_execution/`
+- target Git identity materialization without raw tokens in command payloads
+- SSH automation smoke coverage through command dispatch
+
+Current active worker command kinds:
+
+```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
+materialize_environment
+start_session
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+close_session
+sync_existing_workspace
+```
+
+Current storage differs from the early broad baseline:
+
+- command lease fields live inline on `cloud_commands`
+- there is no separate `cloud_command_leases` table
+- worker event sync does not yet have a durable local event outbox table
+- the user-facing product rows are sessions/messages/requests/config/targets,
+  with projection as an implementation term rather than a standalone product
+  object
 
 ## Core Mental Model
 
@@ -187,11 +224,12 @@ Core tables:
 - `cloud_targets`
 - `cloud_workers`
 - `cloud_commands`
-- `cloud_command_leases`
 - `cloud_session_events`
-- `cloud_event_ingest_cursors`
-- `cloud_projection_snapshots`
-- `cloud_artifact_refs`
+- `cloud_event_ingest_state`
+- `cloud_synced_workspaces`
+- `cloud_sessions`
+- `cloud_transcript_items`
+- `cloud_pending_interactions`
 
 ### Review Checklist
 
@@ -1124,4 +1162,3 @@ create future drift:
 - What exact production pub/sub backend will replace or back the current
   process-local live fanout?
 - What is the signed update artifact/trust-root plan after supervisor staging?
-

--- a/docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md
+++ b/docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md
@@ -1,8 +1,9 @@
 # Cloud Worker Runtime Bundle And Supervisor Spec
 
-Status: concrete follow-up PR spec.
+Status: current implementation spec, verified against `main` on 2026-05-15.
 
-Scope: PR A in the Cloud Worker migration sequence.
+Scope: supervised target runtime bundle for SSH, managed cloud, and future
+cloud-addressable targets.
 
 This spec defines the implementation work required to make every
 cloud-addressable target boot the same supervised runtime bundle:
@@ -18,13 +19,44 @@ The target may be a managed cloud sandbox, an SSH machine, or a future
 self-hosted/VPC target. The process shape must be the same even when the
 onboarding flow differs.
 
-This spec intentionally does not cover the next two PRs:
+The original PR-A framing in this file is historical. The runtime bundle,
+worker, and supervisor pieces now exist on `main`; this document describes the
+current shape and the remaining hardening work.
 
-- adding missing command kinds such as workspace/worktree materialization
-- migrating automations fully to target-agnostic CloudCommand orchestration
+## Current Main State
 
-Those PRs should assume the runtime bundle and process lifecycle in this file
-are already correct.
+`main` currently has the target runtime split intended by this spec:
+
+```text
+proliferate-supervisor
+  -> anyharness
+  -> proliferate-worker
+```
+
+Implemented pieces:
+
+- `anyharness/crates/proliferate-worker/**`
+- `anyharness/crates/proliferate-supervisor/**`
+- release builds for all three target binaries:
+  `anyharness`, `proliferate-worker`, `proliferate-supervisor`
+- SSH installer installs all three binaries and creates a user systemd service
+  whose `ExecStart` invokes `proliferate-supervisor`
+- worker enrollment, heartbeat, inventory, command leasing, command result
+  reporting, event upload, and update-status endpoints
+- managed cloud bootstrap writes worker and supervisor config and launches the
+  supervisor for new supervised runtimes
+- legacy managed-cloud relaunch fallbacks remain only for older sandboxes that
+  do not have supervisor config
+- worker heartbeat reports AnyHarness, worker, and supervisor versions
+- worker update reconciliation stages a supervisor update request; supervisor
+  supports verify/stage primitives, not a full production binary swap flow
+
+Important current follow-up:
+
+- Agent process installation/readiness is separate from supervisor bootstrap.
+  A fresh target can have AnyHarness/worker/supervisor running but still reject
+  `start_session` with `InstallRequired` until the requested agent is installed
+  through AnyHarness, for example `POST /v1/agents/{kind}/install`.
 
 ## Goal
 
@@ -36,7 +68,7 @@ exist on that machine, who starts them, who restarts them, how versions are
 reported, and how can we prove the target is alive?
 ```
 
-By the end of this PR:
+Current target state:
 
 - runtime artifacts contain `anyharness`, `proliferate-worker`, and
   `proliferate-supervisor`
@@ -51,17 +83,20 @@ By the end of this PR:
 
 ## Non-Goals
 
-Do not add or change automation execution semantics in this PR.
+Do not add or change automation execution semantics in this runtime-bundle
+layer.
 
-Do not add missing CloudCommand kinds such as `materialize_workspace` in this
-PR.
+Do not add CloudCommand behavior such as `materialize_workspace` in this
+runtime-bundle layer.
 
-Do not delete all direct server-to-AnyHarness runtime calls in this PR. Direct
-execution mutation removal belongs to the automation migration PR. This PR may
-move managed cloud process launch away from direct detached process scripts.
+Do not delete all direct server-to-AnyHarness runtime calls in this layer.
+Direct execution mutation removal belongs to the automation migration. Runtime
+bundle work may move managed cloud process launch away from direct detached
+process scripts.
 
-Do not build a full update rollout product in this PR. The PR should make
-component version reporting and supervisor update hooks structurally correct.
+Do not treat the current supervisor update hooks as a full update rollout
+product. This layer should make component version reporting and supervisor
+update hooks structurally correct.
 The production rollout policy can remain basic.
 
 ## Invariants
@@ -85,9 +120,9 @@ the supervisor restarts it.
 The supervisor should not own Cloud command semantics, session semantics,
 credential policy, or transcript/event interpretation.
 
-## Current State On Stack Tip
+## Current State On Main
 
-The stack already includes these pieces:
+`main` includes these pieces:
 
 - `anyharness/crates/proliferate-worker/**`
 - `anyharness/crates/proliferate-supervisor/**`
@@ -95,39 +130,30 @@ The stack already includes these pieces:
   update status endpoints
 - SSH installer that downloads/copies all three binaries and creates a
   supervisor systemd user service
-- managed cloud bootstrap that can stage `anyharness` and `proliferate-worker`
-  and launch them directly
+- managed cloud bootstrap that stages/verifies all three binaries and launches
+  `proliferate-supervisor` for supervised runtimes
 
-The main gap is managed cloud process ownership:
+The remaining managed-cloud process ownership caveat is legacy fallback:
 
 ```text
-current managed cloud shape:
-  server writes AnyHarness launch script
-  server starts AnyHarness with nohup
-  server writes worker config
-  server starts worker with nohup
-
-target managed cloud shape:
+current new managed cloud shape:
   server writes worker config
   server writes supervisor config
   server starts supervisor with nohup or template entrypoint
   supervisor starts AnyHarness and worker
+
+legacy reconnect fallback:
+  old sandboxes without supervisor config may still use the old AnyHarness
+  launcher until they are replaced or migrated
 ```
 
-SSH is closer to target state than managed cloud. It still needs test hardening
-and possibly bundle download cleanup.
+SSH is in the target state. It still needs product hardening around automatic
+agent installation/readiness before user-facing automations depend on a target.
 
 ## Branching
 
-Implement this PR on top of the current worker stack tip, not on the first SDK
-branch:
-
-```text
-base: origin/proliferate/cloud-worker-phase8-hardening
-branch: proliferate/cloud-worker-runtime-supervisor
-```
-
-If the stack tip changes, rebase this PR onto the latest tip before opening.
+Historical branch guidance has been removed from the active spec. New changes
+to this area should branch from current `main`.
 
 ## File Ownership Map
 
@@ -280,12 +306,14 @@ $PROLIFERATE_HOME/
     proliferate-supervisor.log
 ```
 
-The first PR does not have to migrate every log path if that creates churn, but
-the spec target should be represented in helper names and tests.
+The implementation does not currently normalize every log path to this target
+layout. Helper names and tests should still describe the runtime bundle rather
+than only the AnyHarness process.
 
 ## Supervisor Config
 
-The config should be sufficient to start both child processes:
+The config is sufficient to start both child processes. Managed cloud and SSH
+use the same supervisor schema, but not identical AnyHarness auth/bind args:
 
 ```toml
 anyharness_binary = "/home/user/.proliferate/bin/anyharness"
@@ -302,12 +330,14 @@ anyharness_args = [
 restart_delay_seconds = 5
 ```
 
-For SSH, binding AnyHarness to `127.0.0.1` is preferred. The worker talks to
+For SSH, binding AnyHarness to `127.0.0.1` is preferred and the current
+installer leaves bearer auth disabled by default. The worker talks to
 AnyHarness locally. Direct remote access should be explicit, not the default.
 
 For managed cloud, the runtime endpoint behavior depends on E2B/provider
 networking. If a provider endpoint requires `0.0.0.0`, the config may use that
-for managed cloud, but the reason must live in the bootstrap helper and tests.
+for managed cloud. Managed cloud currently writes bearer auth and provider bind
+args in bootstrap config.
 
 ## Worker Config
 
@@ -345,13 +375,13 @@ Target flow:
    preparation.
 9. Cloud waits for worker enrollment/heartbeat and target online.
 10. Cloud stores runtime_environment.target_id.
-11. Provisioning continues with workspace preparation until PR C moves that
-    work behind commands.
+11. Provisioning hands command-backed workspace/session work to the worker
+    automation path.
 ```
 
-This PR may keep the existing direct workspace preparation calls after
-supervisor boot. The automation migration PR will remove execution mutation
-calls.
+Legacy managed-cloud reconnect paths may still keep direct workspace
+preparation calls after supervisor boot. New automation execution mutations
+should be command-backed through the worker.
 
 ## SSH Boot Flow
 
@@ -392,10 +422,10 @@ update_generation
 update_channel
 ```
 
-This PR should ensure every process can produce real version values and that
-managed cloud and SSH both report them.
+Every process should produce real version values and managed cloud and SSH both
+report them through worker heartbeat.
 
-Minimum update flow for this PR:
+Current minimum update flow:
 
 ```text
 1. Worker heartbeat receives desired versions.
@@ -690,19 +720,24 @@ worktree)` commands can use.
 
 ## Completion Checklist
 
-Before opening the PR:
+Current `main` status:
 
-- [ ] all three binaries build locally for the target Linux release profile
-- [ ] SSH installer still works against a clean target
-- [ ] managed cloud starts supervisor instead of direct detached AnyHarness and
-      worker processes
-- [ ] Cloud target online is driven by worker heartbeat/enrollment
-- [ ] runtime environment stores `target_id`
-- [ ] template build/smoke checks all three binaries
-- [ ] docs mention supervised runtime bundle, not only AnyHarness binary
-- [ ] `rg "launch_worker_nohup|launch_runtime_nohup|build_detached_worker_launch_command"` has
-      no managed cloud production process-launch usage left, or each remaining
-      hit is a backwards-compatible helper marked for deletion
+- [x] all three binaries build locally for the target Linux release profile
+- [x] SSH installer works against a clean target
+- [x] managed cloud starts supervisor for supervised runtimes instead of
+      independently launching AnyHarness and worker
+- [x] Cloud target online is driven by worker heartbeat/enrollment
+- [x] runtime environment stores `target_id`
+- [x] template build/smoke checks all three binaries
+- [x] docs mention supervised runtime bundle, not only AnyHarness binary
+- [x] legacy managed-cloud direct launch hits are fallback/provisioning code,
+      not the target process model for new supervised runtimes
+
+Remaining follow-ups:
+
+- [ ] automate agent process install/readiness for targets before `start_session`
+- [ ] finish the production update swap/restart flow after supervisor staging
+- [ ] retire legacy managed-cloud launch fallback after old sandboxes age out
 
 ## Review Questions
 

--- a/docs/architecture/cloud-worker-workspace-command-spec.md
+++ b/docs/architecture/cloud-worker-workspace-command-spec.md
@@ -1,11 +1,16 @@
 # Cloud Worker Workspace Command Spec
 
-Status: concrete follow-up PR spec.
+Status: current implementation spec, verified against `main` on 2026-05-15.
 
-Scope: PR B in the Cloud Worker migration sequence.
+Scope: target-side Git checkout, workspace registration, and worktree creation
+commands used by Proliferate Worker.
 
-This spec defines the missing CloudCommand primitive for target-side workspace
-creation and worktree creation.
+This spec defines the CloudCommand primitives that let Cloud prepare a target
+for a session without directly calling AnyHarness:
+
+- `configure_git_identity`
+- `ensure_repo_checkout`
+- `materialize_workspace`
 
 It assumes the supervised runtime bundle from
 `docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md` exists:
@@ -16,14 +21,84 @@ proliferate-supervisor
   -> proliferate-worker
 ```
 
+The original PR-B framing in this file is historical. These command kinds now
+exist on `main`; this document describes the current behavior and remaining
+hardening work.
+
+## Current Main State
+
+`main` currently supports these worker command kinds:
+
+```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
+materialize_environment
+start_session
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+close_session
+sync_existing_workspace
+```
+
+The workspace-preparation path used by automations is:
+
+```text
+configure_git_identity
+  -> worker fetches encrypted target Git identity material through a
+     worker-authenticated Cloud endpoint
+  -> worker writes target-scoped Git credential/config under Proliferate-owned
+     target storage
+
+ensure_repo_checkout
+  -> worker verifies Git identity is configured
+  -> worker clones or fetches the target repo root path
+
+materialize_workspace(mode=existing_path)
+  -> worker calls AnyHarness /v1/workspaces/resolve for the repo root
+  -> worker returns anyharnessWorkspaceId and repoRootId
+
+materialize_workspace(mode=worktree)
+  -> worker calls AnyHarness /v1/workspaces/worktrees
+  -> if creation reports a compatible existing worktree, worker resolves it
+     through AnyHarness and returns the existing workspace id
+
+materialize_environment
+  -> worker fetches the target config materialization plan through Cloud
+  -> worker applies env vars, tracked files, MCP config, skills, agent
+     credential files, and manifests to the final workspace path
+```
+
+Current caveats:
+
+- Cloud command leasing uses inline fields on `cloud_commands`; there is no
+  separate lease table.
+- Worker command polling returns immediately from the server and sleeps briefly
+  on empty responses. It is polling, not server-side long-poll blocking.
+- The worker sync loop tails AnyHarness events by polling
+  `/v1/sessions/{id}/events?after_seq=...` and uploads batches directly. There
+  is no durable local event outbox table yet.
+- Command preconditions and worker min-version gating are not implemented yet.
+- Fresh SSH targets still need the requested agent installed before
+  `start_session`; Git/workspace materialization alone does not install Claude,
+  Codex, Gemini, or other agent binaries.
+
 ## Goal
 
 Cloud must be able to ask any registered target to create or resolve the
 AnyHarness workspace needed before a session can start.
 
-The command sequence after this PR should be:
+The command sequence is:
 
 ```text
+configure_git_identity
+  -> configures target Git credentials without raw tokens in command payloads
+
+ensure_repo_checkout
+  -> ensures the repo root exists and is fetchable on the target
+
 materialize_workspace
   -> returns anyharnessWorkspaceId, repoRootId, path, branch
 
@@ -34,7 +109,7 @@ send_prompt / update_session_config / resolve_interaction / cancel_turn
   -> normal live session control
 ```
 
-This PR answers one question:
+This command family answers one question:
 
 ```text
 How does Cloud create the target-side AnyHarness workspace/worktree without
@@ -43,23 +118,28 @@ directly calling AnyHarness from the server?
 
 ## Non-Goals
 
-Do not migrate automations in this PR.
+Do not put automation-specific business logic in the worker. Automations use
+these commands from the server-side staged pipeline.
 
-Do not add session MCP bundle launch semantics in this PR.
+Do not add session MCP bundle launch semantics to `materialize_workspace`.
 
 Do not move model/mode/reasoning/session config into this command.
 
 Do not make this command responsible for all target environment files. Target
 environment materialization remains separate.
 
-Do not remove server direct AnyHarness calls in this PR except where they are
-trivially unused. Full deletion belongs to the automation migration PR.
+Do not make `materialize_workspace` install agent binaries or resolve provider
+readiness. Agent installation/readiness is an AnyHarness agent-catalog concern
+and is orchestrated separately.
 
-## Current Command Coverage
+## Command Coverage
 
-Already present on the worker stack:
+Present on the worker stack:
 
 ```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
 start_session
 materialize_environment
 send_prompt
@@ -70,8 +150,9 @@ close_session
 sync_existing_workspace
 ```
 
-These cover live session control and target config application. They do not
-create the target-side AnyHarness workspace/worktree.
+These cover target Git bootstrap, repo checkout, workspace/worktree
+materialization, target config application, live session control, and existing
+workspace sync.
 
 `materialize_environment` currently applies configuration files to a filesystem
 root:
@@ -86,11 +167,11 @@ skill refs
 target-config manifest
 ```
 
-It does not call:
+It intentionally does not call:
 
 ```text
-POST /v1/workspaces
 POST /v1/workspaces/worktrees
+POST /v1/workspaces/resolve
 ```
 
 It therefore does not produce:
@@ -101,9 +182,12 @@ repoRootId
 workspace path registered in AnyHarness SQLite
 ```
 
-## Command Name
+Those ids are produced by `materialize_workspace`, after
+`ensure_repo_checkout` has made sure the repo root exists on the target.
 
-Add one active command kind:
+## Workspace Command Name
+
+The active workspace command kind is:
 
 ```text
 materialize_workspace
@@ -145,13 +229,23 @@ server/proliferate/constants/cloud.py
 anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
 ```
 
-Add:
+Current active command kinds include:
 
-```python
-CloudCommandKind.materialize_workspace = "materialize_workspace"
+```text
+configure_git_identity
+ensure_repo_checkout
+materialize_workspace
+materialize_environment
+start_session
+send_prompt
+resolve_interaction
+update_session_config
+cancel_turn
+close_session
+sync_existing_workspace
 ```
 
-Add to:
+Each active kind must be present in:
 
 ```text
 ACTIVE_CLOUD_COMMAND_KINDS
@@ -202,7 +296,7 @@ creatorContext
 Worker behavior:
 
 ```text
-POST /v1/workspaces
+POST /v1/workspaces/resolve
 {
   "path": payload.path,
   "origin": payload.origin,
@@ -210,12 +304,8 @@ POST /v1/workspaces
 }
 ```
 
-If `displayName` is present, either:
-
-- call the existing AnyHarness display-name endpoint if available, or
-- defer display-name support and return the natural AnyHarness display name
-
-Do not invent a worker-side display-name store.
+If `displayName` is present, the worker applies it through AnyHarness after the
+workspace is resolved. Do not invent a worker-side display-name store.
 
 ### Worktree Mode
 
@@ -273,8 +363,14 @@ POST /v1/workspaces/worktrees
 }
 ```
 
-For this PR, `setupScript` may be passed through to AnyHarness if the endpoint
-already supports it. Do not add worker-side setup-script execution.
+`setupScript` may be passed through to AnyHarness if the endpoint supports it.
+Do not add worker-side setup-script execution.
+
+If AnyHarness reports that the requested worktree already exists or returns a
+non-success response that could correspond to an existing compatible worktree,
+the worker may recover by resolving `targetPath` through
+`/v1/workspaces/resolve`. Recovery must only accept a workspace whose repo root
+and branch/path match the command request.
 
 ## Result Schema
 
@@ -402,18 +498,18 @@ Changes:
 
 ### AnyHarness Workspace Client
 
-New file:
+File:
 
 ```text
 anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
 ```
 
-Changes:
+Current behavior:
 
-- add `AnyHarnessClient::create_workspace`
-- add `AnyHarnessClient::create_worktree_workspace`
-- parse response into a typed Rust struct, not loose `serde_json::Value`
-  where practical
+- `existing_path` calls AnyHarness workspace resolve, not create.
+- `worktree` calls AnyHarness worktree creation.
+- optional display names are applied after workspace materialization.
+- command results extract stable workspace fields from AnyHarness responses.
 
 Expected structs:
 
@@ -454,13 +550,12 @@ File:
 anyharness/crates/proliferate-worker/src/commands/mapping.rs
 ```
 
-Changes:
+Current behavior:
 
-- add `AnyHarnessCommand::MaterializeWorkspace`
-- parse a typed `MaterializeWorkspacePayload`
-- reject invalid mode or missing fields with stable error codes
-- map `existing_path` to AnyHarness create-workspace request
-- map `worktree` to AnyHarness create-worktree request
+- parses a typed `MaterializeWorkspacePayload`
+- rejects invalid mode or missing fields with stable error codes
+- maps `existing_path` to AnyHarness resolve-workspace request
+- maps `worktree` to AnyHarness create-worktree request
 
 Suggested worker-side enum:
 
@@ -504,13 +599,14 @@ File:
 anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
 ```
 
-Changes:
+Current behavior:
 
-- advertise `materialize_workspace`
-- dispatch it only when AnyHarness is healthy
-- call the new AnyHarness workspace client method
-- report stable result fields
-- register the new workspace for sync if the command succeeds
+- advertises `materialize_workspace`
+- dispatches it only when AnyHarness is healthy
+- calls the AnyHarness workspace client
+- reports stable result fields
+- leaves session event sync registration to later session commands because
+  `materialize_workspace` is workspace-scoped, not session-scoped
 
 Registration detail:
 
@@ -519,16 +615,16 @@ store.upsert_sync_session(...) is session-scoped and should not be reused for
 workspace-only commands unless the store already has a workspace sync table.
 ```
 
-If no workspace-sync store exists yet, PR B should not invent a large sync
-store. Return the workspace id in command result and let PR C decide how to
-wire automation run state to Cloud workspace/session rows.
+Do not invent a workspace-sync store inside this command. Return the workspace
+id in the command result and let the server-side automation stage attach it to
+the run and Cloud workspace rows.
 
 ## AnyHarness API Dependency
 
-This PR should use existing AnyHarness APIs:
+This command uses existing AnyHarness APIs:
 
 ```text
-POST /v1/workspaces
+POST /v1/workspaces/resolve
 POST /v1/workspaces/worktrees
 ```
 
@@ -549,11 +645,17 @@ WorkspaceCreatorContext
 OriginContext
 ```
 
-## Command Sequencing After PR B
+## Command Sequencing
 
 Existing path session:
 
 ```text
+CloudCommand configure_git_identity
+  -> worker configures target Git credentials if stale/missing
+
+CloudCommand ensure_repo_checkout
+  -> worker clones/fetches repo root path
+
 CloudCommand materialize_workspace(mode=existing_path)
   -> worker returns anyharnessWorkspaceId
 
@@ -564,6 +666,15 @@ CloudCommand start_session(workspaceId=anyharnessWorkspaceId)
 Automation worktree session:
 
 ```text
+CloudCommand configure_git_identity
+  -> worker configures target Git credentials if stale/missing
+
+CloudCommand ensure_repo_checkout
+  -> worker clones/fetches repo root path
+
+CloudCommand materialize_workspace(mode=existing_path)
+  -> worker resolves the repo root and returns repoRootId
+
 CloudCommand materialize_workspace(mode=worktree)
   -> worker returns anyharnessWorkspaceId
 
@@ -577,9 +688,9 @@ CloudCommand send_prompt
   -> worker sends automation prompt
 ```
 
-PR C may choose to reorder `materialize_environment` before or after
-`materialize_workspace` if the target config plan already contains a final path.
-The preferred order is workspace first, environment second.
+Automation execution uses workspace first, environment second. If a later
+target-config design needs to apply files before workspace creation, that
+should be modeled explicitly rather than hidden inside the worker.
 
 ## Tests
 
@@ -623,7 +734,9 @@ Add tests:
 
 ### Integration/Smoke
 
-No full automation smoke is required in this PR.
+The original PR-level spec did not require a full automation smoke. The current
+mainline acceptance path should include a full automation smoke because the
+workspace command is now part of the automation pipeline.
 
 Minimal existing-path smoke:
 
@@ -655,7 +768,7 @@ Minimal worktree smoke:
      branch/newBranchName
 ```
 
-The worktree smoke is the important handoff to PR C. Automations should be
+The worktree smoke is the important automation handoff. Automations should be
 able to take the returned workspace id/path and attach them to
 `automation_run.cloud_workspace_id` and
 `automation_run.anyharness_workspace_id` without any direct Cloud ->
@@ -664,20 +777,47 @@ AnyHarness workspace call.
 If this is too expensive for CI, keep it as a local smoke command and cover
 server/worker mapping in unit tests.
 
+Full SSH automation smoke:
+
+```text
+1. run local Cloud profile, for example runtime on API port 8040
+2. enroll an SSH target through the installer
+3. ensure target Git identity is configured through configure_git_identity
+4. trigger automation targeting that SSH target
+5. verify command order:
+     configure_git_identity
+     ensure_repo_checkout
+     materialize_workspace existing_path
+     materialize_workspace worktree
+     materialize_environment
+     start_session
+     send_prompt
+6. verify run reaches dispatched and AnyHarness has a session id
+```
+
+Current manual caveat: the requested agent must be installed/readied on a fresh
+SSH target before `start_session`, or the run can fail with `InstallRequired`.
+
 ## Completion Checklist
 
-- [ ] `materialize_workspace` is an active CloudCommand kind
-- [ ] worker advertises `materialize_workspace`
-- [ ] server validates payload shape
-- [ ] worker strictly parses payload shape
-- [ ] worker calls AnyHarness workspace and worktree APIs
-- [ ] command result exposes stable workspace fields
-- [ ] worktree command returns enough path/branch/repo-root data for automation
+- [x] `configure_git_identity` is an active CloudCommand kind
+- [x] `ensure_repo_checkout` is an active CloudCommand kind
+- [x] `materialize_workspace` is an active CloudCommand kind
+- [x] worker advertises `materialize_workspace`
+- [x] server validates payload shape
+- [x] worker parses payload shape
+- [x] worker calls AnyHarness resolve-workspace and worktree APIs
+- [x] command result exposes stable workspace fields
+- [x] worktree command returns enough path/branch/repo-root data for automation
       run attachment
-- [ ] no MCP/session bundle logic is added to this command
-- [ ] no automation migration occurs in this PR
-- [ ] docs explain the difference between `materialize_workspace` and
+- [x] no MCP/session bundle logic is added to this command
+- [x] automation migration consumes the command through the staged pipeline
+- [x] docs explain the difference between `materialize_workspace` and
       `materialize_environment`
+- [ ] command-kind/min-version gating rejects unsupported old workers before
+      enqueue
+- [ ] repeatable automation smoke installs/readies requested agents on fresh
+      targets before `start_session`
 
 ## Review Questions
 
@@ -687,7 +827,7 @@ Reviewers should be able to answer:
 2. Which command applies env/credentials/MCP/skills files?
 3. Does `start_session` require an existing AnyHarness workspace id?
 4. Can an SSH target and managed cloud target use the same command?
-5. Does the command result give PR C enough data to attach automation runs to
+5. Does the command result give automations enough data to attach runs to
    the workspace?
 6. For automation worktrees, which path and branch did Cloud request, and which
    workspace id did AnyHarness return?

--- a/docs/reference/deployment-self-hosting.md
+++ b/docs/reference/deployment-self-hosting.md
@@ -166,14 +166,17 @@ POSTGRES_PASSWORD=
 JWT_SECRET=
 CLOUD_SECRET_KEY=
 
-# ── Cloud workspace runtime ──────────────────────────────
-# The control plane uploads an AnyHarness binary into each
-# cloud sandbox (both E2B and Daytona). The host needs this
-# binary available locally.
+# ── Cloud workspace runtime bundle ───────────────────────
+# The control plane uploads AnyHarness, Proliferate Worker,
+# and Proliferate Supervisor binaries into each cloud sandbox
+# (both E2B and Daytona). The host needs these binaries
+# available locally.
 #
-# Option 1: place the binary manually at the path below.
-# Option 2: set RUNTIME_BINARY_URL and let bootstrap fetch it.
+# Option 1: place the binaries manually at the paths below.
+# Option 2: set RUNTIME_BINARY_URL and let bootstrap fetch release assets.
 CLOUD_RUNTIME_SOURCE_BINARY_PATH=/opt/proliferate/bin/anyharness-linux
+CLOUD_WORKER_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-worker-linux
+CLOUD_SUPERVISOR_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-supervisor-linux
 PROLIFERATE_HOST_BIN_DIR=/opt/proliferate/bin
 RUNTIME_BINARY_URL=https://github.com/proliferate-ai/proliferate/releases/download/server-v0.1.0/anyharness-x86_64-unknown-linux-musl.tar.gz
 RUNTIME_BINARY_SHA256_URL=https://github.com/proliferate-ai/proliferate/releases/download/server-v0.1.0/self-hosted-assets.SHA256SUMS

--- a/docs/reference/env-secrets-matrix.md
+++ b/docs/reference/env-secrets-matrix.md
@@ -170,6 +170,7 @@ env overrides.
 | --- | --- | --- | --- |
 | `CLOUD_RUNTIME_SOURCE_BINARY_PATH` | No | No | Override path for the Linux AnyHarness binary uploaded into cloud sandboxes |
 | `CLOUD_WORKER_SOURCE_BINARY_PATH` | No | No | Override path for the Linux Proliferate Worker binary uploaded into cloud sandboxes |
+| `CLOUD_SUPERVISOR_SOURCE_BINARY_PATH` | No | No | Override path for the Linux Proliferate Supervisor binary uploaded into cloud sandboxes |
 | `CLOUD_RUNTIME_SENTRY_DSN` | Yes | No | Remote AnyHarness Sentry DSN |
 | `CLOUD_RUNTIME_SENTRY_ENVIRONMENT` | No | No | Remote AnyHarness Sentry environment |
 | `CLOUD_RUNTIME_SENTRY_RELEASE` | No | No | Remote AnyHarness Sentry release |

--- a/docs/reference/self-hosted-deploy.md
+++ b/docs/reference/self-hosted-deploy.md
@@ -101,24 +101,31 @@ Cloud workspace runtimes are still provider-hosted. The control plane returns a
    - `GITHUB_OAUTH_CLIENT_SECRET`
    - `SANDBOX_PROVIDER`
    - `E2B_API_KEY` or `DAYTONA_API_KEY`
-   - `CLOUD_RUNTIME_SOURCE_BINARY_PATH` if you want cloud workspaces
+   - `CLOUD_RUNTIME_SOURCE_BINARY_PATH`,
+     `CLOUD_WORKER_SOURCE_BINARY_PATH`, and
+     `CLOUD_SUPERVISOR_SOURCE_BINARY_PATH` if you want cloud workspaces
    - for advanced auth-flow, sandbox template, timeout, or runtime-path
      overrides, add the extra env vars manually from
      [docs/reference/env-secrets-matrix.md](/Users/pablo/proliferate/docs/reference/env-secrets-matrix.md)
 5. Leave `POSTGRES_PASSWORD`, `JWT_SECRET`, and `CLOUD_SECRET_KEY` blank if you want
    `bootstrap.sh` to generate and persist them in `server/deploy/.env.generated`
    on first startup.
-6. Either place a Linux `anyharness` binary on the host at
-   `${PROLIFERATE_HOST_BIN_DIR:-/opt/proliferate/bin}/anyharness-linux` and set:
+6. Either place Linux `anyharness`, `proliferate-worker`, and
+   `proliferate-supervisor` binaries on the host under
+   `${PROLIFERATE_HOST_BIN_DIR:-/opt/proliferate/bin}` and set:
 
 ```text
 CLOUD_RUNTIME_SOURCE_BINARY_PATH=/opt/proliferate/bin/anyharness-linux
+CLOUD_WORKER_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-worker-linux
+CLOUD_SUPERVISOR_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-supervisor-linux
 ```
 
 Or set:
 
 ```text
 CLOUD_RUNTIME_SOURCE_BINARY_PATH=/opt/proliferate/bin/anyharness-linux
+CLOUD_WORKER_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-worker-linux
+CLOUD_SUPERVISOR_SOURCE_BINARY_PATH=/opt/proliferate/bin/proliferate-supervisor-linux
 RUNTIME_BINARY_URL=https://github.com/proliferate-ai/proliferate/releases/download/server-vX.Y.Z/anyharness-x86_64-unknown-linux-musl.tar.gz
 RUNTIME_BINARY_SHA256_URL=https://github.com/proliferate-ai/proliferate/releases/download/server-vX.Y.Z/self-hosted-assets.SHA256SUMS
 ```

--- a/install/README.md
+++ b/install/README.md
@@ -35,9 +35,27 @@ The installer writes:
 - `~/.proliferate/supervisor/config.toml`
 - `~/.config/systemd/user/proliferate-target.service` when `systemctl` exists
 
-Managed cloud images can use the same installer with a one-time enrollment
-token at boot. SSH onboarding uses the same command surfaced in the Desktop
-Compute settings page.
+SSH onboarding uses this command surfaced in the Desktop Compute settings page.
+Managed cloud does not normally run this shell installer; managed cloud
+bootstrap writes equivalent worker/supervisor config and starts the same
+runtime bundle directly inside the sandbox.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `PROLIFERATE_CLOUD_URL` | Cloud API base URL used by the worker. | Required |
+| `PROLIFERATE_ENROLLMENT_TOKEN` | One-time target enrollment token. | Required |
+| `PROLIFERATE_HOME` | Target runtime home for binaries/config/state. | `$HOME/.proliferate` |
+| `PROLIFERATE_ARTIFACT_BASE_URL` | Base URL for platform binary downloads. | Release artifact base |
+| `PROLIFERATE_ANYHARNESS_BASE_URL` | Local URL the worker uses to call AnyHarness. | `http://127.0.0.1:8457` |
+| `PROLIFERATE_ANYHARNESS_BEARER_TOKEN` | Bearer token when local AnyHarness requires auth. | empty |
+| `PROLIFERATE_SERVICE_NAME` | user systemd service name. | `proliferate-target` |
+
+Enrollment only registers the target and worker. It does not carry GitHub,
+agent, MCP, or model credentials. Those are materialized later through
+worker-authenticated Cloud commands such as `configure_git_identity` and
+`materialize_environment`.
 
 ## Local SSH Worker Smoke Test
 
@@ -64,3 +82,22 @@ make dev-cloud-ssh-worker \
 The smoke command requires `ngrok`, `cargo-zigbuild`, local Postgres, and
 `server/.venv`. Set `CLOUD_SSH_WORKER_SKIP_BUILD=1` to reuse previously built
 Linux binaries, or `NGROK_URL=https://...` to reuse an existing tunnel.
+
+This smoke validates target enrollment, supervisor startup, AnyHarness health,
+worker heartbeat, and version reporting. A full automation smoke has additional
+requirements:
+
+- the local Cloud profile must have GitHub OAuth configured for the run creator
+- the target must receive `configure_git_identity`
+- the target must clone/fetch the repo through `ensure_repo_checkout`
+- the requested agent must be installed/readied before `start_session`
+
+Until agent install/readiness is automated as part of target preparation, a
+fresh SSH target may need a one-time install through AnyHarness, for example:
+
+```sh
+ssh ubuntu@target-host \
+  'curl -fsS -X POST http://127.0.0.1:8457/v1/agents/claude/install \
+    -H "Content-Type: application/json" \
+    -d "{}"'
+```


### PR DESCRIPTION
## Summary

- update Cloud Worker, workspace command, automation migration, and supervisor specs to match current main
- document active worker command kinds, polling/event sync behavior, lease storage, and remaining hardening gaps
- add AnyHarness worker-facing API notes plus installer/self-hosted runtime bundle guidance

## Validation

- `git diff --cached --check`
- `git diff --check -- docs/architecture/cloud-worker-runtime-bundle-supervisor-spec.md docs/architecture/cloud-worker-workspace-command-spec.md docs/architecture/cloud-worker-automation-migration-spec.md docs/architecture/cloud-worker-implementation-phases.md docs/architecture/cloud-worker-control-plane.md docs/architecture/cloud-worker-pr-stack-review-guide.md install/README.md docs/anyharness/contract.md docs/anyharness/src/workspaces.md docs/anyharness/src/sessions.md docs/anyharness/src/agents.md docs/reference/env-secrets-matrix.md docs/reference/self-hosted-deploy.md docs/reference/deployment-self-hosting.md`
