### PR TITLE
feat(desktop): polish update and file browsing UI

### DIFF
--- a/desktop/src/components/feedback/Toast.tsx
+++ b/desktop/src/components/feedback/Toast.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { X } from "@/components/ui/icons";
+import { UpdateNotificationCard } from "./UpdateNotificationCard";
 
 type ToastTimer = ReturnType<typeof setTimeout>;
 
@@ -31,8 +32,6 @@ export function ToastContainer() {
     };
   }, []);
 
-  if (toasts.length === 0) return null;
-
   return (
     <div
       className="fixed bottom-4 right-4 z-[100] flex max-w-sm flex-col gap-2"
@@ -53,6 +52,7 @@ export function ToastContainer() {
           </button>
         </div>
       ))}
+      <UpdateNotificationCard />
     </div>
   );
 }

--- a/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpdateNotificationCard } from "./UpdateNotificationCard";
+
+const updaterMocks = vi.hoisted(() => ({
+  phase: "available",
+  availableVersion: "0.1.24",
+  downloadProgress: null as number | null,
+  downloadUpdate: vi.fn(),
+  openRestartPrompt: vi.fn(),
+}));
+
+const shellMocks = vi.hoisted(() => ({
+  openExternal: vi.fn(),
+}));
+
+vi.mock("@/hooks/access/tauri/use-updater", () => ({
+  useUpdater: () => updaterMocks,
+}));
+
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => shellMocks,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  updaterMocks.phase = "available";
+  updaterMocks.availableVersion = "0.1.24";
+  updaterMocks.downloadProgress = null;
+});
+
+describe("UpdateNotificationCard", () => {
+  it("renders update actions and links to the changelog", () => {
+    render(<UpdateNotificationCard />);
+
+    expect(screen.getByLabelText("Desktop update is available")).toBeTruthy();
+    expect(screen.getByText("New update available")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "See changes" }));
+    expect(shellMocks.openExternal).toHaveBeenCalledWith(
+      "https://github.com/proliferate-ai/proliferate/releases/latest",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    expect(updaterMocks.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be dismissed for the current update version", () => {
+    render(<UpdateNotificationCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss update notification" }));
+
+    expect(screen.queryByLabelText("Desktop update is available")).toBeNull();
+  });
+});

--- a/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
@@ -41,7 +41,7 @@ describe("UpdateNotificationCard", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "See changes" }));
     expect(shellMocks.openExternal).toHaveBeenCalledWith(
-      "https://github.com/proliferate-ai/proliferate/releases/latest",
+      "https://proliferate.com/changelog",
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Download" }));

--- a/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
@@ -55,4 +55,12 @@ describe("UpdateNotificationCard", () => {
 
     expect(screen.queryByLabelText("Desktop update is available")).toBeNull();
   });
+
+  it("does not render when no update is available", () => {
+    updaterMocks.phase = "current";
+
+    render(<UpdateNotificationCard />);
+
+    expect(screen.queryByText("New update available")).toBeNull();
+  });
 });

--- a/desktop/src/components/feedback/UpdateNotificationCard.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.tsx
@@ -12,9 +12,6 @@ const UPDATE_CARD_PHASES = new Set<UpdaterPhase>([
   "downloading",
   "ready",
 ]);
-const FORCE_DEV_UPDATE_CARD_PREVIEW = import.meta.env.DEV && import.meta.env.MODE !== "test";
-const DEV_UPDATE_CARD_PREVIEW_PHASE: UpdaterPhase = "ready";
-const DEV_UPDATE_CARD_PREVIEW_VERSION = "0.1.99";
 
 export function UpdateNotificationCard() {
   const {
@@ -26,22 +23,17 @@ export function UpdateNotificationCard() {
   } = useUpdater();
   const { openExternal } = useTauriShellActions();
   const [dismissedKey, setDismissedKey] = useState<string | null>(null);
-  const previewingDevCard = FORCE_DEV_UPDATE_CARD_PREVIEW && !UPDATE_CARD_PHASES.has(phase);
-  const displayPhase = previewingDevCard ? DEV_UPDATE_CARD_PREVIEW_PHASE : phase;
-  const displayAvailableVersion = previewingDevCard
-    ? DEV_UPDATE_CARD_PREVIEW_VERSION
-    : availableVersion;
-  const visibleKey = `${displayPhase}:${displayAvailableVersion ?? "unknown"}`;
+  const visibleKey = `${phase}:${availableVersion ?? "unknown"}`;
 
   useEffect(() => {
     setDismissedKey(null);
   }, [visibleKey]);
 
-  if (!UPDATE_CARD_PHASES.has(displayPhase) || dismissedKey === visibleKey) {
+  if (!UPDATE_CARD_PHASES.has(phase) || dismissedKey === visibleKey) {
     return null;
   }
 
-  const card = updateCardPresentation(displayPhase, downloadProgress);
+  const card = updateCardPresentation(phase, downloadProgress);
 
   return (
     <aside
@@ -65,7 +57,7 @@ export function UpdateNotificationCard() {
         </h2>
       </div>
 
-      {displayPhase === "downloading" && typeof downloadProgress === "number" && (
+      {phase === "downloading" && typeof downloadProgress === "number" && (
         <ProgressBar
           value={downloadProgress}
           className="h-1 w-full bg-muted"
@@ -87,14 +79,14 @@ export function UpdateNotificationCard() {
           type="button"
           variant="inverted"
           size="sm"
-          disabled={displayPhase === "downloading"}
+          disabled={phase === "downloading"}
           className="h-7 rounded-md px-2.5 text-xs font-medium"
           onClick={() => {
-            if (displayPhase === "available") {
+            if (phase === "available") {
               void downloadUpdate();
               return;
             }
-            if (displayPhase === "ready") {
+            if (phase === "ready") {
               openRestartPrompt();
             }
           }}

--- a/desktop/src/components/feedback/UpdateNotificationCard.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.tsx
@@ -5,7 +5,7 @@ import { X } from "@/components/ui/icons";
 import { useUpdater, type UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 
-const CHANGELOG_URL = "https://github.com/proliferate-ai/proliferate/releases/latest";
+const CHANGELOG_URL = "https://proliferate.com/changelog";
 
 const UPDATE_CARD_PHASES = new Set<UpdaterPhase>([
   "available",

--- a/desktop/src/components/feedback/UpdateNotificationCard.tsx
+++ b/desktop/src/components/feedback/UpdateNotificationCard.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { X } from "@/components/ui/icons";
+import { useUpdater, type UpdaterPhase } from "@/hooks/access/tauri/use-updater";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+
+const CHANGELOG_URL = "https://github.com/proliferate-ai/proliferate/releases/latest";
+
+const UPDATE_CARD_PHASES = new Set<UpdaterPhase>([
+  "available",
+  "downloading",
+  "ready",
+]);
+const FORCE_DEV_UPDATE_CARD_PREVIEW = import.meta.env.DEV && import.meta.env.MODE !== "test";
+const DEV_UPDATE_CARD_PREVIEW_PHASE: UpdaterPhase = "ready";
+const DEV_UPDATE_CARD_PREVIEW_VERSION = "0.1.99";
+
+export function UpdateNotificationCard() {
+  const {
+    phase,
+    availableVersion,
+    downloadProgress,
+    downloadUpdate,
+    openRestartPrompt,
+  } = useUpdater();
+  const { openExternal } = useTauriShellActions();
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+  const previewingDevCard = FORCE_DEV_UPDATE_CARD_PREVIEW && !UPDATE_CARD_PHASES.has(phase);
+  const displayPhase = previewingDevCard ? DEV_UPDATE_CARD_PREVIEW_PHASE : phase;
+  const displayAvailableVersion = previewingDevCard
+    ? DEV_UPDATE_CARD_PREVIEW_VERSION
+    : availableVersion;
+  const visibleKey = `${displayPhase}:${displayAvailableVersion ?? "unknown"}`;
+
+  useEffect(() => {
+    setDismissedKey(null);
+  }, [visibleKey]);
+
+  if (!UPDATE_CARD_PHASES.has(displayPhase) || dismissedKey === visibleKey) {
+    return null;
+  }
+
+  const card = updateCardPresentation(displayPhase, downloadProgress);
+
+  return (
+    <aside
+      aria-label={card.ariaLabel}
+      className="relative flex w-[min(22rem,calc(100vw-2rem))] flex-wrap items-start gap-2 rounded-lg border border-border bg-background px-3 py-3 pr-10 text-sm text-foreground shadow-floating-dark animate-toast-in"
+    >
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        aria-label="Dismiss update notification"
+        className="absolute right-2 top-2 flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        onClick={() => setDismissedKey(visibleKey)}
+      >
+        <X className="size-3" />
+      </Button>
+
+      <div className="w-full min-w-0">
+        <h2 className="select-text truncate text-sm font-medium leading-5 text-foreground">
+          {card.title}
+        </h2>
+      </div>
+
+      {displayPhase === "downloading" && typeof downloadProgress === "number" && (
+        <ProgressBar
+          value={downloadProgress}
+          className="h-1 w-full bg-muted"
+          indicatorClassName="h-full bg-foreground transition-[width]"
+        />
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 rounded-md border-input bg-background px-2.5 text-xs font-normal"
+          onClick={() => { void openExternal(CHANGELOG_URL); }}
+        >
+          See changes
+        </Button>
+        <Button
+          type="button"
+          variant="inverted"
+          size="sm"
+          disabled={displayPhase === "downloading"}
+          className="h-7 rounded-md px-2.5 text-xs font-medium"
+          onClick={() => {
+            if (displayPhase === "available") {
+              void downloadUpdate();
+              return;
+            }
+            if (displayPhase === "ready") {
+              openRestartPrompt();
+            }
+          }}
+        >
+          {card.actionLabel}
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+function updateCardPresentation(
+  phase: UpdaterPhase,
+  downloadProgress: number | null,
+) {
+  if (phase === "downloading") {
+    const progressLabel = typeof downloadProgress === "number" ? ` ${downloadProgress}%` : "";
+    return {
+      phase,
+      ariaLabel: `Desktop update is downloading${progressLabel}`,
+      title: "Downloading update",
+      actionLabel: "Downloading",
+    } as const;
+  }
+
+  if (phase === "ready") {
+    return {
+      phase,
+      ariaLabel: "Desktop update is ready to install",
+      title: "New update available",
+      actionLabel: "Restart",
+    } as const;
+  }
+
+  return {
+    phase: "available",
+    ariaLabel: "Desktop update is available",
+    title: "New update available",
+    actionLabel: "Download",
+  } as const;
+}

--- a/desktop/src/components/ui/content/FileDiffCard.test.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.test.tsx
@@ -26,8 +26,9 @@ describe("FileChangesCard and FileDiffCard", () => {
     expect(html).toContain("2 files changed");
     expect(html).not.toContain("+7");
     expect(html).not.toContain("text-git-red\">-3</span>");
-    expect(html).toContain("+4");
-    expect(html).toContain("-1");
+    expect(html).toContain('text-right">+</span><span class="text-right">4');
+    expect(html).toContain('text-right">-</span><span class="text-right">1');
+    expect(html).toContain("grid-cols-[0.65ch_minmax(1ch,max-content)]");
     expect(html).toContain("bg-[var(--color-diff-panel-surface)]");
     expect(html).toContain("text-chat leading-[var(--text-chat--line-height)]");
     expect(html).toContain("thread-diff-virtualized");

--- a/desktop/src/components/ui/content/FileDiffCard.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.tsx
@@ -19,14 +19,31 @@ export function FileChangeStats({
 
   return (
     <span
-      className={`inline-flex shrink-0 items-center gap-1 tabular-nums tracking-tight ${className ?? ""}`}
+      className={`inline-flex shrink-0 items-baseline gap-1 tabular-nums tracking-tight ${className ?? ""}`}
     >
       {additions > 0 && (
-        <span className="shrink-0 text-git-green">+{additions}</span>
+        <FileChangeStat sign="+" value={additions} className="text-git-green" />
       )}
       {deletions > 0 && (
-        <span className="shrink-0 text-git-red">-{deletions}</span>
+        <FileChangeStat sign="-" value={deletions} className="text-git-red" />
       )}
+    </span>
+  );
+}
+
+function FileChangeStat({
+  sign,
+  value,
+  className,
+}: {
+  sign: "+" | "-";
+  value: number;
+  className: string;
+}) {
+  return (
+    <span className={`inline-grid shrink-0 grid-cols-[0.65ch_minmax(1ch,max-content)] items-baseline ${className}`}>
+      <span className="text-right">{sign}</span>
+      <span className="text-right">{value}</span>
     </span>
   );
 }

--- a/desktop/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -4,7 +4,7 @@ import type {
   ToolCallItem,
 } from "@anyharness/sdk";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
-import { FileDiffCard } from "@/components/ui/content/FileDiffCard";
+import { FileChangeStats, FileDiffCard } from "@/components/ui/content/FileDiffCard";
 import { HighlightedCodePanel } from "@/components/ui/content/HighlightedCodePanel";
 import { ChevronRight } from "@/components/ui/icons";
 import { useFileReferenceActions } from "@/hooks/workspaces/files/use-file-reference-actions";
@@ -94,10 +94,11 @@ function EditActionRow({
           displayName={displayName}
         />
         {(additions > 0 || deletions > 0) && (
-          <span className="inline-flex shrink-0 items-center gap-1 tabular-nums tracking-tight text-sm">
-            {additions > 0 && <span className="text-git-green">+{additions}</span>}
-            {deletions > 0 && <span className="text-git-red">-{deletions}</span>}
-          </span>
+          <FileChangeStats
+            additions={additions}
+            deletions={deletions}
+            className="text-sm"
+          />
         )}
         {hasDetails && (
           <ChevronRight

--- a/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
@@ -18,8 +18,9 @@ describe("TurnDiffPanel", () => {
     expect(html).toContain("2 files changed");
     expect(html).not.toContain("+4");
     expect(html).not.toContain("text-git-red\">-2</span>");
-    expect(html).toContain("+2");
-    expect(html).toContain("-1");
+    expect(html).toContain('text-right">+</span><span class="text-right">2');
+    expect(html).toContain('text-right">-</span><span class="text-right">1');
+    expect(html).toContain("grid-cols-[0.65ch_minmax(1ch,max-content)]");
     expect(html).toContain("data-diff-surface=\"chat\"");
     expect(html).toContain("README.md");
     expect(html).toContain("GitPanel.tsx");

--- a/desktop/src/components/workspace/files/FileEditorView.test.tsx
+++ b/desktop/src/components/workspace/files/FileEditorView.test.tsx
@@ -256,20 +256,27 @@ describe("FileEditorView", () => {
       isLoading: false,
     });
 
-    const { container } = render(createElement(FileEditorView, {
+    render(createElement(FileEditorView, {
       filePath: "package.json",
       targetKey,
     }));
 
     fireEvent.click(screen.getByLabelText("Show files"));
 
-    expect(container.querySelector("[data-file-browser-overlay]")).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Browse files" })).toBeTruthy();
+    expect(document.body.querySelector("[data-file-browser-overlay]")).toBeTruthy();
     expect(screen.getByText("{\"ok\":true}")).toBeTruthy();
     expect(screen.getByText("README.md")).toBeTruthy();
     expect(workspaceFilesQuery).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
       path: "",
       enabled: true,
+    });
+    expect(searchWorkspaceFilesQuery).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      query: "",
+      limit: 60,
+      enabled: false,
     });
   });
 });

--- a/desktop/src/components/workspace/files/viewer/WorkspaceFileBrowserOverlay.tsx
+++ b/desktop/src/components/workspace/files/viewer/WorkspaceFileBrowserOverlay.tsx
@@ -1,4 +1,4 @@
-import { PaneSideOverlay } from "@/components/workspace/pane/PaneSideOverlay";
+import { ModalShell } from "@/components/ui/ModalShell";
 import { WorkspaceFileBrowserPane } from "./WorkspaceFileBrowserPane";
 
 interface WorkspaceFileBrowserOverlayProps {
@@ -20,22 +20,29 @@ export function WorkspaceFileBrowserOverlay({
   onOpenFile,
   onClose,
 }: WorkspaceFileBrowserOverlayProps) {
+  const directoryLabel = pathPrefix.trim() || "Workspace root";
+
   return (
-    <PaneSideOverlay
+    <ModalShell
       open={open}
-      label="File browser"
-      widthClassName="w-[min(360px,calc(100%-1rem))]"
-      dataAttribute="file-browser-overlay"
       onClose={onClose}
+      title="Browse files"
+      description={directoryLabel}
+      sizeClassName="h-[min(72vh,42rem)] max-w-2xl"
+      bodyClassName="p-0"
+      panelClassName="border-sidebar-border/80 bg-sidebar-background/95 text-sidebar-foreground shadow-floating-dark backdrop-blur"
+      overlayClassName="bg-overlay/40 backdrop-blur-sm"
     >
-      <WorkspaceFileBrowserPane
-        workspaceId={workspaceId}
-        selectedPath={selectedPath}
-        pathPrefix={pathPrefix}
-        autoFocusSearch
-        onPathPrefixChange={onPathPrefixChange}
-        onOpenFile={onOpenFile}
-      />
-    </PaneSideOverlay>
+      <div className="h-full min-h-0" data-file-browser-overlay>
+        <WorkspaceFileBrowserPane
+          workspaceId={workspaceId}
+          selectedPath={selectedPath}
+          pathPrefix={pathPrefix}
+          autoFocusSearch
+          onPathPrefixChange={onPathPrefixChange}
+          onOpenFile={onOpenFile}
+        />
+      </div>
+    </ModalShell>
   );
 }

--- a/desktop/src/components/workspace/files/viewer/WorkspaceFileBrowserPane.tsx
+++ b/desktop/src/components/workspace/files/viewer/WorkspaceFileBrowserPane.tsx
@@ -36,43 +36,46 @@ export function WorkspaceFileBrowserPane({
   const searchQuery = useSearchWorkspaceFilesQuery({
     workspaceId,
     query: pathPrefix.trim(),
-    limit: 80,
-    enabled: Boolean(workspaceId) && pathPrefix.trim().length > 0 && directoryQuery.isError,
+    limit: 60,
+    enabled: Boolean(workspaceId) && pathPrefix.trim().length > 0,
   });
 
   const sections = useMemo<PaneFileTreeSection[]>(() => {
+    const nextSections: PaneFileTreeSection[] = [];
+
+    if (searchQuery.data?.results?.length) {
+      nextSections.push({
+        id: "search",
+        label: "Matches",
+        nodes: searchQuery.data.results.map((result) => ({
+          id: `search:${result.path}`,
+          name: result.name,
+          path: result.path,
+          kind: "file",
+          selected: result.path === selectedPath,
+          title: result.path,
+        })),
+      });
+    }
+
     if (directoryQuery.data?.entries) {
-      return [{
+      nextSections.push({
         id: "directory",
-        label: directoryPath || "Workspace",
+        label: directoryPath ? `Folder: ${directoryPath}` : "Workspace",
         nodes: directoryEntriesToNodes({
           directoryPath,
           entries: directoryQuery.data.entries,
           selectedPath,
         }),
-      }];
+      });
     }
 
-    if (searchQuery.data?.results) {
-      return [{
-        id: "search",
-        label: "Matches",
-        nodes: searchQuery.data.results.map((result) => ({
-          id: result.path,
-          name: result.name,
-          path: result.path,
-          kind: "file",
-          selected: result.path === selectedPath,
-        })),
-      }];
-    }
-
-    return [];
+    return nextSections;
   }, [directoryPath, directoryQuery.data?.entries, searchQuery.data?.results, selectedPath]);
 
   const emptyMessage = directoryQuery.isLoading || searchQuery.isLoading
     ? "Loading files"
-    : directoryQuery.isError
+    : pathPrefix.trim().length > 0
       ? "No matching files"
       : "No files";
 
@@ -80,7 +83,7 @@ export function WorkspaceFileBrowserPane({
     <PaneFileTree
       sections={sections}
       searchValue={pathPrefix}
-      searchPlaceholder="Filter files..."
+      searchPlaceholder="Search or jump to a folder..."
       searchAutoFocus={autoFocusSearch}
       emptyMessage={emptyMessage}
       onSearchChange={onPathPrefixChange}


### PR DESCRIPTION
## Summary
- Add a compact bottom-right desktop update toast with changelog and update/restart actions.
- Keep the update toast mounted even when there are no ordinary toasts, while rendering it only for real updater states (`available`, `downloading`, or `ready`).
- Redesign the update toast against the conductor reference: no bulky icon block, no explanatory paragraph, tight title/actions, and a small close affordance.
- Replace the file browser side overlay with a modal-style browser and show search matches alongside the current folder.
- Align + / - file change counts in diff cards and collapsed edit rows through the shared FileChangeStats component.
- Update focused tests for the update card, diff stats, transcript diff panel, and file browser behavior.

## Verification
- pnpm --dir desktop test src/components/feedback/UpdateNotificationCard.test.tsx
- pnpm --dir desktop exec tsc --noEmit
- pnpm --dir desktop test src/components/feedback/UpdateNotificationCard.test.tsx src/components/ui/content/FileDiffCard.test.tsx src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx src/components/workspace/files/FileEditorView.test.tsx
- python3 scripts/check_frontend_boundaries.py && python3 scripts/check_max_lines.py && git diff --check

## Notes
- Left unrelated Cargo.lock and generated OpenAPI ordering churn uncommitted and out of this PR.
