### PR TITLE
test(desktop): split sidebar local slot coverage

### DIFF
--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-local-slots.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-local-slots.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { buildLocalSlotLogicalWorkspaceId } from "@/lib/domain/workspaces/cloud/logical-workspace-id";
+import { resolveAutoShowMoreRepoKey } from "./sidebar-groups";
+import {
+  buildGroups,
+  makeLocalLogicalWorkspace,
+} from "./sidebar-test-fixtures";
+
+describe("local-slot sidebar aliases", () => {
+  it("uses local-slot aliases for active, archived, and queued sidebar state", () => {
+    const logicalWorkspace = makeLocalLogicalWorkspace({
+      id: "remote:github:proliferate-ai:repo-a:main",
+      workspaceId: "workspace-local",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+    const slotId = buildLocalSlotLogicalWorkspaceId("workspace-local");
+
+    const groups = buildGroups({
+      logicalWorkspaces: [logicalWorkspace],
+      selectedLogicalWorkspaceId: slotId,
+      archivedIds: [slotId],
+      pendingPromptCounts: {
+        [slotId]: 2,
+      },
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items[0]?.id).toBe("remote:github:proliferate-ai:repo-a:main");
+    expect(groups[0]?.items[0]?.active).toBe(true);
+    expect(groups[0]?.items[0]?.archived).toBe(true);
+    expect(groups[0]?.items[0]?.statusIndicator).toEqual({
+      kind: "queued_prompt",
+      tooltip: "2 queued Home prompts",
+    });
+  });
+
+  it("resolves a repo key when the selected local-slot alias is past the item cap", () => {
+    const selectedSlotId = buildLocalSlotLogicalWorkspaceId("worktree-6-materialization");
+    const groups = buildGroups({
+      logicalWorkspaces: Array.from({ length: 7 }, (_, index) =>
+        makeLocalLogicalWorkspace({
+          id: `worktree-${index}`,
+          workspaceId: `worktree-${index}-materialization`,
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+          branch: `feature/worktree-${index}`,
+          updatedAt: `2026-04-13T10:0${index}:00.000Z`,
+        })),
+      selectedLogicalWorkspaceId: selectedSlotId,
+    });
+
+    const repoKey = resolveAutoShowMoreRepoKey({
+      groups,
+      selectedLogicalWorkspaceId: selectedSlotId,
+      itemLimit: 6,
+    });
+
+    expect(repoKey).toBe("/tmp/repo-a");
+  });
+
+  it("suffixes duplicate local visible names within a repo group without marking overrides", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "local-older",
+          workspaceId: "workspace-older",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          updatedAt: "2026-04-13T10:00:00.000Z",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "local-newer",
+          workspaceId: "workspace-newer",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          updatedAt: "2026-04-13T11:00:00.000Z",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "local-override",
+          workspaceId: "workspace-override",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          displayName: "repo-a",
+          updatedAt: "2026-04-13T12:00:00.000Z",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "local-other-group",
+          workspaceId: "workspace-other-group",
+          repoKey: "/tmp/repo-b",
+          repoName: "repo-a",
+          updatedAt: "2026-04-13T13:00:00.000Z",
+        }),
+      ],
+    });
+
+    const firstGroupItems = groups.find((group) => group.sourceRoot === "/tmp/repo-a")?.items;
+    const secondGroupItems = groups.find((group) => group.sourceRoot === "/tmp/repo-b")?.items;
+
+    expect(firstGroupItems?.map((item) => ({
+      id: item.id,
+      name: item.name,
+      defaultName: item.defaultName,
+      hasDisplayNameOverride: item.hasDisplayNameOverride,
+    }))).toEqual([
+      {
+        id: "local-older",
+        name: "repo-a",
+        defaultName: "repo-a",
+        hasDisplayNameOverride: false,
+      },
+      {
+        id: "local-newer",
+        name: "repo-a #2",
+        defaultName: "repo-a",
+        hasDisplayNameOverride: false,
+      },
+      {
+        id: "local-override",
+        name: "repo-a #3",
+        defaultName: "repo-a",
+        hasDisplayNameOverride: true,
+      },
+    ]);
+    expect(secondGroupItems?.[0]?.name).toBe("repo-a");
+  });
+});

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
@@ -16,7 +16,6 @@ import {
   makeLocalLogicalWorkspace,
   makeRepoRoot,
 } from "./sidebar-test-fixtures";
-import { buildLocalSlotLogicalWorkspaceId } from "@/lib/domain/workspaces/cloud/logical-workspace-id";
 
 describe("repo-root seeded groups", () => {
   it("shows zero-workspace repo roots in the sidebar", () => {
@@ -232,34 +231,6 @@ describe("sidebar workspace filters", () => {
     expect(groups[0]?.items[1]?.active).toBe(true);
   });
 
-  it("uses local-slot aliases for active, archived, and queued sidebar state", () => {
-    const logicalWorkspace = makeLocalLogicalWorkspace({
-      id: "remote:github:proliferate-ai:repo-a:main",
-      workspaceId: "workspace-local",
-      repoKey: "/tmp/repo-a",
-      repoName: "repo-a",
-    });
-    const slotId = buildLocalSlotLogicalWorkspaceId("workspace-local");
-
-    const groups = buildGroups({
-      logicalWorkspaces: [logicalWorkspace],
-      selectedLogicalWorkspaceId: slotId,
-      archivedIds: [slotId],
-      pendingPromptCounts: {
-        [slotId]: 2,
-      },
-    });
-
-    expect(groups).toHaveLength(1);
-    expect(groups[0]?.items[0]?.id).toBe("remote:github:proliferate-ai:repo-a:main");
-    expect(groups[0]?.items[0]?.active).toBe(true);
-    expect(groups[0]?.items[0]?.archived).toBe(true);
-    expect(groups[0]?.items[0]?.statusIndicator).toEqual({
-      kind: "queued_prompt",
-      tooltip: "2 queued Home prompts",
-    });
-  });
-
   it("composes archived visibility with workspace-type filtering", () => {
     const logicalWorkspaces = [
       makeLocalLogicalWorkspace({
@@ -455,31 +426,6 @@ describe("sidebar workspace filters", () => {
     expect(repoKey).toBe("/tmp/repo-a");
   });
 
-  it("resolves a repo key when the selected local-slot alias is past the item cap", () => {
-    const selectedSlotId = buildLocalSlotLogicalWorkspaceId("worktree-6-materialization");
-    const groups = buildGroups({
-      logicalWorkspaces: Array.from({ length: 7 }, (_, index) =>
-        makeLocalLogicalWorkspace({
-          id: `worktree-${index}`,
-          workspaceId: `worktree-${index}-materialization`,
-          repoKey: "/tmp/repo-a",
-          repoName: "repo-a",
-          kind: "worktree",
-          branch: `feature/worktree-${index}`,
-          updatedAt: `2026-04-13T10:0${index}:00.000Z`,
-        })),
-      selectedLogicalWorkspaceId: selectedSlotId,
-    });
-
-    const repoKey = resolveAutoShowMoreRepoKey({
-      groups,
-      selectedLogicalWorkspaceId: selectedSlotId,
-      itemLimit: 6,
-    });
-
-    expect(repoKey).toBe("/tmp/repo-a");
-  });
-
   it("does not resolve a repo key when no logical workspace is selected", () => {
     const groups = buildGroups({
       logicalWorkspaces: Array.from({ length: 7 }, (_, index) =>
@@ -595,72 +541,6 @@ describe("sidebar workspace filters", () => {
       readinessFingerprint: "fingerprint-1",
       tooltip: "Ready to delete workspace",
     });
-  });
-
-  it("suffixes duplicate local visible names within a repo group without marking overrides", () => {
-    const groups = buildGroups({
-      logicalWorkspaces: [
-        makeLocalLogicalWorkspace({
-          id: "local-older",
-          workspaceId: "workspace-older",
-          repoKey: "/tmp/repo-a",
-          repoName: "repo-a",
-          updatedAt: "2026-04-13T10:00:00.000Z",
-        }),
-        makeLocalLogicalWorkspace({
-          id: "local-newer",
-          workspaceId: "workspace-newer",
-          repoKey: "/tmp/repo-a",
-          repoName: "repo-a",
-          updatedAt: "2026-04-13T11:00:00.000Z",
-        }),
-        makeLocalLogicalWorkspace({
-          id: "local-override",
-          workspaceId: "workspace-override",
-          repoKey: "/tmp/repo-a",
-          repoName: "repo-a",
-          displayName: "repo-a",
-          updatedAt: "2026-04-13T12:00:00.000Z",
-        }),
-        makeLocalLogicalWorkspace({
-          id: "local-other-group",
-          workspaceId: "workspace-other-group",
-          repoKey: "/tmp/repo-b",
-          repoName: "repo-a",
-          updatedAt: "2026-04-13T13:00:00.000Z",
-        }),
-      ],
-    });
-
-    const firstGroupItems = groups.find((group) => group.sourceRoot === "/tmp/repo-a")?.items;
-    const secondGroupItems = groups.find((group) => group.sourceRoot === "/tmp/repo-b")?.items;
-
-    expect(firstGroupItems?.map((item) => ({
-      id: item.id,
-      name: item.name,
-      defaultName: item.defaultName,
-      hasDisplayNameOverride: item.hasDisplayNameOverride,
-    }))).toEqual([
-      {
-        id: "local-older",
-        name: "repo-a",
-        defaultName: "repo-a",
-        hasDisplayNameOverride: false,
-      },
-      {
-        id: "local-newer",
-        name: "repo-a #2",
-        defaultName: "repo-a",
-        hasDisplayNameOverride: false,
-      },
-      {
-        id: "local-override",
-        name: "repo-a #3",
-        defaultName: "repo-a",
-        hasDisplayNameOverride: true,
-      },
-    ]);
-    expect(secondGroupItems?.[0]?.name).toBe("repo-a");
   });
 
   it("normalizes all selected workspace types back to the default order", () => {


### PR DESCRIPTION
## Summary
- split local-slot sidebar coverage into a separate test file
- bring sidebar.test.ts back under the repo max-lines threshold

## Verification
- python3 scripts/check_max_lines.py
- git diff --check