### PR TITLE
nit(desktop): scale sticky page title up to text-xl

### DIFF
--- a/desktop/src/components/ui/PageContentFrame.tsx
+++ b/desktop/src/components/ui/PageContentFrame.tsx
@@ -50,7 +50,7 @@ export function PageContentFrame({
             <div
               className={`mx-auto flex h-10 w-full ${maxWidthClassName} items-center justify-between gap-3 px-6`}
             >
-              <h2 className="min-w-0 truncate text-sm font-medium text-foreground">
+              <h2 className="min-w-0 truncate text-xl font-medium text-foreground">
                 {stickyTitle}
               </h2>
               {stickyAction && <div className="shrink-0">{stickyAction}</div>}


### PR DESCRIPTION
## Summary
- Sticky page title in PageContentFrame goes from text-sm to text-xl. Matches the design pattern of larger sticky titles being more readable on scroll.

## Test plan
- [ ] Visual check: scroll any page with a sticky title (e.g. settings, support) and confirm the header title is text-xl size when stuck.