### PR TITLE
feat(desktop): add scratch list autoformat

### DIFF
--- a/desktop/src/components/workspace/scratch/ScratchPadPanel.test.tsx
+++ b/desktop/src/components/workspace/scratch/ScratchPadPanel.test.tsx
@@ -205,6 +205,50 @@ describe("ScratchPadPanel", () => {
     expect(editor.value).toContain("- [ ] ");
   });
 
+  it("continues Markdown lists on Enter and saves the autoformatted draft", async () => {
+    vi.useFakeTimers();
+    scratchQueryMocks.record = {
+      content: "- [x] done",
+      updatedAtMs: 1,
+    };
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    editor.setSelectionRange(editor.value.length, editor.value.length);
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor.value).toBe("- [x] done\n- [ ] ");
+    expect(editor.selectionStart).toBe(editor.value.length);
+    expect(editor.selectionEnd).toBe(editor.value.length);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(scratchQueryMocks.writeScratchPad).toHaveBeenCalledWith(
+      "- [x] done\n- [ ] ",
+      "workspace-1",
+    );
+  });
+
+  it("removes empty Markdown list markers on Enter", () => {
+    scratchQueryMocks.record = {
+      content: "- first\n- ",
+      updatedAtMs: 1,
+    };
+    render(<ScratchPadPanel workspaceKey="workspace-1" />);
+
+    const editor = screen.getByPlaceholderText(/Capture follow-ups/) as HTMLTextAreaElement;
+    editor.setSelectionRange(editor.value.length, editor.value.length);
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor.value).toBe("- first\n");
+    expect(editor.selectionStart).toBe(editor.value.length);
+    expect(editor.selectionEnd).toBe(editor.value.length);
+  });
+
   it("copies scratch content through the shell access boundary", async () => {
     scratchQueryMocks.record = {
       content: "durable note",

--- a/desktop/src/components/workspace/scratch/ScratchPadPanel.tsx
+++ b/desktop/src/components/workspace/scratch/ScratchPadPanel.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type ChangeEvent,
+  type KeyboardEvent,
 } from "react";
 import { Textarea } from "@/components/ui/Textarea";
 import {
@@ -21,6 +22,7 @@ import {
 import { useWorkspaceScratchPad } from "@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad";
 import { useWorkspaceScratchPadMutations } from "@/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { applyScratchMarkdownEnterAutoformat } from "@/lib/domain/workspaces/scratch/markdown-list-autoformat";
 
 const SAVE_DEBOUNCE_MS = 500;
 const SCRATCH_PLACEHOLDER = "- [ ] Capture follow-ups\n- [ ] Keep durable workspace notes here";
@@ -183,6 +185,37 @@ export function ScratchPadPanel({ workspaceKey }: ScratchPadPanelProps) {
     updateDraft(draft.replace(COMPLETED_TASK_PATTERN, ""));
   }, [draft, updateDraft]);
 
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key !== "Enter"
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+      || event.shiftKey
+      || event.nativeEvent.isComposing
+    ) {
+      return;
+    }
+
+    const textarea = event.currentTarget;
+    const result = applyScratchMarkdownEnterAutoformat({
+      value: draft,
+      selectionStart: textarea.selectionStart ?? draft.length,
+      selectionEnd: textarea.selectionEnd ?? textarea.selectionStart ?? draft.length,
+    });
+
+    if (!result) {
+      return;
+    }
+
+    event.preventDefault();
+    updateDraft(result.value);
+    window.requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
+    });
+  }, [draft, updateDraft]);
+
   const handleCopyContent = useCallback(async () => {
     await copyText(draft);
     setCopied(true);
@@ -235,6 +268,7 @@ export function ScratchPadPanel({ workspaceKey }: ScratchPadPanelProps) {
           wrap={wordWrap ? "soft" : "off"}
           spellCheck
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           onBlur={handleBlur}
           className={`h-full overflow-auto px-4 py-3 font-[family:var(--diffs-font-family)] text-[length:var(--diffs-font-size)] leading-[var(--diffs-line-height)] text-foreground placeholder:text-sidebar-muted-foreground/65 disabled:cursor-not-allowed ${wordWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
         />

--- a/desktop/src/lib/domain/workspaces/scratch/markdown-list-autoformat.test.ts
+++ b/desktop/src/lib/domain/workspaces/scratch/markdown-list-autoformat.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { applyScratchMarkdownEnterAutoformat } from "./markdown-list-autoformat";
+
+describe("applyScratchMarkdownEnterAutoformat", () => {
+  it("continues dash bullets", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first",
+      selectionStart: 7,
+      selectionEnd: 7,
+    })).toEqual({
+      value: "- first\n- ",
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+  });
+
+  it("continues star bullets", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "* first",
+      selectionStart: 7,
+      selectionEnd: 7,
+    })).toEqual({
+      value: "* first\n* ",
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+  });
+
+  it("continues checklist items as unchecked tasks", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- [x] done",
+      selectionStart: 10,
+      selectionEnd: 10,
+    })).toEqual({
+      value: "- [x] done\n- [ ] ",
+      selectionStart: 17,
+      selectionEnd: 17,
+    });
+  });
+
+  it("removes an empty bullet marker to exit the list", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first\n- ",
+      selectionStart: 10,
+      selectionEnd: 10,
+    })).toEqual({
+      value: "- first\n",
+      selectionStart: 8,
+      selectionEnd: 8,
+    });
+  });
+
+  it("removes an empty checklist marker to exit the task list", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first\n  - [ ] ",
+      selectionStart: 16,
+      selectionEnd: 16,
+    })).toEqual({
+      value: "- first\n  ",
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+  });
+
+  it("removes an empty checklist marker without requiring trailing whitespace", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- [ ]",
+      selectionStart: 5,
+      selectionEnd: 5,
+    })).toEqual({
+      value: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+    });
+  });
+
+  it("preserves indentation for continued bullets", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "  - nested",
+      selectionStart: 10,
+      selectionEnd: 10,
+    })).toEqual({
+      value: "  - nested\n  - ",
+      selectionStart: 15,
+      selectionEnd: 15,
+    });
+  });
+
+  it("replaces selected text with the inserted continued marker", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first selected",
+      selectionStart: 7,
+      selectionEnd: 16,
+    })).toEqual({
+      value: "- first\n- ",
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+  });
+
+  it("does not intercept Enter at the start of a list item", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first",
+      selectionStart: 0,
+      selectionEnd: 0,
+    })).toBeNull();
+  });
+
+  it("does not intercept Enter inside a bullet marker", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- first",
+      selectionStart: 1,
+      selectionEnd: 1,
+    })).toBeNull();
+  });
+
+  it("does not remove an empty marker when the caret is before the marker end", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- ",
+      selectionStart: 0,
+      selectionEnd: 0,
+    })).toBeNull();
+  });
+
+  it("does not intercept Enter inside a task marker", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "- [ ] task",
+      selectionStart: 4,
+      selectionEnd: 4,
+    })).toBeNull();
+  });
+
+  it("returns null for non-list lines", () => {
+    expect(applyScratchMarkdownEnterAutoformat({
+      value: "plain text",
+      selectionStart: 10,
+      selectionEnd: 10,
+    })).toBeNull();
+  });
+});

--- a/desktop/src/lib/domain/workspaces/scratch/markdown-list-autoformat.ts
+++ b/desktop/src/lib/domain/workspaces/scratch/markdown-list-autoformat.ts
@@ -1,0 +1,74 @@
+export interface ScratchMarkdownEnterInput {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+export interface ScratchMarkdownEnterResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+const LIST_LINE_PATTERN = /^(\s*)([-*])\s+(?:(\[([ xX])\])(?:\s+(.*))?|(.*))$/;
+
+export function applyScratchMarkdownEnterAutoformat({
+  value,
+  selectionStart,
+  selectionEnd,
+}: ScratchMarkdownEnterInput): ScratchMarkdownEnterResult | null {
+  const start = clampOffset(selectionStart, value.length);
+  const end = clampOffset(selectionEnd, value.length);
+  const lineStart = value.lastIndexOf("\n", Math.max(0, start - 1)) + 1;
+  const lineEndIndex = value.indexOf("\n", start);
+  const lineEnd = lineEndIndex === -1 ? value.length : lineEndIndex;
+  const line = value.slice(lineStart, lineEnd);
+  const match = LIST_LINE_PATTERN.exec(line);
+
+  if (!match) {
+    return null;
+  }
+
+  const indent = match[1] ?? "";
+  const marker = match[2] ?? "-";
+  const taskState = match[4];
+  const body = match[5] ?? match[6] ?? "";
+  const prefixLength = taskState === undefined
+    ? indent.length + marker.length + 1
+    : indent.length + marker.length + 1 + 3;
+  const caretColumn = start - lineStart;
+
+  if (caretColumn < prefixLength) {
+    return null;
+  }
+
+  if (body.trim().length === 0) {
+    const next = `${value.slice(0, lineStart)}${indent}${value.slice(lineEnd)}`;
+    const caret = lineStart + indent.length;
+    return {
+      value: next,
+      selectionStart: caret,
+      selectionEnd: caret,
+    };
+  }
+
+  const nextMarker = taskState === undefined
+    ? `${indent}${marker} `
+    : `${indent}${marker} [ ] `;
+  const insertion = `\n${nextMarker}`;
+  const next = `${value.slice(0, start)}${insertion}${value.slice(end)}`;
+  const caret = start + insertion.length;
+
+  return {
+    value: next,
+    selectionStart: caret,
+    selectionEnd: caret,
+  };
+}
+
+function clampOffset(value: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(Math.trunc(value), 0), max);
+}


### PR DESCRIPTION
## Summary
- add Obsidian-style Enter autoformat for Scratch Markdown bullets and checklist items
- preserve Markdown storage while continuing bullets, checklist tasks, indentation, and empty-marker exit behavior
- add pure domain coverage plus Scratch panel integration tests

## Verification
- pnpm --dir desktop test src/lib/domain/workspaces/scratch/markdown-list-autoformat.test.ts src/components/workspace/scratch/ScratchPadPanel.test.tsx
- pnpm --dir desktop exec tsc --noEmit
- python3 scripts/check_frontend_boundaries.py
- git diff --check
