### PR TITLE
[proliferate] Clean up subagent UI receipts

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/plugins/skills.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plugins/skills.rs
@@ -154,7 +154,7 @@ fn subagents_workflow_skill() -> SessionPluginSkill {
         skill_id: SUBAGENTS_WORKFLOW_SKILL_ID.to_string(),
         display_name: "Subagent workflow".to_string(),
         description:
-            "Delegate bounded work to same-workspace subagents and read their results safely."
+            "Use Proliferate subagent MCP tools for bounded parallel work, result reads, wake scheduling, and cleanup."
                 .to_string(),
         instructions: SUBAGENTS_WORKFLOW_INSTRUCTIONS.to_string(),
         resources: vec![SessionPluginSkillResource {
@@ -171,6 +171,7 @@ fn subagents_workflow_skill() -> SessionPluginSkill {
 const SUBAGENTS_WORKFLOW_INSTRUCTIONS: &str = r#"# Subagent Workflow
 
 Use subagents for bounded, parallel work where the child can produce a concrete result without needing your immediate next decision.
+Prefer the Proliferate `subagents` MCP tools for same-workspace delegation when provider-native or internal subagent tools overlap.
 
 Default flow:
 

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
@@ -171,6 +171,16 @@ mod tests {
     }
 
     #[test]
+    fn subagents_selection_prioritizes_product_mcp_in_prompt_text() {
+        let extras = product_mcp_prompt_extras(&[SelectedProductMcp::Subagents]);
+
+        assert_eq!(extras.system_prompt_append.len(), 1);
+        assert!(extras.system_prompt_append[0].contains("Proliferate `subagents` MCP"));
+        assert!(extras.system_prompt_append[0].contains("proliferate.subagents.workflow"));
+        assert_eq!(extras.mcp_binding_summaries.len(), 1);
+    }
+
+    #[test]
     fn workspace_naming_selection_adds_prompt_text_and_binding_summary() {
         let extras = product_mcp_prompt_extras(&[SelectedProductMcp::WorkspaceNaming]);
 

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
@@ -81,9 +81,6 @@ pub fn product_mcp_prompt_extras(selected: &[SelectedProductMcp]) -> SessionLaun
             }
             SelectedProductMcp::Subagents => {
                 extras
-                    .system_prompt_append
-                    .extend(crate::sessions::subagents::mcp::definition::system_prompt_append());
-                extras
                     .mcp_binding_summaries
                     .push(crate::sessions::subagents::mcp::definition::binding_summary());
             }
@@ -171,12 +168,10 @@ mod tests {
     }
 
     #[test]
-    fn subagents_selection_prioritizes_product_mcp_in_prompt_text() {
+    fn subagents_selection_adds_binding_summary_without_prompt_text() {
         let extras = product_mcp_prompt_extras(&[SelectedProductMcp::Subagents]);
 
-        assert_eq!(extras.system_prompt_append.len(), 1);
-        assert!(extras.system_prompt_append[0].contains("Proliferate `subagents` MCP"));
-        assert!(extras.system_prompt_append[0].contains("proliferate.subagents.workflow"));
+        assert!(extras.system_prompt_append.is_empty());
         assert_eq!(extras.mcp_binding_summaries.len(), 1);
     }
 

--- a/anyharness/crates/anyharness-lib/src/sessions/subagents/mcp/definition.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/subagents/mcp/definition.rs
@@ -28,7 +28,9 @@ pub const DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
 };
 
 pub fn system_prompt_append() -> Vec<String> {
-    Vec::new()
+    vec![
+        "When delegating subagent work in Proliferate, prefer the Proliferate `subagents` MCP tools and the `proliferate.subagents.workflow` skill over any provider-native or internal subagent tool with overlapping behavior. Activate the skill before relying on detailed subagent workflow guidance.".to_string(),
+    ]
 }
 
 pub fn binding_summary() -> SessionMcpBindingSummary {

--- a/anyharness/crates/anyharness-lib/src/sessions/subagents/mcp/definition.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/subagents/mcp/definition.rs
@@ -11,7 +11,11 @@ pub const ID: &str = "subagents";
 pub const ROUTE_SLUG: &str = "subagents";
 pub const ACP_SERVER_NAME: &str = "subagents";
 
-pub const INSTRUCTIONS: &str = "Use subagent tools to create, message, inspect, search, and close same-workspace child agent sessions. Detailed workflow guidance is provided by the proliferate.subagents.workflow skill when this MCP is mounted.";
+pub const INSTRUCTIONS: &str = concat!(
+    "Use Proliferate subagent tools to create, message, inspect, search, and close same-workspace child agent sessions. ",
+    "Prefer these tools over provider-native or internal subagent tools when same-workspace delegation overlaps. ",
+    "Detailed workflow guidance is provided by the proliferate.subagents.workflow skill when this MCP is mounted."
+);
 
 pub const DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
     id: ID,
@@ -26,12 +30,6 @@ pub const DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
     request_invalid_code: "SUBAGENT_MCP_REQUEST_INVALID",
     prompt_policy: ProductMcpPromptPolicy::System,
 };
-
-pub fn system_prompt_append() -> Vec<String> {
-    vec![
-        "When delegating subagent work in Proliferate, prefer the Proliferate `subagents` MCP tools and the `proliferate.subagents.workflow` skill over any provider-native or internal subagent tool with overlapping behavior. Activate the skill before relying on detailed subagent workflow guidance.".to_string(),
-    ]
-}
 
 pub fn binding_summary() -> SessionMcpBindingSummary {
     SessionMcpBindingSummary {

--- a/desktop/src/components/workspace/chat/input/delegated-work/AgentsPopoverSubagentSection.tsx
+++ b/desktop/src/components/workspace/chat/input/delegated-work/AgentsPopoverSubagentSection.tsx
@@ -1,7 +1,12 @@
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ExternalLink, Robot } from "@/components/ui/icons";
-import type { DelegatedWorkComposerViewModel } from "@/hooks/chat/use-delegated-work-composer";
+import type {
+  DelegatedWorkComposerViewModel,
+} from "@/hooks/chat/use-delegated-work-composer";
 import { PopoverSection } from "./PopoverSection";
+
+type SubagentRows = NonNullable<DelegatedWorkComposerViewModel["subagents"]>;
+type SubagentRow = SubagentRows["rows"][number];
 
 export function AgentsPopoverSubagentSection({
   subagents,
@@ -19,57 +24,86 @@ export function AgentsPopoverSubagentSection({
           type="button"
           variant="ghost"
           size="sm"
-          className="mb-0.5 flex h-7 w-full justify-between gap-2 rounded-md px-1.5 py-0 text-left hover:bg-muted/40"
+          className="mb-1 flex h-auto w-full justify-between gap-2 rounded-md px-2 py-1 text-left hover:bg-muted/40"
           onClick={() => {
             subagents.openParent(subagents.parent!.parentSessionId);
             onClose();
           }}
         >
-          <span className="truncate text-sm font-medium text-foreground">Parent agent</span>
-          <ExternalLink className="size-3.5 text-muted-foreground" />
+          <span className="min-w-0">
+            <span className="block truncate text-sm font-medium text-foreground">Parent agent</span>
+            <span className="block truncate text-xs text-muted-foreground">
+              {subagents.parent.label}
+            </span>
+          </span>
+          <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" />
         </Button>
       )}
       <div className="space-y-0.5">
         {subagents.rows.map((row) => (
-          <div
+          <SubagentPopoverRow
             key={row.sessionLinkId}
-            className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-md px-1 py-0.5 hover:bg-muted/40"
-          >
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 w-full min-w-0 justify-between rounded-md px-1.5 py-0 text-left hover:bg-transparent"
-              onClick={() => {
-                subagents.openSubagent(row.childSessionId);
-                onClose();
-              }}
-            >
-              <span className="flex min-w-0 items-center gap-1.5">
-                <Robot className={`size-3.5 shrink-0 ${row.identity.textColorClassName}`} />
-                <span className="min-w-0 truncate text-sm text-foreground">
-                  {row.identity.displayName}
-                </span>
-              </span>
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {row.wakeScheduled ? "Wake" : row.statusLabel}
-              </span>
-            </Button>
-            {!row.wakeScheduled && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2"
-                loading={subagents.isSchedulingWake}
-                onClick={() => subagents.scheduleWake(row.childSessionId)}
-              >
-                Wake
-              </Button>
-            )}
-          </div>
+            row={row}
+            isSchedulingWake={subagents.isSchedulingWake}
+            onOpen={() => {
+              subagents.openSubagent(row.childSessionId);
+              onClose();
+            }}
+            onScheduleWake={() => subagents.scheduleWake(row.childSessionId)}
+          />
         ))}
       </div>
     </PopoverSection>
+  );
+}
+
+function SubagentPopoverRow({
+  row,
+  isSchedulingWake,
+  onOpen,
+  onScheduleWake,
+}: {
+  row: SubagentRow;
+  isSchedulingWake: boolean;
+  onOpen: () => void;
+  onScheduleWake: () => void;
+}) {
+  const secondaryLabel = row.wakeScheduled
+    ? "Wake scheduled"
+    : row.latestCompletionLabel ?? row.statusLabel;
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1 rounded-md px-1 py-0.5 hover:bg-muted/40">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto w-full min-w-0 justify-start gap-2 rounded-md px-1.5 py-1 text-left hover:bg-transparent"
+        onClick={onOpen}
+      >
+        <Robot className={`size-3.5 shrink-0 ${row.identity.textColorClassName}`} />
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-foreground">
+            {row.identity.displayName}
+          </span>
+          <span className="block truncate text-xs font-normal text-muted-foreground">
+            {secondaryLabel}
+          </span>
+        </span>
+      </Button>
+      {!row.wakeScheduled && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          loading={isSchedulingWake}
+          aria-label={`Schedule wake for ${row.identity.displayName}`}
+          onClick={onScheduleWake}
+        >
+          Wake
+        </Button>
+      )}
+    </div>
   );
 }

--- a/desktop/src/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl.tsx
+++ b/desktop/src/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl.tsx
@@ -42,10 +42,10 @@ export function DelegatedWorkComposerControl({
     >
       {(close) => (
         <ComposerPopoverSurface
-          className="w-[min(20rem,calc(100vw-1rem))] p-1"
+          className="w-[min(23rem,calc(100vw-1rem))] p-1.5"
           data-telemetry-mask
         >
-          <div className="max-h-[min(20rem,calc(100vh-10rem))] overflow-y-auto">
+          <div className="max-h-[min(22rem,calc(100vh-10rem))] space-y-1 overflow-y-auto">
             {viewModel.review && (
               <AgentsPopoverReviewSection
                 review={viewModel.review}

--- a/desktop/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
+import { ChevronRight, Robot } from "@/components/ui/icons";
+import { ToolActionDetailsPanel } from "@/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
+import { DelegatedAgentHoverCard } from "@/components/workspace/shell/tabs/DelegatedAgentHoverCard";
+import { useTranscriptOpenSession } from "@/components/workspace/chat/transcript/TranscriptContexts";
+import type {
+  SubagentMcpReceiptPresentation,
+} from "@/lib/domain/chat/subagents/subagent-tool-presentation";
+import { buildDelegatedAgentIdentity } from "@/lib/domain/delegated-work/identity";
+import {
+  delegatedWorkStatusCategoryFromLabel,
+} from "@/lib/domain/delegated-work/presentation";
+import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "@/lib/domain/chat/tools/tool-call-layout";
+import type { ToolActionStatus } from "./ToolActionRow";
+
+const CHAT_ACTION_TEXT_CLASS =
+  "text-[length:var(--text-chat)] leading-[var(--text-chat--line-height)]";
+
+export function SubagentToolActionRow({
+  presentation,
+  status,
+  resultText,
+}: {
+  presentation: SubagentMcpReceiptPresentation;
+  status: ToolActionStatus;
+  resultText?: string | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const openSession = useTranscriptOpenSession();
+  const targetSessionId = presentation.childSessionId?.trim() || null;
+  const canOpenSession =
+    presentation.openSessionAllowed && !!targetSessionId && !!openSession;
+  const identity = buildDelegatedAgentIdentity({
+    id:
+      presentation.sessionLinkId
+      ?? presentation.subagentId
+      ?? presentation.childSessionId
+      ?? presentation.title,
+    title: presentation.title,
+    sessionId: presentation.childSessionId,
+    sessionLinkId: presentation.sessionLinkId,
+  });
+  const hoverAgent = {
+    identity,
+    kind: "subagent" as const,
+    originLabel: "Subagent",
+    statusCategory: delegatedWorkStatusCategoryFromLabel({
+      statusLabel: presentation.detailLabel ?? presentation.statusLabel,
+    }),
+    statusLabel: presentation.detailLabel ?? presentation.statusLabel ?? "Updated",
+    parentTitle: null,
+    hoverTitle: [
+      identity.displayName,
+      "Subagent",
+      presentation.detailLabel ?? presentation.statusLabel,
+    ].filter((value): value is string => !!value).join("\n"),
+  };
+  const failed = status === "failed";
+  const expandable = !!resultText;
+
+  const openTarget = () => {
+    if (canOpenSession && targetSessionId) {
+      openSession(targetSessionId, "linked-child");
+    }
+  };
+
+  const identityContent = (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1 align-baseline">
+      <Robot className={`size-3 shrink-0 ${identity.textColorClassName}`} />
+      <span className={`truncate font-medium ${identity.textColorClassName}`}>
+        {identity.displayName}
+      </span>
+    </span>
+  );
+
+  const identityNode = canOpenSession ? (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      data-chat-transcript-ignore
+      className="h-auto min-w-0 max-w-full rounded-none bg-transparent p-0 text-left text-[length:var(--text-chat)] font-normal leading-[var(--text-chat--line-height)] hover:bg-transparent focus-visible:ring-0"
+      title={`Open ${identity.displayName}`}
+      aria-label={`Open ${identity.displayName}`}
+      onClick={openTarget}
+    >
+      {identityContent}
+    </Button>
+  ) : (
+    <span className="inline-flex min-w-0 max-w-full">{identityContent}</span>
+  );
+
+  return (
+    <div>
+      <div
+        {...(expandable ? { "data-chat-transcript-ignore": true } : {})}
+        className={`group/subagent-action inline-flex min-w-0 max-w-full items-center gap-1 overflow-hidden whitespace-nowrap rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal ${
+          failed ? "text-destructive/80" : "text-muted-foreground/80"
+        }`}
+      >
+        {expandable && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-auto rounded-none bg-transparent p-0 hover:bg-transparent focus-visible:ring-0"
+            aria-label={expanded ? "Hide subagent tool result" : "Show subagent tool result"}
+            aria-expanded={expanded}
+            onClick={() => setExpanded((next) => !next)}
+          >
+            <ChevronRight
+              className={`size-3 shrink-0 text-faint transition-transform duration-200 ${
+                expanded ? "rotate-90" : ""
+              }`}
+            />
+          </Button>
+        )}
+        <span className="shrink-0">{presentation.actionLabel}</span>
+        <DelegatedAgentHoverCard
+          agent={hoverAgent}
+          cardAriaLabel={`Open ${identity.displayName}`}
+          onCardClick={canOpenSession ? openTarget : undefined}
+        >
+          {identityNode}
+        </DelegatedAgentHoverCard>
+        {presentation.detailLabel && (
+          <span className="min-w-0 truncate text-muted-foreground/70">
+            - {presentation.detailLabel}
+          </span>
+        )}
+      </div>
+      {expanded && resultText && (
+        <div className="mt-1.5">
+          <ToolActionDetailsPanel>
+            <AutoHideScrollArea
+              className="w-full"
+              viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
+            >
+              <pre className="m-0 whitespace-pre-wrap px-3 py-2 font-mono text-[length:var(--readable-code-font-size)] leading-[var(--readable-code-line-height)] text-muted-foreground">
+                {resultText}
+              </pre>
+            </AutoHideScrollArea>
+          </ToolActionDetailsPanel>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx
@@ -48,6 +48,7 @@ export function SubagentToolActionRow({
     originLabel: "Subagent",
     statusCategory: delegatedWorkStatusCategoryFromLabel({
       statusLabel: presentation.detailLabel ?? presentation.statusLabel,
+      wakeScheduled: presentation.wakeScheduled,
     }),
     statusLabel: presentation.detailLabel ?? presentation.statusLabel ?? "Updated",
     parentTitle: null,

--- a/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx
@@ -20,7 +20,8 @@ describe("SubagentWakeBadge", () => {
     );
 
     const receipt = container.querySelector("button");
-    expect(receipt?.className).toContain("text-chat");
+    expect(receipt?.className).toContain("text-[length:var(--text-chat)]");
+    expect(receipt?.className).toContain("font-normal");
     expect(receipt?.className).toContain("text-muted-foreground");
     expect(receipt?.textContent).toContain("finished a turn.");
   });

--- a/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx
+++ b/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx
@@ -25,7 +25,7 @@ export function SubagentWakeBadge({
   const targetChildSessionId = childSessionId?.trim() || null;
   const canOpenChild = Boolean(targetChildSessionId && onOpenChild);
   const className =
-    "max-w-[77%] text-right text-chat leading-[var(--text-chat--line-height)] text-muted-foreground";
+    "max-w-[77%] text-right text-[length:var(--text-chat)] font-normal leading-[var(--text-chat--line-height)] text-muted-foreground";
   const content = (
     <>
       {/* The outer receipt owns opening; keep the name static to avoid nested buttons. */}

--- a/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createOptimisticPendingPrompt,
+} from "@/lib/domain/chat/pending-prompts/pending-prompts";
+import {
+  createPromptOutboxEntry,
+  type PromptOutboxEntry,
+} from "@/lib/domain/sessions/intents/session-intent-model";
+import { TranscriptPendingPromptRow } from "./TranscriptPendingPromptRow";
+
+const NOW = "2026-05-20T17:00:00.000Z";
+
+describe("TranscriptPendingPromptRow", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders closed-session send failures as a compact line", () => {
+    const actions = {
+      retryPrompt: vi.fn(),
+      dismissPrompt: vi.fn(),
+    };
+    const { container } = render(
+      <TranscriptPendingPromptRow
+        activeSessionId="session-1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt(
+          "This prompt should not stay in a large failed bubble.",
+          "prompt-1",
+          NOW,
+        )}
+        outboxEntry={failedOutboxEntry("session is closed")}
+        optimisticTrailingStatus={null}
+        outboxActions={actions}
+      />,
+    );
+
+    const statusLine = screen.getByText("Not sent");
+    expect(statusLine.parentElement?.textContent).toBe("Not sent: session is closed");
+    expect(container.querySelector("[data-chat-user-message]")).toBeNull();
+    expect(container.innerHTML).not.toContain("min-h-[calc");
+    expect(container.innerHTML).toContain("text-[length:var(--text-chat)]");
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(actions.dismissPrompt).toHaveBeenCalledWith("prompt-1");
+    expect(actions.retryPrompt).not.toHaveBeenCalled();
+  });
+
+  it("keeps retry available for non-closed send failures", () => {
+    const actions = {
+      retryPrompt: vi.fn(),
+      dismissPrompt: vi.fn(),
+    };
+    render(
+      <TranscriptPendingPromptRow
+        activeSessionId="session-1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt("Try again", "prompt-1", NOW)}
+        outboxEntry={failedOutboxEntry("network dropped")}
+        optimisticTrailingStatus={null}
+        outboxActions={actions}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(actions.retryPrompt).toHaveBeenCalledWith("prompt-1");
+  });
+});
+
+function failedOutboxEntry(errorMessage: string): PromptOutboxEntry {
+  return {
+    ...createPromptOutboxEntry({
+      clientPromptId: "prompt-1",
+      clientSessionId: "session-1",
+      text: "Queued prompt text",
+      blocks: [{ type: "text", text: "Queued prompt text" }],
+      now: NOW,
+    }),
+    status: "failed",
+    deliveryState: "failed_before_dispatch",
+    errorMessage,
+    updatedAt: NOW,
+  };
+}

--- a/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
@@ -46,6 +46,17 @@ export function TranscriptPendingPromptRow({
   optimisticTrailingStatus: ReactNode;
   outboxActions: OutboxActionHandlers;
 }) {
+  if (outboxEntry?.deliveryState === "failed_before_dispatch") {
+    return (
+      <TurnShell isFirst={rowIndex === 0}>
+        <OutboxPromptFailureLine
+          entry={outboxEntry}
+          outboxActions={outboxActions}
+        />
+      </TurnShell>
+    );
+  }
+
   const trailingStatus = outboxEntry
     ? <OutboxPromptTrailingStatus entry={outboxEntry} />
     : optimisticTrailingStatus;
@@ -146,7 +157,7 @@ function resolveOutboxPromptTrailingStatus(
   }
   switch (entry.deliveryState) {
     case "failed_before_dispatch":
-      return entry.errorMessage ? `Not sent: ${entry.errorMessage}` : "Not sent";
+      return formatOutboxPromptFailureLabel(entry);
     case "unknown_after_dispatch":
       return "Waiting for confirmation…";
     case "preparing":
@@ -161,6 +172,65 @@ function resolveOutboxPromptTrailingStatus(
     default:
       return null;
   }
+}
+
+function OutboxPromptFailureLine({
+  entry,
+  outboxActions,
+}: {
+  entry: PromptOutboxEntry;
+  outboxActions: OutboxActionHandlers;
+}) {
+  const canRetry = !isSessionClosedFailure(entry.errorMessage);
+
+  return (
+    <div className="flex justify-end">
+      <div
+        data-chat-transcript-ignore
+        className="inline-flex max-w-[77%] items-center gap-2 overflow-hidden whitespace-nowrap text-[length:var(--text-chat)] font-normal leading-[var(--text-chat--line-height)] text-muted-foreground/80"
+      >
+        <span className="min-w-0 truncate" title={formatOutboxPromptFailureLabel(entry)}>
+          <span className="text-destructive/80">Not sent</span>
+          {entry.errorMessage ? (
+            <span>: {entry.errorMessage}</span>
+          ) : null}
+        </span>
+        <span className="inline-flex shrink-0 items-center gap-1">
+          {canRetry && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-auto rounded-none px-1 py-0 text-[11px] font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline"
+              onClick={() => outboxActions.retryPrompt(entry.clientPromptId)}
+            >
+              Retry
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-auto rounded-none px-1 py-0 text-[11px] font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline"
+            onClick={() => outboxActions.dismissPrompt(entry.clientPromptId)}
+          >
+            Dismiss
+          </Button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function formatOutboxPromptFailureLabel(entry: PromptOutboxEntry): string {
+  return entry.errorMessage ? `Not sent: ${entry.errorMessage}` : "Not sent";
+}
+
+function isSessionClosedFailure(message: string | null): boolean {
+  return message
+    ?.replace(/\s+/gu, " ")
+    .trim()
+    .toLowerCase() === "session is closed";
 }
 
 function hasAcceptedRunningOutboxEntryExceededEchoGrace(

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
@@ -1,7 +1,11 @@
+// @vitest-environment jsdom
+
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toolCallItem } from "@/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
+import { TranscriptContextProviders } from "./TranscriptContexts";
 import { TranscriptToolCallItemBlock } from "./TranscriptToolCallItemBlock";
 
 vi.mock("@/hooks/cowork/workflows/use-open-cowork-coding-session", () => ({
@@ -37,6 +41,26 @@ vi.mock("@/hooks/workspaces/files/use-file-reference-actions", () => ({
 }));
 
 describe("TranscriptToolCallItemBlock", () => {
+  beforeEach(() => {
+    class TestResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("collapses long file-change groups in chat", () => {
     const item = toolCallItem({
       semanticKind: "file_change",
@@ -93,6 +117,60 @@ describe("TranscriptToolCallItemBlock", () => {
     expect(html).toContain("text-[length:var(--text-chat)]");
   });
 
+  it("renders subagent event reads as delegated agent receipts", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__read_subagent_events",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        events: [{ id: "event-1" }, { id: "event-2" }],
+      },
+      contentParts: [{
+        type: "tool_result_text",
+        text: "{\"events\":[{\"id\":\"event-1\"},{\"id\":\"event-2\"}]}",
+      }],
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TranscriptToolCallItemBlock, {
+        item,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      }),
+    );
+
+    expect(html).toContain("Read subagent events");
+    expect(html).toContain("API Surface Check");
+    expect(html).toContain("2 events");
+    expect(html).not.toContain("event-1");
+  });
+
+  it("does not expose raw subagent ids as receipt titles", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__get_subagent_status",
+      rawOutput: {
+        subagentId: "subagent_abc123",
+        status: "idle",
+      },
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TranscriptToolCallItemBlock, {
+        item,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      }),
+    );
+
+    expect(html).toContain("Checked subagent");
+    expect(html).toContain("Subagent");
+    expect(html).not.toContain("subagent_abc123");
+  });
+
   it("renders subagent close receipts without an open-session affordance", () => {
     const item = toolCallItem({
       semanticKind: "subagent",
@@ -117,5 +195,95 @@ describe("TranscriptToolCallItemBlock", () => {
     expect(html).toContain("Closed subagent");
     expect(html).toContain("API Surface Check");
     expect(html).not.toContain("Open API Surface Check");
+  });
+
+  it("opens non-closed subagent receipts by child session id", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__get_subagent_status",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        status: "running",
+      },
+    });
+    const onOpenSession = vi.fn();
+
+    render(
+      <TranscriptContextProviders
+        sessionId="parent-session"
+        onOpenSession={onOpenSession}
+      >
+        <TranscriptToolCallItemBlock
+          item={item}
+          workspaceId="workspace-1"
+          onOpenArtifact={() => {}}
+        />
+      </TranscriptContextProviders>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open .*api surface check/i }));
+
+    expect(onOpenSession).toHaveBeenCalledWith("child-123", "linked-child");
+  });
+
+  it("keeps closed subagent receipts non-openable in interactive render", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__close_subagent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        closed: true,
+      },
+    });
+
+    render(
+      <TranscriptContextProviders
+        sessionId="parent-session"
+        onOpenSession={() => {}}
+      >
+        <TranscriptToolCallItemBlock
+          item={item}
+          workspaceId="workspace-1"
+          onOpenArtifact={() => {}}
+        />
+      </TranscriptContextProviders>,
+    );
+
+    expect(screen.queryByRole("button", { name: /open .*api surface check/i })).toBeNull();
+  });
+
+  it("expands subagent receipt result text on demand", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__search_subagent_transcript",
+      rawOutput: {
+        label: "API Surface Check",
+        matches: [{ line: "needle" }],
+      },
+      contentParts: [{
+        type: "tool_result_text",
+        text: "{\"matches\":[{\"line\":\"needle\"}]}",
+      }],
+    });
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/needle/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /show subagent tool result/i }));
+
+    expect(screen.getByText(/needle/)).toBeTruthy();
   });
 });

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
@@ -65,4 +65,57 @@ describe("TranscriptToolCallItemBlock", () => {
     expect(html).not.toContain("src/file-3.ts");
     expect(html).toContain("Show 2 more");
   });
+
+  it("renders subagent status checks as delegated agent receipts", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__get_subagent_status",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        status: "running",
+      },
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TranscriptToolCallItemBlock, {
+        item,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      }),
+    );
+
+    expect(html).toContain("Checked subagent");
+    expect(html).toContain("API Surface Check");
+    expect(html).toContain("Working");
+    expect(html).toContain("text-[length:var(--text-chat)]");
+  });
+
+  it("renders subagent close receipts without an open-session affordance", () => {
+    const item = toolCallItem({
+      semanticKind: "subagent",
+      nativeToolName: "mcp__subagents__close_subagent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        closed: true,
+      },
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TranscriptToolCallItemBlock, {
+        item,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      }),
+    );
+
+    expect(html).toContain("Closed subagent");
+    expect(html).toContain("API Surface Check");
+    expect(html).not.toContain("Open API Surface Check");
+  });
 });

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
@@ -15,8 +15,10 @@ import { FileChangeCall } from "@/components/workspace/chat/tool-calls/FileChang
 import { FileReadCall } from "@/components/workspace/chat/tool-calls/FileReadCall";
 import { GenericToolResultRow } from "@/components/workspace/chat/tool-calls/GenericToolResultRow";
 import { SkillsToolResultRow } from "@/components/workspace/chat/tool-calls/SkillsToolResultRow";
+import { SubagentToolActionRow } from "@/components/workspace/chat/tool-calls/SubagentToolActionRow";
 import { useOpenCoworkCodingSession } from "@/hooks/cowork/workflows/use-open-cowork-coding-session";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
+import { deriveSubagentMcpReceiptPresentation } from "@/lib/domain/chat/subagents/subagent-tool-presentation";
 import { deriveSkillsToolResultPresentation } from "@/lib/domain/chat/tools/skills-tool-result";
 import { describeToolCallDisplay } from "@/lib/domain/chat/tools/tool-call-display";
 import { normalizeToolResultText } from "@/lib/domain/chat/tools/tool-result-text";
@@ -89,6 +91,7 @@ export function TranscriptToolCallItemBlock({
   const rows: React.ReactNode[] = [];
   const status = mapStatus(item.status);
   const skillsToolResult = deriveSkillsToolResultPresentation(item, normalizedResultText);
+  const subagentReceipt = deriveSubagentMcpReceiptPresentation(item);
   const visibleFileChanges = showAllFileChanges
     ? fileChanges
     : fileChanges.slice(0, CHAT_VISIBLE_FILE_CHANGE_LIMIT);
@@ -192,6 +195,17 @@ export function TranscriptToolCallItemBlock({
         key="skills-result"
         presentation={skillsToolResult}
         status={status}
+      />,
+    );
+  }
+
+  if (rows.length === 0 && subagentReceipt) {
+    rows.push(
+      <SubagentToolActionRow
+        key="subagent-receipt"
+        presentation={subagentReceipt}
+        status={status}
+        resultText={normalizedResultText}
       />,
     );
   }

--- a/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
+++ b/desktop/src/components/workspace/reviews/ReviewFeedbackSummary.tsx
@@ -148,7 +148,7 @@ function ReviewTerminalReceipt({
     <div className="flex justify-end" data-telemetry-mask>
       <p
         data-testid="review-terminal-receipt"
-        className="max-w-[77%] text-right text-chat leading-[var(--text-chat--line-height)] text-muted-foreground"
+        className="max-w-[77%] text-right text-[length:var(--text-chat)] font-normal leading-[var(--text-chat--line-height)] text-muted-foreground"
       >
         {/* Multiple reviewers can open different sessions, so each name owns its own target. */}
         {reviewerNameList(assignments, onOpenReviewerSession)}

--- a/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { toolCallItem } from "@/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
 import {
+  deriveSubagentMcpReceiptPresentation,
   formatSubagentHeaderVerb,
   formatSubagentMcpActionLabel,
   isSubagentProvisioningAction,
@@ -41,5 +43,50 @@ describe("subagent tool presentation", () => {
     expect(isSubagentProvisioningAction({
       nativeToolName: "mcp__subagents__read_subagent_latest_turns",
     })).toBe(false);
+  });
+
+  it("derives concise status receipt presentation with the child target", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__get_subagent_status",
+      rawInput: { subagentId: "subagent_123" },
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        status: "running",
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "status",
+      actionLabel: "Checked subagent",
+      title: "API Surface Check",
+      subagentId: "subagent_123",
+      sessionLinkId: "link-123",
+      childSessionId: "child-123",
+      detailLabel: "Working",
+      openSessionAllowed: true,
+    });
+  });
+
+  it("derives close receipts as non-openable agent receipts", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__close_subagent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        childSessionId: "child-123",
+        label: "API Surface Check",
+        closed: true,
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "close",
+      actionLabel: "Closed subagent",
+      title: "API Surface Check",
+      openSessionAllowed: false,
+    });
   });
 });

--- a/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -43,6 +43,9 @@ describe("subagent tool presentation", () => {
     expect(isSubagentProvisioningAction({
       nativeToolName: "mcp__subagents__read_subagent_latest_turns",
     })).toBe(false);
+    expect(isSubagentProvisioningAction({
+      nativeToolName: "mcp__subagents__read_subagent_events",
+    })).toBe(false);
   });
 
   it("derives concise status receipt presentation with the child target", () => {
@@ -66,7 +69,60 @@ describe("subagent tool presentation", () => {
       sessionLinkId: "link-123",
       childSessionId: "child-123",
       detailLabel: "Working",
+      wakeScheduled: false,
       openSessionAllowed: true,
+    });
+  });
+
+  it("uses a generic title when a receipt only has a raw subagent id", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__get_subagent_status",
+      rawOutput: {
+        subagentId: "subagent_abc123",
+        status: "idle",
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Subagent",
+      subagentId: "subagent_abc123",
+      detailLabel: "Idle",
+    });
+  });
+
+  it("derives read-event receipts with event counts", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__read_subagent_events",
+      rawOutput: {
+        label: "Runtime Server Survey",
+        events: [{ id: "event-1" }, { id: "event-2" }],
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "read",
+      actionLabel: "Read subagent events",
+      title: "Runtime Server Survey",
+      detailLabel: "2 events",
+    });
+  });
+
+  it("derives receipt output from JSON result text when raw output is absent", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__search_subagent_transcript",
+      contentParts: [{
+        type: "tool_result_text",
+        text: JSON.stringify({
+          label: "Runtime Server Survey",
+          matches: [{ line: "first" }],
+        }, null, 2),
+      }],
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "search",
+      title: "Runtime Server Survey",
+      detailLabel: "1 match",
     });
   });
 

--- a/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.ts
+++ b/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.ts
@@ -1,7 +1,27 @@
-import type { ToolCallItem } from "@anyharness/sdk";
+import type { ToolCallItem, ToolResultTextContentPart } from "@anyharness/sdk";
 import type { SubagentExecutionState } from "@/lib/domain/chat/subagents/subagent-launch";
 
 type ToolNameOwner = Pick<ToolCallItem, "nativeToolName">;
+
+export type SubagentMcpReceiptAction =
+  | "send"
+  | "wake"
+  | "status"
+  | "read"
+  | "search"
+  | "close";
+
+export interface SubagentMcpReceiptPresentation {
+  action: SubagentMcpReceiptAction;
+  actionLabel: string;
+  title: string;
+  subagentId: string | null;
+  sessionLinkId: string | null;
+  childSessionId: string | null;
+  statusLabel: string | null;
+  detailLabel: string | null;
+  openSessionAllowed: boolean;
+}
 
 export function formatSubagentMcpActionLabel(toolName: string | null | undefined): string | null {
   switch (normalizeToolName(toolName)) {
@@ -72,6 +92,187 @@ export function isSubagentCreationAction(item: ToolNameOwner): boolean {
   return normalizeToolName(item.nativeToolName) === "mcp__subagents__create_subagent";
 }
 
+export function deriveSubagentMcpReceiptPresentation(
+  item: ToolCallItem,
+): SubagentMcpReceiptPresentation | null {
+  const action = receiptActionFromToolName(item.nativeToolName);
+  if (!action) {
+    return null;
+  }
+
+  const rawInput = isRecord(item.rawInput) ?? {};
+  const rawOutput = isRecord(item.rawOutput) ?? parseToolResultJsonObject(item) ?? {};
+  const subagentId =
+    readStringField(rawOutput, "subagentId")
+    ?? readStringField(rawInput, "subagentId")
+    ?? readStringField(rawInput, "subagent_id");
+  const sessionLinkId =
+    readStringField(rawOutput, "sessionLinkId")
+    ?? readStringField(rawInput, "sessionLinkId")
+    ?? readStringField(rawInput, "session_link_id");
+  const childSessionId =
+    readStringField(rawOutput, "childSessionId")
+    ?? readStringField(rawInput, "childSessionId")
+    ?? readStringField(rawInput, "child_session_id");
+  const title =
+    readStringField(rawOutput, "label")
+    ?? readStringField(rawInput, "label")
+    ?? subagentId
+    ?? "Subagent";
+  const rawStatus =
+    readStringField(rawOutput, "status")
+    ?? readStringField(rawOutput, "promptStatus");
+  const statusLabel = action === "status" || rawStatus
+    ? formatStatusLabel(rawStatus)
+    : null;
+  const detailLabel = detailLabelForAction(action, rawOutput, statusLabel);
+
+  return {
+    action,
+    actionLabel: actionLabel(action, item.status === "in_progress"),
+    title,
+    subagentId,
+    sessionLinkId,
+    childSessionId,
+    statusLabel,
+    detailLabel,
+    openSessionAllowed: action !== "close" && normalizeStatus(rawStatus) !== "closed",
+  };
+}
+
 function normalizeToolName(toolName: string | null | undefined): string {
   return toolName?.trim().toLowerCase() ?? "";
+}
+
+function receiptActionFromToolName(toolName: string | null | undefined): SubagentMcpReceiptAction | null {
+  switch (normalizeToolName(toolName)) {
+    case "mcp__subagents__send_subagent_message":
+      return "send";
+    case "mcp__subagents__schedule_subagent_wake":
+      return "wake";
+    case "mcp__subagents__get_subagent_status":
+      return "status";
+    case "mcp__subagents__read_subagent_latest_turns":
+      return "read";
+    case "mcp__subagents__search_subagent_transcript":
+      return "search";
+    case "mcp__subagents__close_subagent":
+      return "close";
+    default:
+      return null;
+  }
+}
+
+function actionLabel(action: SubagentMcpReceiptAction, running: boolean): string {
+  switch (action) {
+    case "send":
+      return running ? "Sending message to subagent" : "Sent message to subagent";
+    case "wake":
+      return running ? "Scheduling wake for subagent" : "Scheduled wake for subagent";
+    case "status":
+      return running ? "Checking subagent" : "Checked subagent";
+    case "read":
+      return running ? "Reading subagent turns" : "Read subagent turns";
+    case "search":
+      return running ? "Searching subagent" : "Searched subagent";
+    case "close":
+      return running ? "Closing subagent" : "Closed subagent";
+  }
+}
+
+function detailLabelForAction(
+  action: SubagentMcpReceiptAction,
+  output: Record<string, unknown>,
+  statusLabel: string | null,
+): string | null {
+  switch (action) {
+    case "send":
+      return statusLabel;
+    case "wake":
+      return readBooleanField(output, "alreadyScheduled") ? "Already scheduled" : "Wake scheduled";
+    case "status":
+      return statusLabel;
+    case "read": {
+      const turns = output.turns;
+      return Array.isArray(turns)
+        ? `${turns.length} ${turns.length === 1 ? "turn" : "turns"}`
+        : null;
+    }
+    case "search": {
+      const matches = output.matches;
+      return Array.isArray(matches)
+        ? `${matches.length} ${matches.length === 1 ? "match" : "matches"}`
+        : null;
+    }
+    case "close":
+      return readBooleanField(output, "alreadyClosed") ? "Already closed" : null;
+  }
+}
+
+function formatStatusLabel(status: string | null): string | null {
+  const normalized = normalizeStatus(status);
+  if (!normalized) {
+    return null;
+  }
+  switch (normalized) {
+    case "running":
+      return "Working";
+    case "idle":
+      return "Idle";
+    case "completed":
+      return "Done";
+    case "errored":
+      return "Failed";
+    case "starting":
+      return "Starting";
+    case "queued":
+      return "Queued";
+    case "closed":
+      return "Closed";
+    default:
+      return normalized.replace(/\b\w/gu, (char) => char.toUpperCase());
+  }
+}
+
+function normalizeStatus(status: string | null | undefined): string {
+  return status
+    ?.replace(/[_-]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .toLowerCase() ?? "";
+}
+
+function parseToolResultJsonObject(item: ToolCallItem): Record<string, unknown> | null {
+  const text = item.contentParts
+    .filter((part): part is ToolResultTextContentPart => part.type === "tool_result_text")
+    .map((part) => part.text.trim())
+    .filter((textPart) => textPart.length > 0)
+    .join("\n\n");
+  if (!text.startsWith("{") || !text.endsWith("}")) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+function readStringField(value: Record<string, unknown>, key: string): string | null {
+  const field = value[key];
+  if (typeof field !== "string") {
+    return null;
+  }
+  const trimmed = field.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readBooleanField(value: Record<string, unknown>, key: string): boolean {
+  return value[key] === true;
 }

--- a/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.ts
+++ b/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.ts
@@ -20,6 +20,7 @@ export interface SubagentMcpReceiptPresentation {
   childSessionId: string | null;
   statusLabel: string | null;
   detailLabel: string | null;
+  wakeScheduled: boolean;
   openSessionAllowed: boolean;
 }
 
@@ -117,7 +118,6 @@ export function deriveSubagentMcpReceiptPresentation(
   const title =
     readStringField(rawOutput, "label")
     ?? readStringField(rawInput, "label")
-    ?? subagentId
     ?? "Subagent";
   const rawStatus =
     readStringField(rawOutput, "status")
@@ -129,13 +129,14 @@ export function deriveSubagentMcpReceiptPresentation(
 
   return {
     action,
-    actionLabel: actionLabel(action, item.status === "in_progress"),
+    actionLabel: actionLabel(action, item.status === "in_progress", item.nativeToolName),
     title,
     subagentId,
     sessionLinkId,
     childSessionId,
     statusLabel,
     detailLabel,
+    wakeScheduled: action === "wake",
     openSessionAllowed: action !== "close" && normalizeStatus(rawStatus) !== "closed",
   };
 }
@@ -152,6 +153,8 @@ function receiptActionFromToolName(toolName: string | null | undefined): Subagen
       return "wake";
     case "mcp__subagents__get_subagent_status":
       return "status";
+    case "mcp__subagents__read_subagent_events":
+      return "read";
     case "mcp__subagents__read_subagent_latest_turns":
       return "read";
     case "mcp__subagents__search_subagent_transcript":
@@ -163,7 +166,11 @@ function receiptActionFromToolName(toolName: string | null | undefined): Subagen
   }
 }
 
-function actionLabel(action: SubagentMcpReceiptAction, running: boolean): string {
+function actionLabel(
+  action: SubagentMcpReceiptAction,
+  running: boolean,
+  toolName: string | null | undefined,
+): string {
   switch (action) {
     case "send":
       return running ? "Sending message to subagent" : "Sent message to subagent";
@@ -172,6 +179,9 @@ function actionLabel(action: SubagentMcpReceiptAction, running: boolean): string
     case "status":
       return running ? "Checking subagent" : "Checked subagent";
     case "read":
+      if (normalizeToolName(toolName) === "mcp__subagents__read_subagent_events") {
+        return running ? "Reading subagent events" : "Read subagent events";
+      }
       return running ? "Reading subagent turns" : "Read subagent turns";
     case "search":
       return running ? "Searching subagent" : "Searched subagent";
@@ -193,10 +203,8 @@ function detailLabelForAction(
     case "status":
       return statusLabel;
     case "read": {
-      const turns = output.turns;
-      return Array.isArray(turns)
-        ? `${turns.length} ${turns.length === 1 ? "turn" : "turns"}`
-        : null;
+      return readArrayCountLabel(output, "turns", "turn")
+        ?? readArrayCountLabel(output, "events", "event");
     }
     case "search": {
       const matches = output.matches;
@@ -207,6 +215,18 @@ function detailLabelForAction(
     case "close":
       return readBooleanField(output, "alreadyClosed") ? "Already closed" : null;
   }
+}
+
+function readArrayCountLabel(
+  output: Record<string, unknown>,
+  key: string,
+  singular: string,
+): string | null {
+  const value = output[key];
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  return `${value.length} ${value.length === 1 ? singular : `${singular}s`}`;
 }
 
 function formatStatusLabel(status: string | null): string | null {

--- a/docs/anyharness/product-mcps/prompt-and-skill-policy.md
+++ b/docs/anyharness/product-mcps/prompt-and-skill-policy.md
@@ -173,8 +173,9 @@ Use list_available_skills to inspect them and activate_skill before relying on
 a skill's full instructions.
 
 Available skills:
-- proliferate.subagents.workflow (Subagent workflow) - Use subagents for bounded
-  parallel work, result reads, wake scheduling, and cleanup.
+- proliferate.subagents.workflow (Subagent workflow) - Use Proliferate
+  subagent MCP tools for bounded parallel work, result reads, wake scheduling,
+  and cleanup.
 ```
 
 The skill body should be concise and operational. It should name exact tools,

--- a/docs/anyharness/product-mcps/subagents.md
+++ b/docs/anyharness/product-mcps/subagents.md
@@ -594,12 +594,14 @@ Required skill:
 ```text
 skill id: proliferate.subagents.workflow
 display name: Subagent workflow
-description: Use subagents for bounded parallel work, read their results, and
-  close them when done.
+description: Use Proliferate subagent MCP tools for bounded parallel work,
+  result reads, wake scheduling, and cleanup.
 ```
 
 The skill should teach:
 
+- why Proliferate `subagents` MCP tools are preferred for same-workspace
+  delegation when provider-native or internal subagent tools overlap
 - when to delegate
 - how to choose labels
 - when to call `get_subagent_launch_options`


### PR DESCRIPTION
## Summary

- Render subagent status, close, read, search, send, and wake MCP results as concise delegated-agent receipt rows instead of generic JSON-first output.
- Keep closed subagent receipts non-clickable while preserving the colored delegated-agent identity treatment for active receipts.
- Tighten the composer Agents popover rows and normalize delegated completion/review receipt typography to chat text sizing.
- Add a short Proliferate subagents MCP priority instruction to the product MCP system prompt append.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx`
- `pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm shared:build && pnpm --dir desktop exec tsc --noEmit`
- `cargo test -p anyharness-lib subagents_selection_prioritizes_product_mcp_in_prompt_text`
- `cargo fmt --check`
- `git diff --check`