### PR TITLE
fix(desktop): restore shortcut reveal surfaces

### DIFF
--- a/desktop/src/components/settings/panes/KeyboardShortcutsPane.test.tsx
+++ b/desktop/src/components/settings/panes/KeyboardShortcutsPane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { KeyboardShortcutsPane } from "@/components/settings/panes/KeyboardShortcutsPane";
 
@@ -10,7 +10,7 @@ describe("KeyboardShortcutsPane", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders shortcuts in a searchable Codex-style keybinding table", () => {
+  it("renders shortcuts in searchable sections with trailing keybindings", () => {
     vi.stubGlobal("navigator", {
       platform: "MacIntel",
       userAgent: "Mac OS X",
@@ -19,15 +19,20 @@ describe("KeyboardShortcutsPane", () => {
     render(<KeyboardShortcutsPane />);
 
     expect(screen.getByRole("heading", { name: "Keyboard shortcuts" })).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Command" })).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Keybinding" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "App" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Tabs" })).toBeTruthy();
     expect(screen.getByText("Open browser tab")).toBeTruthy();
-    expect(screen.getByText("⌘T")).toBeTruthy();
+    const browserRow = screen.getByText("Open browser tab").closest("li");
+    if (!(browserRow instanceof HTMLElement)) {
+      throw new Error("Expected browser shortcut row");
+    }
+    expect(within(browserRow).getByText("⌘T").closest("div")?.className).toContain("ml-auto");
 
     fireEvent.change(screen.getByLabelText("Search keyboard shortcuts"), {
       target: { value: "terminal" },
     });
 
+    expect(screen.getByRole("heading", { name: "Current Workspace" })).toBeTruthy();
     expect(screen.getByText("Open terminal")).toBeTruthy();
     expect(screen.getByText("⌘J")).toBeTruthy();
     expect(screen.queryByText("Open browser tab")).toBeNull();

--- a/desktop/src/components/settings/panes/KeyboardShortcutsPane.tsx
+++ b/desktop/src/components/settings/panes/KeyboardShortcutsPane.tsx
@@ -14,60 +14,58 @@ import { Search } from "@/components/ui/icons";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
 
-interface ShortcutTableEntry {
+interface ShortcutEntryView {
   id: string;
   command: string;
-  groupTitle: string;
   label: string;
+}
+
+interface ShortcutSectionView {
+  title: string;
+  entries: ShortcutEntryView[];
 }
 
 function ShortcutBadge({ label }: { label: string }) {
   return (
-    <kbd className="inline-flex min-h-8 shrink-0 items-center justify-center rounded-md border-0 bg-current/10 px-2 py-1 font-sans text-sm leading-none text-current shadow-none">
+    <kbd className="inline-flex min-h-7 shrink-0 items-center justify-center rounded-md border-0 bg-current/10 px-2 py-1 font-sans text-xs leading-none text-current shadow-none">
       {label}
     </kbd>
   );
 }
 
-function ShortcutRow({ command, groupTitle, label }: ShortcutTableEntry) {
+function ShortcutRow({ command, label }: ShortcutEntryView) {
   return (
-    <tr className="group border-t border-border-light align-middle first:border-t-0 hover:bg-foreground/5">
-      <td className="px-4 py-2">
-        <span className="block truncate text-sm text-foreground">{command}</span>
-        <span className="mt-0.5 block truncate text-xs text-muted-foreground">{groupTitle}</span>
-      </td>
-      <td className="px-4 py-2">
-        <div className="flex min-h-8 items-center text-muted-foreground">
-          <ShortcutBadge label={label} />
-        </div>
-      </td>
-    </tr>
+    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-2.5 hover:bg-foreground/5">
+      <span className="min-w-0 truncate text-sm text-foreground">{command}</span>
+      <div className="ml-auto flex min-h-7 items-center justify-end text-muted-foreground">
+        <ShortcutBadge label={label} />
+      </div>
+    </li>
   );
 }
 
-function ShortcutTable({ entries }: { entries: ShortcutTableEntry[] }) {
+function ShortcutSection({ section }: { section: ShortcutSectionView }) {
+  const sectionId = `keyboard-shortcuts-${section.title.toLowerCase().replace(/\s+/g, "-")}`;
+
   return (
-    <div className="overflow-hidden rounded-lg border border-border-light bg-surface-elevated shadow-subtle">
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[32rem] table-fixed border-collapse text-sm">
-          <colgroup>
-            <col />
-            <col className="w-56" />
-          </colgroup>
-          <thead className="text-left text-muted-foreground">
-            <tr className="border-b border-border-light bg-foreground/5">
-              <th className="px-4 py-2 text-xs font-medium">Command</th>
-              <th className="px-4 py-2 text-xs font-medium">Keybinding</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map((entry) => (
-              <ShortcutRow key={entry.id} {...entry} />
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <section
+      aria-labelledby={sectionId}
+      className="overflow-hidden rounded-lg border border-border-light bg-surface-elevated shadow-subtle"
+    >
+      <header className="border-b border-border-light bg-foreground/5 px-4 py-2.5">
+        <h3
+          id={sectionId}
+          className="text-sm font-medium text-foreground"
+        >
+          {section.title}
+        </h3>
+      </header>
+      <ul className="divide-y divide-border-light">
+        {section.entries.map((entry) => (
+          <ShortcutRow key={entry.id} {...entry} />
+        ))}
+      </ul>
+    </section>
   );
 }
 
@@ -149,26 +147,32 @@ export function KeyboardShortcutsPane() {
     };
   }).filter((group) => group.shortcutKeys.length > 0), [normalizedQuery]);
 
-  const tableEntries = useMemo<ShortcutTableEntry[]>(() => [
-    ...shortcutGroups.flatMap((group) => group.shortcutKeys.map((shortcutKey) => {
-      const shortcut = SHORTCUTS[shortcutKey];
-      return {
-        id: shortcut.id,
-        command: shortcut.description,
-        groupTitle: group.title,
-        label: getShortcutDisplayLabel(shortcut),
-      };
+  const sections = useMemo<ShortcutSectionView[]>(() => [
+    ...shortcutGroups.map((group) => ({
+      title: group.title,
+      entries: group.shortcutKeys.map((shortcutKey) => {
+        const shortcut = SHORTCUTS[shortcutKey];
+        return {
+          id: shortcut.id,
+          command: shortcut.description,
+          label: getShortcutDisplayLabel(shortcut),
+        };
+      }),
     })),
-    ...composerShortcutGroups.flatMap((group) => group.shortcutKeys.map((shortcutKey) => {
-      const shortcut = COMPOSER_SHORTCUTS[shortcutKey];
-      return {
-        id: `${group.title}:${shortcut.key}:${shortcutKey}`,
-        command: shortcut.description,
-        groupTitle: group.title,
-        label: getShortcutDisplayLabel(shortcut),
-      };
+    ...composerShortcutGroups.map((group) => ({
+      title: group.title,
+      entries: group.shortcutKeys.map((shortcutKey) => {
+        const shortcut = COMPOSER_SHORTCUTS[shortcutKey];
+        return {
+          id: `${group.title}:${shortcut.key}:${shortcutKey}`,
+          command: shortcut.description,
+          label: getShortcutDisplayLabel(shortcut),
+        };
+      }),
     })),
   ], [composerShortcutGroups, shortcutGroups]);
+
+  const hasShortcuts = sections.length > 0;
 
   return (
     <section className="space-y-5">
@@ -188,8 +192,12 @@ export function KeyboardShortcutsPane() {
           />
         </div>
 
-        {tableEntries.length > 0 ? (
-          <ShortcutTable entries={tableEntries} />
+        {hasShortcuts ? (
+          <div className="space-y-3">
+            {sections.map((section) => (
+              <ShortcutSection key={section.title} section={section} />
+            ))}
+          </div>
         ) : (
           <div className="rounded-lg border border-border-light bg-surface-elevated px-4 py-8 text-center text-sm text-muted-foreground shadow-subtle">
             No shortcuts found

--- a/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.test.tsx
+++ b/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.test.tsx
@@ -1,12 +1,21 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SHORTCUT_REVEAL_DELAY_MS,
   SHORTCUT_REVEAL_RESET_EVENT,
   useShortcutRevealState,
 } from "@/hooks/shortcuts/lifecycle/use-shortcut-reveal-state";
+import {
+  ShortcutRevealProvider,
+  useShortcutRevealVisible,
+} from "@/providers/ShortcutRevealProvider";
+
+function ShortcutRevealProbe() {
+  const visible = useShortcutRevealVisible();
+  return <output aria-label="shortcut reveal visible">{String(visible)}</output>;
+}
 
 describe("useShortcutRevealState", () => {
   beforeEach(() => {
@@ -139,5 +148,26 @@ describe("useShortcutRevealState", () => {
       document.dispatchEvent(new Event("visibilitychange"));
     });
     expect(result.current).toBe(false);
+  });
+
+  it("shares reveal visibility with consumers outside the provider subtree", () => {
+    render(
+      <>
+        <ShortcutRevealProvider>
+          <span>Lifecycle host</span>
+        </ShortcutRevealProvider>
+        <ShortcutRevealProbe />
+      </>,
+    );
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Meta",
+        metaKey: true,
+      }));
+      vi.advanceTimersByTime(SHORTCUT_REVEAL_DELAY_MS);
+    });
+
+    expect(screen.getByLabelText("shortcut reveal visible").textContent).toBe("true");
   });
 });

--- a/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.ts
+++ b/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.ts
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 import { isApplePlatform } from "@/lib/domain/shortcuts/matching"
+import { useShortcutRevealStore } from "@/stores/shortcuts/shortcut-reveal-store"
 
 export const SHORTCUT_REVEAL_DELAY_MS = 1000
 export const SHORTCUT_REVEAL_RESET_EVENT = "proliferate:shortcut-reveal-reset"
@@ -20,7 +21,8 @@ function primaryModifierPressed(event: KeyboardEvent, isApple: boolean): boolean
 }
 
 export function useShortcutRevealState(): boolean {
-  const [visible, setVisible] = useState(false)
+  const visible = useShortcutRevealStore((state) => state.visible)
+  const setStoreVisible = useShortcutRevealStore((state) => state.setVisible)
   const timerRef = useRef<number | null>(null)
   const primaryDownRef = useRef(false)
 
@@ -31,7 +33,7 @@ export function useShortcutRevealState(): boolean {
         window.clearTimeout(timerRef.current)
         timerRef.current = null
       }
-      setVisible(false)
+      setStoreVisible(false)
     }
 
     const startRevealTimer = () => {
@@ -42,7 +44,7 @@ export function useShortcutRevealState(): boolean {
       timerRef.current = window.setTimeout(() => {
         timerRef.current = null
         if (primaryDownRef.current) {
-          setVisible(true)
+          setStoreVisible(true)
         }
       }, SHORTCUT_REVEAL_DELAY_MS)
     }
@@ -99,7 +101,7 @@ export function useShortcutRevealState(): boolean {
       window.removeEventListener(SHORTCUT_REVEAL_RESET_EVENT, clearReveal)
       document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
-  }, [])
+  }, [setStoreVisible])
 
   return visible
 }

--- a/desktop/src/providers/ShortcutRevealProvider.tsx
+++ b/desktop/src/providers/ShortcutRevealProvider.tsx
@@ -1,18 +1,13 @@
-import { createContext, useContext, type ReactNode } from "react"
+import { type ReactNode } from "react"
 import { useShortcutRevealState } from "@/hooks/shortcuts/lifecycle/use-shortcut-reveal-state"
-
-const ShortcutRevealContext = createContext(false)
+import { useShortcutRevealStore } from "@/stores/shortcuts/shortcut-reveal-store"
 
 export function ShortcutRevealProvider({ children }: { children: ReactNode }) {
-  const visible = useShortcutRevealState()
+  useShortcutRevealState()
 
-  return (
-    <ShortcutRevealContext.Provider value={visible}>
-      {children}
-    </ShortcutRevealContext.Provider>
-  )
+  return <>{children}</>
 }
 
 export function useShortcutRevealVisible(): boolean {
-  return useContext(ShortcutRevealContext)
+  return useShortcutRevealStore((state) => state.visible)
 }

--- a/desktop/src/stores/shortcuts/shortcut-reveal-store.ts
+++ b/desktop/src/stores/shortcuts/shortcut-reveal-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ShortcutRevealStore {
+  visible: boolean;
+  setVisible: (visible: boolean) => void;
+}
+
+export const useShortcutRevealStore = create<ShortcutRevealStore>((set) => ({
+  visible: false,
+  setVisible: (visible) => set((state) =>
+    state.visible === visible ? state : { visible }
+  ),
+}));


### PR DESCRIPTION
## Summary
- Move shortcut reveal visibility into a shared store so surfaces outside the provider subtree receive the held-modifier reveal state.
- Group the keyboard shortcuts settings page into sections and keep shortcut badges pinned to the trailing side of each row.
- Add coverage for cross-subtree reveal consumers and the sectioned keyboard shortcuts UI.

## Validation
- pnpm exec vitest run src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.test.tsx src/components/settings/panes/KeyboardShortcutsPane.test.tsx src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx src/components/workspace/shell/tabs/ChromeWorkspaceTab.test.tsx
- pnpm --filter @proliferate/product-ui test -- ProductSidebar.test.tsx
- pnpm --filter @proliferate/ui typecheck
- pnpm --filter @proliferate/product-ui typecheck
- python3 scripts/check_frontend_boundaries.py
- git diff --check
- pnpm --filter proliferate build