### PR TITLE
feat(server): add agent LLM auth gateway foundation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,15 @@ start of the task, not after implementation has already started.
 - `docs/architecture/model-catalog-and-dynamic-registries.md`
   - model catalog, target-discovered model registry, user visibility intent,
     and launch-time model resolution boundaries
+- `docs/architecture/target-runtime-mcp-skills-config.md`
+  - target-scoped MCP/skill runtime manifests, lazy artifact/credential
+    resolution, and the Desktop/worker gap-fill boundary
+- `docs/architecture/agent-llm-auth-gateway-spec.md`
+  - centralized agent LLM auth gateway, LiteLLM routing/budget enforcement,
+    runtime grants, synced-path cutover, and sandbox agent-auth selections
+- `docs/architecture/shared-sandbox-config-admin-ui-spec.md`
+  - personal/shared sandbox profile configuration, admin UI ownership, public
+    MCP/skill publication, and shared sandbox consumption of agent auth
 - `docs/architecture/cloud-worker-control-plane.md`
   - reference architecture for target workers, Cloud-mediated session control,
     command delivery, event ingestion, and snapshots
@@ -139,6 +148,12 @@ start of the task, not after implementation has already started.
 - `docs/notes/agent-credentials-sync.md`
   - non-authoritative design/reference note for local agent credentials and
     future credential sync
+- `docs/notes/model-gateway-auth-facts.md`
+  - empirical source-inspection facts for Claude, Codex, OpenCode, Gemini, and
+    LiteLLM gateway auth compatibility
+- `docs/notes/agent-gateway-phase0-compatibility.md`
+  - runnable Phase 0B proof matrix for LiteLLM team routing, Claude streaming,
+    Codex Responses, and OpenCode isolation gates
 - `docs/reference/self-hosted-deploy.md`
   - canonical Docker Compose self-hosted deployment
 - `docs/reference/self-hosted-aws.md`

--- a/docs/notes/agent-gateway-phase0-compatibility.md
+++ b/docs/notes/agent-gateway-phase0-compatibility.md
@@ -1,0 +1,112 @@
+# Agent Gateway Phase 0 Compatibility Proof
+
+Status: Phase 0A implemented; Phase 0B proof harness implemented; live proof
+pending external gateway/provider configuration
+
+Date: 2026-05-17
+
+This note is the execution companion for
+`docs/architecture/agent-llm-auth-gateway-spec.md` Phase 0B. It records the
+probes that must pass before gateway-backed credentials are exposed in product
+UI.
+
+Phase 0B is not considered passed by this note alone. It is passed only by a
+`--require-live` run in an environment with the LiteLLM proxy, gateway facade,
+and provider credentials configured.
+
+Run:
+
+```bash
+python3 scripts/agent-gateway-phase0-probe.py all
+```
+
+or:
+
+```bash
+pnpm agent-gateway:phase0
+```
+
+Use `--require-live` when running the official proof. Without it, missing
+external services or provider keys report `SKIP` so local dry-runs remain
+useful.
+
+## Probe Matrix
+
+```text
+litellm
+  Proves team-scoped duplicate public model names can be created through
+  LiteLLM control-plane APIs and are visible to the matching team keys.
+  With provider keys present, also proves live chat routing through those team
+  keys.
+
+claude
+  Proves an Anthropic-compatible streaming request against the configured
+  gateway/LiteLLM path.
+
+codex
+  Proves an OpenAI Responses streaming request against the configured
+  gateway/LiteLLM path.
+
+opencode
+  Records the OpenCode managed-config isolation gate. V1 remains disabled until
+  this is explicitly proven.
+```
+
+## Environment
+
+LiteLLM control-plane proof:
+
+```text
+LITELLM_PROXY_URL=http://127.0.0.1:4000
+LITELLM_MASTER_KEY=...
+PHASE0_LITELLM_PUBLIC_MODEL=optional-public-name
+PHASE0_LITELLM_BACKING_MODEL=gpt-4o-mini
+PHASE0_LITELLM_PROVIDER=openai
+OPENAI_API_KEY=...
+PHASE0_OPENAI_API_KEY_TEAM_A=optional distinct key
+PHASE0_OPENAI_API_KEY_TEAM_B=optional distinct key
+```
+
+Claude streaming proof:
+
+```text
+PHASE0_ANTHROPIC_BASE_URL=https://gateway.example.com/anthropic
+PHASE0_GATEWAY_TOKEN=...
+PHASE0_ANTHROPIC_MODEL=...
+```
+
+Codex Responses proof:
+
+```text
+PHASE0_OPENAI_BASE_URL=https://gateway.example.com/openai/v1
+PHASE0_GATEWAY_TOKEN=...
+PHASE0_RESPONSES_MODEL=...
+```
+
+OpenCode isolation decision:
+
+```text
+PHASE0_OPENCODE_MANAGED_CONFIG_PROOF=1
+```
+
+Only set `PHASE0_OPENCODE_MANAGED_CONFIG_PROOF=1` after AnyHarness can force a
+managed OpenCode provider config that project/workspace config cannot override.
+
+## Current Local Run
+
+The local checkout does not currently have a LiteLLM proxy running on port
+4000, nor provider tokens in the environment. The dry-run command verifies the
+probe harness and reports missing live inputs as `SKIP`.
+
+The official Phase 0B gate is complete only when:
+
+```text
+litellm-team-routing          PASS with live_calls=true
+litellm-live-chat-routing     PASS for both teams
+claude-anthropic-streaming    PASS
+codex-responses-streaming     PASS or Codex managed credits explicitly gated off
+opencode-managed-config       PASS or OpenCode gateway explicitly gated off
+```
+
+If Codex or OpenCode remains gated off, product feature flags must keep those
+gateway-backed paths unavailable.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.ts",
   "scripts": {
-    "build:shared": "pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-model build",
+    "build:shared": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-model build",
     "start": "pnpm build:shared && expo start",
     "ios": "pnpm build:shared && expo start --ios",
     "android": "pnpm build:shared && expo start --android",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mobile:build:ios": "pnpm --filter @proliferate/mobile build:ios",
     "mobile:submit:ios": "pnpm --filter @proliferate/mobile submit:ios",
     "shared:build": "pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-model build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build",
-    "shared:typecheck": "pnpm --filter @proliferate/design typecheck && pnpm --filter @proliferate/product-model typecheck && pnpm --filter @proliferate/ui typecheck && pnpm --filter @proliferate/product-ui typecheck",
+    "shared:typecheck": "pnpm --filter @proliferate/design typecheck && pnpm --filter @proliferate/product-model typecheck && pnpm --filter @proliferate/ui typecheck && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui typecheck",
     "web:dev": "pnpm --filter @proliferate/web dev",
     "web:build": "pnpm --filter @proliferate/web build",
     "web:typecheck": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm shared:build && pnpm --filter @proliferate/web typecheck",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "e2b:template": "node scripts/build-template.mjs",
     "e2b:smoke": "node scripts/smoke-e2b-runtime.mjs",
     "latency:benchmark": "node scripts/latency-benchmark.mjs",
+    "agent-gateway:phase0": "python3 scripts/agent-gateway-phase0-probe.py all",
     "mobile:start": "pnpm --filter @proliferate/mobile start",
     "mobile:typecheck": "pnpm --filter @proliferate/mobile typecheck",
     "mobile:build:ios": "pnpm --filter @proliferate/mobile build:ios",

--- a/scripts/agent-gateway-phase0-probe.py
+++ b/scripts/agent-gateway-phase0-probe.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Phase 0 compatibility probes for the agent LLM auth gateway spec.
+
+The script intentionally uses only the Python standard library so it can run
+from a fresh checkout. It never prints provider keys or runtime grants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+PASS = "PASS"
+SKIP = "SKIP"
+FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    name: str
+    status: str
+    detail: str
+
+
+class HttpClient:
+    def __init__(self, base_url: str, bearer: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.bearer = bearer
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> tuple[int, dict[str, Any] | str, dict[str, str]]:
+        url = self.base_url + path
+        payload = None if body is None else json.dumps(body).encode("utf-8")
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(headers or {})
+        bearer = token if token is not None else self.bearer
+        if bearer:
+            request_headers["Authorization"] = f"Bearer {bearer}"
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers=request_headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                raw = response.read()
+                status = response.status
+                response_headers = dict(response.headers.items())
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            status = exc.code
+            response_headers = dict(exc.headers.items())
+        text = raw.decode("utf-8", errors="replace")
+        try:
+            parsed: dict[str, Any] | str = json.loads(text) if text else {}
+        except json.JSONDecodeError:
+            parsed = text
+        return status, parsed, response_headers
+
+
+def env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def is_truthy(name: str) -> bool:
+    return (env(name, "") or "").lower() in {"1", "true", "yes", "on"}
+
+
+def result(name: str, status: str, detail: str) -> ProbeResult:
+    return ProbeResult(name=name, status=status, detail=detail)
+
+
+def require_env(names: list[str]) -> list[str]:
+    return [name for name in names if not env(name)]
+
+
+def expect_2xx(
+    name: str,
+    status: int,
+    payload: dict[str, Any] | str,
+    action: str,
+) -> ProbeResult | None:
+    if 200 <= status < 300:
+        return None
+    return result(name, FAIL, f"{action} failed with HTTP {status}: {redact(payload)}")
+
+
+def redact(payload: dict[str, Any] | str) -> str:
+    text = payload if isinstance(payload, str) else json.dumps(payload, sort_keys=True)
+    for key in (
+        env("LITELLM_MASTER_KEY"),
+        env("OPENAI_API_KEY"),
+        env("PHASE0_OPENAI_API_KEY_TEAM_A"),
+        env("PHASE0_OPENAI_API_KEY_TEAM_B"),
+        env("PHASE0_GATEWAY_TOKEN"),
+    ):
+        if key:
+            text = text.replace(key, "[REDACTED]")
+    return text[:1000]
+
+
+def cleanup_model(client: HttpClient, model_id: str | None) -> None:
+    if not model_id:
+        return
+    client.request("POST", "/model/delete", body={"id": model_id}, timeout=15.0)
+
+
+def probe_litellm_team_routing() -> list[ProbeResult]:
+    missing = require_env(["LITELLM_MASTER_KEY"])
+    if missing:
+        return [
+            result(
+                "litellm-team-routing",
+                SKIP,
+                "Set LITELLM_PROXY_URL and LITELLM_MASTER_KEY to run the LiteLLM control-plane proof.",
+            )
+        ]
+
+    base_url = env("LITELLM_PROXY_URL", "http://127.0.0.1:4000") or ""
+    master_key = env("LITELLM_MASTER_KEY") or ""
+    client = HttpClient(base_url, master_key)
+    run_id = uuid.uuid4().hex[:8]
+    public_model = env("PHASE0_LITELLM_PUBLIC_MODEL", f"proliferate-phase0-{run_id}") or ""
+    backing_model = env("PHASE0_LITELLM_BACKING_MODEL", "gpt-4o-mini") or ""
+    provider = env("PHASE0_LITELLM_PROVIDER", "openai") or ""
+    key_a = env("PHASE0_OPENAI_API_KEY_TEAM_A") or env("OPENAI_API_KEY") or "sk-phase0-fake-a"
+    key_b = env("PHASE0_OPENAI_API_KEY_TEAM_B") or env("OPENAI_API_KEY") or "sk-phase0-fake-b"
+    live = bool(env("PHASE0_OPENAI_API_KEY_TEAM_A") or env("PHASE0_OPENAI_API_KEY_TEAM_B") or env("OPENAI_API_KEY"))
+
+    created_model_ids: list[str] = []
+    try:
+        health_status, health_payload, _ = client.request("GET", "/health/readiness", timeout=5.0)
+        if health_status >= 500:
+            return [result("litellm-team-routing", FAIL, f"LiteLLM readiness failed: {redact(health_payload)}")]
+
+        team_ids: list[str] = []
+        team_keys: list[str] = []
+        for label in ("a", "b"):
+            team_status, team_payload, _ = client.request(
+                "POST",
+                "/team/new",
+                body={"team_alias": f"phase0-{label}-{run_id}", "models": []},
+            )
+            failure = expect_2xx("litellm-team-routing", team_status, team_payload, f"create team {label}")
+            if failure:
+                return [failure]
+            team_id = str(team_payload["team_id"])  # type: ignore[index]
+            team_ids.append(team_id)
+
+            api_key = key_a if label == "a" else key_b
+            model_status, model_payload, _ = client.request(
+                "POST",
+                "/model/new",
+                body={
+                    "model_name": public_model,
+                    "litellm_params": {
+                        "model": backing_model,
+                        "custom_llm_provider": provider,
+                        "api_key": api_key,
+                    },
+                    "model_info": {
+                        "team_id": team_id,
+                        "metadata": {"phase0_run_id": run_id, "credential_marker": label},
+                    },
+                },
+            )
+            failure = expect_2xx("litellm-team-routing", model_status, model_payload, f"create team model {label}")
+            if failure:
+                return [failure]
+            model_info = model_payload.get("model_info", {}) if isinstance(model_payload, dict) else {}
+            created_model_ids.append(str(model_info.get("id") or ""))
+
+            key_status, key_payload, _ = client.request(
+                "POST",
+                "/key/generate",
+                body={"team_id": team_id},
+            )
+            failure = expect_2xx("litellm-team-routing", key_status, key_payload, f"generate key {label}")
+            if failure:
+                return [failure]
+            team_keys.append(str(key_payload["key"]))  # type: ignore[index]
+
+        visibility_details: list[str] = []
+        for label, team_key in zip(("a", "b"), team_keys):
+            models_status, models_payload, _ = client.request("GET", "/models", token=team_key)
+            failure = expect_2xx("litellm-team-routing", models_status, models_payload, f"list models for team {label}")
+            if failure:
+                return [failure]
+            data = models_payload.get("data", []) if isinstance(models_payload, dict) else []
+            visible = any(item.get("id") == public_model for item in data if isinstance(item, dict))
+            if not visible:
+                return [result("litellm-team-routing", FAIL, f"team {label} key cannot see public model {public_model}")]
+            visibility_details.append(f"team {label} sees {public_model}")
+
+        info_status, info_payload, _ = client.request(
+            "GET",
+            "/v2/model/info?" + urllib.parse.urlencode({"model_name": public_model}),
+        )
+        failure = expect_2xx("litellm-team-routing", info_status, info_payload, "read model info")
+        if failure:
+            return [failure]
+        info_rows = info_payload.get("data", []) if isinstance(info_payload, dict) else []
+        seen_team_ids = {
+            str((row.get("model_info") or {}).get("team_id"))
+            for row in info_rows
+            if isinstance(row, dict)
+            and (row.get("model_info") or {}).get("team_public_model_name") == public_model
+        }
+        missing_team_ids = [team_id for team_id in team_ids if team_id not in seen_team_ids]
+        if missing_team_ids:
+            return [
+                result(
+                    "litellm-team-routing",
+                    FAIL,
+                    f"model info did not show duplicate team-scoped rows for: {', '.join(missing_team_ids)}",
+                )
+            ]
+
+        results = [
+            result(
+                "litellm-team-routing",
+                PASS,
+                "; ".join(visibility_details)
+                + f"; /v2/model/info has team_public_model_name rows for both teams. live_calls={live}",
+            )
+        ]
+
+        if live:
+            for label, team_key in zip(("a", "b"), team_keys):
+                chat_status, chat_payload, _ = client.request(
+                    "POST",
+                    "/v1/chat/completions",
+                    token=team_key,
+                    body={
+                        "model": public_model,
+                        "messages": [{"role": "user", "content": "Reply with OK."}],
+                        "max_tokens": 8,
+                    },
+                    timeout=60.0,
+                )
+                failure = expect_2xx("litellm-live-chat-routing", chat_status, chat_payload, f"chat completion team {label}")
+                if failure:
+                    results.append(failure)
+                else:
+                    results.append(result("litellm-live-chat-routing", PASS, f"team {label} routed live chat completion"))
+
+        if is_truthy("PHASE0_LITELLM_EXERCISE_BUDGET"):
+            results.append(result("litellm-budget-exhaustion", SKIP, "Budget exhaustion exercise is intentionally manual for V1; set a tiny team budget and inspect LiteLLM spend before enabling broadly."))
+        return results
+    except urllib.error.URLError as exc:
+        return [result("litellm-team-routing", FAIL, f"Could not reach LiteLLM at {base_url}: {exc}")]
+    finally:
+        for model_id in created_model_ids:
+            cleanup_model(client, model_id)
+
+
+def probe_anthropic_streaming() -> list[ProbeResult]:
+    missing = require_env(["PHASE0_ANTHROPIC_BASE_URL", "PHASE0_GATEWAY_TOKEN", "PHASE0_ANTHROPIC_MODEL"])
+    if missing:
+        return [
+            result(
+                "claude-anthropic-streaming",
+                SKIP,
+                "Set PHASE0_ANTHROPIC_BASE_URL, PHASE0_GATEWAY_TOKEN, and PHASE0_ANTHROPIC_MODEL to run the Claude streaming proof.",
+            )
+        ]
+    client = HttpClient(env("PHASE0_ANTHROPIC_BASE_URL") or "", env("PHASE0_GATEWAY_TOKEN"))
+    status, payload, headers = client.request(
+        "POST",
+        "/v1/messages?beta=true",
+        body={
+            "model": env("PHASE0_ANTHROPIC_MODEL"),
+            "max_tokens": 8,
+            "stream": True,
+            "messages": [{"role": "user", "content": "Reply with OK."}],
+        },
+        headers={"anthropic-version": "2023-06-01"},
+        timeout=60.0,
+    )
+    failure = expect_2xx("claude-anthropic-streaming", status, payload, "Claude Anthropic streaming request")
+    if failure:
+        return [failure]
+    content_type = headers.get("content-type", headers.get("Content-Type", ""))
+    return [result("claude-anthropic-streaming", PASS, f"HTTP {status}; content-type={content_type or 'unknown'}")]
+
+
+def probe_codex_responses() -> list[ProbeResult]:
+    missing = require_env(["PHASE0_OPENAI_BASE_URL", "PHASE0_GATEWAY_TOKEN", "PHASE0_RESPONSES_MODEL"])
+    if missing:
+        return [
+            result(
+                "codex-responses-streaming",
+                SKIP,
+                "Set PHASE0_OPENAI_BASE_URL, PHASE0_GATEWAY_TOKEN, and PHASE0_RESPONSES_MODEL to run the Codex Responses proof.",
+            )
+        ]
+    client = HttpClient(env("PHASE0_OPENAI_BASE_URL") or "", env("PHASE0_GATEWAY_TOKEN"))
+    status, payload, headers = client.request(
+        "POST",
+        "/responses",
+        body={
+            "model": env("PHASE0_RESPONSES_MODEL"),
+            "input": "Reply with OK.",
+            "stream": True,
+            "max_output_tokens": 8,
+        },
+        timeout=60.0,
+    )
+    failure = expect_2xx("codex-responses-streaming", status, payload, "Codex Responses streaming request")
+    if failure:
+        return [failure]
+    content_type = headers.get("content-type", headers.get("Content-Type", ""))
+    return [result("codex-responses-streaming", PASS, f"HTTP {status}; content-type={content_type or 'unknown'}")]
+
+
+def probe_opencode_isolation() -> list[ProbeResult]:
+    if is_truthy("PHASE0_OPENCODE_MANAGED_CONFIG_PROOF"):
+        return [
+            result(
+                "opencode-managed-config-isolation",
+                PASS,
+                "Caller asserted OpenCode managed config isolation has been proven for this environment.",
+            )
+        ]
+    return [
+        result(
+            "opencode-managed-config-isolation",
+            SKIP,
+            "OpenCode gateway remains disabled until managed provider config isolation is proven.",
+        )
+    ]
+
+
+def run_probe(name: str) -> list[ProbeResult]:
+    if name == "litellm":
+        return probe_litellm_team_routing()
+    if name == "claude":
+        return probe_anthropic_streaming()
+    if name == "codex":
+        return probe_codex_responses()
+    if name == "opencode":
+        return probe_opencode_isolation()
+    if name == "all":
+        results: list[ProbeResult] = []
+        for child in ("litellm", "claude", "codex", "opencode"):
+            results.extend(run_probe(child))
+        return results
+    raise ValueError(f"unknown probe {name}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "probe",
+        choices=["all", "litellm", "claude", "codex", "opencode"],
+        nargs="?",
+        default="all",
+    )
+    parser.add_argument(
+        "--require-live",
+        action="store_true",
+        help="Treat skipped live probes as failures.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON results.")
+    args = parser.parse_args()
+
+    started = time.time()
+    results = run_probe(args.probe)
+    elapsed_ms = int((time.time() - started) * 1000)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "elapsed_ms": elapsed_ms,
+                    "results": [result.__dict__ for result in results],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for item in results:
+            print(f"[{item.status}] {item.name}: {item.detail}")
+        print(f"elapsed_ms={elapsed_ms}")
+
+    has_failure = any(item.status == FAIL for item in results)
+    has_required_skip = args.require_live and any(item.status == SKIP for item in results)
+    return 1 if has_failure or has_required_skip else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -45,11 +45,15 @@ desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
 desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
 desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
 desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
+desktop/src/lib/integrations/auth/orchestration.ts
 server/tests/integration/test_cloud_api.py
+server/tests/integration/test_auth_flow.py
 server/tests/integration/test_billing_accounting.py
 server/tests/integration/test_billing_api.py
 server/tests/integration/test_stripe_webhooks.py
+server/proliferate/db/models/cloud/agent_auth.py
 server/proliferate/db/store/billing.py
+server/proliferate/db/store/cloud_agent_auth/store.py
 server/proliferate/db/store/cloud_mobility.py
 server/proliferate/db/store/cloud_sync/events.py
 server/tests/unit/test_cloud_runtime_provision.py
@@ -61,6 +65,7 @@ server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/runtime/bootstrap.py
 server/proliferate/server/cloud/runtime/credential_freshness.py
 server/proliferate/server/cloud/worker/service.py
+server/proliferate/server/cloud/agent_auth/service.py
 server/proliferate/server/cloud/runtime/provision.py
 server/proliferate/server/cloud/workspaces/service.py
 server/tests/integration/test_cloud_commands_api.py

--- a/server/alembic/versions/c8d9e0f1a2b3_cloud_event_sync_projections.py
+++ b/server/alembic/versions/c8d9e0f1a2b3_cloud_event_sync_projections.py
@@ -19,195 +19,269 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_table_once(table_name: str) -> None:
+    if _has_table(table_name):
+        op.drop_table(table_name)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
-    op.create_table(
-        "cloud_session_events",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("worker_id", sa.Uuid(), nullable=True),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
-        sa.Column("workspace_id", sa.String(length=255), nullable=True),
-        sa.Column("session_id", sa.String(length=255), nullable=False),
-        sa.Column("anyharness_seq", sa.Integer(), nullable=False),
-        sa.Column("event_type", sa.String(length=128), nullable=False),
-        sa.Column("schema_version", sa.Integer(), server_default=sa.text("1"), nullable=False),
-        sa.Column("source_kind", sa.String(length=32), nullable=False),
-        sa.Column("turn_id", sa.String(length=255), nullable=True),
-        sa.Column("item_id", sa.String(length=255), nullable=True),
-        sa.Column("occurred_at", sa.String(length=64), nullable=True),
-        sa.Column("payload_json", sa.Text(), nullable=True),
-        sa.Column("payload_hash", sa.String(length=64), nullable=False),
-        sa.Column("payload_ref", sa.Text(), nullable=True),
-        sa.Column("payload_size_bytes", sa.Integer(), server_default=sa.text("0"), nullable=False),
-        sa.Column("payload_truncated_at_bytes", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "target_id",
-            "session_id",
-            "anyharness_seq",
-            name="uq_cloud_session_events_target_session_seq",
-        ),
-    )
-    op.create_index(
+    if not _has_table("cloud_session_events"):
+        op.create_table(
+            "cloud_session_events",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("worker_id", sa.Uuid(), nullable=True),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column("session_id", sa.String(length=255), nullable=False),
+            sa.Column("anyharness_seq", sa.Integer(), nullable=False),
+            sa.Column("event_type", sa.String(length=128), nullable=False),
+            sa.Column("schema_version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+            sa.Column("source_kind", sa.String(length=32), nullable=False),
+            sa.Column("turn_id", sa.String(length=255), nullable=True),
+            sa.Column("item_id", sa.String(length=255), nullable=True),
+            sa.Column("occurred_at", sa.String(length=64), nullable=True),
+            sa.Column("payload_json", sa.Text(), nullable=True),
+            sa.Column("payload_hash", sa.String(length=64), nullable=False),
+            sa.Column("payload_ref", sa.Text(), nullable=True),
+            sa.Column(
+                "payload_size_bytes", sa.Integer(), server_default=sa.text("0"), nullable=False
+            ),
+            sa.Column("payload_truncated_at_bytes", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "target_id",
+                "session_id",
+                "anyharness_seq",
+                name="uq_cloud_session_events_target_session_seq",
+            ),
+        )
+    _create_index_once(
         "ix_cloud_session_events_cloud_workspace",
         "cloud_session_events",
         ["cloud_workspace_id"],
-        unique=False,
     )
-    op.create_index("ix_cloud_session_events_type", "cloud_session_events", ["event_type"])
-    op.create_index(
+    _create_index_once("ix_cloud_session_events_type", "cloud_session_events", ["event_type"])
+    _create_index_once(
         "ix_cloud_session_events_session_seq",
         "cloud_session_events",
         ["session_id", "anyharness_seq"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_session_events_target_session",
         "cloud_session_events",
         ["target_id", "session_id"],
     )
-    op.create_index("ix_cloud_session_events_session_id", "cloud_session_events", ["session_id"])
-    op.create_index("ix_cloud_session_events_target_id", "cloud_session_events", ["target_id"])
+    _create_index_once(
+        "ix_cloud_session_events_session_id",
+        "cloud_session_events",
+        ["session_id"],
+    )
+    _create_index_once("ix_cloud_session_events_target_id", "cloud_session_events", ["target_id"])
 
-    op.create_table(
-        "cloud_event_ingest_state",
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("session_id", sa.String(length=255), nullable=False),
-        sa.Column("worker_id", sa.Uuid(), nullable=True),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
-        sa.Column("workspace_id", sa.String(length=255), nullable=True),
-        sa.Column("last_contiguous_seq", sa.Integer(), server_default=sa.text("0"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
-        sa.PrimaryKeyConstraint("target_id", "session_id"),
+    if not _has_table("cloud_event_ingest_state"):
+        op.create_table(
+            "cloud_event_ingest_state",
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("session_id", sa.String(length=255), nullable=False),
+            sa.Column("worker_id", sa.Uuid(), nullable=True),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_contiguous_seq",
+                sa.Integer(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("target_id", "session_id"),
+        )
+
+    if not _has_table("cloud_sessions"):
+        op.create_table(
+            "cloud_sessions",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column("session_id", sa.String(length=255), nullable=False),
+            sa.Column("native_session_id", sa.String(length=255), nullable=True),
+            sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
+            sa.Column("title", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("phase", sa.String(length=64), nullable=True),
+            sa.Column("live_config_json", sa.Text(), nullable=True),
+            sa.Column("last_event_seq", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("last_event_at", sa.String(length=64), nullable=True),
+            sa.Column("started_at", sa.String(length=64), nullable=True),
+            sa.Column("ended_at", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "target_id", "session_id", name="uq_cloud_sessions_target_session"
+            ),
+        )
+    _create_index_once(
+        "ix_cloud_sessions_cloud_workspace", "cloud_sessions", ["cloud_workspace_id"]
+    )
+    _create_index_once("ix_cloud_sessions_last_event_seq", "cloud_sessions", ["last_event_seq"])
+    _create_index_once("ix_cloud_sessions_session_id", "cloud_sessions", ["session_id"])
+    _create_index_once("ix_cloud_sessions_target_id", "cloud_sessions", ["target_id"])
+    _create_index_once(
+        "ix_cloud_sessions_target_status", "cloud_sessions", ["target_id", "status"]
     )
 
-    op.create_table(
-        "cloud_sessions",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
-        sa.Column("workspace_id", sa.String(length=255), nullable=True),
-        sa.Column("session_id", sa.String(length=255), nullable=False),
-        sa.Column("native_session_id", sa.String(length=255), nullable=True),
-        sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
-        sa.Column("title", sa.Text(), nullable=True),
-        sa.Column("status", sa.String(length=32), nullable=False),
-        sa.Column("phase", sa.String(length=64), nullable=True),
-        sa.Column("live_config_json", sa.Text(), nullable=True),
-        sa.Column("last_event_seq", sa.Integer(), server_default=sa.text("0"), nullable=False),
-        sa.Column("last_event_at", sa.String(length=64), nullable=True),
-        sa.Column("started_at", sa.String(length=64), nullable=True),
-        sa.Column("ended_at", sa.String(length=64), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("target_id", "session_id", name="uq_cloud_sessions_target_session"),
-    )
-    op.create_index("ix_cloud_sessions_cloud_workspace", "cloud_sessions", ["cloud_workspace_id"])
-    op.create_index("ix_cloud_sessions_last_event_seq", "cloud_sessions", ["last_event_seq"])
-    op.create_index("ix_cloud_sessions_session_id", "cloud_sessions", ["session_id"])
-    op.create_index("ix_cloud_sessions_target_id", "cloud_sessions", ["target_id"])
-    op.create_index("ix_cloud_sessions_target_status", "cloud_sessions", ["target_id", "status"])
-
-    op.create_table(
-        "cloud_transcript_items",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
-        sa.Column("workspace_id", sa.String(length=255), nullable=True),
-        sa.Column("session_id", sa.String(length=255), nullable=False),
-        sa.Column("item_id", sa.String(length=255), nullable=False),
-        sa.Column("turn_id", sa.String(length=255), nullable=True),
-        sa.Column("kind", sa.String(length=64), nullable=True),
-        sa.Column("status", sa.String(length=64), nullable=True),
-        sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
-        sa.Column("title", sa.Text(), nullable=True),
-        sa.Column("text", sa.Text(), nullable=True),
-        sa.Column("payload_json", sa.Text(), nullable=True),
-        sa.Column("first_seq", sa.Integer(), nullable=False),
-        sa.Column("last_seq", sa.Integer(), nullable=False),
-        sa.Column("completed_seq", sa.Integer(), nullable=True),
-        sa.Column("first_event_at", sa.String(length=64), nullable=True),
-        sa.Column("last_event_at", sa.String(length=64), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "target_id",
-            "session_id",
-            "item_id",
-            name="uq_cloud_transcript_items_target_session_item",
-        ),
-    )
-    op.create_index(
+    if not _has_table("cloud_transcript_items"):
+        op.create_table(
+            "cloud_transcript_items",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column("session_id", sa.String(length=255), nullable=False),
+            sa.Column("item_id", sa.String(length=255), nullable=False),
+            sa.Column("turn_id", sa.String(length=255), nullable=True),
+            sa.Column("kind", sa.String(length=64), nullable=True),
+            sa.Column("status", sa.String(length=64), nullable=True),
+            sa.Column("source_agent_kind", sa.String(length=64), nullable=True),
+            sa.Column("title", sa.Text(), nullable=True),
+            sa.Column("text", sa.Text(), nullable=True),
+            sa.Column("payload_json", sa.Text(), nullable=True),
+            sa.Column("first_seq", sa.Integer(), nullable=False),
+            sa.Column("last_seq", sa.Integer(), nullable=False),
+            sa.Column("completed_seq", sa.Integer(), nullable=True),
+            sa.Column("first_event_at", sa.String(length=64), nullable=True),
+            sa.Column("last_event_at", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "target_id",
+                "session_id",
+                "item_id",
+                name="uq_cloud_transcript_items_target_session_item",
+            ),
+        )
+    _create_index_once(
         "ix_cloud_transcript_items_cloud_workspace",
         "cloud_transcript_items",
         ["cloud_workspace_id"],
     )
-    op.create_index("ix_cloud_transcript_items_session_id", "cloud_transcript_items", ["session_id"])
-    op.create_index(
+    _create_index_once(
+        "ix_cloud_transcript_items_session_id",
+        "cloud_transcript_items",
+        ["session_id"],
+    )
+    _create_index_once(
         "ix_cloud_transcript_items_session_seq",
         "cloud_transcript_items",
         ["session_id", "last_seq"],
     )
-    op.create_index("ix_cloud_transcript_items_target_id", "cloud_transcript_items", ["target_id"])
-
-    op.create_table(
-        "cloud_pending_interactions",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
-        sa.Column("workspace_id", sa.String(length=255), nullable=True),
-        sa.Column("session_id", sa.String(length=255), nullable=False),
-        sa.Column("request_id", sa.String(length=255), nullable=False),
-        sa.Column("kind", sa.String(length=64), nullable=True),
-        sa.Column("status", sa.String(length=32), nullable=False),
-        sa.Column("title", sa.Text(), nullable=True),
-        sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("payload_json", sa.Text(), nullable=True),
-        sa.Column("requested_seq", sa.Integer(), nullable=False),
-        sa.Column("resolved_seq", sa.Integer(), nullable=True),
-        sa.Column("requested_at", sa.String(length=64), nullable=True),
-        sa.Column("resolved_at", sa.String(length=64), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "target_id",
-            "session_id",
-            "request_id",
-            name="uq_cloud_pending_interactions_target_session_request",
-        ),
+    _create_index_once(
+        "ix_cloud_transcript_items_target_id",
+        "cloud_transcript_items",
+        ["target_id"],
     )
-    op.create_index(
+
+    if not _has_table("cloud_pending_interactions"):
+        op.create_table(
+            "cloud_pending_interactions",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=True),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column("session_id", sa.String(length=255), nullable=False),
+            sa.Column("request_id", sa.String(length=255), nullable=False),
+            sa.Column("kind", sa.String(length=64), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("title", sa.Text(), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("payload_json", sa.Text(), nullable=True),
+            sa.Column("requested_seq", sa.Integer(), nullable=False),
+            sa.Column("resolved_seq", sa.Integer(), nullable=True),
+            sa.Column("requested_at", sa.String(length=64), nullable=True),
+            sa.Column("resolved_at", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "target_id",
+                "session_id",
+                "request_id",
+                name="uq_cloud_pending_interactions_target_session_request",
+            ),
+        )
+    _create_index_once(
         "ix_cloud_pending_interactions_cloud_workspace",
         "cloud_pending_interactions",
         ["cloud_workspace_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_pending_interactions_session_id",
         "cloud_pending_interactions",
         ["session_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_pending_interactions_session_status",
         "cloud_pending_interactions",
         ["session_id", "status"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_pending_interactions_target_id",
         "cloud_pending_interactions",
         ["target_id"],
@@ -216,37 +290,37 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index("ix_cloud_pending_interactions_target_id", table_name="cloud_pending_interactions")
-    op.drop_index(
+    _drop_index_once("ix_cloud_pending_interactions_target_id", "cloud_pending_interactions")
+    _drop_index_once(
         "ix_cloud_pending_interactions_session_status",
-        table_name="cloud_pending_interactions",
+        "cloud_pending_interactions",
     )
-    op.drop_index("ix_cloud_pending_interactions_session_id", table_name="cloud_pending_interactions")
-    op.drop_index(
+    _drop_index_once("ix_cloud_pending_interactions_session_id", "cloud_pending_interactions")
+    _drop_index_once(
         "ix_cloud_pending_interactions_cloud_workspace",
-        table_name="cloud_pending_interactions",
+        "cloud_pending_interactions",
     )
-    op.drop_table("cloud_pending_interactions")
+    _drop_table_once("cloud_pending_interactions")
 
-    op.drop_index("ix_cloud_transcript_items_target_id", table_name="cloud_transcript_items")
-    op.drop_index("ix_cloud_transcript_items_session_seq", table_name="cloud_transcript_items")
-    op.drop_index("ix_cloud_transcript_items_session_id", table_name="cloud_transcript_items")
-    op.drop_index("ix_cloud_transcript_items_cloud_workspace", table_name="cloud_transcript_items")
-    op.drop_table("cloud_transcript_items")
+    _drop_index_once("ix_cloud_transcript_items_target_id", "cloud_transcript_items")
+    _drop_index_once("ix_cloud_transcript_items_session_seq", "cloud_transcript_items")
+    _drop_index_once("ix_cloud_transcript_items_session_id", "cloud_transcript_items")
+    _drop_index_once("ix_cloud_transcript_items_cloud_workspace", "cloud_transcript_items")
+    _drop_table_once("cloud_transcript_items")
 
-    op.drop_index("ix_cloud_sessions_target_status", table_name="cloud_sessions")
-    op.drop_index("ix_cloud_sessions_target_id", table_name="cloud_sessions")
-    op.drop_index("ix_cloud_sessions_session_id", table_name="cloud_sessions")
-    op.drop_index("ix_cloud_sessions_last_event_seq", table_name="cloud_sessions")
-    op.drop_index("ix_cloud_sessions_cloud_workspace", table_name="cloud_sessions")
-    op.drop_table("cloud_sessions")
+    _drop_index_once("ix_cloud_sessions_target_status", "cloud_sessions")
+    _drop_index_once("ix_cloud_sessions_target_id", "cloud_sessions")
+    _drop_index_once("ix_cloud_sessions_session_id", "cloud_sessions")
+    _drop_index_once("ix_cloud_sessions_last_event_seq", "cloud_sessions")
+    _drop_index_once("ix_cloud_sessions_cloud_workspace", "cloud_sessions")
+    _drop_table_once("cloud_sessions")
 
-    op.drop_table("cloud_event_ingest_state")
+    _drop_table_once("cloud_event_ingest_state")
 
-    op.drop_index("ix_cloud_session_events_target_id", table_name="cloud_session_events")
-    op.drop_index("ix_cloud_session_events_session_id", table_name="cloud_session_events")
-    op.drop_index("ix_cloud_session_events_target_session", table_name="cloud_session_events")
-    op.drop_index("ix_cloud_session_events_session_seq", table_name="cloud_session_events")
-    op.drop_index("ix_cloud_session_events_type", table_name="cloud_session_events")
-    op.drop_index("ix_cloud_session_events_cloud_workspace", table_name="cloud_session_events")
-    op.drop_table("cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_target_id", "cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_session_id", "cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_target_session", "cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_session_seq", "cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_type", "cloud_session_events")
+    _drop_index_once("ix_cloud_session_events_cloud_workspace", "cloud_session_events")
+    _drop_table_once("cloud_session_events")

--- a/server/alembic/versions/c9d0e1f2a3b4_cloud_synced_workspace_mappings.py
+++ b/server/alembic/versions/c9d0e1f2a3b4_cloud_synced_workspace_mappings.py
@@ -19,46 +19,80 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_table_once(table_name: str) -> None:
+    if _has_table(table_name):
+        op.drop_table(table_name)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
-    op.create_table(
-        "cloud_synced_workspaces",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("cloud_workspace_id", sa.Uuid(), nullable=False),
-        sa.Column("workspace_id", sa.String(length=255), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="CASCADE"
-        ),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint(
-            "target_id",
-            "workspace_id",
-            name="uq_cloud_synced_workspaces_target_workspace",
-        ),
-    )
-    op.create_index(
+    if not _has_table("cloud_synced_workspaces"):
+        op.create_table(
+            "cloud_synced_workspaces",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("cloud_workspace_id", sa.Uuid(), nullable=False),
+            sa.Column("workspace_id", sa.String(length=255), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["cloud_workspace_id"], ["cloud_workspace.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "target_id",
+                "workspace_id",
+                name="uq_cloud_synced_workspaces_target_workspace",
+            ),
+        )
+    _create_index_once(
         "ix_cloud_synced_workspaces_cloud_workspace",
         "cloud_synced_workspaces",
         ["cloud_workspace_id"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_synced_workspaces_target_id",
         "cloud_synced_workspaces",
         ["target_id"],
-        unique=False,
     )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index("ix_cloud_synced_workspaces_target_id", table_name="cloud_synced_workspaces")
-    op.drop_index(
+    _drop_index_once("ix_cloud_synced_workspaces_target_id", "cloud_synced_workspaces")
+    _drop_index_once(
         "ix_cloud_synced_workspaces_cloud_workspace",
-        table_name="cloud_synced_workspaces",
+        "cloud_synced_workspaces",
     )
-    op.drop_table("cloud_synced_workspaces")
+    _drop_table_once("cloud_synced_workspaces")

--- a/server/alembic/versions/d0e1f2a3b4c5_cloud_target_config.py
+++ b/server/alembic/versions/d0e1f2a3b4c5_cloud_target_config.py
@@ -66,108 +66,148 @@ def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
     return f"{column_name} IN {values}"
 
 
-def upgrade() -> None:
-    """Upgrade schema."""
-    op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
+def _has_check_constraint(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_check_constraints(table_name)
+    }
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_table_once(table_name: str) -> None:
+    if _has_table(table_name):
+        op.drop_table(table_name)
+
+
+def _replace_command_kind_constraint(values: tuple[str, ...]) -> None:
+    if _has_check_constraint("cloud_commands", "ck_cloud_commands_kind"):
+        op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
     op.create_check_constraint(
         "ck_cloud_commands_kind",
         "cloud_commands",
-        _in_constraint("kind", _NEW_COMMAND_KINDS),
+        _in_constraint("kind", values),
     )
 
-    op.create_table(
-        "cloud_target_configs",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("organization_id", sa.Uuid(), nullable=True),
-        sa.Column("git_provider", sa.String(length=32), nullable=False),
-        sa.Column("git_owner", sa.String(length=255), nullable=False),
-        sa.Column("git_repo_name", sa.String(length=255), nullable=False),
-        sa.Column("workspace_root", sa.Text(), nullable=False),
-        sa.Column("config_version", sa.Integer(), nullable=False),
-        sa.Column("payload_ciphertext", sa.Text(), nullable=False),
-        sa.Column("summary_json", sa.Text(), nullable=False),
-        sa.Column("env_vars_version", sa.Integer(), nullable=False),
-        sa.Column("files_version", sa.Integer(), nullable=False),
-        sa.Column("credential_snapshot_version", sa.Integer(), nullable=False),
-        sa.Column("mcp_materialization_version", sa.Integer(), nullable=False),
-        sa.Column("materialization_status", sa.String(length=32), nullable=False),
-        sa.Column("last_command_id", sa.Uuid(), nullable=True),
-        sa.Column("last_materialized_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("last_error_code", sa.String(length=128), nullable=True),
-        sa.Column("last_error_message", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.CheckConstraint(
-            _in_constraint("materialization_status", _TARGET_CONFIG_STATUSES),
-            name="ck_cloud_target_configs_materialization_status",
-        ),
-        sa.ForeignKeyConstraint(["last_command_id"], ["cloud_commands.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _replace_command_kind_constraint(_NEW_COMMAND_KINDS)
+
+    if not _has_table("cloud_target_configs"):
+        op.create_table(
+            "cloud_target_configs",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("git_provider", sa.String(length=32), nullable=False),
+            sa.Column("git_owner", sa.String(length=255), nullable=False),
+            sa.Column("git_repo_name", sa.String(length=255), nullable=False),
+            sa.Column("workspace_root", sa.Text(), nullable=False),
+            sa.Column("config_version", sa.Integer(), nullable=False),
+            sa.Column("payload_ciphertext", sa.Text(), nullable=False),
+            sa.Column("summary_json", sa.Text(), nullable=False),
+            sa.Column("env_vars_version", sa.Integer(), nullable=False),
+            sa.Column("files_version", sa.Integer(), nullable=False),
+            sa.Column("credential_snapshot_version", sa.Integer(), nullable=False),
+            sa.Column("mcp_materialization_version", sa.Integer(), nullable=False),
+            sa.Column("materialization_status", sa.String(length=32), nullable=False),
+            sa.Column("last_command_id", sa.Uuid(), nullable=True),
+            sa.Column("last_materialized_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_error_code", sa.String(length=128), nullable=True),
+            sa.Column("last_error_message", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                _in_constraint("materialization_status", _TARGET_CONFIG_STATUSES),
+                name="ck_cloud_target_configs_materialization_status",
+            ),
+            sa.ForeignKeyConstraint(
+                ["last_command_id"], ["cloud_commands.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "uq_cloud_target_configs_target_repo",
         "cloud_target_configs",
         ["target_id", "git_provider", "git_owner", "git_repo_name"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_target_id",
         "cloud_target_configs",
         ["target_id"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_user_id",
         "cloud_target_configs",
         ["user_id"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_organization_id",
         "cloud_target_configs",
         ["organization_id"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_last_command",
         "cloud_target_configs",
         ["last_command_id"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_target_status",
         "cloud_target_configs",
         ["target_id", "materialization_status"],
-        unique=False,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_configs_user_repo",
         "cloud_target_configs",
         ["user_id", "git_owner", "git_repo_name"],
-        unique=False,
     )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     op.execute("DELETE FROM cloud_commands WHERE kind = 'materialize_environment'")
-    op.drop_index("ix_cloud_target_configs_user_repo", table_name="cloud_target_configs")
-    op.drop_index("ix_cloud_target_configs_target_status", table_name="cloud_target_configs")
-    op.drop_index("ix_cloud_target_configs_last_command", table_name="cloud_target_configs")
-    op.drop_index("ix_cloud_target_configs_organization_id", table_name="cloud_target_configs")
-    op.drop_index("ix_cloud_target_configs_user_id", table_name="cloud_target_configs")
-    op.drop_index("ix_cloud_target_configs_target_id", table_name="cloud_target_configs")
-    op.drop_index("uq_cloud_target_configs_target_repo", table_name="cloud_target_configs")
-    op.drop_table("cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_user_repo", "cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_target_status", "cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_last_command", "cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_organization_id", "cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_user_id", "cloud_target_configs")
+    _drop_index_once("ix_cloud_target_configs_target_id", "cloud_target_configs")
+    _drop_index_once("uq_cloud_target_configs_target_repo", "cloud_target_configs")
+    _drop_table_once("cloud_target_configs")
 
-    op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
-    op.create_check_constraint(
-        "ck_cloud_commands_kind",
-        "cloud_commands",
-        _in_constraint("kind", _OLD_COMMAND_KINDS),
-    )
+    _replace_command_kind_constraint(_OLD_COMMAND_KINDS)

--- a/server/alembic/versions/d4e5f6a7b8c9_automation_target_snapshots.py
+++ b/server/alembic/versions/d4e5f6a7b8c9_automation_target_snapshots.py
@@ -18,42 +18,92 @@ branch_labels: str | None = None
 depends_on: str | None = None
 
 
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _has_foreign_key(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_foreign_keys(table_name)
+    }
+
+
+def _add_column_once(table_name: str, column: sa.Column) -> None:
+    if not _has_column(table_name, column.name):
+        op.add_column(table_name, column)
+
+
+def _create_index_once(index_name: str, table_name: str, columns: list[str]) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns)
+
+
+def _drop_column_once(table_name: str, column_name: str) -> None:
+    if _has_column(table_name, column_name):
+        op.drop_column(table_name, column_name)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_foreign_key_once(constraint_name: str, table_name: str) -> None:
+    if _has_foreign_key(table_name, constraint_name):
+        op.drop_constraint(constraint_name, table_name, type_="foreignkey")
+
+
 def upgrade() -> None:
-    op.add_column(
+    _add_column_once(
         "automation",
         sa.Column("cloud_target_id", postgresql.UUID(as_uuid=True), nullable=True),
     )
-    op.add_column(
+    _add_column_once(
         "automation",
         sa.Column("cloud_target_kind_snapshot", sa.String(length=32), nullable=True),
     )
-    op.create_foreign_key(
-        "fk_automation_cloud_target_id_cloud_targets",
-        "automation",
-        "cloud_targets",
-        ["cloud_target_id"],
-        ["id"],
-        ondelete="SET NULL",
-    )
-    op.create_index("ix_automation_cloud_target_id", "automation", ["cloud_target_id"])
+    if not _has_foreign_key("automation", "fk_automation_cloud_target_id_cloud_targets"):
+        op.create_foreign_key(
+            "fk_automation_cloud_target_id_cloud_targets",
+            "automation",
+            "cloud_targets",
+            ["cloud_target_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    _create_index_once("ix_automation_cloud_target_id", "automation", ["cloud_target_id"])
 
-    op.add_column(
+    _add_column_once(
         "automation_run",
         sa.Column("cloud_target_id_snapshot", postgresql.UUID(as_uuid=True), nullable=True),
     )
-    op.add_column(
+    _add_column_once(
         "automation_run",
         sa.Column("cloud_target_kind_snapshot", sa.String(length=32), nullable=True),
     )
-    op.create_foreign_key(
-        "fk_automation_run_cloud_target_id_snapshot_cloud_targets",
+    if not _has_foreign_key(
         "automation_run",
-        "cloud_targets",
-        ["cloud_target_id_snapshot"],
-        ["id"],
-        ondelete="SET NULL",
-    )
-    op.create_index(
+        "fk_automation_run_cloud_target_id_snapshot_cloud_targets",
+    ):
+        op.create_foreign_key(
+            "fk_automation_run_cloud_target_id_snapshot_cloud_targets",
+            "automation_run",
+            "cloud_targets",
+            ["cloud_target_id_snapshot"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    _create_index_once(
         "ix_automation_run_cloud_target_id_snapshot",
         "automation_run",
         ["cloud_target_id_snapshot"],
@@ -61,20 +111,18 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_automation_run_cloud_target_id_snapshot", table_name="automation_run")
-    op.drop_constraint(
+    _drop_index_once("ix_automation_run_cloud_target_id_snapshot", "automation_run")
+    _drop_foreign_key_once(
         "fk_automation_run_cloud_target_id_snapshot_cloud_targets",
         "automation_run",
-        type_="foreignkey",
     )
-    op.drop_column("automation_run", "cloud_target_kind_snapshot")
-    op.drop_column("automation_run", "cloud_target_id_snapshot")
+    _drop_column_once("automation_run", "cloud_target_kind_snapshot")
+    _drop_column_once("automation_run", "cloud_target_id_snapshot")
 
-    op.drop_index("ix_automation_cloud_target_id", table_name="automation")
-    op.drop_constraint(
+    _drop_index_once("ix_automation_cloud_target_id", "automation")
+    _drop_foreign_key_once(
         "fk_automation_cloud_target_id_cloud_targets",
         "automation",
-        type_="foreignkey",
     )
-    op.drop_column("automation", "cloud_target_kind_snapshot")
-    op.drop_column("automation", "cloud_target_id")
+    _drop_column_once("automation", "cloud_target_kind_snapshot")
+    _drop_column_once("automation", "cloud_target_id")

--- a/server/alembic/versions/d5e6f7a8b9c0_cloud_target_git_identity.py
+++ b/server/alembic/versions/d5e6f7a8b9c0_cloud_target_git_identity.py
@@ -69,8 +69,52 @@ def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
     return f"{column_name} IN {values}"
 
 
+def _has_check_constraint(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_check_constraints(table_name)
+    }
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_table_once(table_name: str) -> None:
+    if _has_table(table_name):
+        op.drop_table(table_name)
+
+
 def _replace_command_kind_constraint(values: tuple[str, ...]) -> None:
-    op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
+    if _has_check_constraint("cloud_commands", "ck_cloud_commands_kind"):
+        op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
     op.create_check_constraint(
         "ck_cloud_commands_kind",
         "cloud_commands",
@@ -80,50 +124,53 @@ def _replace_command_kind_constraint(values: tuple[str, ...]) -> None:
 
 def upgrade() -> None:
     _replace_command_kind_constraint(_NEW_COMMAND_KINDS)
-    op.create_table(
-        "cloud_target_git_identities",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("target_id", sa.Uuid(), nullable=False),
-        sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("organization_id", sa.Uuid(), nullable=True),
-        sa.Column("provider", sa.String(length=32), nullable=False),
-        sa.Column("config_version", sa.Integer(), nullable=False),
-        sa.Column("payload_ciphertext", sa.Text(), nullable=False),
-        sa.Column("summary_json", sa.Text(), nullable=False),
-        sa.Column("materialization_status", sa.String(length=32), nullable=False),
-        sa.Column("last_command_id", sa.Uuid(), nullable=True),
-        sa.Column("last_materialized_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("last_error_code", sa.String(length=128), nullable=True),
-        sa.Column("last_error_message", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.CheckConstraint(
-            _in_constraint("materialization_status", _TARGET_CONFIG_STATUSES),
-            name="ck_cloud_target_git_identities_materialization_status",
-        ),
-        sa.ForeignKeyConstraint(["last_command_id"], ["cloud_commands.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+    if not _has_table("cloud_target_git_identities"):
+        op.create_table(
+            "cloud_target_git_identities",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("target_id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("provider", sa.String(length=32), nullable=False),
+            sa.Column("config_version", sa.Integer(), nullable=False),
+            sa.Column("payload_ciphertext", sa.Text(), nullable=False),
+            sa.Column("summary_json", sa.Text(), nullable=False),
+            sa.Column("materialization_status", sa.String(length=32), nullable=False),
+            sa.Column("last_command_id", sa.Uuid(), nullable=True),
+            sa.Column("last_materialized_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_error_code", sa.String(length=128), nullable=True),
+            sa.Column("last_error_message", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                _in_constraint("materialization_status", _TARGET_CONFIG_STATUSES),
+                name="ck_cloud_target_git_identities_materialization_status",
+            ),
+            sa.ForeignKeyConstraint(
+                ["last_command_id"], ["cloud_commands.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "uq_cloud_target_git_identities_target_provider",
         "cloud_target_git_identities",
         ["target_id", "provider"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_git_identities_target_status",
         "cloud_target_git_identities",
         ["target_id", "materialization_status"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_git_identities_user_id",
         "cloud_target_git_identities",
         ["user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_target_git_identities_last_command",
         "cloud_target_git_identities",
         ["last_command_id"],
@@ -133,21 +180,21 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.execute("DELETE FROM cloud_commands WHERE kind = 'configure_git_identity'")
     op.execute("DELETE FROM cloud_commands WHERE kind = 'ensure_repo_checkout'")
-    op.drop_index(
+    _drop_index_once(
         "ix_cloud_target_git_identities_last_command",
-        table_name="cloud_target_git_identities",
+        "cloud_target_git_identities",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_cloud_target_git_identities_user_id",
-        table_name="cloud_target_git_identities",
+        "cloud_target_git_identities",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_cloud_target_git_identities_target_status",
-        table_name="cloud_target_git_identities",
+        "cloud_target_git_identities",
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_cloud_target_git_identities_target_provider",
-        table_name="cloud_target_git_identities",
+        "cloud_target_git_identities",
     )
-    op.drop_table("cloud_target_git_identities")
+    _drop_table_once("cloud_target_git_identities")
     _replace_command_kind_constraint(_OLD_COMMAND_KINDS)

--- a/server/alembic/versions/e6f7a8b9c0d1_agent_llm_auth_gateway_phase1.py
+++ b/server/alembic/versions/e6f7a8b9c0d1_agent_llm_auth_gateway_phase1.py
@@ -1,7 +1,7 @@
 """Add agent LLM auth gateway Phase 1 schema.
 
 Revision ID: e6f7a8b9c0d1
-Revises: d5e6f7a8b9c0
+Revises: f8a9b0c1d2e3
 Create Date: 2026-05-17 12:00:00.000000
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "e6f7a8b9c0d1"
-down_revision: str | None = "d5e6f7a8b9c0"
+down_revision: str | None = "f8a9b0c1d2e3"
 branch_labels: str | None = None
 depends_on: str | None = None
 
@@ -47,8 +47,51 @@ def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
     return f"{column_name} IN ({quoted})"
 
 
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _create_table_once(
+    table_name: str,
+    *columns: sa.SchemaItem,
+    **kwargs: object,
+) -> None:
+    if not _has_table(table_name):
+        op.create_table(table_name, *columns, **kwargs)
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    **kwargs: object,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, **kwargs)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_table_once(table_name: str) -> None:
+    if _has_table(table_name):
+        op.drop_table(table_name)
+
+
 def upgrade() -> None:
-    op.create_table(
+    _create_table_once(
         "sandbox_profile",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("owner_scope", sa.String(length=32), nullable=False),
@@ -79,7 +122,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_sandbox_profile_active_personal_user",
         "sandbox_profile",
         ["owner_user_id"],
@@ -88,7 +131,7 @@ def upgrade() -> None:
             "owner_scope = 'personal' AND deleted_at IS NULL AND status = 'active'"
         ),
     )
-    op.create_index(
+    _create_index_once(
         "uq_sandbox_profile_active_organization",
         "sandbox_profile",
         ["organization_id"],
@@ -97,15 +140,17 @@ def upgrade() -> None:
             "owner_scope = 'organization' AND deleted_at IS NULL AND status = 'active'"
         ),
     )
-    op.create_index("ix_sandbox_profile_owner_scope", "sandbox_profile", ["owner_scope"])
-    op.create_index("ix_sandbox_profile_owner_user_id", "sandbox_profile", ["owner_user_id"])
-    op.create_index("ix_sandbox_profile_organization_id", "sandbox_profile", ["organization_id"])
-    op.create_index(
+    _create_index_once("ix_sandbox_profile_owner_scope", "sandbox_profile", ["owner_scope"])
+    _create_index_once("ix_sandbox_profile_owner_user_id", "sandbox_profile", ["owner_user_id"])
+    _create_index_once(
+        "ix_sandbox_profile_organization_id", "sandbox_profile", ["organization_id"]
+    )
+    _create_index_once(
         "ix_sandbox_profile_managed_target_id", "sandbox_profile", ["managed_target_id"]
     )
-    op.create_index("ix_sandbox_profile_status", "sandbox_profile", ["status"])
+    _create_index_once("ix_sandbox_profile_status", "sandbox_profile", ["status"])
 
-    op.create_table(
+    _create_table_once(
         "sandbox_profile_agent_auth_revision",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
@@ -120,24 +165,24 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_sandbox_profile_agent_auth_revision_profile_revision",
         "sandbox_profile_agent_auth_revision",
         ["sandbox_profile_id", "revision"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_revision_sandbox_profile_id",
         "sandbox_profile_agent_auth_revision",
         ["sandbox_profile_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_revision_created_by_user_id",
         "sandbox_profile_agent_auth_revision",
         ["created_by_user_id"],
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_auth_credential",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("owner_scope", sa.String(length=32), nullable=False),
@@ -186,37 +231,39 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("legacy_cloud_credential_id"),
     )
-    op.create_index("ix_agent_auth_credential_agent_kind", "agent_auth_credential", ["agent_kind"])
-    op.create_index(
+    _create_index_once(
+        "ix_agent_auth_credential_agent_kind", "agent_auth_credential", ["agent_kind"]
+    )
+    _create_index_once(
         "ix_agent_auth_credential_credential_kind", "agent_auth_credential", ["credential_kind"]
     )
-    op.create_index("ix_agent_auth_credential_status", "agent_auth_credential", ["status"])
-    op.create_index(
+    _create_index_once("ix_agent_auth_credential_status", "agent_auth_credential", ["status"])
+    _create_index_once(
         "ix_agent_auth_credential_owner_scope", "agent_auth_credential", ["owner_scope"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_owner_user_id", "agent_auth_credential", ["owner_user_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_organization_id", "agent_auth_credential", ["organization_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_created_by_user_id",
         "agent_auth_credential",
         ["created_by_user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_owner_user_kind_status",
         "agent_auth_credential",
         ["owner_scope", "owner_user_id", "agent_kind", "status"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_org_kind_status",
         "agent_auth_credential",
         ["owner_scope", "organization_id", "agent_kind", "status"],
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_auth_credential_share",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("credential_id", sa.Uuid(), nullable=False),
@@ -248,45 +295,45 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["shared_by_user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_share_credential_id",
         "agent_auth_credential_share",
         ["credential_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_share_owner_user_id",
         "agent_auth_credential_share",
         ["owner_user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_share_organization_id",
         "agent_auth_credential_share",
         ["organization_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_share_shared_by_user_id",
         "agent_auth_credential_share",
         ["shared_by_user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_credential_share_revoked_by_user_id",
         "agent_auth_credential_share",
         ["revoked_by_user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "uq_agent_auth_active_share_credential_org",
         "agent_auth_credential_share",
         ["credential_id", "organization_id"],
         unique=True,
         postgresql_where=sa.text("status = 'active'"),
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_share_org_kind_status",
         "agent_auth_credential_share",
         ["organization_id", "allowed_agent_kind", "status"],
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_gateway_budget_subject",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("budget_kind", sa.String(length=32), nullable=False),
@@ -326,20 +373,20 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_budget_subject_organization_id",
         "agent_gateway_budget_subject",
         ["organization_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_budget_subject_litellm_sync_status",
         "agent_gateway_budget_subject",
         ["litellm_sync_status"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_budget_subject_status", "agent_gateway_budget_subject", ["status"]
     )
-    op.create_index(
+    _create_index_once(
         "uq_agent_gateway_managed_budget_subject_org",
         "agent_gateway_budget_subject",
         ["organization_id"],
@@ -347,7 +394,7 @@ def upgrade() -> None:
         postgresql_where=sa.text("budget_kind = 'proliferate_managed' AND status != 'revoked'"),
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_gateway_policy",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("credential_id", sa.Uuid(), nullable=False),
@@ -399,7 +446,7 @@ def upgrade() -> None:
             _in_constraint("status", _POLICY_STATUSES), name="ck_agent_gateway_policy_status"
         ),
         sa.ForeignKeyConstraint(
-            ["budget_subject_id"], ["agent_gateway_budget_subject.id"], ondelete="SET NULL"
+            ["budget_subject_id"], ["agent_gateway_budget_subject.id"], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
             ["credential_id"], ["agent_auth_credential.id"], ondelete="CASCADE"
@@ -408,34 +455,38 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_agent_gateway_policy_credential",
         "agent_gateway_policy",
         ["credential_id"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_policy_credential_id", "agent_gateway_policy", ["credential_id"]
     )
-    op.create_index("ix_agent_gateway_policy_policy_kind", "agent_gateway_policy", ["policy_kind"])
-    op.create_index("ix_agent_gateway_policy_owner_scope", "agent_gateway_policy", ["owner_scope"])
-    op.create_index(
+    _create_index_once(
+        "ix_agent_gateway_policy_policy_kind", "agent_gateway_policy", ["policy_kind"]
+    )
+    _create_index_once(
+        "ix_agent_gateway_policy_owner_scope", "agent_gateway_policy", ["owner_scope"]
+    )
+    _create_index_once(
         "ix_agent_gateway_policy_owner_user_id", "agent_gateway_policy", ["owner_user_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_policy_organization_id", "agent_gateway_policy", ["organization_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_policy_budget_subject_id", "agent_gateway_policy", ["budget_subject_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_policy_litellm_sync_status",
         "agent_gateway_policy",
         ["litellm_sync_status"],
     )
-    op.create_index("ix_agent_gateway_policy_status", "agent_gateway_policy", ["status"])
+    _create_index_once("ix_agent_gateway_policy_status", "agent_gateway_policy", ["status"])
 
-    op.create_table(
+    _create_table_once(
         "agent_gateway_provider_credential",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("policy_id", sa.Uuid(), nullable=False),
@@ -461,29 +512,29 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["policy_id"], ["agent_gateway_policy.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_agent_gateway_provider_credential_policy",
         "agent_gateway_provider_credential",
         ["policy_id"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_provider_credential_policy_id",
         "agent_gateway_provider_credential",
         ["policy_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_provider_credential_provider_kind",
         "agent_gateway_provider_credential",
         ["provider_kind"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_provider_credential_validation_status",
         "agent_gateway_provider_credential",
         ["validation_status"],
     )
 
-    op.create_table(
+    _create_table_once(
         "sandbox_agent_auth_selection",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
@@ -528,42 +579,42 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_sandbox_agent_auth_selection_profile_agent",
         "sandbox_agent_auth_selection",
         ["sandbox_profile_id", "agent_kind"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_sandbox_profile_id",
         "sandbox_agent_auth_selection",
         ["sandbox_profile_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_credential_id",
         "sandbox_agent_auth_selection",
         ["credential_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_credential_share_id",
         "sandbox_agent_auth_selection",
         ["credential_share_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_owner_scope",
         "sandbox_agent_auth_selection",
         ["owner_scope"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_agent_kind",
         "sandbox_agent_auth_selection",
         ["agent_kind"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_agent_auth_selection_status", "sandbox_agent_auth_selection", ["status"]
     )
 
-    op.create_table(
+    _create_table_once(
         "sandbox_profile_agent_auth_target_state",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
@@ -596,39 +647,39 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_sandbox_profile_agent_auth_target_state_target_profile",
         "sandbox_profile_agent_auth_target_state",
         ["target_id", "sandbox_profile_id"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_target_state_sandbox_profile_id",
         "sandbox_profile_agent_auth_target_state",
         ["sandbox_profile_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_target_state_target_id",
         "sandbox_profile_agent_auth_target_state",
         ["target_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_target_state_last_command_id",
         "sandbox_profile_agent_auth_target_state",
         ["last_command_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_target_state_last_worker_id",
         "sandbox_profile_agent_auth_target_state",
         ["last_worker_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_sandbox_profile_agent_auth_target_state_status_revision",
         "sandbox_profile_agent_auth_target_state",
         ["target_id", "status", "desired_revision", "applied_revision"],
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_gateway_runtime_grant",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("token_hash", sa.String(length=64), nullable=False),
@@ -670,64 +721,64 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
+    _create_index_once(
         "uq_agent_gateway_runtime_grant_token_hash",
         "agent_gateway_runtime_grant",
         ["token_hash"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_policy_id", "agent_gateway_runtime_grant", ["policy_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_credential_id",
         "agent_gateway_runtime_grant",
         ["credential_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_selection_id",
         "agent_gateway_runtime_grant",
         ["selection_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_target_id", "agent_gateway_runtime_grant", ["target_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_sandbox_profile_id",
         "agent_gateway_runtime_grant",
         ["sandbox_profile_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_organization_id",
         "agent_gateway_runtime_grant",
         ["organization_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_user_id", "agent_gateway_runtime_grant", ["user_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_agent_kind", "agent_gateway_runtime_grant", ["agent_kind"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_expires_at", "agent_gateway_runtime_grant", ["expires_at"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_policy_revocation_expiry",
         "agent_gateway_runtime_grant",
         ["policy_id", "revoked_at", "expires_at"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_target_profile_agent",
         "agent_gateway_runtime_grant",
         ["target_id", "sandbox_profile_id", "agent_kind"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_gateway_runtime_grant_selection_revision",
         "agent_gateway_runtime_grant",
         ["selection_id", "issued_profile_revision"],
     )
 
-    op.create_table(
+    _create_table_once(
         "agent_auth_audit_event",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("action", sa.String(length=64), nullable=False),
@@ -752,39 +803,41 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_agent_auth_audit_event_action", "agent_auth_audit_event", ["action"])
-    op.create_index(
+    _create_index_once("ix_agent_auth_audit_event_action", "agent_auth_audit_event", ["action"])
+    _create_index_once(
         "ix_agent_auth_audit_event_actor_user_id", "agent_auth_audit_event", ["actor_user_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_owner_scope", "agent_auth_audit_event", ["owner_scope"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_owner_user_id", "agent_auth_audit_event", ["owner_user_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_organization_id", "agent_auth_audit_event", ["organization_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_credential_id", "agent_auth_audit_event", ["credential_id"]
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_sandbox_profile_id",
         "agent_auth_audit_event",
         ["sandbox_profile_id"],
     )
-    op.create_index("ix_agent_auth_audit_event_target_id", "agent_auth_audit_event", ["target_id"])
-    op.create_index(
+    _create_index_once(
+        "ix_agent_auth_audit_event_target_id", "agent_auth_audit_event", ["target_id"]
+    )
+    _create_index_once(
         "ix_agent_auth_audit_event_actor_created",
         "agent_auth_audit_event",
         ["actor_user_id", "created_at"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_org_created",
         "agent_auth_audit_event",
         ["organization_id", "created_at"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_agent_auth_audit_event_credential_created",
         "agent_auth_audit_event",
         ["credential_id", "created_at"],
@@ -792,221 +845,243 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_audit_event_credential_created", table_name="agent_auth_audit_event"
     )
-    op.drop_index("ix_agent_auth_audit_event_org_created", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_actor_created", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_target_id", table_name="agent_auth_audit_event")
-    op.drop_index(
+    _drop_index_once("ix_agent_auth_audit_event_org_created", table_name="agent_auth_audit_event")
+    _drop_index_once(
+        "ix_agent_auth_audit_event_actor_created", table_name="agent_auth_audit_event"
+    )
+    _drop_index_once("ix_agent_auth_audit_event_target_id", table_name="agent_auth_audit_event")
+    _drop_index_once(
         "ix_agent_auth_audit_event_sandbox_profile_id", table_name="agent_auth_audit_event"
     )
-    op.drop_index("ix_agent_auth_audit_event_credential_id", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_organization_id", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_owner_user_id", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_owner_scope", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_actor_user_id", table_name="agent_auth_audit_event")
-    op.drop_index("ix_agent_auth_audit_event_action", table_name="agent_auth_audit_event")
-    op.drop_table("agent_auth_audit_event")
+    _drop_index_once(
+        "ix_agent_auth_audit_event_credential_id", table_name="agent_auth_audit_event"
+    )
+    _drop_index_once(
+        "ix_agent_auth_audit_event_organization_id", table_name="agent_auth_audit_event"
+    )
+    _drop_index_once(
+        "ix_agent_auth_audit_event_owner_user_id", table_name="agent_auth_audit_event"
+    )
+    _drop_index_once("ix_agent_auth_audit_event_owner_scope", table_name="agent_auth_audit_event")
+    _drop_index_once(
+        "ix_agent_auth_audit_event_actor_user_id", table_name="agent_auth_audit_event"
+    )
+    _drop_index_once("ix_agent_auth_audit_event_action", table_name="agent_auth_audit_event")
+    _drop_table_once("agent_auth_audit_event")
 
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_selection_revision",
         table_name="agent_gateway_runtime_grant",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_target_profile_agent",
         table_name="agent_gateway_runtime_grant",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_policy_revocation_expiry",
         table_name="agent_gateway_runtime_grant",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_expires_at", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_agent_kind", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_user_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_organization_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_sandbox_profile_id",
         table_name="agent_gateway_runtime_grant",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_target_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_selection_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_credential_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_runtime_grant_policy_id", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_agent_gateway_runtime_grant_token_hash", table_name="agent_gateway_runtime_grant"
     )
-    op.drop_table("agent_gateway_runtime_grant")
+    _drop_table_once("agent_gateway_runtime_grant")
 
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_target_state_status_revision",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_target_state_last_worker_id",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_target_state_last_command_id",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_target_state_target_id",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_target_state_sandbox_profile_id",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_sandbox_profile_agent_auth_target_state_target_profile",
         table_name="sandbox_profile_agent_auth_target_state",
     )
-    op.drop_table("sandbox_profile_agent_auth_target_state")
+    _drop_table_once("sandbox_profile_agent_auth_target_state")
 
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_status", table_name="sandbox_agent_auth_selection"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_agent_kind", table_name="sandbox_agent_auth_selection"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_owner_scope", table_name="sandbox_agent_auth_selection"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_credential_share_id",
         table_name="sandbox_agent_auth_selection",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_credential_id", table_name="sandbox_agent_auth_selection"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_agent_auth_selection_sandbox_profile_id",
         table_name="sandbox_agent_auth_selection",
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_sandbox_agent_auth_selection_profile_agent", table_name="sandbox_agent_auth_selection"
     )
-    op.drop_table("sandbox_agent_auth_selection")
+    _drop_table_once("sandbox_agent_auth_selection")
 
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_provider_credential_validation_status",
         table_name="agent_gateway_provider_credential",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_provider_credential_provider_kind",
         table_name="agent_gateway_provider_credential",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_provider_credential_policy_id",
         table_name="agent_gateway_provider_credential",
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_agent_gateway_provider_credential_policy",
         table_name="agent_gateway_provider_credential",
     )
-    op.drop_table("agent_gateway_provider_credential")
+    _drop_table_once("agent_gateway_provider_credential")
 
-    op.drop_index("ix_agent_gateway_policy_status", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_litellm_sync_status", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_budget_subject_id", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_organization_id", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_owner_user_id", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_owner_scope", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_policy_kind", table_name="agent_gateway_policy")
-    op.drop_index("ix_agent_gateway_policy_credential_id", table_name="agent_gateway_policy")
-    op.drop_index("uq_agent_gateway_policy_credential", table_name="agent_gateway_policy")
-    op.drop_table("agent_gateway_policy")
+    _drop_index_once("ix_agent_gateway_policy_status", table_name="agent_gateway_policy")
+    _drop_index_once(
+        "ix_agent_gateway_policy_litellm_sync_status", table_name="agent_gateway_policy"
+    )
+    _drop_index_once(
+        "ix_agent_gateway_policy_budget_subject_id", table_name="agent_gateway_policy"
+    )
+    _drop_index_once("ix_agent_gateway_policy_organization_id", table_name="agent_gateway_policy")
+    _drop_index_once("ix_agent_gateway_policy_owner_user_id", table_name="agent_gateway_policy")
+    _drop_index_once("ix_agent_gateway_policy_owner_scope", table_name="agent_gateway_policy")
+    _drop_index_once("ix_agent_gateway_policy_policy_kind", table_name="agent_gateway_policy")
+    _drop_index_once("ix_agent_gateway_policy_credential_id", table_name="agent_gateway_policy")
+    _drop_index_once("uq_agent_gateway_policy_credential", table_name="agent_gateway_policy")
+    _drop_table_once("agent_gateway_policy")
 
-    op.drop_index(
+    _drop_index_once(
         "uq_agent_gateway_managed_budget_subject_org", table_name="agent_gateway_budget_subject"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_budget_subject_status", table_name="agent_gateway_budget_subject"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_budget_subject_litellm_sync_status",
         table_name="agent_gateway_budget_subject",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_gateway_budget_subject_organization_id",
         table_name="agent_gateway_budget_subject",
     )
-    op.drop_table("agent_gateway_budget_subject")
+    _drop_table_once("agent_gateway_budget_subject")
 
-    op.drop_index("ix_agent_auth_share_org_kind_status", table_name="agent_auth_credential_share")
-    op.drop_index(
+    _drop_index_once(
+        "ix_agent_auth_share_org_kind_status", table_name="agent_auth_credential_share"
+    )
+    _drop_index_once(
         "uq_agent_auth_active_share_credential_org", table_name="agent_auth_credential_share"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_share_revoked_by_user_id",
         table_name="agent_auth_credential_share",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_share_shared_by_user_id",
         table_name="agent_auth_credential_share",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_share_organization_id", table_name="agent_auth_credential_share"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_share_owner_user_id", table_name="agent_auth_credential_share"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_share_credential_id", table_name="agent_auth_credential_share"
     )
-    op.drop_table("agent_auth_credential_share")
+    _drop_table_once("agent_auth_credential_share")
 
-    op.drop_index("ix_agent_auth_credential_org_kind_status", table_name="agent_auth_credential")
-    op.drop_index(
+    _drop_index_once(
+        "ix_agent_auth_credential_org_kind_status", table_name="agent_auth_credential"
+    )
+    _drop_index_once(
         "ix_agent_auth_credential_owner_user_kind_status", table_name="agent_auth_credential"
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_agent_auth_credential_created_by_user_id", table_name="agent_auth_credential"
     )
-    op.drop_index("ix_agent_auth_credential_organization_id", table_name="agent_auth_credential")
-    op.drop_index("ix_agent_auth_credential_owner_user_id", table_name="agent_auth_credential")
-    op.drop_index("ix_agent_auth_credential_owner_scope", table_name="agent_auth_credential")
-    op.drop_index("ix_agent_auth_credential_status", table_name="agent_auth_credential")
-    op.drop_index("ix_agent_auth_credential_credential_kind", table_name="agent_auth_credential")
-    op.drop_index("ix_agent_auth_credential_agent_kind", table_name="agent_auth_credential")
-    op.drop_table("agent_auth_credential")
+    _drop_index_once(
+        "ix_agent_auth_credential_organization_id", table_name="agent_auth_credential"
+    )
+    _drop_index_once("ix_agent_auth_credential_owner_user_id", table_name="agent_auth_credential")
+    _drop_index_once("ix_agent_auth_credential_owner_scope", table_name="agent_auth_credential")
+    _drop_index_once("ix_agent_auth_credential_status", table_name="agent_auth_credential")
+    _drop_index_once(
+        "ix_agent_auth_credential_credential_kind", table_name="agent_auth_credential"
+    )
+    _drop_index_once("ix_agent_auth_credential_agent_kind", table_name="agent_auth_credential")
+    _drop_table_once("agent_auth_credential")
 
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_revision_created_by_user_id",
         table_name="sandbox_profile_agent_auth_revision",
     )
-    op.drop_index(
+    _drop_index_once(
         "ix_sandbox_profile_agent_auth_revision_sandbox_profile_id",
         table_name="sandbox_profile_agent_auth_revision",
     )
-    op.drop_index(
+    _drop_index_once(
         "uq_sandbox_profile_agent_auth_revision_profile_revision",
         table_name="sandbox_profile_agent_auth_revision",
     )
-    op.drop_table("sandbox_profile_agent_auth_revision")
+    _drop_table_once("sandbox_profile_agent_auth_revision")
 
-    op.drop_index("ix_sandbox_profile_status", table_name="sandbox_profile")
-    op.drop_index("ix_sandbox_profile_managed_target_id", table_name="sandbox_profile")
-    op.drop_index("ix_sandbox_profile_organization_id", table_name="sandbox_profile")
-    op.drop_index("ix_sandbox_profile_owner_user_id", table_name="sandbox_profile")
-    op.drop_index("ix_sandbox_profile_owner_scope", table_name="sandbox_profile")
-    op.drop_index("uq_sandbox_profile_active_organization", table_name="sandbox_profile")
-    op.drop_index("uq_sandbox_profile_active_personal_user", table_name="sandbox_profile")
-    op.drop_table("sandbox_profile")
+    _drop_index_once("ix_sandbox_profile_status", table_name="sandbox_profile")
+    _drop_index_once("ix_sandbox_profile_managed_target_id", table_name="sandbox_profile")
+    _drop_index_once("ix_sandbox_profile_organization_id", table_name="sandbox_profile")
+    _drop_index_once("ix_sandbox_profile_owner_user_id", table_name="sandbox_profile")
+    _drop_index_once("ix_sandbox_profile_owner_scope", table_name="sandbox_profile")
+    _drop_index_once("uq_sandbox_profile_active_organization", table_name="sandbox_profile")
+    _drop_index_once("uq_sandbox_profile_active_personal_user", table_name="sandbox_profile")
+    _drop_table_once("sandbox_profile")

--- a/server/alembic/versions/e6f7a8b9c0d1_agent_llm_auth_gateway_phase1.py
+++ b/server/alembic/versions/e6f7a8b9c0d1_agent_llm_auth_gateway_phase1.py
@@ -1,0 +1,1012 @@
+"""Add agent LLM auth gateway Phase 1 schema.
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-05-17 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: str | None = "d5e6f7a8b9c0"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_AGENT_KINDS = ("claude", "codex", "opencode", "gemini")
+_OWNER_SCOPES = ("system", "personal", "organization")
+_PROFILE_OWNER_SCOPES = ("personal", "organization")
+_CREDENTIAL_KINDS = ("managed_gateway", "synced_path")
+_CREDENTIAL_STATUSES = ("pending", "ready", "needs_resync", "invalid", "revoked")
+_SHARE_STATUSES = ("active", "revoked")
+_POLICY_KINDS = ("proliferate_managed", "org_byok", "personal_byok")
+_BUDGET_KINDS = ("proliferate_managed",)
+_SYNC_STATUSES = ("pending", "synced", "drifted", "failed")
+_POLICY_STATUSES = ("provisioning", "ready", "invalid", "revoked")
+_BUDGET_STATUSES = ("ready", "exhausted", "invalid", "revoked")
+_PROVIDER_KINDS = (
+    "proliferate_bedrock_pool",
+    "anthropic_api_key",
+    "openai_api_key",
+    "bedrock_assume_role",
+    "openai_compatible",
+)
+_VALIDATION_STATUSES = ("unvalidated", "valid", "invalid")
+_MATERIALIZATION_MODES = ("gateway_env", "synced_files")
+_SELECTION_STATUSES = ("active", "needs_resync", "invalid")
+_TARGET_STATE_STATUSES = ("pending", "materializing", "applied", "failed", "superseded")
+_PROTOCOL_FACADES = ("anthropic", "openai")
+_PROFILE_STATUSES = ("active", "archived")
+
+
+def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{value}'" for value in values)
+    return f"{column_name} IN ({quoted})"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sandbox_profile",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+        sa.Column("managed_target_id", sa.Uuid(), nullable=True),
+        sa.Column("agent_auth_revision", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            _in_constraint("owner_scope", _PROFILE_OWNER_SCOPES),
+            name="ck_sandbox_profile_owner_scope",
+        ),
+        sa.CheckConstraint(
+            "((owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_sandbox_profile_owner_fields",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _PROFILE_STATUSES), name="ck_sandbox_profile_status"
+        ),
+        sa.ForeignKeyConstraint(["managed_target_id"], ["cloud_targets.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sandbox_profile_active_personal_user",
+        "sandbox_profile",
+        ["owner_user_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "owner_scope = 'personal' AND deleted_at IS NULL AND status = 'active'"
+        ),
+    )
+    op.create_index(
+        "uq_sandbox_profile_active_organization",
+        "sandbox_profile",
+        ["organization_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "owner_scope = 'organization' AND deleted_at IS NULL AND status = 'active'"
+        ),
+    )
+    op.create_index("ix_sandbox_profile_owner_scope", "sandbox_profile", ["owner_scope"])
+    op.create_index("ix_sandbox_profile_owner_user_id", "sandbox_profile", ["owner_user_id"])
+    op.create_index("ix_sandbox_profile_organization_id", "sandbox_profile", ["organization_id"])
+    op.create_index(
+        "ix_sandbox_profile_managed_target_id", "sandbox_profile", ["managed_target_id"]
+    )
+    op.create_index("ix_sandbox_profile_status", "sandbox_profile", ["status"])
+
+    op.create_table(
+        "sandbox_profile_agent_auth_revision",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.String(length=128), nullable=False),
+        sa.Column("force_restart", sa.Boolean(), nullable=False),
+        sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["sandbox_profile_id"], ["sandbox_profile.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sandbox_profile_agent_auth_revision_profile_revision",
+        "sandbox_profile_agent_auth_revision",
+        ["sandbox_profile_id", "revision"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_revision_sandbox_profile_id",
+        "sandbox_profile_agent_auth_revision",
+        ["sandbox_profile_id"],
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_revision_created_by_user_id",
+        "sandbox_profile_agent_auth_revision",
+        ["created_by_user_id"],
+    )
+
+    op.create_table(
+        "agent_auth_credential",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
+        sa.Column("agent_kind", sa.String(length=32), nullable=False),
+        sa.Column("credential_kind", sa.String(length=32), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("redacted_summary_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("legacy_cloud_credential_id", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            _in_constraint("owner_scope", _OWNER_SCOPES),
+            name="ck_agent_auth_credential_owner_scope",
+        ),
+        sa.CheckConstraint(
+            "((owner_scope = 'system' AND owner_user_id IS NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_agent_auth_credential_owner_fields",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("agent_kind", _AGENT_KINDS), name="ck_agent_auth_credential_agent_kind"
+        ),
+        sa.CheckConstraint(
+            _in_constraint("credential_kind", _CREDENTIAL_KINDS),
+            name="ck_agent_auth_credential_kind",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _CREDENTIAL_STATUSES), name="ck_agent_auth_credential_status"
+        ),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["legacy_cloud_credential_id"], ["cloud_credential.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("legacy_cloud_credential_id"),
+    )
+    op.create_index("ix_agent_auth_credential_agent_kind", "agent_auth_credential", ["agent_kind"])
+    op.create_index(
+        "ix_agent_auth_credential_credential_kind", "agent_auth_credential", ["credential_kind"]
+    )
+    op.create_index("ix_agent_auth_credential_status", "agent_auth_credential", ["status"])
+    op.create_index(
+        "ix_agent_auth_credential_owner_scope", "agent_auth_credential", ["owner_scope"]
+    )
+    op.create_index(
+        "ix_agent_auth_credential_owner_user_id", "agent_auth_credential", ["owner_user_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_credential_organization_id", "agent_auth_credential", ["organization_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_credential_created_by_user_id",
+        "agent_auth_credential",
+        ["created_by_user_id"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_owner_user_kind_status",
+        "agent_auth_credential",
+        ["owner_scope", "owner_user_id", "agent_kind", "status"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_org_kind_status",
+        "agent_auth_credential",
+        ["owner_scope", "organization_id", "agent_kind", "status"],
+    )
+
+    op.create_table(
+        "agent_auth_credential_share",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("credential_id", sa.Uuid(), nullable=False),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("share_scope", sa.String(length=32), nullable=False),
+        sa.Column("shared_by_user_id", sa.Uuid(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("allowed_agent_kind", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_by_user_id", sa.Uuid(), nullable=True),
+        sa.CheckConstraint(
+            "share_scope = 'organization'", name="ck_agent_auth_credential_share_scope"
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _SHARE_STATUSES), name="ck_agent_auth_credential_share_status"
+        ),
+        sa.CheckConstraint(
+            _in_constraint("allowed_agent_kind", _AGENT_KINDS),
+            name="ck_agent_auth_credential_share_agent_kind",
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["agent_auth_credential.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["revoked_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["shared_by_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_auth_credential_share_credential_id",
+        "agent_auth_credential_share",
+        ["credential_id"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_share_owner_user_id",
+        "agent_auth_credential_share",
+        ["owner_user_id"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_share_organization_id",
+        "agent_auth_credential_share",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_share_shared_by_user_id",
+        "agent_auth_credential_share",
+        ["shared_by_user_id"],
+    )
+    op.create_index(
+        "ix_agent_auth_credential_share_revoked_by_user_id",
+        "agent_auth_credential_share",
+        ["revoked_by_user_id"],
+    )
+    op.create_index(
+        "uq_agent_auth_active_share_credential_org",
+        "agent_auth_credential_share",
+        ["credential_id", "organization_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+    op.create_index(
+        "ix_agent_auth_share_org_kind_status",
+        "agent_auth_credential_share",
+        ["organization_id", "allowed_agent_kind", "status"],
+    )
+
+    op.create_table(
+        "agent_gateway_budget_subject",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("budget_kind", sa.String(length=32), nullable=False),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("litellm_team_id", sa.String(length=255), nullable=True),
+        sa.Column("included_budget_usd", sa.String(length=64), nullable=False),
+        sa.Column("budget_duration", sa.String(length=32), nullable=False),
+        sa.Column("litellm_sync_status", sa.String(length=32), nullable=False),
+        sa.Column("litellm_sync_fingerprint", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("last_provisioned_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_litellm_reconciled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_code", sa.String(length=128), nullable=True),
+        sa.Column("last_error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("budget_kind", _BUDGET_KINDS),
+            name="ck_agent_gateway_budget_subject_kind",
+        ),
+        sa.CheckConstraint(
+            "owner_scope = 'organization'", name="ck_agent_gateway_budget_subject_owner_scope"
+        ),
+        sa.CheckConstraint(
+            "organization_id IS NOT NULL", name="ck_agent_gateway_budget_subject_org"
+        ),
+        sa.CheckConstraint(
+            _in_constraint("litellm_sync_status", _SYNC_STATUSES),
+            name="ck_agent_gateway_budget_subject_sync_status",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _BUDGET_STATUSES),
+            name="ck_agent_gateway_budget_subject_status",
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_gateway_budget_subject_organization_id",
+        "agent_gateway_budget_subject",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_budget_subject_litellm_sync_status",
+        "agent_gateway_budget_subject",
+        ["litellm_sync_status"],
+    )
+    op.create_index(
+        "ix_agent_gateway_budget_subject_status", "agent_gateway_budget_subject", ["status"]
+    )
+    op.create_index(
+        "uq_agent_gateway_managed_budget_subject_org",
+        "agent_gateway_budget_subject",
+        ["organization_id"],
+        unique=True,
+        postgresql_where=sa.text("budget_kind = 'proliferate_managed' AND status != 'revoked'"),
+    )
+
+    op.create_table(
+        "agent_gateway_policy",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("credential_id", sa.Uuid(), nullable=False),
+        sa.Column("policy_kind", sa.String(length=32), nullable=False),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+        sa.Column("budget_subject_id", sa.Uuid(), nullable=True),
+        sa.Column("litellm_team_id", sa.String(length=255), nullable=True),
+        sa.Column("litellm_virtual_key_id", sa.String(length=255), nullable=True),
+        sa.Column("litellm_virtual_key_ciphertext", sa.Text(), nullable=True),
+        sa.Column("litellm_virtual_key_ciphertext_key_id", sa.String(length=64), nullable=True),
+        sa.Column("litellm_sync_status", sa.String(length=32), nullable=False),
+        sa.Column("litellm_sync_fingerprint", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("last_provisioned_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_litellm_reconciled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_code", sa.String(length=128), nullable=True),
+        sa.Column("last_error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("policy_kind", _POLICY_KINDS), name="ck_agent_gateway_policy_kind"
+        ),
+        sa.CheckConstraint(
+            _in_constraint("owner_scope", _OWNER_SCOPES),
+            name="ck_agent_gateway_policy_owner_scope",
+        ),
+        sa.CheckConstraint(
+            "((owner_scope = 'system' AND owner_user_id IS NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_agent_gateway_policy_owner_fields",
+        ),
+        sa.CheckConstraint(
+            "((policy_kind = 'proliferate_managed' AND budget_subject_id IS NOT NULL) OR "
+            "(policy_kind != 'proliferate_managed' AND budget_subject_id IS NULL))",
+            name="ck_agent_gateway_policy_budget_subject",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("litellm_sync_status", _SYNC_STATUSES),
+            name="ck_agent_gateway_policy_sync_status",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _POLICY_STATUSES), name="ck_agent_gateway_policy_status"
+        ),
+        sa.ForeignKeyConstraint(
+            ["budget_subject_id"], ["agent_gateway_budget_subject.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["agent_auth_credential.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_agent_gateway_policy_credential",
+        "agent_gateway_policy",
+        ["credential_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_agent_gateway_policy_credential_id", "agent_gateway_policy", ["credential_id"]
+    )
+    op.create_index("ix_agent_gateway_policy_policy_kind", "agent_gateway_policy", ["policy_kind"])
+    op.create_index("ix_agent_gateway_policy_owner_scope", "agent_gateway_policy", ["owner_scope"])
+    op.create_index(
+        "ix_agent_gateway_policy_owner_user_id", "agent_gateway_policy", ["owner_user_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_policy_organization_id", "agent_gateway_policy", ["organization_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_policy_budget_subject_id", "agent_gateway_policy", ["budget_subject_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_policy_litellm_sync_status",
+        "agent_gateway_policy",
+        ["litellm_sync_status"],
+    )
+    op.create_index("ix_agent_gateway_policy_status", "agent_gateway_policy", ["status"])
+
+    op.create_table(
+        "agent_gateway_provider_credential",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("policy_id", sa.Uuid(), nullable=False),
+        sa.Column("provider_kind", sa.String(length=64), nullable=False),
+        sa.Column("payload_ciphertext", sa.Text(), nullable=False),
+        sa.Column("payload_ciphertext_key_id", sa.String(length=64), nullable=False),
+        sa.Column("redacted_summary_json", sa.Text(), nullable=False),
+        sa.Column("validation_status", sa.String(length=32), nullable=False),
+        sa.Column("validated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("validation_error_code", sa.String(length=128), nullable=True),
+        sa.Column("validation_error_message", sa.Text(), nullable=True),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("provider_kind", _PROVIDER_KINDS),
+            name="ck_agent_gateway_provider_credential_kind",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("validation_status", _VALIDATION_STATUSES),
+            name="ck_agent_gateway_provider_credential_validation_status",
+        ),
+        sa.ForeignKeyConstraint(["policy_id"], ["agent_gateway_policy.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_agent_gateway_provider_credential_policy",
+        "agent_gateway_provider_credential",
+        ["policy_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_agent_gateway_provider_credential_policy_id",
+        "agent_gateway_provider_credential",
+        ["policy_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_provider_credential_provider_kind",
+        "agent_gateway_provider_credential",
+        ["provider_kind"],
+    )
+    op.create_index(
+        "ix_agent_gateway_provider_credential_validation_status",
+        "agent_gateway_provider_credential",
+        ["validation_status"],
+    )
+
+    op.create_table(
+        "sandbox_agent_auth_selection",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("agent_kind", sa.String(length=32), nullable=False),
+        sa.Column("credential_id", sa.Uuid(), nullable=False),
+        sa.Column("credential_share_id", sa.Uuid(), nullable=True),
+        sa.Column("materialization_mode", sa.String(length=32), nullable=False),
+        sa.Column("selected_revision", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("last_error_code", sa.String(length=128), nullable=True),
+        sa.Column("last_error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("owner_scope", _PROFILE_OWNER_SCOPES),
+            name="ck_sandbox_agent_auth_selection_owner_scope",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("agent_kind", _AGENT_KINDS),
+            name="ck_sandbox_agent_auth_selection_agent_kind",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("materialization_mode", _MATERIALIZATION_MODES),
+            name="ck_sandbox_agent_auth_selection_materialization_mode",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("status", _SELECTION_STATUSES),
+            name="ck_sandbox_agent_auth_selection_status",
+        ),
+        sa.CheckConstraint(
+            "selected_revision > 0", name="ck_sandbox_agent_auth_selection_revision_positive"
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["agent_auth_credential.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_share_id"], ["agent_auth_credential_share.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["sandbox_profile_id"], ["sandbox_profile.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sandbox_agent_auth_selection_profile_agent",
+        "sandbox_agent_auth_selection",
+        ["sandbox_profile_id", "agent_kind"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_sandbox_profile_id",
+        "sandbox_agent_auth_selection",
+        ["sandbox_profile_id"],
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_credential_id",
+        "sandbox_agent_auth_selection",
+        ["credential_id"],
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_credential_share_id",
+        "sandbox_agent_auth_selection",
+        ["credential_share_id"],
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_owner_scope",
+        "sandbox_agent_auth_selection",
+        ["owner_scope"],
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_agent_kind",
+        "sandbox_agent_auth_selection",
+        ["agent_kind"],
+    )
+    op.create_index(
+        "ix_sandbox_agent_auth_selection_status", "sandbox_agent_auth_selection", ["status"]
+    )
+
+    op.create_table(
+        "sandbox_profile_agent_auth_target_state",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("desired_revision", sa.Integer(), nullable=False),
+        sa.Column("applied_revision", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("force_restart_required", sa.Boolean(), nullable=False),
+        sa.Column("last_command_id", sa.Uuid(), nullable=True),
+        sa.Column("last_worker_id", sa.Uuid(), nullable=True),
+        sa.Column("last_attempted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_applied_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_code", sa.String(length=128), nullable=True),
+        sa.Column("last_error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("status", _TARGET_STATE_STATUSES),
+            name="ck_sandbox_profile_agent_auth_target_state_status",
+        ),
+        sa.CheckConstraint(
+            "applied_revision IS NULL OR applied_revision <= desired_revision",
+            name="ck_sandbox_profile_agent_auth_target_state_applied_lte_desired",
+        ),
+        sa.ForeignKeyConstraint(["last_command_id"], ["cloud_commands.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["last_worker_id"], ["cloud_workers.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["sandbox_profile_id"], ["sandbox_profile.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sandbox_profile_agent_auth_target_state_target_profile",
+        "sandbox_profile_agent_auth_target_state",
+        ["target_id", "sandbox_profile_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_target_state_sandbox_profile_id",
+        "sandbox_profile_agent_auth_target_state",
+        ["sandbox_profile_id"],
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_target_state_target_id",
+        "sandbox_profile_agent_auth_target_state",
+        ["target_id"],
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_target_state_last_command_id",
+        "sandbox_profile_agent_auth_target_state",
+        ["last_command_id"],
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_target_state_last_worker_id",
+        "sandbox_profile_agent_auth_target_state",
+        ["last_worker_id"],
+    )
+    op.create_index(
+        "ix_sandbox_profile_agent_auth_target_state_status_revision",
+        "sandbox_profile_agent_auth_target_state",
+        ["target_id", "status", "desired_revision", "applied_revision"],
+    )
+
+    op.create_table(
+        "agent_gateway_runtime_grant",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("hash_key_id", sa.String(length=64), nullable=False),
+        sa.Column("policy_id", sa.Uuid(), nullable=False),
+        sa.Column("credential_id", sa.Uuid(), nullable=False),
+        sa.Column("selection_id", sa.Uuid(), nullable=False),
+        sa.Column("issued_profile_revision", sa.Integer(), nullable=False),
+        sa.Column("target_id", sa.Uuid(), nullable=False),
+        sa.Column("sandbox_profile_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column("agent_kind", sa.String(length=32), nullable=False),
+        sa.Column("protocol_facade", sa.String(length=32), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _in_constraint("agent_kind", _AGENT_KINDS),
+            name="ck_agent_gateway_runtime_grant_agent_kind",
+        ),
+        sa.CheckConstraint(
+            _in_constraint("protocol_facade", _PROTOCOL_FACADES),
+            name="ck_agent_gateway_runtime_grant_protocol_facade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["agent_auth_credential.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["policy_id"], ["agent_gateway_policy.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["sandbox_profile_id"], ["sandbox_profile.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["selection_id"], ["sandbox_agent_auth_selection.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_agent_gateway_runtime_grant_token_hash",
+        "agent_gateway_runtime_grant",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_policy_id", "agent_gateway_runtime_grant", ["policy_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_credential_id",
+        "agent_gateway_runtime_grant",
+        ["credential_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_selection_id",
+        "agent_gateway_runtime_grant",
+        ["selection_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_target_id", "agent_gateway_runtime_grant", ["target_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_sandbox_profile_id",
+        "agent_gateway_runtime_grant",
+        ["sandbox_profile_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_organization_id",
+        "agent_gateway_runtime_grant",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_user_id", "agent_gateway_runtime_grant", ["user_id"]
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_agent_kind", "agent_gateway_runtime_grant", ["agent_kind"]
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_expires_at", "agent_gateway_runtime_grant", ["expires_at"]
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_policy_revocation_expiry",
+        "agent_gateway_runtime_grant",
+        ["policy_id", "revoked_at", "expires_at"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_target_profile_agent",
+        "agent_gateway_runtime_grant",
+        ["target_id", "sandbox_profile_id", "agent_kind"],
+    )
+    op.create_index(
+        "ix_agent_gateway_runtime_grant_selection_revision",
+        "agent_gateway_runtime_grant",
+        ["selection_id", "issued_profile_revision"],
+    )
+
+    op.create_table(
+        "agent_auth_audit_event",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("actor_user_id", sa.Uuid(), nullable=True),
+        sa.Column("owner_scope", sa.String(length=32), nullable=False),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+        sa.Column("credential_id", sa.Uuid(), nullable=True),
+        sa.Column("sandbox_profile_id", sa.Uuid(), nullable=True),
+        sa.Column("target_id", sa.Uuid(), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["agent_auth_credential.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["sandbox_profile_id"], ["sandbox_profile.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["target_id"], ["cloud_targets.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_agent_auth_audit_event_action", "agent_auth_audit_event", ["action"])
+    op.create_index(
+        "ix_agent_auth_audit_event_actor_user_id", "agent_auth_audit_event", ["actor_user_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_owner_scope", "agent_auth_audit_event", ["owner_scope"]
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_owner_user_id", "agent_auth_audit_event", ["owner_user_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_organization_id", "agent_auth_audit_event", ["organization_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_credential_id", "agent_auth_audit_event", ["credential_id"]
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_sandbox_profile_id",
+        "agent_auth_audit_event",
+        ["sandbox_profile_id"],
+    )
+    op.create_index("ix_agent_auth_audit_event_target_id", "agent_auth_audit_event", ["target_id"])
+    op.create_index(
+        "ix_agent_auth_audit_event_actor_created",
+        "agent_auth_audit_event",
+        ["actor_user_id", "created_at"],
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_org_created",
+        "agent_auth_audit_event",
+        ["organization_id", "created_at"],
+    )
+    op.create_index(
+        "ix_agent_auth_audit_event_credential_created",
+        "agent_auth_audit_event",
+        ["credential_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_agent_auth_audit_event_credential_created", table_name="agent_auth_audit_event"
+    )
+    op.drop_index("ix_agent_auth_audit_event_org_created", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_actor_created", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_target_id", table_name="agent_auth_audit_event")
+    op.drop_index(
+        "ix_agent_auth_audit_event_sandbox_profile_id", table_name="agent_auth_audit_event"
+    )
+    op.drop_index("ix_agent_auth_audit_event_credential_id", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_organization_id", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_owner_user_id", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_owner_scope", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_actor_user_id", table_name="agent_auth_audit_event")
+    op.drop_index("ix_agent_auth_audit_event_action", table_name="agent_auth_audit_event")
+    op.drop_table("agent_auth_audit_event")
+
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_selection_revision",
+        table_name="agent_gateway_runtime_grant",
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_target_profile_agent",
+        table_name="agent_gateway_runtime_grant",
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_policy_revocation_expiry",
+        table_name="agent_gateway_runtime_grant",
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_expires_at", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_agent_kind", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_user_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_organization_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_sandbox_profile_id",
+        table_name="agent_gateway_runtime_grant",
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_target_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_selection_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_credential_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "ix_agent_gateway_runtime_grant_policy_id", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_index(
+        "uq_agent_gateway_runtime_grant_token_hash", table_name="agent_gateway_runtime_grant"
+    )
+    op.drop_table("agent_gateway_runtime_grant")
+
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_target_state_status_revision",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_target_state_last_worker_id",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_target_state_last_command_id",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_target_state_target_id",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_target_state_sandbox_profile_id",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_index(
+        "uq_sandbox_profile_agent_auth_target_state_target_profile",
+        table_name="sandbox_profile_agent_auth_target_state",
+    )
+    op.drop_table("sandbox_profile_agent_auth_target_state")
+
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_status", table_name="sandbox_agent_auth_selection"
+    )
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_agent_kind", table_name="sandbox_agent_auth_selection"
+    )
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_owner_scope", table_name="sandbox_agent_auth_selection"
+    )
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_credential_share_id",
+        table_name="sandbox_agent_auth_selection",
+    )
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_credential_id", table_name="sandbox_agent_auth_selection"
+    )
+    op.drop_index(
+        "ix_sandbox_agent_auth_selection_sandbox_profile_id",
+        table_name="sandbox_agent_auth_selection",
+    )
+    op.drop_index(
+        "uq_sandbox_agent_auth_selection_profile_agent", table_name="sandbox_agent_auth_selection"
+    )
+    op.drop_table("sandbox_agent_auth_selection")
+
+    op.drop_index(
+        "ix_agent_gateway_provider_credential_validation_status",
+        table_name="agent_gateway_provider_credential",
+    )
+    op.drop_index(
+        "ix_agent_gateway_provider_credential_provider_kind",
+        table_name="agent_gateway_provider_credential",
+    )
+    op.drop_index(
+        "ix_agent_gateway_provider_credential_policy_id",
+        table_name="agent_gateway_provider_credential",
+    )
+    op.drop_index(
+        "uq_agent_gateway_provider_credential_policy",
+        table_name="agent_gateway_provider_credential",
+    )
+    op.drop_table("agent_gateway_provider_credential")
+
+    op.drop_index("ix_agent_gateway_policy_status", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_litellm_sync_status", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_budget_subject_id", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_organization_id", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_owner_user_id", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_owner_scope", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_policy_kind", table_name="agent_gateway_policy")
+    op.drop_index("ix_agent_gateway_policy_credential_id", table_name="agent_gateway_policy")
+    op.drop_index("uq_agent_gateway_policy_credential", table_name="agent_gateway_policy")
+    op.drop_table("agent_gateway_policy")
+
+    op.drop_index(
+        "uq_agent_gateway_managed_budget_subject_org", table_name="agent_gateway_budget_subject"
+    )
+    op.drop_index(
+        "ix_agent_gateway_budget_subject_status", table_name="agent_gateway_budget_subject"
+    )
+    op.drop_index(
+        "ix_agent_gateway_budget_subject_litellm_sync_status",
+        table_name="agent_gateway_budget_subject",
+    )
+    op.drop_index(
+        "ix_agent_gateway_budget_subject_organization_id",
+        table_name="agent_gateway_budget_subject",
+    )
+    op.drop_table("agent_gateway_budget_subject")
+
+    op.drop_index("ix_agent_auth_share_org_kind_status", table_name="agent_auth_credential_share")
+    op.drop_index(
+        "uq_agent_auth_active_share_credential_org", table_name="agent_auth_credential_share"
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_share_revoked_by_user_id",
+        table_name="agent_auth_credential_share",
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_share_shared_by_user_id",
+        table_name="agent_auth_credential_share",
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_share_organization_id", table_name="agent_auth_credential_share"
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_share_owner_user_id", table_name="agent_auth_credential_share"
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_share_credential_id", table_name="agent_auth_credential_share"
+    )
+    op.drop_table("agent_auth_credential_share")
+
+    op.drop_index("ix_agent_auth_credential_org_kind_status", table_name="agent_auth_credential")
+    op.drop_index(
+        "ix_agent_auth_credential_owner_user_kind_status", table_name="agent_auth_credential"
+    )
+    op.drop_index(
+        "ix_agent_auth_credential_created_by_user_id", table_name="agent_auth_credential"
+    )
+    op.drop_index("ix_agent_auth_credential_organization_id", table_name="agent_auth_credential")
+    op.drop_index("ix_agent_auth_credential_owner_user_id", table_name="agent_auth_credential")
+    op.drop_index("ix_agent_auth_credential_owner_scope", table_name="agent_auth_credential")
+    op.drop_index("ix_agent_auth_credential_status", table_name="agent_auth_credential")
+    op.drop_index("ix_agent_auth_credential_credential_kind", table_name="agent_auth_credential")
+    op.drop_index("ix_agent_auth_credential_agent_kind", table_name="agent_auth_credential")
+    op.drop_table("agent_auth_credential")
+
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_revision_created_by_user_id",
+        table_name="sandbox_profile_agent_auth_revision",
+    )
+    op.drop_index(
+        "ix_sandbox_profile_agent_auth_revision_sandbox_profile_id",
+        table_name="sandbox_profile_agent_auth_revision",
+    )
+    op.drop_index(
+        "uq_sandbox_profile_agent_auth_revision_profile_revision",
+        table_name="sandbox_profile_agent_auth_revision",
+    )
+    op.drop_table("sandbox_profile_agent_auth_revision")
+
+    op.drop_index("ix_sandbox_profile_status", table_name="sandbox_profile")
+    op.drop_index("ix_sandbox_profile_managed_target_id", table_name="sandbox_profile")
+    op.drop_index("ix_sandbox_profile_organization_id", table_name="sandbox_profile")
+    op.drop_index("ix_sandbox_profile_owner_user_id", table_name="sandbox_profile")
+    op.drop_index("ix_sandbox_profile_owner_scope", table_name="sandbox_profile")
+    op.drop_index("uq_sandbox_profile_active_organization", table_name="sandbox_profile")
+    op.drop_index("uq_sandbox_profile_active_personal_user", table_name="sandbox_profile")
+    op.drop_table("sandbox_profile")

--- a/server/alembic/versions/f8a9b0c1d2e3_auth_identity_multiple_provider_accounts.py
+++ b/server/alembic/versions/f8a9b0c1d2e3_auth_identity_multiple_provider_accounts.py
@@ -27,18 +27,62 @@ depends_on: str | Sequence[str] | None = None
 LEGACY_GITHUB_OAUTH_SCOPES = ["repo", "user", "user:email"]
 
 
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_constraint(table_name: str, constraint_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_unique_constraints(table_name)
+    }
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _drop_constraint_once(constraint_name: str, table_name: str, *, type_: str) -> None:
+    if _has_constraint(table_name, constraint_name):
+        op.drop_constraint(constraint_name, table_name, type_=type_)
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
-    op.drop_constraint(
+    _drop_constraint_once(
         "uq_auth_identity_user_provider",
         "auth_identity",
         type_="unique",
     )
-    op.create_index(
+    _create_index_once(
         "ix_auth_identity_user_provider",
         "auth_identity",
         ["user_id", "provider"],
-        unique=False,
     )
     _backfill_additional_oauth_accounts()
 
@@ -147,7 +191,7 @@ def _backfill_additional_oauth_accounts() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index("ix_auth_identity_user_provider", table_name="auth_identity")
+    _drop_index_once("ix_auth_identity_user_provider", "auth_identity")
     op.create_unique_constraint(
         "uq_auth_identity_user_provider",
         "auth_identity",

--- a/server/proliferate/auth/identity/providers.py
+++ b/server/proliferate/auth/identity/providers.py
@@ -97,19 +97,16 @@ async def build_authorization_url(
             extras_params=extras,
         )
     if provider == "apple" and surface == "web":
-        return (
-            f"{APPLE_AUTHORIZE_URL}?"
-            + urlencode(
-                {
-                    "client_id": apple_client_id_for_surface(surface),
-                    "redirect_uri": provider_callback_url,
-                    "response_type": "code id_token",
-                    "response_mode": "form_post",
-                    "scope": "name email",
-                    "state": state,
-                    "nonce": nonce,
-                }
-            )
+        return f"{APPLE_AUTHORIZE_URL}?" + urlencode(
+            {
+                "client_id": apple_client_id_for_surface(surface),
+                "redirect_uri": provider_callback_url,
+                "response_type": "code id_token",
+                "response_mode": "form_post",
+                "scope": "name email",
+                "state": state,
+                "nonce": nonce,
+            }
         )
     return None
 

--- a/server/proliferate/auth/identity/store.py
+++ b/server/proliferate/auth/identity/store.py
@@ -71,9 +71,7 @@ def _provider_grant_status(verified: VerifiedProviderIdentity) -> AuthProviderGr
         )
         if expires_at <= _now():
             return AuthProviderGrantStatus.EXPIRED
-    if verified.provider == "github" and not _github_scopes_satisfy_requirements(
-        verified.scopes
-    ):
+    if verified.provider == "github" and not _github_scopes_satisfy_requirements(verified.scopes):
         return AuthProviderGrantStatus.NEEDS_REAUTH
     return AuthProviderGrantStatus.READY
 

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -150,6 +150,7 @@ class Settings(BaseSettings):
     agent_gateway_default_managed_budget_usd: str = "0"
     agent_gateway_max_request_bytes: int = 4_194_304
     agent_gateway_request_timeout_seconds: float = 120.0
+    agent_gateway_opencode_enabled: bool = False
     e2b_api_key: str = ""
     e2b_template_name: str = ""
     e2b_webhook_signature_secret: str = ""

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -143,6 +143,13 @@ class Settings(BaseSettings):
     cloud_mcp_google_workspace_enabled: bool = False
     cloud_mcp_google_workspace_oauth_client_id: str = ""
     cloud_mcp_google_workspace_oauth_client_secret: str = ""
+    agent_gateway_enabled: bool = False
+    agent_gateway_litellm_base_url: str = "http://127.0.0.1:4000"
+    agent_gateway_litellm_master_key: str = ""
+    agent_gateway_public_base_url: str = ""
+    agent_gateway_default_managed_budget_usd: str = "0"
+    agent_gateway_max_request_bytes: int = 4_194_304
+    agent_gateway_request_timeout_seconds: float = 120.0
     e2b_api_key: str = ""
     e2b_template_name: str = ""
     e2b_webhook_signature_secret: str = ""

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -17,9 +17,23 @@ from typing import Final, Literal
 # Supported cloud agent kinds
 # ---------------------------------------------------------------------------
 
-CloudAgentKind = Literal["claude", "codex", "gemini"]
+CloudAgentKind = Literal["claude", "codex", "opencode", "gemini"]
 
-SUPPORTED_CLOUD_AGENTS: tuple[CloudAgentKind, ...] = ("claude", "codex", "gemini")
+SUPPORTED_CLOUD_AGENTS: tuple[CloudAgentKind, ...] = (
+    "claude",
+    "codex",
+    "opencode",
+    "gemini",
+)
+
+# Legacy native credential sync does not support every catalog agent kind yet.
+# The agent-auth gateway model can refer to OpenCode, but old CloudCredential
+# sync/status APIs must not advertise it until they can materialize its files.
+SUPPORTED_CLOUD_CREDENTIAL_SYNC_AGENTS: tuple[CloudAgentKind, ...] = (
+    "claude",
+    "codex",
+    "gemini",
+)
 
 ANYHARNESS_RESERVED_ENV_PREFIX: str = "ANYHARNESS_"
 PROLIFERATE_RESERVED_ENV_PREFIX: str = "PROLIFERATE_"
@@ -40,6 +54,171 @@ RESERVED_CLOUD_REPO_ENV_VARS: frozenset[str] = frozenset(
 )
 
 CLOUD_REPO_CONFIG_FILE_MAX_BYTES: Final = 1_048_576
+
+# ---------------------------------------------------------------------------
+# Agent LLM auth gateway
+# ---------------------------------------------------------------------------
+
+
+class SandboxProfileOwnerScope(StrEnum):
+    personal = "personal"
+    organization = "organization"
+
+
+class SandboxProfileStatus(StrEnum):
+    active = "active"
+    archived = "archived"
+
+
+class AgentAuthOwnerScope(StrEnum):
+    system = "system"
+    personal = "personal"
+    organization = "organization"
+
+
+class AgentAuthCredentialKind(StrEnum):
+    managed_gateway = "managed_gateway"
+    synced_path = "synced_path"
+
+
+class AgentAuthCredentialStatus(StrEnum):
+    pending = "pending"
+    ready = "ready"
+    needs_resync = "needs_resync"
+    invalid = "invalid"
+    revoked = "revoked"
+
+
+class AgentAuthCredentialShareStatus(StrEnum):
+    active = "active"
+    revoked = "revoked"
+
+
+class AgentGatewayPolicyKind(StrEnum):
+    proliferate_managed = "proliferate_managed"
+    org_byok = "org_byok"
+    personal_byok = "personal_byok"
+
+
+class AgentGatewayBudgetKind(StrEnum):
+    proliferate_managed = "proliferate_managed"
+
+
+class AgentGatewaySyncStatus(StrEnum):
+    pending = "pending"
+    synced = "synced"
+    drifted = "drifted"
+    failed = "failed"
+
+
+class AgentGatewayPolicyStatus(StrEnum):
+    provisioning = "provisioning"
+    ready = "ready"
+    invalid = "invalid"
+    revoked = "revoked"
+
+
+class AgentGatewayBudgetSubjectStatus(StrEnum):
+    ready = "ready"
+    exhausted = "exhausted"
+    invalid = "invalid"
+    revoked = "revoked"
+
+
+class AgentGatewayProviderKind(StrEnum):
+    proliferate_bedrock_pool = "proliferate_bedrock_pool"
+    anthropic_api_key = "anthropic_api_key"
+    openai_api_key = "openai_api_key"
+    bedrock_assume_role = "bedrock_assume_role"
+    openai_compatible = "openai_compatible"
+
+
+class AgentGatewayProviderValidationStatus(StrEnum):
+    unvalidated = "unvalidated"
+    valid = "valid"
+    invalid = "invalid"
+
+
+class SandboxAgentAuthMaterializationMode(StrEnum):
+    gateway_env = "gateway_env"
+    synced_files = "synced_files"
+
+
+class SandboxAgentAuthSelectionStatus(StrEnum):
+    active = "active"
+    needs_resync = "needs_resync"
+    invalid = "invalid"
+
+
+class SandboxAgentAuthTargetStateStatus(StrEnum):
+    pending = "pending"
+    materializing = "materializing"
+    applied = "applied"
+    failed = "failed"
+    superseded = "superseded"
+
+
+class AgentGatewayProtocolFacade(StrEnum):
+    anthropic = "anthropic"
+    openai = "openai"
+
+
+SUPPORTED_SANDBOX_PROFILE_OWNER_SCOPES: tuple[str, ...] = tuple(
+    scope.value for scope in SandboxProfileOwnerScope
+)
+SUPPORTED_SANDBOX_PROFILE_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in SandboxProfileStatus
+)
+SUPPORTED_AGENT_AUTH_OWNER_SCOPES: tuple[str, ...] = tuple(
+    scope.value for scope in AgentAuthOwnerScope
+)
+SUPPORTED_AGENT_AUTH_CREDENTIAL_KINDS: tuple[str, ...] = tuple(
+    kind.value for kind in AgentAuthCredentialKind
+)
+SUPPORTED_AGENT_AUTH_CREDENTIAL_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentAuthCredentialStatus
+)
+SUPPORTED_AGENT_AUTH_CREDENTIAL_SHARE_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentAuthCredentialShareStatus
+)
+SUPPORTED_AGENT_GATEWAY_POLICY_KINDS: tuple[str, ...] = tuple(
+    kind.value for kind in AgentGatewayPolicyKind
+)
+SUPPORTED_AGENT_GATEWAY_BUDGET_KINDS: tuple[str, ...] = tuple(
+    kind.value for kind in AgentGatewayBudgetKind
+)
+SUPPORTED_AGENT_GATEWAY_SYNC_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentGatewaySyncStatus
+)
+SUPPORTED_AGENT_GATEWAY_POLICY_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentGatewayPolicyStatus
+)
+SUPPORTED_AGENT_GATEWAY_BUDGET_SUBJECT_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentGatewayBudgetSubjectStatus
+)
+SUPPORTED_AGENT_GATEWAY_PROVIDER_KINDS: tuple[str, ...] = tuple(
+    kind.value for kind in AgentGatewayProviderKind
+)
+SUPPORTED_AGENT_GATEWAY_PROVIDER_VALIDATION_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in AgentGatewayProviderValidationStatus
+)
+SUPPORTED_SANDBOX_AGENT_AUTH_MATERIALIZATION_MODES: tuple[str, ...] = tuple(
+    mode.value for mode in SandboxAgentAuthMaterializationMode
+)
+SUPPORTED_SANDBOX_AGENT_AUTH_SELECTION_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in SandboxAgentAuthSelectionStatus
+)
+SUPPORTED_SANDBOX_AGENT_AUTH_TARGET_STATE_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in SandboxAgentAuthTargetStateStatus
+)
+SUPPORTED_AGENT_GATEWAY_PROTOCOL_FACADES: tuple[str, ...] = tuple(
+    facade.value for facade in AgentGatewayProtocolFacade
+)
+
+AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN: Final = "agent-gateway-runtime-grant"
+AGENT_GATEWAY_TOKEN_HASH_KEY_ID: Final = "cloud_secret_key:v1"
+AGENT_GATEWAY_CIPHERTEXT_KEY_ID: Final = "cloud_secret_key:v1"
+AGENT_GATEWAY_BUDGET_DURATION_V1: Final = "30d"
 
 # ---------------------------------------------------------------------------
 # Allowed credential auth files

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -4,6 +4,7 @@ Importing this package registers all cloud ORM tables with SQLAlchemy metadata.
 Callers should import concrete models from the owning module in this package.
 """
 
+from . import agent_auth as agent_auth  # noqa: F401
 from . import commands as commands  # noqa: F401
 from . import credentials as credentials  # noqa: F401
 from . import mcp as mcp  # noqa: F401

--- a/server/proliferate/db/models/cloud/agent_auth.py
+++ b/server/proliferate/db/models/cloud/agent_auth.py
@@ -376,7 +376,7 @@ class AgentGatewayPolicy(Base):
         nullable=True,
     )
     budget_subject_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("agent_gateway_budget_subject.id", ondelete="SET NULL"),
+        ForeignKey("agent_gateway_budget_subject.id", ondelete="RESTRICT"),
         index=True,
         nullable=True,
     )

--- a/server/proliferate/db/models/cloud/agent_auth.py
+++ b/server/proliferate/db/models/cloud/agent_auth.py
@@ -1,0 +1,690 @@
+"""Agent LLM auth gateway ORM models."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.constants.cloud import (
+    SUPPORTED_AGENT_AUTH_CREDENTIAL_KINDS,
+    SUPPORTED_AGENT_AUTH_CREDENTIAL_SHARE_STATUSES,
+    SUPPORTED_AGENT_AUTH_CREDENTIAL_STATUSES,
+    SUPPORTED_AGENT_AUTH_OWNER_SCOPES,
+    SUPPORTED_AGENT_GATEWAY_BUDGET_SUBJECT_STATUSES,
+    SUPPORTED_AGENT_GATEWAY_POLICY_KINDS,
+    SUPPORTED_AGENT_GATEWAY_POLICY_STATUSES,
+    SUPPORTED_AGENT_GATEWAY_PROTOCOL_FACADES,
+    SUPPORTED_AGENT_GATEWAY_PROVIDER_KINDS,
+    SUPPORTED_AGENT_GATEWAY_PROVIDER_VALIDATION_STATUSES,
+    SUPPORTED_AGENT_GATEWAY_SYNC_STATUSES,
+    SUPPORTED_CLOUD_AGENTS,
+    SUPPORTED_SANDBOX_AGENT_AUTH_MATERIALIZATION_MODES,
+    SUPPORTED_SANDBOX_AGENT_AUTH_SELECTION_STATUSES,
+    SUPPORTED_SANDBOX_AGENT_AUTH_TARGET_STATE_STATUSES,
+    SUPPORTED_SANDBOX_PROFILE_OWNER_SCOPES,
+    SUPPORTED_SANDBOX_PROFILE_STATUSES,
+)
+from proliferate.db.models.base import Base, utcnow
+
+
+class SandboxProfile(Base):
+    __tablename__ = "sandbox_profile"
+    __table_args__ = (
+        CheckConstraint(
+            f"owner_scope IN {SUPPORTED_SANDBOX_PROFILE_OWNER_SCOPES}",
+            name="ck_sandbox_profile_owner_scope",
+        ),
+        CheckConstraint(
+            "((owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_sandbox_profile_owner_fields",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_SANDBOX_PROFILE_STATUSES}",
+            name="ck_sandbox_profile_status",
+        ),
+        Index(
+            "uq_sandbox_profile_active_personal_user",
+            "owner_user_id",
+            unique=True,
+            postgresql_where=text(
+                "owner_scope = 'personal' AND deleted_at IS NULL AND status = 'active'"
+            ),
+        ),
+        Index(
+            "uq_sandbox_profile_active_organization",
+            "organization_id",
+            unique=True,
+            postgresql_where=text(
+                "owner_scope = 'organization' AND deleted_at IS NULL AND status = 'active'"
+            ),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    managed_target_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    agent_auth_revision: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[str] = mapped_column(String(32), default="active", index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class SandboxProfileAgentAuthRevision(Base):
+    __tablename__ = "sandbox_profile_agent_auth_revision"
+    __table_args__ = (
+        Index(
+            "uq_sandbox_profile_agent_auth_revision_profile_revision",
+            "sandbox_profile_id",
+            "revision",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sandbox_profile_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sandbox_profile.id", ondelete="CASCADE"),
+        index=True,
+    )
+    revision: Mapped[int] = mapped_column(Integer)
+    reason: Mapped[str] = mapped_column(String(128))
+    force_restart: Mapped[bool] = mapped_column(default=False)
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class AgentAuthCredential(Base):
+    __tablename__ = "agent_auth_credential"
+    __table_args__ = (
+        CheckConstraint(
+            f"owner_scope IN {SUPPORTED_AGENT_AUTH_OWNER_SCOPES}",
+            name="ck_agent_auth_credential_owner_scope",
+        ),
+        CheckConstraint(
+            "((owner_scope = 'system' AND owner_user_id IS NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_agent_auth_credential_owner_fields",
+        ),
+        CheckConstraint(
+            f"agent_kind IN {SUPPORTED_CLOUD_AGENTS}",
+            name="ck_agent_auth_credential_agent_kind",
+        ),
+        CheckConstraint(
+            f"credential_kind IN {SUPPORTED_AGENT_AUTH_CREDENTIAL_KINDS}",
+            name="ck_agent_auth_credential_kind",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_AGENT_AUTH_CREDENTIAL_STATUSES}",
+            name="ck_agent_auth_credential_status",
+        ),
+        Index(
+            "ix_agent_auth_credential_owner_user_kind_status",
+            "owner_scope",
+            "owner_user_id",
+            "agent_kind",
+            "status",
+        ),
+        Index(
+            "ix_agent_auth_credential_org_kind_status",
+            "owner_scope",
+            "organization_id",
+            "agent_kind",
+            "status",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    agent_kind: Mapped[str] = mapped_column(String(32), index=True)
+    credential_kind: Mapped[str] = mapped_column(String(32), index=True)
+    display_name: Mapped[str] = mapped_column(String(255))
+    redacted_summary_json: Mapped[str] = mapped_column(Text, default="{}")
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    legacy_cloud_credential_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_credential.id", ondelete="SET NULL"),
+        unique=True,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AgentAuthCredentialShare(Base):
+    __tablename__ = "agent_auth_credential_share"
+    __table_args__ = (
+        CheckConstraint(
+            "share_scope = 'organization'",
+            name="ck_agent_auth_credential_share_scope",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_AGENT_AUTH_CREDENTIAL_SHARE_STATUSES}",
+            name="ck_agent_auth_credential_share_status",
+        ),
+        CheckConstraint(
+            f"allowed_agent_kind IN {SUPPORTED_CLOUD_AGENTS}",
+            name="ck_agent_auth_credential_share_agent_kind",
+        ),
+        Index(
+            "uq_agent_auth_active_share_credential_org",
+            "credential_id",
+            "organization_id",
+            unique=True,
+            postgresql_where=text("status = 'active'"),
+        ),
+        Index(
+            "ix_agent_auth_share_org_kind_status",
+            "organization_id",
+            "allowed_agent_kind",
+            "status",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    credential_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_auth_credential.id", ondelete="CASCADE"),
+        index=True,
+    )
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+    )
+    share_scope: Mapped[str] = mapped_column(String(32), default="organization")
+    shared_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(String(32), default="active", index=True)
+    allowed_agent_kind: Mapped[str] = mapped_column(String(32), index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+
+
+class AgentGatewayBudgetSubject(Base):
+    __tablename__ = "agent_gateway_budget_subject"
+    __table_args__ = (
+        CheckConstraint(
+            "budget_kind = 'proliferate_managed'",
+            name="ck_agent_gateway_budget_subject_kind",
+        ),
+        CheckConstraint(
+            "owner_scope = 'organization'",
+            name="ck_agent_gateway_budget_subject_owner_scope",
+        ),
+        CheckConstraint(
+            "organization_id IS NOT NULL",
+            name="ck_agent_gateway_budget_subject_org",
+        ),
+        CheckConstraint(
+            f"litellm_sync_status IN {SUPPORTED_AGENT_GATEWAY_SYNC_STATUSES}",
+            name="ck_agent_gateway_budget_subject_sync_status",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_AGENT_GATEWAY_BUDGET_SUBJECT_STATUSES}",
+            name="ck_agent_gateway_budget_subject_status",
+        ),
+        Index(
+            "uq_agent_gateway_managed_budget_subject_org",
+            "organization_id",
+            unique=True,
+            postgresql_where=text("budget_kind = 'proliferate_managed' AND status != 'revoked'"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    budget_kind: Mapped[str] = mapped_column(String(32), default="proliferate_managed")
+    owner_scope: Mapped[str] = mapped_column(String(32), default="organization")
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+    )
+    litellm_team_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    included_budget_usd: Mapped[str] = mapped_column(String(64))
+    budget_duration: Mapped[str] = mapped_column(String(32), default="30d")
+    litellm_sync_status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    litellm_sync_fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="invalid", index=True)
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    last_provisioned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_litellm_reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class AgentGatewayPolicy(Base):
+    __tablename__ = "agent_gateway_policy"
+    __table_args__ = (
+        CheckConstraint(
+            f"policy_kind IN {SUPPORTED_AGENT_GATEWAY_POLICY_KINDS}",
+            name="ck_agent_gateway_policy_kind",
+        ),
+        CheckConstraint(
+            f"owner_scope IN {SUPPORTED_AGENT_AUTH_OWNER_SCOPES}",
+            name="ck_agent_gateway_policy_owner_scope",
+        ),
+        CheckConstraint(
+            "((owner_scope = 'system' AND owner_user_id IS NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND owner_user_id IS NULL "
+            "AND organization_id IS NOT NULL))",
+            name="ck_agent_gateway_policy_owner_fields",
+        ),
+        CheckConstraint(
+            "((policy_kind = 'proliferate_managed' AND budget_subject_id IS NOT NULL) OR "
+            "(policy_kind != 'proliferate_managed' AND budget_subject_id IS NULL))",
+            name="ck_agent_gateway_policy_budget_subject",
+        ),
+        CheckConstraint(
+            f"litellm_sync_status IN {SUPPORTED_AGENT_GATEWAY_SYNC_STATUSES}",
+            name="ck_agent_gateway_policy_sync_status",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_AGENT_GATEWAY_POLICY_STATUSES}",
+            name="ck_agent_gateway_policy_status",
+        ),
+        Index("uq_agent_gateway_policy_credential", "credential_id", unique=True),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    credential_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_auth_credential.id", ondelete="CASCADE"),
+        index=True,
+    )
+    policy_kind: Mapped[str] = mapped_column(String(32), index=True)
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    budget_subject_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("agent_gateway_budget_subject.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    litellm_team_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    litellm_virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    litellm_virtual_key_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
+    litellm_virtual_key_ciphertext_key_id: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+    )
+    litellm_sync_status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    litellm_sync_fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="provisioning", index=True)
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    last_provisioned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_litellm_reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class AgentGatewayProviderCredential(Base):
+    __tablename__ = "agent_gateway_provider_credential"
+    __table_args__ = (
+        CheckConstraint(
+            f"provider_kind IN {SUPPORTED_AGENT_GATEWAY_PROVIDER_KINDS}",
+            name="ck_agent_gateway_provider_credential_kind",
+        ),
+        CheckConstraint(
+            f"validation_status IN {SUPPORTED_AGENT_GATEWAY_PROVIDER_VALIDATION_STATUSES}",
+            name="ck_agent_gateway_provider_credential_validation_status",
+        ),
+        Index("uq_agent_gateway_provider_credential_policy", "policy_id", unique=True),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    policy_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_gateway_policy.id", ondelete="CASCADE"),
+        index=True,
+    )
+    provider_kind: Mapped[str] = mapped_column(String(64), index=True)
+    payload_ciphertext: Mapped[str] = mapped_column(Text)
+    payload_ciphertext_key_id: Mapped[str] = mapped_column(String(64))
+    redacted_summary_json: Mapped[str] = mapped_column(Text, default="{}")
+    validation_status: Mapped[str] = mapped_column(String(32), default="unvalidated", index=True)
+    validated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    validation_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    validation_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class SandboxAgentAuthSelection(Base):
+    __tablename__ = "sandbox_agent_auth_selection"
+    __table_args__ = (
+        CheckConstraint(
+            f"owner_scope IN {SUPPORTED_SANDBOX_PROFILE_OWNER_SCOPES}",
+            name="ck_sandbox_agent_auth_selection_owner_scope",
+        ),
+        CheckConstraint(
+            f"agent_kind IN {SUPPORTED_CLOUD_AGENTS}",
+            name="ck_sandbox_agent_auth_selection_agent_kind",
+        ),
+        CheckConstraint(
+            f"materialization_mode IN {SUPPORTED_SANDBOX_AGENT_AUTH_MATERIALIZATION_MODES}",
+            name="ck_sandbox_agent_auth_selection_materialization_mode",
+        ),
+        CheckConstraint(
+            f"status IN {SUPPORTED_SANDBOX_AGENT_AUTH_SELECTION_STATUSES}",
+            name="ck_sandbox_agent_auth_selection_status",
+        ),
+        CheckConstraint(
+            "selected_revision > 0",
+            name="ck_sandbox_agent_auth_selection_revision_positive",
+        ),
+        Index(
+            "uq_sandbox_agent_auth_selection_profile_agent",
+            "sandbox_profile_id",
+            "agent_kind",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sandbox_profile_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sandbox_profile.id", ondelete="CASCADE"),
+        index=True,
+    )
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    agent_kind: Mapped[str] = mapped_column(String(32), index=True)
+    credential_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_auth_credential.id", ondelete="CASCADE"),
+        index=True,
+    )
+    credential_share_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("agent_auth_credential_share.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    materialization_mode: Mapped[str] = mapped_column(String(32))
+    selected_revision: Mapped[int] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(String(32), default="active", index=True)
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class SandboxProfileAgentAuthTargetState(Base):
+    __tablename__ = "sandbox_profile_agent_auth_target_state"
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN {SUPPORTED_SANDBOX_AGENT_AUTH_TARGET_STATE_STATUSES}",
+            name="ck_sandbox_profile_agent_auth_target_state_status",
+        ),
+        CheckConstraint(
+            "applied_revision IS NULL OR applied_revision <= desired_revision",
+            name="ck_sandbox_profile_agent_auth_target_state_applied_lte_desired",
+        ),
+        Index(
+            "uq_sandbox_profile_agent_auth_target_state_target_profile",
+            "target_id",
+            "sandbox_profile_id",
+            unique=True,
+        ),
+        Index(
+            "ix_sandbox_profile_agent_auth_target_state_status_revision",
+            "target_id",
+            "status",
+            "desired_revision",
+            "applied_revision",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    sandbox_profile_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sandbox_profile.id", ondelete="CASCADE"),
+        index=True,
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    desired_revision: Mapped[int] = mapped_column(Integer)
+    applied_revision: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    force_restart_required: Mapped[bool] = mapped_column(default=False)
+    last_command_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_commands.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    last_worker_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_workers.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    last_attempted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_applied_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class AgentGatewayRuntimeGrant(Base):
+    __tablename__ = "agent_gateway_runtime_grant"
+    __table_args__ = (
+        CheckConstraint(
+            f"agent_kind IN {SUPPORTED_CLOUD_AGENTS}",
+            name="ck_agent_gateway_runtime_grant_agent_kind",
+        ),
+        CheckConstraint(
+            f"protocol_facade IN {SUPPORTED_AGENT_GATEWAY_PROTOCOL_FACADES}",
+            name="ck_agent_gateway_runtime_grant_protocol_facade",
+        ),
+        Index("uq_agent_gateway_runtime_grant_token_hash", "token_hash", unique=True),
+        Index(
+            "ix_agent_gateway_runtime_grant_policy_revocation_expiry",
+            "policy_id",
+            "revoked_at",
+            "expires_at",
+        ),
+        Index(
+            "ix_agent_gateway_runtime_grant_target_profile_agent",
+            "target_id",
+            "sandbox_profile_id",
+            "agent_kind",
+        ),
+        Index(
+            "ix_agent_gateway_runtime_grant_selection_revision",
+            "selection_id",
+            "issued_profile_revision",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    token_hash: Mapped[str] = mapped_column(String(64))
+    hash_key_id: Mapped[str] = mapped_column(String(64))
+    policy_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_gateway_policy.id", ondelete="CASCADE"),
+        index=True,
+    )
+    credential_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("agent_auth_credential.id", ondelete="CASCADE"),
+        index=True,
+    )
+    selection_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sandbox_agent_auth_selection.id", ondelete="CASCADE"),
+        index=True,
+    )
+    issued_profile_revision: Mapped[int] = mapped_column(Integer)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="CASCADE"),
+        index=True,
+    )
+    sandbox_profile_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sandbox_profile.id", ondelete="CASCADE"),
+        index=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    agent_kind: Mapped[str] = mapped_column(String(32), index=True)
+    protocol_facade: Mapped[str] = mapped_column(String(32))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class AgentAuthAuditEvent(Base):
+    __tablename__ = "agent_auth_audit_event"
+    __table_args__ = (
+        Index("ix_agent_auth_audit_event_actor_created", "actor_user_id", "created_at"),
+        Index("ix_agent_auth_audit_event_org_created", "organization_id", "created_at"),
+        Index("ix_agent_auth_audit_event_credential_created", "credential_id", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    action: Mapped[str] = mapped_column(String(64), index=True)
+    actor_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    credential_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("agent_auth_credential.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    sandbox_profile_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("sandbox_profile.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    target_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_targets.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    metadata_json: Mapped[str] = mapped_column(Text, default="{}")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/server/proliferate/db/models/cloud/target_git_identity.py
+++ b/server/proliferate/db/models/cloud/target_git_identity.py
@@ -39,7 +39,6 @@ class CloudTargetGitIdentity(Base):
     )
     user_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"),
-        index=True,
     )
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("organization.id", ondelete="CASCADE"),

--- a/server/proliferate/db/models/cloud/targets.py
+++ b/server/proliferate/db/models/cloud/targets.py
@@ -143,7 +143,7 @@ class CloudTargetEnrollment(Base):
         ForeignKey("user.id", ondelete="CASCADE"),
         index=True,
     )
-    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/server/proliferate/db/store/cloud_agent_auth/__init__.py
+++ b/server/proliferate/db/store/cloud_agent_auth/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud agent-auth store package."""

--- a/server/proliferate/db/store/cloud_agent_auth/records.py
+++ b/server/proliferate/db/store/cloud_agent_auth/records.py
@@ -1,0 +1,199 @@
+"""Typed records for cloud agent-auth stores."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class SandboxProfileRecord:
+    id: UUID
+    owner_scope: str
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    managed_target_id: UUID | None
+    agent_auth_revision: int
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None
+
+
+@dataclass(frozen=True)
+class AgentAuthCredentialRecord:
+    id: UUID
+    owner_scope: str
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    created_by_user_id: UUID | None
+    agent_kind: str
+    credential_kind: str
+    display_name: str
+    redacted_summary_json: str
+    status: str
+    revision: int
+    legacy_cloud_credential_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+    revoked_at: datetime | None
+
+
+@dataclass(frozen=True)
+class AgentAuthCredentialShareRecord:
+    id: UUID
+    credential_id: UUID
+    owner_user_id: UUID
+    organization_id: UUID
+    share_scope: str
+    shared_by_user_id: UUID
+    status: str
+    allowed_agent_kind: str
+    created_at: datetime
+    revoked_at: datetime | None
+    revoked_by_user_id: UUID | None
+
+
+@dataclass(frozen=True)
+class AgentGatewayBudgetSubjectRecord:
+    id: UUID
+    budget_kind: str
+    owner_scope: str
+    organization_id: UUID
+    litellm_team_id: str | None
+    included_budget_usd: str
+    budget_duration: str
+    litellm_sync_status: str
+    litellm_sync_fingerprint: str | None
+    status: str
+    revision: int
+    last_provisioned_at: datetime | None
+    last_litellm_reconciled_at: datetime | None
+    last_error_code: str | None
+    last_error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentGatewayPolicyRecord:
+    id: UUID
+    credential_id: UUID
+    policy_kind: str
+    owner_scope: str
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    budget_subject_id: UUID | None
+    litellm_team_id: str | None
+    litellm_virtual_key_id: str | None
+    litellm_virtual_key_ciphertext: str | None
+    litellm_virtual_key_ciphertext_key_id: str | None
+    litellm_sync_status: str
+    litellm_sync_fingerprint: str | None
+    status: str
+    revision: int
+    last_provisioned_at: datetime | None
+    last_litellm_reconciled_at: datetime | None
+    last_error_code: str | None
+    last_error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentGatewayProviderCredentialRecord:
+    id: UUID
+    policy_id: UUID
+    provider_kind: str
+    payload_ciphertext: str
+    payload_ciphertext_key_id: str
+    redacted_summary_json: str
+    validation_status: str
+    validated_at: datetime | None
+    validation_error_code: str | None
+    validation_error_message: str | None
+    revision: int
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SandboxAgentAuthSelectionRecord:
+    id: UUID
+    sandbox_profile_id: UUID
+    owner_scope: str
+    agent_kind: str
+    credential_id: UUID
+    credential_share_id: UUID | None
+    materialization_mode: str
+    selected_revision: int
+    status: str
+    last_error_code: str | None
+    last_error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SandboxProfileAgentAuthTargetStateRecord:
+    id: UUID
+    sandbox_profile_id: UUID
+    target_id: UUID
+    desired_revision: int
+    applied_revision: int | None
+    status: str
+    force_restart_required: bool
+    last_command_id: UUID | None
+    last_worker_id: UUID | None
+    last_attempted_at: datetime | None
+    last_applied_at: datetime | None
+    last_error_code: str | None
+    last_error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentGatewayRuntimeGrantRecord:
+    id: UUID
+    token_hash: str
+    hash_key_id: str
+    policy_id: UUID
+    credential_id: UUID
+    selection_id: UUID
+    issued_profile_revision: int
+    target_id: UUID
+    sandbox_profile_id: UUID
+    organization_id: UUID | None
+    user_id: UUID | None
+    agent_kind: str
+    protocol_facade: str
+    expires_at: datetime
+    revoked_at: datetime | None
+    last_used_at: datetime | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentAuthAuditEventRecord:
+    id: UUID
+    action: str
+    actor_user_id: UUID | None
+    owner_scope: str
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    credential_id: UUID | None
+    sandbox_profile_id: UUID | None
+    target_id: UUID | None
+    metadata_json: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class LegacyCloudCredentialRecord:
+    id: UUID
+    provider: str
+    auth_mode: str
+    revoked_at: datetime | None
+    updated_at: datetime | None

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -1,0 +1,1286 @@
+"""Persistence helpers for cloud agent-auth state."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import AGENT_GATEWAY_BUDGET_DURATION_V1
+from proliferate.db.models.cloud.agent_auth import (
+    AgentAuthAuditEvent,
+    AgentAuthCredential,
+    AgentAuthCredentialShare,
+    AgentGatewayBudgetSubject,
+    AgentGatewayPolicy,
+    AgentGatewayProviderCredential,
+    AgentGatewayRuntimeGrant,
+    SandboxAgentAuthSelection,
+    SandboxProfile,
+    SandboxProfileAgentAuthRevision,
+    SandboxProfileAgentAuthTargetState,
+)
+from proliferate.db.models.cloud.credentials import CloudCredential
+from proliferate.db.store.cloud_agent_auth.records import (
+    AgentAuthAuditEventRecord,
+    AgentAuthCredentialRecord,
+    AgentAuthCredentialShareRecord,
+    AgentGatewayBudgetSubjectRecord,
+    AgentGatewayPolicyRecord,
+    AgentGatewayProviderCredentialRecord,
+    AgentGatewayRuntimeGrantRecord,
+    LegacyCloudCredentialRecord,
+    SandboxAgentAuthSelectionRecord,
+    SandboxProfileAgentAuthTargetStateRecord,
+    SandboxProfileRecord,
+)
+from proliferate.utils.time import utcnow
+
+
+def _profile_record(row: SandboxProfile) -> SandboxProfileRecord:
+    return SandboxProfileRecord(
+        id=row.id,
+        owner_scope=row.owner_scope,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        managed_target_id=row.managed_target_id,
+        agent_auth_revision=row.agent_auth_revision,
+        status=row.status,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        deleted_at=row.deleted_at,
+    )
+
+
+def _credential_record(row: AgentAuthCredential) -> AgentAuthCredentialRecord:
+    return AgentAuthCredentialRecord(
+        id=row.id,
+        owner_scope=row.owner_scope,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        created_by_user_id=row.created_by_user_id,
+        agent_kind=row.agent_kind,
+        credential_kind=row.credential_kind,
+        display_name=row.display_name,
+        redacted_summary_json=row.redacted_summary_json,
+        status=row.status,
+        revision=row.revision,
+        legacy_cloud_credential_id=row.legacy_cloud_credential_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        revoked_at=row.revoked_at,
+    )
+
+
+def _share_record(row: AgentAuthCredentialShare) -> AgentAuthCredentialShareRecord:
+    return AgentAuthCredentialShareRecord(
+        id=row.id,
+        credential_id=row.credential_id,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        share_scope=row.share_scope,
+        shared_by_user_id=row.shared_by_user_id,
+        status=row.status,
+        allowed_agent_kind=row.allowed_agent_kind,
+        created_at=row.created_at,
+        revoked_at=row.revoked_at,
+        revoked_by_user_id=row.revoked_by_user_id,
+    )
+
+
+def _budget_subject_record(row: AgentGatewayBudgetSubject) -> AgentGatewayBudgetSubjectRecord:
+    return AgentGatewayBudgetSubjectRecord(
+        id=row.id,
+        budget_kind=row.budget_kind,
+        owner_scope=row.owner_scope,
+        organization_id=row.organization_id,
+        litellm_team_id=row.litellm_team_id,
+        included_budget_usd=row.included_budget_usd,
+        budget_duration=row.budget_duration,
+        litellm_sync_status=row.litellm_sync_status,
+        litellm_sync_fingerprint=row.litellm_sync_fingerprint,
+        status=row.status,
+        revision=row.revision,
+        last_provisioned_at=row.last_provisioned_at,
+        last_litellm_reconciled_at=row.last_litellm_reconciled_at,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _policy_record(row: AgentGatewayPolicy) -> AgentGatewayPolicyRecord:
+    return AgentGatewayPolicyRecord(
+        id=row.id,
+        credential_id=row.credential_id,
+        policy_kind=row.policy_kind,
+        owner_scope=row.owner_scope,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        budget_subject_id=row.budget_subject_id,
+        litellm_team_id=row.litellm_team_id,
+        litellm_virtual_key_id=row.litellm_virtual_key_id,
+        litellm_virtual_key_ciphertext=row.litellm_virtual_key_ciphertext,
+        litellm_virtual_key_ciphertext_key_id=row.litellm_virtual_key_ciphertext_key_id,
+        litellm_sync_status=row.litellm_sync_status,
+        litellm_sync_fingerprint=row.litellm_sync_fingerprint,
+        status=row.status,
+        revision=row.revision,
+        last_provisioned_at=row.last_provisioned_at,
+        last_litellm_reconciled_at=row.last_litellm_reconciled_at,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _provider_credential_record(
+    row: AgentGatewayProviderCredential,
+) -> AgentGatewayProviderCredentialRecord:
+    return AgentGatewayProviderCredentialRecord(
+        id=row.id,
+        policy_id=row.policy_id,
+        provider_kind=row.provider_kind,
+        payload_ciphertext=row.payload_ciphertext,
+        payload_ciphertext_key_id=row.payload_ciphertext_key_id,
+        redacted_summary_json=row.redacted_summary_json,
+        validation_status=row.validation_status,
+        validated_at=row.validated_at,
+        validation_error_code=row.validation_error_code,
+        validation_error_message=row.validation_error_message,
+        revision=row.revision,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _selection_record(row: SandboxAgentAuthSelection) -> SandboxAgentAuthSelectionRecord:
+    return SandboxAgentAuthSelectionRecord(
+        id=row.id,
+        sandbox_profile_id=row.sandbox_profile_id,
+        owner_scope=row.owner_scope,
+        agent_kind=row.agent_kind,
+        credential_id=row.credential_id,
+        credential_share_id=row.credential_share_id,
+        materialization_mode=row.materialization_mode,
+        selected_revision=row.selected_revision,
+        status=row.status,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _target_state_record(
+    row: SandboxProfileAgentAuthTargetState,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    return SandboxProfileAgentAuthTargetStateRecord(
+        id=row.id,
+        sandbox_profile_id=row.sandbox_profile_id,
+        target_id=row.target_id,
+        desired_revision=row.desired_revision,
+        applied_revision=row.applied_revision,
+        status=row.status,
+        force_restart_required=row.force_restart_required,
+        last_command_id=row.last_command_id,
+        last_worker_id=row.last_worker_id,
+        last_attempted_at=row.last_attempted_at,
+        last_applied_at=row.last_applied_at,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _runtime_grant_record(row: AgentGatewayRuntimeGrant) -> AgentGatewayRuntimeGrantRecord:
+    return AgentGatewayRuntimeGrantRecord(
+        id=row.id,
+        token_hash=row.token_hash,
+        hash_key_id=row.hash_key_id,
+        policy_id=row.policy_id,
+        credential_id=row.credential_id,
+        selection_id=row.selection_id,
+        issued_profile_revision=row.issued_profile_revision,
+        target_id=row.target_id,
+        sandbox_profile_id=row.sandbox_profile_id,
+        organization_id=row.organization_id,
+        user_id=row.user_id,
+        agent_kind=row.agent_kind,
+        protocol_facade=row.protocol_facade,
+        expires_at=row.expires_at,
+        revoked_at=row.revoked_at,
+        last_used_at=row.last_used_at,
+        created_at=row.created_at,
+    )
+
+
+def _audit_event_record(row: AgentAuthAuditEvent) -> AgentAuthAuditEventRecord:
+    return AgentAuthAuditEventRecord(
+        id=row.id,
+        action=row.action,
+        actor_user_id=row.actor_user_id,
+        owner_scope=row.owner_scope,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        credential_id=row.credential_id,
+        sandbox_profile_id=row.sandbox_profile_id,
+        target_id=row.target_id,
+        metadata_json=row.metadata_json,
+        created_at=row.created_at,
+    )
+
+
+def _legacy_cloud_credential_record(row: CloudCredential) -> LegacyCloudCredentialRecord:
+    return LegacyCloudCredentialRecord(
+        id=row.id,
+        provider=row.provider,
+        auth_mode=row.auth_mode,
+        revoked_at=row.revoked_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def get_sandbox_profile(
+    db: AsyncSession,
+    sandbox_profile_id: UUID,
+) -> SandboxProfileRecord | None:
+    row = await db.get(SandboxProfile, sandbox_profile_id)
+    if row is None or row.deleted_at is not None:
+        return None
+    return _profile_record(row)
+
+
+async def ensure_personal_sandbox_profile(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    managed_target_id: UUID | None = None,
+) -> SandboxProfileRecord:
+    row = (
+        await db.execute(
+            select(SandboxProfile)
+            .where(
+                SandboxProfile.owner_scope == "personal",
+                SandboxProfile.owner_user_id == user_id,
+                SandboxProfile.deleted_at.is_(None),
+                SandboxProfile.status == "active",
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = SandboxProfile(
+            owner_scope="personal",
+            owner_user_id=user_id,
+            organization_id=None,
+            managed_target_id=managed_target_id,
+            agent_auth_revision=0,
+            status="active",
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+        db.add(row)
+        await db.flush()
+    elif managed_target_id is not None and row.managed_target_id != managed_target_id:
+        row.managed_target_id = managed_target_id
+        row.updated_at = now
+        await db.flush()
+    return _profile_record(row)
+
+
+async def ensure_organization_sandbox_profile(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    managed_target_id: UUID | None = None,
+) -> SandboxProfileRecord:
+    row = (
+        await db.execute(
+            select(SandboxProfile)
+            .where(
+                SandboxProfile.owner_scope == "organization",
+                SandboxProfile.organization_id == organization_id,
+                SandboxProfile.deleted_at.is_(None),
+                SandboxProfile.status == "active",
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = SandboxProfile(
+            owner_scope="organization",
+            owner_user_id=None,
+            organization_id=organization_id,
+            managed_target_id=managed_target_id,
+            agent_auth_revision=0,
+            status="active",
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+        db.add(row)
+        await db.flush()
+    elif managed_target_id is not None and row.managed_target_id != managed_target_id:
+        row.managed_target_id = managed_target_id
+        row.updated_at = now
+        await db.flush()
+    return _profile_record(row)
+
+
+async def bump_sandbox_profile_agent_auth_revision(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    reason: str,
+    actor_user_id: UUID | None,
+    force_restart: bool,
+) -> SandboxProfileRecord | None:
+    row = (
+        await db.execute(
+            select(SandboxProfile)
+            .where(
+                SandboxProfile.id == sandbox_profile_id,
+                SandboxProfile.deleted_at.is_(None),
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    now = utcnow()
+    row.agent_auth_revision += 1
+    row.updated_at = now
+    db.add(
+        SandboxProfileAgentAuthRevision(
+            sandbox_profile_id=row.id,
+            revision=row.agent_auth_revision,
+            reason=reason,
+            force_restart=force_restart,
+            created_by_user_id=actor_user_id,
+            created_at=now,
+        )
+    )
+    await db.flush()
+    return _profile_record(row)
+
+
+async def list_visible_credentials(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID | None = None,
+    agent_kind: str | None = None,
+) -> tuple[AgentAuthCredentialRecord, ...]:
+    filters = [
+        AgentAuthCredential.revoked_at.is_(None),
+        AgentAuthCredential.status != "revoked",
+    ]
+    if agent_kind is not None:
+        filters.append(AgentAuthCredential.agent_kind == agent_kind)
+    visibility = [
+        AgentAuthCredential.owner_scope == "system",
+        and_(
+            AgentAuthCredential.owner_scope == "personal",
+            AgentAuthCredential.owner_user_id == actor_user_id,
+        ),
+    ]
+    if organization_id is not None:
+        visibility.append(
+            and_(
+                AgentAuthCredential.owner_scope == "organization",
+                AgentAuthCredential.organization_id == organization_id,
+            )
+        )
+        shared_credential_ids = select(AgentAuthCredentialShare.credential_id).where(
+            AgentAuthCredentialShare.organization_id == organization_id,
+            AgentAuthCredentialShare.status == "active",
+        )
+        visibility.append(AgentAuthCredential.id.in_(shared_credential_ids))
+    rows = (
+        (
+            await db.execute(
+                select(AgentAuthCredential)
+                .where(*filters, or_(*visibility))
+                .order_by(
+                    AgentAuthCredential.agent_kind.asc(),
+                    AgentAuthCredential.owner_scope.asc(),
+                    AgentAuthCredential.display_name.asc(),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_credential_record(row) for row in rows)
+
+
+async def get_credential(
+    db: AsyncSession,
+    credential_id: UUID,
+) -> AgentAuthCredentialRecord | None:
+    row = await db.get(AgentAuthCredential, credential_id)
+    if row is None:
+        return None
+    return _credential_record(row)
+
+
+async def get_selection(
+    db: AsyncSession,
+    selection_id: UUID,
+) -> SandboxAgentAuthSelectionRecord | None:
+    row = await db.get(SandboxAgentAuthSelection, selection_id)
+    return _selection_record(row) if row is not None else None
+
+
+async def get_credential_for_update(
+    db: AsyncSession,
+    credential_id: UUID,
+) -> AgentAuthCredentialRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredential)
+            .where(AgentAuthCredential.id == credential_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return _credential_record(row)
+
+
+async def create_agent_auth_credential(
+    db: AsyncSession,
+    *,
+    owner_scope: str,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+    created_by_user_id: UUID | None,
+    agent_kind: str,
+    credential_kind: str,
+    display_name: str,
+    redacted_summary_json: str,
+    status: str,
+    legacy_cloud_credential_id: UUID | None = None,
+) -> AgentAuthCredentialRecord:
+    now = utcnow()
+    row = AgentAuthCredential(
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+        agent_kind=agent_kind,
+        credential_kind=credential_kind,
+        display_name=display_name,
+        redacted_summary_json=redacted_summary_json,
+        status=status,
+        revision=1,
+        legacy_cloud_credential_id=legacy_cloud_credential_id,
+        created_at=now,
+        updated_at=now,
+        revoked_at=None,
+    )
+    db.add(row)
+    await db.flush()
+    return _credential_record(row)
+
+
+async def update_credential_status(
+    db: AsyncSession,
+    *,
+    credential_id: UUID,
+    status: str,
+    redacted_summary_json: str | None = None,
+) -> AgentAuthCredentialRecord | None:
+    row = await db.get(AgentAuthCredential, credential_id)
+    if row is None:
+        return None
+    row.status = status
+    row.revision += 1
+    row.updated_at = utcnow()
+    if redacted_summary_json is not None:
+        row.redacted_summary_json = redacted_summary_json
+    await db.flush()
+    return _credential_record(row)
+
+
+async def revoke_credential(
+    db: AsyncSession,
+    *,
+    credential_id: UUID,
+) -> AgentAuthCredentialRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredential)
+            .where(AgentAuthCredential.id == credential_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    now = utcnow()
+    row.status = "revoked"
+    row.revoked_at = now
+    row.updated_at = now
+    row.revision += 1
+    await db.flush()
+    return _credential_record(row)
+
+
+async def find_agent_auth_credential_for_legacy_cloud_credential(
+    db: AsyncSession,
+    legacy_cloud_credential_id: UUID,
+) -> AgentAuthCredentialRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredential).where(
+                AgentAuthCredential.legacy_cloud_credential_id == legacy_cloud_credential_id
+            )
+        )
+    ).scalar_one_or_none()
+    return _credential_record(row) if row is not None else None
+
+
+async def list_active_legacy_cloud_credentials_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> tuple[LegacyCloudCredentialRecord, ...]:
+    return tuple(
+        row
+        for row in await list_legacy_cloud_credentials_for_user(db, user_id)
+        if row.revoked_at is None
+    )
+
+
+async def list_legacy_cloud_credentials_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> tuple[LegacyCloudCredentialRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(CloudCredential)
+                .where(
+                    CloudCredential.user_id == user_id,
+                )
+                .order_by(CloudCredential.updated_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_legacy_cloud_credential_record(row) for row in rows)
+
+
+async def list_imported_legacy_credentials_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> tuple[AgentAuthCredentialRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(AgentAuthCredential)
+                .where(
+                    AgentAuthCredential.owner_scope == "personal",
+                    AgentAuthCredential.owner_user_id == user_id,
+                    AgentAuthCredential.legacy_cloud_credential_id.is_not(None),
+                    AgentAuthCredential.revoked_at.is_(None),
+                )
+                .order_by(AgentAuthCredential.updated_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_credential_record(row) for row in rows)
+
+
+async def create_or_reactivate_credential_share(
+    db: AsyncSession,
+    *,
+    credential_id: UUID,
+    owner_user_id: UUID,
+    organization_id: UUID,
+    shared_by_user_id: UUID,
+    allowed_agent_kind: str,
+) -> AgentAuthCredentialShareRecord:
+    row = (
+        await db.execute(
+            select(AgentAuthCredentialShare)
+            .where(
+                AgentAuthCredentialShare.credential_id == credential_id,
+                AgentAuthCredentialShare.organization_id == organization_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = AgentAuthCredentialShare(
+            credential_id=credential_id,
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            share_scope="organization",
+            shared_by_user_id=shared_by_user_id,
+            status="active",
+            allowed_agent_kind=allowed_agent_kind,
+            created_at=now,
+            revoked_at=None,
+            revoked_by_user_id=None,
+        )
+        db.add(row)
+    else:
+        row.status = "active"
+        row.allowed_agent_kind = allowed_agent_kind
+        row.revoked_at = None
+        row.revoked_by_user_id = None
+    await db.flush()
+    return _share_record(row)
+
+
+async def get_active_credential_share(
+    db: AsyncSession,
+    *,
+    credential_id: UUID,
+    organization_id: UUID,
+) -> AgentAuthCredentialShareRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredentialShare).where(
+                AgentAuthCredentialShare.credential_id == credential_id,
+                AgentAuthCredentialShare.organization_id == organization_id,
+                AgentAuthCredentialShare.status == "active",
+            )
+        )
+    ).scalar_one_or_none()
+    return _share_record(row) if row is not None else None
+
+
+async def get_credential_share(
+    db: AsyncSession,
+    share_id: UUID,
+) -> AgentAuthCredentialShareRecord | None:
+    row = await db.get(AgentAuthCredentialShare, share_id)
+    return _share_record(row) if row is not None else None
+
+
+async def revoke_credential_share(
+    db: AsyncSession,
+    *,
+    share_id: UUID,
+    revoked_by_user_id: UUID,
+) -> AgentAuthCredentialShareRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredentialShare)
+            .where(AgentAuthCredentialShare.id == share_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    row.status = "revoked"
+    row.revoked_at = utcnow()
+    row.revoked_by_user_id = revoked_by_user_id
+    await db.flush()
+    return _share_record(row)
+
+
+async def list_active_selections_for_credential_or_share(
+    db: AsyncSession,
+    *,
+    credential_id: UUID | None = None,
+    credential_share_id: UUID | None = None,
+) -> tuple[SandboxAgentAuthSelectionRecord, ...]:
+    filters = [SandboxAgentAuthSelection.status == "active"]
+    if credential_id is not None:
+        filters.append(SandboxAgentAuthSelection.credential_id == credential_id)
+    if credential_share_id is not None:
+        filters.append(SandboxAgentAuthSelection.credential_share_id == credential_share_id)
+    rows = (await db.execute(select(SandboxAgentAuthSelection).where(*filters))).scalars().all()
+    return tuple(_selection_record(row) for row in rows)
+
+
+async def ensure_managed_budget_subject(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    included_budget_usd: str,
+    litellm_team_id: str | None,
+    litellm_sync_status: str,
+    litellm_sync_fingerprint: str | None,
+    status: str,
+    last_error_code: str | None = None,
+    last_error_message: str | None = None,
+) -> AgentGatewayBudgetSubjectRecord:
+    row = (
+        await db.execute(
+            select(AgentGatewayBudgetSubject)
+            .where(
+                AgentGatewayBudgetSubject.organization_id == organization_id,
+                AgentGatewayBudgetSubject.budget_kind == "proliferate_managed",
+                AgentGatewayBudgetSubject.status != "revoked",
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = AgentGatewayBudgetSubject(
+            budget_kind="proliferate_managed",
+            owner_scope="organization",
+            organization_id=organization_id,
+            litellm_team_id=litellm_team_id,
+            included_budget_usd=included_budget_usd,
+            budget_duration=AGENT_GATEWAY_BUDGET_DURATION_V1,
+            litellm_sync_status=litellm_sync_status,
+            litellm_sync_fingerprint=litellm_sync_fingerprint,
+            status=status,
+            revision=1,
+            last_provisioned_at=now if litellm_sync_status == "synced" else None,
+            last_litellm_reconciled_at=now if litellm_sync_status == "synced" else None,
+            last_error_code=last_error_code,
+            last_error_message=last_error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        changed = (
+            row.litellm_team_id != litellm_team_id
+            or row.included_budget_usd != included_budget_usd
+            or row.litellm_sync_status != litellm_sync_status
+            or row.litellm_sync_fingerprint != litellm_sync_fingerprint
+            or row.status != status
+            or row.last_error_code != last_error_code
+            or row.last_error_message != last_error_message
+        )
+        row.litellm_team_id = litellm_team_id
+        row.included_budget_usd = included_budget_usd
+        row.litellm_sync_status = litellm_sync_status
+        row.litellm_sync_fingerprint = litellm_sync_fingerprint
+        row.status = status
+        row.last_error_code = last_error_code
+        row.last_error_message = last_error_message
+        if litellm_sync_status == "synced":
+            row.last_provisioned_at = now
+            row.last_litellm_reconciled_at = now
+        if changed:
+            row.revision += 1
+        row.updated_at = now
+    await db.flush()
+    return _budget_subject_record(row)
+
+
+async def get_managed_budget_subject(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> AgentGatewayBudgetSubjectRecord | None:
+    row = (
+        await db.execute(
+            select(AgentGatewayBudgetSubject).where(
+                AgentGatewayBudgetSubject.organization_id == organization_id,
+                AgentGatewayBudgetSubject.budget_kind == "proliferate_managed",
+                AgentGatewayBudgetSubject.status != "revoked",
+            )
+        )
+    ).scalar_one_or_none()
+    return _budget_subject_record(row) if row is not None else None
+
+
+async def ensure_gateway_policy(
+    db: AsyncSession,
+    *,
+    credential_id: UUID,
+    policy_kind: str,
+    owner_scope: str,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+    budget_subject_id: UUID | None,
+    litellm_team_id: str | None,
+    litellm_virtual_key_id: str | None,
+    litellm_virtual_key_ciphertext: str | None,
+    litellm_virtual_key_ciphertext_key_id: str | None,
+    litellm_sync_status: str,
+    litellm_sync_fingerprint: str | None,
+    status: str,
+    last_error_code: str | None = None,
+    last_error_message: str | None = None,
+) -> AgentGatewayPolicyRecord:
+    row = (
+        await db.execute(
+            select(AgentGatewayPolicy)
+            .where(AgentGatewayPolicy.credential_id == credential_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = AgentGatewayPolicy(
+            credential_id=credential_id,
+            policy_kind=policy_kind,
+            owner_scope=owner_scope,
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            budget_subject_id=budget_subject_id,
+            litellm_team_id=litellm_team_id,
+            litellm_virtual_key_id=litellm_virtual_key_id,
+            litellm_virtual_key_ciphertext=litellm_virtual_key_ciphertext,
+            litellm_virtual_key_ciphertext_key_id=litellm_virtual_key_ciphertext_key_id,
+            litellm_sync_status=litellm_sync_status,
+            litellm_sync_fingerprint=litellm_sync_fingerprint,
+            status=status,
+            revision=1,
+            last_provisioned_at=now if litellm_sync_status == "synced" else None,
+            last_litellm_reconciled_at=now if litellm_sync_status == "synced" else None,
+            last_error_code=last_error_code,
+            last_error_message=last_error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        changed = (
+            row.policy_kind != policy_kind
+            or row.budget_subject_id != budget_subject_id
+            or row.litellm_team_id != litellm_team_id
+            or row.litellm_virtual_key_id != litellm_virtual_key_id
+            or row.litellm_virtual_key_ciphertext != litellm_virtual_key_ciphertext
+            or row.litellm_sync_status != litellm_sync_status
+            or row.litellm_sync_fingerprint != litellm_sync_fingerprint
+            or row.status != status
+            or row.last_error_code != last_error_code
+            or row.last_error_message != last_error_message
+        )
+        row.policy_kind = policy_kind
+        row.owner_scope = owner_scope
+        row.owner_user_id = owner_user_id
+        row.organization_id = organization_id
+        row.budget_subject_id = budget_subject_id
+        row.litellm_team_id = litellm_team_id
+        row.litellm_virtual_key_id = litellm_virtual_key_id
+        row.litellm_virtual_key_ciphertext = litellm_virtual_key_ciphertext
+        row.litellm_virtual_key_ciphertext_key_id = litellm_virtual_key_ciphertext_key_id
+        row.litellm_sync_status = litellm_sync_status
+        row.litellm_sync_fingerprint = litellm_sync_fingerprint
+        row.status = status
+        row.last_error_code = last_error_code
+        row.last_error_message = last_error_message
+        if litellm_sync_status == "synced":
+            row.last_provisioned_at = now
+            row.last_litellm_reconciled_at = now
+        if changed:
+            row.revision += 1
+        row.updated_at = now
+    await db.flush()
+    return _policy_record(row)
+
+
+async def get_gateway_policy_for_credential(
+    db: AsyncSession,
+    credential_id: UUID,
+) -> AgentGatewayPolicyRecord | None:
+    row = (
+        await db.execute(
+            select(AgentGatewayPolicy).where(AgentGatewayPolicy.credential_id == credential_id)
+        )
+    ).scalar_one_or_none()
+    return _policy_record(row) if row is not None else None
+
+
+async def get_gateway_policy(
+    db: AsyncSession,
+    policy_id: UUID,
+) -> AgentGatewayPolicyRecord | None:
+    row = await db.get(AgentGatewayPolicy, policy_id)
+    return _policy_record(row) if row is not None else None
+
+
+async def get_budget_subject(
+    db: AsyncSession,
+    budget_subject_id: UUID,
+) -> AgentGatewayBudgetSubjectRecord | None:
+    row = await db.get(AgentGatewayBudgetSubject, budget_subject_id)
+    return _budget_subject_record(row) if row is not None else None
+
+
+async def upsert_provider_credential(
+    db: AsyncSession,
+    *,
+    policy_id: UUID,
+    provider_kind: str,
+    payload_ciphertext: str,
+    payload_ciphertext_key_id: str,
+    redacted_summary_json: str,
+    validation_status: str,
+    validated_at: datetime | None,
+    validation_error_code: str | None,
+    validation_error_message: str | None,
+) -> AgentGatewayProviderCredentialRecord:
+    row = (
+        await db.execute(
+            select(AgentGatewayProviderCredential)
+            .where(AgentGatewayProviderCredential.policy_id == policy_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = AgentGatewayProviderCredential(
+            policy_id=policy_id,
+            provider_kind=provider_kind,
+            payload_ciphertext=payload_ciphertext,
+            payload_ciphertext_key_id=payload_ciphertext_key_id,
+            redacted_summary_json=redacted_summary_json,
+            validation_status=validation_status,
+            validated_at=validated_at,
+            validation_error_code=validation_error_code,
+            validation_error_message=validation_error_message,
+            revision=1,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.provider_kind = provider_kind
+        row.payload_ciphertext = payload_ciphertext
+        row.payload_ciphertext_key_id = payload_ciphertext_key_id
+        row.redacted_summary_json = redacted_summary_json
+        row.validation_status = validation_status
+        row.validated_at = validated_at
+        row.validation_error_code = validation_error_code
+        row.validation_error_message = validation_error_message
+        row.revision += 1
+        row.updated_at = now
+    await db.flush()
+    return _provider_credential_record(row)
+
+
+async def list_selections_for_profile(
+    db: AsyncSession,
+    sandbox_profile_id: UUID,
+) -> tuple[SandboxAgentAuthSelectionRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(SandboxAgentAuthSelection)
+                .where(SandboxAgentAuthSelection.sandbox_profile_id == sandbox_profile_id)
+                .order_by(SandboxAgentAuthSelection.agent_kind.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_selection_record(row) for row in rows)
+
+
+async def upsert_selection(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    owner_scope: str,
+    agent_kind: str,
+    credential_id: UUID,
+    credential_share_id: UUID | None,
+    materialization_mode: str,
+    selected_revision: int,
+    status: str,
+    last_error_code: str | None,
+    last_error_message: str | None,
+) -> SandboxAgentAuthSelectionRecord:
+    row = (
+        await db.execute(
+            select(SandboxAgentAuthSelection)
+            .where(
+                SandboxAgentAuthSelection.sandbox_profile_id == sandbox_profile_id,
+                SandboxAgentAuthSelection.agent_kind == agent_kind,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    if row is None:
+        row = SandboxAgentAuthSelection(
+            sandbox_profile_id=sandbox_profile_id,
+            owner_scope=owner_scope,
+            agent_kind=agent_kind,
+            credential_id=credential_id,
+            credential_share_id=credential_share_id,
+            materialization_mode=materialization_mode,
+            selected_revision=selected_revision,
+            status=status,
+            last_error_code=last_error_code,
+            last_error_message=last_error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.owner_scope = owner_scope
+        row.credential_id = credential_id
+        row.credential_share_id = credential_share_id
+        row.materialization_mode = materialization_mode
+        row.selected_revision = selected_revision
+        row.status = status
+        row.last_error_code = last_error_code
+        row.last_error_message = last_error_message
+        row.updated_at = now
+    await db.flush()
+    return _selection_record(row)
+
+
+async def mark_selection_invalid(
+    db: AsyncSession,
+    *,
+    selection_id: UUID,
+    error_code: str,
+    error_message: str,
+) -> SandboxAgentAuthSelectionRecord | None:
+    row = await db.get(SandboxAgentAuthSelection, selection_id)
+    if row is None:
+        return None
+    row.status = "invalid"
+    row.last_error_code = error_code
+    row.last_error_message = error_message
+    row.updated_at = utcnow()
+    await db.flush()
+    return _selection_record(row)
+
+
+async def list_target_states_for_profile(
+    db: AsyncSession,
+    sandbox_profile_id: UUID,
+) -> tuple[SandboxProfileAgentAuthTargetStateRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(SandboxProfileAgentAuthTargetState)
+                .where(SandboxProfileAgentAuthTargetState.sandbox_profile_id == sandbox_profile_id)
+                .order_by(SandboxProfileAgentAuthTargetState.updated_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_target_state_record(row) for row in rows)
+
+
+async def upsert_target_state(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    desired_revision: int,
+    applied_revision: int | None,
+    status: str,
+    force_restart_required: bool,
+    last_command_id: UUID | None,
+    last_worker_id: UUID | None,
+    last_error_code: str | None,
+    last_error_message: str | None,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    row = (
+        await db.execute(
+            select(SandboxProfileAgentAuthTargetState)
+            .where(
+                SandboxProfileAgentAuthTargetState.sandbox_profile_id == sandbox_profile_id,
+                SandboxProfileAgentAuthTargetState.target_id == target_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    attempted_at = now if status in {"materializing", "failed", "applied"} else None
+    applied_at = now if status == "applied" else None
+    if row is None:
+        row = SandboxProfileAgentAuthTargetState(
+            sandbox_profile_id=sandbox_profile_id,
+            target_id=target_id,
+            desired_revision=desired_revision,
+            applied_revision=applied_revision,
+            status=status,
+            force_restart_required=force_restart_required,
+            last_command_id=last_command_id,
+            last_worker_id=last_worker_id,
+            last_attempted_at=attempted_at,
+            last_applied_at=applied_at,
+            last_error_code=last_error_code,
+            last_error_message=last_error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.desired_revision = desired_revision
+        row.applied_revision = applied_revision
+        row.status = status
+        row.force_restart_required = force_restart_required
+        row.last_command_id = last_command_id
+        row.last_worker_id = last_worker_id
+        if attempted_at is not None:
+            row.last_attempted_at = attempted_at
+        if applied_at is not None:
+            row.last_applied_at = applied_at
+        row.last_error_code = last_error_code
+        row.last_error_message = last_error_message
+        row.updated_at = now
+    await db.flush()
+    return _target_state_record(row)
+
+
+async def create_runtime_grant(
+    db: AsyncSession,
+    *,
+    token_hash: str,
+    hash_key_id: str,
+    policy_id: UUID,
+    credential_id: UUID,
+    selection_id: UUID,
+    issued_profile_revision: int,
+    target_id: UUID,
+    sandbox_profile_id: UUID,
+    organization_id: UUID | None,
+    user_id: UUID | None,
+    agent_kind: str,
+    protocol_facade: str,
+    expires_at: datetime,
+) -> AgentGatewayRuntimeGrantRecord:
+    now = utcnow()
+    row = AgentGatewayRuntimeGrant(
+        token_hash=token_hash,
+        hash_key_id=hash_key_id,
+        policy_id=policy_id,
+        credential_id=credential_id,
+        selection_id=selection_id,
+        issued_profile_revision=issued_profile_revision,
+        target_id=target_id,
+        sandbox_profile_id=sandbox_profile_id,
+        organization_id=organization_id,
+        user_id=user_id,
+        agent_kind=agent_kind,
+        protocol_facade=protocol_facade,
+        expires_at=expires_at,
+        revoked_at=None,
+        last_used_at=None,
+        created_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    return _runtime_grant_record(row)
+
+
+async def get_runtime_grant_by_token_hash(
+    db: AsyncSession,
+    token_hash: str,
+) -> AgentGatewayRuntimeGrantRecord | None:
+    row = (
+        await db.execute(
+            select(AgentGatewayRuntimeGrant).where(
+                AgentGatewayRuntimeGrant.token_hash == token_hash
+            )
+        )
+    ).scalar_one_or_none()
+    return _runtime_grant_record(row) if row is not None else None
+
+
+async def list_active_runtime_grants_for_route(
+    db: AsyncSession,
+    *,
+    policy_id: UUID,
+    target_id: UUID,
+    sandbox_profile_id: UUID,
+    agent_kind: str,
+    now: datetime,
+) -> tuple[AgentGatewayRuntimeGrantRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(AgentGatewayRuntimeGrant)
+                .where(
+                    AgentGatewayRuntimeGrant.policy_id == policy_id,
+                    AgentGatewayRuntimeGrant.target_id == target_id,
+                    AgentGatewayRuntimeGrant.sandbox_profile_id == sandbox_profile_id,
+                    AgentGatewayRuntimeGrant.agent_kind == agent_kind,
+                    AgentGatewayRuntimeGrant.revoked_at.is_(None),
+                    AgentGatewayRuntimeGrant.expires_at > now,
+                )
+                .order_by(AgentGatewayRuntimeGrant.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_runtime_grant_record(row) for row in rows)
+
+
+async def mark_runtime_grant_used(
+    db: AsyncSession,
+    grant_id: UUID,
+) -> AgentGatewayRuntimeGrantRecord | None:
+    row = await db.get(AgentGatewayRuntimeGrant, grant_id)
+    if row is None:
+        return None
+    row.last_used_at = utcnow()
+    await db.flush()
+    return _runtime_grant_record(row)
+
+
+async def revoke_runtime_grants_for_selection(
+    db: AsyncSession,
+    *,
+    selection_id: UUID,
+) -> int:
+    rows = (
+        (
+            await db.execute(
+                select(AgentGatewayRuntimeGrant).where(
+                    AgentGatewayRuntimeGrant.selection_id == selection_id,
+                    AgentGatewayRuntimeGrant.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = utcnow()
+    for row in rows:
+        row.revoked_at = now
+    return len(rows)
+
+
+async def record_audit_event(
+    db: AsyncSession,
+    *,
+    action: str,
+    actor_user_id: UUID | None,
+    owner_scope: str,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+    credential_id: UUID | None = None,
+    sandbox_profile_id: UUID | None = None,
+    target_id: UUID | None = None,
+    metadata_json: str = "{}",
+) -> AgentAuthAuditEventRecord:
+    row = AgentAuthAuditEvent(
+        action=action,
+        actor_user_id=actor_user_id,
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        credential_id=credential_id,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+        metadata_json=metadata_json,
+        created_at=utcnow(),
+    )
+    db.add(row)
+    await db.flush()
+    return _audit_event_record(row)

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -256,6 +256,23 @@ async def get_sandbox_profile(
     return _profile_record(row)
 
 
+async def get_active_personal_sandbox_profile_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> SandboxProfileRecord | None:
+    row = (
+        await db.execute(
+            select(SandboxProfile).where(
+                SandboxProfile.owner_scope == "personal",
+                SandboxProfile.owner_user_id == user_id,
+                SandboxProfile.deleted_at.is_(None),
+                SandboxProfile.status == "active",
+            )
+        )
+    ).scalar_one_or_none()
+    return _profile_record(row) if row is not None else None
+
+
 async def ensure_personal_sandbox_profile(
     db: AsyncSession,
     *,
@@ -1253,6 +1270,31 @@ async def revoke_runtime_grants_for_selection(
     now = utcnow()
     for row in rows:
         row.revoked_at = now
+    return len(rows)
+
+
+async def revoke_runtime_grants_by_ids(
+    db: AsyncSession,
+    grant_ids: set[UUID],
+) -> int:
+    if not grant_ids:
+        return 0
+    rows = (
+        (
+            await db.execute(
+                select(AgentGatewayRuntimeGrant).where(
+                    AgentGatewayRuntimeGrant.id.in_(grant_ids),
+                    AgentGatewayRuntimeGrant.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = utcnow()
+    for row in rows:
+        row.revoked_at = now
+    await db.flush()
     return len(rows)
 
 

--- a/server/proliferate/db/store/cloud_sync/__init__.py
+++ b/server/proliferate/db/store/cloud_sync/__init__.py
@@ -1,2 +1,1 @@
 """Persistence helpers for Cloud Worker sync and target registry state."""
-

--- a/server/proliferate/db/store/cloud_sync/target_config.py
+++ b/server/proliferate/db/store/cloud_sync/target_config.py
@@ -221,9 +221,7 @@ async def mark_target_config_queued(
 ) -> CloudTargetConfigSnapshot | None:
     row = (
         await db.execute(
-            select(CloudTargetConfig)
-            .where(CloudTargetConfig.id == config_id)
-            .with_for_update()
+            select(CloudTargetConfig).where(CloudTargetConfig.id == config_id).with_for_update()
         )
     ).scalar_one_or_none()
     if row is None:
@@ -246,9 +244,7 @@ async def update_target_config_payload(
 ) -> CloudTargetConfigSnapshot | None:
     row = (
         await db.execute(
-            select(CloudTargetConfig)
-            .where(CloudTargetConfig.id == config_id)
-            .with_for_update()
+            select(CloudTargetConfig).where(CloudTargetConfig.id == config_id).with_for_update()
         )
     ).scalar_one_or_none()
     if row is None:

--- a/server/proliferate/integrations/aws/__init__.py
+++ b/server/proliferate/integrations/aws/__init__.py
@@ -1,0 +1,11 @@
+"""Public AWS integration API."""
+
+from proliferate.integrations.aws.bedrock import validate_bedrock_assume_role_payload
+from proliferate.integrations.aws.errors import AwsIntegrationError
+from proliferate.integrations.aws.models import BedrockAssumeRoleValidation
+
+__all__ = [
+    "AwsIntegrationError",
+    "BedrockAssumeRoleValidation",
+    "validate_bedrock_assume_role_payload",
+]

--- a/server/proliferate/integrations/aws/bedrock.py
+++ b/server/proliferate/integrations/aws/bedrock.py
@@ -1,0 +1,45 @@
+"""AWS Bedrock credential validation helpers."""
+
+from __future__ import annotations
+
+import re
+
+from proliferate.integrations.aws.errors import AwsIntegrationError
+from proliferate.integrations.aws.models import BedrockAssumeRoleValidation
+
+_ROLE_ARN_RE = re.compile(
+    r"^arn:(?P<partition>aws|aws-us-gov|aws-cn):iam::(?P<account_id>\d{12}):role\/[A-Za-z0-9+=,.@_\-/]+$"
+)
+_REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d$")
+
+
+def validate_bedrock_assume_role_payload(
+    *,
+    role_arn: str,
+    external_id: str,
+    region: str,
+) -> BedrockAssumeRoleValidation:
+    """Validate the V1 Bedrock role payload without performing network I/O.
+
+    Phase 1 stores and validates provider credential shape. The live STS assume-role
+    check belongs to deploy-time operator setup once server AWS credentials exist.
+    """
+
+    role_arn = role_arn.strip()
+    external_id = external_id.strip()
+    region = region.strip()
+    match = _ROLE_ARN_RE.match(role_arn)
+    if match is None:
+        raise AwsIntegrationError(
+            "Bedrock role ARN must be an IAM role ARN.", code="invalid_role_arn"
+        )
+    if not external_id:
+        raise AwsIntegrationError("Bedrock external ID is required.", code="missing_external_id")
+    if not _REGION_RE.match(region):
+        raise AwsIntegrationError("Bedrock region is invalid.", code="invalid_region")
+    return BedrockAssumeRoleValidation(
+        role_arn=role_arn,
+        region=region,
+        external_id=external_id,
+        account_id=match.group("account_id"),
+    )

--- a/server/proliferate/integrations/aws/errors.py
+++ b/server/proliferate/integrations/aws/errors.py
@@ -1,0 +1,11 @@
+"""AWS integration errors."""
+
+from __future__ import annotations
+
+
+class AwsIntegrationError(Exception):
+    """Raised when AWS credential validation fails."""
+
+    def __init__(self, message: str, *, code: str = "aws_validation_failed") -> None:
+        super().__init__(message)
+        self.code = code

--- a/server/proliferate/integrations/aws/models.py
+++ b/server/proliferate/integrations/aws/models.py
@@ -1,0 +1,13 @@
+"""AWS integration payload models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BedrockAssumeRoleValidation:
+    role_arn: str
+    region: str
+    external_id: str
+    account_id: str

--- a/server/proliferate/integrations/litellm/__init__.py
+++ b/server/proliferate/integrations/litellm/__init__.py
@@ -1,0 +1,27 @@
+"""Public LiteLLM integration API."""
+
+from proliferate.integrations.litellm.client import LiteLLMAdminClient
+from proliferate.integrations.litellm.errors import LiteLLMIntegrationError
+from proliferate.integrations.litellm.models import (
+    LiteLLMKeyResult,
+    LiteLLMModelDeploymentResult,
+    LiteLLMTeamResult,
+)
+from proliferate.integrations.litellm.runtime import (
+    LiteLLMRuntimeClient,
+    LiteLLMRuntimeResponse,
+    LiteLLMRuntimeStatusError,
+    LiteLLMRuntimeStream,
+)
+
+__all__ = [
+    "LiteLLMAdminClient",
+    "LiteLLMIntegrationError",
+    "LiteLLMKeyResult",
+    "LiteLLMModelDeploymentResult",
+    "LiteLLMRuntimeClient",
+    "LiteLLMRuntimeResponse",
+    "LiteLLMRuntimeStatusError",
+    "LiteLLMRuntimeStream",
+    "LiteLLMTeamResult",
+]

--- a/server/proliferate/integrations/litellm/client.py
+++ b/server/proliferate/integrations/litellm/client.py
@@ -1,0 +1,171 @@
+"""Async client for the private LiteLLM proxy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from proliferate.config import settings
+from proliferate.integrations.litellm.errors import LiteLLMIntegrationError
+from proliferate.integrations.litellm.models import (
+    LiteLLMKeyResult,
+    LiteLLMModelDeploymentResult,
+    LiteLLMTeamResult,
+)
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class LiteLLMAdminClient:
+    """Thin wrapper around LiteLLM control-plane APIs used by provisioning."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        master_key: str | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._base_url = (base_url or settings.agent_gateway_litellm_base_url).rstrip("/")
+        self._master_key = (
+            master_key if master_key is not None else settings.agent_gateway_litellm_master_key
+        )
+        self._timeout_seconds = timeout_seconds
+
+    async def ensure_team(
+        self,
+        *,
+        team_alias: str,
+        team_id: str | None = None,
+        max_budget: str | None = None,
+        budget_duration: str | None = None,
+    ) -> LiteLLMTeamResult:
+        body: dict[str, Any] = {
+            "team_alias": team_alias,
+            "models": [],
+        }
+        if team_id:
+            body["team_id"] = team_id
+        if max_budget is not None:
+            body["max_budget"] = float(max_budget)
+        if budget_duration is not None:
+            body["budget_duration"] = budget_duration
+        path = "/team/update" if team_id else "/team/new"
+        payload = await self._request("POST", path, json=body)
+        return LiteLLMTeamResult(team_id=str(payload.get("team_id") or team_id or ""))
+
+    async def generate_key(
+        self,
+        *,
+        team_id: str,
+        key_alias: str,
+    ) -> LiteLLMKeyResult:
+        payload = await self._request(
+            "POST",
+            "/key/generate",
+            json={
+                "team_id": team_id,
+                "key_alias": key_alias,
+            },
+        )
+        key = payload.get("key")
+        if not isinstance(key, str) or not key:
+            raise LiteLLMIntegrationError("LiteLLM did not return a virtual key.")
+        key_id = payload.get("key_id") or payload.get("token_id")
+        return LiteLLMKeyResult(key=key, key_id=str(key_id) if key_id else None)
+
+    async def create_model_deployment(
+        self,
+        *,
+        public_model_name: str,
+        provider_model: str,
+        team_id: str,
+        litellm_params: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+    ) -> LiteLLMModelDeploymentResult:
+        params = dict(litellm_params)
+        params["model"] = provider_model
+        payload = await self._request(
+            "POST",
+            "/model/new",
+            json={
+                "model_name": public_model_name,
+                "litellm_params": params,
+                "model_info": {
+                    "team_id": team_id,
+                    "metadata": dict(metadata or {}),
+                },
+            },
+        )
+        model_info = payload.get("model_info", {})
+        model_id = model_info.get("id") if isinstance(model_info, dict) else None
+        return LiteLLMModelDeploymentResult(
+            model_id=str(model_id) if model_id else None,
+            public_model_name=public_model_name,
+            team_id=team_id,
+        )
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Mapping[str, object] | None = None,
+    ) -> dict[str, Any]:
+        if not self._master_key:
+            raise LiteLLMIntegrationError("LiteLLM master key is not configured.")
+        request_json = dict(json or {})
+        redaction_secrets = (self._master_key, *_collect_sensitive_values(request_json))
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            try:
+                response = await client.request(
+                    method,
+                    f"{self._base_url}{path}",
+                    headers={"Authorization": f"Bearer {self._master_key}"},
+                    json=request_json,
+                )
+            except httpx.HTTPError as exc:
+                raise LiteLLMIntegrationError("Could not reach LiteLLM proxy.") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            detail = _redact(response.text, redaction_secrets)
+            raise LiteLLMIntegrationError(
+                f"LiteLLM request failed with HTTP {response.status_code}: {detail}",
+                status_code=response.status_code,
+            )
+        payload = response.json() if response.content else {}
+        if not isinstance(payload, dict):
+            raise LiteLLMIntegrationError("LiteLLM response was not a JSON object.")
+        return payload
+
+
+def _redact(value: str, secrets: str | tuple[str | None, ...]) -> str:
+    secret_values = (secrets,) if isinstance(secrets, str) else secrets
+    for secret in secret_values:
+        if secret:
+            value = value.replace(secret, "[REDACTED]")
+    return value[:1000]
+
+
+def _collect_sensitive_values(value: object) -> tuple[str, ...]:
+    found: list[str] = []
+
+    def visit(item: object, *, key: str | None = None) -> None:
+        if isinstance(item, Mapping):
+            for child_key, child_value in item.items():
+                visit(child_value, key=str(child_key).lower())
+            return
+        if isinstance(item, list | tuple):
+            for child in item:
+                visit(child, key=key)
+            return
+        if not isinstance(item, str) or not item:
+            return
+        if key is None:
+            return
+        if any(marker in key for marker in ("api_key", "token", "secret", "external_id")):
+            found.append(item)
+
+    visit(value)
+    return tuple(found)

--- a/server/proliferate/integrations/litellm/errors.py
+++ b/server/proliferate/integrations/litellm/errors.py
@@ -1,0 +1,11 @@
+"""LiteLLM integration errors."""
+
+from __future__ import annotations
+
+
+class LiteLLMIntegrationError(Exception):
+    """Raised when the LiteLLM proxy rejects or cannot process a request."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/server/proliferate/integrations/litellm/models.py
+++ b/server/proliferate/integrations/litellm/models.py
@@ -1,0 +1,23 @@
+"""Typed LiteLLM integration payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LiteLLMTeamResult:
+    team_id: str
+
+
+@dataclass(frozen=True)
+class LiteLLMKeyResult:
+    key: str
+    key_id: str | None
+
+
+@dataclass(frozen=True)
+class LiteLLMModelDeploymentResult:
+    model_id: str | None
+    public_model_name: str
+    team_id: str

--- a/server/proliferate/integrations/litellm/runtime.py
+++ b/server/proliferate/integrations/litellm/runtime.py
@@ -1,0 +1,170 @@
+"""Runtime forwarding client for the private LiteLLM proxy."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+
+import httpx
+
+from proliferate.config import settings
+from proliferate.integrations.litellm.errors import LiteLLMIntegrationError
+
+_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "content-encoding",
+    "content-length",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+@dataclass(frozen=True)
+class LiteLLMRuntimeResponse:
+    status_code: int
+    headers: dict[str, str]
+    content: bytes
+
+
+@dataclass(frozen=True)
+class LiteLLMRuntimeStream:
+    status_code: int
+    headers: dict[str, str]
+    chunks: AsyncIterator[bytes]
+
+
+class LiteLLMRuntimeStatusError(LiteLLMIntegrationError):
+    """Raised when LiteLLM returns an error response for a gateway request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        body: bytes,
+    ) -> None:
+        super().__init__(message, status_code=status_code)
+        self.body = body
+
+
+class LiteLLMRuntimeClient:
+    """Thin runtime proxy for model calls after gateway authorization."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._base_url = (base_url or settings.agent_gateway_litellm_base_url).rstrip("/")
+        self._timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else settings.agent_gateway_request_timeout_seconds
+        )
+
+    async def forward(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: bytes,
+        litellm_key: str,
+        content_type: str | None,
+        metadata: Mapping[str, str],
+    ) -> LiteLLMRuntimeResponse:
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            try:
+                response = await client.request(
+                    method,
+                    f"{self._base_url}{path}",
+                    content=body,
+                    headers=_headers(litellm_key, content_type, metadata),
+                )
+            except httpx.HTTPError as exc:
+                raise LiteLLMIntegrationError("Could not reach LiteLLM proxy.") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise LiteLLMRuntimeStatusError(
+                f"LiteLLM runtime request failed with HTTP {response.status_code}.",
+                status_code=response.status_code,
+                body=response.content,
+            )
+        return LiteLLMRuntimeResponse(
+            status_code=response.status_code,
+            headers=_response_headers(response.headers),
+            content=response.content,
+        )
+
+    async def open_stream(
+        self,
+        *,
+        method: str,
+        path: str,
+        body: bytes,
+        litellm_key: str,
+        content_type: str | None,
+        metadata: Mapping[str, str],
+    ) -> LiteLLMRuntimeStream:
+        client = httpx.AsyncClient(timeout=None)
+        request = client.build_request(
+            method,
+            f"{self._base_url}{path}",
+            content=body,
+            headers=_headers(litellm_key, content_type, metadata),
+        )
+        try:
+            response = await client.send(request, stream=True)
+        except httpx.HTTPError as exc:
+            await client.aclose()
+            raise LiteLLMIntegrationError("Could not reach LiteLLM proxy.") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            body_bytes = await response.aread()
+            await response.aclose()
+            await client.aclose()
+            raise LiteLLMRuntimeStatusError(
+                f"LiteLLM runtime request failed with HTTP {response.status_code}.",
+                status_code=response.status_code,
+                body=body_bytes,
+            )
+
+        async def chunks() -> AsyncIterator[bytes]:
+            try:
+                async for chunk in response.aiter_bytes():
+                    yield chunk
+            finally:
+                await response.aclose()
+                await client.aclose()
+
+        return LiteLLMRuntimeStream(
+            status_code=response.status_code,
+            headers=_response_headers(response.headers),
+            chunks=chunks(),
+        )
+
+
+def _headers(
+    litellm_key: str,
+    content_type: str | None,
+    metadata: Mapping[str, str],
+) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {litellm_key}",
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    for key, value in metadata.items():
+        headers[f"x-proliferate-{key.replace('_', '-')}"] = value
+    return headers
+
+
+def _response_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in _HOP_BY_HOP_HEADERS
+    }

--- a/server/proliferate/integrations/litellm/runtime.py
+++ b/server/proliferate/integrations/litellm/runtime.py
@@ -73,18 +73,25 @@ class LiteLLMRuntimeClient:
         *,
         method: str,
         path: str,
+        query_string: str,
         body: bytes,
         litellm_key: str,
         content_type: str | None,
+        protocol_headers: Mapping[str, str],
         metadata: Mapping[str, str],
     ) -> LiteLLMRuntimeResponse:
         async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
             try:
                 response = await client.request(
                     method,
-                    f"{self._base_url}{path}",
+                    _url(self._base_url, path, query_string),
                     content=body,
-                    headers=_headers(litellm_key, content_type, metadata),
+                    headers=_headers(
+                        litellm_key,
+                        content_type,
+                        protocol_headers,
+                        metadata,
+                    ),
                 )
             except httpx.HTTPError as exc:
                 raise LiteLLMIntegrationError("Could not reach LiteLLM proxy.") from exc
@@ -105,17 +112,29 @@ class LiteLLMRuntimeClient:
         *,
         method: str,
         path: str,
+        query_string: str,
         body: bytes,
         litellm_key: str,
         content_type: str | None,
+        protocol_headers: Mapping[str, str],
         metadata: Mapping[str, str],
     ) -> LiteLLMRuntimeStream:
-        client = httpx.AsyncClient(timeout=None)
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                self._timeout_seconds,
+                connect=min(10.0, self._timeout_seconds),
+            )
+        )
         request = client.build_request(
             method,
-            f"{self._base_url}{path}",
+            _url(self._base_url, path, query_string),
             content=body,
-            headers=_headers(litellm_key, content_type, metadata),
+            headers=_headers(
+                litellm_key,
+                content_type,
+                protocol_headers,
+                metadata,
+            ),
         )
         try:
             response = await client.send(request, stream=True)
@@ -150,6 +169,7 @@ class LiteLLMRuntimeClient:
 def _headers(
     litellm_key: str,
     content_type: str | None,
+    protocol_headers: Mapping[str, str],
     metadata: Mapping[str, str],
 ) -> dict[str, str]:
     headers = {
@@ -157,14 +177,24 @@ def _headers(
     }
     if content_type:
         headers["Content-Type"] = content_type
+    for key, value in protocol_headers.items():
+        if key.lower() not in _HOP_BY_HOP_HEADERS and key.lower() not in {
+            "authorization",
+            "content-length",
+            "content-type",
+            "x-api-key",
+        }:
+            headers[key] = value
     for key, value in metadata.items():
         headers[f"x-proliferate-{key.replace('_', '-')}"] = value
     return headers
 
 
+def _url(base_url: str, path: str, query_string: str) -> str:
+    if query_string:
+        return f"{base_url}{path}?{query_string}"
+    return f"{base_url}{path}"
+
+
 def _response_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    return {
-        key: value
-        for key, value in headers.items()
-        if key.lower() not in _HOP_BY_HOP_HEADERS
-    }
+    return {key: value for key, value in headers.items() if key.lower() not in _HOP_BY_HOP_HEADERS}

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -25,6 +25,7 @@ from proliferate.errors import ProliferateError
 from proliferate.integrations.sentry import flush_server_sentry, init_server_sentry
 from proliferate.middleware.request_context import RequestContextMiddleware
 from proliferate.middleware.request_telemetry import RequestTelemetryMiddleware
+from proliferate.server.agent_gateway.api import router as agent_gateway_router
 from proliferate.server.ai_magic.api import router as ai_magic_router
 from proliferate.server.anonymous_telemetry.api import router as anonymous_telemetry_router
 from proliferate.server.anonymous_telemetry.worker import (
@@ -183,6 +184,7 @@ def create_app() -> FastAPI:
     app.include_router(cloud_router, prefix=f"{api_prefix}/v1", tags=["cloud"])
     app.include_router(catalogs_router, prefix=f"{api_prefix}/v1", tags=["catalogs"])
     app.include_router(ai_magic_router, prefix=f"{api_prefix}/v1", tags=["ai_magic"])
+    app.include_router(agent_gateway_router, prefix=api_prefix, tags=["agent_gateway"])
     app.include_router(support_router, prefix=f"{api_prefix}/v1", tags=["support"])
     app.include_router(billing_router, prefix=f"{api_prefix}/v1", tags=["billing"])
     app.include_router(organizations_router, prefix=f"{api_prefix}/v1", tags=["organizations"])

--- a/server/proliferate/server/agent_gateway/api.py
+++ b/server/proliferate/server/agent_gateway/api.py
@@ -6,7 +6,9 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.config import settings
 from proliferate.db.engine import get_async_session
+from proliferate.server.agent_gateway.errors import AgentGatewayError
 from proliferate.server.agent_gateway.models import (
     GatewayForwardResponse,
     GatewayForwardStream,
@@ -17,6 +19,14 @@ from proliferate.server.agent_gateway.service import (
 )
 
 router = APIRouter(tags=["agent_gateway"])
+
+_PROTOCOL_HEADER_ALLOWLIST = frozenset(
+    {
+        "anthropic-version",
+        "anthropic-beta",
+        "openai-beta",
+    }
+)
 
 
 @router.get("/agent-gateway/health")
@@ -86,9 +96,11 @@ async def forward_protocol_request(
         db,
         raw_token=_bearer_token(request),
         gateway_path=request.url.path,
+        query_string=request.url.query,
         method=request.method,
-        body=await request.body(),
+        body=await _limited_request_body(request),
         content_type=request.headers.get("content-type"),
+        protocol_headers=_protocol_headers(request),
     )
     if isinstance(result, GatewayForwardStream):
         return StreamingResponse(
@@ -113,3 +125,24 @@ def _bearer_token(request: Request) -> str:
     if not authorization.startswith(prefix):
         return ""
     return authorization[len(prefix) :].strip()
+
+
+def _protocol_headers(request: Request) -> dict[str, str]:
+    return {
+        key.lower(): value
+        for key, value in request.headers.items()
+        if key.lower() in _PROTOCOL_HEADER_ALLOWLIST
+    }
+
+
+async def _limited_request_body(request: Request) -> bytes:
+    body = bytearray()
+    async for chunk in request.stream():
+        body.extend(chunk)
+        if len(body) > settings.agent_gateway_max_request_bytes:
+            raise AgentGatewayError(
+                "Gateway request body is too large.",
+                code="gateway_request_too_large",
+                status_code=413,
+            )
+    return bytes(body)

--- a/server/proliferate/server/agent_gateway/api.py
+++ b/server/proliferate/server/agent_gateway/api.py
@@ -1,0 +1,115 @@
+"""Protocol facade routes for the agent model gateway."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import get_async_session
+from proliferate.server.agent_gateway.models import (
+    GatewayForwardResponse,
+    GatewayForwardStream,
+)
+from proliferate.server.agent_gateway.service import (
+    forward_gateway_request,
+    list_gateway_models,
+)
+
+router = APIRouter(tags=["agent_gateway"])
+
+
+@router.get("/agent-gateway/health")
+async def agent_gateway_health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/anthropic/v1/models")
+async def anthropic_models(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+) -> JSONResponse:
+    result = await list_gateway_models(
+        db,
+        raw_token=_bearer_token(request),
+        gateway_path=request.url.path,
+    )
+    return JSONResponse(
+        {
+            "data": [
+                {
+                    "id": model_id,
+                    "type": "model",
+                    "display_name": model_id,
+                }
+                for model_id in result.model_ids
+            ],
+            "has_more": False,
+        }
+    )
+
+
+@router.get("/openai/v1/models")
+async def openai_models(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+) -> JSONResponse:
+    result = await list_gateway_models(
+        db,
+        raw_token=_bearer_token(request),
+        gateway_path=request.url.path,
+    )
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": model_id,
+                    "object": "model",
+                    "owned_by": "proliferate",
+                }
+                for model_id in result.model_ids
+            ],
+        }
+    )
+
+
+@router.post("/anthropic/v1/messages")
+@router.post("/anthropic/v1/messages/count_tokens")
+@router.post("/openai/v1/responses")
+@router.post("/openai/v1/chat/completions")
+async def forward_protocol_request(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+) -> Response:
+    result = await forward_gateway_request(
+        db,
+        raw_token=_bearer_token(request),
+        gateway_path=request.url.path,
+        method=request.method,
+        body=await request.body(),
+        content_type=request.headers.get("content-type"),
+    )
+    if isinstance(result, GatewayForwardStream):
+        return StreamingResponse(
+            result.chunks,
+            status_code=result.status_code,
+            headers=result.headers,
+            media_type=result.headers.get("content-type", "text/event-stream"),
+        )
+    if isinstance(result, GatewayForwardResponse):
+        return Response(
+            content=result.content,
+            status_code=result.status_code,
+            headers=result.headers,
+            media_type=result.headers.get("content-type", "application/json"),
+        )
+    raise AssertionError("Unexpected gateway response type.")
+
+
+def _bearer_token(request: Request) -> str:
+    authorization = request.headers.get("authorization", "")
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        return ""
+    return authorization[len(prefix) :].strip()

--- a/server/proliferate/server/agent_gateway/domain/protocols.py
+++ b/server/proliferate/server/agent_gateway/domain/protocols.py
@@ -1,0 +1,40 @@
+"""Pure protocol/model rules for the agent gateway."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def protocol_for_path(path: str) -> str:
+    if "/anthropic/" in path:
+        return "anthropic"
+    if "/openai/" in path:
+        return "openai"
+    return "unknown"
+
+
+def litellm_path_for_gateway_path(path: str) -> str:
+    if "/anthropic" in path:
+        return path[path.index("/anthropic") :].removeprefix("/anthropic")
+    if "/openai" in path:
+        return path[path.index("/openai") :].removeprefix("/openai")
+    return path
+
+
+def model_from_body(body: Mapping[str, object]) -> str | None:
+    model = body.get("model")
+    return model if isinstance(model, str) and model else None
+
+
+def request_wants_stream(body: Mapping[str, object]) -> bool:
+    return body.get("stream") is True
+
+
+def allowed_models_for_agent(agent_kind: str) -> tuple[str, ...]:
+    if agent_kind == "claude":
+        return ("us.anthropic.claude-sonnet-4-6",)
+    if agent_kind == "codex":
+        return ("gpt-5.5",)
+    if agent_kind == "opencode":
+        return ("opencode/big-pickle",)
+    return ()

--- a/server/proliferate/server/agent_gateway/errors.py
+++ b/server/proliferate/server/agent_gateway/errors.py
@@ -1,0 +1,18 @@
+"""Product errors for the agent model gateway."""
+
+from __future__ import annotations
+
+from proliferate.errors import ProliferateError
+
+
+class AgentGatewayError(ProliferateError):
+    """Stable gateway error returned to harness protocol clients."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        status_code: int,
+    ) -> None:
+        super().__init__(message, code=code, status_code=status_code)

--- a/server/proliferate/server/agent_gateway/models.py
+++ b/server/proliferate/server/agent_gateway/models.py
@@ -1,0 +1,40 @@
+"""Gateway service internal models."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class AuthorizedGatewayRequest:
+    litellm_key: str
+    agent_kind: str
+    protocol_facade: str
+    policy_id: UUID
+    organization_id: UUID | None
+    user_id: UUID | None
+    target_id: UUID
+    sandbox_profile_id: UUID
+    allowed_model_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GatewayForwardResponse:
+    status_code: int
+    headers: dict[str, str]
+    content: bytes
+
+
+@dataclass(frozen=True)
+class GatewayForwardStream:
+    status_code: int
+    headers: dict[str, str]
+    chunks: AsyncIterator[bytes]
+
+
+@dataclass(frozen=True)
+class GatewayModelsResponse:
+    protocol_facade: str
+    model_ids: tuple[str, ...]

--- a/server/proliferate/server/agent_gateway/service.py
+++ b/server/proliferate/server/agent_gateway/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from collections.abc import Mapping
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -64,22 +65,31 @@ async def forward_gateway_request(
     *,
     raw_token: str,
     gateway_path: str,
+    query_string: str,
     method: str,
     body: bytes,
     content_type: str | None,
+    protocol_headers: Mapping[str, str],
 ) -> GatewayForwardResponse | GatewayForwardStream:
     if len(body) > settings.agent_gateway_max_request_bytes:
         raise AgentGatewayError(
             "Gateway request body is too large.",
-            code="gateway_route_unavailable",
+            code="gateway_request_too_large",
             status_code=413,
         )
     body_json = _json_body(body)
+    request_model = model_from_body(body_json)
+    if request_model is None:
+        raise AgentGatewayError(
+            "Gateway request model is required.",
+            code="invalid_model",
+            status_code=400,
+        )
     authorized = await authorize_gateway_request(
         db,
         raw_token=raw_token,
         gateway_path=gateway_path,
-        request_model=model_from_body(body_json),
+        request_model=request_model,
     )
     client = LiteLLMRuntimeClient()
     metadata = _metadata_for_request(authorized)
@@ -89,9 +99,11 @@ async def forward_gateway_request(
             response_stream = await client.open_stream(
                 method=method,
                 path=litellm_path,
+                query_string=query_string,
                 body=body,
                 litellm_key=authorized.litellm_key,
                 content_type=content_type,
+                protocol_headers=protocol_headers,
                 metadata=metadata,
             )
             return GatewayForwardStream(
@@ -102,9 +114,11 @@ async def forward_gateway_request(
         response = await client.forward(
             method=method,
             path=litellm_path,
+            query_string=query_string,
             body=body,
             litellm_key=authorized.litellm_key,
             content_type=content_type,
+            protocol_headers=protocol_headers,
             metadata=metadata,
         )
         return GatewayForwardResponse(
@@ -129,6 +143,12 @@ async def authorize_gateway_request(
     gateway_path: str,
     request_model: str | None,
 ) -> AuthorizedGatewayRequest:
+    if not settings.agent_gateway_enabled:
+        raise AgentGatewayError(
+            "Agent gateway is disabled.",
+            code="gateway_route_unavailable",
+            status_code=503,
+        )
     if not raw_token:
         raise AgentGatewayError(
             "Missing gateway token.",
@@ -149,6 +169,18 @@ async def authorize_gateway_request(
             "Agent auth is not configured.",
             code="agent_auth_not_configured",
             status_code=403,
+        )
+    if profile.managed_target_id is not None and grant.target_id != profile.managed_target_id:
+        raise AgentGatewayError(
+            "Gateway token is stale.",
+            code="invalid_gateway_token",
+            status_code=401,
+        )
+    if grant.issued_profile_revision != profile.agent_auth_revision:
+        raise AgentGatewayError(
+            "Gateway token is stale.",
+            code="invalid_gateway_token",
+            status_code=401,
         )
     selection = await store.get_selection(db, grant.selection_id)
     if selection is None or selection.status != "active":
@@ -185,6 +217,8 @@ async def authorize_gateway_request(
     _require_policy_ready(policy)
     await _require_budget_ready(db, policy)
     allowed_models = allowed_models_for_agent(grant.agent_kind)
+    if grant.agent_kind == "opencode" and not settings.agent_gateway_opencode_enabled:
+        allowed_models = ()
     if not allowed_models:
         raise AgentGatewayError(
             "Gateway route is unavailable for this agent.",

--- a/server/proliferate/server/agent_gateway/service.py
+++ b/server/proliferate/server/agent_gateway/service.py
@@ -1,0 +1,356 @@
+"""Business logic for the agent model gateway."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.cloud import (
+    AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN,
+    AGENT_GATEWAY_TOKEN_HASH_KEY_ID,
+)
+from proliferate.db.store.cloud_agent_auth import store
+from proliferate.db.store.cloud_agent_auth.records import (
+    AgentGatewayPolicyRecord,
+    AgentGatewayRuntimeGrantRecord,
+)
+from proliferate.integrations.litellm import (
+    LiteLLMIntegrationError,
+    LiteLLMRuntimeClient,
+    LiteLLMRuntimeStatusError,
+)
+from proliferate.server.agent_gateway.domain.protocols import (
+    allowed_models_for_agent,
+    litellm_path_for_gateway_path,
+    model_from_body,
+    protocol_for_path,
+    request_wants_stream,
+)
+from proliferate.server.agent_gateway.errors import AgentGatewayError
+from proliferate.server.agent_gateway.models import (
+    AuthorizedGatewayRequest,
+    GatewayForwardResponse,
+    GatewayForwardStream,
+    GatewayModelsResponse,
+)
+from proliferate.utils.crypto import decrypt_text
+from proliferate.utils.time import utcnow
+
+
+async def list_gateway_models(
+    db: AsyncSession,
+    *,
+    raw_token: str,
+    gateway_path: str,
+) -> GatewayModelsResponse:
+    authorized = await authorize_gateway_request(
+        db,
+        raw_token=raw_token,
+        gateway_path=gateway_path,
+        request_model=None,
+    )
+    return GatewayModelsResponse(
+        protocol_facade=authorized.protocol_facade,
+        model_ids=authorized.allowed_model_ids,
+    )
+
+
+async def forward_gateway_request(
+    db: AsyncSession,
+    *,
+    raw_token: str,
+    gateway_path: str,
+    method: str,
+    body: bytes,
+    content_type: str | None,
+) -> GatewayForwardResponse | GatewayForwardStream:
+    if len(body) > settings.agent_gateway_max_request_bytes:
+        raise AgentGatewayError(
+            "Gateway request body is too large.",
+            code="gateway_route_unavailable",
+            status_code=413,
+        )
+    body_json = _json_body(body)
+    authorized = await authorize_gateway_request(
+        db,
+        raw_token=raw_token,
+        gateway_path=gateway_path,
+        request_model=model_from_body(body_json),
+    )
+    client = LiteLLMRuntimeClient()
+    metadata = _metadata_for_request(authorized)
+    litellm_path = litellm_path_for_gateway_path(gateway_path)
+    try:
+        if request_wants_stream(body_json):
+            response_stream = await client.open_stream(
+                method=method,
+                path=litellm_path,
+                body=body,
+                litellm_key=authorized.litellm_key,
+                content_type=content_type,
+                metadata=metadata,
+            )
+            return GatewayForwardStream(
+                status_code=response_stream.status_code,
+                headers=response_stream.headers,
+                chunks=response_stream.chunks,
+            )
+        response = await client.forward(
+            method=method,
+            path=litellm_path,
+            body=body,
+            litellm_key=authorized.litellm_key,
+            content_type=content_type,
+            metadata=metadata,
+        )
+        return GatewayForwardResponse(
+            status_code=response.status_code,
+            headers=response.headers,
+            content=response.content,
+        )
+    except LiteLLMRuntimeStatusError as exc:
+        raise _map_litellm_error(exc) from exc
+    except LiteLLMIntegrationError as exc:
+        raise AgentGatewayError(
+            "LiteLLM is unavailable.",
+            code="litellm_unavailable",
+            status_code=503,
+        ) from exc
+
+
+async def authorize_gateway_request(
+    db: AsyncSession,
+    *,
+    raw_token: str,
+    gateway_path: str,
+    request_model: str | None,
+) -> AuthorizedGatewayRequest:
+    if not raw_token:
+        raise AgentGatewayError(
+            "Missing gateway token.",
+            code="invalid_gateway_token",
+            status_code=401,
+        )
+    grant = await _load_grant(db, raw_token)
+    requested_protocol = protocol_for_path(gateway_path)
+    if requested_protocol == "unknown" or grant.protocol_facade != requested_protocol:
+        raise AgentGatewayError(
+            "Gateway token is not valid for this protocol.",
+            code="protocol_not_supported",
+            status_code=403,
+        )
+    profile = await store.get_sandbox_profile(db, grant.sandbox_profile_id)
+    if profile is None:
+        raise AgentGatewayError(
+            "Agent auth is not configured.",
+            code="agent_auth_not_configured",
+            status_code=403,
+        )
+    selection = await store.get_selection(db, grant.selection_id)
+    if selection is None or selection.status != "active":
+        raise AgentGatewayError(
+            "Agent auth selection is not active.",
+            code="agent_auth_not_configured",
+            status_code=403,
+        )
+    if selection.credential_id != grant.credential_id or selection.agent_kind != grant.agent_kind:
+        raise AgentGatewayError(
+            "Gateway token is stale.",
+            code="invalid_gateway_token",
+            status_code=401,
+        )
+    credential = await store.get_credential(db, grant.credential_id)
+    if (
+        credential is None
+        or credential.status != "ready"
+        or credential.revoked_at is not None
+        or selection.selected_revision != credential.revision
+    ):
+        raise AgentGatewayError(
+            "Agent auth credential is not ready.",
+            code="agent_auth_not_configured",
+            status_code=403,
+        )
+    policy = await store.get_gateway_policy(db, grant.policy_id)
+    if policy is None or policy.credential_id != credential.id:
+        raise AgentGatewayError(
+            "Agent gateway policy is not configured.",
+            code="agent_auth_not_configured",
+            status_code=403,
+        )
+    _require_policy_ready(policy)
+    await _require_budget_ready(db, policy)
+    allowed_models = allowed_models_for_agent(grant.agent_kind)
+    if not allowed_models:
+        raise AgentGatewayError(
+            "Gateway route is unavailable for this agent.",
+            code="gateway_route_unavailable",
+            status_code=403,
+        )
+    if request_model is not None and request_model not in allowed_models:
+        raise AgentGatewayError(
+            "Model is not available for this gateway policy.",
+            code="model_not_available",
+            status_code=404,
+        )
+    if not policy.litellm_virtual_key_ciphertext:
+        raise AgentGatewayError(
+            "Agent gateway policy is not configured.",
+            code="agent_auth_not_configured",
+            status_code=403,
+        )
+    await store.mark_runtime_grant_used(db, grant.id)
+    return AuthorizedGatewayRequest(
+        litellm_key=decrypt_text(policy.litellm_virtual_key_ciphertext),
+        agent_kind=grant.agent_kind,
+        protocol_facade=grant.protocol_facade,
+        policy_id=policy.id,
+        organization_id=grant.organization_id,
+        user_id=grant.user_id,
+        target_id=grant.target_id,
+        sandbox_profile_id=grant.sandbox_profile_id,
+        allowed_model_ids=allowed_models,
+    )
+
+
+async def _load_grant(
+    db: AsyncSession,
+    raw_token: str,
+) -> AgentGatewayRuntimeGrantRecord:
+    token_hash = _hash_token(raw_token)
+    grant = await store.get_runtime_grant_by_token_hash(db, token_hash)
+    if grant is None or grant.hash_key_id != AGENT_GATEWAY_TOKEN_HASH_KEY_ID:
+        raise AgentGatewayError(
+            "Invalid gateway token.",
+            code="invalid_gateway_token",
+            status_code=401,
+        )
+    now = utcnow()
+    if grant.revoked_at is not None:
+        raise AgentGatewayError(
+            "Invalid gateway token.",
+            code="invalid_gateway_token",
+            status_code=401,
+        )
+    if grant.expires_at <= now:
+        raise AgentGatewayError(
+            "Gateway token expired.",
+            code="gateway_token_expired",
+            status_code=401,
+        )
+    return grant
+
+
+def _require_policy_ready(policy: AgentGatewayPolicyRecord) -> None:
+    if policy.status != "ready" or policy.litellm_sync_status != "synced":
+        raise AgentGatewayError(
+            "Gateway route is unavailable.",
+            code="gateway_route_unavailable",
+            status_code=503,
+        )
+
+
+async def _require_budget_ready(
+    db: AsyncSession,
+    policy: AgentGatewayPolicyRecord,
+) -> None:
+    if policy.budget_subject_id is None:
+        return
+    budget = await store.get_budget_subject(db, policy.budget_subject_id)
+    if budget is None or budget.litellm_sync_status != "synced":
+        raise AgentGatewayError(
+            "Gateway route is unavailable.",
+            code="gateway_route_unavailable",
+            status_code=503,
+        )
+    if budget.status == "exhausted":
+        raise AgentGatewayError(
+            "Managed credits are exhausted.",
+            code="credits_exhausted",
+            status_code=402,
+        )
+    if budget.status != "ready":
+        raise AgentGatewayError(
+            "Gateway route is unavailable.",
+            code="gateway_route_unavailable",
+            status_code=503,
+        )
+
+
+def _json_body(body: bytes) -> dict[str, object]:
+    if not body:
+        return {}
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AgentGatewayError(
+            "Gateway request body must be a JSON object.",
+            code="gateway_route_unavailable",
+            status_code=400,
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise AgentGatewayError(
+            "Gateway request body must be a JSON object.",
+            code="gateway_route_unavailable",
+            status_code=400,
+        )
+    return parsed
+
+
+def _metadata_for_request(authorized: AuthorizedGatewayRequest) -> dict[str, str]:
+    metadata = {
+        "target_id": str(authorized.target_id),
+        "sandbox_profile_id": str(authorized.sandbox_profile_id),
+        "agent_kind": authorized.agent_kind,
+        "policy_id": str(authorized.policy_id),
+    }
+    if authorized.organization_id is not None:
+        metadata["org_id"] = str(authorized.organization_id)
+    if authorized.user_id is not None:
+        metadata["user_id"] = str(authorized.user_id)
+    return metadata
+
+
+def _map_litellm_error(error: LiteLLMRuntimeStatusError) -> AgentGatewayError:
+    body_text = error.body.decode("utf-8", errors="replace").lower()
+    if "budget" in body_text or "max_budget" in body_text or "credit" in body_text:
+        return AgentGatewayError(
+            "Managed credits are exhausted.",
+            code="credits_exhausted",
+            status_code=402,
+        )
+    if error.status_code in {401, 403}:
+        return AgentGatewayError(
+            "Provider authentication failed.",
+            code="provider_auth_failed",
+            status_code=502,
+        )
+    if error.status_code == 404:
+        return AgentGatewayError(
+            "Model is not available.",
+            code="model_not_available",
+            status_code=404,
+        )
+    if error.status_code == 429:
+        return AgentGatewayError(
+            "Provider rate limit reached.",
+            code="provider_rate_limited",
+            status_code=429,
+        )
+    return AgentGatewayError(
+        "LiteLLM is unavailable.",
+        code="litellm_unavailable",
+        status_code=503,
+    )
+
+
+def _hash_token(raw_token: str) -> str:
+    return hmac.new(
+        settings.cloud_secret_key.encode("utf-8"),
+        f"{AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN}:{raw_token}".encode(),
+        hashlib.sha256,
+    ).hexdigest()

--- a/server/proliferate/server/cloud/agent_auth/__init__.py
+++ b/server/proliferate/server/cloud/agent_auth/__init__.py
@@ -1,0 +1,1 @@
+"""Agent LLM auth gateway control-plane domain."""

--- a/server/proliferate/server/cloud/agent_auth/api.py
+++ b/server/proliferate/server/cloud/agent_auth/api.py
@@ -1,0 +1,204 @@
+"""HTTP API for agent LLM auth gateway state."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_active_user
+from proliferate.constants.cloud import CloudAgentKind
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.agent_auth.models import (
+    AgentAuthCredentialResponse,
+    AgentAuthCredentialShareResponse,
+    AgentAuthMutationResponse,
+    CreateGatewayCredentialRequest,
+    CreateGatewayCredentialResponse,
+    EnsureOrganizationSandboxProfileRequest,
+    EnsurePersonalSandboxProfileRequest,
+    SandboxAgentAuthSelectionResponse,
+    SandboxProfileAgentAuthTargetStateResponse,
+    SandboxProfileResponse,
+    SelectAgentAuthCredentialRequest,
+    ShareCredentialRequest,
+    credential_response,
+    credential_share_response,
+    policy_response,
+    provider_credential_response,
+    sandbox_profile_response,
+    selection_response,
+    target_state_response,
+)
+from proliferate.server.cloud.agent_auth.service import (
+    create_gateway_credential,
+    ensure_organization_sandbox_profile,
+    ensure_personal_sandbox_profile,
+    list_credentials,
+    list_selections,
+    list_target_states,
+    revoke_credential,
+    revoke_credential_share,
+    select_credential_for_profile,
+    share_personal_credential_with_organization,
+)
+
+router = APIRouter()
+
+
+@router.get("/agent-auth/credentials", response_model=list[AgentAuthCredentialResponse])
+async def list_agent_auth_credentials_endpoint(
+    organization_id: UUID | None = Query(default=None, alias="organizationId"),
+    agent_kind: str | None = Query(default=None, alias="agentKind"),
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> list[AgentAuthCredentialResponse]:
+    return [
+        credential_response(record)
+        for record in await list_credentials(
+            db,
+            actor_user_id=user.id,
+            organization_id=organization_id,
+            agent_kind=agent_kind,
+        )
+    ]
+
+
+@router.post("/agent-auth/credentials/gateway")
+async def create_gateway_credential_endpoint(
+    body: CreateGatewayCredentialRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> CreateGatewayCredentialResponse:
+    result = await create_gateway_credential(db, actor_user_id=user.id, body=body)
+    return CreateGatewayCredentialResponse(
+        credential=credential_response(result.credential),
+        policy=policy_response(result.policy),
+        providerCredential=provider_credential_response(result.provider_credential),
+    )
+
+
+@router.delete("/agent-auth/credentials/{credential_id}")
+async def revoke_agent_auth_credential_endpoint(
+    credential_id: UUID,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AgentAuthMutationResponse:
+    await revoke_credential(db, actor_user_id=user.id, credential_id=credential_id)
+    return AgentAuthMutationResponse(changed=True)
+
+
+@router.post("/agent-auth/credentials/{credential_id}/shares")
+async def share_agent_auth_credential_endpoint(
+    credential_id: UUID,
+    body: ShareCredentialRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AgentAuthCredentialShareResponse:
+    share = await share_personal_credential_with_organization(
+        db,
+        actor_user_id=user.id,
+        credential_id=credential_id,
+        organization_id=body.organization_id,
+    )
+    return credential_share_response(share)
+
+
+@router.delete("/agent-auth/credential-shares/{share_id}")
+async def revoke_agent_auth_credential_share_endpoint(
+    share_id: UUID,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AgentAuthCredentialShareResponse:
+    share = await revoke_credential_share(db, actor_user_id=user.id, share_id=share_id)
+    return credential_share_response(share)
+
+
+@router.post("/sandbox-profiles/personal")
+async def ensure_personal_sandbox_profile_endpoint(
+    body: EnsurePersonalSandboxProfileRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> SandboxProfileResponse:
+    profile = await ensure_personal_sandbox_profile(
+        db,
+        actor_user_id=user.id,
+        managed_target_id=body.managed_target_id,
+    )
+    return sandbox_profile_response(profile)
+
+
+@router.post("/organizations/{organization_id}/sandbox-profile")
+async def ensure_organization_sandbox_profile_endpoint(
+    organization_id: UUID,
+    body: EnsureOrganizationSandboxProfileRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> SandboxProfileResponse:
+    profile = await ensure_organization_sandbox_profile(
+        db,
+        actor_user_id=user.id,
+        organization_id=organization_id,
+        managed_target_id=body.managed_target_id,
+    )
+    return sandbox_profile_response(profile)
+
+
+@router.get(
+    "/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections",
+    response_model=list[SandboxAgentAuthSelectionResponse],
+)
+async def list_agent_auth_selections_endpoint(
+    sandbox_profile_id: UUID,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> list[SandboxAgentAuthSelectionResponse]:
+    return [
+        selection_response(record)
+        for record in await list_selections(
+            db,
+            actor_user_id=user.id,
+            sandbox_profile_id=sandbox_profile_id,
+        )
+    ]
+
+
+@router.put("/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections/{agent_kind}")
+async def select_agent_auth_credential_endpoint(
+    sandbox_profile_id: UUID,
+    agent_kind: CloudAgentKind,
+    body: SelectAgentAuthCredentialRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> SandboxAgentAuthSelectionResponse:
+    selection = await select_credential_for_profile(
+        db,
+        actor_user_id=user.id,
+        sandbox_profile_id=sandbox_profile_id,
+        agent_kind=agent_kind,
+        credential_id=body.credential_id,
+        credential_share_id=body.credential_share_id,
+        force_restart=body.force_restart,
+    )
+    return selection_response(selection)
+
+
+@router.get(
+    "/sandbox-profiles/{sandbox_profile_id}/agent-auth-target-states",
+    response_model=list[SandboxProfileAgentAuthTargetStateResponse],
+)
+async def list_agent_auth_target_states_endpoint(
+    sandbox_profile_id: UUID,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> list[SandboxProfileAgentAuthTargetStateResponse]:
+    return [
+        target_state_response(record)
+        for record in await list_target_states(
+            db,
+            actor_user_id=user.id,
+            sandbox_profile_id=sandbox_profile_id,
+        )
+    ]

--- a/server/proliferate/server/cloud/agent_auth/domain/__init__.py
+++ b/server/proliferate/server/cloud/agent_auth/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Pure agent-auth product rules."""

--- a/server/proliferate/server/cloud/agent_auth/domain/desired_state.py
+++ b/server/proliferate/server/cloud/agent_auth/domain/desired_state.py
@@ -1,0 +1,41 @@
+"""Pure desired-state helpers for LiteLLM provisioning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LiteLLMModelDeploymentPlan:
+    public_model_name: str
+    provider_model: str
+    litellm_params: Mapping[str, object]
+
+
+def fingerprint_litellm_policy_state(
+    *,
+    policy_kind: str,
+    litellm_team_id: str | None,
+    budget_subject_id: str | None,
+    provider_kind: str | None,
+    model_deployments: Sequence[LiteLLMModelDeploymentPlan],
+) -> str:
+    payload = {
+        "budgetSubjectId": budget_subject_id,
+        "litellmTeamId": litellm_team_id,
+        "modelDeployments": [
+            {
+                "publicModelName": item.public_model_name,
+                "providerModel": item.provider_model,
+                "litellmParams": dict(item.litellm_params),
+            }
+            for item in model_deployments
+        ],
+        "policyKind": policy_kind,
+        "providerKind": provider_kind,
+    }
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/server/proliferate/server/cloud/agent_auth/domain/policy.py
+++ b/server/proliferate/server/cloud/agent_auth/domain/policy.py
@@ -1,0 +1,99 @@
+"""Pure product rules for agent-auth credentials and selections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from proliferate.auth.authorization import PolicyAllowed, PolicyDenied, PolicyVerdict
+from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS
+
+
+@dataclass(frozen=True)
+class SelectionPlan:
+    materialization_mode: Literal["gateway_env", "synced_files"]
+    protocol_facade: Literal["anthropic", "openai"] | None
+
+
+def is_supported_agent_kind(agent_kind: str) -> bool:
+    return agent_kind in SUPPORTED_CLOUD_AGENTS
+
+
+def selection_plan_for_credential(
+    *,
+    agent_kind: str,
+    credential_kind: str,
+) -> SelectionPlan | PolicyDenied:
+    if credential_kind == "synced_path":
+        return SelectionPlan(materialization_mode="synced_files", protocol_facade=None)
+    if credential_kind != "managed_gateway":
+        return PolicyDenied(
+            code="unsupported_credential_kind",
+            message="Unsupported credential kind.",
+            status_code=400,
+        )
+    if agent_kind == "claude":
+        return SelectionPlan(materialization_mode="gateway_env", protocol_facade="anthropic")
+    if agent_kind in {"codex", "opencode"}:
+        return SelectionPlan(materialization_mode="gateway_env", protocol_facade="openai")
+    return PolicyDenied(
+        code="gateway_not_supported_for_agent",
+        message="Gateway auth is not supported for this agent.",
+        status_code=400,
+    )
+
+
+def can_select_credential_for_profile(
+    *,
+    profile_owner_scope: str,
+    profile_owner_user_id: object | None,
+    profile_organization_id: object | None,
+    credential_owner_scope: str,
+    credential_owner_user_id: object | None,
+    credential_organization_id: object | None,
+    credential_kind: str,
+    has_active_share: bool,
+) -> PolicyVerdict:
+    if profile_owner_scope == "personal":
+        if credential_owner_scope == "system":
+            return PolicyAllowed()
+        if (
+            credential_owner_scope == "personal"
+            and credential_owner_user_id == profile_owner_user_id
+        ):
+            return PolicyAllowed()
+        if (
+            credential_owner_scope == "organization"
+            and profile_organization_id is not None
+            and credential_organization_id == profile_organization_id
+        ):
+            return PolicyAllowed()
+        return PolicyDenied(
+            code="credential_not_visible",
+            message="Credential is not visible to this sandbox profile.",
+        )
+
+    if profile_owner_scope != "organization":
+        return PolicyDenied(
+            code="invalid_profile_owner_scope",
+            message="Invalid sandbox profile owner scope.",
+            status_code=400,
+        )
+    if credential_owner_scope == "system":
+        return PolicyAllowed()
+    if (
+        credential_owner_scope == "organization"
+        and credential_organization_id == profile_organization_id
+    ):
+        return PolicyAllowed()
+    if credential_owner_scope == "personal" and credential_kind == "synced_path":
+        if has_active_share:
+            return PolicyAllowed()
+        return PolicyDenied(
+            code="credential_share_required",
+            message="Personal synced credentials require owner sharing before organization use.",
+        )
+    return PolicyDenied(
+        code="credential_not_selectable",
+        message="Credential cannot be selected for this sandbox profile.",
+    )

--- a/server/proliferate/server/cloud/agent_auth/errors.py
+++ b/server/proliferate/server/cloud/agent_auth/errors.py
@@ -1,0 +1,9 @@
+"""Agent-auth domain errors."""
+
+from __future__ import annotations
+
+from proliferate.errors import ProliferateError
+
+
+class AgentAuthError(ProliferateError):
+    """Raised for agent-auth control-plane failures."""

--- a/server/proliferate/server/cloud/agent_auth/models.py
+++ b/server/proliferate/server/cloud/agent_auth/models.py
@@ -38,9 +38,7 @@ class LiteLLMModelDeploymentRequest(BaseModel):
 
 class EnsureManagedCreditsRequest(BaseModel):
     included_budget_usd: str | None = Field(default=None, alias="includedBudgetUsd")
-    agent_kinds: list[AgentKind] = Field(
-        default_factory=lambda: ["claude"], alias="agentKinds"
-    )
+    agent_kinds: list[AgentKind] = Field(default_factory=lambda: ["claude"], alias="agentKinds")
 
 
 class CreateGatewayCredentialRequest(BaseModel):

--- a/server/proliferate/server/cloud/agent_auth/models.py
+++ b/server/proliferate/server/cloud/agent_auth/models.py
@@ -1,0 +1,336 @@
+"""Request and response schemas for cloud agent auth."""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.cloud_agent_auth.records import (
+    AgentAuthCredentialRecord,
+    AgentAuthCredentialShareRecord,
+    AgentGatewayBudgetSubjectRecord,
+    AgentGatewayPolicyRecord,
+    AgentGatewayProviderCredentialRecord,
+    SandboxAgentAuthSelectionRecord,
+    SandboxProfileAgentAuthTargetStateRecord,
+    SandboxProfileRecord,
+)
+
+AgentKind = Literal["claude", "codex", "opencode", "gemini"]
+OwnerScope = Literal["personal", "organization"]
+
+
+class EnsurePersonalSandboxProfileRequest(BaseModel):
+    managed_target_id: UUID | None = Field(default=None, alias="managedTargetId")
+
+
+class EnsureOrganizationSandboxProfileRequest(BaseModel):
+    managed_target_id: UUID | None = Field(default=None, alias="managedTargetId")
+
+
+class LiteLLMModelDeploymentRequest(BaseModel):
+    public_model_name: str = Field(alias="publicModelName")
+    provider_model: str = Field(alias="providerModel")
+
+
+class EnsureManagedCreditsRequest(BaseModel):
+    included_budget_usd: str | None = Field(default=None, alias="includedBudgetUsd")
+    agent_kinds: list[AgentKind] = Field(
+        default_factory=lambda: ["claude"], alias="agentKinds"
+    )
+
+
+class CreateGatewayCredentialRequest(BaseModel):
+    owner_scope: Literal["personal", "organization"] = Field(alias="ownerScope")
+    organization_id: UUID | None = Field(default=None, alias="organizationId")
+    agent_kind: AgentKind = Field(alias="agentKind")
+    display_name: str = Field(alias="displayName")
+    policy_kind: Literal["org_byok", "personal_byok"] = Field(alias="policyKind")
+    provider_kind: Literal[
+        "anthropic_api_key",
+        "openai_api_key",
+        "bedrock_assume_role",
+        "openai_compatible",
+    ] = Field(alias="providerKind")
+    payload: dict[str, str]
+
+
+class ShareCredentialRequest(BaseModel):
+    organization_id: UUID = Field(alias="organizationId")
+
+
+class SelectAgentAuthCredentialRequest(BaseModel):
+    credential_id: UUID = Field(alias="credentialId")
+    credential_share_id: UUID | None = Field(default=None, alias="credentialShareId")
+    force_restart: bool = Field(default=False, alias="forceRestart")
+
+
+class AgentAuthMutationResponse(BaseModel):
+    ok: bool = True
+    changed: bool = False
+
+
+class SandboxProfileResponse(BaseModel):
+    id: UUID
+    owner_scope: str = Field(alias="ownerScope")
+    owner_user_id: UUID | None = Field(alias="ownerUserId")
+    organization_id: UUID | None = Field(alias="organizationId")
+    managed_target_id: UUID | None = Field(alias="managedTargetId")
+    agent_auth_revision: int = Field(alias="agentAuthRevision")
+    status: str
+
+
+class AgentAuthCredentialResponse(BaseModel):
+    id: UUID
+    owner_scope: str = Field(alias="ownerScope")
+    owner_user_id: UUID | None = Field(alias="ownerUserId")
+    organization_id: UUID | None = Field(alias="organizationId")
+    created_by_user_id: UUID | None = Field(alias="createdByUserId")
+    agent_kind: str = Field(alias="agentKind")
+    credential_kind: str = Field(alias="credentialKind")
+    display_name: str = Field(alias="displayName")
+    redacted_summary: dict[str, object] = Field(alias="redactedSummary")
+    status: str
+    revision: int
+    legacy_cloud_credential_id: UUID | None = Field(alias="legacyCloudCredentialId")
+    revoked_at: str | None = Field(alias="revokedAt")
+
+
+class AgentAuthCredentialShareResponse(BaseModel):
+    id: UUID
+    credential_id: UUID = Field(alias="credentialId")
+    owner_user_id: UUID = Field(alias="ownerUserId")
+    organization_id: UUID = Field(alias="organizationId")
+    share_scope: str = Field(alias="shareScope")
+    shared_by_user_id: UUID = Field(alias="sharedByUserId")
+    status: str
+    allowed_agent_kind: str = Field(alias="allowedAgentKind")
+    revoked_at: str | None = Field(alias="revokedAt")
+    revoked_by_user_id: UUID | None = Field(alias="revokedByUserId")
+
+
+class AgentGatewayBudgetSubjectResponse(BaseModel):
+    id: UUID
+    organization_id: UUID = Field(alias="organizationId")
+    litellm_team_id: str | None = Field(alias="litellmTeamId")
+    included_budget_usd: str = Field(alias="includedBudgetUsd")
+    budget_duration: str = Field(alias="budgetDuration")
+    litellm_sync_status: str = Field(alias="litellmSyncStatus")
+    status: str
+    revision: int
+    last_error_code: str | None = Field(alias="lastErrorCode")
+    last_error_message: str | None = Field(alias="lastErrorMessage")
+
+
+class AgentGatewayPolicyResponse(BaseModel):
+    id: UUID
+    credential_id: UUID = Field(alias="credentialId")
+    policy_kind: str = Field(alias="policyKind")
+    owner_scope: str = Field(alias="ownerScope")
+    owner_user_id: UUID | None = Field(alias="ownerUserId")
+    organization_id: UUID | None = Field(alias="organizationId")
+    budget_subject_id: UUID | None = Field(alias="budgetSubjectId")
+    litellm_team_id: str | None = Field(alias="litellmTeamId")
+    litellm_virtual_key_id: str | None = Field(alias="litellmVirtualKeyId")
+    litellm_sync_status: str = Field(alias="litellmSyncStatus")
+    status: str
+    revision: int
+    last_error_code: str | None = Field(alias="lastErrorCode")
+    last_error_message: str | None = Field(alias="lastErrorMessage")
+
+
+class AgentGatewayProviderCredentialResponse(BaseModel):
+    id: UUID
+    policy_id: UUID = Field(alias="policyId")
+    provider_kind: str = Field(alias="providerKind")
+    redacted_summary: dict[str, object] = Field(alias="redactedSummary")
+    validation_status: str = Field(alias="validationStatus")
+    validation_error_code: str | None = Field(alias="validationErrorCode")
+    validation_error_message: str | None = Field(alias="validationErrorMessage")
+    revision: int
+
+
+class SandboxAgentAuthSelectionResponse(BaseModel):
+    id: UUID
+    sandbox_profile_id: UUID = Field(alias="sandboxProfileId")
+    owner_scope: str = Field(alias="ownerScope")
+    agent_kind: str = Field(alias="agentKind")
+    credential_id: UUID = Field(alias="credentialId")
+    credential_share_id: UUID | None = Field(alias="credentialShareId")
+    materialization_mode: str = Field(alias="materializationMode")
+    selected_revision: int = Field(alias="selectedRevision")
+    status: str
+    last_error_code: str | None = Field(alias="lastErrorCode")
+    last_error_message: str | None = Field(alias="lastErrorMessage")
+
+
+class SandboxProfileAgentAuthTargetStateResponse(BaseModel):
+    id: UUID
+    sandbox_profile_id: UUID = Field(alias="sandboxProfileId")
+    target_id: UUID = Field(alias="targetId")
+    desired_revision: int = Field(alias="desiredRevision")
+    applied_revision: int | None = Field(alias="appliedRevision")
+    status: str
+    force_restart_required: bool = Field(alias="forceRestartRequired")
+    last_command_id: UUID | None = Field(alias="lastCommandId")
+    last_worker_id: UUID | None = Field(alias="lastWorkerId")
+    last_error_code: str | None = Field(alias="lastErrorCode")
+    last_error_message: str | None = Field(alias="lastErrorMessage")
+
+
+class CreateGatewayCredentialResponse(BaseModel):
+    credential: AgentAuthCredentialResponse
+    policy: AgentGatewayPolicyResponse
+    provider_credential: AgentGatewayProviderCredentialResponse = Field(alias="providerCredential")
+
+
+class EnsureManagedCreditsResponse(BaseModel):
+    budget_subject: AgentGatewayBudgetSubjectResponse = Field(alias="budgetSubject")
+    credentials: list[AgentAuthCredentialResponse]
+    policies: list[AgentGatewayPolicyResponse]
+
+
+def sandbox_profile_response(record: SandboxProfileRecord) -> SandboxProfileResponse:
+    return SandboxProfileResponse(
+        id=record.id,
+        ownerScope=record.owner_scope,
+        ownerUserId=record.owner_user_id,
+        organizationId=record.organization_id,
+        managedTargetId=record.managed_target_id,
+        agentAuthRevision=record.agent_auth_revision,
+        status=record.status,
+    )
+
+
+def credential_response(record: AgentAuthCredentialRecord) -> AgentAuthCredentialResponse:
+    return AgentAuthCredentialResponse(
+        id=record.id,
+        ownerScope=record.owner_scope,
+        ownerUserId=record.owner_user_id,
+        organizationId=record.organization_id,
+        createdByUserId=record.created_by_user_id,
+        agentKind=record.agent_kind,
+        credentialKind=record.credential_kind,
+        displayName=record.display_name,
+        redactedSummary=_json_object(record.redacted_summary_json),
+        status=record.status,
+        revision=record.revision,
+        legacyCloudCredentialId=record.legacy_cloud_credential_id,
+        revokedAt=_iso(record.revoked_at),
+    )
+
+
+def credential_share_response(
+    record: AgentAuthCredentialShareRecord,
+) -> AgentAuthCredentialShareResponse:
+    return AgentAuthCredentialShareResponse(
+        id=record.id,
+        credentialId=record.credential_id,
+        ownerUserId=record.owner_user_id,
+        organizationId=record.organization_id,
+        shareScope=record.share_scope,
+        sharedByUserId=record.shared_by_user_id,
+        status=record.status,
+        allowedAgentKind=record.allowed_agent_kind,
+        revokedAt=_iso(record.revoked_at),
+        revokedByUserId=record.revoked_by_user_id,
+    )
+
+
+def budget_subject_response(
+    record: AgentGatewayBudgetSubjectRecord,
+) -> AgentGatewayBudgetSubjectResponse:
+    return AgentGatewayBudgetSubjectResponse(
+        id=record.id,
+        organizationId=record.organization_id,
+        litellmTeamId=record.litellm_team_id,
+        includedBudgetUsd=record.included_budget_usd,
+        budgetDuration=record.budget_duration,
+        litellmSyncStatus=record.litellm_sync_status,
+        status=record.status,
+        revision=record.revision,
+        lastErrorCode=record.last_error_code,
+        lastErrorMessage=record.last_error_message,
+    )
+
+
+def policy_response(record: AgentGatewayPolicyRecord) -> AgentGatewayPolicyResponse:
+    return AgentGatewayPolicyResponse(
+        id=record.id,
+        credentialId=record.credential_id,
+        policyKind=record.policy_kind,
+        ownerScope=record.owner_scope,
+        ownerUserId=record.owner_user_id,
+        organizationId=record.organization_id,
+        budgetSubjectId=record.budget_subject_id,
+        litellmTeamId=record.litellm_team_id,
+        litellmVirtualKeyId=record.litellm_virtual_key_id,
+        litellmSyncStatus=record.litellm_sync_status,
+        status=record.status,
+        revision=record.revision,
+        lastErrorCode=record.last_error_code,
+        lastErrorMessage=record.last_error_message,
+    )
+
+
+def provider_credential_response(
+    record: AgentGatewayProviderCredentialRecord,
+) -> AgentGatewayProviderCredentialResponse:
+    return AgentGatewayProviderCredentialResponse(
+        id=record.id,
+        policyId=record.policy_id,
+        providerKind=record.provider_kind,
+        redactedSummary=_json_object(record.redacted_summary_json),
+        validationStatus=record.validation_status,
+        validationErrorCode=record.validation_error_code,
+        validationErrorMessage=record.validation_error_message,
+        revision=record.revision,
+    )
+
+
+def selection_response(
+    record: SandboxAgentAuthSelectionRecord,
+) -> SandboxAgentAuthSelectionResponse:
+    return SandboxAgentAuthSelectionResponse(
+        id=record.id,
+        sandboxProfileId=record.sandbox_profile_id,
+        ownerScope=record.owner_scope,
+        agentKind=record.agent_kind,
+        credentialId=record.credential_id,
+        credentialShareId=record.credential_share_id,
+        materializationMode=record.materialization_mode,
+        selectedRevision=record.selected_revision,
+        status=record.status,
+        lastErrorCode=record.last_error_code,
+        lastErrorMessage=record.last_error_message,
+    )
+
+
+def target_state_response(
+    record: SandboxProfileAgentAuthTargetStateRecord,
+) -> SandboxProfileAgentAuthTargetStateResponse:
+    return SandboxProfileAgentAuthTargetStateResponse(
+        id=record.id,
+        sandboxProfileId=record.sandbox_profile_id,
+        targetId=record.target_id,
+        desiredRevision=record.desired_revision,
+        appliedRevision=record.applied_revision,
+        status=record.status,
+        forceRestartRequired=record.force_restart_required,
+        lastCommandId=record.last_command_id,
+        lastWorkerId=record.last_worker_id,
+        lastErrorCode=record.last_error_code,
+        lastErrorMessage=record.last_error_message,
+    )
+
+
+def _json_object(value: str) -> dict[str, object]:
+    parsed = json.loads(value or "{}")
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _iso(value: object) -> str | None:
+    return value.isoformat() if hasattr(value, "isoformat") else None

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -101,6 +101,25 @@ async def ensure_personal_sandbox_profile(
     return await _backfill_legacy_cloud_credentials(db, actor_user_id, profile)
 
 
+async def reconcile_legacy_cloud_credentials_for_user(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    create_profile: bool,
+) -> SandboxProfileRecord | None:
+    if create_profile:
+        profile = await store.ensure_personal_sandbox_profile(
+            db,
+            user_id=actor_user_id,
+            managed_target_id=None,
+        )
+    else:
+        profile = await store.get_active_personal_sandbox_profile_for_user(db, actor_user_id)
+        if profile is None:
+            return None
+    return await _backfill_legacy_cloud_credentials(db, actor_user_id, profile)
+
+
 async def ensure_organization_sandbox_profile(
     db: AsyncSession,
     *,
@@ -420,11 +439,14 @@ async def ensure_managed_credits_for_organization(
             error_code=error_code,
             error_message=error_message,
         )
-        credential = await store.update_credential_status(
-            db,
-            credential_id=credential.id,
-            status="ready" if policy.status == "ready" else "invalid",
-        ) or credential
+        credential = (
+            await store.update_credential_status(
+                db,
+                credential_id=credential.id,
+                status="ready" if policy.status == "ready" else "invalid",
+            )
+            or credential
+        )
         credentials.append(credential)
         policies.append(policy)
     await store.record_audit_event(
@@ -657,6 +679,16 @@ async def select_credential_for_profile(
     )
     if not isinstance(plan, SelectionPlan):
         raise AgentAuthError(plan.message, code=plan.code, status_code=plan.status_code)
+    if (
+        agent_kind == "opencode"
+        and plan.materialization_mode == "gateway_env"
+        and not settings.agent_gateway_opencode_enabled
+    ):
+        raise AgentAuthError(
+            "Gateway auth for OpenCode is not enabled.",
+            code="gateway_not_supported_for_agent",
+            status_code=400,
+        )
     selection = await store.upsert_selection(
         db,
         sandbox_profile_id=profile.id,
@@ -759,6 +791,12 @@ async def issue_runtime_grant_for_selection(
         raise AgentAuthError(
             "Selection does not use gateway auth.", code="not_gateway_selection", status_code=400
         )
+    if selection.agent_kind == "opencode" and not settings.agent_gateway_opencode_enabled:
+        raise AgentAuthError(
+            "Gateway auth for OpenCode is not enabled.",
+            code="gateway_not_supported_for_agent",
+            status_code=400,
+        )
 
     now = utcnow()
     existing = await store.list_active_runtime_grants_for_route(
@@ -770,9 +808,10 @@ async def issue_runtime_grant_for_selection(
         now=now,
     )
     # The raw token is intentionally not persisted. Materialization retries get
-    # a fresh overlapping grant instead of failing or trying to recover a secret
-    # from durable storage. Later cleanup removes expired grants.
-    _ = existing
+    # a fresh overlapping grant, but keep only the newest prior grant as a
+    # short compatibility grace token for already-configured runtimes.
+    stale_grant_ids = {grant.id for grant in existing[1:]}
+    await store.revoke_runtime_grants_by_ids(db, stale_grant_ids)
 
     raw_token = secrets.token_urlsafe(32)
     grant = await store.create_runtime_grant(
@@ -801,18 +840,26 @@ async def _backfill_legacy_cloud_credentials(
 ) -> SandboxProfileRecord:
     all_legacy_rows = await store.list_legacy_cloud_credentials_for_user(db, actor_user_id)
     active_legacy_by_id = {row.id: row for row in all_legacy_rows if row.revoked_at is None}
-    existing_selections = {
-        selection.agent_kind: selection
-        for selection in await store.list_selections_for_profile(db, profile.id)
-    }
+    imported_legacy_credentials = await store.list_imported_legacy_credentials_for_user(
+        db,
+        actor_user_id,
+    )
+    imported_credential_ids = {credential.id for credential in imported_legacy_credentials}
     changed = False
-    for imported in await store.list_imported_legacy_credentials_for_user(db, actor_user_id):
+    for imported in imported_legacy_credentials:
         legacy = next(
             (row for row in all_legacy_rows if row.id == imported.legacy_cloud_credential_id),
             None,
         )
         if legacy is None or legacy.revoked_at is not None:
             await store.revoke_credential(db, credential_id=imported.id)
+            replacement_exists = legacy is not None and any(
+                active.provider == legacy.provider and active.id != legacy.id
+                for active in active_legacy_by_id.values()
+            )
+            if replacement_exists:
+                changed = True
+                continue
             affected = await store.list_active_selections_for_credential_or_share(
                 db,
                 credential_id=imported.id,
@@ -834,6 +881,10 @@ async def _backfill_legacy_cloud_credentials(
             changed = True
     if not active_legacy_by_id:
         return profile
+    existing_selections = {
+        selection.agent_kind: selection
+        for selection in await store.list_selections_for_profile(db, profile.id)
+    }
     for legacy in active_legacy_by_id.values():
         credential = await store.find_agent_auth_credential_for_legacy_cloud_credential(
             db,
@@ -872,25 +923,42 @@ async def _backfill_legacy_cloud_credentials(
                     {"legacyCloudCredentialId": str(legacy.id)}, sort_keys=True
                 ),
             )
+            imported_credential_ids.add(credential.id)
         elif (
             credential.revoked_at is None
             and legacy.updated_at is not None
             and legacy.updated_at > credential.updated_at
         ):
-            credential = await store.update_credential_status(
-                db,
-                credential_id=credential.id,
-                status="ready",
-                redacted_summary_json=json.dumps(
-                    {
-                        "source": "cloud_credential",
-                        "authMode": legacy.auth_mode,
-                    },
-                    sort_keys=True,
-                ),
-            ) or credential
+            credential = (
+                await store.update_credential_status(
+                    db,
+                    credential_id=credential.id,
+                    status="ready",
+                    redacted_summary_json=json.dumps(
+                        {
+                            "source": "cloud_credential",
+                            "authMode": legacy.auth_mode,
+                        },
+                        sort_keys=True,
+                    ),
+                )
+                or credential
+            )
+            imported_credential_ids.add(credential.id)
             changed = True
-        if legacy.provider not in existing_selections:
+        if credential.revoked_at is not None:
+            continue
+        selection = existing_selections.get(legacy.provider)
+        should_select = False
+        if selection is None:
+            should_select = True
+        elif selection.credential_id in imported_credential_ids:
+            should_select = (
+                selection.status != "active"
+                or selection.credential_id != credential.id
+                or selection.selected_revision != credential.revision
+            )
+        if should_select:
             await store.upsert_selection(
                 db,
                 sandbox_profile_id=profile.id,

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -1,0 +1,1471 @@
+"""Service layer for cloud agent auth."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import json
+import secrets
+import socket
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal, InvalidOperation
+from urllib.parse import urlparse
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.authorization import PolicyDenied
+from proliferate.config import settings
+from proliferate.constants.cloud import (
+    AGENT_GATEWAY_CIPHERTEXT_KEY_ID,
+    AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN,
+    AGENT_GATEWAY_TOKEN_HASH_KEY_ID,
+    CloudAgentKind,
+)
+from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
+from proliferate.db.store import organizations as organization_store
+from proliferate.db.store.cloud_agent_auth import store
+from proliferate.db.store.cloud_agent_auth.records import (
+    AgentAuthCredentialRecord,
+    AgentAuthCredentialShareRecord,
+    AgentGatewayBudgetSubjectRecord,
+    AgentGatewayPolicyRecord,
+    AgentGatewayProviderCredentialRecord,
+    AgentGatewayRuntimeGrantRecord,
+    SandboxAgentAuthSelectionRecord,
+    SandboxProfileAgentAuthTargetStateRecord,
+    SandboxProfileRecord,
+)
+from proliferate.integrations.aws import (
+    AwsIntegrationError,
+    validate_bedrock_assume_role_payload,
+)
+from proliferate.integrations.litellm import LiteLLMAdminClient, LiteLLMIntegrationError
+from proliferate.server.cloud.agent_auth.domain.desired_state import (
+    LiteLLMModelDeploymentPlan,
+    fingerprint_litellm_policy_state,
+)
+from proliferate.server.cloud.agent_auth.domain.policy import (
+    SelectionPlan,
+    can_select_credential_for_profile,
+    is_supported_agent_kind,
+    selection_plan_for_credential,
+)
+from proliferate.server.cloud.agent_auth.errors import AgentAuthError
+from proliferate.server.cloud.agent_auth.models import (
+    CreateGatewayCredentialRequest,
+    EnsureManagedCreditsRequest,
+    LiteLLMModelDeploymentRequest,
+)
+from proliferate.utils.crypto import encrypt_json, encrypt_text
+from proliferate.utils.time import utcnow
+
+_ORG_ADMIN_ROLES = {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}
+_GATEWAY_GRANT_TTL = timedelta(days=7)
+
+
+@dataclass(frozen=True)
+class CreateGatewayCredentialResult:
+    credential: AgentAuthCredentialRecord
+    policy: AgentGatewayPolicyRecord
+    provider_credential: AgentGatewayProviderCredentialRecord
+
+
+@dataclass(frozen=True)
+class EnsureManagedCreditsResult:
+    budget_subject: AgentGatewayBudgetSubjectRecord
+    credentials: tuple[AgentAuthCredentialRecord, ...]
+    policies: tuple[AgentGatewayPolicyRecord, ...]
+
+
+@dataclass(frozen=True)
+class RuntimeGrantIssueResult:
+    grant: AgentGatewayRuntimeGrantRecord
+    raw_token: str
+
+
+async def ensure_personal_sandbox_profile(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    managed_target_id: UUID | None,
+) -> SandboxProfileRecord:
+    profile = await store.ensure_personal_sandbox_profile(
+        db,
+        user_id=actor_user_id,
+        managed_target_id=managed_target_id,
+    )
+    return await _backfill_legacy_cloud_credentials(db, actor_user_id, profile)
+
+
+async def ensure_organization_sandbox_profile(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID,
+    managed_target_id: UUID | None,
+) -> SandboxProfileRecord:
+    await _require_organization_admin(db, actor_user_id, organization_id)
+    return await store.ensure_organization_sandbox_profile(
+        db,
+        organization_id=organization_id,
+        managed_target_id=managed_target_id,
+    )
+
+
+async def list_credentials(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID | None,
+    agent_kind: str | None,
+) -> tuple[AgentAuthCredentialRecord, ...]:
+    if organization_id is not None:
+        await _require_organization_member(db, actor_user_id, organization_id)
+    if agent_kind is not None and not is_supported_agent_kind(agent_kind):
+        raise AgentAuthError(
+            "Unsupported agent kind.", code="unsupported_agent_kind", status_code=400
+        )
+    return await store.list_visible_credentials(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+        agent_kind=agent_kind,
+    )
+
+
+async def create_gateway_credential(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    body: CreateGatewayCredentialRequest,
+) -> CreateGatewayCredentialResult:
+    if body.owner_scope == "organization":
+        if body.organization_id is None:
+            raise AgentAuthError(
+                "organizationId is required.", code="missing_organization_id", status_code=400
+            )
+        await _require_organization_admin(db, actor_user_id, body.organization_id)
+        owner_user_id = None
+        organization_id = body.organization_id
+    else:
+        if body.organization_id is not None:
+            raise AgentAuthError(
+                "organizationId is not valid for personal credentials.",
+                code="invalid_owner_scope",
+                status_code=400,
+            )
+        owner_user_id = actor_user_id
+        organization_id = None
+
+    if body.agent_kind == "gemini":
+        raise AgentAuthError(
+            "Gateway auth is not supported for Gemini in V1.",
+            code="gateway_not_supported_for_agent",
+            status_code=400,
+        )
+    _validate_policy_owner_scope(body.policy_kind, body.owner_scope)
+
+    validation = _validate_provider_payload(body.provider_kind, body.payload)
+    credential = await store.create_agent_auth_credential(
+        db,
+        owner_scope=body.owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        created_by_user_id=actor_user_id,
+        agent_kind=body.agent_kind,
+        credential_kind="managed_gateway",
+        display_name=_clean_display_name(body.display_name),
+        redacted_summary_json=json.dumps(validation.redacted_summary, sort_keys=True),
+        status="pending",
+    )
+    await store.record_audit_event(
+        db,
+        action="credential.create",
+        actor_user_id=actor_user_id,
+        owner_scope=body.owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        credential_id=credential.id,
+        metadata_json=json.dumps(
+            {
+                "agentKind": body.agent_kind,
+                "credentialKind": "managed_gateway",
+                "providerKind": body.provider_kind,
+            },
+            sort_keys=True,
+        ),
+    )
+    if validation.status != "valid":
+        policy = await store.ensure_gateway_policy(
+            db,
+            credential_id=credential.id,
+            policy_kind=body.policy_kind,
+            owner_scope=body.owner_scope,
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            budget_subject_id=None,
+            litellm_team_id=None,
+            litellm_virtual_key_id=None,
+            litellm_virtual_key_ciphertext=None,
+            litellm_virtual_key_ciphertext_key_id=None,
+            litellm_sync_status="failed",
+            litellm_sync_fingerprint=None,
+            status="invalid",
+            last_error_code=validation.error_code,
+            last_error_message=_safe_error_message(validation.error_message, body.payload),
+        )
+        sync_status = "failed"
+        status = "invalid"
+        error_code = validation.error_code
+        error_message = _safe_error_message(validation.error_message, body.payload)
+    else:
+        policy, sync_status, status, error_code, error_message = await _provision_policy(
+            db,
+            credential=credential,
+            policy_kind=body.policy_kind,
+            owner_scope=body.owner_scope,
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            budget_subject_id=None,
+            provider_kind=body.provider_kind,
+            provider_payload=body.payload,
+            model_deployments=_gateway_deployments_for_credential(
+                agent_kind=body.agent_kind,
+                provider_kind=body.provider_kind,
+            ),
+        )
+    provider_credential = await store.upsert_provider_credential(
+        db,
+        policy_id=policy.id,
+        provider_kind=body.provider_kind,
+        payload_ciphertext=encrypt_json(dict(body.payload)),
+        payload_ciphertext_key_id=AGENT_GATEWAY_CIPHERTEXT_KEY_ID,
+        redacted_summary_json=json.dumps(validation.redacted_summary, sort_keys=True),
+        validation_status=validation.status,
+        validated_at=utcnow() if validation.status == "valid" else None,
+        validation_error_code=validation.error_code,
+        validation_error_message=_safe_error_message(validation.error_message, body.payload),
+    )
+    credential = await store.update_credential_status(
+        db,
+        credential_id=credential.id,
+        status="ready" if sync_status == "synced" and status == "ready" else "invalid",
+        redacted_summary_json=json.dumps(validation.redacted_summary, sort_keys=True),
+    )
+    if credential is None:
+        raise AgentAuthError("Credential disappeared during creation.", code="credential_missing")
+    if error_code is not None:
+        await store.record_audit_event(
+            db,
+            action="credential.validate",
+            actor_user_id=actor_user_id,
+            owner_scope=body.owner_scope,
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            credential_id=credential.id,
+            metadata_json=json.dumps(
+                {"status": "failed", "errorCode": error_code, "errorMessage": error_message},
+                sort_keys=True,
+            ),
+        )
+    return CreateGatewayCredentialResult(
+        credential=credential,
+        policy=policy,
+        provider_credential=provider_credential,
+    )
+
+
+async def ensure_managed_credits_for_organization(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID,
+    body: EnsureManagedCreditsRequest,
+) -> EnsureManagedCreditsResult:
+    await _require_organization_admin(db, actor_user_id, organization_id)
+    # Customer-facing callers never choose managed-credit amounts. The value
+    # comes from Proliferate entitlement/billing state; Phase 1 uses settings as
+    # that entitlement source until billing integration wires this internally.
+    included_budget_usd = _budget_amount(settings.agent_gateway_default_managed_budget_usd)
+    existing_budget = await store.get_managed_budget_subject(db, organization_id)
+    team_id = existing_budget.litellm_team_id if existing_budget else None
+    sync_status = "failed"
+    status = "invalid"
+    fingerprint = None
+    error_code = "litellm_not_configured"
+    error_message = "LiteLLM provisioning is not configured."
+    requested_agent_kinds = tuple(
+        agent_kind for agent_kind in body.agent_kinds if agent_kind != "gemini"
+    )
+    managed_deployments = tuple(
+        deployment
+        for agent_kind in requested_agent_kinds
+        for deployment in _gateway_deployments_for_credential(
+            agent_kind=agent_kind,
+            provider_kind="proliferate_bedrock_pool",
+        )
+    )
+    if not managed_deployments:
+        error_code = "managed_credit_models_not_configured"
+        error_message = "No managed-credit model deployments are configured."
+    if settings.agent_gateway_enabled and settings.agent_gateway_litellm_master_key:
+        try:
+            if not managed_deployments:
+                raise LiteLLMIntegrationError(error_message)
+            client = LiteLLMAdminClient()
+            team = await client.ensure_team(
+                team_alias=f"org-{organization_id}-managed-credits",
+                team_id=team_id,
+                max_budget=included_budget_usd,
+                budget_duration="30d",
+            )
+            team_id = team.team_id
+            for deployment in managed_deployments:
+                await client.create_model_deployment(
+                    public_model_name=deployment.public_model_name,
+                    provider_model=deployment.provider_model,
+                    team_id=team_id,
+                    litellm_params=_provider_litellm_params(
+                        provider_kind="proliferate_bedrock_pool",
+                        provider_payload={},
+                        deployment=deployment,
+                    ),
+                    metadata={
+                        "organizationId": str(organization_id),
+                        "budgetKind": "proliferate_managed",
+                    },
+                )
+            sync_status = "synced"
+            status = "ready"
+            fingerprint = _deployment_fingerprint(
+                policy_kind="proliferate_managed",
+                litellm_team_id=team_id,
+                budget_subject_id=str(existing_budget.id) if existing_budget else None,
+                provider_kind="proliferate_bedrock_pool",
+                deployments=managed_deployments,
+            )
+            error_code = None
+            error_message = None
+        except LiteLLMIntegrationError as exc:
+            error_code = "litellm_provisioning_failed"
+            error_message = _safe_error_message(str(exc), {})
+    budget = await store.ensure_managed_budget_subject(
+        db,
+        organization_id=organization_id,
+        included_budget_usd=included_budget_usd,
+        litellm_team_id=team_id,
+        litellm_sync_status=sync_status,
+        litellm_sync_fingerprint=fingerprint,
+        status=status,
+        last_error_code=error_code,
+        last_error_message=error_message,
+    )
+
+    credentials: list[AgentAuthCredentialRecord] = []
+    policies: list[AgentGatewayPolicyRecord] = []
+    visible = await store.list_visible_credentials(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+        agent_kind=None,
+    )
+    for agent_kind in requested_agent_kinds:
+        if not _gateway_deployments_for_credential(
+            agent_kind=agent_kind,
+            provider_kind="proliferate_bedrock_pool",
+        ):
+            continue
+        credential = next(
+            (
+                item
+                for item in visible
+                if item.owner_scope == "organization"
+                and item.organization_id == organization_id
+                and item.agent_kind == agent_kind
+                and item.credential_kind == "managed_gateway"
+                and item.display_name == "Proliferate managed credits"
+            ),
+            None,
+        )
+        if credential is None:
+            credential = await store.create_agent_auth_credential(
+                db,
+                owner_scope="organization",
+                owner_user_id=None,
+                organization_id=organization_id,
+                created_by_user_id=actor_user_id,
+                agent_kind=agent_kind,
+                credential_kind="managed_gateway",
+                display_name="Proliferate managed credits",
+                redacted_summary_json=json.dumps(
+                    {
+                        "providerKind": "proliferate_bedrock_pool",
+                        "budgetSubjectId": str(budget.id),
+                    },
+                    sort_keys=True,
+                ),
+                status="ready" if status == "ready" else "invalid",
+            )
+        policy = await _ensure_managed_policy(
+            db,
+            credential=credential,
+            budget=budget,
+            sync_status=sync_status,
+            status=status,
+            fingerprint=fingerprint,
+            error_code=error_code,
+            error_message=error_message,
+        )
+        credential = await store.update_credential_status(
+            db,
+            credential_id=credential.id,
+            status="ready" if policy.status == "ready" else "invalid",
+        ) or credential
+        credentials.append(credential)
+        policies.append(policy)
+    await store.record_audit_event(
+        db,
+        action="managed_credits.ensure",
+        actor_user_id=actor_user_id,
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id,
+        metadata_json=json.dumps(
+            {
+                "includedBudgetUsd": included_budget_usd,
+                "agentKinds": list(body.agent_kinds),
+                "litellmSyncStatus": sync_status,
+            },
+            sort_keys=True,
+        ),
+    )
+    return EnsureManagedCreditsResult(
+        budget_subject=budget,
+        credentials=tuple(credentials),
+        policies=tuple(policies),
+    )
+
+
+async def share_personal_credential_with_organization(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    credential_id: UUID,
+    organization_id: UUID,
+) -> AgentAuthCredentialShareRecord:
+    await _require_organization_member(db, actor_user_id, organization_id)
+    credential = await store.get_credential(db, credential_id)
+    if credential is None or credential.revoked_at is not None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    if credential.owner_scope != "personal" or credential.owner_user_id != actor_user_id:
+        raise AgentAuthError(
+            "Only the credential owner can share this credential.",
+            code="credential_share_forbidden",
+            status_code=403,
+        )
+    if credential.credential_kind != "synced_path":
+        raise AgentAuthError(
+            "Only synced-path credentials can be shared in V1.",
+            code="credential_share_not_supported",
+            status_code=400,
+        )
+    share = await store.create_or_reactivate_credential_share(
+        db,
+        credential_id=credential.id,
+        owner_user_id=actor_user_id,
+        organization_id=organization_id,
+        shared_by_user_id=actor_user_id,
+        allowed_agent_kind=credential.agent_kind,
+    )
+    await store.record_audit_event(
+        db,
+        action="credential.share",
+        actor_user_id=actor_user_id,
+        owner_scope="personal",
+        owner_user_id=actor_user_id,
+        organization_id=organization_id,
+        credential_id=credential.id,
+        metadata_json=json.dumps({"shareId": str(share.id)}, sort_keys=True),
+    )
+    return share
+
+
+async def revoke_credential_share(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    share_id: UUID,
+) -> AgentAuthCredentialShareRecord:
+    existing = await store.get_credential_share(db, share_id)
+    if existing is None:
+        raise AgentAuthError(
+            "Credential share not found.", code="credential_share_not_found", status_code=404
+        )
+    if existing.owner_user_id != actor_user_id:
+        raise AgentAuthError(
+            "Only the credential owner can revoke this share.",
+            code="credential_share_forbidden",
+            status_code=403,
+        )
+    share = await store.revoke_credential_share(
+        db,
+        share_id=share_id,
+        revoked_by_user_id=actor_user_id,
+    )
+    if share is None:
+        raise AgentAuthError(
+            "Credential share not found.", code="credential_share_not_found", status_code=404
+        )
+    affected = await store.list_active_selections_for_credential_or_share(
+        db,
+        credential_share_id=share.id,
+    )
+    for selection in affected:
+        await store.mark_selection_invalid(
+            db,
+            selection_id=selection.id,
+            error_code="credential_share_revoked",
+            error_message="Credential owner revoked the share.",
+        )
+        await _bump_profile_for_selection(
+            db,
+            selection,
+            actor_user_id=actor_user_id,
+            reason="credential_share_revoked",
+            force_restart=True,
+        )
+    await store.record_audit_event(
+        db,
+        action="credential_share.revoke",
+        actor_user_id=actor_user_id,
+        owner_scope="personal",
+        owner_user_id=share.owner_user_id,
+        organization_id=share.organization_id,
+        credential_id=share.credential_id,
+        metadata_json=json.dumps({"shareId": str(share.id)}, sort_keys=True),
+    )
+    return share
+
+
+async def revoke_credential(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    credential_id: UUID,
+) -> AgentAuthCredentialRecord:
+    credential = await store.get_credential(db, credential_id)
+    if credential is None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    await _require_can_manage_credential(db, actor_user_id, credential)
+    revoked = await store.revoke_credential(db, credential_id=credential_id)
+    if revoked is None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    affected = await store.list_active_selections_for_credential_or_share(
+        db,
+        credential_id=credential_id,
+    )
+    for selection in affected:
+        await store.mark_selection_invalid(
+            db,
+            selection_id=selection.id,
+            error_code="credential_revoked",
+            error_message="Selected credential was revoked.",
+        )
+        await _bump_profile_for_selection(
+            db,
+            selection,
+            actor_user_id=actor_user_id,
+            reason="credential_revoked",
+            force_restart=True,
+        )
+    await store.record_audit_event(
+        db,
+        action="credential.revoke",
+        actor_user_id=actor_user_id,
+        owner_scope=credential.owner_scope,
+        owner_user_id=credential.owner_user_id,
+        organization_id=credential.organization_id,
+        credential_id=credential.id,
+    )
+    return revoked
+
+
+async def list_selections(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    sandbox_profile_id: UUID,
+) -> tuple[SandboxAgentAuthSelectionRecord, ...]:
+    profile = await _require_profile_access(db, actor_user_id, sandbox_profile_id, admin=False)
+    return await store.list_selections_for_profile(db, profile.id)
+
+
+async def select_credential_for_profile(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    sandbox_profile_id: UUID,
+    agent_kind: CloudAgentKind,
+    credential_id: UUID,
+    credential_share_id: UUID | None,
+    force_restart: bool,
+) -> SandboxAgentAuthSelectionRecord:
+    profile = await _require_profile_access(db, actor_user_id, sandbox_profile_id, admin=True)
+    credential = await store.get_credential(db, credential_id)
+    if credential is None or credential.revoked_at is not None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    if credential.agent_kind != agent_kind:
+        raise AgentAuthError(
+            "Credential is for a different agent kind.",
+            code="agent_kind_mismatch",
+            status_code=400,
+        )
+    await _require_credential_ready_for_selection(db, credential)
+    share = None
+    if credential_share_id is not None:
+        share = await store.get_active_credential_share(
+            db,
+            credential_id=credential.id,
+            organization_id=profile.organization_id or UUID(int=0),
+        )
+        if share is None or share.id != credential_share_id:
+            raise AgentAuthError(
+                "Credential share is not active.",
+                code="credential_share_required",
+                status_code=403,
+            )
+    has_active_share = share is not None
+    verdict = can_select_credential_for_profile(
+        profile_owner_scope=profile.owner_scope,
+        profile_owner_user_id=profile.owner_user_id,
+        profile_organization_id=profile.organization_id,
+        credential_owner_scope=credential.owner_scope,
+        credential_owner_user_id=credential.owner_user_id,
+        credential_organization_id=credential.organization_id,
+        credential_kind=credential.credential_kind,
+        has_active_share=has_active_share,
+    )
+    if isinstance(verdict, PolicyDenied):
+        raise AgentAuthError(verdict.message, code=verdict.code, status_code=verdict.status_code)
+    plan = selection_plan_for_credential(
+        agent_kind=agent_kind,
+        credential_kind=credential.credential_kind,
+    )
+    if not isinstance(plan, SelectionPlan):
+        raise AgentAuthError(plan.message, code=plan.code, status_code=plan.status_code)
+    selection = await store.upsert_selection(
+        db,
+        sandbox_profile_id=profile.id,
+        owner_scope=profile.owner_scope,
+        agent_kind=agent_kind,
+        credential_id=credential.id,
+        credential_share_id=share.id if share is not None else None,
+        materialization_mode=plan.materialization_mode,
+        selected_revision=credential.revision,
+        status="active",
+        last_error_code=None,
+        last_error_message=None,
+    )
+    updated_profile = await store.bump_sandbox_profile_agent_auth_revision(
+        db,
+        sandbox_profile_id=profile.id,
+        reason="selection_changed",
+        actor_user_id=actor_user_id,
+        force_restart=force_restart,
+    )
+    if updated_profile is None:
+        raise AgentAuthError(
+            "Sandbox profile not found.", code="sandbox_profile_not_found", status_code=404
+        )
+    if profile.managed_target_id is not None:
+        await store.upsert_target_state(
+            db,
+            sandbox_profile_id=profile.id,
+            target_id=profile.managed_target_id,
+            desired_revision=updated_profile.agent_auth_revision,
+            applied_revision=None,
+            status="pending",
+            force_restart_required=force_restart,
+            last_command_id=None,
+            last_worker_id=None,
+            last_error_code=None,
+            last_error_message=None,
+        )
+    await store.record_audit_event(
+        db,
+        action="selection.write",
+        actor_user_id=actor_user_id,
+        owner_scope=profile.owner_scope,
+        owner_user_id=profile.owner_user_id,
+        organization_id=profile.organization_id,
+        credential_id=credential.id,
+        sandbox_profile_id=profile.id,
+        metadata_json=json.dumps(
+            {
+                "agentKind": agent_kind,
+                "credentialShareId": str(share.id) if share else None,
+                "forceRestart": force_restart,
+                "revision": updated_profile.agent_auth_revision,
+            },
+            sort_keys=True,
+        ),
+    )
+    return selection
+
+
+async def list_target_states(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    sandbox_profile_id: UUID,
+) -> tuple[SandboxProfileAgentAuthTargetStateRecord, ...]:
+    profile = await _require_profile_access(db, actor_user_id, sandbox_profile_id, admin=False)
+    return await store.list_target_states_for_profile(db, profile.id)
+
+
+async def issue_runtime_grant_for_selection(
+    db: AsyncSession,
+    *,
+    selection: SandboxAgentAuthSelectionRecord,
+    profile: SandboxProfileRecord,
+    target_id: UUID,
+) -> RuntimeGrantIssueResult:
+    if selection.status != "active":
+        raise AgentAuthError(
+            "Selection is not active.", code="selection_not_active", status_code=409
+        )
+    credential = await store.get_credential(db, selection.credential_id)
+    if credential is None or credential.revoked_at is not None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    if selection.selected_revision != credential.revision:
+        raise AgentAuthError(
+            "Selection is stale.", code="selection_revision_stale", status_code=409
+        )
+    await _require_credential_ready_for_selection(db, credential)
+    policy = await store.get_gateway_policy_for_credential(db, credential.id)
+    if policy is None or policy.status != "ready" or policy.litellm_sync_status != "synced":
+        raise AgentAuthError(
+            "Gateway policy is not ready.", code="gateway_policy_not_ready", status_code=409
+        )
+    plan = selection_plan_for_credential(
+        agent_kind=selection.agent_kind,
+        credential_kind=credential.credential_kind,
+    )
+    if not isinstance(plan, SelectionPlan) or plan.protocol_facade is None:
+        raise AgentAuthError(
+            "Selection does not use gateway auth.", code="not_gateway_selection", status_code=400
+        )
+
+    now = utcnow()
+    existing = await store.list_active_runtime_grants_for_route(
+        db,
+        policy_id=policy.id,
+        target_id=target_id,
+        sandbox_profile_id=profile.id,
+        agent_kind=selection.agent_kind,
+        now=now,
+    )
+    # The raw token is intentionally not persisted. Materialization retries get
+    # a fresh overlapping grant instead of failing or trying to recover a secret
+    # from durable storage. Later cleanup removes expired grants.
+    _ = existing
+
+    raw_token = secrets.token_urlsafe(32)
+    grant = await store.create_runtime_grant(
+        db,
+        token_hash=_hash_token(raw_token),
+        hash_key_id=AGENT_GATEWAY_TOKEN_HASH_KEY_ID,
+        policy_id=policy.id,
+        credential_id=credential.id,
+        selection_id=selection.id,
+        issued_profile_revision=profile.agent_auth_revision,
+        target_id=target_id,
+        sandbox_profile_id=profile.id,
+        organization_id=profile.organization_id,
+        user_id=profile.owner_user_id,
+        agent_kind=selection.agent_kind,
+        protocol_facade=plan.protocol_facade,
+        expires_at=now + _GATEWAY_GRANT_TTL,
+    )
+    return RuntimeGrantIssueResult(grant=grant, raw_token=raw_token)
+
+
+async def _backfill_legacy_cloud_credentials(
+    db: AsyncSession,
+    actor_user_id: UUID,
+    profile: SandboxProfileRecord,
+) -> SandboxProfileRecord:
+    all_legacy_rows = await store.list_legacy_cloud_credentials_for_user(db, actor_user_id)
+    active_legacy_by_id = {row.id: row for row in all_legacy_rows if row.revoked_at is None}
+    existing_selections = {
+        selection.agent_kind: selection
+        for selection in await store.list_selections_for_profile(db, profile.id)
+    }
+    changed = False
+    for imported in await store.list_imported_legacy_credentials_for_user(db, actor_user_id):
+        legacy = next(
+            (row for row in all_legacy_rows if row.id == imported.legacy_cloud_credential_id),
+            None,
+        )
+        if legacy is None or legacy.revoked_at is not None:
+            await store.revoke_credential(db, credential_id=imported.id)
+            affected = await store.list_active_selections_for_credential_or_share(
+                db,
+                credential_id=imported.id,
+            )
+            for selection in affected:
+                await store.mark_selection_invalid(
+                    db,
+                    selection_id=selection.id,
+                    error_code="legacy_cloud_credential_revoked",
+                    error_message="Synced cloud credential was revoked.",
+                )
+                await _bump_profile_for_selection(
+                    db,
+                    selection,
+                    actor_user_id=actor_user_id,
+                    reason="legacy_cloud_credential_revoked",
+                    force_restart=True,
+                )
+            changed = True
+    if not active_legacy_by_id:
+        return profile
+    for legacy in active_legacy_by_id.values():
+        credential = await store.find_agent_auth_credential_for_legacy_cloud_credential(
+            db,
+            legacy.id,
+        )
+        if credential is None:
+            credential = await store.create_agent_auth_credential(
+                db,
+                owner_scope="personal",
+                owner_user_id=actor_user_id,
+                organization_id=None,
+                created_by_user_id=actor_user_id,
+                agent_kind=legacy.provider,
+                credential_kind="synced_path",
+                display_name=f"Synced {legacy.provider} auth",
+                redacted_summary_json=json.dumps(
+                    {
+                        "source": "cloud_credential",
+                        "authMode": legacy.auth_mode,
+                    },
+                    sort_keys=True,
+                ),
+                status="ready",
+                legacy_cloud_credential_id=legacy.id,
+            )
+            await store.record_audit_event(
+                db,
+                action="credential.import_legacy",
+                actor_user_id=actor_user_id,
+                owner_scope="personal",
+                owner_user_id=actor_user_id,
+                organization_id=None,
+                credential_id=credential.id,
+                sandbox_profile_id=profile.id,
+                metadata_json=json.dumps(
+                    {"legacyCloudCredentialId": str(legacy.id)}, sort_keys=True
+                ),
+            )
+        elif (
+            credential.revoked_at is None
+            and legacy.updated_at is not None
+            and legacy.updated_at > credential.updated_at
+        ):
+            credential = await store.update_credential_status(
+                db,
+                credential_id=credential.id,
+                status="ready",
+                redacted_summary_json=json.dumps(
+                    {
+                        "source": "cloud_credential",
+                        "authMode": legacy.auth_mode,
+                    },
+                    sort_keys=True,
+                ),
+            ) or credential
+            changed = True
+        if legacy.provider not in existing_selections:
+            await store.upsert_selection(
+                db,
+                sandbox_profile_id=profile.id,
+                owner_scope="personal",
+                agent_kind=legacy.provider,
+                credential_id=credential.id,
+                credential_share_id=None,
+                materialization_mode="synced_files",
+                selected_revision=credential.revision,
+                status="active",
+                last_error_code=None,
+                last_error_message=None,
+            )
+            changed = True
+    if not changed:
+        return profile
+    updated = await store.bump_sandbox_profile_agent_auth_revision(
+        db,
+        sandbox_profile_id=profile.id,
+        reason="legacy_cloud_credential_import",
+        actor_user_id=actor_user_id,
+        force_restart=False,
+    )
+    return updated or profile
+
+
+async def _ensure_managed_policy(
+    db: AsyncSession,
+    *,
+    credential: AgentAuthCredentialRecord,
+    budget: AgentGatewayBudgetSubjectRecord,
+    sync_status: str,
+    status: str,
+    fingerprint: str | None,
+    error_code: str | None,
+    error_message: str | None,
+) -> AgentGatewayPolicyRecord:
+    virtual_key_id = None
+    virtual_key_ciphertext = None
+    if sync_status == "synced" and budget.litellm_team_id:
+        try:
+            key = await LiteLLMAdminClient().generate_key(
+                team_id=budget.litellm_team_id,
+                key_alias=f"credential-{credential.id}",
+            )
+            virtual_key_id = key.key_id
+            virtual_key_ciphertext = encrypt_text(key.key)
+        except LiteLLMIntegrationError as exc:
+            sync_status = "failed"
+            status = "invalid"
+            error_code = "litellm_key_provisioning_failed"
+            error_message = _safe_error_message(str(exc), {})
+    return await store.ensure_gateway_policy(
+        db,
+        credential_id=credential.id,
+        policy_kind="proliferate_managed",
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=credential.organization_id,
+        budget_subject_id=budget.id,
+        litellm_team_id=budget.litellm_team_id,
+        litellm_virtual_key_id=virtual_key_id,
+        litellm_virtual_key_ciphertext=virtual_key_ciphertext,
+        litellm_virtual_key_ciphertext_key_id=(
+            AGENT_GATEWAY_CIPHERTEXT_KEY_ID if virtual_key_ciphertext else None
+        ),
+        litellm_sync_status=sync_status,
+        litellm_sync_fingerprint=fingerprint,
+        status=status,
+        last_error_code=error_code,
+        last_error_message=error_message,
+    )
+
+
+async def _provision_policy(
+    db: AsyncSession,
+    *,
+    credential: AgentAuthCredentialRecord,
+    policy_kind: str,
+    owner_scope: str,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+    budget_subject_id: UUID | None,
+    provider_kind: str,
+    provider_payload: dict[str, str],
+    model_deployments: Sequence[LiteLLMModelDeploymentRequest],
+) -> tuple[AgentGatewayPolicyRecord, str, str, str | None, str | None]:
+    sync_status = "failed"
+    status = "invalid"
+    litellm_team_id = None
+    virtual_key_id = None
+    virtual_key_ciphertext = None
+    error_code = "litellm_not_configured"
+    error_message = "LiteLLM provisioning is not configured."
+    if not model_deployments:
+        error_code = "model_deployments_not_configured"
+        error_message = "No gateway model deployments are configured for this credential."
+    fingerprint = _deployment_fingerprint(
+        policy_kind=policy_kind,
+        litellm_team_id=None,
+        budget_subject_id=str(budget_subject_id) if budget_subject_id else None,
+        provider_kind=provider_kind,
+        deployments=model_deployments,
+    )
+    if (
+        model_deployments
+        and settings.agent_gateway_enabled
+        and settings.agent_gateway_litellm_master_key
+    ):
+        try:
+            client = LiteLLMAdminClient()
+            team = await client.ensure_team(team_alias=f"credential-{credential.id}")
+            litellm_team_id = team.team_id
+            key = await client.generate_key(
+                team_id=team.team_id,
+                key_alias=f"credential-{credential.id}",
+            )
+            virtual_key_id = key.key_id
+            virtual_key_ciphertext = encrypt_text(key.key)
+            for deployment in model_deployments:
+                await client.create_model_deployment(
+                    public_model_name=deployment.public_model_name,
+                    provider_model=deployment.provider_model,
+                    team_id=team.team_id,
+                    litellm_params=_provider_litellm_params(
+                        provider_kind=provider_kind,
+                        provider_payload=provider_payload,
+                        deployment=deployment,
+                    ),
+                    metadata={
+                        "credentialId": str(credential.id),
+                        "agentKind": credential.agent_kind,
+                    },
+                )
+            sync_status = "synced"
+            status = "ready"
+            fingerprint = _deployment_fingerprint(
+                policy_kind=policy_kind,
+                litellm_team_id=litellm_team_id,
+                budget_subject_id=str(budget_subject_id) if budget_subject_id else None,
+                provider_kind=provider_kind,
+                deployments=model_deployments,
+            )
+            error_code = None
+            error_message = None
+        except LiteLLMIntegrationError as exc:
+            error_code = "litellm_provisioning_failed"
+            error_message = _safe_error_message(str(exc), provider_payload)
+
+    policy = await store.ensure_gateway_policy(
+        db,
+        credential_id=credential.id,
+        policy_kind=policy_kind,
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        budget_subject_id=budget_subject_id,
+        litellm_team_id=litellm_team_id,
+        litellm_virtual_key_id=virtual_key_id,
+        litellm_virtual_key_ciphertext=virtual_key_ciphertext,
+        litellm_virtual_key_ciphertext_key_id=(
+            AGENT_GATEWAY_CIPHERTEXT_KEY_ID if virtual_key_ciphertext else None
+        ),
+        litellm_sync_status=sync_status,
+        litellm_sync_fingerprint=fingerprint,
+        status=status,
+        last_error_code=error_code,
+        last_error_message=error_message,
+    )
+    return policy, sync_status, status, error_code, error_message
+
+
+def _provider_litellm_params(
+    *,
+    provider_kind: str,
+    provider_payload: dict[str, str],
+    deployment: LiteLLMModelDeploymentRequest,
+) -> dict[str, object]:
+    params: dict[str, object] = {}
+    if provider_kind == "anthropic_api_key":
+        params["api_key"] = provider_payload["apiKey"]
+        params.setdefault("custom_llm_provider", "anthropic")
+    elif provider_kind == "openai_api_key":
+        params["api_key"] = provider_payload["apiKey"]
+        params.setdefault("custom_llm_provider", "openai")
+    elif provider_kind == "openai_compatible":
+        params["api_key"] = provider_payload["apiKey"]
+        params["api_base"] = provider_payload["baseUrl"]
+        params.setdefault("custom_llm_provider", "openai")
+    elif provider_kind == "bedrock_assume_role":
+        params["aws_role_name"] = provider_payload["roleArn"]
+        params["aws_external_id"] = provider_payload["externalId"]
+        params["aws_region_name"] = provider_payload["region"]
+        params.setdefault("custom_llm_provider", "bedrock")
+    elif provider_kind == "proliferate_bedrock_pool":
+        params.setdefault("custom_llm_provider", "bedrock")
+    return params
+
+
+def _gateway_deployments_for_credential(
+    *,
+    agent_kind: str,
+    provider_kind: str,
+) -> tuple[LiteLLMModelDeploymentRequest, ...]:
+    if agent_kind == "claude":
+        if provider_kind in {"bedrock_assume_role", "proliferate_bedrock_pool"}:
+            return (
+                LiteLLMModelDeploymentRequest(
+                    publicModelName="us.anthropic.claude-sonnet-4-6",
+                    providerModel="us.anthropic.claude-sonnet-4-6",
+                ),
+            )
+        if provider_kind == "anthropic_api_key":
+            return (
+                LiteLLMModelDeploymentRequest(
+                    publicModelName="us.anthropic.claude-sonnet-4-6",
+                    providerModel="claude-sonnet-4-6",
+                ),
+            )
+    if agent_kind == "codex" and provider_kind in {"openai_api_key", "openai_compatible"}:
+        return (
+            LiteLLMModelDeploymentRequest(
+                publicModelName="gpt-5.5",
+                providerModel="gpt-5.5",
+            ),
+        )
+    if agent_kind == "opencode" and provider_kind in {"openai_api_key", "openai_compatible"}:
+        return (
+            LiteLLMModelDeploymentRequest(
+                publicModelName="opencode/big-pickle",
+                providerModel="gpt-5.5",
+            ),
+        )
+    return ()
+
+
+async def _require_credential_ready_for_selection(
+    db: AsyncSession,
+    credential: AgentAuthCredentialRecord,
+) -> None:
+    if credential.status != "ready" or credential.revoked_at is not None:
+        raise AgentAuthError(
+            "Credential is not ready.",
+            code="credential_not_ready",
+            status_code=409,
+        )
+    if credential.credential_kind != "managed_gateway":
+        return
+    policy = await store.get_gateway_policy_for_credential(db, credential.id)
+    if policy is None or policy.status != "ready" or policy.litellm_sync_status != "synced":
+        raise AgentAuthError(
+            "Gateway policy is not ready.",
+            code="gateway_policy_not_ready",
+            status_code=409,
+        )
+
+
+def _validate_policy_owner_scope(policy_kind: str, owner_scope: str) -> None:
+    if policy_kind == "personal_byok" and owner_scope != "personal":
+        raise AgentAuthError(
+            "personal_byok can only be used for personal credentials.",
+            code="policy_owner_scope_mismatch",
+            status_code=400,
+        )
+    if policy_kind == "org_byok" and owner_scope != "organization":
+        raise AgentAuthError(
+            "org_byok can only be used for organization credentials.",
+            code="policy_owner_scope_mismatch",
+            status_code=400,
+        )
+
+
+def _safe_error_message(
+    message: str | None,
+    secret_payload: dict[str, str],
+) -> str | None:
+    if message is None:
+        return None
+    safe = message
+    for value in secret_payload.values():
+        if value:
+            safe = safe.replace(value, "[REDACTED]")
+    return safe[:1000]
+
+
+@dataclass(frozen=True)
+class _ProviderValidation:
+    status: str
+    redacted_summary: dict[str, object]
+    error_code: str | None
+    error_message: str | None
+
+
+def _validate_provider_payload(
+    provider_kind: str,
+    payload: dict[str, str],
+) -> _ProviderValidation:
+    try:
+        if provider_kind in {"anthropic_api_key", "openai_api_key"}:
+            api_key = payload.get("apiKey", "").strip()
+            if not api_key:
+                raise AgentAuthError(
+                    "apiKey is required.", code="missing_api_key", status_code=400
+                )
+            return _ProviderValidation(
+                status="unvalidated",
+                redacted_summary={
+                    "providerKind": provider_kind,
+                    "apiKey": _redact_secret(api_key),
+                },
+                error_code="provider_live_validation_deferred",
+                error_message="Provider credentials require live validation before use.",
+            )
+        if provider_kind == "bedrock_assume_role":
+            result = validate_bedrock_assume_role_payload(
+                role_arn=payload.get("roleArn", ""),
+                external_id=payload.get("externalId", ""),
+                region=payload.get("region", ""),
+            )
+            return _ProviderValidation(
+                status="unvalidated",
+                redacted_summary={
+                    "providerKind": provider_kind,
+                    "roleArn": result.role_arn,
+                    "region": result.region,
+                    "accountId": result.account_id,
+                },
+                error_code="provider_live_validation_deferred",
+                error_message="Provider credentials require live validation before use.",
+            )
+        if provider_kind == "openai_compatible":
+            base_url = _validate_openai_compatible_url(payload.get("baseUrl", ""))
+            api_key = payload.get("apiKey", "").strip()
+            if not api_key:
+                raise AgentAuthError(
+                    "apiKey is required.", code="missing_api_key", status_code=400
+                )
+            return _ProviderValidation(
+                status="unvalidated",
+                redacted_summary={
+                    "providerKind": provider_kind,
+                    "baseUrl": base_url,
+                    "apiKey": _redact_secret(api_key),
+                },
+                error_code="provider_live_validation_deferred",
+                error_message="Provider credentials require live validation before use.",
+            )
+    except AwsIntegrationError as exc:
+        return _ProviderValidation(
+            status="invalid",
+            redacted_summary={"providerKind": provider_kind},
+            error_code=exc.code,
+            error_message=str(exc),
+        )
+    raise AgentAuthError(
+        "Unsupported provider kind.", code="unsupported_provider_kind", status_code=400
+    )
+
+
+def _validate_openai_compatible_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url.strip())
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise AgentAuthError(
+            "OpenAI-compatible base URL must be an HTTPS URL.",
+            code="invalid_base_url",
+            status_code=400,
+        )
+    host = parsed.hostname
+    if host is None:
+        raise AgentAuthError(
+            "OpenAI-compatible base URL host is required.",
+            code="invalid_base_url",
+            status_code=400,
+        )
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        raise AgentAuthError(
+            "OpenAI-compatible base URL cannot point to localhost.",
+            code="invalid_base_url",
+            status_code=400,
+        )
+    try:
+        addresses = {item[4][0] for item in socket.getaddrinfo(host, None)}
+    except socket.gaierror as exc:
+        raise AgentAuthError(
+            "OpenAI-compatible base URL host could not be resolved.",
+            code="invalid_base_url",
+            status_code=400,
+        ) from exc
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast:
+            raise AgentAuthError(
+                "OpenAI-compatible base URL cannot resolve to a private network.",
+                code="invalid_base_url",
+                status_code=400,
+            )
+    return raw_url.strip().rstrip("/")
+
+
+def _deployment_fingerprint(
+    *,
+    policy_kind: str,
+    litellm_team_id: str | None,
+    budget_subject_id: str | None,
+    provider_kind: str | None,
+    deployments: Sequence[LiteLLMModelDeploymentRequest],
+) -> str:
+    return fingerprint_litellm_policy_state(
+        policy_kind=policy_kind,
+        litellm_team_id=litellm_team_id,
+        budget_subject_id=budget_subject_id,
+        provider_kind=provider_kind,
+        model_deployments=[
+            LiteLLMModelDeploymentPlan(
+                public_model_name=item.public_model_name,
+                provider_model=item.provider_model,
+                litellm_params={},
+            )
+            for item in deployments
+        ],
+    )
+
+
+async def _require_profile_access(
+    db: AsyncSession,
+    actor_user_id: UUID,
+    sandbox_profile_id: UUID,
+    *,
+    admin: bool,
+) -> SandboxProfileRecord:
+    profile = await store.get_sandbox_profile(db, sandbox_profile_id)
+    if profile is None:
+        raise AgentAuthError(
+            "Sandbox profile not found.", code="sandbox_profile_not_found", status_code=404
+        )
+    if profile.owner_scope == "personal":
+        if profile.owner_user_id != actor_user_id:
+            raise AgentAuthError(
+                "Sandbox profile not found.", code="sandbox_profile_not_found", status_code=404
+            )
+        return profile
+    if profile.organization_id is None:
+        raise AgentAuthError("Sandbox profile is invalid.", code="invalid_sandbox_profile")
+    if admin:
+        await _require_organization_admin(db, actor_user_id, profile.organization_id)
+    else:
+        await _require_organization_member(db, actor_user_id, profile.organization_id)
+    return profile
+
+
+async def _require_can_manage_credential(
+    db: AsyncSession,
+    actor_user_id: UUID,
+    credential: AgentAuthCredentialRecord,
+) -> None:
+    if credential.owner_scope == "personal":
+        if credential.owner_user_id != actor_user_id:
+            raise AgentAuthError(
+                "Credential not found.", code="credential_not_found", status_code=404
+            )
+        return
+    if credential.owner_scope == "organization" and credential.organization_id is not None:
+        await _require_organization_admin(db, actor_user_id, credential.organization_id)
+        return
+    raise AgentAuthError(
+        "Credential cannot be modified.", code="credential_modify_forbidden", status_code=403
+    )
+
+
+async def _require_organization_member(
+    db: AsyncSession,
+    actor_user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    membership = await organization_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=actor_user_id,
+    )
+    if membership is None:
+        raise AgentAuthError(
+            "Organization not found.", code="organization_not_found", status_code=404
+        )
+
+
+async def _require_organization_admin(
+    db: AsyncSession,
+    actor_user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    membership = await organization_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=actor_user_id,
+    )
+    if membership is None:
+        raise AgentAuthError(
+            "Organization not found.", code="organization_not_found", status_code=404
+        )
+    if membership.role not in _ORG_ADMIN_ROLES:
+        raise AgentAuthError(
+            "You do not have permission to manage this organization.",
+            code="organization_permission_denied",
+            status_code=403,
+        )
+
+
+async def _bump_profile_for_selection(
+    db: AsyncSession,
+    selection: SandboxAgentAuthSelectionRecord,
+    *,
+    actor_user_id: UUID,
+    reason: str,
+    force_restart: bool,
+) -> None:
+    updated_profile = await store.bump_sandbox_profile_agent_auth_revision(
+        db,
+        sandbox_profile_id=selection.sandbox_profile_id,
+        reason=reason,
+        actor_user_id=actor_user_id,
+        force_restart=force_restart,
+    )
+    if updated_profile is not None and updated_profile.managed_target_id is not None:
+        await store.upsert_target_state(
+            db,
+            sandbox_profile_id=updated_profile.id,
+            target_id=updated_profile.managed_target_id,
+            desired_revision=updated_profile.agent_auth_revision,
+            applied_revision=None,
+            status="pending",
+            force_restart_required=force_restart,
+            last_command_id=None,
+            last_worker_id=None,
+            last_error_code=None,
+            last_error_message=None,
+        )
+    await store.revoke_runtime_grants_for_selection(db, selection_id=selection.id)
+
+
+def _hash_token(raw_token: str) -> str:
+    return hmac.new(
+        settings.cloud_secret_key.encode("utf-8"),
+        f"{AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN}:{raw_token}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _clean_display_name(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise AgentAuthError(
+            "displayName is required.", code="missing_display_name", status_code=400
+        )
+    if len(cleaned) > 255:
+        raise AgentAuthError(
+            "displayName is too long.", code="display_name_too_long", status_code=400
+        )
+    return cleaned
+
+
+def _budget_amount(value: str) -> str:
+    try:
+        amount = Decimal(value)
+    except InvalidOperation as exc:
+        raise AgentAuthError(
+            "Included budget must be a decimal string.", code="invalid_budget", status_code=400
+        ) from exc
+    if amount < 0:
+        raise AgentAuthError(
+            "Included budget must be non-negative.", code="invalid_budget", status_code=400
+        )
+    return format(amount, "f")
+
+
+def _redact_secret(value: str) -> str:
+    if len(value) <= 8:
+        return "[REDACTED]"
+    return f"{value[:4]}...{value[-4:]}"

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from proliferate.server.cloud.agent_auth.api import router as agent_auth_router
 from proliferate.server.cloud.backfill.api import router as backfill_router
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.compute.api import router as compute_router
@@ -33,6 +34,7 @@ router.include_router(worktree_policy_router)
 router.include_router(workspaces_router)
 router.include_router(mobility_router)
 router.include_router(credentials_router)
+router.include_router(agent_auth_router)
 router.include_router(mcp_catalog_router)
 router.include_router(mcp_connections_router)
 router.include_router(mcp_materialization_router)

--- a/server/proliferate/server/cloud/credentials/domain/status.py
+++ b/server/proliferate/server/cloud/credentials/domain/status.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS, CloudAgentKind
+from proliferate.constants.cloud import SUPPORTED_CLOUD_CREDENTIAL_SYNC_AGENTS, CloudAgentKind
 from proliferate.server.cloud.credentials.domain.types import CloudCredentialAuthMode
 
 _DEFAULT_AUTH_MODES: dict[CloudAgentKind, CloudCredentialAuthMode] = {
@@ -30,11 +30,14 @@ def build_credential_statuses(
     by_provider: dict[str, object] = {}
     for record in records:
         provider = getattr(record, "provider", None)
-        if provider in SUPPORTED_CLOUD_AGENTS and getattr(record, "revoked_at", None) is None:
+        if (
+            provider in SUPPORTED_CLOUD_CREDENTIAL_SYNC_AGENTS
+            and getattr(record, "revoked_at", None) is None
+        ):
             by_provider[provider] = record
 
     statuses: list[CredentialStatusRecord] = []
-    for provider in SUPPORTED_CLOUD_AGENTS:
+    for provider in SUPPORTED_CLOUD_CREDENTIAL_SYNC_AGENTS:
         record = by_provider.get(provider)
         raw_auth_mode = (
             getattr(record, "auth_mode", None) if record else None
@@ -57,7 +60,7 @@ def build_credential_statuses(
 
 
 def allowed_agent_kinds() -> list[CloudAgentKind]:
-    return list(SUPPORTED_CLOUD_AGENTS)
+    return list(SUPPORTED_CLOUD_CREDENTIAL_SYNC_AGENTS)
 
 
 def ready_agent_kinds(statuses: Sequence[CredentialStatusRecord]) -> list[CloudAgentKind]:

--- a/server/proliferate/server/cloud/credentials/domain/sync_payload.py
+++ b/server/proliferate/server/cloud/credentials/domain/sync_payload.py
@@ -107,7 +107,10 @@ def normalize_cloud_credential_payload(
 
 
 def _provider_spec(provider: CloudAgentKind) -> CredentialProviderSpec:
-    return _CREDENTIAL_SPECS[provider]
+    spec = _CREDENTIAL_SPECS.get(provider)
+    if spec is None:
+        _invalid_payload(f"Cloud credential sync is not supported for provider '{provider}'.")
+    return spec
 
 
 def _normalize_env_payload(

--- a/server/proliferate/server/cloud/credentials/service.py
+++ b/server/proliferate/server/cloud/credentials/service.py
@@ -14,6 +14,9 @@ from proliferate.db.store.cloud_credentials import (
     get_user_cloud_credentials,
     sync_cloud_credential_if_changed,
 )
+from proliferate.server.cloud.agent_auth.service import (
+    reconcile_legacy_cloud_credentials_for_user,
+)
 from proliferate.server.cloud.credentials.domain.status import (
     CredentialStatusRecord,
     build_credential_statuses,
@@ -84,13 +87,20 @@ async def sync_cloud_credential_for_user(
         env_vars=getattr(body, "env_vars", None),
         files=getattr(body, "files", None),
     )
-    return await _persist_cloud_credential_if_changed(
+    changed = await _persist_cloud_credential_if_changed(
         db,
         user_id=user_id,
         provider=provider,
         payload=normalized.payload,
         auth_mode=normalized.auth_mode,
     )
+    if changed:
+        await reconcile_legacy_cloud_credentials_for_user(
+            db,
+            actor_user_id=user_id,
+            create_profile=True,
+        )
+    return changed
 
 
 async def _persist_cloud_credential_if_changed(
@@ -117,4 +127,11 @@ async def delete_cloud_credential_for_user(
     user_id: UUID,
     provider: CloudAgentKind,
 ) -> bool:
-    return await delete_cloud_credential(db, user_id, provider)
+    changed = await delete_cloud_credential(db, user_id, provider)
+    if changed:
+        await reconcile_legacy_cloud_credentials_for_user(
+            db,
+            actor_user_id=user_id,
+            create_profile=False,
+        )
+    return changed

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -237,10 +237,7 @@ async def _check_component_binary_preinstalled(
         workspace_id=workspace_id,
         label=f"check_{label_prefix}_binary_sha256",
         command=(
-            "bash -lc "
-            + shlex.quote(
-                f"sha256sum {shlex.quote(remote_path)} | cut -d' ' -f1"
-            )
+            "bash -lc " + shlex.quote(f"sha256sum {shlex.quote(remote_path)} | cut -d' ' -f1")
         ),
         runtime_context=runtime_context,
         timeout_seconds=30,

--- a/server/proliferate/server/cloud/runtime/git_operations.py
+++ b/server/proliferate/server/cloud/runtime/git_operations.py
@@ -47,7 +47,8 @@ async def clone_repository(
         workspace_id=ctx.workspace_id,
         label="ensure_git_available",
         command=(
-            'bash -lc "command -v git >/dev/null 2>&1 || (apt-get update && apt-get install -y git)"'
+            'bash -lc "command -v git >/dev/null 2>&1 || '
+            '(apt-get update && apt-get install -y git)"'
         ),
         user="root",
         timeout_seconds=240,

--- a/server/proliferate/server/cloud/runtime/sandbox_exec.py
+++ b/server/proliferate/server/cloud/runtime/sandbox_exec.py
@@ -92,7 +92,7 @@ def _redacted_launcher_command(path: str) -> str:
         "awk 'BEGIN { IGNORECASE = 1 } "
         "/^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*"
         "(TOKEN|KEY|SECRET|PASSWORD|AUTH|CREDENTIAL|COOKIE)[A-Za-z0-9_]*=/ "
-        "{ sub(/=.*/, \"=<redacted>\"); print; next } "
+        '{ sub(/=.*/, "=<redacted>"); print; next } '
         "{ print }' "
         f"{path} || true"
     )
@@ -104,7 +104,7 @@ def _redacted_supervisor_config_command(path: str) -> str:
         "/^\\[anyharness_env\\]/ { in_env = 1; print; next } "
         "/^\\[/ { in_env = 0 } "
         "in_env && /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ "
-        "{ sub(/=.*/, \"= \\\"<redacted>\\\"\"); print; next } "
+        '{ sub(/=.*/, "= \\"<redacted>\\""); print; next } '
         "{ print }' "
         f"{path} || true"
     )

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -1134,7 +1134,8 @@ async def get_cloud_connection(
     ):
         raise CloudApiError(
             "direct_target_connection_required",
-            "This workspace runs on an SSH target and must be opened through direct target access.",
+            "This workspace runs on an SSH target and must be opened through "
+            "direct target access.",
             status_code=409,
         )
     try:

--- a/server/tests/integration/schema_migration_assertions.py
+++ b/server/tests/integration/schema_migration_assertions.py
@@ -23,6 +23,17 @@ async def assert_current_schema(
         "cloud_workspace_handoff_op",
         "cloud_workspace_mobility",
         "cloud_sandbox",
+        "agent_auth_audit_event",
+        "agent_auth_credential",
+        "agent_auth_credential_share",
+        "agent_gateway_budget_subject",
+        "agent_gateway_policy",
+        "agent_gateway_provider_credential",
+        "agent_gateway_runtime_grant",
+        "sandbox_agent_auth_selection",
+        "sandbox_profile",
+        "sandbox_profile_agent_auth_revision",
+        "sandbox_profile_agent_auth_target_state",
         "cloud_worktree_retention_policy",
         "cloud_workspace",
         "desktop_auth_code",
@@ -275,6 +286,45 @@ async def assert_current_schema(
         "settings_json",
         "config_version",
     } <= mcp_connection_columns
+
+    agent_auth_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"] for index in inspect(sync_conn).get_indexes("agent_auth_credential")
+        }
+    )
+    assert {
+        "ix_agent_auth_credential_owner_user_kind_status",
+        "ix_agent_auth_credential_org_kind_status",
+    } <= agent_auth_indexes
+
+    sandbox_profile_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"] for index in inspect(sync_conn).get_indexes("sandbox_profile")
+        }
+    )
+    assert {
+        "uq_sandbox_profile_active_personal_user",
+        "uq_sandbox_profile_active_organization",
+    } <= sandbox_profile_indexes
+
+    target_state_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"]
+            for index in inspect(sync_conn).get_indexes("sandbox_profile_agent_auth_target_state")
+        }
+    )
+    assert "uq_sandbox_profile_agent_auth_target_state_target_profile" in target_state_indexes
+
+    runtime_grant_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"]
+            for index in inspect(sync_conn).get_indexes("agent_gateway_runtime_grant")
+        }
+    )
+    assert {
+        "uq_agent_gateway_runtime_grant_token_hash",
+        "ix_agent_gateway_runtime_grant_target_profile_agent",
+    } <= runtime_grant_indexes
 
     version = await conn.scalar(text("SELECT version_num FROM alembic_version"))
     assert version == head_revision

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -10,6 +10,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.config import settings
 from proliferate.db.models.auth import User
 from proliferate.db.models.cloud.targets import CloudTarget
 from proliferate.db.store.cloud_agent_auth import store
@@ -25,6 +26,11 @@ class _GatewaySeed:
     sandbox_profile_id: UUID
     policy_id: UUID
     selection_id: UUID
+
+
+@pytest.fixture(autouse=True)
+def _enable_agent_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
 
 
 async def _seed_gateway_grant(
@@ -148,14 +154,23 @@ async def test_anthropic_gateway_forwards_valid_grant_to_litellm(
     )
 
     response = await client.post(
-        "/anthropic/v1/messages",
-        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        "/anthropic/v1/messages?beta=true",
+        headers={
+            "Authorization": f"Bearer {seed.raw_token}",
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "messages-2023-12-15",
+        },
         json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
     )
 
     assert response.status_code == 200
     assert response.json() == {"ok": True}
     assert fake_client.calls[0]["path"] == "/v1/messages"
+    assert fake_client.calls[0]["query_string"] == "beta=true"
+    assert fake_client.calls[0]["protocol_headers"] == {
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "messages-2023-12-15",
+    }
     assert fake_client.calls[0]["litellm_key"] == "litellm-runtime-key"
     assert fake_client.calls[0]["metadata"] == {
         "target_id": str(seed.target_id),
@@ -176,6 +191,59 @@ async def test_gateway_rejects_invalid_token(client: AsyncClient) -> None:
 
     assert response.status_code == 401
     assert response.json()["detail"]["code"] == "invalid_gateway_token"
+
+
+@pytest.mark.asyncio
+async def test_gateway_fails_closed_when_disabled(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    monkeypatch.setattr(settings, "agent_gateway_enabled", False)
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "gateway_route_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_oversized_body_before_authorization(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_max_request_bytes", 8)
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": "Bearer invalid"},
+        content=b'{"model":"too-large"}',
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "gateway_request_too_large"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_missing_model(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"messages": []},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_model"
 
 
 @pytest.mark.asyncio
@@ -215,6 +283,71 @@ async def test_gateway_rejects_revoked_token(
 
 
 @pytest.mark.asyncio
+async def test_gateway_rejects_stale_profile_revision(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    await store.bump_sandbox_profile_agent_auth_revision(
+        db_session,
+        sandbox_profile_id=seed.sandbox_profile_id,
+        reason="test_revision_change",
+        actor_user_id=None,
+        force_restart=True,
+    )
+    await db_session.commit()
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_gateway_token"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_grant_after_target_rebind(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    profile = await store.get_sandbox_profile(db_session, seed.sandbox_profile_id)
+    assert profile is not None
+    user_id = profile.owner_user_id
+    assert user_id is not None
+    target = CloudTarget(
+        display_name="Replacement Target",
+        kind="managed_cloud",
+        status="online",
+        owner_scope="personal",
+        owner_user_id=user_id,
+        organization_id=None,
+        created_by_user_id=user_id,
+        default_workspace_root=None,
+        update_channel="stable",
+    )
+    db_session.add(target)
+    await db_session.flush()
+    await store.ensure_personal_sandbox_profile(
+        db_session,
+        user_id=user_id,
+        managed_target_id=target.id,
+    )
+    await db_session.commit()
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_gateway_token"
+
+
+@pytest.mark.asyncio
 async def test_gateway_rejects_unavailable_model(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -229,6 +362,40 @@ async def test_gateway_rejects_unavailable_model(
 
     assert response.status_code == 404
     assert response.json()["detail"]["code"] == "model_not_available"
+
+
+@pytest.mark.asyncio
+async def test_runtime_grant_rotation_keeps_one_grace_grant(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    profile = await store.get_sandbox_profile(db_session, seed.sandbox_profile_id)
+    selection = await store.get_selection(db_session, seed.selection_id)
+    assert profile is not None
+    assert selection is not None
+
+    await issue_runtime_grant_for_selection(
+        db_session,
+        selection=selection,
+        profile=profile,
+        target_id=seed.target_id,
+    )
+    await issue_runtime_grant_for_selection(
+        db_session,
+        selection=selection,
+        profile=profile,
+        target_id=seed.target_id,
+    )
+    active = await store.list_active_runtime_grants_for_route(
+        db_session,
+        policy_id=seed.policy_id,
+        target_id=seed.target_id,
+        sandbox_profile_id=seed.sandbox_profile_id,
+        agent_kind="claude",
+        now=profile.updated_at,
+    )
+
+    assert len(active) == 2
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from unittest.mock import ANY
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.targets import CloudTarget
+from proliferate.db.store.cloud_agent_auth import store
+from proliferate.integrations.litellm import LiteLLMRuntimeResponse, LiteLLMRuntimeStatusError
+from proliferate.server.cloud.agent_auth.service import issue_runtime_grant_for_selection
+from proliferate.utils.crypto import encrypt_text
+
+
+@dataclass(frozen=True)
+class _GatewaySeed:
+    raw_token: str
+    target_id: UUID
+    sandbox_profile_id: UUID
+    policy_id: UUID
+    selection_id: UUID
+
+
+async def _seed_gateway_grant(
+    db_session: AsyncSession,
+    *,
+    agent_kind: str = "claude",
+    materialization_mode: str = "gateway_env",
+) -> _GatewaySeed:
+    user = User(
+        email=f"gateway-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="unused",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        display_name="Gateway User",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    target = CloudTarget(
+        display_name="Gateway Test Target",
+        kind="managed_cloud",
+        status="online",
+        owner_scope="personal",
+        owner_user_id=user.id,
+        organization_id=None,
+        created_by_user_id=user.id,
+        default_workspace_root=None,
+        update_channel="stable",
+    )
+    db_session.add(target)
+    await db_session.flush()
+    profile = await store.ensure_personal_sandbox_profile(
+        db_session,
+        user_id=user.id,
+        managed_target_id=target.id,
+    )
+    credential = await store.create_agent_auth_credential(
+        db_session,
+        owner_scope="personal",
+        owner_user_id=user.id,
+        organization_id=None,
+        created_by_user_id=user.id,
+        agent_kind=agent_kind,
+        credential_kind="managed_gateway",
+        display_name="Gateway test credential",
+        redacted_summary_json=json.dumps({"providerKind": "test"}, sort_keys=True),
+        status="ready",
+    )
+    policy = await store.ensure_gateway_policy(
+        db_session,
+        credential_id=credential.id,
+        policy_kind="personal_byok",
+        owner_scope="personal",
+        owner_user_id=user.id,
+        organization_id=None,
+        budget_subject_id=None,
+        litellm_team_id="team-test",
+        litellm_virtual_key_id="key-test",
+        litellm_virtual_key_ciphertext=encrypt_text("litellm-runtime-key"),
+        litellm_virtual_key_ciphertext_key_id="cloud_secret_key:v1",
+        litellm_sync_status="synced",
+        litellm_sync_fingerprint="fingerprint",
+        status="ready",
+    )
+    selection = await store.upsert_selection(
+        db_session,
+        sandbox_profile_id=profile.id,
+        owner_scope="personal",
+        agent_kind=agent_kind,
+        credential_id=credential.id,
+        credential_share_id=None,
+        materialization_mode=materialization_mode,
+        selected_revision=credential.revision,
+        status="active",
+        last_error_code=None,
+        last_error_message=None,
+    )
+    result = await issue_runtime_grant_for_selection(
+        db_session,
+        selection=selection,
+        profile=profile,
+        target_id=target.id,
+    )
+    await db_session.commit()
+    return _GatewaySeed(
+        raw_token=result.raw_token,
+        target_id=target.id,
+        sandbox_profile_id=profile.id,
+        policy_id=policy.id,
+        selection_id=selection.id,
+    )
+
+
+class _FakeRuntimeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.error: Exception | None = None
+
+    async def forward(self, **kwargs: object) -> LiteLLMRuntimeResponse:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return LiteLLMRuntimeResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            content=b'{"ok":true}',
+        )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_gateway_forwards_valid_grant_to_litellm(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    fake_client = _FakeRuntimeClient()
+    monkeypatch.setattr(
+        "proliferate.server.agent_gateway.service.LiteLLMRuntimeClient",
+        lambda: fake_client,
+    )
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert fake_client.calls[0]["path"] == "/v1/messages"
+    assert fake_client.calls[0]["litellm_key"] == "litellm-runtime-key"
+    assert fake_client.calls[0]["metadata"] == {
+        "target_id": str(seed.target_id),
+        "sandbox_profile_id": str(seed.sandbox_profile_id),
+        "agent_kind": "claude",
+        "policy_id": str(seed.policy_id),
+        "user_id": ANY,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_invalid_token(client: AsyncClient) -> None:
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": "Bearer nope"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_gateway_token"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_wrong_protocol(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+
+    response = await client.post(
+        "/openai/v1/responses",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "gpt-5.5", "input": "hello"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "protocol_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_revoked_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    await store.revoke_runtime_grants_for_selection(db_session, selection_id=seed.selection_id)
+    await db_session.commit()
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_gateway_token"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_unavailable_model(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "not-allowed", "messages": []},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "model_not_available"
+
+
+@pytest.mark.asyncio
+async def test_gateway_maps_litellm_budget_errors(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+    fake_client = _FakeRuntimeClient()
+    fake_client.error = LiteLLMRuntimeStatusError(
+        "budget",
+        status_code=429,
+        body=b"max_budget exceeded",
+    )
+    monkeypatch.setattr(
+        "proliferate.server.agent_gateway.service.LiteLLMRuntimeClient",
+        lambda: fake_client,
+    )
+
+    response = await client.post(
+        "/anthropic/v1/messages",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+        json={"model": "us.anthropic.claude-sonnet-4-6", "messages": []},
+    )
+
+    assert response.status_code == 402
+    assert response.json()["detail"]["code"] == "credits_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_gateway_models_endpoint_returns_allowed_models(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_gateway_grant(db_session)
+
+    response = await client.get(
+        "/anthropic/v1/models",
+        headers={"Authorization": f"Bearer {seed.raw_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"][0]["id"] == "us.anthropic.claude-sonnet-4-6"

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import base64
-import hashlib
 import uuid
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.models.auth import User
+from proliferate.db.models.auth import OAuthAccount, User
+from tests.helpers.desktop_auth import mint_desktop_token_payload
 
 
 async def _create_user_and_get_tokens(
@@ -26,37 +25,26 @@ async def _create_user_and_get_tokens(
         display_name="Agent Auth Tester",
     )
     db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="github",
+            access_token="github-access-token",
+            account_id=f"github-{user.id}",
+            account_email=email,
+        )
+    )
     await db_session.commit()
 
-    verifier = "test-code-verifier-that-is-long-enough-for-pkce"
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-    response = await client.post(
-        "/auth/desktop/authorize",
-        params={"user_id": str(user.id)},
-        json={
-            "state": f"agent-auth-state-{uuid.uuid4().hex[:8]}",
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-            "redirect_uri": "proliferate://auth/callback",
-        },
+    token_data = await mint_desktop_token_payload(
+        client,
+        user_id=user.id,
+        state_prefix="agent-auth-state",
     )
-    assert response.status_code == 201
-
-    response = await client.post(
-        "/auth/desktop/token",
-        json={
-            "code": response.json()["code"],
-            "code_verifier": verifier,
-            "grant_type": "authorization_code",
-        },
-    )
-    assert response.status_code == 200
-    token_data = response.json()
     return {
         "user_id": str(user.id),
-        "access_token": token_data["access_token"],
+        "access_token": str(token_data["access_token"]),
     }
 
 
@@ -103,6 +91,115 @@ async def test_personal_profile_backfills_legacy_cloud_credentials(
     selections = response.json()
     assert selections[0]["agentKind"] == "claude"
     assert selections[0]["materializationMode"] == "synced_files"
+
+
+@pytest.mark.asyncio
+async def test_legacy_cloud_credential_update_reconciles_existing_selection(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-legacy-update@example.com",
+    )
+
+    response = await client.put(
+        "/v1/cloud/credentials/claude",
+        headers=_headers(tokens),
+        json={
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "first-key"},
+        },
+    )
+    assert response.status_code == 200
+
+    response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+    profile = response.json()
+
+    response = await client.get(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-selections",
+        headers=_headers(tokens),
+    )
+    assert response.status_code == 200
+    original_selection = response.json()[0]
+
+    response = await client.put(
+        "/v1/cloud/credentials/claude",
+        headers=_headers(tokens),
+        json={
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "second-key"},
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["changed"] is True
+
+    response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+    assert response.json()["agentAuthRevision"] == 2
+
+    response = await client.get(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-selections",
+        headers=_headers(tokens),
+    )
+    assert response.status_code == 200
+    updated_selection = response.json()[0]
+    assert updated_selection["status"] == "active"
+    assert updated_selection["agentKind"] == "claude"
+    assert updated_selection["credentialId"] != original_selection["credentialId"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_cloud_credential_delete_invalidates_existing_selection(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-legacy-delete@example.com",
+    )
+
+    response = await client.put(
+        "/v1/cloud/credentials/claude",
+        headers=_headers(tokens),
+        json={
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "test-anthropic-key"},
+        },
+    )
+    assert response.status_code == 200
+
+    response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+    profile = response.json()
+
+    response = await client.delete("/v1/cloud/credentials/claude", headers=_headers(tokens))
+    assert response.status_code == 200
+    assert response.json()["changed"] is True
+
+    response = await client.get(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-selections",
+        headers=_headers(tokens),
+    )
+    assert response.status_code == 200
+    selection = response.json()[0]
+    assert selection["status"] == "invalid"
+    assert selection["lastErrorCode"] == "legacy_cloud_credential_revoked"
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+
+
+async def _create_user_and_get_tokens(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    *,
+    email: str,
+) -> dict[str, str]:
+    user = User(
+        email=email,
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        display_name="Agent Auth Tester",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    verifier = "test-code-verifier-that-is-long-enough-for-pkce"
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    response = await client.post(
+        "/auth/desktop/authorize",
+        params={"user_id": str(user.id)},
+        json={
+            "state": f"agent-auth-state-{uuid.uuid4().hex[:8]}",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "proliferate://auth/callback",
+        },
+    )
+    assert response.status_code == 201
+
+    response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": response.json()["code"],
+            "code_verifier": verifier,
+            "grant_type": "authorization_code",
+        },
+    )
+    assert response.status_code == 200
+    token_data = response.json()
+    return {
+        "user_id": str(user.id),
+        "access_token": token_data["access_token"],
+    }
+
+
+def _headers(tokens: dict[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_personal_profile_backfills_legacy_cloud_credentials(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-backfill@example.com",
+    )
+
+    response = await client.put(
+        "/v1/cloud/credentials/claude",
+        headers=_headers(tokens),
+        json={
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "test-anthropic-key"},
+        },
+    )
+    assert response.status_code == 200
+
+    response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+    profile = response.json()
+    assert profile["ownerScope"] == "personal"
+    assert profile["agentAuthRevision"] == 1
+
+    response = await client.get(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-selections",
+        headers=_headers(tokens),
+    )
+    assert response.status_code == 200
+    selections = response.json()
+    assert selections[0]["agentKind"] == "claude"
+    assert selections[0]["materializationMode"] == "synced_files"
+
+
+@pytest.mark.asyncio
+async def test_gateway_credential_fails_closed_without_live_provider_validation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-gateway@example.com",
+    )
+
+    response = await client.post(
+        "/v1/cloud/agent-auth/credentials/gateway",
+        headers=_headers(tokens),
+        json={
+            "ownerScope": "personal",
+            "agentKind": "claude",
+            "displayName": "Personal Anthropic gateway",
+            "policyKind": "personal_byok",
+            "providerKind": "anthropic_api_key",
+            "payload": {"apiKey": "sk-ant-test"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["credential"]["status"] == "invalid"
+    assert body["policy"]["litellmSyncStatus"] == "failed"
+    assert body["policy"]["lastErrorCode"] == "provider_live_validation_deferred"
+    assert body["providerCredential"]["validationStatus"] == "unvalidated"
+    assert body["providerCredential"]["redactedSummary"]["apiKey"] == "sk-a...test"
+
+
+@pytest.mark.asyncio
+async def test_invalid_gateway_credential_cannot_be_selected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-select-invalid@example.com",
+    )
+
+    credential_response = await client.post(
+        "/v1/cloud/agent-auth/credentials/gateway",
+        headers=_headers(tokens),
+        json={
+            "ownerScope": "personal",
+            "agentKind": "claude",
+            "displayName": "Invalid Anthropic gateway",
+            "policyKind": "personal_byok",
+            "providerKind": "anthropic_api_key",
+            "payload": {"apiKey": "sk-ant-test"},
+        },
+    )
+    assert credential_response.status_code == 200
+    credential_id = credential_response.json()["credential"]["id"]
+
+    profile_response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert profile_response.status_code == 200
+    profile_id = profile_response.json()["id"]
+
+    select_response = await client.put(
+        f"/v1/cloud/sandbox-profiles/{profile_id}/agent-auth-selections/claude",
+        headers=_headers(tokens),
+        json={"credentialId": credential_id},
+    )
+    assert select_response.status_code == 409
+    assert select_response.json()["detail"]["code"] == "credential_not_ready"
+
+
+@pytest.mark.asyncio
+async def test_gateway_policy_kind_must_match_owner_scope(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-policy-scope@example.com",
+    )
+
+    response = await client.post(
+        "/v1/cloud/agent-auth/credentials/gateway",
+        headers=_headers(tokens),
+        json={
+            "ownerScope": "personal",
+            "agentKind": "claude",
+            "displayName": "Wrong policy scope",
+            "policyKind": "org_byok",
+            "providerKind": "anthropic_api_key",
+            "payload": {"apiKey": "sk-ant-test"},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "policy_owner_scope_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_managed_credits_route_is_not_customer_accessible(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-managed-credits@example.com",
+    )
+
+    response = await client.post(
+        f"/v1/cloud/agent-auth/managed-credits/organizations/{uuid.uuid4()}",
+        headers=_headers(tokens),
+        json={"includedBudgetUsd": "999999"},
+    )
+
+    assert response.status_code == 404

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -216,7 +216,7 @@ def _patch_repo_branches_lookup(
 ) -> None:
     monkeypatch.setattr(repos_service, "get_github_repo_branches", resolver)
     monkeypatch.setattr(cloud_service, "get_github_repo_branches", resolver)
-    monkeypatch.setattr(repo_config_service, "get_repo_branches_for_user", resolver)
+    monkeypatch.setattr(repo_config_service, "get_repo_branches_for_credentials", resolver)
 
 
 class TestCloudWorktreeRetentionPolicy:

--- a/server/tests/integration/test_cloud_event_sync_api.py
+++ b/server/tests/integration/test_cloud_event_sync_api.py
@@ -406,9 +406,7 @@ class TestCloudEventSyncApi:
             assert _sse_event(target_snapshot_frame) == "snapshot"
             assert _mapping(_sse_data(target_snapshot_frame)["target"])["id"] == target_id
 
-            cursor_task: asyncio.Task[str] = asyncio.create_task(
-                _next_stream_frame(target_stream)
-            )
+            cursor_task: asyncio.Task[str] = asyncio.create_task(_next_stream_frame(target_stream))
             bus = get_pubsub_bus()
             await bus.publish(
                 target_channel(target_id=UUID(target_id)),

--- a/server/tests/unit/auth/test_desktop_customerio.py
+++ b/server/tests/unit/auth/test_desktop_customerio.py
@@ -65,6 +65,12 @@ def _github_profile() -> SimpleNamespace:
     )
 
 
+def _stub_identity_attachment(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    attach_identity_mock = AsyncMock()
+    monkeypatch.setattr(desktop_service, "attach_verified_identity", attach_identity_mock)
+    return attach_identity_mock
+
+
 @pytest.mark.asyncio
 async def test_finish_github_desktop_callback_syncs_customerio_for_new_user(
     monkeypatch: pytest.MonkeyPatch,
@@ -80,6 +86,7 @@ async def test_finish_github_desktop_callback_syncs_customerio_for_new_user(
     create_auth_code_mock = AsyncMock(return_value=SimpleNamespace(code="auth-code"))
     schedule_mock = Mock()
     sync_profile_mock = AsyncMock(return_value=synced_user)
+    attach_identity_mock = _stub_identity_attachment(monkeypatch)
 
     monkeypatch.setattr(settings, "github_oauth_client_id", "github-client-id")
     monkeypatch.setattr(settings, "github_oauth_client_secret", "github-client-secret")
@@ -121,6 +128,7 @@ async def test_finish_github_desktop_callback_syncs_customerio_for_new_user(
 
     assert response.status_code == 200
     assert "proliferate://auth/callback?code=auth-code" in response.body.decode()
+    attach_identity_mock.assert_awaited_once()
     create_auth_code_mock.assert_awaited_once()
     sync_profile_mock.assert_awaited_once_with(
         db,
@@ -143,6 +151,7 @@ async def test_finish_github_desktop_callback_syncs_customerio_for_existing_user
     create_auth_code_mock = AsyncMock(return_value=SimpleNamespace(code="auth-code"))
     schedule_mock = Mock()
     sync_profile_mock = AsyncMock(return_value=user)
+    attach_identity_mock = _stub_identity_attachment(monkeypatch)
 
     monkeypatch.setattr(settings, "github_oauth_client_id", "github-client-id")
     monkeypatch.setattr(settings, "github_oauth_client_secret", "github-client-secret")
@@ -183,6 +192,7 @@ async def test_finish_github_desktop_callback_syncs_customerio_for_existing_user
     )
 
     assert response.status_code == 200
+    attach_identity_mock.assert_awaited_once()
     sync_profile_mock.assert_awaited_once()
     schedule_mock.assert_called_once_with(user)
 
@@ -237,6 +247,7 @@ async def test_finish_github_desktop_callback_skips_customerio_when_auth_code_cr
     user_manager = SimpleNamespace(oauth_callback=AsyncMock(return_value=user))
     schedule_mock = Mock()
     sync_profile_mock = AsyncMock(return_value=user)
+    attach_identity_mock = _stub_identity_attachment(monkeypatch)
 
     monkeypatch.setattr(settings, "github_oauth_client_id", "github-client-id")
     monkeypatch.setattr(settings, "github_oauth_client_secret", "github-client-secret")
@@ -282,6 +293,7 @@ async def test_finish_github_desktop_callback_skips_customerio_when_auth_code_cr
         )
 
     schedule_mock.assert_not_called()
+    attach_identity_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_agent_auth_domain.py
+++ b/server/tests/unit/test_agent_auth_domain.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from proliferate.auth.authorization import PolicyDenied, PolicyAllowed
+from proliferate.server.cloud.agent_auth.domain.policy import (
+    SelectionPlan,
+    can_select_credential_for_profile,
+    selection_plan_for_credential,
+)
+
+
+def test_gateway_selection_plan_maps_agent_protocols() -> None:
+    claude = selection_plan_for_credential(
+        agent_kind="claude",
+        credential_kind="managed_gateway",
+    )
+    assert claude == SelectionPlan(materialization_mode="gateway_env", protocol_facade="anthropic")
+
+    codex = selection_plan_for_credential(
+        agent_kind="codex",
+        credential_kind="managed_gateway",
+    )
+    assert codex == SelectionPlan(materialization_mode="gateway_env", protocol_facade="openai")
+
+    gemini = selection_plan_for_credential(
+        agent_kind="gemini",
+        credential_kind="managed_gateway",
+    )
+    assert isinstance(gemini, PolicyDenied)
+    assert gemini.code == "gateway_not_supported_for_agent"
+
+
+def test_org_profile_requires_share_for_personal_synced_credential() -> None:
+    denied = can_select_credential_for_profile(
+        profile_owner_scope="organization",
+        profile_owner_user_id=None,
+        profile_organization_id="org-1",
+        credential_owner_scope="personal",
+        credential_owner_user_id="user-1",
+        credential_organization_id=None,
+        credential_kind="synced_path",
+        has_active_share=False,
+    )
+    assert isinstance(denied, PolicyDenied)
+    assert denied.code == "credential_share_required"
+
+    allowed = can_select_credential_for_profile(
+        profile_owner_scope="organization",
+        profile_owner_user_id=None,
+        profile_organization_id="org-1",
+        credential_owner_scope="personal",
+        credential_owner_user_id="user-1",
+        credential_organization_id=None,
+        credential_kind="synced_path",
+        has_active_share=True,
+    )
+    assert isinstance(allowed, PolicyAllowed)

--- a/server/tests/unit/test_agent_gateway_integrations.py
+++ b/server/tests/unit/test_agent_gateway_integrations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from proliferate.integrations.aws import AwsIntegrationError, validate_bedrock_assume_role_payload
+from proliferate.integrations.litellm.client import _redact
+from proliferate.server.cloud.credentials.domain.status import allowed_agent_kinds
+
+
+def test_bedrock_assume_role_validation_extracts_account_id() -> None:
+    result = validate_bedrock_assume_role_payload(
+        role_arn="arn:aws:iam::123456789012:role/ProliferateBedrockRole",
+        external_id="org_abc",
+        region="us-west-2",
+    )
+
+    assert result.account_id == "123456789012"
+    assert result.region == "us-west-2"
+
+
+def test_bedrock_assume_role_validation_rejects_non_role_arn() -> None:
+    with pytest.raises(AwsIntegrationError) as exc:
+        validate_bedrock_assume_role_payload(
+            role_arn="arn:aws:iam::123456789012:user/not-a-role",
+            external_id="org_abc",
+            region="us-west-2",
+        )
+
+    assert exc.value.code == "invalid_role_arn"
+
+
+def test_litellm_redaction_scrubs_master_key() -> None:
+    assert _redact("bad sk-secret-token payload", "sk-secret-token") == "bad [REDACTED] payload"
+
+
+def test_litellm_redaction_scrubs_provider_secrets() -> None:
+    assert (
+        _redact(
+            "bad sk-master payload with sk-provider-key and external-id",
+            ("sk-master", "sk-provider-key", "external-id"),
+        )
+        == "bad [REDACTED] payload with [REDACTED] and [REDACTED]"
+    )
+
+
+def test_legacy_cloud_credential_sync_does_not_advertise_opencode_yet() -> None:
+    assert allowed_agent_kinds() == ["claude", "codex", "gemini"]

--- a/server/tests/unit/test_cloud_orm_models.py
+++ b/server/tests/unit/test_cloud_orm_models.py
@@ -20,6 +20,17 @@ def test_cloud_orm_package_registers_all_cloud_tables() -> None:
         "cloud_mcp_oauth_client",
         "cloud_repo_config",
         "cloud_repo_file",
+        "agent_auth_audit_event",
+        "agent_auth_credential",
+        "agent_auth_credential_share",
+        "agent_gateway_budget_subject",
+        "agent_gateway_policy",
+        "agent_gateway_provider_credential",
+        "agent_gateway_runtime_grant",
+        "sandbox_agent_auth_selection",
+        "sandbox_profile",
+        "sandbox_profile_agent_auth_revision",
+        "sandbox_profile_agent_auth_target_state",
     }
 
     assert expected_tables <= set(Base.metadata.tables)

--- a/server/tests/unit/test_cloud_runtime_ensure_running.py
+++ b/server/tests/unit/test_cloud_runtime_ensure_running.py
@@ -388,14 +388,6 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
     ) -> None:
         events.append("relaunch")
 
-    async def _ensure_launcher_defers_startup_retention(
-        _provider: object,
-        _sandbox: object,
-        _runtime_context: object,
-        _workspace: object,
-    ) -> None:
-        events.append("patch_launcher")
-
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
     monkeypatch.setattr(ensure_running, "verify_runtime_auth_enforced", _verify)
     monkeypatch.setattr(ensure_running, "load_active_sandbox_for_workspace", _load_active_sandbox)
@@ -406,11 +398,6 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
         _persist,
     )
     monkeypatch.setattr(ensure_running, "_relaunch_runtime", _relaunch)
-    monkeypatch.setattr(
-        ensure_running,
-        "_ensure_launcher_defers_startup_retention",
-        _ensure_launcher_defers_startup_retention,
-    )
 
     runtime_url = await ensure_running.ensure_workspace_runtime_ready(
         workspace,
@@ -419,7 +406,7 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
     )
 
     assert runtime_url == "https://fresh.invalid"
-    assert events == ["connect", "endpoint", "context", "patch_launcher", "relaunch", "verify"]
+    assert events == ["connect", "endpoint", "context", "relaunch", "verify"]
     assert persisted == [(True, "https://fresh.invalid")]
 
 


### PR DESCRIPTION
## Summary

Adds the first implementation slices for the agent LLM auth gateway work:

- lands the agent gateway architecture docs and Phase 0 compatibility probe artifacts
- adds Phase 1 server data model, Alembic migration, stores, Cloud agent-auth APIs, AWS/LiteLLM integrations, and fail-closed credential selection behavior
- adds Phase 2 gateway service routes for Anthropic/OpenAI-compatible facades, runtime grant authorization, LiteLLM forwarding, and canonical gateway error mapping
- adds focused unit/integration coverage for credential readiness, runtime grants, gateway authorization, model allowlists, and LiteLLM error handling

## Notes

This intentionally does not include Phase 3 worker/AnyHarness materialization, launch preflight, SDK/frontend wiring, or live provider validation rollout. Those remain separate follow-up phases.

## Verification

- `PROLIFERATE_TEST_DATABASE_NAME=proliferate_test_agent_auth_phase12_final DEBUG=1 .venv/bin/pytest -q tests/unit/test_agent_auth_domain.py tests/unit/test_agent_gateway_integrations.py tests/unit/test_cloud_orm_models.py tests/integration/test_cloud_agent_auth_api.py tests/integration/test_agent_gateway_api.py tests/integration/test_schema_migrations.py::test_alembic_upgrade_creates_current_schema`
- `DEBUG=1 .venv/bin/pytest -q tests/unit/test_server_boundary_checker.py`
- `.venv/bin/ruff check alembic/versions/e6f7a8b9c0d1_agent_llm_auth_gateway_phase1.py proliferate/db/models/cloud/agent_auth.py proliferate/db/store/cloud_agent_auth proliferate/integrations/aws proliferate/integrations/litellm proliferate/server/cloud/agent_auth proliferate/server/agent_gateway proliferate/config.py proliferate/constants/cloud.py proliferate/main.py proliferate/server/cloud/credentials/domain/status.py proliferate/server/cloud/credentials/domain/sync_payload.py tests/unit/test_agent_auth_domain.py tests/unit/test_agent_gateway_integrations.py tests/integration/test_cloud_agent_auth_api.py tests/integration/test_agent_gateway_api.py tests/integration/schema_migration_assertions.py tests/unit/test_cloud_orm_models.py`
- `DEBUG=1 .venv/bin/python - <<'PY'
from proliferate.main import create_app
app = create_app()
print(len(app.routes))
PY`
- `git diff --check`