### PR TITLE
fix(desktop): clean up chat view affordances

### DIFF
--- a/desktop/src/components/playground/transcript/PlaygroundToolTranscript.tsx
+++ b/desktop/src/components/playground/transcript/PlaygroundToolTranscript.tsx
@@ -33,7 +33,6 @@ export function renderPlaygroundToolTranscript(
             output="RUN  src/config/playground.test.ts\n"
             status="running"
             duration="for 12s"
-            defaultExpanded
           />
         </TranscriptPreviewShell>
       );
@@ -45,7 +44,6 @@ export function renderPlaygroundToolTranscript(
             output="Done in 4.2s\n"
             status="completed"
             duration="for 4s"
-            defaultExpanded
           />
         </TranscriptPreviewShell>
       );
@@ -57,7 +55,6 @@ export function renderPlaygroundToolTranscript(
             output="error TS2322: Type 'string' is not assignable to type 'number'.\n"
             status="failed"
             duration="for 7s"
-            defaultExpanded
           />
         </TranscriptPreviewShell>
       );

--- a/desktop/src/components/ui/PopoverMenuItem.tsx
+++ b/desktop/src/components/ui/PopoverMenuItem.tsx
@@ -30,7 +30,7 @@ export function PopoverMenuItem({
     <button
       type={type}
       className={twMerge(
-        "group/menu-item flex w-full cursor-default select-none flex-col rounded-lg px-2.5 py-1.5 text-sm font-[430] leading-5 text-popover-foreground outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent",
+        "group/menu-item flex w-full cursor-default select-none flex-col rounded-lg px-2.5 py-1 text-sm font-[430] leading-[18px] text-popover-foreground outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent",
         hoverClassName,
         className,
       )}
@@ -40,7 +40,7 @@ export function PopoverMenuItem({
         onClick?.(event);
       }}
     >
-      <span className="flex w-full items-center gap-2">
+      <span className="flex w-full items-center gap-1.5">
         {icon && (
           <span className="flex shrink-0 items-center justify-center text-muted-foreground">
             {icon}
@@ -54,8 +54,8 @@ export function PopoverMenuItem({
         )}
       </span>
       {hasDescription && (
-        <span className={`mt-0.5 flex w-full items-center gap-2 ${icon ? "pl-6" : ""}`}>
-          <span className="min-w-0 flex-1 text-left text-sm leading-5 text-muted-foreground [&_*]:text-sm [&_*]:leading-5">
+        <span className={`mt-0.5 flex w-full items-center gap-1.5 ${icon ? "pl-5" : ""}`}>
+          <span className="min-w-0 flex-1 text-left text-xs leading-4 text-muted-foreground [&_*]:text-xs [&_*]:leading-4">
             {children}
           </span>
         </span>

--- a/desktop/src/components/ui/PopoverMenuItem.tsx
+++ b/desktop/src/components/ui/PopoverMenuItem.tsx
@@ -30,7 +30,7 @@ export function PopoverMenuItem({
     <button
       type={type}
       className={twMerge(
-        "group/menu-item flex w-full cursor-default select-none flex-col rounded-lg px-2.5 py-1 text-sm font-[430] leading-[18px] text-popover-foreground outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent",
+        "group/menu-item flex w-full cursor-default select-none flex-col rounded-lg px-2.5 py-1.5 text-sm font-[430] leading-5 text-popover-foreground outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent",
         hoverClassName,
         className,
       )}
@@ -40,7 +40,7 @@ export function PopoverMenuItem({
         onClick?.(event);
       }}
     >
-      <span className="flex w-full items-center gap-1.5">
+      <span className="flex w-full items-center gap-2">
         {icon && (
           <span className="flex shrink-0 items-center justify-center text-muted-foreground">
             {icon}
@@ -54,8 +54,8 @@ export function PopoverMenuItem({
         )}
       </span>
       {hasDescription && (
-        <span className={`mt-0.5 flex w-full items-center gap-1.5 ${icon ? "pl-5" : ""}`}>
-          <span className="min-w-0 flex-1 text-left text-xs leading-4 text-muted-foreground [&_*]:text-xs [&_*]:leading-4">
+        <span className={`mt-0.5 flex w-full items-center gap-2 ${icon ? "pl-6" : ""}`}>
+          <span className="min-w-0 flex-1 text-left text-xs leading-4 text-muted-foreground [&>*]:!mt-0 [&_*]:text-xs [&_*]:leading-4">
             {children}
           </span>
         </span>

--- a/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
+++ b/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
@@ -50,6 +50,11 @@ type ComposerConfigSubmenu =
 const COMPOSER_SUBMENU_GAP_PX = 4;
 const COMPOSER_SUBMENU_VIEWPORT_MARGIN_PX = 8;
 
+interface ComposerSubmenuPosition {
+  left: number;
+  top: number;
+}
+
 export function ComposerModelConfigSelector({
   modelSelectorProps,
   agentKind,
@@ -60,7 +65,8 @@ export function ComposerModelConfigSelector({
   const [search, setSearch] = useState("");
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [activeSubmenu, setActiveSubmenu] = useState<ComposerConfigSubmenu | null>(null);
-  const [submenuLeft, setSubmenuLeft] = useState<number | null>(null);
+  const [submenuAnchorTop, setSubmenuAnchorTop] = useState<number | null>(null);
+  const [submenuPosition, setSubmenuPosition] = useState<ComposerSubmenuPosition | null>(null);
   const [setupAgent, setSetupAgent] = useState<ModelSelectorProps["notReadyAgents"][number] | null>(null);
   const {
     connectionState,
@@ -101,11 +107,12 @@ export function ComposerModelConfigSelector({
 
   useLayoutEffect(() => {
     if (!activeSubmenu) {
-      setSubmenuLeft(null);
+      setSubmenuAnchorTop(null);
+      setSubmenuPosition(null);
       return;
     }
 
-    const updateSubmenuOffset = () => {
+    const updateSubmenuPosition = () => {
       const root = menuRootRef.current;
       const submenu = submenuRef.current;
       if (!root || !submenu) {
@@ -115,10 +122,16 @@ export function ComposerModelConfigSelector({
       const rootRect = root.getBoundingClientRect();
       const submenuRect = submenu.getBoundingClientRect();
       const viewportLeft = window.visualViewport?.offsetLeft ?? 0;
+      const viewportTop = window.visualViewport?.offsetTop ?? 0;
       const viewportRight = viewportLeft + (
         window.visualViewport?.width
         ?? document.documentElement.clientWidth
         ?? window.innerWidth
+      );
+      const viewportBottom = viewportTop + (
+        window.visualViewport?.height
+        ?? document.documentElement.clientHeight
+        ?? window.innerHeight
       );
       const preferredRightLeft = rootRect.width + COMPOSER_SUBMENU_GAP_PX;
       const preferredLeftLeft = -submenuRect.width - COMPOSER_SUBMENU_GAP_PX;
@@ -132,18 +145,31 @@ export function ComposerModelConfigSelector({
         - COMPOSER_SUBMENU_VIEWPORT_MARGIN_PX
         - rootRect.left
         - submenuRect.width;
+      const preferredTop = submenuAnchorTop ?? 0;
+      const minTop = viewportTop + COMPOSER_SUBMENU_VIEWPORT_MARGIN_PX - rootRect.top;
+      const maxTop = viewportBottom
+        - COMPOSER_SUBMENU_VIEWPORT_MARGIN_PX
+        - rootRect.top
+        - submenuRect.height;
 
-      setSubmenuLeft(clamp(
-        preferredLeft,
-        Math.min(minLeft, maxLeft),
-        Math.max(minLeft, maxLeft),
-      ));
+      setSubmenuPosition({
+        left: clamp(
+          preferredLeft,
+          Math.min(minLeft, maxLeft),
+          Math.max(minLeft, maxLeft),
+        ),
+        top: clamp(
+          preferredTop,
+          Math.min(minTop, maxTop),
+          Math.max(minTop, maxTop),
+        ),
+      });
     };
 
-    updateSubmenuOffset();
-    window.addEventListener("resize", updateSubmenuOffset);
-    return () => window.removeEventListener("resize", updateSubmenuOffset);
-  }, [activeSubmenu]);
+    updateSubmenuPosition();
+    window.addEventListener("resize", updateSubmenuPosition);
+    return () => window.removeEventListener("resize", updateSubmenuPosition);
+  }, [activeSubmenu, submenuAnchorTop]);
 
   if (!selectorEnabled) {
     return (
@@ -185,6 +211,8 @@ export function ComposerModelConfigSelector({
             setSearch("");
             setAddProviderOpen(false);
             setActiveSubmenu(null);
+            setSubmenuAnchorTop(null);
+            setSubmenuPosition(null);
           }
         }}
       >
@@ -231,9 +259,10 @@ export function ComposerModelConfigSelector({
                         <ComposerSubmenuMenuItem
                           active={activeSubmenu?.kind === "harness"}
                           label={harnessLabel}
-                          onOpen={() => {
+                          onOpen={(anchorElement) => {
                             setAddProviderOpen(false);
-                            setSubmenuLeft(null);
+                            setSubmenuPosition(null);
+                            setSubmenuAnchorTop(resolveSubmenuAnchorTop(menuRootRef.current, anchorElement));
                             setActiveSubmenu({ kind: "harness" });
                           }}
                         />
@@ -244,9 +273,10 @@ export function ComposerModelConfigSelector({
                           key={control.key}
                           active={activeSubmenu?.kind === "control" && activeSubmenu.key === control.key}
                           label={resolveControlSubmenuLabel(control)}
-                          onOpen={() => {
+                          onOpen={(anchorElement) => {
                             setAddProviderOpen(false);
-                            setSubmenuLeft(null);
+                            setSubmenuPosition(null);
+                            setSubmenuAnchorTop(resolveSubmenuAnchorTop(menuRootRef.current, anchorElement));
                             setActiveSubmenu({ kind: "control", key: control.key });
                           }}
                         />
@@ -258,10 +288,11 @@ export function ComposerModelConfigSelector({
 
               <div
                 ref={submenuRef}
-                className="absolute bottom-0 z-10"
+                className="absolute z-10"
                 style={{
-                  left: submenuLeft ?? 0,
-                  visibility: activeSubmenu && submenuLeft === null ? "hidden" : undefined,
+                  left: submenuPosition?.left ?? 0,
+                  top: submenuPosition?.top ?? 0,
+                  visibility: activeSubmenu && submenuPosition === null ? "hidden" : undefined,
                 }}
               >
                 {activeSubmenu?.kind === "harness" && (
@@ -343,7 +374,7 @@ function ComposerSubmenuMenuItem({
   active: boolean;
   icon?: ReactNode;
   label: string;
-  onOpen: () => void;
+  onOpen: (anchorElement: HTMLElement) => void;
 }) {
   return (
     <PopoverMenuItem
@@ -354,9 +385,9 @@ function ComposerSubmenuMenuItem({
       icon={icon}
       label={label}
       trailing={<ChevronDown className="-rotate-90 size-3.5 shrink-0" />}
-      onClick={onOpen}
-      onFocus={onOpen}
-      onMouseEnter={onOpen}
+      onClick={(event) => onOpen(event.currentTarget)}
+      onFocus={(event) => onOpen(event.currentTarget)}
+      onMouseEnter={(event) => onOpen(event.currentTarget)}
     />
   );
 }
@@ -512,7 +543,7 @@ function ComposerModelGroup({
   return (
     <>
       {showSeparator && <div className="mx-2 my-1 border-t border-border/60" />}
-      <div className="min-h-6 truncate px-2 py-1 text-sm font-[430] leading-4 text-muted-foreground/70">
+      <div className="min-h-5 truncate px-2 py-0.5 text-sm font-[430] leading-4 text-muted-foreground/70">
         {group.providerDisplayName}
       </div>
       {group.models.map((model) => (
@@ -538,10 +569,22 @@ function ComposerModelGroup({
 
 function ComposerMenuSeparator() {
   return (
-    <div className="w-full px-2 py-1">
+    <div className="w-full px-2 py-0.5">
       <div className="h-px w-full bg-border/60" />
     </div>
   );
+}
+
+function resolveSubmenuAnchorTop(
+  root: HTMLElement | null,
+  anchorElement: HTMLElement,
+): number {
+  if (!root) {
+    return 0;
+  }
+  const rootRect = root.getBoundingClientRect();
+  const anchorRect = anchorElement.getBoundingClientRect();
+  return anchorRect.top - rootRect.top;
 }
 
 function sortComposerConfigSubmenuControls(

--- a/desktop/src/components/workspace/chat/input/ModelSelector.tsx
+++ b/desktop/src/components/workspace/chat/input/ModelSelector.tsx
@@ -151,7 +151,7 @@ export function ModelSelector({
                 <button
                   type="button"
                   onClick={toggleAddProvider}
-                  className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm font-[430] leading-5 text-muted-foreground hover:bg-popover-accent hover:text-popover-foreground"
+                  className="flex w-full items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm font-[430] leading-[18px] text-muted-foreground hover:bg-popover-accent hover:text-popover-foreground"
                 >
                   <Plus className="size-3.5 shrink-0" />
                   <span>{CHAT_MODEL_SELECTOR_LABELS.addProvider}</span>
@@ -166,7 +166,7 @@ export function ModelSelector({
                     key={agent.kind}
                     type="button"
                     onClick={() => openSetupAgent(agent)}
-                    className="flex w-full cursor-default items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm font-[430] leading-5 text-popover-foreground hover:bg-popover-accent focus:bg-popover-accent"
+                    className="flex w-full cursor-default items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm font-[430] leading-[18px] text-popover-foreground hover:bg-popover-accent focus:bg-popover-accent"
                   >
                     <ProviderIcon kind={agent.kind} className="size-3.5 shrink-0 text-muted-foreground" />
                     <span className="flex-1 truncate text-left">{agent.displayName}</span>
@@ -202,7 +202,7 @@ function ProviderModelGroup({
   return (
     <>
       {showSeparator && <div className="mx-2 my-1 border-t border-border/60" />}
-      <div className="min-h-6 truncate px-2 py-1 text-sm font-[430] leading-4 text-muted-foreground/70">
+      <div className="min-h-5 truncate px-2 py-0.5 text-sm font-[430] leading-4 text-muted-foreground/70">
         {group.providerDisplayName}
       </div>
       {group.models.map((model) => (
@@ -238,7 +238,7 @@ function ModelRow({
     <button
       type="button"
       onClick={onSelect}
-      className="flex w-full cursor-default items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm font-[430] leading-5 text-popover-foreground hover:bg-popover-accent focus:bg-popover-accent"
+      className="flex w-full cursor-default items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm font-[430] leading-[18px] text-popover-foreground hover:bg-popover-accent focus:bg-popover-accent"
     >
       <ProviderIcon kind={kind} className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="flex-1 truncate text-left">{displayName}</span>

--- a/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.test.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BashCommandCall } from "./BashCommandCall";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BashCommandCall", () => {
+  it("keeps command output hidden until the row is clicked", () => {
+    render(
+      <BashCommandCall
+        command="pnpm test"
+        output="test output"
+        status="running"
+        duration="for 3s"
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Running command pnpm test/i });
+    expect(row).toBeTruthy();
+    expect(screen.queryByText("test output")).toBeNull();
+
+    fireEvent.click(row);
+
+    expect(screen.getByText("test output")).toBeTruthy();
+  });
+});

--- a/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.tsx
@@ -9,7 +9,6 @@ interface BashCommandCallProps {
   output?: string;
   status: "running" | "completed" | "failed";
   duration?: string;
-  defaultExpanded?: boolean;
 }
 
 export function BashCommandCall({
@@ -18,7 +17,6 @@ export function BashCommandCall({
   output,
   status,
   duration,
-  defaultExpanded = false,
 }: BashCommandCallProps) {
   const label = description
     ?? (status === "failed" ? "Command" : "Running command");
@@ -32,7 +30,6 @@ export function BashCommandCall({
       hint={command}
       status={status}
       duration={duration}
-      defaultExpanded={defaultExpanded}
     >
       {output && (
         <ToolActionDetailsPanel>

--- a/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -1,7 +1,10 @@
+// @vitest-environment jsdom
+
 import { createElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createTranscriptState } from "@anyharness/sdk";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { toolItem } from "@/lib/domain/chat/transcript/transcript-presentation-test-fixtures";
 import { CollapsedActions, InlineToolActions } from "./CollapsedActions";
 
@@ -27,21 +30,47 @@ vi.mock("@/hooks/workspaces/files/use-file-reference-actions", () => ({
   }),
 }));
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("CollapsedActions", () => {
+  it("keeps the action ledger hidden until the summary row is clicked", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      read: toolItem("read", "turn-1", 1, "file_read", "in_progress"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["read"]}
+        transcript={transcript}
+        autoFollow
+      />,
+    );
+
+    expect(screen.queryByText("Reading read.ts")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Explored 1 file/i }));
+
+    expect(screen.getByText("Reading read.ts")).toBeTruthy();
+  });
+
   it("does not cap the expanded ledger when it contains edits", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       edit: toolItem("edit", "turn-1", 1, "file_change"),
     };
 
-    const html = renderToStaticMarkup(
-      createElement(CollapsedActions, {
-        itemIds: ["edit"],
-        transcript,
-        forceExpanded: true,
-      }),
+    render(
+      <CollapsedActions
+        itemIds={["edit"]}
+        transcript={transcript}
+      />,
     );
+    fireEvent.click(screen.getByRole("button", { name: /Edited 1 file/i }));
 
+    const html = document.body.innerHTML;
     expect(html).toContain("data-collapsed-actions-ledger");
     expect(html).toContain("Edited");
     expect(html).not.toContain("max-h-80");
@@ -56,14 +85,16 @@ describe("CollapsedActions", () => {
       read: toolItem("read", "turn-1", 1, "file_read"),
     };
 
-    const html = renderToStaticMarkup(
-      createElement(CollapsedActions, {
-        itemIds: ["read"],
-        transcript,
-        forceExpanded: true,
-      }),
+    render(
+      <CollapsedActions
+        itemIds={["read"]}
+        transcript={transcript}
+        autoFollow
+      />,
     );
+    fireEvent.click(screen.getByRole("button", { name: /Explored 1 file/i }));
 
+    const html = document.body.innerHTML;
     expect(html).toContain("data-collapsed-actions-ledger");
     expect(html).toContain("Read read.ts");
     expect(html).toContain("overflow-y-auto overflow-x-hidden");

--- a/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
+++ b/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
@@ -16,13 +16,13 @@ const CHAT_BUTTON_TEXT_CLASS = "text-[length:var(--text-chat)] leading-[var(--te
 interface CollapsedActionsProps {
   itemIds: string[];
   transcript: TranscriptState;
-  forceExpanded?: boolean;
+  autoFollow?: boolean;
 }
 
 export function CollapsedActions({
   itemIds,
   transcript,
-  forceExpanded = false,
+  autoFollow = false,
 }: CollapsedActionsProps) {
   const hasActiveExploration = itemIds.some((itemId) => {
     const item = transcript.itemsById[itemId];
@@ -30,14 +30,11 @@ export function CollapsedActions({
       && item.status !== "completed"
       && item.status !== "failed";
   });
-  const shouldForceExpanded = forceExpanded || hasActiveExploration;
-  const [userExpansionOverride, setUserExpansionOverride] = useState<"expanded" | "collapsed" | null>(null);
-  const expanded = userExpansionOverride === "collapsed"
-    ? false
-    : shouldForceExpanded || userExpansionOverride === "expanded";
+  const [expanded, setExpanded] = useState(false);
   const actionSummary = summarizeCollapsedActions(itemIds, transcript);
   const summary = formatCollapsedActionsSummary(actionSummary);
   const containsEdits = actionSummary.edits > 0;
+  const shouldAutoFollow = autoFollow || hasActiveExploration;
 
   return (
     <div className="min-w-0 text-chat leading-[var(--text-chat--line-height)]">
@@ -47,24 +44,23 @@ export function CollapsedActions({
         size="sm"
         data-chat-transcript-ignore
         aria-expanded={expanded}
-        className={`group/collapsed-actions h-auto max-w-full justify-start gap-1.5 rounded-none bg-transparent p-0 text-left ${CHAT_BUTTON_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline`}
-        onClick={() => {
-          setUserExpansionOverride(expanded ? "collapsed" : "expanded");
-        }}
+        className={`group/collapsed-actions h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_BUTTON_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline`}
+        onClick={() => setExpanded((value) => !value)}
       >
-        <span className="min-w-0 truncate">{summary}</span>
         <ChevronRight
-          className={`size-3 shrink-0 text-faint opacity-0 transition-all duration-200 group-hover/collapsed-actions:opacity-100 group-focus-visible/collapsed-actions:opacity-100 ${
-            expanded ? "rotate-90 opacity-100" : ""
+          aria-hidden="true"
+          className={`size-3 shrink-0 text-faint opacity-75 transition-transform duration-200 group-hover/collapsed-actions:text-muted-foreground group-focus-visible/collapsed-actions:text-muted-foreground ${
+            expanded ? "rotate-90" : ""
           }`}
         />
+        <span className="min-w-0 truncate">{summary}</span>
       </Button>
       {expanded && (
         <div className="mt-1 flex flex-col gap-1">
           <CollapsedActionsLedger
             itemIds={itemIds}
             transcript={transcript}
-            autoFollow={shouldForceExpanded}
+            autoFollow={shouldAutoFollow}
             containsEdits={containsEdits}
           />
         </div>
@@ -107,7 +103,7 @@ function CollapsedActionsLedger({
   transcript,
   autoFollow,
   containsEdits,
-}: CollapsedActionsProps & { autoFollow: boolean; containsEdits: boolean }) {
+}: Pick<CollapsedActionsProps, "itemIds" | "transcript"> & { autoFollow: boolean; containsEdits: boolean }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const itemSignature = itemIds.join("|");
   const shouldScrollLedger = !containsEdits;
@@ -125,8 +121,8 @@ function CollapsedActionsLedger({
         ref={viewportRef}
         data-collapsed-actions-ledger
         className={containsEdits
-          ? "px-2.5"
-          : `overflow-y-auto overflow-x-hidden px-2.5 ${
+          ? "pl-4 pr-2.5"
+          : `overflow-y-auto overflow-x-hidden pl-4 pr-2.5 ${
             autoFollow ? "max-h-[7.5rem]" : "max-h-80"
           }`}
       >

--- a/desktop/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
+++ b/desktop/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
@@ -13,12 +13,12 @@ import { SubagentCreationGroupBlock } from "./SubagentCreationGroupBlock";
 export function ScopedTranscriptBlocks({
   displayBlocks,
   transcript,
-  forceExpandedCollapsedActionBlockId,
+  autoFollowCollapsedActionBlockId,
   renderItem,
 }: {
   displayBlocks: readonly TurnDisplayBlock[];
   transcript: TranscriptState;
-  forceExpandedCollapsedActionBlockId?: string | null;
+  autoFollowCollapsedActionBlockId?: string | null;
   renderItem: (itemId: string) => ReactNode;
 }) {
   return (
@@ -28,7 +28,7 @@ export function ScopedTranscriptBlocks({
           key={getTurnDisplayBlockKey(block)}
           block={block}
           transcript={transcript}
-          forceExpandedCollapsedActionBlockId={forceExpandedCollapsedActionBlockId}
+          autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
           renderItem={renderItem}
         />
       ))}
@@ -39,12 +39,12 @@ export function ScopedTranscriptBlocks({
 export function TurnDisplayBlockNode({
   block,
   transcript,
-  forceExpandedCollapsedActionBlockId,
+  autoFollowCollapsedActionBlockId,
   renderItem,
 }: {
   block: TurnDisplayBlock;
   transcript: TranscriptState;
-  forceExpandedCollapsedActionBlockId?: string | null;
+  autoFollowCollapsedActionBlockId?: string | null;
   renderItem: (itemId: string) => ReactNode;
 }) {
   if (block.kind === "collapsed_actions") {
@@ -52,7 +52,7 @@ export function TurnDisplayBlockNode({
       <CollapsedActions
         itemIds={block.itemIds}
         transcript={transcript}
-        forceExpanded={block.blockId === forceExpandedCollapsedActionBlockId}
+        autoFollow={block.blockId === autoFollowCollapsedActionBlockId}
       />
     );
   }

--- a/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
+++ b/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import type { ErrorItem } from "@anyharness/sdk";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { RefreshCw } from "@/components/ui/icons";
+import { CircleAlert, ChevronRight, RefreshCw } from "@/components/ui/icons";
 import { useSessionModelFallbackAction } from "@/hooks/sessions/workflows/use-session-model-fallback-action";
+import { presentSessionError } from "@/lib/domain/chat/transcript/session-error-presentation";
 import { useToastStore } from "@/stores/toast/toast-store";
 
 export function SessionErrorItem({
@@ -13,9 +14,11 @@ export function SessionErrorItem({
   sessionId: string | null;
 }) {
   const fallback = providerRateLimitFallback(item);
+  const presentation = presentSessionError(item);
   const setFallbackModel = useSessionModelFallbackAction();
   const showToast = useToastStore((state) => state.show);
   const [isApplyingFallback, setIsApplyingFallback] = useState(false);
+  const [detailsExpanded, setDetailsExpanded] = useState(false);
 
   const handleFallback = () => {
     if (!fallback || !sessionId || isApplyingFallback) {
@@ -24,7 +27,10 @@ export function SessionErrorItem({
     setIsApplyingFallback(true);
     void setFallbackModel(sessionId, fallback.fallbackModelId)
       .then(() => {
-        showToast("Session model changed to Opus 4.6.", "info");
+        showToast(
+          `Session model changed to ${presentation.fallbackModelLabel ?? "the fallback model"}.`,
+          "info",
+        );
       })
       .catch((error) => {
         showToast(`Failed to change model: ${errorMessage(error)}`);
@@ -35,21 +41,50 @@ export function SessionErrorItem({
   };
 
   return (
-    <div className="rounded-lg bg-foreground/5 px-3 py-2 text-xs text-destructive">
-      <div>{item.message}</div>
-      {fallback && sessionId && (
-        <div className="mt-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            loading={isApplyingFallback}
-            onClick={handleFallback}
-            className="px-2.5 text-sm"
-          >
-            <RefreshCw className="size-3.5" />
-            Switch to Opus 4.6
-          </Button>
+    <div className="rounded-lg border border-destructive/20 bg-destructive/[0.04] px-3 py-2 text-sm">
+      <div className="flex min-w-0 items-start gap-2">
+        <CircleAlert className="mt-0.5 size-4 shrink-0 text-destructive/80" />
+        <div className="min-w-0 flex-1">
+          <div className="font-[520] text-destructive">{presentation.title}</div>
+          <div className="mt-0.5 text-muted-foreground">{presentation.description}</div>
+        </div>
+      </div>
+      {(fallback && sessionId) || presentation.technicalDetail ? (
+        <div className="mt-2 flex flex-wrap items-center gap-2 pl-6">
+          {fallback && sessionId && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              loading={isApplyingFallback}
+              onClick={handleFallback}
+              className="px-2.5 text-sm"
+            >
+              <RefreshCw className="size-3.5" />
+              Switch to {presentation.fallbackModelLabel ?? "fallback model"}
+            </Button>
+          )}
+          {presentation.technicalDetail && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setDetailsExpanded((value) => !value)}
+              className="gap-1 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+              aria-expanded={detailsExpanded}
+            >
+              <ChevronRight
+                aria-hidden="true"
+                className={`size-3 transition-transform ${detailsExpanded ? "rotate-90" : ""}`}
+              />
+              Details
+            </Button>
+          )}
+        </div>
+      ) : null}
+      {detailsExpanded && presentation.technicalDetail && (
+        <div className="mt-2 whitespace-pre-wrap rounded-md border border-border/70 bg-background/70 px-2.5 py-2 font-mono text-xs leading-5 text-muted-foreground select-text">
+          {presentation.technicalDetail}
         </div>
       )}
     </div>

--- a/desktop/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -119,12 +119,12 @@ export function TranscriptAgentGroupBlock({
   const hasLaunchLedger = !!normalizedPrompt || hasProvisioningLedger;
   const hasBodyContent = hasWork || hasLaunchLedger || !!normalizedAgentResult;
   const renderScopedWork = (
-    forceExpandedCollapsedActionBlockId: string | null,
+    autoFollowCollapsedActionBlockId: string | null,
   ) => (
     <ScopedTranscriptBlocks
       displayBlocks={scopedDisplayBlocks}
       transcript={transcript}
-      forceExpandedCollapsedActionBlockId={forceExpandedCollapsedActionBlockId}
+      autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
       renderItem={renderChild}
     />
   );

--- a/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { createTranscriptState, type ToolCallItem } from "@anyharness/sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import { toolItem } from "@/lib/domain/chat/transcript/transcript-presentation-test-fixtures";
+import { ProposedPlanToolCallIdsProvider } from "./ProposedPlanToolCallIdsContext";
+import { TranscriptItemBlock } from "./TranscriptItemBlock";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TranscriptItemBlock", () => {
+  it("suppresses Claude plan fallback rendering when the source item id matches", () => {
+    const transcript = createTranscriptState("session-1");
+    const fallback = claudeExitPlanFallback();
+    transcript.itemsById = { fallback };
+
+    const { container } = render(
+      <ProposedPlanToolCallIdsProvider value={new Set(["fallback"])}>
+        <TranscriptItemBlock
+          item={fallback}
+          transcript={transcript}
+          workspaceId={null}
+          onOpenArtifact={() => {}}
+        />
+      </ProposedPlanToolCallIdsProvider>,
+    );
+
+    expect(container.textContent).not.toContain("Fallback plan body");
+  });
+
+  it("renders Claude plan fallback content when no proposed plan source matches", () => {
+    const transcript = createTranscriptState("session-1");
+    const fallback = claudeExitPlanFallback();
+    transcript.itemsById = { fallback };
+
+    const { container } = render(
+      <ProposedPlanToolCallIdsProvider value={new Set()}>
+        <TranscriptItemBlock
+          item={fallback}
+          transcript={transcript}
+          workspaceId={null}
+          onOpenArtifact={() => {}}
+        />
+      </ProposedPlanToolCallIdsProvider>,
+    );
+
+    expect(container.textContent).toContain("Fallback plan body");
+  });
+});
+
+function claudeExitPlanFallback(): ToolCallItem {
+  return {
+    ...toolItem("fallback", "turn-1", 1, "mode_switch"),
+    sourceAgentKind: "claude",
+    nativeToolName: "ExitPlanMode",
+    toolCallId: null,
+    contentParts: [{ type: "tool_result_text", text: "Fallback plan body" }],
+  };
+}

--- a/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -15,6 +15,9 @@ import {
   resolveReviewFeedbackPromptReference,
 } from "@/lib/domain/chat/subagents/provenance";
 import {
+  hasProposedPlanForToolCallItem,
+} from "@/lib/domain/chat/transcript/transcript-rendering";
+import {
   resolveUserMessageActionTime,
 } from "@/lib/domain/chat/transcript/transcript-action-time";
 import type { TranscriptOpenSessionRole } from "@/lib/domain/chat/transcript/transcript-open-target";
@@ -192,7 +195,7 @@ export function TranscriptItemBlock({
 
     case "tool_call": {
       if (isClaudeExitPlanModeCall(item)) {
-        if (hasProposedPlanForToolCall(toolCallIdsWithProposedPlan, item.toolCallId)) {
+        if (hasProposedPlanForToolCallItem(toolCallIdsWithProposedPlan, item)) {
           return null;
         }
         const body = extractClaudePlanBody(item) ?? "";
@@ -245,14 +248,4 @@ export function TranscriptItemBlock({
     default:
       return null;
   }
-}
-
-function hasProposedPlanForToolCall(
-  toolCallIdsWithProposedPlan: ReadonlySet<string>,
-  toolCallId: string | null,
-): boolean {
-  if (!toolCallId) {
-    return false;
-  }
-  return toolCallIdsWithProposedPlan.has(toolCallId);
 }

--- a/desktop/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
@@ -71,7 +71,6 @@ export function TranscriptToolCallGroupBlock({
       icon={<ToolKindIcon iconKey={display.iconKey} />}
       label={display.label}
       summary={summary}
-      defaultExpanded={item.status === "in_progress"}
       itemCount={renderableItemCount}
       typeIcons={buildCollapsedSummaryIcons({
         messages: messageCount,

--- a/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -124,7 +124,7 @@ export function TranscriptTurnRow({
           transcript={transcript}
           isTurnComplete={!!turn.completedAt}
           presentation={renderPresentation}
-          forceExpandedCollapsedActionBlockId={liveExplorationBlock?.blockId ?? null}
+          autoFollowCollapsedActionBlockId={liveExplorationBlock?.blockId ?? null}
           tailAssistantProseRootId={tailAssistantProseRootId}
           showCompletedArtifactFallback={row.isLastTurnRow}
           workspaceId={selectedWorkspaceId}

--- a/desktop/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -34,7 +34,7 @@ export function TurnItemSequence({
   transcript,
   isTurnComplete,
   presentation,
-  forceExpandedCollapsedActionBlockId,
+  autoFollowCollapsedActionBlockId,
   tailAssistantProseRootId,
   showCompletedArtifactFallback,
   workspaceId,
@@ -45,7 +45,7 @@ export function TurnItemSequence({
   transcript: TranscriptState;
   isTurnComplete: boolean;
   presentation: TurnPresentation;
-  forceExpandedCollapsedActionBlockId?: string | null;
+  autoFollowCollapsedActionBlockId?: string | null;
   tailAssistantProseRootId: string | null;
   showCompletedArtifactFallback: boolean;
   workspaceId: string | null;
@@ -97,7 +97,7 @@ export function TurnItemSequence({
                         key={`history-${getTurnDisplayBlockKey(historyBlock)}`}
                         block={historyBlock}
                         transcript={transcript}
-                        forceExpandedCollapsedActionBlockId={null}
+                        autoFollowCollapsedActionBlockId={null}
                         renderItem={(itemId) => (
                           <FragmentWithArtifacts
                             itemId={itemId}
@@ -122,7 +122,7 @@ export function TurnItemSequence({
             key={getTurnDisplayBlockKey(block)}
             block={block}
             transcript={transcript}
-            forceExpandedCollapsedActionBlockId={forceExpandedCollapsedActionBlockId}
+            autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
             renderItem={(itemId) => (
               <FragmentWithArtifacts
                 itemId={itemId}

--- a/desktop/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/desktop/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -45,7 +45,7 @@ export function FileReferenceBadge({
     && !actions.reference.workspacePath
     && Boolean(actions.reference.absolutePath);
   const iconShellClassName = variant === "inline"
-    ? "relative mr-[3px] inline-block h-[1lh] w-4 shrink-0 align-bottom"
+    ? "relative mr-px inline-block h-[1lh] w-3.5 shrink-0 align-bottom"
     : "inline-flex shrink-0 items-center justify-center";
 
   const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
@@ -117,7 +117,7 @@ function resolveBadgeClassName(
 ): string {
   if (variant === "chip") {
     return [
-      "inline-flex h-auto min-w-0 max-w-full items-center gap-0.5 rounded-sm border border-border/60 bg-muted/45 px-1 py-px font-mono text-[0.625rem] leading-none text-foreground/90 shadow-none transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+      "inline-flex h-auto min-w-0 max-w-full items-center gap-px rounded-sm border border-border/60 bg-muted/45 px-1 py-px font-mono text-[0.625rem] leading-none text-foreground/90 shadow-none transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
       className,
     ].filter(Boolean).join(" ");
   }

--- a/desktop/src/config/chat-layout.test.ts
+++ b/desktop/src/config/chat-layout.test.ts
@@ -45,10 +45,11 @@ describe("chat layout", () => {
     })).toBeNull();
   });
 
-  it("keeps sticky transcript scrolling above the stable composer reserve", () => {
+  it("keeps sticky transcript scrolling above the full composer dock reserve", () => {
     expect(computeChatStableBottomInsetPx({
       composerSurfaceHeightPx: 120,
+      composerSurfaceOffsetTopPx: 80,
       composerFooterHeightPx: 24,
-    })).toBe(184);
+    })).toBe(264);
   });
 });

--- a/desktop/src/config/chat-layout.ts
+++ b/desktop/src/config/chat-layout.ts
@@ -31,12 +31,14 @@ export function computeChatSurfaceBottomInsetPx({
 
 export function computeChatStableBottomInsetPx({
   composerSurfaceHeightPx,
+  composerSurfaceOffsetTopPx = 0,
   composerFooterHeightPx = 0,
-}: Pick<ChatSurfaceBottomInsetArgs, "composerSurfaceHeightPx" | "composerFooterHeightPx">): number {
+}: Pick<ChatSurfaceBottomInsetArgs, "composerSurfaceHeightPx" | "composerSurfaceOffsetTopPx" | "composerFooterHeightPx">): number {
+  const surfaceOffsetTop = Math.max(0, Math.ceil(composerSurfaceOffsetTopPx));
   const surfaceHeight = Math.max(0, Math.ceil(composerSurfaceHeightPx));
   const footerHeight = Math.max(0, Math.ceil(composerFooterHeightPx));
 
-  return surfaceHeight + footerHeight + CHAT_SCROLL_BASE_BOTTOM_PADDING_PX;
+  return surfaceOffsetTop + surfaceHeight + footerHeight + CHAT_SCROLL_BASE_BOTTOM_PADDING_PX;
 }
 
 export function computeChatDockLowerBackdropTopPx({

--- a/desktop/src/lib/domain/chat/transcript/session-error-presentation.test.ts
+++ b/desktop/src/lib/domain/chat/transcript/session-error-presentation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorItem } from "@anyharness/sdk";
+import {
+  formatModelLabel,
+  presentSessionError,
+} from "@/lib/domain/chat/transcript/session-error-presentation";
+
+describe("presentSessionError", () => {
+  it("turns provider rate limits into concise user-facing copy", () => {
+    const presentation = presentSessionError(errorItem({
+      message: "Error: provider returned 429 with a long upstream explanation",
+      details: {
+        kind: "provider_rate_limit",
+        provider: "anthropic",
+        providerModel: "claude-opus-4-7",
+        limit: 30000,
+        unit: "input_tokens_per_minute",
+        fallbackModelId: "claude-opus-4-6",
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Anthropic rate limit reached",
+      description: "This chat exceeded the provider limit for Opus 4.7. Try again later or switch to Opus 4.6.",
+      fallbackModelLabel: "Opus 4.6",
+      technicalDetail: "provider returned 429 with a long upstream explanation",
+    });
+  });
+
+  it("keeps generic failures short and moves long text into details", () => {
+    const presentation = presentSessionError(errorItem({
+      code: "RUNTIME_STREAM_FAILED",
+      message: "Runtime error: " + "x".repeat(220),
+    }));
+
+    expect(presentation.title).toBe("Chat stopped");
+    expect(presentation.description.length).toBeLessThanOrEqual(180);
+    expect(presentation.technicalDetail).toContain("Error code: RUNTIME_STREAM_FAILED");
+    expect(presentation.technicalDetail).toContain("x".repeat(40));
+  });
+});
+
+describe("formatModelLabel", () => {
+  it("formats Claude model ids as compact names", () => {
+    expect(formatModelLabel("claude-opus-4-6")).toBe("Opus 4.6");
+  });
+});
+
+function errorItem(overrides: Partial<ErrorItem>): ErrorItem {
+  return {
+    kind: "error",
+    itemId: "error-1",
+    turnId: "turn-1",
+    status: "failed",
+    sourceAgentKind: "claude",
+    messageId: null,
+    title: null,
+    nativeToolName: null,
+    parentToolCallId: null,
+    contentParts: [],
+    timestamp: "2026-04-04T00:00:00Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: 1,
+    completedAt: "2026-04-04T00:00:00Z",
+    message: "Something failed",
+    code: null,
+    details: null,
+    ...overrides,
+  };
+}

--- a/desktop/src/lib/domain/chat/transcript/session-error-presentation.ts
+++ b/desktop/src/lib/domain/chat/transcript/session-error-presentation.ts
@@ -1,0 +1,127 @@
+import type { ErrorItem } from "@anyharness/sdk";
+
+export interface SessionErrorPresentation {
+  title: string;
+  description: string;
+  technicalDetail: string | null;
+  fallbackModelLabel: string | null;
+}
+
+const GENERIC_ERROR_TITLE = "Chat stopped";
+const GENERIC_ERROR_DESCRIPTION = "The session stopped before it could continue.";
+const MAX_DESCRIPTION_LENGTH = 180;
+
+export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
+  if (item.details?.kind === "provider_rate_limit") {
+    const provider = formatProviderLabel(item.details.provider);
+    const model = formatModelLabel(item.details.providerModel);
+    const fallbackModelLabel = formatModelLabel(item.details.fallbackModelId);
+    const retryGuidance = fallbackModelLabel
+      ? `Try again later or switch to ${fallbackModelLabel}.`
+      : "Try again later.";
+
+    return {
+      title: `${provider} rate limit reached`,
+      description: `This chat exceeded the provider limit${model ? ` for ${model}` : ""}. ${retryGuidance}`,
+      technicalDetail: normalizeTechnicalDetail(item.message),
+      fallbackModelLabel,
+    };
+  }
+
+  const normalizedMessage = normalizeTechnicalDetail(item.message);
+  const description = normalizedMessage
+    ? truncateSentence(normalizedMessage, MAX_DESCRIPTION_LENGTH)
+    : GENERIC_ERROR_DESCRIPTION;
+  const technicalDetail = buildGenericTechnicalDetail({
+    code: item.code,
+    message: normalizedMessage,
+    description,
+  });
+
+  return {
+    title: GENERIC_ERROR_TITLE,
+    description,
+    technicalDetail,
+    fallbackModelLabel: null,
+  };
+}
+
+export function formatModelLabel(modelId: string | null | undefined): string | null {
+  const normalized = modelId?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const claudeMatch = /^claude-(.+)-(\d+)-(\d+)$/i.exec(normalized);
+  if (claudeMatch) {
+    const family = claudeMatch[1]
+      ?.split("-")
+      .filter(Boolean)
+      .map(capitalize)
+      .join(" ");
+    const major = claudeMatch[2];
+    const minor = claudeMatch[3];
+    return [family, major && minor ? `${major}.${minor}` : null]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  return normalized;
+}
+
+function formatProviderLabel(provider: string | null | undefined): string {
+  const normalized = provider?.trim();
+  if (!normalized) {
+    return "Provider";
+  }
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(capitalize)
+    .join(" ");
+}
+
+function normalizeTechnicalDetail(message: string | null | undefined): string | null {
+  const normalized = message
+    ?.replace(/\s+/g, " ")
+    .replace(/^(error|runtime error|anyharness error):\s*/i, "")
+    .trim();
+  return normalized || null;
+}
+
+function buildGenericTechnicalDetail({
+  code,
+  message,
+  description,
+}: {
+  code: string | null | undefined;
+  message: string | null;
+  description: string;
+}): string | null {
+  const lines: string[] = [];
+  const normalizedCode = code?.trim();
+  if (normalizedCode) {
+    lines.push(`Error code: ${normalizedCode}`);
+  }
+  if (message && (message !== description || normalizedCode)) {
+    lines.push(message);
+  }
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function truncateSentence(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  const sentenceEnd = value.slice(0, maxLength).search(/[.!?]\s/);
+  if (sentenceEnd > 40) {
+    return value.slice(0, sentenceEnd + 1);
+  }
+
+  return `${value.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/desktop/src/lib/domain/chat/transcript/transcript-copy-items.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-copy-items.ts
@@ -23,6 +23,7 @@ import {
   getToolCallParsedCommands,
   getToolCallShellCommand,
 } from "@/lib/domain/chat/transcript/transcript-tool-commands";
+import { hasProposedPlanForToolCallItem } from "@/lib/domain/chat/transcript/transcript-rendering";
 
 export function serializeTranscriptItem(
   item: TranscriptItem,
@@ -98,7 +99,7 @@ function serializeToolCall(
   proposedPlanToolCallIds: ReadonlySet<string>,
 ): string[] {
   if (isClaudeExitPlanModeCall(item)) {
-    if (item.toolCallId && proposedPlanToolCallIds.has(item.toolCallId)) {
+    if (hasProposedPlanForToolCallItem(proposedPlanToolCallIds, item)) {
       return [];
     }
     return normalizeCopySections([extractClaudePlanBody(item)]);

--- a/desktop/src/lib/domain/chat/transcript/transcript-copy.test.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-copy.test.ts
@@ -9,6 +9,7 @@ import {
   type TranscriptState,
 } from "@anyharness/sdk";
 import { buildTranscriptCopyText } from "@/lib/domain/chat/transcript/transcript-copy";
+import { collectToolCallIdsWithProposedPlan } from "@/lib/domain/chat/transcript/transcript-rendering";
 import {
   assistantItem,
   parsedCommandItem,
@@ -225,6 +226,28 @@ describe("buildTranscriptCopyText", () => {
       proposedPlanToolCallIds: new Set(["tool-1"]),
     });
 
+    expect(copied).toContain("Approved plan body");
+    expect(copied).not.toContain("Fallback plan body");
+  });
+
+  it("suppresses duplicate Claude plan fallback when only the source item id matches", () => {
+    const proposed = proposedPlanItem("plan", "tool-1", "Approved plan body");
+    proposed.plan.sourceItemId = "fallback";
+    const fallback: ToolCallItem = {
+      ...toolItem("fallback", "turn-1", 2, "mode_switch"),
+      sourceAgentKind: "claude",
+      nativeToolName: "ExitPlanMode",
+      toolCallId: null,
+      contentParts: [{ type: "tool_result_text", text: "Fallback plan body" }],
+    };
+    const transcript = makeTranscript([proposed, fallback], ["plan", "fallback"]);
+    const proposedPlanToolCallIds = collectToolCallIdsWithProposedPlan(transcript);
+    const copied = copyText({
+      transcript,
+      proposedPlanToolCallIds,
+    });
+
+    expect(proposedPlanToolCallIds.has("fallback")).toBe(true);
     expect(copied).toContain("Approved plan body");
     expect(copied).not.toContain("Fallback plan body");
   });

--- a/desktop/src/lib/domain/chat/transcript/transcript-rendering.ts
+++ b/desktop/src/lib/domain/chat/transcript/transcript-rendering.ts
@@ -1,6 +1,7 @@
 import type {
   TranscriptItem,
   TranscriptState,
+  ToolCallItem,
   TurnRecord,
 } from "@anyharness/sdk";
 import { summarizeCollapsedActions } from "@/lib/domain/chat/transcript/transcript-collapsed-actions";
@@ -80,11 +81,21 @@ export function collectToolCallIdsWithProposedPlan(
 ): Set<string> {
   const toolCallIds = new Set<string>();
   for (const item of Object.values(transcript.itemsById)) {
-    if (item.kind === "proposed_plan" && item.plan.sourceToolCallId) {
-      toolCallIds.add(item.plan.sourceToolCallId);
+    if (item.kind === "proposed_plan") {
+      addProposedPlanSourceIds(item.plan, toolCallIds);
     }
   }
   return toolCallIds;
+}
+
+export function hasProposedPlanForToolCallItem(
+  proposedPlanToolCallIds: ReadonlySet<string>,
+  item: Pick<ToolCallItem, "itemId" | "toolCallId">,
+): boolean {
+  return Boolean(
+    (item.toolCallId && proposedPlanToolCallIds.has(item.toolCallId))
+      || proposedPlanToolCallIds.has(item.itemId),
+  );
 }
 
 export function collectToolCallIdsWithProposedPlanForBlocks(
@@ -126,8 +137,8 @@ function collectToolCallIdsWithProposedPlanFromItem(
   output: Set<string>,
 ): void {
   const item = transcript.itemsById[itemId];
-  if (item?.kind === "proposed_plan" && item.plan.sourceToolCallId) {
-    output.add(item.plan.sourceToolCallId);
+  if (item?.kind === "proposed_plan") {
+    addProposedPlanSourceIds(item.plan, output);
   }
   for (const childId of childrenByParentId.get(itemId) ?? []) {
     collectToolCallIdsWithProposedPlanFromItem(
@@ -136,6 +147,18 @@ function collectToolCallIdsWithProposedPlanFromItem(
       childrenByParentId,
       output,
     );
+  }
+}
+
+function addProposedPlanSourceIds(
+  plan: Extract<TranscriptItem, { kind: "proposed_plan" }>["plan"],
+  output: Set<string>,
+): void {
+  if (plan.sourceToolCallId) {
+    output.add(plan.sourceToolCallId);
+  }
+  if (plan.sourceItemId) {
+    output.add(plan.sourceItemId);
   }
 }
 


### PR DESCRIPTION
## Summary

Clean up several chat-view affordances across the composer, transcript, and tool-call UI:

- Anchor composer selector submenus to the active selector row and reduce vertical spacing in selector-style popovers.
- Reserve the full composer dock height for sticky transcript positioning so top-attached composer panels do not obscure transcript text.
- Keep tool command/details rows hidden by default and reveal them on explicit row click.
- Suppress duplicate Claude plan fallback rendering by matching proposed-plan source tool call ids and source item ids without adding repeated full-transcript scans to turn rendering.
- Tighten file reference icon/name spacing.
- Replace raw session error dumps in the transcript with concise error cards, optional technical details, and cleaner fallback-model actions.

## Root Cause

Several chat surfaces had drifted independently: selector submenus were bottom-aligned, transcript bottom reserves ignored composer top attachments, tool rows still had live/default expansion paths, and plan suppression only matched one source id shape.

## Validation

- `pnpm --dir desktop exec vitest run src/config/chat-layout.test.ts src/components/workspace/chat/tool-calls/BashCommandCall.test.tsx src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx src/lib/domain/chat/transcript/transcript-copy.test.ts src/lib/domain/chat/transcript/session-error-presentation.test.ts`
- `pnpm --dir desktop exec tsc --noEmit`
- Local playground sanity check on a temporary Vite port for command collapse/expand and selector submenu positioning.

## Review Follow-Up

After xhigh review, this PR also removes the per-turn full-transcript proposed-plan scan, keeps internal error codes out of generic card titles, and adds render-level coverage for source-item-id plan fallback suppression.