### PR TITLE
feat(server): add agent auth refresh materialization contract

### DIFF
--- a/server/alembic/versions/e7f8a9b0c1d2_agent_auth_refresh_command.py
+++ b/server/alembic/versions/e7f8a9b0c1d2_agent_auth_refresh_command.py
@@ -1,0 +1,63 @@
+"""Add agent-auth refresh cloud command.
+
+Revision ID: e7f8a9b0c1d2
+Revises: e6f7a8b9c0d1
+Create Date: 2026-05-18 10:20:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: str | None = "e6f7a8b9c0d1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_OLD_COMMAND_KINDS = (
+    "start_session",
+    "configure_git_identity",
+    "ensure_repo_checkout",
+    "materialize_workspace",
+    "materialize_environment",
+    "resume_session",
+    "send_prompt",
+    "resolve_interaction",
+    "update_session_config",
+    "cancel_turn",
+    "close_session",
+    "cancel_session",
+    "stop_workspace",
+    "hibernate_workspace",
+    "resume_workspace",
+    "prune_workspace",
+    "extend_workspace_ttl",
+    "sync_existing_workspace",
+)
+
+_NEW_COMMAND_KINDS = (
+    *_OLD_COMMAND_KINDS,
+    "refresh_agent_auth_config",
+)
+
+
+def _in_constraint(column_name: str, values: tuple[str, ...]) -> str:
+    return f"{column_name} IN {values}"
+
+
+def _replace_command_kind_constraint(values: tuple[str, ...]) -> None:
+    op.drop_constraint("ck_cloud_commands_kind", "cloud_commands", type_="check")
+    op.create_check_constraint(
+        "ck_cloud_commands_kind",
+        "cloud_commands",
+        _in_constraint("kind", values),
+    )
+
+
+def upgrade() -> None:
+    _replace_command_kind_constraint(_NEW_COMMAND_KINDS)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM cloud_commands WHERE kind = 'refresh_agent_auth_config'")
+    _replace_command_kind_constraint(_OLD_COMMAND_KINDS)

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -501,7 +501,6 @@ DEFAULT_CLOUD_WORKER_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.ensure_repo_checkout.value,
     CloudCommandKind.materialize_workspace.value,
     CloudCommandKind.materialize_environment.value,
-    CloudCommandKind.refresh_agent_auth_config.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.resolve_interaction.value,
     CloudCommandKind.update_session_config.value,

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -435,6 +435,7 @@ class CloudCommandKind(StrEnum):
     ensure_repo_checkout = "ensure_repo_checkout"
     materialize_workspace = "materialize_workspace"
     materialize_environment = "materialize_environment"
+    refresh_agent_auth_config = "refresh_agent_auth_config"
     resume_session = "resume_session"
     send_prompt = "send_prompt"
     resolve_interaction = "resolve_interaction"
@@ -486,6 +487,7 @@ ACTIVE_CLOUD_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.ensure_repo_checkout.value,
     CloudCommandKind.materialize_workspace.value,
     CloudCommandKind.materialize_environment.value,
+    CloudCommandKind.refresh_agent_auth_config.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.resolve_interaction.value,
     CloudCommandKind.update_session_config.value,
@@ -499,6 +501,7 @@ DEFAULT_CLOUD_WORKER_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.ensure_repo_checkout.value,
     CloudCommandKind.materialize_workspace.value,
     CloudCommandKind.materialize_environment.value,
+    CloudCommandKind.refresh_agent_auth_config.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.resolve_interaction.value,
     CloudCommandKind.update_session_config.value,

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -1090,6 +1090,23 @@ async def list_target_states_for_profile(
     return tuple(_target_state_record(row) for row in rows)
 
 
+async def get_target_state(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+) -> SandboxProfileAgentAuthTargetStateRecord | None:
+    row = (
+        await db.execute(
+            select(SandboxProfileAgentAuthTargetState).where(
+                SandboxProfileAgentAuthTargetState.sandbox_profile_id == sandbox_profile_id,
+                SandboxProfileAgentAuthTargetState.target_id == target_id,
+            )
+        )
+    ).scalar_one_or_none()
+    return _target_state_record(row) if row is not None else None
+
+
 async def upsert_target_state(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_credentials.py
+++ b/server/proliferate/db/store/cloud_credentials.py
@@ -49,6 +49,14 @@ async def get_user_cloud_credentials(
     return [_credential_record(record) for record in records]
 
 
+async def get_cloud_credential_by_id(
+    db: AsyncSession,
+    credential_id: UUID,
+) -> CloudCredentialRecord | None:
+    record = await db.get(CloudCredential, credential_id)
+    return _credential_record(record) if record is not None else None
+
+
 async def sync_cloud_credential_if_changed(
     db: AsyncSession,
     user_id: UUID,

--- a/server/proliferate/db/store/cloud_sync/commands.py
+++ b/server/proliferate/db/store/cloud_sync/commands.py
@@ -357,7 +357,7 @@ async def record_command_result(
     row.status = effective_status
     row.error_code = effective_error_code
     row.error_message = effective_error_message
-    row.result_json = result_json
+    row.result_json = _safe_result_json(kind=row.kind, result_json=result_json)
     if materialized_workspace_id is not None:
         row.workspace_id = materialized_workspace_id
     row.updated_at = now
@@ -404,6 +404,28 @@ def _materialized_workspace_id(
     if not isinstance(workspace_id, str) or not workspace_id.strip():
         return None
     return workspace_id.strip()
+
+
+def _safe_result_json(*, kind: str, result_json: str | None) -> str | None:
+    if kind != CloudCommandKind.refresh_agent_auth_config.value:
+        return result_json
+    try:
+        result = json.loads(result_json or "{}")
+    except ValueError:
+        return None
+    if not isinstance(result, dict):
+        return None
+    safe: dict[str, object] = {}
+    if isinstance(result.get("applied"), bool):
+        safe["applied"] = result["applied"]
+    if isinstance(result.get("reason"), str):
+        safe["reason"] = str(result["reason"])[:128]
+    if isinstance(result.get("currentRevision"), int) and not isinstance(
+        result.get("currentRevision"),
+        bool,
+    ):
+        safe["currentRevision"] = result["currentRevision"]
+    return json.dumps(safe, separators=(",", ":"), sort_keys=True) if safe else None
 
 
 def _is_terminal_status(status: str) -> bool:

--- a/server/proliferate/server/cloud/agent_auth/api.py
+++ b/server/proliferate/server/cloud/agent_auth/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Header, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
@@ -24,6 +24,9 @@ from proliferate.server.cloud.agent_auth.models import (
     SandboxProfileResponse,
     SelectAgentAuthCredentialRequest,
     ShareCredentialRequest,
+    WorkerAgentAuthMaterializationPlan,
+    WorkerAgentAuthStatusRequest,
+    WorkerAgentAuthStatusResponse,
     credential_response,
     credential_share_response,
     policy_response,
@@ -39,13 +42,20 @@ from proliferate.server.cloud.agent_auth.service import (
     list_credentials,
     list_selections,
     list_target_states,
+    record_worker_agent_auth_status,
     revoke_credential,
     revoke_credential_share,
     select_credential_for_profile,
     share_personal_credential_with_organization,
+    worker_agent_auth_materialization_plan,
 )
+from proliferate.server.cloud.worker.service import authenticate_worker
 
 router = APIRouter()
+worker_router = APIRouter(
+    prefix="/worker/agent-auth-configs",
+    tags=["cloud-worker-agent-auth"],
+)
 
 
 @router.get("/agent-auth/credentials", response_model=list[AgentAuthCredentialResponse])
@@ -202,3 +212,45 @@ async def list_agent_auth_target_states_endpoint(
             sandbox_profile_id=sandbox_profile_id,
         )
     ]
+
+
+@worker_router.get(
+    "/{sandbox_profile_id}/materialization",
+    response_model=WorkerAgentAuthMaterializationPlan,
+)
+async def worker_agent_auth_materialization_endpoint(
+    sandbox_profile_id: UUID,
+    revision: int,
+    command_id: UUID,
+    lease_id: str,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerAgentAuthMaterializationPlan:
+    auth = await authenticate_worker(db, authorization=authorization)
+    return await worker_agent_auth_materialization_plan(
+        db,
+        auth=auth,
+        sandbox_profile_id=sandbox_profile_id,
+        command_id=command_id,
+        revision=revision,
+        lease_id=lease_id,
+    )
+
+
+@worker_router.post(
+    "/{sandbox_profile_id}/status",
+    response_model=WorkerAgentAuthStatusResponse,
+)
+async def worker_agent_auth_status_endpoint(
+    sandbox_profile_id: UUID,
+    body: WorkerAgentAuthStatusRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkerAgentAuthStatusResponse:
+    auth = await authenticate_worker(db, authorization=authorization)
+    return await record_worker_agent_auth_status(
+        db,
+        auth=auth,
+        sandbox_profile_id=sandbox_profile_id,
+        body=body,
+    )

--- a/server/proliferate/server/cloud/agent_auth/models.py
+++ b/server/proliferate/server/cloud/agent_auth/models.py
@@ -179,6 +179,66 @@ class SandboxProfileAgentAuthTargetStateResponse(BaseModel):
     last_error_message: str | None = Field(alias="lastErrorMessage")
 
 
+class WorkerAgentAuthGatewayConfig(BaseModel):
+    protocol_facade: str = Field(alias="protocolFacade")
+    base_urls: dict[str, str] = Field(alias="baseUrls")
+    runtime_grant_token: str = Field(alias="runtimeGrantToken")
+    expires_at: str = Field(alias="expiresAt")
+    protected_env: dict[str, str] = Field(default_factory=dict, alias="protectedEnv")
+    support_env: dict[str, str] = Field(default_factory=dict, alias="supportEnv")
+    protected_config: dict[str, object] = Field(default_factory=dict, alias="protectedConfig")
+    support_config: dict[str, object] = Field(default_factory=dict, alias="supportConfig")
+
+
+class WorkerAgentAuthSyncedFilesConfig(BaseModel):
+    credential_share_id: UUID | None = Field(default=None, alias="credentialShareId")
+    env_vars: dict[str, str] = Field(default_factory=dict, alias="envVars")
+    files: list[dict[str, object]] = Field(default_factory=list)
+    cleanup: list[dict[str, object]] = Field(default_factory=list)
+
+
+class WorkerAgentAuthSelectionPlan(BaseModel):
+    agent_kind: str = Field(alias="agentKind")
+    materialization_mode: str = Field(alias="materializationMode")
+    credential_id: UUID = Field(alias="credentialId")
+    credential_revision: int = Field(alias="credentialRevision")
+    credential_share_id: UUID | None = Field(default=None, alias="credentialShareId")
+    gateway: WorkerAgentAuthGatewayConfig | None = None
+    synced_files: WorkerAgentAuthSyncedFilesConfig | None = Field(
+        default=None,
+        alias="syncedFiles",
+    )
+
+
+class WorkerAgentAuthMaterializationPlan(BaseModel):
+    applied: bool = True
+    reason: str | None = None
+    current_revision: int | None = Field(default=None, alias="currentRevision")
+    target_id: UUID | None = Field(default=None, alias="targetId")
+    sandbox_profile_id: UUID = Field(alias="sandboxProfileId")
+    revision: int
+    selections: list[WorkerAgentAuthSelectionPlan] = Field(default_factory=list)
+
+
+class WorkerAgentAuthStatusRequest(BaseModel):
+    status: str
+    command_id: UUID = Field(alias="commandId")
+    revision: int
+    lease_id: str = Field(alias="leaseId")
+    applied_revision: int | None = Field(default=None, alias="appliedRevision")
+    current_revision: int | None = Field(default=None, alias="currentRevision")
+    error_code: str | None = Field(default=None, alias="errorCode")
+    error_message: str | None = Field(default=None, alias="errorMessage")
+
+
+class WorkerAgentAuthStatusResponse(BaseModel):
+    sandbox_profile_id: UUID = Field(alias="sandboxProfileId")
+    target_id: UUID = Field(alias="targetId")
+    desired_revision: int = Field(alias="desiredRevision")
+    applied_revision: int | None = Field(alias="appliedRevision")
+    status: str
+
+
 class CreateGatewayCredentialResponse(BaseModel):
     credential: AgentAuthCredentialResponse
     policy: AgentGatewayPolicyResponse

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -865,7 +865,7 @@ async def worker_agent_auth_materialization_plan(
     revision: int,
     lease_id: str,
 ) -> WorkerAgentAuthMaterializationPlan:
-    await _require_agent_auth_refresh_command(
+    command = await _require_agent_auth_refresh_command(
         db,
         auth=auth,
         sandbox_profile_id=sandbox_profile_id,
@@ -896,6 +896,12 @@ async def worker_agent_auth_materialization_plan(
             code="agent_auth_revision_mismatch",
             status_code=409,
         )
+    await _require_agent_auth_target_state(
+        db,
+        profile=profile,
+        auth=auth,
+        command=command,
+    )
     selections = []
     for selection in await store.list_selections_for_profile(db, profile.id):
         if selection.status != "active":
@@ -926,7 +932,7 @@ async def record_worker_agent_auth_status(
     sandbox_profile_id: UUID,
     body: WorkerAgentAuthStatusRequest,
 ) -> WorkerAgentAuthStatusResponse:
-    await _require_agent_auth_refresh_command(
+    command = await _require_agent_auth_refresh_command(
         db,
         auth=auth,
         sandbox_profile_id=sandbox_profile_id,
@@ -947,6 +953,13 @@ async def record_worker_agent_auth_status(
             code="sandbox_profile_not_found",
             status_code=404,
         )
+    _validate_worker_status_revisions(body, profile)
+    await _require_agent_auth_target_state(
+        db,
+        profile=profile,
+        auth=auth,
+        command=command,
+    )
     existing = await store.get_target_state(
         db,
         sandbox_profile_id=profile.id,
@@ -970,7 +983,7 @@ async def record_worker_agent_auth_status(
         status = "superseded"
     elif body.status == "failed":
         error_code = body.error_code or "agent_auth_materialization_failed"
-        error_message = body.error_message or "Agent auth materialization failed."
+        error_message = _worker_status_error_message(error_code)
     if applied_revision is not None and applied_revision > desired_revision:
         desired_revision = applied_revision
     force_restart_required = existing.force_restart_required if existing is not None else False
@@ -996,6 +1009,30 @@ async def record_worker_agent_auth_status(
         appliedRevision=state.applied_revision,
         status=state.status,
     )
+
+
+def _validate_worker_status_revisions(
+    body: WorkerAgentAuthStatusRequest,
+    profile: SandboxProfileRecord,
+) -> None:
+    current_revision = body.current_revision
+    applied_revision = body.applied_revision
+    if current_revision is not None and current_revision > profile.agent_auth_revision:
+        raise AgentAuthError(
+            "Worker reported an unknown agent-auth revision.",
+            code="agent_auth_revision_mismatch",
+            status_code=409,
+        )
+    if applied_revision is not None and applied_revision > profile.agent_auth_revision:
+        raise AgentAuthError(
+            "Worker reported an unknown applied agent-auth revision.",
+            code="agent_auth_revision_mismatch",
+            status_code=409,
+        )
+
+
+def _worker_status_error_message(error_code: str) -> str:
+    return f"Agent auth materialization failed ({error_code})."
 
 
 async def _require_agent_auth_refresh_command(
@@ -1044,6 +1081,27 @@ async def _require_agent_auth_refresh_command(
             status_code=409,
         )
     return command
+
+
+async def _require_agent_auth_target_state(
+    db: AsyncSession,
+    *,
+    profile: SandboxProfileRecord,
+    auth: WorkerAuthContext,
+    command: commands_store.CloudCommandSnapshot,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    state = await store.get_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=auth.target_id,
+    )
+    if state is None or state.last_command_id != command.id:
+        raise AgentAuthError(
+            "Agent auth config command is not current for this profile and target.",
+            code="agent_auth_command_mismatch",
+            status_code=409,
+        )
+    return state
 
 
 async def _worker_selection_plan(

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -15,6 +15,7 @@ from decimal import Decimal, InvalidOperation
 from urllib.parse import urlparse
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import PolicyDenied
@@ -24,6 +25,10 @@ from proliferate.constants.cloud import (
     AGENT_GATEWAY_RUNTIME_GRANT_TOKEN_DOMAIN,
     AGENT_GATEWAY_TOKEN_HASH_KEY_ID,
     CloudAgentKind,
+    CloudCommandActorKind,
+    CloudCommandKind,
+    CloudCommandSource,
+    CloudCommandStatus,
 )
 from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
 from proliferate.db.store import organizations as organization_store
@@ -39,6 +44,8 @@ from proliferate.db.store.cloud_agent_auth.records import (
     SandboxProfileAgentAuthTargetStateRecord,
     SandboxProfileRecord,
 )
+from proliferate.db.store.cloud_credentials import get_cloud_credential_by_id
+from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.integrations.aws import (
     AwsIntegrationError,
     validate_bedrock_assume_role_payload,
@@ -59,8 +66,17 @@ from proliferate.server.cloud.agent_auth.models import (
     CreateGatewayCredentialRequest,
     EnsureManagedCreditsRequest,
     LiteLLMModelDeploymentRequest,
+    WorkerAgentAuthGatewayConfig,
+    WorkerAgentAuthMaterializationPlan,
+    WorkerAgentAuthSelectionPlan,
+    WorkerAgentAuthStatusRequest,
+    WorkerAgentAuthStatusResponse,
+    WorkerAgentAuthSyncedFilesConfig,
 )
-from proliferate.utils.crypto import encrypt_json, encrypt_text
+from proliferate.server.cloud.commands.domain.rules import compact_command_json
+from proliferate.server.cloud.live.service import publish_command_status_after_commit
+from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
+from proliferate.utils.crypto import decrypt_json, encrypt_json, encrypt_text
 from proliferate.utils.time import utcnow
 
 _ORG_ADMIN_ROLES = {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}
@@ -98,7 +114,14 @@ async def ensure_personal_sandbox_profile(
         user_id=actor_user_id,
         managed_target_id=managed_target_id,
     )
-    return await _backfill_legacy_cloud_credentials(db, actor_user_id, profile)
+    profile = await _backfill_legacy_cloud_credentials(db, actor_user_id, profile)
+    await _ensure_profile_target_refresh_if_needed(
+        db,
+        profile=profile,
+        actor_user_id=actor_user_id,
+        reason="sandbox_profile_target_attached",
+    )
+    return profile
 
 
 async def reconcile_legacy_cloud_credentials_for_user(
@@ -128,11 +151,18 @@ async def ensure_organization_sandbox_profile(
     managed_target_id: UUID | None,
 ) -> SandboxProfileRecord:
     await _require_organization_admin(db, actor_user_id, organization_id)
-    return await store.ensure_organization_sandbox_profile(
+    profile = await store.ensure_organization_sandbox_profile(
         db,
         organization_id=organization_id,
         managed_target_id=managed_target_id,
     )
+    await _ensure_profile_target_refresh_if_needed(
+        db,
+        profile=profile,
+        actor_user_id=actor_user_id,
+        reason="sandbox_profile_target_attached",
+    )
+    return profile
 
 
 async def list_credentials(
@@ -713,20 +743,13 @@ async def select_credential_for_profile(
         raise AgentAuthError(
             "Sandbox profile not found.", code="sandbox_profile_not_found", status_code=404
         )
-    if profile.managed_target_id is not None:
-        await store.upsert_target_state(
-            db,
-            sandbox_profile_id=profile.id,
-            target_id=profile.managed_target_id,
-            desired_revision=updated_profile.agent_auth_revision,
-            applied_revision=None,
-            status="pending",
-            force_restart_required=force_restart,
-            last_command_id=None,
-            last_worker_id=None,
-            last_error_code=None,
-            last_error_message=None,
-        )
+    await _mark_target_pending_and_queue_refresh(
+        db,
+        profile=updated_profile,
+        actor_user_id=actor_user_id,
+        reason="selection_changed",
+        force_restart=force_restart,
+    )
     await store.record_audit_event(
         db,
         action="selection.write",
@@ -831,6 +854,393 @@ async def issue_runtime_grant_for_selection(
         expires_at=now + _GATEWAY_GRANT_TTL,
     )
     return RuntimeGrantIssueResult(grant=grant, raw_token=raw_token)
+
+
+async def worker_agent_auth_materialization_plan(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    sandbox_profile_id: UUID,
+    command_id: UUID,
+    revision: int,
+    lease_id: str,
+) -> WorkerAgentAuthMaterializationPlan:
+    await _require_agent_auth_refresh_command(
+        db,
+        auth=auth,
+        sandbox_profile_id=sandbox_profile_id,
+        command_id=command_id,
+        revision=revision,
+        lease_id=lease_id,
+    )
+    profile = await store.get_sandbox_profile(db, sandbox_profile_id)
+    if profile is None:
+        raise AgentAuthError(
+            "Sandbox profile not found.",
+            code="sandbox_profile_not_found",
+            status_code=404,
+        )
+    if revision < profile.agent_auth_revision:
+        return WorkerAgentAuthMaterializationPlan(
+            applied=False,
+            reason="superseded",
+            currentRevision=profile.agent_auth_revision,
+            targetId=auth.target_id,
+            sandboxProfileId=profile.id,
+            revision=revision,
+            selections=[],
+        )
+    if revision != profile.agent_auth_revision:
+        raise AgentAuthError(
+            "Requested agent-auth revision does not match the profile.",
+            code="agent_auth_revision_mismatch",
+            status_code=409,
+        )
+    selections = []
+    for selection in await store.list_selections_for_profile(db, profile.id):
+        if selection.status != "active":
+            continue
+        selections.append(
+            await _worker_selection_plan(
+                db,
+                auth=auth,
+                profile=profile,
+                selection=selection,
+            )
+        )
+    return WorkerAgentAuthMaterializationPlan(
+        applied=True,
+        reason=None,
+        currentRevision=profile.agent_auth_revision,
+        targetId=auth.target_id,
+        sandboxProfileId=profile.id,
+        revision=revision,
+        selections=selections,
+    )
+
+
+async def record_worker_agent_auth_status(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    sandbox_profile_id: UUID,
+    body: WorkerAgentAuthStatusRequest,
+) -> WorkerAgentAuthStatusResponse:
+    await _require_agent_auth_refresh_command(
+        db,
+        auth=auth,
+        sandbox_profile_id=sandbox_profile_id,
+        command_id=body.command_id,
+        revision=body.revision,
+        lease_id=body.lease_id,
+    )
+    if body.status not in {"materializing", "applied", "superseded", "failed"}:
+        raise AgentAuthError(
+            "Agent auth status is invalid.",
+            code="agent_auth_status_invalid",
+            status_code=400,
+        )
+    profile = await store.get_sandbox_profile(db, sandbox_profile_id)
+    if profile is None:
+        raise AgentAuthError(
+            "Sandbox profile not found.",
+            code="sandbox_profile_not_found",
+            status_code=404,
+        )
+    existing = await store.get_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=auth.target_id,
+    )
+    existing_applied = existing.applied_revision if existing is not None else None
+    desired_revision = max(profile.agent_auth_revision, body.current_revision or body.revision)
+    applied_revision = existing_applied
+    status = body.status
+    error_code = None
+    error_message = None
+    if body.status == "applied":
+        applied_revision = (
+            body.applied_revision if body.applied_revision is not None else body.revision
+        )
+        if applied_revision < desired_revision:
+            status = "superseded"
+        else:
+            desired_revision = applied_revision
+    elif body.status == "superseded":
+        status = "superseded"
+    elif body.status == "failed":
+        error_code = body.error_code or "agent_auth_materialization_failed"
+        error_message = body.error_message or "Agent auth materialization failed."
+    if applied_revision is not None and applied_revision > desired_revision:
+        desired_revision = applied_revision
+    force_restart_required = existing.force_restart_required if existing is not None else False
+    if status == "applied" and applied_revision == desired_revision:
+        force_restart_required = False
+    state = await store.upsert_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=auth.target_id,
+        desired_revision=desired_revision,
+        applied_revision=applied_revision,
+        status=status,
+        force_restart_required=force_restart_required,
+        last_command_id=body.command_id,
+        last_worker_id=auth.worker_id,
+        last_error_code=error_code,
+        last_error_message=error_message,
+    )
+    return WorkerAgentAuthStatusResponse(
+        sandboxProfileId=profile.id,
+        targetId=auth.target_id,
+        desiredRevision=state.desired_revision,
+        appliedRevision=state.applied_revision,
+        status=state.status,
+    )
+
+
+async def _require_agent_auth_refresh_command(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    sandbox_profile_id: UUID,
+    command_id: UUID,
+    revision: int,
+    lease_id: str,
+) -> commands_store.CloudCommandSnapshot:
+    command = await commands_store.get_command_by_id(db, command_id)
+    if (
+        command is None
+        or command.target_id != auth.target_id
+        or command.leased_by_worker_id != auth.worker_id
+        or command.kind != CloudCommandKind.refresh_agent_auth_config.value
+        or command.status != CloudCommandStatus.leased.value
+        or command.lease_id != lease_id
+    ):
+        raise AgentAuthError(
+            "Agent auth config command is not leased by this worker.",
+            code="agent_auth_command_not_found",
+            status_code=404,
+        )
+    try:
+        payload = json.loads(command.payload_json)
+    except json.JSONDecodeError as exc:
+        raise AgentAuthError(
+            "Agent auth config command payload is invalid.",
+            code="agent_auth_command_invalid",
+            status_code=409,
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("sandboxProfileId") != str(
+        sandbox_profile_id
+    ):
+        raise AgentAuthError(
+            "Agent auth config command does not match the requested profile.",
+            code="agent_auth_command_mismatch",
+            status_code=409,
+        )
+    if payload.get("revision") != revision:
+        raise AgentAuthError(
+            "Agent auth config command does not match the requested revision.",
+            code="agent_auth_command_mismatch",
+            status_code=409,
+        )
+    return command
+
+
+async def _worker_selection_plan(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    profile: SandboxProfileRecord,
+    selection: SandboxAgentAuthSelectionRecord,
+) -> WorkerAgentAuthSelectionPlan:
+    credential = await store.get_credential(db, selection.credential_id)
+    if credential is None or credential.revoked_at is not None:
+        raise AgentAuthError("Credential not found.", code="credential_not_found", status_code=404)
+    if selection.selected_revision != credential.revision:
+        raise AgentAuthError(
+            "Selection is stale.",
+            code="selection_revision_stale",
+            status_code=409,
+        )
+    await _require_credential_ready_for_selection(db, credential)
+    if selection.materialization_mode == "gateway_env":
+        gateway = await _worker_gateway_config(
+            db,
+            auth=auth,
+            profile=profile,
+            selection=selection,
+        )
+        return WorkerAgentAuthSelectionPlan(
+            agentKind=selection.agent_kind,
+            materializationMode=selection.materialization_mode,
+            credentialId=credential.id,
+            credentialRevision=credential.revision,
+            credentialShareId=selection.credential_share_id,
+            gateway=gateway,
+            syncedFiles=None,
+        )
+    if selection.materialization_mode == "synced_files":
+        synced_files = await _worker_synced_files_config(db, credential, selection)
+        return WorkerAgentAuthSelectionPlan(
+            agentKind=selection.agent_kind,
+            materializationMode=selection.materialization_mode,
+            credentialId=credential.id,
+            credentialRevision=credential.revision,
+            credentialShareId=selection.credential_share_id,
+            gateway=None,
+            syncedFiles=synced_files,
+        )
+    raise AgentAuthError(
+        "Unsupported materialization mode.",
+        code="unsupported_materialization_mode",
+        status_code=400,
+    )
+
+
+async def _worker_gateway_config(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    profile: SandboxProfileRecord,
+    selection: SandboxAgentAuthSelectionRecord,
+) -> WorkerAgentAuthGatewayConfig:
+    result = await issue_runtime_grant_for_selection(
+        db,
+        selection=selection,
+        profile=profile,
+        target_id=auth.target_id,
+    )
+    base = _gateway_base_url()
+    if selection.agent_kind == "claude":
+        facade_base = f"{base}/anthropic"
+        return WorkerAgentAuthGatewayConfig(
+            protocolFacade="anthropic",
+            baseUrls={"anthropic": facade_base},
+            runtimeGrantToken=result.raw_token,
+            expiresAt=result.grant.expires_at.isoformat(),
+            protectedEnv={
+                "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": "1",
+                "ANTHROPIC_BASE_URL": facade_base,
+                "ANTHROPIC_CUSTOM_HEADERS": f"Authorization: Bearer {result.raw_token}",
+                "ANTHROPIC_AUTH_TOKEN": "",
+            },
+            supportEnv={},
+            protectedConfig={},
+            supportConfig={},
+        )
+    if selection.agent_kind == "codex":
+        facade_base = f"{base}/openai/v1"
+        return WorkerAgentAuthGatewayConfig(
+            protocolFacade="openai",
+            baseUrls={"openai": facade_base},
+            runtimeGrantToken=result.raw_token,
+            expiresAt=result.grant.expires_at.isoformat(),
+            protectedEnv={"CODEX_API_KEY": result.raw_token},
+            supportEnv={},
+            protectedConfig={
+                "codex": {
+                    "model_provider_id": "proliferate",
+                    "model_providers": {
+                        "proliferate": {
+                            "name": "Proliferate Gateway",
+                            "base_url": facade_base,
+                            "env_key": "CODEX_API_KEY",
+                            "wire_api": "responses",
+                            "requires_openai_auth": False,
+                        }
+                    },
+                }
+            },
+            supportConfig={},
+        )
+    if selection.agent_kind == "opencode":
+        facade_base = f"{base}/openai/v1"
+        return WorkerAgentAuthGatewayConfig(
+            protocolFacade="openai",
+            baseUrls={"openai": facade_base},
+            runtimeGrantToken=result.raw_token,
+            expiresAt=result.grant.expires_at.isoformat(),
+            protectedEnv={
+                "OPENAI_API_KEY": result.raw_token,
+                "OPENAI_BASE_URL": facade_base,
+            },
+            supportEnv={},
+            protectedConfig={},
+            supportConfig={},
+        )
+    raise AgentAuthError(
+        "Gateway auth is not supported for this agent.",
+        code="gateway_not_supported_for_agent",
+        status_code=400,
+    )
+
+
+async def _worker_synced_files_config(
+    db: AsyncSession,
+    credential: AgentAuthCredentialRecord,
+    selection: SandboxAgentAuthSelectionRecord,
+) -> WorkerAgentAuthSyncedFilesConfig:
+    if credential.legacy_cloud_credential_id is None:
+        raise AgentAuthError(
+            "Synced credential is missing its source credential.",
+            code="synced_credential_source_missing",
+            status_code=409,
+        )
+    legacy = await get_cloud_credential_by_id(db, credential.legacy_cloud_credential_id)
+    if (
+        legacy is None
+        or legacy.revoked_at is not None
+        or legacy.provider != credential.agent_kind
+    ):
+        raise AgentAuthError(
+            "Synced credential source is not active.",
+            code="synced_credential_source_missing",
+            status_code=409,
+        )
+    payload = decrypt_json(legacy.payload_ciphertext)
+    if not isinstance(payload, dict):
+        raise AgentAuthError(
+            "Synced credential payload is invalid.",
+            code="synced_credential_payload_invalid",
+            status_code=409,
+        )
+    raw_env_vars = payload.get("envVars")
+    env_vars = {
+        key: value
+        for key, value in (raw_env_vars if isinstance(raw_env_vars, dict) else {}).items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+    raw_files = payload.get("files")
+    files = [
+        {"relativePath": relative_path, "content": content}
+        for relative_path, content in (
+            raw_files if isinstance(raw_files, dict) else {}
+        ).items()
+        if isinstance(relative_path, str) and isinstance(content, str)
+    ]
+    if not env_vars and not files:
+        raise AgentAuthError(
+            "Synced credential payload is empty.",
+            code="synced_credential_payload_invalid",
+            status_code=409,
+        )
+    return WorkerAgentAuthSyncedFilesConfig(
+        credentialShareId=selection.credential_share_id,
+        envVars=env_vars,
+        files=files,
+        cleanup=[],
+    )
+
+
+def _gateway_base_url() -> str:
+    base = settings.agent_gateway_public_base_url.strip().rstrip("/")
+    if not base:
+        raise AgentAuthError(
+            "Agent gateway public base URL is not configured.",
+            code="agent_gateway_public_base_url_missing",
+            status_code=409,
+        )
+    return base
 
 
 async def _backfill_legacy_cloud_credentials(
@@ -982,6 +1392,14 @@ async def _backfill_legacy_cloud_credentials(
         actor_user_id=actor_user_id,
         force_restart=False,
     )
+    if updated is not None:
+        await _mark_target_pending_and_queue_refresh(
+            db,
+            profile=updated,
+            actor_user_id=actor_user_id,
+            reason="legacy_cloud_credential_import",
+            force_restart=False,
+        )
     return updated or profile
 
 
@@ -1481,21 +1899,152 @@ async def _bump_profile_for_selection(
         actor_user_id=actor_user_id,
         force_restart=force_restart,
     )
-    if updated_profile is not None and updated_profile.managed_target_id is not None:
-        await store.upsert_target_state(
+    if updated_profile is not None:
+        await _mark_target_pending_and_queue_refresh(
             db,
-            sandbox_profile_id=updated_profile.id,
-            target_id=updated_profile.managed_target_id,
-            desired_revision=updated_profile.agent_auth_revision,
-            applied_revision=None,
-            status="pending",
-            force_restart_required=force_restart,
-            last_command_id=None,
-            last_worker_id=None,
-            last_error_code=None,
-            last_error_message=None,
+            profile=updated_profile,
+            actor_user_id=actor_user_id,
+            reason=reason,
+            force_restart=force_restart,
         )
     await store.revoke_runtime_grants_for_selection(db, selection_id=selection.id)
+
+
+async def _mark_target_pending_and_queue_refresh(
+    db: AsyncSession,
+    *,
+    profile: SandboxProfileRecord,
+    actor_user_id: UUID | None,
+    reason: str,
+    force_restart: bool,
+) -> None:
+    if profile.managed_target_id is None:
+        return
+    command = await _queue_agent_auth_refresh_command(
+        db,
+        profile=profile,
+        target_id=profile.managed_target_id,
+        actor_user_id=actor_user_id,
+        reason=reason,
+        force_restart=force_restart,
+    )
+    await store.upsert_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=profile.managed_target_id,
+        desired_revision=profile.agent_auth_revision,
+        applied_revision=None,
+        status="pending",
+        force_restart_required=force_restart,
+        last_command_id=command.id,
+        last_worker_id=None,
+        last_error_code=None,
+        last_error_message=None,
+    )
+
+
+async def _ensure_profile_target_refresh_if_needed(
+    db: AsyncSession,
+    *,
+    profile: SandboxProfileRecord,
+    actor_user_id: UUID | None,
+    reason: str,
+) -> None:
+    if profile.managed_target_id is None:
+        return
+    if profile.agent_auth_revision == 0:
+        selections = await store.list_selections_for_profile(db, profile.id)
+        if not selections:
+            return
+    state = await store.get_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=profile.managed_target_id,
+    )
+    if (
+        state is not None
+        and state.desired_revision == profile.agent_auth_revision
+        and state.last_command_id is not None
+    ):
+        return
+    await _mark_target_pending_and_queue_refresh(
+        db,
+        profile=profile,
+        actor_user_id=actor_user_id,
+        reason=reason,
+        force_restart=False,
+    )
+
+
+async def _queue_agent_auth_refresh_command(
+    db: AsyncSession,
+    *,
+    profile: SandboxProfileRecord,
+    target_id: UUID,
+    actor_user_id: UUID | None,
+    reason: str,
+    force_restart: bool,
+) -> commands_store.CloudCommandSnapshot:
+    idempotency_scope = f"target:{target_id}:agent-auth-config:{profile.id}"
+    idempotency_key = f"agent-auth-config:{target_id}:{profile.id}:{profile.agent_auth_revision}"
+    existing = await commands_store.get_command_by_idempotency(
+        db,
+        idempotency_scope=idempotency_scope,
+        idempotency_key=idempotency_key,
+    )
+    if existing is not None:
+        await publish_command_status_after_commit(db, existing)
+        return existing
+    payload = {
+        "sandboxProfileId": str(profile.id),
+        "revision": profile.agent_auth_revision,
+        "reason": reason,
+        "forceRestart": force_restart,
+    }
+    actor_kind = (
+        CloudCommandActorKind.user.value
+        if actor_user_id is not None
+        else CloudCommandActorKind.system.value
+    )
+    try:
+        async with db.begin_nested():
+            command = await commands_store.create_command(
+                db,
+                idempotency_scope=idempotency_scope,
+                idempotency_key=idempotency_key,
+                target_id=target_id,
+                organization_id=profile.organization_id,
+                actor_user_id=actor_user_id,
+                actor_kind=actor_kind,
+                source=CloudCommandSource.api.value,
+                workspace_id=None,
+                session_id=None,
+                kind=CloudCommandKind.refresh_agent_auth_config.value,
+                payload_json=compact_command_json(payload) or "{}",
+                observed_event_seq=None,
+                preconditions_json=None,
+                authorization_context_json=compact_command_json(
+                    {
+                        "actorUserId": str(actor_user_id) if actor_user_id else None,
+                        "sandboxProfileId": str(profile.id),
+                        "targetOwnerScope": profile.owner_scope,
+                        "targetOrganizationId": (
+                            str(profile.organization_id) if profile.organization_id else None
+                        ),
+                    }
+                ),
+            )
+    except IntegrityError:
+        duplicate = await commands_store.get_command_by_idempotency(
+            db,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+        )
+        if duplicate is None:
+            raise
+        command = duplicate
+    await publish_command_status_after_commit(db, command)
+    return command
 
 
 def _hash_token(raw_token: str) -> str:

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from proliferate.server.cloud.agent_auth.api import router as agent_auth_router
+from proliferate.server.cloud.agent_auth.api import worker_router as agent_auth_worker_router
 from proliferate.server.cloud.backfill.api import router as backfill_router
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.compute.api import router as compute_router
@@ -47,6 +48,7 @@ router.include_router(commands_router)
 router.include_router(events_router)
 router.include_router(live_router)
 router.include_router(backfill_router)
+router.include_router(agent_auth_worker_router)
 router.include_router(target_config_worker_router)
 router.include_router(target_git_identity_worker_router)
 router.include_router(worker_router)

--- a/server/proliferate/server/cloud/commands/domain/rules.py
+++ b/server/proliferate/server/cloud/commands/domain/rules.py
@@ -32,6 +32,12 @@ _MATERIALIZE_WORKTREE_FIELDS = {
 }
 _CONFIGURE_GIT_IDENTITY_FIELDS = {"targetGitIdentityId", "configVersion"}
 _ENSURE_REPO_CHECKOUT_FIELDS = {"provider", "owner", "name", "path", "baseBranch"}
+_REFRESH_AGENT_AUTH_CONFIG_FIELDS = {
+    "sandboxProfileId",
+    "revision",
+    "reason",
+    "forceRestart",
+}
 _MAX_MATERIALIZE_WORKSPACE_DISPLAY_NAME_CHARS = 160
 
 
@@ -81,6 +87,7 @@ def validate_command_shape(
         CloudCommandKind.configure_git_identity.value,
         CloudCommandKind.ensure_repo_checkout.value,
         CloudCommandKind.materialize_environment.value,
+        CloudCommandKind.refresh_agent_auth_config.value,
     } and (workspace_id or session_id):
         raise CloudApiError(
             "cloud_command_target_only",
@@ -123,6 +130,12 @@ def validate_command_payload(*, kind: str, payload: dict[str, object]) -> None:
         return
     if kind == CloudCommandKind.ensure_repo_checkout.value:
         _validate_ensure_repo_checkout_payload(payload)
+        return
+    if kind == CloudCommandKind.refresh_agent_auth_config.value:
+        _validate_refresh_agent_auth_config_payload(payload)
+        return
+    if kind in {CloudCommandKind.start_session.value, CloudCommandKind.send_prompt.value}:
+        _validate_optional_agent_auth_preflight_payload(kind=kind, payload=payload)
         return
     if kind != CloudCommandKind.materialize_workspace.value:
         return
@@ -224,6 +237,75 @@ def _validate_ensure_repo_checkout_payload(payload: dict[str, object]) -> None:
             message=f"ensure_repo_checkout payload must contain {field}.",
         )
     _optional_string(payload, "baseBranch")
+
+
+def _validate_refresh_agent_auth_config_payload(payload: dict[str, object]) -> None:
+    _reject_unknown_fields(
+        payload,
+        _REFRESH_AGENT_AUTH_CONFIG_FIELDS,
+        code="cloud_command_refresh_agent_auth_payload_unknown",
+        message_prefix="refresh_agent_auth_config payload contains unsupported field(s): ",
+    )
+    _required_string(
+        payload,
+        "sandboxProfileId",
+        code="cloud_command_refresh_agent_auth_profile_required",
+        message="refresh_agent_auth_config payload must contain sandboxProfileId.",
+    )
+    revision = _required_int(
+        payload,
+        "revision",
+        code="cloud_command_refresh_agent_auth_revision_required",
+        message="refresh_agent_auth_config payload must contain revision.",
+    )
+    if revision < 0:
+        raise CloudApiError(
+            "cloud_command_refresh_agent_auth_revision_invalid",
+            "refresh_agent_auth_config revision must be non-negative.",
+            status_code=400,
+        )
+    _required_string(
+        payload,
+        "reason",
+        code="cloud_command_refresh_agent_auth_reason_required",
+        message="refresh_agent_auth_config payload must contain reason.",
+    )
+    value = payload.get("forceRestart")
+    if not isinstance(value, bool):
+        raise CloudApiError(
+            "cloud_command_refresh_agent_auth_force_restart_required",
+            "refresh_agent_auth_config payload must contain boolean forceRestart.",
+            status_code=400,
+        )
+
+
+def _validate_optional_agent_auth_preflight_payload(
+    *,
+    kind: str,
+    payload: dict[str, object],
+) -> None:
+    has_profile = "sandboxProfileId" in payload
+    has_revision = "requiredAgentAuthRevision" in payload
+    if not has_profile and not has_revision:
+        return
+    _required_string(
+        payload,
+        "sandboxProfileId",
+        code="cloud_command_agent_auth_profile_required",
+        message=f"{kind} payload must contain sandboxProfileId with auth preflight.",
+    )
+    revision = _required_int(
+        payload,
+        "requiredAgentAuthRevision",
+        code="cloud_command_agent_auth_revision_required",
+        message=f"{kind} payload must contain requiredAgentAuthRevision with auth preflight.",
+    )
+    if revision < 0:
+        raise CloudApiError(
+            "cloud_command_agent_auth_revision_invalid",
+            f"{kind} requiredAgentAuthRevision must be non-negative.",
+            status_code=400,
+        )
 
 
 def _required_string(

--- a/server/proliferate/server/cloud/commands/models.py
+++ b/server/proliferate/server/cloud/commands/models.py
@@ -106,6 +106,7 @@ def _parse_result_json(kind: str, value: str | None) -> dict[str, object] | None
         CloudCommandKind.materialize_workspace.value,
         CloudCommandKind.ensure_repo_checkout.value,
         CloudCommandKind.configure_git_identity.value,
+        CloudCommandKind.refresh_agent_auth_config.value,
     }:
         return None
     if value is None:

--- a/server/proliferate/server/cloud/commands/models.py
+++ b/server/proliferate/server/cloud/commands/models.py
@@ -106,7 +106,6 @@ def _parse_result_json(kind: str, value: str | None) -> dict[str, object] | None
         CloudCommandKind.materialize_workspace.value,
         CloudCommandKind.ensure_repo_checkout.value,
         CloudCommandKind.configure_git_identity.value,
-        CloudCommandKind.refresh_agent_auth_config.value,
     }:
         return None
     if value is None:

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -16,6 +16,7 @@ from proliferate.constants.cloud import (
 )
 from proliferate.db.models.auth import User
 from proliferate.db.store import cloud_runtime_environments, cloud_workspaces
+from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.cloud.commands.domain.rules import (
@@ -143,6 +144,12 @@ async def enqueue_command(
         )
     kind = validate_active_command_kind(body.kind)
     source = validate_command_source(body.source)
+    if kind == CloudCommandKind.refresh_agent_auth_config.value:
+        raise CloudApiError(
+            "cloud_command_internal_only",
+            "Agent auth refresh commands are created by sandbox profile changes.",
+            status_code=400,
+        )
     validate_command_shape(
         kind=kind,
         workspace_id=body.workspace_id or _direct_start_session_workspace_id(body.payload),
@@ -150,6 +157,12 @@ async def enqueue_command(
         preconditions=body.preconditions,
     )
     validate_command_payload(kind=kind, payload=body.payload)
+    await _validate_agent_auth_preflight(
+        db,
+        user=user,
+        target=target,
+        payload=body.payload,
+    )
     resolved_workspace_id, payload, cloud_workspace_id = await _resolve_command_workspace(
         db,
         user=user,
@@ -211,6 +224,81 @@ async def enqueue_command(
         if duplicate is not None:
             return duplicate
         raise
+
+
+async def _validate_agent_auth_preflight(
+    db: AsyncSession,
+    *,
+    user: User,
+    target: targets_store.CloudTargetSnapshot,
+    payload: dict[str, object],
+) -> None:
+    sandbox_profile_id = payload.get("sandboxProfileId")
+    required_revision = payload.get("requiredAgentAuthRevision")
+    if sandbox_profile_id is None and required_revision is None:
+        return
+    try:
+        profile_id = UUID(str(sandbox_profile_id))
+    except (TypeError, ValueError) as exc:
+        raise CloudApiError(
+            "cloud_command_agent_auth_profile_invalid",
+            "Agent auth preflight sandboxProfileId is invalid.",
+            status_code=400,
+        ) from exc
+    if not isinstance(required_revision, int) or isinstance(required_revision, bool):
+        raise CloudApiError(
+            "cloud_command_agent_auth_revision_required",
+            "Agent auth preflight requiredAgentAuthRevision is required.",
+            status_code=400,
+        )
+    profile = await agent_auth_store.get_sandbox_profile(db, profile_id)
+    if profile is None:
+        raise CloudApiError(
+            "cloud_command_agent_auth_profile_not_found",
+            "Agent auth sandbox profile not found.",
+            status_code=404,
+        )
+    if profile.managed_target_id != target.id:
+        raise CloudApiError(
+            "cloud_command_agent_auth_target_mismatch",
+            "Agent auth sandbox profile is not attached to this target.",
+            status_code=409,
+        )
+    if profile.owner_scope == "personal":
+        if profile.owner_user_id != user.id:
+            raise CloudApiError(
+                "cloud_command_agent_auth_profile_not_found",
+                "Agent auth sandbox profile not found.",
+                status_code=404,
+            )
+    elif profile.organization_id != target.organization_id or profile.organization_id is None:
+        raise CloudApiError(
+            "cloud_command_agent_auth_target_mismatch",
+            "Agent auth sandbox profile does not match this target organization.",
+            status_code=409,
+        )
+    if required_revision != profile.agent_auth_revision:
+        raise CloudApiError(
+            "cloud_command_agent_auth_revision_stale",
+            "Agent auth preflight revision is stale.",
+            status_code=409,
+        )
+    state = await agent_auth_store.get_target_state(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=target.id,
+    )
+    if (
+        state is None
+        or state.status != "applied"
+        or state.applied_revision is None
+        or state.applied_revision < required_revision
+    ):
+        raise CloudApiError(
+            "cloud_command_agent_auth_not_ready",
+            "Agent auth config has not been applied to this target.",
+            status_code=409,
+        )
 
 
 async def get_command_status(

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -504,6 +504,28 @@ async def test_agent_auth_selection_queues_secret_safe_worker_materialization(
     assert applied.json()["status"] == "applied"
     assert applied.json()["appliedRevision"] == 1
 
+    result = await client.post(
+        f"/v1/cloud/worker/commands/{command['commandId']}/result",
+        headers=worker_headers,
+        json={
+            "status": "accepted",
+            "leaseId": command["leaseId"],
+            "result": {
+                "applied": True,
+                "runtimeGrantToken": token,
+                "protectedEnv": selection["gateway"]["protectedEnv"],
+            },
+        },
+    )
+    assert result.status_code == 200
+    command_status = await client.get(
+        f"/v1/cloud/commands/{command['commandId']}",
+        headers=_headers(tokens),
+    )
+    assert command_status.status_code == 200
+    assert command_status.json()["result"] is None
+    assert token not in str(command_status.json())
+
     target_states = await client.get(
         f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-target-states",
         headers=_headers(tokens),

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import uuid
+from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.db.store.cloud_agent_auth import store
 from proliferate.db.models.auth import OAuthAccount, User
+from proliferate.utils.crypto import encrypt_text
+from tests.e2e.cloud.helpers.github import seed_linked_github_account
 from tests.helpers.desktop_auth import mint_desktop_token_payload
 
 
@@ -50,6 +54,39 @@ async def _create_user_and_get_tokens(
 
 def _headers(tokens: dict[str, str]) -> dict[str, str]:
     return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+async def _create_enrolled_target(
+    client: AsyncClient,
+    headers: dict[str, str],
+    *,
+    suffix: str,
+) -> tuple[str, dict[str, str]]:
+    create = await client.post(
+        "/v1/cloud/targets/enrollments",
+        headers=headers,
+        json={
+            "displayName": f"Agent Auth Target {suffix}",
+            "kind": "ssh",
+            "ownerScope": "personal",
+            "defaultWorkspaceRoot": "~/proliferate-workspaces",
+        },
+    )
+    assert create.status_code == 200
+    enrollment = create.json()
+    enrolled = await client.post(
+        "/v1/cloud/worker/enroll",
+        json={
+            "enrollmentToken": enrollment["enrollmentToken"],
+            "machineFingerprint": f"agent-auth-{suffix}-{uuid.uuid4()}",
+            "hostname": f"agent-auth-{suffix}",
+            "workerVersion": "0.1.0",
+        },
+    )
+    assert enrolled.status_code == 200
+    return enrollment["target"]["id"], {
+        "Authorization": f"Bearer {enrolled.json()['workerToken']}"
+    }
 
 
 @pytest.mark.asyncio
@@ -324,3 +361,156 @@ async def test_managed_credits_route_is_not_customer_accessible(
     )
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_agent_auth_selection_queues_secret_safe_worker_materialization(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings.agent_gateway_public_base_url",
+        "https://gateway.test",
+    )
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-worker-materialization@example.com",
+    )
+    await seed_linked_github_account(
+        db_session,
+        user_id=tokens["user_id"],
+        access_token="gh-agent-auth-worker-token",
+        account_email="agent-auth-worker@example.com",
+    )
+    target_id, worker_headers = await _create_enrolled_target(
+        client,
+        _headers(tokens),
+        suffix="materialization",
+    )
+
+    actor_user_id = UUID(tokens["user_id"])
+    credential = await store.create_agent_auth_credential(
+        db_session,
+        owner_scope="personal",
+        owner_user_id=actor_user_id,
+        organization_id=None,
+        created_by_user_id=actor_user_id,
+        agent_kind="claude",
+        credential_kind="managed_gateway",
+        display_name="Ready Claude gateway",
+        redacted_summary_json='{"providerKind":"anthropic_api_key"}',
+        status="ready",
+    )
+    await store.ensure_gateway_policy(
+        db_session,
+        credential_id=credential.id,
+        policy_kind="personal_byok",
+        owner_scope="personal",
+        owner_user_id=actor_user_id,
+        organization_id=None,
+        budget_subject_id=None,
+        litellm_team_id="team-agent-auth",
+        litellm_virtual_key_id="key-agent-auth",
+        litellm_virtual_key_ciphertext=encrypt_text("litellm-secret-key"),
+        litellm_virtual_key_ciphertext_key_id="local",
+        litellm_sync_status="synced",
+        litellm_sync_fingerprint="fingerprint-agent-auth",
+        status="ready",
+        last_error_code=None,
+        last_error_message=None,
+    )
+    await db_session.commit()
+
+    profile_response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={"managedTargetId": target_id},
+    )
+    assert profile_response.status_code == 200
+    profile = profile_response.json()
+
+    select_response = await client.put(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-selections/claude",
+        headers=_headers(tokens),
+        json={"credentialId": str(credential.id), "forceRestart": True},
+    )
+    assert select_response.status_code == 200
+
+    lease = await client.post(
+        "/v1/cloud/worker/commands/lease",
+        headers=worker_headers,
+        json={"supportedKinds": ["refresh_agent_auth_config"], "leaseTimeoutSeconds": 30},
+    )
+    assert lease.status_code == 200
+    command = lease.json()["command"]
+    assert command["kind"] == "refresh_agent_auth_config"
+    assert command["payload"]["sandboxProfileId"] == profile["id"]
+    assert command["payload"]["revision"] == 1
+    assert command["payload"]["forceRestart"] is True
+    assert "litellm-secret-key" not in str(command)
+
+    materializing = await client.post(
+        f"/v1/cloud/worker/agent-auth-configs/{profile['id']}/status",
+        headers=worker_headers,
+        json={
+            "status": "materializing",
+            "commandId": command["commandId"],
+            "revision": command["payload"]["revision"],
+            "leaseId": command["leaseId"],
+        },
+    )
+    assert materializing.status_code == 200
+    assert materializing.json()["status"] == "materializing"
+
+    materialization = await client.get(
+        f"/v1/cloud/worker/agent-auth-configs/{profile['id']}/materialization",
+        headers=worker_headers,
+        params={
+            "command_id": command["commandId"],
+            "revision": command["payload"]["revision"],
+            "lease_id": command["leaseId"],
+        },
+    )
+    assert materialization.status_code == 200
+    plan = materialization.json()
+    assert plan["applied"] is True
+    assert plan["sandboxProfileId"] == profile["id"]
+    selection = plan["selections"][0]
+    assert selection["agentKind"] == "claude"
+    assert selection["gateway"]["protocolFacade"] == "anthropic"
+    assert selection["gateway"]["baseUrls"]["anthropic"] == "https://gateway.test/anthropic"
+    token = selection["gateway"]["runtimeGrantToken"]
+    assert token
+    assert selection["gateway"]["protectedEnv"]["ANTHROPIC_BASE_URL"] == (
+        "https://gateway.test/anthropic"
+    )
+    assert selection["gateway"]["protectedEnv"]["ANTHROPIC_CUSTOM_HEADERS"] == (
+        f"Authorization: Bearer {token}"
+    )
+
+    applied = await client.post(
+        f"/v1/cloud/worker/agent-auth-configs/{profile['id']}/status",
+        headers=worker_headers,
+        json={
+            "status": "applied",
+            "commandId": command["commandId"],
+            "revision": command["payload"]["revision"],
+            "leaseId": command["leaseId"],
+        },
+    )
+    assert applied.status_code == 200
+    assert applied.json()["status"] == "applied"
+    assert applied.json()["appliedRevision"] == 1
+
+    target_states = await client.get(
+        f"/v1/cloud/sandbox-profiles/{profile['id']}/agent-auth-target-states",
+        headers=_headers(tokens),
+    )
+    assert target_states.status_code == 200
+    state = target_states.json()[0]
+    assert state["desiredRevision"] == 1
+    assert state["appliedRevision"] == 1
+    assert state["status"] == "applied"
+    assert state["forceRestartRequired"] is False

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import CloudWorkspaceStatus
 from proliferate.db.models.cloud.commands import CloudCommand
+from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store import cloud_runtime_environments, cloud_workspaces
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
@@ -884,6 +885,128 @@ class TestCloudCommandsApi:
         )
         assert created.status_code == 400
         assert created.json()["detail"]["code"] == "cloud_command_kind_unsupported"
+
+    @pytest.mark.asyncio
+    async def test_agent_auth_refresh_command_is_internal_only(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-agent-auth-internal",
+        )
+        target_id, _worker_headers = await _create_enrolled_target(client, db_session, auth)
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "agent-auth-refresh-direct",
+                "targetId": target_id,
+                "kind": "refresh_agent_auth_config",
+                "payload": {
+                    "sandboxProfileId": str(UUID(int=1)),
+                    "revision": 1,
+                    "reason": "direct_api",
+                    "forceRestart": False,
+                },
+            },
+        )
+        assert created.status_code == 400
+        assert created.json()["detail"]["code"] == "cloud_command_internal_only"
+
+    @pytest.mark.asyncio
+    async def test_agent_auth_preflight_requires_applied_target_state(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-agent-auth-preflight",
+        )
+        target_id, _worker_headers = await _create_enrolled_target(client, db_session, auth)
+        target_uuid = UUID(target_id)
+        profile = await agent_auth_store.ensure_personal_sandbox_profile(
+            db_session,
+            user_id=UUID(auth.user_id),
+            managed_target_id=target_uuid,
+        )
+        profile = await agent_auth_store.bump_sandbox_profile_agent_auth_revision(
+            db_session,
+            sandbox_profile_id=profile.id,
+            reason="test_preflight",
+            actor_user_id=UUID(auth.user_id),
+            force_restart=False,
+        )
+        assert profile is not None
+        await agent_auth_store.upsert_target_state(
+            db_session,
+            sandbox_profile_id=profile.id,
+            target_id=target_uuid,
+            desired_revision=profile.agent_auth_revision,
+            applied_revision=None,
+            status="pending",
+            force_restart_required=False,
+            last_command_id=None,
+            last_worker_id=None,
+            last_error_code=None,
+            last_error_message=None,
+        )
+        await db_session.commit()
+
+        pending = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "agent-auth-preflight-pending",
+                "targetId": target_id,
+                "kind": "start_session",
+                "payload": {
+                    "workspaceId": "anyharness-workspace-1",
+                    "agentKind": "claude",
+                    "sandboxProfileId": str(profile.id),
+                    "requiredAgentAuthRevision": profile.agent_auth_revision,
+                },
+            },
+        )
+        assert pending.status_code == 409
+        assert pending.json()["detail"]["code"] == "cloud_command_agent_auth_not_ready"
+
+        await agent_auth_store.upsert_target_state(
+            db_session,
+            sandbox_profile_id=profile.id,
+            target_id=target_uuid,
+            desired_revision=profile.agent_auth_revision,
+            applied_revision=profile.agent_auth_revision,
+            status="applied",
+            force_restart_required=False,
+            last_command_id=None,
+            last_worker_id=None,
+            last_error_code=None,
+            last_error_message=None,
+        )
+        await db_session.commit()
+
+        ready = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "agent-auth-preflight-ready",
+                "targetId": target_id,
+                "kind": "start_session",
+                "payload": {
+                    "workspaceId": "anyharness-workspace-1",
+                    "agentKind": "claude",
+                    "sandboxProfileId": str(profile.id),
+                    "requiredAgentAuthRevision": profile.agent_auth_revision,
+                },
+            },
+        )
+        assert ready.status_code == 200
 
     @pytest.mark.asyncio
     async def test_preconditions_are_rejected_until_supported(


### PR DESCRIPTION
## Summary

Stacked on #254.

Adds the server-side Phase 3 contract for agent-auth refresh materialization:

- adds `refresh_agent_auth_config` as an active CloudCommand kind, including payload/preflight validation and an Alembic constraint update
- queues refresh commands when managed sandbox profile auth selections or imported legacy credentials change
- adds worker-only materialization/status endpoints under `/v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}`
- returns gateway runtime grants and protected harness env/config only from the worker materialization endpoint, keeping command payloads secret-safe
- updates per-target agent-auth applied state from worker status reports

## Validation

- `uv run ruff check proliferate/server/cloud/agent_auth proliferate/server/cloud/commands proliferate/db/store/cloud_credentials.py tests/integration/test_cloud_agent_auth_api.py alembic/versions/e7f8a9b0c1d2_agent_auth_refresh_command.py`
- `DEBUG=1 uv run --extra dev python -m pytest -q tests/integration/test_cloud_agent_auth_api.py tests/integration/test_cloud_commands_api.py`
- `DEBUG=1 uv run --extra dev python -m pytest -q tests/integration/test_schema_migrations.py::test_alembic_upgrade_creates_current_schema tests/unit/test_cloud_orm_models.py`
- `DEBUG=1 uv run --extra dev python -m pytest -q tests/unit/test_server_boundary_checker.py`
- `DEBUG=1 uv run --extra dev python - <<'PY' ... create_app() ... PY`
- `git diff --check`