### PR TITLE
feat(desktop): add settings sidebar shortcuts

### DIFF
--- a/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
@@ -6,6 +6,12 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SupportMessageContext } from "@proliferate/cloud-sdk/client/support";
 import { SettingsSidebar } from "@/components/settings/sidebar/SettingsSidebar";
+import type { SettingsSection } from "@/config/settings";
+import {
+  clearShortcutHandlerRegistryForTests,
+  getShortcutHandler,
+  runShortcutHandler,
+} from "@/lib/domain/shortcuts/registry";
 import { requestSupportDialog } from "@/lib/infra/support/support-dialog-request";
 
 const supportDialogRender = vi.hoisted(() => vi.fn());
@@ -29,9 +35,17 @@ vi.mock("@/components/support/SupportDialog", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  clearShortcutHandlerRegistryForTests();
 });
 
-function renderSettingsSidebar() {
+function renderSettingsSidebar({
+  onNavigateHome = vi.fn(),
+  onSelectSection = vi.fn(),
+}: {
+  onNavigateHome?: () => void;
+  onSelectSection?: (section: SettingsSection) => void;
+} = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -44,8 +58,8 @@ function renderSettingsSidebar() {
       <MemoryRouter initialEntries={["/settings?section=general"]}>
         <SettingsSidebar
           activeSection="general"
-          onNavigateHome={vi.fn()}
-          onSelectSection={vi.fn()}
+          onNavigateHome={onNavigateHome}
+          onSelectSection={onSelectSection}
           onCheckForUpdates={vi.fn()}
           onDownloadUpdate={vi.fn()}
           onOpenRestartPrompt={vi.fn()}
@@ -93,5 +107,49 @@ describe("SettingsSidebar support mount boundary", () => {
 
     expect(supportDialogRender).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("support-dialog")).toBeTruthy();
+  });
+});
+
+describe("SettingsSidebar layout and shortcuts", () => {
+  it("keeps the back row full width", () => {
+    renderSettingsSidebar();
+
+    const backRow = screen.getByRole("button", { name: "Back to app" });
+    expect(backRow.className).toContain("w-full");
+    expect(backRow.className).not.toContain("w-fit");
+  });
+
+  it("renders Cmd number labels with the sidebar reveal treatment", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    renderSettingsSidebar();
+
+    const shortcutLabel = screen.getByText("⌘1");
+    expect(shortcutLabel.className).toContain("opacity-0");
+    expect(shortcutLabel.className).toContain("group-hover:opacity-100");
+  });
+
+  it("selects settings sections from Cmd number shortcuts", async () => {
+    const onSelectSection = vi.fn();
+    renderSettingsSidebar({ onSelectSection });
+
+    await waitFor(() => {
+      expect(getShortcutHandler("workspace.tab-by-index")).not.toBeNull();
+    });
+
+    expect(runShortcutHandler("workspace.tab-by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("appearance");
+
+    expect(runShortcutHandler("workspace.tab-by-index", {
+      source: "keyboard",
+      digit: 9,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("review");
   });
 });

--- a/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
@@ -40,9 +40,11 @@ afterEach(() => {
 });
 
 function renderSettingsSidebar({
+  disabledSections,
   onNavigateHome = vi.fn(),
   onSelectSection = vi.fn(),
 }: {
+  disabledSections?: Partial<Record<SettingsSection, boolean>>;
   onNavigateHome?: () => void;
   onSelectSection?: (section: SettingsSection) => void;
 } = {}) {
@@ -58,6 +60,7 @@ function renderSettingsSidebar({
       <MemoryRouter initialEntries={["/settings?section=general"]}>
         <SettingsSidebar
           activeSection="general"
+          disabledSections={disabledSections}
           onNavigateHome={onNavigateHome}
           onSelectSection={onSelectSection}
           onCheckForUpdates={vi.fn()}
@@ -137,19 +140,50 @@ describe("SettingsSidebar layout and shortcuts", () => {
     renderSettingsSidebar({ onSelectSection });
 
     await waitFor(() => {
-      expect(getShortcutHandler("workspace.tab-by-index")).not.toBeNull();
+      expect(getShortcutHandler("settings.section-by-index")).not.toBeNull();
     });
 
-    expect(runShortcutHandler("workspace.tab-by-index", {
+    expect(runShortcutHandler("settings.section-by-index", {
       source: "keyboard",
       digit: 2,
     })).toBe(true);
     expect(onSelectSection).toHaveBeenLastCalledWith("appearance");
 
-    expect(runShortcutHandler("workspace.tab-by-index", {
+    expect(runShortcutHandler("settings.section-by-index", {
       source: "keyboard",
       digit: 9,
     })).toBe(true);
     expect(onSelectSection).toHaveBeenLastCalledWith("review");
+  });
+
+  it("keeps disabled sections in numbering but declines their shortcut", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    const onSelectSection = vi.fn();
+    renderSettingsSidebar({
+      disabledSections: { appearance: true },
+      onSelectSection,
+    });
+
+    await waitFor(() => {
+      expect(getShortcutHandler("settings.section-by-index")).not.toBeNull();
+    });
+
+    expect(screen.getByText("⌘2")).toBeTruthy();
+
+    expect(runShortcutHandler("settings.section-by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(false);
+    expect(onSelectSection).not.toHaveBeenCalled();
+
+    expect(runShortcutHandler("settings.section-by-index", {
+      source: "keyboard",
+      digit: 3,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("keyboard");
   });
 });

--- a/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -1,15 +1,19 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { ArrowLeft } from "@/components/ui/icons";
 import { SidebarNavRow } from "@/components/ui/SidebarNavRow";
 import { SupportDialog } from "@/components/support/SupportDialog";
 import { SETTINGS_COPY } from "@/copy/settings/settings-copy";
+import { SHORTCUTS } from "@/config/shortcuts";
 import type { SettingsSection } from "@/config/settings";
 import {
   SETTINGS_NAV_GROUPS,
   type SettingsNavItem,
 } from "@/components/settings/settings-navigation";
 import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
+import { useSettingsSectionShortcuts } from "@/hooks/settings/ui/use-settings-section-shortcuts";
+import { useShortcutRevealVisible } from "@/providers/ShortcutRevealProvider";
+import { buildShortcutRangeLabelById } from "@/lib/domain/shortcuts/presentation";
 import { subscribeSupportDialogRequest } from "@/lib/infra/support/support-dialog-request";
 import type { UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 
@@ -92,6 +96,18 @@ function settingsItemStatus(
   return null;
 }
 
+function settingsShortcutSectionIds(
+  disabledSections: Partial<Record<SettingsSection, boolean>> | undefined,
+): SettingsSection[] {
+  return SETTINGS_NAV_GROUPS.flatMap((group) =>
+    group.items.flatMap((item) =>
+      item.kind === "section" && !disabledSections?.[item.id]
+        ? [item.id]
+        : []
+    )
+  );
+}
+
 export function SettingsSidebar({
   activeSection,
   disabledSections,
@@ -105,6 +121,19 @@ export function SettingsSidebar({
   const location = useLocation();
   const [supportOpen, setSupportOpen] = useState(false);
   const appVersion = useAppVersion().data?.trim();
+  const shortcutRevealVisible = useShortcutRevealVisible();
+  const shortcutSectionIds = useMemo(
+    () => settingsShortcutSectionIds(disabledSections),
+    [disabledSections],
+  );
+  const shortcutLabelBySection = useMemo(
+    () => buildShortcutRangeLabelById(shortcutSectionIds, SHORTCUTS.tabByIndex),
+    [shortcutSectionIds],
+  );
+  useSettingsSectionShortcuts({
+    sections: shortcutSectionIds,
+    onSelectSection,
+  });
   useEffect(() => subscribeSupportDialogRequest(() => setSupportOpen(true)), []);
 
   function handleItemClick(item: SettingsNavItem) {
@@ -190,7 +219,7 @@ export function SettingsSidebar({
           icon={<ArrowLeft className="size-4" />}
           label={SETTINGS_COPY.back}
           onPress={onNavigateHome}
-          className={`w-fit ${SETTINGS_BACK_ROW_CLASS}`}
+          className={SETTINGS_BACK_ROW_CLASS}
         />
       </div>
 
@@ -218,11 +247,17 @@ export function SettingsSidebar({
                       icon={<Icon className="size-4" />}
                       label={item.label}
                       status={settingsItemStatus(item, updateActionState)}
+                      shortcutLabel={
+                        item.kind === "section"
+                          ? shortcutLabelBySection.get(item.id)
+                          : undefined
+                      }
                       onPress={() => handleItemClick(item)}
                       active={active}
                       disabled={disabled}
                       aria-current={active ? "page" : undefined}
                       className={settingsRowClass(active, disabled)}
+                      shortcutRevealVisible={shortcutRevealVisible}
                     />
                     {item.kind === "action" && item.id === "checkForUpdates"
                       ? renderUpdateCommand()

--- a/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -5,7 +5,10 @@ import { SidebarNavRow } from "@/components/ui/SidebarNavRow";
 import { SupportDialog } from "@/components/support/SupportDialog";
 import { SETTINGS_COPY } from "@/copy/settings/settings-copy";
 import { SHORTCUTS } from "@/config/shortcuts";
-import type { SettingsSection } from "@/config/settings";
+import {
+  SETTINGS_SHORTCUT_SECTION_ORDER,
+  type SettingsSection,
+} from "@/config/settings";
 import {
   SETTINGS_NAV_GROUPS,
   type SettingsNavItem,
@@ -14,6 +17,7 @@ import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
 import { useSettingsSectionShortcuts } from "@/hooks/settings/ui/use-settings-section-shortcuts";
 import { useShortcutRevealVisible } from "@/providers/ShortcutRevealProvider";
 import { buildShortcutRangeLabelById } from "@/lib/domain/shortcuts/presentation";
+import { buildSettingsShortcutSectionTargets } from "@/lib/domain/settings/shortcut-targets";
 import { subscribeSupportDialogRequest } from "@/lib/infra/support/support-dialog-request";
 import type { UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 
@@ -96,18 +100,6 @@ function settingsItemStatus(
   return null;
 }
 
-function settingsShortcutSectionIds(
-  disabledSections: Partial<Record<SettingsSection, boolean>> | undefined,
-): SettingsSection[] {
-  return SETTINGS_NAV_GROUPS.flatMap((group) =>
-    group.items.flatMap((item) =>
-      item.kind === "section" && !disabledSections?.[item.id]
-        ? [item.id]
-        : []
-    )
-  );
-}
-
 export function SettingsSidebar({
   activeSection,
   disabledSections,
@@ -122,16 +114,22 @@ export function SettingsSidebar({
   const [supportOpen, setSupportOpen] = useState(false);
   const appVersion = useAppVersion().data?.trim();
   const shortcutRevealVisible = useShortcutRevealVisible();
-  const shortcutSectionIds = useMemo(
-    () => settingsShortcutSectionIds(disabledSections),
+  const shortcutTargets = useMemo(
+    () => buildSettingsShortcutSectionTargets(
+      SETTINGS_SHORTCUT_SECTION_ORDER,
+      disabledSections,
+    ),
     [disabledSections],
   );
   const shortcutLabelBySection = useMemo(
-    () => buildShortcutRangeLabelById(shortcutSectionIds, SHORTCUTS.tabByIndex),
-    [shortcutSectionIds],
+    () => buildShortcutRangeLabelById(
+      shortcutTargets.map((target) => target.section),
+      SHORTCUTS.settingsSectionByIndex,
+    ),
+    [shortcutTargets],
   );
   useSettingsSectionShortcuts({
-    sections: shortcutSectionIds,
+    targets: shortcutTargets,
     onSelectSection,
   });
   useEffect(() => subscribeSupportDialogRequest(() => setSupportOpen(true)), []);

--- a/desktop/src/components/ui/SidebarNavRow.tsx
+++ b/desktop/src/components/ui/SidebarNavRow.tsx
@@ -9,6 +9,7 @@ interface SidebarNavRowProps extends Omit<HTMLAttributes<HTMLElement>, "children
   disabled?: boolean;
   status?: ReactNode;
   shortcutLabel?: string;
+  shortcutRevealVisible?: boolean;
   onPress: () => void;
 }
 
@@ -19,6 +20,7 @@ export function SidebarNavRow({
   disabled = false,
   status,
   shortcutLabel,
+  shortcutRevealVisible,
   onPress,
   ...props
 }: SidebarNavRowProps) {
@@ -34,6 +36,7 @@ export function SidebarNavRow({
         shortcutLabel,
       }}
       onSelect={onPress}
+      shortcutRevealVisible={shortcutRevealVisible}
       {...props}
     />
   );

--- a/desktop/src/config/settings.ts
+++ b/desktop/src/config/settings.ts
@@ -18,3 +18,19 @@ export type SettingsSection = (typeof SETTINGS_CONTENT_SECTIONS)[number];
 export type SettingsStaticSection = Exclude<SettingsSection, "repo">;
 
 export const SETTINGS_DEFAULT_SECTION: SettingsStaticSection = "general";
+
+export const SETTINGS_SHORTCUT_SECTION_ORDER = [
+  "general",
+  "appearance",
+  "keyboard",
+  "account",
+  "organization",
+  "billing",
+  "repo",
+  "worktrees",
+  "compute",
+  "cloud",
+  "agents",
+  "agent-defaults",
+  "review",
+] as const satisfies readonly SettingsSection[];

--- a/desktop/src/config/shortcuts.ts
+++ b/desktop/src/config/shortcuts.ts
@@ -260,6 +260,15 @@ export const SHORTCUTS = {
     match: { kind: "digit-key", meta: true, shift: false, alt: false },
     allowInInputs: true,
   },
+  settingsSectionByIndex: {
+    id: "settings.section-by-index",
+    label: "⌘1-9",
+    nonMacLabel: "Ctrl+1-9",
+    description: "Switch settings section by index",
+    owner: "js",
+    match: { kind: "digit-key", meta: true, shift: false, alt: false },
+    allowInInputs: false,
+  },
   newSessionTab: {
     id: "workspace.new-session-tab",
     label: "⌘T",
@@ -412,6 +421,7 @@ export const SHORTCUT_GROUPS = [
       "goAutomations",
       "openSupport",
       "showKeyboardShortcuts",
+      "settingsSectionByIndex",
       "increaseTextSize",
       "decreaseTextSize",
     ],

--- a/desktop/src/hooks/settings/ui/use-settings-section-shortcuts.ts
+++ b/desktop/src/hooks/settings/ui/use-settings-section-shortcuts.ts
@@ -1,0 +1,26 @@
+import { type SettingsSection } from "@/config/settings";
+import { useShortcutHandler } from "@/hooks/shortcuts/lifecycle/use-shortcut-handler";
+import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/presentation";
+
+interface UseSettingsSectionShortcutsArgs {
+  sections: readonly SettingsSection[];
+  onSelectSection: (section: SettingsSection) => void;
+}
+
+export function useSettingsSectionShortcuts({
+  sections,
+  onSelectSection,
+}: UseSettingsSectionShortcutsArgs): void {
+  useShortcutHandler("workspace.tab-by-index", ({ digit }) => {
+    if (!digit) {
+      return false;
+    }
+
+    const section = resolveShortcutRangeDigitTarget(sections, digit);
+    if (!section) {
+      return false;
+    }
+
+    onSelectSection(section);
+  }, { enabled: sections.length > 0 });
+}

--- a/desktop/src/hooks/settings/ui/use-settings-section-shortcuts.ts
+++ b/desktop/src/hooks/settings/ui/use-settings-section-shortcuts.ts
@@ -1,26 +1,28 @@
+import { SHORTCUTS } from "@/config/shortcuts";
 import { type SettingsSection } from "@/config/settings";
 import { useShortcutHandler } from "@/hooks/shortcuts/lifecycle/use-shortcut-handler";
-import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/presentation";
+import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/range";
+import type { SettingsShortcutSectionTarget } from "@/lib/domain/settings/shortcut-targets";
 
 interface UseSettingsSectionShortcutsArgs {
-  sections: readonly SettingsSection[];
+  targets: readonly SettingsShortcutSectionTarget[];
   onSelectSection: (section: SettingsSection) => void;
 }
 
 export function useSettingsSectionShortcuts({
-  sections,
+  targets,
   onSelectSection,
 }: UseSettingsSectionShortcutsArgs): void {
-  useShortcutHandler("workspace.tab-by-index", ({ digit }) => {
+  useShortcutHandler(SHORTCUTS.settingsSectionByIndex.id, ({ digit }) => {
     if (!digit) {
       return false;
     }
 
-    const section = resolveShortcutRangeDigitTarget(sections, digit);
-    if (!section) {
+    const target = resolveShortcutRangeDigitTarget(targets, digit);
+    if (!target || target.disabled) {
       return false;
     }
 
-    onSelectSection(section);
-  }, { enabled: sections.length > 0 });
+    onSelectSection(target.section);
+  }, { enabled: targets.length > 0 });
 }

--- a/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.test.tsx
+++ b/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useShortcutDispatcher } from "@/hooks/shortcuts/lifecycle/use-shortcut-dispatcher";
+import {
+  clearShortcutHandlerRegistryForTests,
+  registerShortcutHandler,
+} from "@/lib/domain/shortcuts/registry";
+
+vi.mock("@/hooks/access/tauri/use-menu-events", () => ({
+  useTauriMenuEvents: () => ({
+    listenForShortcutMenuEvents: vi.fn(async () => vi.fn()),
+  }),
+}));
+
+describe("useShortcutDispatcher", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+    clearShortcutHandlerRegistryForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearShortcutHandlerRegistryForTests();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("falls through duplicate keyboard matches until a registered handler consumes one", () => {
+    const settingsHandler = vi.fn();
+    registerShortcutHandler("settings.section-by-index", settingsHandler);
+    renderHook(() => useShortcutDispatcher());
+
+    const event = new KeyboardEvent("keydown", {
+      key: "1",
+      code: "Digit1",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(settingsHandler).toHaveBeenCalledWith({
+      source: "keyboard",
+      digit: 1,
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.ts
+++ b/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.ts
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
-import {
-  runShortcutHandler,
-} from "@/lib/domain/shortcuts/registry";
+import { runShortcutHandler } from "@/lib/domain/shortcuts/registry";
 import {
   isShortcutId,
-  resolveKeyboardShortcut,
+  resolveKeyboardShortcuts,
 } from "@/lib/domain/shortcuts/keyboard-resolution";
 import { shouldDispatchKeyboardShortcut } from "@/lib/domain/shortcuts/dispatch-policy";
 import { useTauriMenuEvents } from "@/hooks/access/tauri/use-menu-events";
@@ -17,21 +15,24 @@ export function useShortcutDispatcher(): void {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const resolved = resolveKeyboardShortcut(event);
-      if (!resolved) {
+      const resolvedShortcuts = resolveKeyboardShortcuts(event);
+      if (resolvedShortcuts.length === 0) {
         return;
       }
 
-      if (!shouldDispatchKeyboardShortcut(resolved.shortcut, event)) {
-        return;
-      }
+      for (const resolved of resolvedShortcuts) {
+        if (!shouldDispatchKeyboardShortcut(resolved.shortcut, event)) {
+          continue;
+        }
 
-      const consumed = runShortcutHandler(resolved.id, resolved.trigger);
-      if (consumed) {
-        window.dispatchEvent(new Event(SHORTCUT_REVEAL_RESET_EVENT));
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
+        const consumed = runShortcutHandler(resolved.id, resolved.trigger);
+        if (consumed) {
+          window.dispatchEvent(new Event(SHORTCUT_REVEAL_RESET_EVENT));
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          return;
+        }
       }
     };
 

--- a/desktop/src/lib/domain/settings/shortcut-targets.ts
+++ b/desktop/src/lib/domain/settings/shortcut-targets.ts
@@ -1,0 +1,16 @@
+import type { SettingsSection } from "@/config/settings";
+
+export interface SettingsShortcutSectionTarget {
+  disabled: boolean;
+  section: SettingsSection;
+}
+
+export function buildSettingsShortcutSectionTargets(
+  sectionOrder: readonly SettingsSection[],
+  disabledSections: Partial<Record<SettingsSection, boolean>> | undefined,
+): SettingsShortcutSectionTarget[] {
+  return sectionOrder.map((section) => ({
+    section,
+    disabled: Boolean(disabledSections?.[section]),
+  }));
+}

--- a/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -356,6 +356,22 @@ describe("shortcut dispatch policy", () => {
     } as KeyboardEvent)).toBe(true);
   });
 
+  it("blocks settings section index shortcuts in text-entry targets", () => {
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.settingsSectionByIndex, {
+      key: "3",
+      code: "Digit3",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: false,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(false);
+  });
+
   it("allows tab cycling aliases from right-panel text inputs even when handled locally", () => {
     expect(shouldDispatchKeyboardShortcut(SHORTCUTS.previousTab, {
       key: "{",

--- a/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
+++ b/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
@@ -70,7 +70,10 @@ function canBypassDefaultPrevented(
   }
 
   if (
-    shortcut.id === SHORTCUTS.tabByIndex.id
+    (
+      shortcut.id === SHORTCUTS.tabByIndex.id
+      || shortcut.id === SHORTCUTS.settingsSectionByIndex.id
+    )
     && (event.metaKey || event.ctrlKey)
     && !event.altKey
     && !event.shiftKey

--- a/desktop/src/lib/domain/shortcuts/keyboard-resolution.test.ts
+++ b/desktop/src/lib/domain/shortcuts/keyboard-resolution.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveKeyboardShortcut } from "@/lib/domain/shortcuts/keyboard-resolution";
+import {
+  resolveKeyboardShortcut,
+  resolveKeyboardShortcuts,
+} from "@/lib/domain/shortcuts/keyboard-resolution";
 
 describe("resolveKeyboardShortcut", () => {
   beforeEach(() => {
@@ -284,6 +287,18 @@ describe("resolveKeyboardShortcut", () => {
       shortcut: expect.objectContaining({ id: "workspace.by-index" }),
       trigger: expect.objectContaining({ source: "keyboard", digit: 1 }),
     });
+
+    expect(resolveKeyboardShortcuts({
+      key: "1",
+      code: "Digit1",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent).map((resolved) => resolved.id)).toEqual([
+      "workspace.tab-by-index",
+      "settings.section-by-index",
+    ]);
 
     expect(resolveKeyboardShortcut({
       key: "t",

--- a/desktop/src/lib/domain/shortcuts/keyboard-resolution.ts
+++ b/desktop/src/lib/domain/shortcuts/keyboard-resolution.ts
@@ -1,39 +1,47 @@
 import { SHORTCUTS, type ShortcutId } from "@/config/shortcuts";
-import {
-  matchShortcutDef,
-} from "@/lib/domain/shortcuts/matching";
+import { matchShortcutDef } from "@/lib/domain/shortcuts/matching";
 import type { ShortcutTrigger } from "@/lib/domain/shortcuts/registry";
 
 const DISPATCH_SHORTCUTS = Object.values(SHORTCUTS);
 const SHORTCUT_IDS = new Set<ShortcutId>(DISPATCH_SHORTCUTS.map((shortcut) => shortcut.id));
 
+export interface ResolvedKeyboardShortcut {
+  id: ShortcutId;
+  shortcut: (typeof DISPATCH_SHORTCUTS)[number];
+  trigger: ShortcutTrigger;
+}
+
 export function isShortcutId(id: string): id is ShortcutId {
   return SHORTCUT_IDS.has(id as ShortcutId);
 }
 
-export function resolveKeyboardShortcut(
+export function resolveKeyboardShortcuts(
   event: KeyboardEvent,
-): {
-  id: ShortcutId;
-  shortcut: (typeof DISPATCH_SHORTCUTS)[number];
-  trigger: ShortcutTrigger;
-} | null {
-  // Declaration order in SHORTCUTS is authoritative here: the first match wins.
+): ResolvedKeyboardShortcut[] {
+  const resolved: ResolvedKeyboardShortcut[] = [];
+
   for (const shortcut of DISPATCH_SHORTCUTS) {
     const match = matchShortcutDef(shortcut, event);
     if (!match) {
       continue;
     }
 
-    return {
+    resolved.push({
       id: shortcut.id,
       shortcut,
       trigger: {
         source: "keyboard",
         digit: match.digit,
       },
-    };
+    });
   }
 
-  return null;
+  return resolved;
+}
+
+export function resolveKeyboardShortcut(
+  event: KeyboardEvent,
+): ResolvedKeyboardShortcut | null {
+  // Declaration order in SHORTCUTS is authoritative here: the first match wins.
+  return resolveKeyboardShortcuts(event)[0] ?? null;
 }

--- a/desktop/src/lib/domain/shortcuts/presentation.test.ts
+++ b/desktop/src/lib/domain/shortcuts/presentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { SHORTCUTS } from "@/config/shortcuts";
 import {
   buildShortcutRangeLabelById,
+  resolveShortcutRangeDigitTarget,
   shortcutDigitForRangeIndex,
 } from "@/lib/domain/shortcuts/presentation";
 
@@ -28,5 +29,14 @@ describe("shortcut presentation", () => {
     expect(labels.get("workspace-8")).toBe("⌘⌥8");
     expect(labels.has("workspace-9")).toBe(false);
     expect(labels.get("workspace-10")).toBe("⌘⌥9");
+  });
+
+  it("resolves range shortcut digits from the same first-eight-and-final rule", () => {
+    const targets = Array.from({ length: 10 }, (_, index) => `target-${index + 1}`);
+
+    expect(resolveShortcutRangeDigitTarget(targets, 1)).toBe("target-1");
+    expect(resolveShortcutRangeDigitTarget(targets, 8)).toBe("target-8");
+    expect(resolveShortcutRangeDigitTarget(targets, 9)).toBe("target-10");
+    expect(resolveShortcutRangeDigitTarget([], 9)).toBeNull();
   });
 });

--- a/desktop/src/lib/domain/shortcuts/presentation.test.ts
+++ b/desktop/src/lib/domain/shortcuts/presentation.test.ts
@@ -1,24 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { SHORTCUTS } from "@/config/shortcuts";
-import {
-  buildShortcutRangeLabelById,
-  resolveShortcutRangeDigitTarget,
-  shortcutDigitForRangeIndex,
-} from "@/lib/domain/shortcuts/presentation";
+import { buildShortcutRangeLabelById } from "@/lib/domain/shortcuts/presentation";
 
 describe("shortcut presentation", () => {
-  it("labels first eight range targets and uses digit nine for the final target", () => {
-    expect(Array.from({ length: 10 }, (_, index) =>
-      shortcutDigitForRangeIndex(index, 10)
-    )).toEqual([1, 2, 3, 4, 5, 6, 7, 8, null, 9]);
-    expect(Array.from({ length: 9 }, (_, index) =>
-      shortcutDigitForRangeIndex(index, 9)
-    )).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(Array.from({ length: 4 }, (_, index) =>
-      shortcutDigitForRangeIndex(index, 4)
-    )).toEqual([1, 2, 3, 4]);
-  });
-
   it("builds labels that match range shortcut digit resolution", () => {
     const labels = buildShortcutRangeLabelById(
       Array.from({ length: 10 }, (_, index) => `workspace-${index + 1}`),
@@ -29,14 +13,5 @@ describe("shortcut presentation", () => {
     expect(labels.get("workspace-8")).toBe("⌘⌥8");
     expect(labels.has("workspace-9")).toBe(false);
     expect(labels.get("workspace-10")).toBe("⌘⌥9");
-  });
-
-  it("resolves range shortcut digits from the same first-eight-and-final rule", () => {
-    const targets = Array.from({ length: 10 }, (_, index) => `target-${index + 1}`);
-
-    expect(resolveShortcutRangeDigitTarget(targets, 1)).toBe("target-1");
-    expect(resolveShortcutRangeDigitTarget(targets, 8)).toBe("target-8");
-    expect(resolveShortcutRangeDigitTarget(targets, 9)).toBe("target-10");
-    expect(resolveShortcutRangeDigitTarget([], 9)).toBeNull();
   });
 });

--- a/desktop/src/lib/domain/shortcuts/presentation.ts
+++ b/desktop/src/lib/domain/shortcuts/presentation.ts
@@ -3,33 +3,13 @@ import {
   getShortcutDisplayLabel,
   type ShortcutDigit,
 } from "@/lib/domain/shortcuts/matching";
-
-export function shortcutDigitForRangeIndex(
-  index: number,
-  total: number,
-): ShortcutDigit | null {
-  if (index < 0 || total <= 0 || index >= total) {
-    return null;
-  }
-  if (index < 8) {
-    return (index + 1) as ShortcutDigit;
-  }
-  return index === total - 1 ? 9 : null;
-}
+import { shortcutDigitForRangeIndex } from "@/lib/domain/shortcuts/range";
 
 export function getShortcutRangeItemDisplayLabel(
   shortcut: Pick<ShortcutDef, "label" | "nonMacLabel">,
   digit: ShortcutDigit,
 ): string {
   return getShortcutDisplayLabel(shortcut).replace("1-9", String(digit));
-}
-
-export function resolveShortcutRangeDigitTarget<T>(
-  targets: readonly T[],
-  digit: ShortcutDigit,
-): T | null {
-  const index = digit === 9 ? targets.length - 1 : digit - 1;
-  return targets[index] ?? null;
 }
 
 export function buildShortcutRangeLabelById(

--- a/desktop/src/lib/domain/shortcuts/presentation.ts
+++ b/desktop/src/lib/domain/shortcuts/presentation.ts
@@ -24,6 +24,14 @@ export function getShortcutRangeItemDisplayLabel(
   return getShortcutDisplayLabel(shortcut).replace("1-9", String(digit));
 }
 
+export function resolveShortcutRangeDigitTarget<T>(
+  targets: readonly T[],
+  digit: ShortcutDigit,
+): T | null {
+  const index = digit === 9 ? targets.length - 1 : digit - 1;
+  return targets[index] ?? null;
+}
+
 export function buildShortcutRangeLabelById(
   ids: readonly string[],
   shortcut: Pick<ShortcutDef, "label" | "nonMacLabel">,

--- a/desktop/src/lib/domain/shortcuts/range.test.ts
+++ b/desktop/src/lib/domain/shortcuts/range.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveShortcutRangeDigitTarget,
+  shortcutDigitForRangeIndex,
+} from "@/lib/domain/shortcuts/range";
+
+describe("shortcut range", () => {
+  it("labels first eight range targets and uses digit nine for the final target", () => {
+    expect(
+      Array.from({ length: 10 }, (_, index) =>
+        shortcutDigitForRangeIndex(index, 10),
+      ),
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, null, 9]);
+    expect(
+      Array.from({ length: 9 }, (_, index) =>
+        shortcutDigitForRangeIndex(index, 9),
+      ),
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(
+      Array.from({ length: 4 }, (_, index) =>
+        shortcutDigitForRangeIndex(index, 4),
+      ),
+    ).toEqual([1, 2, 3, 4]);
+  });
+
+  it("resolves range shortcut digits from the same first-eight-and-final rule", () => {
+    const targets = Array.from(
+      { length: 10 },
+      (_, index) => `target-${index + 1}`,
+    );
+
+    expect(resolveShortcutRangeDigitTarget(targets, 1)).toBe("target-1");
+    expect(resolveShortcutRangeDigitTarget(targets, 8)).toBe("target-8");
+    expect(resolveShortcutRangeDigitTarget(targets, 9)).toBe("target-10");
+    expect(resolveShortcutRangeDigitTarget([], 9)).toBeNull();
+  });
+});

--- a/desktop/src/lib/domain/shortcuts/range.ts
+++ b/desktop/src/lib/domain/shortcuts/range.ts
@@ -1,0 +1,22 @@
+import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
+
+export function shortcutDigitForRangeIndex(
+  index: number,
+  total: number,
+): ShortcutDigit | null {
+  if (index < 0 || total <= 0 || index >= total) {
+    return null;
+  }
+  if (index < 8) {
+    return (index + 1) as ShortcutDigit;
+  }
+  return index === total - 1 ? 9 : null;
+}
+
+export function resolveShortcutRangeDigitTarget<T>(
+  targets: readonly T[],
+  digit: ShortcutDigit,
+): T | null {
+  const index = digit === 9 ? targets.length - 1 : digit - 1;
+  return targets[index] ?? null;
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
@@ -1,4 +1,5 @@
 import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
+import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/presentation";
 import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { visibleSidebarGroupItems } from "@/lib/domain/workspaces/sidebar/sidebar-visible-items";
 
@@ -32,8 +33,7 @@ export function resolveSidebarShortcutDigitTarget(
   targetIds: readonly string[],
   digit: ShortcutDigit,
 ): string | null {
-  const index = digit === 9 ? targetIds.length - 1 : digit - 1;
-  return targetIds[index] ?? null;
+  return resolveShortcutRangeDigitTarget(targetIds, digit);
 }
 
 export function resolveAdjacentSidebarShortcutTarget(

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts
@@ -1,5 +1,5 @@
 import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
-import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/presentation";
+import { resolveShortcutRangeDigitTarget } from "@/lib/domain/shortcuts/range";
 import type { SidebarGroupState } from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { visibleSidebarGroupItems } from "@/lib/domain/workspaces/sidebar/sidebar-visible-items";
 

--- a/packages/product-ui/src/settings/SettingsPageHeader.tsx
+++ b/packages/product-ui/src/settings/SettingsPageHeader.tsx
@@ -14,7 +14,7 @@ export function SettingsPageHeader({
   return (
     <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0 space-y-1.5">
-        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <h1 className="text-2xl font-semibold text-foreground/80">{title}</h1>
         {description ? (
           <p className="max-w-2xl text-sm leading-6 text-muted-foreground">{description}</p>
         ) : null}


### PR DESCRIPTION
## Summary
- soften shared settings page title color in light and dark themes
- make the settings "Back to app" row full width
- add settings sidebar Cmd/Ctrl+number shortcuts with workspace-style reveal labels
- keep disabled settings sections in the numbering while declining their shortcut activation

## Review follow-up
- split settings section shortcuts onto `settings.section-by-index` instead of reusing the workspace tab shortcut id
- moved range shortcut resolution out of presentation code into shortcut domain logic
- updated dispatch to fall through duplicate keyboard matches until a registered handler consumes one

## Verification
- `pnpm --dir desktop exec vitest run src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.test.tsx src/lib/domain/shortcuts/range.test.ts src/lib/domain/shortcuts/presentation.test.ts src/lib/domain/shortcuts/keyboard-resolution.test.ts src/lib/domain/shortcuts/dispatch-policy.test.ts src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts src/components/settings/sidebar/SettingsSidebar.test.tsx`
- `python3 scripts/check_frontend_boundaries.py`
- `pnpm --filter @proliferate/product-ui typecheck`

## Known check gap
- `pnpm --dir desktop exec tsc --noEmit --pretty false` still fails on existing cloud SDK declaration resolution and unrelated implicit-any/type errors outside this patch.