### PR TITLE
feat(desktop): add agent auth gateway configuration UI

### DIFF
--- a/cloud/sdk-react/src/hooks/agent-auth.ts
+++ b/cloud/sdk-react/src/hooks/agent-auth.ts
@@ -1,0 +1,171 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createAgentAuthCredentialShare,
+  createGatewayCredential,
+  deleteAgentAuthCredential,
+  deleteAgentAuthCredentialShare,
+  ensureManagedCreditsForOrganization,
+  ensureOrganizationSandboxProfile,
+  ensurePersonalSandboxProfile,
+  getSandboxAgentAuthSelections,
+  getSandboxAgentAuthTargetStates,
+  listAgentAuthCredentials,
+  putSandboxAgentAuthSelection,
+  type AgentAuthAgentKind,
+  type AgentAuthCredential,
+  type AgentAuthCredentialListOptions,
+  type CreateGatewayCredentialRequest,
+  type EnsureManagedCreditsRequest,
+  type SandboxAgentAuthSelection,
+  type SandboxAgentAuthTargetState,
+  type SandboxProfile,
+  type SelectAgentAuthCredentialInput,
+} from "@proliferate/cloud-sdk";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+import {
+  agentAuthCredentialsKey,
+  agentAuthRootKey,
+  sandboxAgentAuthSelectionsKey,
+  sandboxAgentAuthTargetStatesKey,
+} from "../lib/query-keys.js";
+
+const EMPTY_CREDENTIALS: AgentAuthCredential[] = [];
+const EMPTY_SELECTIONS: SandboxAgentAuthSelection[] = [];
+const EMPTY_TARGET_STATES: SandboxAgentAuthTargetState[] = [];
+
+export function useAgentAuthCredentials(
+  options: AgentAuthCredentialListOptions & { enabled?: boolean } = {},
+) {
+  const client = useCloudClient();
+  const organizationId = options.organizationId ?? null;
+  const agentKind = options.agentKind ?? null;
+  return useQuery<AgentAuthCredential[]>({
+    queryKey: agentAuthCredentialsKey(organizationId, agentKind),
+    queryFn: () => listAgentAuthCredentials({ organizationId, agentKind }, client),
+    enabled: options.enabled ?? true,
+    placeholderData: EMPTY_CREDENTIALS,
+  });
+}
+
+export function useSandboxAgentAuthSelections(
+  sandboxProfileId: string | null,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<SandboxAgentAuthSelection[]>({
+    queryKey: sandboxAgentAuthSelectionsKey(sandboxProfileId),
+    queryFn: () => getSandboxAgentAuthSelections(sandboxProfileId!, client),
+    enabled: enabled && sandboxProfileId !== null,
+    placeholderData: EMPTY_SELECTIONS,
+  });
+}
+
+export function useSandboxAgentAuthTargetStates(
+  sandboxProfileId: string | null,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<SandboxAgentAuthTargetState[]>({
+    queryKey: sandboxAgentAuthTargetStatesKey(sandboxProfileId),
+    queryFn: () => getSandboxAgentAuthTargetStates(sandboxProfileId!, client),
+    enabled: enabled && sandboxProfileId !== null,
+    placeholderData: EMPTY_TARGET_STATES,
+  });
+}
+
+export function useAgentAuthMutations() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+
+  const invalidateAgentAuth = async () => {
+    await queryClient.invalidateQueries({ queryKey: agentAuthRootKey() });
+  };
+
+  const createCredential = useMutation({
+    mutationFn: (body: CreateGatewayCredentialRequest) =>
+      createGatewayCredential(body, client),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const deleteCredential = useMutation({
+    mutationFn: (credentialId: string) => deleteAgentAuthCredential(credentialId, client),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const createShare = useMutation({
+    mutationFn: (input: { credentialId: string; organizationId: string }) =>
+      createAgentAuthCredentialShare(
+        input.credentialId,
+        input.organizationId,
+        client,
+      ),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const deleteShare = useMutation({
+    mutationFn: (shareId: string) => deleteAgentAuthCredentialShare(shareId, client),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const ensurePersonalProfile = useMutation({
+    mutationFn: (input: { managedTargetId?: string | null } = {}) =>
+      ensurePersonalSandboxProfile(input, client),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const ensureOrganizationProfile = useMutation({
+    mutationFn: (input: { organizationId: string; managedTargetId?: string | null }) =>
+      ensureOrganizationSandboxProfile(
+        input.organizationId,
+        { managedTargetId: input.managedTargetId ?? null },
+        client,
+      ),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const selectCredential = useMutation({
+    mutationFn: (input: {
+      sandboxProfileId: string;
+      agentKind: AgentAuthAgentKind;
+      selection: SelectAgentAuthCredentialInput;
+    }) => putSandboxAgentAuthSelection(
+      input.sandboxProfileId,
+      input.agentKind,
+      input.selection,
+      client,
+    ),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  const ensureManagedCredits = useMutation({
+    mutationFn: (input: {
+      organizationId: string;
+      request: EnsureManagedCreditsRequest;
+    }) => ensureManagedCreditsForOrganization(
+      input.organizationId,
+      input.request,
+      client,
+    ),
+    onSuccess: invalidateAgentAuth,
+  });
+
+  return {
+    createCredential: createCredential.mutateAsync,
+    isCreatingCredential: createCredential.isPending,
+    deleteCredential: deleteCredential.mutateAsync,
+    isDeletingCredential: deleteCredential.isPending,
+    createShare: createShare.mutateAsync,
+    isCreatingShare: createShare.isPending,
+    deleteShare: deleteShare.mutateAsync,
+    isDeletingShare: deleteShare.isPending,
+    ensurePersonalProfile: ensurePersonalProfile.mutateAsync as (
+      input?: { managedTargetId?: string | null },
+    ) => Promise<SandboxProfile>,
+    ensureOrganizationProfile: ensureOrganizationProfile.mutateAsync,
+    isEnsuringProfile: ensurePersonalProfile.isPending || ensureOrganizationProfile.isPending,
+    selectCredential: selectCredential.mutateAsync,
+    isSelectingCredential: selectCredential.isPending,
+    ensureManagedCredits: ensureManagedCredits.mutateAsync,
+    isEnsuringManagedCredits: ensureManagedCredits.isPending,
+  };
+}

--- a/cloud/sdk-react/src/hooks/agent-auth.ts
+++ b/cloud/sdk-react/src/hooks/agent-auth.ts
@@ -140,10 +140,10 @@ export function useAgentAuthMutations() {
   const ensureManagedCredits = useMutation({
     mutationFn: (input: {
       organizationId: string;
-      request: EnsureManagedCreditsRequest;
+      request?: EnsureManagedCreditsRequest;
     }) => ensureManagedCreditsForOrganization(
       input.organizationId,
-      input.request,
+      input.request ?? {},
       client,
     ),
     onSuccess: invalidateAgentAuth,

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./context/CloudClientProvider.js";
 export * from "./hooks/auth.js";
 export * from "./hooks/automations.js";
+export * from "./hooks/agent-auth.js";
 export * from "./hooks/commands.js";
 export * from "./hooks/config.js";
 export * from "./hooks/credentials.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -18,6 +18,33 @@ export function cloudCredentialsKey() {
   return [...cloudRootKey(), "credentials"] as const;
 }
 
+export function agentAuthRootKey() {
+  return [...cloudRootKey(), "agent-auth"] as const;
+}
+
+export function agentAuthCredentialsKey(
+  organizationId: string | null = null,
+  agentKind: string | null = null,
+) {
+  return [...agentAuthRootKey(), "credentials", organizationId, agentKind] as const;
+}
+
+export function sandboxProfileKey(sandboxProfileId: string | null) {
+  return [...agentAuthRootKey(), "sandbox-profile", sandboxProfileId] as const;
+}
+
+export function sandboxAgentAuthSelectionsKey(sandboxProfileId: string | null) {
+  return [...sandboxProfileKey(sandboxProfileId), "selections"] as const;
+}
+
+export function sandboxAgentAuthTargetStatesKey(sandboxProfileId: string | null) {
+  return [...sandboxProfileKey(sandboxProfileId), "target-states"] as const;
+}
+
+export function agentAuthManagedCreditsKey(organizationId: string | null) {
+  return [...agentAuthRootKey(), "managed-credits", organizationId] as const;
+}
+
 export type CloudOwnerScope = "personal" | "organization";
 
 export interface CloudOwnerSelectionKey {

--- a/cloud/sdk/src/client/agent-auth.ts
+++ b/cloud/sdk/src/client/agent-auth.ts
@@ -1,0 +1,246 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type {
+  AgentAuthAgentKind,
+  AgentAuthCredential,
+  AgentAuthCredentialListOptions,
+  AgentAuthCredentialShare,
+  AgentAuthMutationResponse,
+  CreateAnthropicApiKeyCredentialInput,
+  CreateBedrockAssumeRoleCredentialInput,
+  CreateGatewayCredentialRequest,
+  CreateGatewayCredentialResponse,
+  CreateOpenAiApiKeyCredentialInput,
+  CreateOpenAiCompatibleCredentialInput,
+  EnsureManagedCreditsRequest,
+  EnsureManagedCreditsResponse,
+  EnsureSandboxProfileInput,
+  SandboxAgentAuthSelection,
+  SandboxAgentAuthTargetState,
+  SandboxProfile,
+  SelectAgentAuthCredentialInput,
+} from "../types/index.js";
+
+export async function listAgentAuthCredentials(
+  options: AgentAuthCredentialListOptions = {},
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthCredential[]> {
+  return client.requestJson<AgentAuthCredential[]>({
+    method: "GET",
+    path: "/v1/cloud/agent-auth/credentials",
+    query: {
+      organizationId: options.organizationId,
+      agentKind: options.agentKind,
+    },
+  });
+}
+
+export async function createGatewayCredential(
+  body: CreateGatewayCredentialRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<CreateGatewayCredentialResponse> {
+  return client.requestJson<CreateGatewayCredentialResponse>({
+    method: "POST",
+    path: "/v1/cloud/agent-auth/credentials/gateway",
+    body,
+  });
+}
+
+export function createAnthropicApiKeyCredential(
+  input: CreateAnthropicApiKeyCredentialInput,
+  client?: ProliferateCloudClient,
+): Promise<CreateGatewayCredentialResponse> {
+  return createGatewayCredential(
+    {
+      ownerScope: input.ownerScope,
+      organizationId: input.organizationId ?? null,
+      agentKind: "claude",
+      displayName: input.displayName,
+      policyKind: policyKindForOwner(input.ownerScope),
+      providerKind: "anthropic_api_key",
+      payload: { apiKey: input.apiKey },
+    },
+    client,
+  );
+}
+
+export function createOpenAiApiKeyCredential(
+  input: CreateOpenAiApiKeyCredentialInput,
+  client?: ProliferateCloudClient,
+): Promise<CreateGatewayCredentialResponse> {
+  return createGatewayCredential(
+    {
+      ownerScope: input.ownerScope,
+      organizationId: input.organizationId ?? null,
+      agentKind: input.agentKind,
+      displayName: input.displayName,
+      policyKind: policyKindForOwner(input.ownerScope),
+      providerKind: "openai_api_key",
+      payload: { apiKey: input.apiKey },
+    },
+    client,
+  );
+}
+
+export function createOpenAiCompatibleCredential(
+  input: CreateOpenAiCompatibleCredentialInput,
+  client?: ProliferateCloudClient,
+): Promise<CreateGatewayCredentialResponse> {
+  return createGatewayCredential(
+    {
+      ownerScope: input.ownerScope,
+      organizationId: input.organizationId ?? null,
+      agentKind: input.agentKind,
+      displayName: input.displayName,
+      policyKind: policyKindForOwner(input.ownerScope),
+      providerKind: "openai_compatible",
+      payload: {
+        baseUrl: input.baseUrl,
+        apiKey: input.apiKey,
+      },
+    },
+    client,
+  );
+}
+
+export function createBedrockAssumeRoleCredential(
+  input: CreateBedrockAssumeRoleCredentialInput,
+  client?: ProliferateCloudClient,
+): Promise<CreateGatewayCredentialResponse> {
+  return createGatewayCredential(
+    {
+      ownerScope: input.ownerScope,
+      organizationId: input.organizationId ?? null,
+      agentKind: "claude",
+      displayName: input.displayName,
+      policyKind: policyKindForOwner(input.ownerScope),
+      providerKind: "bedrock_assume_role",
+      payload: {
+        roleArn: input.roleArn,
+        region: input.region,
+        externalId: input.externalId,
+      },
+    },
+    client,
+  );
+}
+
+export async function deleteAgentAuthCredential(
+  credentialId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthMutationResponse> {
+  return client.requestJson<AgentAuthMutationResponse>({
+    method: "DELETE",
+    path: "/v1/cloud/agent-auth/credentials/{credential_id}",
+    pathParams: { credential_id: credentialId },
+  });
+}
+
+export async function createAgentAuthCredentialShare(
+  credentialId: string,
+  organizationId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthCredentialShare> {
+  return client.requestJson<AgentAuthCredentialShare>({
+    method: "POST",
+    path: "/v1/cloud/agent-auth/credentials/{credential_id}/shares",
+    pathParams: { credential_id: credentialId },
+    body: { organizationId },
+  });
+}
+
+export async function deleteAgentAuthCredentialShare(
+  shareId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthCredentialShare> {
+  return client.requestJson<AgentAuthCredentialShare>({
+    method: "DELETE",
+    path: "/v1/cloud/agent-auth/credential-shares/{share_id}",
+    pathParams: { share_id: shareId },
+  });
+}
+
+export async function ensurePersonalSandboxProfile(
+  input: EnsureSandboxProfileInput = {},
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<SandboxProfile> {
+  return client.requestJson<SandboxProfile>({
+    method: "POST",
+    path: "/v1/cloud/sandbox-profiles/personal",
+    body: { managedTargetId: input.managedTargetId ?? null },
+  });
+}
+
+export async function ensureOrganizationSandboxProfile(
+  organizationId: string,
+  input: EnsureSandboxProfileInput = {},
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<SandboxProfile> {
+  return client.requestJson<SandboxProfile>({
+    method: "POST",
+    path: "/v1/cloud/organizations/{organization_id}/sandbox-profile",
+    pathParams: { organization_id: organizationId },
+    body: { managedTargetId: input.managedTargetId ?? null },
+  });
+}
+
+export async function getSandboxAgentAuthSelections(
+  sandboxProfileId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<SandboxAgentAuthSelection[]> {
+  return client.requestJson<SandboxAgentAuthSelection[]>({
+    method: "GET",
+    path: "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections",
+    pathParams: { sandbox_profile_id: sandboxProfileId },
+  });
+}
+
+export async function putSandboxAgentAuthSelection(
+  sandboxProfileId: string,
+  agentKind: AgentAuthAgentKind,
+  input: SelectAgentAuthCredentialInput,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<SandboxAgentAuthSelection> {
+  return client.requestJson<SandboxAgentAuthSelection>({
+    method: "PUT",
+    path: "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections/{agent_kind}",
+    pathParams: {
+      sandbox_profile_id: sandboxProfileId,
+      agent_kind: agentKind,
+    },
+    body: {
+      credentialId: input.credentialId,
+      credentialShareId: input.credentialShareId ?? null,
+      forceRestart: input.forceRestart ?? false,
+    },
+  });
+}
+
+export async function getSandboxAgentAuthTargetStates(
+  sandboxProfileId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<SandboxAgentAuthTargetState[]> {
+  return client.requestJson<SandboxAgentAuthTargetState[]>({
+    method: "GET",
+    path: "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-target-states",
+    pathParams: { sandbox_profile_id: sandboxProfileId },
+  });
+}
+
+export async function ensureManagedCreditsForOrganization(
+  organizationId: string,
+  input: EnsureManagedCreditsRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<EnsureManagedCreditsResponse> {
+  return client.requestJson<EnsureManagedCreditsResponse>({
+    method: "POST",
+    path: "/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits",
+    pathParams: { organization_id: organizationId },
+    body: input,
+  });
+}
+
+function policyKindForOwner(
+  ownerScope: CreateGatewayCredentialRequest["ownerScope"],
+): CreateGatewayCredentialRequest["policyKind"] {
+  return ownerScope === "organization" ? "org_byok" : "personal_byok";
+}

--- a/cloud/sdk/src/client/agent-auth.ts
+++ b/cloud/sdk/src/client/agent-auth.ts
@@ -228,7 +228,7 @@ export async function getSandboxAgentAuthTargetStates(
 
 export async function ensureManagedCreditsForOrganization(
   organizationId: string,
-  input: EnsureManagedCreditsRequest,
+  input: EnsureManagedCreditsRequest = {},
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<EnsureManagedCreditsResponse> {
   return client.requestJson<EnsureManagedCreditsResponse>({

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1971,108 +1971,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/anthropic/v1/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Anthropic Models */
-        get: operations["anthropic_models_anthropic_v1_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/openai/v1/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Openai Models */
-        get: operations["openai_models_openai_v1_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/openai/v1/chat/completions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Forward Protocol Request */
-        post: operations["forward_protocol_request_openai_v1_chat_completions_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/openai/v1/responses": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Forward Protocol Request */
-        post: operations["forward_protocol_request_openai_v1_responses_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/anthropic/v1/messages/count_tokens": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Forward Protocol Request */
-        post: operations["forward_protocol_request_anthropic_v1_messages_count_tokens_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/anthropic/v1/messages": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Forward Protocol Request */
-        post: operations["forward_protocol_request_anthropic_v1_messages_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/support/messages": {
         parameters: {
             query?: never;
@@ -2685,6 +2583,8 @@ export interface components {
             revision: number;
             /** Legacycloudcredentialid */
             legacyCloudCredentialId: string | null;
+            /** Activecredentialshareid */
+            activeCredentialShareId?: string | null;
             /** Revokedat */
             revokedAt: string | null;
         };
@@ -4456,12 +4356,7 @@ export interface components {
             received: boolean;
         };
         /** EnsureManagedCreditsRequest */
-        EnsureManagedCreditsRequest: {
-            /** Includedbudgetusd */
-            includedBudgetUsd?: string | null;
-            /** Agentkinds */
-            agentKinds?: ("claude" | "codex" | "opencode" | "gemini")[];
-        };
+        EnsureManagedCreditsRequest: Record<string, never>;
         /** EnsureManagedCreditsResponse */
         EnsureManagedCreditsResponse: {
             budgetSubject: components["schemas"]["AgentGatewayBudgetSubjectResponse"];
@@ -10977,126 +10872,6 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
-                };
-            };
-        };
-    };
-    anthropic_models_anthropic_v1_models_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    openai_models_openai_v1_models_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    forward_protocol_request_openai_v1_chat_completions_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    forward_protocol_request_openai_v1_responses_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    forward_protocol_request_anthropic_v1_messages_count_tokens_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    forward_protocol_request_anthropic_v1_messages_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -914,6 +914,193 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/agent-auth/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Auth Credentials Endpoint */
+        get: operations["list_agent_auth_credentials_endpoint_v1_cloud_agent_auth_credentials_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-auth/credentials/gateway": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Gateway Credential Endpoint */
+        post: operations["create_gateway_credential_endpoint_v1_cloud_agent_auth_credentials_gateway_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ensure Managed Credits Endpoint */
+        post: operations["ensure_managed_credits_endpoint_v1_cloud_organizations__organization_id__agent_auth_managed_credits_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-auth/credentials/{credential_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke Agent Auth Credential Endpoint */
+        delete: operations["revoke_agent_auth_credential_endpoint_v1_cloud_agent_auth_credentials__credential_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-auth/credentials/{credential_id}/shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Share Agent Auth Credential Endpoint */
+        post: operations["share_agent_auth_credential_endpoint_v1_cloud_agent_auth_credentials__credential_id__shares_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-auth/credential-shares/{share_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke Agent Auth Credential Share Endpoint */
+        delete: operations["revoke_agent_auth_credential_share_endpoint_v1_cloud_agent_auth_credential_shares__share_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sandbox-profiles/personal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ensure Personal Sandbox Profile Endpoint */
+        post: operations["ensure_personal_sandbox_profile_endpoint_v1_cloud_sandbox_profiles_personal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/organizations/{organization_id}/sandbox-profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ensure Organization Sandbox Profile Endpoint */
+        post: operations["ensure_organization_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profile_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Auth Selections Endpoint */
+        get: operations["list_agent_auth_selections_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_selections_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-selections/{agent_kind}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Select Agent Auth Credential Endpoint */
+        put: operations["select_agent_auth_credential_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_selections__agent_kind__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/sandbox-profiles/{sandbox_profile_id}/agent-auth-target-states": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Auth Target States Endpoint */
+        get: operations["list_agent_auth_target_states_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_target_states_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/mcp/catalog": {
         parameters: {
             query?: never;
@@ -1495,6 +1682,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/materialization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Worker Agent Auth Materialization Endpoint */
+        get: operations["worker_agent_auth_materialization_endpoint_v1_cloud_worker_agent_auth_configs__sandbox_profile_id__materialization_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Agent Auth Status Endpoint */
+        post: operations["worker_agent_auth_status_endpoint_v1_cloud_worker_agent_auth_configs__sandbox_profile_id__status_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/worker/target-configs/{config_id}/materialization": {
         parameters: {
             query?: never;
@@ -1727,6 +1948,125 @@ export interface paths {
         put?: never;
         /** Generate Session Title Endpoint */
         post: operations["generate_session_title_endpoint_v1_ai_magic_session_titles_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agent-gateway/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Agent Gateway Health */
+        get: operations["agent_gateway_health_agent_gateway_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/anthropic/v1/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Anthropic Models */
+        get: operations["anthropic_models_anthropic_v1_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/openai/v1/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Openai Models */
+        get: operations["openai_models_openai_v1_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/openai/v1/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forward Protocol Request */
+        post: operations["forward_protocol_request_openai_v1_chat_completions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/openai/v1/responses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forward Protocol Request */
+        post: operations["forward_protocol_request_openai_v1_responses_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/anthropic/v1/messages/count_tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forward Protocol Request */
+        post: operations["forward_protocol_request_anthropic_v1_messages_count_tokens_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/anthropic/v1/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forward Protocol Request */
+        post: operations["forward_protocol_request_anthropic_v1_messages_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2314,6 +2654,91 @@ export interface components {
             /** Githubgrantstatus */
             githubGrantStatus: string | null;
         };
+        /** AgentAuthCredentialResponse */
+        AgentAuthCredentialResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Createdbyuserid */
+            createdByUserId: string | null;
+            /** Agentkind */
+            agentKind: string;
+            /** Credentialkind */
+            credentialKind: string;
+            /** Displayname */
+            displayName: string;
+            /** Redactedsummary */
+            redactedSummary: {
+                [key: string]: unknown;
+            };
+            /** Status */
+            status: string;
+            /** Revision */
+            revision: number;
+            /** Legacycloudcredentialid */
+            legacyCloudCredentialId: string | null;
+            /** Revokedat */
+            revokedAt: string | null;
+        };
+        /** AgentAuthCredentialShareResponse */
+        AgentAuthCredentialShareResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Credentialid
+             * Format: uuid
+             */
+            credentialId: string;
+            /**
+             * Owneruserid
+             * Format: uuid
+             */
+            ownerUserId: string;
+            /**
+             * Organizationid
+             * Format: uuid
+             */
+            organizationId: string;
+            /** Sharescope */
+            shareScope: string;
+            /**
+             * Sharedbyuserid
+             * Format: uuid
+             */
+            sharedByUserId: string;
+            /** Status */
+            status: string;
+            /** Allowedagentkind */
+            allowedAgentKind: string;
+            /** Revokedat */
+            revokedAt: string | null;
+            /** Revokedbyuserid */
+            revokedByUserId: string | null;
+        };
+        /** AgentAuthMutationResponse */
+        AgentAuthMutationResponse: {
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
+            /**
+             * Changed
+             * @default false
+             */
+            changed: boolean;
+        };
         /** AgentCatalogAgent */
         AgentCatalogAgent: {
             /**
@@ -2530,6 +2955,99 @@ export interface components {
             controls: components["schemas"]["AgentCatalogControl"][];
         } & {
             [key: string]: unknown;
+        };
+        /** AgentGatewayBudgetSubjectResponse */
+        AgentGatewayBudgetSubjectResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Organizationid
+             * Format: uuid
+             */
+            organizationId: string;
+            /** Litellmteamid */
+            litellmTeamId: string | null;
+            /** Includedbudgetusd */
+            includedBudgetUsd: string;
+            /** Budgetduration */
+            budgetDuration: string;
+            /** Litellmsyncstatus */
+            litellmSyncStatus: string;
+            /** Status */
+            status: string;
+            /** Revision */
+            revision: number;
+            /** Lasterrorcode */
+            lastErrorCode: string | null;
+            /** Lasterrormessage */
+            lastErrorMessage: string | null;
+        };
+        /** AgentGatewayPolicyResponse */
+        AgentGatewayPolicyResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Credentialid
+             * Format: uuid
+             */
+            credentialId: string;
+            /** Policykind */
+            policyKind: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Budgetsubjectid */
+            budgetSubjectId: string | null;
+            /** Litellmteamid */
+            litellmTeamId: string | null;
+            /** Litellmvirtualkeyid */
+            litellmVirtualKeyId: string | null;
+            /** Litellmsyncstatus */
+            litellmSyncStatus: string;
+            /** Status */
+            status: string;
+            /** Revision */
+            revision: number;
+            /** Lasterrorcode */
+            lastErrorCode: string | null;
+            /** Lasterrormessage */
+            lastErrorMessage: string | null;
+        };
+        /** AgentGatewayProviderCredentialResponse */
+        AgentGatewayProviderCredentialResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Policyid
+             * Format: uuid
+             */
+            policyId: string;
+            /** Providerkind */
+            providerKind: string;
+            /** Redactedsummary */
+            redactedSummary: {
+                [key: string]: unknown;
+            };
+            /** Validationstatus */
+            validationStatus: string;
+            /** Validationerrorcode */
+            validationErrorCode: string | null;
+            /** Validationerrormessage */
+            validationErrorMessage: string | null;
+            /** Revision */
+            revision: number;
         };
         /** AnonymousTelemetryAcceptedResponse */
         AnonymousTelemetryAcceptedResponse: {
@@ -3874,6 +4392,43 @@ export interface components {
             /** Organizationid */
             organizationId?: string | null;
         };
+        /** CreateGatewayCredentialRequest */
+        CreateGatewayCredentialRequest: {
+            /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
+            /**
+             * Agentkind
+             * @enum {string}
+             */
+            agentKind: "claude" | "codex" | "opencode" | "gemini";
+            /** Displayname */
+            displayName: string;
+            /**
+             * Policykind
+             * @enum {string}
+             */
+            policyKind: "org_byok" | "personal_byok";
+            /**
+             * Providerkind
+             * @enum {string}
+             */
+            providerKind: "anthropic_api_key" | "openai_api_key" | "bedrock_assume_role" | "openai_compatible";
+            /** Payload */
+            payload: {
+                [key: string]: string;
+            };
+        };
+        /** CreateGatewayCredentialResponse */
+        CreateGatewayCredentialResponse: {
+            credential: components["schemas"]["AgentAuthCredentialResponse"];
+            policy: components["schemas"]["AgentGatewayPolicyResponse"];
+            providerCredential: components["schemas"]["AgentGatewayProviderCredentialResponse"];
+        };
         /** CredentialStatus */
         CredentialStatus: {
             /** Provider */
@@ -3900,6 +4455,21 @@ export interface components {
              */
             received: boolean;
         };
+        /** EnsureManagedCreditsRequest */
+        EnsureManagedCreditsRequest: {
+            /** Includedbudgetusd */
+            includedBudgetUsd?: string | null;
+            /** Agentkinds */
+            agentKinds?: ("claude" | "codex" | "opencode" | "gemini")[];
+        };
+        /** EnsureManagedCreditsResponse */
+        EnsureManagedCreditsResponse: {
+            budgetSubject: components["schemas"]["AgentGatewayBudgetSubjectResponse"];
+            /** Credentials */
+            credentials: components["schemas"]["AgentAuthCredentialResponse"][];
+            /** Policies */
+            policies: components["schemas"]["AgentGatewayPolicyResponse"][];
+        };
         /** EnsureMobilityWorkspaceRequest */
         EnsureMobilityWorkspaceRequest: {
             /** Gitprovider */
@@ -3917,6 +4487,16 @@ export interface components {
              * @default local
              */
             ownerHint: string;
+        };
+        /** EnsureOrganizationSandboxProfileRequest */
+        EnsureOrganizationSandboxProfileRequest: {
+            /** Managedtargetid */
+            managedTargetId?: string | null;
+        };
+        /** EnsurePersonalSandboxProfileRequest */
+        EnsurePersonalSandboxProfileRequest: {
+            /** Managedtargetid */
+            managedTargetId?: string | null;
         };
         /** ErrorModel */
         ErrorModel: {
@@ -4747,6 +5327,94 @@ export interface components {
             /** Activecommandcount */
             activeCommandCount: number;
         };
+        /** SandboxAgentAuthSelectionResponse */
+        SandboxAgentAuthSelectionResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Sandboxprofileid
+             * Format: uuid
+             */
+            sandboxProfileId: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Agentkind */
+            agentKind: string;
+            /**
+             * Credentialid
+             * Format: uuid
+             */
+            credentialId: string;
+            /** Credentialshareid */
+            credentialShareId: string | null;
+            /** Materializationmode */
+            materializationMode: string;
+            /** Selectedrevision */
+            selectedRevision: number;
+            /** Status */
+            status: string;
+            /** Lasterrorcode */
+            lastErrorCode: string | null;
+            /** Lasterrormessage */
+            lastErrorMessage: string | null;
+        };
+        /** SandboxProfileAgentAuthTargetStateResponse */
+        SandboxProfileAgentAuthTargetStateResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Sandboxprofileid
+             * Format: uuid
+             */
+            sandboxProfileId: string;
+            /**
+             * Targetid
+             * Format: uuid
+             */
+            targetId: string;
+            /** Desiredrevision */
+            desiredRevision: number;
+            /** Appliedrevision */
+            appliedRevision: number | null;
+            /** Status */
+            status: string;
+            /** Forcerestartrequired */
+            forceRestartRequired: boolean;
+            /** Lastcommandid */
+            lastCommandId: string | null;
+            /** Lastworkerid */
+            lastWorkerId: string | null;
+            /** Lasterrorcode */
+            lastErrorCode: string | null;
+            /** Lasterrormessage */
+            lastErrorMessage: string | null;
+        };
+        /** SandboxProfileResponse */
+        SandboxProfileResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Managedtargetid */
+            managedTargetId: string | null;
+            /** Agentauthrevision */
+            agentAuthRevision: number;
+            /** Status */
+            status: string;
+        };
         /** SaveCloudRepoConfigFile */
         SaveCloudRepoConfigFile: {
             /** Relativepath */
@@ -4776,6 +5444,21 @@ export interface components {
             runCommand: string;
             /** Files */
             files?: components["schemas"]["SaveCloudRepoConfigFile"][];
+        };
+        /** SelectAgentAuthCredentialRequest */
+        SelectAgentAuthCredentialRequest: {
+            /**
+             * Credentialid
+             * Format: uuid
+             */
+            credentialId: string;
+            /** Credentialshareid */
+            credentialShareId?: string | null;
+            /**
+             * Forcerestart
+             * @default false
+             */
+            forceRestart: boolean;
         };
         /** SessionMcpBindingSummaryModel */
         SessionMcpBindingSummaryModel: {
@@ -4866,6 +5549,14 @@ export interface components {
         /** SetDesiredVersionsResponse */
         SetDesiredVersionsResponse: {
             target: components["schemas"]["CloudTargetDetail"];
+        };
+        /** ShareCredentialRequest */
+        ShareCredentialRequest: {
+            /**
+             * Organizationid
+             * Format: uuid
+             */
+            organizationId: string;
         };
         /** StartAuthRequest */
         StartAuthRequest: {
@@ -5356,6 +6047,134 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /** WorkerAgentAuthGatewayConfig */
+        WorkerAgentAuthGatewayConfig: {
+            /** Protocolfacade */
+            protocolFacade: string;
+            /** Baseurls */
+            baseUrls: {
+                [key: string]: string;
+            };
+            /** Runtimegranttoken */
+            runtimeGrantToken: string;
+            /** Expiresat */
+            expiresAt: string;
+            /** Protectedenv */
+            protectedEnv?: {
+                [key: string]: string;
+            };
+            /** Supportenv */
+            supportEnv?: {
+                [key: string]: string;
+            };
+            /** Protectedconfig */
+            protectedConfig?: {
+                [key: string]: unknown;
+            };
+            /** Supportconfig */
+            supportConfig?: {
+                [key: string]: unknown;
+            };
+        };
+        /** WorkerAgentAuthMaterializationPlan */
+        WorkerAgentAuthMaterializationPlan: {
+            /**
+             * Applied
+             * @default true
+             */
+            applied: boolean;
+            /** Reason */
+            reason?: string | null;
+            /** Currentrevision */
+            currentRevision?: number | null;
+            /** Targetid */
+            targetId?: string | null;
+            /**
+             * Sandboxprofileid
+             * Format: uuid
+             */
+            sandboxProfileId: string;
+            /** Revision */
+            revision: number;
+            /** Selections */
+            selections?: components["schemas"]["WorkerAgentAuthSelectionPlan"][];
+        };
+        /** WorkerAgentAuthSelectionPlan */
+        WorkerAgentAuthSelectionPlan: {
+            /** Agentkind */
+            agentKind: string;
+            /** Materializationmode */
+            materializationMode: string;
+            /**
+             * Credentialid
+             * Format: uuid
+             */
+            credentialId: string;
+            /** Credentialrevision */
+            credentialRevision: number;
+            /** Credentialshareid */
+            credentialShareId?: string | null;
+            gateway?: components["schemas"]["WorkerAgentAuthGatewayConfig"] | null;
+            syncedFiles?: components["schemas"]["WorkerAgentAuthSyncedFilesConfig"] | null;
+        };
+        /** WorkerAgentAuthStatusRequest */
+        WorkerAgentAuthStatusRequest: {
+            /** Status */
+            status: string;
+            /**
+             * Commandid
+             * Format: uuid
+             */
+            commandId: string;
+            /** Revision */
+            revision: number;
+            /** Leaseid */
+            leaseId: string;
+            /** Appliedrevision */
+            appliedRevision?: number | null;
+            /** Currentrevision */
+            currentRevision?: number | null;
+            /** Errorcode */
+            errorCode?: string | null;
+            /** Errormessage */
+            errorMessage?: string | null;
+        };
+        /** WorkerAgentAuthStatusResponse */
+        WorkerAgentAuthStatusResponse: {
+            /**
+             * Sandboxprofileid
+             * Format: uuid
+             */
+            sandboxProfileId: string;
+            /**
+             * Targetid
+             * Format: uuid
+             */
+            targetId: string;
+            /** Desiredrevision */
+            desiredRevision: number;
+            /** Appliedrevision */
+            appliedRevision: number | null;
+            /** Status */
+            status: string;
+        };
+        /** WorkerAgentAuthSyncedFilesConfig */
+        WorkerAgentAuthSyncedFilesConfig: {
+            /** Credentialshareid */
+            credentialShareId?: string | null;
+            /** Envvars */
+            envVars?: {
+                [key: string]: string;
+            };
+            /** Files */
+            files?: {
+                [key: string]: unknown;
+            }[];
+            /** Cleanup */
+            cleanup?: {
+                [key: string]: unknown;
+            }[];
+        };
         /** WorkerBackfillPendingInteraction */
         WorkerBackfillPendingInteraction: {
             /** Requestid */
@@ -5842,7 +6661,7 @@ export interface components {
             /** Runtimegeneration */
             runtimeGeneration: number;
             /** Allowedagentkinds */
-            allowedAgentKinds: ("claude" | "codex" | "gemini")[];
+            allowedAgentKinds: ("claude" | "codex" | "opencode" | "gemini")[];
             /** Readyagentkinds */
             readyAgentKinds: string[];
             credentialFreshness: components["schemas"]["WorkspaceCredentialFreshness"];
@@ -7974,7 +8793,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                provider: "claude" | "codex" | "gemini";
+                provider: "claude" | "codex" | "opencode" | "gemini";
             };
             cookie?: never;
         };
@@ -8009,7 +8828,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                provider: "claude" | "codex" | "gemini";
+                provider: "claude" | "codex" | "opencode" | "gemini";
             };
             cookie?: never;
         };
@@ -8022,6 +8841,369 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CloudCredentialMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_auth_credentials_endpoint_v1_cloud_agent_auth_credentials_get: {
+        parameters: {
+            query?: {
+                organizationId?: string | null;
+                agentKind?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthCredentialResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_gateway_credential_endpoint_v1_cloud_agent_auth_credentials_gateway_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateGatewayCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateGatewayCredentialResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ensure_managed_credits_endpoint_v1_cloud_organizations__organization_id__agent_auth_managed_credits_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnsureManagedCreditsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnsureManagedCreditsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_agent_auth_credential_endpoint_v1_cloud_agent_auth_credentials__credential_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                credential_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    share_agent_auth_credential_endpoint_v1_cloud_agent_auth_credentials__credential_id__shares_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                credential_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ShareCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthCredentialShareResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_agent_auth_credential_share_endpoint_v1_cloud_agent_auth_credential_shares__share_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                share_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthCredentialShareResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ensure_personal_sandbox_profile_endpoint_v1_cloud_sandbox_profiles_personal_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnsurePersonalSandboxProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ensure_organization_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profile_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnsureOrganizationSandboxProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_auth_selections_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_selections_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sandbox_profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxAgentAuthSelectionResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    select_agent_auth_credential_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_selections__agent_kind__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sandbox_profile_id: string;
+                agent_kind: "claude" | "codex" | "opencode" | "gemini";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SelectAgentAuthCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxAgentAuthSelectionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_auth_target_states_endpoint_v1_cloud_sandbox_profiles__sandbox_profile_id__agent_auth_target_states_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sandbox_profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxProfileAgentAuthTargetStateResponse"][];
                 };
             };
             /** @description Validation Error */
@@ -9193,6 +10375,80 @@ export interface operations {
             };
         };
     };
+    worker_agent_auth_materialization_endpoint_v1_cloud_worker_agent_auth_configs__sandbox_profile_id__materialization_get: {
+        parameters: {
+            query: {
+                revision: number;
+                command_id: string;
+                lease_id: string;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                sandbox_profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerAgentAuthMaterializationPlan"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_agent_auth_status_endpoint_v1_cloud_worker_agent_auth_configs__sandbox_profile_id__status_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                sandbox_profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerAgentAuthStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerAgentAuthStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     worker_target_config_materialization_endpoint_v1_cloud_worker_target_configs__config_id__materialization_get: {
         parameters: {
             query: {
@@ -9699,6 +10955,148 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    agent_gateway_health_agent_gateway_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+    };
+    anthropic_models_anthropic_v1_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    openai_models_openai_v1_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    forward_protocol_request_openai_v1_chat_completions_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    forward_protocol_request_openai_v1_responses_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    forward_protocol_request_anthropic_v1_messages_count_tokens_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    forward_protocol_request_anthropic_v1_messages_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./client/core.js";
 export * from "./client/auth.js";
 export * from "./client/viewer.js";
+export * from "./client/agent-auth.js";
 export * from "./client/agent-catalog.js";
 export * from "./client/ai-magic.js";
 export * from "./client/automations.js";

--- a/cloud/sdk/src/types/agent-auth.ts
+++ b/cloud/sdk/src/types/agent-auth.ts
@@ -1,0 +1,84 @@
+import type { components } from "../generated/openapi.js";
+
+export type AgentAuthAgentKind = "claude" | "codex" | "opencode" | "gemini";
+export type AgentAuthOwnerScope = "system" | "personal" | "organization";
+export type SandboxProfileOwnerScope = "personal" | "organization";
+export type AgentAuthCredentialKind = "managed_gateway" | "synced_path";
+export type AgentGatewayProviderKind =
+  | "anthropic_api_key"
+  | "openai_api_key"
+  | "bedrock_assume_role"
+  | "openai_compatible";
+
+export type AgentAuthCredential =
+  components["schemas"]["AgentAuthCredentialResponse"];
+export type AgentAuthCredentialShare =
+  components["schemas"]["AgentAuthCredentialShareResponse"];
+export type AgentAuthMutationResponse =
+  components["schemas"]["AgentAuthMutationResponse"];
+export type AgentGatewayPolicy =
+  components["schemas"]["AgentGatewayPolicyResponse"];
+export type AgentGatewayProviderCredential =
+  components["schemas"]["AgentGatewayProviderCredentialResponse"];
+export type AgentGatewayBudgetSubject =
+  components["schemas"]["AgentGatewayBudgetSubjectResponse"];
+export type CreateGatewayCredentialRequest =
+  components["schemas"]["CreateGatewayCredentialRequest"];
+export type CreateGatewayCredentialResponse =
+  components["schemas"]["CreateGatewayCredentialResponse"];
+export type EnsureManagedCreditsRequest =
+  components["schemas"]["EnsureManagedCreditsRequest"];
+export type EnsureManagedCreditsResponse =
+  components["schemas"]["EnsureManagedCreditsResponse"];
+export type SandboxProfile =
+  components["schemas"]["SandboxProfileResponse"];
+export type SandboxAgentAuthSelection =
+  components["schemas"]["SandboxAgentAuthSelectionResponse"];
+export type SandboxAgentAuthTargetState =
+  components["schemas"]["SandboxProfileAgentAuthTargetStateResponse"];
+
+export interface AgentAuthCredentialListOptions {
+  organizationId?: string | null;
+  agentKind?: AgentAuthAgentKind | null;
+}
+
+export interface AgentAuthCredentialOwnerInput {
+  ownerScope: SandboxProfileOwnerScope;
+  organizationId?: string | null;
+  displayName: string;
+}
+
+export interface CreateAnthropicApiKeyCredentialInput
+  extends AgentAuthCredentialOwnerInput {
+  apiKey: string;
+}
+
+export interface CreateOpenAiApiKeyCredentialInput
+  extends AgentAuthCredentialOwnerInput {
+  agentKind: Extract<AgentAuthAgentKind, "codex" | "opencode">;
+  apiKey: string;
+}
+
+export interface CreateOpenAiCompatibleCredentialInput
+  extends AgentAuthCredentialOwnerInput {
+  agentKind: Extract<AgentAuthAgentKind, "codex" | "opencode">;
+  baseUrl: string;
+  apiKey: string;
+}
+
+export interface CreateBedrockAssumeRoleCredentialInput
+  extends AgentAuthCredentialOwnerInput {
+  roleArn: string;
+  region: string;
+  externalId: string;
+}
+
+export interface EnsureSandboxProfileInput {
+  managedTargetId?: string | null;
+}
+
+export interface SelectAgentAuthCredentialInput {
+  credentialId: string;
+  credentialShareId?: string | null;
+  forceRestart?: boolean;
+}

--- a/cloud/sdk/src/types/index.ts
+++ b/cloud/sdk/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./generated.js";
 export * from "./auth.js";
+export * from "./agent-auth.js";
 export * from "./targets.js";
 export * from "./commands.js";
 export * from "./sessions.js";

--- a/desktop/src/components/settings/panes/CloudPane.tsx
+++ b/desktop/src/components/settings/panes/CloudPane.tsx
@@ -7,6 +7,7 @@ import { ChevronRight } from "@/components/ui/icons";
 import { SettingsPageHeader } from "@/components/settings/shared/SettingsPageHeader";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
+import { CloudAgentAuthLibrary } from "@/components/settings/panes/cloud/CloudAgentAuthLibrary";
 import { AUTH_ACCOUNT_LABELS } from "@/copy/auth/auth-copy";
 import { CLOUD_CREDENTIAL_PROVIDER_ORDER } from "@/config/cloud-providers";
 import { getProviderDisplayName } from "@/lib/domain/agents/provider-display";
@@ -196,6 +197,8 @@ export function CloudPane({ repositories }: CloudPaneProps) {
       {signInError && !canManageCloudCredentials && (
         <p className="text-sm text-destructive">{signInError}</p>
       )}
+
+      <CloudAgentAuthLibrary />
 
       <CloudPaneSection
         title="Cloud environments"

--- a/desktop/src/components/settings/panes/cloud/CloudAgentAuthCredentialForm.tsx
+++ b/desktop/src/components/settings/panes/cloud/CloudAgentAuthCredentialForm.tsx
@@ -1,0 +1,322 @@
+import { useState } from "react";
+import type {
+  AgentAuthAgentKind,
+  CreateGatewayCredentialRequest,
+} from "@proliferate/cloud-sdk";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { Select } from "@/components/ui/Select";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import { useAgentAuthMutations } from "@/hooks/access/cloud/agent-auth/use-agent-auth";
+
+type ProviderChoice =
+  | "anthropic_api_key"
+  | "openai_api_key"
+  | "bedrock_assume_role"
+  | "openai_compatible";
+
+interface OrganizationOption {
+  id: string;
+  name: string;
+}
+
+interface CloudAgentAuthCredentialFormProps {
+  organizations: OrganizationOption[];
+  libraryOrganizationId: string | null;
+  onLibraryOrganizationChange: (organizationId: string | null) => void;
+}
+
+const PROVIDER_OPTIONS: { value: ProviderChoice; label: string }[] = [
+  { value: "anthropic_api_key", label: "Anthropic API key" },
+  { value: "openai_api_key", label: "OpenAI API key" },
+  { value: "bedrock_assume_role", label: "AWS Bedrock role" },
+  { value: "openai_compatible", label: "OpenAI-compatible provider" },
+];
+
+export function CloudAgentAuthCredentialForm({
+  organizations,
+  libraryOrganizationId,
+  onLibraryOrganizationChange,
+}: CloudAgentAuthCredentialFormProps) {
+  const firstOrganizationId = organizations[0]?.id ?? null;
+  const mutations = useAgentAuthMutations();
+  const [providerKind, setProviderKind] = useState<ProviderChoice>("anthropic_api_key");
+  const [agentKind, setAgentKind] = useState<Extract<AgentAuthAgentKind, "codex" | "opencode">>("codex");
+  const [ownerScope, setOwnerScope] = useState<"personal" | "organization">("personal");
+  const [displayName, setDisplayName] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [roleArn, setRoleArn] = useState("");
+  const [region, setRegion] = useState("us-east-1");
+  const [externalId, setExternalId] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const selectedOrganizationId = ownerScope === "organization"
+    ? libraryOrganizationId ?? firstOrganizationId
+    : null;
+  const canCreate =
+    displayName.trim().length > 0
+    && (ownerScope === "personal" || Boolean(selectedOrganizationId))
+    && createPayloadReady(providerKind, { apiKey, baseUrl, roleArn, region, externalId });
+
+  async function handleCreateCredential() {
+    const body = buildCreateCredentialRequest({
+      providerKind,
+      agentKind,
+      ownerScope,
+      organizationId: selectedOrganizationId,
+      displayName,
+      apiKey,
+      baseUrl,
+      roleArn,
+      region,
+      externalId,
+    });
+    setFeedback(null);
+    try {
+      const result = await mutations.createCredential(body);
+      setDisplayName("");
+      setApiKey("");
+      setBaseUrl("");
+      setRoleArn("");
+      setExternalId("");
+      setFeedback(`${result.credential.displayName} saved.`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Could not save credential.");
+    }
+  }
+
+  return (
+    <SettingsCard>
+      <div className="space-y-3 p-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <Label htmlFor="agent-auth-library-scope">Library scope</Label>
+            <Select
+              id="agent-auth-library-scope"
+              value={libraryOrganizationId ?? ""}
+              onChange={(event) => onLibraryOrganizationChange(event.target.value || null)}
+            >
+              <option value="">Personal</option>
+              {organizations.map((organization) => (
+                <option key={organization.id} value={organization.id}>
+                  {organization.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="agent-auth-owner-scope">New credential owner</Label>
+            <Select
+              id="agent-auth-owner-scope"
+              value={ownerScope}
+              onChange={(event) => {
+                const nextOwnerScope = event.target.value as typeof ownerScope;
+                setOwnerScope(nextOwnerScope);
+                if (
+                  nextOwnerScope === "organization"
+                  && !libraryOrganizationId
+                  && firstOrganizationId
+                ) {
+                  onLibraryOrganizationChange(firstOrganizationId);
+                }
+              }}
+            >
+              <option value="personal">Personal</option>
+              <option value="organization" disabled={!firstOrganizationId}>
+                Organization
+              </option>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <Label htmlFor="agent-auth-provider-kind">Provider</Label>
+            <Select
+              id="agent-auth-provider-kind"
+              value={providerKind}
+              onChange={(event) => setProviderKind(event.target.value as ProviderChoice)}
+            >
+              {PROVIDER_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          {(providerKind === "openai_api_key" || providerKind === "openai_compatible") && (
+            <div>
+              <Label htmlFor="agent-auth-agent-kind">Agent</Label>
+              <Select
+                id="agent-auth-agent-kind"
+                value={agentKind}
+                onChange={(event) => setAgentKind(
+                  event.target.value as Extract<AgentAuthAgentKind, "codex" | "opencode">,
+                )}
+              >
+                <option value="codex">Codex</option>
+                <option value="opencode">OpenCode</option>
+              </Select>
+            </div>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="agent-auth-display-name">Display name</Label>
+          <Input
+            id="agent-auth-display-name"
+            value={displayName}
+            placeholder="Production Bedrock"
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+        </div>
+
+        {(providerKind === "anthropic_api_key" || providerKind === "openai_api_key") && (
+          <div>
+            <Label htmlFor="agent-auth-api-key">API key</Label>
+            <Input
+              id="agent-auth-api-key"
+              value={apiKey}
+              type="password"
+              placeholder="sk-..."
+              onChange={(event) => setApiKey(event.target.value)}
+            />
+          </div>
+        )}
+
+        {providerKind === "openai_compatible" && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="agent-auth-base-url">Base URL</Label>
+              <Input
+                id="agent-auth-base-url"
+                value={baseUrl}
+                placeholder="https://api.example.com/v1"
+                onChange={(event) => setBaseUrl(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="agent-auth-compatible-api-key">API key</Label>
+              <Input
+                id="agent-auth-compatible-api-key"
+                value={apiKey}
+                type="password"
+                placeholder="sk-..."
+                onChange={(event) => setApiKey(event.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        {providerKind === "bedrock_assume_role" && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Label htmlFor="agent-auth-role-arn">Role ARN</Label>
+              <Input
+                id="agent-auth-role-arn"
+                value={roleArn}
+                placeholder="arn:aws:iam::123456789012:role/proliferate-bedrock"
+                onChange={(event) => setRoleArn(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="agent-auth-region">Region</Label>
+              <Input
+                id="agent-auth-region"
+                value={region}
+                placeholder="us-east-1"
+                onChange={(event) => setRegion(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="agent-auth-external-id">External ID</Label>
+              <Input
+                id="agent-auth-external-id"
+                value={externalId}
+                placeholder="proliferate-..."
+                onChange={(event) => setExternalId(event.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="min-w-0 text-xs text-muted-foreground">
+            {feedback ?? "Secrets are stored in Cloud and never displayed after saving."}
+          </p>
+          <Button
+            type="button"
+            variant="secondary"
+            loading={mutations.isCreatingCredential}
+            disabled={!canCreate}
+            onClick={() => { void handleCreateCredential(); }}
+          >
+            Add credential
+          </Button>
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}
+
+function createPayloadReady(
+  providerKind: ProviderChoice,
+  values: {
+    apiKey: string;
+    baseUrl: string;
+    roleArn: string;
+    region: string;
+    externalId: string;
+  },
+) {
+  if (providerKind === "anthropic_api_key" || providerKind === "openai_api_key") {
+    return values.apiKey.trim().length > 0;
+  }
+  if (providerKind === "openai_compatible") {
+    return values.apiKey.trim().length > 0 && values.baseUrl.trim().length > 0;
+  }
+  return values.roleArn.trim().length > 0
+    && values.region.trim().length > 0
+    && values.externalId.trim().length > 0;
+}
+
+function buildCreateCredentialRequest(input: {
+  providerKind: ProviderChoice;
+  agentKind: Extract<AgentAuthAgentKind, "codex" | "opencode">;
+  ownerScope: "personal" | "organization";
+  organizationId: string | null;
+  displayName: string;
+  apiKey: string;
+  baseUrl: string;
+  roleArn: string;
+  region: string;
+  externalId: string;
+}): CreateGatewayCredentialRequest {
+  const agentKind = input.providerKind === "openai_api_key"
+    || input.providerKind === "openai_compatible"
+    ? input.agentKind
+    : "claude";
+  const payload: Record<string, string> = input.providerKind === "bedrock_assume_role"
+    ? {
+        roleArn: input.roleArn.trim(),
+        region: input.region.trim(),
+        externalId: input.externalId.trim(),
+      }
+    : input.providerKind === "openai_compatible"
+      ? {
+          baseUrl: input.baseUrl.trim(),
+          apiKey: input.apiKey.trim(),
+        }
+      : { apiKey: input.apiKey.trim() };
+
+  return {
+    ownerScope: input.ownerScope,
+    organizationId: input.ownerScope === "organization" ? input.organizationId : null,
+    agentKind,
+    displayName: input.displayName.trim(),
+    policyKind: input.ownerScope === "organization" ? "org_byok" : "personal_byok",
+    providerKind: input.providerKind,
+    payload,
+  };
+}

--- a/desktop/src/components/settings/panes/cloud/CloudAgentAuthCredentialForm.tsx
+++ b/desktop/src/components/settings/panes/cloud/CloudAgentAuthCredentialForm.tsx
@@ -19,6 +19,9 @@ type ProviderChoice =
 interface OrganizationOption {
   id: string;
   name: string;
+  membership?: {
+    role?: "owner" | "admin" | "member";
+  } | null;
 }
 
 interface CloudAgentAuthCredentialFormProps {
@@ -39,7 +42,8 @@ export function CloudAgentAuthCredentialForm({
   libraryOrganizationId,
   onLibraryOrganizationChange,
 }: CloudAgentAuthCredentialFormProps) {
-  const firstOrganizationId = organizations[0]?.id ?? null;
+  const adminOrganizations = organizations.filter(isAdminOrganization);
+  const firstAdminOrganizationId = adminOrganizations[0]?.id ?? null;
   const mutations = useAgentAuthMutations();
   const [providerKind, setProviderKind] = useState<ProviderChoice>("anthropic_api_key");
   const [agentKind, setAgentKind] = useState<Extract<AgentAuthAgentKind, "codex" | "opencode">>("codex");
@@ -51,8 +55,12 @@ export function CloudAgentAuthCredentialForm({
   const [region, setRegion] = useState("us-east-1");
   const [externalId, setExternalId] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
+  const libraryOrganizationCanOwnCredential = adminOrganizations.some(
+    (organization) => organization.id === libraryOrganizationId,
+  );
   const selectedOrganizationId = ownerScope === "organization"
-    ? libraryOrganizationId ?? firstOrganizationId
+    ? adminOrganizations.find((organization) => organization.id === libraryOrganizationId)?.id
+      ?? null
     : null;
   const canCreate =
     displayName.trim().length > 0
@@ -115,15 +123,15 @@ export function CloudAgentAuthCredentialForm({
                 setOwnerScope(nextOwnerScope);
                 if (
                   nextOwnerScope === "organization"
-                  && !libraryOrganizationId
-                  && firstOrganizationId
+                  && !libraryOrganizationCanOwnCredential
+                  && firstAdminOrganizationId
                 ) {
-                  onLibraryOrganizationChange(firstOrganizationId);
+                  onLibraryOrganizationChange(firstAdminOrganizationId);
                 }
               }}
             >
               <option value="personal">Personal</option>
-              <option value="organization" disabled={!firstOrganizationId}>
+              <option value="organization" disabled={!firstAdminOrganizationId}>
                 Organization
               </option>
             </Select>
@@ -279,6 +287,11 @@ function createPayloadReady(
   return values.roleArn.trim().length > 0
     && values.region.trim().length > 0
     && values.externalId.trim().length > 0;
+}
+
+function isAdminOrganization(organization: OrganizationOption): boolean {
+  const role = organization.membership?.role;
+  return role === "owner" || role === "admin";
 }
 
 function buildCreateCredentialRequest(input: {

--- a/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
+++ b/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
@@ -16,6 +16,7 @@ import {
   agentAuthCredentialStatusTone,
   describeAgentAuthCredential,
 } from "@/lib/domain/agent-auth/agent-auth-presentation";
+import { useAuthStore } from "@/stores/auth/auth-store";
 
 export function CloudAgentAuthLibrary() {
   const organizations = useOrganizations();
@@ -27,6 +28,18 @@ export function CloudAgentAuthLibrary() {
   const [feedback, setFeedback] = useState<string | null>(null);
   const [sharingCredentialId, setSharingCredentialId] = useState<string | null>(null);
   const [revokingCredentialId, setRevokingCredentialId] = useState<string | null>(null);
+  const currentUserId = useAuthStore((state) => state.user?.id ?? null);
+  const adminOrganizationIds = useMemo(
+    () => new Set(
+      (organizations.data?.organizations ?? [])
+        .filter((organization) => {
+          const role = organization.membership?.role;
+          return role === "owner" || role === "admin";
+        })
+        .map((organization) => organization.id),
+    ),
+    [organizations.data?.organizations],
+  );
 
   const grouped = useMemo(() => groupCredentialsByAgent(credentials), [credentials]);
 
@@ -88,6 +101,8 @@ export function CloudAgentAuthLibrary() {
           sharingCredentialId={sharingCredentialId}
           revokingCredentialId={revokingCredentialId}
           sharingEnabled={Boolean(libraryOrganizationId)}
+          currentUserId={currentUserId}
+          adminOrganizationIds={adminOrganizationIds}
           onShare={handleShareCredential}
           onRevoke={handleRevokeCredential}
         />
@@ -102,6 +117,8 @@ function AgentCredentialGroup({
   sharingCredentialId,
   revokingCredentialId,
   sharingEnabled,
+  currentUserId,
+  adminOrganizationIds,
   onShare,
   onRevoke,
 }: {
@@ -110,6 +127,8 @@ function AgentCredentialGroup({
   sharingCredentialId: string | null;
   revokingCredentialId: string | null;
   sharingEnabled: boolean;
+  currentUserId: string | null;
+  adminOrganizationIds: ReadonlySet<string>;
   onShare: (credential: AgentAuthCredential) => void;
   onRevoke: (credential: AgentAuthCredential) => void;
 }) {
@@ -122,6 +141,11 @@ function AgentCredentialGroup({
       {credentials.map((credential) => {
         const canShare = credential.ownerScope === "personal"
           && credential.credentialKind === "synced_path";
+        const canManage = canManageCredential(
+          credential,
+          currentUserId,
+          adminOrganizationIds,
+        );
         return (
           <SettingsCardRow
             key={credential.id}
@@ -135,7 +159,7 @@ function AgentCredentialGroup({
               <Badge tone={agentAuthCredentialStatusTone(credential.status)}>
                 {agentAuthCredentialStatusLabel(credential.status)}
               </Badge>
-              {canShare && (
+              {canShare && credential.ownerUserId === currentUserId && (
                 <Button
                   type="button"
                   variant="outline"
@@ -147,15 +171,17 @@ function AgentCredentialGroup({
                   Share
                 </Button>
               )}
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                loading={revokingCredentialId === credential.id}
-                onClick={() => onRevoke(credential)}
-              >
-                Revoke
-              </Button>
+              {canManage && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  loading={revokingCredentialId === credential.id}
+                  onClick={() => onRevoke(credential)}
+                >
+                  Revoke
+                </Button>
+              )}
             </div>
           </SettingsCardRow>
         );
@@ -172,4 +198,18 @@ function groupCredentialsByAgent(credentials: AgentAuthCredential[]) {
     grouped.set(credential.agentKind, entries);
   }
   return grouped;
+}
+
+function canManageCredential(
+  credential: AgentAuthCredential,
+  currentUserId: string | null,
+  adminOrganizationIds: ReadonlySet<string>,
+): boolean {
+  if (credential.ownerScope === "personal") {
+    return credential.ownerUserId === currentUserId;
+  }
+  if (credential.ownerScope === "organization" && credential.organizationId) {
+    return adminOrganizationIds.has(credential.organizationId);
+  }
+  return false;
 }

--- a/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
+++ b/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from "react";
+import type { AgentAuthCredential } from "@proliferate/cloud-sdk";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
+import { CloudAgentAuthCredentialForm } from "@/components/settings/panes/cloud/CloudAgentAuthCredentialForm";
+import { useAgentAuthCredentials, useAgentAuthMutations } from "@/hooks/access/cloud/agent-auth/use-agent-auth";
+import { useOrganizations } from "@/hooks/access/cloud/organizations/use-organizations";
+import {
+  AGENT_AUTH_AGENT_ORDER,
+  agentAuthAgentLabel,
+  agentAuthCredentialKindLabel,
+  agentAuthCredentialOwnerLabel,
+  agentAuthCredentialStatusLabel,
+  agentAuthCredentialStatusTone,
+  describeAgentAuthCredential,
+} from "@/lib/domain/agent-auth/agent-auth-presentation";
+
+export function CloudAgentAuthLibrary() {
+  const organizations = useOrganizations();
+  const [libraryOrganizationId, setLibraryOrganizationId] = useState<string | null>(null);
+  const { data: credentials = [] } = useAgentAuthCredentials({
+    organizationId: libraryOrganizationId,
+  });
+  const mutations = useAgentAuthMutations();
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [sharingCredentialId, setSharingCredentialId] = useState<string | null>(null);
+  const [revokingCredentialId, setRevokingCredentialId] = useState<string | null>(null);
+
+  const grouped = useMemo(() => groupCredentialsByAgent(credentials), [credentials]);
+
+  async function handleShareCredential(credential: AgentAuthCredential) {
+    if (!libraryOrganizationId) {
+      setFeedback("Select an organization scope before sharing.");
+      return;
+    }
+    setSharingCredentialId(credential.id);
+    setFeedback(null);
+    try {
+      await mutations.createShare({
+        credentialId: credential.id,
+        organizationId: libraryOrganizationId,
+      });
+      setFeedback(`${credential.displayName} shared with organization.`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Could not share credential.");
+    } finally {
+      setSharingCredentialId(null);
+    }
+  }
+
+  async function handleRevokeCredential(credential: AgentAuthCredential) {
+    setRevokingCredentialId(credential.id);
+    setFeedback(null);
+    try {
+      await mutations.deleteCredential(credential.id);
+      setFeedback(`${credential.displayName} revoked.`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Could not revoke credential.");
+    } finally {
+      setRevokingCredentialId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium text-foreground">Agent auth library</h2>
+        <p className="text-sm text-muted-foreground">
+          Gateway and synced credentials available to cloud agent harnesses.
+        </p>
+      </div>
+
+      <CloudAgentAuthCredentialForm
+        organizations={organizations.data?.organizations ?? []}
+        libraryOrganizationId={libraryOrganizationId}
+        onLibraryOrganizationChange={setLibraryOrganizationId}
+      />
+
+      {feedback && <p className="text-xs text-muted-foreground">{feedback}</p>}
+
+      {AGENT_AUTH_AGENT_ORDER.map((kind) => (
+        <AgentCredentialGroup
+          key={kind}
+          title={agentAuthAgentLabel(kind)}
+          credentials={grouped.get(kind) ?? []}
+          sharingCredentialId={sharingCredentialId}
+          revokingCredentialId={revokingCredentialId}
+          sharingEnabled={Boolean(libraryOrganizationId)}
+          onShare={handleShareCredential}
+          onRevoke={handleRevokeCredential}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AgentCredentialGroup({
+  title,
+  credentials,
+  sharingCredentialId,
+  revokingCredentialId,
+  sharingEnabled,
+  onShare,
+  onRevoke,
+}: {
+  title: string;
+  credentials: AgentAuthCredential[];
+  sharingCredentialId: string | null;
+  revokingCredentialId: string | null;
+  sharingEnabled: boolean;
+  onShare: (credential: AgentAuthCredential) => void;
+  onRevoke: (credential: AgentAuthCredential) => void;
+}) {
+  if (credentials.length === 0) {
+    return null;
+  }
+  return (
+    <SettingsCard>
+      <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{title}</div>
+      {credentials.map((credential) => {
+        const canShare = credential.ownerScope === "personal"
+          && credential.credentialKind === "synced_path";
+        return (
+          <SettingsCardRow
+            key={credential.id}
+            label={credential.displayName}
+            description={`${agentAuthCredentialKindLabel(credential)} · ${describeAgentAuthCredential(credential)}`}
+          >
+            <div className="flex items-center gap-2">
+              <span className="hidden text-xs text-muted-foreground sm:inline">
+                {agentAuthCredentialOwnerLabel(credential)}
+              </span>
+              <Badge tone={agentAuthCredentialStatusTone(credential.status)}>
+                {agentAuthCredentialStatusLabel(credential.status)}
+              </Badge>
+              {canShare && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!sharingEnabled}
+                  loading={sharingCredentialId === credential.id}
+                  onClick={() => onShare(credential)}
+                >
+                  Share
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                loading={revokingCredentialId === credential.id}
+                onClick={() => onRevoke(credential)}
+              >
+                Revoke
+              </Button>
+            </div>
+          </SettingsCardRow>
+        );
+      })}
+    </SettingsCard>
+  );
+}
+
+function groupCredentialsByAgent(credentials: AgentAuthCredential[]) {
+  const grouped = new Map<string, AgentAuthCredential[]>();
+  for (const credential of credentials) {
+    const entries = grouped.get(credential.agentKind) ?? [];
+    entries.push(credential);
+    grouped.set(credential.agentKind, entries);
+  }
+  return grouped;
+}

--- a/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
@@ -75,7 +75,12 @@ export function ComputeTargetAgentAuthCard({ target }: ComputeTargetAgentAuthCar
       await mutations.selectCredential({
         sandboxProfileId: profile.id,
         agentKind,
-        selection: { credentialId },
+        selection: {
+          credentialId,
+          credentialShareId: credentials.find(
+            (credential) => credential.id === credentialId && credential.agentKind === agentKind,
+          )?.activeCredentialShareId ?? null,
+        },
       });
       setFeedback(`${agentAuthAgentLabel(agentKind)} auth selection saved.`);
     } catch (error) {

--- a/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  AgentAuthAgentKind,
+  AgentAuthCredential,
+  SandboxProfile,
+} from "@proliferate/cloud-sdk";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import {
+  useAgentAuthCredentials,
+  useAgentAuthMutations,
+  useSandboxAgentAuthSelections,
+  useSandboxAgentAuthTargetStates,
+} from "@/hooks/access/cloud/agent-auth/use-agent-auth";
+import {
+  AGENT_AUTH_AGENT_ORDER,
+  agentAuthAgentLabel,
+  agentAuthCredentialKindLabel,
+  agentAuthCredentialStatusLabel,
+  agentAuthCredentialStatusTone,
+  credentialSelectableReason,
+  selectionByAgentKind,
+  targetStateSummary,
+} from "@/lib/domain/agent-auth/agent-auth-presentation";
+import type {
+  ComputeTargetDetail,
+  ComputeTargetSummary,
+} from "@/lib/domain/compute/target-types";
+
+interface ComputeTargetAgentAuthCardProps {
+  target: ComputeTargetDetail | ComputeTargetSummary;
+}
+
+export function ComputeTargetAgentAuthCard({ target }: ComputeTargetAgentAuthCardProps) {
+  const [profile, setProfile] = useState<SandboxProfile | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const mutations = useAgentAuthMutations();
+  const { data: credentials = [] } = useAgentAuthCredentials({
+    organizationId: profile?.organizationId ?? null,
+    enabled: profile !== null,
+  });
+  const { data: selections = [] } = useSandboxAgentAuthSelections(profile?.id ?? null);
+  const { data: targetStates = [] } = useSandboxAgentAuthTargetStates(profile?.id ?? null);
+  const selectionsByAgent = useMemo(() => selectionByAgentKind(selections), [selections]);
+  const targetState = profile ? targetStateSummary(targetStates, target.id) : null;
+
+  useEffect(() => {
+    setProfile(null);
+    setFeedback(null);
+  }, [target.id]);
+
+  async function handleEnsureProfile() {
+    setFeedback(null);
+    try {
+      const nextProfile = target.ownerScope === "organization"
+        ? await mutations.ensureOrganizationProfile({
+            organizationId: target.organizationId!,
+            managedTargetId: target.id,
+          })
+        : await mutations.ensurePersonalProfile({ managedTargetId: target.id });
+      setProfile(nextProfile);
+      setFeedback("Agent auth profile loaded.");
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Could not load agent auth profile.");
+    }
+  }
+
+  async function handleSelect(agentKind: AgentAuthAgentKind, credentialId: string) {
+    if (!profile || !credentialId) {
+      return;
+    }
+    setFeedback(null);
+    try {
+      await mutations.selectCredential({
+        sandboxProfileId: profile.id,
+        agentKind,
+        selection: { credentialId },
+      });
+      setFeedback(`${agentAuthAgentLabel(agentKind)} auth selection saved.`);
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : "Could not save auth selection.");
+    }
+  }
+
+  return (
+    <div className="space-y-3 border-t border-border/40 pt-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <h4 className="text-xs font-medium text-foreground">Agent auth</h4>
+          <p className="text-xs text-muted-foreground">
+            Select launch credentials for agent harnesses on this target.
+          </p>
+        </div>
+        {targetState && (
+          <Badge tone={agentAuthCredentialStatusTone(targetState.status)}>
+            {agentAuthCredentialStatusLabel(targetState.status)}
+          </Badge>
+        )}
+      </div>
+
+      {!profile ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 p-3">
+          <p className="text-xs text-muted-foreground">
+            {feedback ?? "Initialize this target's sandbox profile before selecting auth."}
+          </p>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            loading={mutations.isEnsuringProfile}
+            disabled={target.ownerScope === "organization" && !target.organizationId}
+            onClick={() => { void handleEnsureProfile(); }}
+          >
+            Configure
+          </Button>
+        </div>
+      ) : (
+        <div className="divide-y divide-border/40 rounded-md border border-border/50">
+          {AGENT_AUTH_AGENT_ORDER.map((agentKind) => {
+            const selection = selectionsByAgent.get(agentKind);
+            const agentCredentials = credentials.filter(
+              (credential) => credential.agentKind === agentKind,
+            );
+            return (
+              <AgentAuthSelectionRow
+                key={agentKind}
+                agentKind={agentKind}
+                profile={profile}
+                credentials={agentCredentials}
+                selectedCredentialId={selection?.credentialId ?? ""}
+                selecting={mutations.isSelectingCredential}
+                onSelect={handleSelect}
+              />
+            );
+          })}
+          {feedback && <p className="px-3 py-2 text-xs text-muted-foreground">{feedback}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentAuthSelectionRow({
+  agentKind,
+  profile,
+  credentials,
+  selectedCredentialId,
+  selecting,
+  onSelect,
+}: {
+  agentKind: AgentAuthAgentKind;
+  profile: SandboxProfile;
+  credentials: AgentAuthCredential[];
+  selectedCredentialId: string;
+  selecting: boolean;
+  onSelect: (agentKind: AgentAuthAgentKind, credentialId: string) => void;
+}) {
+  return (
+    <div className="grid gap-2 px-3 py-3 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-center">
+      <div className="text-sm font-medium text-foreground">{agentAuthAgentLabel(agentKind)}</div>
+      <Select
+        value={selectedCredentialId}
+        disabled={selecting || credentials.length === 0}
+        onChange={(event) => onSelect(agentKind, event.target.value)}
+      >
+        <option value="">
+          {credentials.length === 0 ? "No compatible credentials" : "Select credential"}
+        </option>
+        {credentials.map((credential) => {
+          const disabledReason = credentialSelectableReason(credential, profile.ownerScope);
+          return (
+            <option
+              key={credential.id}
+              value={credential.id}
+              disabled={disabledReason !== null}
+            >
+              {credential.displayName} · {agentAuthCredentialKindLabel(credential)}
+              {disabledReason ? ` · ${disabledReason}` : ""}
+            </option>
+          );
+        })}
+      </Select>
+    </div>
+  );
+}

--- a/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
+++ b/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
@@ -15,6 +15,7 @@ import type {
   ComputeTargetDetail,
   ComputeTargetSummary,
 } from "@/lib/domain/compute/target-types";
+import { ComputeTargetAgentAuthCard } from "./ComputeTargetAgentAuthCard";
 import { ComputeTargetReadiness } from "./ComputeTargetReadiness";
 
 interface ComputeTargetDetailsProps {
@@ -97,6 +98,8 @@ export function ComputeTargetDetails({
         </dl>
 
         <ComputeTargetReadiness inventory={target.inventory} />
+
+        <ComputeTargetAgentAuthCard target={target} />
 
         {target.kind === "ssh" && (
           <div className="space-y-3 border-t border-border/40 pt-3">

--- a/desktop/src/hooks/access/cloud/agent-auth/query-keys.ts
+++ b/desktop/src/hooks/access/cloud/agent-auth/query-keys.ts
@@ -1,0 +1,10 @@
+import "@/lib/access/cloud/client";
+
+export {
+  agentAuthCredentialsKey,
+  agentAuthManagedCreditsKey,
+  agentAuthRootKey,
+  sandboxAgentAuthSelectionsKey,
+  sandboxAgentAuthTargetStatesKey,
+  sandboxProfileKey,
+} from "@proliferate/cloud-sdk-react/lib/query-keys";

--- a/desktop/src/hooks/access/cloud/agent-auth/use-agent-auth.ts
+++ b/desktop/src/hooks/access/cloud/agent-auth/use-agent-auth.ts
@@ -1,0 +1,8 @@
+import "@/lib/access/cloud/client";
+
+export {
+  useAgentAuthCredentials,
+  useAgentAuthMutations,
+  useSandboxAgentAuthSelections,
+  useSandboxAgentAuthTargetStates,
+} from "@proliferate/cloud-sdk-react/hooks/agent-auth";

--- a/desktop/src/lib/access/anyharness/runtime-target.ts
+++ b/desktop/src/lib/access/anyharness/runtime-target.ts
@@ -1,5 +1,4 @@
-import type { CloudAgentKind, CloudWorkspaceDetail } from "@/lib/access/cloud/client";
-import { isCloudAgentKind } from "@/lib/access/cloud/client";
+import type { AgentAuthAgentKind, CloudWorkspaceDetail } from "@/lib/access/cloud/client";
 import {
   getCloudWorkspace,
   getCloudWorkspaceConnection,
@@ -15,8 +14,8 @@ export interface RuntimeTarget {
   authToken?: string;
   anyharnessWorkspaceId: string;
   runtimeGeneration: number;
-  allowedAgentKinds?: CloudAgentKind[];
-  readyAgentKinds?: CloudAgentKind[];
+  allowedAgentKinds?: AgentAuthAgentKind[];
+  readyAgentKinds?: AgentAuthAgentKind[];
 }
 
 export async function resolveRuntimeTargetForWorkspace(
@@ -71,7 +70,14 @@ export async function resolveRuntimeTargetForWorkspace(
     authToken: connection.accessToken,
     anyharnessWorkspaceId: connection.anyharnessWorkspaceId ?? "",
     runtimeGeneration: connection.runtimeGeneration,
-    allowedAgentKinds: connection.allowedAgentKinds.filter(isCloudAgentKind),
-    readyAgentKinds: connection.readyAgentKinds.filter(isCloudAgentKind),
+    allowedAgentKinds: connection.allowedAgentKinds.filter(isCloudAgentRuntimeKind),
+    readyAgentKinds: connection.readyAgentKinds.filter(isCloudAgentRuntimeKind),
   };
+}
+
+function isCloudAgentRuntimeKind(value: string): value is AgentAuthAgentKind {
+  return value === "claude"
+    || value === "codex"
+    || value === "opencode"
+    || value === "gemini";
 }

--- a/desktop/src/lib/access/anyharness/runtime-target.ts
+++ b/desktop/src/lib/access/anyharness/runtime-target.ts
@@ -1,4 +1,5 @@
 import type { CloudAgentKind, CloudWorkspaceDetail } from "@/lib/access/cloud/client";
+import { isCloudAgentKind } from "@/lib/access/cloud/client";
 import {
   getCloudWorkspace,
   getCloudWorkspaceConnection,
@@ -70,7 +71,7 @@ export async function resolveRuntimeTargetForWorkspace(
     authToken: connection.accessToken,
     anyharnessWorkspaceId: connection.anyharnessWorkspaceId ?? "",
     runtimeGeneration: connection.runtimeGeneration,
-    allowedAgentKinds: connection.allowedAgentKinds,
-    readyAgentKinds: connection.readyAgentKinds as CloudAgentKind[],
+    allowedAgentKinds: connection.allowedAgentKinds.filter(isCloudAgentKind),
+    readyAgentKinds: connection.readyAgentKinds.filter(isCloudAgentKind),
   };
 }

--- a/desktop/src/lib/domain/agent-auth/agent-auth-presentation.test.ts
+++ b/desktop/src/lib/domain/agent-auth/agent-auth-presentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { AgentAuthCredential } from "@proliferate/cloud-sdk";
+import { credentialSelectableReason } from "./agent-auth-presentation";
+
+function credential(
+  overrides: Partial<AgentAuthCredential>,
+): AgentAuthCredential {
+  return {
+    id: "credential-1",
+    ownerScope: "personal",
+    ownerUserId: "user-1",
+    organizationId: null,
+    createdByUserId: "user-1",
+    agentKind: "claude",
+    credentialKind: "synced_path",
+    displayName: "Synced Claude auth",
+    redactedSummary: {},
+    status: "ready",
+    revision: 1,
+    legacyCloudCredentialId: null,
+    activeCredentialShareId: null,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+describe("credentialSelectableReason", () => {
+  it("requires an active share for personal synced credentials in organization profiles", () => {
+    expect(
+      credentialSelectableReason(credential({}), "organization"),
+    ).toBe("Personal synced credentials need an active owner share before shared sandbox selection.");
+  });
+
+  it("allows shared personal synced credentials in organization profiles", () => {
+    expect(
+      credentialSelectableReason(
+        credential({ activeCredentialShareId: "share-1" }),
+        "organization",
+      ),
+    ).toBeNull();
+  });
+});

--- a/desktop/src/lib/domain/agent-auth/agent-auth-presentation.ts
+++ b/desktop/src/lib/domain/agent-auth/agent-auth-presentation.ts
@@ -120,6 +120,7 @@ export function credentialSelectableReason(
     profileOwnerScope === "organization"
     && credential.ownerScope === "personal"
     && credential.credentialKind === "synced_path"
+    && !credential.activeCredentialShareId
   ) {
     return "Personal synced credentials need an active owner share before shared sandbox selection.";
   }

--- a/desktop/src/lib/domain/agent-auth/agent-auth-presentation.ts
+++ b/desktop/src/lib/domain/agent-auth/agent-auth-presentation.ts
@@ -1,0 +1,140 @@
+import type {
+  AgentAuthAgentKind,
+  AgentAuthCredential,
+  SandboxAgentAuthSelection,
+  SandboxAgentAuthTargetState,
+} from "@proliferate/cloud-sdk";
+
+export type AgentAuthBadgeTone = "neutral" | "success" | "warning" | "destructive";
+
+export const AGENT_AUTH_AGENT_ORDER: AgentAuthAgentKind[] = [
+  "claude",
+  "codex",
+  "opencode",
+  "gemini",
+];
+
+export function agentAuthAgentLabel(agentKind: string): string {
+  if (agentKind === "claude") {
+    return "Claude Code";
+  }
+  if (agentKind === "codex") {
+    return "Codex";
+  }
+  if (agentKind === "opencode") {
+    return "OpenCode";
+  }
+  if (agentKind === "gemini") {
+    return "Gemini";
+  }
+  return agentKind;
+}
+
+export function agentAuthCredentialKindLabel(credential: AgentAuthCredential): string {
+  if (credential.credentialKind === "managed_gateway") {
+    const providerKind = credential.redactedSummary.providerKind;
+    if (providerKind === "proliferate_bedrock_pool") {
+      return "Proliferate managed credits";
+    }
+    if (providerKind === "bedrock_assume_role") {
+      return "AWS Bedrock role";
+    }
+    if (providerKind === "anthropic_api_key") {
+      return "Anthropic API key";
+    }
+    if (providerKind === "openai_api_key") {
+      return "OpenAI API key";
+    }
+    if (providerKind === "openai_compatible") {
+      return "OpenAI-compatible provider";
+    }
+    return "Gateway credential";
+  }
+  if (credential.credentialKind === "synced_path") {
+    return `Synced ${agentAuthAgentLabel(credential.agentKind)} auth`;
+  }
+  return credential.credentialKind;
+}
+
+export function agentAuthCredentialOwnerLabel(credential: AgentAuthCredential): string {
+  if (credential.ownerScope === "system") {
+    return "System";
+  }
+  if (credential.ownerScope === "organization") {
+    return "Organization";
+  }
+  return "Personal";
+}
+
+export function agentAuthCredentialStatusTone(status: string): AgentAuthBadgeTone {
+  if (status === "ready" || status === "active" || status === "applied") {
+    return "success";
+  }
+  if (status === "pending" || status === "materializing") {
+    return "warning";
+  }
+  if (status === "revoked" || status === "invalid" || status === "failed") {
+    return "destructive";
+  }
+  return "neutral";
+}
+
+export function agentAuthCredentialStatusLabel(status: string): string {
+  if (status === "needs_resync") {
+    return "Needs resync";
+  }
+  return status.replaceAll("_", " ");
+}
+
+export function describeAgentAuthCredential(credential: AgentAuthCredential): string {
+  const details = credentialSummaryDetails(credential);
+  const owner = agentAuthCredentialOwnerLabel(credential);
+  return details ? `${owner} · ${details}` : owner;
+}
+
+export function credentialSummaryDetails(credential: AgentAuthCredential): string {
+  const summary = credential.redactedSummary;
+  if (typeof summary.roleArn === "string" && typeof summary.region === "string") {
+    return `${summary.roleArn} · ${summary.region}`;
+  }
+  if (typeof summary.baseUrl === "string") {
+    return summary.baseUrl;
+  }
+  if (typeof summary.apiKey === "string") {
+    return summary.apiKey;
+  }
+  if (typeof summary.authMode === "string") {
+    return `Synced ${summary.authMode}`;
+  }
+  return "";
+}
+
+export function credentialSelectableReason(
+  credential: AgentAuthCredential,
+  profileOwnerScope: string,
+): string | null {
+  if (credential.status !== "ready") {
+    return `Credential is ${agentAuthCredentialStatusLabel(credential.status)}.`;
+  }
+  if (
+    profileOwnerScope === "organization"
+    && credential.ownerScope === "personal"
+    && credential.credentialKind === "synced_path"
+  ) {
+    return "Personal synced credentials need an active owner share before shared sandbox selection.";
+  }
+  return null;
+}
+
+export function selectionByAgentKind(
+  selections: SandboxAgentAuthSelection[],
+): Map<string, SandboxAgentAuthSelection> {
+  return new Map(selections.map((selection) => [selection.agentKind, selection]));
+}
+
+export function targetStateSummary(
+  states: SandboxAgentAuthTargetState[],
+  targetId: string,
+): SandboxAgentAuthTargetState | null {
+  return states.find((state) => state.targetId === targetId) ?? null;
+}

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -913,6 +913,35 @@ async def get_gateway_policy_for_credential(
     return _policy_record(row) if row is not None else None
 
 
+async def get_managed_gateway_credential(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    agent_kind: str,
+) -> AgentAuthCredentialRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthCredential)
+            .join(
+                AgentGatewayPolicy,
+                AgentGatewayPolicy.credential_id == AgentAuthCredential.id,
+            )
+            .where(
+                AgentAuthCredential.owner_scope == "organization",
+                AgentAuthCredential.organization_id == organization_id,
+                AgentAuthCredential.agent_kind == agent_kind,
+                AgentAuthCredential.credential_kind == "managed_gateway",
+                AgentAuthCredential.revoked_at.is_(None),
+                AgentAuthCredential.status != "revoked",
+                AgentGatewayPolicy.policy_kind == "proliferate_managed",
+            )
+            .order_by(AgentAuthCredential.created_at.asc())
+            .with_for_update()
+        )
+    ).scalars().first()
+    return _credential_record(row) if row is not None else None
+
+
 async def get_gateway_policy(
     db: AsyncSession,
     policy_id: UUID,

--- a/server/proliferate/server/agent_gateway/api.py
+++ b/server/proliferate/server/agent_gateway/api.py
@@ -34,7 +34,7 @@ async def agent_gateway_health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@router.get("/anthropic/v1/models")
+@router.get("/anthropic/v1/models", include_in_schema=False)
 async def anthropic_models(
     request: Request,
     db: AsyncSession = Depends(get_async_session),
@@ -59,7 +59,7 @@ async def anthropic_models(
     )
 
 
-@router.get("/openai/v1/models")
+@router.get("/openai/v1/models", include_in_schema=False)
 async def openai_models(
     request: Request,
     db: AsyncSession = Depends(get_async_session),
@@ -84,10 +84,10 @@ async def openai_models(
     )
 
 
-@router.post("/anthropic/v1/messages")
-@router.post("/anthropic/v1/messages/count_tokens")
-@router.post("/openai/v1/responses")
-@router.post("/openai/v1/chat/completions")
+@router.post("/anthropic/v1/messages", include_in_schema=False)
+@router.post("/anthropic/v1/messages/count_tokens", include_in_schema=False)
+@router.post("/openai/v1/responses", include_in_schema=False)
+@router.post("/openai/v1/chat/completions", include_in_schema=False)
 async def forward_protocol_request(
     request: Request,
     db: AsyncSession = Depends(get_async_session),

--- a/server/proliferate/server/cloud/agent_auth/api.py
+++ b/server/proliferate/server/cloud/agent_auth/api.py
@@ -17,6 +17,8 @@ from proliferate.server.cloud.agent_auth.models import (
     AgentAuthMutationResponse,
     CreateGatewayCredentialRequest,
     CreateGatewayCredentialResponse,
+    EnsureManagedCreditsRequest,
+    EnsureManagedCreditsResponse,
     EnsureOrganizationSandboxProfileRequest,
     EnsurePersonalSandboxProfileRequest,
     SandboxAgentAuthSelectionResponse,
@@ -27,6 +29,7 @@ from proliferate.server.cloud.agent_auth.models import (
     WorkerAgentAuthMaterializationPlan,
     WorkerAgentAuthStatusRequest,
     WorkerAgentAuthStatusResponse,
+    budget_subject_response,
     credential_response,
     credential_share_response,
     policy_response,
@@ -37,6 +40,7 @@ from proliferate.server.cloud.agent_auth.models import (
 )
 from proliferate.server.cloud.agent_auth.service import (
     create_gateway_credential,
+    ensure_managed_credits_for_organization,
     ensure_organization_sandbox_profile,
     ensure_personal_sandbox_profile,
     list_credentials,
@@ -87,6 +91,29 @@ async def create_gateway_credential_endpoint(
         credential=credential_response(result.credential),
         policy=policy_response(result.policy),
         providerCredential=provider_credential_response(result.provider_credential),
+    )
+
+
+@router.post(
+    "/organizations/{organization_id}/agent-auth/managed-credits",
+    response_model=EnsureManagedCreditsResponse,
+)
+async def ensure_managed_credits_endpoint(
+    organization_id: UUID,
+    body: EnsureManagedCreditsRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> EnsureManagedCreditsResponse:
+    result = await ensure_managed_credits_for_organization(
+        db,
+        actor_user_id=user.id,
+        organization_id=organization_id,
+        body=body,
+    )
+    return EnsureManagedCreditsResponse(
+        budgetSubject=budget_subject_response(result.budget_subject),
+        credentials=[credential_response(record) for record in result.credentials],
+        policies=[policy_response(record) for record in result.policies],
     )
 
 

--- a/server/proliferate/server/cloud/agent_auth/api.py
+++ b/server/proliferate/server/cloud/agent_auth/api.py
@@ -43,7 +43,7 @@ from proliferate.server.cloud.agent_auth.service import (
     ensure_managed_credits_for_organization,
     ensure_organization_sandbox_profile,
     ensure_personal_sandbox_profile,
-    list_credentials,
+    list_credentials_for_response,
     list_selections,
     list_target_states,
     record_worker_agent_auth_status,
@@ -70,8 +70,11 @@ async def list_agent_auth_credentials_endpoint(
     db: AsyncSession = Depends(get_async_session),
 ) -> list[AgentAuthCredentialResponse]:
     return [
-        credential_response(record)
-        for record in await list_credentials(
+        credential_response(
+            item.credential,
+            active_credential_share_id=item.active_share.id if item.active_share else None,
+        )
+        for item in await list_credentials_for_response(
             db,
             actor_user_id=user.id,
             organization_id=organization_id,

--- a/server/proliferate/server/cloud/agent_auth/models.py
+++ b/server/proliferate/server/cloud/agent_auth/models.py
@@ -37,8 +37,7 @@ class LiteLLMModelDeploymentRequest(BaseModel):
 
 
 class EnsureManagedCreditsRequest(BaseModel):
-    included_budget_usd: str | None = Field(default=None, alias="includedBudgetUsd")
-    agent_kinds: list[AgentKind] = Field(default_factory=lambda: ["claude"], alias="agentKinds")
+    pass
 
 
 class CreateGatewayCredentialRequest(BaseModel):
@@ -94,6 +93,10 @@ class AgentAuthCredentialResponse(BaseModel):
     status: str
     revision: int
     legacy_cloud_credential_id: UUID | None = Field(alias="legacyCloudCredentialId")
+    active_credential_share_id: UUID | None = Field(
+        default=None,
+        alias="activeCredentialShareId",
+    )
     revoked_at: str | None = Field(alias="revokedAt")
 
 
@@ -263,7 +266,11 @@ def sandbox_profile_response(record: SandboxProfileRecord) -> SandboxProfileResp
     )
 
 
-def credential_response(record: AgentAuthCredentialRecord) -> AgentAuthCredentialResponse:
+def credential_response(
+    record: AgentAuthCredentialRecord,
+    *,
+    active_credential_share_id: UUID | None = None,
+) -> AgentAuthCredentialResponse:
     return AgentAuthCredentialResponse(
         id=record.id,
         ownerScope=record.owner_scope,
@@ -277,6 +284,7 @@ def credential_response(record: AgentAuthCredentialRecord) -> AgentAuthCredentia
         status=record.status,
         revision=record.revision,
         legacyCloudCredentialId=record.legacy_cloud_credential_id,
+        activeCredentialShareId=active_credential_share_id,
         revokedAt=_iso(record.revoked_at),
     )
 

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -81,6 +81,7 @@ from proliferate.utils.time import utcnow
 
 _ORG_ADMIN_ROLES = {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}
 _GATEWAY_GRANT_TTL = timedelta(days=7)
+_MANAGED_CREDIT_AGENT_KINDS_V1: tuple[CloudAgentKind, ...] = ("claude",)
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,12 @@ class EnsureManagedCreditsResult:
     budget_subject: AgentGatewayBudgetSubjectRecord
     credentials: tuple[AgentAuthCredentialRecord, ...]
     policies: tuple[AgentGatewayPolicyRecord, ...]
+
+
+@dataclass(frozen=True)
+class CredentialListItem:
+    credential: AgentAuthCredentialRecord
+    active_share: AgentAuthCredentialShareRecord | None
 
 
 @dataclass(frozen=True)
@@ -184,6 +191,36 @@ async def list_credentials(
         organization_id=organization_id,
         agent_kind=agent_kind,
     )
+
+
+async def list_credentials_for_response(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID | None,
+    agent_kind: str | None,
+) -> tuple[CredentialListItem, ...]:
+    credentials = await list_credentials(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+        agent_kind=agent_kind,
+    )
+    items: list[CredentialListItem] = []
+    for credential in credentials:
+        active_share = None
+        if (
+            organization_id is not None
+            and credential.owner_scope == "personal"
+            and credential.credential_kind == "synced_path"
+        ):
+            active_share = await store.get_active_credential_share(
+                db,
+                credential_id=credential.id,
+                organization_id=organization_id,
+            )
+        items.append(CredentialListItem(credential=credential, active_share=active_share))
+    return tuple(items)
 
 
 async def create_gateway_credential(
@@ -339,7 +376,7 @@ async def ensure_managed_credits_for_organization(
     # Customer-facing callers never choose managed-credit amounts. The value
     # comes from Proliferate entitlement/billing state; Phase 1 uses settings as
     # that entitlement source until billing integration wires this internally.
-    included_budget_usd = _budget_amount(settings.agent_gateway_default_managed_budget_usd)
+    included_budget_usd = _managed_credit_entitlement_budget()
     existing_budget = await store.get_managed_budget_subject(db, organization_id)
     team_id = existing_budget.litellm_team_id if existing_budget else None
     sync_status = "failed"
@@ -347,9 +384,7 @@ async def ensure_managed_credits_for_organization(
     fingerprint = None
     error_code = "litellm_not_configured"
     error_message = "LiteLLM provisioning is not configured."
-    requested_agent_kinds = tuple(
-        agent_kind for agent_kind in body.agent_kinds if agent_kind != "gemini"
-    )
+    requested_agent_kinds = _MANAGED_CREDIT_AGENT_KINDS_V1
     managed_deployments = tuple(
         deployment
         for agent_kind in requested_agent_kinds
@@ -416,29 +451,16 @@ async def ensure_managed_credits_for_organization(
 
     credentials: list[AgentAuthCredentialRecord] = []
     policies: list[AgentGatewayPolicyRecord] = []
-    visible = await store.list_visible_credentials(
-        db,
-        actor_user_id=actor_user_id,
-        organization_id=organization_id,
-        agent_kind=None,
-    )
     for agent_kind in requested_agent_kinds:
         if not _gateway_deployments_for_credential(
             agent_kind=agent_kind,
             provider_kind="proliferate_bedrock_pool",
         ):
             continue
-        credential = next(
-            (
-                item
-                for item in visible
-                if item.owner_scope == "organization"
-                and item.organization_id == organization_id
-                and item.agent_kind == agent_kind
-                and item.credential_kind == "managed_gateway"
-                and item.display_name == "Proliferate managed credits"
-            ),
-            None,
+        credential = await store.get_managed_gateway_credential(
+            db,
+            organization_id=organization_id,
+            agent_kind=agent_kind,
         )
         if credential is None:
             credential = await store.create_agent_auth_credential(
@@ -489,7 +511,7 @@ async def ensure_managed_credits_for_organization(
         metadata_json=json.dumps(
             {
                 "includedBudgetUsd": included_budget_usd,
-                "agentKinds": list(body.agent_kinds),
+                "agentKinds": list(requested_agent_kinds),
                 "litellmSyncStatus": sync_status,
             },
             sort_keys=True,
@@ -1066,9 +1088,7 @@ async def _require_agent_auth_refresh_command(
             code="agent_auth_command_invalid",
             status_code=409,
         ) from exc
-    if not isinstance(payload, dict) or payload.get("sandboxProfileId") != str(
-        sandbox_profile_id
-    ):
+    if not isinstance(payload, dict) or payload.get("sandboxProfileId") != str(sandbox_profile_id):
         raise AgentAuthError(
             "Agent auth config command does not match the requested profile.",
             code="agent_auth_command_mismatch",
@@ -1245,11 +1265,7 @@ async def _worker_synced_files_config(
             status_code=409,
         )
     legacy = await get_cloud_credential_by_id(db, credential.legacy_cloud_credential_id)
-    if (
-        legacy is None
-        or legacy.revoked_at is not None
-        or legacy.provider != credential.agent_kind
-    ):
+    if legacy is None or legacy.revoked_at is not None or legacy.provider != credential.agent_kind:
         raise AgentAuthError(
             "Synced credential source is not active.",
             code="synced_credential_source_missing",
@@ -1271,9 +1287,7 @@ async def _worker_synced_files_config(
     raw_files = payload.get("files")
     files = [
         {"relativePath": relative_path, "content": content}
-        for relative_path, content in (
-            raw_files if isinstance(raw_files, dict) else {}
-        ).items()
+        for relative_path, content in (raw_files if isinstance(raw_files, dict) else {}).items()
         if isinstance(relative_path, str) and isinstance(content, str)
     ]
     if not env_vars and not files:
@@ -2138,6 +2152,17 @@ def _budget_amount(value: str) -> str:
             "Included budget must be non-negative.", code="invalid_budget", status_code=400
         )
     return format(amount, "f")
+
+
+def _managed_credit_entitlement_budget() -> str:
+    budget = _budget_amount(settings.agent_gateway_default_managed_budget_usd)
+    if Decimal(budget) <= 0:
+        raise AgentAuthError(
+            "Managed credits are not enabled for this organization.",
+            code="managed_credits_not_entitled",
+            status_code=403,
+        )
+    return budget
 
 
 def _redact_secret(value: str) -> str:

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -344,7 +344,7 @@ async def test_gateway_policy_kind_must_match_owner_scope(
 
 
 @pytest.mark.asyncio
-async def test_managed_credits_route_is_not_customer_accessible(
+async def test_managed_credits_route_uses_server_entitlement_budget(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
@@ -354,13 +354,21 @@ async def test_managed_credits_route_is_not_customer_accessible(
         email="agent-auth-managed-credits@example.com",
     )
 
+    organizations = await client.get("/v1/organizations", headers=_headers(tokens))
+    assert organizations.status_code == 200
+    organization_id = organizations.json()["organizations"][0]["id"]
+
     response = await client.post(
-        f"/v1/cloud/agent-auth/managed-credits/organizations/{uuid.uuid4()}",
+        f"/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits",
         headers=_headers(tokens),
-        json={"includedBudgetUsd": "999999"},
+        json={"includedBudgetUsd": "999999", "agentKinds": ["claude"]},
     )
 
-    assert response.status_code == 404
+    assert response.status_code == 200
+    body = response.json()
+    assert body["budgetSubject"]["includedBudgetUsd"] != "999999"
+    assert body["credentials"][0]["displayName"] == "Proliferate managed credits"
+    assert body["credentials"][0]["status"] == "invalid"
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -347,7 +347,13 @@ async def test_gateway_policy_kind_must_match_owner_scope(
 async def test_managed_credits_route_uses_server_entitlement_budget(
     client: AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_default_managed_budget_usd",
+        "12.50",
+    )
     tokens = await _create_user_and_get_tokens(
         client,
         db_session,
@@ -361,12 +367,13 @@ async def test_managed_credits_route_uses_server_entitlement_budget(
     response = await client.post(
         f"/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits",
         headers=_headers(tokens),
-        json={"includedBudgetUsd": "999999", "agentKinds": ["claude"]},
+        json={"includedBudgetUsd": "999999", "agentKinds": ["claude", "claude", "gemini"]},
     )
 
     assert response.status_code == 200
     body = response.json()
-    assert body["budgetSubject"]["includedBudgetUsd"] != "999999"
+    assert body["budgetSubject"]["includedBudgetUsd"] == "12.50"
+    assert len(body["credentials"]) == 1
     assert body["credentials"][0]["displayName"] == "Proliferate managed credits"
     assert body["credentials"][0]["status"] == "invalid"
 

--- a/server/tests/integration/test_cloud_agent_auth_sharing_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_sharing_api.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+from proliferate.db.store.cloud_agent_auth import store
+
+
+async def _create_user_and_get_tokens(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    *,
+    email: str,
+) -> dict[str, str]:
+    user = User(
+        email=email,
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        display_name="Agent Auth Tester",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    verifier = "test-code-verifier-that-is-long-enough-for-pkce"
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    response = await client.post(
+        "/auth/desktop/authorize",
+        params={"user_id": str(user.id)},
+        json={
+            "state": f"agent-auth-state-{uuid.uuid4().hex[:8]}",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "proliferate://auth/callback",
+        },
+    )
+    assert response.status_code == 201
+
+    response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": response.json()["code"],
+            "code_verifier": verifier,
+            "grant_type": "authorization_code",
+        },
+    )
+    assert response.status_code == 200
+    token_data = response.json()
+    return {
+        "user_id": str(user.id),
+        "access_token": token_data["access_token"],
+    }
+
+
+def _headers(tokens: dict[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_shared_personal_synced_credential_lists_active_share_for_org_selection(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-shared-synced@example.com",
+    )
+
+    organizations = await client.get("/v1/organizations", headers=_headers(tokens))
+    assert organizations.status_code == 200
+    organization_id = organizations.json()["organizations"][0]["id"]
+
+    response = await client.put(
+        "/v1/cloud/credentials/claude",
+        headers=_headers(tokens),
+        json={
+            "authMode": "env",
+            "envVars": {"ANTHROPIC_API_KEY": "test-anthropic-key"},
+        },
+    )
+    assert response.status_code == 200
+
+    response = await client.post(
+        "/v1/cloud/sandbox-profiles/personal",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+
+    response = await client.get(
+        "/v1/cloud/agent-auth/credentials",
+        headers=_headers(tokens),
+        params={"organizationId": organization_id, "agentKind": "claude"},
+    )
+    assert response.status_code == 200
+    credential = next(
+        record for record in response.json() if record["credentialKind"] == "synced_path"
+    )
+    assert credential["activeCredentialShareId"] is None
+
+    share_response = await client.post(
+        f"/v1/cloud/agent-auth/credentials/{credential['id']}/shares",
+        headers=_headers(tokens),
+        json={"organizationId": organization_id},
+    )
+    assert share_response.status_code == 200
+    share_id = share_response.json()["id"]
+
+    response = await client.get(
+        "/v1/cloud/agent-auth/credentials",
+        headers=_headers(tokens),
+        params={"organizationId": organization_id, "agentKind": "claude"},
+    )
+    assert response.status_code == 200
+    shared_credential = next(
+        record for record in response.json() if record["id"] == credential["id"]
+    )
+    assert shared_credential["activeCredentialShareId"] == share_id
+
+    profile_response = await client.post(
+        f"/v1/cloud/organizations/{organization_id}/sandbox-profile",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert profile_response.status_code == 200
+
+    select_response = await client.put(
+        "/v1/cloud/sandbox-profiles/"
+        f"{profile_response.json()['id']}/agent-auth-selections/claude",
+        headers=_headers(tokens),
+        json={"credentialId": credential["id"], "credentialShareId": share_id},
+    )
+    assert select_response.status_code == 200
+    assert select_response.json()["credentialShareId"] == share_id
+
+
+@pytest.mark.asyncio
+async def test_managed_credits_route_requires_server_entitlement_budget(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_default_managed_budget_usd",
+        "0",
+    )
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-managed-credits-not-entitled@example.com",
+    )
+
+    organizations = await client.get("/v1/organizations", headers=_headers(tokens))
+    assert organizations.status_code == 200
+    organization_id = organizations.json()["organizations"][0]["id"]
+
+    response = await client.post(
+        f"/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits",
+        headers=_headers(tokens),
+        json={},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "managed_credits_not_entitled"
+
+
+@pytest.mark.asyncio
+async def test_managed_credits_do_not_reuse_org_byok_credential_with_same_name(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_default_managed_budget_usd",
+        "12.50",
+    )
+    tokens = await _create_user_and_get_tokens(
+        client,
+        db_session,
+        email="agent-auth-managed-credits-display-collision@example.com",
+    )
+
+    organizations = await client.get("/v1/organizations", headers=_headers(tokens))
+    assert organizations.status_code == 200
+    organization_id = organizations.json()["organizations"][0]["id"]
+
+    byok = await client.post(
+        "/v1/cloud/agent-auth/credentials/gateway",
+        headers=_headers(tokens),
+        json={
+            "ownerScope": "organization",
+            "organizationId": organization_id,
+            "agentKind": "claude",
+            "displayName": "Proliferate managed credits",
+            "policyKind": "org_byok",
+            "providerKind": "anthropic_api_key",
+            "payload": {"apiKey": "sk-ant-test"},
+        },
+    )
+    assert byok.status_code == 200
+    byok_credential_id = byok.json()["credential"]["id"]
+
+    response = await client.post(
+        f"/v1/cloud/organizations/{organization_id}/agent-auth/managed-credits",
+        headers=_headers(tokens),
+        json={},
+    )
+    assert response.status_code == 200
+    managed_credential_id = response.json()["credentials"][0]["id"]
+    assert managed_credential_id != byok_credential_id
+
+    byok_policy = await store.get_gateway_policy_for_credential(
+        db_session,
+        UUID(byok_credential_id),
+    )
+    assert byok_policy is not None
+    assert byok_policy.policy_kind == "org_byok"


### PR DESCRIPTION
## Summary
- add Cloud SDK and SDK React helpers/query keys for agent-auth credentials, sandbox profiles, selections, target states, shares, and managed credits
- add the Cloud settings agent-auth library with harness-scoped credential creation, status display, revoke, and synced-credential sharing entry points
- add Compute target agent-auth selection UI that initializes the target sandbox profile and saves per-harness credential selections
- expose the existing managed-credits service through a Cloud API endpoint and regenerate the Cloud OpenAPI client

## Verification
- `pnpm --filter @proliferate/cloud-sdk typecheck`
- `pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build`
- `pnpm --filter proliferate exec tsc --noEmit`
- `python3 scripts/check_frontend_boundaries.py`
- `uv run ruff check proliferate/server/cloud/agent_auth tests/integration/test_cloud_agent_auth_api.py`
- `DEBUG=1 uv run --extra dev python -m pytest -q tests/integration/test_cloud_agent_auth_api.py`
- Playwright smoke loaded `/settings?section=cloud` against local Vite dev server

## Notes
- `python3 scripts/check_max_lines.py` still reports inherited phase-1/3 agent-auth server files over 600 lines; this PR does not add those oversized files.
