### PR TITLE
fix(desktop): revert light mode refresh

### DIFF
--- a/desktop/src/components/feedback/Toast.tsx
+++ b/desktop/src/components/feedback/Toast.tsx
@@ -42,7 +42,7 @@ export function ToastContainer() {
       {toasts.map((t) => (
         <div
           key={t.id}
-          className="flex items-start gap-2 rounded-lg border border-border bg-card px-4 py-3 text-sm text-card-foreground shadow-floating animate-toast-in"
+          className="flex items-start gap-2 rounded-lg border border-border bg-card px-4 py-3 text-sm text-card-foreground shadow-floating-dark animate-toast-in"
         >
           <span className="flex-1">{t.message}</span>
           <button

--- a/desktop/src/components/ui/CommandPalette.tsx
+++ b/desktop/src/components/ui/CommandPalette.tsx
@@ -138,7 +138,7 @@ export function CommandPaletteRoot({
           role="dialog"
           aria-modal="true"
           aria-label={label}
-          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[calc(100vw-16px)] max-w-[580px] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border/70 bg-popover/85 text-foreground shadow-floating backdrop-blur-[16px]"
+          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[calc(100vw-16px)] max-w-[580px] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border/70 bg-popover/85 text-foreground shadow-floating-dark backdrop-blur-[16px]"
           onKeyDown={onKeyDown}
         >
           <Command

--- a/desktop/src/components/ui/FilePathContextMenuContent.tsx
+++ b/desktop/src/components/ui/FilePathContextMenuContent.tsx
@@ -61,7 +61,7 @@ export function FilePathContextMenuContent({
             disabled={!canOpen}
             trailing={<ChevronRight className="size-3.5" />}
             className={openWithActive
-              ? "bg-primary text-primary-foreground hover:bg-primary focus:bg-primary [&_*]:text-primary-foreground"
+              ? "bg-[var(--color-link-foreground)] text-white hover:bg-[var(--color-link-foreground)] focus:bg-[var(--color-link-foreground)] [&_*]:text-white"
               : ""}
           />
           {openWithActive && (

--- a/desktop/src/components/ui/OpenTargetIcon.tsx
+++ b/desktop/src/components/ui/OpenTargetIcon.tsx
@@ -11,9 +11,8 @@ export function AppIconWrapper({ children }: { children: ReactNode }) {
   return (
     <div className="relative size-3.5 rounded">
       {children}
-      {/* Theme mode is stored on data-mode; Tailwind's dark: selector is not used here. */}
       <div
-        className="pointer-events-none absolute inset-0 rounded border border-border mix-blend-darken [html[data-mode=dark]_&]:mix-blend-lighten"
+        className="pointer-events-none absolute inset-0 rounded border border-border mix-blend-darken dark:mix-blend-lighten"
       />
     </div>
   );

--- a/desktop/src/components/workspace/browser/BrowserFallbackStates.tsx
+++ b/desktop/src/components/workspace/browser/BrowserFallbackStates.tsx
@@ -20,7 +20,7 @@ export function BrowserUnavailableOverlay({
   return (
     <div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-sidebar-background/95 px-8 backdrop-blur">
       <div className="flex max-w-72 flex-col items-center text-center">
-        <div className="mb-4 flex size-11 items-center justify-center rounded-lg border border-sidebar-border bg-sidebar-accent text-sidebar-muted-foreground">
+        <div className="mb-4 flex size-11 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
           <CircleAlert className="size-5" />
         </div>
         <p className="text-sm font-medium text-sidebar-foreground">
@@ -56,7 +56,7 @@ export function BrowserEmptyState({
   return (
     <div className="flex h-full items-center justify-center px-8 text-center">
       <div className="flex max-w-72 flex-col items-center">
-        <div className="mb-4 flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-sidebar-accent text-sidebar-muted-foreground">
+        <div className="mb-4 flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-foreground/5 text-sidebar-muted-foreground">
           <Globe className="size-6 opacity-70" />
         </div>
         <p className="text-sm font-medium text-sidebar-foreground">{title}</p>

--- a/desktop/src/components/workspace/browser/BrowserToolbar.tsx
+++ b/desktop/src/components/workspace/browser/BrowserToolbar.tsx
@@ -63,7 +63,7 @@ export function BrowserToolbar({
             value={activeDraft}
             disabled={!activeTab}
             placeholder="Enter URL or localhost port"
-            className={`h-7 rounded-md border-sidebar-border bg-sidebar-accent pl-7 pr-8 text-xs text-sidebar-foreground placeholder:text-sidebar-muted-foreground focus:ring-sidebar-border ${
+            className={`h-7 rounded-md border-sidebar-border bg-foreground/5 pl-7 pr-8 text-xs text-sidebar-foreground placeholder:text-sidebar-muted-foreground focus:ring-sidebar-border ${
               urlError ? "border-destructive" : ""
             }`}
             spellCheck={false}

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
@@ -43,14 +43,14 @@ export function CoworkThreadRow({
         </div>
 
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <div className="flex flex-1 items-center gap-2 truncate text-base leading-5 text-sidebar-foreground">
+          <div className="flex flex-1 items-center gap-2 truncate text-base leading-5 text-foreground">
             {coworkThreadTitle(thread)}
           </div>
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
           {!active && !canExpand && (
-            <div className="truncate text-right text-sm leading-4 tabular-nums text-sidebar-muted-foreground group-focus-within:opacity-0 group-hover:opacity-0">
+            <div className="truncate text-right text-sm leading-4 tabular-nums text-foreground/40 group-focus-within:opacity-0 group-hover:opacity-0">
               {formatSidebarRelativeTime(thread.updatedAt)}
             </div>
           )}
@@ -63,7 +63,7 @@ export function CoworkThreadRow({
                 event.stopPropagation();
                 onToggleExpanded();
               }}
-              className="inline-flex size-5 shrink-0 items-center justify-center rounded text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-offset-[-2px]"
+              className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent hover:text-foreground focus-visible:outline-offset-[-2px]"
             >
               {expanded
                 ? <ChevronDown className="size-3" />

--- a/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.tsx
@@ -277,7 +277,7 @@ function GitReviewEmptyState({
   return (
     <div className="flex min-h-[260px] items-center justify-center px-4 py-8">
       <div className="flex max-w-[280px] flex-col items-center text-center">
-        <div className="mb-3 flex size-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent text-sidebar-muted-foreground">
+        <div className="mb-3 flex size-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-foreground/5 text-sidebar-muted-foreground">
           <Icon className="size-4" />
         </div>
         <p className="text-sm font-medium text-sidebar-foreground">

--- a/desktop/src/components/workspace/pane/PaneSideOverlay.tsx
+++ b/desktop/src/components/workspace/pane/PaneSideOverlay.tsx
@@ -58,7 +58,7 @@ export function PaneSideOverlay({
         role="dialog"
         aria-label={label}
         className={[
-          "pointer-events-auto absolute bottom-2 right-2 top-2 flex min-w-0 flex-col overflow-hidden rounded-lg border border-sidebar-border/80 bg-sidebar-background/95 shadow-floating backdrop-blur",
+          "pointer-events-auto absolute bottom-2 right-2 top-2 flex min-w-0 flex-col overflow-hidden rounded-lg border border-sidebar-border/80 bg-sidebar-background/95 shadow-floating-dark backdrop-blur",
           widthClassName,
         ].join(" ")}
       >

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -837,143 +837,448 @@
   background-color: transparent;
 }
 
-/* Shared light-mode foundation.
-   Light mode needs its own hierarchy rather than a mechanical inversion of
-   dark mode: white document surfaces, quiet gray under-surfaces, foreground-
-   alpha borders, and blue as the only strong interactive accent. */
-:root[data-mode="light"] {
-  --color-scrollbar-thumb: color-mix(in oklab, #1a1c1f 8%, transparent);
-  --color-scrollbar-thumb-active: color-mix(in oklab, #1a1c1f 16%, transparent);
+/* ========================================================================
+ * SHIP LIGHT — warm-tinted light palette
+ * ======================================================================== */
 
-  --shadow-subtle: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-keystone: 0 1px 2px 0 rgb(0 0 0 / 0.06), 0 0 0 0.5px rgb(0 0 0 / 0.04);
-  --shadow-floating: 0 16px 32px -8px rgb(0 0 0 / 0.18);
-  --shadow-popover: 0 0 0 0.5px var(--color-popover-ring), 0 8px 16px -4px rgb(0 0 0 / 0.12);
+:root[data-mode="light"] {
+  --color-scrollbar-thumb: rgba(0, 0, 0, 0.08);
+  --color-scrollbar-thumb-active: rgba(0, 0, 0, 0.16);
+
+  --color-background: hsl(44 0% 100%);
+  --color-foreground: hsl(39 8% 16%);
+  --color-overlay: hsl(0 0% 0%);
+
+  --color-primary: hsl(14 15% 22%);
+  --color-primary-foreground: hsl(44 9% 95%);
+
+  --color-secondary: hsl(44 10% 98%);
+  --color-secondary-foreground: hsl(39 8% 16%);
+
+  --color-accent: hsl(44 10% 98%);
+  --color-accent-foreground: hsl(39 8% 16%);
+  --color-muted: hsl(44 10% 98%);
+  --color-muted-foreground: hsl(36 4% 54%);
+  --color-faint: hsl(37 5% 63%);
+  --color-helper: hsl(37 5% 63%);
+
+  --color-card: hsl(44 0% 100%);
+  --color-card-foreground: hsl(38 9% 12%);
+
+  --color-popover: hsl(44 0% 100%);
+  --color-popover-foreground: hsl(38 9% 12%);
+  --color-popover-accent: hsl(18 14% 7% / 0.05);
+  --color-popover-ring: hsl(38 9% 12% / 0.05);
+
+  --color-border: hsl(44 8% 91%);
+  --color-input: hsl(18 14% 7% / 0.1);
+  --color-input-border: hsl(18 14% 7% / 0.1);
+  --color-separator: hsl(44 8% 91%);
+  --color-ring: hsl(39 8% 16%);
+
+  --color-highlight: hsl(42 33% 97%);
+  --color-highlight-foreground: hsl(14 13% 31%);
+  --color-highlight-muted: hsl(33 35% 69%);
+  --color-border-highlight: hsl(23 17% 57%);
+  --color-unread: hsl(23 17% 57%);
+  --color-special: hsl(33 35% 69%);
+
+  --color-destructive: hsl(0 72% 51%);
+  --color-destructive-foreground: hsl(0 86% 97%);
+  --color-success: hsl(142 76% 36%);
+  --color-success-foreground: hsl(138 76% 97%);
+  --color-warning: hsl(42 33% 97%);
+  --color-warning-foreground: hsl(14 13% 31%);
+  --color-warning-foreground-secondary: hsl(23 17% 57%);
+  --color-warning-border: hsl(39 38% 86%);
+  --color-info: hsl(199 89% 48%);
+  --color-info-foreground: hsl(199 89% 95%);
+  --color-positive: hsl(142 76% 36%);
+  --color-positive-muted: hsl(138 76% 97%);
+  --color-positive-foreground: hsl(138 76% 97%);
+
+  --color-link: hsl(42 33% 97%);
+  --color-link-foreground: hsl(23 17% 57%);
+  --color-link-elevated: hsl(38 33% 93%);
+
+  --color-tip: hsl(58 100% 100%);
+  --color-tip-border: hsl(42 33% 97%);
+  --color-tip-secondary: hsl(58 100% 100%);
+  --color-tip-secondary-border: hsl(42 33% 97%);
+  --color-tip-muted: hsl(23 17% 57%);
+  --color-tip-foreground: hsl(14 15% 22%);
+  --color-plan-border: hsl(33 35% 69%);
+
+  --color-switch-background: hsl(39 8% 16%);
+  --color-switch-foreground: hsl(44 0% 100%);
+
+  --color-composer-background: hsl(44 10% 98% / 0.82);
+
+  --color-prose-border: hsl(38 7% 81%);
+
+  --color-sidebar: hsl(44 10% 98%);
+  --color-sidebar-background: hsl(44 10% 98%);
+  --color-sidebar-foreground: hsl(18 14% 7% / 0.62);
+  --color-sidebar-primary: hsl(39 8% 16%);
+  --color-sidebar-primary-foreground: hsl(44 9% 95%);
+  --color-sidebar-muted-foreground: hsl(18 14% 7% / 0.4);
+  --color-sidebar-accent: hsl(18 14% 7% / 0.035);
+  --color-sidebar-accent-foreground: hsl(18 14% 7% / 0.8);
+  --color-sidebar-border: hsl(18 14% 7% / 0.08);
+  --color-sidebar-ring: hsl(37 5% 63%);
+  --color-sidebar-blue: hsl(221 83% 53%);
+
+  --color-status-backlog: hsl(36 4% 54%);
+  --color-status-backlog-hover: hsl(38 6% 35%);
+  --color-status-in-progress: hsl(50 100% 44%);
+  --color-status-in-progress-hover: hsl(50 100% 36%);
+  --color-status-in-review: hsl(142 76% 36%);
+  --color-status-in-review-hover: hsl(142 72% 29%);
+  --color-status-done: hsl(33 35% 69%);
+  --color-status-done-hover: hsl(23 17% 57%);
+  --color-status-canceled: hsl(37 5% 63%);
+  --color-status-canceled-hover: hsl(36 4% 54%);
+
+  --color-delegated-agent-1: hsl(221 83% 53%);
+  --color-delegated-agent-2: hsl(292 100% 46%);
+  --color-delegated-agent-3: hsl(0 72% 51%);
+  --color-delegated-agent-4: hsl(36 95% 42%);
+  --color-delegated-agent-5: hsl(265 80% 55%);
+  --color-delegated-agent-6: hsl(192 90% 36%);
+  --color-delegated-agent-7: hsl(25 95% 46%);
+  --color-delegated-agent-8: hsl(199 89% 42%);
+
+  --color-todo-in-progress: hsl(221 83% 53%);
+  --color-todo-completed: hsl(142 76% 36%);
+  --color-todo-pending: hsl(37 5% 44%);
+
+  --color-app-switcher-bg: hsl(38 7% 81%);
+
+  --color-git-green: hsl(142 76% 36%);
+  --color-git-red: hsl(0 72% 51%);
+  --color-git-yellow: hsl(50 100% 59%);
+  --color-git-gray: hsl(37 5% 63%);
+  --color-git-new-line: hsl(142 76% 44%);
+  --color-git-removed-line: hsl(0 100% 45%);
+
+  --color-terminal-black: hsl(39 8% 16%);
+  --color-terminal-red: hsl(0 72% 51%);
+  --color-terminal-green: hsl(142 76% 36%);
+  --color-terminal-yellow: hsl(50 100% 59%);
+  --color-terminal-blue: hsl(221 83% 53%);
+  --color-terminal-magenta: hsl(292 100% 46%);
+  --color-terminal-cyan: hsl(192 90% 36%);
+  --color-terminal-white: hsl(44 8% 91%);
+
+  --color-terminal-bright-black: hsl(37 5% 44%);
+  --color-terminal-bright-red: hsl(0 84% 60%);
+  --color-terminal-bright-green: hsl(142 71% 45%);
+  --color-terminal-bright-yellow: hsl(50 100% 69%);
+  --color-terminal-bright-blue: hsl(217 91% 60%);
+  --color-terminal-bright-magenta: hsl(292 100% 54%);
+  --color-terminal-bright-cyan: hsl(189 94% 43%);
+  --color-terminal-bright-white: hsl(44 9% 95%);
+
+  --color-file-icon-folder: hsl(0 0% 17%);
+  --color-file-icon-neutral: hsl(0 0% 17%);
+  --color-file-icon-muted: hsl(0 0% 43%);
+  --color-file-icon-accent: hsl(0 0% 17%);
+  --color-file-icon-red: hsl(0 0% 17%);
+
+  --git-new-line-bg: color-mix(in oklab, hsl(142 76% 44%) 10%, transparent);
+  --git-new-line-border: color-mix(in oklab, hsl(142 76% 44%) 60%, transparent);
+  --git-new-line-highlight: color-mix(in oklab, hsl(142 76% 44%) 20%, transparent);
+  --git-removed-line-bg: color-mix(in oklab, hsl(0 100% 45%) 10%, transparent);
+  --git-removed-line-border: color-mix(in oklab, hsl(0 100% 45%) 60%, transparent);
+  --git-removed-line-highlight: color-mix(in oklab, hsl(0 100% 45%) 20%, transparent);
+  --color-diff-main-surface: hsl(44 0% 100%);
+  --color-diff-surface: color-mix(in srgb, hsl(44 0% 100%) 94%, hsl(39 8% 16%));
+  --color-diff-panel-surface: color-mix(in oklab, hsl(39 8% 16%) 3%, transparent);
+  --color-diff-header-surface: var(--color-diff-surface);
+  --color-diff-added: hsl(142 76% 44%);
+  --color-diff-deleted: hsl(0 100% 45%);
+  --diffs-bg-addition-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-addition-color-override));
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-deletion-color-override));
+  --color-diff-added-bg: var(--diffs-bg-addition-override);
+  --color-diff-deleted-bg: var(--diffs-bg-deletion-override);
+}
+
+
+/* ========================================================================
+ * MONO LIGHT — cool neutral light palette
+ * (Original preset shares this via the combined selector.)
+ * ======================================================================== */
+
+:root[data-theme="mono"][data-mode="light"],
+:root[data-theme="original"][data-mode="light"] {
+  --color-scrollbar-thumb: rgba(0, 0, 0, 0.08);
+  --color-scrollbar-thumb-active: rgba(0, 0, 0, 0.16);
 
   --color-background: #ffffff;
-  --color-foreground: #1a1c1f;
+  --color-foreground: #0d0d0d;
   --color-overlay: #000000;
 
-  --color-primary: #1a1c1f;
+  --color-primary: #0d0d0d;
   --color-primary-foreground: #ffffff;
 
-  --color-secondary: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --color-secondary-foreground: var(--color-foreground);
-  --color-accent: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --color-accent-foreground: var(--color-foreground);
-  --color-muted: color-mix(in oklab, var(--color-foreground) 2.5%, transparent);
-  --color-muted-foreground: color-mix(in oklab, var(--color-foreground) 70%, transparent);
-  --color-faint: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-helper: color-mix(in oklab, var(--color-foreground) 70%, transparent);
+  --color-secondary: #f5f5f5;
+  --color-secondary-foreground: #0d0d0d;
 
-  --color-card: color-mix(in oklab, var(--color-foreground) 3.5%, transparent);
-  --color-card-foreground: var(--color-foreground);
+  --color-accent: #f5f5f5;
+  --color-accent-foreground: #0d0d0d;
+  --color-muted: #f5f5f5;
+  --color-muted-foreground: rgba(13, 13, 13, 0.695);
+  --color-faint: rgba(13, 13, 13, 0.495);
+  --color-helper: rgba(13, 13, 13, 0.695);
+
+  --color-card: #ffffff;
+  --color-card-foreground: #0d0d0d;
+
   --color-popover: #ffffff;
-  --color-popover-foreground: var(--color-foreground);
-  --color-popover-accent: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --color-popover-ring: color-mix(in oklab, var(--color-foreground) 8%, transparent);
+  --color-popover-foreground: #0d0d0d;
+  --color-popover-accent: rgba(13, 13, 13, 0.05);
+  --color-popover-ring: rgba(13, 13, 13, 0.078);
 
-  --color-border: color-mix(in oklab, var(--color-foreground) 8%, transparent);
-  --color-input: color-mix(in oklab, var(--color-foreground) 10%, transparent);
-  --color-input-border: color-mix(in oklab, var(--color-foreground) 8%, transparent);
-  --color-separator: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --color-ring: #339cff;
+  --color-border: rgba(13, 13, 13, 0.078);
+  --color-input: rgba(13, 13, 13, 0.1);
+  --color-input-border: rgba(13, 13, 13, 0.1);
+  --color-separator: #f5f5f5;
+  --color-ring: #0285ff;
 
-  --color-highlight: #e5f3ff;
-  --color-highlight-foreground: var(--color-foreground);
-  --color-highlight-muted: #339cff;
-  --color-border-highlight: #339cff;
-  --color-unread: #339cff;
-  --color-special: #339cff;
+  --color-highlight: #dfefff;
+  --color-highlight-foreground: #0d0d0d;
+  --color-highlight-muted: #0285ff;
+  --color-border-highlight: #0285ff;
+  --color-unread: #0285ff;
+  --color-special: #0285ff;
 
-  --color-destructive: #d53538;
+  --color-destructive: #ba2623;
   --color-destructive-foreground: #ffffff;
-  --color-success: #008809;
+  --color-success: #00a240;
   --color-success-foreground: #ffffff;
   --color-warning: #fff8e6;
-  --color-warning-foreground: var(--color-foreground);
-  --color-warning-foreground-secondary: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-warning-border: color-mix(in oklab, #bd5800 20%, transparent);
-  --color-info: #0169cc;
+  --color-warning-foreground: #0d0d0d;
+  --color-warning-foreground-secondary: rgba(13, 13, 13, 0.495);
+  --color-warning-border: rgba(13, 13, 13, 0.078);
+  --color-info: #0285ff;
   --color-info-foreground: #ffffff;
-  --color-positive: #008809;
-  --color-positive-muted: color-mix(in oklab, #00a240 10%, transparent);
+  --color-positive: #00a240;
+  --color-positive-muted: rgba(0, 162, 64, 0.1);
   --color-positive-foreground: #ffffff;
 
-  --color-link: #e5f3ff;
-  --color-link-foreground: #0169cc;
-  --color-link-elevated: #d8e8f7;
-  --color-tip: #e5f3ff;
-  --color-tip-border: color-mix(in oklab, #0169cc 12%, transparent);
-  --color-tip-secondary: #d8e8f7;
-  --color-tip-secondary-border: color-mix(in oklab, #0169cc 16%, transparent);
-  --color-tip-muted: #0169cc;
-  --color-tip-foreground: var(--color-foreground);
-  --color-plan-border: #339cff;
+  --color-link: #dfefff;
+  --color-link-foreground: #0285ff;
+  --color-link-elevated: #dceeff;
 
-  --color-switch-background: var(--color-foreground);
+  --color-tip: #dfefff;
+  --color-tip-border: rgba(13, 13, 13, 0.078);
+  --color-tip-secondary: #dceeff;
+  --color-tip-secondary-border: rgba(13, 13, 13, 0.078);
+  --color-tip-muted: #0285ff;
+  --color-tip-foreground: #0d0d0d;
+  --color-plan-border: #0285ff;
+
+  --color-switch-background: #0d0d0d;
   --color-switch-foreground: #ffffff;
 
-  --color-composer-background: rgb(255 255 255 / 0.864);
-  --color-composer-border: rgb(0 0 0 / 0.1);
-  --color-composer-control-foreground: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-composer-control-active-foreground: var(--color-foreground);
-  --color-composer-control-muted-foreground: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-composer-control-hover: color-mix(in oklab, var(--color-foreground) 5.5%, transparent);
-  --color-composer-send-background: var(--color-foreground);
-  --color-composer-send-foreground: #ffffff;
-  --color-composer-shadow: 0 4px 16px 0 rgb(0 0 0 / 0.05);
-  --color-composer-backdrop-filter: blur(16px);
+  --color-composer-background: #f4f4f4;
 
-  --color-prose-border: color-mix(in oklab, var(--color-foreground) 12%, transparent);
+  --color-prose-border: rgba(13, 13, 13, 0.117);
 
-  --color-sidebar: #f9f9f9;
-  --color-sidebar-background: #f9f9f9;
-  --color-sidebar-foreground: var(--color-foreground);
-  --color-sidebar-primary: var(--color-foreground);
-  --color-sidebar-primary-foreground: #ffffff;
-  --color-sidebar-muted-foreground: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-sidebar-accent: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --color-sidebar-accent-foreground: var(--color-foreground);
-  --color-sidebar-border: color-mix(in oklab, var(--color-foreground) 8%, transparent);
-  --color-sidebar-ring: #339cff;
-  --color-sidebar-blue: #0169cc;
+  --color-sidebar: #f5f5f5;
+  --color-sidebar-background: #f5f5f5;
+  --color-sidebar-foreground: rgba(13, 13, 13, 0.74);
+  --color-sidebar-primary: #0d0d0d;
+  --color-sidebar-primary-foreground: #0d0d0d;
+  --color-sidebar-muted-foreground: rgba(13, 13, 13, 0.42);
+  --color-sidebar-accent: rgba(13, 13, 13, 0.036);
+  --color-sidebar-accent-foreground: #0d0d0d;
+  --color-sidebar-border: rgba(13, 13, 13, 0.068);
+  --color-sidebar-ring: #0285ff;
+  --color-sidebar-blue: #0285ff;
 
-  --color-status-backlog: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-status-backlog-hover: color-mix(in oklab, var(--color-foreground) 70%, transparent);
-  --color-status-in-progress: #bd5800;
-  --color-status-in-progress-hover: #9a4600;
-  --color-status-in-review: #008809;
-  --color-status-in-review-hover: #006f07;
-  --color-status-done: #0169cc;
-  --color-status-done-hover: #0057aa;
-  --color-status-canceled: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-status-canceled-hover: color-mix(in oklab, var(--color-foreground) 70%, transparent);
+  --color-status-backlog: rgba(13, 13, 13, 0.495);
+  --color-status-backlog-hover: rgba(13, 13, 13, 0.695);
+  --color-status-in-progress: #e0c200;
+  --color-status-in-progress-hover: #b89e00;
+  --color-status-in-review: #00a240;
+  --color-status-in-review-hover: #008833;
+  --color-status-done: #0285ff;
+  --color-status-done-hover: #0070d6;
+  --color-status-canceled: rgba(13, 13, 13, 0.495);
+  --color-status-canceled-hover: rgba(13, 13, 13, 0.695);
 
-  --color-delegated-agent-1: #0169cc;
-  --color-delegated-agent-2: #751ed9;
-  --color-delegated-agent-3: #d53538;
-  --color-delegated-agent-4: #bd5800;
-  --color-delegated-agent-5: #924ff7;
-  --color-delegated-agent-6: #0071ea;
-  --color-delegated-agent-7: #e25507;
-  --color-delegated-agent-8: #006aff;
+  --color-todo-in-progress: #0285ff;
+  --color-todo-completed: #00a240;
+  --color-todo-pending: rgba(13, 13, 13, 0.495);
 
-  --color-todo-in-progress: #0169cc;
-  --color-todo-completed: #008809;
-  --color-todo-pending: color-mix(in oklab, var(--color-foreground) 50%, transparent);
+  --color-app-switcher-bg: rgba(13, 13, 13, 0.1);
 
-  --color-app-switcher-bg: color-mix(in oklab, var(--color-foreground) 10%, transparent);
-  --color-brand-logo-tile: #ffffff;
-
-  --color-git-green: #008809;
+  --color-git-green: #00a240;
   --color-git-red: #ba2623;
-  --color-git-yellow: #bd5800;
-  --color-git-gray: color-mix(in oklab, var(--color-foreground) 50%, transparent);
+  --color-git-yellow: #ffc300;
+  --color-git-gray: rgba(13, 13, 13, 0.495);
   --color-git-new-line: #00a240;
   --color-git-removed-line: #ba2623;
 
-  --color-terminal-black: #000000;
+  --color-terminal-black: rgba(13, 13, 13, 0.495);
+  --color-terminal-red: #e02e2a;
+  --color-terminal-green: #00a240;
+  --color-terminal-yellow: #ffc300;
+  --color-terminal-blue: #0285ff;
+  --color-terminal-magenta: #924ff7;
+  --color-terminal-cyan: #0285ff;
+  --color-terminal-white: #0d0d0d;
+
+  --color-terminal-bright-black: rgba(13, 13, 13, 0.695);
+  --color-terminal-bright-red: #e02e2a;
+  --color-terminal-bright-green: #00a240;
+  --color-terminal-bright-yellow: #ffc300;
+  --color-terminal-bright-blue: #0285ff;
+  --color-terminal-bright-magenta: #924ff7;
+  --color-terminal-bright-cyan: #0285ff;
+  --color-terminal-bright-white: #0d0d0d;
+
+  --git-new-line-bg: color-mix(in oklab, #00a240 10%, transparent);
+  --git-new-line-border: color-mix(in oklab, #00a240 60%, transparent);
+  --git-new-line-highlight: color-mix(in oklab, #00a240 15%, transparent);
+  --git-removed-line-bg: color-mix(in oklab, #ba2623 10%, transparent);
+  --git-removed-line-border: color-mix(in oklab, #ba2623 60%, transparent);
+  --git-removed-line-highlight: color-mix(in oklab, #ba2623 15%, transparent);
+  --color-diff-main-surface: #ffffff;
+  --color-diff-surface: color-mix(in srgb, #ffffff 94%, #0d0d0d);
+  --color-diff-panel-surface: color-mix(in oklab, #0d0d0d 3%, transparent);
+  --color-diff-header-surface: var(--color-diff-surface);
+  --color-diff-added: #00a240;
+  --color-diff-deleted: #ba2623;
+  --diffs-fg: #0d0d0d;
+  --diffs-mixer: #0d0d0d;
+  --color-diff-added-bg: var(--diffs-bg-addition-override);
+  --color-diff-deleted-bg: var(--diffs-bg-deletion-override);
+}
+
+/* Mono light tracks Codex Electron light without changing the original preset. */
+:root[data-theme="mono"][data-mode="light"] {
+  --color-scrollbar-thumb: rgba(13, 13, 13, 0.08);
+  --color-scrollbar-thumb-active: rgba(13, 13, 13, 0.16);
+
+  --color-background: #ffffff;
+  --color-foreground: #0d0d0d;
+  --color-overlay: #000000;
+
+  --color-primary: #0d0d0d;
+  --color-primary-foreground: #ffffff;
+
+  --color-secondary: rgba(13, 13, 13, 0.05);
+  --color-secondary-foreground: #0d0d0d;
+
+  --color-accent: rgba(13, 13, 13, 0.05);
+  --color-accent-foreground: #0d0d0d;
+  --color-muted: rgba(13, 13, 13, 0.025);
+  --color-muted-foreground: rgba(13, 13, 13, 0.7);
+  --color-faint: rgba(13, 13, 13, 0.5);
+  --color-helper: rgba(13, 13, 13, 0.7);
+
+  --color-card: rgba(13, 13, 13, 0.035);
+  --color-card-foreground: #0d0d0d;
+
+  --color-popover: #ffffff;
+  --color-popover-foreground: #0d0d0d;
+  --color-popover-accent: rgba(13, 13, 13, 0.05);
+  --color-popover-ring: rgba(13, 13, 13, 0.08);
+
+  --color-border: rgba(13, 13, 13, 0.08);
+  --color-input: rgba(13, 13, 13, 0.1);
+  --color-input-border: rgba(13, 13, 13, 0.08);
+  --color-separator: rgba(13, 13, 13, 0.05);
+  --color-ring: #0169cc;
+
+  --color-highlight: #deecf8;
+  --color-highlight-foreground: #0d0d0d;
+  --color-highlight-muted: #0169cc;
+  --color-border-highlight: #0169cc;
+  --color-unread: #0169cc;
+  --color-special: #0169cc;
+
+  --color-destructive: #e02e2a;
+  --color-destructive-foreground: #ffffff;
+  --color-success: #00a240;
+  --color-success-foreground: #ffffff;
+  --color-warning: #fff8e6;
+  --color-warning-foreground: #0d0d0d;
+  --color-warning-foreground-secondary: rgba(13, 13, 13, 0.5);
+  --color-warning-border: rgba(13, 13, 13, 0.08);
+  --color-info: #0169cc;
+  --color-info-foreground: #ffffff;
+  --color-positive: #00a240;
+  --color-positive-muted: rgba(0, 162, 64, 0.1);
+  --color-positive-foreground: #ffffff;
+
+  --color-link: #deecf8;
+  --color-link-foreground: #0169cc;
+  --color-link-elevated: #d8e8f7;
+
+  --color-tip: #deecf8;
+  --color-tip-border: rgba(13, 13, 13, 0.08);
+  --color-tip-secondary: #d8e8f7;
+  --color-tip-secondary-border: rgba(13, 13, 13, 0.08);
+  --color-tip-muted: #0169cc;
+  --color-tip-foreground: #0d0d0d;
+  --color-plan-border: #0169cc;
+
+  --color-switch-background: #0d0d0d;
+  --color-switch-foreground: #ffffff;
+
+  --color-composer-background: rgba(255, 255, 255, 0.864);
+  --color-composer-border: rgba(0, 0, 0, 0.1);
+  --color-composer-control-foreground: rgba(13, 13, 13, 0.5);
+  --color-composer-control-active-foreground: #0d0d0d;
+  --color-composer-control-muted-foreground: rgba(13, 13, 13, 0.5);
+  --color-composer-control-hover: rgba(13, 13, 13, 0.055);
+  --color-composer-send-background: #0d0d0d;
+  --color-composer-send-foreground: #ffffff;
+  --color-composer-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.05);
+  --color-composer-backdrop-filter: blur(16px);
+
+  --color-prose-border: rgba(13, 13, 13, 0.12);
+
+  --color-sidebar: #f5f5f5;
+  --color-sidebar-background: #f5f5f5;
+  --color-sidebar-foreground: #1a1c1f;
+  --color-sidebar-primary: #1a1c1f;
+  --color-sidebar-primary-foreground: #1a1c1f;
+  --color-sidebar-muted-foreground: color-mix(in oklab, #1a1c1f 50%, transparent);
+  --color-sidebar-accent: color-mix(in oklab, #1a1c1f 5%, transparent);
+  --color-sidebar-accent-foreground: #1a1c1f;
+  --color-sidebar-border: color-mix(in oklab, #1a1c1f 8%, transparent);
+  --color-sidebar-ring: #0169cc;
+  --color-sidebar-blue: #0169cc;
+
+  --color-status-backlog: rgba(13, 13, 13, 0.5);
+  --color-status-backlog-hover: rgba(13, 13, 13, 0.7);
+  --color-status-in-progress: #bd5800;
+  --color-status-in-progress-hover: #9a4600;
+  --color-status-in-review: #00a240;
+  --color-status-in-review-hover: #008833;
+  --color-status-done: #0169cc;
+  --color-status-done-hover: #0057aa;
+  --color-status-canceled: rgba(13, 13, 13, 0.5);
+  --color-status-canceled-hover: rgba(13, 13, 13, 0.7);
+
+  --color-todo-in-progress: #0169cc;
+  --color-todo-completed: #00a240;
+  --color-todo-pending: rgba(13, 13, 13, 0.5);
+
+  --color-app-switcher-bg: rgba(13, 13, 13, 0.1);
+
+  --color-git-green: #00a240;
+  --color-git-red: #ba2623;
+  --color-git-yellow: #ffc300;
+  --color-git-gray: rgba(13, 13, 13, 0.5);
+  --color-git-new-line: #00a240;
+  --color-git-removed-line: #ba2623;
+
+  --color-terminal-black: rgba(13, 13, 13, 0.5);
   --color-terminal-red: #d53538;
   --color-terminal-green: #008809;
   --color-terminal-yellow: #bd5800;
@@ -981,6 +1286,7 @@
   --color-terminal-magenta: #751ed9;
   --color-terminal-cyan: #0071ea;
   --color-terminal-white: #666666;
+
   --color-terminal-bright-black: #000000;
   --color-terminal-bright-red: #f44a4c;
   --color-terminal-bright-green: #59d24e;
@@ -990,30 +1296,20 @@
   --color-terminal-bright-cyan: #20b8ff;
   --color-terminal-bright-white: #828282;
 
-  --color-file-icon-folder: #1a1c1f;
-  --color-file-icon-neutral: #1a1c1f;
-  --color-file-icon-muted: color-mix(in oklab, var(--color-foreground) 50%, transparent);
-  --color-file-icon-accent: #1a1c1f;
-  --color-file-icon-red: #1a1c1f;
-
-  --git-new-line-bg: color-mix(in oklab, #00a240 10%, transparent);
+  --git-new-line-bg: color-mix(in oklab, #00a240 15%, transparent);
   --git-new-line-border: color-mix(in oklab, #00a240 60%, transparent);
   --git-new-line-highlight: color-mix(in oklab, #00a240 15%, transparent);
-  --git-removed-line-bg: color-mix(in oklab, #ba2623 10%, transparent);
+  --git-removed-line-bg: color-mix(in oklab, #ba2623 15%, transparent);
   --git-removed-line-border: color-mix(in oklab, #ba2623 60%, transparent);
   --git-removed-line-highlight: color-mix(in oklab, #ba2623 15%, transparent);
   --color-diff-main-surface: #ffffff;
-  --color-diff-code-surface: #fafafa;
-  --color-diff-surface: color-mix(in srgb, #ffffff 94%, #1a1c1f);
-  --color-diff-panel-surface: color-mix(in oklab, #1a1c1f 3%, transparent);
+  --color-diff-surface: color-mix(in srgb, #ffffff 94%, #0d0d0d);
+  --color-diff-panel-surface: color-mix(in oklab, #0d0d0d 3%, transparent);
   --color-diff-header-surface: var(--color-diff-surface);
-  --color-code-block-background: var(--color-diff-surface);
   --color-diff-added: #00a240;
   --color-diff-deleted: #ba2623;
-  --diffs-fg: var(--color-foreground);
-  --diffs-mixer: var(--color-foreground);
-  --diffs-bg-addition-override: color-mix(in srgb, var(--codex-diffs-surface) 85%, var(--diffs-addition-color-override));
-  --diffs-bg-deletion-override: color-mix(in srgb, var(--codex-diffs-surface) 85%, var(--diffs-deletion-color-override));
+  --diffs-fg: #0d0d0d;
+  --diffs-mixer: #0d0d0d;
   --color-diff-added-bg: var(--diffs-bg-addition-override);
   --color-diff-deleted-bg: var(--diffs-bg-deletion-override);
 }

--- a/desktop/src/lib/infra/editor/highlighting.ts
+++ b/desktop/src/lib/infra/editor/highlighting.ts
@@ -39,8 +39,8 @@ const PROLIFERATE_LIGHT_THEME = {
   name: "proliferate-light",
   type: "light" as const,
   settings: [
-    { settings: { foreground: "#1a1c1f", background: "#ffffff" } },
-    { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: "#777777" } },
+    { settings: { foreground: "#0d0d0d", background: "#ffffff" } },
+    { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: "#949494" } },
     { scope: ["string", "string.quoted"], settings: { foreground: "#008809" } },
     { scope: ["constant.numeric", "constant.language"], settings: { foreground: "#bd5800" } },
     { scope: ["keyword", "keyword.control", "keyword.operator.expression", "keyword.operator.new"], settings: { foreground: "#d53538" } },
@@ -138,7 +138,7 @@ const CODEX_MARKDOWN_COLORS = {
     emphasis: "#FFD452",
   },
   light: {
-    foreground: "#1a1c1f",
+    foreground: "#0d0d0d",
     muted: "#666666",
     string: "#008809",
     heading: "#d53538",

--- a/desktop/src/lib/infra/editor/monaco-theme.ts
+++ b/desktop/src/lib/infra/editor/monaco-theme.ts
@@ -102,69 +102,27 @@ type MonacoThemeData = typeof proliferateDarkTheme;
 export const proliferateLightTheme: MonacoThemeData = {
   base: "vs",
   inherit: true,
-  rules: [
-    { token: "comment", foreground: "777777", fontStyle: "italic" },
-    { token: "keyword", foreground: "D53538" },
-    { token: "keyword.control", foreground: "D53538" },
-    { token: "storage", foreground: "751ED9" },
-    { token: "storage.type", foreground: "751ED9" },
-    { token: "string", foreground: "008809" },
-    { token: "string.key.json", foreground: "BD5800" },
-    { token: "number", foreground: "BD5800" },
-    { token: "constant", foreground: "BD5800" },
-    { token: "type", foreground: "751ED9" },
-    { token: "type.identifier", foreground: "751ED9" },
-    { token: "entity.name.type", foreground: "751ED9" },
-    { token: "entity.name.function", foreground: "751ED9" },
-    { token: "variable", foreground: "1A1C1F" },
-    { token: "variable.predefined", foreground: "BD5800" },
-    { token: "delimiter", foreground: "666666" },
-    { token: "delimiter.bracket", foreground: "666666" },
-    { token: "operator", foreground: "0071EA" },
-    { token: "tag", foreground: "D53538" },
-    { token: "attribute.name", foreground: "751ED9" },
-    { token: "attribute.value", foreground: "008809" },
-    { token: "metatag", foreground: "D53538" },
-  ],
+  rules: [],
   colors: {
-    "editor.background": "#ffffff",
-    "editor.foreground": "#1a1c1f",
+    // Line numbers — warm gray, not green
+    "editorLineNumber.foreground": "#A09890",
+    "editorLineNumber.activeForeground": "#6B6560",
 
-    "editor.lineHighlightBackground": "#1a1c1f08",
+    // Subtle line highlight
+    "editor.lineHighlightBackground": "#00000006",
     "editor.lineHighlightBorder": "#00000000",
 
-    "editor.selectionBackground": "#d7e9ff",
-    "editor.inactiveSelectionBackground": "#e5f3ff",
-    "editor.selectionHighlightBackground": "#e5f3ff80",
-
-    "editor.findMatchBackground": "#ffd24066",
-    "editor.findMatchHighlightBackground": "#ffd24033",
-
-    "editorCursor.foreground": "#1a1c1f",
-
-    "editorLineNumber.foreground": "#8a8f96",
-    "editorLineNumber.activeForeground": "#1a1c1f",
-
+    // Gutter matches editor bg
     "editorGutter.background": "#ffffff",
 
-    "editorIndentGuide.background": "#1a1c1f0d",
-    "editorIndentGuide.activeBackground": "#1a1c1f1f",
+    // Indentation guides
+    "editorIndentGuide.background": "#00000008",
+    "editorIndentGuide.activeBackground": "#00000014",
 
-    "editorBracketMatch.background": "#339cff20",
-    "editorBracketMatch.border": "#339cff66",
-
+    // Scrollbar
     "scrollbarSlider.background": "#00000010",
     "scrollbarSlider.hoverBackground": "#00000018",
     "scrollbarSlider.activeBackground": "#00000024",
-
-    "editorWidget.background": "#ffffff",
-    "editorWidget.border": "#1a1c1f14",
-    "editorSuggestWidget.background": "#ffffff",
-    "editorSuggestWidget.border": "#1a1c1f14",
-    "editorSuggestWidget.selectedBackground": "#1a1c1f0d",
-    "editorSuggestWidget.highlightForeground": "#0169cc",
-
-    "minimapSlider.background": "#00000010",
   },
 };
 


### PR DESCRIPTION
## Summary
- revert the light-mode visual refresh from PR #233
- restore the previous light theme token blocks, component styling, and editor light palette
- keep the unrelated subagent receipt open-target fix from PR #233

## Verification
- pnpm --filter proliferate exec tsc --noEmit
- pnpm --filter proliferate exec vite build
- git diff --cached --check
- python3 scripts/check_max_lines.py