### PR TITLE
release(desktop): bump version to 0.1.30

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proliferate",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-model build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proliferate"
-version = "0.1.29"
+version = "0.1.30"
 edition.workspace = true
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Proliferate",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "identifier": "com.proliferate.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for desktop release 0.1.30.

Includes all changes since 0.1.29:
- feat(product): Sentry + PostHog observability
- feat(web): Vercel deployment + session recording gate
- feat(server): Slack signup and billing notifications
- feat(server): Customer.io welcome email
- Metabase analytics storage
- Various desktop/UI fixes

## Checklist
- [x] Version bumped in `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml`