### PR TITLE
docs(architecture): add cloud runtime specs

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -229,6 +229,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/{provider}/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Oauth Shared Provider Callback */
+        get: operations["oauth_shared_provider_callback_auth__provider__callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/web/apple/callback": {
         parameters: {
             query?: never;
@@ -6582,6 +6599,41 @@ export interface operations {
             header?: never;
             path: {
                 surface: string;
+                provider: "github" | "google" | "apple";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    oauth_shared_provider_callback_auth__provider__callback_get: {
+        parameters: {
+            query?: {
+                state?: string | null;
+                code?: string | null;
+                error?: string | null;
+            };
+            header?: never;
+            path: {
                 provider: "github" | "google" | "apple";
             };
             cookie?: never;

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,9 +105,22 @@ start of the task, not after implementation has already started.
   - concrete implementation spec for the shared target/workspace/materialization
     launch model used by automations, Slack, web, mobile, and Desktop cloud
     surfaces
+- `docs/architecture/target-runtime-mcp-skills-config.md`
+  - proposed target model for replacing session plugin bundles with
+    target-scoped MCP/skill runtime config, refresh, and lazy artifact/credential
+    resolution
+- `docs/architecture/shared-sandbox-config-admin-ui-spec.md`
+  - proposed shared sandbox configuration model for personal and organization
+    cloud profiles, agent credential sync, public MCP/skill publication, and
+    admin/user configuration UI
+- `docs/architecture/agent-llm-auth-gateway-spec.md`
+  - proposed centralized agent LLM auth gateway model for Proliferate managed
+    credits, BYOK credentials, synced-path auth selections, LiteLLM
+    provisioning, and sandbox runtime grants
 - `docs/architecture/plugins-and-skills.md`
-  - reference architecture for plugin packages, skill bundles, plugin-owned
-    MCP servers, the plugins UI, and the session bundle boundary
+  - legacy/current-state reference for plugin packages, skill bundles,
+    plugin-owned MCP servers, the plugins UI, and the current session bundle
+    boundary
 
 ## Deployment and environment reference
 

--- a/docs/architecture/agent-llm-auth-gateway-spec.md
+++ b/docs/architecture/agent-llm-auth-gateway-spec.md
@@ -1,0 +1,2676 @@
+# Agent LLM Auth Gateway Spec
+
+Status: proposed implementation spec
+
+Date: 2026-05-17
+
+## Purpose
+
+This spec defines the centralized agent LLM auth gateway for managed cloud
+targets and shared sandboxes.
+
+The gateway gives a sandbox one of these auth sources for each agent harness:
+
+```text
+Proliferate managed credits
+  Proliferate-owned provider credentials, org-scoped included usage, no overage.
+
+BYOK through gateway
+  User/org-owned provider credentials stored server-side, never injected into
+  the sandbox.
+
+Synced path
+  Existing native auth files or env vars synced into the sandbox by Desktop and
+  worker.
+```
+
+The core runtime boundary is:
+
+```text
+AnyHarness launches a harness with a chosen model string.
+The harness sends that exact model string to Proliferate Gateway.
+Proliferate Gateway validates the sandbox token and forwards to LiteLLM.
+LiteLLM routes the model for that team/policy, calls the provider, tracks
+spend, and enforces budgets.
+```
+
+Proliferate does not do per-request model remapping. It provisions LiteLLM so
+the harness-visible model ids that AnyHarness launches are valid LiteLLM public
+model names for the policy's team.
+
+## Docs Read For This Spec
+
+This spec is cross-cutting and follows:
+
+- `docs/README.md`
+- `docs/server/README.md`
+- `docs/server/guides/database.md`
+- `docs/server/guides/integrations.md`
+- `docs/frontend/README.md`
+- `docs/frontend/guides/access.md`
+- `docs/anyharness/README.md`
+- `docs/ci-cd/README.md` before adding deployable gateway/LiteLLM services,
+  deployment env vars, or runtime process changes
+- `docs/architecture/cloud-worker-control-plane.md`
+- `docs/architecture/cloud-worker-workspace-command-spec.md`
+- `docs/architecture/target-runtime-mcp-skills-config.md` when present in the
+  worktree; otherwise this spec's runtime-auth sections stand alone
+- `docs/architecture/shared-sandbox-config-admin-ui-spec.md` when present in
+  the worktree; otherwise this spec's consumer contract stands alone
+- `docs/architecture/model-catalog-and-dynamic-registries.md`
+- `docs/notes/model-gateway-auth-facts.md`
+
+## Scope
+
+In scope:
+
+- Agent auth credential library for personal, organization, and system
+  credentials.
+- Gateway-backed provider auth for Proliferate managed credits and BYOK.
+- Synced-path credentials as a selectable auth source for personal and shared
+  sandboxes.
+- Org-scoped Proliferate managed credits with LiteLLM-enforced hard budget.
+- LiteLLM provisioning for teams, virtual keys, provider credentials, and
+  team-scoped model deployments.
+- Gateway runtime grants and runtime agent auth refresh through worker and
+  AnyHarness.
+- UI flows for adding provider credentials and selecting agent auth per
+  sandbox/harness.
+
+Out of scope:
+
+- Overage billing.
+- Proliferate-owned per-request usage ledger.
+- Self-hosted gateway/LiteLLM management.
+- Gemini gateway support. V1 may keep Gemini on synced-path auth.
+- A new product model catalog. `catalogs/agents/v1/catalog.json` remains the
+  product model catalog.
+- Direct exposure of LiteLLM virtual keys to sandboxes.
+
+## Relationship To Adjacent Specs
+
+This spec is one layer of the shared cloud sandbox stack:
+
+```text
+target-runtime-mcp-skills-config.md
+  owns target-scoped MCP/skill manifests, lazy artifact fetch, and MCP/skill
+  credential gap fill.
+
+agent-llm-auth-gateway-spec.md
+  owns agent harness LLM auth: Proliferate managed credits, BYOK through the
+  gateway, synced native auth files, LiteLLM provisioning, and runtime grants.
+
+shared-sandbox-config-admin-ui-spec.md
+  consumes both layers to let admins configure shared sandboxes.
+```
+
+The MCP/skill system and this LLM auth system should use the same target
+profile/materialization shape where possible, but they should not be collapsed
+into one credential model. MCP credentials authorize tools. Agent LLM
+credentials authorize the model calls made by Claude Code, Codex, OpenCode, or
+Gemini.
+
+This document must also stand alone in worktrees that do not yet contain the
+adjacent target-runtime or shared-sandbox specs. When an adjacent spec is absent
+or older, use this document as the canonical source for agent LLM auth names,
+ownership, worker commands, and sandbox selection semantics. Adjacent specs can
+reference this one, but they do not need to repeat its data model.
+
+### Consumer Contract For Shared Sandbox Specs
+
+Adjacent specs and UI work should treat this spec as the source of truth for
+agent LLM auth. They should consume only the public auth objects and APIs:
+
+```text
+Read/select:
+  agent_auth_credential
+  sandbox_agent_auth_selection
+  agent auth readiness/status summaries
+
+Write:
+  sandbox_agent_auth_selection for a sandbox profile
+
+Observe:
+  selection status
+  target/profile applied revision and materialization status
+  credential owner/status/revision
+```
+
+They should not create parallel models for agent credentials or gateway
+policies. In particular, shared sandbox specs should not define their own
+`cloud_agent_credential`, `cloud_agent_api_key_credential`,
+`cloud_agent_managed_gateway_credential`, or
+`cloud_agent_credential_source` as normative data models. Those older concepts
+map to this spec as:
+
+```text
+old cloud_agent_credential/source  -> agent_auth_credential
+old shared credential source       -> sandbox_agent_auth_selection
+old api_key credential             -> managed_gateway credential + provider credential
+old managed_gateway credential     -> agent_gateway_policy
+old worker credential apply        -> refresh_agent_auth_config
+```
+
+The shared sandbox/admin UI spec still owns the page composition and the fact
+that an organization shared sandbox has per-harness selections. This spec owns
+how credentials are created, validated, provisioned, selected, refreshed,
+materialized, revoked, and enforced.
+
+### Implementation Posture
+
+This is an implementation spec, not only a north-star architecture note.
+Existing launch docs may still describe synced credentials as the current V1
+bridge or say that there is no centralized agent gateway for that launch. Those
+statements describe current state, not the target state here.
+
+Implementation should be phased, but the target model should not be watered
+down into a second temporary credential abstraction. The immediate alignment
+work is:
+
+```text
+1. Use this spec's names for new agent-auth work:
+   agent_auth_credential
+   sandbox_agent_auth_selection
+   refresh_agent_auth_config
+
+2. Treat unsupported gateway-backed paths as feature-gated statuses, not
+   different models.
+
+3. Keep synced-path credentials as one credential kind inside this model.
+
+4. Prove gateway/provider compatibility through Phase 0 before enabling a
+   provider broadly, but do not create provider-specific product models while
+   waiting for that proof.
+```
+
+For doc-only landings, include this spec in `docs/README.md`. If adjacent specs
+are landing in another worktree, they should link to this spec and consume the
+consumer contract above instead of copying the older credential-source model.
+
+## Decisions
+
+1. LiteLLM is the hot-path router and budget enforcer.
+
+   Proliferate validates the sandbox token, resolves the selected gateway
+   policy, and forwards to LiteLLM with the internal key for that policy.
+   LiteLLM decides which configured deployment handles the requested model and
+   updates spend.
+
+2. Proliferate concepts are canonical; LiteLLM ids are internal mirrors.
+
+   Product state uses `agent_auth_credential`, `agent_gateway_policy`, provider
+   credentials, sandbox selections, and runtime grants. LiteLLM team ids,
+   virtual keys, and model ids are stored only so Proliferate can reconcile
+   and repair the LiteLLM mirror.
+
+3. LiteLLM team ownership follows the budget/routing subject.
+
+   A gateway policy is the concrete auth/routing contract:
+
+   ```text
+   ACME shared sandbox uses Proliferate managed credits
+   ACME shared sandbox uses ACME Bedrock role
+   Alice personal sandbox uses Alice OpenAI key
+   ```
+
+   For BYOK, use one LiteLLM team per gateway policy unless isolation later
+   requires a different shape. For Proliferate managed credits, policies for
+   the same org must share one `agent_gateway_budget_subject` and one LiteLLM
+   team so the included credit budget is enforced across harnesses, not once
+   per harness.
+
+4. Proliferate managed credits are org-scoped in V1.
+
+   The org gets an included dollar budget for the period. V1 has no overage.
+   When the budget is exhausted, managed-credit requests fail closed.
+
+5. Budget enforcement is outsourced to LiteLLM, but entitlement is not.
+
+   Proliferate stores the plan/free-trial entitlement and provisions LiteLLM
+   with `max_budget` and `budget_duration` on the shared managed-credit budget
+   subject. LiteLLM stores and enforces current spend. Proliferate does not
+   write a usage ledger on every request in V1.
+
+6. V1 budget duration is LiteLLM-native `30d`.
+
+   Do not use `30m`: in LiteLLM duration syntax that means 30 minutes. Stripe
+   subscription-period alignment can be added later by updating/resetting the
+   LiteLLM team on renewal.
+
+7. BYOK has no default dollar cap.
+
+   BYOK usage is reported, but Proliferate does not hard cap BYOK by default.
+   Gateway still applies operational abuse protection. Admin-configured BYOK
+   caps can be a later feature.
+
+8. Fail closed.
+
+   If the selected credential or policy is invalid, missing, unvalidated,
+   exhausted, or revoked, launches and requests fail. They never silently fall
+   back to Proliferate credits unless an explicit future fallback flag exists.
+
+9. Managed-gateway provider secrets never enter the sandbox.
+
+   Provider API keys, AWS role credentials, OAuth refresh tokens, and LiteLLM
+   internal keys stay server-side. The sandbox receives only a scoped,
+   revocable Proliferate gateway runtime grant.
+
+10. Synced path intentionally writes native auth into the sandbox.
+
+    Synced-path credentials are a separate auth kind. They are allowed for
+    personal sandboxes and, by admin selection, shared sandboxes. Their whole
+    purpose is to materialize native auth files/env vars in the sandbox.
+
+11. Shared sandbox auth selection is admin-only in V1.
+
+    Everyone may effectively be admin during early product rollout, but the
+    authorization model should still use admin-only checks. A shared sandbox can
+    select org/system gateway credentials or a selected user's personal synced
+    files. The UI must show the source owner clearly.
+
+12. Harness model strings pass through.
+
+    AnyHarness chooses the model string from the existing product catalog and
+    launches the harness with it. The harness sends the same model string to
+    the gateway. Proliferate Gateway does not translate it. LiteLLM team-scoped
+    deployments expose the same public model name and translate to provider
+    model ids internally.
+
+13. Team-scoped LiteLLM model support is a V1 gate.
+
+    LiteLLM must support multiple teams using the same public model name with
+    different provider credentials. The intended mechanism is team-scoped model
+    deployments: `/model/new` with `model_info.team_id`, where LiteLLM stores a
+    unique internal `model_name_*` and exposes `team_public_model_name` equal to
+    the harness-visible model string. If this cannot be validated in the
+    deployed LiteLLM edition, do not ship shared BYOK/managed gateway broadly.
+
+14. Request/response bodies are not persisted by default.
+
+    Store usage metadata and diagnostics only. Debug body logging, if added,
+    must be explicit and expire automatically.
+
+## System Architecture
+
+```text
+Desktop/Web
+  -> api.proliferate.ai
+       canonical product DB
+       auth library and sandbox selections
+       LiteLLM provisioning
+       worker commands
+
+Sandbox harness process
+  -> gateway.proliferate.ai
+       validates Proliferate runtime grant
+       resolves grant -> gateway policy -> LiteLLM internal key
+       protocol facade: Anthropic, OpenAI-compatible, Responses
+       forwards to private LiteLLM
+
+Private LiteLLM
+  -> provider APIs
+       Bedrock, Anthropic, OpenAI, OpenAI-compatible
+       team-scoped model routing
+       spend tracking and hard budget enforcement
+```
+
+Production should run these as separate processes/services even if they live in
+the same repo:
+
+```text
+api service       public control plane
+gateway service   public model gateway
+litellm service   private/internal, not exposed to sandboxes
+```
+
+## Product Object Model
+
+### Sandbox Profile Contract
+
+This spec depends on a sandbox profile identity owned by shared sandbox/admin
+configuration work. Agent auth should consume that identity, not become the
+owning domain for shared-sandbox configuration. If that schema has not landed
+yet, Phase 1 must first add the minimal profile contract in the shared
+sandbox/profile owning area, then agent auth can reference it.
+
+```text
+sandbox_profile
+  id
+  owner_scope                 personal | organization
+  owner_user_id               nullable for org rows
+  organization_id             nullable for personal rows
+  managed_target_id           nullable until cloud is enabled
+  agent_auth_revision         denormalized current pointer
+  status                      active | archived
+  created_at
+  updated_at
+  deleted_at
+```
+
+The auth gateway does not own repo environment config, MCP/skill selection, or
+target cardinality. It only needs a stable `sandbox_profile_id` so the product
+can say "this personal or shared sandbox profile uses these credentials for
+these harnesses."
+
+If another spec lands a fuller profile model first, use that table and keep
+these fields as the auth gateway's required subset. Do not create a second
+profile-like table under `agent_auth`. If no owning profile domain exists when
+implementation starts, create it in the shared sandbox/profile owning area
+first; agent auth owns only credential, selection, target-state, and grant
+rows.
+
+Profile lifecycle:
+
+```text
+personal profile
+  create lazily when the user enables cloud, creates/selects an agent auth
+  credential for cloud use, or launches the first cloud workspace.
+
+organization profile
+  create when an admin enables shared cloud or configures the first shared
+  sandbox selection.
+
+CloudCredential cutover
+  backfill personal profiles for users with existing CloudCredential rows so
+  new materialization can switch to sandbox_agent_auth_selection deterministically.
+
+first launch after cutover
+  if a user has legacy CloudCredential state but no sandbox profile yet, the
+  server must create the personal profile, import the CloudCredential rows as
+  synced-path agent_auth_credential rows, create default selections, bump
+  agent_auth_revision, and dispatch the launch with requiredAgentAuthRevision.
+  This happens before worker launch preflight so the old injection path can be
+  removed without leaving a gap.
+```
+
+`sandbox_profile.agent_auth_revision` is the current desired revision pointer.
+`sandbox_profile_agent_auth_revision` is the append-only revision history and
+the source for `force_restart` and reason. Treat them as one revision stream,
+not two independent counters.
+
+### Agent Auth Credential
+
+Reusable auth source visible in the Proliferate product.
+
+`agent_kind` values must be catalog/AnyHarness agent kind strings. Do not
+invent gateway-specific names based on product display names. Current canonical
+values used here are `claude`, `codex`, `opencode`, and `gemini`; server Cloud
+constants must be extended before exposing a kind that is not currently cloud
+supported.
+
+```text
+agent_auth_credential
+  id
+  owner_scope                 system | personal | organization
+  owner_user_id               nullable for org/system
+  organization_id             nullable for personal/system
+  created_by_user_id
+  agent_kind                  claude | codex | opencode | gemini
+  credential_kind             managed_gateway | synced_path
+  display_name
+  redacted_summary_json
+  status                      pending | ready | needs_resync | invalid | revoked
+  revision
+  created_at
+  updated_at
+  revoked_at
+```
+
+Examples:
+
+```text
+System Proliferate managed credits
+Org ACME AWS Bedrock role
+Alice synced Claude auth files
+Alice personal OpenAI key through gateway
+```
+
+Credential visibility is derived, not stored as a second state machine:
+
+```text
+system credential        visible where the system policy allows it
+organization credential  visible to admins/users with org credential access
+personal credential      visible only to the owner unless an active
+                         agent_auth_credential_share exists for that org
+```
+
+There is no separate visibility column in V1. `agent_auth_credential_share` is
+the single source of truth for owner opt-in of personal synced credentials.
+This avoids overlapping states like a cached "shared" flag plus a revoked
+share.
+
+### Agent Auth Credential Share
+
+Owner opt-in/delegation record for using a personal credential outside the
+owner's personal sandbox.
+
+```text
+agent_auth_credential_share
+  id
+  credential_id
+  owner_user_id
+  organization_id
+  share_scope                 organization
+  shared_by_user_id
+  status                      active | revoked
+  allowed_agent_kind
+  created_at
+  revoked_at
+  revoked_by_user_id
+```
+
+Rules:
+
+```text
+only the credential owner can create or revoke a share
+admins can select only active shares for organization shared sandboxes
+revoking the share invalidates affected sandbox_agent_auth_selection rows
+selection UI must show the source owner and shared credential label
+share consent copy must say this is reusable org-wide delegation for shared
+  sandboxes until revoked
+owner consent UI must show current where-used and later where-used must remain
+  visible from the auth library
+all create/select/revoke actions emit audit events
+```
+
+### Gateway Policy
+
+Concrete LiteLLM-backed policy for `managed_gateway` credentials.
+
+```text
+agent_gateway_policy
+  id
+  credential_id
+  policy_kind                 proliferate_managed | org_byok | personal_byok
+  owner_scope                 system | personal | organization
+  owner_user_id
+  organization_id
+  budget_subject_id           nullable; set for proliferate_managed
+  litellm_team_id
+  litellm_virtual_key_id
+  litellm_virtual_key_ciphertext
+  litellm_virtual_key_ciphertext_key_id
+  litellm_sync_status         pending | synced | drifted | failed
+  litellm_sync_fingerprint
+  status                      provisioning | ready | invalid | revoked
+  revision
+  last_provisioned_at
+  last_litellm_reconciled_at
+  last_error_code
+  last_error_message
+```
+
+For Proliferate managed credits, every org policy that spends the same included
+credits must reference the same `budget_subject_id`; `litellm_team_id` mirrors
+the budget subject's team for fast gateway lookup. For BYOK, `budget_subject_id`
+is null, the policy owns its LiteLLM team, and no LiteLLM max budget is set
+unless an admin cap is later added.
+
+### Gateway Budget Subject
+
+Budget-enforcement subject shared across one or more gateway policies.
+
+```text
+agent_gateway_budget_subject
+  id
+  budget_kind                 proliferate_managed
+  owner_scope                 organization
+  organization_id
+  litellm_team_id
+  included_budget_usd
+  budget_duration             V1 "30d"
+  litellm_sync_status         pending | synced | drifted | failed
+  litellm_sync_fingerprint
+  status                      ready | exhausted | invalid | revoked
+  revision
+  last_provisioned_at
+  last_litellm_reconciled_at
+  last_error_code
+  last_error_message
+```
+
+V1 only needs `proliferate_managed` org budgets. The invariant is that Claude,
+Codex, or future harnesses using Proliferate managed credits for the same org
+spend against the same LiteLLM team budget.
+
+### Gateway Provider Credential
+
+Provider-side credential or connection config used by a gateway policy.
+
+```text
+agent_gateway_provider_credential
+  id
+  policy_id
+  provider_kind               proliferate_bedrock_pool
+                              anthropic_api_key
+                              openai_api_key
+                              bedrock_assume_role
+                              openai_compatible
+  payload_ciphertext
+  payload_ciphertext_key_id
+  redacted_summary_json
+  validation_status           unvalidated | valid | invalid
+  validated_at
+  validation_error_code
+  validation_error_message
+  revision
+```
+
+Payload examples:
+
+```json
+{
+  "providerKind": "bedrock_assume_role",
+  "roleArn": "arn:aws:iam::123456789012:role/ProliferateBedrockRole",
+  "externalId": "org_..._...",
+  "region": "us-west-2",
+  "validatedAccountId": "123456789012"
+}
+```
+
+```json
+{
+  "providerKind": "openai_compatible",
+  "baseUrl": "https://models.example.com/v1",
+  "apiKey": "...",
+  "discoveredProviderModelIds": ["..."]
+}
+```
+
+Discovered provider model ids are validation/debug facts for that provider
+credential. They are not product catalog entries and must not drive the model
+picker directly.
+
+### Sandbox Agent Auth Selection
+
+What a sandbox profile uses for each harness.
+
+```text
+sandbox_agent_auth_selection
+  id
+  sandbox_profile_id
+  owner_scope                 personal | organization
+  agent_kind                  claude | codex | opencode | gemini
+  credential_id
+  credential_share_id         required when organization selects personal
+                              synced_path credential
+  materialization_mode        gateway_env | synced_files
+  selected_revision
+  status                      active | needs_resync | invalid
+  last_error_code
+  last_error_message
+```
+
+Shared sandbox rules:
+
+```text
+admin-only selection
+may select org/system gateway credentials
+may select a named user's personal synced files only through an active
+  agent_auth_credential_share
+must fail closed when the source credential becomes stale/revoked
+must fail closed when the credential share is revoked
+must show source owner in UI
+```
+
+Selection rows are desired state for the sandbox profile. They are not enough
+to prove a target is current, because one profile can be applied to multiple
+managed targets or SSH targets.
+
+### Target Agent Auth State
+
+Per-target applied/materialized state for a sandbox profile.
+
+```text
+sandbox_profile_agent_auth_target_state
+  id
+  sandbox_profile_id
+  target_id
+  desired_revision
+  applied_revision
+  status                      pending | materializing | applied | failed | superseded
+  force_restart_required
+  last_command_id
+  last_worker_id
+  last_attempted_at
+  last_applied_at
+  last_error_code
+  last_error_message
+  created_at
+  updated_at
+```
+
+Rules:
+
+```text
+selection and credential changes update profile-level desired state
+each target/profile pair records its own applied revision
+worker status updates target_state, not selection rows
+launch preflight checks the target's applied revision and AnyHarness local
+  revision before starting/cold-restarting an actor
+one online target cannot make another target look applied
+```
+
+### Runtime Grant
+
+Scoped, revocable token given to the sandbox for managed gateway calls.
+
+```text
+agent_gateway_runtime_grant
+  id
+  token_hash
+  policy_id
+  credential_id
+  selection_id
+  issued_profile_revision
+  target_id
+  sandbox_profile_id
+  organization_id
+  user_id
+  agent_kind
+  protocol_facade             anthropic | openai
+  expires_at
+  revoked_at
+  last_used_at
+  created_at
+```
+
+The raw token is returned only in the worker materialization response. Store
+only a hash in Proliferate DB.
+
+`target_id` is the Cloud-side managed/SSH target where the grant is intended to
+be valid. In V1 the runtime grant is still a bearer token: `target_id` and
+`sandbox_profile_id` are authorization and revocation metadata checked by the
+gateway after token lookup, not cryptographic source binding. Do not claim a
+stolen grant cannot be replayed from another network location unless a later
+target-proof mechanism is added.
+
+Do not add an AnyHarness-owned sandbox/session id to this table in V1. If
+session-level metadata becomes available, attach it to gateway request metadata
+or logs as optional observability data, not as part of the grant identity.
+
+Runtime grant lifecycle:
+
+```text
+service reuses an existing unexpired grant when it has more than 24h remaining
+service mints a replacement only inside the refresh window or on selection
+  change
+at most two unrevoked/unexpired routine grants should exist for
+  policy_id + target_id + sandbox_profile_id + agent_kind: current plus grace
+routine grant grace is allowed only for the same selection_id and policy_id
+selection change to a different credential/policy revokes old grants after the
+  target reports the new revision applied, unless a future explicit live-grace
+  flag is added
+expired/revoked grants are cleaned up by retention job after the audit window
+```
+
+Future target proof, if needed:
+
+```text
+gateway can require a second signed target proof header derived from a
+target-scoped secret delivered to AnyHarness/worker
+protocol facades must prove the target proof can be sent by the harness config
+before treating target_id as cryptographically source-bound
+```
+
+Personal synced credentials do not create gateway runtime grants. When a
+materialization plan writes synced files because a shared sandbox selected a
+personal credential, the plan and audit event must include the
+`credential_share_id` that authorized that materialization.
+
+Secret handling rules:
+
+```text
+runtime grant token generation:
+  use at least 128 bits of entropy from a CSPRNG
+
+token_hash:
+  store HMAC-SHA256(server_secret, raw_token) or an equivalent keyed hash
+  store a hash_key_id / version so token-hash keys can rotate with dual-read
+  validation windows
+  never store raw runtime grants in DB
+
+ciphertext:
+  store key ids for provider payloads and LiteLLM virtual keys
+  use authenticated encryption with stable associated data such as table name,
+    row id, owner scope, and provider kind
+  support key rotation through write-new/read-old windows before old-key
+    retirement
+
+logs and repr:
+  raw grants, provider payloads, LiteLLM virtual keys, auth headers, and synced
+  file contents must be redacted from structured logs, exceptions, repr/debug
+  output, worker status payloads, and command result payloads
+
+materialization plan:
+  assembled just in time by the worker materialization endpoint
+  do not persist server-side plans containing runtime_grant_token, provider
+    keys, or synced auth file bodies
+  persist only redacted summaries, hashes, references, target state, and audit
+    events
+  returned only over authenticated worker channel
+  never persisted by worker except required synced files/config
+  status responses must not echo secrets
+
+AnyHarness persistence:
+  if agent auth config is persisted, encrypt it at rest or store only
+  non-secret metadata plus a local secret reference
+
+debug logging:
+  request/response body logging and materialization-plan logging are disabled by
+  default; any explicit debug capture must be access-controlled and expire
+```
+
+### Database Invariants
+
+Add explicit constraints/indexes so auth resolution is deterministic:
+
+```text
+all mutable tables
+  created_at and updated_at following server DB conventions
+  revoked_at/deleted_at/status columns where rows are soft-retired
+
+sandbox_profile
+  check owner fields match owner_scope
+  partial unique index for active personal profile by owner_user_id
+  partial unique index for active organization profile by organization_id
+
+agent_auth_credential
+  check owner fields match owner_scope
+  index owner_scope + owner_user_id + agent_kind + status
+  index owner_scope + organization_id + agent_kind + status
+
+agent_auth_credential_share
+  partial unique index for active share by credential_id + organization_id
+  enforce shared credential owner_user_id matches credential.owner_user_id with
+    service validation plus composite FK or trigger; it cannot be a plain check
+  index organization_id + allowed_agent_kind + status
+
+agent_gateway_budget_subject
+  partial unique index for active proliferate_managed budget by organization_id
+
+agent_gateway_policy
+  unique policy by credential_id
+  check proliferate_managed requires budget_subject_id
+  check BYOK policies have null budget_subject_id
+
+agent_gateway_provider_credential
+  unique provider credential by policy_id for provider-backed BYOK policies
+
+sandbox_agent_auth_selection
+  unique sandbox_profile_id + agent_kind
+  check organization-owned selection of personal synced credential requires
+    credential_share_id
+  organization-owned selection must not use personal managed_gateway
+    credentials in V1
+  selected_revision must equal credential revision observed at selection time
+
+sandbox_profile_agent_auth_target_state
+  unique target_id + sandbox_profile_id
+  index target_id + status + desired_revision + applied_revision
+  applied_revision cannot exceed desired_revision
+
+agent_gateway_runtime_grant
+  unique token_hash
+  index policy_id + revoked_at + expires_at
+  index target_id + sandbox_profile_id + agent_kind
+  index selection_id + issued_profile_revision
+  service-level invariant: no more than current plus grace unexpired grants per
+    policy_id + target_id + sandbox_profile_id + agent_kind
+```
+
+Implement these as concrete foreign keys, composite foreign keys, partial
+unique indexes, row locks, service validations, and triggers where needed.
+Cross-row/cross-table invariants must not be documented as plain SQL `CHECK`
+constraints if Postgres cannot enforce them that way.
+
+Revision bump semantics:
+
+```text
+selection writes lock sandbox_profile row
+credential/share revocation locks affected sandbox_profile rows
+target-state updates lock target_id + sandbox_profile_id state row
+increment agent_auth_revision in the same transaction as selection/status change
+enqueue refresh_agent_auth_config after commit using the committed revision
+```
+
+## LiteLLM Provisioning
+
+### Managed Credits
+
+When an org receives included credits:
+
+```text
+1. Create or update agent_gateway_budget_subject
+   budget_kind = proliferate_managed
+   owner_scope = organization
+   included_budget_usd = plan/free-trial amount
+   budget_duration = "30d"
+
+2. Create or update LiteLLM team for the budget subject
+   /team/new or /team/update
+   max_budget = included_budget_usd
+   budget_duration = "30d"
+
+3. For each enabled harness path, create or update agent_auth_credential
+   credential_kind = managed_gateway
+   owner_scope = organization
+   agent_kind = claude | codex | opencode | gemini
+   display_name = "Proliferate managed credits"
+
+4. Create or update agent_gateway_policy
+   policy_kind = proliferate_managed
+   budget_subject_id = shared org managed-credit budget subject
+   litellm_team_id = budget subject LiteLLM team
+
+5. Create internal LiteLLM virtual key
+   /key/generate
+   team_id = litellm_team_id
+
+6. Create team-scoped LiteLLM model deployments for supported harness-visible
+   model ids.
+```
+
+LiteLLM is the source of truth for current spend. Proliferate is the source of
+truth for the budget amount that should be provisioned.
+
+Budget fail-closed rule:
+
+```text
+before a managed-credit credential can become selectable, Proliferate must
+  reconcile the LiteLLM team/key/model/budget mirror and mark budget subject
+  and policy litellm_sync_status = synced
+gateway requests for managed credits fail closed if the budget subject or
+  policy is drifted/failed/stale
+launch preflight fails if required managed-credit policy is not synced
+reconciliation is a launch/readiness gate, not a post-rollout hardening task
+```
+
+### BYOK
+
+When an admin adds BYOK through gateway:
+
+```text
+1. Create agent_auth_credential
+2. Create agent_gateway_policy
+3. Store encrypted provider credential payload
+4. Validate provider credential
+5. Create LiteLLM team with no default dollar budget
+6. Create internal LiteLLM virtual key
+7. Create team-scoped model deployments backed by that provider credential
+```
+
+### Team-Scoped Model Deployment
+
+For every harness-visible model id that should work under a policy, provision a
+team-scoped LiteLLM model whose public name equals the model string AnyHarness
+will launch.
+
+Example for Claude Sonnet backed by Bedrock:
+
+```json
+{
+  "model_name": "us.anthropic.claude-sonnet-4-6",
+  "litellm_params": {
+    "model": "bedrock/us.anthropic.claude-sonnet-...",
+    "aws_region_name": "us-west-2",
+    "aws_role_name": "arn:aws:iam::123456789012:role/ProliferateBedrockRole",
+    "aws_session_name": "proliferate-org-...",
+    "aws_external_id": "org_..._..."
+  },
+  "model_info": {
+    "team_id": "litellm-team-id"
+  }
+}
+```
+
+LiteLLM should internally store a unique deployment name and expose the
+requested `model_name` as `team_public_model_name`. Runtime requests still send
+`model = "us.anthropic.claude-sonnet-4-6"`.
+
+Do not create a Proliferate hot-path route table that maps catalog model ids to
+provider models. The mapping is LiteLLM provisioning state.
+
+This is the exact boundary:
+
+```text
+Catalog:
+  catalogs/agents/v1/catalog.json remains the product model catalog and picker
+  source.
+
+Provisioning time:
+  Proliferate reads the existing agent catalog and creates LiteLLM deployments
+  for the model ids that a harness may request under this policy.
+  catalog model id / harness-visible model string ==
+    LiteLLM team_public_model_name.
+  provider model id exists only in LiteLLM deployment params.
+
+Request time:
+  Proliferate Gateway forwards the request model unchanged.
+  LiteLLM either finds the team-scoped deployment or returns model_not_found.
+  Gateway maps that to model_not_available.
+```
+
+If an admin connects a provider that cannot serve a catalog model, that model is
+simply not provisioned for that policy. The UI may show it as unavailable for
+that credential, but the gateway still does not translate model ids on the hot
+path.
+
+### LiteLLM API Surface Used
+
+V1 should use these LiteLLM primitives:
+
+```text
+/team/new
+/team/update
+/team/info
+/key/generate
+/key/info
+/model/new
+/model/update or /model/delete for reconciliation
+```
+
+Gateway calls should use the internal LiteLLM virtual key for the resolved
+policy, never the LiteLLM master key.
+
+## Provider Setup
+
+### Proliferate Managed Credits
+
+User input: none.
+
+Proliferate operates system provider credentials, preferably Bedrock where the
+target harness/protocol path is compatible. If a harness requires a protocol
+LiteLLM cannot faithfully translate to Bedrock, route that harness through the
+provider account that matches its protocol.
+
+Examples:
+
+```text
+Claude Code
+  preferred: Anthropic-compatible gateway -> LiteLLM -> Proliferate Bedrock
+  fallback: Anthropic-compatible gateway -> LiteLLM -> Proliferate Anthropic
+
+Codex
+  preferred only if Responses API path is compatible
+  fallback: OpenAI Responses-compatible gateway -> Proliferate OpenAI
+```
+
+### AWS Bedrock BYOK
+
+Admin UX asks for:
+
+```text
+AWS region
+Role ARN
+```
+
+Before that, Proliferate generates and displays:
+
+```text
+Proliferate AWS principal
+External ID
+CloudFormation launch link
+copyable IAM trust policy
+copyable Bedrock permission policy
+```
+
+Trust policy shape:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "arn:aws:iam::<proliferate-account>:role/proliferate-agent-gateway"
+  },
+  "Action": "sts:AssumeRole",
+  "Condition": {
+    "StringEquals": {
+      "sts:ExternalId": "<generated-external-id>"
+    }
+  }
+}
+```
+
+Permission policy shape:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:InvokeModel",
+    "bedrock:InvokeModelWithResponseStream",
+    "bedrock:Converse",
+    "bedrock:ConverseStream"
+  ],
+  "Resource": "*"
+}
+```
+
+Validation must fail fast:
+
+```text
+AssumeRole with correct ExternalId succeeds
+AssumeRole with missing/wrong ExternalId fails
+GetCallerIdentity returns expected account
+test Bedrock invocation succeeds in the selected region
+at least one supported Proliferate model is available
+```
+
+Primary setup artifact: CloudFormation launch link. Secondary: copyable IAM
+JSON. Terraform can come later.
+
+### Anthropic API Key
+
+Admin/user input:
+
+```text
+API key
+label
+```
+
+Stored encrypted in Proliferate. Provisioned into LiteLLM model deployments
+server-side. Never written to sandbox for `managed_gateway`.
+
+### OpenAI API Key
+
+Admin/user input:
+
+```text
+API key
+label
+optional organization id
+optional project id
+```
+
+Stored encrypted in Proliferate. Provisioned into LiteLLM model deployments.
+
+### OpenAI-Compatible Provider
+
+Admin/user input:
+
+```text
+Base URL
+optional API key
+label
+```
+
+Proliferate should try `GET /models`. If discovery fails, the advanced path may
+ask for one exact model id plus capability hints. Normal setup should not ask
+users to curate a full model list.
+
+Because this is a server-side probe, V1 must treat the base URL as untrusted
+network input:
+
+```text
+require HTTPS for hosted Proliferate cloud
+reject credentials embedded in the URL
+block localhost, loopback, link-local, RFC1918/private, and metadata IP ranges
+resolve DNS before the request and reject private resolved addresses
+disable redirects or revalidate every redirect target with the same rules
+set short connect/read timeouts and a small response-size cap
+send only the provider API key header needed for the probe
+audit create/validate attempts without logging the key or response body
+```
+
+Self-hosted/private-network providers can be added later behind an explicit
+self-hosted deployment mode. They are not part of hosted-cloud V1.
+
+### Synced Path
+
+Synced path reuses and generalizes current `CloudCredential` behavior:
+
+```text
+Claude Code files/env
+Codex files
+OpenCode config/auth files when added
+Gemini files/env
+```
+
+Synced-path payloads are allowed to write real auth files into the sandbox.
+They are not gateway-backed and do not involve LiteLLM.
+
+V1 target isolation rule:
+
+```text
+synced native auth files are target-global unless/until AnyHarness can launch
+  a harness with per-profile HOME/config isolation
+therefore a target may have at most one active sandbox profile with
+  materialization_mode = synced_files for a given agent_kind
+if multiple profiles must coexist on one target, they must use gateway_env or
+  implementation must first add per-profile home/config isolation
+```
+
+Revocation cleanup:
+
+```text
+materialization plans can contain tombstones/cleanup actions for synced auth
+worker must delete/replace only allowlisted auth paths owned by the selected
+  harness before writing new synced files
+credential/share revocation queues a cleanup materialization so old native auth
+  files do not remain usable on disk
+```
+
+### Current CloudCredential Cutover
+
+Current `CloudCredential` and target-config materialization already sync
+personal agent auth into cloud workspaces. The migration must be explicit so old
+and new paths do not both inject provider auth.
+
+Cutover rules:
+
+```text
+1. Add schema and idempotent backfill first. Import existing CloudCredential
+   rows as personal agent_auth_credential rows with credential_kind =
+   synced_path and the catalog agent_kind string, but do not switch launch
+   reads yet.
+
+2. Keep CloudCredential as the legacy backing/source table only until all reads
+   go through agent_auth_credential.
+
+3. New sandbox/profile materialization must eventually read
+   sandbox_agent_auth_selection, not direct CloudCredential rows.
+
+4. Do not stop legacy target-config credential injection until
+   refresh_agent_auth_config, target/profile applied state, AnyHarness agent
+   auth config, launch auth-scope persistence, worker capability gating, and
+   launch preflight are all live behind a feature flag.
+
+5. Cutover uses a global/profile-aware kill switch so exactly one path writes
+   agent auth for a target: legacy CloudCredential injection or new agent-auth
+   materialization, never both.
+
+6. Workspace/repo env sync must continue to reserve provider-routing env vars
+   so repo `.env` cannot override selected agent auth.
+
+7. Once the new path is live for personal and shared profiles, remove the old
+   direct CloudCredential injection path rather than keeping a permanent dual
+   model.
+
+8. Cover every direct legacy path before flipping the switch, including target
+   config materialization, runtime credential freshness refresh, worker env
+   materialization, and any Desktop sync path that still writes provider env.
+
+9. On the first launch after cutover for an existing user/target with legacy
+   CloudCredential rows but no profile selection yet, the server must
+   synchronously create/backfill the personal sandbox profile, import the
+   credentials, create default selections for the user's personal sandbox, bump
+   the auth revision, and include requiredAgentAuthRevision on the launch
+   command. The worker then applies the new materialization path before
+   dispatching the launch.
+```
+
+## Harness Materialization
+
+### Target Auth Revision
+
+Every sandbox profile has a monotonic agent auth revision. The revision changes
+whenever the target-side auth launch state should be re-applied:
+
+```text
+sandbox_profile_agent_auth_revision
+  sandbox_profile_id
+  revision
+  force_restart
+  reason                      selection_changed
+                              credential_validated
+                              credential_revoked
+                              credential_share_revoked
+                              synced_files_updated
+                              grant_rotation
+                              target_bootstrap
+                              drift_repair
+  created_at
+```
+
+The selected credentials remain in `sandbox_agent_auth_selection`. The revision
+is the compact desired-state marker. Per-target apply state lives in
+`sandbox_profile_agent_auth_target_state`; do not use selection rows as
+materialization status.
+
+### When To Queue Refresh
+
+Queue `refresh_agent_auth_config` whenever the target auth state might have
+changed or might expire:
+
+```text
+sandbox auth selection saved
+gateway credential validated or revalidated
+gateway credential payload changed
+synced-path credential files/env updated
+credential revoked, invalidated, or marked needs_resync
+target created, claimed, restored, or worker reconnects with no applied revision
+worker heartbeat reports applied revision behind desired revision
+earliest gateway runtime grant is inside the refresh window
+```
+
+For managed cloud targets, this should feel immediate: save credential or
+selection, bump revision, enqueue command, worker leases command, target launch
+config updates. If the target is offline, paused, or not bootstrapped yet, the
+command stays queued or the bootstrap path applies the latest revision before
+new launches.
+
+### Command Shape
+
+Add a CloudCommand:
+
+```text
+kind = refresh_agent_auth_config
+scope = target only
+payload:
+  sandboxProfileId
+  revision
+  reason
+  forceRestart
+```
+
+Use an idempotency key scoped to the target/profile/revision:
+
+```text
+agent-auth-config:{target_id}:{sandbox_profile_id}:{revision}
+```
+
+`sandboxProfileId` is the agent-auth config id. There is no separate
+`agent_auth_config` table in V1. The idempotency key also includes `target_id`
+because the same profile revision can be applied to multiple targets, such as
+organization SSH targets that use the same shared profile.
+
+Older queued commands are harmless. If a worker leases revision `N` after
+revision `N+1` exists, the materialization endpoint should return a superseded
+response and the worker should report an accepted no-op result. It must not
+mark revision `N` as applied.
+
+```json
+{
+  "applied": false,
+  "reason": "superseded",
+  "currentRevision": 42
+}
+```
+
+The command is target-scoped because agent auth is target launch state, not a
+workspace/session mutation.
+
+Superseded target-state transition:
+
+```text
+worker receives superseded materialization response
+worker reports status = superseded with currentRevision
+server leaves applied_revision unchanged
+server sets desired_revision to currentRevision and status = pending if the
+  target still needs the newer revision, or leaves the newer in-flight state
+  unchanged if another command is already materializing it
+```
+
+### Launch Preflight And Ordering
+
+Do not rely only on Cloud command ordering to make launches see the latest
+agent auth. Launch-capable commands should carry the sandbox profile auth
+revision they require:
+
+```text
+start_session payload:
+  sandboxProfileId
+  requiredAgentAuthRevision
+
+send_prompt / resume-like payloads that may cold-start an actor:
+  sandboxProfileId
+  requiredAgentAuthRevision
+```
+
+These are existing command contract changes. The server command validators,
+worker command envelope/mapping, and AnyHarness request mapping must preserve
+them for launch-capable commands.
+
+Worker compatibility gate:
+
+```text
+workers must advertise capability agent_auth_launch_preflight_v1 before they
+  can lease launch-capable commands that include requiredAgentAuthRevision
+server lease filtering must route those commands only to capable workers, or
+  use new command kinds that old workers do not advertise
+if no capable worker is connected, launch commands remain queued or fail
+  fast with worker_capability_missing; they must not be delivered to old
+  workers that would ignore the fields
+```
+
+The worker must run an auth preflight before dispatching any command that can
+start or cold-restart an actor:
+
+```text
+1. Read requiredAgentAuthRevision from the Cloud command payload.
+2. Read target/profile applied state and AnyHarness scoped auth status.
+3. If applied >= required, dispatch the original command.
+4. If applied < required, fetch and apply the latest agent auth materialization
+   plan first.
+5. Re-read target/profile applied state and AnyHarness scoped auth status.
+6. Dispatch the original command only if applied >= required.
+7. Otherwise fail the command with agent_auth_refresh_failed.
+```
+
+This avoids race conditions where a user changes credentials and immediately
+starts work before the background `refresh_agent_auth_config` command has been
+leased. The background command still exists for normal drift repair and
+rotation, but launch preflight is the correctness guard.
+
+If a credential was revoked or invalidated, the preflight must fail closed. It
+must not dispatch a launch using stale target auth.
+
+### Gateway Grant TTL And Rotation
+
+Gateway runtime grants should be long-lived enough that a live harness process
+does not fail during normal use, but still revocable:
+
+```text
+default grant TTL: 7 days
+refresh cadence: daily
+refresh threshold: enqueue when earliest grant expires within 24 hours
+```
+
+Routine rotation should overlap grants. Do not revoke the previous routine
+grant merely because a new grant was applied; let it expire naturally. This
+matters because already-running harness processes usually keep their launch env
+for their lifetime and will not see a freshly written token until restart.
+
+Security and correctness invalidation is different:
+
+```text
+credential revoked / invalid / needs_resync -> gateway rejects all grants for
+  that credential or policy immediately
+
+selection changed to another credential -> new launches use the new grant;
+  old grants for the previous credential/policy are revoked after the target
+  reports the replacement revision applied unless a future explicit live-grace
+  flag exists
+```
+
+`force_restart` lives on the committed `sandbox_profile_agent_auth_revision`
+row and is copied into the `refresh_agent_auth_config` command payload. It is
+set by explicit admin action or security-sensitive transitions such as
+credential/share revocation. Routine grant rotation and normal credential
+revalidation should leave it false.
+
+V1 should not rely on sub-hour tokens unless a later local sidecar or
+file-backed token refresh mechanism lets running harnesses read updated tokens
+without restart.
+
+### Worker Flow
+
+The worker receives a materialization plan containing gateway runtime grant
+tokens and harness-specific launch config. It applies that config to AnyHarness
+as runtime-scoped agent auth state. Cloud still scopes the command to a
+CloudTarget, but the AnyHarness API should use AnyHarness-owned runtime/agent
+terms rather than importing the Cloud target model into AnyHarness.
+
+The worker then fetches the plan:
+
+```text
+GET /v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/materialization
+  ?revision=...
+  &command_id=...
+  &lease_id=...
+```
+
+The plan contains:
+
+```text
+target_id
+sandbox_profile_id
+revision
+selections[]
+  agent_kind
+  materialization_mode
+  credential_id
+  credential_revision
+  gateway:
+    base_urls by protocol
+    runtime_grant_token
+    expires_at
+    protected_env
+    support_env
+    protected_config_files or config content
+    support_config_files or config content
+  synced_files:
+    files/env payloads, when materialization_mode = synced_files
+    credential_share_id, when a shared sandbox uses a personal synced
+      credential through owner delegation
+    cleanup actions/tombstones for allowlisted native auth paths when a
+      credential/share was revoked or replaced
+```
+
+Worker apply sequence:
+
+```text
+1. Lease refresh_agent_auth_config.
+2. Report materialization status = materializing.
+3. Fetch the materialization plan with command_id, lease_id, and revision.
+4. Validate plan target_id and revision match the command.
+5. Apply synced-path cleanup actions, if any, restricted to the harness
+   allowlist.
+6. Write synced-path files/env payloads, if any.
+7. Call AnyHarness PUT /v1/agents/auth-config with gateway env/config.
+8. Read AnyHarness redacted auth-config status to confirm applied revision.
+9. Persist local applied revision metadata for reconnect diagnostics.
+10. Report materialization status = applied, superseded, or failed.
+11. Report CloudCommand result.
+```
+
+The worker reports:
+
+```text
+POST /v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/status
+  status = materializing | applied | superseded | failed
+```
+
+Status writes update `sandbox_profile_agent_auth_target_state` for the
+command's `target_id + sandbox_profile_id`. They must not echo raw grants,
+provider secrets, synced file contents, or config file bodies.
+
+### Cloud Command Contract Changes
+
+`refresh_agent_auth_config` must be added to the same concrete command
+surfaces as existing worker commands:
+
+```text
+server/proliferate/constants/cloud.py
+  CloudCommandKind.refresh_agent_auth_config
+  ACTIVE_CLOUD_COMMAND_KINDS
+  SUPPORTED_CLOUD_COMMAND_KINDS
+
+server/proliferate/server/cloud/commands/domain/rules.py
+  target-only command shape validation
+  payload validation for sandboxProfileId, revision, reason, forceRestart
+  launch-command payload validation for sandboxProfileId and
+  requiredAgentAuthRevision on commands that can start/cold-restart actors
+
+anyharness/crates/proliferate-worker/src/cloud_client/commands.rs
+  SUPPORTED_COMMAND_KINDS includes "refresh_agent_auth_config"
+  launch command payloads preserve requiredAgentAuthRevision
+  worker capability advertises agent_auth_launch_preflight_v1
+
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+  process_refresh_agent_auth_config_command
+  launch preflight before start_session/send_prompt/resume-like dispatch
+
+server/proliferate/server/cloud/worker/service.py
+  lease filtering prevents old workers from receiving launch-capable commands
+    that require agent auth preflight
+
+server/proliferate/server/cloud/commands/models.py
+  parses accepted refresh_agent_auth_config result_json so superseded/no-op
+    outcomes are visible in Cloud command responses
+```
+
+Current Cloud commands reject `preconditions`; do not depend on preconditions
+for V1. Use `requiredAgentAuthRevision` in launch-capable command payloads and
+perform launch preflight in the worker.
+
+`CloudCommandStatus.superseded` exists for command lifecycle bookkeeping, but
+auth refresh workers should not depend on a new worker-result shape for
+superseded materialization responses. A superseded auth refresh should report
+an accepted no-op result:
+
+```json
+{
+  "status": "accepted",
+  "result": {
+    "applied": false,
+    "reason": "superseded",
+    "currentRevision": 42
+  }
+}
+```
+
+This fits the current worker result status validator while still making
+superseded revision behavior observable.
+
+### AnyHarness Agent Auth State
+
+Add an AnyHarness agent auth config API:
+
+```text
+PUT /v1/agents/auth-config
+GET /v1/agents/auth-config/status?external_scope_kind=...&external_scope_id=...
+```
+
+`PUT /v1/agents/auth-config` is the write path for secret-bearing launch
+config. The request body contains an opaque external auth scope, a revision,
+and per-agent launch config:
+
+```text
+externalAuthScope:
+  kind = sandbox_profile
+  id = <sandbox_profile_id>
+revision
+selections[]
+  agent_kind
+  protected_env
+  support_env
+  protected_config_files/config content
+  support_config_files/config content
+  expires_at
+```
+
+`GET /v1/agents/auth-config/status` is a redacted status endpoint only:
+
+```text
+externalAuthScope
+revision
+agent_kind summaries
+expires_at
+status
+last_error_code
+```
+
+It must not return raw runtime grants, provider headers, env values, config
+file content, synced auth files, or other bearer material.
+
+`externalAuthScope` is Cloud-owned metadata. AnyHarness stores it only so the
+worker can ask "which auth config revision is applied for this external scope?"
+AnyHarness must not interpret sandbox profile ownership or policy.
+
+Session launch authority:
+
+```text
+CreateSessionRequest / resume-or-cold-start request mapping must carry:
+  launchAuthScope { kind = sandbox_profile, id }
+  requiredAgentAuthRevision
+
+AnyHarness session records persist launchAuthScope and the revision used at
+creation. Bare prompt cold-starts read the persisted scope from the session
+record; they must not rely on `origin` or caller-provided display metadata as
+authority.
+
+At session launch/cold restart, AnyHarness queries its local auth-config state
+for the persisted launchAuthScope and fails closed if the applied revision is
+missing, stale, expired, or incompatible with the requested agent_kind.
+```
+
+AnyHarness stores the current agent auth revision and merges the relevant agent
+auth launch env/config at session launch. Agent auth config has two buckets:
+non-protected support inputs and protected provider-routing inputs. Merge
+precedence should be:
+
+```text
+workspace materialized env
+agent auth non-protected env/config
+session launch env
+adapter spawn override env
+agent auth protected env/config overlay
+```
+
+The protected overlay wins only for provider-routing inputs. Non-protected
+agent auth inputs use the normal runtime-auth slot before session/adapter
+overrides, so existing consumers can still pass non-provider launch knobs. Live
+actors pick up changes only at launch/restart boundaries.
+
+This change must update AnyHarness contract schemas, regenerate SDK clients,
+and wire the launch-env merge in the owned AnyHarness session startup path.
+
+Gateway-backed sessions also require authoritative model application. If
+AnyHarness cannot apply the resolved model string before the harness can issue
+requests, or if the harness rejects the model config, launch fails. Gateway
+auth must not proceed under today's best-effort model-apply behavior.
+
+### Protected Provider-Routing Inputs
+
+Fail-closed gateway auth depends on later untrusted layers not overriding the
+selected auth route. AnyHarness must treat provider-routing inputs from agent
+auth config as protected.
+
+Initial protected inputs:
+
+```text
+Claude:
+  ANTHROPIC_BASE_URL
+  ANTHROPIC_CUSTOM_HEADERS
+  ANTHROPIC_AUTH_TOKEN
+  ANTHROPIC_API_KEY
+  CLAUDE_CODE_USE_BEDROCK
+  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+  managed Claude config files/env fragments
+
+Codex:
+  CODEX_API_KEY
+  model_provider_id
+  model_providers.proliferate.*
+  Codex provider config files/env fragments
+
+OpenCode:
+  provider id
+  baseURL
+  apiKey
+  managed OpenCode config files
+
+Gemini:
+  synced native auth files/env when selected
+```
+
+Merge rule:
+
+```text
+1. Build workspace env/config.
+2. Apply agent auth non-protected env/config.
+3. Apply session launch env/config.
+4. Apply adapter spawn override env/config.
+5. Apply agent auth protected overlay last.
+6. Reject launch if any untrusted layer attempts to override a protected key
+   with a conflicting value for the selected agent.
+```
+
+Workspace/repo env sync should continue filtering reserved provider env vars,
+but AnyHarness must still enforce the protected overlay because session launch
+and adapter layers are later in the local process.
+
+### Claude Code Gateway Config
+
+Use the Anthropic-compatible facade.
+
+Expected env shape:
+
+```text
+CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1
+ANTHROPIC_BASE_URL=https://gateway.proliferate.ai/anthropic
+ANTHROPIC_CUSTOM_HEADERS=Authorization: Bearer <runtime-grant-token>
+ANTHROPIC_AUTH_TOKEN=
+```
+
+Do not set `CLAUDE_CODE_USE_BEDROCK` for managed gateway. Bedrock, if used, is
+behind LiteLLM, not in the sandbox.
+
+### Codex Gateway Config
+
+Use the OpenAI Responses-compatible facade.
+
+Expected config shape:
+
+```text
+model_provider_id = "proliferate"
+
+[model_providers.proliferate]
+name = "Proliferate Gateway"
+base_url = "https://gateway.proliferate.ai/openai/v1"
+env_key = "CODEX_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+
+CODEX_API_KEY = <runtime-grant-token>
+```
+
+Implementation must use the current Codex ACP launch/config override mechanism
+and must not depend on project files that the user can override. The exact
+config injection should follow the facts in
+`docs/notes/model-gateway-auth-facts.md`: custom provider config uses
+`base_url`, `env_key`, and `wire_api = "responses"`.
+
+### OpenCode Gateway Config
+
+Use OpenAI-compatible provider config if AnyHarness can force a managed config
+and isolate project config.
+
+Expected config content:
+
+```text
+provider id = proliferate
+baseURL = https://gateway.proliferate.ai/openai/v1
+apiKey = <runtime-grant-token>
+```
+
+Gateway support for OpenCode is gated on launch hardening. If project config can
+override the managed provider, mark OpenCode gateway auth as
+`protocol_not_supported` and use synced path for V1.
+
+### Gemini
+
+Gemini gateway support is deferred. V1 may support Gemini only through
+synced-path auth.
+
+## Gateway Runtime
+
+### Request Flow
+
+```text
+1. Harness sends request to protocol facade with runtime grant.
+2. Gateway validates grant hash, expiry, revocation, selected revision, target
+   metadata, sandbox profile, protocol facade, and agent kind.
+3. Gateway loads the gateway policy and LiteLLM binding.
+4. Gateway validates the requested route and model are allowed for the policy.
+5. Gateway forwards the original request body to LiteLLM with the internal
+   LiteLLM virtual key for that policy.
+6. LiteLLM routes by team + public model name, calls provider, tracks spend,
+   and enforces budget.
+7. Gateway streams or returns the provider response in the original protocol.
+```
+
+Gateway request authorization must reject:
+
+```text
+grant used on the wrong protocol facade
+unsupported endpoint for that facade
+body over configured size limits
+model not provisioned/allowed for the grant's policy and agent_kind
+policy or budget subject litellm_sync_status not synced
+grant issued for an older selection/revision that is no longer allowed
+```
+
+Gateway should attach metadata to LiteLLM requests when supported:
+
+```json
+{
+  "proliferate_org_id": "...",
+  "proliferate_user_id": "...",
+  "proliferate_target_id": "...",
+  "proliferate_sandbox_profile_id": "...",
+  "proliferate_session_id": "...",
+  "proliferate_agent_kind": "claude",
+  "proliferate_policy_id": "..."
+}
+```
+
+Metadata is for observability and spend slicing. It is not the canonical budget
+counter in V1. `proliferate_session_id` is optional and should be attached only
+when the harness/runtime grant path can reliably propagate it.
+
+### Gateway Errors
+
+Canonical gateway errors:
+
+```text
+invalid_gateway_token
+gateway_token_expired
+agent_auth_not_configured
+provider_auth_failed
+provider_rate_limited
+model_not_available
+credits_exhausted
+gateway_route_unavailable
+protocol_not_supported
+litellm_unavailable
+```
+
+The gateway should map LiteLLM/provider errors to these codes as they are
+encountered. The initial implementation can map coarsely, but the doc and code
+should keep these stable names.
+
+### Budget Exhaustion
+
+For Proliferate managed credits:
+
+```text
+agent_gateway_budget_subject.included_budget_usd = org included credits
+agent_gateway_budget_subject.budget_duration = "30d"
+shared LiteLLM team max_budget = included_budget_usd
+shared LiteLLM team budget_duration = "30d"
+LiteLLM rejects after spend >= max_budget
+Gateway maps to credits_exhausted
+UI shows the budget exhausted state
+```
+
+No overage invoice is generated.
+
+For usage display, Proliferate can query LiteLLM on demand through the control
+plane endpoint. Do not add a persisted spend snapshot table in V1 unless page
+latency or LiteLLM load proves it is necessary.
+
+Gateway must not accept managed-credit requests when Proliferate believes the
+LiteLLM budget mirror is stale or drifted. It should fail closed with
+`gateway_route_unavailable` or `credits_exhausted` depending on the known
+state, then reconciliation can repair the mirror out of band.
+
+## UI Surfaces
+
+The UI must keep credential creation distinct from sandbox/workspace
+assignment:
+
+```text
+Auth library
+  creates, validates, revokes, and audits reusable credentials.
+
+Sandbox profile auth selection
+  chooses which existing credential each agent harness uses in a personal or
+  shared sandbox.
+
+Workspace settings
+  may show the effective cloud auth state and deep-link into setup, but should
+  not own secret forms or store credential ids directly.
+```
+
+This distinction matters because credentials are reused across workspaces,
+credentials have owners, revocation affects every sandbox that selected them,
+and shared sandboxes can intentionally use a named user's synced native auth.
+Workspace pages can still offer an "add/select credential" flow, but that flow
+must create the credential in the auth library and then return to a sandbox
+profile selection. The saved state remains
+`sandbox_agent_auth_selection`, not workspace-local secret state.
+
+If a future product requirement needs per-workspace auth overrides, model that
+as a workspace-to-sandbox-profile binding or an explicit profile override. Do
+not add direct provider-key or auth-file fields to workspace config.
+
+### Harness-First Selection Model
+
+The auth UI is harness-first, not provider-first. A user should start from the
+agent harness they are configuring, then see only credential setup paths that
+can actually satisfy that harness.
+
+V1 matrix:
+
+```text
+Claude Code
+  gateway-backed:
+    Proliferate managed credits, if Anthropic-compatible path is validated
+    AWS Bedrock AssumeRole for Anthropic/Claude models
+    Anthropic API key
+  synced-path:
+    synced Claude Code native auth files/env
+  do not show:
+    OpenAI API key
+    generic OpenAI-compatible provider
+
+Codex
+  gateway-backed:
+    Proliferate managed credits, only after Responses facade is validated
+    OpenAI API key
+    OpenAI-compatible provider, only if compatible with the required OpenAI API
+    shape for the selected Codex path
+  synced-path:
+    synced Codex native auth files
+  do not show:
+    Anthropic API key
+    AWS Bedrock role unless a Codex-compatible gateway path is explicitly
+    validated and enabled
+
+OpenCode
+  gateway-backed:
+    OpenAI API key, if AnyHarness can force managed provider config
+    OpenAI-compatible provider, if AnyHarness can force managed provider config
+    Proliferate managed credits, only if launch hardening is complete
+  synced-path:
+    synced OpenCode native config/auth files
+  do not show:
+    gateway-backed options when project config can override the managed provider
+
+Gemini
+  gateway-backed:
+    none in V1
+  synced-path:
+    synced Gemini native files/env
+```
+
+The same credential library can contain credentials for all harnesses, but
+setup and selection screens must filter by `agent_kind`. Creating a Claude Code
+credential should not offer OpenAI key setup. Creating a Codex credential
+should not offer Anthropic key setup. The only exception is a deliberately
+validated gateway path for that harness, documented in the matrix and gated by
+feature flags/capability checks.
+
+Provider setup can be reused internally across harness-specific credential
+rows, but the user-facing selection handle is still harness-specific. A shared
+Bedrock role may back both a Claude credential and a future Codex-compatible
+credential if that path is validated; the UI still renders them under the
+appropriate harness and does not expose provider model ids as a catalog.
+
+The shared sandbox/admin UI should call into this surface like:
+
+```text
+GET /v1/cloud/agent-auth/credentials
+  ?agent_kind=claude
+  &sandbox_profile_id=...
+
+PUT /v1/cloud/sandbox-profiles/{id}/agent-auth-selections
+  selections:
+    agent_kind
+    credential_id
+```
+
+The response should include enough summary data for the consuming UI to render
+without knowing gateway internals:
+
+```text
+credential_id
+agent_kind
+credential_kind
+owner_scope
+owner display name
+display_name
+redacted_summary_json
+status
+revision
+compatibility reason / disabled reason
+where_used summary
+```
+
+### Agent Auth Library
+
+Personal and admin settings should show an auth library grouped by harness:
+
+```text
+Claude Code
+  Proliferate managed credits
+  AWS Bedrock role
+  Anthropic API key
+  synced Claude Code auth
+
+Codex
+  Proliferate managed credits, if Responses support is enabled
+  OpenAI API key
+  OpenAI-compatible provider
+  synced Codex auth
+
+OpenCode
+  OpenAI API key, if managed config is enforceable
+  OpenAI-compatible provider, if managed config is enforceable
+  synced OpenCode auth
+
+Gemini
+  synced Gemini auth
+```
+
+Each row should show:
+
+```text
+owner
+agent compatibility
+credential kind
+status
+last validated/synced
+where used
+```
+
+No secret values are displayed.
+
+The auth library owns all provider setup forms. It should support:
+
+```text
+create provider credential
+validate provider credential
+resync synced-path credential
+revoke credential
+show where used
+show owner and active org shares
+```
+
+Creating or revoking an org-wide share must make the delegation scope explicit:
+"admins in this organization can use this synced credential for shared
+sandboxes until you revoke it." The owner must be able to see where the share
+is currently selected before consenting and after the fact.
+
+Credential creation from another surface should use the same forms and return a
+created credential id to the selection flow. That keeps the mental model
+"credentials live here, sandboxes choose them" even if the user starts from a
+workspace or sandbox page.
+
+### Add AWS Bedrock
+
+Flow:
+
+```text
+1. Admin chooses "AWS Bedrock".
+2. Proliferate generates External ID and CloudFormation link.
+3. Admin launches stack or copies IAM JSON.
+4. Admin pastes Role ARN and selects region.
+5. Proliferate validates immediately.
+6. On success, policy is provisioned in LiteLLM and becomes selectable.
+```
+
+### Sandbox Auth Selection
+
+Sandbox profile page should allow admin selection:
+
+```text
+Claude Code  -> Proliferate managed credits
+Codex        -> Org AWS Bedrock role
+OpenCode     -> Alice's synced OpenCode auth
+Gemini       -> Alice's synced Gemini auth
+```
+
+For shared sandboxes, personal synced credentials must render owner copy:
+
+```text
+Using Alice's synced Claude credentials.
+If Alice revokes or needs to resync, shared sandbox launches will fail until an
+admin selects another credential or Alice resyncs.
+```
+
+The selection should be available only after Alice has explicitly shared that
+credential with the organization. Admin status alone is not consent to use a
+user's personal native auth files.
+
+Saving selection:
+
+```text
+updates sandbox_agent_auth_selection
+bumps sandbox profile auth revision
+queues refresh_agent_auth_config
+mints replacement gateway grants when needed
+```
+
+Selection UI rules:
+
+```text
+filter credentials by agent_kind compatibility
+filter credentials by sandbox scope and caller permissions
+disable invalid / needs_resync / revoked credentials with a concrete reason
+show synced-path owner before allowing shared sandbox selection
+require active agent_auth_credential_share for personal synced credentials
+show whether the credential is gateway-backed or synced into the sandbox
+show all workspaces/sandboxes affected before replacing a credential already in use
+```
+
+Personal users may configure their personal sandbox credentials. Shared sandbox
+selection is admin-only in V1.
+
+## Backend Placement
+
+### Server Domains
+
+Add a Cloud subdomain:
+
+```text
+server/proliferate/server/cloud/agent_auth/
+  api.py
+  service.py
+  models.py
+  access.py
+  errors.py
+  domain/
+    policy.py
+    validation.py
+    desired_state.py
+    diff.py
+```
+
+`domain/**` must stay pure: ownership checks, compatibility decisions,
+desired-state construction, and diffing. LiteLLM/AWS provisioning performs I/O
+and belongs in `service.py`, a worker service, and `integrations/**`, not in
+domain modules.
+
+Credential ownership during migration:
+
+```text
+agent_auth becomes the owner for new credential/provider payloads
+CloudCredential remains a legacy source/adapter only until cutover completes
+do not add new writes that make both cloud_credentials.py and agent_auth own
+the same provider payload
+delete or freeze the legacy store path once the new materialization path is
+fully switched on
+```
+
+Add integrations:
+
+```text
+server/proliferate/integrations/litellm/
+  client.py
+  models.py
+  errors.py
+
+server/proliferate/integrations/aws/
+  client.py
+  models.py
+  errors.py
+  sts.py
+  bedrock.py
+```
+
+If AWS remains tiny at implementation time, a single `integrations/aws.py` is
+also acceptable. Do not create a one-off Bedrock-only integration shape that
+diverges from `docs/server/guides/integrations.md`.
+
+Gateway can live as:
+
+```text
+server/proliferate/server/agent_gateway/
+  api.py
+  service.py
+  models.py
+  errors.py
+  protocols/
+    anthropic.py
+    openai.py
+```
+
+If gateway is deployed as a separate ASGI app, share domain/integration code but
+keep public routes mounted only in the gateway process.
+
+Deployment ownership:
+
+```text
+gateway service needs explicit deploy/env ownership, health checks, rate-limit
+config, and public routing
+LiteLLM service is private/internal and needs storage, migrations, admin key
+management, health checks, and private networking
+local dev profiles need deterministic ports and process wiring for api,
+gateway, and LiteLLM
+server/deploy and server/infra changes must be included before managed rollout
+```
+
+### DB Models And Stores
+
+ORM:
+
+```text
+server/proliferate/db/models/cloud/agent_auth.py
+```
+
+Stores:
+
+```text
+server/proliferate/db/store/cloud_agent_auth/
+  budget_subjects.py
+  credentials.py
+  policies.py
+  provider_credentials.py
+  selections.py
+  target_states.py
+  runtime_grants.py
+```
+
+Stores return frozen dataclasses and never expose ORM objects.
+
+### Constants
+
+Add command kind:
+
+```text
+CloudCommandKind.refresh_agent_auth_config
+```
+
+Add it to active worker command kinds. In materialization-only mode, this
+command still requires AnyHarness if it writes runtime agent auth state through
+AnyHarness. If AnyHarness is unavailable, fail with `anyharness_unavailable`.
+
+## API Sketch
+
+Control-plane user/admin APIs:
+
+```text
+GET    /v1/cloud/agent-auth/credentials
+POST   /v1/cloud/agent-auth/credentials/bedrock-assume-role
+POST   /v1/cloud/agent-auth/credentials/anthropic-api-key
+POST   /v1/cloud/agent-auth/credentials/openai-api-key
+POST   /v1/cloud/agent-auth/credentials/openai-compatible
+POST   /v1/cloud/agent-auth/credentials/{id}/validate
+DELETE /v1/cloud/agent-auth/credentials/{id}
+POST   /v1/cloud/agent-auth/credentials/{id}/shares
+DELETE /v1/cloud/agent-auth/credentials/{id}/shares/{share_id}
+
+GET    /v1/cloud/sandbox-profiles/{id}/agent-auth-selections
+PUT    /v1/cloud/sandbox-profiles/{id}/agent-auth-selections
+GET    /v1/cloud/sandbox-profiles/{id}/agent-auth-target-states
+
+GET    /v1/cloud/agent-auth/policies/{id}/spend
+```
+
+Worker APIs:
+
+```text
+GET  /v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/materialization
+POST /v1/cloud/worker/agent-auth-configs/{sandbox_profile_id}/status
+```
+
+Gateway APIs:
+
+```text
+/anthropic/v1/messages
+/anthropic/v1/messages/count_tokens
+/anthropic/v1/models
+/openai/v1/responses
+/openai/v1/chat/completions
+/openai/v1/models
+```
+
+The exact protocol routes should match what the harness SDKs call.
+
+### Cloud SDK And Frontend Access
+
+Desktop/Web UI must consume these Cloud APIs through the Cloud SDK stack and
+the documented frontend access layer.
+
+Add generated or handwritten Cloud SDK helpers for:
+
+```text
+listAgentAuthCredentials
+createBedrockAssumeRoleCredential
+createAnthropicApiKeyCredential
+createOpenAiApiKeyCredential
+createOpenAiCompatibleCredential
+validateAgentAuthCredential
+deleteAgentAuthCredential
+createAgentAuthCredentialShare
+deleteAgentAuthCredentialShare
+getSandboxAgentAuthSelections
+putSandboxAgentAuthSelections
+getAgentAuthPolicySpend
+```
+
+Frontend integration should follow `docs/frontend/guides/access.md`:
+
+```text
+cloud/sdk
+  raw client helpers and request/response types
+
+cloud/sdk-react
+  reusable query/mutation hooks and the single query-key/cache owner for Cloud
+  resources
+
+desktop/src/hooks/access/cloud/agent-auth/**
+  desktop-specific adapters only when desktop adds Tauri/local detection,
+  telemetry, or cache invalidation behavior not owned by cloud-sdk-react
+
+desktop/src/lib/domain/**
+  compatibility filtering, disabled reasons, status copy, where-used summaries
+
+components
+  consume access hooks/view models, not raw endpoint paths
+```
+
+Do not create duplicate React Query caches for the same resource. Do not add
+components that call raw endpoint paths or construct ad hoc clients.
+
+## Lifecycle
+
+### Add Bedrock BYOK
+
+```text
+admin submits role ARN + region
+server stores encrypted payload with generated ExternalId
+server validates STS/Bedrock
+server creates gateway policy
+server provisions LiteLLM team/key/model deployments
+credential status -> ready
+```
+
+### Select Auth For Shared Sandbox
+
+```text
+admin saves per-agent selections
+server validates selected credentials are usable for shared sandbox
+server bumps profile auth revision
+server upserts target/profile auth state rows as pending for each affected target
+server mints new grants for gateway-backed selections
+server queues refresh_agent_auth_config
+worker fetches materialization plan
+worker applies synced files or gateway env/config
+worker calls AnyHarness agent auth config refresh
+AnyHarness stores runtime auth revision
+worker status marks only that target/profile applied
+next session launch uses new auth
+```
+
+For selection changes to a different gateway credential or policy, previous
+grants should not be revoked before the target reports the replacement revision
+`applied`; otherwise an offline/failed refresh could strand the target. After
+apply, revoke old grants for that target/profile/agent_kind unless a future
+explicit live-grace flag exists. Routine grant rotation for the same
+selection/policy can keep old grants valid until natural expiry.
+
+### Update Credential Mechanism
+
+```text
+admin/user updates credential payload or synced files
+server validates or marks credential needs_resync/invalid
+server finds sandbox profiles selecting that credential
+server bumps each affected profile auth revision
+server marks each affected target/profile state pending for the new revision
+server enqueues refresh_agent_auth_config per target/profile/revision
+online workers apply immediately
+offline/paused targets apply latest revision on reconnect/bootstrap
+new launches use the updated agent auth config
+live actors keep their launch env until restart unless force_restart is set
+```
+
+Use `force_restart` only for security-sensitive changes or explicit admin
+actions. Routine provider revalidation, grant rotation, and synced-file refresh
+should update target launch config without killing active turns.
+
+### Routine Grant Rotation
+
+```text
+control plane detects earliest grant expires within refresh threshold
+server bumps profile auth revision with reason = grant_rotation
+server enqueues refresh_agent_auth_config
+worker applies new launch config with new grants
+old routine grants remain valid until natural expiry
+```
+
+### Request With Managed Credits
+
+```text
+harness sends model request with runtime grant
+gateway validates grant
+gateway forwards with policy LiteLLM key
+LiteLLM checks team budget
+if budget remains, LiteLLM calls provider and increments spend
+if exhausted, LiteLLM rejects; gateway returns credits_exhausted
+```
+
+### Credential Revocation
+
+```text
+credential revoked
+related policies become revoked/invalid
+runtime grants revoked
+affected sandbox selections -> invalid
+affected target/profile states -> pending or failed with a fail-closed error
+  code for the new revision
+refresh_agent_auth_config queued
+new launches fail closed until admin selects another credential
+```
+
+For shared sandboxes using a user's personal synced credential:
+
+```text
+source user revokes or needs resync
+selection becomes needs_resync / invalid
+shared sandbox launches fail closed
+admin sees source owner and required action
+```
+
+For shared sandboxes using a credential share:
+
+```text
+source user revokes the share
+related selections become invalid
+profile auth revision bumps with force_restart = true
+refresh_agent_auth_config queued
+gateway requests and new launches fail closed
+worker cleanup materialization removes allowlisted synced auth files for the
+  revoked share/credential
+audit event records share revocation and affected selections
+```
+
+## Verification
+
+### LiteLLM Preflight
+
+Before wiring UI broadly, prove:
+
+```text
+same public model name can exist for two teams with different provider creds
+team key routes public model name to that team's deployment
+team spend increments
+team max_budget rejects when exhausted
+team budget_duration resets as expected for 30d
+Bedrock aws_external_id is passed to STS AssumeRole
+```
+
+### Gateway Tests
+
+```text
+invalid token rejected
+expired token rejected
+revoked token rejected
+wrong agent_kind rejected
+wrong protocol facade rejected
+model not allowed for policy rejected before forwarding
+oversized request body rejected before forwarding
+drifted LiteLLM mirror fails closed for managed credits
+grant issued for old revoked selection/revision rejected
+token hash stored as keyed hash, raw token never persisted
+valid token forwards to LiteLLM with internal key
+LiteLLM budget error maps to credits_exhausted
+provider auth error maps to provider_auth_failed
+streaming responses preserve protocol shape
+request/response body logging disabled by default
+logs/status payloads do not contain grants, provider keys, auth headers, or
+  synced file contents
+```
+
+### Worker/AnyHarness Tests
+
+```text
+refresh_agent_auth_config leases and fetches plan
+gateway_env materialization applies target auth revision for only the target
+  receiving the command
+target/profile applied state remains stale for other targets until they apply
+synced_files materialization writes only allowed paths
+synced_files revocation cleanup removes allowlisted old native auth files
+AnyHarness applies protected provider-routing overlay after workspace/session/
+  adapter env
+worker capability gate prevents old workers from leasing preflight-required
+  launch commands
+superseded materialization does not mark stale revision applied
+AnyHarness persists launchAuthScope on sessions and cold-start prompts use it
+AnyHarness status endpoint is redacted and never returns grants/env/config
+untrusted env/config override of protected keys is rejected
+Claude gateway env clears Bedrock/local provider routing
+gateway-backed launch fails if model application is not authoritative
+live session keeps existing env until restart
+new session uses refreshed env
+```
+
+### UI Tests
+
+```text
+admin can add Bedrock role and see validation errors
+admin can select org/system credentials for shared sandbox
+admin can select personal synced credentials only after owner share exists
+non-admin cannot edit shared sandbox auth selections
+shared selection shows source owner
+owner can revoke credential share and affected shared selections fail closed
+credits exhausted state renders distinctly from provider auth failure
+```
+
+## Implementation Phases
+
+Feature flags/capabilities:
+
+```text
+agent_gateway_enabled
+agent_gateway_claude_enabled
+agent_gateway_codex_enabled
+agent_gateway_opencode_enabled
+agent_gateway_managed_credits_enabled
+agent_gateway_bedrock_byok_enabled
+agent_gateway_openai_byok_enabled
+```
+
+Implementation can parallelize within phases, but the correctness gates are
+strict: Phase 0B compatibility proof must pass before exposing gateway-backed
+credentials in UI, launch preflight must land before credential switching on
+managed targets, and target/profile applied state must exist before any worker
+materialization command reports success. `CloudCredential` read cutover must
+not happen until Phase 3 runtime plumbing is live behind a feature flag.
+
+### Phase 0A: Contract Alignment
+
+- Index this spec in `docs/README.md`.
+- Update adjacent specs to consume `agent_auth_credential`,
+  `sandbox_agent_auth_selection`, and `refresh_agent_auth_config` instead of
+  defining parallel credential-source models.
+
+End state: the repo has one canonical agent-auth contract and adjacent specs
+can depend on it without inventing parallel models.
+
+### Phase 0B: Compatibility Proof
+
+- Validate LiteLLM team-scoped model deployments with duplicate public model
+  names and different provider credentials.
+- Validate managed Claude Code -> gateway -> LiteLLM streaming path.
+- Validate Codex Responses path or mark Codex managed credits as unavailable
+  until the facade is implemented.
+- Decide OpenCode gateway availability based on launch/config isolation.
+
+End state: every unproven gateway path is explicitly feature-gated or
+unavailable.
+
+### Phase 1: Server Data And LiteLLM Integration
+
+- Add or consume the owning sandbox-profile domain before agent-auth selection
+  tables reference it.
+- Add DB models/stores for credentials, budget subjects, policies, provider
+  credentials, selections, target/profile applied state, and runtime grants.
+- Add credential share/delegation rows and required audit events for credential
+  create/validate/revoke/share/select actions.
+- Implement idempotent `CloudCredential` import/backfill into
+  `agent_auth_credential`, but leave launch/materialization reads on the legacy
+  path until Phase 3 cutover gates pass.
+- Add LiteLLM integration client.
+- Add Bedrock validation integration.
+- Implement policy provisioning and reconciliation, including fail-closed
+  synced/drifted readiness flags for managed-credit budgets.
+- Add admin/user API endpoints.
+
+End state: Proliferate can create, list, validate, revoke, share, and audit
+agent credentials and gateway policies, with deterministic DB invariants.
+
+### Phase 2: Gateway Service
+
+- Add separate gateway route group/process.
+- Implement runtime grant auth.
+- Implement Anthropic-compatible facade for Claude Code.
+- Implement OpenAI-compatible/Responses facade needed by Codex.
+- Add canonical error mapping.
+- Add deploy/dev-profile wiring for gateway and private LiteLLM service:
+  ports, env vars, health checks, private networking, LiteLLM storage, and
+  server/deploy or server/infra changes.
+
+End state: a runtime grant can call the gateway, stream through LiteLLM, map
+errors, and fail closed on revocation or budget exhaustion.
+
+### Phase 3: Worker And AnyHarness Materialization
+
+- Add `refresh_agent_auth_config` CloudCommand constants, validation, and worker
+  supported-kind wiring plus worker capability/min-version gating for
+  preflight-required launch commands.
+- Add worker materialization fetch/status APIs.
+- Add worker dispatcher/materializer.
+- Add AnyHarness runtime agent auth config contract, generated SDK updates, API,
+  session launchAuthScope persistence, authoritative model application, and
+  launch env merge.
+- Add gateway env configs for Claude and exact Codex provider config.
+- Enforce protected provider-routing env/config overlays.
+- Switch `CloudCredential` launch/materialization reads to the new agent-auth
+  path only after the above pieces pass, then disable the legacy injection path
+  with the cutover kill switch.
+
+End state: sandbox profile selections bump auth revisions, worker applies auth
+config, AnyHarness stores agent auth config, and launch preflight prevents stale
+launches.
+
+### Phase 4: UI
+
+- Add Cloud SDK helpers and SDK React/query-key support.
+- Add auth library surfaces.
+- Add Bedrock setup flow with CloudFormation link and validation.
+- Add sandbox per-agent auth selection.
+- Add owner opt-in UI for sharing personal synced credentials with an org.
+- Add spend/credits status for Proliferate managed credits.
+
+End state: users/admins configure credentials from harness-specific setup
+screens and select credentials per sandbox profile without exposing
+incompatible provider forms or unshared personal credentials.
+
+### Phase 5: Hardening
+
+- Add reconciliation worker for LiteLLM drift.
+- Add privacy-safe gateway metrics and logs.
+
+End state: drift repair, audit, metrics, redaction, and operational checks are
+in place for controlled rollout.
+
+### Phase 6: Manual Provider E2E
+
+Use real provider credentials and a real managed target to prove the system:
+
+```text
+AWS Bedrock AssumeRole with ExternalId validates and serves Claude-compatible traffic.
+Anthropic API key through gateway serves Claude-compatible traffic.
+OpenAI API key through gateway serves OpenAI/Responses-compatible traffic.
+Proliferate managed credits exhaust a tiny test budget and fail closed.
+Synced Claude/Codex/OpenCode credentials materialize and launch correctly.
+Shared sandbox can select a named user's synced credential and shows the owner.
+Shared sandbox cannot select personal synced credential without owner share.
+Owner share revocation invalidates shared selection and fails closed.
+Credential revocation immediately fails gateway requests for affected policies.
+Credential update queues refresh_agent_auth_config and updates target launch config.
+Routine grant rotation refreshes target config without breaking a live turn.
+Offline target applies only the latest auth revision after reconnect/bootstrap.
+```
+
+## Ambiguities And Gates
+
+Resolved defaults:
+
+```text
+Budget period
+  Use LiteLLM-native 30d in V1. Do not implement subscription-aligned ledger
+  resets yet.
+
+Grant lifetime
+  Use 7-day scoped runtime grants, daily refresh, and immediate server-side
+  revocation checks. Do not use sub-hour env tokens in V1.
+
+Live actor updates
+  Existing live actors keep their launch env until restart. New launches and
+  cold restarts must pass launch preflight. If a credential/policy selection is
+  replaced, old grants may be revoked after the replacement applies, so live
+  actors using the old grant can fail rather than silently continuing to spend
+  the old credential.
+
+Fallback
+  Fail closed. Do not silently fall back from BYOK to Proliferate managed
+  credits or from one credential to another.
+
+Usage storage
+  LiteLLM owns spend counters. Proliferate queries LiteLLM on demand in V1 and
+  does not maintain a request ledger or spend snapshot table.
+
+Gemini
+  Synced-path only in V1.
+
+OpenCode
+  Gateway path disabled unless managed config isolation is proven.
+```
+
+Implementation gates:
+
+```text
+LiteLLM team-scoped public model routing
+  Must be validated in the deployed LiteLLM edition before shared BYOK or
+  managed credits rely on duplicate public model names.
+  If it fails, keep the product model and change only the LiteLLM deployment
+  topology: policy/budget subjects can point at isolated LiteLLM routers or
+  instances so each policy still sees the same public model ids without
+  Proliferate doing request-time model remapping.
+
+Claude Code protocol behavior
+  Anthropic-compatible streaming through LiteLLM must be smoke-tested with the
+  current Claude Code SDK behavior.
+
+Codex protocol behavior
+  Responses compatibility must be smoke-tested before enabling managed credits
+  for Codex. If not proven, Codex remains synced-path or OpenAI-key-only via a
+  validated OpenAI-compatible path.
+
+Launch config enforcement
+  AnyHarness must be able to force gateway env/config for the harness. If a
+  project config can override managed gateway config, that harness cannot use
+  gateway-backed auth in V1.
+
+Refresh ordering
+  Launch preflight must be implemented before UI exposes credential switching
+  for managed targets. Background refresh alone is not a correctness guard.
+
+LiteLLM mirror readiness
+  Managed-credit credentials cannot be selectable or launchable unless
+  budget/policy/model/key reconciliation marks the LiteLLM mirror synced.
+
+Provider coverage
+  Proliferate managed credits can use Bedrock only for harness/protocol paths
+  that actually work through the gateway. Otherwise use the provider account
+  matching the protocol or mark that harness unavailable.
+```
+
+Deferred, not V1 blockers:
+
+```text
+self-hosted gateway/LiteLLM management
+BYOK admin dollar caps
+overage billing
+per-workspace auth overrides
+hot token sidecar/file refresh for live actors
+request/response body logging
+Gemini gateway-backed auth
+OpenCode gateway-backed auth if config isolation is not ready
+```

--- a/docs/architecture/cloud-worker-control-plane.md
+++ b/docs/architecture/cloud-worker-control-plane.md
@@ -2,8 +2,8 @@
 
 Status: implementation spec for Cloud-mediated session control, Proliferate
 Worker, target enrollment, command delivery, event ingestion, snapshots,
-compute lifecycle, and cloud sync. Current implementation notes were verified
-against `main` on 2026-05-15.
+compute lifecycle, and Cloud exposure/projection. Current implementation notes
+were verified against `main` on 2026-05-15.
 
 Scope:
 
@@ -29,6 +29,25 @@ Related docs:
 This spec treats plugin and MCP bundles as resolved session launch input.
 Plugin package structure, skills, and bundle composition are owned by
 `docs/architecture/plugins-and-skills.md`.
+
+Terminology note: older implementation paths use `sync_existing_workspace` and
+`cloud_sync` naming. The product/architecture model in this spec is exposure
+and projection:
+
+```text
+exposure
+  Cloud is allowed to know this workspace/session exists.
+
+projection
+  Cloud stores/renders a bounded view of that runtime state.
+
+commandability
+  Cloud-mediated clients may send commands to the runtime.
+```
+
+Do not add new product semantics around "sync workspace" or "copy to cloud."
+Use exposure/projection for visibility/control, and a separate move/migration
+flow for runnable state transfer.
 
 ## Goal
 
@@ -72,6 +91,9 @@ mind:
   `materialize_environment`, `start_session`, `send_prompt`,
   `resolve_interaction`, `update_session_config`, `cancel_turn`,
   `close_session`, and `sync_existing_workspace`.
+- `sync_existing_workspace` is the current implementation name for existing
+  workspace backfill. The target semantic is `backfill_exposed_workspace`:
+  backfill only work covered by active Cloud exposure/projection rows.
 - command leases are stored inline on `cloud_commands`; there is no separate
   lease table.
 - worker command polling currently returns immediately from the server and the
@@ -90,7 +112,7 @@ mind:
 
 ## Non-Goals For V1
 
-Do not implement these in the first worker/cloud-sync pass:
+Do not implement these in the first worker/projection pass:
 
 - full file editing through Cloud
 - full interactive terminal remoting through Cloud
@@ -180,6 +202,95 @@ Every runtime mutation becomes an AnyHarness command:
 Cloud queues and routes commands. AnyHarness accepts, rejects, queues, and
 orders execution.
 
+When the same exposed session is open in Desktop and web/mobile:
+
+```text
+Desktop prompt path
+  Desktop -> AnyHarness directly
+
+Cloud prompt path
+  web/mobile/Slack/API -> CloudCommand -> Worker -> AnyHarness
+
+Projection path
+  AnyHarness events -> Worker cursor -> Cloud projection -> web/mobile/Slack
+```
+
+There is still one runtime session. Desktop and Cloud do not fork or copy the
+conversation. Both prompt paths enter the same AnyHarness session queue, and
+AnyHarness defines ordering by command acceptance. Cloud clients catch up from
+worker event upload; Desktop may render earlier through direct SSE.
+
+## Cloud Exposure And Projection Admission
+
+Workers must not upload every workspace/session they can see. Cloud owns the
+admission policy.
+
+```text
+No active exposure
+  Worker ignores the workspace/session.
+
+Active exposure
+  Worker may map/backfill the workspace/session.
+
+Active session projection
+  Worker tails AnyHarness events after the stored cursor.
+
+Commandable exposure/projection
+  Cloud-mediated clients may enqueue commands, subject to actor authorization.
+```
+
+Exposure and commandability are separate:
+
+```text
+projection_level = transcript
+commandable = false
+```
+
+is a valid read-only Cloud view.
+
+Projection levels:
+
+```text
+index_only
+  workspace appears in Cloud lists; no transcript or commands
+
+session_summaries
+  session title/status/last activity; no full transcript or commands
+
+transcript
+  semantic transcript/pending interactions; usually read-only
+
+live
+  semantic transcript plus live patches; commandable only when policy allows
+```
+
+Default behavior:
+
+```text
+Desktop local-only work
+  no exposure by default
+
+Continue remotely / Open from mobile
+  create exposure
+  create or upgrade session projection to live
+  set commandable according to owner policy
+  worker backfills and tails from cursor
+
+Cloud-created personal work
+  exposure exists by default for the owner
+
+Slack/team/automation work
+  exposure exists by default as shared_unclaimed org work
+
+Claiming
+  changes visibility/control policy
+  does not change projection mechanics
+
+Move/migration
+  separate transfer operation
+  may revoke source exposure and create destination exposure
+```
+
 ## V1 Topology
 
 ```text
@@ -268,6 +379,7 @@ default_workspace_root nullable
 persistence_class: ephemeral | persistent | snapshot_backed | unknown
 direct_attach_policy: disabled | owner_only | team_grant | org_grant
 cloud_sync_enabled
+cloud_exposure_supported
 update_channel: stable | beta | pinned
 desired_anyharness_version nullable
 desired_worker_version nullable
@@ -354,7 +466,7 @@ Session launch asks the same questions for every target:
 - Can this target run the required MCP/plugin bundle?
 - Can this session receive the required credential grants?
 - Can this actor view/control the session?
-- Can this target be cloud-synced?
+- Is this workspace/session exposed, projected, and commandable through Cloud?
 - What stop/prune policy applies after the work completes?
 
 ## Compute Lifecycle Policy
@@ -472,6 +584,10 @@ accepted_at nullable
 rejected_at nullable
 expired_at nullable
 authorization_context json
+exposure_id nullable
+session_projection_id nullable
+exposure_revision nullable
+required_projection_level nullable
 error_code nullable
 error_message nullable
 ```
@@ -489,8 +605,13 @@ resolve_interaction
 update_session_config
 cancel_turn
 close_session
-sync_existing_workspace
+backfill_exposed_workspace
 ```
+
+`sync_existing_workspace` is the current implementation command name on `main`.
+New design and new docs should describe the behavior as
+`backfill_exposed_workspace`: it backfills only Cloud-exposed work, not every
+workspace discovered on the target.
 
 Additional lifecycle commands such as `stop_workspace`,
 `hibernate_workspace`, `resume_workspace`, `prune_workspace`, and
@@ -517,6 +638,10 @@ Precondition examples:
 send_prompt:
   observed_event_seq optional
   append after current accepted queue
+  exposure_id required for Cloud-mediated sessions
+  session_projection_id required for session commands
+  required_projection_level = live
+  commandable = true
 
 update_session_config:
   expected_config_version
@@ -637,7 +762,7 @@ semantic items and references.
 
 ## Large Payload And Retention Policy
 
-Cloud sync must not blindly store every byte produced by the target.
+Cloud projection must not blindly store every byte produced by the target.
 
 Inline payload limits:
 
@@ -716,6 +841,8 @@ Cloud stores:
 - inventory and readiness snapshots
 - workspace records
 - session records
+- workspace exposure records
+- session projection records and cursors
 - commands and command leases
 - normalized durable events
 - ingest cursors
@@ -735,14 +862,14 @@ Cloud does not store:
 - full workspace filesystem contents
 - local desktop tab/layout state as runtime truth
 
-Cloud sync is command routing plus event ingestion plus snapshot building,
-not runtime database replication.
+Cloud exposure/projection is command routing plus event ingestion plus snapshot
+building, not runtime database replication.
 
 ## Server Target File Structure
 
-The Cloud sync implementation lives under the existing `cloud` server domain,
-split by product responsibility. Do not put all worker behavior in
-`cloud/runtime`.
+The Cloud worker/projection implementation lives under the existing `cloud`
+server domain, split by product responsibility. Do not put all worker behavior
+in `cloud/runtime`.
 
 Implementation phase details live in
 `docs/architecture/cloud-worker-implementation-phases.md`. This section defines
@@ -1023,15 +1150,17 @@ identity:
 command_leases:
   command_id, lease_id, status, leased_at, lease_expires_at, last_error
 
-sync_cursors:
-  workspace_id, session_id, last_uploaded_seq, last_ack_seq
+projection_cursors:
+  exposure_id, session_projection_id, workspace_id, session_id,
+  projection_level, last_uploaded_seq, last_ack_seq
 
 event_outbox:
   batch_id, target_id, session_id, seq_start, seq_end, payload, attempt_count
 
-sync_mappings:
+projection_mappings:
   local_workspace_id, cloud_workspace_id
   local_session_id, cloud_session_id
+  exposure_id, session_projection_id
 
 inventory_cache:
   last_report_hash, last_reported_at
@@ -1049,7 +1178,8 @@ runtime main
   -> start heartbeat loop
   -> start inventory loop
   -> start command lease loop
-  -> start event backfill/tail loop for synced sessions
+  -> fetch active exposure/projection list
+  -> start event backfill/tail loop for active projections
   -> start activity/safe-stop reporting loop
   -> start update reconciliation loop
 ```
@@ -1312,7 +1442,7 @@ Managed cloud should preinstall:
 6. Worker starts and enrolls outbound.
 7. Worker reports inventory/readiness.
 8. Cloud shows direct-attach caveat:
-   teammates may control cloud-synced sessions if policy allows, but direct
+   teammates may control cloud-exposed sessions if policy allows, but direct
    Desktop attach requires their own target access or a granted attach path.
 ```
 
@@ -1326,12 +1456,15 @@ fallback.
 1. User enables dispatch for the local desktop runtime.
 2. Desktop starts or installs Proliferate Worker locally.
 3. Worker enrolls as desktop_dispatch target.
-4. User chooses which local workspaces/sessions are sync-enabled.
-5. Worker backfills selected state and tails live events.
-6. Mobile/web/Slack can supervise and send commands while desktop is online.
+4. User chooses which local workspaces/sessions are exposed to Cloud.
+5. Cloud creates exposure/projection rows for those workspaces/sessions.
+6. Worker backfills selected state and tails live events for active projections.
+7. Mobile/web/Slack can supervise and send commands while desktop is online
+   when the exposure is commandable.
 ```
 
-Desktop dispatch should be opt-in per machine and preferably per workspace.
+Desktop dispatch should be opt-in per machine and per workspace/session. It is
+not a sync-all mode.
 
 ## Command Flow: Web Sends Prompt
 
@@ -1346,7 +1479,11 @@ Desktop dispatch should be opt-in per machine and preferably per workspace.
 
 3. commands.service validates:
    session exists in CloudSession snapshot
-   target is cloud-sync addressable
+   target is Cloud-addressable through an active worker
+   workspace exposure exists and is active
+   session projection exists and is active
+   projection level is live
+   exposure/session projection is commandable
    command kind is allowed
    idempotency key is unique or returns existing command
    preconditions are absent until the precondition contract is implemented
@@ -1380,9 +1517,10 @@ Desktop dispatch should be opt-in per machine and preferably per workspace.
 The UI may show the prompt optimistically, but the canonical prompt row comes
 from AnyHarness events.
 
-## Event Upload And Backfill Flow
+## Projection Backfill And Event Upload Flow
 
-Backfill is required when enabling sync for an existing workspace/session.
+Backfill is required when enabling exposure/projection for an existing
+workspace/session.
 
 Current implementation note: worker event sync polls AnyHarness session events
 by sequence and uploads batches directly to Cloud. The explicit local event
@@ -1390,18 +1528,20 @@ outbox steps below describe the target reliability model; they are not a
 separate table in current `main`.
 
 ```text
-1. Cloud enqueues sync_existing_workspace command or worker observes sync flag.
-2. Worker lists workspace/session metadata from AnyHarness.
-3. Worker creates or reconciles cloud id mappings.
-4. Worker reads events after last uploaded seq for each session.
-5. Worker applies payload policy and builds batches.
-6. Worker inserts batches into local outbox.
-7. Worker uploads batches.
-8. Cloud dedupes by target_id/session_id/seq.
-9. Cloud advances ingest cursor only across contiguous sequences.
-10. Cloud rebuilds or updates snapshots.
-11. Worker deletes acknowledged outbox batches.
-12. Worker starts live tail from acknowledged seq.
+1. Cloud creates or updates exposure/projection rows.
+2. Cloud enqueues backfill_exposed_workspace, or worker observes the active
+   exposure/projection list.
+3. Worker lists only the requested workspace/session metadata from AnyHarness.
+4. Worker creates or reconciles cloud id mappings for the exposure/projection.
+5. Worker reads events after last_uploaded_seq for each active projection.
+6. Worker applies payload policy and builds batches.
+7. Worker inserts batches into local outbox.
+8. Worker uploads batches.
+9. Cloud dedupes by target_id/session_id/seq.
+10. Cloud advances ingest cursor only across contiguous sequences.
+11. Cloud rebuilds or updates snapshots.
+12. Worker deletes acknowledged outbox batches.
+13. Worker starts live tail from acknowledged seq.
 ```
 
 Gaps:
@@ -1417,7 +1557,7 @@ Duplicates:
 - Duplicate event insert conflicts on `(target_id, session_id, seq)`.
 - Cloud treats duplicate upload as success if payload hash matches.
 - Payload hash mismatch for same seq is a hard ingest error and should mark
-  target sync degraded.
+  target projection degraded.
 
 ## Live Fanout
 

--- a/docs/architecture/cloud-worker-implementation-phases.md
+++ b/docs/architecture/cloud-worker-implementation-phases.md
@@ -68,6 +68,10 @@ close_session
 sync_existing_workspace
 ```
 
+`sync_existing_workspace` is the current implementation command name. Treat it
+as the implementation spelling of explicit exposure/projection backfill, not a
+product-level sync-all primitive.
+
 - Automation execution is staged through
   `server/proliferate/server/automations/worker/cloud_execution/`:
 
@@ -191,6 +195,11 @@ Where:
   elicitations, user-input requests, stale/expired requests.
 - `CloudSessionConfigState` stores available config options plus current config
   for the session, as reported by AnyHarness events.
+- `CloudWorkspaceExposure` is the Cloud-owned admission/policy row saying which
+  target-side workspace is visible to Cloud, who can see it, and whether Cloud
+  dispatch is allowed.
+- `CloudSessionProjection` is the Cloud-owned cursor/read-model row saying how
+  much session state Cloud should retain/render and where event upload resumes.
 - `CloudCommand` is the durable queue and status record for a requested
   mutation.
 - `CloudSessionEvent` is the bounded semantic event log used for replay,
@@ -199,11 +208,11 @@ Where:
 - `CloudArtifactRef` points at object-storage payloads when data is too large
   to store inline.
 
-`projection` may still appear as an implementation term, but it is not a
-user-facing product object or a default server folder. The server may keep
-snapshot cache rows for fast reads, but the client-facing model should be
-workspaces, sessions, transcript/messages, requests, config, targets, and
-command status.
+Projection is an architecture/control-plane object, not a user-facing noun.
+Users see "remote access", "read-only", "live", "claim", and "move". The server
+may expose projection status through workspace/session APIs, but product UI
+should still be organized around targets, workspaces, sessions, messages,
+requests, config, command status, and access state.
 
 Live deltas are separate:
 
@@ -1068,6 +1077,9 @@ update_session_config
 cancel_turn
 sync_existing_workspace
 ```
+
+`sync_existing_workspace` should evolve toward `backfill_exposed_workspace` once
+the exposure/projection admission model is implemented.
 
 V1.1 command kinds:
 

--- a/docs/architecture/cloud-worker-pr-stack-review-guide.md
+++ b/docs/architecture/cloud-worker-pr-stack-review-guide.md
@@ -692,15 +692,20 @@ Existing target workspaces appear in:
 
 Existing sessions become readable through snapshot and stream APIs.
 
-Users can enqueue `sync_existing_workspace`. Only workers advertising that
-capability should lease it.
+Users should not think in terms of "sync this workspace" as the product
+primitive. The current command name is `sync_existing_workspace`, but the target
+semantic is `backfill_exposed_workspace`: Cloud first creates an
+exposure/projection admission row, then the worker backfills only that exposed
+workspace/session. Only workers advertising the current capability should lease
+the implementation command.
 
 ### Architecture Flow
 
 ```text
-Cloud queues sync_existing_workspace
+Cloud creates exposure/projection admission
+  -> Cloud queues sync_existing_workspace / backfill_exposed_workspace
   -> worker leases special command
-  -> worker fetches AnyHarness repo roots/workspaces/sessions
+  -> worker fetches only requested AnyHarness workspace/session metadata
   -> worker uploads chunks to /worker/backfill
   -> Cloud creates/updates CloudWorkspace and mappings
   -> Cloud creates/updates session projections
@@ -748,6 +753,8 @@ AnyHarness dependencies:
 - Workspace/session mapping is target-scoped.
 - Backfill does not over-resolve active pending interactions.
 - Only capable workers lease `sync_existing_workspace`.
+- User-visible flows create exposure/projection first; backfill is scoped to
+  that admission state.
 - Pending command results survive worker restart and stale leases.
 - Chunk ordering and retries are harmless.
 - Backfilled workspaces with `runtime_environment_id = None` do not break
@@ -755,12 +762,13 @@ AnyHarness dependencies:
 
 ### Relationship And Risk
 
-This closes the gap where only Cloud-created sessions were synced. It sits
-between event sync and the later snapshot/live stream surface.
+This closes the gap where only Cloud-created sessions had Cloud projections. It
+sits between event ingest and the later snapshot/live stream surface.
 
-Risk: the worker can backfill all workspaces if no workspace ID is supplied,
-while Cloud validation may require `workspaceId` for user-queued commands.
-Review whether sync-all is internal-only.
+Risk: the worker can backfill too broadly if no workspace/session admission is
+supplied. Cloud validation should require exposure/projection identity for
+user-queued backfill. Any sync-all behavior must remain internal maintenance,
+not a product path.
 
 ## PR #221: Live Snapshot Streams
 
@@ -1157,8 +1165,9 @@ create future drift:
   rotation and credential revocation?
 - Do worker retries preserve command result and materialization status across
   process restarts?
-- Is `sync_existing_workspace` supposed to support sync-all as a product path,
-  or only as an internal maintenance operation?
+- `sync_existing_workspace` should not support sync-all as a product path. It
+  should remain the implementation name for explicit exposure/projection
+  backfill until the command is renamed.
 - What exact production pub/sub backend will replace or back the current
   process-local live fanout?
 - What is the signed update artifact/trust-root plan after supervisor staging?

--- a/docs/architecture/cloud-worker-workspace-command-spec.md
+++ b/docs/architecture/cloud-worker-workspace-command-spec.md
@@ -80,6 +80,11 @@ Current caveats:
 - The worker sync loop tails AnyHarness events by polling
   `/v1/sessions/{id}/events?after_seq=...` and uploads batches directly. There
   is no durable local event outbox table yet.
+- `sync_existing_workspace` is the current implementation name for existing
+  workspace backfill. The target architecture should treat this as
+  `backfill_exposed_workspace`: backfill only work covered by active Cloud
+  exposure/projection rows. Do not add product semantics around sync-all or
+  copy-to-cloud.
 - Command preconditions and worker min-version gating are not implemented yet.
 - Fresh SSH targets still need the requested agent installed before
   `start_session`; Git/workspace materialization alone does not install Claude,
@@ -152,7 +157,17 @@ sync_existing_workspace
 
 These cover target Git bootstrap, repo checkout, workspace/worktree
 materialization, target config application, live session control, and existing
-workspace sync.
+workspace projection backfill.
+
+Future naming should prefer:
+
+```text
+backfill_exposed_workspace
+```
+
+over `sync_existing_workspace`. The existing command should not upload every
+workspace/session visible to AnyHarness. It should be driven by Cloud-owned
+exposure/projection admission.
 
 `materialize_environment` currently applies configuration files to a filesystem
 root:
@@ -201,6 +216,38 @@ may either:
 
 The command is still narrowly scoped: it materializes the AnyHarness workspace
 identity, not the full session environment.
+
+## Exposure And Projection Boundary
+
+Workspace materialization and workspace projection are separate.
+
+```text
+materialize_workspace
+  creates/resolves target-side AnyHarness workspace identity
+
+backfill_exposed_workspace / current sync_existing_workspace
+  uploads bounded metadata/events for Cloud-exposed work only
+```
+
+Cloud owns the exposure/projection rows. Worker only applies them:
+
+```text
+No active exposure
+  worker ignores the workspace/session
+
+Active exposure
+  worker may map/backfill the workspace/session
+
+Active session projection
+  worker tails AnyHarness events from the stored cursor
+
+Commandable live projection
+  Cloud may enqueue send_prompt/update/resolve commands after auth checks
+```
+
+This keeps "Continue remotely" as a visibility/control operation, not a copy or
+full migration. Moving runnable state to another target is a different command
+family.
 
 ## Data Model
 

--- a/docs/architecture/codebase-knowledge-ownership-spec.md
+++ b/docs/architecture/codebase-knowledge-ownership-spec.md
@@ -1,0 +1,457 @@
+# Codebase Knowledge Ownership Spec
+
+Status: proposed documentation architecture.
+
+Date: 2026-05-17
+
+## Purpose
+
+This spec defines how Proliferate should document the system so engineers and
+agents can build a correct mental model before changing code.
+
+The core problem is that the repo has several distinct services, several
+cross-service product features, and several fundamental technologies. These are
+different kinds of knowledge and should not be mixed into one doc type.
+
+The documentation model has three layers:
+
+```text
+Services       where code lives, what it owns, what it exposes
+Features       end-to-end product flows across services
+Fundamentals   underlying technologies and concepts used by many services
+```
+
+Each layer has a different stability profile:
+
+```text
+Service docs       static-ish; updated when code ownership or interfaces change
+Feature specs      ephemeral; updated while product behavior is designed/built
+Fundamentals       static; updated when the underlying technology model changes
+```
+
+## Non-Goals
+
+- Do not replace focused area docs such as `docs/frontend/README.md`,
+  `docs/server/README.md`, `docs/anyharness/README.md`, or
+  `docs/sdk/README.md`.
+- Do not turn feature specs into folder-structure guides.
+- Do not put product-specific implementation plans into fundamentals primers.
+- Do not create empty documentation folder trees. Add docs when a service,
+  feature, or concept has enough real content to own.
+
+## Source-Of-Truth Rules
+
+When docs overlap, use this precedence:
+
+```text
+1. Service docs own code organization and exposed interfaces.
+2. Feature specs own user/product behavior and cross-service flow.
+3. Fundamentals own technology concepts and low-level mental models.
+```
+
+Examples:
+
+- A Slack feature spec may say that Slack creates a cloud-mediated session.
+  It must not redefine where Server stores live or how AnyHarness domains are
+  organized.
+- The Server service doc owns API/domain/store layering. A feature spec may
+  name new DB tables and endpoints, but it must follow Server layering rules.
+- A Rust primer may explain ownership, async, and crates. It must not decide
+  where AnyHarness session code belongs.
+
+## Layer 1: Service Docs
+
+Service docs answer:
+
+```text
+What is this service?
+What code belongs here?
+What state does it own?
+What interfaces does it expose?
+Who is allowed to call those interfaces?
+What dependencies are allowed?
+How do we test changes?
+What are common anti-patterns?
+```
+
+### Required Service Set
+
+The product should have a clear service-level mental model for:
+
+```text
+Desktop
+AnyHarness
+Proliferate Worker
+Server
+Proliferate AI Gateway
+Mobile
+Web
+AnyHarness SDKs
+Cloud SDKs
+```
+
+Some of these already have strong docs:
+
+- Frontend/Desktop standards live under `docs/frontend/**`.
+- Server standards live under `docs/server/**`.
+- AnyHarness standards live under `docs/anyharness/**`.
+- SDK standards live under `docs/sdk/**`.
+
+The missing service docs should extend that model instead of duplicating it.
+
+### Service Responsibility Map
+
+| Service | Owns | Exposes | Primary callers |
+| --- | --- | --- | --- |
+| Desktop | Tauri app shell, local-first UI, local AnyHarness attachment, Desktop-specific platform access, user workflows | UI, local commands, Cloud client calls, AnyHarness client calls | Human users |
+| AnyHarness | Runtime workspaces, sessions, actors, transcripts, tools, adapters, local persistence, runtime HTTP/SSE contract | AnyHarness HTTP/SSE APIs and generated SDK contract | Desktop, Proliferate Worker, direct local clients |
+| Proliferate Worker | Target-side long polling, CloudCommand execution, target materialization, AnyHarness command transport, event upload | Worker command result/event protocol back to Cloud | Server control plane |
+| Server | Cloud control plane, auth/orgs, DB state, Cloud APIs, worker command queue, projections, billing/account state | Cloud API, worker polling API, web/mobile/desktop API surface | Desktop, Web, Mobile, Worker, integrations |
+| Proliferate AI Gateway | Agent model API facade, runtime grant auth, provider-routing enforcement, LiteLLM forwarding, budget/error mapping | Anthropic/OpenAI-compatible gateway endpoints | Agent harnesses running inside configured sandboxes |
+| Mobile | Mobile user surface for cloud-mediated work, claiming/opening, automation visibility, lightweight session interaction | Native/mobile UI over Cloud APIs | Human users |
+| Web | Browser user surface for cloud-mediated work, admin config, shared workspaces, automations, Slack/work viewing | Web UI over Cloud APIs | Human users |
+| AnyHarness SDKs | Typed AnyHarness transport clients, generated contract bindings, runtime-facing React helpers where applicable | `@anyharness/sdk`, `@anyharness/sdk-react` | Desktop, tools, tests, external clients |
+| Cloud SDKs | Typed Cloud API clients, React/query helpers for Cloud state, surface-safe access helpers | `cloud/sdk`, `cloud/sdk-react` | Desktop, Web, Mobile |
+
+### Service Doc Template
+
+Every service doc should follow this shape:
+
+```text
+# <Service> Standards
+
+Status:
+Scope:
+
+## Purpose
+What the service exists to do.
+
+## Owns
+Durable state, runtime state, product concepts, UI surfaces, protocols, and
+side effects the service is authoritative for.
+
+## Does Not Own
+Adjacent responsibilities that must stay elsewhere.
+
+## Code Shape
+Target folders/modules and what each layer is allowed to contain.
+
+## Interfaces
+Inbound APIs/events/commands and outbound calls. Include caller/callee and
+auth expectations.
+
+## State Model
+DB tables, local files, caches, runtime registries, generated state, and what
+is restart-safe.
+
+## Dependency Direction
+Allowed imports/calls. Explicit banned dependencies.
+
+## Error And Failure Model
+How failures are represented, retried, surfaced, and made safe.
+
+## Testing
+Unit/integration/e2e expectations and smoke commands.
+
+## Anti-Patterns
+Concrete examples that should be rejected in review.
+```
+
+## Layer 2: Feature Specs
+
+Feature specs answer:
+
+```text
+What user/product outcome are we trying to create?
+Which services participate?
+What is the source-of-truth data model?
+What are the exact end-to-end flows?
+What APIs, commands, events, SDK helpers, hooks, and UI states are involved?
+What fails closed, what retries, and what remains visible to users?
+```
+
+Feature specs are the right home for cross-service flows such as:
+
+```text
+AnyHarness ACP session management
+MCPs + skills
+Cloud sandbox lifecycle
+Cloud worker command/event flow
+Automation runs
+Slack threads
+Claiming
+Migration
+Shared workspaces
+Agent LLM auth gateway
+Billing/usage limits
+```
+
+### Feature Doc Template
+
+```text
+# <Feature> Spec
+
+Status:
+Date:
+
+## Goal
+End-state UX and product outcome.
+
+## Non-Goals
+What this feature explicitly does not solve.
+
+## Concepts
+Product primitives and vocabulary used by the feature.
+
+## Services Touched
+For each service: what changes, what it owns, and which service doc governs
+placement.
+
+## Data Model
+DB tables, durable records, external ids, generated schemas, and invariants.
+
+## Interfaces
+Cloud APIs, AnyHarness APIs, worker commands, gateway endpoints, SDK methods,
+hooks, events, webhooks, and auth boundaries.
+
+## End-To-End Flows
+Numbered flows from user/system trigger to final projected state.
+
+## Permissions And Identity
+Actors, org/admin rules, claim semantics, credential ownership, audit events,
+and revocation behavior.
+
+## Failure Model
+Retry behavior, stale state detection, fail-closed paths, user-visible errors,
+and cleanup.
+
+## Phases
+Implementation chunks with concrete end states and acceptance criteria.
+
+## Verification
+Tests, smoke commands, migrations, local manual tests, and production rollout
+checks.
+```
+
+### Feature Specs Must Name Service Boundaries
+
+Every feature spec should include a table like:
+
+| Service | Role In Feature | Owns | Must Not Own |
+| --- | --- | --- | --- |
+| Server | Example: stores config and queues command | DB rows, Cloud API | Target process state |
+| Worker | Example: applies command to target | Target-side materialization | Cloud policy decisions |
+| AnyHarness | Example: executes session | Runtime session truth | Org permissions |
+| Desktop/Web/Mobile | Example: starts or views flow | User interaction | Raw DB or worker protocol |
+
+This is the most important review artifact. If this table is unclear, the
+feature is not implementation-ready.
+
+## Layer 3: Fundamentals
+
+Fundamentals docs answer:
+
+```text
+What is the underlying technology?
+Which concepts matter for this repo?
+What facts must an implementer know?
+What procedures or recipes are safe?
+What pitfalls should reviewers watch for?
+```
+
+Examples:
+
+```text
+Rust ownership, async, channels, SQLx/SQLite patterns
+TypeScript type modeling
+React rendering, hooks, React Query
+Expo/native mobile constraints
+Tauri desktop/mobile constraints
+FastAPI/Pydantic/SQLAlchemy/Alembic
+LiteLLM proxy model
+Anthropic/OpenAI protocol compatibility
+SSH target bootstrap and long polling
+MCP protocol basics
+ACP session model
+```
+
+### Fundamentals Doc Template
+
+```text
+# <Technology> Primer
+
+Status:
+Scope:
+
+## Core Concepts
+The minimum model needed to reason about the technology.
+
+## Repo Usage
+Where the repo uses this technology and which service docs own placement.
+
+## Facts
+Stable facts that should be true across feature work.
+
+## Procedures
+Common workflows and commands.
+
+## Pitfalls
+Mistakes that are likely to produce incorrect implementations.
+
+## References
+Official docs, local facts notes, and high-signal internal docs.
+```
+
+## Recommended Directory Shape
+
+Do not create all of these folders at once. This is the target shape as docs
+earn their place.
+
+```text
+docs/
+  services/
+    desktop.md
+    anyharness.md
+    proliferate-worker.md
+    server.md
+    ai-gateway.md
+    web.md
+    mobile.md
+    anyharness-sdks.md
+    cloud-sdks.md
+
+  features/
+    anyharness-acp-session-management.md
+    mcp-skills.md
+    cloud-sandbox-lifecycle.md
+    cloud-worker-command-flow.md
+    automations.md
+    slack.md
+    claiming.md
+    migration.md
+    shared-workspaces.md
+    agent-llm-auth-gateway.md
+
+  fundamentals/
+    rust.md
+    typescript.md
+    react.md
+    tauri.md
+    fastapi-sqlalchemy-alembic.md
+    litellm.md
+    mcp.md
+    acp.md
+    ssh-targets.md
+```
+
+Existing authoritative area docs should either be linked from these service
+docs or promoted into this shape over time. Do not fork their content.
+
+## Read Workflow For Implementers
+
+Before implementing a feature:
+
+1. Read `docs/README.md`.
+2. Read every service doc for services touched by the feature.
+3. Read the feature spec.
+4. Read fundamentals only for technologies you are actively changing or using
+   in a non-trivial way.
+5. If service docs and feature specs conflict, resolve the conflict in docs
+   before coding.
+
+For example, implementing Slack over cloud sessions should require:
+
+```text
+Service docs:
+  Server
+  Proliferate Worker
+  AnyHarness
+  Web/Desktop as relevant
+  Cloud SDKs
+
+Feature specs:
+  Slack
+  Cloud worker command flow
+  Cloud sandbox lifecycle
+  Claiming
+  MCPs + skills if Slack exposes tools
+
+Fundamentals:
+  Slack API/webhooks
+  AnyHarness session model
+  Worker long polling
+```
+
+## Review Rules
+
+A PR that adds a new cross-service feature should be reviewable against:
+
+- one or more service docs for code placement,
+- one feature spec for product flow and acceptance criteria,
+- optional fundamentals docs for low-level protocol/technology assumptions.
+
+Reviewers should ask:
+
+```text
+Does each service own only its part?
+Is source-of-truth state located in one place?
+Are inbound and outbound interfaces explicit?
+Does the feature spec say what happens on retry, restart, and stale state?
+Are permissions, credentials, and claiming semantics explicit?
+Are SDK/hook surfaces named instead of raw endpoint calls leaking upward?
+Are tests mapped to the service and feature boundaries?
+```
+
+## Applying This To Proliferate AI Gateway
+
+The AI Gateway should get a service doc before broad implementation continues.
+That service doc should say:
+
+```text
+Owns:
+  runtime grant authorization
+  provider-protocol facade behavior
+  LiteLLM forwarding
+  request/response/error mapping
+  model/budget fail-closed enforcement
+
+Does not own:
+  org/admin UI
+  credential collection UX
+  LiteLLM provisioning policy
+  sandbox materialization
+  AnyHarness session state
+
+Inbound:
+  Anthropic-compatible model API routes
+  OpenAI-compatible model API routes
+  health/status route
+
+Outbound:
+  private LiteLLM runtime proxy calls
+  Server store reads for runtime grant validation
+
+Primary callers:
+  agent harnesses inside configured sandboxes
+
+Primary config:
+  gateway enabled flag
+  LiteLLM base URL
+  request size/time limits
+  per-harness feature gates
+```
+
+The existing `agent-llm-auth-gateway-spec.md` remains a feature spec. It should
+depend on the AI Gateway service doc for route ownership, forwarding behavior,
+and security boundaries.
+
+## Migration Path
+
+1. Land this taxonomy spec.
+2. Add a `docs/services/ai-gateway.md` service doc, because that service is new
+   and currently only described indirectly through the feature spec.
+3. Add or promote service docs for Worker, Web, Mobile, and Cloud SDKs as those
+   surfaces become implementation-heavy.
+4. Rename or copy high-value architecture docs into `docs/features/**` only
+   when doing so reduces confusion. Avoid churn for its own sake.
+5. Add fundamentals docs only after a real feature needs a stable primer.

--- a/docs/architecture/plugins-and-skills.md
+++ b/docs/architecture/plugins-and-skills.md
@@ -1,8 +1,15 @@
 # Plugins and Skills Architecture
 
-Status: authoritative for plugin packages, plugin skills, plugin-owned MCP
-servers, the Desktop plugins UI, and the `SessionPluginBundle` runtime
-boundary.
+Status: legacy/current-state reference for plugin packages, plugin skills,
+plugin-owned MCP servers, the Desktop plugins UI, and the
+`SessionPluginBundle` runtime boundary.
+
+The future runtime boundary is superseded by
+`docs/architecture/target-runtime-mcp-skills-config.md`: plugins remain a
+Cloud/Desktop catalog and UX packaging concept, while AnyHarness should see
+only flat target-scoped MCP server and skill manifests with lazy artifact and
+credential resolution. Keep this document useful for understanding today's
+session-bundle implementation until that migration is complete.
 
 This document does not define Cloud worker registration, command delivery,
 event upload, target enrollment, or Cloud session sync. Those systems are being

--- a/docs/architecture/shared-sandbox-config-admin-ui-spec.md
+++ b/docs/architecture/shared-sandbox-config-admin-ui-spec.md
@@ -1,0 +1,1244 @@
+# Shared Sandbox Config And Admin UI Spec
+
+Status: proposed workstream 2 implementation spec
+
+Date: 2026-05-17
+
+## Purpose
+
+This spec defines the workstream 2 model for personal cloud sandbox
+configuration, organization shared sandbox configuration, public MCP/skill
+publication, and the admin/user UI that controls those settings.
+
+Workstream 1 defines the runtime-facing target MCP/skill manifest and lazy
+artifact/credential resolution. This spec defines the Cloud and Desktop product
+model that decides which MCPs, skills, credentials, repo environment inputs, and
+targets should feed that runtime manifest.
+
+The core product shape is:
+
+```text
+personal sandbox profile       one per user
+organization shared profile    one per organization
+repo environment config        per owner scope + repo
+public MCP/skill publication   org-visible projection of a private source
+target runtime config          generated from the profile, then pushed to AnyHarness
+```
+
+AnyHarness still sees only target runtime config, MCP servers, skills, and
+credential refs. It does not learn about plugins, publicization policy, admin
+roles, or org membership.
+
+## Assumptions
+
+This spec assumes `docs/architecture/target-runtime-mcp-skills-config.md` is
+implemented or being implemented as the runtime substrate:
+
+- AnyHarness has target-scoped MCP/skill runtime config.
+- Desktop and proliferate-worker can push runtime config refreshes.
+- AnyHarness can emit lazy artifact and credential gap requests.
+- AnyHarness remains inbound-only and never calls Proliferate Cloud.
+
+This spec should not duplicate that protocol. It only defines the Cloud,
+Desktop, and UI models that decide what the target runtime config contains and
+which Cloud-side credential/artifact records a worker is allowed to fulfill.
+
+## Docs Read For This Spec
+
+This spec is cross-cutting and follows:
+
+- `docs/README.md`
+- `docs/architecture/cloud-work-launch-model-spec.md`
+- `docs/architecture/target-runtime-mcp-skills-config.md`
+- `docs/architecture/plugins-and-skills.md`
+- `docs/frontend/README.md`
+- `docs/frontend/guides/access.md`
+- `docs/frontend/guides/components.md`
+- `docs/frontend/guides/config.md`
+- `docs/frontend/guides/copy.md`
+- `docs/frontend/guides/hooks.md`
+- `docs/frontend/guides/lib.md`
+- `docs/frontend/guides/state.md`
+- `docs/server/README.md`
+- `docs/server/guides/auth.md`
+- `docs/server/guides/database.md`
+- `docs/server/guides/domains.md`
+- `docs/server/guides/workers.md`
+- `docs/anyharness/README.md`
+- `docs/anyharness/guides/api.md`
+- `docs/anyharness/guides/live-runtime.md`
+- `docs/anyharness/guides/persistence.md`
+
+## Scope
+
+In scope for workstream 2:
+
+- Define personal vs organization sandbox profiles.
+- Make managed cloud sandbox cardinality explicit: one active personal managed
+  cloud target per user and one active shared managed cloud target per org.
+- Make repo environment config owner-scoped instead of only user-scoped.
+- Add public MCP and public skill publication models.
+- Feed public MCPs and public skills into organization shared sandboxes.
+- Define agent credential refs and shared-sandbox credential source models,
+  including synced-path, API-key, and future managed-gateway refs.
+- Add admin UI for shared cloud setup, shared repo environments, shared agent
+  credentials, and shared MCPs/skills.
+- Update user UI for personal cloud setup and publicizing MCPs/skills.
+- Ensure Desktop and proliferate-worker are the only components that resolve
+  product policy and push target runtime config refreshes to AnyHarness.
+
+Out of scope for workstream 2:
+
+- AnyHarness shared-mode auth and session claiming. That is workstream 3.
+- The AnyHarness lazy loading protocol itself. That is workstream 1.
+- Billing enforcement changes.
+- Full migration of existing session/workspace state between targets.
+- New product surfaces that consume shared sandboxes. Those can use this
+  substrate later, but they are not specified here.
+- A generic credential gateway. Shared sandboxes still use direct MCP transport
+  after Cloud/worker resolve the credential.
+
+## Terminology
+
+```text
+CloudTarget
+  Durable compute identity. Can be managed_cloud or ssh. Can be personal or
+  organization-owned.
+
+Managed cloud sandbox
+  Ephemeral backing compute for a managed_cloud CloudTarget. It can be
+  restarted or replaced without changing the target identity.
+
+Sandbox profile
+  Product-level owner configuration for a user's personal sandbox or an
+  organization's shared sandbox.
+
+Repo environment config
+  Per-owner, per-repo setup inputs: default branch, setup script, run command,
+  env vars, and tracked files.
+
+Publication
+  Org-visible projection of a private MCP connection or skill source. The
+  product UI can expose this as a "Make public" boolean, but the durable record
+  should be a separate publication row.
+
+Selection
+  A publication, credential source, repo config, or target chosen by a sandbox
+  profile.
+
+Claiming
+  A later workstream 3 feature that allows a user identity to attach directly to
+  an existing shared AnyHarness session. Workstream 2 prepares data ownership
+  but does not enable direct access.
+```
+
+## Decisions
+
+1. Owner scope is first-class everywhere this feature touches.
+
+   Every shared-cloud object that can be personal or organization-owned should
+   carry an explicit owner scope:
+
+   ```text
+   owner_scope = personal | organization
+   owner_user_id
+   organization_id
+   created_by_user_id
+   ```
+
+   Personal rows use `owner_user_id` and no `organization_id`. Organization
+   rows use `organization_id` and no `owner_user_id`.
+
+2. Managed cloud target cardinality becomes one per owner.
+
+   The end state is:
+
+   ```text
+   user personal cloud      -> one unarchived managed_cloud target
+   organization shared cloud -> one unarchived managed_cloud target
+   personal SSH targets     -> many allowed
+   organization SSH targets -> many allowed
+   ```
+
+   Workspaces and repos are materialized under that owner target. A repo should
+   not create a new managed cloud target by default.
+
+3. Repo environment config remains repo-scoped, but becomes owner-scoped.
+
+   Personal and shared sandboxes need different `.env`, tracked files, setup,
+   and run commands. The same repo can therefore have:
+
+   ```text
+   personal repo config for user A
+   personal repo config for user B
+   organization repo config for org X
+   ```
+
+   Organization repo config is admin-managed and may include shared env files.
+
+4. MCPs and skills are target-wide profile inputs.
+
+   MCPs and skills are not per session and not per repo. A personal sandbox
+   profile resolves to the user's enabled MCPs and skills. An organization
+   shared profile resolves to the org's enabled public MCP and skill
+   publications.
+
+5. "Make public" is a UX boolean, not ownership transfer.
+
+   A user can make a private MCP connection or skill available to organization
+   shared sandboxes. The credential remains the user's credential. The
+   org-visible thing is a
+   publication record that points back to the private source.
+
+   This avoids turning `CloudMcpConnection` into a mixed personal/org row and
+   makes unpublishing, source deletion, and source auth expiry explicit.
+
+6. Public publications are included in the shared sandbox by default.
+
+   For V1, an enabled org publication is part of the org shared sandbox
+   profile. Admins can disable or remove a publication from the shared profile,
+   but there is no separate hidden eligibility layer.
+
+7. Duplicate publicized MCPs do not silently collapse.
+
+   If two people publish the same catalog MCP, both publications can exist. The
+   shared runtime resolver namespaces generated server names by publication id
+   or admin override. The admin UI must make duplicates obvious and allow admins
+   to disable the unwanted one.
+
+8. Shared credentials are selected by typed credential ref, not copied blindly.
+
+   Admins can configure shared agent credentials by choosing a
+   `cloud_agent_credential` ref:
+
+   ```text
+   synced_path      encrypted file/path payload synced from Desktop
+   api_key          encrypted key material configured in Cloud/Desktop
+   managed_gateway  future gateway-backed credential authority
+   ```
+
+   The shared sandbox source points at the ref. The ref points at a
+   kind-specific backing record. If the backing credential is revoked, expired,
+   or needs resync, shared cloud status becomes `needs_attention` instead of
+   silently falling back.
+
+9. Non-admins may see shared availability summaries but not secrets.
+
+   Org members can see that GitHub, Linear, or a skill is available to shared
+   sandboxes. They should not see env var values, tracked file contents,
+   credential payloads, or the source user's secret material.
+
+10. Config updates propagate by revision and refresh.
+
+   Updating a personal or shared sandbox profile increments its runtime config
+   revision. Cloud then enqueues target config materialization for affected
+   targets. The worker applies repo/credential artifacts and pushes the
+   workstream 1 target runtime config refresh to AnyHarness. Live sessions pick
+   up the change at the next launch/restart boundary.
+
+## Current State To Change
+
+The repo already has useful substrate, but the ownership model is incomplete.
+
+Targets:
+
+- `CloudTarget` already has `owner_scope`, `owner_user_id`, and
+  `organization_id`.
+- SSH target enrollment can create organization-owned targets when the caller is
+  an org admin.
+- Managed cloud target registration is still tied to a runtime environment and
+  currently creates personal targets.
+
+Managed cloud cardinality:
+
+- `CloudRuntimeEnvironment` is unique by user or org plus repo plus isolation
+  policy.
+- It has `active_sandbox_id` and `target_id`.
+- That means the current managed cloud path is closer to one runtime
+  environment and target per repo/policy than one sandbox per user or org.
+
+Repo config:
+
+- `CloudRepoConfig` is unique by `(user_id, git_owner, git_repo_name)`.
+- `CloudRepoFile` hangs off that personal repo config.
+- Organization cloud workspace repo config currently returns
+  `org_cloud_not_ready`.
+
+Target materialization:
+
+- `CloudTargetConfig` already exists per target/repo and stores an encrypted
+  payload plus summary/version fields.
+- The current materialization service reads personal repo config, personal Git
+  auth, personal cloud credentials, and user MCP connections.
+- Its request still accepts direct `mcpConnectionIds`, which is not enough for
+  shared sandbox profile resolution.
+
+MCPs:
+
+- `CloudMcpConnection` is user-owned.
+- Its table includes `org_id`, but constraints currently require
+  `user_id IS NOT NULL` and `org_id IS NULL`.
+- There is no public flag and no publication model.
+
+Agent credentials:
+
+- `CloudCredential` is user-owned only.
+- The current payload model is enough for personal sync, but it does not yet
+  express shared-sandbox credential sources, selected source users, source
+  readiness, or worker materialization status.
+- Shared/org credential source selection does not exist.
+
+Desktop UI:
+
+- Settings has personal Cloud, Compute, Organization, and repo environment
+  sections.
+- The Cloud pane manages personal automatic sync, personal agent credential
+  sync, and personal cloud environments.
+- The repo pane configures personal repo environment inputs.
+- The Organization pane manages membership, invitations, billing link, and org
+  settings, but not shared cloud.
+
+## Target Data Model
+
+### Sandbox Profiles
+
+Add a profile table for owner-level cloud configuration:
+
+```text
+cloud_sandbox_profile
+  id
+  owner_scope                  personal | organization
+  owner_user_id                nullable for org rows
+  organization_id              nullable for personal rows
+  managed_target_id            nullable until cloud is enabled
+  enabled
+  runtime_config_revision
+  default_workspace_root
+  default_agent_kind
+  default_model_id
+  default_mode_id
+  default_reasoning_effort
+  created_by_user_id
+  updated_by_user_id
+  created_at
+  updated_at
+```
+
+Constraints:
+
+```text
+personal row:
+  owner_user_id is not null
+  organization_id is null
+  unique active row by owner_user_id
+
+organization row:
+  organization_id is not null
+  owner_user_id is null
+  unique active row by organization_id
+```
+
+The profile owns policy. `CloudTarget` owns durable compute identity. For
+managed cloud, the profile points at the owner default managed target. For SSH,
+the profile is still the source of MCP/skill/credential defaults, but a launch
+may select a specific visible SSH target.
+
+### Managed Cloud Targets
+
+Use `CloudTarget` as the durable managed cloud target identity and add partial
+uniqueness for unarchived managed targets:
+
+```text
+personal managed target:
+  kind = managed_cloud
+  owner_scope = personal
+  owner_user_id = <user>
+  organization_id = null
+  unique where archived_at is null
+
+organization managed target:
+  kind = managed_cloud
+  owner_scope = organization
+  owner_user_id = null
+  organization_id = <org>
+  unique where archived_at is null
+```
+
+`CloudRuntimeEnvironment` should stop being the identity for managed cloud
+cardinality. New launches should resolve:
+
+```text
+owner scope -> cloud_sandbox_profile -> managed CloudTarget -> active sandbox
+```
+
+Existing per-repo runtime environments can be migrated through compatibility
+code during the PR, but the steady-state launch path should be target-first.
+
+### 1:1 Sandbox Mapping Workflows
+
+Personal managed cloud enablement:
+
+```text
+1. User enables personal cloud.
+2. Server creates or loads the user's personal sandbox profile.
+3. Server finds the user's canonical unarchived managed_cloud target.
+4. If none exists, server creates one.
+5. If multiple exist, server picks the canonical target and marks the rest for
+   drain/archive after active work completes.
+6. Profile.managed_target_id points at the canonical target.
+7. Future personal cloud launches reuse that target identity.
+```
+
+Organization managed cloud enablement:
+
+```text
+1. Org owner/admin enables shared cloud.
+2. Server creates or loads the organization's shared sandbox profile.
+3. Server finds the org's canonical unarchived managed_cloud target.
+4. If none exists, server creates one with owner_scope = organization.
+5. Profile.managed_target_id points at that target.
+6. Future org shared launches reuse that target identity.
+```
+
+Runtime sandboxes are replaceable. The 1:1 invariant is about durable target
+identity, not one never-restarted container:
+
+```text
+owner profile 1:1 CloudTarget
+CloudTarget 1:many CloudSandbox over time
+CloudTarget 1:1 active CloudSandbox at a time
+```
+
+The compatibility path for existing repo-scoped `CloudRuntimeEnvironment` rows
+should be explicit:
+
+- New managed cloud work resolves through the owner profile and canonical
+  target.
+- Existing runtime environments may finish in place.
+- Any code that creates a managed cloud target must call the same
+  `ensure_owner_managed_cloud_target` service.
+- Partial unique indexes enforce that a bug cannot create two active managed
+  targets for the same user or organization.
+
+### Owner-Scoped Repo Config
+
+Evolve `cloud_repo_config` to owner scope:
+
+```text
+cloud_repo_config
+  id
+  owner_scope                  personal | organization
+  owner_user_id                nullable for org rows
+  organization_id              nullable for personal rows
+  created_by_user_id
+  git_owner
+  git_repo_name
+  configured
+  configured_at
+  default_branch
+  env_vars_ciphertext
+  env_vars_version
+  setup_script
+  setup_script_version
+  run_command
+  files_version
+  created_at
+  updated_at
+```
+
+`cloud_repo_file` can remain a child of `cloud_repo_config`.
+
+Uniqueness should be partial rather than relying on nullable columns:
+
+```text
+unique personal repo config:
+  owner_user_id, git_owner, git_repo_name
+  where owner_scope = 'personal'
+
+unique organization repo config:
+  organization_id, git_owner, git_repo_name
+  where owner_scope = 'organization'
+```
+
+Personal APIs keep the existing repo-config shape. Organization APIs use a new
+org route and require admin membership for writes.
+
+### Agent Credential Refs
+
+Agent credential sync needs a typed reference model instead of treating all
+payloads as one opaque personal blob. The shared sandbox path should not point
+directly at "some encrypted payload." It should point at a specific credential
+ref whose kind says how the worker should resolve and materialize it.
+
+Use `cloud_agent_credential` as the common reference row. It identifies the
+agent provider, credential kind, owner, status, and revision. It does not need
+to inline every possible secret shape.
+
+```text
+cloud_agent_credential
+  id
+  owner_scope                  personal | organization
+  owner_user_id                user who owns/synced/configured the credential
+  organization_id              for org-owned API-key refs if needed
+  provider                     codex | claude | ...
+  credential_kind              synced_path | api_key | managed_gateway
+  source_id                    id in the kind-specific backing table
+  source_revision              revision of the backing record
+  redacted_summary_json        filenames, key names, expiry, account label;
+                               never secret values
+  status                       ready | expired | revoked | invalid |
+                               needs_resync | unsupported
+  last_validated_at
+  last_synced_at
+  created_by_user_id
+  updated_by_user_id
+  created_at
+  updated_at
+```
+
+Kind-specific backing records:
+
+```text
+cloud_agent_synced_path_credential
+  id
+  owner_user_id
+  provider
+  local_source_id              stable Desktop-side source id
+  source_path                  local path label, redacted when needed
+  destination_hint             where this should land in the sandbox
+  payload_ciphertext           encrypted file or file bundle
+  payload_format               agent-synced-path-v1
+  payload_sha256
+  revision
+  status                       ready | expired | revoked | invalid |
+                               needs_resync
+  expires_at
+  last_synced_at
+  revoked_at
+  last_error_code
+  last_error_message
+  created_at
+  updated_at
+
+cloud_agent_api_key_credential
+  id
+  owner_scope                  personal | organization
+  owner_user_id
+  organization_id
+  provider
+  key_schema                   provider-specific key shape
+  payload_ciphertext           encrypted API key fields
+  payload_format               agent-api-key-v1
+  payload_sha256
+  revision
+  status                       ready | expired | revoked | invalid
+  expires_at
+  created_by_user_id
+  updated_by_user_id
+  created_at
+  updated_at
+
+cloud_agent_managed_gateway_credential
+  id
+  owner_scope                  personal | organization
+  owner_user_id
+  organization_id
+  provider
+  gateway_subject_id
+  gateway_policy_id
+  revision
+  status                       unsupported until gateway exists
+  created_by_user_id
+  updated_by_user_id
+  created_at
+  updated_at
+```
+
+Rules:
+
+- `synced_path` covers local auth files and directories synced from Desktop,
+  including JSON credentials files. A single path can materialize to one file
+  or a normalized file bundle.
+- `api_key` covers one or more provider-specific secret values configured in
+  Desktop or Cloud.
+- `managed_gateway` is a reference-only future kind. It should be rejected as
+  unsupported until the gateway exists.
+- The common `cloud_agent_credential` row is the only id shared sandbox config
+  should reference.
+- The backing row owns the encrypted payload and source-specific validation.
+- Updating a backing row increments both the backing revision and the common ref
+  `source_revision`.
+
+Cloud stores every payload encrypted at rest. UI and list endpoints return only
+`redacted_summary_json`, status, provider, kind, revision, and timestamps.
+
+### Shared Agent Credential Sources
+
+Shared sandboxes do not copy a user's credential payload into an org-owned row
+by default. They select a typed credential ref. That keeps source ownership,
+expiry, and resync status clear.
+
+```text
+cloud_agent_credential_source
+  id
+  organization_id
+  provider                     codex | claude | ...
+  credential_ref_id            FK cloud_agent_credential.id
+  credential_kind_snapshot     synced_path | api_key | managed_gateway
+  materialization_mode         files | env | process | mixed
+  enabled
+  status                       ready | missing | expired | revoked |
+                               needs_resync | invalid
+  selected_revision            last credential revision selected/applied
+  last_materialized_revision   last revision worker reported applied
+  last_materialized_target_id
+  last_materialized_at
+  last_error_code
+  last_error_message
+  created_by_user_id
+  updated_by_user_id
+  created_at
+  updated_at
+```
+
+Rules:
+
+- The source resolves exactly one `cloud_agent_credential` ref.
+- The ref can point at a personal `synced_path`, personal or organization
+  `api_key`, or future `managed_gateway` backing record.
+- `managed_gateway` is a reserved kind only if the code can safely reject it
+  until gateway support exists.
+- Shared target materialization fails clearly if a required source is not
+  ready.
+- When a credential ref revision changes, every organization source that
+  references it becomes pending and the shared sandbox profile revision
+  increments.
+- When the backing record is revoked, deleted, or invalidated, the source
+  becomes `needs_resync` or `revoked`; worker materialization must stop using
+  the old payload on future refresh.
+
+Credential sync workflow:
+
+```text
+1. Desktop detects supported local credentials.
+2. Desktop normalizes each item into either a `synced_path` or `api_key`
+   backing payload.
+3. Desktop uploads the encrypted backing payload.
+4. Cloud upserts the common `cloud_agent_credential` ref that points at that
+   backing record.
+5. Cloud increments the ref revision and updates redacted summary.
+6. If an org source references that credential ref, Cloud marks the source
+   pending and increments the org sandbox profile revision.
+7. Cloud enqueues target materialization for the org shared target.
+8. proliferate-worker leases the command and requests the credential payload
+   for the target/profile revision.
+9. Cloud verifies the worker target and source authorization, then returns the
+   decrypted payload over the worker channel.
+10. Worker writes files/env/process config into the sandbox, reports the applied
+   revision, and pushes the target runtime config refresh to AnyHarness.
+```
+
+The worker should only persist credentials in the target locations required by
+the selected agent. It should not write extra copies of decrypted credential
+payloads to cache directories or logs.
+
+### MCP Publications
+
+Keep `CloudMcpConnection` private and user-owned. Add publication rows:
+
+```text
+cloud_mcp_publication
+  id
+  organization_id
+  source_connection_id         FK cloud_mcp_connection.id
+  published_by_user_id
+  catalog_entry_id
+  catalog_entry_version
+  display_name
+  server_name
+  enabled
+  status                       active | disabled | needs_reconnect |
+                               source_disabled | source_deleted
+  last_error_code
+  last_error_message
+  created_at
+  updated_at
+```
+
+Constraints:
+
+```text
+unique organization + source_connection_id
+index organization + enabled + status
+```
+
+The "Make public" toggle creates, enables, disables, or deletes this
+publication. The private MCP connection remains owned by the original user.
+
+When a source connection is disabled or its auth is not ready, the publication
+status becomes non-active and the shared sandbox resolver excludes it or marks
+the org shared profile as `needs_attention`.
+
+### Skill Publications
+
+Skills need the same org-visible projection, even if V1 skills mostly come from
+plugin/catalog packages:
+
+```text
+cloud_skill_publication
+  id
+  organization_id
+  source_kind                  catalog_skill | plugin_skill | user_skill
+  source_id
+  published_by_user_id
+  skill_id
+  display_name
+  content_hash
+  artifact_ref
+  required_mcp_publication_ids
+  enabled
+  status                       active | disabled | artifact_missing |
+                               source_deleted
+  created_at
+  updated_at
+```
+
+For V1, a plugin/package can publish its MCPs and derived skills together. The
+runtime resolver still emits flat `mcpServers[]` and `skills[]`.
+
+### Profile Runtime Selections
+
+If V1 includes every enabled publication by default, a separate selection table
+is optional. If the UI needs per-profile enablement without unpublishing, add
+selection rows:
+
+```text
+cloud_sandbox_profile_mcp
+  profile_id
+  publication_id
+  enabled
+  server_name_override
+
+cloud_sandbox_profile_skill
+  profile_id
+  publication_id
+  enabled
+```
+
+Recommended V1 default:
+
+- Publication `enabled = true` means selected.
+- Add selection tables only if the UI needs "public but not used in shared
+  sandbox" on day one.
+
+## Runtime Resolution
+
+The Cloud resolver builds a workstream 1 target runtime manifest from the
+profile:
+
+```text
+personal profile:
+  enabled user MCP connections
+  enabled personal skills
+  personal cloud agent credentials
+  personal repo config for the selected repo
+
+organization profile:
+  active org MCP publications
+  active org skill publications
+  org credential sources
+  organization repo config for the selected repo
+```
+
+Generated credential refs must not expose the raw user credential id to
+AnyHarness. Use refs shaped around the resolver-owned object:
+
+```text
+credentialRef = cloud-mcp-publication:<publication_id>:auth
+credentialRef = cloud-agent-credential-source:<source_id>:<credential_ref_id>
+```
+
+For agent credentials, Cloud resolves `credential_ref_id` through
+`cloud_agent_credential.credential_kind` and then through the appropriate
+kind-specific backing record.
+
+The worker can use those refs to ask Cloud for credential payloads when
+AnyHarness emits a workstream 1 credential gap. AnyHarness never calls Cloud.
+
+## Gap Fill Responsibilities
+
+Workstream 2 owns the product-side authorization behind workstream 1 lazy
+loading. The runtime gap event is generic, but the caller must resolve it
+against the right owner profile.
+
+```text
+AnyHarness gap:
+  missing artifact <hash/ref>
+  need credential <credentialRef>
+
+Desktop local target:
+  Desktop resolves the ref from local package/cache/cloud account state and
+  fulfills the gap back to AnyHarness.
+
+Cloud personal target:
+  proliferate-worker reports the gap to Cloud with target identity.
+  Cloud validates the target belongs to the user profile and resolves personal
+  MCP/skill/credential sources.
+
+Cloud organization target:
+  proliferate-worker reports the gap to Cloud with target identity.
+  Cloud validates the target belongs to the org shared profile and resolves
+  only active public publications and shared credential sources.
+```
+
+Credential payload APIs must validate both:
+
+- the worker is authenticated for the target; and
+- the requested credential ref is present in the active or pending profile
+  revision being materialized.
+
+The worker can cache credential payloads only for the TTL allowed by the
+workstream 1 credential model. It should not persist shared credential payloads
+to disk.
+
+## Refresh Flow
+
+Every config-changing write should follow the same shape:
+
+```text
+1. Validate actor permission.
+2. Write the product config row.
+3. Increment sandbox profile runtime_config_revision.
+4. Resolve affected targets.
+5. Enqueue materialize_environment or target-runtime-config refresh command.
+6. Worker materializes artifacts and pushes target runtime config to AnyHarness.
+7. AnyHarness persists the manifest and lazily requests gaps when needed.
+```
+
+Refresh triggers:
+
+- User enables/disables a personal MCP.
+- User syncs or deletes a personal agent credential.
+- User changes personal cloud repo config.
+- User publicizes or unpublicizes an MCP or skill.
+- Admin updates shared repo config.
+- Admin updates shared credential source.
+- Admin enables/disables a shared publication.
+- Admin enables/disables the org shared managed target.
+- Catalog/plugin package versions change.
+
+Refresh should be idempotent by profile revision:
+
+```text
+target_runtime_config:<target_id>:profile_revision:<revision>
+```
+
+If the target is offline, Cloud records pending refresh state and the worker
+applies it when it reconnects.
+
+## Cloud API Shape
+
+### Personal Sandbox
+
+Existing personal routes can remain where practical, but responses should
+start exposing the profile model:
+
+```text
+GET    /cloud/sandbox-profile
+PATCH  /cloud/sandbox-profile
+POST   /cloud/sandbox-profile/enable-managed
+GET    /cloud/repo-configs
+GET    /cloud/repo-configs/{owner}/{repo}
+PUT    /cloud/repo-configs/{owner}/{repo}
+```
+
+Personal MCP/skill publicization:
+
+```text
+POST   /cloud/mcp-connections/{connectionId}/publications
+PATCH  /cloud/mcp-connections/{connectionId}/publications/{publicationId}
+DELETE /cloud/mcp-connections/{connectionId}/publications/{publicationId}
+
+POST   /cloud/skills/{skillId}/publications
+PATCH  /cloud/skills/{skillId}/publications/{publicationId}
+DELETE /cloud/skills/{skillId}/publications/{publicationId}
+```
+
+These endpoints require the actor to own the source and belong to the target
+organization.
+
+### Organization Shared Sandbox
+
+Add org routes for admin-managed shared config:
+
+```text
+GET    /cloud/organizations/{orgId}/sandbox-profile
+PATCH  /cloud/organizations/{orgId}/sandbox-profile
+POST   /cloud/organizations/{orgId}/sandbox-profile/enable-managed
+
+GET    /cloud/organizations/{orgId}/repo-configs
+GET    /cloud/organizations/{orgId}/repo-configs/{owner}/{repo}
+PUT    /cloud/organizations/{orgId}/repo-configs/{owner}/{repo}
+
+GET    /cloud/organizations/{orgId}/agent-credential-sources
+PUT    /cloud/organizations/{orgId}/agent-credential-sources/{provider}
+DELETE /cloud/organizations/{orgId}/agent-credential-sources/{provider}
+
+GET    /cloud/organizations/{orgId}/mcp-publications
+PATCH  /cloud/organizations/{orgId}/mcp-publications/{publicationId}
+
+GET    /cloud/organizations/{orgId}/skill-publications
+PATCH  /cloud/organizations/{orgId}/skill-publications/{publicationId}
+```
+
+Reads are available to org members with redacted summaries. Writes require
+owner/admin membership.
+
+Future product surfaces can read these profiles and summaries later. This spec
+does not add APIs for those surfaces.
+
+## Desktop UI Shape
+
+Follow the existing frontend area rules:
+
+- Components render UI only.
+- Product rules and view models live under `lib/domain/**`.
+- React behavior and remote-resource wiring live in hooks.
+- Cloud endpoint access goes through `hooks/access/cloud/**` and the matching
+  access boundary.
+
+### Personal Cloud Page
+
+The existing Settings `Cloud` pane becomes the personal sandbox page:
+
+- Managed cloud enable/status.
+- Automatic sync.
+- Personal agent credentials.
+- Personal MCPs and skills enabled for the personal sandbox.
+- Personal repo environments.
+- Links to repo-specific environment editors.
+
+This page should not show organization shared secret values.
+
+### Personal Repo Environment
+
+The existing repo `Cloud environment` section remains the personal repo
+environment editor:
+
+- default branch
+- run command
+- setup script
+- env vars
+- tracked files
+
+It writes personal owner-scoped repo config.
+
+### Publicization Controls
+
+Connector/plugin/skill detail UI gets an org-aware publicization control:
+
+```text
+Available to organization shared sandboxes
+```
+
+Rules:
+
+- Only show when signed in and a current organization exists.
+- The source owner can publish/unpublish their source.
+- Copy must say the shared sandbox uses this source's credential.
+- If the source auth is not ready, the control can create the publication but
+  status should show that reconnect is required before shared use.
+
+### Organization Shared Cloud Page
+
+Add an admin surface under organization settings or a new settings section
+named `Shared Cloud`. It should be visible to org members but editable only by
+owners/admins.
+
+Sections:
+
+```text
+Shared sandbox
+  enable managed cloud
+  target status
+  default workspace root
+  default agent/model/mode
+
+Shared workspaces
+  repo list
+  default branch
+  run command
+  setup script
+  shared env vars
+  shared tracked files
+  copy from my personal environment
+
+Agent credentials
+  provider
+  source type: synced path | API key | managed gateway
+  status
+  last error
+
+MCPs and skills
+  public publications
+  publisher
+  status
+  duplicate warnings
+  enabled/off
+```
+
+The UI should keep operational pages dense and work-focused. Avoid a marketing
+or landing-page layout inside settings.
+
+### Compute Page
+
+The existing Compute page should distinguish:
+
+```text
+Personal targets
+Organization targets
+```
+
+Managed cloud targets are shown as the owner default managed target. SSH
+targets can still be many. Organization SSH targets use the organization shared
+profile when they run organization work.
+
+## Backend Service Boundaries
+
+Recommended server modules:
+
+```text
+server/cloud/sandbox_profiles/
+  api.py
+  models.py
+  service.py
+  domain/
+
+server/cloud/shared_repo_config/
+  api.py
+  models.py
+  service.py
+
+server/cloud/mcp_publications/
+  api.py
+  models.py
+  service.py
+
+server/cloud/skill_publications/
+  api.py
+  models.py
+  service.py
+
+server/cloud/agent_credential_sources/
+  api.py
+  models.py
+  service.py
+```
+
+Database access should follow `docs/server/guides/database.md`:
+
+- ORM classes in `db/models/**`.
+- Store functions in `db/store/**`.
+- Stores return frozen dataclasses.
+- Services compose stores and enforce permissions.
+- API Pydantic models stay in server domain folders.
+
+Do not put org permission checks in stores. Services should load membership and
+apply policy helpers.
+
+## Target Config Materialization Changes
+
+`MaterializeTargetConfigRequest` should move from "caller supplies user MCP
+ids" to "caller supplies owner scope/profile context":
+
+```text
+ownerScope
+organizationId
+gitProvider
+gitOwner
+gitRepoName
+workspaceRoot
+includeAgentCredentials
+includeGitCredentials
+source
+idempotencyKey
+```
+
+The service resolves:
+
+```text
+profile
+repo environment config
+agent credential sources
+MCP publications or personal connections
+skill publications or personal skills
+target runtime manifest
+```
+
+`CloudTargetConfig` should record:
+
+```text
+owner_scope
+owner_user_id
+organization_id
+sandbox_profile_id
+sandbox_profile_revision
+```
+
+The encrypted payload should include the workstream 1 target runtime manifest
+or enough refs for the worker to request it before AnyHarness refresh.
+
+## Access Control
+
+Personal sandbox config:
+
+- Owner can read/write.
+- Other users cannot read.
+
+Organization shared sandbox profile:
+
+- Org members can read redacted summaries.
+- Org owners/admins can write.
+
+Organization repo config:
+
+- Org members can see configured status, keys, counts, and last updated info.
+- Org owners/admins can read/write secret values and tracked file contents.
+
+Public MCP/skill publications:
+
+- Source owner can create/update/delete their own publication.
+- Org owners/admins can disable any org publication for shared sandbox use.
+- Org members can list redacted publication summaries.
+
+Agent credential sources:
+
+- Org owners/admins can read/write.
+- Org members can see provider/status summaries only.
+
+## SSH And Non-Direct Access
+
+Organization SSH targets should use the same shared profile resolver as the
+organization managed cloud target. The selected target changes where work runs,
+not which shared MCPs, skills, agent credentials, or repo environment config
+apply.
+
+Workstream 2 should not require Desktop to have direct SSH or direct
+AnyHarness access to an organization target. Cloud commands and the worker
+control channel remain the standard path. Workstream 3 can add claiming and
+direct authenticated attachment after a session is created.
+
+## Implementation Plan
+
+Implement workstream 2 as one coherent PR with internal slices. The pieces are
+coupled enough that landing separate backend/UI/runtime-policy PRs would leave
+ambiguous product behavior between them.
+
+Suggested slice order inside the PR:
+
+1. Schema and stores.
+
+   Add sandbox profiles, owner-scoped repo config columns/indexes, MCP
+   publication rows, skill publication rows, and shared agent credential source
+   rows. Backfill personal rows from current user-scoped records.
+
+2. Server services and APIs.
+
+   Add profile, org repo config, publication, and credential-source APIs. Move
+   target config materialization to profile resolution.
+
+3. Managed cloud target cardinality.
+
+   Create or reuse one personal managed target per user and one organization
+   managed target per org. Stop creating new managed targets per repo for new
+   launches.
+
+4. Runtime config refresh integration.
+
+   Increment profile revisions on config writes, enqueue materialization, and
+   connect the worker path to the workstream 1 target runtime config refresh.
+
+5. Desktop access hooks and domain models.
+
+   Add typed access hooks under `hooks/access/cloud/**`, domain view models
+   under `lib/domain/**`, and copy/config helpers in the documented frontend
+   locations.
+
+6. Desktop UI.
+
+   Update personal Cloud, repo environment, Compute, connector/plugin/skill
+   publicization, and Organization Shared Cloud surfaces.
+
+7. Migration and compatibility cleanup.
+
+   Preserve old rows long enough to migrate existing data, but make new
+   launches use the target/profile path. Do not leave permanent duplicate
+   launch paths.
+
+8. Tests and verification.
+
+   Add focused store/service tests for permissions, publication behavior,
+   duplicate MCP handling, owner-scoped repo config, agent credential source
+   materialization, managed target uniqueness, and target materialization
+   payloads. Add frontend tests for view models and core settings state
+   transitions where existing test patterns support it.
+
+## Migration Notes
+
+Data backfill:
+
+- Existing `CloudRepoConfig.user_id` rows become personal
+  `owner_scope = personal` rows.
+- Existing `CloudCredential` rows stay personal.
+- Existing `CloudMcpConnection` rows stay private and unpublished.
+- Existing managed cloud runtime environments can keep running, but new
+  managed cloud launches should allocate through the personal profile target.
+
+Managed cloud target migration:
+
+- If a user already has managed cloud targets, pick the oldest unarchived
+  online target as the personal profile target.
+- Archive or drain extra managed targets after their existing work is complete.
+- Organization profiles start disabled until an admin enables shared cloud.
+
+Org repo config:
+
+- Remove the `org_cloud_not_ready` behavior for org workspaces once the org
+  repo config APIs exist.
+- Shared env vars and tracked files must be encrypted at rest, same as personal
+  repo config.
+
+MCP publication:
+
+- No MCP becomes public automatically.
+- First publish action creates the publication row and increments the org
+  shared profile revision.
+
+## Acceptance Criteria
+
+- A personal user can configure one cloud sandbox profile and repo
+  environments, and new personal cloud work resolves through that profile.
+- An org admin can enable a shared cloud profile and configure shared repo
+  environment inputs.
+- An org admin can configure shared agent credential sources and see readiness
+  status.
+- A user can make an MCP/skill public to an org without transferring ownership
+  of the private source.
+- The shared profile resolver includes enabled public MCPs/skills and excludes
+  disabled or broken publications.
+- Duplicate public MCPs are visible and namespaced, not silently deduped.
+- Synced local agent credentials can be selected as shared credential sources
+  and applied to the organization shared sandbox by proliferate-worker.
+- Source credential revision changes trigger shared profile refresh and worker
+  materialization.
+- Target config materialization no longer depends on raw user
+  `mcpConnectionIds` for organization work.
+- Worker/AnyHarness refresh uses the workstream 1 target runtime config model.
+- Non-admin org members cannot read shared secret values.
+
+## Open Follow-Ups
+
+- Whether publication selection tables are needed in V1, or whether
+  publication `enabled` is enough.
+- Exact UI placement for Shared Cloud: inside Organization vs a dedicated
+  settings nav item.

--- a/docs/architecture/target-runtime-mcp-skills-config.md
+++ b/docs/architecture/target-runtime-mcp-skills-config.md
@@ -1,0 +1,900 @@
+# Target Runtime MCP And Skills Config Spec
+
+Status: proposed workstream 1 implementation spec
+
+Date: 2026-05-17
+
+## Purpose
+
+This spec defines the workstream 1 target model for plugins, MCPs, skills,
+target runtime config refresh, and lazy loading across Desktop, Cloud worker,
+and AnyHarness.
+
+The core change is:
+
+```text
+Plugin package        catalog/UX packaging only, owned by Desktop or Cloud
+MCP server            runtime artifact/connection, understood by AnyHarness
+Skill                 runtime artifact, understood by AnyHarness
+Target runtime config durable target-level manifest in AnyHarness
+```
+
+AnyHarness should not receive a Desktop-shaped `SessionPluginBundle` at session
+create or resume. It should receive and persist a target-scoped runtime
+manifest containing flat MCP server and skill entries. AnyHarness then resolves
+missing artifacts and credentials lazily through the caller that is already
+allowed to talk to the relevant registry or credential store:
+
+```text
+Desktop local target      Desktop fills gaps
+Cloud managed/SSH target  proliferate-worker fills gaps
+AnyHarness                stores manifest, caches artifacts, holds credentials in memory
+```
+
+AnyHarness remains inbound-only. It never calls Proliferate Cloud directly.
+
+## Docs Read For This Spec
+
+This spec is cross-cutting, so the ownership lines below are aligned with:
+
+- `docs/README.md`
+- `docs/architecture/cloud-work-launch-model-spec.md`
+- `docs/architecture/plugins-and-skills.md`
+- `docs/anyharness/README.md`
+- `docs/anyharness/contract.md`
+- `docs/anyharness/guides/api.md`
+- `docs/anyharness/guides/domains.md`
+- `docs/anyharness/guides/integrations.md`
+- `docs/anyharness/guides/live-runtime.md`
+- `docs/anyharness/guides/persistence.md`
+- `docs/anyharness/specs/mcp.md`
+- `docs/server/README.md`
+- `docs/server/guides/auth.md`
+- `docs/server/guides/database.md`
+- `docs/server/guides/domains.md`
+- `docs/server/guides/workers.md`
+- `docs/sdk/README.md`
+- `docs/frontend/README.md`
+- `docs/frontend/guides/access.md`
+- `docs/frontend/guides/lib.md`
+
+## Scope
+
+In scope for workstream 1:
+
+- Replace the runtime-facing session plugin bundle model with a flat target
+  runtime config manifest.
+- Add AnyHarness target runtime config persistence and refresh APIs.
+- Add AnyHarness lazy resolution requests for missing artifacts and
+  credentials.
+- Move the skills MCP server from in-memory session bundle state to the target
+  runtime manifest plus artifact cache.
+- Extend Desktop and proliferate-worker so they push target runtime config and
+  fulfill AnyHarness gap requests.
+- Keep Cloud and Desktop as the only resolvers of plugin/package policy.
+
+Out of scope for workstream 1:
+
+- Public/team exposure policy and shared-sandbox UI. That is workstream 2.
+- Shared mode, direct user auth to AnyHarness, and claiming. That is
+  workstream 3.
+- Hot-swapping MCP servers inside an already-running ACP actor. Workstream 1
+  applies changes at launch/restart boundaries.
+- A generic credential gateway. This model keeps direct MCP transport.
+
+## Decisions
+
+1. The runtime config scope is target-level, not session-level and not
+   workspace-level.
+
+   An AnyHarness process represents one target runtime. It should have one
+   active MCP/skill manifest shared by every workspace and session in that
+   target. Cloud may still have repo/workspace materialization records for
+   env vars, files, setup scripts, and worktrees, but MCPs and skills are a
+   target runtime concern.
+
+2. Plugins do not cross the AnyHarness boundary.
+
+   A plugin is a packaging and catalog concept. It can group one or more MCP
+   server definitions, skill manifests, credential requirements, and UI
+   metadata. Before data reaches AnyHarness, Desktop or Cloud flattens plugins
+   into `mcpServers[]` and `skills[]`.
+
+3. AnyHarness stores a durable manifest, not a full secret-bearing bundle.
+
+   The manifest contains stable ids, versions, hashes, non-secret connection
+   shape, and credential references. It does not persist bearer tokens, API
+   keys, OAuth access tokens, stdio secret env values, or full skill bodies.
+
+4. Artifacts and credentials have different storage rules.
+
+   Artifacts are content-addressed by hash and may be cached on disk.
+   Credentials are resolved by ref, cached only in memory, and expire by TTL or
+   explicit refresh.
+
+5. Refresh and lazy loading are separate.
+
+   Refresh pushes the current manifest into AnyHarness. Lazy loading fills
+   missing artifact or credential gaps for a manifest revision. Refresh may
+   optionally warm artifacts, but correctness cannot depend on every artifact
+   being present at refresh time.
+
+6. AnyHarness never pulls from Cloud.
+
+   AnyHarness creates resolution requests and exposes them to its caller.
+   Desktop or proliferate-worker uses its own authority to fetch package
+   artifacts or credentials, then fulfills the request back into AnyHarness.
+
+7. Running sessions pick up changes at a launch boundary.
+
+   A live actor keeps the MCP servers and skill index it launched with.
+   Updating the target runtime config affects the next actor launch, restart,
+   or explicit restart-required path. Hot remount can be a later feature.
+
+## Current State To Replace
+
+Today, the runtime path is session-scoped and Desktop-shaped:
+
+- `anyharness-contract/src/v1/plugins.rs` defines `SessionPluginBundle`,
+  `SessionPlugin`, and inline `SessionPluginSkill.instructions`.
+- `CreateSessionRequest` and `ResumeSessionRequest` accept `pluginBundle`.
+- `PluginBundleRegistry` stores bundles in memory by session id.
+- `PluginSessionLaunchExtension` reads that registry, mounts plugin MCP
+  servers, injects the skill index, and adds the `proliferate_skills` MCP
+  server.
+- `SkillsProductMcpServer` resolves its context from the same in-memory
+  registry and serves inline skill instructions/resources.
+- Desktop builds the bundle in
+  `desktop/src/lib/domain/plugins/session-plugin-bundle.ts` and sends it from
+  session launch workflows.
+- Cloud MCP materialization currently returns `pluginPackages` as a sidecar to
+  MCP server materialization.
+
+AnyHarness also persists per-session user MCP bindings as encrypted
+`mcp_bindings_ciphertext`. That solves one old restart problem for user MCPs,
+but it does not solve the new target model:
+
+- it is session-scoped;
+- it persists secret-bearing full MCP configs;
+- it has no durable skill manifest equivalent;
+- it keeps plugin packaging visible to AnyHarness.
+
+There is already useful Cloud substrate:
+
+- `cloud_target_configs` stores encrypted target materialization plans and
+  queues `materialize_environment` commands.
+- `TargetConfigMaterializationPlan` already has placeholder `mcp` and
+  `skills` fields.
+- proliferate-worker already fetches those plans, writes
+  `.proliferate/mcp/materialization.json`, and writes skill refs.
+
+Workstream 1 should extend that substrate. It should not invent a parallel
+Cloud materialization system.
+
+Managed cloud target cardinality is also transitional today:
+
+- `CloudRuntimeEnvironment` is unique by user plus repo plus isolation policy
+  for personal cloud environments.
+- it has an `active_sandbox_id` and associated managed-cloud target, so the
+  current system is closer to "one active sandbox per repo-scoped runtime
+  environment" than "one universal cloud sandbox per user."
+- org-scoped runtime environment indexes exist, but organization cloud
+  workspaces are currently rejected as `org_cloud_not_ready`.
+
+Workstream 2 can change the product cardinality for shared sandboxes. The
+workstream 1 AnyHarness manifest should still be target-scoped so either
+cardinality works.
+
+## Target Object Model
+
+### Cloud/Desktop Catalog Objects
+
+These never cross into AnyHarness as runtime concepts:
+
+```text
+PluginPackage
+  id
+  version
+  display metadata
+  skill source refs
+  MCP component refs
+  credential requirements
+  policy metadata
+```
+
+Cloud and Desktop use plugin packages to decide which flat runtime entries are
+available. The output of that resolver is the target runtime config manifest.
+
+### AnyHarness Runtime Objects
+
+AnyHarness should own these concepts:
+
+```text
+TargetRuntimeConfig
+  revision
+  mcp_servers[]
+  mcp_binding_summaries[]
+  skills[]
+  artifact_refs[]
+
+RuntimeMcpServer
+  stable id
+  server name
+  transport
+  non-secret launch shape
+  credential refs for secret values
+
+RuntimeSkill
+  stable id
+  display name
+  description
+  version/source metadata
+  instruction artifact hash/ref
+  resource artifact hashes/refs
+  required MCP server ids
+  credential refs
+
+RuntimeArtifact
+  content hash
+  content type
+  byte size
+  source ref
+  local cache path after materialization
+
+RuntimeCredential
+  credential ref
+  secret field values
+  expires at
+  in-memory only
+```
+
+The implementation names can evolve, but the runtime boundary should keep
+these concepts distinct.
+
+## Target Runtime Manifest
+
+The manifest is the durable AnyHarness input. It should be OpenAPI-visible
+contract state under `anyharness-contract/src/v1/`, with SDK types generated
+from Rust.
+
+Sketch:
+
+```text
+TargetRuntimeConfigRefreshRequest
+  revision: TargetRuntimeConfigRevision
+  mcpServers: RuntimeMcpServer[]
+  mcpBindingSummaries: SessionMcpBindingSummary[]
+  skills: RuntimeSkill[]
+  artifacts: RuntimeArtifactRef[]
+  source: desktop | worker | test
+
+TargetRuntimeConfigRevision
+  id: string              stable opaque revision id
+  sequence: i64           monotonic per target when the caller has one
+  generatedAt: string
+  contentHash: string     hash of canonical manifest payload
+  ownerScope: personal | organization | unknown
+  externalTargetId?: string
+
+RuntimeMcpServer
+  id: string
+  connectionId: string
+  catalogEntryId?: string
+  serverName: string
+  transport: http | stdio
+  launch: RuntimeMcpLaunch
+  credentialRefs: RuntimeCredentialRef[]
+
+RuntimeSkill
+  id: string
+  packageId?: string
+  version?: string
+  displayName: string
+  description: string
+  instructionArtifact: RuntimeArtifactRef
+  resources: RuntimeSkillResource[]
+  requiredMcpServerIds: string[]
+  credentialRefs: string[]
+```
+
+Secret-bearing launch values must be typed as references, not plain strings:
+
+```text
+RuntimeMcpValue
+  literal       non-secret string value
+  credential   reference to a runtime credential field
+```
+
+Examples:
+
+```text
+HTTP Authorization header -> credential ref
+stdio API_KEY env var     -> credential ref
+MCP URL                   -> literal
+stdio command path        -> literal
+stdio args                -> literal unless explicitly credential refs
+```
+
+AnyHarness validation should reject obviously secret inline values in durable
+manifest fields when the field is represented as a credential-capable value.
+
+## AnyHarness Persistence
+
+Add a new AnyHarness domain for target runtime config, following the
+AnyHarness domain/store/service split.
+
+Target placement:
+
+```text
+anyharness-lib/src/domains/runtime_config/
+  model.rs
+  store.rs
+  service.rs
+  artifact_cache.rs
+  credentials.rs
+  resolution.rs
+```
+
+SQLite durable state:
+
+```text
+runtime_config_current
+  id                 singleton row or external target id
+  revision_id
+  revision_sequence
+  content_hash
+  manifest_json      redacted, no secret values
+  applied_at
+  source
+
+runtime_artifact_cache
+  artifact_hash
+  content_type
+  byte_size
+  cache_path
+  created_at
+  last_used_at
+```
+
+In-memory state:
+
+```text
+credential_cache
+  credential_ref -> values, expires_at, revision_id
+
+pending_resolution_requests
+  request_id -> request, status, waiters
+```
+
+Pending resolution requests can be in memory for v1. After an AnyHarness
+process restart, they are recomputed from the durable manifest the next time a
+session launch, MCP activation, or prefetch needs them.
+
+## AnyHarness API Contract
+
+Add target runtime config endpoints under `/v1`. Exact route names can change
+during implementation, but the contract shape should be resource-oriented.
+
+Proposed:
+
+```text
+GET /v1/runtime-config
+  returns current redacted manifest, cache status, and pending gaps
+
+PUT /v1/runtime-config
+  validates and stores a new manifest revision
+  idempotent by revision id/content hash
+  returns applied revision and missing artifact summary
+
+POST /v1/runtime-config/prefetch
+  asks AnyHarness to create resolution requests for missing artifacts
+  does not require credentials unless explicitly requested
+
+GET /v1/runtime-config/resolution-requests
+  lists pending artifact/credential requests
+
+POST /v1/runtime-config/resolution-requests/{requestId}/resolve
+  fulfills a request
+
+POST /v1/runtime-config/resolution-requests/{requestId}/reject
+  rejects a request with a typed reason
+```
+
+Resolution request variants:
+
+```text
+RuntimeArtifactRequest
+  requestId
+  revisionId
+  artifactHash
+  artifactRef
+  kind: skill_instruction | skill_resource | package_metadata
+  reason: missing | stale | prefetch
+
+RuntimeCredentialRequest
+  requestId
+  revisionId
+  credentialRefs[]
+  mcpServerIds[]
+  reason: missing | expired | refresh_requested
+```
+
+Artifact fulfillment accepts one of:
+
+```text
+contentBase64
+localPath
+```
+
+AnyHarness validates `sha256` and `byteSize` before moving/copying into its
+artifact cache. `localPath` is allowed because Desktop and proliferate-worker
+run on the same target filesystem as AnyHarness. `contentBase64` is the
+portable fallback.
+
+Credential fulfillment accepts:
+
+```text
+credentialRef
+values[]
+expiresAt
+redactedSummary
+```
+
+AnyHarness stores credential values only in memory. If the process restarts,
+the next launch recomputes the missing credential request.
+
+Launch-blocking API calls should fail with a typed problem detail that includes
+the pending request ids when a required credential cannot be resolved
+synchronously:
+
+```text
+code: RUNTIME_CONFIG_RESOLUTION_REQUIRED
+resolutionRequestIds: [...]
+```
+
+That lets Desktop/worker fill gaps and retry without guessing.
+
+If no caller is available to fulfill a launch-blocking credential request,
+AnyHarness should fail closed with `RUNTIME_CONFIG_RESOLUTION_REQUIRED` rather
+than silently launching without the MCP server. In Cloud-mediated flows the
+worker is the caller; in Desktop-mediated local flows Desktop is the caller.
+Direct bare requests to AnyHarness without either caller can retry after a
+caller refreshes or fulfills the missing runtime config.
+
+## Session Launch Assembly
+
+Session launch remains the central place where MCP servers are assembled.
+The existing `sessions/mcp_bindings/assembly.rs` path should evolve from
+"per-session encrypted MCP bindings plus session extensions" to:
+
+```text
+SessionRuntime starts a session
+  -> load workspace/session/agent
+  -> read current TargetRuntimeConfig
+  -> skip external target config if session policy is InternalOnly
+  -> resolve required MCP credentials from memory
+  -> create credential resolution requests if missing/expired
+  -> build concrete ACP MCP server configs
+  -> add product MCP servers through existing product MCP selection
+  -> add proliferate_skills MCP server if runtime skills exist
+  -> render skill index from RuntimeSkill metadata
+  -> launch actor
+```
+
+This preserves the AnyHarness MCP spec invariant: one assembly boundary answers
+which MCP servers and prompt additions should launch with a session.
+
+The actor receives concrete launch config. The actor should not inspect plugin
+packages, query artifact caches, or decide which MCPs are enabled.
+
+## Skills MCP Flow
+
+The `proliferate_skills` product MCP server should resolve from the current
+target runtime config, not from a session plugin bundle.
+
+Tool behavior:
+
+```text
+list_available_skills
+  reads RuntimeSkill metadata only
+  never needs artifact content
+
+activate_skill
+  checks instruction artifact cache
+  if present, returns instructions plus resource metadata
+  if missing, creates RuntimeArtifactRequest and waits for bounded fulfillment
+  if not fulfilled, returns retryable tool error
+
+get_skill_resource
+  checks resource artifact cache
+  if present, returns resource content
+  if missing, creates RuntimeArtifactRequest and waits for bounded fulfillment
+  if not fulfilled, returns retryable tool error
+```
+
+The bounded wait is important. It lets Desktop/worker satisfy normal misses
+without making the agent manually retry every first skill activation, but it
+does not hang a turn forever if no caller is available.
+
+The skills MCP capability token can continue to be session-scoped, minted by
+AnyHarness, and validated by the product MCP server. The context behind that
+token changes from `SessionPluginBundle` to:
+
+```text
+workspace id
+session id
+target runtime config revision id observed at launch
+```
+
+Using the launch revision prevents a running actor from observing a different
+skill set halfway through a turn.
+
+## Refresh Flow
+
+Refresh means "replace the target runtime manifest stored in AnyHarness."
+
+Desktop refresh:
+
+```text
+User changes local MCP/skill/plugin toggles
+  -> Desktop resolver flattens enabled plugins into MCPs + skills
+  -> Desktop calls PUT /v1/runtime-config
+  -> Desktop optionally prefetches artifacts
+  -> Desktop watches resolution requests and fulfills local/cloud gaps
+```
+
+Cloud refresh:
+
+```text
+Cloud registry or target materialization changes
+  -> Cloud stores/updates target runtime manifest inputs
+  -> Cloud enqueues materialize_environment or runtime-config refresh command
+  -> proliferate-worker fetches worker-authorized materialization plan
+  -> worker materializes any filesystem artifacts it already has
+  -> worker calls AnyHarness PUT /v1/runtime-config
+  -> worker watches resolution requests and fulfills Cloud-authorized gaps
+```
+
+For v1, it is acceptable for the existing `materialize_environment` command to
+carry the runtime manifest along with repo env/files. The important boundary is
+that MCPs and skills are target-scoped once they reach AnyHarness. The existing
+repo-scoped `cloud_target_configs` record can remain the command and encrypted
+plan carrier, but it should not imply per-workspace MCP/skill state in
+AnyHarness.
+
+If a future Cloud path wants direct target runtime refresh without repo env
+materialization, add a dedicated CloudCommand kind. That is an additive
+optimization, not a prerequisite for workstream 1.
+
+## Lazy Resolution Flow
+
+The lazy resolution loop is the same for Desktop and worker:
+
+```text
+AnyHarness needs artifact or credential
+  -> create RuntimeResolutionRequest
+  -> return typed blocking error or emit/list pending request
+  -> caller resolves from its authority
+  -> caller fulfills request into AnyHarness
+  -> AnyHarness validates and caches
+  -> original operation retries or resumes
+```
+
+Caller responsibilities:
+
+- Desktop resolves from local package cache, local native credential setup,
+  and Cloud APIs it is already authenticated to call.
+- proliferate-worker resolves from worker-authenticated Cloud endpoints and
+  files/materialization plans already delivered to the target.
+- Neither caller sends plugin package objects to AnyHarness.
+
+AnyHarness responsibilities:
+
+- never call Cloud;
+- never persist credential secret values;
+- validate artifact hashes before caching;
+- dedupe concurrent requests for the same artifact hash or credential ref;
+- expose typed redacted status so callers can debug misses.
+
+## Cloud Server Responsibilities
+
+Workstream 1 Cloud changes should follow server domain and DB guide rules:
+API handlers stay thin, services orchestrate, stores own SQL, and worker routes
+authenticate through worker auth.
+
+Cloud should provide:
+
+1. A resolver that turns selected catalog/plugin/MCP state into a flat target
+   runtime manifest.
+
+   Target location:
+
+   ```text
+   server/proliferate/server/cloud/target_config/service.py
+   server/proliferate/server/cloud/target_config/domain/runtime_manifest.py
+   ```
+
+   If it grows beyond target config ownership, promote a
+   `cloud/runtime_config/` subdomain. Do not put this in route handlers.
+
+2. Worker-facing gap-fill endpoints.
+
+   These endpoints should be worker-authenticated and target-scoped. They
+   return only data the worker is authorized to materialize for that target.
+
+   Sketch:
+
+   ```text
+   GET  /v1/cloud/worker/runtime-configs/{revisionId}/artifacts/{hash}
+   POST /v1/cloud/worker/runtime-configs/{revisionId}/credentials/materialize
+   ```
+
+   Exact paths can reuse target-config ids if implementation needs that, but
+   the API semantics should be "worker fills AnyHarness runtime config gaps",
+   not "AnyHarness calls Cloud."
+
+3. No public/team policy in workstream 1.
+
+   Workstream 1 should support owner scope fields in the manifest so
+   workstream 2 can add public org resolution without changing the AnyHarness
+   contract again. The actual `public` flag, org-scoped MCP connection
+   projection, duplicate-public-MCP policy, and shared sandbox UI are
+   workstream 2.
+
+## Worker Responsibilities
+
+proliferate-worker should own target-side Cloud resolution because it already
+has:
+
+- worker identity;
+- target id;
+- Cloud command lease flow;
+- AnyHarness bearer token;
+- local filesystem access to the sandbox;
+- materialization root knowledge.
+
+Required worker changes:
+
+- Extend `TargetConfigMaterializationPlan` with typed runtime manifest fields
+  instead of opaque `mcp: Value` and `skills: Vec<Value>`.
+- After materializing env/files/git, call AnyHarness `PUT /v1/runtime-config`.
+- Add an AnyHarness resolution request loop or poll during command execution.
+- Fulfill artifact requests from Cloud materialization endpoints or local
+  files.
+- Fulfill credential requests from Cloud worker endpoints.
+- Report target config status as failed if required runtime config refresh
+  cannot be applied.
+
+The existing files are the right starting points:
+
+```text
+anyharness/crates/proliferate-worker/src/materialization/mod.rs
+anyharness/crates/proliferate-worker/src/materialization/mcp.rs
+anyharness/crates/proliferate-worker/src/materialization/skills.rs
+anyharness/crates/proliferate-worker/src/cloud_client/target_config.rs
+anyharness/crates/proliferate-worker/src/anyharness_client/
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+```
+
+## Desktop Responsibilities
+
+Desktop should stop building `SessionPluginBundle` for session create/resume.
+Instead:
+
+- plugin/MCP UI state changes trigger a target runtime config refresh;
+- local stdio candidate finalization feeds the target runtime manifest;
+- Desktop watches/list-polls AnyHarness resolution requests while it is the
+  active local caller;
+- session create/resume sends no plugin bundle and no full MCP list after the
+  migration bridge is removed.
+
+Ownership should follow the frontend guides:
+
+```text
+lib/domain/plugins/**        pure flattening/package decisions
+lib/workflows/mcp/**         non-React refresh/gap-fill workflows
+lib/access/anyharness/**     raw runtime config endpoint calls only if SDK lacks them
+hooks/access/...             React Query wrappers for Cloud/Tauri resources
+product hooks                call workflows with explicit deps
+```
+
+## AnyHarness Auth Boundary
+
+Workstream 1 does not solve shared-mode user auth or claiming.
+
+For now:
+
+- local/Desktop targets use the existing selected-runtime connection model;
+- Cloud worker uses the existing AnyHarness bearer token;
+- product MCP capability tokens remain scoped to workspace/session/tool
+  surfaces;
+- resolution request fulfillment is protected by the same AnyHarness bearer
+  boundary as other `/v1` routes.
+
+Workstream 3 will add shared mode and claiming. The workstream 1 contract
+should not assume that every human user can call AnyHarness directly.
+
+## Implementation Plan
+
+Implement workstream 1 as one PR. The PR can be developed in ordered internal
+slices, but it should land as one coherent change so the repo does not carry
+duplicate runtime/plugin models across review boundaries.
+
+### Slice 1: AnyHarness Contract And Store
+
+- Add `runtime_config` contract types.
+- Add `/v1/runtime-config` endpoints.
+- Add `domains/runtime_config` model/store/service.
+- Persist redacted target runtime manifest.
+- Add artifact cache and in-memory credential cache.
+- Add resolution request model and fulfillment endpoints.
+- Generate AnyHarness SDK artifacts.
+
+Verification:
+
+```bash
+cargo test -p anyharness-lib runtime_config
+cd anyharness/sdk && pnpm run generate && pnpm run build
+```
+
+### Slice 2: AnyHarness Session And Skills Integration
+
+- Teach session MCP assembly to read `TargetRuntimeConfig`.
+- Convert runtime MCP manifest entries into concrete ACP MCP servers.
+- Create credential resolution requests on missing/expired credentials.
+- Move `proliferate_skills` from `PluginBundleRegistry` to runtime config.
+- Resolve skill instructions/resources from artifact cache.
+- Keep a temporary in-PR compatibility bridge for `pluginBundle` only while the
+  Desktop slice is being updated.
+
+Verification:
+
+```bash
+cargo test -p anyharness-lib mcp
+cargo test -p anyharness-lib plugins
+```
+
+The end state should delete `PluginBundleRegistry`, the plugin launch
+extension, and session bundle validation once Desktop no longer sends the old
+shape.
+
+### Slice 3: Cloud Target Runtime Manifest
+
+- Replace opaque target-config `mcp`/`skills` values with typed runtime
+  manifest models.
+- Generate flat manifest entries from current MCP materialization plus plugin
+  package skill refs.
+- Add worker-facing artifact and credential materialization endpoints.
+- Keep public/shared policy out of this PR.
+
+Verification:
+
+```bash
+cd server && uv run pytest -q tests/cloud/test_target_config.py
+cd server && uv run pytest -q tests/cloud/test_mcp_materialization.py
+```
+
+### Slice 4: Worker Refresh And Gap Fill
+
+- Parse typed runtime manifest fields.
+- Call AnyHarness runtime config refresh after materialization.
+- Poll or process AnyHarness resolution requests.
+- Fulfill artifacts and credentials via Cloud worker endpoints.
+- Fail materialization when required refresh or required credentials cannot be
+  applied.
+
+Verification:
+
+```bash
+cargo test -p proliferate-worker materialization
+cargo test -p proliferate-worker anyharness_client
+```
+
+### Slice 5: Desktop Refresh And Gap Fill
+
+- Replace session-launch plugin bundle assembly with target runtime config
+  refresh.
+- Keep pure plugin flattening under `lib/domain/plugins/**`.
+- Put refresh/gap-fill workflows under `lib/workflows/mcp/**` or a tighter
+  runtime-config workflow folder.
+- Stop sending `pluginBundle` on create/resume once compatibility is no longer
+  needed.
+
+Verification:
+
+```bash
+cd desktop && pnpm test session-mcp-launch
+cd desktop && pnpm test session-runtime
+```
+
+### Slice 6: Remove Legacy Runtime Plugin Boundary
+
+- Remove `SessionPluginBundle` from create/resume request handling.
+- Remove `PluginBundleRegistry`.
+- Remove the plugin session launch extension.
+- Remove inline skill body runtime handling.
+- Keep Cloud/Desktop plugin catalog objects because those remain product
+  packaging.
+
+Verification:
+
+```bash
+cargo test
+cd anyharness/sdk && pnpm run build
+```
+
+## Backward Compatibility
+
+During migration, AnyHarness may temporarily accept both:
+
+```text
+legacy session pluginBundle
+new target runtime config
+```
+
+Rules for the bridge:
+
+- New target runtime config wins when present.
+- Legacy `pluginBundle` is translated at the API boundary or rejected with a
+  clear compatibility error. Do not pass `SessionPluginBundle` deeper into new
+  runtime config services.
+- The bridge is an in-PR scaffolding step only. The final PR state should not
+  leave duplicate runtime paths permanently unless review explicitly chooses a
+  staged compatibility window.
+
+## Security Rules
+
+- Durable AnyHarness manifest state must be redacted.
+- Credential values are memory-only and TTL-bound.
+- Artifact content is hash-validated before caching.
+- `SessionMcpBindingSummary` remains redacted: no URLs, headers, env values,
+  command args, absolute paths, raw tokens, or raw error strings.
+- Cloud worker gap-fill endpoints must authenticate worker identity and target
+  authorization.
+- AnyHarness resolution request status must expose refs and redacted labels,
+  not secret values.
+
+## Relationship To Workstream 2
+
+Workstream 2 will decide and implement:
+
+- `public` flags or org-visible projections for MCP connections and skills;
+- shared sandbox target config resolution;
+- admin UI for shared sandbox MCPs/skills;
+- duplicate publicized MCP resolution policy;
+- public skill/plugin curation visibility;
+- whether shared sandbox MCP/skill refresh is automatic on every publication
+  change or gated behind admin apply.
+
+Workstream 1 should make this easy by accepting `ownerScope`,
+`externalTargetId`, stable runtime ids, and flat manifests. It should not embed
+personal-only assumptions in AnyHarness.
+
+## Relationship To Workstream 3
+
+Workstream 3 will decide and implement:
+
+- AnyHarness shared mode;
+- worker-only pre-claim access;
+- claim grants;
+- user/session/target authorization in AnyHarness;
+- direct Desktop attach to a shared target after claim.
+
+Workstream 1 should keep using existing bearer auth and should not add
+human-user policy checks to runtime config endpoints yet.
+
+## Open Implementation Choices
+
+These are implementation choices, not product-model blockers:
+
+- Whether the Cloud command kind remains `materialize_environment` for v1 or a
+  new `refresh_runtime_config` command is added immediately.
+- Whether AnyHarness resolution request delivery is initially polling-only or
+  also exposed through SSE.
+- Whether artifact fulfillment prefers local path or base64 in each caller.
+- Whether skill activation waits 5 seconds, 10 seconds, or uses a configurable
+  timeout before returning a retryable tool error.
+
+The model is decided enough to write code: target-scoped flat manifest, plugin
+as packaging only, artifacts on disk by hash, credentials in memory by ref,
+caller-filled gaps, no AnyHarness-to-Cloud pull.


### PR DESCRIPTION
## Summary

- add proposed architecture specs for target runtime MCP/skills config, shared sandbox/admin config, agent LLM auth gateway, and codebase knowledge ownership
- update the cloud worker docs around exposure/projection terminology and command admission
- refresh the generated Cloud SDK OpenAPI output for the shared OAuth provider callback route

## Validation

- `git diff --cached --check`
