### PR TITLE
fix(product): clean up account and organization settings

### DIFF
--- a/desktop/src/components/settings/panes/OrganizationPane.tsx
+++ b/desktop/src/components/settings/panes/OrganizationPane.tsx
@@ -3,6 +3,7 @@ import {
   useMemo,
   useState,
   type FormEvent,
+  type ReactNode,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -162,15 +163,11 @@ export function OrganizationPane() {
       />
 
       {statusMessage ? (
-        <div className="rounded-lg border border-border bg-surface-elevated-secondary px-3 py-2 text-sm text-muted-foreground">
-          {statusMessage}
-        </div>
+        <OrganizationNotice>{statusMessage}</OrganizationNotice>
       ) : null}
 
       {unauthenticatedHandoff ? (
-        <div className="rounded-lg border border-border bg-surface-elevated-secondary px-3 py-2 text-sm text-muted-foreground">
-          Sign in, then reopen the invitation email link to accept it.
-        </div>
+        <OrganizationNotice>Sign in, then reopen the invitation email link to accept it.</OrganizationNotice>
       ) : null}
 
       {organizations.length > 0 ? (
@@ -179,26 +176,27 @@ export function OrganizationPane() {
             label="Active organization"
             description="Choose which organization to view and manage here."
           >
-            <Select
-              value={activeOrganizationId ?? ""}
-              onChange={(event) => setActiveOrganizationId(event.currentTarget.value || null)}
-              aria-label="Active organization"
-              className="min-w-48"
-            >
-              {organizations.map((organization) => (
-                <option key={organization.id} value={organization.id}>
-                  {organization.name}
-                </option>
-              ))}
-            </Select>
+            <div className="w-56 max-w-full">
+              <Select
+                value={activeOrganizationId ?? ""}
+                onChange={(event) => setActiveOrganizationId(event.currentTarget.value || null)}
+                aria-label="Active organization"
+              >
+                {organizations.map((organization) => (
+                  <option key={organization.id} value={organization.id}>
+                    {organization.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
           </SettingsCardRow>
         </SettingsCard>
       ) : null}
 
       {shouldShowSignInState ? (
-        <OrganizationSection title="Membership">
+        <OrganizationSection title="Membership" description="Organization access is tied to your signed-in account.">
           <SettingsCard>
-            <div className="p-3 text-sm text-muted-foreground">
+            <div className="p-4 text-sm text-muted-foreground">
               Sign in to view your organization.
             </div>
           </SettingsCard>
@@ -212,7 +210,7 @@ export function OrganizationPane() {
       {shouldShowErrorState ? (
         <OrganizationSection title="Membership">
           <SettingsCard>
-            <div className="flex items-center justify-between gap-3 p-3">
+            <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-sm text-muted-foreground">
                 Organization settings could not be loaded.
               </div>
@@ -233,7 +231,7 @@ export function OrganizationPane() {
       {shouldShowEmptyState ? (
         <OrganizationSection title="Membership">
           <SettingsCard>
-            <div className="p-3 text-sm text-muted-foreground">
+            <div className="p-4 text-sm text-muted-foreground">
               Organization setup is still being prepared for this account.
             </div>
           </SettingsCard>
@@ -289,5 +287,13 @@ export function OrganizationPane() {
         </>
       ) : null}
     </section>
+  );
+}
+
+function OrganizationNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border-light bg-foreground/5 px-4 py-3 text-sm text-muted-foreground">
+      {children}
+    </div>
   );
 }

--- a/desktop/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx
+++ b/desktop/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx
@@ -36,7 +36,10 @@ export function OrganizationInvitationsSection({
   onRevoke: (invitationId: string) => void;
 }) {
   return (
-    <OrganizationSection title="Invitations">
+    <OrganizationSection
+      title="Invitations"
+      description="Invite teammates and manage pending organization invites."
+    >
       <SettingsCard>
         {canManage ? (
           <form
@@ -44,7 +47,7 @@ export function OrganizationInvitationsSection({
               event.preventDefault();
               void onInviteSubmit();
             }}
-            className="flex gap-2 p-3"
+            className="flex flex-col gap-2 border-b border-border-light p-4 sm:flex-row"
           >
             <Input
               type="email"
@@ -52,16 +55,18 @@ export function OrganizationInvitationsSection({
               onChange={(event) => onInviteEmailChange(event.currentTarget.value)}
               placeholder="name@company.com"
               aria-label="Invite email"
+              className="min-w-0 flex-1"
             />
-            <Select
-              value={inviteRole}
-              onChange={(event) => onInviteRoleChange(event.currentTarget.value as "admin" | "member")}
-              aria-label="Invite role"
-              className="w-32"
-            >
-              <option value="member">Member</option>
-              <option value="admin">Admin</option>
-            </Select>
+            <div className="w-full sm:w-32">
+              <Select
+                value={inviteRole}
+                onChange={(event) => onInviteRoleChange(event.currentTarget.value as "admin" | "member")}
+                aria-label="Invite role"
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </Select>
+            </div>
             <Button type="submit" disabled={!inviteEmail.trim()} loading={creatingInvitation}>
               <Mail className="size-4" />
               Invite
@@ -79,7 +84,7 @@ export function OrganizationInvitationsSection({
           />
         ))}
         {invitations.length === 0 ? (
-          <div className="p-3 text-sm text-muted-foreground">No pending invitations.</div>
+          <div className="p-4 text-sm text-muted-foreground">No pending invitations.</div>
         ) : null}
       </SettingsCard>
     </OrganizationSection>
@@ -102,26 +107,28 @@ function InvitationRow({
   const status = invitationStatusBadge(invitation.status);
 
   return (
-    <div className="flex items-center gap-3 p-3">
+    <div className="flex flex-col gap-3 border-b border-border-light px-4 py-3 last:border-b-0 sm:flex-row sm:items-center">
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium">{invitation.email}</div>
+        <div className="truncate text-sm font-medium text-foreground">{invitation.email}</div>
         <div className="truncate text-sm text-muted-foreground">
           {invitation.role} - {invitation.deliveryStatus}
         </div>
       </div>
-      <Badge tone={status.tone}>{status.label}</Badge>
-      {canManage && invitation.status === "pending" ? (
-        <div className="flex items-center gap-2">
-          <Button type="button" variant="ghost" disabled={working} onClick={onResend}>
-            <RefreshCw className="size-4" />
-            Resend
-          </Button>
-          <Button type="button" variant="ghost" disabled={working} onClick={onRevoke}>
-            <Trash className="size-4" />
-            Revoke
-          </Button>
-        </div>
-      ) : null}
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        <Badge tone={status.tone}>{status.label}</Badge>
+        {canManage && invitation.status === "pending" ? (
+          <>
+            <Button type="button" variant="ghost" disabled={working} onClick={onResend}>
+              <RefreshCw className="size-4" />
+              Resend
+            </Button>
+            <Button type="button" variant="ghost" disabled={working} onClick={onRevoke}>
+              <Trash className="size-4" />
+              Revoke
+            </Button>
+          </>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/desktop/src/components/settings/panes/organization/OrganizationLogo.tsx
+++ b/desktop/src/components/settings/panes/organization/OrganizationLogo.tsx
@@ -21,21 +21,21 @@ export function OrganizationLogo({
   const initials = organization.name.trim().slice(0, 2).toUpperCase() || "OR";
   if (logoImage) {
     return (
-      <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-foreground/5">
+      <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border-light bg-foreground/5">
         <img src={logoImage} alt="" className="size-full object-cover" />
       </div>
     );
   }
   if (!organization.logoDomain) {
     return (
-      <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-foreground/5 text-sm font-medium">
+      <div className="flex size-12 shrink-0 items-center justify-center rounded-lg border border-border-light bg-foreground/5 text-sm font-medium text-muted-foreground">
         {initials}
       </div>
     );
   }
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(organization.logoDomain)}&sz=64`;
   return (
-    <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-foreground/5">
+    <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border-light bg-foreground/5">
       <img src={faviconUrl} alt="" className="size-6" />
     </div>
   );
@@ -48,12 +48,12 @@ export function Avatar({ member }: { member: OrganizationAvatarMember }) {
       <img
         src={member.avatarUrl}
         alt=""
-        className="size-8 rounded-full bg-foreground/5"
+        className="size-8 rounded-full bg-foreground/5 object-cover"
       />
     );
   }
   return (
-    <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground/5 text-xs font-medium">
+    <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border-light bg-foreground/5 text-xs font-medium text-muted-foreground">
       {initials || "U"}
     </div>
   );
@@ -61,14 +61,21 @@ export function Avatar({ member }: { member: OrganizationAvatarMember }) {
 
 export function OrganizationSection({
   title,
+  description,
   children,
 }: {
   title: string;
+  description?: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-2">
-      <h2 className="text-sm font-medium text-foreground">{title}</h2>
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+        {description ? (
+          <p className="max-w-xl text-sm leading-6 text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
       {children}
     </section>
   );

--- a/desktop/src/components/settings/panes/organization/OrganizationMembersSection.tsx
+++ b/desktop/src/components/settings/panes/organization/OrganizationMembersSection.tsx
@@ -31,7 +31,10 @@ export function OrganizationMembersSection({
   onRemove: (membershipId: string) => void;
 }) {
   return (
-    <OrganizationSection title="Members">
+    <OrganizationSection
+      title="Members"
+      description="Review access and adjust roles for everyone in this organization."
+    >
       <SettingsCard>
         {members.map((member) => (
           <MemberRow
@@ -46,7 +49,7 @@ export function OrganizationMembersSection({
           />
         ))}
         {members.length === 0 ? (
-          <div className="p-3 text-sm text-muted-foreground">No members yet.</div>
+          <div className="p-4 text-sm text-muted-foreground">No members yet.</div>
         ) : null}
       </SettingsCard>
     </OrganizationSection>
@@ -76,37 +79,42 @@ function MemberRow({
   const status = membershipStatusBadge(member.status);
 
   return (
-    <div className="flex items-center gap-3 p-3">
-      <Avatar member={member} />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium">
-          {member.displayName || member.email}
+    <div className="flex flex-col gap-3 border-b border-border-light px-4 py-3 last:border-b-0 sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <Avatar member={member} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            {member.displayName || member.email}
+          </div>
+          <div className="truncate text-sm text-muted-foreground">{member.email}</div>
         </div>
-        <div className="truncate text-sm text-muted-foreground">{member.email}</div>
       </div>
-      <Badge tone={status.tone}>{status.label}</Badge>
-      <Select
-        value={member.role}
-        disabled={roleDisabled || updating}
-        onChange={(event) => onRoleChange(event.currentTarget.value as OrganizationRole)}
-        aria-label={`Role for ${member.email}`}
-        className="w-28"
-      >
-        <option value="member">Member</option>
-        <option value="admin">Admin</option>
-        <option value="owner" disabled={!canManageOwners}>Owner</option>
-      </Select>
-      {canManage ? (
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={removeDisabled || updating}
-          onClick={onRemove}
-          aria-label={`Remove ${member.email}`}
-        >
-          <Trash className="size-4" />
-        </Button>
-      ) : null}
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        <Badge tone={status.tone}>{status.label}</Badge>
+        <div className="w-28">
+          <Select
+            value={member.role}
+            disabled={roleDisabled || updating}
+            onChange={(event) => onRoleChange(event.currentTarget.value as OrganizationRole)}
+            aria-label={`Role for ${member.email}`}
+          >
+            <option value="member">Member</option>
+            <option value="admin">Admin</option>
+            <option value="owner" disabled={!canManageOwners}>Owner</option>
+          </Select>
+        </div>
+        {canManage ? (
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={removeDisabled || updating}
+            onClick={onRemove}
+            aria-label={`Remove ${member.email}`}
+          >
+            <Trash className="size-4" />
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/desktop/src/components/settings/panes/organization/OrganizationSettingsCard.tsx
+++ b/desktop/src/components/settings/panes/organization/OrganizationSettingsCard.tsx
@@ -45,14 +45,17 @@ export function OrganizationSettingsCard({
   }
 
   return (
-    <OrganizationSection title="Organization Settings">
+    <OrganizationSection
+      title="Profile"
+      description="Update how this organization appears in switchers, settings, and shared workspace context."
+    >
       <SettingsCard>
         <form onSubmit={(event) => { void onSubmit(event); }}>
           <SettingsCardRow
-            label="Organization image"
-            description="Used in the organization switcher and settings."
+            label="Logo"
+            description="Upload a square image for the clearest result."
           >
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-end gap-2">
               <OrganizationLogo organization={organization} logoImage={settingsLogoImage} />
               <Input
                 ref={fileInputRef}
@@ -91,19 +94,19 @@ export function OrganizationSettingsCard({
             ) : null}
           </SettingsCardRow>
           <SettingsCardRow
-            label="Organization name"
-            description="Shown in the organization switcher and settings."
+            label="Name"
+            description="Shown anywhere organization context is displayed."
           >
             <Input
               value={settingsName}
               onChange={(event) => onNameChange(event.currentTarget.value)}
               aria-label="Organization name"
               disabled={!canManage}
-              className="w-64"
+              className="w-64 max-w-full"
             />
           </SettingsCardRow>
           {canManage ? (
-            <div className="flex justify-end p-3">
+            <div className="flex justify-end border-t border-border-light p-3">
               <Button type="submit" loading={saving} disabled={!settingsName.trim()}>
                 Save
               </Button>

--- a/packages/product-ui/src/account/AccountSettingsPane.tsx
+++ b/packages/product-ui/src/account/AccountSettingsPane.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from "react";
 
+import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
 
 import { SettingsCard } from "../settings/SettingsCard";
@@ -64,13 +65,15 @@ export function AccountSettingsPane({
 }: AccountSettingsPaneProps) {
   return (
     <div className="space-y-6">
-      <AccountProfileHeader
-        avatarUrl={avatarUrl ?? null}
-        displayName={displayName}
-        email={email}
-        githubLabel={githubLabel}
-        profileSummary={profileSummary}
-      />
+      <SettingsCard>
+        <AccountProfileHeader
+          avatarUrl={avatarUrl ?? null}
+          displayName={displayName}
+          email={email}
+          githubLabel={githubLabel}
+          profileSummary={profileSummary}
+        />
+      </SettingsCard>
 
       <SettingsCard>
         <SettingsCardRow label={accessTitle} description={accessDescription}>
@@ -154,7 +157,7 @@ function AccountProfileHeader({
   profileSummary: string;
 }) {
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center">
       <AccountAvatar
         key={avatarUrl ?? "account-avatar"}
         avatarUrl={avatarUrl}
@@ -185,7 +188,7 @@ function AccountAvatar({
   const showAvatar = Boolean(avatarUrl) && !avatarFailed;
 
   return (
-    <div className="flex size-24 shrink-0 items-center justify-center overflow-hidden rounded-full bg-foreground/5 text-xl font-medium text-muted-foreground">
+    <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border-light bg-foreground/5 text-lg font-medium text-muted-foreground">
       {showAvatar ? (
         <img
           src={avatarUrl ?? ""}
@@ -231,26 +234,31 @@ function ProviderRow({ provider }: { provider: AccountProviderView }) {
         <div className="flex items-center gap-2 font-medium text-foreground">
           <span>{provider.label}</span>
           {provider.primary ? (
-            <span className="rounded-full bg-info-subtle px-1.5 py-0.5 text-[10px] font-medium text-info">
-              Primary
-            </span>
+            <Badge tone="neutral">Primary</Badge>
           ) : null}
         </div>
         <div className="truncate text-muted-foreground">
           {provider.accountLabel || (provider.connected ? "Connected" : "Not connected")}
         </div>
       </div>
-      <span
-        className={
-          provider.connected && provider.status !== "expired"
-            ? "shrink-0 text-xs text-foreground"
-            : "shrink-0 text-xs text-muted-foreground"
-        }
-      >
+      <Badge tone={providerStatusTone(provider)} className="shrink-0">
         {statusLabel}
-      </span>
+      </Badge>
     </div>
   );
+}
+
+function providerStatusTone(provider: AccountProviderView): "neutral" | "success" | "warning" | "destructive" {
+  if (!provider.connected) {
+    return "neutral";
+  }
+  if (provider.status === "expired") {
+    return "destructive";
+  }
+  if (provider.status === "needs_reauth") {
+    return "warning";
+  }
+  return "success";
 }
 
 function initialsForName(name: string): string {


### PR DESCRIPTION
## Summary
- Bring the shared account settings pane into the standard settings card treatment.
- Replace the blue `Primary` provider pill with neutral/status badges.
- Tighten organization profile, member, invitation, and notice layouts while leaving billing untouched.

## Validation
- `pnpm --filter @proliferate/product-ui typecheck`
- `pnpm --filter @proliferate/product-ui test -- AccountSettingsPane.test.tsx`
- `pnpm --dir desktop build`
- `pnpm web:build`
- Browser checked web `/settings` with a mock local API and no console errors.