### PR TITLE
fix(desktop): clean up Git diffs and file search

### DIFF
--- a/desktop/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
+++ b/desktop/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
@@ -11,6 +11,9 @@ describe("PlaygroundSidebarGitDiff", () => {
     expect(html).toContain("data-diff-surface=\"sidebar\"");
     expect(html).toContain("data-diff=\"\"");
     expect(html).toContain("composer-diff-simple-line");
+    expect(html).toContain("px-2 pb-2");
+    expect(html).toContain("pt-2");
+    expect(html).not.toContain("px-2 py-2");
     expect(html).toContain("Binary file changed");
     expect(html).toContain("Diff truncated");
     expect(html).toContain("Working tree clean");

--- a/desktop/src/components/playground/PlaygroundSidebarGitDiff.tsx
+++ b/desktop/src/components/playground/PlaygroundSidebarGitDiff.tsx
@@ -31,33 +31,35 @@ export function PlaygroundSidebarGitDiff() {
       <div className="shrink-0 border-b border-sidebar-border/70 px-3 py-2">
         <p className="text-xs text-sidebar-muted-foreground">Git diff sidebar</p>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-2 py-2">
-        {PLAYGROUND_SIDEBAR_GIT_DIFF_SECTIONS.map((section) => {
-          const files = PLAYGROUND_SIDEBAR_GIT_DIFF_FILES.filter(
-            (file) => file.section === section,
-          );
-          return (
-            <section key={section} className="flex flex-col gap-2">
-              <h2 className="px-1 text-xs font-medium text-sidebar-muted-foreground">
-                {section}
-              </h2>
-              {files.length > 0 ? (
-                files.map((file) => (
-                  <PlaygroundSidebarGitDiffCard
-                    key={file.key}
-                    file={file}
-                    isExpanded={expandedKeys.has(file.key)}
-                    onToggle={() => toggleExpanded(file.key)}
-                  />
-                ))
-              ) : (
-                <p className="rounded-lg bg-sidebar-accent px-3 py-4 text-center text-xs text-sidebar-muted-foreground">
-                  Working tree clean
-                </p>
-              )}
-            </section>
-          );
-        })}
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
+        <div className="flex flex-col gap-3 pt-2">
+          {PLAYGROUND_SIDEBAR_GIT_DIFF_SECTIONS.map((section) => {
+            const files = PLAYGROUND_SIDEBAR_GIT_DIFF_FILES.filter(
+              (file) => file.section === section,
+            );
+            return (
+              <section key={section} className="flex flex-col gap-2">
+                <h2 className="px-1 text-xs font-medium text-sidebar-muted-foreground">
+                  {section}
+                </h2>
+                {files.length > 0 ? (
+                  files.map((file) => (
+                    <PlaygroundSidebarGitDiffCard
+                      key={file.key}
+                      file={file}
+                      isExpanded={expandedKeys.has(file.key)}
+                      onToggle={() => toggleExpanded(file.key)}
+                    />
+                  ))
+                ) : (
+                  <p className="rounded-lg bg-sidebar-accent px-3 py-4 text-center text-xs text-sidebar-muted-foreground">
+                    Working tree clean
+                  </p>
+                )}
+              </section>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/desktop/src/components/ui/content/DiffViewer.test.tsx
+++ b/desktop/src/components/ui/content/DiffViewer.test.tsx
@@ -44,7 +44,7 @@ describe("DiffViewer chat variant", () => {
     expect(html).toContain(
       "--diffs-column-number-width:max(24px, 5ch)",
     );
-    expect(html).toContain("diff-content-cell relative flex");
+    expect(html).toContain("diff-content-cell relative min-h");
     expect(html).not.toContain("thread-diff-virtualized");
   });
 
@@ -57,20 +57,40 @@ describe("DiffViewer chat variant", () => {
       }),
     );
 
-    expect(html).toContain("overflow-x-auto overflow-y-auto");
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("overflow-x-auto");
     expect(html).toContain("sticky left-0 z-10");
     expect(html).toContain("min-w-max");
     expect(html).toContain("whitespace-pre");
     expect(html).not.toContain("overflow-clip");
   });
 
-  it("can allow nested diff scroll views to chain wheel scrolling", () => {
+  it("wraps chat diff lines as inline text instead of flex items", () => {
+    const html = renderToStaticMarkup(
+      createElement(DiffViewer, {
+        patch: LONG_LINE_PATCH,
+        filePath: "src/long.ts",
+        variant: "chat",
+        wrapLongLines: true,
+      }),
+    );
+
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("overflow-x-hidden");
+    expect(html).toContain("diff-content-cell relative min-h");
+    expect(html).toContain("block min-w-0 whitespace-pre-wrap break-words");
+    expect(html).not.toContain("diff-content-cell relative flex");
+  });
+
+  it("clamps native overscroll on git diff viewers", () => {
     const chatHtml = renderToStaticMarkup(
       createElement(DiffViewer, {
         patch: PATCH,
         filePath: "src/example.ts",
         variant: "chat",
-        overscrollBehavior: "auto",
+        overscrollBehaviorX: "none",
+        overscrollBehaviorY: "none",
+        chainVerticalWheel: true,
       }),
     );
     const splitHtml = renderToStaticMarkup(
@@ -78,11 +98,30 @@ describe("DiffViewer chat variant", () => {
         patch: PATCH,
         filePath: "src/example.ts",
         layout: "split",
-        overscrollBehavior: "auto",
+        overscrollBehaviorX: "none",
+        overscrollBehaviorY: "none",
+        chainVerticalWheel: true,
       }),
     );
 
-    expect(chatHtml).toContain("overscroll-behavior:auto");
-    expect(splitHtml).toContain("overscroll-behavior:auto");
+    expect(chatHtml).toContain("overscroll-behavior:none");
+    expect(chatHtml).toContain("overscroll-behavior-x:none");
+    expect(chatHtml).toContain("overscroll-behavior-y:none");
+    expect(splitHtml).toContain("overscroll-behavior:none");
+    expect(splitHtml).toContain("overscroll-behavior-x:none");
+    expect(splitHtml).toContain("overscroll-behavior-y:none");
+  });
+
+  it("keeps diff viewer overscroll non-chaining by default", () => {
+    const html = renderToStaticMarkup(
+      createElement(DiffViewer, {
+        patch: PATCH,
+        filePath: "src/example.ts",
+        variant: "chat",
+      }),
+    );
+
+    expect(html).toContain("overscroll-behavior:none");
+    expect(html).not.toContain("overscroll-behavior-y:");
   });
 });

--- a/desktop/src/components/ui/content/DiffViewer.tsx
+++ b/desktop/src/components/ui/content/DiffViewer.tsx
@@ -16,6 +16,9 @@ interface DiffViewerProps {
   layout?: "unified" | "split";
   operationId?: MeasurementOperationId | null;
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
+  overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
+  overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
+  chainVerticalWheel?: boolean;
 }
 
 const ROOT_CLASS =
@@ -31,6 +34,9 @@ export function DiffViewer({
   layout = "unified",
   operationId,
   overscrollBehavior,
+  overscrollBehaviorX,
+  overscrollBehaviorY,
+  chainVerticalWheel,
 }: DiffViewerProps) {
   const { parsed, tokens } = useDiffHighlight(patch, filePath, operationId);
 
@@ -44,6 +50,9 @@ export function DiffViewer({
           viewportClassName={viewportClassName}
           wrapLongLines={wrapLongLines}
           overscrollBehavior={overscrollBehavior}
+          overscrollBehaviorX={overscrollBehaviorX}
+          overscrollBehaviorY={overscrollBehaviorY}
+          chainVerticalWheel={chainVerticalWheel}
         />
       </DebugProfiler>
     );
@@ -60,6 +69,9 @@ export function DiffViewer({
           className={rootClass}
           viewportClassName={viewportClassName}
           overscrollBehavior={overscrollBehavior}
+          overscrollBehaviorX={overscrollBehaviorX}
+          overscrollBehaviorY={overscrollBehaviorY}
+          chainVerticalWheel={chainVerticalWheel}
         />
       </DebugProfiler>
     );
@@ -75,6 +87,9 @@ export function DiffViewer({
         wrapLongLines={wrapLongLines}
         variant={variant}
         overscrollBehavior={overscrollBehavior}
+        overscrollBehaviorX={overscrollBehaviorX}
+        overscrollBehaviorY={overscrollBehaviorY}
+        chainVerticalWheel={chainVerticalWheel}
       />
     </DebugProfiler>
   );

--- a/desktop/src/components/ui/content/FileDiffCard.test.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.test.tsx
@@ -72,4 +72,21 @@ describe("FileChangesCard and FileDiffCard", () => {
 
     expect(html).toContain(">.../ui/content/FileDiffCard.tsx</span>");
   });
+
+  it("renders fallback metadata for zero-stat sidebar rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(FileDiffCard, {
+        filePath: "new-file.ts",
+        additions: 0,
+        deletions: 0,
+        isExpanded: false,
+        onToggleExpand: () => {},
+        metadata: createElement("span", { "aria-label": "Added" }, "A"),
+        surface: "sidebar",
+      }),
+    );
+
+    expect(html).toContain("aria-label=\"Added\"");
+    expect(html).toContain(">A</span>");
+  });
 });

--- a/desktop/src/components/ui/content/FileDiffCard.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.tsx
@@ -191,6 +191,7 @@ interface FileDiffCardProps {
   openActionTitle?: string;
   actions?: ReactNode;
   children?: ReactNode;
+  metadata?: ReactNode;
   embedded?: boolean;
   collapsible?: boolean;
   surface?: "chat" | "sidebar";
@@ -208,6 +209,7 @@ export function FileDiffCard({
   openActionTitle,
   actions,
   children,
+  metadata,
   embedded = false,
   collapsible = true,
   surface = "chat",
@@ -310,6 +312,7 @@ export function FileDiffCard({
                   deletions={deletions}
                   className="leading-none"
                 />
+                {!additions && !deletions && metadata}
                 {handleOpenAction && (
                   <div className="shrink-0 opacity-0 transition-opacity duration-200 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100">
                     <Button

--- a/desktop/src/components/ui/content/diff/ChatDiffViewer.tsx
+++ b/desktop/src/components/ui/content/diff/ChatDiffViewer.tsx
@@ -1,6 +1,13 @@
-import { Fragment, useMemo, useState, type CSSProperties } from "react";
+import {
+  Fragment,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
 import { DiffLineContent } from "@/components/ui/content/diff/DiffLineContent";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
+import { chainVerticalWheelScroll } from "@/lib/infra/dom/scroll-chain";
 import type {
   CollapsedContext,
   DiffLine,
@@ -131,10 +138,10 @@ function ChatContentCell({
       data-alt-line={altLineNumber}
       data-line-type={lineType}
       data-line-index={getChatLineIndex(line)}
-      className={`diff-content-cell relative flex min-h-[var(--diffs-line-height)] items-center pr-3 pl-2 ${
+      className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
         wrapLongLines
-          ? "min-w-0 whitespace-pre-wrap break-words"
-          : "min-w-max whitespace-pre"
+          ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
+          : "flex min-w-max items-center whitespace-pre"
       }`}
     >
       <DiffLineContent line={line} tokens={tokens} />
@@ -175,6 +182,9 @@ export function ChatDiffViewer({
   viewportClassName,
   wrapLongLines,
   overscrollBehavior = "none",
+  overscrollBehaviorX,
+  overscrollBehaviorY,
+  chainVerticalWheel = false,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -182,6 +192,9 @@ export function ChatDiffViewer({
   viewportClassName?: string;
   wrapLongLines: boolean;
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
+  overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
+  overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
+  chainVerticalWheel?: boolean;
 }) {
   const resolvedMode = useResolvedMode();
   const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
@@ -199,6 +212,14 @@ export function ChatDiffViewer({
     }) as CSSProperties,
     [lineNumberDigits],
   );
+  const viewportStyle = useMemo(
+    () => ({
+      overscrollBehavior,
+      ...(overscrollBehaviorX ? { overscrollBehaviorX } : {}),
+      ...(overscrollBehaviorY ? { overscrollBehaviorY } : {}),
+    }) as CSSProperties,
+    [overscrollBehavior, overscrollBehaviorX, overscrollBehaviorY],
+  );
 
   const expandCollapsedRow = (key: string) => {
     setExpandedCollapsedKeys((prev) => {
@@ -207,12 +228,23 @@ export function ChatDiffViewer({
       return next;
     });
   };
+  const handleViewportWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    if (!chainVerticalWheel) {
+      return;
+    }
+    if (chainVerticalWheelScroll(event.currentTarget, event.deltaY)) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <div className={className ?? ""}>
       <div
-        style={{ overscrollBehavior }}
-        className={`relative [contain:content] composer-diff-simple-line overflow-x-auto overflow-y-auto ${
+        style={viewportStyle}
+        onWheel={handleViewportWheel}
+        className={`relative [contain:content] composer-diff-simple-line overflow-y-auto ${
+          wrapLongLines ? "overflow-x-hidden" : "overflow-x-auto"
+        } ${
           viewportClassName ?? ""
         }`}
       >

--- a/desktop/src/components/ui/content/diff/SplitDiffViewer.tsx
+++ b/desktop/src/components/ui/content/diff/SplitDiffViewer.tsx
@@ -57,12 +57,18 @@ export function SplitDiffViewer({
   className,
   viewportClassName,
   overscrollBehavior,
+  overscrollBehaviorX,
+  overscrollBehaviorY,
+  chainVerticalWheel,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
   className?: string;
   viewportClassName?: string;
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
+  overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
+  overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
+  chainVerticalWheel?: boolean;
 }) {
   const rows: SplitDiffRow[] = [];
   parsed.hunks.forEach((hunk, hunkIndex) => {
@@ -89,9 +95,13 @@ export function SplitDiffViewer({
   return (
     <AutoHideScrollArea
       className={`font-mono text-[length:var(--readable-code-font-size)] leading-[var(--readable-code-line-height)] ${className ?? ""}`}
-      viewportClassName={viewportClassName}
+      viewportClassName={`bg-[var(--codex-diffs-surface)] ${viewportClassName ?? ""}`}
+      contentClassName="min-h-full bg-[var(--codex-diffs-surface)]"
       allowHorizontal={false}
       overscrollBehavior={overscrollBehavior}
+      overscrollBehaviorX={overscrollBehaviorX}
+      overscrollBehaviorY={overscrollBehaviorY}
+      chainVerticalWheel={chainVerticalWheel}
     >
       <div className="grid min-w-0 grid-cols-2">
         {rows.map((row) =>

--- a/desktop/src/components/ui/content/diff/UnifiedDiffViewer.tsx
+++ b/desktop/src/components/ui/content/diff/UnifiedDiffViewer.tsx
@@ -155,6 +155,9 @@ export function UnifiedDiffViewer({
   wrapLongLines,
   variant,
   overscrollBehavior,
+  overscrollBehaviorX,
+  overscrollBehaviorY,
+  chainVerticalWheel,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -163,14 +166,22 @@ export function UnifiedDiffViewer({
   wrapLongLines: boolean;
   variant: "default" | "chat";
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
+  overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
+  overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
+  chainVerticalWheel?: boolean;
 }) {
   return (
     <AutoHideScrollArea
       className={className}
-      viewportClassName={viewportClassName}
-      contentClassName={wrapLongLines ? "" : "min-w-max"}
+      viewportClassName={`bg-[var(--codex-diffs-surface)] ${viewportClassName ?? ""}`}
+      contentClassName={`min-h-full bg-[var(--codex-diffs-surface)] ${
+        wrapLongLines ? "" : "min-w-max"
+      }`}
       allowHorizontal={!wrapLongLines}
       overscrollBehavior={overscrollBehavior}
+      overscrollBehaviorX={overscrollBehaviorX}
+      overscrollBehaviorY={overscrollBehaviorY}
+      chainVerticalWheel={chainVerticalWheel}
     >
       {parsed.hunks.map((hunk, index) => (
         <HunkView

--- a/desktop/src/components/ui/layout/AutoHideScrollArea.tsx
+++ b/desktop/src/components/ui/layout/AutoHideScrollArea.tsx
@@ -7,7 +7,9 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type WheelEvent as ReactWheelEvent,
 } from "react";
+import { chainVerticalWheelScroll } from "@/lib/infra/dom/scroll-chain";
 
 interface AutoHideScrollAreaProps {
   children: ReactNode;
@@ -16,6 +18,9 @@ interface AutoHideScrollAreaProps {
   contentClassName?: string;
   allowHorizontal?: boolean;
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
+  overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
+  overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
+  chainVerticalWheel?: boolean;
   onViewportScroll?: (viewport: HTMLDivElement) => void;
 }
 
@@ -43,6 +48,9 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       contentClassName = "",
       allowHorizontal = false,
       overscrollBehavior = "none",
+      overscrollBehaviorX,
+      overscrollBehaviorY,
+      chainVerticalWheel = false,
       onViewportScroll,
     },
     ref,
@@ -201,12 +209,26 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       event.preventDefault();
       event.stopPropagation();
     };
+    const viewportStyle = {
+      overscrollBehavior,
+      ...(overscrollBehaviorX ? { overscrollBehaviorX } : {}),
+      ...(overscrollBehaviorY ? { overscrollBehaviorY } : {}),
+    } as CSSProperties;
+    const handleViewportWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+      if (!chainVerticalWheel) {
+        return;
+      }
+      if (chainVerticalWheelScroll(event.currentTarget, event.deltaY)) {
+        event.preventDefault();
+      }
+    };
 
     return (
       <div className={`relative min-h-0 overflow-hidden ${className}`}>
         <div
           ref={viewportRef}
-          style={{ overscrollBehavior }}
+          style={viewportStyle}
+          onWheel={handleViewportWheel}
           className={`h-full w-full ${
             allowHorizontal
               ? "overflow-auto"

--- a/desktop/src/components/workspace/files/FileEditorView.test.tsx
+++ b/desktop/src/components/workspace/files/FileEditorView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { createElement } from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fileViewerTarget,
@@ -15,6 +15,13 @@ const readWorkspaceFileQuery = vi.fn();
 const gitDiffQuery = vi.fn();
 const workspaceFilesQuery = vi.fn();
 const searchWorkspaceFilesQuery = vi.fn();
+const openFileMock = vi.fn();
+const getWorkspaceRuntimeBlockReasonMock = vi.fn();
+let workspaceFileContext = {
+  workspaceUiKey: "workspace-1",
+  materializedWorkspaceId: "workspace-1",
+  treeStateKey: "workspace-1",
+};
 
 vi.mock("@/components/ui/content/DiffViewer", () => ({
   DiffViewer: () => createElement("div", null, "diff rendered"),
@@ -48,18 +55,20 @@ vi.mock("@/hooks/workspaces/files/use-file-reference-actions", () => ({
 }));
 
 vi.mock("@/hooks/workspaces/files/derived/use-workspace-file-context", () => ({
-  useWorkspaceFileContext: () => ({
-    workspaceUiKey: "workspace-1",
-    materializedWorkspaceId: "workspace-1",
-    treeStateKey: "workspace-1",
-  }),
+  useWorkspaceFileContext: () => workspaceFileContext,
 }));
 
 vi.mock("@/hooks/workspaces/files/workflows/use-workspace-file-target-actions", () => ({
   useWorkspaceFileTargetActions: () => ({
-    openFile: vi.fn(),
+    openFile: openFileMock,
     openFileDiff: vi.fn(),
     openViewerTarget: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: getWorkspaceRuntimeBlockReasonMock,
   }),
 }));
 
@@ -73,6 +82,7 @@ vi.mock("@anyharness/sdk-react", () => ({
 describe("FileEditorView", () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -93,6 +103,14 @@ describe("FileEditorView", () => {
     gitDiffQuery.mockReset();
     workspaceFilesQuery.mockReset();
     searchWorkspaceFilesQuery.mockReset();
+    openFileMock.mockReset();
+    getWorkspaceRuntimeBlockReasonMock.mockReset();
+    getWorkspaceRuntimeBlockReasonMock.mockReturnValue(null);
+    workspaceFileContext = {
+      workspaceUiKey: "workspace-1",
+      materializedWorkspaceId: "workspace-1",
+      treeStateKey: "workspace-1",
+    };
     readWorkspaceFileQuery.mockReturnValue({
       data: undefined,
       error: new Error("not found"),
@@ -197,7 +215,7 @@ describe("FileEditorView", () => {
     expect(container.querySelector("[data-file-source-view]")?.getAttribute("data-word-wrap"))
       .toBe("false");
     expect(container.querySelector("[data-file-source-virtualized]")).toBeTruthy();
-    expect(container.querySelector(".file-source-gutter-rail")).toBeTruthy();
+    expect(container.querySelector(".file-source-line-number")?.textContent).toBe("1");
     expect(container.querySelector(".file-source-scroll")).toBeTruthy();
     fireEvent.click(screen.getByLabelText("File viewer options"));
     expect(screen.getByText("Enable word wrap")).toBeTruthy();
@@ -232,7 +250,6 @@ describe("FileEditorView", () => {
     }));
 
     expect(screen.getByText("unique first line")).toBeTruthy();
-    expect(container.querySelector(".file-source-gutter-rail")).toBeTruthy();
     expect(container.querySelectorAll("[data-source-line]").length).toBeLessThan(lines.length);
   });
 
@@ -278,5 +295,103 @@ describe("FileEditorView", () => {
       limit: 60,
       enabled: false,
     });
+  });
+
+  it("searches workspace files from the file viewer and opens a selected result", () => {
+    vi.useFakeTimers();
+    const target = fileViewerTarget("package.json");
+    const targetKey = viewerTargetKey(target);
+    useWorkspaceViewerTabsStore.setState({
+      materializedWorkspaceId: "workspace-1",
+    });
+    useWorkspaceViewerTabsStore.getState().openTarget(target);
+    readWorkspaceFileQuery.mockReturnValue({
+      data: {
+        content: "{\"ok\":true}",
+        isText: true,
+        path: "package.json",
+        sizeBytes: 11,
+        tooLarge: false,
+        versionToken: "v1",
+      },
+      error: null,
+      isLoading: false,
+    });
+    searchWorkspaceFilesQuery.mockReturnValue({
+      data: {
+        results: [
+          { name: "README.md", path: "docs/README.md" },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(createElement(FileEditorView, {
+      filePath: "package.json",
+      targetKey,
+    }));
+
+    fireEvent.click(screen.getByLabelText("Search files"));
+    const input = screen.getByPlaceholderText("Search workspace files...");
+    fireEvent.change(input, { target: { value: "readme" } });
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    const result = screen.getByText("README.md");
+    fireEvent.click(result);
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(openFileMock).toHaveBeenCalledWith("docs/README.md");
+    expect(screen.queryByRole("dialog", { name: "Search workspace files" })).toBeNull();
+    expect(searchWorkspaceFilesQuery).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      query: "readme",
+      limit: 80,
+      enabled: true,
+    });
+  });
+
+  it("shows runtime-blocked state in file search without enabling search", () => {
+    vi.useFakeTimers();
+    getWorkspaceRuntimeBlockReasonMock.mockReturnValue("Cloud workspace is reconnecting.");
+    const target = fileViewerTarget("package.json");
+    const targetKey = viewerTargetKey(target);
+    useWorkspaceViewerTabsStore.setState({
+      materializedWorkspaceId: "workspace-1",
+    });
+    useWorkspaceViewerTabsStore.getState().openTarget(target);
+    readWorkspaceFileQuery.mockReturnValue({
+      data: {
+        content: "{\"ok\":true}",
+        isText: true,
+        path: "package.json",
+        sizeBytes: 11,
+        tooLarge: false,
+        versionToken: "v1",
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    render(createElement(FileEditorView, {
+      filePath: "package.json",
+      targetKey,
+    }));
+
+    fireEvent.click(screen.getByLabelText("Search files"));
+    expect(screen.getByText("Cloud workspace is reconnecting.")).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText("Search workspace files..."), {
+      target: { value: "readme" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(searchWorkspaceFilesQuery.mock.calls.some(([options]) => options?.enabled === true))
+      .toBe(false);
   });
 });

--- a/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -8,11 +8,13 @@ import { FileViewerContent } from "./FileViewerContent";
 import { LoadingState } from "@/components/feedback/LoadingIllustration";
 import { useReadWorkspaceFileQuery } from "@anyharness/sdk-react";
 import { CenterMessage } from "@/components/workspace/files/viewer/CenterMessage";
+import { WorkspaceFileSearchModal } from "@/components/workspace/files/search/WorkspaceFileSearchModal";
 import { FileViewerFrame } from "@/components/workspace/files/viewer/FileViewerFrame";
 import { WorkspaceFileBrowserOverlay } from "@/components/workspace/files/viewer/WorkspaceFileBrowserOverlay";
 import { useFileReferenceActions } from "@/hooks/workspaces/files/use-file-reference-actions";
 import { useWorkspaceFileContext } from "@/hooks/workspaces/files/derived/use-workspace-file-context";
 import { useWorkspaceFileTargetActions } from "@/hooks/workspaces/files/workflows/use-workspace-file-target-actions";
+import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
 import { canPreviewAsRichFile } from "@/lib/domain/files/document-preview";
 import type { FileDiffTarget } from "@/lib/domain/workspaces/viewer/file-diff-options";
 import {
@@ -31,6 +33,8 @@ interface FileEditorViewProps {
 export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorViewProps) {
   const fileContext = useWorkspaceFileContext();
   const materializedWorkspaceId = fileContext.materializedWorkspaceId;
+  const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
+  const runtimeBlockedReason = getWorkspaceRuntimeBlockReason(materializedWorkspaceId);
   const rawMode = useWorkspaceViewerTabsStore(
     (s) => s.modeByTargetKey[targetKey] ?? defaultFileViewerMode(filePath),
   );
@@ -45,6 +49,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
   const parentPath = useMemo(() => parentDirectoryPath(filePath), [filePath]);
   const [browserOpen, setBrowserOpen] = useState(false);
   const [browserPath, setBrowserPath] = useState(parentPath);
+  const [fileSearchOpen, setFileSearchOpen] = useState(false);
   const activeDiffTarget = diffTarget ?? null;
   const effectiveMode = activeDiffTarget
     ? "diff"
@@ -97,7 +102,18 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
   const closeBrowser = () => {
     setBrowserOpen(false);
   };
+  const openFileSearch = () => {
+    setFileSearchOpen(true);
+  };
+  const closeFileSearch = () => {
+    setFileSearchOpen(false);
+  };
   const openBrowserFile = (path: string) => {
+    setBrowserOpen(false);
+    void openFile(path);
+  };
+  const openSearchFile = (path: string) => {
+    setFileSearchOpen(false);
     setBrowserOpen(false);
     void openFile(path);
   };
@@ -114,6 +130,13 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         onPathPrefixChange={setBrowserPath}
         onOpenFile={openBrowserFile}
         onClose={closeBrowser}
+      />
+      <WorkspaceFileSearchModal
+        open={fileSearchOpen}
+        workspaceId={materializedWorkspaceId}
+        runtimeBlockedReason={runtimeBlockedReason}
+        onClose={closeFileSearch}
+        onOpenFile={openSearchFile}
       />
     </div>
   );
@@ -133,6 +156,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         onOpenExternal={openExternal}
         browserOpen={browserOpen}
         onToggleBrowser={toggleBrowser}
+        onOpenSearch={openFileSearch}
         onBrowsePath={browsePath}
       >
         {renderPaneContent(
@@ -157,6 +181,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         onOpenExternal={openExternal}
         browserOpen={browserOpen}
         onToggleBrowser={toggleBrowser}
+        onOpenSearch={openFileSearch}
         onBrowsePath={browsePath}
       >
         {renderPaneContent(
@@ -182,6 +207,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       onOpenExternal={openExternal}
       browserOpen={browserOpen}
       onToggleBrowser={toggleBrowser}
+      onOpenSearch={openFileSearch}
       onBrowsePath={browsePath}
     >
       {renderPaneContent(

--- a/desktop/src/components/workspace/files/search/WorkspaceFileSearchModal.test.tsx
+++ b/desktop/src/components/workspace/files/search/WorkspaceFileSearchModal.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceFileSearchModal } from "./WorkspaceFileSearchModal";
+
+const useWorkspaceFileSearchMock = vi.fn();
+
+vi.mock("@/hooks/workspaces/files/ui/use-workspace-file-search", () => ({
+  useWorkspaceFileSearch: (options: unknown) => useWorkspaceFileSearchMock(options),
+}));
+
+describe("WorkspaceFileSearchModal", () => {
+  beforeEach(() => {
+    class TestResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    useWorkspaceFileSearchMock.mockReset();
+    useWorkspaceFileSearchMock.mockReturnValue({
+      query: "",
+      debouncedQuery: "",
+      searchEnabled: false,
+      isLoading: false,
+      isError: false,
+      results: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows unavailable state when no workspace is selected", () => {
+    render(
+      <WorkspaceFileSearchModal
+        open
+        workspaceId={null}
+        runtimeBlockedReason={null}
+        onClose={vi.fn()}
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog", { name: "Search workspace files" })).toBeTruthy();
+    expect(screen.getByText("Workspace is still opening.")).toBeTruthy();
+  });
+
+  it("opens selected search results and closes without restoring focus", () => {
+    const onClose = vi.fn();
+    const onOpenFile = vi.fn();
+    useWorkspaceFileSearchMock.mockReturnValue({
+      query: "app",
+      debouncedQuery: "app",
+      searchEnabled: true,
+      isLoading: false,
+      isError: false,
+      results: [
+        { name: "App.tsx", path: "src/App.tsx" },
+      ],
+    });
+
+    render(
+      <WorkspaceFileSearchModal
+        open
+        workspaceId="workspace-1"
+        runtimeBlockedReason={null}
+        onClose={onClose}
+        onOpenFile={onOpenFile}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("App.tsx"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpenFile).toHaveBeenCalledWith("src/App.tsx");
+  });
+
+  it("shows search error state", () => {
+    useWorkspaceFileSearchMock.mockReturnValue({
+      query: "app",
+      debouncedQuery: "app",
+      searchEnabled: true,
+      isLoading: false,
+      isError: true,
+      results: [],
+    });
+
+    render(
+      <WorkspaceFileSearchModal
+        open
+        workspaceId="workspace-1"
+        runtimeBlockedReason={null}
+        onClose={vi.fn()}
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("No files found")).toBeNull();
+    expect(screen.getByText("Failed to search files.")).toBeTruthy();
+  });
+});

--- a/desktop/src/components/workspace/files/search/WorkspaceFileSearchModal.tsx
+++ b/desktop/src/components/workspace/files/search/WorkspaceFileSearchModal.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import {
+  CommandPaletteGroup,
+  CommandPaletteInput,
+  CommandPaletteItem,
+  CommandPaletteList,
+  CommandPaletteRoot,
+  useCommandPaletteClose,
+} from "@/components/ui/CommandPalette";
+import { CommandPaletteGlyph } from "@/components/ui/command-palette-icons";
+import { FileTreeEntryIcon } from "@/components/ui/file-icons";
+import { useWorkspaceFileSearch } from "@/hooks/workspaces/files/ui/use-workspace-file-search";
+import { splitFilePath } from "@/lib/domain/command-palette/entries";
+
+interface WorkspaceFileSearchModalProps {
+  open: boolean;
+  workspaceId: string | null;
+  runtimeBlockedReason: string | null;
+  onClose: () => void;
+  onOpenFile: (path: string) => void;
+}
+
+export function WorkspaceFileSearchModal({
+  open,
+  workspaceId,
+  runtimeBlockedReason,
+  onClose,
+  onOpenFile,
+}: WorkspaceFileSearchModalProps) {
+  const [query, setQuery] = useState("");
+  const runtimeReady = Boolean(workspaceId) && runtimeBlockedReason === null;
+  const search = useWorkspaceFileSearch({
+    open,
+    workspaceId,
+    runtimeReady,
+    query,
+    limit: 80,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+    }
+  }, [open]);
+
+  const disabledMessage = workspaceId
+    ? runtimeReady
+      ? null
+      : runtimeBlockedReason ?? "Workspace runtime is not ready yet."
+    : "Workspace is still opening.";
+  const hasQuery = search.query.length > 0;
+  const hasResults = search.results.length > 0;
+  const showLoading = hasQuery && (search.isLoading || search.debouncedQuery.length === 0);
+  const showEmpty = hasQuery
+    && search.debouncedQuery.length > 0
+    && !search.isLoading
+    && !search.isError
+    && !hasResults;
+
+  return (
+    <CommandPaletteRoot
+      open={open}
+      onClose={onClose}
+      label="Search workspace files"
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <div className="flex h-11 shrink-0 items-center border-b border-border/70 px-3">
+        <CommandPaletteGlyph
+          name="search"
+          className="mr-1 size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <CommandPaletteInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Search workspace files..."
+          className="px-0"
+        />
+      </div>
+      <CommandPaletteList>
+        {disabledMessage ? (
+          <WorkspaceFileSearchMessage>{disabledMessage}</WorkspaceFileSearchMessage>
+        ) : !hasQuery ? (
+          <WorkspaceFileSearchMessage>Type to search workspace files.</WorkspaceFileSearchMessage>
+        ) : hasResults ? (
+          <CommandPaletteGroup heading="Files">
+            {search.results.map((result) => (
+              <WorkspaceFileSearchRow
+                key={result.path}
+                path={result.path}
+                name={result.name}
+                onOpenFile={onOpenFile}
+              />
+            ))}
+          </CommandPaletteGroup>
+        ) : showLoading ? (
+          <WorkspaceFileSearchMessage>Searching files</WorkspaceFileSearchMessage>
+        ) : showEmpty ? (
+          <WorkspaceFileSearchMessage>No files found</WorkspaceFileSearchMessage>
+        ) : null}
+        {search.isError && (
+          <WorkspaceFileSearchMessage>Failed to search files.</WorkspaceFileSearchMessage>
+        )}
+      </CommandPaletteList>
+    </CommandPaletteRoot>
+  );
+}
+
+function WorkspaceFileSearchRow({
+  path,
+  name,
+  onOpenFile,
+}: {
+  path: string;
+  name: string;
+  onOpenFile: (path: string) => void;
+}) {
+  const close = useCommandPaletteClose();
+  const display = splitFilePath(path);
+  const label = name || display.name;
+
+  return (
+    <CommandPaletteItem
+      value={path}
+      onSelect={() => {
+        close({ restoreFocus: false });
+        window.requestAnimationFrame(() => onOpenFile(path));
+      }}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+        <FileTreeEntryIcon
+          name={label}
+          path={path}
+          kind="file"
+          className="size-4"
+        />
+      </span>
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="truncate">{label}</span>
+        {display.parent && (
+          <span
+            className="min-w-0 truncate text-muted-foreground"
+            title={display.parent}
+            data-telemetry-mask
+          >
+            {display.parent}
+          </span>
+        )}
+      </span>
+    </CommandPaletteItem>
+  );
+}
+
+function WorkspaceFileSearchMessage({ children }: { children: string }) {
+  return (
+    <div
+      className="px-3 py-8 text-center text-xs text-muted-foreground"
+      data-telemetry-mask
+    >
+      {children}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
+++ b/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
@@ -81,7 +81,6 @@ export function FileSourceView({
         "--file-source-line-number-gutter-width": lineNumberGutterWidth,
       } as CSSProperties}
     >
-      <div className="file-source-gutter-rail" aria-hidden="true" />
       <div
         ref={scrollRef}
         className="file-source-scroll h-full min-h-0 min-w-0 overflow-auto"

--- a/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -8,6 +8,7 @@ import {
   ExternalLink,
   FileText,
   FolderOpen,
+  Search,
   WrapText,
 } from "@/components/ui/icons";
 import {
@@ -35,6 +36,7 @@ export function FileViewerFrame({
   onOpenExternal,
   browserOpen,
   onToggleBrowser,
+  onOpenSearch,
   onBrowsePath,
   children,
 }: {
@@ -51,6 +53,7 @@ export function FileViewerFrame({
   onOpenExternal: () => void;
   browserOpen: boolean;
   onToggleBrowser: () => void;
+  onOpenSearch: () => void;
   onBrowsePath: (path: string) => void;
   children: ReactNode;
 }) {
@@ -75,6 +78,12 @@ export function FileViewerFrame({
             onClick={onOpenExternal}
           >
             <ExternalLink className="size-3.5" />
+          </PaneIconButton>
+          <PaneIconButton
+            label="Search files"
+            onClick={onOpenSearch}
+          >
+            <Search className="size-3.5" />
           </PaneIconButton>
           <PaneIconButton
             label={browserOpen ? "Hide files" : "Show files"}

--- a/desktop/src/components/workspace/git/GitPanel.test.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.test.tsx
@@ -117,6 +117,9 @@ describe("GitPanel", () => {
     expect(html).toContain("Git review options");
     expect(html).toContain("Show files");
     expect(html).toContain("data-diff-surface=\"sidebar\"");
+    expect(html).toContain("px-2 pb-2");
+    expect(html).toContain("pt-2");
+    expect(html).not.toContain("px-2 py-2");
     expect(html).not.toContain("No diff available");
     expect(html).toContain("GitPanel.tsx");
   });
@@ -148,17 +151,25 @@ describe("GitPanel", () => {
     expect(html).toContain("Refresh");
   });
 
-  it("renders last-turn touched files without stage actions when current diff is clean", () => {
+  it("renders last-turn current diffs without stage actions", () => {
+    const currentDiff = {
+      key: ":README.md:modified",
+      path: "README.md",
+      oldPath: null,
+      displayPath: "README.md",
+      status: "modified",
+      includedState: null,
+      additions: 1,
+      deletions: 0,
+      binary: false,
+    };
     mockGitPanelState.mockReturnValue(createGitPanelState({
       sections: [{
         scope: "last_turn",
         label: "Last turn",
         files: [{
-          key: "last-turn:README.md:edit",
-          path: "README.md",
-          oldPath: null,
-          displayPath: "README.md",
-          currentDiff: null,
+          ...currentDiff,
+          currentDiff,
         }],
       }],
       visibleChangedCount: 1,
@@ -168,8 +179,42 @@ describe("GitPanel", () => {
     const html = renderToStaticMarkup(createElement(GitPanel));
 
     expect(html).toContain("README.md");
-    expect(html).toContain("No current diff against base");
+    expect(html).toContain('text-right">+</span><span class="text-right">1');
     expect(html).not.toContain("Stage README.md");
+  });
+
+  it("keeps zero-stat rows expanded so empty status entries can resolve", () => {
+    const files = Array.from({ length: 4 }, (_, index) => {
+      const path = index === 3 ? "src/unknown-stat.ts" : `src/file-${index}.ts`;
+      const diff = {
+        key: `:${path}:modified`,
+        path,
+        oldPath: null,
+        displayPath: path,
+        status: "modified",
+        includedState: "excluded",
+        additions: index === 3 ? 0 : 1,
+        deletions: index === 3 ? 0 : 1,
+        binary: false,
+      };
+      return {
+        ...diff,
+        currentDiff: diff,
+      };
+    });
+    mockGitPanelState.mockReturnValue(createGitPanelState({
+      sections: [{
+        scope: "unstaged",
+        label: "Unstaged",
+        files,
+      }],
+      visibleChangedCount: files.length,
+    }));
+
+    const html = renderToStaticMarkup(createElement(GitPanel));
+
+    expect(html).toContain("src/unknown-stat.ts");
+    expect(html.match(/new line/g)).toHaveLength(4);
   });
 
   it("skips loaded changed-file rows that have no renderable diff", () => {

--- a/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.tsx
@@ -116,8 +116,16 @@ function GitPanelContent({
             deletions: currentDiff.deletions,
           })
         : null;
-      return index >= INITIAL_EXPANDED_DIFF_FILE_LIMIT
-        || Boolean(displayPolicy?.shouldAutoCollapse)
+      const hasKnownChangedLines = currentDiff
+        ? currentDiff.additions + currentDiff.deletions > 0
+        : false;
+      const shouldResolveInline = Boolean(
+        currentDiff
+        && !hasKnownChangedLines
+        && !displayPolicy?.shouldAutoCollapse,
+      );
+      return Boolean(displayPolicy?.shouldAutoCollapse)
+        || (index >= INITIAL_EXPANDED_DIFF_FILE_LIMIT && !shouldResolveInline)
         ? [entry.key]
         : [];
     });
@@ -295,7 +303,11 @@ function GitPanelContent({
       />
 
       <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
-        <AutoHideScrollArea className="h-full min-h-0 min-w-0" viewportClassName="px-2 py-2">
+        <AutoHideScrollArea
+          className="h-full min-h-0 min-w-0"
+          viewportClassName="px-2 pb-2"
+          contentClassName="pt-2"
+        >
           {isLoading && (
             <div className="space-y-2 px-2 py-4">
               <div className="h-3 w-32 animate-pulse rounded bg-sidebar-accent" />

--- a/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from "@/components/ui/Tooltip";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type {
+  GitPanelFile,
   GitPanelReviewFile,
   GitPanelReviewScope,
 } from "@/lib/domain/workspaces/changes/git-panel-diff";
@@ -142,6 +143,9 @@ export function GitReviewFileRow({
         filePath={file.displayPath}
         additions={additions}
         deletions={deletions}
+        metadata={currentDiff && additions === 0 && deletions === 0 ? (
+          <GitReviewStatusBadge status={currentDiff.status} />
+        ) : null}
         isExpanded={!collapsed}
         onToggleExpand={onToggleCollapsed}
         onOpenFile={() => void openFile(file.path)}
@@ -216,7 +220,9 @@ export function GitReviewFileRow({
                 variant={layout === "unified" ? "chat" : "default"}
                 viewportClassName="max-h-[calc(var(--diffs-line-height)*24)]"
                 operationId={measurementOperationId ?? null}
-                overscrollBehavior="auto"
+                overscrollBehaviorX="none"
+                overscrollBehaviorY="none"
+                chainVerticalWheel
               />
               {diffQuery.data?.truncated ? (
                 <p className="px-3 py-2 text-center text-xs text-sidebar-muted-foreground">
@@ -233,6 +239,66 @@ export function GitReviewFileRow({
       </FileDiffCard>
     </div>
   );
+}
+
+function GitReviewStatusBadge({ status }: { status: GitPanelFile["status"] }) {
+  const meta = fileStatusMeta(status);
+  return (
+    <span
+      className={`inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded px-1 text-[9px] font-medium leading-none ${meta.className}`}
+      title={meta.title}
+      aria-label={meta.title}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function fileStatusMeta(status: GitPanelFile["status"]): {
+  label: string;
+  title: string;
+  className: string;
+} {
+  switch (status) {
+    case "added":
+    case "untracked":
+      return {
+        label: "A",
+        title: "Added",
+        className: "bg-git-green/10 text-git-green",
+      };
+    case "deleted":
+      return {
+        label: "D",
+        title: "Deleted",
+        className: "bg-git-red/10 text-git-red",
+      };
+    case "renamed":
+      return {
+        label: "R",
+        title: "Renamed",
+        className: "bg-sidebar-accent text-sidebar-foreground",
+      };
+    case "copied":
+      return {
+        label: "C",
+        title: "Copied",
+        className: "bg-sidebar-accent text-sidebar-foreground",
+      };
+    case "conflicted":
+      return {
+        label: "!",
+        title: "Conflicted",
+        className: "bg-destructive/10 text-destructive",
+      };
+    case "modified":
+    default:
+      return {
+        label: "M",
+        title: "Modified",
+        className: "bg-sidebar-accent text-sidebar-muted-foreground",
+      };
+  }
 }
 
 function DiffDisplayPolicyPlaceholder({

--- a/desktop/src/hooks/workspaces/facade/use-workspace-command-palette.ts
+++ b/desktop/src/hooks/workspaces/facade/use-workspace-command-palette.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { SHORTCUTS } from "@/config/shortcuts";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
-import { useWorkspaceCommandPaletteFileSearch } from "@/hooks/workspaces/ui/use-workspace-command-palette-file-search";
+import { useWorkspaceFileSearch } from "@/hooks/workspaces/files/ui/use-workspace-file-search";
 import { useWorkspaceCommandPaletteOpenFiles } from "@/hooks/workspaces/derived/use-workspace-command-palette-open-files";
 import { useWorkspaceCommandPaletteTabs } from "@/hooks/workspaces/workflows/use-workspace-command-palette-tabs";
 import { useAppCommandActionsContext } from "@/providers/AppCommandActionsProvider";
@@ -72,10 +72,10 @@ export function useWorkspaceCommandPalette({
     restoreLastDismissedTab,
     restoreTabDisabledReason,
   } = useWorkspaceCommandPaletteTabs();
-  const fileSearch = useWorkspaceCommandPaletteFileSearch({
+  const fileSearch = useWorkspaceFileSearch({
     open,
-    selectedWorkspaceId,
-    hasRuntimeReadyWorkspace,
+    workspaceId: selectedWorkspaceId,
+    runtimeReady: hasRuntimeReadyWorkspace,
     query,
   });
   const openFiles = useWorkspaceCommandPaletteOpenFiles(selectedWorkspaceId);

--- a/desktop/src/hooks/workspaces/files/ui/use-workspace-file-search.test.tsx
+++ b/desktop/src/hooks/workspaces/files/ui/use-workspace-file-search.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFileSearch } from "./use-workspace-file-search";
+
+const searchWorkspaceFilesQuery = vi.fn();
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useSearchWorkspaceFilesQuery: (options: unknown) => searchWorkspaceFilesQuery(options),
+}));
+
+describe("useWorkspaceFileSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    searchWorkspaceFilesQuery.mockReset();
+    searchWorkspaceFilesQuery.mockReturnValue({
+      data: {
+        results: [
+          { name: "README.md", path: "README.md" },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("debounces search and gates on runtime readiness", () => {
+    const rendered = renderHook(
+      ({ runtimeReady }) => useWorkspaceFileSearch({
+        open: true,
+        workspaceId: "workspace-1",
+        runtimeReady,
+        query: "readme",
+      }),
+      { initialProps: { runtimeReady: false } },
+    );
+
+    expect(rendered.result.current.searchEnabled).toBe(false);
+    expect(searchWorkspaceFilesQuery).toHaveBeenLastCalledWith({
+      workspaceId: "workspace-1",
+      query: "",
+      limit: 50,
+      enabled: false,
+    });
+
+    rendered.rerender({ runtimeReady: true });
+    expect(rendered.result.current.searchEnabled).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(rendered.result.current.searchEnabled).toBe(true);
+    expect(rendered.result.current.results).toEqual([
+      { name: "README.md", path: "README.md" },
+    ]);
+    expect(searchWorkspaceFilesQuery).toHaveBeenLastCalledWith({
+      workspaceId: "workspace-1",
+      query: "readme",
+      limit: 50,
+      enabled: true,
+    });
+  });
+
+  it("does not enable search without a workspace", () => {
+    const rendered = renderHook(() => useWorkspaceFileSearch({
+      open: true,
+      workspaceId: null,
+      runtimeReady: true,
+      query: "readme",
+    }));
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(rendered.result.current.searchEnabled).toBe(false);
+    expect(rendered.result.current.results).toEqual([]);
+    expect(searchWorkspaceFilesQuery).toHaveBeenLastCalledWith({
+      workspaceId: null,
+      query: "readme",
+      limit: 50,
+      enabled: false,
+    });
+  });
+});

--- a/desktop/src/hooks/workspaces/files/ui/use-workspace-file-search.ts
+++ b/desktop/src/hooks/workspaces/files/ui/use-workspace-file-search.ts
@@ -1,32 +1,34 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchWorkspaceFilesQuery } from "@anyharness/sdk-react";
 
-const EMPTY_FILE_RESULTS: Array<{ path: string; name: string }> = [];
+const EMPTY_FILE_RESULTS: WorkspaceFileSearchResult[] = [];
 
-export interface CommandPaletteFileSearchResult {
+interface WorkspaceFileSearchResult {
   path: string;
   name: string;
 }
 
-interface UseWorkspaceCommandPaletteFileSearchArgs {
+interface UseWorkspaceFileSearchArgs {
   open: boolean;
-  selectedWorkspaceId: string | null;
-  hasRuntimeReadyWorkspace: boolean;
+  workspaceId: string | null;
+  runtimeReady: boolean;
   query: string;
+  limit?: number;
 }
 
-// Owns command-palette-specific file search debouncing and query state.
-export function useWorkspaceCommandPaletteFileSearch({
+// Owns debounced workspace file path search state for palette-style surfaces.
+export function useWorkspaceFileSearch({
   open,
-  selectedWorkspaceId,
-  hasRuntimeReadyWorkspace,
+  workspaceId,
+  runtimeReady,
   query,
-}: UseWorkspaceCommandPaletteFileSearchArgs) {
+  limit = 50,
+}: UseWorkspaceFileSearchArgs) {
   const trimmedQuery = query.trim();
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
   useEffect(() => {
-    if (!open || trimmedQuery.length === 0 || !hasRuntimeReadyWorkspace) {
+    if (!open || trimmedQuery.length === 0 || !runtimeReady) {
       setDebouncedQuery("");
       return undefined;
     }
@@ -36,21 +38,22 @@ export function useWorkspaceCommandPaletteFileSearch({
     }, 120);
 
     return () => window.clearTimeout(timeoutId);
-  }, [hasRuntimeReadyWorkspace, open, trimmedQuery]);
+  }, [open, runtimeReady, trimmedQuery]);
 
-  const searchEnabled = open
-    && hasRuntimeReadyWorkspace
-    && selectedWorkspaceId !== null
+  const searchEnabled =
+    open
+    && runtimeReady
+    && workspaceId !== null
     && debouncedQuery.length > 0;
 
   const queryResult = useSearchWorkspaceFilesQuery({
-    workspaceId: selectedWorkspaceId,
+    workspaceId,
     query: debouncedQuery,
-    limit: 50,
+    limit,
     enabled: searchEnabled,
   });
 
-  const results = useMemo<CommandPaletteFileSearchResult[]>(() => {
+  const results = useMemo<WorkspaceFileSearchResult[]>(() => {
     if (!searchEnabled) {
       return EMPTY_FILE_RESULTS;
     }

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -351,9 +351,29 @@
   --file-source-line-number-hover: color-mix(in srgb, var(--color-foreground) 58%, transparent);
   --file-source-content-gap: 0.625rem;
   --file-source-content-padding-inline: 0.125rem;
+  background:
+    linear-gradient(
+      to right,
+      var(--file-source-gutter-surface) 0,
+      var(--file-source-gutter-surface) var(--file-source-line-number-gutter-width),
+      var(--file-source-surface) var(--file-source-line-number-gutter-width),
+      var(--file-source-surface) 100%
+    );
+}
+
+.file-source-view::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: calc(var(--file-source-line-number-gutter-width) - 1px);
+  z-index: 6;
+  width: 1px;
+  pointer-events: none;
+  background: var(--file-source-gutter-border);
 }
 
 .file-source-scroll {
+  overscroll-behavior: none;
   scrollbar-color: var(--color-scrollbar-thumb) transparent;
 }
 
@@ -361,21 +381,8 @@
   scrollbar-color: var(--color-scrollbar-thumb-active) transparent;
 }
 
-.file-source-gutter-rail {
-  position: absolute;
-  inset-block: 0;
-  left: 0;
-  z-index: 5;
-  width: var(--file-source-line-number-gutter-width);
-  pointer-events: none;
-  background: var(--file-source-gutter-surface);
-  box-shadow:
-    inset 1px 0 0 var(--file-source-gutter-border),
-    inset -1px 0 0 var(--file-source-gutter-border);
-}
-
 .file-source-view [data-file] {
-  background: var(--file-source-surface);
+  background: transparent;
   color: var(--diffs-fg);
 }
 
@@ -389,7 +396,12 @@
 }
 
 .file-source-line-number {
+  box-sizing: border-box;
+  background: var(--file-source-gutter-surface);
   color: var(--file-source-line-number);
+  box-shadow:
+    inset 1px 0 0 var(--file-source-gutter-border),
+    inset -1px 0 0 var(--file-source-gutter-border);
 }
 
 .file-source-line:hover .file-source-line-number {

--- a/desktop/src/lib/domain/workspaces/changes/git-panel-diff.test.ts
+++ b/desktop/src/lib/domain/workspaces/changes/git-panel-diff.test.ts
@@ -2,6 +2,7 @@ import type { GitChangedFile, GitDiffFile } from "@anyharness/sdk";
 import { describe, expect, it } from "vitest";
 import {
   buildGitPanelFiles,
+  buildGitPanelSections,
   gitPanelRuntimeBlockWorkspaceId,
   resolveGitPanelBaseRef,
 } from "./git-panel-diff";
@@ -72,6 +73,38 @@ describe("git panel diff domain", () => {
       path: "deleted.ts",
       status: "deleted",
     });
+  });
+
+  it("omits last-turn touched files that no longer have a current diff", () => {
+    const sections = buildGitPanelSections({
+      mode: "last_turn",
+      statusFiles: [],
+      branchFiles: [],
+      lastTurnFiles: [
+        {
+          key: ":clean.md:edit",
+          path: "clean.md",
+          oldPath: null,
+          displayPath: "clean.md",
+          operation: "edit",
+          topLevel: true,
+        },
+        {
+          key: ":dirty.md:edit",
+          path: "dirty.md",
+          oldPath: null,
+          displayPath: "dirty.md",
+          operation: "edit",
+          topLevel: true,
+        },
+      ],
+      baseWorktreeFiles: [
+        branchFile({ path: "dirty.md", additions: 2 }),
+      ],
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].files.map((file) => file.path)).toEqual(["dirty.md"]);
   });
 
   it("resolves branch base-ref precedence", () => {

--- a/desktop/src/lib/domain/workspaces/changes/git-panel-diff.ts
+++ b/desktop/src/lib/domain/workspaces/changes/git-panel-diff.ts
@@ -118,7 +118,9 @@ export function buildGitPanelSections(input: BuildGitPanelFilesInput): GitPanelS
       label: "Last turn",
       files: (input.lastTurnFiles ?? [])
         .filter((file) => isVisibleGitPath(file.path))
-        .map((file) => toReviewFileFromTouchedFile(file, currentByPath.get(file.path) ?? null)),
+        .map((file) => currentByPath.get(file.path) ?? null)
+        .filter((file): file is GitPanelFile => Boolean(file))
+        .map(toReviewFile),
     }];
   }
   const scope: GitPanelSectionScope = input.mode;
@@ -227,20 +229,6 @@ export function toReviewFile(file: GitPanelFile): GitPanelReviewFile {
     oldPath: file.oldPath,
     displayPath: file.displayPath,
     currentDiff: file,
-  };
-}
-
-function toReviewFileFromTouchedFile(
-  file: LastTurnTouchedFile,
-  currentDiff: GitPanelFile | null,
-): GitPanelReviewFile {
-  return {
-    key: currentDiff?.key ?? `last-turn:${file.key}`,
-    path: currentDiff?.path ?? file.path,
-    oldPath: currentDiff?.oldPath ?? file.oldPath,
-    displayPath: currentDiff?.displayPath ?? file.displayPath,
-    currentDiff,
-    touched: file,
   };
 }
 

--- a/desktop/src/lib/infra/dom/scroll-chain.test.ts
+++ b/desktop/src/lib/infra/dom/scroll-chain.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { chainVerticalWheelScroll } from "./scroll-chain";
+
+describe("chainVerticalWheelScroll", () => {
+  it("scrolls the parent when the child reaches the bottom edge", () => {
+    const parent = document.createElement("div");
+    const child = document.createElement("div");
+    parent.style.overflowY = "auto";
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    setScrollMetrics(parent, { clientHeight: 100, scrollHeight: 500, scrollTop: 10 });
+    setScrollMetrics(child, { clientHeight: 100, scrollHeight: 300, scrollTop: 200 });
+
+    const chained = chainVerticalWheelScroll(child, 40);
+
+    expect(chained).toBe(true);
+    expect(parent.scrollTop).toBe(50);
+  });
+
+  it("does not chain while the child can still scroll", () => {
+    const parent = document.createElement("div");
+    const child = document.createElement("div");
+    parent.style.overflowY = "auto";
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    setScrollMetrics(parent, { clientHeight: 100, scrollHeight: 500, scrollTop: 10 });
+    setScrollMetrics(child, { clientHeight: 100, scrollHeight: 300, scrollTop: 50 });
+
+    const chained = chainVerticalWheelScroll(child, 40);
+
+    expect(chained).toBe(false);
+    expect(parent.scrollTop).toBe(10);
+  });
+});
+
+function setScrollMetrics(
+  element: HTMLElement,
+  metrics: { clientHeight: number; scrollHeight: number; scrollTop: number },
+) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop,
+  });
+}

--- a/desktop/src/lib/infra/dom/scroll-chain.ts
+++ b/desktop/src/lib/infra/dom/scroll-chain.ts
@@ -1,0 +1,56 @@
+const SCROLL_EDGE_EPSILON = 1;
+
+export function chainVerticalWheelScroll(
+  element: HTMLElement,
+  deltaY: number,
+): boolean {
+  if (deltaY === 0 || !isAtVerticalScrollEdge(element, deltaY)) {
+    return false;
+  }
+
+  const parent = findScrollableParent(element);
+  if (!parent) {
+    return false;
+  }
+
+  const previousScrollTop = parent.scrollTop;
+  parent.scrollTop += deltaY;
+  return parent.scrollTop !== previousScrollTop;
+}
+
+function isAtVerticalScrollEdge(element: HTMLElement, deltaY: number): boolean {
+  const maxScrollTop = Math.max(element.scrollHeight - element.clientHeight, 0);
+  if (maxScrollTop <= SCROLL_EDGE_EPSILON) {
+    return true;
+  }
+
+  if (deltaY < 0) {
+    return element.scrollTop <= SCROLL_EDGE_EPSILON;
+  }
+
+  return element.scrollTop >= maxScrollTop - SCROLL_EDGE_EPSILON;
+}
+
+function findScrollableParent(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    if (canScrollVertically(current)) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  const scrollingElement = document.scrollingElement;
+  return scrollingElement instanceof HTMLElement && canScrollVertically(scrollingElement)
+    ? scrollingElement
+    : null;
+}
+
+function canScrollVertically(element: HTMLElement): boolean {
+  if (element.scrollHeight <= element.clientHeight + SCROLL_EDGE_EPSILON) {
+    return false;
+  }
+
+  const overflowY = window.getComputedStyle(element).overflowY;
+  return overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
+}

--- a/docs/frontend/specs/workspace-files.md
+++ b/docs/frontend/specs/workspace-files.md
@@ -8,9 +8,10 @@ all-changes review surfaces.
 Files is filesystem navigation from file-viewing surfaces:
 
 - open file viewer targets from chat links, command-palette results, git rows,
-  and the file viewer browser overlay
-- browse or search files from the overlay attached to file/diff viewing
-  surfaces
+  the file viewer browser overlay, and the file viewer search modal
+- browse directories from the overlay attached to file/diff viewing surfaces
+- search workspace files from the command palette or the file-viewer-local
+  search modal
 
 Files is not a standalone durable right-panel tool. The old Files pane/tab must
 not be rendered in the shared right-panel header.
@@ -106,6 +107,11 @@ closed.
 The file viewer frame owns the path header, copy path, save/reload actions,
 dirty/conflict states, and binary/too-large placeholders. Cmd/Ctrl+S saves the
 active file target only.
+
+The file viewer may open a palette-style file search modal scoped to the
+current viewer tab. It reuses the workspace file search API and command-palette
+input/list primitives; global shortcut ownership remains with the workspace
+command palette unless a dedicated binding is introduced later.
 
 ## Diff Viewing
 

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -42,6 +42,7 @@ desktop/src/hooks/sessions/use-session-runtime-actions.ts
 desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
 desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
 desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
+desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
 desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
 desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
 server/tests/integration/test_cloud_api.py


### PR DESCRIPTION
## Summary
- Fix Git diff gutter/overscroll polish, sticky header bleed, and zero-stat empty Git rows.
- Add the file-viewer workspace file search modal and share the debounced file search hook with the command palette.
- Update workspace files documentation and focused coverage for the new UI and scroll behavior.

## Validation
- pnpm --dir desktop exec tsc --noEmit
- git diff --check
- pnpm --dir desktop exec vitest run src/components/workspace/files/FileEditorView.test.tsx src/components/ui/content/DiffViewer.test.tsx src/components/workspace/files/search/WorkspaceFileSearchModal.test.tsx src/hooks/workspaces/files/ui/use-workspace-file-search.test.tsx src/components/workspace/git/GitPanel.test.tsx src/components/playground/PlaygroundSidebarGitDiff.test.tsx src/components/ui/content/FileDiffCard.test.tsx src/lib/infra/dom/scroll-chain.test.ts src/lib/domain/workspaces/changes/git-panel-diff.test.ts
