### PR TITLE
[proliferate] Preserve projected launch sessions

### DIFF
--- a/desktop/src/hooks/chat/use-cloud-workspace-polling.test.tsx
+++ b/desktop/src/hooks/chat/use-cloud-workspace-polling.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import { useCloudWorkspacePolling } from "./use-cloud-workspace-polling";
+
+const mocks = vi.hoisted(() => ({
+  refreshCloudWorkspace: vi.fn(),
+  selectWorkspace: vi.fn(),
+  materializePendingWorkspaceSessions: vi.fn(),
+  workspaceCollections: {
+    cloudWorkspaces: [] as CloudWorkspaceSummary[],
+  },
+}));
+
+vi.mock("@/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    data: mocks.workspaceCollections,
+  }),
+}));
+
+vi.mock("@/hooks/cloud/workflows/use-cloud-workspace-actions", () => ({
+  useCloudWorkspaceActions: () => ({
+    refreshCloudWorkspace: mocks.refreshCloudWorkspace,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({
+    selectWorkspace: mocks.selectWorkspace,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-pending-workspace-session-materialization", () => ({
+  usePendingWorkspaceSessionMaterialization: () => mocks.materializePendingWorkspaceSessions,
+}));
+
+vi.mock("@/lib/infra/measurement/debug-latency", () => ({
+  elapsedMs: () => 0,
+  elapsedSince: () => 0,
+  logLatency: vi.fn(),
+  startLatencyTimer: () => 0,
+}));
+
+describe("useCloudWorkspacePolling", () => {
+  beforeEach(() => {
+    mocks.refreshCloudWorkspace.mockReset();
+    mocks.selectWorkspace.mockReset();
+    mocks.materializePendingWorkspaceSessions.mockReset();
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "pending" })];
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: null,
+      workspaceSelectionNonce: 0,
+      workspaceArrivalEvent: null,
+      activeSessionId: null,
+      activeSessionVersion: 0,
+      sessionActivationIntentEpochByWorkspace: {},
+      hotPaintGate: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("preserves the active projected session when a pending cloud workspace becomes ready", async () => {
+    const workspaceId = "cloud:cloud-1";
+    const projectedSessionId = "client-session:claude:1";
+    const pendingEntry = {
+      ...buildSubmittingPendingWorkspaceEntry({
+        attemptId: "attempt-1",
+        selectedWorkspaceId: null,
+        source: "cloud-created",
+        displayName: "feature-branch",
+        repoLabel: "proliferate-ai/proliferate",
+        baseBranchName: "main",
+        request: {
+          kind: "select-existing" as const,
+          workspaceId,
+        },
+      }),
+      stage: "awaiting-cloud-ready" as const,
+      workspaceId,
+    };
+    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(pendingEntry);
+    putSessionRecord(createEmptySessionRecord(projectedSessionId, "claude", {
+      workspaceId: pendingWorkspaceUiKey,
+      materializedSessionId: null,
+      modelId: "claude-sonnet-4.5",
+      modeId: "default",
+      sessionRelationship: { kind: "root" },
+    }));
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: pendingEntry,
+      selectedWorkspaceId: workspaceId,
+      activeSessionId: projectedSessionId,
+    });
+    mocks.refreshCloudWorkspace.mockResolvedValueOnce(cloudWorkspace({ status: "ready" }));
+    mocks.selectWorkspace.mockResolvedValueOnce(undefined);
+    mocks.materializePendingWorkspaceSessions.mockReturnValueOnce({
+      pendingWorkspaceUiKey,
+      projectedSessionCount: 1,
+      projectedSessionIds: [projectedSessionId],
+    });
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(mocks.selectWorkspace).toHaveBeenCalledWith(workspaceId, {
+        force: true,
+        preservePending: true,
+        initialActiveSessionId: projectedSessionId,
+      });
+    });
+    expect(mocks.materializePendingWorkspaceSessions).toHaveBeenCalledWith(
+      pendingEntry,
+      workspaceId,
+      { eventPrefix: "workspace.cloud_polling" },
+    );
+  });
+});
+
+function cloudWorkspace(input: {
+  status: CloudWorkspaceSummary["status"];
+}): CloudWorkspaceSummary {
+  return {
+    id: "cloud-1",
+    displayName: "feature-branch",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "feature-branch",
+      baseBranch: "main",
+    },
+    status: input.status,
+    workspaceStatus: input.status,
+    runtime: undefined,
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    updatedAt: null,
+    createdAt: null,
+    actionBlockKind: null,
+    actionBlockReason: null,
+    postReadyPhase: "",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+  };
+}

--- a/desktop/src/hooks/chat/use-cloud-workspace-polling.ts
+++ b/desktop/src/hooks/chat/use-cloud-workspace-polling.ts
@@ -8,6 +8,9 @@ import {
   usePendingWorkspaceSessionMaterialization,
 } from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
 import {
+  resolveActiveProjectedSessionForPendingWorkspace,
+} from "@/hooks/workspaces/workflows/pending-workspace-projected-session";
+import {
   isCloudWorkspacePostReadyPending,
   shouldPollCloudWorkspaceForUpdates,
   shouldShowCloudWorkspaceStatusScreen,
@@ -83,16 +86,21 @@ export function useCloudWorkspacePolling() {
           const pending = useSessionSelectionStore.getState().pendingWorkspaceEntry;
           const shouldPreservePending = pending?.workspaceId === selectedWorkspaceId
             && pending.stage === "awaiting-cloud-ready";
+          const initialActiveSessionId = shouldPreservePending
+            ? resolveActiveProjectedSessionForPendingWorkspace(selectedWorkspaceId, pending)
+            : null;
           logLatency("workspace.cloud_polling.ready_selection.start", {
             workspaceId: selectedWorkspaceId,
             pendingAttemptId: pending?.attemptId ?? null,
             shouldPreservePending,
+            initialActiveSessionId,
           });
 
           try {
             await selectWorkspace(selectedWorkspaceId, {
               force: true,
               preservePending: shouldPreservePending,
+              ...(initialActiveSessionId ? { initialActiveSessionId } : {}),
             });
           } catch (error) {
             if (

--- a/desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts
+++ b/desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts
@@ -19,6 +19,9 @@ import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspac
 import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useCloudCredentialActions } from "@/hooks/cloud/workflows/use-cloud-credential-actions";
+import {
+  resolveActiveProjectedSessionForPendingWorkspace,
+} from "@/hooks/workspaces/workflows/pending-workspace-projected-session";
 import { clearViewedSessionErrors } from "@/stores/preferences/workspace-ui-store";
 import {
   captureTelemetryException,
@@ -99,10 +102,14 @@ export function useCloudWorkspaceActions() {
       const pendingWorkspaceEntry = useSessionSelectionStore.getState().pendingWorkspaceEntry;
       const shouldPreservePending = pendingWorkspaceEntry?.workspaceId === syntheticWorkspaceId
         && pendingWorkspaceEntry.stage === "awaiting-cloud-ready";
+      const initialActiveSessionId = shouldPreservePending
+        ? resolveActiveProjectedSessionForPendingWorkspace(syntheticWorkspaceId, pendingWorkspaceEntry)
+        : null;
       if (selectedWorkspaceId === syntheticWorkspaceId) {
         await selectWorkspace(syntheticWorkspaceId, {
           force: true,
           preservePending: shouldPreservePending,
+          ...(initialActiveSessionId ? { initialActiveSessionId } : {}),
         });
       }
       trackProductEvent("cloud_workspace_started", {

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
-import { getSessionRecord } from "@/stores/sessions/session-records";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
 import { chatWorkspaceShellTabKey } from "@/lib/domain/workspaces/tabs/shell-tabs";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
 import {
   listActiveLatencyFlows,
   resetLatencyFlowsForTest,
@@ -334,6 +342,81 @@ describe("runWorkspaceSelection", () => {
 
     expect(useSessionSelectionStore.getState().selectedWorkspaceId).toBe("workspace-1");
     expect(useSessionSelectionStore.getState().activeSessionId).toBe("session-explicit");
+  });
+
+  it("does not materialize a pending projected client session during workspace selection", async () => {
+    vi.mocked(resolveCloudWorkspaceReadiness).mockResolvedValueOnce({ kind: "local" });
+    vi.mocked(resolveSelectionConnection).mockResolvedValueOnce({
+      runtimeUrl: "http://runtime.test",
+      workspaceConnection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "ah-workspace-1",
+      },
+    });
+    const pendingEntry = {
+      ...buildSubmittingPendingWorkspaceEntry({
+        attemptId: "attempt-1",
+        selectedWorkspaceId: null,
+        source: "worktree-created",
+        displayName: "workspace-1",
+        request: {
+          kind: "worktree",
+          input: {
+            repoRootId: "repo-1",
+            workspaceName: "workspace-1",
+            branchName: "pablo/workspace-1",
+            baseBranch: "main",
+            targetPath: "/tmp/workspace-1",
+          },
+        },
+      }),
+      workspaceId: "workspace-1",
+    };
+    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(pendingEntry);
+    const projectedSessionId = "client-session:codex:1";
+    useSessionSelectionStore.setState({ pendingWorkspaceEntry: pendingEntry });
+    putSessionRecord(createEmptySessionRecord(projectedSessionId, "codex", {
+      workspaceId: pendingWorkspaceUiKey,
+      materializedSessionId: null,
+      modelId: "gpt-5.5",
+      modeId: "xhigh",
+      sessionRelationship: { kind: "root" },
+    }));
+
+    const bootstrapWorkspace = vi.fn().mockImplementation(async () => {
+      expect(getSessionRecord(projectedSessionId)).toMatchObject({
+        workspaceId: pendingWorkspaceUiKey,
+        materializedSessionId: null,
+      });
+      return { sessions: [] };
+    });
+
+    await runWorkspaceSelection({
+      cache: selectionCache(),
+      logicalWorkspaces,
+      rawWorkspaces: [],
+      setSelectedLogicalWorkspaceId: (id) =>
+        useSessionSelectionStore.getState().setSelectedLogicalWorkspaceId(id),
+      setSelectedWorkspace,
+      removeWorkspaceSlots: vi.fn(),
+      clearSelection: vi.fn(),
+      bootstrapWorkspace,
+      reconcileHotWorkspace: vi.fn(),
+    }, {
+      workspaceId: "workspace-1",
+      options: {
+        force: true,
+        preservePending: true,
+        initialActiveSessionId: projectedSessionId,
+      },
+    });
+
+    expect(bootstrapWorkspace).toHaveBeenCalledTimes(1);
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(projectedSessionId);
+    expect(getSessionRecord(projectedSessionId)).toMatchObject({
+      workspaceId: pendingWorkspaceUiKey,
+      materializedSessionId: null,
+    });
   });
 });
 

--- a/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
+++ b/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts
@@ -19,6 +19,7 @@ import {
   trackWorkspaceInteraction,
   useWorkspaceUiStore,
 } from "@/stores/preferences/workspace-ui-store";
+import { isPendingWorkspaceUiKey } from "@/lib/domain/workspaces/creation/pending-entry";
 import { getLatestWorkspaceInteractionTimestamp } from "@/lib/domain/workspaces/selection/selection";
 import {
   logLatency,
@@ -68,9 +69,27 @@ function resolveInitialActiveSessionId(
   }
 
   const cachedSlot = getSessionRecord(candidate);
-  return cachedSlot?.workspaceId && cachedSlot.workspaceId !== workspaceId
-    ? null
-    : candidate;
+  if (!cachedSlot?.workspaceId || cachedSlot.workspaceId === workspaceId) {
+    return candidate;
+  }
+
+  const shouldPreservePendingProjection =
+    options?.preservePending === true
+    && isTransientClientSessionId(candidate)
+    && !cachedSlot.materializedSessionId
+    && isPendingWorkspaceUiKey(cachedSlot.workspaceId);
+  if (shouldPreservePendingProjection) {
+    logLatency("workspace.select.projected_initial_session_preserved", {
+      workspaceId,
+      workspaceUiKey,
+      sessionId: candidate,
+      existingWorkspaceId: cachedSlot.workspaceId,
+      reason: "preserve_pending_projection",
+    });
+    return candidate;
+  }
+
+  return null;
 }
 
 function prepareOptimisticWorkspaceSessionShell(input: {
@@ -94,6 +113,17 @@ function prepareOptimisticWorkspaceSessionShell(input: {
         workspaceId: input.workspaceId,
       },
     ));
+  } else if (!existing.materializedSessionId && isTransientClientSessionId(input.sessionId)) {
+    if (!existing.workspaceId) {
+      patchSessionRecord(input.sessionId, { workspaceId: input.workspaceId });
+    }
+    logLatency("workspace.select.projected_session_preserved", {
+      workspaceId: input.workspaceId,
+      workspaceUiKey: input.workspaceUiKey,
+      sessionId: input.sessionId,
+      existingWorkspaceId: existing.workspaceId ?? null,
+      reason: "transient_unmaterialized_session",
+    });
   } else if (!existing.workspaceId || !existing.materializedSessionId) {
     patchSessionRecord(input.sessionId, {
       materializedSessionId: existing.materializedSessionId ?? input.sessionId,
@@ -113,6 +143,11 @@ function prepareOptimisticWorkspaceSessionShell(input: {
     sessionId: input.sessionId,
     createdRecord: !existing,
   });
+}
+
+function isTransientClientSessionId(sessionId: string): boolean {
+  return sessionId.startsWith("client-session:")
+    || sessionId.startsWith("pending-session:");
 }
 
 async function invalidateCloudWorkspaceStartState(

--- a/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
+++ b/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
@@ -59,7 +59,9 @@ import {
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
 import { markWorkspaceBootstrappedInSession } from "@/hooks/workspaces/lifecycle/workspace-bootstrap-memory";
-import { buildPendingWorkspaceUiKey } from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  resolveActiveProjectedSessionForPendingWorkspace,
+} from "@/hooks/workspaces/workflows/pending-workspace-projected-session";
 import { writeChatShellIntentForEmptySurface } from "@/hooks/workspaces/tabs/workspace-shell-intent-writer";
 import {
   isOptimisticWorkspaceSessionPlaceholder,
@@ -90,24 +92,6 @@ interface ReconcileHotWorkspaceInput {
 const EMPTY_WORKSPACES = [] as const;
 const WORKSPACE_BOOTSTRAP_SESSION_LIST_TIMEOUT_MS = 8_000;
 const WORKSPACE_RECONCILE_SESSION_LIST_TIMEOUT_MS = 3_000;
-
-function activeProjectedSessionForPendingWorkspace(workspaceId: string): string | null {
-  const selection = useSessionSelectionStore.getState();
-  const activeSessionId = selection.activeSessionId;
-  const pendingEntry = selection.pendingWorkspaceEntry;
-  if (!activeSessionId || pendingEntry?.workspaceId !== workspaceId) {
-    return null;
-  }
-
-  const activeSession = getSessionRecord(activeSessionId);
-  if (!activeSession || activeSession.materializedSessionId) {
-    return null;
-  }
-
-  return activeSession.workspaceId === buildPendingWorkspaceUiKey(pendingEntry)
-    ? activeSessionId
-    : null;
-}
 
 function findLoadedSessionForClientSession(
   clientSessionId: string,
@@ -454,7 +438,10 @@ export function useWorkspaceBootstrapActions() {
         return { sessions };
       }
 
-      const activeProjectedSessionId = activeProjectedSessionForPendingWorkspace(workspaceId);
+      const activeProjectedSessionId = resolveActiveProjectedSessionForPendingWorkspace(
+        workspaceId,
+        useSessionSelectionStore.getState().pendingWorkspaceEntry,
+      );
       if (activeProjectedSessionId) {
         logLatency("workspace.select.initial_session_open.skipped", {
           workspaceId,

--- a/desktop/src/hooks/workspaces/workflows/pending-workspace-projected-session.ts
+++ b/desktop/src/hooks/workspaces/workflows/pending-workspace-projected-session.ts
@@ -1,0 +1,25 @@
+import {
+  buildPendingWorkspaceUiKey,
+  type PendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import { getSessionRecord } from "@/stores/sessions/session-records";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+export function resolveActiveProjectedSessionForPendingWorkspace(
+  workspaceId: string,
+  pendingEntry: PendingWorkspaceEntry | null | undefined,
+): string | null {
+  const activeSessionId = useSessionSelectionStore.getState().activeSessionId;
+  if (!activeSessionId || pendingEntry?.workspaceId !== workspaceId) {
+    return null;
+  }
+
+  const activeSession = getSessionRecord(activeSessionId);
+  if (!activeSession || activeSession.materializedSessionId) {
+    return null;
+  }
+
+  return activeSession.workspaceId === buildPendingWorkspaceUiKey(pendingEntry)
+    ? activeSessionId
+    : null;
+}

--- a/desktop/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
@@ -12,6 +12,9 @@ import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import {
   usePendingWorkspaceSessionMaterialization,
 } from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
+import {
+  resolveActiveProjectedSessionForPendingWorkspace,
+} from "@/hooks/workspaces/workflows/pending-workspace-projected-session";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
 import {
@@ -78,9 +81,15 @@ export function usePendingWorkspaceEntryActions() {
             errorMessage: null,
           });
           try {
+            const pending = useSessionSelectionStore.getState().pendingWorkspaceEntry;
+            const initialActiveSessionId = resolveActiveProjectedSessionForPendingWorkspace(
+              entry.request.workspaceId,
+              pending,
+            );
             await selectWorkspace(entry.request.workspaceId, {
               force: true,
               preservePending: true,
+              ...(initialActiveSessionId ? { initialActiveSessionId } : {}),
               latencyFlowId,
             });
 

--- a/desktop/src/lib/domain/preferences/workspace-chrome.test.ts
+++ b/desktop/src/lib/domain/preferences/workspace-chrome.test.ts
@@ -36,11 +36,11 @@ describe("workspace chrome classes", () => {
     }).contentShell).toBe("bg-background");
   });
 
-  it("preserves cowork-specific content rounding", () => {
+  it("matches cowork content chrome to the standard shell", () => {
     expect(resolveCoworkWorkspaceChromeClasses({
       transparent: true,
       sidebarOpen: true,
-    }).contentShell).toBe("bg-transparent rounded-tl-lg");
+    }).contentShell).toBe("bg-transparent");
     expect(resolveCoworkWorkspaceChromeClasses({
       transparent: false,
       sidebarOpen: false,
@@ -52,7 +52,7 @@ describe("workspace chrome classes", () => {
     expect(resolveCoworkWorkspaceChromeClasses({
       transparent: false,
       sidebarOpen: true,
-    }).contentShell).toBe("bg-background rounded-tl-lg");
+    }).contentShell).toBe("bg-background rounded-tl-[22px] border-l border-t border-sidebar-border");
   });
 
   it("preserves editor tab classes", () => {

--- a/desktop/src/lib/domain/preferences/workspace-chrome.ts
+++ b/desktop/src/lib/domain/preferences/workspace-chrome.ts
@@ -65,7 +65,7 @@ export function resolveCoworkWorkspaceChromeClasses({
     root: transparent ? "bg-transparent" : "bg-sidebar",
     contentShell: [
       transparent ? "bg-transparent" : "bg-background",
-      sidebarOpen ? "rounded-tl-lg" : "",
+      sidebarOpen && !transparent ? "rounded-tl-[22px] border-l border-t border-sidebar-border" : "",
     ].filter(Boolean).join(" "),
     header: transparent ? WORKSPACE_GLASS_HEADER_CLASS : WORKSPACE_SOLID_HEADER_CLASS,
   };


### PR DESCRIPTION
## Summary
- Preserve unresolved projected `client-session:*` records during pending workspace selection so bootstrap does not mark them as materialized too early.
- Preserve the active projected session through cloud-ready polling/start/retry handoffs before materializing pending workspace sessions.
- Align cowork thread content chrome with the standard workspace shell border/radius treatment.

## Root Cause
Workspace selection rejected or mutated pending projected client sessions while `preservePending` was active. The cloud-ready handoff also preserved the pending entry without passing the active projected session into selection, so bootstrap could still create a second empty session before pending-session materialization ran.

## Validation
- `pnpm --dir desktop exec vitest run src/hooks/chat/use-cloud-workspace-polling.test.tsx src/hooks/workspaces/selection/run-workspace-selection.test.ts src/lib/domain/preferences/workspace-chrome.test.ts`
- `pnpm --dir desktop exec vitest run src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx src/hooks/workspaces/use-workspace-entry-flow.test.ts src/hooks/workspaces/use-workspace-entry-actions.test.tsx`
- `pnpm --dir desktop exec vitest run src/hooks/sessions/use-session-creation-actions.test.ts src/stores/sessions/session-intent-store.test.ts src/lib/domain/sessions/intents/session-intent.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`