### PR TITLE
feat(cloud): integrate runtime config with sandbox auth

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/sessions.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/sessions.rs
@@ -450,6 +450,8 @@ pub enum PromptAttachmentSource {
 pub struct PromptSessionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_runtime_config_revision: Option<RuntimeConfigRevisionExpectation>,
     pub blocks: Vec<PromptInputBlock>,
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/runtime_config.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/runtime_config.rs
@@ -70,6 +70,10 @@ pub fn map_runtime_config_error(error: RuntimeConfigError) -> ApiError {
             format!("runtime config artifact is missing: {hash}"),
             "RUNTIME_CONFIG_ARTIFACT_MISSING",
         ),
+        RuntimeConfigError::ArtifactIntegrityMismatch(hash) => ApiError::bad_request(
+            format!("runtime config artifact integrity mismatch: {hash}"),
+            "RUNTIME_CONFIG_ARTIFACT_INTEGRITY_MISMATCH",
+        ),
         RuntimeConfigError::UnmaterializedValue => ApiError::conflict(
             "runtime config contains an unmaterialized launch value",
             "RUNTIME_CONFIG_UNMATERIALIZED_VALUE",

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
@@ -290,6 +290,12 @@ pub async fn prompt_session(
     let _lease =
         acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
             .await?;
+    if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
+        state
+            .runtime_config_service
+            .assert_session_context_matches(&session_id, expected)
+            .map_err(super::runtime_config::map_runtime_config_error)?;
+    }
     let outcome = state
         .session_runtime
         .send_prompt(&session_id, req.blocks, prompt_id, latency.as_ref())

--- a/anyharness/crates/anyharness-lib/src/domains/plugins/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plugins/mcp/mod.rs
@@ -47,6 +47,7 @@ mod tests {
         RuntimeConfigRevisionExpectation, RuntimeConfigSource, RuntimeSkill,
         RuntimeSkillSourceKind,
     };
+    use sha2::{Digest, Sha256};
 
     use super::auth::SkillsMcpAuth;
     use super::SkillsProductMcpServer;
@@ -111,18 +112,22 @@ mod tests {
     }
 
     fn apply_request() -> ApplyRuntimeConfigRequest {
+        let instruction_content = "# Runtime config skill\n";
+        let instruction_hash = runtime_artifact_hash(instruction_content);
+        let guide_content = "Use issues.";
+        let guide_hash = runtime_artifact_hash(guide_content);
         let instruction = RuntimeArtifactRef {
-            hash: "sha256:instructions".to_string(),
+            hash: instruction_hash.clone(),
             content_type: "text/markdown".to_string(),
-            byte_size: 23,
+            byte_size: instruction_content.as_bytes().len() as i64,
             source_ref: Some("plugin:github:triage:instructions".to_string()),
             resource_id: None,
             display_name: None,
         };
         let resource = RuntimeArtifactRef {
-            hash: "sha256:guide".to_string(),
+            hash: guide_hash.clone(),
             content_type: "text/markdown".to_string(),
-            byte_size: 11,
+            byte_size: guide_content.as_bytes().len() as i64,
             source_ref: Some("plugin:github:triage:resource:triage-guide".to_string()),
             resource_id: Some("triage-guide".to_string()),
             display_name: Some("Triage guide".to_string()),
@@ -156,27 +161,31 @@ mod tests {
             },
             artifact_payloads: vec![
                 RuntimeArtifactPayload {
-                    hash: "sha256:instructions".to_string(),
+                    hash: instruction_hash,
                     content_type: "text/markdown".to_string(),
-                    byte_size: 23,
+                    byte_size: instruction_content.as_bytes().len() as i64,
                     source_ref: Some("plugin:github:triage:instructions".to_string()),
                     resource_id: None,
                     display_name: None,
-                    content: "# Runtime config skill\n".to_string(),
+                    content: instruction_content.to_string(),
                 },
                 RuntimeArtifactPayload {
-                    hash: "sha256:guide".to_string(),
+                    hash: guide_hash,
                     content_type: "text/markdown".to_string(),
-                    byte_size: 11,
+                    byte_size: guide_content.as_bytes().len() as i64,
                     source_ref: Some("plugin:github:triage:resource:triage-guide".to_string()),
                     resource_id: Some("triage-guide".to_string()),
                     display_name: Some("Triage guide".to_string()),
-                    content: "Use issues.".to_string(),
+                    content: guide_content.to_string(),
                 },
             ],
             credential_values: Vec::new(),
             source: RuntimeConfigSource::Worker,
         }
+    }
+
+    fn runtime_artifact_hash(content: &str) -> String {
+        format!("sha256:{:x}", Sha256::digest(content.as_bytes()))
     }
 
     fn expectation(revision: &RuntimeConfigRevision) -> RuntimeConfigRevisionExpectation {

--- a/anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs
@@ -3,12 +3,13 @@ use std::sync::{Arc, Mutex};
 
 use anyharness_contract::v1::{
     ApplyRuntimeConfigRequest, ApplyRuntimeConfigResponse, RuntimeArtifactPayload,
-    RuntimeArtifactStatus, RuntimeConfigExternalScope, RuntimeConfigManifest,
+    RuntimeArtifactRef, RuntimeArtifactStatus, RuntimeConfigExternalScope, RuntimeConfigManifest,
     RuntimeConfigRevision, RuntimeConfigRevisionExpectation, RuntimeConfigStatusResponse,
     RuntimeCredentialValue, RuntimeMcpLaunch, RuntimeMcpNamedValue, RuntimeMcpServer,
     RuntimeMcpTemplatePart, RuntimeMcpValue, RuntimeSkill, SessionMcpBindingSummary,
 };
 use rusqlite::{params, OptionalExtension, Row};
+use sha2::{Digest, Sha256};
 use url::Url;
 
 use super::model::{
@@ -299,6 +300,8 @@ pub enum RuntimeConfigError {
     InlineSecretLiteral(String),
     #[error("runtime config artifact is missing: {0}")]
     MissingArtifact(String),
+    #[error("runtime config artifact integrity mismatch: {0}")]
+    ArtifactIntegrityMismatch(String),
     #[error("runtime config value is not materialized")]
     UnmaterializedValue,
     #[error("runtime config storage error: {0}")]
@@ -538,6 +541,7 @@ fn session_inputs_from_record(
 
 fn validate_materialized_record(record: &RuntimeConfigRecord) -> Result<(), RuntimeConfigError> {
     validate_no_inline_secret_literals(&record.manifest)?;
+    validate_artifact_payloads(&record.manifest, &record.artifact_payloads)?;
     Ok(())
 }
 
@@ -555,20 +559,46 @@ fn validate_apply_request(request: &ApplyRuntimeConfigRequest) -> Result<(), Run
     if !missing.is_empty() {
         return Err(RuntimeConfigError::MissingCredentials(missing));
     }
-    let payloads = request
-        .artifact_payloads
+    validate_artifact_payloads(&request.manifest, &request.artifact_payloads)?;
+    Ok(())
+}
+
+fn validate_artifact_payloads(
+    manifest: &RuntimeConfigManifest,
+    artifact_payloads: &[RuntimeArtifactPayload],
+) -> Result<(), RuntimeConfigError> {
+    let payloads = artifact_payloads
         .iter()
         .map(|artifact| (artifact.hash.as_str(), artifact))
         .collect::<HashMap<_, _>>();
-    for artifact in &request.manifest.artifacts {
+    for artifact in &manifest.artifacts {
         match payloads.get(artifact.hash.as_str()) {
-            Some(payload)
-                if payload.content_type == artifact.content_type
-                    && payload.byte_size == artifact.byte_size => {}
+            Some(payload) => validate_artifact_payload(artifact, payload)?,
             _ => return Err(RuntimeConfigError::MissingArtifact(artifact.hash.clone())),
         }
     }
     Ok(())
+}
+
+fn validate_artifact_payload(
+    artifact: &RuntimeArtifactRef,
+    payload: &RuntimeArtifactPayload,
+) -> Result<(), RuntimeConfigError> {
+    if payload.hash != artifact.hash
+        || payload.content_type != artifact.content_type
+        || payload.byte_size != artifact.byte_size
+        || payload.content.as_bytes().len() as i64 != artifact.byte_size
+        || runtime_artifact_hash(&payload.content) != artifact.hash
+    {
+        return Err(RuntimeConfigError::ArtifactIntegrityMismatch(
+            artifact.hash.clone(),
+        ));
+    }
+    Ok(())
+}
+
+fn runtime_artifact_hash(content: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(content.as_bytes()))
 }
 
 fn validate_no_inline_secret_literals(
@@ -986,6 +1016,19 @@ mod tests {
     }
 
     #[test]
+    fn apply_rejects_artifact_hash_mismatch() {
+        let db = Db::open_in_memory().expect("db");
+        let service = RuntimeConfigService::new(RuntimeConfigStore::new(db));
+        let mut request = apply_request();
+        request.artifact_payloads[0].content = "# Use GitLub\n".to_string();
+        assert!(matches!(
+            service.apply_config(request),
+            Err(RuntimeConfigError::ArtifactIntegrityMismatch(hash))
+                if hash == runtime_artifact_hash("# Use GitHub\n")
+        ));
+    }
+
+    #[test]
     fn apply_rejects_unresolved_credentials() {
         let db = Db::open_in_memory().expect("db");
         let service = RuntimeConfigService::new(RuntimeConfigStore::new(db));
@@ -1188,18 +1231,22 @@ mod tests {
     }
 
     fn apply_request() -> ApplyRuntimeConfigRequest {
+        let instruction_content = "# Use GitHub\n";
+        let instruction_hash = runtime_artifact_hash(instruction_content);
+        let guide_content = "Use issues.";
+        let guide_hash = runtime_artifact_hash(guide_content);
         let artifact = RuntimeArtifactRef {
-            hash: "sha256:instructions".to_string(),
+            hash: instruction_hash.clone(),
             content_type: "text/markdown".to_string(),
-            byte_size: 13,
+            byte_size: instruction_content.as_bytes().len() as i64,
             source_ref: Some("plugin:github:instructions".to_string()),
             resource_id: None,
             display_name: None,
         };
         let resource = RuntimeArtifactRef {
-            hash: "sha256:guide".to_string(),
+            hash: guide_hash.clone(),
             content_type: "text/markdown".to_string(),
-            byte_size: 11,
+            byte_size: guide_content.as_bytes().len() as i64,
             source_ref: Some("plugin:github:resource:guide".to_string()),
             resource_id: Some("triage-guide".to_string()),
             display_name: Some("Triage guide".to_string()),
@@ -1259,22 +1306,22 @@ mod tests {
             },
             artifact_payloads: vec![
                 RuntimeArtifactPayload {
-                    hash: "sha256:instructions".to_string(),
+                    hash: instruction_hash,
                     content_type: "text/markdown".to_string(),
-                    byte_size: 13,
+                    byte_size: instruction_content.as_bytes().len() as i64,
                     source_ref: Some("plugin:github:instructions".to_string()),
                     resource_id: None,
                     display_name: None,
-                    content: "# Use GitHub\n".to_string(),
+                    content: instruction_content.to_string(),
                 },
                 RuntimeArtifactPayload {
-                    hash: "sha256:guide".to_string(),
+                    hash: guide_hash,
                     content_type: "text/markdown".to_string(),
-                    byte_size: 11,
+                    byte_size: guide_content.as_bytes().len() as i64,
                     source_ref: Some("plugin:github:resource:guide".to_string()),
                     resource_id: Some("triage-guide".to_string()),
                     display_name: Some("Triage guide".to_string()),
-                    content: "Use issues.".to_string(),
+                    content: guide_content.to_string(),
                 },
             ],
             credential_values: Vec::new(),

--- a/anyharness/crates/anyharness-lib/src/domains/runtime_config/session_extension.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/runtime_config/session_extension.rs
@@ -113,6 +113,7 @@ mod tests {
         RuntimeSkillSourceKind, SessionMcpBindingOutcome, SessionMcpBindingSummary,
         SessionMcpTransport,
     };
+    use sha2::{Digest, Sha256};
 
     use super::RuntimeConfigSessionLaunchExtension;
     use crate::domains::plugins::mcp::auth::SkillsMcpAuth;
@@ -201,10 +202,12 @@ mod tests {
     }
 
     fn apply_request() -> ApplyRuntimeConfigRequest {
+        let instruction_content = "# Use GitHub\n";
+        let instruction_hash = runtime_artifact_hash(instruction_content);
         let artifact = RuntimeArtifactRef {
-            hash: "sha256:instructions".to_string(),
+            hash: instruction_hash.clone(),
             content_type: "text/markdown".to_string(),
-            byte_size: 13,
+            byte_size: instruction_content.as_bytes().len() as i64,
             source_ref: Some("plugin:github:instructions".to_string()),
             resource_id: None,
             display_name: None,
@@ -258,17 +261,21 @@ mod tests {
                 warnings: Vec::new(),
             },
             artifact_payloads: vec![RuntimeArtifactPayload {
-                hash: "sha256:instructions".to_string(),
+                hash: instruction_hash,
                 content_type: "text/markdown".to_string(),
-                byte_size: 13,
+                byte_size: instruction_content.as_bytes().len() as i64,
                 source_ref: Some("plugin:github:instructions".to_string()),
                 resource_id: None,
                 display_name: None,
-                content: "# Use GitHub\n".to_string(),
+                content: instruction_content.to_string(),
             }],
             credential_values: Vec::new(),
             source: RuntimeConfigSource::Worker,
         }
+    }
+
+    fn runtime_artifact_hash(content: &str) -> String {
+        format!("sha256:{:x}", Sha256::digest(content.as_bytes()))
     }
 
     fn session_record() -> SessionRecord {

--- a/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
@@ -31,7 +31,10 @@ use crate::{
         git_identity::{parse_configure_git_identity_payload, write_target_git_identity},
         materialize_plan, parse_materialize_environment_payload,
         repo_checkout::{ensure_repo_checkout, parse_ensure_repo_checkout_payload},
-        runtime_config::{manifest_credential_refs, RuntimeConfigMaterializationFragment},
+        runtime_config::{
+            manifest_credential_refs, validate_runtime_artifact_payload,
+            RuntimeConfigMaterializationFragment,
+        },
     },
     store::{PendingCommandResult, WorkerStore},
     sync,
@@ -618,52 +621,61 @@ async fn process_materialize_environment_command(
             )
             .await?;
         let outcome = materialize_plan(materialization_root, payload.config_version, &plan)?;
+        let mut should_report_runtime_config_applied = false;
         if let Some(runtime_config) = plan.runtime_config.as_ref() {
             let Some(anyharness) = anyharness else {
                 return Err(WorkerError::Materialization(
                     "AnyHarness is required to apply runtime config.".to_string(),
                 ));
             };
-            if let Err(error) = apply_runtime_config_to_anyharness(
+            let runtime_config_applied = match apply_runtime_config_to_anyharness(
                 cloud,
                 anyharness,
                 &identity.worker_token,
+                &command.target_id,
                 runtime_config,
             )
             .await
             {
-                let missing_credentials = match &error {
-                    WorkerError::MissingRuntimeConfigCredentials(refs) => refs.clone(),
-                    _ => Vec::new(),
-                };
-                let error_code = match &error {
-                    WorkerError::MissingRuntimeConfigCredentials(_) => {
-                        "runtime_config_credentials_missing"
-                    }
-                    _ => "anyharness_runtime_config_apply_failed",
-                };
-                cloud
-                    .report_runtime_config_status(
-                        &identity.worker_token,
-                        &runtime_config.revision_id,
-                        &crate::cloud_client::target_config::RuntimeConfigStatusRequest {
-                            status: "failed".to_string(),
-                            missing_artifacts: Vec::new(),
-                            missing_credentials,
-                            error_code: Some(error_code.to_string()),
-                            error_message: Some(error.to_string()),
-                        },
-                    )
-                    .await
-                    .ok();
-                return Err(error);
+                Ok(applied) => applied,
+                Err(error) => {
+                    let missing_credentials = match &error {
+                        WorkerError::MissingRuntimeConfigCredentials(refs) => refs.clone(),
+                        _ => Vec::new(),
+                    };
+                    let error_code = match &error {
+                        WorkerError::MissingRuntimeConfigCredentials(_) => {
+                            "runtime_config_credentials_missing"
+                        }
+                        _ => "anyharness_runtime_config_apply_failed",
+                    };
+                    cloud
+                        .report_runtime_config_status(
+                            &identity.worker_token,
+                            &runtime_config.revision_id,
+                            &crate::cloud_client::target_config::RuntimeConfigStatusRequest {
+                                status: "failed".to_string(),
+                                missing_artifacts: Vec::new(),
+                                missing_credentials,
+                                error_code: Some(error_code.to_string()),
+                                error_message: Some(error.to_string()),
+                            },
+                        )
+                        .await
+                        .ok();
+                    return Err(error);
+                }
+            };
+            if !runtime_config_applied {
+                return Ok((outcome, false));
             }
+            should_report_runtime_config_applied = true;
         }
-        Ok(outcome)
+        Ok((outcome, should_report_runtime_config_applied))
     }
     .await;
     let result = match response {
-        Ok(outcome) => {
+        Ok((outcome, should_report_runtime_config_applied)) => {
             cloud
                 .report_target_config_status(
                     &identity.worker_token,
@@ -679,7 +691,13 @@ async fn process_materialize_environment_command(
                 )
                 .await
                 .ok();
-            if let Some(runtime_config) = outcome.runtime_config.as_ref() {
+            if should_report_runtime_config_applied {
+                let runtime_config = outcome.runtime_config.as_ref().ok_or_else(|| {
+                    WorkerError::Materialization(
+                        "Runtime config apply succeeded without runtime config outcome."
+                            .to_string(),
+                    )
+                })?;
                 cloud
                     .report_runtime_config_status(
                         &identity.worker_token,
@@ -735,8 +753,14 @@ async fn apply_runtime_config_to_anyharness(
     cloud: &CloudClient,
     anyharness: &AnyHarnessClient,
     worker_token: &str,
+    target_id: &str,
     runtime_config: &RuntimeConfigMaterializationFragment,
-) -> Result<(), WorkerError> {
+) -> Result<bool, WorkerError> {
+    if runtime_config.target_id.as_deref() != Some(target_id) {
+        return Err(WorkerError::Materialization(
+            "Runtime config target does not match leased command target.".to_string(),
+        ));
+    }
     let credential_refs = manifest_credential_refs(&runtime_config.manifest);
     let credential_values = if credential_refs.is_empty() {
         Vec::new()
@@ -771,7 +795,7 @@ async fn apply_runtime_config_to_anyharness(
                 &artifact.hash,
             )
             .await?;
-        artifact_payloads.push(RuntimeArtifactPayload {
+        let payload = RuntimeArtifactPayload {
             hash: payload.hash,
             content_type: payload.content_type,
             byte_size: payload.byte_size,
@@ -779,7 +803,9 @@ async fn apply_runtime_config_to_anyharness(
             resource_id: payload.resource_id,
             display_name: payload.display_name,
             content: payload.content,
-        });
+        };
+        validate_runtime_artifact_payload(artifact, &payload)?;
+        artifact_payloads.push(payload);
     }
     let request = ApplyRuntimeConfigRequest {
         revision: RuntimeConfigRevision {
@@ -798,20 +824,23 @@ async fn apply_runtime_config_to_anyharness(
         source: RuntimeConfigSource::Worker,
     };
     let response = anyharness.apply_runtime_config(&request).await?;
-    if response.status.is_success()
-        && response
+    if response.status.is_success() {
+        if response
             .body
             .get("applied")
             .and_then(Value::as_bool)
             .unwrap_or(false)
-    {
-        Ok(())
-    } else {
-        Err(WorkerError::AnyHarness {
-            status: response.status,
-            body: response.body.to_string(),
-        })
+        {
+            return Ok(true);
+        }
+        if response.body.get("status").and_then(Value::as_str) == Some("stale") {
+            return Ok(false);
+        }
     }
+    Err(WorkerError::AnyHarness {
+        status: response.status,
+        body: response.body.to_string(),
+    })
 }
 
 async fn process_sync_existing_workspace_command(

--- a/anyharness/crates/proliferate-worker/src/commands/mapping.rs
+++ b/anyharness/crates/proliferate-worker/src/commands/mapping.rs
@@ -224,7 +224,8 @@ fn prompt_body(command: &CloudCommandEnvelope) -> Result<Value, CommandMappingEr
         ));
     };
     let mut body = object.clone();
-    strip_preflight_fields(&mut body);
+    strip_agent_auth_preflight_fields(&mut body);
+    map_runtime_config_preflight(&mut body, &command.target_id)?;
     if !body.contains_key("promptId") && !body.contains_key("prompt_id") {
         body.insert(
             "promptId".to_string(),
@@ -294,13 +295,9 @@ fn map_runtime_config_preflight(
     Ok(())
 }
 
-fn strip_preflight_fields(body: &mut Map<String, Value>) {
+fn strip_agent_auth_preflight_fields(body: &mut Map<String, Value>) {
     body.remove("agentAuthScope");
-    body.remove("sandboxProfileId");
     body.remove("requiredAgentAuthRevision");
-    body.remove("requiredRuntimeConfigRevisionId");
-    body.remove("requiredRuntimeConfigSequence");
-    body.remove("requiredRuntimeConfigContentHash");
 }
 
 fn interaction_resolution_body(payload: &Value) -> Result<(String, Value), CommandMappingError> {
@@ -573,6 +570,16 @@ mod tests {
         assert!(body.get("sandboxProfileId").is_none());
         assert!(body.get("requiredAgentAuthRevision").is_none());
         assert!(body.get("requiredRuntimeConfigRevisionId").is_none());
+        assert_eq!(
+            body.pointer("/expectedRuntimeConfigRevision/revisionId")
+                .and_then(serde_json::Value::as_str),
+            Some("rev-1")
+        );
+        assert_eq!(
+            body.pointer("/expectedRuntimeConfigRevision/externalScope/targetId")
+                .and_then(serde_json::Value::as_str),
+            Some("target-1")
+        );
         assert!(body.get("blocks").is_some());
     }
 

--- a/anyharness/crates/proliferate-worker/src/materialization/runtime_config.rs
+++ b/anyharness/crates/proliferate-worker/src/materialization/runtime_config.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
 
 use anyharness_contract::v1::{
-    RuntimeArtifactRef, RuntimeConfigManifest, RuntimeMcpLaunch, RuntimeMcpTemplatePart,
-    RuntimeMcpValue,
+    RuntimeArtifactPayload, RuntimeArtifactRef, RuntimeConfigManifest, RuntimeMcpLaunch,
+    RuntimeMcpTemplatePart, RuntimeMcpValue,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::error::WorkerError;
 
@@ -86,6 +87,28 @@ pub fn manifest_credential_refs(manifest: &RuntimeConfigManifest) -> Vec<String>
         }
     }
     refs
+}
+
+pub fn validate_runtime_artifact_payload(
+    artifact: &RuntimeArtifactRef,
+    payload: &RuntimeArtifactPayload,
+) -> Result<(), WorkerError> {
+    if payload.hash != artifact.hash
+        || payload.content_type != artifact.content_type
+        || payload.byte_size != artifact.byte_size
+        || payload.content.as_bytes().len() as i64 != artifact.byte_size
+        || runtime_artifact_hash(&payload.content) != artifact.hash
+    {
+        return Err(WorkerError::Materialization(format!(
+            "Runtime config artifact integrity mismatch for {}.",
+            artifact.hash
+        )));
+    }
+    Ok(())
+}
+
+fn runtime_artifact_hash(content: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(content.as_bytes()))
 }
 
 pub fn write_runtime_config_projection(
@@ -214,5 +237,32 @@ mod tests {
             panic!("expected http launch");
         };
         assert!(matches!(headers[0].value, RuntimeMcpValue::Template { .. }));
+    }
+
+    #[test]
+    fn validates_runtime_artifact_payload_hash_and_metadata() {
+        let content = "# Skill\n";
+        let artifact = RuntimeArtifactRef {
+            hash: runtime_artifact_hash(content),
+            content_type: "text/markdown".to_string(),
+            byte_size: content.as_bytes().len() as i64,
+            source_ref: Some("skill:instructions".to_string()),
+            resource_id: None,
+            display_name: None,
+        };
+        let payload = RuntimeArtifactPayload {
+            hash: artifact.hash.clone(),
+            content_type: artifact.content_type.clone(),
+            byte_size: artifact.byte_size,
+            source_ref: artifact.source_ref.clone(),
+            resource_id: None,
+            display_name: None,
+            content: content.to_string(),
+        };
+        validate_runtime_artifact_payload(&artifact, &payload).expect("valid payload");
+
+        let mut tampered = payload;
+        tampered.content = "# Different\n".to_string();
+        assert!(validate_runtime_artifact_payload(&artifact, &tampered).is_err());
     }
 }

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -11619,6 +11619,16 @@
               "$ref": "#/components/schemas/PromptInputBlock"
             }
           },
+          "expectedRuntimeConfigRevision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RuntimeConfigRevisionExpectation"
+              }
+            ]
+          },
           "promptId": {
             "type": [
               "string",

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -3077,6 +3077,7 @@ export interface components {
         };
         PromptSessionRequest: {
             blocks: components["schemas"]["PromptInputBlock"][];
+            expectedRuntimeConfigRevision?: null | components["schemas"]["RuntimeConfigRevisionExpectation"];
             promptId?: string | null;
         };
         PromptSessionResponse: {

--- a/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
+++ b/desktop/src/components/settings/panes/cloud/CloudAgentAuthLibrary.tsx
@@ -10,12 +10,12 @@ import {
   useAgentAuthMutations,
   useCloudCapabilities,
 } from "@proliferate/cloud-sdk-react/hooks/agent-auth";
-import { useTauriCredentialsActions } from "@/hooks/access/tauri/use-credentials-actions";
+import {
+  useTauriCredentialsActions,
+  type AgentAuthProvider,
+  type LocalAgentAuthSource,
+} from "@/hooks/access/tauri/use-credentials-actions";
 import { useOrganizations } from "@/hooks/access/cloud/organizations/use-organizations";
-import type {
-  AgentAuthProvider,
-  LocalAgentAuthSource,
-} from "@/lib/access/tauri/credentials";
 import {
   AGENT_AUTH_AGENT_ORDER,
   agentAuthAgentLabel,

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -3,7 +3,9 @@ anyharness/crates/anyharness-lib/src/acp/manager.rs
 anyharness/crates/anyharness-lib/src/acp/runtime_client.rs
 anyharness/crates/anyharness-lib/src/adapters/git/diff.rs
 anyharness/crates/anyharness-lib/src/domains/agents/installer.rs
+anyharness/crates/anyharness-lib/src/domains/agents/auth_config.rs
 anyharness/crates/anyharness-lib/src/domains/agents/readiness/resolver.rs
+anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs
 anyharness/crates/anyharness-lib/src/api/openapi.rs
 anyharness/crates/anyharness-lib/src/api/router_tests.rs
@@ -30,6 +32,7 @@ anyharness/crates/anyharness-lib/src/workspaces/service.rs
 anyharness/crates/anyharness-lib/src/workspaces/runtime.rs
 anyharness/crates/anyharness-lib/src/workspaces/store.rs
 anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
+anyharness/crates/proliferate-worker/src/commands/mapping.rs
 desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
 desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
 desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -51,6 +54,7 @@ desktop/src/lib/integrations/auth/orchestration.ts
 server/tests/integration/test_cloud_api.py
 server/tests/integration/test_auth_flow.py
 server/tests/integration/test_cloud_agent_auth_api.py
+server/tests/integration/test_agent_gateway_api.py
 server/tests/integration/test_billing_accounting.py
 server/tests/integration/test_billing_api.py
 server/tests/integration/test_stripe_webhooks.py
@@ -58,15 +62,18 @@ server/proliferate/db/models/cloud/agent_auth.py
 server/proliferate/db/store/billing.py
 server/proliferate/db/store/cloud_agent_auth/store.py
 server/proliferate/db/store/cloud_mobility.py
+server/proliferate/db/store/cloud_sync/commands.py
 server/proliferate/db/store/cloud_sync/events.py
+server/proliferate/db/store/cloud_sync/targets.py
 server/tests/unit/test_cloud_runtime_provision.py
 server/tests/integration/test_cloud_commands_api.py
 server/proliferate/server/billing/service.py
-server/proliferate/server/cloud/runtime/credential_freshness.py
 server/proliferate/db/store/cloud_workspaces.py
+server/proliferate/server/cloud/commands/service.py
 server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/runtime/bootstrap.py
-server/proliferate/server/cloud/runtime/credential_freshness.py
+server/proliferate/server/cloud/runtime_config/domain/resolver.py
+server/proliferate/server/cloud/runtime_config/service.py
 server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/agent_auth/service.py
 server/proliferate/server/cloud/runtime/provision.py
@@ -77,3 +84,4 @@ server/proliferate/db/models/cloud/agent_auth.py
 server/proliferate/db/store/cloud_agent_auth/store.py
 server/proliferate/server/cloud/agent_auth/service.py
 server/tests/integration/test_cloud_agent_auth_api.py
+server/tests/integration/test_sandbox_profile_foundation.py

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -12,11 +12,13 @@ SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional s
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/commands/service.py 1 transitional cloud command service imports ORM model during worker migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/compute/service.py 1 transitional cloud compute service imports ORM model during worker migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
+SERVICE_ORM_IMPORT server/proliferate/server/cloud/sandbox_profiles/service.py 1 transitional sandbox profile service imports auth model
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/target_config/service.py 1 transitional target config service imports ORM model during worker migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/target_git_identity/service.py 1 transitional target git identity service imports ORM model during worker migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/targets/service.py 1 transitional cloud targets service imports ORM model during worker migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 transitional service imports ORM/auth model
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 transitional live service opens DB session during worker migration
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 transitional workspace service opens DB session during managed-cloud migration
 SERVICE_SQLALCHEMY_IMPORT server/proliferate/server/cloud/agent_auth/service.py 1 transitional agent auth service handles SQLAlchemy integrity errors during worker migration
 SERVICE_SQLALCHEMY_IMPORT server/proliferate/server/cloud/commands/service.py 1 transitional cloud command service builds SQLAlchemy query during worker migration
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/target_config/domain/policy.py 1 transitional target config policy imports product config during worker migration

--- a/server/alembic/versions/a2b3c4d5e6f7_cloud_owned_mcp_model.py
+++ b/server/alembic/versions/a2b3c4d5e6f7_cloud_owned_mcp_model.py
@@ -47,9 +47,15 @@ def _has_check_constraint(table_name: str, constraint_name: str) -> bool:
 
 def upgrade() -> None:
     """Upgrade schema."""
-    if not _has_column("cloud_mcp_connection", "org_id"):
+    if not _has_column("cloud_mcp_connection", "org_id") and not _has_column(
+        "cloud_mcp_connection",
+        "organization_id",
+    ):
         op.add_column("cloud_mcp_connection", sa.Column("org_id", sa.Uuid(), nullable=True))
-    if not _has_index("cloud_mcp_connection", "ix_cloud_mcp_connection_org_id"):
+    if _has_column("cloud_mcp_connection", "org_id") and not _has_index(
+        "cloud_mcp_connection",
+        "ix_cloud_mcp_connection_org_id",
+    ):
         op.create_index(
             "ix_cloud_mcp_connection_org_id",
             "cloud_mcp_connection",
@@ -83,7 +89,7 @@ def upgrade() -> None:
         )
 
     op.alter_column("cloud_mcp_connection", "payload_ciphertext", nullable=True)
-    if not _has_check_constraint(
+    if _has_column("cloud_mcp_connection", "user_id") and not _has_check_constraint(
         "cloud_mcp_connection",
         "ck_cloud_mcp_connection_v1_user_id",
     ):
@@ -92,7 +98,7 @@ def upgrade() -> None:
             "cloud_mcp_connection",
             "user_id IS NOT NULL",
         )
-    if not _has_check_constraint(
+    if _has_column("cloud_mcp_connection", "org_id") and not _has_check_constraint(
         "cloud_mcp_connection",
         "ck_cloud_mcp_connection_v1_org_id_null",
     ):

--- a/server/proliferate/db/models/cloud/agent_auth.py
+++ b/server/proliferate/db/models/cloud/agent_auth.py
@@ -51,17 +51,13 @@ class SandboxProfile(Base):
             "uq_sandbox_profile_active_personal_user",
             "owner_user_id",
             unique=True,
-            postgresql_where=text(
-                "owner_scope = 'personal' AND archived_at IS NULL"
-            ),
+            postgresql_where=text("owner_scope = 'personal' AND archived_at IS NULL"),
         ),
         Index(
             "uq_sandbox_profile_active_organization",
             "organization_id",
             unique=True,
-            postgresql_where=text(
-                "owner_scope = 'organization' AND archived_at IS NULL"
-            ),
+            postgresql_where=text("owner_scope = 'organization' AND archived_at IS NULL"),
         ),
     )
 

--- a/server/proliferate/db/models/cloud/sandboxes.py
+++ b/server/proliferate/db/models/cloud/sandboxes.py
@@ -28,8 +28,7 @@ class CloudSandbox(Base):
             "target_id",
             unique=True,
             postgresql_where=text(
-                "superseded_at IS NULL "
-                "AND status IN ('creating','running','paused','blocked')"
+                "superseded_at IS NULL AND status IN ('creating','running','paused','blocked')"
             ),
         ),
     )

--- a/server/proliferate/db/models/cloud/targets.py
+++ b/server/proliferate/db/models/cloud/targets.py
@@ -63,9 +63,7 @@ class CloudTarget(Base):
             "ux_cloud_target_primary_per_profile",
             "sandbox_profile_id",
             unique=True,
-            postgresql_where=text(
-                "profile_target_role = 'primary' AND archived_at IS NULL"
-            ),
+            postgresql_where=text("profile_target_role = 'primary' AND archived_at IS NULL"),
         ),
     )
 

--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -296,7 +296,24 @@ async def list_cloud_sandboxes_for_subject(
     return list(
         (
             await db.execute(
-                select(CloudSandbox).where(CloudSandbox.billing_subject_id == billing_subject_id)
+                select(CloudSandbox)
+                .outerjoin(
+                    CloudRuntimeEnvironment,
+                    CloudRuntimeEnvironment.id == CloudSandbox.runtime_environment_id,
+                )
+                .outerjoin(CloudWorkspace, CloudWorkspace.id == CloudSandbox.cloud_workspace_id)
+                .where(
+                    or_(
+                        CloudSandbox.billing_subject_id == billing_subject_id,
+                        (
+                            CloudSandbox.billing_subject_id.is_(None)
+                            & or_(
+                                CloudRuntimeEnvironment.billing_subject_id == billing_subject_id,
+                                CloudWorkspace.billing_subject_id == billing_subject_id,
+                            )
+                        ),
+                    )
+                )
             )
         )
         .scalars()

--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -296,9 +296,7 @@ async def list_cloud_sandboxes_for_subject(
     return list(
         (
             await db.execute(
-                select(CloudSandbox).where(
-                    CloudSandbox.billing_subject_id == billing_subject_id
-                )
+                select(CloudSandbox).where(CloudSandbox.billing_subject_id == billing_subject_id)
             )
         )
         .scalars()

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -604,21 +604,25 @@ async def get_active_personal_synced_credential_for_update(
     agent_kind: str,
 ) -> AgentAuthCredentialRecord | None:
     row = (
-        await db.execute(
-            select(AgentAuthCredential)
-            .where(
-                AgentAuthCredential.owner_scope == "personal",
-                AgentAuthCredential.owner_user_id == user_id,
-                AgentAuthCredential.organization_id.is_(None),
-                AgentAuthCredential.agent_kind == agent_kind,
-                AgentAuthCredential.credential_kind == "synced_path",
-                AgentAuthCredential.revoked_at.is_(None),
-                AgentAuthCredential.status != "revoked",
+        (
+            await db.execute(
+                select(AgentAuthCredential)
+                .where(
+                    AgentAuthCredential.owner_scope == "personal",
+                    AgentAuthCredential.owner_user_id == user_id,
+                    AgentAuthCredential.organization_id.is_(None),
+                    AgentAuthCredential.agent_kind == agent_kind,
+                    AgentAuthCredential.credential_kind == "synced_path",
+                    AgentAuthCredential.revoked_at.is_(None),
+                    AgentAuthCredential.status != "revoked",
+                )
+                .order_by(AgentAuthCredential.created_at.asc())
+                .with_for_update()
             )
-            .order_by(AgentAuthCredential.created_at.asc())
-            .with_for_update()
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     return _credential_record(row) if row is not None else None
 
 

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -1384,6 +1384,167 @@ async def upsert_target_state(
     return _target_state_record(row)
 
 
+async def mark_runtime_config_pending(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    sequence: int,
+    revision_id: UUID,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    row = await _get_or_create_target_state_for_update(
+        db,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+        runtime_config_status="pending",
+    )
+    if (
+        row.applied_runtime_config_revision_id != str(revision_id)
+        or row.applied_runtime_config_sequence < sequence
+    ):
+        row.runtime_config_status = "pending"
+        row.updated_at = utcnow()
+    await db.flush()
+    return _target_state_record(row)
+
+
+async def mark_runtime_config_failed(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    sequence: int,
+    revision_id: UUID,
+    error_code: str,
+    error_message: str,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    row = await _get_or_create_target_state_for_update(
+        db,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+        runtime_config_status="failed",
+    )
+    row.runtime_config_status = "failed"
+    row.last_runtime_config_attempted_at = utcnow()
+    row.last_runtime_config_error_code = error_code
+    row.last_runtime_config_error_message = error_message
+    if (
+        row.applied_runtime_config_revision_id == str(revision_id)
+        and row.applied_runtime_config_sequence >= sequence
+    ):
+        row.applied_runtime_config_sequence = 0
+        row.applied_runtime_config_revision_id = None
+    row.updated_at = utcnow()
+    await db.flush()
+    return _target_state_record(row)
+
+
+async def record_runtime_config_command(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    command_id: UUID,
+) -> SandboxProfileAgentAuthTargetStateRecord | None:
+    row = await _load_target_state_for_update(
+        db,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+    )
+    if row is None:
+        return None
+    row.last_runtime_config_command_id = command_id
+    row.runtime_config_status = "pending"
+    row.updated_at = utcnow()
+    await db.flush()
+    return _target_state_record(row)
+
+
+async def record_runtime_config_worker_status(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    sequence: int,
+    revision_id: UUID,
+    worker_id: UUID,
+    status: str,
+    error_code: str | None,
+    error_message: str | None,
+) -> SandboxProfileAgentAuthTargetStateRecord:
+    row = await _get_or_create_target_state_for_update(
+        db,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+        runtime_config_status=status,
+    )
+    now = utcnow()
+    row.runtime_config_status = status
+    row.last_runtime_config_worker_id = worker_id
+    row.last_runtime_config_attempted_at = now
+    row.last_runtime_config_error_code = error_code
+    row.last_runtime_config_error_message = error_message
+    if status == "applied":
+        row.applied_runtime_config_sequence = sequence
+        row.applied_runtime_config_revision_id = str(revision_id)
+        row.last_runtime_config_applied_at = now
+        row.last_runtime_config_error_code = None
+        row.last_runtime_config_error_message = None
+    row.updated_at = now
+    await db.flush()
+    return _target_state_record(row)
+
+
+async def _load_target_state_for_update(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+) -> SandboxProfileTargetState | None:
+    return (
+        await db.execute(
+            select(SandboxProfileTargetState)
+            .where(
+                SandboxProfileTargetState.sandbox_profile_id == sandbox_profile_id,
+                SandboxProfileTargetState.target_id == target_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+
+
+async def _get_or_create_target_state_for_update(
+    db: AsyncSession,
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    runtime_config_status: str,
+) -> SandboxProfileTargetState:
+    row = await _load_target_state_for_update(
+        db,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+    )
+    if row is not None:
+        return row
+    now = utcnow()
+    row = SandboxProfileTargetState(
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+        desired_agent_auth_revision=0,
+        applied_agent_auth_revision=None,
+        agent_auth_status="applied",
+        agent_auth_force_restart_required=False,
+        applied_runtime_config_sequence=0,
+        applied_runtime_config_revision_id=None,
+        runtime_config_status=runtime_config_status,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    return row
+
+
 async def create_runtime_grant(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_mcp/connections.py
+++ b/server/proliferate/db/store/cloud_mcp/connections.py
@@ -141,14 +141,6 @@ async def get_user_connection_by_db_id(
     return await _connection_record(db, record)
 
 
-async def get_connection_payload_ciphertext(
-    db: AsyncSession,
-    connection_db_id: UUID,
-) -> str | None:
-    record = await db.get(CloudMcpConnection, connection_db_id)
-    return record.payload_ciphertext if record is not None else None
-
-
 async def upsert_user_connection(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_mcp/connections.py
+++ b/server/proliferate/db/store/cloud_mcp/connections.py
@@ -141,6 +141,14 @@ async def get_user_connection_by_db_id(
     return await _connection_record(db, record)
 
 
+async def get_connection_payload_ciphertext(
+    db: AsyncSession,
+    connection_db_id: UUID,
+) -> str | None:
+    record = await db.get(CloudMcpConnection, connection_db_id)
+    return record.payload_ciphertext if record is not None else None
+
+
 async def upsert_user_connection(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_sandbox_profiles.py
+++ b/server/proliferate/db/store/cloud_sandbox_profiles.py
@@ -82,8 +82,7 @@ async def ensure_personal_sandbox_profile(
         .on_conflict_do_nothing(
             index_elements=[SandboxProfile.owner_user_id],
             index_where=(
-                (SandboxProfile.owner_scope == "personal")
-                & SandboxProfile.archived_at.is_(None)
+                (SandboxProfile.owner_scope == "personal") & SandboxProfile.archived_at.is_(None)
             ),
         )
         .returning(SandboxProfile.id)

--- a/server/proliferate/db/store/cloud_sync/commands.py
+++ b/server/proliferate/db/store/cloud_sync/commands.py
@@ -248,8 +248,7 @@ async def lease_next_command(
             return None
         active_slot = (
             await db.execute(
-                select(CloudSandbox.id)
-                .where(
+                select(CloudSandbox.id).where(
                     CloudSandbox.id == worker.cloud_sandbox_id,
                     CloudSandbox.target_id == target_id,
                     CloudSandbox.slot_generation == worker.slot_generation,

--- a/server/proliferate/db/store/cloud_sync/targets.py
+++ b/server/proliferate/db/store/cloud_sync/targets.py
@@ -551,9 +551,7 @@ async def load_active_runtime_access_for_target(
 ) -> CloudTargetRuntimeAccessSnapshot | None:
     row = (
         await db.execute(
-            select(CloudTargetRuntimeAccess).where(
-                CloudTargetRuntimeAccess.target_id == target_id
-            )
+            select(CloudTargetRuntimeAccess).where(CloudTargetRuntimeAccess.target_id == target_id)
         )
     ).scalar_one_or_none()
     return _runtime_access_snapshot(row) if row is not None else None
@@ -621,8 +619,7 @@ async def update_target_runtime_access(
         db.add(row)
     else:
         slot_changed = (
-            row.active_sandbox_id != active_sandbox_id
-            or row.slot_generation != slot_generation
+            row.active_sandbox_id != active_sandbox_id or row.slot_generation != slot_generation
         )
         if row.active_sandbox_id not in {None, active_sandbox_id}:
             previous_slot = await db.get(CloudSandbox, row.active_sandbox_id)

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -1346,9 +1346,8 @@ async def record_worker_agent_auth_status(
             status = "failed"
             applied_revision = existing_applied
             error_code = "agent_auth_cleanup_incomplete"
-            error_message = (
-                "Agent auth cleanup did not report all required paths: "
-                + ", ".join(missing_cleanup_paths)
+            error_message = "Agent auth cleanup did not report all required paths: " + ", ".join(
+                missing_cleanup_paths
             )
         elif applied_revision < desired_revision:
             status = "superseded"
@@ -1729,13 +1728,7 @@ async def _cleanup_paths_from_credential_payload(
     if not isinstance(files, dict):
         return ()
     allowed_paths = set(_native_auth_file_paths(selection.agent_kind))
-    return tuple(
-        sorted(
-            path
-            for path in files
-            if isinstance(path, str) and path in allowed_paths
-        )
-    )
+    return tuple(sorted(path for path in files if isinstance(path, str) and path in allowed_paths))
 
 
 def _native_auth_file_paths(agent_kind: str) -> tuple[str, ...]:

--- a/server/proliferate/server/cloud/capabilities/models.py
+++ b/server/proliferate/server/cloud/capabilities/models.py
@@ -15,9 +15,7 @@ class AgentGatewayByokProviderCapabilities(BaseModel):
 class AgentGatewayCapabilities(BaseModel):
     enabled: bool
     managed_credits_personal_enabled: bool = Field(alias="managedCreditsPersonalEnabled")
-    managed_credits_organization_enabled: bool = Field(
-        alias="managedCreditsOrganizationEnabled"
-    )
+    managed_credits_organization_enabled: bool = Field(alias="managedCreditsOrganizationEnabled")
     default_managed_budget_usd: str | None = Field(alias="defaultManagedBudgetUsd")
     byok_enabled: bool = Field(alias="byokEnabled")
     byok_providers: AgentGatewayByokProviderCapabilities = Field(alias="byokProviders")

--- a/server/proliferate/server/cloud/capabilities/service.py
+++ b/server/proliferate/server/cloud/capabilities/service.py
@@ -21,9 +21,7 @@ def cloud_capabilities() -> CloudCapabilitiesResponse:
             enabled=gateway_enabled,
             managedCreditsPersonalEnabled=managed_credits_enabled,
             managedCreditsOrganizationEnabled=managed_credits_enabled,
-            defaultManagedBudgetUsd=(
-                default_managed_budget if managed_credits_enabled else None
-            ),
+            defaultManagedBudgetUsd=(default_managed_budget if managed_credits_enabled else None),
             byokEnabled=gateway_enabled and settings.agent_gateway_byok_enabled,
             byokProviders=AgentGatewayByokProviderCapabilities(
                 anthropicApiKey=(

--- a/server/proliferate/server/cloud/runtime/anyharness_api.py
+++ b/server/proliferate/server/cloud/runtime/anyharness_api.py
@@ -305,9 +305,9 @@ async def reconcile_remote_agents(
     agent_summaries = (
         await _list_remote_agents(
             runtime_url,
-        access_token,
-        workspace_id=workspace_id,
-    )
+            access_token,
+            workspace_id=workspace_id,
+        )
         if agent_kinds_to_install
         else initial_summaries
     )

--- a/server/proliferate/server/cloud/runtime/auth_status.py
+++ b/server/proliferate/server/cloud/runtime/auth_status.py
@@ -160,11 +160,5 @@ async def selected_agent_auth_agent_kinds(
 ) -> tuple[str, ...]:
     selections = await agent_auth_store.list_selections_for_profile(db, sandbox_profile_id)
     return tuple(
-        sorted(
-            {
-                selection.agent_kind
-                for selection in selections
-                if selection.status == "active"
-            }
-        )
+        sorted({selection.agent_kind for selection in selections if selection.status == "active"})
     )

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -578,6 +578,7 @@ async def _prepare_runtime_template(
         )
         tracker.complete(node_version=installed_version)
 
+
 async def _launch_supervised_runtime_bundle(
     tracker: _StepTracker,
     ctx: CloudProvisionInput,

--- a/server/proliferate/server/cloud/runtime_config/domain/manifest.py
+++ b/server/proliferate/server/cloud/runtime_config/domain/manifest.py
@@ -37,16 +37,8 @@ def compile_runtime_config_manifest(
     sandbox_profile_id: str,
 ) -> CompiledRuntimeConfigManifest:
     warning_payloads = [_warning_payload(warning) for warning in plan.warnings]
-    blocking_error_payloads = tuple(
-        _warning_payload(blocker) for blocker in plan.blocking_errors
-    )
-    manifest_without_hash = {
-        "runtimeConfigVersion": 1,
-        "externalScope": {
-            "provider": "proliferate-cloud",
-            "id": sandbox_profile_id,
-            "targetId": None,
-        },
+    blocking_error_payloads = tuple(_warning_payload(blocker) for blocker in plan.blocking_errors)
+    runtime_manifest_payload = {
         "mcpServers": [_mcp_server_payload(server) for server in plan.mcp_servers],
         "mcpBindingSummaries": [
             {
@@ -62,6 +54,15 @@ def compile_runtime_config_manifest(
         "skills": [_skill_payload(skill) for skill in plan.skills],
         "artifacts": [_artifact_payload(artifact) for artifact in plan.artifacts],
         "warnings": warning_payloads,
+    }
+    manifest_without_hash = {
+        "runtimeConfigVersion": 1,
+        "externalScope": {
+            "provider": "proliferate-cloud",
+            "id": sandbox_profile_id,
+            "targetId": None,
+        },
+        **runtime_manifest_payload,
         "blockingErrors": list(blocking_error_payloads),
         "sourceRowRefs": [
             {
@@ -74,7 +75,7 @@ def compile_runtime_config_manifest(
             for source in plan.source_row_refs
         ],
     }
-    hash_value = _content_hash(manifest_without_hash)
+    hash_value = _content_hash(runtime_manifest_payload)
     manifest = {
         **manifest_without_hash,
         "contentHash": hash_value,

--- a/server/proliferate/server/cloud/runtime_config/service.py
+++ b/server/proliferate/server/cloud/runtime_config/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from uuid import UUID
 
@@ -285,7 +286,7 @@ async def worker_runtime_config_fragment(
     revision_id: UUID,
 ) -> RuntimeConfigMaterializationFragment:
     await require_current_managed_worker_slot(db, auth=auth)
-    await _require_worker_revision(db, auth=auth, revision_id=revision_id)
+    await _require_current_worker_revision(db, auth=auth, revision_id=revision_id)
     return await runtime_config_fragment_for_revision(db, revision_id=revision_id)
 
 
@@ -297,7 +298,7 @@ async def worker_runtime_config_artifact(
     artifact_hash: str,
 ) -> RuntimeConfigArtifactResponse:
     await require_current_managed_worker_slot(db, auth=auth)
-    revision = await _require_worker_revision(db, auth=auth, revision_id=revision_id)
+    revision = await _require_current_worker_revision(db, auth=auth, revision_id=revision_id)
     artifact = await artifact_store.get_artifact(
         db,
         revision_id=revision.id,
@@ -317,6 +318,7 @@ async def worker_runtime_config_artifact(
             "Runtime config artifact payload is invalid.",
             status_code=500,
         )
+    _raise_if_artifact_integrity_invalid(artifact, payload=payload, content=content)
     return RuntimeConfigArtifactResponse(
         hash=artifact.artifact_hash,
         content_type=artifact.content_type,
@@ -338,7 +340,7 @@ async def worker_runtime_config_credentials(
     body: WorkerRuntimeConfigCredentialMaterializationRequest,
 ) -> WorkerRuntimeConfigCredentialMaterializationResponse:
     await require_current_managed_worker_slot(db, auth=auth)
-    revision = await _require_worker_revision(db, auth=auth, revision_id=revision_id)
+    revision = await _require_current_worker_revision(db, auth=auth, revision_id=revision_id)
     manifest = parse_json_dict(revision.manifest_json) or {}
     allowed_refs = {
         str(ref["credentialRef"])
@@ -380,6 +382,12 @@ async def record_worker_runtime_config_status(
 ) -> WorkerRuntimeConfigStatusResponse:
     await require_current_managed_worker_slot(db, auth=auth)
     revision = await _require_worker_revision(db, auth=auth, revision_id=revision_id)
+    if not await _worker_revision_is_current(db, revision=revision):
+        return WorkerRuntimeConfigStatusResponse(
+            revision_id=str(revision.id),
+            status="stale",
+            updated=False,
+        )
     row = (
         await db.execute(
             select(SandboxProfileTargetState)
@@ -845,6 +853,61 @@ async def _require_worker_revision(
             status_code=404,
         )
     return revision
+
+
+async def _require_current_worker_revision(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    revision_id: UUID,
+) -> SandboxProfileRuntimeConfigRevisionSnapshot:
+    revision = await _require_worker_revision(db, auth=auth, revision_id=revision_id)
+    if not await _worker_revision_is_current(db, revision=revision):
+        raise CloudApiError(
+            "runtime_config_revision_stale",
+            "Runtime config revision is no longer current for this target.",
+            status_code=409,
+        )
+    return revision
+
+
+async def _worker_revision_is_current(
+    db: AsyncSession,
+    *,
+    revision: SandboxProfileRuntimeConfigRevisionSnapshot,
+) -> bool:
+    _current, current_revision = await revision_store.get_current(
+        db,
+        sandbox_profile_id=revision.sandbox_profile_id,
+    )
+    return current_revision is not None and current_revision.id == revision.id
+
+
+def _raise_if_artifact_integrity_invalid(
+    artifact: artifact_store.SandboxProfileRuntimeConfigArtifactSnapshot,
+    *,
+    payload: dict[str, object],
+    content: str,
+) -> None:
+    expected_hash = artifact.artifact_hash
+    byte_size = len(content.encode("utf-8"))
+    payload_hash = payload.get("hash")
+    payload_content_type = payload.get("contentType")
+    if (
+        byte_size != artifact.byte_size
+        or _artifact_content_hash(content) != expected_hash
+        or (payload_hash is not None and payload_hash != expected_hash)
+        or (payload_content_type is not None and payload_content_type != artifact.content_type)
+    ):
+        raise CloudApiError(
+            "runtime_config_artifact_integrity_mismatch",
+            "Runtime config artifact payload does not match its recorded hash.",
+            status_code=500,
+        )
+
+
+def _artifact_content_hash(content: str) -> str:
+    return f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
 
 
 def _credential_refs_from_manifest(manifest: dict[str, object]) -> list[dict[str, object]]:

--- a/server/proliferate/server/cloud/runtime_config/service.py
+++ b/server/proliferate/server/cloud/runtime_config/service.py
@@ -4,13 +4,11 @@ import hashlib
 import json
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import CloudCommandActorKind, CloudCommandKind, CloudCommandSource
-from proliferate.db.models.cloud.agent_auth import SandboxProfileTargetState
-from proliferate.db.models.cloud.mcp import CloudMcpConnection
 from proliferate.db.store import cloud_sandbox_profiles as sandbox_profile_store
+from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_mcp import auth as mcp_auth_store
 from proliferate.db.store.cloud_mcp.connections import (
     list_enabled_connections_for_organization_profile,
@@ -70,7 +68,6 @@ from proliferate.server.cloud.target_config.models import (
 from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
 from proliferate.server.cloud.worker.slot_guard import require_current_managed_worker_slot
 from proliferate.utils.crypto import decrypt_json, encrypt_json
-from proliferate.utils.time import utcnow
 
 
 async def refresh_profile_runtime_config(
@@ -388,60 +385,33 @@ async def record_worker_runtime_config_status(
             status="stale",
             updated=False,
         )
-    row = (
-        await db.execute(
-            select(SandboxProfileTargetState)
-            .where(
-                SandboxProfileTargetState.sandbox_profile_id == revision.sandbox_profile_id,
-                SandboxProfileTargetState.target_id == auth.target_id,
-            )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
-    now = utcnow()
-    if row is None:
-        row = SandboxProfileTargetState(
-            sandbox_profile_id=revision.sandbox_profile_id,
-            target_id=auth.target_id,
-            desired_agent_auth_revision=0,
-            applied_agent_auth_revision=None,
-            agent_auth_status="applied",
-            agent_auth_force_restart_required=False,
-            applied_runtime_config_sequence=0,
-            applied_runtime_config_revision_id=None,
-            runtime_config_status=body.status,
-            created_at=now,
-            updated_at=now,
-        )
-        db.add(row)
-    row.runtime_config_status = body.status
-    row.last_runtime_config_worker_id = auth.worker_id
-    row.last_runtime_config_attempted_at = now
-    row.last_runtime_config_error_code = body.error_code
-    row.last_runtime_config_error_message = body.error_message
-    if body.status == "applied":
-        row.applied_runtime_config_sequence = revision.sequence
-        row.applied_runtime_config_revision_id = str(revision.id)
-        row.last_runtime_config_applied_at = now
-        row.last_runtime_config_error_code = None
-        row.last_runtime_config_error_message = None
-    elif body.status == "failed":
+    error_message = body.error_message
+    if body.status == "failed":
         details = {
             "missingArtifacts": body.missing_artifacts,
             "missingCredentials": body.missing_credentials,
             "errorMessage": body.error_message,
         }
-        row.last_runtime_config_error_message = json.dumps(
+        error_message = json.dumps(
             details,
             ensure_ascii=True,
             separators=(",", ":"),
             sort_keys=True,
         )
-    row.updated_at = now
-    await db.flush()
+    state = await agent_auth_store.record_runtime_config_worker_status(
+        db,
+        sandbox_profile_id=revision.sandbox_profile_id,
+        target_id=auth.target_id,
+        sequence=revision.sequence,
+        revision_id=revision.id,
+        worker_id=auth.worker_id,
+        status=body.status,
+        error_code=body.error_code,
+        error_message=error_message,
+    )
     return WorkerRuntimeConfigStatusResponse(
         revision_id=str(revision.id),
-        status=row.runtime_config_status,
+        status=state.runtime_config_status,
         updated=True,
     )
 
@@ -538,42 +508,13 @@ async def _mark_primary_target_runtime_config_pending(
     target_id = await sandbox_profile_store.load_primary_target_id(db, profile_id)
     if target_id is None:
         return
-    row = (
-        await db.execute(
-            select(SandboxProfileTargetState)
-            .where(
-                SandboxProfileTargetState.sandbox_profile_id == profile_id,
-                SandboxProfileTargetState.target_id == target_id,
-            )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
-    now = utcnow()
-    if row is None:
-        row = SandboxProfileTargetState(
-            sandbox_profile_id=profile_id,
-            target_id=target_id,
-            desired_agent_auth_revision=0,
-            applied_agent_auth_revision=None,
-            agent_auth_status="applied",
-            agent_auth_force_restart_required=False,
-            applied_runtime_config_sequence=0,
-            applied_runtime_config_revision_id=None,
-            runtime_config_status="pending",
-            created_at=now,
-            updated_at=now,
-        )
-        db.add(row)
-        await db.flush()
-        return
-    if (
-        row.applied_runtime_config_revision_id == str(revision_id)
-        and row.applied_runtime_config_sequence >= sequence
-    ):
-        return
-    row.runtime_config_status = "pending"
-    row.updated_at = now
-    await db.flush()
+    await agent_auth_store.mark_runtime_config_pending(
+        db,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+        sequence=sequence,
+        revision_id=revision_id,
+    )
 
 
 async def _mark_primary_target_runtime_config_failed(
@@ -587,49 +528,20 @@ async def _mark_primary_target_runtime_config_failed(
     target_id = await sandbox_profile_store.load_primary_target_id(db, profile_id)
     if target_id is None:
         return
-    row = (
-        await db.execute(
-            select(SandboxProfileTargetState)
-            .where(
-                SandboxProfileTargetState.sandbox_profile_id == profile_id,
-                SandboxProfileTargetState.target_id == target_id,
-            )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
-    now = utcnow()
-    if row is None:
-        row = SandboxProfileTargetState(
-            sandbox_profile_id=profile_id,
-            target_id=target_id,
-            desired_agent_auth_revision=0,
-            applied_agent_auth_revision=None,
-            agent_auth_status="applied",
-            agent_auth_force_restart_required=False,
-            applied_runtime_config_sequence=0,
-            applied_runtime_config_revision_id=None,
-            runtime_config_status="failed",
-            created_at=now,
-            updated_at=now,
-        )
-        db.add(row)
-    row.runtime_config_status = "failed"
-    row.last_runtime_config_attempted_at = now
-    row.last_runtime_config_error_code = _first_blocking_error_code(blocking_errors)
-    row.last_runtime_config_error_message = json.dumps(
-        {"blockingErrors": list(blocking_errors)},
-        ensure_ascii=True,
-        separators=(",", ":"),
-        sort_keys=True,
+    await agent_auth_store.mark_runtime_config_failed(
+        db,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+        sequence=sequence,
+        revision_id=revision_id,
+        error_code=_first_blocking_error_code(blocking_errors),
+        error_message=json.dumps(
+            {"blockingErrors": list(blocking_errors)},
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
     )
-    if (
-        row.applied_runtime_config_revision_id == str(revision_id)
-        and row.applied_runtime_config_sequence >= sequence
-    ):
-        row.applied_runtime_config_sequence = 0
-        row.applied_runtime_config_revision_id = None
-    row.updated_at = now
-    await db.flush()
 
 
 def _first_blocking_error_code(blocking_errors: tuple[dict[str, object], ...]) -> str:
@@ -814,22 +726,12 @@ async def _record_runtime_config_command(
     target_id: UUID,
     command_id: UUID,
 ) -> None:
-    row = (
-        await db.execute(
-            select(SandboxProfileTargetState)
-            .where(
-                SandboxProfileTargetState.sandbox_profile_id == profile_id,
-                SandboxProfileTargetState.target_id == target_id,
-            )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
-    if row is None:
-        return
-    row.last_runtime_config_command_id = command_id
-    row.runtime_config_status = "pending"
-    row.updated_at = utcnow()
-    await db.flush()
+    await agent_auth_store.record_runtime_config_command(
+        db,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+        command_id=command_id,
+    )
 
 
 async def _require_worker_revision(
@@ -936,9 +838,6 @@ async def _resolve_runtime_credential_ref(
     except ValueError:
         return None
     field_name = parts[2]
-    connection = await db.get(CloudMcpConnection, connection_db_id)
-    if connection is None:
-        return None
     auth = await mcp_auth_store.load_connection_auth(
         db,
         connection_db_id=connection_db_id,

--- a/server/tests/e2e/cloud/test_provisioning.py
+++ b/server/tests/e2e/cloud/test_provisioning.py
@@ -80,7 +80,7 @@ async def test_provisioned_workspace_is_sane(
         assert connection["accessToken"]
         assert connection["anyharnessWorkspaceId"]
         assert connection["runtimeGeneration"] >= 1
-        assert connection["allowedAgentKinds"] == ["claude", "codex", "gemini"]
+        assert connection["allowedAgentKinds"] == ["claude", "codex", "opencode", "gemini"]
         assert connection["readyAgentKinds"] == ["claude"]
 
         await assert_workspace_sane(

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -69,9 +69,7 @@ def _claude_file_payload(api_key: str) -> dict[str, object]:
         "files": [
             {
                 "relativePath": ".claude.json",
-                "contentBase64": b64encode(
-                    f'{{"apiKey":"{api_key}"}}'.encode()
-                ).decode("ascii"),
+                "contentBase64": b64encode(f'{{"apiKey":"{api_key}"}}'.encode()).decode("ascii"),
             }
         ],
     }
@@ -316,9 +314,7 @@ async def test_revoked_synced_selection_materializes_invalid_cleanup_plan(
             "files": [
                 {
                     "relativePath": ".claude.json",
-                    "contentBase64": b64encode(
-                        b'{"apiKey":"sk-ant-test"}'
-                    ).decode("ascii"),
+                    "contentBase64": b64encode(b'{"apiKey":"sk-ant-test"}').decode("ascii"),
                 }
             ],
         },
@@ -404,9 +400,9 @@ async def test_revoked_synced_selection_materializes_invalid_cleanup_plan(
     assert selection["agentKind"] == "claude"
     assert selection["status"] == "invalid"
     assert selection["syncedFiles"]["files"] == []
-    assert {
-        cleanup["relativePath"] for cleanup in selection["syncedFiles"]["cleanup"]
-    } == {".claude.json"}
+    assert {cleanup["relativePath"] for cleanup in selection["syncedFiles"]["cleanup"]} == {
+        ".claude.json"
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_agent_auth_sharing_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_sharing_api.py
@@ -60,9 +60,7 @@ def _claude_file_payload(api_key: str) -> dict[str, object]:
         "files": [
             {
                 "relativePath": ".claude.json",
-                "contentBase64": b64encode(
-                    f'{{"apiKey":"{api_key}"}}'.encode()
-                ).decode("ascii"),
+                "contentBase64": b64encode(f'{{"apiKey":"{api_key}"}}'.encode()).decode("ascii"),
             }
         ],
     }

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -67,9 +67,9 @@ def _claude_file_payload(api_key: str) -> dict[str, object]:
         "files": [
             {
                 "relativePath": ".claude.json",
-                "contentBase64": base64.b64encode(
-                    f'{{"apiKey":"{api_key}"}}'.encode()
-                ).decode("ascii"),
+                "contentBase64": base64.b64encode(f'{{"apiKey":"{api_key}"}}'.encode()).decode(
+                    "ascii"
+                ),
             }
         ],
     }
@@ -157,7 +157,6 @@ async def _link_secondary_account(db_session: AsyncSession, user_id: str) -> Non
     )
     db_session.add(account)
     await db_session.commit()
-
 
 
 async def _list_mcp_connections(
@@ -900,6 +899,7 @@ class TestCloudRepoConfig:
             },
         )
         assert response.status_code == 400
+
 
 class TestCloudRepoBranches:
     @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1225,7 +1225,7 @@ class TestCloudWorkspaces:
             "baseBranch": "main",
         }
         assert payload["workspaceStatus"] == "pending"
-        assert payload["allowedAgentKinds"] == ["claude", "codex", "gemini"]
+        assert payload["allowedAgentKinds"] == ["claude", "codex", "opencode", "gemini"]
         assert payload["readyAgentKinds"] == ["claude"]
         assert payload["runtime"]["generation"] == 0
         assert payload["origin"] == {"kind": "human", "entrypoint": "cloud"}

--- a/server/tests/integration/test_sandbox_profile_foundation.py
+++ b/server/tests/integration/test_sandbox_profile_foundation.py
@@ -21,13 +21,14 @@ from proliferate.constants.organizations import (
     ORGANIZATION_ROLE_OWNER,
 )
 from proliferate.db.models.cloud.commands import CloudCommand
-from proliferate.db.models.cloud.agent_auth import SandboxProfile
+from proliferate.db.models.cloud.agent_auth import SandboxProfile, SandboxProfileTargetState
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.targets import CloudTarget
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_sandboxes import ensure_profile_slot, supersede_slot
+from proliferate.db.store.cloud_runtime_config import store as runtime_config_store
 from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
@@ -807,6 +808,220 @@ async def test_lease_supersedes_launch_when_agent_auth_revision_stales(
     assert row.error_code == "agent_auth_revision_stale"
     assert row.leased_cloud_sandbox_id is None
     assert slot.slot_generation is not None
+
+
+@pytest.mark.asyncio
+async def test_lease_supersedes_launch_when_runtime_config_revision_stales(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    auth, profile_id, target_id = await _create_personal_profile(
+        client,
+        db_session,
+        email_prefix="stale-runtime-config-lease",
+    )
+    _slot, worker = await _create_profile_slot_worker(
+        db_session,
+        profile_id=profile_id,
+        target_id=target_id,
+        worker_name="stale-runtime-config-lease-worker",
+    )
+    profile = await agent_auth_store.bump_sandbox_profile_agent_auth_revision(
+        db_session,
+        sandbox_profile_id=profile_id,
+        reason="initial",
+        actor_user_id=uuid.UUID(auth.user_id),
+        force_restart=False,
+    )
+    assert profile is not None
+    await agent_auth_store.upsert_target_state(
+        db_session,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+        desired_revision=profile.agent_auth_revision,
+        applied_revision=profile.agent_auth_revision,
+        status="applied",
+        force_restart_required=False,
+        last_command_id=None,
+        last_worker_id=worker.id,
+        last_error_code=None,
+        last_error_message=None,
+    )
+    revision, _created = await runtime_config_store.upsert_revision_and_current(
+        db_session,
+        sandbox_profile_id=profile_id,
+        content_hash="sha256:runtime-config-v1",
+        manifest_json='{"mcpServers":[],"skills":[],"blockingErrors":[]}',
+        warnings_json=None,
+        source="test",
+        generated_by_user_id=uuid.UUID(auth.user_id),
+    )
+    state = (
+        await db_session.execute(
+            select(SandboxProfileTargetState).where(
+                SandboxProfileTargetState.sandbox_profile_id == profile_id,
+                SandboxProfileTargetState.target_id == target_id,
+            )
+        )
+    ).scalar_one()
+    state.applied_runtime_config_revision_id = str(revision.id)
+    state.applied_runtime_config_sequence = revision.sequence
+    state.runtime_config_status = "applied"
+    command = await commands_store.create_command(
+        db_session,
+        idempotency_scope="stale-runtime-config-lease",
+        idempotency_key="stale-runtime-config-lease",
+        target_id=target_id,
+        organization_id=None,
+        actor_user_id=uuid.UUID(auth.user_id),
+        actor_kind="user",
+        source="api",
+        workspace_id=None,
+        cloud_workspace_id=None,
+        session_id=None,
+        kind=CloudCommandKind.start_session.value,
+        payload_json=json.dumps(
+            {
+                "workspaceId": "workspace-runtime-stale",
+                "agent": "claude",
+                "sandboxProfileId": str(profile_id),
+                "requiredAgentAuthRevision": profile.agent_auth_revision,
+                "requiredRuntimeConfigRevisionId": str(revision.id),
+                "requiredRuntimeConfigSequence": revision.sequence,
+                "requiredRuntimeConfigContentHash": revision.content_hash,
+            }
+        ),
+        observed_event_seq=None,
+        preconditions_json=None,
+        authorization_context_json=None,
+    )
+    await runtime_config_store.upsert_revision_and_current(
+        db_session,
+        sandbox_profile_id=profile_id,
+        content_hash="sha256:runtime-config-v2",
+        manifest_json='{"mcpServers":[],"skills":[],"blockingErrors":[]}',
+        warnings_json=None,
+        source="test",
+        generated_by_user_id=uuid.UUID(auth.user_id),
+    )
+
+    leased = await commands_store.lease_next_command(
+        db_session,
+        target_id=target_id,
+        worker_id=worker.id,
+        supported_kinds=(
+            CloudCommandKind.start_session.value,
+            CloudCommandKind.refresh_agent_auth_config.value,
+        ),
+        lease_id="stale-runtime-config-lease",
+        lease_expires_at=utcnow() + timedelta(minutes=5),
+        now=utcnow(),
+    )
+
+    assert leased is None
+    row = await db_session.get(CloudCommand, command.id)
+    assert row is not None
+    assert row.status == CloudCommandStatus.superseded.value
+    assert row.error_code == "runtime_config_revision_stale"
+    assert row.leased_cloud_sandbox_id is None
+
+
+@pytest.mark.asyncio
+async def test_stale_worker_runtime_config_status_does_not_regress_target_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    auth, profile_id, target_id = await _create_personal_profile(
+        client,
+        db_session,
+        email_prefix="stale-runtime-config-status",
+    )
+    slot = await ensure_profile_slot(
+        db_session,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+    )
+    worker_token = "stale-runtime-config-status-token"
+    worker = await worker_auth_store.create_worker(
+        db_session,
+        target_id=target_id,
+        cloud_sandbox_id=slot.id,
+        slot_generation=slot.slot_generation,
+        token_hash=worker_service._hash_token(
+            domain=CLOUD_WORKER_TOKEN_DOMAIN,
+            token=worker_token,
+        ),
+        machine_fingerprint="stale-runtime-config-status",
+        hostname="stale-runtime-config-status",
+        worker_version="0.1.0",
+        anyharness_version="0.1.0",
+        supervisor_version=None,
+        now=utcnow(),
+    )
+    first_revision, _created = await runtime_config_store.upsert_revision_and_current(
+        db_session,
+        sandbox_profile_id=profile_id,
+        content_hash="sha256:stale-status-v1",
+        manifest_json='{"mcpServers":[],"skills":[],"artifacts":[],"warnings":[]}',
+        warnings_json=None,
+        source="test",
+        generated_by_user_id=uuid.UUID(auth.user_id),
+    )
+    second_revision, _created = await runtime_config_store.upsert_revision_and_current(
+        db_session,
+        sandbox_profile_id=profile_id,
+        content_hash="sha256:stale-status-v2",
+        manifest_json='{"mcpServers":[],"skills":[],"artifacts":[],"warnings":[]}',
+        warnings_json=None,
+        source="test",
+        generated_by_user_id=uuid.UUID(auth.user_id),
+    )
+    await agent_auth_store.upsert_target_state(
+        db_session,
+        sandbox_profile_id=profile_id,
+        target_id=target_id,
+        desired_revision=0,
+        applied_revision=0,
+        status="applied",
+        force_restart_required=False,
+        last_command_id=None,
+        last_worker_id=worker.id,
+        last_error_code=None,
+        last_error_message=None,
+    )
+    state = (
+        await db_session.execute(
+            select(SandboxProfileTargetState).where(
+                SandboxProfileTargetState.sandbox_profile_id == profile_id,
+                SandboxProfileTargetState.target_id == target_id,
+            )
+        )
+    ).scalar_one()
+    state.runtime_config_status = "pending"
+    state.applied_runtime_config_sequence = second_revision.sequence
+    state.applied_runtime_config_revision_id = str(second_revision.id)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/v1/cloud/worker/runtime-configs/{first_revision.id}/status",
+        headers={"Authorization": f"Bearer {worker_token}"},
+        json={
+            "status": "applied",
+            "missingArtifacts": [],
+            "missingCredentials": [],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "revisionId": str(first_revision.id),
+        "status": "stale",
+        "updated": False,
+    }
+    await db_session.refresh(state)
+    assert state.runtime_config_status == "pending"
+    assert state.applied_runtime_config_revision_id == str(second_revision.id)
+    assert state.applied_runtime_config_sequence == second_revision.sequence
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_agent_gateway_integrations.py
+++ b/server/tests/unit/test_agent_gateway_integrations.py
@@ -43,5 +43,5 @@ def test_litellm_redaction_scrubs_provider_secrets() -> None:
     )
 
 
-def test_synced_native_auth_does_not_advertise_opencode_yet() -> None:
-    assert allowed_agent_kinds() == ["claude", "codex", "gemini"]
+def test_allowed_agent_kinds_include_opencode() -> None:
+    assert allowed_agent_kinds() == ["claude", "codex", "opencode", "gemini"]

--- a/server/tests/unit/test_cloud_runtime_anyharness_api.py
+++ b/server/tests/unit/test_cloud_runtime_anyharness_api.py
@@ -10,8 +10,8 @@ from proliferate.integrations.anyharness import (
 )
 from proliferate.server.cloud.runtime import anyharness_api
 from proliferate.server.cloud.runtime.anyharness_api import (
-    _install_required_synced_providers,
-    _synced_ready_providers,
+    _install_required_agent_kinds,
+    _ready_required_agent_kinds,
 )
 
 
@@ -113,7 +113,7 @@ async def test_verify_runtime_auth_enforced_raises_when_probe_request_errors(
 
 
 @pytest.mark.asyncio
-async def test_reconcile_remote_agents_skips_install_when_synced_agents_are_already_ready(
+async def test_reconcile_remote_agents_skips_install_when_required_agents_are_already_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     list_calls: list[str] = []
@@ -136,7 +136,7 @@ async def test_reconcile_remote_agents_skips_install_when_synced_agents_are_alre
     ready_agents = await anyharness_api.reconcile_remote_agents(
         "https://runtime.invalid",
         "runtime-token",
-        synced_providers=["claude", "codex"],
+        required_agent_kinds=["claude", "codex"],
     )
 
     assert ready_agents == ["claude", "codex"]
@@ -145,7 +145,7 @@ async def test_reconcile_remote_agents_skips_install_when_synced_agents_are_alre
 
 
 @pytest.mark.asyncio
-async def test_reconcile_remote_agents_installs_only_install_required_synced_agents(
+async def test_reconcile_remote_agents_installs_only_install_required_agents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     list_responses = [
@@ -190,15 +190,15 @@ async def test_reconcile_remote_agents_installs_only_install_required_synced_age
     ready_agents = await anyharness_api.reconcile_remote_agents(
         "https://runtime.invalid",
         "runtime-token",
-        synced_providers=["claude", "codex", "gemini"],
+        required_agent_kinds=["claude", "codex", "gemini"],
     )
 
     assert ready_agents == ["claude", "codex"]
     assert install_calls == ["codex"]
 
 
-def test_install_required_synced_providers_includes_gemini() -> None:
-    providers = _install_required_synced_providers(
+def test_install_required_agent_kinds_includes_gemini() -> None:
+    providers = _install_required_agent_kinds(
         [
             RemoteAgentSummary(kind="claude", readiness="ready", credential_state=None),
             RemoteAgentSummary(
@@ -213,8 +213,8 @@ def test_install_required_synced_providers_includes_gemini() -> None:
     assert providers == ["gemini"]
 
 
-def test_synced_ready_providers_includes_gemini() -> None:
-    providers = _synced_ready_providers(
+def test_ready_required_agent_kinds_includes_gemini() -> None:
+    providers = _ready_required_agent_kinds(
         [
             RemoteAgentSummary(kind="claude", readiness="ready", credential_state=None),
             RemoteAgentSummary(kind="gemini", readiness="ready", credential_state=None),

--- a/server/tests/unit/test_runtime_config_domain.py
+++ b/server/tests/unit/test_runtime_config_domain.py
@@ -16,6 +16,7 @@ from proliferate.server.cloud.plugins.catalog.domain.types import (
     PluginSkillResource,
 )
 from proliferate.server.cloud.runtime_config.domain.manifest import (
+    _content_hash,
     compile_runtime_config_manifest,
 )
 from proliferate.server.cloud.runtime_config.domain.resolver import (
@@ -349,8 +350,13 @@ def test_manifest_hash_is_stable_and_redacts_secret_values() -> None:
 
     first = compile_runtime_config_manifest(plan, sandbox_profile_id="profile-1")
     second = compile_runtime_config_manifest(plan, sandbox_profile_id="profile-1")
+    wire_manifest = {
+        key: first.manifest[key]
+        for key in ("mcpServers", "mcpBindingSummaries", "skills", "artifacts", "warnings")
+    }
 
     assert first.content_hash == second.content_hash
+    assert first.content_hash == _content_hash(wire_manifest)
     assert "Bearer secret" not in first.manifest_json
     assert "api_key" in first.manifest_json
     assert "Use the configured MCP carefully." not in first.manifest_json


### PR DESCRIPTION
## Summary
- integrates the MCP/skills runtime-config model with the managed sandbox agent-auth preflight path
- removes the legacy MCP materialization and session-plugin bundle paths instead of leaving duplicate runtime configuration flows
- adds runtime-config worker materialization, AnyHarness auth-config contracts, Cloud SDK helpers, launch preflight validation, and lease-time stale revision guards
- preserves fail-closed launch behavior by requiring both applied agent auth and applied runtime config on managed sandbox session starts

## Validation
- `cargo fmt --all --check`
- `cargo test -p anyharness-lib runtime_config`
- `cargo test -p anyharness-lib auth_config`
- `cargo test -p proliferate-worker runtime_config`
- `cargo test -p proliferate-worker agent_auth`
- `cd server && DEBUG=1 uv run --python 3.12 --extra dev ruff check ...`
- `cd server && DEBUG=1 uv run --python 3.12 --extra dev pytest -q tests/unit/test_runtime_config_command_preflight.py tests/unit/test_runtime_config_domain.py tests/unit/test_cloud_executor_worker_commands.py tests/integration/test_cloud_commands_api.py tests/integration/test_cloud_target_config_api.py tests/integration/test_sandbox_profile_foundation.py`
- `cd anyharness/sdk && pnpm run build`
- `cd anyharness/sdk-react && pnpm run build`
- `cd cloud/sdk && pnpm run build`
- `cd cloud/sdk-react && pnpm run build`
- `pnpm shared:build`
- `cd desktop && pnpm exec tsc --noEmit`

## Notes
- `tests/integration/test_schema_migrations.py` was attempted separately, but the local Postgres teardown failed with an `InsufficientPrivilegeError` while terminating backend connections, so I did not treat that as a product assertion failure.
