### PR TITLE
fix(desktop): remove unscoped button font:inherit in dom.css (cascade bug)

### DIFF
--- a/packages/design/src/dom.css
+++ b/packages/design/src/dom.css
@@ -35,12 +35,6 @@ body {
   background: var(--color-background);
 }
 
-button,
-input,
-textarea {
-  font: inherit;
-}
-
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## Summary
Removes the duplicate \`button, input, textarea { font: inherit; }\` block in \`packages/design/src/dom.css\` (added in #7af8ec91 \"share web desktop product UI\"). Because the rule sat outside any \`@layer\`, plain-CSS cascade priority made it beat every Tailwind \`.text-*\` utility on buttons. Effect: chat divider buttons, settings menu triggers, and the chat composer button all silently fell through to \`<body>\` default 16px instead of their intended utility sizes (12px chat / 8px text-xs / etc).

Tailwind v4's own preflight already does the exact same reset for \`button, input, select, optgroup, textarea, ::file-selector-button\` inside \`@layer base\`. That preflight is properly scoped so utility classes can override it. The duplicate in dom.css was redundant *and* broke the cascade.

## Root-cause walk-through
1. Source: \`packages/design/src/dom.css\` lines 38-42, outside \`@layer\`.
2. Cascade: any plain-CSS rule beats all \`@layer\` declarations.
3. Effect on \`.text-xs { font-size: var(--text-xs) }\` (in @layer utilities): overridden.
4. Effect on \`.text-chat\`, \`text-[length:var(--text-chat)]\`, etc.: same — overridden.
5. Button computes \`font-size: inherit\` from \`<body>\` default = 16px.
6. Visually: divider buttons, composer placeholder, settings dropdowns rendered ~30-50% too large.

## Verified via DevTools
- Before fix: divider button computed \`font-size: 16px\`, with \`.text-xs\` rule visibly crossed-out in Styles panel.
- After fix: \`.text-xs\` / \`text-[length:var(--text-chat)]\` apply, computed \`font-size\` matches utility value.

## Test plan
- [ ] Hard-refresh the Tauri app and confirm chat dividers, composer placeholder, and settings menu triggers render at correct sizes
- [ ] CI typecheck/build passes