### PR TITLE
feat(desktop): add appearance size bounds

### DIFF
--- a/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppCommandActions } from "@/hooks/app/workflows/use-app-command-actions";
+import {
+  clearShortcutHandlerRegistryForTests,
+  runShortcutHandler,
+} from "@/lib/domain/shortcuts/registry";
+import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+import { useAppShortcuts } from "./use-app-shortcuts";
+
+vi.mock("@/hooks/workspaces/derived/use-sidebar-shortcut-targets", () => ({
+  useSidebarShortcutTargets: () => [],
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    selectWorkspaceFromSurface: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: {
+      selectedWorkspaceId: string | null;
+      selectedLogicalWorkspaceId: string | null;
+    }) => unknown,
+  ) =>
+    selector({
+      selectedWorkspaceId: null,
+      selectedLogicalWorkspaceId: null,
+    }),
+}));
+
+function buildCommandActions(): AppCommandActions {
+  const action = {
+    execute: vi.fn(),
+    disabledReason: null,
+  };
+
+  return {
+    openSettings: action,
+    showKeyboardShortcuts: action,
+    goHome: action,
+    goPlugins: action,
+    goAutomations: action,
+    openSupport: action,
+    addRepository: action,
+    newLocalWorkspace: action,
+    newWorktreeWorkspace: action,
+    newCloudWorkspace: action,
+  };
+}
+
+describe("useAppShortcuts", () => {
+  beforeEach(() => {
+    clearShortcutHandlerRegistryForTests();
+    useUserPreferencesStore.setState({
+      ...USER_PREFERENCE_DEFAULTS,
+      _hydrated: true,
+      _persistedMetadata: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearShortcutHandlerRegistryForTests();
+    vi.clearAllMocks();
+  });
+
+  it("steps appearance font sizes through the registered app shortcuts", () => {
+    renderHook(() => useAppShortcuts(buildCommandActions()));
+
+    useUserPreferencesStore.setState({
+      uiFontSizeId: "xsmall",
+      readableCodeFontSizeId: "xsmall",
+    });
+
+    expect(runShortcutHandler("app.decrease-text-size", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxsmall");
+    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xxsmall");
+
+    expect(runShortcutHandler("app.decrease-text-size", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxsmall");
+    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xxsmall");
+
+    useUserPreferencesStore.setState({
+      uiFontSizeId: "xxxlarge",
+      readableCodeFontSizeId: "large",
+    });
+
+    expect(runShortcutHandler("app.increase-text-size", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxxlarge");
+    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xlarge");
+  });
+});

--- a/desktop/src/lib/domain/preferences/appearance-presentation.ts
+++ b/desktop/src/lib/domain/preferences/appearance-presentation.ts
@@ -25,14 +25,14 @@ export const UI_FONT_SIZE_OPTIONS: AppearanceSizeOption<UiFontSizeId>[] =
   APPEARANCE_SIZE_IDS.map((id) => ({
     id,
     label: SIZE_LABELS[id],
-    detail: id === "default" ? "Current density" : "App and chat text",
+    detail: id === "default" ? "Default app and chat text" : "App and chat text",
   }));
 
 export const READABLE_CODE_FONT_SIZE_OPTIONS: AppearanceSizeOption<ReadableCodeFontSizeId>[] =
   APPEARANCE_SIZE_IDS.map((id) => ({
     id,
     label: SIZE_LABELS[id],
-    detail: id === "default" ? "Current code density" : "Editor, diffs, and code blocks",
+    detail: id === "default" ? "Default editor and code text" : "Editor, diffs, and code blocks",
   }));
 
 export const UI_FONT_SIZE_LABELS: Record<UiFontSizeId, string> = SIZE_LABELS;

--- a/desktop/src/lib/domain/preferences/appearance-presentation.ts
+++ b/desktop/src/lib/domain/preferences/appearance-presentation.ts
@@ -11,14 +11,14 @@ interface AppearanceSizeOption<T extends string> {
 }
 
 const SIZE_LABELS: Record<UiFontSizeId, string> = {
-  xxsmall: "Extra Extra Small",
+  xxsmall: "Smallest",
   xsmall: "Extra Small",
   small: "Small",
   default: "Default",
   large: "Large",
   xlarge: "Extra Large",
   xxlarge: "Extra Extra Large",
-  xxxlarge: "Extra Extra Extra Large",
+  xxxlarge: "Largest",
 };
 
 export const UI_FONT_SIZE_OPTIONS: AppearanceSizeOption<UiFontSizeId>[] =

--- a/desktop/src/lib/domain/preferences/appearance.test.ts
+++ b/desktop/src/lib/domain/preferences/appearance.test.ts
@@ -3,11 +3,44 @@ import {
   APPEARANCE_SIZE_IDS,
   CHAT_LINE_HEIGHTS,
   READABLE_CODE_FONT_SCALES,
+  type TextTokenScale,
   resolveAppearanceSizeId,
   stepAppearanceFontSizes,
   stepAppearanceSizeId,
   UI_FONT_SCALES,
 } from "./appearance";
+
+function cssLengthToPx(value: string): number {
+  if (value.endsWith("rem")) {
+    return Number.parseFloat(value) * 16;
+  }
+  if (value.endsWith("px")) {
+    return Number.parseFloat(value);
+  }
+  return Number.parseFloat(value);
+}
+
+function expectMonotonicTokenScale(token: keyof TextTokenScale) {
+  for (let index = 1; index < APPEARANCE_SIZE_IDS.length; index += 1) {
+    const previousId = APPEARANCE_SIZE_IDS[index - 1];
+    const id = APPEARANCE_SIZE_IDS[index];
+    if (!previousId || !id) {
+      continue;
+    }
+    expect(cssLengthToPx(UI_FONT_SCALES[id].xs[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].xs[token]));
+    expect(cssLengthToPx(UI_FONT_SCALES[id].sm[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].sm[token]));
+    expect(cssLengthToPx(UI_FONT_SCALES[id].base[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].base[token]));
+    expect(cssLengthToPx(UI_FONT_SCALES[id].chat[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].chat[token]));
+    expect(cssLengthToPx(UI_FONT_SCALES[id].lg[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].lg[token]));
+    expect(cssLengthToPx(UI_FONT_SCALES[id].xl[token]))
+      .toBeGreaterThanOrEqual(cssLengthToPx(UI_FONT_SCALES[previousId].xl[token]));
+  }
+}
 
 describe("appearance preferences", () => {
   it("resolves invalid size ids to default", () => {
@@ -59,12 +92,12 @@ describe("appearance preferences", () => {
   it("defines exact UI font preset values", () => {
     expect(UI_FONT_SCALES).toEqual({
       xxsmall: {
-        xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
-        sm: { fontSize: "0.46875rem", lineHeight: "0.75rem" },
-        base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
-        chat: { fontSize: "9px", lineHeight: "17px" },
-        lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },
-        xl: { fontSize: "0.9375rem", lineHeight: "1.375rem" },
+        xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
+        sm: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
+        base: { fontSize: "0.53125rem", lineHeight: "0.84375rem" },
+        chat: { fontSize: "9.5px", lineHeight: "17.5px" },
+        lg: { fontSize: "0.71875rem", lineHeight: "1.09375rem" },
+        xl: { fontSize: "0.96875rem", lineHeight: "1.4375rem" },
       },
       xsmall: {
         xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
@@ -139,11 +172,11 @@ describe("appearance preferences", () => {
   it("defines exact readable code preset values", () => {
     expect(READABLE_CODE_FONT_SCALES).toEqual({
       xxsmall: {
-        monacoFontSize: 8,
-        monacoLineHeight: 15,
-        diffsFontSize: "8px",
+        monacoFontSize: 8.5,
+        monacoLineHeight: 15.5,
+        diffsFontSize: "8.5px",
         diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
-        codeFontSize: "0.5rem",
+        codeFontSize: "0.53125rem",
         codeLineHeight: "1.625",
       },
       xsmall: {
@@ -211,5 +244,39 @@ describe("appearance preferences", () => {
       const diffPx = Number.parseFloat(READABLE_CODE_FONT_SCALES[id].diffsFontSize);
       expect(diffPx).toBeLessThan(chatPx);
     }
+  });
+
+  it("keeps appearance scales monotonic", () => {
+    expectMonotonicTokenScale("fontSize");
+    expectMonotonicTokenScale("lineHeight");
+
+    for (let index = 1; index < APPEARANCE_SIZE_IDS.length; index += 1) {
+      const previousId = APPEARANCE_SIZE_IDS[index - 1];
+      const id = APPEARANCE_SIZE_IDS[index];
+      if (!previousId || !id) {
+        continue;
+      }
+
+      expect(READABLE_CODE_FONT_SCALES[id].monacoFontSize)
+        .toBeGreaterThanOrEqual(READABLE_CODE_FONT_SCALES[previousId].monacoFontSize);
+      expect(READABLE_CODE_FONT_SCALES[id].monacoLineHeight)
+        .toBeGreaterThanOrEqual(READABLE_CODE_FONT_SCALES[previousId].monacoLineHeight);
+      expect(cssLengthToPx(READABLE_CODE_FONT_SCALES[id].diffsFontSize))
+        .toBeGreaterThanOrEqual(cssLengthToPx(READABLE_CODE_FONT_SCALES[previousId].diffsFontSize));
+      expect(cssLengthToPx(READABLE_CODE_FONT_SCALES[id].codeFontSize))
+        .toBeGreaterThanOrEqual(cssLengthToPx(READABLE_CODE_FONT_SCALES[previousId].codeFontSize));
+    }
+  });
+
+  it("keeps the new lower bound close to the previous smallest size", () => {
+    expect(cssLengthToPx(UI_FONT_SCALES.xxsmall.xs.fontSize)).toBe(7);
+    expect(cssLengthToPx(UI_FONT_SCALES.xxsmall.sm.fontSize)).toBe(8);
+    expect(cssLengthToPx(UI_FONT_SCALES.xxsmall.base.fontSize)).toBeGreaterThanOrEqual(8.5);
+    expect(cssLengthToPx(UI_FONT_SCALES.xxsmall.chat.fontSize)).toBeGreaterThanOrEqual(9.5);
+    expect(READABLE_CODE_FONT_SCALES.xxsmall.monacoFontSize).toBeGreaterThanOrEqual(8.5);
+    expect(cssLengthToPx(READABLE_CODE_FONT_SCALES.xxsmall.diffsFontSize))
+      .toBeGreaterThanOrEqual(8.5);
+    expect(cssLengthToPx(READABLE_CODE_FONT_SCALES.xxsmall.codeFontSize))
+      .toBeGreaterThanOrEqual(8.5);
   });
 });

--- a/desktop/src/lib/domain/preferences/appearance.test.ts
+++ b/desktop/src/lib/domain/preferences/appearance.test.ts
@@ -60,7 +60,7 @@ describe("appearance preferences", () => {
     expect(UI_FONT_SCALES).toEqual({
       xxsmall: {
         xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
-        sm: { fontSize: "0.4375rem", lineHeight: "0.75rem" },
+        sm: { fontSize: "0.46875rem", lineHeight: "0.75rem" },
         base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
         chat: { fontSize: "9px", lineHeight: "17px" },
         lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },

--- a/desktop/src/lib/domain/preferences/appearance.ts
+++ b/desktop/src/lib/domain/preferences/appearance.ts
@@ -66,7 +66,7 @@ export const CHAT_LINE_HEIGHTS: Record<UiFontSizeId, string> = {
 export const UI_FONT_SCALES: Record<UiFontSizeId, UiFontScale> = {
   xxsmall: {
     xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
-    sm: { fontSize: "0.4375rem", lineHeight: "0.75rem" },
+    sm: { fontSize: "0.46875rem", lineHeight: "0.75rem" },
     base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
     chat: { fontSize: "9px", lineHeight: CHAT_LINE_HEIGHTS.xxsmall },
     lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },

--- a/desktop/src/lib/domain/preferences/appearance.ts
+++ b/desktop/src/lib/domain/preferences/appearance.ts
@@ -53,7 +53,7 @@ export interface ReadableCodeFontScale {
 
 export const DEFAULT_APPEARANCE_SIZE_ID: AppearanceSizeId = "default";
 export const CHAT_LINE_HEIGHTS: Record<UiFontSizeId, string> = {
-  xxsmall: "17px",
+  xxsmall: "17.5px",
   xsmall: "18px",
   small: "19px",
   default: "20px",
@@ -65,12 +65,12 @@ export const CHAT_LINE_HEIGHTS: Record<UiFontSizeId, string> = {
 
 export const UI_FONT_SCALES: Record<UiFontSizeId, UiFontScale> = {
   xxsmall: {
-    xs: { fontSize: "0.40625rem", lineHeight: "0.625rem" },
-    sm: { fontSize: "0.46875rem", lineHeight: "0.75rem" },
-    base: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
-    chat: { fontSize: "9px", lineHeight: CHAT_LINE_HEIGHTS.xxsmall },
-    lg: { fontSize: "0.6875rem", lineHeight: "1.0625rem" },
-    xl: { fontSize: "0.9375rem", lineHeight: "1.375rem" },
+    xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
+    sm: { fontSize: "0.5rem", lineHeight: "0.8125rem" },
+    base: { fontSize: "0.53125rem", lineHeight: "0.84375rem" },
+    chat: { fontSize: "9.5px", lineHeight: CHAT_LINE_HEIGHTS.xxsmall },
+    lg: { fontSize: "0.71875rem", lineHeight: "1.09375rem" },
+    xl: { fontSize: "0.96875rem", lineHeight: "1.4375rem" },
   },
   xsmall: {
     xs: { fontSize: "0.4375rem", lineHeight: "0.6875rem" },
@@ -132,11 +132,11 @@ export const UI_FONT_SCALES: Record<UiFontSizeId, UiFontScale> = {
 
 export const READABLE_CODE_FONT_SCALES: Record<ReadableCodeFontSizeId, ReadableCodeFontScale> = {
   xxsmall: {
-    monacoFontSize: 8,
-    monacoLineHeight: 15,
-    diffsFontSize: "8px",
+    monacoFontSize: 8.5,
+    monacoLineHeight: 15.5,
+    diffsFontSize: "8.5px",
     diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
-    codeFontSize: "0.5rem",
+    codeFontSize: "0.53125rem",
     codeLineHeight: "1.625",
   },
   xsmall: {

--- a/desktop/src/stores/preferences/user-preferences-appearance-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-appearance-store.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { selectPersistedUserPreferencesSlice } from "@/lib/domain/preferences/persisted-metadata";
+import {
+  USER_PREFERENCE_DEFAULTS,
+  type UserPreferences,
+} from "@/lib/domain/preferences/user/model";
+import {
+  loadUserPreferences,
+  persistUserPreferences,
+} from "@/lib/workflows/preferences/user-preferences-persistence";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+const storeMocks = vi.hoisted(() => {
+  const values = new Map<string, unknown>();
+  const get = vi.fn(async (key: string) => values.get(key));
+  const set = vi.fn(async (key: string, value: unknown) => {
+    values.set(key, value);
+  });
+
+  return {
+    values,
+    get,
+    set,
+    getPreferencesStore: vi.fn(async () => ({ get, set })),
+  };
+});
+
+vi.mock("@/lib/access/tauri/store", () => ({
+  getPreferencesStore: storeMocks.getPreferencesStore,
+}));
+
+async function bootstrapUserPreferencesForTest(): Promise<void> {
+  const loaded = await loadUserPreferences();
+  useUserPreferencesStore.getState().hydrate(loaded);
+  if (loaded.shouldPersist) {
+    await persistUserPreferences(loaded.preferences, loaded.persistedMetadata);
+  }
+}
+
+describe("user appearance preference persistence", () => {
+  beforeEach(() => {
+    storeMocks.values.clear();
+    storeMocks.get.mockClear();
+    storeMocks.set.mockClear();
+    storeMocks.getPreferencesStore.mockClear();
+    useUserPreferencesStore.setState({
+      ...USER_PREFERENCE_DEFAULTS,
+      _hydrated: false,
+      _persistedMetadata: {},
+    });
+  });
+
+  it("round-trips the appearance font preference bounds", async () => {
+    storeMocks.values.set("user_preferences", {
+      ...USER_PREFERENCE_DEFAULTS,
+      uiFontSizeId: "xxsmall",
+      readableCodeFontSizeId: "xxxlarge",
+    } satisfies UserPreferences);
+
+    await bootstrapUserPreferencesForTest();
+
+    const preferences = useUserPreferencesStore.getState();
+    expect(preferences.uiFontSizeId).toBe("xxsmall");
+    expect(preferences.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(storeMocks.set).not.toHaveBeenCalled();
+
+    preferences.set("turnEndSoundEnabled", true);
+    await persistUserPreferences(
+      selectPersistedUserPreferencesSlice(useUserPreferencesStore.getState()),
+      useUserPreferencesStore.getState()._persistedMetadata,
+    );
+
+    const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
+    expect(persisted.uiFontSizeId).toBe("xxsmall");
+    expect(persisted.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(persisted.turnEndSoundEnabled).toBe(true);
+  });
+});

--- a/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -501,6 +501,32 @@ describe("user preference migration", () => {
     expect(result.preferences.readableCodeFontSizeId).toBe("xxxlarge");
   });
 
+  it("round-trips the appearance font preference bounds", async () => {
+    storeMocks.values.set("user_preferences", {
+      ...USER_PREFERENCE_DEFAULTS,
+      uiFontSizeId: "xxsmall",
+      readableCodeFontSizeId: "xxxlarge",
+    } satisfies UserPreferences);
+
+    await bootstrapUserPreferencesForTest();
+
+    const preferences = useUserPreferencesStore.getState();
+    expect(preferences.uiFontSizeId).toBe("xxsmall");
+    expect(preferences.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(storeMocks.set).not.toHaveBeenCalled();
+
+    preferences.set("turnEndSoundEnabled", true);
+    await persistUserPreferences(
+      selectPersistedUserPreferencesSlice(useUserPreferencesStore.getState()),
+      useUserPreferencesStore.getState()._persistedMetadata,
+    );
+
+    const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
+    expect(persisted.uiFontSizeId).toBe("xxsmall");
+    expect(persisted.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(persisted.turnEndSoundEnabled).toBe(true);
+  });
+
   it("sanitizes partially present review defaults", () => {
     const result = migrateUserPreferences({
       ...USER_PREFERENCE_DEFAULTS,

--- a/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -501,32 +501,6 @@ describe("user preference migration", () => {
     expect(result.preferences.readableCodeFontSizeId).toBe("xxxlarge");
   });
 
-  it("round-trips the appearance font preference bounds", async () => {
-    storeMocks.values.set("user_preferences", {
-      ...USER_PREFERENCE_DEFAULTS,
-      uiFontSizeId: "xxsmall",
-      readableCodeFontSizeId: "xxxlarge",
-    } satisfies UserPreferences);
-
-    await bootstrapUserPreferencesForTest();
-
-    const preferences = useUserPreferencesStore.getState();
-    expect(preferences.uiFontSizeId).toBe("xxsmall");
-    expect(preferences.readableCodeFontSizeId).toBe("xxxlarge");
-    expect(storeMocks.set).not.toHaveBeenCalled();
-
-    preferences.set("turnEndSoundEnabled", true);
-    await persistUserPreferences(
-      selectPersistedUserPreferencesSlice(useUserPreferencesStore.getState()),
-      useUserPreferencesStore.getState()._persistedMetadata,
-    );
-
-    const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
-    expect(persisted.uiFontSizeId).toBe("xxsmall");
-    expect(persisted.readableCodeFontSizeId).toBe("xxxlarge");
-    expect(persisted.turnEndSoundEnabled).toBe(true);
-  });
-
   it("sanitizes partially present review defaults", () => {
     const result = migrateUserPreferences({
       ...USER_PREFERENCE_DEFAULTS,


### PR DESCRIPTION
## Summary

- Adds one smaller and one larger appearance size preset around the existing range.
- Wires the new presets through UI text scaling, readable code scaling, Monaco sizing, diff sizing, and settings menu labels.
- Keeps the new smallest preset close to the previous lower bound so it is a slight density step rather than an unreadably tiny mode.
- Adds tests for exact values, monotonic scale ordering, lower-bound usability floors, preference round-trip persistence, and the registered app shortcut path.

## Validation

- `pnpm --dir desktop exec vitest run src/lib/domain/preferences/appearance.test.ts src/stores/preferences/user-preferences-store.test.ts src/lib/domain/preferences/user/migration.test.ts src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.test.tsx src/hooks/app/lifecycle/use-app-shortcuts.test.tsx`
- `pnpm --dir desktop exec tsc --noEmit`

## Review follow-up

Xhigh critique agents flagged that the initial `xxsmall` values were too aggressive, that the default menu detail copy was misleading, and that persistence/shortcut paths deserved coverage. This branch now raises the lower bound, clarifies the default option details, and covers those paths in focused tests.

## Notes

This preserves existing preference IDs and defaults; stored user preferences continue to resolve as before.