### PR TITLE
perf(desktop): keep large diffs boot responsive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,12 +4202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
 name = "proliferate-supervisor"
 version = "0.1.0"
 dependencies = [
@@ -4242,6 +4236,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -5537,18 +5537,6 @@ export interface components {
             /** Label */
             label?: string | null;
         };
-        /**
-         * WorkspaceDirectTargetContext
-         * @description Direct runtime materialization for non-managed cloud targets.
-         */
-        WorkspaceDirectTargetContext: {
-            /** Targetid */
-            targetId: string;
-            /** Targetkind */
-            targetKind: string;
-            /** Anyharnessworkspaceid */
-            anyharnessWorkspaceId: string;
-        };
         /** WorkspaceCredentialFreshness */
         WorkspaceCredentialFreshness: {
             /**
@@ -5619,6 +5607,18 @@ export interface components {
             readyAgentKinds: string[];
             /** Anyharnessworkspaceid */
             anyharnessWorkspaceId: string | null;
+        };
+        /**
+         * WorkspaceDirectTargetContext
+         * @description Direct runtime materialization for non-managed cloud targets.
+         */
+        WorkspaceDirectTargetContext: {
+            /** Targetid */
+            targetId: string;
+            /** Targetkind */
+            targetKind: string;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId: string;
         };
         /** WorkspaceMobilityPreflightRequest */
         WorkspaceMobilityPreflightRequest: {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -31,6 +31,10 @@ import {
   logStartupDebug,
   startStartupTimer,
 } from "@/lib/infra/measurement/debug-startup"
+import {
+  recordBootDiagnostic,
+  recordBootDiagnosticOnce,
+} from "@/lib/infra/measurement/boot-stall-diagnostics"
 import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap"
 import { AppErrorBoundary } from "@/components/ui/AppErrorBoundary"
 import { RepoSetupModalHost } from "@/components/workspace/repo-setup/RepoSetupModalHost"
@@ -47,6 +51,9 @@ import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-s
 import { AppCommandActionsProvider } from "@/providers/AppCommandActionsProvider"
 
 const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"])
+const APP_RUNTIME_RENDER_MILESTONES = new Set([1, 2, 3, 5, 10, 25, 50, 100, 250])
+
+let appRuntimeRenderCount = 0
 
 // Dev-only playground. Lazy-loaded with a DEV guard so neither this file
 // nor any of its fixtures / transitive deps land in production bundles.
@@ -93,6 +100,10 @@ function cloudSettingsDeepLink(search: string): string {
 }
 
 function recordAppRendererEvent(message: string, elapsedMs?: number): void {
+  recordBootDiagnostic(
+    `app_bootstrap.${message}`,
+    elapsedMs === undefined ? undefined : { elapsedMs },
+  )
   void logRendererEvent({
     source: "app_bootstrap",
     message,
@@ -145,21 +156,55 @@ function App() {
 }
 
 function AppRuntime() {
+  appRuntimeRenderCount += 1
+  if (APP_RUNTIME_RENDER_MILESTONES.has(appRuntimeRenderCount)) {
+    recordBootDiagnostic("app_runtime.render.pass", { count: appRuntimeRenderCount })
+  }
+  recordBootDiagnosticOnce("app_runtime.render.before.use_auth_bootstrap")
   const bootstrapAuth = useAuthBootstrap()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_auth_bootstrap")
+  recordBootDiagnosticOnce("app_runtime.render.before.auth_status")
   const authStatus = useAuthStore((s) => s.status)
+  recordBootDiagnosticOnce("app_runtime.render.after.auth_status", { authStatus })
+  recordBootDiagnosticOnce("app_runtime.render.before.use_app_command_actions")
   const appCommandActions = useAppCommandActions()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_app_command_actions")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_export_running_agent_count")
   useExportRunningAgentCount()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_export_running_agent_count")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_shortcut_dispatcher")
   useShortcutDispatcher()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_shortcut_dispatcher")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_app_shortcuts")
   useAppShortcuts(appCommandActions)
+  recordBootDiagnosticOnce("app_runtime.render.after.use_app_shortcuts")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_turn_end_sound")
   useTurnEndSound()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_turn_end_sound")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_agent_auto_reconcile")
   useAgentAutoReconcile()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_agent_auto_reconcile")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_local_automation_executor")
   useLocalAutomationExecutor()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_local_automation_executor")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_home_deferred_launch_runner")
   useHomeDeferredLaunchRunner()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_home_deferred_launch_runner")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_user_preferences_lifecycle")
   useUserPreferencesLifecycle()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_user_preferences_lifecycle")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_repo_preferences_lifecycle")
   useRepoPreferencesLifecycle()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_repo_preferences_lifecycle")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_workspace_ui_lifecycle")
   useWorkspaceUiLifecycle()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_workspace_ui_lifecycle")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_session_intent_dispatcher")
   useSessionIntentDispatcher()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_session_intent_dispatcher")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_session_selection_lifecycle")
   useSessionSelectionLifecycle()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_session_selection_lifecycle")
 
   useEffect(() => {
     recordAppRendererEvent("app.bootstrap.start")
@@ -235,6 +280,8 @@ function AppRuntime() {
       })
     }
   }, [authStatus])
+
+  recordBootDiagnosticOnce("app_runtime.render.before_return", { authStatus })
 
   return (
     <>

--- a/desktop/src/assets.d.ts
+++ b/desktop/src/assets.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_PROLIFERATE_DEBUG_LATENCY?: string;
   readonly VITE_PROLIFERATE_DEBUG_MAIN_THREAD?: string;
   readonly VITE_PROLIFERATE_DEBUG_ANYHARNESS_TIMING?: string;
+  readonly VITE_PROLIFERATE_BOOT_DIAGNOSTICS?: string;
   readonly VITE_DEV_DISABLE_AUTH?: string;
   readonly VITE_REQUIRE_AUTH?: string;
   readonly VITE_PROLIFERATE_SENTRY_DSN?: string;

--- a/desktop/src/components/ui/DebugProfiler.test.tsx
+++ b/desktop/src/components/ui/DebugProfiler.test.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactElement } from "react";
+import { Fragment, Profiler, type ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DebugProfiler } from "@/components/ui/DebugProfiler";
@@ -10,11 +10,23 @@ describe("DebugProfiler", () => {
 
   it("returns children without a Profiler wrapper when disabled", () => {
     vi.stubEnv("VITE_PROLIFERATE_DEBUG_MAIN_THREAD", "0");
+    vi.stubEnv("VITE_PROLIFERATE_BOOT_DIAGNOSTICS", "0");
     const rendered = DebugProfiler({
       id: "workspace-shell",
       children: "child",
     }) as ReactElement;
 
     expect(rendered.type).toBe(Fragment);
+  });
+
+  it("wraps children when boot diagnostics are enabled", () => {
+    vi.stubEnv("VITE_PROLIFERATE_DEBUG_MAIN_THREAD", "0");
+    vi.stubEnv("VITE_PROLIFERATE_BOOT_DIAGNOSTICS", "1");
+    const rendered = DebugProfiler({
+      id: "workspace-shell",
+      children: "child",
+    }) as ReactElement;
+
+    expect(rendered.type).toBe(Profiler);
   });
 });

--- a/desktop/src/components/ui/DebugProfiler.tsx
+++ b/desktop/src/components/ui/DebugProfiler.tsx
@@ -1,6 +1,11 @@
 import { Profiler, type ProfilerOnRenderCallback, type ReactNode } from "react";
 import { recordMeasurementMetric } from "@/lib/infra/measurement/debug-measurement";
 import { isMainThreadMeasurementEnabled } from "@/lib/infra/measurement/debug-measurement-env";
+import {
+  isBootDiagnosticsBrowserFlagEnabled,
+  recordBootDiagnostic,
+} from "@/lib/infra/measurement/boot-stall-diagnostics";
+import { envFlagEnabled, round } from "@/lib/infra/measurement/debug-measurement-utils";
 import type { MeasurementSurface } from "@/lib/domain/telemetry/debug-measurement-catalog";
 
 interface DebugProfilerProps {
@@ -9,7 +14,7 @@ interface DebugProfilerProps {
 }
 
 export function DebugProfiler({ id, children }: DebugProfilerProps) {
-  if (!isMainThreadMeasurementEnabled()) {
+  if (!isDebugProfilerEnabled()) {
     return <>{children}</>;
   }
 
@@ -22,12 +27,20 @@ export function DebugProfiler({ id, children }: DebugProfilerProps) {
 
 const handleRender: ProfilerOnRenderCallback = (
   id,
-  _phase,
+  phase,
   actualDuration,
-  _baseDuration,
+  baseDuration,
   startTime,
   commitTime,
 ) => {
+  recordBootProfilerRender({
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+  });
   recordMeasurementMetric({
     type: "main_thread",
     surface: id as MeasurementSurface,
@@ -37,3 +50,49 @@ const handleRender: ProfilerOnRenderCallback = (
     endedAtMs: commitTime,
   });
 };
+
+function isDebugProfilerEnabled(): boolean {
+  return isMainThreadMeasurementEnabled()
+    || (
+      import.meta.env.DEV
+      && (
+        envFlagEnabled(import.meta.env.VITE_PROLIFERATE_BOOT_DIAGNOSTICS, false)
+        || isBootDiagnosticsBrowserFlagEnabled()
+      )
+    );
+}
+
+const PROFILER_RENDER_MILESTONES = new Set([1, 2, 3, 5, 10, 25, 50, 100, 250, 500, 1_000]);
+const SLOW_PROFILER_RENDER_MS = 16;
+const profilerRenderCounts = new Map<string, number>();
+
+function recordBootProfilerRender({
+  id,
+  phase,
+  actualDuration,
+  baseDuration,
+  startTime,
+  commitTime,
+}: {
+  id: string;
+  phase: string;
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}): void {
+  const count = (profilerRenderCounts.get(id) ?? 0) + 1;
+  profilerRenderCounts.set(id, count);
+  if (actualDuration < SLOW_PROFILER_RENDER_MS && !PROFILER_RENDER_MILESTONES.has(count)) {
+    return;
+  }
+
+  recordBootDiagnostic("react_profiler.render", {
+    surface: id,
+    phase,
+    count,
+    durationMs: round(actualDuration),
+    baseDurationMs: round(baseDuration),
+    commitDelayMs: round(commitTime - startTime),
+  });
+}

--- a/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -65,4 +65,27 @@ describe("FileChangeCall", () => {
     expect(html).toContain("Long preview body");
     expect(html).toContain("max-h-[220px]");
   });
+
+  it("does not render oversized completed patches inline", () => {
+    const largePatch = [
+      "@@ -1 +1 @@",
+      ...Array.from({ length: 5_001 }, (_, index) => `+generated ${index}`),
+    ].join("\n");
+
+    const html = renderToStaticMarkup(
+      createElement(FileChangeCall, {
+        operation: "edit",
+        path: "anyharness/sdk/generated/openapi.json",
+        basename: "openapi.json",
+        additions: 5_001,
+        deletions: 0,
+        patch: largePatch,
+        status: "completed",
+        defaultExpanded: true,
+      }),
+    );
+
+    expect(html).toContain("Too large to render inline");
+    expect(html).not.toContain("overflow-x-auto overflow-y-auto");
+  });
 });

--- a/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/icons";
 import { useFileReferenceActions } from "@/hooks/workspaces/files/use-file-reference-actions";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "@/lib/domain/chat/tools/tool-call-layout";
+import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import { ToolActionDetailsPanel } from "./ToolActionDetailsPanel";
 import { ToolActionRow } from "./ToolActionRow";
 import { ToolFileChip } from "./ToolFileChip";
@@ -74,6 +75,14 @@ export function FileChangeCall({
     newBasename,
   );
   const statsHint = buildStatsHint(additions, deletions);
+  const diffDisplayPolicy = patch
+    ? resolveDiffDisplayPolicy({
+        path: displayPath,
+        additions,
+        deletions,
+        patch,
+      })
+    : null;
 
   if (status === "completed" && hasDiff) {
     const nextAdditions = additions ?? 0;
@@ -104,13 +113,20 @@ export function FileChangeCall({
                 ? handleOpenFile
                 : undefined}
             >
-              <DiffViewer
-                patch={patch!}
-                filePath={displayPath}
-                className="w-full"
-                viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
-                variant="chat"
-              />
+              {diffDisplayPolicy && !diffDisplayPolicy.canRenderInline ? (
+                <DiffDisplayPolicyPlaceholder
+                  title={diffDisplayPolicy.placeholderTitle}
+                  description={diffDisplayPolicy.placeholderDescription}
+                />
+              ) : (
+                <DiffViewer
+                  patch={patch!}
+                  filePath={displayPath}
+                  className="w-full"
+                  viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
+                  variant="chat"
+                />
+              )}
             </FileDiffCard>
           </div>
         )}
@@ -130,7 +146,12 @@ export function FileChangeCall({
     >
       {hasDiff || preview ? (
         <ToolActionDetailsPanel>
-          {hasDiff ? (
+          {hasDiff && diffDisplayPolicy && !diffDisplayPolicy.canRenderInline ? (
+            <DiffDisplayPolicyPlaceholder
+              title={diffDisplayPolicy.placeholderTitle}
+              description={diffDisplayPolicy.placeholderDescription}
+            />
+          ) : hasDiff ? (
             <DiffViewer
               patch={patch!}
               filePath={displayPath}
@@ -152,6 +173,21 @@ export function FileChangeCall({
         </ToolActionDetailsPanel>
       ) : null}
     </ToolActionRow>
+  );
+}
+
+function DiffDisplayPolicyPlaceholder({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="px-3 py-4 text-xs text-muted-foreground">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-0.5 leading-5">{description}</p>
+    </div>
   );
 }
 

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
@@ -1,0 +1,68 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { toolCallItem } from "@/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
+import { TranscriptToolCallItemBlock } from "./TranscriptToolCallItemBlock";
+
+vi.mock("@/hooks/cowork/workflows/use-open-cowork-coding-session", () => ({
+  useOpenCoworkCodingSession: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/workspaces/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({
+    selectWorkspace: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/files/use-file-reference-actions", () => ({
+  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
+    reference: {
+      rawPath,
+      path: rawPath,
+      line: null,
+      column: null,
+      absolutePath: `/repo/${rawPath}`,
+      workspacePath: rawPath,
+    },
+    openTargets: [],
+    canOpenInSidebar: true,
+    canOpenExternal: true,
+    copyPath: vi.fn(),
+    openInSidebar: vi.fn(),
+    openDefault: vi.fn(),
+    openPrimary: vi.fn(),
+    openWithTarget: vi.fn(),
+    reveal: vi.fn(),
+  }),
+}));
+
+describe("TranscriptToolCallItemBlock", () => {
+  it("collapses long file-change groups in chat", () => {
+    const item = toolCallItem({
+      semanticKind: "file_change",
+      contentParts: Array.from({ length: 5 }, (_, index) => ({
+        type: "file_change",
+        operation: "edit",
+        path: `/Users/pablo/proliferate/src/file-${index}.ts`,
+        workspacePath: `src/file-${index}.ts`,
+        basename: `file-${index}.ts`,
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -1 +1 @@\n-old\n+new",
+      })),
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TranscriptToolCallItemBlock, {
+        item,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      }),
+    );
+
+    expect(html).toContain("src/file-0.ts");
+    expect(html).toContain("src/file-2.ts");
+    expect(html).not.toContain("src/file-3.ts");
+    expect(html).toContain("Show 2 more");
+  });
+});

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type {
   FileChangeContentPart,
   FileReadContentPart,
@@ -6,6 +7,7 @@ import type {
   ToolCallItem,
   ToolResultTextContentPart,
 } from "@anyharness/sdk";
+import { Button } from "@/components/ui/Button";
 import { BashCommandCall } from "@/components/workspace/chat/tool-calls/BashCommandCall";
 import { CoworkArtifactToolActionRow } from "@/components/workspace/chat/tool-calls/CoworkArtifactToolActionRow";
 import { CoworkCodingToolActionRow } from "@/components/workspace/chat/tool-calls/cowork/CoworkCodingToolActionRow";
@@ -18,6 +20,7 @@ import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspac
 import { deriveSkillsToolResultPresentation } from "@/lib/domain/chat/tools/skills-tool-result";
 import { describeToolCallDisplay } from "@/lib/domain/chat/tools/tool-call-display";
 import { normalizeToolResultText } from "@/lib/domain/chat/tools/tool-result-text";
+import { CHAT_VISIBLE_FILE_CHANGE_LIMIT } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import { ToolKindIcon } from "./TranscriptToolKindIcon";
 
 export function TranscriptToolCallItemBlock({
@@ -31,6 +34,7 @@ export function TranscriptToolCallItemBlock({
 }) {
   const openCodingSession = useOpenCoworkCodingSession();
   const { selectWorkspace } = useWorkspaceSelection();
+  const [showAllFileChanges, setShowAllFileChanges] = useState(false);
 
   if (
     item.semanticKind === "cowork_artifact_create"
@@ -85,8 +89,13 @@ export function TranscriptToolCallItemBlock({
   const rows: React.ReactNode[] = [];
   const status = mapStatus(item.status);
   const skillsToolResult = deriveSkillsToolResultPresentation(item, normalizedResultText);
+  const visibleFileChanges = showAllFileChanges
+    ? fileChanges
+    : fileChanges.slice(0, CHAT_VISIBLE_FILE_CHANGE_LIMIT);
+  const hiddenFileChangeCount = fileChanges.length - visibleFileChanges.length;
+  const canToggleFileChanges = fileChanges.length > CHAT_VISIBLE_FILE_CHANGE_LIMIT;
 
-  fileChanges.forEach((part, idx) => {
+  visibleFileChanges.forEach((part, idx) => {
     rows.push(
       <FileChangeCall
         key={`file-change-${idx}`}
@@ -105,6 +114,16 @@ export function TranscriptToolCallItemBlock({
       />,
     );
   });
+  if (canToggleFileChanges) {
+    rows.push(
+      <FileChangesToggleRow
+        key="file-change-toggle"
+        expanded={showAllFileChanges}
+        hiddenCount={hiddenFileChangeCount}
+        onToggle={() => setShowAllFileChanges((value) => !value)}
+      />,
+    );
+  }
 
   fileReads.forEach((part, idx) => {
     rows.push(
@@ -206,11 +225,36 @@ export function TranscriptToolCallItemBlock({
     return <>{rows[0]}</>;
   }
 
-  const hasOnlyFileChangeRows = rows.length === fileChanges.length;
+  const hasOnlyFileChangeRows =
+    fileChanges.length > 0
+    && fileReads.length === 0
+    && terminalParts.length === 0;
   return (
     <div className={hasOnlyFileChangeRows ? "flex flex-col" : "space-y-1.5"}>
       {rows}
     </div>
+  );
+}
+
+function FileChangesToggleRow({
+  expanded,
+  hiddenCount,
+  onToggle,
+}: {
+  expanded: boolean;
+  hiddenCount: number;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onToggle}
+      className="h-7 w-fit justify-start rounded-md px-1.5 text-chat font-normal text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {expanded ? "Show less" : `Show ${hiddenCount} more`}
+    </Button>
   );
 }
 

--- a/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
@@ -1,7 +1,11 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { PLAYGROUND_END_TURN_DIFF_TRANSCRIPT } from "@/lib/domain/chat/__fixtures__/playground/git-diff-fixtures";
+import {
+  PLAYGROUND_END_TURN_DIFF_TRANSCRIPT,
+  PLAYGROUND_PATCH_README,
+} from "@/lib/domain/chat/__fixtures__/playground/git-diff-fixtures";
+import { toolCallItem } from "@/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
 import { TurnDiffPanel } from "./TurnDiffPanel";
 
 describe("TurnDiffPanel", () => {
@@ -61,5 +65,46 @@ describe("TurnDiffPanel", () => {
     );
 
     expect(html).toBe("");
+  });
+
+  it("shows only the first few file changes until expanded", () => {
+    const transcript = structuredClone(PLAYGROUND_END_TURN_DIFF_TRANSCRIPT);
+    const itemIds = Array.from({ length: 5 }, (_, index) => `tool-end-diff-extra-${index}`);
+    transcript.turnsById["turn-end-diff"].itemOrder = ["assistant-end-diff", ...itemIds];
+    for (const [index, itemId] of itemIds.entries()) {
+      transcript.itemsById[itemId] = toolCallItem({
+        itemId,
+        toolCallId: itemId,
+        turnId: "turn-end-diff",
+        title: `Edit file-${index}.ts`,
+        nativeToolName: "Edit",
+        toolKind: "edit",
+        semanticKind: "file_change",
+        contentParts: [{
+          type: "file_change",
+          operation: "edit",
+          path: `/Users/pablo/proliferate/src/file-${index}.ts`,
+          workspacePath: `src/file-${index}.ts`,
+          basename: `file-${index}.ts`,
+          additions: 1,
+          deletions: 1,
+          patch: PLAYGROUND_PATCH_README,
+        }],
+      });
+    }
+
+    const html = renderToStaticMarkup(
+      createElement(TurnDiffPanel, {
+        turn: transcript.turnsById["turn-end-diff"],
+        transcript,
+        onOpenFile: () => {},
+      }),
+    );
+
+    expect(html).toContain("5 files changed");
+    expect(html).toContain("src/file-0.ts");
+    expect(html).toContain("src/file-2.ts");
+    expect(html).not.toContain("src/file-3.ts");
+    expect(html).toContain("Show 2 more");
   });
 });

--- a/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
@@ -1,10 +1,15 @@
 import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/Button";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
 import {
   FileChangesCard,
   FileDiffCard,
 } from "@/components/ui/content/FileDiffCard";
 import { collectTurnFilePatches } from "@/lib/domain/chat/transcript/turn-file-patches";
+import {
+  CHAT_VISIBLE_FILE_CHANGE_LIMIT,
+  resolveDiffDisplayPolicy,
+} from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type { TranscriptState, TurnRecord } from "@anyharness/sdk";
 
 const TURN_DIFF_VIEWPORT_CLASS = "max-h-[calc(var(--diffs-line-height)*18)]";
@@ -33,12 +38,18 @@ export function TurnDiffPanel({
   );
   const hasPatches = filePatches.length > 0;
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [showAllFiles, setShowAllFiles] = useState(false);
 
   if (!hasPatches) {
     return null;
   }
 
   const fileCount = filePatches.length;
+  const visibleFilePatches = showAllFiles
+    ? filePatches
+    : filePatches.slice(0, CHAT_VISIBLE_FILE_CHANGE_LIMIT);
+  const canToggleVisibleFiles = filePatches.length > CHAT_VISIBLE_FILE_CHANGE_LIMIT;
+  const hiddenFileCount = filePatches.length - visibleFilePatches.length;
 
   const toggleExpanded = (path: string) => {
     setExpandedPaths((prev) => {
@@ -57,9 +68,15 @@ export function TurnDiffPanel({
       fileCount={fileCount}
       className="mt-2"
     >
-      {filePatches.map((fp) => {
+      {visibleFilePatches.map((fp) => {
         const isExpanded = expandedPaths.has(fp.path);
         const combinedPatch = fp.patches.join("\n");
+        const displayPolicy = resolveDiffDisplayPolicy({
+          path: fp.path,
+          additions: fp.additions,
+          deletions: fp.deletions,
+          patch: combinedPatch,
+        });
 
         return (
           <FileDiffCard
@@ -75,17 +92,48 @@ export function TurnDiffPanel({
             openActionTitle={onOpenReviewPane ? "Open changes review" : undefined}
             embedded
           >
-            {combinedPatch && (
+            {combinedPatch && !displayPolicy.canRenderInline ? (
+              <DiffDisplayPolicyPlaceholder
+                title={displayPolicy.placeholderTitle}
+                description={displayPolicy.placeholderDescription}
+              />
+            ) : combinedPatch ? (
               <DiffViewer
                 patch={combinedPatch}
                 filePath={fp.path}
                 viewportClassName={TURN_DIFF_VIEWPORT_CLASS}
                 variant="chat"
               />
-            )}
+            ) : null}
           </FileDiffCard>
         );
       })}
+      {canToggleVisibleFiles && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowAllFiles((value) => !value)}
+          className="h-8 w-full justify-center rounded-none px-3 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          {showAllFiles ? "Show less" : `Show ${hiddenFileCount} more`}
+        </Button>
+      )}
     </FileChangesCard>
+  );
+}
+
+function DiffDisplayPolicyPlaceholder({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="px-3 py-4 text-xs text-muted-foreground">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-0.5 leading-5">{description}</p>
+    </div>
   );
 }

--- a/desktop/src/components/workspace/files/viewer/FileDiffPane.tsx
+++ b/desktop/src/components/workspace/files/viewer/FileDiffPane.tsx
@@ -1,5 +1,6 @@
 import { useGitDiffQuery } from "@anyharness/sdk-react";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
+import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type { FileDiffTarget } from "@/lib/domain/workspaces/viewer/file-diff-options";
 import { CenterMessage } from "./CenterMessage";
 
@@ -27,6 +28,18 @@ export function FileDiffPane({
   }
 
   if (diffQuery.data?.patch) {
+    const displayPolicy = resolveDiffDisplayPolicy({
+      path: target.path,
+      additions: diffQuery.data.additions,
+      deletions: diffQuery.data.deletions,
+      patch: diffQuery.data.patch,
+    });
+    if (!displayPolicy.canRenderInline) {
+      return (
+        <CenterMessage message={displayPolicy.placeholderTitle} />
+      );
+    }
+
     return (
       <div className="min-h-0 min-w-0 flex-1 overflow-auto">
         <DiffViewer patch={diffQuery.data.patch} layout={layout} />

--- a/desktop/src/components/workspace/git/GitPanel.test.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.test.tsx
@@ -5,6 +5,7 @@ import { GitPanel } from "./GitPanel";
 
 const mockGitPanelState = vi.hoisted(() => vi.fn());
 const gitDiffQuery = vi.hoisted(() => ({
+  calls: [] as unknown[],
   state: {
     data: null as unknown,
     error: null as unknown,
@@ -17,7 +18,10 @@ vi.mock("@anyharness/sdk-react", () => ({
   useAnyHarnessRuntimeContext: () => ({
     runtimeUrl: null,
   }),
-  useGitDiffQuery: () => gitDiffQuery.state,
+  useGitDiffQuery: (options: unknown) => {
+    gitDiffQuery.calls.push(options);
+    return gitDiffQuery.state;
+  },
   useStageGitPathsMutation: () => ({
     mutateAsync: vi.fn(),
   }),
@@ -85,6 +89,7 @@ function createGitPanelState(overrides = {}) {
 describe("GitPanel", () => {
   beforeEach(() => {
     mockGitPanelState.mockReturnValue(createGitPanelState());
+    gitDiffQuery.calls = [];
     gitDiffQuery.state = {
       data: {
         patch: [
@@ -200,5 +205,74 @@ describe("GitPanel", () => {
     const html = renderToStaticMarkup(createElement(GitPanel));
 
     expect(html).toContain("Diff unavailable: pathspec did not match any files");
+  });
+
+  it("does not auto-fetch oversized generated diffs on first render", () => {
+    const largeDiff = {
+      key: ":anyharness/sdk/generated/openapi.json:modified",
+      path: "anyharness/sdk/generated/openapi.json",
+      oldPath: null,
+      displayPath: "anyharness/sdk/generated/openapi.json",
+      status: "modified",
+      includedState: "excluded",
+      additions: 0,
+      deletions: 16_393,
+      binary: false,
+    };
+    mockGitPanelState.mockReturnValue(createGitPanelState({
+      sections: [{
+        scope: "unstaged",
+        label: "Unstaged",
+        files: [{
+          ...largeDiff,
+          currentDiff: largeDiff,
+        }],
+      }],
+    }));
+
+    const html = renderToStaticMarkup(createElement(GitPanel));
+
+    expect(html).toContain("openapi.json");
+    expect(html).toContain("1 large/generated diff collapsed to keep review responsive.");
+    expect(html).toContain("1 too large to render inline");
+    expect(gitDiffQuery.calls[0]).toMatchObject({
+      path: "anyharness/sdk/generated/openapi.json",
+      enabled: false,
+    });
+  });
+
+  it("limits initial expanded diff fetches", () => {
+    const files = Array.from({ length: 4 }, (_, index) => {
+      const path = `src/file-${index}.ts`;
+      const diff = {
+        key: `:${path}:modified`,
+        path,
+        oldPath: null,
+        displayPath: path,
+        status: "modified",
+        includedState: "excluded",
+        additions: 1,
+        deletions: 1,
+        binary: false,
+      };
+      return {
+        ...diff,
+        currentDiff: diff,
+      };
+    });
+    mockGitPanelState.mockReturnValue(createGitPanelState({
+      sections: [{
+        scope: "unstaged",
+        label: "Unstaged",
+        files,
+      }],
+      visibleChangedCount: files.length,
+    }));
+
+    renderToStaticMarkup(createElement(GitPanel));
+
+    expect(gitDiffQuery.calls).toHaveLength(4);
+    expect(gitDiffQuery.calls.map((call) => (call as { enabled?: boolean }).enabled))
+      .toEqual([true, true, false, false]);
   });
 });

--- a/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.tsx
@@ -22,11 +22,20 @@ import {
   type GitPanelSection,
 } from "@/lib/domain/workspaces/changes/git-panel-diff";
 import {
+  GIT_DIFF_FETCH_CONCURRENCY_LIMIT,
+  resolveDiffDisplayPolicy,
+  summarizeDiffDisplayPolicies,
+  type DiffDisplayPolicySummary,
+} from "@/lib/domain/workspaces/changes/diff-display-policy";
+import {
   buildGitReviewFileEntries,
   gitReviewEntryForFile,
   type GitReviewFileEntry,
 } from "@/lib/domain/workspaces/changes/git-review-entries";
 import { useGitPanelUiStore } from "@/stores/editor/git-panel-ui-store";
+
+const INITIAL_EXPANDED_DIFF_FILE_LIMIT = 3;
+const EMPTY_COLLAPSED_FILE_KEYS = new Set<string>();
 
 export function GitPanel() {
   const diffReviewMeasurement = useDiffReviewMeasurement();
@@ -57,6 +66,8 @@ function GitPanelContent({
   const [fileTreeOpen, setFileTreeOpen] = useState(false);
   const [collapsedSections, setCollapsedSections] = useState<Set<GitPanelReviewScope>>(new Set());
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const [fileCollapseTouched, setFileCollapseTouched] = useState(false);
+  const [settledDiffFetchKeys, setSettledDiffFetchKeys] = useState<Set<string>>(new Set());
   const fileContext = useWorkspaceFileContext();
   const modeRequest = useGitPanelUiStore((state) =>
     fileContext.materializedWorkspaceId
@@ -92,12 +103,102 @@ function GitPanelContent({
     () => buildGitReviewFileEntries(sections),
     [sections],
   );
+  const autoCollapsedFiles = useMemo<ReadonlySet<string>>(() => {
+    if (fileCollapseTouched) {
+      return EMPTY_COLLAPSED_FILE_KEYS;
+    }
+    const collapsedKeys = reviewEntries.flatMap((entry, index) => {
+      const currentDiff = entry.file.currentDiff;
+      const displayPolicy = currentDiff
+        ? resolveDiffDisplayPolicy({
+            path: currentDiff.path,
+            additions: currentDiff.additions,
+            deletions: currentDiff.deletions,
+          })
+        : null;
+      return index >= INITIAL_EXPANDED_DIFF_FILE_LIMIT
+        || Boolean(displayPolicy?.shouldAutoCollapse)
+        ? [entry.key]
+        : [];
+    });
+    return collapsedKeys.length === 0
+      ? EMPTY_COLLAPSED_FILE_KEYS
+      : new Set(collapsedKeys);
+  }, [fileCollapseTouched, reviewEntries]);
+  const effectiveCollapsedFiles = useMemo<ReadonlySet<string>>(() => {
+    if (autoCollapsedFiles.size === 0) {
+      return collapsedFiles;
+    }
+    const next = new Set(collapsedFiles);
+    for (const key of autoCollapsedFiles) {
+      next.add(key);
+    }
+    return next;
+  }, [autoCollapsedFiles, collapsedFiles]);
   const visibleSections = useMemo(
     () => sections.filter((section) => !collapsedSections.has(section.scope)),
     [collapsedSections, sections],
   );
+  const visibleSectionScopes = useMemo(
+    () => new Set(visibleSections.map((section) => section.scope)),
+    [visibleSections],
+  );
+  const diffPolicySummary = useMemo(
+    () => summarizeDiffDisplayPolicies(
+      reviewEntries.flatMap((entry) => {
+        const currentDiff = entry.file.currentDiff;
+        return currentDiff
+          ? [resolveDiffDisplayPolicy({
+              path: currentDiff.path,
+              additions: currentDiff.additions,
+              deletions: currentDiff.deletions,
+            })]
+          : [];
+      }),
+    ),
+    [reviewEntries],
+  );
+  const diffFetchScopeKey = useMemo(
+    () => [
+      activeWorkspaceId ?? "",
+      baseRef ?? "",
+      changesFilter,
+      reviewEntries.map((entry) => entry.key).join("\n"),
+    ].join("\u001f"),
+    [activeWorkspaceId, baseRef, changesFilter, reviewEntries],
+  );
+  useEffect(() => {
+    setSettledDiffFetchKeys(new Set());
+  }, [diffFetchScopeKey]);
+  const permittedDiffFetchKeys = useMemo<ReadonlySet<string>>(() => {
+    const permitted = new Set(settledDiffFetchKeys);
+    let activeFetchCount = 0;
+    for (const entry of reviewEntries) {
+      if (activeFetchCount >= GIT_DIFF_FETCH_CONCURRENCY_LIMIT) {
+        break;
+      }
+      if (permitted.has(entry.key) || !visibleSectionScopes.has(entry.sectionScope)) {
+        continue;
+      }
+      const currentDiff = entry.file.currentDiff;
+      if (!currentDiff || effectiveCollapsedFiles.has(entry.key)) {
+        continue;
+      }
+      const displayPolicy = resolveDiffDisplayPolicy({
+        path: currentDiff.path,
+        additions: currentDiff.additions,
+        deletions: currentDiff.deletions,
+      });
+      if (!displayPolicy.canFetchInline) {
+        continue;
+      }
+      permitted.add(entry.key);
+      activeFetchCount += 1;
+    }
+    return permitted;
+  }, [effectiveCollapsedFiles, reviewEntries, settledDiffFetchKeys, visibleSectionScopes]);
   const allFilesCollapsed = reviewEntries.length > 0
-    && reviewEntries.every((entry) => collapsedFiles.has(entry.key));
+    && reviewEntries.every((entry) => effectiveCollapsedFiles.has(entry.key));
 
   useEffect(() => {
     if (!modeRequest) {
@@ -106,6 +207,7 @@ function GitPanelContent({
     setChangesFilter(modeRequest.mode);
     setCollapsedSections(new Set());
     setCollapsedFiles(new Set());
+    setFileCollapseTouched(false);
   }, [modeRequest]);
 
   const handleToggleLayout = useCallback(() => {
@@ -117,25 +219,36 @@ function GitPanelContent({
   }, []);
 
   const handleToggleAllFiles = useCallback(() => {
-    setCollapsedFiles((current) => {
-      const allCollapsed = reviewEntries.length > 0
-        && reviewEntries.every((entry) => current.has(entry.key));
-      if (allCollapsed) {
-        return new Set();
-      }
-      return new Set(reviewEntries.map((entry) => entry.key));
-    });
-  }, [reviewEntries]);
+    setFileCollapseTouched(true);
+    if (allFilesCollapsed) {
+      setCollapsedFiles(new Set());
+      return;
+    }
+    setCollapsedFiles(new Set(reviewEntries.map((entry) => entry.key)));
+  }, [allFilesCollapsed, reviewEntries]);
 
   const toggleSectionCollapsed = useCallback((scope: GitPanelReviewScope) => {
     setCollapsedSections((current) => toggleSetValue(current, scope));
   }, []);
 
   const toggleFileCollapsed = useCallback((key: string) => {
-    setCollapsedFiles((current) => toggleSetValue(current, key));
+    setFileCollapseTouched(true);
+    setCollapsedFiles(() => toggleSetValue(new Set(effectiveCollapsedFiles), key));
+  }, [effectiveCollapsedFiles]);
+
+  const markDiffFetchSettled = useCallback((key: string) => {
+    setSettledDiffFetchKeys((current) => {
+      if (current.has(key)) {
+        return current;
+      }
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
   }, []);
 
   const focusReviewFile = useCallback((entry: GitReviewFileEntry) => {
+    setFileCollapseTouched(true);
     setCollapsedSections((current) => {
       if (!current.has(entry.sectionScope)) {
         return current;
@@ -145,10 +258,10 @@ function GitPanelContent({
       return next;
     });
     setCollapsedFiles((current) => {
-      if (!current.has(entry.key)) {
+      if (!effectiveCollapsedFiles.has(entry.key)) {
         return current;
       }
-      const next = new Set(current);
+      const next = new Set(effectiveCollapsedFiles);
       next.delete(entry.key);
       return next;
     });
@@ -158,7 +271,7 @@ function GitPanelContent({
         behavior: "smooth",
       });
     });
-  }, []);
+  }, [effectiveCollapsedFiles]);
 
   return (
     <div className="flex h-full flex-col bg-sidebar-background text-sidebar-foreground">
@@ -208,6 +321,9 @@ function GitPanelContent({
 
           {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length > 0 && (
             <div className="flex flex-col gap-2">
+              {diffPolicySummary.total > 0 && (
+                <GitReviewDiffPolicyNotice summary={diffPolicySummary} />
+              )}
               {sections.map((section) => (
                 <div key={section.scope} className="flex flex-col gap-1.5">
                   {changesFilter === "working_tree_composite" && (
@@ -230,9 +346,11 @@ function GitPanelContent({
                           baseRef={baseRef}
                           layout={layout}
                           wrapLongLines={wrapLongLines}
-                          collapsed={collapsedFiles.has(entry.key)}
+                          collapsed={effectiveCollapsedFiles.has(entry.key)}
                           isRuntimeReady={isRuntimeReady}
+                          fetchDiff={permittedDiffFetchKeys.has(entry.key)}
                           onToggleCollapsed={() => toggleFileCollapsed(entry.key)}
+                          onDiffFetchSettled={() => markDiffFetchSettled(entry.key)}
                           openFile={openFile}
                           stagePath={(path) => stageMutation.mutateAsync([path])}
                           unstagePath={(path) => unstageMutation.mutateAsync([path])}
@@ -260,6 +378,23 @@ function GitPanelContent({
           />
         </PaneSideOverlay>
       </div>
+    </div>
+  );
+}
+
+function GitReviewDiffPolicyNotice({ summary }: { summary: DiffDisplayPolicySummary }) {
+  const hiddenLabel = `${summary.total} large/generated diff${summary.total === 1 ? "" : "s"}`;
+  const tooLargeLabel = summary.tooLargeInline > 0
+    ? `${summary.tooLargeInline} too large to render inline`
+    : null;
+  return (
+    <div className="rounded-md border border-sidebar-border/70 bg-sidebar-accent/35 px-2.5 py-2 text-xs leading-5 text-sidebar-muted-foreground">
+      <span>
+        {hiddenLabel} collapsed to keep review responsive.
+      </span>
+      {tooLargeLabel && (
+        <span> {tooLargeLabel}; open the file to inspect those changes.</span>
+      )}
     </div>
   );
 }

--- a/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from "react";
 import {
   type AnyHarnessQueryTimingOptions,
   useGitDiffQuery,
@@ -8,6 +9,7 @@ import { FileDiffCard } from "@/components/ui/content/FileDiffCard";
 import { Minus, Plus } from "@/components/ui/icons";
 import { Tooltip } from "@/components/ui/Tooltip";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
+import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type {
   GitPanelReviewFile,
   GitPanelReviewScope,
@@ -26,7 +28,9 @@ export function GitReviewFileRow({
   wrapLongLines,
   collapsed,
   isRuntimeReady,
+  fetchDiff,
   onToggleCollapsed,
+  onDiffFetchSettled,
   openFile,
   stagePath,
   unstagePath,
@@ -42,7 +46,9 @@ export function GitReviewFileRow({
   wrapLongLines: boolean;
   collapsed: boolean;
   isRuntimeReady: boolean;
+  fetchDiff: boolean;
   onToggleCollapsed: () => void;
+  onDiffFetchSettled: () => void;
   openFile: OpenFile;
   stagePath: StagePath;
   unstagePath: StagePath;
@@ -53,28 +59,72 @@ export function GitReviewFileRow({
   const isBranchMode = sectionScope === "branch";
   const isLastTurnMode = sectionScope === "last_turn";
   const shouldUnstage = sectionScope === "staged";
+  const metadataPolicy = useMemo(
+    () => currentDiff
+      ? resolveDiffDisplayPolicy({
+          path: currentDiff.path,
+          additions: currentDiff.additions,
+          deletions: currentDiff.deletions,
+        })
+      : null,
+    [currentDiff],
+  );
   const diffQuery = useGitDiffQuery({
     workspaceId,
     path: file.path,
     scope: isLastTurnMode ? "base_worktree" : sectionScope,
     baseRef: isBranchMode || isLastTurnMode ? baseRef : null,
     oldPath: isBranchMode || isLastTurnMode ? file.oldPath : null,
-    enabled: isRuntimeReady && !collapsed && Boolean(currentDiff),
+    enabled:
+      isRuntimeReady
+      && !collapsed
+      && fetchDiff
+      && Boolean(currentDiff)
+      && Boolean(metadataPolicy?.canFetchInline),
     ...(diffTimingOptions ?? {}),
   });
   const diffErrorMessage = diffQuery.isError ? formatDiffErrorMessage(diffQuery.error) : null;
   const additions = diffQuery.data?.additions ?? currentDiff?.additions ?? 0;
   const deletions = diffQuery.data?.deletions ?? currentDiff?.deletions ?? 0;
   const patch = diffQuery.data?.patch ?? null;
+  const patchPolicy = useMemo(
+    () => patch
+      ? resolveDiffDisplayPolicy({
+          path: file.path,
+          additions,
+          deletions,
+          patch,
+        })
+      : metadataPolicy,
+    [additions, deletions, file.path, metadataPolicy, patch],
+  );
+  const waitingForDiffPermit = Boolean(
+    currentDiff
+    && isRuntimeReady
+    && !collapsed
+    && metadataPolicy?.canFetchInline
+    && !fetchDiff
+    && !patch
+    && !diffQuery.data
+    && !diffQuery.isError,
+  );
   const emptyDiffMessage = formatEmptyDiffMessage({
     binary: Boolean(diffQuery.data?.binary || currentDiff?.binary),
     truncated: Boolean(diffQuery.data?.truncated && !patch),
   });
 
+  useEffect(() => {
+    if (diffQuery.data || diffQuery.isError) {
+      onDiffFetchSettled();
+    }
+  }, [diffQuery.data, diffQuery.isError, onDiffFetchSettled]);
+
   if (
     currentDiff
     && isRuntimeReady
     && !collapsed
+    && fetchDiff
+    && metadataPolicy?.canFetchInline
     && !patch
     && !diffQuery.isLoading
     && !diffErrorMessage
@@ -131,6 +181,16 @@ export function GitReviewFileRow({
           <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
             No current diff against base
           </p>
+        ) : !metadataPolicy?.canFetchInline ? (
+          <DiffDisplayPolicyPlaceholder
+            title={metadataPolicy?.placeholderTitle ?? "Too large to render inline"}
+            description={metadataPolicy?.placeholderDescription ?? "Open the file to inspect this change."}
+            onOpenFile={() => void openFile(file.path)}
+          />
+        ) : waitingForDiffPermit ? (
+          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
+            Waiting to load diff
+          </p>
         ) : diffQuery.isLoading ? (
           <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
             Loading diff
@@ -140,29 +200,65 @@ export function GitReviewFileRow({
             Diff unavailable: {diffErrorMessage}
           </p>
         ) : patch ? (
-          <>
-            <DiffViewer
-              patch={patch}
-              filePath={file.displayPath}
-              wrapLongLines={wrapLongLines}
-              layout={layout}
-              variant={layout === "unified" ? "chat" : "default"}
-              viewportClassName="max-h-[calc(var(--diffs-line-height)*24)]"
-              operationId={measurementOperationId ?? null}
-              overscrollBehavior="auto"
+          patchPolicy && !patchPolicy.canRenderInline ? (
+            <DiffDisplayPolicyPlaceholder
+              title={patchPolicy.placeholderTitle}
+              description={patchPolicy.placeholderDescription}
+              onOpenFile={() => void openFile(file.path)}
             />
-            {diffQuery.data?.truncated ? (
-              <p className="px-3 py-2 text-center text-xs text-sidebar-muted-foreground">
-                Diff truncated because it is too large
-              </p>
-            ) : null}
-          </>
+          ) : (
+            <>
+              <DiffViewer
+                patch={patch}
+                filePath={file.displayPath}
+                wrapLongLines={wrapLongLines}
+                layout={layout}
+                variant={layout === "unified" ? "chat" : "default"}
+                viewportClassName="max-h-[calc(var(--diffs-line-height)*24)]"
+                operationId={measurementOperationId ?? null}
+                overscrollBehavior="auto"
+              />
+              {diffQuery.data?.truncated ? (
+                <p className="px-3 py-2 text-center text-xs text-sidebar-muted-foreground">
+                  Diff truncated because it is too large
+                </p>
+              ) : null}
+            </>
+          )
         ) : emptyDiffMessage ? (
           <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
             {emptyDiffMessage}
           </p>
         ) : null}
       </FileDiffCard>
+    </div>
+  );
+}
+
+function DiffDisplayPolicyPlaceholder({
+  title,
+  description,
+  onOpenFile,
+}: {
+  title: string;
+  description: string;
+  onOpenFile: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-3 py-4 text-xs text-sidebar-muted-foreground">
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-sidebar-foreground">{title}</p>
+        <p className="mt-0.5 leading-5">{description}</p>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onOpenFile}
+        className="h-7 shrink-0 rounded-md border border-sidebar-border/70 px-2.5 text-xs text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+      >
+        Open file
+      </Button>
     </div>
   );
 }

--- a/desktop/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts
+++ b/desktop/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts
@@ -3,26 +3,63 @@ import {
   anyHarnessWorkspaceRetirePreflightKey,
 } from "@anyharness/sdk-react";
 import { useQueries, type UseQueryResult } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
 import { getWorkspaceRetirePreflight } from "@/lib/access/anyharness/workspaces";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 export type WorkspaceRetirePreflightQuery =
   UseQueryResult<WorkspaceRetirePreflightResponse, Error>;
 
+const RETIRE_PREFLIGHT_INITIAL_BATCH_SIZE = 4;
+const RETIRE_PREFLIGHT_BATCH_SIZE = 4;
+const RETIRE_PREFLIGHT_BATCH_DELAY_MS = 1_200;
+
 // Owns AnyHarness retire-preflight query keys and cache shape for workspace lists.
 export function useWorkspaceRetirePreflightQueries(
   workspaceIds: string[],
 ): WorkspaceRetirePreflightQuery[] {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const enabledWorkspaceIds = useBatchedRetirePreflightWorkspaceIds(workspaceIds);
 
   return useQueries({
     queries: workspaceIds.map((workspaceId) => ({
       queryKey: anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
-      enabled: runtimeUrl.trim().length > 0,
+      enabled: runtimeUrl.trim().length > 0 && enabledWorkspaceIds.has(workspaceId),
       staleTime: 60_000,
+      retry: false,
       queryFn: async ({ signal }) => {
         return getWorkspaceRetirePreflight({ runtimeUrl }, workspaceId, { signal });
       },
     })),
   });
+}
+
+function useBatchedRetirePreflightWorkspaceIds(workspaceIds: string[]): Set<string> {
+  const workspaceSignature = useMemo(() => workspaceIds.join("\u001f"), [workspaceIds]);
+  const [enabledCount, setEnabledCount] = useState(() =>
+    Math.min(RETIRE_PREFLIGHT_INITIAL_BATCH_SIZE, workspaceIds.length)
+  );
+
+  useEffect(() => {
+    setEnabledCount(Math.min(RETIRE_PREFLIGHT_INITIAL_BATCH_SIZE, workspaceIds.length));
+  }, [workspaceIds.length, workspaceSignature]);
+
+  useEffect(() => {
+    if (enabledCount >= workspaceIds.length) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setEnabledCount((current) =>
+        Math.min(current + RETIRE_PREFLIGHT_BATCH_SIZE, workspaceIds.length)
+      );
+    }, RETIRE_PREFLIGHT_BATCH_DELAY_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [enabledCount, workspaceIds.length, workspaceSignature]);
+
+  return useMemo(
+    () => new Set(workspaceIds.slice(0, enabledCount)),
+    [enabledCount, workspaceIds],
+  );
 }

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -62,7 +62,12 @@ export interface WorkspaceHeaderSubagentHierarchy {
   resolvedSessionIds: Set<string>;
 }
 
+const HEADER_HIERARCHY_INITIAL_QUERY_BATCH_SIZE = 4;
+const HEADER_HIERARCHY_QUERY_BATCH_SIZE = 4;
+const HEADER_HIERARCHY_QUERY_BATCH_DELAY_MS = 1_200;
+
 export function useWorkspaceHeaderSubagentHierarchy(args: {
+  prioritySessionIds?: string[];
   workspaceId: string | null;
   sessionIds: string[];
 }): WorkspaceHeaderSubagentHierarchy {
@@ -75,6 +80,11 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     () => [...new Set(args.sessionIds)].filter(Boolean),
     [args.sessionIds],
   );
+  const enabledSessionIds = useBatchedHeaderHierarchySessionIds({
+    prioritySessionIds: args.prioritySessionIds ?? [],
+    sessionIds: uniqueSessionIds,
+    workspaceId: args.workspaceId,
+  });
   const materializedSessionIds = useSessionDirectoryStore(useShallow((state) =>
     uniqueSessionIds.map((sessionId) => resolveHierarchyMaterializedSessionId({
       sessionId,
@@ -95,7 +105,10 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, args.workspaceId, sessionId),
-        enabled: !!args.workspaceId && !!sessionId && !!materializedSessionId,
+        enabled: !!args.workspaceId
+          && !!sessionId
+          && !!materializedSessionId
+          && enabledSessionIds.has(sessionId),
         queryFn: async ({ signal }): Promise<SessionSubagentsResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -116,7 +129,10 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessSessionReviewsKey(runtimeUrl, args.workspaceId, sessionId),
-        enabled: !!args.workspaceId && !!sessionId && !!materializedSessionId,
+        enabled: !!args.workspaceId
+          && !!sessionId
+          && !!materializedSessionId
+          && enabledSessionIds.has(sessionId),
         queryFn: async ({ signal }): Promise<SessionReviewsResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -128,6 +144,7 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
           return listSessionReviews(resolved.connection, materializedSessionId, { signal });
         },
         staleTime: 2_500,
+        retry: false,
       };
     }),
   });
@@ -136,7 +153,10 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, materializedSessionId),
-        enabled: !!args.workspaceId && !!sessionId && !!materializedSessionId,
+        enabled: !!args.workspaceId
+          && !!sessionId
+          && !!materializedSessionId
+          && enabledSessionIds.has(sessionId),
         queryFn: async ({ signal }): Promise<CoworkManagedWorkspacesResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -370,6 +390,58 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     hierarchyQueryRows,
     resolveClientSessionId,
   ]);
+}
+
+function useBatchedHeaderHierarchySessionIds({
+  prioritySessionIds,
+  sessionIds,
+  workspaceId,
+}: {
+  prioritySessionIds: string[];
+  sessionIds: string[];
+  workspaceId: string | null;
+}): Set<string> {
+  const orderedSessionIds = useMemo(() => {
+    const sessionIdSet = new Set(sessionIds);
+    const prioritized = prioritySessionIds.filter((sessionId) => sessionIdSet.has(sessionId));
+    return [
+      ...new Set(prioritized),
+      ...sessionIds.filter((sessionId) => !prioritized.includes(sessionId)),
+    ];
+  }, [prioritySessionIds, sessionIds]);
+  const sessionSignature = useMemo(
+    () => [workspaceId ?? "", ...orderedSessionIds].join("\u001f"),
+    [orderedSessionIds, workspaceId],
+  );
+  const [enabledCount, setEnabledCount] = useState(() =>
+    Math.min(HEADER_HIERARCHY_INITIAL_QUERY_BATCH_SIZE, orderedSessionIds.length)
+  );
+
+  useEffect(() => {
+    setEnabledCount(Math.min(
+      HEADER_HIERARCHY_INITIAL_QUERY_BATCH_SIZE,
+      orderedSessionIds.length,
+    ));
+  }, [orderedSessionIds.length, sessionSignature]);
+
+  useEffect(() => {
+    if (enabledCount >= orderedSessionIds.length) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setEnabledCount((current) =>
+        Math.min(current + HEADER_HIERARCHY_QUERY_BATCH_SIZE, orderedSessionIds.length)
+      );
+    }, HEADER_HIERARCHY_QUERY_BATCH_DELAY_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [enabledCount, orderedSessionIds.length, sessionSignature]);
+
+  return useMemo(
+    () => new Set(orderedSessionIds.slice(0, enabledCount)),
+    [enabledCount, orderedSessionIds],
+  );
 }
 
 function buildHierarchyQuerySignature({

--- a/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
+++ b/desktop/src/hooks/workspaces/tabs/use-workspace-header-tabs-view-model.ts
@@ -194,7 +194,15 @@ export function useWorkspaceHeaderTabsViewModel() {
   const knownSessionIds = useStableStringArray(
     useMemo(() => Array.from(knownSessions.keys()), [knownSessions]),
   );
+  const hierarchyPrioritySessionIds = useStableStringArray(useMemo(
+    () => uniqueIds([
+      activeSessionId ?? "",
+      ...(persistedVisibleIds ?? []),
+    ]).filter(Boolean),
+    [activeSessionId, persistedVisibleIds],
+  ));
   const hierarchy = useWorkspaceHeaderSubagentHierarchy({
+    prioritySessionIds: hierarchyPrioritySessionIds,
     workspaceId: selectedWorkspaceId,
     sessionIds: knownSessionIds,
   });

--- a/desktop/src/lib/domain/workspaces/changes/diff-display-policy.test.ts
+++ b/desktop/src/lib/domain/workspaces/changes/diff-display-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  DIFF_HARD_INLINE_BYTE_LIMIT,
+  resolveDiffDisplayPolicy,
+} from "./diff-display-policy";
+
+describe("resolveDiffDisplayPolicy", () => {
+  it("keeps normal source diffs renderable", () => {
+    const policy = resolveDiffDisplayPolicy({
+      path: "desktop/src/components/workspace/git/GitPanel.tsx",
+      additions: 8,
+      deletions: 4,
+      patch: "@@ -1 +1 @@\n-old\n+new",
+    });
+
+    expect(policy.kind).toBe("safe");
+    expect(policy.shouldAutoCollapse).toBe(false);
+    expect(policy.canFetchInline).toBe(true);
+    expect(policy.canRenderInline).toBe(true);
+  });
+
+  it("collapses generated diffs without blocking explicit inline review", () => {
+    const policy = resolveDiffDisplayPolicy({
+      path: "anyharness/sdk/generated/openapi.json",
+      additions: 10,
+      deletions: 5,
+    });
+
+    expect(policy.kind).toBe("collapsedGenerated");
+    expect(policy.shouldAutoCollapse).toBe(true);
+    expect(policy.canFetchInline).toBe(true);
+    expect(policy.canRenderInline).toBe(true);
+  });
+
+  it("blocks huge metadata-only diffs before fetching the patch", () => {
+    const policy = resolveDiffDisplayPolicy({
+      path: "anyharness/sdk/generated/openapi.json",
+      additions: 0,
+      deletions: 16_393,
+    });
+
+    expect(policy.kind).toBe("tooLargeInline");
+    expect(policy.shouldAutoCollapse).toBe(true);
+    expect(policy.canFetchInline).toBe(false);
+    expect(policy.canRenderInline).toBe(false);
+  });
+
+  it("blocks patches that exceed the inline byte budget", () => {
+    const policy = resolveDiffDisplayPolicy({
+      path: "src/generated-client.ts",
+      additions: 1,
+      deletions: 1,
+      patch: `@@ -1 +1 @@\n+${"x".repeat(DIFF_HARD_INLINE_BYTE_LIMIT + 1)}`,
+    });
+
+    expect(policy.kind).toBe("tooLargeInline");
+    expect(policy.canRenderInline).toBe(false);
+  });
+});

--- a/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
+++ b/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
@@ -1,0 +1,206 @@
+export const DIFF_AUTO_COLLAPSE_LINE_LIMIT = 1_000;
+export const DIFF_HARD_INLINE_LINE_LIMIT = 5_000;
+export const DIFF_HARD_INLINE_BYTE_LIMIT = 250_000;
+export const CHAT_VISIBLE_FILE_CHANGE_LIMIT = 3;
+export const GIT_DIFF_FETCH_CONCURRENCY_LIMIT = 2;
+
+export type DiffDisplayPolicyKind =
+  | "safe"
+  | "collapsedLarge"
+  | "collapsedGenerated"
+  | "tooLargeInline";
+
+export interface DiffDisplayPolicyInput {
+  path: string;
+  additions?: number | null;
+  deletions?: number | null;
+  patch?: string | null;
+}
+
+export interface DiffDisplayPolicy {
+  kind: DiffDisplayPolicyKind;
+  changedLines: number;
+  patchLineCount: number;
+  patchByteCount: number;
+  generated: boolean;
+  shouldAutoCollapse: boolean;
+  canFetchInline: boolean;
+  canRenderInline: boolean;
+  placeholderTitle: string;
+  placeholderDescription: string;
+}
+
+export interface DiffDisplayPolicySummary {
+  total: number;
+  generated: number;
+  large: number;
+  tooLargeInline: number;
+}
+
+export function resolveDiffDisplayPolicy({
+  path,
+  additions,
+  deletions,
+  patch,
+}: DiffDisplayPolicyInput): DiffDisplayPolicy {
+  const changedLines = diffChangedLineCount(additions, deletions);
+  const patchLineCount = patch ? patch.split("\n").length : 0;
+  const patchByteCount = patch ? utf8ByteLength(patch) : 0;
+  const generated = isGeneratedDiffPath(path);
+  const tooLargeInline =
+    changedLines > DIFF_HARD_INLINE_LINE_LIMIT
+    || patchLineCount > DIFF_HARD_INLINE_LINE_LIMIT
+    || patchByteCount > DIFF_HARD_INLINE_BYTE_LIMIT;
+
+  if (tooLargeInline) {
+    return buildPolicy({
+      kind: "tooLargeInline",
+      changedLines,
+      patchLineCount,
+      patchByteCount,
+      generated,
+      shouldAutoCollapse: true,
+      canFetchInline: false,
+      canRenderInline: false,
+    });
+  }
+
+  if (
+    changedLines > DIFF_AUTO_COLLAPSE_LINE_LIMIT
+    || patchLineCount > DIFF_AUTO_COLLAPSE_LINE_LIMIT
+  ) {
+    return buildPolicy({
+      kind: "collapsedLarge",
+      changedLines,
+      patchLineCount,
+      patchByteCount,
+      generated,
+      shouldAutoCollapse: true,
+      canFetchInline: true,
+      canRenderInline: true,
+    });
+  }
+
+  if (generated) {
+    return buildPolicy({
+      kind: "collapsedGenerated",
+      changedLines,
+      patchLineCount,
+      patchByteCount,
+      generated,
+      shouldAutoCollapse: true,
+      canFetchInline: true,
+      canRenderInline: true,
+    });
+  }
+
+  return buildPolicy({
+    kind: "safe",
+    changedLines,
+    patchLineCount,
+    patchByteCount,
+    generated,
+    shouldAutoCollapse: false,
+    canFetchInline: true,
+    canRenderInline: true,
+  });
+}
+
+export function diffChangedLineCount(
+  additions: number | null | undefined,
+  deletions: number | null | undefined,
+): number {
+  return Math.max(0, additions ?? 0) + Math.max(0, deletions ?? 0);
+}
+
+export function summarizeDiffDisplayPolicies(
+  policies: readonly DiffDisplayPolicy[],
+): DiffDisplayPolicySummary {
+  return policies.reduce<DiffDisplayPolicySummary>(
+    (summary, policy) => {
+      if (policy.kind === "safe") {
+        return summary;
+      }
+      summary.total += 1;
+      if (policy.kind === "collapsedGenerated") {
+        summary.generated += 1;
+      } else if (policy.kind === "collapsedLarge") {
+        summary.large += 1;
+      } else if (policy.kind === "tooLargeInline") {
+        summary.tooLargeInline += 1;
+      }
+      return summary;
+    },
+    { total: 0, generated: 0, large: 0, tooLargeInline: 0 },
+  );
+}
+
+export function isGeneratedDiffPath(path: string): boolean {
+  const normalizedPath = path.replace(/\\/g, "/").toLowerCase();
+  const basename = normalizedPath.split("/").pop() ?? normalizedPath;
+  if (
+    hasPathSegment(normalizedPath, "generated")
+    || hasPathSegment(normalizedPath, "__generated__")
+    || hasPathSegment(normalizedPath, "gen")
+  ) {
+    return true;
+  }
+  if (
+    basename === "openapi.json"
+    || basename === "openapi.ts"
+    || basename === "schema.json"
+    || basename === "package-lock.json"
+    || basename === "pnpm-lock.yaml"
+    || basename === "yarn.lock"
+    || basename === "cargo.lock"
+    || basename === "uv.lock"
+  ) {
+    return true;
+  }
+  return basename.endsWith(".snap") || basename.endsWith(".snapshot");
+}
+
+function buildPolicy(
+  input: Omit<DiffDisplayPolicy, "placeholderTitle" | "placeholderDescription">,
+): DiffDisplayPolicy {
+  const lineLabel = formatChangedLineCount(input.changedLines);
+  const placeholderTitle = input.kind === "tooLargeInline"
+    ? "Too large to render inline"
+    : input.kind === "collapsedGenerated"
+      ? "Generated diff collapsed"
+      : input.kind === "collapsedLarge"
+        ? "Large diff collapsed"
+        : "Diff ready";
+  const placeholderDescription = input.kind === "tooLargeInline"
+    ? [
+        `${lineLabel} exceeds the inline renderer limit.`,
+        "Open the file to inspect it without loading the full diff here.",
+      ].join(" ")
+    : input.kind === "collapsedGenerated"
+      ? `${lineLabel} in a generated file. Expand only when you need to inspect it.`
+      : input.kind === "collapsedLarge"
+        ? `${lineLabel}. Expand only when you need to inspect it.`
+        : `${lineLabel}.`;
+
+  return {
+    ...input,
+    placeholderTitle,
+    placeholderDescription,
+  };
+}
+
+function formatChangedLineCount(changedLines: number): string {
+  const formatted = changedLines.toLocaleString("en-US");
+  return `${formatted} changed line${changedLines === 1 ? "" : "s"}`;
+}
+
+function utf8ByteLength(value: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(value).byteLength;
+  }
+  return value.length;
+}
+
+function hasPathSegment(path: string, segment: string): boolean {
+  return path.split("/").includes(segment);
+}

--- a/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
+++ b/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
@@ -1,0 +1,1284 @@
+import { logRendererEvent } from "@/lib/access/tauri/diagnostics";
+import {
+  envFlagEnabled,
+  getMeasurementMemorySnapshot,
+  now,
+  round,
+} from "@/lib/infra/measurement/debug-measurement-utils";
+
+const BOOT_DIAGNOSTICS_PARAM = "proliferateBootDiagnostics";
+const BOOT_DIAGNOSTICS_STORAGE_KEY = "proliferate.bootDiagnostics";
+const BOOT_DIAGNOSTICS_EVENTS_STORAGE_KEY = "proliferate.bootDiagnostics.events";
+const BOOT_DIAGNOSTICS_OVERLAY_ID = "proliferate-boot-diagnostics";
+const MAX_BOOT_EVENTS = 160;
+const MAX_VISIBLE_EVENTS = 18;
+const MAX_FETCH_SUMMARY_ENTRIES = 240;
+const MAX_LAYOUT_READ_STACK_SUMMARIES = 80;
+const MAX_PERFORMANCE_MEASURE_SUMMARIES = 80;
+const MAX_PERFORMANCE_MEASURE_REPORTS = 30;
+const FRAME_GAP_THRESHOLD_MS = 200;
+const MAX_LAYOUT_READ_REPORTS = 40;
+const MAX_LAYOUT_READ_STACK_CAPTURE_COUNT = 80;
+const SLOW_LAYOUT_READ_THRESHOLD_MS = 12;
+const LAYOUT_READ_TOTAL_MILESTONES = new Set([1, 5, 10, 25, 50, 100, 250, 500, 1_000]);
+const INTERNAL_LOG_RENDERER_EVENT_URL = "ipc://localhost/log_renderer_event";
+const NOISY_BOOT_LABEL_PREFIXES = ["app_runtime.render.", "fetch.", "performance.measure."];
+
+interface BootDiagnosticEvent {
+  seq: number;
+  elapsedMs: number;
+  timestampMs: number;
+  label: string;
+  route: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+interface BootDiagnosticDump {
+  tag: "boot_stall_diagnostics";
+  version: 3;
+  createdAt: string;
+  timestampMs: number;
+  route: string | null;
+  eventSeq: number;
+  droppedEvents: number;
+  maxFrameGapMs: number;
+  memory: ReturnType<typeof getMeasurementMemorySnapshot>;
+  fetches: {
+    starts: number;
+    ends: number;
+    errors: number;
+    inFlight: number;
+    top: FetchDiagnosticSummary[];
+  };
+  performanceMeasures: {
+    calls: number;
+    detailStripped: number;
+    top: PerformanceMeasureDiagnosticSummary[];
+  };
+  layoutReads: {
+    inAnimationFrames: number;
+    reported: number;
+    uniqueStacks: number;
+    topStacks: LayoutReadStackDiagnosticSummary[];
+  };
+  events: BootDiagnosticEvent[];
+}
+
+interface FetchDiagnosticSummary {
+  key: string;
+  method: string;
+  url: string;
+  starts: number;
+  ends: number;
+  errors: number;
+  inFlight: number;
+  lastStatus: number | null;
+  lastDurationMs: number | null;
+  maxDurationMs: number;
+  lastError: unknown;
+}
+
+interface LayoutReadStackDiagnosticSummary {
+  signature: string;
+  count: number;
+  reported: number;
+  slow: number;
+  lastDurationMs: number;
+  maxDurationMs: number;
+  lastElement: string | null;
+  lastStack: string | null;
+}
+
+interface PerformanceMeasureDiagnosticSummary {
+  name: string;
+  calls: number;
+  detailStripped: number;
+  nativeSkipped: number;
+  lastDetailSummary: unknown;
+  lastStack: string | null;
+}
+
+interface PreparedPerformanceMeasureCall {
+  args: unknown[];
+  fallbackEntry: PerformanceMeasure | null;
+  skipNative: boolean;
+}
+
+interface ActiveAnimationFrameDiagnostic {
+  callbackName: string;
+  id: number;
+  scheduledAtMs: number;
+  startedAtMs: number;
+}
+
+interface BootDiagnosticOverlay {
+  root: HTMLElement;
+  summary: HTMLElement;
+  events: HTMLElement;
+}
+
+interface BootDiagnosticApi {
+  dump: () => BootDiagnosticDump;
+  clear: () => void;
+}
+
+declare global {
+  interface Window {
+    proliferateBootDiagnostics?: BootDiagnosticApi;
+    __PROLIFERATE_BOOT_DIAGNOSTICS__?: BootDiagnosticApi;
+  }
+}
+
+let installed = false;
+let enabledCache: boolean | null = null;
+let startedAtMs = now();
+let nextSeq = 1;
+let droppedEventCount = 0;
+let animationFrameId: number | null = null;
+let heartbeatIntervalId: number | null = null;
+let lastFrameAtMs = now();
+let maxFrameGapMs = 0;
+let overlay: BootDiagnosticOverlay | null = null;
+let originalFetch: typeof window.fetch | null = null;
+let originalRequestAnimationFrame: typeof window.requestAnimationFrame | null = null;
+let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect | null = null;
+let originalPerformanceMeasure: Performance["measure"] | null = null;
+let flushScheduled = false;
+let nextAnimationFrameDiagnosticId = 1;
+let activeAnimationFrame: ActiveAnimationFrameDiagnostic | null = null;
+let layoutReadInAnimationFrameCount = 0;
+let layoutReadReportCount = 0;
+let performanceMeasureCallCount = 0;
+let performanceMeasureDetailStripCount = 0;
+const events: BootDiagnosticEvent[] = [];
+const recordedOnceLabels = new Set<string>();
+const layoutReadStackCounts = new Map<string, number>();
+const layoutReadStackSummaries = new Map<string, LayoutReadStackDiagnosticSummary>();
+const fetchSummaries = new Map<string, FetchDiagnosticSummary>();
+const performanceMeasureSummaries = new Map<string, PerformanceMeasureDiagnosticSummary>();
+
+export function installBootStallDiagnostics(): () => void {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  applyBootDiagnosticsUrlFlag();
+  if (installed || !isBootStallDiagnosticsEnabled()) {
+    return () => undefined;
+  }
+
+  installed = true;
+  startedAtMs = now();
+  lastFrameAtMs = now();
+  maxFrameGapMs = 0;
+
+  ensureBootDiagnosticsOverlay();
+  installBootDiagnosticsGlobal();
+  installBootDiagnosticsErrorListeners();
+  installWebKitPerformanceMeasureDetailGuard();
+  installBootDiagnosticsFetchProbe();
+  installBootDiagnosticsLayoutReadProbe();
+  installBootDiagnosticsFrameProbe();
+  recordBootDiagnostic("boot_diagnostics.installed", {
+    userAgent: navigator.userAgent,
+  });
+
+  return uninstallBootStallDiagnostics;
+}
+
+export function installWebKitPerformanceMeasureDetailGuard(): void {
+  if (!import.meta.env.DEV || typeof window === "undefined" || !isLikelyWebKitRuntime()) {
+    return;
+  }
+
+  installBootDiagnosticsPerformanceMeasureProbe();
+}
+
+export function uninstallBootStallDiagnostics(): void {
+  installed = false;
+
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+
+  if (heartbeatIntervalId !== null) {
+    window.clearInterval(heartbeatIntervalId);
+    heartbeatIntervalId = null;
+  }
+
+  if (originalFetch !== null) {
+    window.fetch = originalFetch;
+    originalFetch = null;
+  }
+
+  if (originalRequestAnimationFrame !== null) {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    originalRequestAnimationFrame = null;
+  }
+
+  if (originalGetBoundingClientRect !== null && typeof Element !== "undefined") {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    originalGetBoundingClientRect = null;
+  }
+
+  if (originalPerformanceMeasure !== null && typeof performance !== "undefined") {
+    performance.measure = originalPerformanceMeasure;
+    originalPerformanceMeasure = null;
+  }
+
+  if (window.proliferateBootDiagnostics?.dump === getBootDiagnosticsDump) {
+    delete window.proliferateBootDiagnostics;
+  }
+  if (window.__PROLIFERATE_BOOT_DIAGNOSTICS__?.dump === getBootDiagnosticsDump) {
+    delete window.__PROLIFERATE_BOOT_DIAGNOSTICS__;
+  }
+}
+
+export function recordBootDiagnostic(
+  label: string,
+  metadata?: Record<string, unknown>,
+): void {
+  if (!isBootStallDiagnosticsEnabled()) {
+    return;
+  }
+
+  const event: BootDiagnosticEvent = {
+    seq: nextSeq,
+    elapsedMs: round(now() - startedAtMs),
+    timestampMs: Date.now(),
+    label,
+    route: currentRoute(),
+    metadata: metadata === undefined ? undefined : sanitizeBootMetadata(metadata),
+  };
+  nextSeq += 1;
+
+  events.push(event);
+  if (events.length > MAX_BOOT_EVENTS) {
+    droppedEventCount += events.length - MAX_BOOT_EVENTS;
+    events.splice(0, events.length - MAX_BOOT_EVENTS);
+  }
+
+  scheduleBootDiagnosticsFlush();
+  if (!isNoisyBootLabel(label)) {
+    logBootDiagnosticToConsole(event);
+    void logRendererEvent({
+      source: "renderer_boot_diagnostics",
+      message: label,
+      route: event.route,
+      elapsedMs: event.elapsedMs,
+    }).catch(() => {
+      // Boot diagnostics must stay best-effort and cannot affect startup.
+    });
+  }
+}
+
+export function recordBootDiagnosticOnce(
+  label: string,
+  metadata?: Record<string, unknown>,
+): void {
+  if (recordedOnceLabels.has(label)) {
+    return;
+  }
+  recordedOnceLabels.add(label);
+  recordBootDiagnostic(label, metadata);
+}
+
+export function isBootStallDiagnosticsEnabled(): boolean {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return false;
+  }
+
+  if (enabledCache !== null) {
+    return enabledCache;
+  }
+
+  enabledCache = envFlagEnabled(import.meta.env.VITE_PROLIFERATE_BOOT_DIAGNOSTICS, false)
+    || readBootDiagnosticsBrowserFlag()
+    || readBootDiagnosticsUrlFlag();
+  return enabledCache;
+}
+
+export function isBootDiagnosticsBrowserFlagEnabled(): boolean {
+  return readBootDiagnosticsBrowserFlag() || readBootDiagnosticsUrlFlag();
+}
+
+function isLikelyWebKitRuntime(): boolean {
+  const userAgent = navigator.userAgent;
+  return userAgent.includes("AppleWebKit")
+    && !/(Chrome|Chromium|Edg|OPR|Firefox)\//.test(userAgent);
+}
+
+function installBootDiagnosticsGlobal(): void {
+  const api: BootDiagnosticApi = {
+    dump: getBootDiagnosticsDump,
+    clear: clearBootDiagnostics,
+  };
+  window.proliferateBootDiagnostics = api;
+  window.__PROLIFERATE_BOOT_DIAGNOSTICS__ = api;
+}
+
+function installBootDiagnosticsErrorListeners(): void {
+  window.addEventListener("error", (event) => {
+    recordBootDiagnostic("window.error", {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    recordBootDiagnostic("window.unhandled_rejection", {
+      reason: summarizeBootValue(event.reason),
+    });
+  });
+}
+
+function installBootDiagnosticsPerformanceMeasureProbe(): void {
+  if (
+    originalPerformanceMeasure !== null
+    || typeof performance === "undefined"
+    || typeof performance.measure !== "function"
+  ) {
+    return;
+  }
+
+  originalPerformanceMeasure = performance.measure;
+  const measureWithDiagnostics = function bootDiagnosticsPerformanceMeasure(
+    ...args: unknown[]
+  ): PerformanceMeasure {
+    performanceMeasureCallCount += 1;
+    const preparedCall = preparePerformanceMeasureCall(args);
+    if (preparedCall.skipNative && preparedCall.fallbackEntry) {
+      return preparedCall.fallbackEntry;
+    }
+    return (originalPerformanceMeasure as (...measureArgs: unknown[]) => PerformanceMeasure)
+      .apply(performance, preparedCall.args);
+  } as Performance["measure"];
+
+  try {
+    performance.measure = measureWithDiagnostics;
+  } catch (error) {
+    originalPerformanceMeasure = null;
+    recordBootDiagnostic("performance.measure_probe.install_failed", {
+      error: summarizeBootValue(error),
+    });
+  }
+}
+
+function preparePerformanceMeasureCall(args: unknown[]): PreparedPerformanceMeasureCall {
+  const name = typeof args[0] === "string" ? args[0] : "[unknown]";
+  const options = args[1];
+  if (!isPerformanceMeasureOptionsWithDetail(options)) {
+    recordPerformanceMeasureSummary(name, {
+      detailSummary: null,
+      nativeSkipped: false,
+      stack: null,
+      strippedDetail: false,
+    });
+    return {
+      args,
+      fallbackEntry: null,
+      skipNative: false,
+    };
+  }
+
+  const stack = stackWithoutBootDiagnosticFrames(new Error().stack ?? "");
+  const detailSummary = summarizePerformanceMeasureDetail(options.detail);
+  const skipNative = isReactDevToolsPerformanceDetail(options.detail);
+  performanceMeasureDetailStripCount += 1;
+  recordPerformanceMeasureSummary(name, {
+    detailSummary,
+    nativeSkipped: skipNative,
+    stack: stack || null,
+    strippedDetail: true,
+  });
+
+  if (performanceMeasureDetailStripCount <= MAX_PERFORMANCE_MEASURE_REPORTS) {
+    recordBootDiagnostic("performance.measure.detail_stripped", {
+      name,
+      detailSummary,
+      nativeSkipped: skipNative,
+      stack: stack || null,
+    });
+  }
+
+  if (skipNative) {
+    return {
+      args,
+      fallbackEntry: createSyntheticPerformanceMeasure(name, options, detailSummary),
+      skipNative: true,
+    };
+  }
+
+  const sanitizedOptions = {
+    ...options,
+    detail: detailSummary,
+  };
+  return {
+    args: [args[0], sanitizedOptions, ...args.slice(2)],
+    fallbackEntry: null,
+    skipNative: false,
+  };
+}
+
+function isPerformanceMeasureOptionsWithDetail(
+  value: unknown,
+): value is PerformanceMeasureOptions & { detail: unknown } {
+  return typeof value === "object"
+    && value !== null
+    && "detail" in value
+    && (value as PerformanceMeasureOptions).detail !== undefined
+    && (value as PerformanceMeasureOptions).detail !== null;
+}
+
+function recordPerformanceMeasureSummary(
+  name: string,
+  {
+    detailSummary,
+    nativeSkipped,
+    stack,
+    strippedDetail,
+  }: {
+    detailSummary: unknown;
+    nativeSkipped: boolean;
+    stack: string | null;
+    strippedDetail: boolean;
+  },
+): void {
+  let summary = performanceMeasureSummaries.get(name);
+  if (!summary) {
+    if (performanceMeasureSummaries.size >= MAX_PERFORMANCE_MEASURE_SUMMARIES) {
+      return;
+    }
+    summary = {
+      name,
+      calls: 0,
+      detailStripped: 0,
+      nativeSkipped: 0,
+      lastDetailSummary: null,
+      lastStack: null,
+    };
+    performanceMeasureSummaries.set(name, summary);
+  }
+
+  summary.calls += 1;
+  if (strippedDetail) {
+    summary.detailStripped += 1;
+    if (nativeSkipped) {
+      summary.nativeSkipped += 1;
+    }
+    summary.lastDetailSummary = detailSummary;
+    summary.lastStack = stack;
+  }
+}
+
+function isReactDevToolsPerformanceDetail(value: unknown): boolean {
+  return typeof value === "object"
+    && value !== null
+    && "devtools" in value;
+}
+
+function createSyntheticPerformanceMeasure(
+  name: string,
+  options: PerformanceMeasureOptions,
+  detail: unknown,
+): PerformanceMeasure {
+  const startTime = typeof options.start === "number" ? options.start : now();
+  const endTime = typeof options.end === "number" ? options.end : startTime;
+  const duration = typeof options.duration === "number"
+    ? options.duration
+    : Math.max(0, endTime - startTime);
+  const entry = {
+    detail,
+    duration,
+    entryType: "measure",
+    name,
+    startTime,
+    toJSON() {
+      return {
+        detail,
+        duration,
+        entryType: "measure",
+        name,
+        startTime,
+      };
+    },
+  };
+  return entry as PerformanceMeasure;
+}
+
+function summarizePerformanceMeasureDetail(value: unknown): unknown {
+  if (
+    value === null
+    || typeof value === "number"
+    || typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return {
+      type: "string",
+      length: value.length,
+      preview: value.length > 160 ? `${value.slice(0, 160)}...` : value,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      type: "array",
+      length: value.length,
+    };
+  }
+
+  if (typeof value === "object") {
+    return {
+      type: Object.prototype.toString.call(value),
+      constructorName: value.constructor?.name ?? null,
+    };
+  }
+
+  return {
+    type: typeof value,
+    value: String(value),
+  };
+}
+
+function installBootDiagnosticsFetchProbe(): void {
+  if (originalFetch !== null || typeof window.fetch !== "function") {
+    return;
+  }
+
+  originalFetch = window.fetch;
+  window.fetch = async function bootDiagnosticsFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const requestSeq = nextSeq;
+    const startedAt = now();
+    const request = summarizeFetchRequest(input, init);
+    if (request.url === INTERNAL_LOG_RENDERER_EVENT_URL) {
+      return originalFetch!.call(window, input, init);
+    }
+
+    recordFetchSummaryStart(request);
+    recordBootDiagnostic("fetch.start", {
+      requestSeq,
+      ...request,
+    });
+
+    try {
+      const response = await originalFetch!.call(window, input, init);
+      const durationMs = round(now() - startedAt);
+      recordFetchSummaryEnd(request, response.status, durationMs);
+      recordBootDiagnostic("fetch.end", {
+        requestSeq,
+        ...request,
+        status: response.status,
+        durationMs,
+      });
+      return response;
+    } catch (error) {
+      const durationMs = round(now() - startedAt);
+      recordFetchSummaryError(request, error, durationMs);
+      recordBootDiagnostic("fetch.error", {
+        requestSeq,
+        ...request,
+        durationMs,
+        error: summarizeBootValue(error),
+      });
+      throw error;
+    }
+  };
+}
+
+function recordFetchSummaryStart(request: Record<string, unknown>): void {
+  const summary = getFetchSummary(request);
+  if (!summary) {
+    return;
+  }
+
+  summary.starts += 1;
+  summary.inFlight += 1;
+}
+
+function recordFetchSummaryEnd(
+  request: Record<string, unknown>,
+  status: number,
+  durationMs: number,
+): void {
+  const summary = getFetchSummary(request);
+  if (!summary) {
+    return;
+  }
+
+  summary.ends += 1;
+  summary.inFlight = Math.max(0, summary.inFlight - 1);
+  summary.lastStatus = status;
+  summary.lastDurationMs = durationMs;
+  summary.maxDurationMs = Math.max(summary.maxDurationMs, durationMs);
+}
+
+function recordFetchSummaryError(
+  request: Record<string, unknown>,
+  error: unknown,
+  durationMs: number,
+): void {
+  const summary = getFetchSummary(request);
+  if (!summary) {
+    return;
+  }
+
+  summary.errors += 1;
+  summary.inFlight = Math.max(0, summary.inFlight - 1);
+  summary.lastDurationMs = durationMs;
+  summary.maxDurationMs = Math.max(summary.maxDurationMs, durationMs);
+  summary.lastError = summarizeBootValue(error);
+}
+
+function getFetchSummary(request: Record<string, unknown>): FetchDiagnosticSummary | null {
+  const method = typeof request.method === "string" ? request.method : "GET";
+  const url = typeof request.url === "string" ? request.url : "[unknown-url]";
+  const key = `${method} ${url}`;
+  const existing = fetchSummaries.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  if (fetchSummaries.size >= MAX_FETCH_SUMMARY_ENTRIES) {
+    return null;
+  }
+
+  const summary: FetchDiagnosticSummary = {
+    key,
+    method,
+    url,
+    starts: 0,
+    ends: 0,
+    errors: 0,
+    inFlight: 0,
+    lastStatus: null,
+    lastDurationMs: null,
+    maxDurationMs: 0,
+    lastError: null,
+  };
+  fetchSummaries.set(key, summary);
+  return summary;
+}
+
+function installBootDiagnosticsLayoutReadProbe(): void {
+  if (
+    originalRequestAnimationFrame !== null
+    || originalGetBoundingClientRect !== null
+    || typeof window.requestAnimationFrame !== "function"
+    || typeof Element === "undefined"
+  ) {
+    return;
+  }
+
+  originalRequestAnimationFrame = window.requestAnimationFrame;
+  originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+  window.requestAnimationFrame = function bootDiagnosticsRequestAnimationFrame(
+    callback: FrameRequestCallback,
+  ): number {
+    const frameDiagnostic: ActiveAnimationFrameDiagnostic = {
+      callbackName: callback.name || "[anonymous]",
+      id: nextAnimationFrameDiagnosticId,
+      scheduledAtMs: now(),
+      startedAtMs: 0,
+    };
+    nextAnimationFrameDiagnosticId += 1;
+
+    return originalRequestAnimationFrame!.call(window, (timestamp) => {
+      const previousFrame = activeAnimationFrame;
+      frameDiagnostic.startedAtMs = now();
+      activeAnimationFrame = frameDiagnostic;
+      try {
+        callback(timestamp);
+      } finally {
+        activeAnimationFrame = previousFrame;
+      }
+    });
+  };
+
+  Element.prototype.getBoundingClientRect = function bootDiagnosticsGetBoundingClientRect(
+    this: Element,
+  ): DOMRect {
+    const activeFrame = activeAnimationFrame;
+    if (!activeFrame) {
+      return originalGetBoundingClientRect!.call(this);
+    }
+
+    const startedAt = now();
+    const rect = originalGetBoundingClientRect!.call(this);
+    recordLayoutReadInAnimationFrame(this, activeFrame, now() - startedAt);
+    return rect;
+  };
+}
+
+function installBootDiagnosticsFrameProbe(): void {
+  const tick = (frameAtMs: number) => {
+    const frameGapMs = frameAtMs - lastFrameAtMs;
+    lastFrameAtMs = frameAtMs;
+    if (frameGapMs > FRAME_GAP_THRESHOLD_MS) {
+      maxFrameGapMs = Math.max(maxFrameGapMs, frameGapMs);
+      recordBootDiagnostic("main_thread.frame_gap", {
+        frameGapMs: round(frameGapMs),
+        maxFrameGapMs: round(maxFrameGapMs),
+      });
+    }
+    animationFrameId = requestAnimationFrame(tick);
+  };
+
+  animationFrameId = requestAnimationFrame(tick);
+  heartbeatIntervalId = window.setInterval(() => {
+    flushBootDiagnostics();
+  }, 1_000);
+}
+
+function recordLayoutReadInAnimationFrame(
+  element: Element,
+  frameDiagnostic: ActiveAnimationFrameDiagnostic,
+  durationMs: number,
+): void {
+  layoutReadInAnimationFrameCount += 1;
+  if (layoutReadReportCount >= MAX_LAYOUT_READ_REPORTS) {
+    return;
+  }
+
+  const shouldCaptureStack =
+    layoutReadInAnimationFrameCount <= MAX_LAYOUT_READ_STACK_CAPTURE_COUNT
+    || durationMs >= SLOW_LAYOUT_READ_THRESHOLD_MS;
+  const stack = shouldCaptureStack ? new Error().stack ?? "" : "";
+  const displayStack = stack ? stackWithoutBootDiagnosticFrames(stack) : null;
+  const signature = displayStack ? layoutReadStackSignature(displayStack) : "[stack-not-captured]";
+  const stackCount = (layoutReadStackCounts.get(signature) ?? 0) + 1;
+  layoutReadStackCounts.set(signature, stackCount);
+  const stackSummary = getLayoutReadStackSummary(signature, displayStack);
+  if (stackSummary) {
+    const roundedDurationMs = round(durationMs);
+    stackSummary.count += 1;
+    stackSummary.lastDurationMs = roundedDurationMs;
+    stackSummary.maxDurationMs = Math.max(stackSummary.maxDurationMs, roundedDurationMs);
+    stackSummary.lastElement = describeBootElement(element);
+    if (displayStack) {
+      stackSummary.lastStack = displayStack;
+    }
+    if (durationMs >= SLOW_LAYOUT_READ_THRESHOLD_MS) {
+      stackSummary.slow += 1;
+    }
+  }
+
+  if (
+    !LAYOUT_READ_TOTAL_MILESTONES.has(layoutReadInAnimationFrameCount)
+    && stackCount !== 1
+    && durationMs < SLOW_LAYOUT_READ_THRESHOLD_MS
+  ) {
+    return;
+  }
+
+  layoutReadReportCount += 1;
+  if (stackSummary) {
+    stackSummary.reported += 1;
+  }
+  recordBootDiagnostic("layout_read.in_animation_frame", {
+    callbackName: frameDiagnostic.callbackName,
+    durationMs: round(durationMs),
+    element: describeBootElement(element),
+    frameAgeMs: round(now() - frameDiagnostic.startedAtMs),
+    frameId: frameDiagnostic.id,
+    stack: displayStack,
+    stackCount,
+    totalCount: layoutReadInAnimationFrameCount,
+    waitMs: round(frameDiagnostic.startedAtMs - frameDiagnostic.scheduledAtMs),
+  });
+}
+
+function getLayoutReadStackSummary(
+  signature: string,
+  stack: string | null,
+): LayoutReadStackDiagnosticSummary | null {
+  const existing = layoutReadStackSummaries.get(signature);
+  if (existing) {
+    return existing;
+  }
+
+  if (layoutReadStackSummaries.size >= MAX_LAYOUT_READ_STACK_SUMMARIES) {
+    return null;
+  }
+
+  const summary: LayoutReadStackDiagnosticSummary = {
+    signature,
+    count: 0,
+    reported: 0,
+    slow: 0,
+    lastDurationMs: 0,
+    maxDurationMs: 0,
+    lastElement: null,
+    lastStack: stack,
+  };
+  layoutReadStackSummaries.set(signature, summary);
+  return summary;
+}
+
+function layoutReadStackSignature(stack: string): string {
+  return stack
+    .split("\n")
+    .slice(0, 4)
+    .join("\n");
+}
+
+function stackWithoutBootDiagnosticFrames(stack: string): string {
+  return stack
+    .split("\n")
+    .filter((line) =>
+      !line.includes("recordLayoutReadInAnimationFrame")
+      && !line.includes("bootDiagnosticsGetBoundingClientRect")
+    )
+    .slice(0, 9)
+    .join("\n");
+}
+
+function scheduleBootDiagnosticsFlush(): void {
+  if (flushScheduled || typeof window === "undefined") {
+    return;
+  }
+
+  flushScheduled = true;
+  window.setTimeout(flushBootDiagnostics, 0);
+}
+
+function flushBootDiagnostics(): void {
+  flushScheduled = false;
+  renderBootDiagnosticsOverlay();
+  persistBootDiagnosticsEvents();
+}
+
+function applyBootDiagnosticsUrlFlag(): void {
+  const flag = readBootDiagnosticsUrlParam();
+  if (flag === null) {
+    return;
+  }
+
+  if (["clear", "0", "false", "off", "no"].includes(flag)) {
+    try {
+      window.localStorage.removeItem(BOOT_DIAGNOSTICS_STORAGE_KEY);
+      window.localStorage.removeItem(BOOT_DIAGNOSTICS_EVENTS_STORAGE_KEY);
+    } catch {
+      // Local storage may be unavailable in privacy-restricted browser contexts.
+    }
+    enabledCache = false;
+    return;
+  }
+
+  if (["persist", "save"].includes(flag)) {
+    try {
+      window.localStorage.setItem(BOOT_DIAGNOSTICS_STORAGE_KEY, "1");
+    } catch {
+      // Local storage is optional for this diagnostic path.
+    }
+  }
+  enabledCache = null;
+}
+
+function readBootDiagnosticsUrlFlag(): boolean {
+  const flag = readBootDiagnosticsUrlParam();
+  return flag !== null && envFlagEnabled(flag, true);
+}
+
+function readBootDiagnosticsUrlParam(): string | null {
+  try {
+    const value = new URLSearchParams(window.location.search).get(BOOT_DIAGNOSTICS_PARAM);
+    return value?.trim().toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+function readBootDiagnosticsBrowserFlag(): boolean {
+  try {
+    return envFlagEnabled(
+      window.localStorage.getItem(BOOT_DIAGNOSTICS_STORAGE_KEY) ?? undefined,
+      false,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function ensureBootDiagnosticsOverlay(): BootDiagnosticOverlay | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  if (overlay) {
+    return overlay;
+  }
+
+  const existingRoot = document.getElementById(BOOT_DIAGNOSTICS_OVERLAY_ID);
+  const root = existingRoot ?? document.createElement("aside");
+  root.id = BOOT_DIAGNOSTICS_OVERLAY_ID;
+  root.style.cssText = [
+    "position:fixed",
+    "right:10px",
+    "bottom:10px",
+    "z-index:2147483647",
+    "box-sizing:border-box",
+    "width:min(620px,calc(100vw - 20px))",
+    "max-height:min(520px,65vh)",
+    "overflow:hidden",
+    "border:1px solid rgba(255,255,255,.22)",
+    "border-radius:8px",
+    "background:rgba(11,11,13,.94)",
+    "box-shadow:0 18px 50px rgba(0,0,0,.35)",
+    "color:#f4f4f5",
+    "font:11px/1.35 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace",
+    "letter-spacing:0",
+    "pointer-events:auto",
+  ].join(";");
+
+  root.innerHTML = [
+    "<div data-role=\"header\" style=\"display:flex;align-items:center;gap:8px;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.12);font-weight:700;\">",
+    "<span style=\"flex:1;\">Boot diagnostics</span>",
+    "<button data-action=\"copy\" style=\"border:1px solid rgba(255,255,255,.18);border-radius:5px;background:rgba(255,255,255,.08);color:inherit;padding:2px 7px;font:inherit;\">Copy</button>",
+    "<button data-action=\"clear\" style=\"border:1px solid rgba(255,255,255,.18);border-radius:5px;background:rgba(255,255,255,.08);color:inherit;padding:2px 7px;font:inherit;\">Clear</button>",
+    "</div>",
+    "<div data-role=\"summary\" style=\"padding:7px 10px;color:#d4d4d8;border-bottom:1px solid rgba(255,255,255,.1);\"></div>",
+    "<ol data-role=\"events\" style=\"list-style:none;margin:0;padding:6px 10px 9px;overflow:auto;max-height:410px;\"></ol>",
+  ].join("");
+
+  root.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const action = target.dataset.action;
+    if (action === "copy") {
+      void copyBootDiagnosticsDump();
+    }
+    if (action === "clear") {
+      clearBootDiagnostics();
+    }
+  });
+
+  if (!existingRoot) {
+    const attach = () => document.body.appendChild(root);
+    if (document.body) {
+      attach();
+    } else {
+      document.addEventListener("DOMContentLoaded", attach, { once: true });
+    }
+  }
+
+  overlay = {
+    root,
+    summary: root.querySelector<HTMLElement>("[data-role='summary']")!,
+    events: root.querySelector<HTMLElement>("[data-role='events']")!,
+  };
+  return overlay;
+}
+
+function renderBootDiagnosticsOverlay(): void {
+  const currentOverlay = ensureBootDiagnosticsOverlay();
+  if (!currentOverlay) {
+    return;
+  }
+
+  const elapsedMs = round(now() - startedAtMs);
+  const sinceLastFrameMs = round(now() - lastFrameAtMs);
+  const memory = getMeasurementMemorySnapshot();
+  const fetchTotals = getFetchDiagnosticTotals();
+  currentOverlay.summary.textContent = [
+    `elapsed ${elapsedMs}ms`,
+    `events ${events.length}/${nextSeq - 1}`,
+    `max gap ${round(maxFrameGapMs)}ms`,
+    `last frame ${sinceLastFrameMs}ms ago`,
+    `fetch ${fetchTotals.starts}/${fetchTotals.errors}err`,
+    `measure ${performanceMeasureDetailStripCount} stripped`,
+    `layout ${layoutReadInAnimationFrameCount}`,
+    memory.usedJSHeapSize === null
+      ? "heap n/a"
+      : `heap ${formatBytes(memory.usedJSHeapSize)}`,
+    currentRoute() ?? "",
+  ].filter(Boolean).join(" | ");
+
+  const visibleEvents = events.slice(-MAX_VISIBLE_EVENTS).reverse();
+  currentOverlay.events.textContent = "";
+  for (const event of visibleEvents) {
+    const item = document.createElement("li");
+    item.style.cssText = [
+      "display:grid",
+      "grid-template-columns:58px minmax(0,1fr)",
+      "gap:8px",
+      "padding:2px 0",
+      "border-bottom:1px solid rgba(255,255,255,.04)",
+    ].join(";");
+
+    const time = document.createElement("span");
+    time.style.color = "#a1a1aa";
+    time.textContent = `${event.elapsedMs}ms`;
+
+    const body = document.createElement("span");
+    body.style.cssText = "min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+    body.title = JSON.stringify(event);
+    body.textContent = formatEventLine(event);
+
+    item.append(time, body);
+    currentOverlay.events.appendChild(item);
+  }
+}
+
+function clearBootDiagnostics(): void {
+  events.splice(0);
+  recordedOnceLabels.clear();
+  layoutReadStackCounts.clear();
+  layoutReadStackSummaries.clear();
+  fetchSummaries.clear();
+  performanceMeasureSummaries.clear();
+  nextSeq = 1;
+  droppedEventCount = 0;
+  layoutReadInAnimationFrameCount = 0;
+  layoutReadReportCount = 0;
+  performanceMeasureCallCount = 0;
+  performanceMeasureDetailStripCount = 0;
+  maxFrameGapMs = 0;
+  try {
+    window.localStorage.removeItem(BOOT_DIAGNOSTICS_STORAGE_KEY);
+    window.localStorage.removeItem(BOOT_DIAGNOSTICS_EVENTS_STORAGE_KEY);
+  } catch {
+    // Local storage is optional for this diagnostic path.
+  }
+  enabledCache = false;
+  overlay?.root.remove();
+  overlay = null;
+}
+
+function getFetchDiagnosticTotals(): Pick<
+  BootDiagnosticDump["fetches"],
+  "starts" | "ends" | "errors" | "inFlight"
+> {
+  let starts = 0;
+  let ends = 0;
+  let errors = 0;
+  let inFlight = 0;
+  for (const summary of fetchSummaries.values()) {
+    starts += summary.starts;
+    ends += summary.ends;
+    errors += summary.errors;
+    inFlight += summary.inFlight;
+  }
+  return { starts, ends, errors, inFlight };
+}
+
+function getTopFetchSummaries(): FetchDiagnosticSummary[] {
+  return Array.from(fetchSummaries.values())
+    .sort((left, right) =>
+      (right.starts + right.errors * 4 + right.inFlight * 2 + right.maxDurationMs / 100)
+      - (left.starts + left.errors * 4 + left.inFlight * 2 + left.maxDurationMs / 100)
+    )
+    .slice(0, 20)
+    .map((summary) => ({ ...summary }));
+}
+
+function getTopLayoutReadStackSummaries(): LayoutReadStackDiagnosticSummary[] {
+  return Array.from(layoutReadStackSummaries.values())
+    .sort((left, right) =>
+      (right.count + right.slow * 4 + right.maxDurationMs / 10)
+      - (left.count + left.slow * 4 + left.maxDurationMs / 10)
+    )
+    .slice(0, 20)
+    .map((summary) => ({ ...summary }));
+}
+
+function getTopPerformanceMeasureSummaries(): PerformanceMeasureDiagnosticSummary[] {
+  return Array.from(performanceMeasureSummaries.values())
+    .sort((left, right) =>
+      (right.detailStripped * 8 + right.nativeSkipped * 4 + right.calls)
+      - (left.detailStripped * 8 + left.nativeSkipped * 4 + left.calls)
+    )
+    .slice(0, 20)
+    .map((summary) => ({ ...summary }));
+}
+
+function getBootDiagnosticsDump(): BootDiagnosticDump {
+  const fetchTotals = getFetchDiagnosticTotals();
+  return {
+    tag: "boot_stall_diagnostics",
+    version: 3,
+    createdAt: new Date().toISOString(),
+    timestampMs: Date.now(),
+    route: currentRoute(),
+    eventSeq: nextSeq - 1,
+    droppedEvents: droppedEventCount,
+    maxFrameGapMs: round(maxFrameGapMs),
+    memory: getMeasurementMemorySnapshot(),
+    fetches: {
+      ...fetchTotals,
+      top: getTopFetchSummaries(),
+    },
+    performanceMeasures: {
+      calls: performanceMeasureCallCount,
+      detailStripped: performanceMeasureDetailStripCount,
+      top: getTopPerformanceMeasureSummaries(),
+    },
+    layoutReads: {
+      inAnimationFrames: layoutReadInAnimationFrameCount,
+      reported: layoutReadReportCount,
+      uniqueStacks: layoutReadStackCounts.size,
+      topStacks: getTopLayoutReadStackSummaries(),
+    },
+    events: [...events],
+  };
+}
+
+async function copyBootDiagnosticsDump(): Promise<void> {
+  const body = JSON.stringify(getBootDiagnosticsDump(), null, 2);
+  try {
+    await navigator.clipboard.writeText(body);
+    recordBootDiagnostic("boot_diagnostics.copy.completed");
+  } catch {
+    console.info("[boot-diagnostics-json]", body);
+    recordBootDiagnostic("boot_diagnostics.copy.failed");
+  }
+}
+
+function persistBootDiagnosticsEvents(): void {
+  try {
+    window.localStorage.setItem(
+      BOOT_DIAGNOSTICS_EVENTS_STORAGE_KEY,
+      JSON.stringify(getBootDiagnosticsDump()),
+    );
+  } catch {
+    // Ignore quota or availability errors. The visible overlay is the primary path.
+  }
+}
+
+function logBootDiagnosticToConsole(event: BootDiagnosticEvent): void {
+  if (event.metadata) {
+    console.info(`[boot-diagnostics] ${event.label}`, event.metadata);
+    return;
+  }
+  console.info(`[boot-diagnostics] ${event.label}`);
+}
+
+function isNoisyBootLabel(label: string): boolean {
+  return NOISY_BOOT_LABEL_PREFIXES.some((prefix) => label.startsWith(prefix));
+}
+
+function summarizeFetchRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Record<string, unknown> {
+  const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+  return {
+    method,
+    url: sanitizeBootUrl(input instanceof Request ? input.url : String(input)),
+  };
+}
+
+function sanitizeBootUrl(value: string): string {
+  try {
+    const url = new URL(value, window.location.href);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "[unparseable-url]";
+  }
+}
+
+function describeBootElement(element: Element): string {
+  const tagName = element.tagName.toLowerCase();
+  const id = element.id ? `#${element.id}` : "";
+  const classes = Array.from(element.classList)
+    .slice(0, 5)
+    .map((className) => `.${className}`)
+    .join("");
+  const dataAttributes = [
+    "data-chat-transcript-root",
+    "data-chat-composer-footer",
+    "data-chat-composer-surface",
+    "data-code",
+    "data-file",
+    "data-file-source-virtualized",
+    "data-index",
+    "data-transcript-virtual-row",
+  ]
+    .flatMap((name) => {
+      const value = element.getAttribute(name);
+      return value === null ? [] : [`[${name}=${JSON.stringify(value)}]`];
+    })
+    .join("");
+  return `${tagName}${id}${classes}${dataAttributes}`.slice(0, 500);
+}
+
+function sanitizeBootMetadata(value: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value).slice(0, 12)) {
+    sanitized[key] = summarizeBootValue(item);
+  }
+  return sanitized;
+}
+
+function summarizeBootValue(value: unknown): unknown {
+  if (
+    value === null
+    || typeof value === "number"
+    || typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value.length > 500 ? `${value.slice(0, 500)}...` : value;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack?.slice(0, 1_000) ?? null,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 10).map(summarizeBootValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .slice(0, 10)
+        .map(([key, item]) => [key, summarizeBootValue(item)]),
+    );
+  }
+
+  return String(value);
+}
+
+function formatEventLine(event: BootDiagnosticEvent): string {
+  if (!event.metadata || Object.keys(event.metadata).length === 0) {
+    return event.label;
+  }
+
+  return `${event.label} ${JSON.stringify(event.metadata)}`;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${round(value / 1024)} KB`;
+  }
+  return `${round(value / (1024 * 1024))} MB`;
+}
+
+function currentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}

--- a/desktop/src/lib/infra/measurement/debug-startup.ts
+++ b/desktop/src/lib/infra/measurement/debug-startup.ts
@@ -17,7 +17,8 @@ function browserFlagEnabled(): boolean {
   }
 
   try {
-    return envFlagEnabled(window.localStorage.getItem("proliferate.debugStartup") ?? undefined, false);
+    return envFlagEnabled(window.localStorage.getItem("proliferate.debugStartup") ?? undefined, false)
+      || envFlagEnabled(window.localStorage.getItem("proliferate.bootDiagnostics") ?? undefined, false);
   } catch {
     return false;
   }
@@ -25,6 +26,7 @@ function browserFlagEnabled(): boolean {
 
 export function isStartupDebugLoggingEnabled(): boolean {
   return envFlagEnabled(import.meta.env.VITE_PROLIFERATE_DEBUG_STARTUP, false)
+    || envFlagEnabled(import.meta.env.VITE_PROLIFERATE_BOOT_DIAGNOSTICS, false)
     || browserFlagEnabled();
 }
 

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -12,6 +12,11 @@ import {
   initializeDesktopTelemetry,
 } from "./lib/integrations/telemetry/client";
 import { elapsedStartupMs, startStartupTimer } from "./lib/infra/measurement/debug-startup";
+import {
+  installBootStallDiagnostics,
+  installWebKitPerformanceMeasureDetailGuard,
+  recordBootDiagnostic,
+} from "./lib/infra/measurement/boot-stall-diagnostics";
 import { installDebugMeasurement } from "./lib/infra/measurement/debug-measurement-install";
 import { logRendererEvent } from "./lib/access/tauri/diagnostics";
 import { AppProviders } from "./providers/AppProviders";
@@ -22,9 +27,12 @@ const IS_TAURI_DESKTOP =
   && "__TAURI_INTERNALS__" in (window as unknown as Record<string, unknown>);
 
 const rendererStartupStartedAt = startStartupTimer();
+installWebKitPerformanceMeasureDetailGuard();
+installBootStallDiagnostics();
 installDebugMeasurement();
 
 function recordRendererStartupEvent(message: string): void {
+  recordBootDiagnostic(`renderer_startup.${message}`);
   void logRendererEvent({
     source: "renderer_startup",
     message,

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,10 @@ start of the task, not after implementation has already started.
 - `docs/architecture/cloud-worker-automation-migration-spec.md`
   - concrete implementation spec for migrating automations to a target-agnostic
     staged CloudCommand pipeline
+- `docs/architecture/cloud-work-launch-model-spec.md`
+  - concrete implementation spec for the shared target/workspace/materialization
+    launch model used by automations, Slack, web, mobile, and Desktop cloud
+    surfaces
 - `docs/architecture/plugins-and-skills.md`
   - reference architecture for plugin packages, skill bundles, plugin-owned
     MCP servers, the plugins UI, and the session bundle boundary

--- a/docs/architecture/cloud-surfaces-launch-plan.md
+++ b/docs/architecture/cloud-surfaces-launch-plan.md
@@ -1,0 +1,514 @@
+# Cloud Surfaces Launch Plan
+
+Status: implementation plan for the cloud target, automation, Slack, web, and
+mobile push.
+
+Date: 2026-05-15
+
+## Purpose
+
+This document turns the current architecture decisions into an implementation
+order that can be executed without re-litigating the model on every PR.
+
+The near-term goal is to make cloud-mediated Proliferate useful from Desktop,
+web/mobile-shaped surfaces, Slack, and automations without waiting for the
+long-term centralized agent credential gateway.
+
+The urgent launch bar is:
+
+- Desktop can create and run automations against managed cloud, SSH, and local
+  targets through the target/worker model.
+- Users can target cloud-addressable work from a clean target selector instead
+  of a local-vs-cloud special case.
+- Team automation runs can be listed, opened, claimed, and continued.
+- A mobile/TestFlight build is possible if the repo/local environment has a
+  working Tauri iOS project and signing setup. If it does not, the immediate
+  deliverable is a mobile-responsive cloud surface plus a clear native iOS
+  bootstrap task.
+- Slack can be brought up as a thread adapter over the same cloud command/run
+  objects, not as a separate execution path.
+
+## Current Repo Facts
+
+These facts matter for the launch plan:
+
+- The workspace has `cloud/sdk` and `cloud/sdk-react` packages.
+- The workspace does not currently have a separate committed `mobile/` package.
+- The desktop app is a Tauri app and has iOS icon assets, but a committed Tauri
+  iOS project was not found during the planning pass.
+- Desktop already has an Automations surface and editor under
+  `desktop/src/components/automations/**`.
+- Server automations already expose `targetId` / target kind fields in the API
+  models, but the Desktop automation UI still primarily thinks in
+  local-vs-cloud execution target terms.
+- Slack currently has message/webhook helpers, but not a full Slack thread link
+  product backend.
+
+## Non-Goals For This Push
+
+Do not block the launch on these:
+
+- Full centralized agent credential gateway.
+- Full team/service credential model for every provider.
+- Full web IDE features.
+- Mobile file editing, terminal streaming, browser streaming, or computer-use
+  streaming.
+- Slack-native full configuration/admin UI.
+- Cloud durable storage of token-level deltas or raw tool bodies.
+
+## Core Mental Model
+
+The system remains:
+
+```text
+commands down
+events up
+AnyHarness orders
+Cloud projects
+Worker transports
+Desktop can direct-attach
+```
+
+The object model is:
+
+```text
+Target
+  compute that can run AnyHarness work
+
+Workspace / Worktree
+  repo-root and unit of work on a target
+
+Session
+  execution inside a workspace
+
+Automation
+  reusable definition that creates runs
+
+AutomationRun
+  concrete run with target, workspace, session, prompt, and outputs
+
+SlackThreadLink
+  Slack thread mapped to a session/run
+
+Claim
+  user takes ownership of next action; it does not transfer credentials or move
+  the sandbox
+```
+
+## Target Selection Model
+
+All entry points should converge on a single target-first selection model.
+
+This applies to:
+
+- New chat / new workspace.
+- Automation creation.
+- Automation run-now.
+- Slack start-session flow.
+- Mobile/web start-session flow.
+
+The stable shape should be:
+
+```text
+TargetLaunchSelection
+  target_id
+  target_kind
+  execution_route
+  repo_identity
+  workspace_policy
+  base_branch
+  credential_source_ref
+  mcp_bundle_ref
+  skill_bundle_refs
+  env_materialization_ref
+  default_agent
+  default_model
+  default_mode
+```
+
+`target_kind` values:
+
+```text
+managed_cloud
+ssh
+desktop_dispatch
+local_direct
+self_hosted_cloud
+```
+
+`execution_route` values:
+
+```text
+cloud_worker
+desktop_direct
+local_executor
+```
+
+`workspace_policy` values:
+
+```text
+existing_workspace
+existing_repo_root
+new_worktree
+fresh_repo_checkout
+```
+
+Rules:
+
+- Cloud-mediated clients only submit CloudCommands.
+- Desktop may direct-attach when it has access, but mutations still go through
+  AnyHarness command APIs.
+- A target may be visible but not directly openable from Desktop. In that case
+  Desktop should show it as cloud-dispatchable and route open/claim actions to
+  web or require direct access setup.
+- Target selection is target-id first. Local-vs-cloud is only an execution route
+  detail.
+
+## Workspace/Run Config vs Session Config
+
+The durable launch configuration belongs primarily to the workspace/run, not to
+the individual chat row.
+
+Workspace or automation-run launch config owns:
+
+- target
+- repo identity and checkout path policy
+- workspace/worktree policy
+- base branch
+- MCP bundle
+- skill bundle
+- env/materialization config
+- credential source reference
+- default agent/model/mode
+
+Session config owns:
+
+- current agent/model/mode/config snapshot
+- transcript
+- pending interactions
+- turn state
+- session status
+
+Sessions consume the workspace/run config. They should not be the only place
+where target, repo, MCP, credential, and materialization decisions live.
+
+## Credentials V1
+
+Long term, credentials should come from Cloud-resolved provider/team/service
+grants and an agent/provider gateway.
+
+V1 bridge:
+
+- Personal cloud work uses the user's synced/local credential material where
+  needed.
+- Team work can use creator/user-synced credentials as a launch bridge, but the
+  UI must label the run as `runs as <user>` or equivalent.
+- GitHub auth is required for the current product path.
+- Git identity is target/workspace materialization data, not the same thing as
+  claim ownership.
+- Claiming a run does not switch Git identity, provider credentials, sandbox
+  ownership, or workspace ownership.
+
+Do not add hidden broad secret sharing for team targets. If a credential is
+used as a V1 bridge, make it explicit in the launch config and run metadata.
+
+## MCP / Skill Bundles V1
+
+The launch config must have fields for MCP and skill bundles now, even if V1
+uses a narrow/default implementation.
+
+V1 behavior:
+
+- Desktop exposes bundle selection where the data already exists.
+- Team automation launch records the selected MCP/skill bundle refs.
+- Worker materialization installs or configures what it can through the existing
+  materialization path.
+- Missing target readiness should show as a target setup problem, not as a
+  mysterious session failure.
+
+Long term:
+
+- Catalog -> configuration -> target readiness -> session authorization.
+- Team work only uses admin-approved bundles.
+- Personal MCPs are not silently inherited into team work.
+
+## Phase 0: Mobile/TestFlight Feasibility Check
+
+Before promising TestFlight, verify the native mobile path.
+
+Check:
+
+- Is there a committed or local `desktop/src-tauri/gen/apple` project?
+- Does `pnpm tauri ios init` succeed from `desktop` without restructuring?
+- Does the local machine have valid Apple signing identities/profiles?
+- Can the app reach the correct Cloud API base URL in an iOS build?
+- Is GitHub auth/deep linking configured for iOS?
+
+If the answer is no, the fallback launch artifact is:
+
+- mobile-responsive cloud UI in the existing app/web shell;
+- a documented iOS bootstrap task;
+- no claim that TestFlight is ready until the native project signs and uploads.
+
+Relevant files/directories:
+
+- `desktop/package.json`
+- `desktop/src-tauri/`
+- `desktop/src/config/app-routes.ts`
+- `cloud/sdk/**`
+- `cloud/sdk-react/**`
+
+Acceptance:
+
+- We can state clearly whether native TestFlight is buildable tonight.
+- If buildable, produce the exact command sequence for local build/upload.
+- If not buildable, document the smallest missing setup.
+
+## Phase 1: Clean Targeting
+
+Goal: replace local-vs-cloud special cases with a target-id-first model in the
+Desktop automation/new-work launch path.
+
+Implementation shape:
+
+- Extend frontend automation/run records to preserve `targetId` and target kind.
+- Update target selection domain logic to select `TargetLaunchSelection`.
+- Build target picker UI from the Cloud target list plus local/direct target.
+- Ensure create/update automation requests pass `targetId`.
+- Ensure run detail displays target name/kind/status and whether it is directly
+  openable.
+- Keep server API shape aligned with existing `targetId` fields.
+
+Likely files:
+
+- `server/proliferate/server/automations/models.py`
+- `server/proliferate/server/automations/api.py`
+- `cloud/sdk/src/client/automations.ts`
+- `cloud/sdk/src/generated/openapi.ts`
+- `desktop/src/lib/domain/automations/run/ui-records.ts`
+- `desktop/src/lib/domain/automations/target/records.ts`
+- `desktop/src/lib/domain/automations/target/selection.ts`
+- `desktop/src/hooks/automations/derived/use-automation-target-selection.ts`
+- `desktop/src/components/automations/controls/AutomationTargetPicker.tsx`
+- `desktop/src/components/automations/editor/AutomationEditorModal.tsx`
+- `desktop/src/components/automations/list/AutomationDetailContent.tsx`
+
+Acceptance:
+
+- A user can choose managed cloud, SSH, or local/direct where available.
+- The selected target is visible on automation details and run details.
+- The request payload contains target identity rather than only
+  `executionTarget: cloud | local`.
+- Existing local automations still work.
+
+## Phase 2: Desktop Team Automations MVP
+
+Goal: team automation workflows are useful before full web/mobile surfaces.
+
+Desktop should support:
+
+- List team and personal automations.
+- Create automation with target, repo, prompt, schedule, MCP/skill refs where
+  available, and explicit `runs as` credential source.
+- Trigger run now.
+- View run timeline/status/result.
+- Claim a run.
+- Continue/open the session when direct access is available.
+- Show “open in web” or “configure direct access” when the target is not
+  directly reachable from Desktop.
+
+Likely files:
+
+- `desktop/src/components/automations/**`
+- `desktop/src/hooks/automations/**`
+- `desktop/src/lib/domain/automations/**`
+- `cloud/sdk/src/client/automations.ts`
+- `server/proliferate/server/automations/**`
+
+Acceptance:
+
+- Automation create/edit/run-now works with target-id-first selection.
+- Run detail explains the credential/target state.
+- Claiming does not imply sandbox or credential transfer.
+
+## Phase 3: Slack Backend MVP
+
+Goal: Slack becomes a cloud-mediated thread adapter over automation/session
+objects.
+
+Core object:
+
+```text
+SlackThreadLink
+  slack_workspace_id
+  channel_id
+  thread_ts
+  org_id
+  workspace_id
+  session_id
+  automation_run_id
+  created_by_user_id
+```
+
+V1 flows:
+
+- Start/link work from a Slack command or message action.
+- Reply in a linked thread to send a prompt.
+- Post compact run/session progress.
+- Post pending interaction buttons when available.
+- Post completion/failure summaries with web/Desktop links.
+
+Likely files:
+
+- `server/proliferate/integrations/slack/messages.py`
+- `server/proliferate/integrations/slack/webhooks.py`
+- `server/proliferate/server/**/slack*.py` or a new server-owned Slack module
+  following `docs/server/README.md`.
+- Cloud command and automation services used by Slack handlers.
+
+Acceptance:
+
+- Slack never sees target credentials or AnyHarness URLs.
+- Slack actions become normal CloudCommands or automation operations.
+- Complex actions route to web/Desktop links.
+
+## Phase 4: Mobile/TestFlight V1
+
+Goal: mobile is supervision and lightweight action, not a mobile IDE.
+
+V1 screens:
+
+- Sign in / GitHub auth.
+- Active sessions and automation runs.
+- Needs-attention queue.
+- Run/session detail with transcript/result summary where cloud-visible.
+- Claim/continue/open links.
+- Approve/deny or answer pending interactions if the cloud projection supports
+  them.
+
+V1 excludes:
+
+- file editing
+- terminal
+- browser/computer-use stream
+- full target admin
+- complex automation builder
+
+Implementation options:
+
+1. Native Tauri iOS shell if Phase 0 passes.
+2. Mobile-responsive web shell if native iOS is not ready.
+
+Likely files:
+
+- `desktop/src/App.tsx`
+- `desktop/src/pages/MainPage.tsx`
+- `desktop/src/config/app-routes.ts`
+- `desktop/src/components/automations/**`
+- `desktop/src/components/cloud/**` where present
+- `cloud/sdk-react/**`
+- `cloud/sdk/**`
+- `desktop/src-tauri/**` only if native iOS is enabled.
+
+Acceptance:
+
+- A first-time tester can sign in and see useful cloud-visible work without
+  installing Desktop.
+- If native iOS is built, the build is signed and uploadable.
+- If native iOS is not buildable, the blocker is explicit and the responsive web
+  fallback works.
+
+## Phase 5: Web V1
+
+Goal: web is the team control room.
+
+V1 pages:
+
+- Workspaces / runs list.
+- Automation list and run detail.
+- Session transcript/result view where projected.
+- Target status.
+- Claim/continue/open links.
+
+V1 excludes:
+
+- full file review
+- interactive terminal
+- browser/computer-use streaming
+- full target admin
+
+Implementation should reuse the same Cloud SDK and product/domain logic as
+Desktop/mobile where ownership rules allow it.
+
+Acceptance:
+
+- Web and mobile render the same core cloud objects.
+- Surface-specific UI differs, but commands and snapshots do not.
+
+## Implementation Order
+
+The order for the next implementation passes should be:
+
+1. Phase 0: decide if TestFlight is actually buildable from the current repo and
+   local machine.
+2. Phase 1: clean target selection in Desktop and SDK models.
+3. Phase 2: Desktop team automations MVP.
+4. Phase 3: Slack backend MVP if credentials/app configuration are available.
+5. Phase 4: mobile/TestFlight V1 or responsive mobile fallback.
+6. Phase 5: web V1.
+
+Do not build web/mobile before the target/run model is clean. They should render
+the shared model, not invent another one.
+
+## Testing Plan
+
+Unit tests:
+
+- target selection maps managed cloud, SSH, and local targets correctly.
+- automation create/update requests include target identity.
+- run UI records preserve target kind/id and claim/open state.
+- Slack thread link mapping creates the expected command/run operation.
+
+Integration/manual smoke:
+
+- managed cloud automation run creates workspace, session, and accepted prompt.
+- SSH automation run creates/uses repo checkout, worktree, session, and accepted
+  prompt.
+- Desktop can open or correctly explain why it cannot directly open the target.
+- Mobile viewport renders active runs and needs-attention cards without desktop
+  layout overflow.
+
+Visual checks:
+
+- Playwright/browser screenshots for automation editor, target picker, run
+  detail, and mobile viewport.
+- No giant raw event/tool payload UI in run/session views.
+
+Release checks:
+
+- `pnpm`/frontend tests for changed Desktop/SDK code.
+- Server tests for changed automation/Slack APIs.
+- Native iOS build/upload check only if Phase 0 passes.
+
+## Hard Decisions
+
+- No centralized agent gateway for this launch.
+- User-synced credentials are the V1 bridge, but must be visible in UI and run
+  metadata.
+- Target selection is target-id first everywhere.
+- Workspace/run launch config owns target/repo/MCP/skills/credential refs.
+- Sessions execute inside the selected workspace/run config.
+- Slack, mobile, and web are Cloud surfaces. They do not talk directly to
+  AnyHarness or target credentials.
+- Claiming a run means ownership of the next action, not transferring
+  credentials or moving compute.
+
+## Open Questions To Resolve Before Coding Each Phase
+
+- Is native TestFlight possible from the current repo tonight?
+- What exact Apple signing/App Store Connect credentials are available?
+- What Slack app credentials/event URL are available for local/prod testing?
+- Which target access states should show “open in Desktop” vs “open in web” vs
+  “configure direct SSH access”?
+- Which MCP/skill bundle picker data is already available in Desktop, and which
+  fields should be saved but hidden for V1?

--- a/docs/architecture/cloud-work-launch-model-spec.md
+++ b/docs/architecture/cloud-work-launch-model-spec.md
@@ -1,0 +1,882 @@
+# Cloud Work Launch Model Spec
+
+Status: detailed implementation spec for the shared work launch model.
+
+Date: 2026-05-15
+
+## Purpose
+
+This spec defines the shared model for starting work across Desktop, Web,
+Mobile, Slack, and Automations.
+
+The goal is to make every surface answer the same core question with the same
+objects:
+
+> What work are we starting, on which target, against which repo/workspace, with
+> which runtime/materialization/config, and how do we verify it ran?
+
+This spec is intentionally narrower than the full cloud surfaces plan. It owns
+the launch model and backend boundaries. UI-specific flows are handled by later
+surface specs.
+
+## Current State
+
+The repo already has most of the backend mechanics:
+
+- Cloud targets, workers, enrollment, inventory, versions, and update state.
+- SSH target enrollment with worker install command.
+- Managed cloud target registration during sandbox boot.
+- Target-level Git identity materialization.
+- Automation definitions and runs with target/repo/agent/model snapshots.
+- CloudCommands for `configure_git_identity`, `ensure_repo_checkout`,
+  `materialize_workspace`, `materialize_environment`, `start_session`,
+  `send_prompt`, `resolve_interaction`, `update_session_config`, `cancel_turn`,
+  and `close_session`.
+- Worker command dispatch for target materialization and AnyHarness commands.
+- Cloud MCP connections and materialization.
+- User-scoped cloud agent credential sync.
+
+The main missing piece is not raw capability. The missing piece is a shared
+product contract. Today the launch model is split across:
+
+```text
+Automation model:
+  target, repo, prompt, agent, model, mode
+
+Target config:
+  env vars, files, setup, Git credential, agent credentials, MCP, skills
+
+Cloud workspace:
+  repo, branch, runtime state, AnyHarness workspace id
+
+Desktop automation target picker:
+  local-vs-cloud repo selection, not target-id-first compute selection
+```
+
+This spec consolidates those pieces into a single work launch model without
+rewriting the whole stack at once.
+
+## Core Layers
+
+There are four distinct setup/execution layers.
+
+### 1. Target Bootstrap
+
+Happens when a machine or sandbox becomes a Proliferate target.
+
+Owns:
+
+```text
+CloudTarget
+CloudWorker
+worker identity
+worker/supervisor/AnyHarness versions
+inventory/readiness
+base workspace root
+target GitHub credential
+git user.name / user.email
+```
+
+Does not own:
+
+```text
+repo checkout
+worktree creation
+workspace env vars
+MCP session config
+agent session config
+prompt execution
+```
+
+Invariant:
+
+```text
+After target bootstrap succeeds, ordinary git clone/fetch/push should work on
+that target for the configured target user without per-workspace Git token
+injection.
+```
+
+### 2. Workspace Preparation
+
+Happens when a workspace, automation run, Slack command, or cloud chat needs a
+repo/worktree on a target.
+
+Owns:
+
+```text
+repo checkout
+repo identity validation
+git fetch
+base branch selection
+worktree path
+AnyHarness repo-root registration
+AnyHarness workspace/worktree registration
+CloudWorkspace <-> AnyHarness workspace mapping
+```
+
+Does not own:
+
+```text
+target Git bootstrap
+agent credential files
+MCP config
+prompt execution
+```
+
+Invariant:
+
+```text
+Workspace preparation assumes target Git is already configured. If Git is not
+ready, it fails clearly as target_git_not_ready or an equivalent explicit
+target-readiness error.
+```
+
+### 3. Workspace / Run Materialization
+
+Happens after the repo/worktree exists and before the agent session starts.
+
+Owns:
+
+```text
+env vars
+tracked files
+setup script
+run command
+MCP config
+skills
+agent credential files
+workspace-root readiness requirements
+```
+
+Does not own:
+
+```text
+target bootstrap
+repo checkout
+worktree creation
+session prompt execution
+```
+
+Invariant:
+
+```text
+Materialization is scoped to a workspace root or worktree. It may use reusable
+target caches, but the input contract is workspace/run scoped.
+```
+
+### 4. Session Execution
+
+Happens after workspace/run materialization.
+
+Owns:
+
+```text
+start session
+agent/model/mode/reasoning
+config updates
+prompt delivery
+pending interactions
+cancel/close
+AnyHarness event stream
+Cloud projections
+```
+
+Invariant:
+
+```text
+AnyHarness accepts, rejects, and orders execution-affecting commands. Cloud
+queues commands and projects results; it does not manufacture canonical session
+truth.
+```
+
+## Canonical Launch Flow
+
+Every cloud-mediated launch should eventually follow this shape:
+
+```text
+1. Resolve actor, org, and source surface.
+2. Resolve target.
+3. Assert target is online and compatible.
+4. Ensure target bootstrap is current.
+5. Create or load CloudWorkspace / AutomationRun / SlackThreadLink as needed.
+6. Ensure repo checkout exists on target.
+7. Register repo root with AnyHarness.
+8. Create/register worktree with AnyHarness.
+9. Materialize workspace/run environment.
+10. Start AnyHarness session.
+11. Apply session config.
+12. Send prompt or attach to existing session.
+13. Sync events/projections back to Cloud.
+```
+
+For automations, steps 5-12 are driven by the automation run.
+
+For Slack, steps 5-12 are driven by a Slack thread command/link.
+
+For web/mobile new work, steps 5-12 are driven by a launch request.
+
+For Desktop direct work, Desktop may direct-attach to AnyHarness, but equivalent
+runtime-affecting actions still map to AnyHarness command/session APIs.
+
+## Target Bootstrap Implementation
+
+### Existing Files
+
+```text
+server/proliferate/server/cloud/targets/service.py
+server/proliferate/server/cloud/targets/api.py
+server/proliferate/server/cloud/targets/models.py
+server/proliferate/server/cloud/targets/domain/rules.py
+server/proliferate/server/cloud/targets/domain/policy.py
+
+server/proliferate/server/cloud/worker/service.py
+server/proliferate/server/cloud/worker/api.py
+server/proliferate/server/cloud/worker/models.py
+
+server/proliferate/server/cloud/target_git_identity/service.py
+server/proliferate/server/cloud/target_git_identity/api.py
+server/proliferate/server/cloud/target_git_identity/models.py
+
+server/proliferate/db/models/cloud/targets.py
+server/proliferate/db/models/cloud/target_git_identity.py
+server/proliferate/db/store/cloud_sync/targets.py
+server/proliferate/db/store/cloud_sync/worker_auth.py
+server/proliferate/db/store/cloud_sync/target_git_identity.py
+
+server/proliferate/server/cloud/runtime/target_registration.py
+server/proliferate/server/cloud/runtime/provision.py
+
+anyharness/crates/proliferate-worker/src/runtime.rs
+anyharness/crates/proliferate-worker/src/identity/enrollment.rs
+anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+anyharness/crates/proliferate-worker/src/cloud_client/target_git_identity.rs
+anyharness/crates/proliferate-worker/src/materialization/git_identity.rs
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+
+install/proliferate-target-install.sh
+```
+
+### Required Behavior
+
+SSH enrollment:
+
+```text
+Desktop/Cloud creates target enrollment.
+Cloud requires creator GitHub auth.
+Cloud creates CloudTarget and single-use enrollment token.
+Installer writes worker/supervisor config on SSH target.
+Worker enrolls with token.
+Cloud creates CloudWorker and stores inventory.
+Cloud marks target online.
+Cloud enqueues configure_git_identity for created_by_user_id.
+Worker fetches worker-authenticated Git identity plan.
+Worker writes Git credential and Git user config.
+```
+
+Managed cloud:
+
+```text
+Cloud creates or reuses a runtime environment target.
+Cloud mints a fresh worker enrollment token for the sandbox boot.
+Sandbox starts supervisor, worker, and AnyHarness.
+Worker enrolls.
+Cloud stores inventory and marks target online.
+Cloud enqueues configure_git_identity for the creator/user.
+Worker applies target Git identity.
+```
+
+### Required Changes
+
+1. Make source naming explicit.
+
+```text
+server/proliferate/server/cloud/worker/service.py
+  _enqueue_initial_git_identity(...)
+    source should be target_enrollment, not automation
+```
+
+2. Make managed cloud target bootstrap match SSH conceptually.
+
+```text
+server/proliferate/server/cloud/runtime/provision.py
+  keep legacy direct Git configuration only while needed for compatibility
+  prefer worker target Git bootstrap for the durable target model
+  document any transitional overlap inline or in this spec
+```
+
+3. Preserve no-secret enrollment.
+
+```text
+Enrollment tokens must never contain GitHub tokens, agent credentials, MCP
+tokens, or repo env material.
+```
+
+### Tests
+
+```text
+server/tests/integration/test_cloud_targets_api.py
+server/tests/integration/test_cloud_worker_updates_api.py
+server/tests/unit/test_cloud_runtime_provision.py
+```
+
+Add/verify cases:
+
+```text
+SSH enrollment requires GitHub auth.
+Worker enrollment queues configure_git_identity.
+configure_git_identity command payload contains only targetGitIdentityId and
+configVersion.
+Worker fetches secrets through worker-authenticated materialization endpoint.
+Managed cloud target enrollment follows the same target/worker path.
+```
+
+## Workspace Preparation Implementation
+
+### Existing Files
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
+server/proliferate/server/automations/worker/cloud_execution/commands.py
+server/proliferate/server/automations/worker/cloud_execution/command_models.py
+server/proliferate/server/automations/worker/cloud_execution/context.py
+
+server/proliferate/server/cloud/workspaces/service.py
+server/proliferate/server/cloud/workspaces/models.py
+server/proliferate/db/models/cloud/workspaces.py
+server/proliferate/db/store/cloud_workspaces.py
+
+anyharness/crates/proliferate-worker/src/materialization/repo_checkout.rs
+anyharness/crates/proliferate-worker/src/anyharness_client/workspaces.rs
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+```
+
+### Required Behavior
+
+```text
+Given target, repo, base branch, and desired worktree branch:
+
+1. ensure_repo_checkout clones repo if missing.
+2. ensure_repo_checkout validates existing repo if present.
+3. ensure_repo_checkout fetches updates.
+4. materialize_workspace(existing_path) registers repo root with AnyHarness.
+5. materialize_workspace(worktree) creates/registers a worktree with AnyHarness.
+6. Cloud stores the AnyHarness workspace id on the CloudWorkspace/AutomationRun.
+```
+
+### Required Changes
+
+Create a shared work launch package so automations are no longer the only owner
+of repo/worktree preparation.
+
+```text
+server/proliferate/server/cloud/work_launch/__init__.py
+server/proliferate/server/cloud/work_launch/models.py
+server/proliferate/server/cloud/work_launch/commands.py
+server/proliferate/server/cloud/work_launch/workspace.py
+```
+
+Responsibilities:
+
+```text
+models.py
+  WorkLaunchConfig
+  WorkspacePrepConfig
+  WorkspacePrepResult
+  MaterializationConfig
+  SessionLaunchConfig
+
+commands.py
+  enqueue_ensure_repo_checkout
+  wait_for_ensure_repo_checkout
+  enqueue_materialize_workspace
+  wait_for_materialize_workspace
+  enqueue_start_session
+  enqueue_update_session_config
+  enqueue_send_prompt
+
+workspace.py
+  ensure_repo_checkout_on_target(...)
+  register_repo_root_with_anyharness(...)
+  create_worktree_with_anyharness(...)
+  prepare_workspace(...)
+```
+
+Then thin automation wrapper:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
+  call server.cloud.work_launch.workspace.prepare_workspace(...)
+  keep automation-specific run status transitions and claim checks here
+```
+
+Do not move automation claim lifecycle into `cloud.work_launch`.
+
+### Tests
+
+```text
+server/tests/unit/test_cloud_executor_worker_commands.py
+server/tests/unit/test_automation_cloud_execution_pipeline.py
+server/tests/integration/test_cloud_commands_api.py
+```
+
+Add/verify cases:
+
+```text
+prepare_workspace enqueues checkout before AnyHarness workspace commands.
+prepare_workspace fails clearly when target Git is not ready.
+automation stage preserves current run transitions while delegating work prep.
+materialize_workspace command payloads stay stable.
+```
+
+## Workspace / Run Materialization Implementation
+
+### Existing Files
+
+```text
+server/proliferate/server/cloud/target_config/service.py
+server/proliferate/server/cloud/target_config/api.py
+server/proliferate/server/cloud/target_config/models.py
+server/proliferate/server/cloud/target_config/domain/rules.py
+server/proliferate/server/cloud/target_config/domain/policy.py
+
+server/proliferate/db/models/cloud/target_config.py
+server/proliferate/db/store/cloud_sync/target_config.py
+
+server/proliferate/server/cloud/mcp_materialization/*
+server/proliferate/server/cloud/mcp_connections/*
+server/proliferate/db/models/cloud/mcp.py
+
+server/proliferate/server/cloud/credentials/*
+server/proliferate/db/models/cloud/credentials.py
+
+server/proliferate/server/automations/worker/cloud_execution/stages/environment.py
+
+anyharness/crates/proliferate-worker/src/materialization/mod.rs
+```
+
+### Required Behavior
+
+```text
+Given target, workspace root, repo, and materialization config:
+
+1. Cloud resolves repo config.
+2. Cloud resolves selected MCP connections.
+3. Cloud resolves selected skill bundle refs.
+4. Cloud resolves selected agent credential source.
+5. Cloud creates encrypted materialization plan.
+6. Cloud enqueues materialize_environment with targetConfigId/configVersion.
+7. Worker fetches plan through worker-authenticated endpoint.
+8. Worker writes env/files/setup/MCP/skills/agent credentials into workspace root.
+9. Worker reports applied/failed.
+```
+
+### Required Changes
+
+Rename the concept in docs and call sites, even if endpoint/table names remain
+`target_config` for compatibility.
+
+Conceptual rule:
+
+```text
+target_config implementation == workspace/run materialization plan
+target Git identity == target bootstrap
+```
+
+Add launch config snapshots to automation definitions/runs.
+
+```text
+server/proliferate/db/models/automations.py
+  Automation.launch_config_json
+  AutomationRun.launch_config_snapshot_json
+
+server/alembic/versions/<new>_automation_work_launch_config.py
+```
+
+Request/response/API updates:
+
+```text
+server/proliferate/server/automations/models.py
+server/proliferate/server/automations/api.py
+server/proliferate/db/store/automations.py
+cloud/sdk/src/client/automations.ts
+cloud/sdk/src/generated/openapi.ts
+```
+
+V1 launch config JSON:
+
+```json
+{
+  "version": 1,
+  "workspacePolicy": {
+    "kind": "new_worktree"
+  },
+  "credentialSource": {
+    "kind": "user_synced"
+  },
+  "gitIdentity": {
+    "kind": "target_bootstrap"
+  },
+  "mcp": {
+    "connectionIds": []
+  },
+  "skills": {
+    "bundleRefs": []
+  },
+  "materialization": {
+    "includeAgentCredentials": true,
+    "includeGitCredentials": false
+  }
+}
+```
+
+Rules:
+
+- `includeGitCredentials` defaults to false for workspace/run materialization
+  because Git is target bootstrap.
+- `includeAgentCredentials` defaults to true for V1 user-synced credential
+  bridge.
+- MCP connection ids are user-scoped in V1.
+- Skills are carried as refs now, even if materialization initially writes an
+  empty list.
+
+### Tests
+
+```text
+server/tests/integration/test_automations_api.py
+server/tests/unit/test_automation_service.py
+server/tests/integration/test_cloud_target_config_api.py
+server/tests/unit/test_mcp_materialization.py
+```
+
+Add/verify cases:
+
+```text
+Automation create stores launch_config_json.
+Automation run snapshots launch_config_snapshot_json.
+materialize_environment defaults includeGitCredentials=false for target-backed work.
+MCP connection ids flow into materialization.
+Agent credential source is visible in run metadata.
+```
+
+## Session Execution Implementation
+
+### Existing Files
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/session.py
+server/proliferate/server/automations/worker/cloud_execution/stages/prompt.py
+server/proliferate/server/cloud/commands/service.py
+server/proliferate/server/cloud/commands/models.py
+server/proliferate/server/cloud/commands/domain/rules.py
+
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+anyharness/crates/proliferate-worker/src/anyharness_client/sessions.rs
+```
+
+### Required Behavior
+
+```text
+Cloud enqueues start_session.
+Worker calls AnyHarness start session.
+Cloud stores AnyHarness session id.
+Cloud enqueues update_session_config if needed.
+Cloud enqueues send_prompt.
+Worker uploads events.
+Cloud updates projections.
+```
+
+### Required Changes
+
+Move reusable command helpers into:
+
+```text
+server/proliferate/server/cloud/work_launch/commands.py
+```
+
+Automation-specific stages remain:
+
+```text
+server/proliferate/server/automations/worker/cloud_execution/stages/session.py
+server/proliferate/server/automations/worker/cloud_execution/stages/prompt.py
+```
+
+They should call shared helpers but keep:
+
+```text
+run status transitions
+claim lifecycle checks
+automation-specific error codes
+```
+
+Future web/mobile/Slack should call the same command helpers or higher-level
+`work_launch.service` entry points.
+
+### Tests
+
+```text
+server/tests/unit/test_cloud_executor_worker_commands.py
+server/tests/unit/test_automation_cloud_execution_pipeline.py
+server/tests/integration/test_cloud_commands_api.py
+```
+
+Add/verify cases:
+
+```text
+start_session payload is stable.
+update_session_config supports normalized controls.
+send_prompt uses stable prompt id/idempotency.
+AnyHarness remains the accept/reject/order point.
+```
+
+## WorkLaunchConfig
+
+The shared model should be stored as JSON at first and later promoted into
+normalized tables only where we need queryability.
+
+### V1 Shape
+
+```text
+WorkLaunchConfig
+  version
+  target
+  repo
+  workspacePolicy
+  gitIdentity
+  credentialSource
+  mcp
+  skills
+  materialization
+  sessionDefaults
+  origin
+```
+
+Example:
+
+```json
+{
+  "version": 1,
+  "target": {
+    "targetId": "uuid",
+    "targetKind": "ssh",
+    "executionRoute": "cloud_worker"
+  },
+  "repo": {
+    "provider": "github",
+    "owner": "proliferate-ai",
+    "name": "proliferate",
+    "baseBranch": "main"
+  },
+  "workspacePolicy": {
+    "kind": "new_worktree"
+  },
+  "gitIdentity": {
+    "kind": "target_bootstrap"
+  },
+  "credentialSource": {
+    "kind": "user_synced"
+  },
+  "mcp": {
+    "connectionIds": []
+  },
+  "skills": {
+    "bundleRefs": []
+  },
+  "materialization": {
+    "includeAgentCredentials": true,
+    "includeGitCredentials": false
+  },
+  "sessionDefaults": {
+    "agentKind": "claude",
+    "modelId": null,
+    "modeId": null,
+    "reasoningEffort": null
+  },
+  "origin": {
+    "source": "automation"
+  }
+}
+```
+
+### Persistence
+
+Add:
+
+```text
+Automation.launch_config_json
+AutomationRun.launch_config_snapshot_json
+```
+
+Keep existing columns:
+
+```text
+execution_target
+cloud_target_id
+cloud_target_kind_snapshot
+git_owner
+git_repo_name
+agent_kind
+model_id
+mode_id
+reasoning_effort
+```
+
+Reason:
+
+```text
+Existing columns remain stable/queryable and preserve backwards compatibility.
+launch_config_json carries new launch semantics without excessive migrations.
+```
+
+## Desktop / Client Follow-Up
+
+This spec does not fully define Desktop UX, but it does define the required
+client-facing shape.
+
+Current Desktop automation target selection:
+
+```text
+desktop/src/lib/domain/automations/target/selection.ts
+  executionTarget: cloud | local
+  gitOwner
+  gitRepoName
+```
+
+Required next shape:
+
+```text
+AutomationTargetSelection
+  targetId
+  targetKind
+  executionRoute
+  gitOwner
+  gitRepoName
+```
+
+Likely files:
+
+```text
+desktop/src/lib/domain/automations/target/selection.ts
+desktop/src/lib/domain/automations/target/records.ts
+desktop/src/hooks/automations/derived/use-automation-target-selection.ts
+desktop/src/components/automations/controls/AutomationTargetPicker.tsx
+desktop/src/components/automations/editor/AutomationEditorModal.tsx
+desktop/src/components/automations/list/AutomationDetailContent.tsx
+
+desktop/src/components/home/screen/HomeTargetPicker.tsx
+desktop/src/hooks/home/workflows/use-home-next-launch.ts
+desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
+```
+
+Required behavior:
+
+```text
+Automations and new chat use target-id-first selection.
+Managed cloud, SSH, and local/direct are shown as target choices.
+The UI explains whether a target can be opened directly or only dispatched via
+Cloud.
+```
+
+## DDD Ownership
+
+Final ownership:
+
+```text
+server/cloud/targets
+  target bootstrap, enrollment, workers, inventory, readiness, updates
+
+server/cloud/target_git_identity
+  target-level Git identity materialization
+
+server/cloud/work_launch
+  shared target/repo/workspace/materialization/session launch contract
+
+server/cloud/target_config
+  lower-level workspace/run materialization implementation
+
+server/cloud/workspaces
+  CloudWorkspace records, access, lifecycle, projections
+
+server/automations
+  automation definition, schedule, run snapshots, claim/retry/cancel
+
+server/integrations/slack
+  Slack event parsing and formatting only; maps into work_launch/commands
+
+anyharness/crates/proliferate-worker
+  command leasing, target materialization, AnyHarness API dispatch, event upload
+```
+
+Avoid:
+
+```text
+Automation code owning generic workspace preparation forever.
+Target config being treated as target bootstrap.
+Slack inventing a separate launch path.
+Mobile/web inventing separate Cloud command semantics.
+Worker choosing credentials or product policy.
+```
+
+## Acceptance Demos
+
+### Managed Cloud
+
+```text
+Create automation with managed cloud target.
+Run now.
+Cloud creates workspace/run.
+Target bootstrap is current.
+Repo/worktree is prepared.
+Environment materializes.
+Session starts.
+Prompt is accepted.
+Run shows target, workspace, session, and result state.
+```
+
+### SSH
+
+```text
+Create SSH target enrollment.
+Run installer on SSH box.
+Worker enrolls and applies target Git identity.
+Create automation with SSH target.
+Run now.
+Repo clones/fetches on SSH target.
+Worktree is created.
+AnyHarness workspace/session starts on SSH target.
+Prompt is accepted.
+Desktop can direct-open if SSH direct access is configured; otherwise it shows
+cloud-dispatch-only/open-in-web state.
+```
+
+### Local/Direct
+
+```text
+Create automation with local target.
+Local executor claims run.
+Local worktree/session flow remains compatible.
+Run record still snapshots WorkLaunchConfig shape where applicable.
+```
+
+## Implementation Order
+
+1. Fix naming/semantics in target bootstrap.
+2. Add `server.cloud.work_launch` shared command/workspace helpers.
+3. Add launch config JSON to automation definitions and runs.
+4. Route automation workspace/environment/session stages through shared
+   `work_launch` helpers.
+5. Update SDK/OpenAPI for launch config fields.
+6. Update Desktop automation target selection to target-id-first.
+7. Reuse the same model for new chat, then web/mobile, then Slack.
+
+## Open Follow-Up Questions
+
+- Should `target_config` be renamed in code later, or remain as a compatibility
+  implementation name behind `work_launch`?
+- Which MCP bundle selector data exists today for Desktop automation creation?
+- Should skills remain refs-only in V1 or materialize actual files immediately?
+- Which launch config fields must become first-class DB columns for querying
+  before web/mobile launch?
+- Should managed cloud direct Git provisioning be removed immediately or kept as
+  compatibility until all managed cloud launches go through worker bootstrap?


### PR DESCRIPTION
## Summary
- cap initial inline diff expansion and fetch concurrency for Git, transcript, and file diff surfaces
- add boot-stall diagnostics with bounded fetch/layout/performance summaries and a WebKit performance.measure detail guard
- add cloud launch architecture docs and include the generated/lockfile ordering updates currently in the worktree

## Validation
- pnpm --dir desktop exec tsc --noEmit
- python3 scripts/check_frontend_boundaries.py
- pnpm --dir desktop exec vitest run src/components/ui/DebugProfiler.test.tsx src/components/workspace/git/GitPanel.test.tsx src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx src/lib/domain/workspaces/changes/diff-display-policy.test.ts