### PR TITLE
fix(desktop): tune scratch typography

### DIFF
--- a/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -203,7 +203,12 @@ const scratchHighlightStyle = HighlightStyle.define([
   { tag: tags.emphasis, fontStyle: "italic" },
   { tag: tags.strong, fontWeight: "600" },
   { tag: tags.link, color: "var(--color-foreground)", textDecoration: "underline" },
-  { tag: tags.monospace, color: "var(--color-muted-foreground)" },
+  {
+    tag: tags.monospace,
+    color: "var(--color-muted-foreground)",
+    fontFamily: "var(--scratch-code-font-family)",
+    fontSize: "0.93em",
+  },
 ]);
 
 const scratchEditorTheme = EditorView.theme({
@@ -211,9 +216,9 @@ const scratchEditorTheme = EditorView.theme({
     height: "100%",
     color: "var(--color-foreground)",
     backgroundColor: "transparent",
-    fontFamily: "var(--diffs-font-family)",
-    fontSize: "var(--diffs-font-size)",
-    lineHeight: "var(--diffs-line-height)",
+    fontFamily: "var(--scratch-font-family)",
+    fontSize: "var(--scratch-font-size)",
+    lineHeight: "var(--scratch-line-height)",
   },
   ".cm-scroller": {
     height: "100%",
@@ -222,7 +227,7 @@ const scratchEditorTheme = EditorView.theme({
   },
   ".cm-content": {
     minHeight: "100%",
-    padding: "0.75rem 1rem",
+    padding: "0.9rem 1.05rem",
     caretColor: "var(--color-foreground)",
   },
   ".cm-line": {
@@ -233,6 +238,9 @@ const scratchEditorTheme = EditorView.theme({
   },
   ".cm-cursor": {
     borderLeftColor: "var(--color-foreground)",
+    borderLeftWidth: "1px",
+    minHeight: "1.1em",
+    marginTop: "0.2em",
   },
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
     backgroundColor: "color-mix(in oklab, var(--color-foreground) 18%, transparent)",
@@ -242,26 +250,26 @@ const scratchEditorTheme = EditorView.theme({
   },
   ".scratch-list-marker": {
     display: "inline-flex",
-    width: "1.6ch",
+    width: "var(--scratch-list-marker-width)",
     justifyContent: "center",
     color: "var(--color-sidebar-muted-foreground)",
   },
   ".scratch-task-checkbox": {
     display: "inline-flex",
-    width: "1.85ch",
+    width: "var(--scratch-list-marker-width)",
     height: "1em",
-    margin: "0 0.18ch 0 0",
+    margin: "0 0.1em 0 0",
     alignItems: "center",
     justifyContent: "center",
     boxSizing: "border-box",
     lineHeight: "1",
     position: "relative",
-    top: "0.1em",
+    top: "0.06em",
   },
   ".scratch-task-box": {
     display: "inline-flex",
-    width: "0.78em",
-    height: "0.78em",
+    width: "var(--scratch-task-box-size)",
+    height: "var(--scratch-task-box-size)",
     alignItems: "center",
     justifyContent: "center",
     boxSizing: "border-box",

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -283,6 +283,12 @@
   --diffs-font-family: var(--font-mono);
   --diffs-font-size: 11px;
   --diffs-line-height: calc(var(--diffs-font-size, 11px) * 1.8);
+  --scratch-font-family: "Geist", var(--font-sans);
+  --scratch-code-font-family: var(--font-mono);
+  --scratch-font-size: var(--text-chat);
+  --scratch-line-height: var(--text-chat--line-height);
+  --scratch-list-marker-width: 1.35em;
+  --scratch-task-box-size: 0.82em;
   --readable-code-font-size: 0.6875rem;
   --readable-code-line-height: 1.625;
   --diffs-min-number-column-width: 4ch;


### PR DESCRIPTION
## Summary
- give Scratch its own Geist-based prose typography tokens
- make Scratch font size follow the existing UI text-size preference
- keep inline code on the readable code font stack and tune caret/marker sizing for the prose font

## Verification
- pnpm --dir desktop test src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts src/components/workspace/scratch/ScratchPadPanel.test.tsx
- pnpm --dir desktop exec tsc --noEmit
- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check
