### PR TITLE
fix(desktop): align sidebar colors with reference app

### DIFF
--- a/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -32,7 +32,7 @@ interface SettingsSidebarProps {
 }
 
 const SETTINGS_SIDEBAR_ROOT_CLASS =
-  "flex h-full w-[300px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar";
+  "flex h-full w-[300px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar-background";
 const SETTINGS_NAV_CLASS = "flex-1 overflow-y-auto px-2.5 pb-4";
 const SETTINGS_GROUPS_CLASS = "flex flex-col";
 const SETTINGS_GROUP_CLASS = "flex flex-col gap-0.5";

--- a/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -32,7 +32,7 @@ interface SettingsSidebarProps {
 }
 
 const SETTINGS_SIDEBAR_ROOT_CLASS =
-  "flex h-full w-[300px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar-background";
+  "flex h-full w-[300px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar";
 const SETTINGS_NAV_CLASS = "flex-1 overflow-y-auto px-2.5 pb-4";
 const SETTINGS_GROUPS_CLASS = "flex flex-col";
 const SETTINGS_GROUP_CLASS = "flex flex-col gap-0.5";

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -122,7 +122,7 @@ export function CoworkWorkspaceShell({
       >
         <div
           id="cowork-sidebar"
-          className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
+          className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
           style={{ width: sidebarOpen ? sidebarWidth : 0 }}
         >
           <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -122,7 +122,7 @@ export function CoworkWorkspaceShell({
       >
         <div
           id="cowork-sidebar"
-          className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
+          className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
           style={{ width: sidebarOpen ? sidebarWidth : 0 }}
         >
           <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -194,7 +194,7 @@ export function CoworkWorkspaceShell({
             />
           </div>
 
-          <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
+          <div className="flex min-h-0 flex-1 overflow-hidden bg-sidebar-background">
             <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
               <div
                 aria-hidden="true"

--- a/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -110,7 +110,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
           )}
         </div>
 
-        <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
+        <div className="flex min-h-0 flex-1 overflow-hidden bg-sidebar-background">
           {children}
         </div>
       </div>

--- a/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -48,7 +48,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
     >
       <div
         id="main-sidebar"
-        className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
+        className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
         style={{ width: sidebarOpen ? sidebarWidth : 0 }}
       >
         <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">

--- a/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -48,7 +48,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
     >
       <div
         id="main-sidebar"
-        className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
+        className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
         style={{ width: sidebarOpen ? sidebarWidth : 0 }}
       >
         <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">

--- a/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -201,7 +201,7 @@ export function StandardWorkspaceShell() {
             >
               <div
                 id="main-sidebar"
-                className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
+                className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
                 style={{ width: sidebarOpen ? sidebarWidth : 0 }}
               >
                 <DebugProfiler id="workspace-sidebar-frame">

--- a/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -201,7 +201,7 @@ export function StandardWorkspaceShell() {
             >
               <div
                 id="main-sidebar"
-                className="flex shrink-0 flex-col overflow-hidden bg-sidebar-background transition-[width] duration-150 ease-in-out"
+                className="flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-150 ease-in-out"
                 style={{ width: sidebarOpen ? sidebarWidth : 0 }}
               >
                 <DebugProfiler id="workspace-sidebar-frame">

--- a/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -242,7 +242,7 @@ export function StandardWorkspaceShell() {
               )}
 
               <div
-                className="flex min-w-0 flex-1 overflow-hidden bg-background"
+                className="flex min-w-0 flex-1 overflow-hidden bg-sidebar"
               >
                 <div
                   className={`flex min-w-0 flex-1 flex-col overflow-hidden ${chromeClasses.contentShell}`}
@@ -288,7 +288,7 @@ export function StandardWorkspaceShell() {
                     </DebugProfiler>
                   </div>
 
-                  <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
+                  <div className="flex min-h-0 flex-1 overflow-hidden bg-sidebar-background">
                     {hasLaunchIntentOnlyShell ? (
                       <DebugProfiler id="workspace-content-frame">
                         <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -200,7 +200,7 @@
   --color-prose-border: hsl(25 7% 26%);
 
   /* -- Sidebar -- */
-  --color-sidebar: #141414;
+  --color-sidebar: #1f1f1f;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -532,7 +532,7 @@
   --color-prose-border: rgba(255, 255, 255, 0.15);
 
   /* -- Sidebar -- */
-  --color-sidebar: #141414;
+  --color-sidebar: #1f1f1f;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -660,7 +660,7 @@
   --color-composer-background: #212121;
   --color-prose-border: color-mix(in oklab, #ffffff 8%, transparent);
 
-  --color-sidebar: #141414;
+  --color-sidebar: #1f1f1f;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -1180,8 +1180,8 @@
 
   --color-prose-border: rgba(13, 13, 13, 0.117);
 
-  --color-sidebar: #f5f5f5;
-  --color-sidebar-background: #f5f5f5;
+  --color-sidebar: #f9f9f9;
+  --color-sidebar-background: #f9f9f9;
   --color-sidebar-foreground: rgba(13, 13, 13, 0.74);
   --color-sidebar-primary: #0d0d0d;
   --color-sidebar-primary-foreground: #0d0d0d;

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -201,7 +201,7 @@
 
   /* -- Sidebar -- */
   --color-sidebar: #141414;
-  --color-sidebar-background: #141414;
+  --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
   --color-sidebar-primary-foreground: #ffffff;
@@ -533,7 +533,7 @@
 
   /* -- Sidebar -- */
   --color-sidebar: #141414;
-  --color-sidebar-background: #141414;
+  --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
   --color-sidebar-primary-foreground: #ffffff;
@@ -661,7 +661,7 @@
   --color-prose-border: color-mix(in oklab, #ffffff 8%, transparent);
 
   --color-sidebar: #141414;
-  --color-sidebar-background: #141414;
+  --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
   --color-sidebar-primary-foreground: #ffffff;

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -200,16 +200,16 @@
   --color-prose-border: hsl(25 7% 26%);
 
   /* -- Sidebar -- */
-  --color-sidebar: hsl(24 9% 12%);
-  --color-sidebar-background: hsl(24 9% 12%);
-  --color-sidebar-foreground: hsl(0 0% 100% / 0.9);
-  --color-sidebar-primary: hsl(30 8% 91%);
-  --color-sidebar-primary-foreground: hsl(30 0% 100%);
-  --color-sidebar-muted-foreground: hsl(0 0% 100% / 0.6);
-  --color-sidebar-accent: hsl(0 0% 100% / 0.05);
-  --color-sidebar-accent-foreground: hsl(0 0% 100% / 0.9);
-  --color-sidebar-border: hsl(0 0% 100% / 0.1);
-  --color-sidebar-ring: hsl(20 6% 72%);
+  --color-sidebar: #141414;
+  --color-sidebar-background: #141414;
+  --color-sidebar-foreground: #ffffff;
+  --color-sidebar-primary: #ffffff;
+  --color-sidebar-primary-foreground: #ffffff;
+  --color-sidebar-muted-foreground: rgba(255, 255, 255, 0.481);
+  --color-sidebar-accent: rgba(255, 255, 255, 0.074);
+  --color-sidebar-accent-foreground: #ffffff;
+  --color-sidebar-border: rgba(255, 255, 255, 0.079);
+  --color-sidebar-ring: rgba(127, 193, 255, 0.747);
   --color-sidebar-blue: hsl(213 94% 68%);
 
   /* -- Status -- */
@@ -534,14 +534,14 @@
   /* -- Sidebar -- */
   --color-sidebar: #141414;
   --color-sidebar-background: #141414;
-  --color-sidebar-foreground: rgba(255, 255, 255, 0.82);
+  --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
   --color-sidebar-primary-foreground: #ffffff;
-  --color-sidebar-muted-foreground: rgba(255, 255, 255, 0.42);
-  --color-sidebar-accent: rgba(255, 255, 255, 0.038);
-  --color-sidebar-accent-foreground: rgba(255, 255, 255, 0.9);
-  --color-sidebar-border: rgba(255, 255, 255, 0.066);
-  --color-sidebar-ring: rgba(131, 195, 255, 0.76);
+  --color-sidebar-muted-foreground: rgba(255, 255, 255, 0.481);
+  --color-sidebar-accent: rgba(255, 255, 255, 0.074);
+  --color-sidebar-accent-foreground: #ffffff;
+  --color-sidebar-border: rgba(255, 255, 255, 0.079);
+  --color-sidebar-ring: rgba(127, 193, 255, 0.747);
   --color-sidebar-blue: #339cff;
 
   /* -- Status -- */
@@ -662,14 +662,14 @@
 
   --color-sidebar: #141414;
   --color-sidebar-background: #141414;
-  --color-sidebar-foreground: color-mix(in oklab, #ffffff 82%, transparent);
+  --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
   --color-sidebar-primary-foreground: #ffffff;
-  --color-sidebar-muted-foreground: color-mix(in oklab, #ffffff 50%, transparent);
-  --color-sidebar-accent: color-mix(in oklab, #ffffff 5%, transparent);
+  --color-sidebar-muted-foreground: rgba(255, 255, 255, 0.481);
+  --color-sidebar-accent: rgba(255, 255, 255, 0.074);
   --color-sidebar-accent-foreground: #ffffff;
-  --color-sidebar-border: color-mix(in oklab, #ffffff 8%, transparent);
-  --color-sidebar-ring: color-mix(in oklab, #339cff 70%, transparent);
+  --color-sidebar-border: rgba(255, 255, 255, 0.079);
+  --color-sidebar-ring: rgba(127, 193, 255, 0.747);
   --color-sidebar-blue: #339cff;
 
   --color-git-green: #40c977;

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -200,7 +200,7 @@
   --color-prose-border: hsl(25 7% 26%);
 
   /* -- Sidebar -- */
-  --color-sidebar: #1f1f1f;
+  --color-sidebar: #1d1d1d;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -532,7 +532,7 @@
   --color-prose-border: rgba(255, 255, 255, 0.15);
 
   /* -- Sidebar -- */
-  --color-sidebar: #1f1f1f;
+  --color-sidebar: #1d1d1d;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -660,7 +660,7 @@
   --color-composer-background: #212121;
   --color-prose-border: color-mix(in oklab, #ffffff 8%, transparent);
 
-  --color-sidebar: #1f1f1f;
+  --color-sidebar: #1d1d1d;
   --color-sidebar-background: #181818;
   --color-sidebar-foreground: #ffffff;
   --color-sidebar-primary: #ffffff;
@@ -1181,7 +1181,7 @@
   --color-prose-border: rgba(13, 13, 13, 0.117);
 
   --color-sidebar: #f9f9f9;
-  --color-sidebar-background: #f9f9f9;
+  --color-sidebar-background: #ffffff;
   --color-sidebar-foreground: rgba(13, 13, 13, 0.74);
   --color-sidebar-primary: #0d0d0d;
   --color-sidebar-primary-foreground: #0d0d0d;
@@ -1346,7 +1346,7 @@
   --color-prose-border: var(--color-border-heavy);
 
   --color-sidebar: var(--color-surface-under);
-  --color-sidebar-background: var(--color-surface-under);
+  --color-sidebar-background: var(--color-background);
   --color-sidebar-foreground: color-mix(in oklab, var(--color-foreground) 85%, transparent);
   --color-sidebar-primary: var(--color-foreground);
   --color-sidebar-primary-foreground: #ffffff;

--- a/packages/design/src/tokens.ts
+++ b/packages/design/src/tokens.ts
@@ -41,11 +41,11 @@ export const colors = {
   infoForeground: "#ffffff",
   sidebar: "#141414",
   sidebarBackground: "#141414",
-  sidebarForeground: "rgba(255,255,255,0.82)",
-  sidebarMutedForeground: "rgba(255,255,255,0.42)",
-  sidebarAccent: "rgba(255,255,255,0.05)",
+  sidebarForeground: "#ffffff",
+  sidebarMutedForeground: "rgba(255,255,255,0.481)",
+  sidebarAccent: "rgba(255,255,255,0.074)",
   sidebarAccentForeground: "#ffffff",
-  sidebarBorder: "rgba(255,255,255,0.084)",
+  sidebarBorder: "rgba(255,255,255,0.079)",
   sidebarBlue: "#339cff",
 } as const;
 

--- a/packages/design/src/tokens.ts
+++ b/packages/design/src/tokens.ts
@@ -39,7 +39,7 @@ export const colors = {
   info: "#339cff",
   infoSubtle: "rgba(51,156,255,0.14)",
   infoForeground: "#ffffff",
-  sidebar: "#1f1f1f",
+  sidebar: "#1d1d1d",
   sidebarBackground: "#181818",
   sidebarForeground: "#ffffff",
   sidebarMutedForeground: "rgba(255,255,255,0.481)",

--- a/packages/design/src/tokens.ts
+++ b/packages/design/src/tokens.ts
@@ -39,7 +39,7 @@ export const colors = {
   info: "#339cff",
   infoSubtle: "rgba(51,156,255,0.14)",
   infoForeground: "#ffffff",
-  sidebar: "#141414",
+  sidebar: "#1f1f1f",
   sidebarBackground: "#181818",
   sidebarForeground: "#ffffff",
   sidebarMutedForeground: "rgba(255,255,255,0.481)",

--- a/packages/design/src/tokens.ts
+++ b/packages/design/src/tokens.ts
@@ -40,7 +40,7 @@ export const colors = {
   infoSubtle: "rgba(51,156,255,0.14)",
   infoForeground: "#ffffff",
   sidebar: "#141414",
-  sidebarBackground: "#141414",
+  sidebarBackground: "#181818",
   sidebarForeground: "#ffffff",
   sidebarMutedForeground: "rgba(255,255,255,0.481)",
   sidebarAccent: "rgba(255,255,255,0.074)",

--- a/packages/product-ui/src/sidebar/ProductSidebar.tsx
+++ b/packages/product-ui/src/sidebar/ProductSidebar.tsx
@@ -224,7 +224,7 @@ export function ProductSidebarFrame({
   className?: string;
 }) {
   return (
-    <div className={`flex h-full flex-col gap-2 bg-sidebar pb-2 text-sidebar-foreground select-none ${className}`}>
+    <div className={`flex h-full flex-col gap-2 bg-sidebar-background pb-2 text-sidebar-foreground select-none ${className}`}>
       {children}
       {footer}
     </div>

--- a/packages/product-ui/src/sidebar/ProductSidebar.tsx
+++ b/packages/product-ui/src/sidebar/ProductSidebar.tsx
@@ -224,7 +224,7 @@ export function ProductSidebarFrame({
   className?: string;
 }) {
   return (
-    <div className={`flex h-full flex-col gap-2 bg-sidebar-background pb-2 text-sidebar-foreground select-none ${className}`}>
+    <div className={`flex h-full flex-col gap-2 bg-sidebar pb-2 text-sidebar-foreground select-none ${className}`}>
       {children}
       {footer}
     </div>

--- a/packages/product-ui/test/ProductSidebar.test.tsx
+++ b/packages/product-ui/test/ProductSidebar.test.tsx
@@ -65,8 +65,8 @@ describe("ProductSidebar", () => {
       />,
     );
 
-    expect(container.innerHTML).toContain("bg-sidebar-background");
-    expect(container.innerHTML).not.toContain("bg-sidebar pb-2");
+    expect(container.innerHTML).toContain("bg-sidebar");
+    expect(container.innerHTML).not.toContain("bg-sidebar-background");
     expect(screen.getByText("Proliferate")).toBeTruthy();
     expect(screen.getByText("Home")).toBeTruthy();
     expect(screen.getAllByText("Shared cloud").length).toBeGreaterThan(0);

--- a/packages/product-ui/test/ProductSidebar.test.tsx
+++ b/packages/product-ui/test/ProductSidebar.test.tsx
@@ -14,7 +14,7 @@ describe("ProductSidebar", () => {
     const onGroupToggle = vi.fn();
     const onAction = vi.fn();
 
-    render(
+    const { container } = render(
       <ProductSidebar
         brand={<span>P</span>}
         title="Proliferate"
@@ -65,6 +65,8 @@ describe("ProductSidebar", () => {
       />,
     );
 
+    expect(container.innerHTML).toContain("bg-sidebar");
+    expect(container.innerHTML).not.toContain("bg-sidebar-background");
     expect(screen.getByText("Proliferate")).toBeTruthy();
     expect(screen.getByText("Home")).toBeTruthy();
     expect(screen.getAllByText("Shared cloud").length).toBeGreaterThan(0);

--- a/packages/product-ui/test/ProductSidebar.test.tsx
+++ b/packages/product-ui/test/ProductSidebar.test.tsx
@@ -65,8 +65,8 @@ describe("ProductSidebar", () => {
       />,
     );
 
-    expect(container.innerHTML).toContain("bg-sidebar");
-    expect(container.innerHTML).not.toContain("bg-sidebar-background");
+    expect(container.innerHTML).toContain("bg-sidebar-background");
+    expect(container.innerHTML).not.toContain("bg-sidebar pb-2");
     expect(screen.getByText("Proliferate")).toBeTruthy();
     expect(screen.getByText("Home")).toBeTruthy();
     expect(screen.getAllByText("Shared cloud").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- match the sidebar/main surfaces to the measured reference in dark and light mode
- make the dark primary sidebar slightly darker than the previous measured pass
- keep the chat main surface aligned with the right side panel and settings main page
- fix the Standard workspace rounded-corner layer so the exposed corner shows the left sidebar color instead of the page surface

## Current Colors
- Dark left sidebar / corner parent: #1d1d1d / rgb(29, 29, 29)
- Dark main chat / right panel / settings main: #181818 / rgb(24, 24, 24)
- Light left sidebar / corner parent: #f9f9f9 / rgb(249, 249, 249)
- Light main chat / right panel / settings main: #ffffff / rgb(255, 255, 255)

## Root Cause
The prior shell wrapper painted the parent behind the rounded Standard workspace content with the page surface. At the rounded top-left edge, that let the page color show through next to the main sidebar. The wrapper now uses the sidebar surface, and the chat content area uses the pane/main surface token shared with the right panel.

## Validation
- pnpm --filter @proliferate/product-ui test
- pnpm --filter @proliferate/product-ui build
- pnpm --filter @proliferate/design build
- pnpm --filter proliferate exec vitest run src/lib/domain/preferences/workspace-chrome.test.ts src/components/playground/PlaygroundSidebarGitDiff.test.tsx
- pnpm --filter proliferate build
- screenshot preview computed dark sidebar/corner rgb(29, 29, 29), dark main/right rgb(24, 24, 24), light sidebar/corner rgb(249, 249, 249), light main/right rgb(255, 255, 255)
