### PR TITLE
feat(web): gate session recording on env var + docs followup

### DIFF
--- a/docs/analytics/posthog.md
+++ b/docs/analytics/posthog.md
@@ -8,8 +8,8 @@ covers identified hosted-product usage.
 
 PostHog is currently configured for:
 - desktop hosted-product analytics and optional session recording
-- web hosted-product route analytics; web session recording is kept disabled
-  until URL metadata can be scrubbed safely
+- web hosted-product route analytics and optional session recording
+  (env-gated; off by default, page-URL metadata is recorded when enabled)
 - mobile hosted-product screen analytics; replay startup is guarded behind env
   and requires the optional native replay package in the mobile build
 
@@ -130,10 +130,18 @@ Server/cloud API PostHog is not configured.
     - when enabled, inputs are masked and `[data-telemetry-block]` /
       `[data-telemetry-mask]` selectors are respected
   - web:
-    - session recording is disabled in code even if the env toggle is set,
-      because the browser replay SDK can emit URL metadata independently of DOM
-      masking
-    - web event payloads are still scrubbed through `before_send`
+    - session recording is gated by
+      `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED`; off by default
+    - when enabled, inputs are masked, `[data-telemetry-block]` /
+      `[data-telemetry-mask]` selectors are respected, and network request
+      bodies/headers are not recorded
+    - web event payloads are still scrubbed through `before_send`; URL-shaped
+      properties (`$current_url`, `$pathname`, `$host`, `$referrer`,
+      `$referring_domain`) are stripped from capture events
+    - note: the rrweb-side recording still emits the page URL with route IDs
+      visible in workspace/chat paths; consider stopping recording on
+      sensitive routes via `posthog.stopSessionRecording()` if those IDs are
+      sensitive
   - mobile:
     - session replay defaults to disabled
     - automatic lifecycle capture is disabled so OAuth callback deep links are

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -34,6 +34,8 @@ scripts/
   build-agent-seed.mjs
   generate-desktop-installer-manifest.mjs
   generate-updater-manifest.mjs
+vercel.json                  # web app deploy config (Vercel project proliferate-web)
+.vercelignore                # excludes Rust target/, node_modules/, etc. from web upload
 ```
 
 ## 2. Non-Negotiable Rules
@@ -457,3 +459,4 @@ Current boundary:
 | Desktop updater infra and publish permissions | `desktop/infra/main.tf` |
 | Cloud API infra | `server/infra/main.tf` |
 | Self-hosted production deploy | `server/deploy/**` |
+| Hosted web app | Vercel project `proliferate-web` (team `getonyx`), serving `https://web.proliferate.com/`. Build config: `vercel.json` + `.vercelignore` at repo root. PR previews auto-created via Vercel's GitHub integration. |

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,22 @@
+# Local development env for the standalone web app (pnpm web:dev).
+# Vite reads .env.local at build time; production values are set in Vercel.
+VITE_PROLIFERATE_API_BASE_URL=https://app.proliferate.com/api
+VITE_PROLIFERATE_ENVIRONMENT=development
+VITE_PROLIFERATE_RELEASE=proliferate-web@dev
+VITE_PROLIFERATE_TELEMETRY_DISABLED=false
+
+# Web renderer telemetry. Vendor telemetry is inert without these.
+VITE_PROLIFERATE_SENTRY_DSN=
+VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE=1.0
+VITE_PROLIFERATE_SENTRY_ENABLE_LOGS=true
+VITE_PROLIFERATE_POSTHOG_KEY=
+VITE_PROLIFERATE_POSTHOG_HOST=https://us.i.posthog.com
+# Set true to start session replay in production builds.
+# See docs/analytics/posthog.md for masking + URL caveats.
+VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=false
+
+# Optional build-time Sentry sourcemap upload (CI only, normally set by Vercel).
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_URL=https://sentry.io/

--- a/web/src/lib/integrations/telemetry/posthog.ts
+++ b/web/src/lib/integrations/telemetry/posthog.ts
@@ -62,7 +62,7 @@ export function initializeWebPostHog(config: WebPostHogInitConfig): void {
     capture_pageleave: false,
     person_profiles: "identified_only",
     before_send: scrubPostHogCapture,
-    disable_session_recording: true,
+    disable_session_recording: !config.posthog.sessionRecordingEnabled,
     session_recording: {
       maskAllInputs: true,
       maskTextSelector: "[data-telemetry-mask]",


### PR DESCRIPTION
## Summary
- Real code change: `web/src/lib/integrations/telemetry/posthog.ts` swaps `disable_session_recording: true` for `!config.posthog.sessionRecordingEnabled`. The `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED` env var (already wired through `config.ts`) now actually controls whether the web replay SDK starts. Default OFF preserved; existing masking config unchanged.
- Doc cleanup falling out of PR #272:
  - `docs/analytics/posthog.md` — the "session recording is disabled in code even if the env toggle is set" claim was accurate before this change; updated to reflect the new env-gated behavior, with a fresh caveat about page-URL leakage in rrweb captures.
  - `docs/ci-cd/README.md` — adds the Vercel web deploy (`https://web.proliferate.com/`) to the file tree + deployment ownership table.
  - `web/.env.example` (new) — mirror of `desktop/.env.example` for local dev with `VITE_PROLIFERATE_*` placeholders.

## Context
While auditing docs after PR #272, I found that the Vercel env var I set in that session (`VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=true`) did nothing because `web/src/lib/integrations/telemetry/posthog.ts:65` was hardcoded `disable_session_recording: true`. This PR makes the env var do what it says.

## Privacy note
Session replay records the rendered DOM with masking, but the *page URL itself* is still recorded by rrweb (workspace IDs, chat IDs visible). Existing `before_send` only strips URL-shaped properties from capture events, not from recordings. If those IDs are sensitive on certain routes, call `posthog.stopSessionRecording()` on those routes — documented in `posthog.md`.

## Test plan
- [ ] `pnpm web:typecheck` passes
- [ ] After merge + Vercel redeploy with `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=true`, browser DevTools shows recording requests to PostHog (`/s/?ip=*` endpoints)
- [ ] Confirm a recording appears in the PostHog `Proliferate` project under Replay
- [ ] Confirm masked inputs (e.g., signup form fields) show as black blocks in the recording