### PR TITLE
feat(desktop): adjust appearance sizing and auth defaults

### DIFF
--- a/desktop/src/components/auth/AuthAppearanceBoundary.tsx
+++ b/desktop/src/components/auth/AuthAppearanceBoundary.tsx
@@ -1,0 +1,37 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+const DEFAULT_APPEARANCE_TEXT_SCALE_CLASS = [
+  "[--text-xs:0.5rem]",
+  "[--text-xs--line-height:0.75rem]",
+  "[--text-sm:0.625rem]",
+  "[--text-sm--line-height:1rem]",
+  "[--text-base:0.6875rem]",
+  "[--text-base--line-height:1rem]",
+  "[--text-chat:12px]",
+  "[--text-chat--line-height:20px]",
+  "[--text-lg:0.875rem]",
+  "[--text-lg--line-height:1.25rem]",
+  "[--text-xl:1.125rem]",
+  "[--text-xl--line-height:1.75rem]",
+].join(" ");
+
+interface AuthAppearanceBoundaryProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function AuthAppearanceBoundary({
+  children,
+  className,
+  ...props
+}: AuthAppearanceBoundaryProps) {
+  return (
+    <div
+      {...props}
+      className={twMerge(DEFAULT_APPEARANCE_TEXT_SCALE_CLASS, className)}
+      data-auth-default-appearance=""
+    >
+      {children}
+    </div>
+  );
+}

--- a/desktop/src/components/auth/AuthAppearanceBoundary.tsx
+++ b/desktop/src/components/auth/AuthAppearanceBoundary.tsx
@@ -1,20 +1,9 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import { DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES } from "@/lib/domain/preferences/appearance";
 import { twMerge } from "tailwind-merge";
 
-const DEFAULT_APPEARANCE_TEXT_SCALE_CLASS = [
-  "[--text-xs:0.5rem]",
-  "[--text-xs--line-height:0.75rem]",
-  "[--text-sm:0.625rem]",
-  "[--text-sm--line-height:1rem]",
-  "[--text-base:0.6875rem]",
-  "[--text-base--line-height:1rem]",
-  "[--text-chat:12px]",
-  "[--text-chat--line-height:20px]",
-  "[--text-lg:0.875rem]",
-  "[--text-lg--line-height:1.25rem]",
-  "[--text-xl:1.125rem]",
-  "[--text-xl--line-height:1.75rem]",
-].join(" ");
+const DEFAULT_AUTH_APPEARANCE_STYLE =
+  DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES as CSSProperties;
 
 interface AuthAppearanceBoundaryProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
@@ -23,13 +12,18 @@ interface AuthAppearanceBoundaryProps extends HTMLAttributes<HTMLDivElement> {
 export function AuthAppearanceBoundary({
   children,
   className,
+  style,
   ...props
 }: AuthAppearanceBoundaryProps) {
   return (
     <div
       {...props}
-      className={twMerge(DEFAULT_APPEARANCE_TEXT_SCALE_CLASS, className)}
+      className={twMerge(className)}
       data-auth-default-appearance=""
+      style={{
+        ...DEFAULT_AUTH_APPEARANCE_STYLE,
+        ...style,
+      }}
     >
       {children}
     </div>

--- a/desktop/src/components/auth/AuthGate.test.tsx
+++ b/desktop/src/components/auth/AuthGate.test.tsx
@@ -5,8 +5,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { BootstrappedRoute } from "@/components/auth/AuthGate";
+import { LoginScreen } from "@/components/auth/LoginScreen";
 import { SessionCheckScreen } from "@/components/auth/SessionCheckScreen";
 import { useAuthStore } from "@/stores/auth/auth-store";
+
+function expectDefaultAuthAppearance(html: string) {
+  expect(html).toContain("data-auth-default-appearance");
+  expect(html).toContain("--text-sm:0.625rem");
+  expect(html).toContain("--text-chat:12px");
+}
 
 describe("SessionCheckScreen", () => {
   it("uses the auth-style checking copy and branded mark surface", () => {
@@ -16,6 +23,30 @@ describe("SessionCheckScreen", () => {
     expect(html).toContain("Checking your session");
     expect(html).toContain("Proliferate is restoring your account");
     expect(html).not.toContain("data-jank-canary=\"braille\"");
+  });
+
+  it("ignores user appearance text-size preferences", () => {
+    expectDefaultAuthAppearance(renderToStaticMarkup(<SessionCheckScreen />));
+  });
+});
+
+describe("LoginScreen", () => {
+  it("ignores user appearance text-size preferences", () => {
+    const html = renderToStaticMarkup(
+      <LoginScreen
+        submitting={false}
+        busy={false}
+        error={null}
+        githubSignInAvailable
+        githubSignInChecking={false}
+        githubSignInUnavailableDescription=""
+        onGitHubSignIn={() => {}}
+        onContinueLocally={() => {}}
+        canContinueLocally
+      />,
+    );
+
+    expectDefaultAuthAppearance(html);
   });
 });
 

--- a/desktop/src/components/auth/AuthGate.test.tsx
+++ b/desktop/src/components/auth/AuthGate.test.tsx
@@ -7,12 +7,40 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { BootstrappedRoute } from "@/components/auth/AuthGate";
 import { LoginScreen } from "@/components/auth/LoginScreen";
 import { SessionCheckScreen } from "@/components/auth/SessionCheckScreen";
+import {
+  buildUiTextScaleCssVariables,
+  DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES,
+  UI_FONT_SCALES,
+} from "@/lib/domain/preferences/appearance";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
-function expectDefaultAuthAppearance(html: string) {
-  expect(html).toContain("data-auth-default-appearance");
-  expect(html).toContain("--text-sm:0.625rem");
-  expect(html).toContain("--text-chat:12px");
+afterEach(() => {
+  cleanup();
+  for (const property of Object.keys(DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES)) {
+    document.documentElement.style.removeProperty(property);
+  }
+});
+
+function setRootToNonDefaultTextScale() {
+  for (const [property, value] of Object.entries(
+    buildUiTextScaleCssVariables(UI_FONT_SCALES.xxxlarge),
+  )) {
+    document.documentElement.style.setProperty(property, value);
+  }
+}
+
+function getAuthAppearanceBoundary(): HTMLElement {
+  const boundary = document.querySelector<HTMLElement>("[data-auth-default-appearance]");
+  if (!boundary) {
+    throw new Error("Missing auth appearance boundary");
+  }
+  return boundary;
+}
+
+function expectDefaultAuthAppearance(element: HTMLElement) {
+  for (const [property, value] of Object.entries(DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES)) {
+    expect(element.style.getPropertyValue(property)).toBe(value);
+  }
 }
 
 describe("SessionCheckScreen", () => {
@@ -26,13 +54,17 @@ describe("SessionCheckScreen", () => {
   });
 
   it("ignores user appearance text-size preferences", () => {
-    expectDefaultAuthAppearance(renderToStaticMarkup(<SessionCheckScreen />));
+    setRootToNonDefaultTextScale();
+    render(<SessionCheckScreen />);
+
+    expectDefaultAuthAppearance(getAuthAppearanceBoundary());
   });
 });
 
 describe("LoginScreen", () => {
   it("ignores user appearance text-size preferences", () => {
-    const html = renderToStaticMarkup(
+    setRootToNonDefaultTextScale();
+    render(
       <LoginScreen
         submitting={false}
         busy={false}
@@ -46,7 +78,7 @@ describe("LoginScreen", () => {
       />,
     );
 
-    expectDefaultAuthAppearance(html);
+    expectDefaultAuthAppearance(getAuthAppearanceBoundary());
   });
 });
 
@@ -56,7 +88,6 @@ describe("BootstrappedRoute", () => {
   });
 
   afterEach(() => {
-    cleanup();
     useAuthStore.setState({ status: "bootstrapping", session: null, user: null, error: null });
   });
 

--- a/desktop/src/components/auth/LoginScreen.tsx
+++ b/desktop/src/components/auth/LoginScreen.tsx
@@ -1,4 +1,5 @@
 import { ProliferateLivingMark } from "@/components/brand/ProliferateLivingMark";
+import { AuthAppearanceBoundary } from "@/components/auth/AuthAppearanceBoundary";
 import { ArrowRight, GitHub } from "@/components/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { AUTH_LOGIN_LABELS } from "@/copy/auth/auth-copy";
@@ -27,7 +28,7 @@ export function LoginScreen({
   canContinueLocally,
 }: LoginScreenProps) {
   return (
-    <div
+    <AuthAppearanceBoundary
       className="flex min-h-screen flex-col items-center justify-center bg-background p-8"
       data-tauri-drag-region="true"
     >
@@ -91,6 +92,6 @@ export function LoginScreen({
           )}
         </div>
       </div>
-    </div>
+    </AuthAppearanceBoundary>
   );
 }

--- a/desktop/src/components/auth/SessionCheckScreen.tsx
+++ b/desktop/src/components/auth/SessionCheckScreen.tsx
@@ -1,4 +1,5 @@
 import { ProliferateLivingMark } from "@/components/brand/ProliferateLivingMark";
+import { AuthAppearanceBoundary } from "@/components/auth/AuthAppearanceBoundary";
 import { AUTH_GATE_LABELS } from "@/copy/auth/auth-copy";
 import { twMerge } from "tailwind-merge";
 
@@ -14,7 +15,7 @@ export function SessionCheckScreen({
   onResolved,
 }: SessionCheckScreenProps) {
   return (
-    <div
+    <AuthAppearanceBoundary
       className={twMerge(
         "flex min-h-screen flex-col items-center justify-center bg-background p-8",
         className,
@@ -35,6 +36,6 @@ export function SessionCheckScreen({
           </div>
         </div>
       </div>
-    </div>
+    </AuthAppearanceBoundary>
   );
 }

--- a/desktop/src/config/theme.ts
+++ b/desktop/src/config/theme.ts
@@ -1,4 +1,5 @@
 import {
+  buildUiTextScaleCssVariables,
   DEFAULT_APPEARANCE_SIZE_ID,
   resolveAppearanceSizeId,
   resolveReadableCodeFontScale,
@@ -72,14 +73,6 @@ export interface AppearancePreference {
   readableCodeFontSizeId: ReadableCodeFontSizeId;
 }
 
-function setTextScaleVariables(
-  prefix: string,
-  scale: { fontSize: string; lineHeight: string },
-) {
-  document.documentElement.style.setProperty(`--text-${prefix}`, scale.fontSize);
-  document.documentElement.style.setProperty(`--text-${prefix}--line-height`, scale.lineHeight);
-}
-
 export function applyAppearancePreference({
   themePreset,
   colorMode,
@@ -97,12 +90,9 @@ export function applyAppearancePreference({
   root.dataset.readableCodeFontSize = resolvedReadableCodeFontSizeId;
   applyMode(colorMode, themePreset);
 
-  setTextScaleVariables("xs", uiScale.xs);
-  setTextScaleVariables("sm", uiScale.sm);
-  setTextScaleVariables("base", uiScale.base);
-  setTextScaleVariables("chat", uiScale.chat);
-  setTextScaleVariables("lg", uiScale.lg);
-  setTextScaleVariables("xl", uiScale.xl);
+  for (const [property, value] of Object.entries(buildUiTextScaleCssVariables(uiScale))) {
+    root.style.setProperty(property, value);
+  }
 
   root.style.setProperty("--diffs-font-size", readableCodeScale.diffsFontSize);
   root.style.setProperty("--diffs-line-height", readableCodeScale.diffsLineHeight);

--- a/desktop/src/lib/domain/preferences/appearance-presentation.ts
+++ b/desktop/src/lib/domain/preferences/appearance-presentation.ts
@@ -11,12 +11,14 @@ interface AppearanceSizeOption<T extends string> {
 }
 
 const SIZE_LABELS: Record<UiFontSizeId, string> = {
+  xxsmall: "Extra Extra Small",
   xsmall: "Extra Small",
   small: "Small",
   default: "Default",
   large: "Large",
   xlarge: "Extra Large",
   xxlarge: "Extra Extra Large",
+  xxxlarge: "Extra Extra Extra Large",
 };
 
 export const UI_FONT_SIZE_OPTIONS: AppearanceSizeOption<UiFontSizeId>[] =

--- a/desktop/src/lib/domain/preferences/appearance.test.ts
+++ b/desktop/src/lib/domain/preferences/appearance.test.ts
@@ -11,9 +11,11 @@ import {
 
 describe("appearance preferences", () => {
   it("resolves invalid size ids to default", () => {
+    expect(resolveAppearanceSizeId("xxsmall")).toBe("xxsmall");
     expect(resolveAppearanceSizeId("xsmall")).toBe("xsmall");
     expect(resolveAppearanceSizeId("small")).toBe("small");
     expect(resolveAppearanceSizeId("xxlarge")).toBe("xxlarge");
+    expect(resolveAppearanceSizeId("xxxlarge")).toBe("xxxlarge");
     expect(resolveAppearanceSizeId("unknown")).toBe("default");
     expect(resolveAppearanceSizeId(undefined)).toBe("default");
   });
@@ -21,16 +23,18 @@ describe("appearance preferences", () => {
   it("steps appearance size ids within bounds", () => {
     expect(stepAppearanceSizeId("default", 1)).toBe("large");
     expect(stepAppearanceSizeId("default", -1)).toBe("small");
-    expect(stepAppearanceSizeId("xxlarge", 1)).toBe("xxlarge");
-    expect(stepAppearanceSizeId("xsmall", -1)).toBe("xsmall");
+    expect(stepAppearanceSizeId("xxlarge", 1)).toBe("xxxlarge");
+    expect(stepAppearanceSizeId("xxxlarge", 1)).toBe("xxxlarge");
+    expect(stepAppearanceSizeId("xsmall", -1)).toBe("xxsmall");
+    expect(stepAppearanceSizeId("xxsmall", -1)).toBe("xxsmall");
   });
 
   it("steps UI and readable code font sizes independently", () => {
     expect(stepAppearanceFontSizes({
-      uiFontSizeId: "xxlarge",
+      uiFontSizeId: "xxxlarge",
       readableCodeFontSizeId: "large",
     }, 1)).toEqual({
-      uiFontSizeId: "xxlarge",
+      uiFontSizeId: "xxxlarge",
       readableCodeFontSizeId: "xlarge",
     });
   });
@@ -54,6 +58,14 @@ describe("appearance preferences", () => {
 
   it("defines exact UI font preset values", () => {
     expect(UI_FONT_SCALES).toEqual({
+      xxsmall: {
+        xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
+        sm: { fontSize: "0.4375rem", lineHeight: "0.75rem" },
+        base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
+        chat: { fontSize: "9px", lineHeight: "17px" },
+        lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },
+        xl: { fontSize: "0.9375rem", lineHeight: "1.375rem" },
+      },
       xsmall: {
         xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
         sm: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
@@ -102,6 +114,14 @@ describe("appearance preferences", () => {
         lg: { fontSize: "1.0625rem", lineHeight: "1.625rem" },
         xl: { fontSize: "1.3125rem", lineHeight: "2.125rem" },
       },
+      xxxlarge: {
+        xs: { fontSize: "0.75rem", lineHeight: "1.125rem" },
+        sm: { fontSize: "0.875rem", lineHeight: "1.3125rem" },
+        base: { fontSize: "0.9375rem", lineHeight: "1.5rem" },
+        chat: { fontSize: "16px", lineHeight: "24px" },
+        lg: { fontSize: "1.125rem", lineHeight: "1.75rem" },
+        xl: { fontSize: "1.375rem", lineHeight: "2.25rem" },
+      },
     });
   });
 
@@ -118,6 +138,14 @@ describe("appearance preferences", () => {
 
   it("defines exact readable code preset values", () => {
     expect(READABLE_CODE_FONT_SCALES).toEqual({
+      xxsmall: {
+        monacoFontSize: 8,
+        monacoLineHeight: 15,
+        diffsFontSize: "8px",
+        diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
+        codeFontSize: "0.5rem",
+        codeLineHeight: "1.625",
+      },
       xsmall: {
         monacoFontSize: 9,
         monacoLineHeight: 16,
@@ -164,6 +192,14 @@ describe("appearance preferences", () => {
         diffsFontSize: "14px",
         diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
         codeFontSize: "0.875rem",
+        codeLineHeight: "1.625",
+      },
+      xxxlarge: {
+        monacoFontSize: 15,
+        monacoLineHeight: 24,
+        diffsFontSize: "15px",
+        diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
+        codeFontSize: "0.9375rem",
         codeLineHeight: "1.625",
       },
     });

--- a/desktop/src/lib/domain/preferences/appearance.ts
+++ b/desktop/src/lib/domain/preferences/appearance.ts
@@ -1,4 +1,13 @@
-export const APPEARANCE_SIZE_IDS = ["xsmall", "small", "default", "large", "xlarge", "xxlarge"] as const;
+export const APPEARANCE_SIZE_IDS = [
+  "xxsmall",
+  "xsmall",
+  "small",
+  "default",
+  "large",
+  "xlarge",
+  "xxlarge",
+  "xxxlarge",
+] as const;
 
 export type AppearanceSizeId = (typeof APPEARANCE_SIZE_IDS)[number];
 export type UiFontSizeId = AppearanceSizeId;
@@ -29,15 +38,25 @@ export interface ReadableCodeFontScale {
 
 export const DEFAULT_APPEARANCE_SIZE_ID: AppearanceSizeId = "default";
 export const CHAT_LINE_HEIGHTS: Record<UiFontSizeId, string> = {
+  xxsmall: "17px",
   xsmall: "18px",
   small: "19px",
   default: "20px",
   large: "21px",
   xlarge: "22px",
   xxlarge: "23px",
+  xxxlarge: "24px",
 };
 
 export const UI_FONT_SCALES: Record<UiFontSizeId, UiFontScale> = {
+  xxsmall: {
+    xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
+    sm: { fontSize: "0.4375rem", lineHeight: "0.75rem" },
+    base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
+    chat: { fontSize: "9px", lineHeight: CHAT_LINE_HEIGHTS.xxsmall },
+    lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },
+    xl: { fontSize: "0.9375rem", lineHeight: "1.375rem" },
+  },
   xsmall: {
     xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
     sm: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
@@ -86,9 +105,25 @@ export const UI_FONT_SCALES: Record<UiFontSizeId, UiFontScale> = {
     lg: { fontSize: "1.0625rem", lineHeight: "1.625rem" },
     xl: { fontSize: "1.3125rem", lineHeight: "2.125rem" },
   },
+  xxxlarge: {
+    xs: { fontSize: "0.75rem", lineHeight: "1.125rem" },
+    sm: { fontSize: "0.875rem", lineHeight: "1.3125rem" },
+    base: { fontSize: "0.9375rem", lineHeight: "1.5rem" },
+    chat: { fontSize: "16px", lineHeight: CHAT_LINE_HEIGHTS.xxxlarge },
+    lg: { fontSize: "1.125rem", lineHeight: "1.75rem" },
+    xl: { fontSize: "1.375rem", lineHeight: "2.25rem" },
+  },
 };
 
 export const READABLE_CODE_FONT_SCALES: Record<ReadableCodeFontSizeId, ReadableCodeFontScale> = {
+  xxsmall: {
+    monacoFontSize: 8,
+    monacoLineHeight: 15,
+    diffsFontSize: "8px",
+    diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
+    codeFontSize: "0.5rem",
+    codeLineHeight: "1.625",
+  },
   xsmall: {
     monacoFontSize: 9,
     monacoLineHeight: 16,
@@ -135,6 +170,14 @@ export const READABLE_CODE_FONT_SCALES: Record<ReadableCodeFontSizeId, ReadableC
     diffsFontSize: "14px",
     diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
     codeFontSize: "0.875rem",
+    codeLineHeight: "1.625",
+  },
+  xxxlarge: {
+    monacoFontSize: 15,
+    monacoLineHeight: 24,
+    diffsFontSize: "15px",
+    diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
+    codeFontSize: "0.9375rem",
     codeLineHeight: "1.625",
   },
 };

--- a/desktop/src/lib/domain/preferences/appearance.ts
+++ b/desktop/src/lib/domain/preferences/appearance.ts
@@ -27,6 +27,21 @@ export interface UiFontScale {
   xl: TextTokenScale;
 }
 
+export type UiTextScaleCssVariables = {
+  "--text-xs": string;
+  "--text-xs--line-height": string;
+  "--text-sm": string;
+  "--text-sm--line-height": string;
+  "--text-base": string;
+  "--text-base--line-height": string;
+  "--text-chat": string;
+  "--text-chat--line-height": string;
+  "--text-lg": string;
+  "--text-lg--line-height": string;
+  "--text-xl": string;
+  "--text-xl--line-height": string;
+};
+
 export interface ReadableCodeFontScale {
   monacoFontSize: number;
   monacoLineHeight: number;
@@ -193,6 +208,27 @@ export function resolveAppearanceSizeId(value: unknown): AppearanceSizeId {
 export function resolveUiFontScale(value: unknown): UiFontScale {
   return UI_FONT_SCALES[resolveAppearanceSizeId(value)];
 }
+
+export function buildUiTextScaleCssVariables(scale: UiFontScale): UiTextScaleCssVariables {
+  return {
+    "--text-xs": scale.xs.fontSize,
+    "--text-xs--line-height": scale.xs.lineHeight,
+    "--text-sm": scale.sm.fontSize,
+    "--text-sm--line-height": scale.sm.lineHeight,
+    "--text-base": scale.base.fontSize,
+    "--text-base--line-height": scale.base.lineHeight,
+    "--text-chat": scale.chat.fontSize,
+    "--text-chat--line-height": scale.chat.lineHeight,
+    "--text-lg": scale.lg.fontSize,
+    "--text-lg--line-height": scale.lg.lineHeight,
+    "--text-xl": scale.xl.fontSize,
+    "--text-xl--line-height": scale.xl.lineHeight,
+  };
+}
+
+export const DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES = buildUiTextScaleCssVariables(
+  UI_FONT_SCALES[DEFAULT_APPEARANCE_SIZE_ID],
+);
 
 export function resolveReadableCodeFontScale(value: unknown): ReadableCodeFontScale {
   return READABLE_CODE_FONT_SCALES[resolveAppearanceSizeId(value)];

--- a/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -488,13 +488,13 @@ describe("user preference migration", () => {
   it("preserves explicit valid appearance font preferences", () => {
     const result = migrateUserPreferences({
       ...USER_PREFERENCE_DEFAULTS,
-      uiFontSizeId: "xsmall",
-      readableCodeFontSizeId: "xxlarge",
+      uiFontSizeId: "xxsmall",
+      readableCodeFontSizeId: "xxxlarge",
     });
 
     expect(result.changed).toBe(false);
-    expect(result.preferences.uiFontSizeId).toBe("xsmall");
-    expect(result.preferences.readableCodeFontSizeId).toBe("xxlarge");
+    expect(result.preferences.uiFontSizeId).toBe("xxsmall");
+    expect(result.preferences.readableCodeFontSizeId).toBe("xxxlarge");
   });
 
   it("sanitizes partially present review defaults", () => {


### PR DESCRIPTION
## Summary

- Adds one smaller and one larger Appearance size option for UI and readable code scaling.
- Keeps auth and session-restore screens on the default text scale regardless of the user's Appearance preference.
- Extends preference and auth screen tests for the new size bounds and default-auth appearance behavior.

## Why

The prior Appearance range did not provide enough room at either end, and the auth redirect/status UI should stay stable while the app is restoring or prompting for account state rather than inheriting user-selected density.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/preferences/appearance.test.ts src/stores/preferences/user-preferences-store.test.ts`
- `pnpm --dir desktop exec vitest run src/components/auth/AuthGate.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --filter proliferate build`
- `git diff --check`
