### PR TITLE
fix(desktop): keep scratch enter handling single-pass

### DIFF
--- a/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -85,7 +85,7 @@ export function useScratchCodeMirrorEditor({
   // Owns the imperative CodeMirror editor lifecycle and keeps React as the source of saved text.
   const extensions = useMemo(() => [
     history(),
-    markdown(),
+    markdown({ addKeymap: false }),
     syntaxHighlighting(scratchHighlightStyle),
     placeholderCompartmentRef.current.of(placeholder(placeholderText)),
     scratchEditorTheme,


### PR DESCRIPTION
## Summary
- disable CodeMirror markdown's built-in high-priority Enter keymap for Scratch
- keep Scratch's custom list Enter formatter as the single owner of bullet/task continuation

## Verification
- pnpm --dir desktop test src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts src/components/workspace/scratch/ScratchPadPanel.test.tsx
- pnpm --dir desktop exec tsc --noEmit
- git diff --check
