### PR TITLE
feat(web): deploy web to Vercel + observability cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ codex/
 
 # Lock files not managed by workspace
 package-lock.json
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,42 @@
+# Build outputs and caches (these are what bloated the upload to 4.4GB)
+node_modules
+**/node_modules
+target
+**/target
+dist
+**/dist
+build
+**/build
+.next
+.cache
+.turbo
+coverage
+**/coverage
+
+# Python
+.venv
+**/.venv
+.pytest_cache
+**/.pytest_cache
+__pycache__
+**/__pycache__
+*.pyc
+
+# OS / editor / VCS
+.DS_Store
+**/.DS_Store
+.git
+tmp
+*.log
+
+# Local dev state
+.proliferate-local
+.claude
+
+# Not needed by the web build — anchor to repo root only (leading /)
+# so we don't accidentally strip nested e.g. packages/design/scripts.
+/reference
+/docs
+/scripts
+/install
+/catalogs

--- a/desktop/src/lib/integrations/telemetry/client.ts
+++ b/desktop/src/lib/integrations/telemetry/client.ts
@@ -85,6 +85,8 @@ export function initializeDesktopTelemetry(): void {
     telemetryMode: runtimeState.telemetryMode,
   });
   initializeDesktopPostHog({
+    environment: config.environment,
+    release: config.release,
     posthog: config.posthog,
   });
 }

--- a/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -7,6 +7,8 @@ import { scrubPostHogPayload, scrubTelemetryData } from "./scrub";
 let posthogInitialized = false;
 
 interface DesktopPostHogInitConfig {
+  environment: string;
+  release: string;
   posthog: DesktopTelemetryConfig["posthog"];
 }
 
@@ -39,6 +41,13 @@ export function initializeDesktopPostHog(config: DesktopPostHogInitConfig): void
         client.startSessionRecording();
       }
       : undefined,
+  });
+
+  posthog.register({
+    app: "proliferate-desktop",
+    surface: "desktop",
+    environment: config.environment,
+    release: config.release,
   });
 }
 

--- a/docs/analytics/sentry-setup-runbook.md
+++ b/docs/analytics/sentry-setup-runbook.md
@@ -1,0 +1,129 @@
+# Sentry Setup Runbook
+
+Operational checklist for first-time Sentry setup. Reference doc is
+`sentry.md` — that owns the canonical project list, env-var names, and privacy
+posture. This doc is the click-through.
+
+## 1. Org-level prep
+
+In Sentry org `proliferate`:
+
+1. **Settings → Integrations → Slack**: install. Authorize the Slack workspace.
+   This enables routing alert actions to channels.
+2. **Settings → Auth Tokens**: confirm a project-scoped auth token exists for
+   release / debug-file uploads. Token already lives in GitHub secret
+   `SENTRY_AUTH_TOKEN`.
+
+## 2. Create projects
+
+For each row below: **Projects → Create Project →** pick platform, name it
+exactly as shown, copy the DSN from the suggested SDK init screen.
+
+| Project slug | Platform | Owns errors from |
+|---|---|---|
+| `proliferate-server` | Python · FastAPI | server (`server/`) |
+| `proliferate-desktop` | JavaScript · React | desktop renderer (`desktop/src/`) |
+| `proliferate-desktop-native` | Rust | Tauri shell (`desktop/src-tauri/`) |
+| `anyharness` | Rust | bundled + cloud AnyHarness runtime |
+| `proliferate-target` | Rust | cloud supervisor + worker binaries |
+| `proliferate-web` | JavaScript · React | hosted web app (`web/`) |
+| `proliferate-mobile` | React Native | Expo mobile app (`mobile/`) |
+
+After creating each project, paste its DSN into the corresponding row of the
+hand-off table in section 5.
+
+## 3. Slack integration per project
+
+Once Slack is installed at org level, each project gets the same alert action
+available. No per-project Slack install is required.
+
+## 4. Alert rules
+
+Create the following in each project: **Alerts → Create Alert → Issues**.
+
+### Default rule (every project)
+
+- **Conditions**:
+  - A new issue is created
+  - OR: The issue changes state from resolved to unresolved (regression)
+- **Filters**:
+  - The issue's level is equal to `error` or higher
+  - The event's environment is equal to `production`
+- **Actions**:
+  - Send a Slack notification to workspace `proliferate`, channel
+    `#proliferate-errors`
+- **Frequency**: perform actions at most once every `30 minutes` for an issue
+- **Name**: `prod errors → #proliferate-errors`
+
+### High-priority escalation (server + target only)
+
+For `proliferate-server` and `proliferate-target`, add a second rule:
+
+- **Conditions**:
+  - An issue is seen more than `25` times in `1 hour`
+- **Filters**:
+  - The event's environment is equal to `production`
+- **Actions**:
+  - Send a Slack notification to channel `#proliferate-errors` with the prefix
+    `[burst]`
+- **Frequency**: at most once every `1 hour` per issue
+- **Name**: `prod burst → #proliferate-errors`
+
+### Native-crash rule (desktop-native + target only)
+
+For `proliferate-desktop-native` and `proliferate-target`:
+
+- **Conditions**:
+  - A new issue is created
+- **Filters**:
+  - The event's `mechanism.handled` is equal to `false`
+  - The event's environment is equal to `production`
+- **Actions**:
+  - Send a Slack notification to `#proliferate-errors` with the prefix
+    `[native crash]`
+- **Name**: `prod native crash → #proliferate-errors`
+
+Skip the high-priority and native-crash rules in client projects (`desktop`,
+`web`, `mobile`) until baseline volume is known — the default rule covers them.
+
+## 5. Hand-off table
+
+After projects exist, paste DSNs here, then I'll wire them.
+
+| Project | DSN target |
+|---|---|
+| `proliferate-server` | AWS Secrets Manager `proliferate/prod/server-app` key `SENTRY_DSN` (already set) |
+| `proliferate-desktop` | GitHub var `VITE_PROLIFERATE_SENTRY_DSN` (already set) |
+| `proliferate-desktop-native` | GitHub var `PROLIFERATE_DESKTOP_SENTRY_DSN` (already set) |
+| `anyharness` | GitHub var `ANYHARNESS_SENTRY_DSN` (already set) |
+| `proliferate-target` | AWS Secrets Manager `proliferate/prod/server-app` key `CLOUD_TARGET_SENTRY_DSN` (**new — needs to be added**) |
+| `proliferate-web` | GitHub var `VITE_PROLIFERATE_SENTRY_DSN` for web build (**new var needed if web has its own deploy**) |
+| `proliferate-mobile` | EAS env `EXPO_PUBLIC_PROLIFERATE_SENTRY_DSN` (**new — needs to be set**) |
+
+Also set these non-secret GitHub variables once projects exist (used by
+`release-desktop.yml` and the mobile sourcemap script):
+
+- `SENTRY_URL=https://sentry.io/`
+- `SENTRY_WEB_PROJECT=proliferate-web`
+- `SENTRY_DESKTOP_NATIVE_PROJECT=proliferate-desktop-native`
+- `SENTRY_ANYHARNESS_PROJECT=anyharness`
+- `SENTRY_MOBILE_PROJECT=proliferate-mobile`
+
+## 6. Verification
+
+After each project is created and the default rule is active:
+
+1. **Test event**: Project → Settings → Debug → "Send a test event". Confirm
+   it appears in Issues.
+2. **Slack alert dry-run**: edit the test issue's `level` to `error` if needed,
+   then resolve and re-trigger. Confirm a Slack message lands in
+   `#proliferate-errors`.
+3. **Release association** (server + clients only): confirm releases show up
+   under Releases after the next prod deploy / desktop build.
+
+## 7. Out of scope for this runbook
+
+- PostHog setup — see `posthog.md`.
+- Customer.io — see `customerio.md`.
+- Slack channel + webhook creation — that's a Slack workspace admin task,
+  separate from Sentry's Slack integration.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "VITE_PROLIFERATE_RELEASE=\"proliferate-web@$VERCEL_GIT_COMMIT_SHA\" pnpm web:build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "web/dist",
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Deploy `web/` to Vercel (project `proliferate-web` under team `getonyx`). Live at https://web.proliferate.com/. Adds repo-root `vercel.json` + `.vercelignore`.
- Fix `initializeDesktopPostHog`: was missing the `posthog.register({app, surface, environment, release})` call that `web/` and `mobile/` both make. Desktop events were lacking the `surface=desktop` baseline property.
- Add `docs/analytics/sentry-setup-runbook.md` — operational runbook for first-time Sentry org setup (projects, alert rules, Slack integration, DSN hand-off table). Companion to existing `docs/analytics/sentry.md`.

## Out-of-band changes (already applied, no code review needed)
- **Sentry org**: created 4 missing projects (`proliferate-web`, `proliferate-mobile`, `proliferate-desktop-native`, `proliferate-target`); renamed `proliferate-anyharness-runtime` → `anyharness`, `proliferate-desktop-web` → `proliferate-desktop`; deleted junk (`javascript-nextjs`, `todo-app`); enabled IP scrubbing across all projects; enabled browser inbound filters on browser projects.
- **Sentry alerts**: 12 alert rules created (default per project + burst for server/target + native-crash for desktop-native/target), all routed to Slack `#sentry-channel`.
- **PostHog**: enabled `anonymize_ips` on the Proliferate project; turned on session recording (`VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=true` in Vercel).
- **GitHub vars**: set `SENTRY_URL`, `SENTRY_WEB_PROJECT`, `SENTRY_MOBILE_PROJECT`, `SENTRY_DESKTOP_NATIVE_PROJECT`, `SENTRY_ANYHARNESS_PROJECT`; updated `SENTRY_PROJECT` + `SENTRY_ANYHARNESS_PROJECT` to match renamed slugs; updated `PROLIFERATE_DESKTOP_SENTRY_DSN` to the dedicated native project DSN.
- **AWS ECS prod task-def**:
  - rev 22: added `https://web.proliferate.com` to `CORS_ALLOW_ORIGINS`
  - rev 23: added `CLOUD_TARGET_SENTRY_{DSN,ENVIRONMENT,RELEASE,TRACES_SAMPLE_RATE}` for the new `proliferate-target` project

## Test plan
- [x] `https://web.proliferate.com/` returns 200 with the SPA HTML, served by Vercel (`x-vercel-id` from sfo1)
- [x] `https://web.proliferate.com/workspaces` (and other client-side routes) return 200 via SPA fallback
- [x] TLS cert is Let's Encrypt R12, subject `web.proliferate.com`, valid through 2026-08-18
- [x] CORS preflight from `https://web.proliferate.com` → `https://app.proliferate.com/api/health` returns `access-control-allow-origin: https://web.proliferate.com`
- [x] Production web bundle contains the new `proliferate-web` DSN (`ingest.us.sentry.io/4511421758898176`)
- [x] Production web bundle contains `sessionRecordingEnabled` resolving from `"true"`
- [x] ECS prod service stable on rev 23 (1/1 tasks running)
- [ ] **Smoke test in browser**: open https://web.proliferate.com/, throw a test error from devtools — confirm it appears in Sentry `proliferate-web` project; confirm a `$pageview` lands in PostHog with `surface=web`
- [ ] **Slack alert dry-run**: resolve a test issue in any Sentry project and re-trigger — confirm a message lands in `#sentry-channel`