### PR TITLE
fix(desktop): clear home selection and cowork footer flicker

### DIFF
--- a/desktop/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/desktop/src/components/home/screen/HomeNextScreen.test.tsx
@@ -133,6 +133,7 @@ describe("HomeNextScreen model availability notices", () => {
     resetHomeNext();
     screenMocks.handleHomeAction.mockClear();
     screenMocks.launch.mockClear();
+    screenMocks.launch.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -191,5 +192,33 @@ describe("HomeNextScreen model availability notices", () => {
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "hello" } });
 
     expect(screen.getByText("Choose a repository")).toBeTruthy();
+  });
+
+  it("does not render a submitted preview below the composer for cowork launches", () => {
+    render(<HomeNextScreen />);
+
+    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "start cowork" } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
+      text: "start cowork",
+      target: { kind: "cowork" },
+    }));
+    expect(screen.queryByText("start cowork")).toBeNull();
+  });
+
+  it("keeps the submitted preview for repository launches", () => {
+    screenMocks.homeNext.launchTarget = {
+      kind: "worktree",
+      repoRootId: "repo-root-1",
+      sourceWorkspaceId: null,
+      baseBranch: null,
+    };
+    render(<HomeNextScreen />);
+
+    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "start worktree" } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(screen.getByText("start worktree")).toBeTruthy();
   });
 });

--- a/desktop/src/components/home/screen/HomeNextScreen.tsx
+++ b/desktop/src/components/home/screen/HomeNextScreen.tsx
@@ -142,14 +142,19 @@ export function HomeNextScreen() {
 
     const submittedDraft = draft;
     const submittedText = submittedDraft.trim();
+    const shouldShowHomeSubmittedPreview = homeNext.launchTarget.kind !== "cowork";
     flushSync(() => {
-      setSubmittedPreview({
-        id: crypto.randomUUID(),
-        text: submittedText,
-      });
+      if (shouldShowHomeSubmittedPreview) {
+        setSubmittedPreview({
+          id: crypto.randomUUID(),
+          text: submittedText,
+        });
+      }
       setDraft("");
     });
-    await waitForNextPaint();
+    if (shouldShowHomeSubmittedPreview) {
+      await waitForNextPaint();
+    }
     const succeeded = await launch({
       text: submittedDraft,
       modelSelection: homeNext.effectiveModelSelection,

--- a/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/desktop/src/components/workspace/chat/ChatView.tsx
@@ -98,8 +98,10 @@ function shouldShowSessionInputChrome(mode: ChatSurfaceState): boolean {
 
 export const ChatView = memo(function ChatView({
   shellRenderSurface = null,
+  showWorkspaceFooter = true,
 }: {
   shellRenderSurface?: WorkspaceRenderSurface | null;
+  showWorkspaceFooter?: boolean;
 }) {
   useDebugRenderCount("chat-surface");
   const { mode } = useChatSurfaceState(shellRenderSurface);
@@ -151,7 +153,10 @@ export const ChatView = memo(function ChatView({
       suppressActiveSessionState={suppressComposerActiveSessionState}
     />
   ), [promptAttachments, suppressComposerActiveSessionState]);
-  const footerSlot = useMemo(() => <WorkspaceMobilityFooterRow />, []);
+  const footerSlot = useMemo(
+    () => showWorkspaceFooter ? <WorkspaceMobilityFooterRow /> : null,
+    [showWorkspaceFooter],
+  );
 
   const handleFileDrag = useCallback((event: DragEvent<HTMLDivElement>) => {
     const dragInput = readFileDragInput(event.dataTransfer);

--- a/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/desktop/src/components/workspace/chat/ChatView.tsx
@@ -99,9 +99,11 @@ function shouldShowSessionInputChrome(mode: ChatSurfaceState): boolean {
 export const ChatView = memo(function ChatView({
   shellRenderSurface = null,
   showWorkspaceFooter = true,
+  showWorkspaceStatusPanels = true,
 }: {
   shellRenderSurface?: WorkspaceRenderSurface | null;
   showWorkspaceFooter?: boolean;
+  showWorkspaceStatusPanels?: boolean;
 }) {
   useDebugRenderCount("chat-surface");
   const { mode } = useChatSurfaceState(shellRenderSurface);
@@ -116,6 +118,7 @@ export const ChatView = memo(function ChatView({
   const isSessionMode = shouldShowSessionInputChrome(mode);
   const composerDockSlots = useComposerDockSlots({
     suppressSessionSlots,
+    suppressWorkspaceStatusPanels: !showWorkspaceStatusPanels,
   });
   const promptCapabilities = suppressComposerActiveSessionState
     ? null

--- a/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
+++ b/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
@@ -1,0 +1,62 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatLaunchIntentPane } from "./ChatLaunchIntentPane";
+import type { ChatLaunchIntent } from "@/lib/domain/chat/launch/launch-intent";
+import { useChatLaunchIntentStore } from "@/stores/chat/chat-launch-intent-store";
+
+vi.mock("@/hooks/chat/use-chat-launch-intent-actions", () => ({
+  useChatLaunchIntentActions: () => ({
+    dismiss: vi.fn(),
+    isRetrying: false,
+    retry: vi.fn(),
+    returnHome: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  useChatLaunchIntentStore.setState({ activeIntent: null });
+});
+
+describe("ChatLaunchIntentPane", () => {
+  it("renders pending thinking outside the right-aligned user message", () => {
+    useChatLaunchIntentStore.getState().begin(intent());
+
+    render(<ChatLaunchIntentPane bottomInsetPx={0} />);
+
+    expect(screen.getByText("Start cowork")).not.toBeNull();
+    expect(screen.getByText("Thinking").closest("[data-chat-user-message]")).toBeNull();
+  });
+});
+
+function intent(): ChatLaunchIntent {
+  return {
+    id: "launch-1",
+    promptId: "prompt-1",
+    text: "Start cowork",
+    contentParts: [],
+    targetKind: "cowork",
+    retryInput: {
+      text: "Start cowork",
+      modelSelection: { kind: "agent", modelId: "model-1" },
+      modeId: null,
+      target: { kind: "cowork" },
+    },
+    materializedWorkspaceId: null,
+    materializedSessionId: null,
+    createdAt: 1_700_000_000_000,
+    sendAttemptedAt: null,
+    failure: null,
+  } as ChatLaunchIntent;
+}

--- a/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.tsx
+++ b/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.tsx
@@ -3,6 +3,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { ArrowLeft, RefreshCw } from "@/components/ui/icons";
 import { UserMessage } from "@/components/workspace/chat/transcript/UserMessage";
 import { StreamingIndicator } from "@/components/workspace/chat/transcript/StreamingIndicator";
+import { TRAILING_STATUS_MIN_HEIGHT } from "@/components/workspace/chat/transcript/TranscriptTurnChrome";
 import { CHAT_COLUMN_CLASSNAME, CHAT_SURFACE_GUTTER_CLASSNAME } from "@/config/chat-layout";
 import { useChatLaunchIntentActions } from "@/hooks/chat/use-chat-launch-intent-actions";
 import { resolveChatLaunchIntentView } from "@/lib/domain/chat/launch/launch-intent";
@@ -27,6 +28,55 @@ export function ChatLaunchIntentPane({ bottomInsetPx }: ChatLaunchIntentPaneProp
 
   const view = resolveChatLaunchIntentView(activeIntent);
   const isPending = activeIntent.failure === null;
+  const failureFooter = isPending
+    ? null
+    : (
+      <div className="flex flex-col items-end gap-2 text-right">
+        <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+          <span>{view.title}</span>
+        </div>
+        <p className="text-xs leading-5 text-muted-foreground">
+          {view.detail}
+        </p>
+        {(view.canReturnHome || view.canRetry || view.canDismiss) && (
+          <div className="flex flex-wrap justify-end gap-2">
+            {view.canReturnHome && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={returnHome}
+              >
+                <ArrowLeft className="size-3.5" />
+                Back
+              </Button>
+            )}
+            {view.canDismiss && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={dismiss}
+              >
+                {view.dismissLabel}
+              </Button>
+            )}
+            {view.canRetry && (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                loading={isRetrying}
+                onClick={retry}
+              >
+                {!isRetrying && <RefreshCw className="size-3.5" />}
+                Retry
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    );
 
   return (
     <div className="flex-1 min-h-0" data-telemetry-block>
@@ -41,60 +91,13 @@ export function ChatLaunchIntentPane({ bottomInsetPx }: ChatLaunchIntentPaneProp
                 sessionId={null}
                 content={activeIntent.text}
                 contentParts={activeIntent.contentParts}
-                footer={(
-                  <div className="flex flex-col items-end gap-2 text-right">
-                    {isPending ? (
-                      <StreamingIndicator startedAt={new Date(activeIntent.createdAt).toISOString()} />
-                    ) : (
-                      <>
-                        <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
-                          <span>{view.title}</span>
-                        </div>
-                        <p className="text-xs leading-5 text-muted-foreground">
-                          {view.detail}
-                        </p>
-                      </>
-                    )}
-                    {(view.canReturnHome || view.canRetry || view.canDismiss) && (
-                      <div className="flex flex-wrap justify-end gap-2">
-                        {view.canReturnHome && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={returnHome}
-                          >
-                            <ArrowLeft className="size-3.5" />
-                            Back
-                          </Button>
-                        )}
-                        {view.canDismiss && (
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            onClick={dismiss}
-                          >
-                            {view.dismissLabel}
-                          </Button>
-                        )}
-                        {view.canRetry && (
-                          <Button
-                            type="button"
-                            variant="primary"
-                            size="sm"
-                            loading={isRetrying}
-                            onClick={retry}
-                          >
-                            {!isRetrying && <RefreshCw className="size-3.5" />}
-                            Retry
-                          </Button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
+                footer={failureFooter}
               />
+              {isPending && (
+                <div className={`mt-2 ${TRAILING_STATUS_MIN_HEIGHT}`}>
+                  <StreamingIndicator startedAt={new Date(activeIntent.createdAt).toISOString()} />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
@@ -8,7 +8,10 @@ import { CoworkWorkspaceShell } from "@/components/workspace/cowork/CoworkWorksp
 const chatViewRender = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/workspace/chat/ChatView", () => ({
-  ChatView: (props: { showWorkspaceFooter?: boolean }) => {
+  ChatView: (props: {
+    showWorkspaceFooter?: boolean;
+    showWorkspaceStatusPanels?: boolean;
+  }) => {
     chatViewRender(props);
     return <div data-testid="chat-view" />;
   },
@@ -123,7 +126,7 @@ afterEach(() => {
 });
 
 describe("CoworkWorkspaceShell", () => {
-  it("renders chat without the standard workspace footer", () => {
+  it("renders chat without standard workspace composer panels", () => {
     render(
       <CoworkWorkspaceShell
         workspaceId="workspace-cowork"
@@ -132,7 +135,10 @@ describe("CoworkWorkspaceShell", () => {
     );
 
     expect(chatViewRender).toHaveBeenCalledWith(
-      expect.objectContaining({ showWorkspaceFooter: false }),
+      expect.objectContaining({
+        showWorkspaceFooter: false,
+        showWorkspaceStatusPanels: false,
+      }),
     );
   });
 });

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
@@ -1,0 +1,138 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CoworkWorkspaceShell } from "@/components/workspace/cowork/CoworkWorkspaceShell";
+
+const chatViewRender = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/workspace/chat/ChatView", () => ({
+  ChatView: (props: { showWorkspaceFooter?: boolean }) => {
+    chatViewRender(props);
+    return <div data-testid="chat-view" />;
+  },
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/MainSidebar", () => ({
+  MainSidebar: () => <div data-testid="main-sidebar" />,
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/SidebarUpdatePill", () => ({
+  SidebarUpdatePill: () => <div data-testid="sidebar-update-pill" />,
+}));
+
+vi.mock("@proliferate/ui/primitives/IconButton", () => ({
+  IconButton: ({
+    children,
+    onClick,
+    title,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    title?: string;
+  }) => (
+    <button type="button" aria-label={title} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/icons", () => ({
+  SplitPanel: () => <span data-testid="split-panel-icon" />,
+}));
+
+vi.mock("@/components/workspace/cowork/CoworkArtifactsPanel", () => ({
+  CoworkArtifactsPanel: () => <div data-testid="cowork-artifacts-panel" />,
+}));
+
+vi.mock("@/components/workspace/cowork/CoworkWorkspaceHeader", () => ({
+  CoworkWorkspaceHeader: ({ title }: { title: string }) => (
+    <div data-testid="cowork-workspace-header">{title}</div>
+  ),
+}));
+
+vi.mock("@/hooks/ui/layout/use-resize", () => ({
+  useResize: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/shortcuts/lifecycle/use-shortcut-handler", () => ({
+  useShortcutHandler: () => {},
+}));
+
+vi.mock("@/hooks/theme/derived/use-transparent-chrome", () => ({
+  useTransparentChromeEnabled: () => false,
+}));
+
+vi.mock("@/hooks/access/tauri/use-updater", () => ({
+  useUpdater: () => ({
+    phase: "idle",
+    downloadProgress: null,
+    downloadUpdate: vi.fn(),
+    openRestartPrompt: vi.fn(),
+  }),
+}));
+
+const workspaceUiState = vi.hoisted(() => ({
+  sidebarOpen: true,
+  setSidebarOpen: vi.fn(),
+  sidebarWidth: 280,
+  setSidebarWidth: vi.fn(),
+}));
+
+vi.mock("@/stores/preferences/workspace-ui-store", () => ({
+  useWorkspaceUiStore: (selector: (state: typeof workspaceUiState) => unknown) =>
+    selector(workspaceUiState),
+}));
+
+const coworkUiState = vi.hoisted(() => ({
+  artifactPanelOpenByWorkspaceId: {},
+  setArtifactPanelOpen: vi.fn(),
+}));
+
+vi.mock("@/stores/cowork/cowork-ui-store", () => ({
+  useCoworkUiStore: (selector: (state: typeof coworkUiState) => unknown) =>
+    selector(coworkUiState),
+}));
+
+const sessionDirectoryState = vi.hoisted(() => ({
+  entriesById: {},
+}));
+
+vi.mock("@/stores/sessions/session-directory-store", () => ({
+  useSessionDirectoryStore: (selector: (state: typeof sessionDirectoryState) => unknown) =>
+    selector(sessionDirectoryState),
+}));
+
+const sessionSelectionState = vi.hoisted(() => ({
+  activeSessionId: null as string | null,
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: typeof sessionSelectionState) => unknown) =>
+    selector(sessionSelectionState),
+}));
+
+vi.mock("@/providers/WorkspacePathProvider", () => ({
+  WorkspacePathProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("CoworkWorkspaceShell", () => {
+  it("renders chat without the standard workspace footer", () => {
+    render(
+      <CoworkWorkspaceShell
+        workspaceId="workspace-cowork"
+        workspacePath="/tmp/workspace-cowork"
+      />,
+    );
+
+    expect(chatViewRender).toHaveBeenCalledWith(
+      expect.objectContaining({ showWorkspaceFooter: false }),
+    );
+  });
+});

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -202,7 +202,7 @@ export function CoworkWorkspaceShell({
                 aria-hidden="true"
                 className="pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-gradient-to-b from-background to-transparent"
               />
-              <ChatView />
+              <ChatView showWorkspaceFooter={false} />
             </div>
 
             {canShowArtifactPanel && rightPanelOpen && (

--- a/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -202,7 +202,10 @@ export function CoworkWorkspaceShell({
                 aria-hidden="true"
                 className="pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-gradient-to-b from-background to-transparent"
               />
-              <ChatView showWorkspaceFooter={false} />
+              <ChatView
+                showWorkspaceFooter={false}
+                showWorkspaceStatusPanels={false}
+              />
             </div>
 
             {canShowArtifactPanel && rightPanelOpen && (

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
@@ -1,0 +1,224 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoworkThread } from "@anyharness/sdk";
+import { CoworkThreadsSection } from "./CoworkThreadsSection";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+const coworkState = vi.hoisted(() => ({
+  statusLoading: false,
+  threadsLoading: false,
+  threads: [] as CoworkThread[],
+  createThread: vi.fn(),
+  openThread: vi.fn(),
+  isCreatingThread: false,
+}));
+
+vi.mock("@/components/feedback/Skeleton", () => ({
+  SkeletonBlock: () => <div data-testid="threads-skeleton" />,
+}));
+
+vi.mock("@/components/ui/icons", () => ({
+  CollapseAll: () => <span data-testid="collapse-icon" />,
+  ExpandAll: () => <span data-testid="expand-icon" />,
+  Plus: () => <span data-testid="plus-icon" />,
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/SidebarActionButton", () => ({
+  SidebarActionButton: ({
+    children,
+    disabled,
+    onClick,
+    title,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    title: string;
+  }) => (
+    <button type="button" aria-label={title} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/SidebarIndicators", () => ({
+  SidebarStatusIndicatorView: ({ indicator }: { indicator: { kind: string } | null }) => (
+    <span data-testid={indicator ? `status-${indicator.kind}` : "status-none"} />
+  ),
+}));
+
+vi.mock("@proliferate/product-ui/sidebar/ProductSidebar", () => ({
+  ProductSidebarSectionHeader: ({
+    actions,
+    label,
+  }: {
+    actions?: ReactNode;
+    label: string;
+  }) => (
+    <div>
+      <h2>{label}</h2>
+      {actions}
+    </div>
+  ),
+  ProductSidebarThreadRow: ({
+    active,
+    label,
+    status,
+    trailingLabel,
+  }: {
+    active?: boolean;
+    label: ReactNode;
+    status?: ReactNode;
+    trailingLabel?: string | null;
+  }) => (
+    <div data-testid="thread-row" data-active={String(!!active)}>
+      {status}
+      <span>{label}</span>
+      {trailingLabel ? <span>{trailingLabel}</span> : null}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/workspace/cowork/sidebar/CoworkThreadItem", () => ({
+  CoworkThreadItem: ({ thread }: { thread: CoworkThread }) => (
+    <div data-testid="real-thread-row">{thread.title ?? thread.id}</div>
+  ),
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/SidebarShowToggleRow", () => ({
+  SidebarShowToggleRow: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+vi.mock("@/hooks/access/anyharness/cowork/use-cowork-status", () => ({
+  useCoworkStatus: () => ({
+    status: { enabled: true },
+    isLoading: coworkState.statusLoading,
+  }),
+}));
+
+vi.mock("@/hooks/access/anyharness/cowork/use-cowork-threads", () => ({
+  useCoworkThreads: () => ({
+    threads: coworkState.threads,
+    isLoading: coworkState.threadsLoading,
+  }),
+}));
+
+vi.mock("@/hooks/cowork/workflows/use-cowork-thread-workflow", () => ({
+  useCoworkThreadWorkflow: () => ({
+    createThread: coworkState.createThread,
+    openThread: coworkState.openThread,
+    isCreatingThread: coworkState.isCreatingThread,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-sidebar-activities", () => ({
+  useWorkspaceSidebarActivityStates: () => ({}),
+}));
+
+const workspaceUiState = vi.hoisted(() => ({
+  threadsCollapsed: false,
+  setThreadsCollapsed: vi.fn(),
+}));
+
+vi.mock("@/stores/preferences/workspace-ui-store", () => ({
+  useWorkspaceUiStore: (selector: (state: typeof workspaceUiState) => unknown) =>
+    selector(workspaceUiState),
+}));
+
+describe("CoworkThreadsSection", () => {
+  beforeEach(() => {
+    coworkState.statusLoading = false;
+    coworkState.threadsLoading = false;
+    coworkState.threads = [];
+    coworkState.isCreatingThread = false;
+    coworkState.createThread.mockClear();
+    coworkState.openThread.mockClear();
+    workspaceUiState.threadsCollapsed = false;
+    workspaceUiState.setThreadsCollapsed.mockClear();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a pending cowork thread while the real thread list loads", () => {
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-1",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Cowork thread",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "sonnet",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+    coworkState.threadsLoading = true;
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: pendingEntry,
+      selectedLogicalWorkspaceId: buildPendingWorkspaceUiKey(pendingEntry),
+    });
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.getByText("Cowork thread")).not.toBeNull();
+    expect(screen.getByText("Setting up")).not.toBeNull();
+    expect(screen.getByTestId("status-iterating")).not.toBeNull();
+    expect(screen.getByTestId("thread-row").getAttribute("data-active")).toBe("true");
+    expect(screen.queryByText("No chats yet")).toBeNull();
+    expect(screen.queryByTestId("threads-skeleton")).toBeNull();
+  });
+
+  it("does not duplicate the pending row after the real cowork thread appears", () => {
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-2",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Cowork thread",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "sonnet",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: {
+        ...pendingEntry,
+        workspaceId: "workspace-cowork",
+      },
+    });
+    coworkState.threads = [{
+      id: "thread-1",
+      agentKind: "claude",
+      branchName: "main",
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: null,
+      repoRootId: "repo-root-1",
+      requestedModelId: "sonnet",
+      sessionId: "session-1",
+      title: "Real thread",
+      updatedAt: "2026-01-01T00:00:00Z",
+      workspaceDelegationEnabled: false,
+      workspaceId: "workspace-cowork",
+    }];
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.queryByText("Setting up")).toBeNull();
+    expect(screen.getByTestId("real-thread-row").textContent).toBe("Real thread");
+  });
+});

--- a/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -6,16 +6,25 @@ import { useCoworkStatus } from "@/hooks/access/anyharness/cowork/use-cowork-sta
 import { useCoworkThreadWorkflow } from "@/hooks/cowork/workflows/use-cowork-thread-workflow";
 import { useCoworkThreads } from "@/hooks/access/anyharness/cowork/use-cowork-threads";
 import { useWorkspaceSidebarActivityStates } from "@/hooks/workspaces/derived/use-workspace-sidebar-activities";
+import { buildPendingWorkspaceUiKey } from "@/lib/domain/workspaces/creation/pending-entry";
+import { SidebarStatusIndicatorView } from "@/components/workspace/shell/sidebar/SidebarIndicators";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { SidebarActionButton } from "@/components/workspace/shell/sidebar/SidebarActionButton";
 import { CoworkThreadItem } from "./CoworkThreadItem";
-import { ProductSidebarSectionHeader } from "@proliferate/product-ui/sidebar/ProductSidebar";
+import {
+  ProductSidebarSectionHeader,
+  ProductSidebarThreadRow,
+} from "@proliferate/product-ui/sidebar/ProductSidebar";
 
 const DEFAULT_VISIBLE_THREAD_COUNT = 5;
 
 export function CoworkThreadsSection() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const selectedLogicalWorkspaceId = useSessionSelectionStore((state) =>
+    state.selectedLogicalWorkspaceId
+  );
+  const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
   const workspaceActivities = useWorkspaceSidebarActivityStates();
   const { status, isLoading: statusLoading } = useCoworkStatus();
   const { threads, isLoading: threadsLoading } = useCoworkThreads(status?.enabled ?? false);
@@ -26,6 +35,27 @@ export function CoworkThreadsSection() {
   const handleToggleCollapsed = useCallback(() => {
     setThreadsCollapsed(!threadsCollapsed);
   }, [setThreadsCollapsed, threadsCollapsed]);
+  const pendingCoworkEntry = pendingWorkspaceEntry?.source === "cowork-created"
+    ? pendingWorkspaceEntry
+    : null;
+  const pendingCoworkUiKey = pendingCoworkEntry
+    ? buildPendingWorkspaceUiKey(pendingCoworkEntry)
+    : null;
+  const showPendingCoworkThread = Boolean(
+    pendingCoworkEntry
+    && !threads.some((thread) => thread.workspaceId === pendingCoworkEntry.workspaceId),
+  );
+  const pendingCoworkThreadActive = Boolean(
+    pendingCoworkEntry
+    && (
+      selectedLogicalWorkspaceId === pendingCoworkUiKey
+      || (
+        pendingCoworkEntry.workspaceId
+        && selectedWorkspaceId === pendingCoworkEntry.workspaceId
+      )
+    ),
+  );
+  const renderedThreadCount = threads.length + (showPendingCoworkThread ? 1 : 0);
 
   const [expandedThreadIds, setExpandedThreadIds] = useState<Set<string>>(new Set());
   const toggleThreadExpanded = useCallback((threadId: string) => {
@@ -65,7 +95,7 @@ export function CoworkThreadsSection() {
         label="Threads"
         actions={(
           <>
-          {threads.length > 0 && (
+          {renderedThreadCount > 0 && (
             <SidebarActionButton
               onClick={handleToggleCollapsed}
               title={threadsCollapsed ? "Expand threads" : "Collapse threads"}
@@ -92,16 +122,32 @@ export function CoworkThreadsSection() {
 
       {!threadsCollapsed && (
         <div className="flex flex-col gap-px">
+          {showPendingCoworkThread && pendingCoworkEntry && (
+            <ProductSidebarThreadRow
+              active={pendingCoworkThreadActive}
+              status={(
+                <SidebarStatusIndicatorView
+                  indicator={{ kind: "iterating", tooltip: "Creating chat" }}
+                />
+              )}
+              label={pendingCoworkEntry.displayName}
+              trailingLabel="Setting up"
+            />
+          )}
           {statusLoading || threadsLoading ? (
-            <div className="flex flex-col gap-1 px-2 py-2" aria-label="Loading threads" role="status">
-              <SkeletonBlock className="h-7 w-full bg-sidebar-accent" />
-              <SkeletonBlock className="h-7 w-[82%] bg-sidebar-accent/80" />
-              <p className="sr-only">Loading threads</p>
-            </div>
+            showPendingCoworkThread ? null : (
+              <div className="flex flex-col gap-1 px-2 py-2" aria-label="Loading threads" role="status">
+                <SkeletonBlock className="h-7 w-full bg-sidebar-accent" />
+                <SkeletonBlock className="h-7 w-[82%] bg-sidebar-accent/80" />
+                <p className="sr-only">Loading threads</p>
+              </div>
+            )
           ) : threads.length === 0 ? (
-            <div className="px-2 py-2 text-xs text-sidebar-muted-foreground">
-              {isCreatingThread ? "Creating chat" : "No chats yet"}
-            </div>
+            showPendingCoworkThread ? null : (
+              <div className="px-2 py-2 text-xs text-sidebar-muted-foreground">
+                {isCreatingThread ? "Creating chat" : "No chats yet"}
+              </div>
+            )
           ) : (
             <>
               {visibleThreads.map((thread) => (

--- a/desktop/src/hooks/chat/ui/use-composer-dock-slots.test.tsx
+++ b/desktop/src/hooks/chat/ui/use-composer-dock-slots.test.tsx
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useComposerDockSlots } from "./use-composer-dock-slots";
+
+const workspaceStatusPanelState = vi.hoisted(() => ({
+  value: { kind: "pending" } as unknown,
+}));
+
+vi.mock("@/hooks/chat/derived/use-active-chat-session-selectors", () => ({
+  useActivePendingInteractionState: () => ({ primaryPendingInteraction: null }),
+  useActivePendingPrompts: () => [],
+}));
+
+vi.mock("@/hooks/chat/derived/use-active-todo-tracker", () => ({
+  useActiveTodoTracker: () => null,
+}));
+
+vi.mock("@/hooks/chat/use-delegated-work-composer", () => ({
+  useDelegatedWorkComposer: () => null,
+}));
+
+vi.mock("@/hooks/workspaces/use-selected-cloud-runtime-state", () => ({
+  useSelectedCloudRuntimeState: () => ({ state: null }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-status-panel-state", () => ({
+  useWorkspaceStatusPanelState: () => workspaceStatusPanelState.value,
+}));
+
+vi.mock("@/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel", () => ({
+  WorkspaceArrivalAttachedPanel: () => <div data-testid="workspace-status-panel" />,
+}));
+
+vi.mock("@/components/workspace/chat/surface/CloudRuntimeAttachedPanel", () => ({
+  CloudRuntimeAttachedPanel: () => <div data-testid="cloud-runtime-panel" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/TodoTrackerPanel", () => ({
+  TodoTrackerPanel: () => <div data-testid="todo-tracker-panel" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/ApprovalCard", () => ({
+  ConnectedApprovalCard: () => <div data-testid="approval-card" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/McpElicitationCard", () => ({
+  ConnectedMcpElicitationCard: () => <div data-testid="mcp-elicitation-card" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/PendingPromptList", () => ({
+  ConnectedPendingPromptList: () => <div data-testid="pending-prompt-list" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/DelegatedWorkComposerPanel", () => ({
+  DelegatedWorkComposerPanel: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl", () => ({
+  DelegatedWorkComposerControl: () => <div data-testid="delegated-work-control" />,
+}));
+
+vi.mock("@/components/workspace/chat/input/UserInputCard", () => ({
+  ConnectedUserInputCard: () => <div data-testid="user-input-card" />,
+}));
+
+afterEach(() => {
+  cleanup();
+  workspaceStatusPanelState.value = { kind: "pending" };
+});
+
+describe("useComposerDockSlots", () => {
+  it("renders workspace status panels by default", () => {
+    const { result } = renderHook(() => useComposerDockSlots());
+
+    render(<>{result.current.attachedSlot}</>);
+
+    expect(screen.getByTestId("workspace-status-panel")).not.toBeNull();
+  });
+
+  it("suppresses workspace status panels when requested", () => {
+    const { result } = renderHook(() => useComposerDockSlots({
+      suppressWorkspaceStatusPanels: true,
+    }));
+
+    render(<>{result.current.attachedSlot}</>);
+
+    expect(screen.queryByTestId("workspace-status-panel")).toBeNull();
+  });
+});

--- a/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
+++ b/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
@@ -25,8 +25,10 @@ export interface ComposerDockSlots {
 
 export function useComposerDockSlots(options?: {
   suppressSessionSlots?: boolean;
+  suppressWorkspaceStatusPanels?: boolean;
 }): ComposerDockSlots {
   const suppressSessionSlots = options?.suppressSessionSlots ?? false;
+  const suppressWorkspaceStatusPanels = options?.suppressWorkspaceStatusPanels ?? false;
   const { primaryPendingInteraction } = useActivePendingInteractionState();
   const pendingPrompts = useActivePendingPrompts();
   const activeTodoTracker = useActiveTodoTracker();
@@ -45,12 +47,14 @@ export function useComposerDockSlots(options?: {
   ), [primaryPendingInteraction?.kind]);
 
   const ambientContextSlot = useMemo<ReactNode | null>(() => (
-    workspaceStatusPanel
+    suppressWorkspaceStatusPanels
+      ? null
+      : workspaceStatusPanel
       ? <WorkspaceArrivalAttachedPanel />
       : selectedCloudRuntime.state && selectedCloudRuntime.state.phase !== "ready"
         ? <CloudRuntimeAttachedPanel />
         : null
-  ), [selectedCloudRuntime.state, workspaceStatusPanel]);
+  ), [selectedCloudRuntime.state, suppressWorkspaceStatusPanels, workspaceStatusPanel]);
   const activeAgentSlot = useMemo<ReactNode | null>(() => (
     suppressSessionSlots
       ? null

--- a/desktop/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts
+++ b/desktop/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts
@@ -3,11 +3,13 @@ import {
   useAnyHarnessRuntimeContext,
   useCreateCoworkThreadMutation,
 } from "@anyharness/sdk-react";
+import type { Session } from "@anyharness/sdk";
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 import { resolveEffectiveChatDefaults } from "@/lib/domain/chat/composer/preference-resolvers";
 import { resolveCoworkDefaultSessionModeId } from "@/lib/domain/cowork/session-mode-defaults";
+import { resolveStatusFromExecutionSummary } from "@/lib/domain/sessions/activity";
 import { workspaceFileTreeStateKey } from "@/lib/domain/workspaces/cloud/collections";
 import {
   buildSubmittingPendingWorkspaceEntry,
@@ -24,6 +26,7 @@ import {
 import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useWorkspaceSelection } from "@/hooks/workspaces/selection/use-workspace-selection";
 import { useWorkspaceFileActions } from "@/hooks/workspaces/files/use-workspace-file-actions";
+import { useWorkspaceEntryFlow } from "@/hooks/workspaces/use-workspace-entry-flow";
 import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { useCloudLaunchModelRegistries } from "@/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog";
@@ -33,22 +36,27 @@ import {
   resolveSessionMcpServersForLaunch,
 } from "@/lib/workflows/sessions/session-mcp-launch";
 import {
-  createSessionRecordFromSummary,
+  createEmptySessionRecord,
+  getSessionRecord,
   putSessionRecord,
 } from "@/stores/sessions/session-records";
 import { applySessionLaunchDefaults } from "@/lib/workflows/sessions/session-launch-defaults";
 import { createSessionLaunchDefaultsClient } from "@/lib/access/anyharness/session-launch-defaults-client";
+import { materializeSessionRecord } from "@/hooks/sessions/workflows/session-creation-local-state";
 import {
   markWorkspaceViewed,
   rememberLastViewedSession,
   trackWorkspaceInteraction,
+  useWorkspaceUiStore,
 } from "@/stores/preferences/workspace-ui-store";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { markWorkspaceBootstrappedInSession } from "@/hooks/workspaces/lifecycle/workspace-bootstrap-memory";
+import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
 
 const EMPTY_MODEL_REGISTRIES: ModelRegistry[] = [];
 
@@ -60,19 +68,59 @@ function resolveErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function materializedCoworkSessionRecord(input: {
+  clientSessionId: string;
+  session: Session;
+  workspaceId: string;
+  fallbackAgentKind: string;
+  fallbackModelId: string;
+  fallbackModeId: string | null;
+  fallbackTitle: string | null;
+}): SessionRuntimeRecord {
+  const modeId =
+    input.session.liveConfig?.normalizedControls.mode?.currentValue
+    ?? input.session.modeId
+    ?? input.fallbackModeId;
+  const record = createEmptySessionRecord(
+    input.clientSessionId,
+    input.session.agentKind || input.fallbackAgentKind,
+    {
+      workspaceId: input.workspaceId,
+      materializedSessionId: input.session.id,
+      modelId: input.session.modelId ?? input.fallbackModelId,
+      modeId,
+      title: input.session.title ?? input.fallbackTitle,
+      actionCapabilities: input.session.actionCapabilities,
+      liveConfig: input.session.liveConfig ?? null,
+      executionSummary: input.session.executionSummary ?? null,
+      mcpBindingSummaries: input.session.mcpBindingSummaries ?? null,
+      lastPromptAt: input.session.lastPromptAt ?? null,
+      optimisticPrompt: null,
+      sessionRelationship: { kind: "root" },
+    },
+  );
+
+  return {
+    ...record,
+    status: resolveStatusFromExecutionSummary(
+      input.session.executionSummary,
+      input.session.status ?? "idle",
+    ),
+    transcriptHydrated: true,
+  };
+}
+
 export function useCoworkThreadWorkflow() {
   const location = useLocation();
   const navigate = useNavigate();
   const anyHarnessRuntime = useAnyHarnessRuntimeContext();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const { upsertLocalWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
-  const enterPendingWorkspaceShell = useSessionSelectionStore(
-    (state) => state.enterPendingWorkspaceShell,
-  );
   const setPendingWorkspaceEntry = useSessionSelectionStore(
     (state) => state.setPendingWorkspaceEntry,
   );
   const activateWorkspace = useSessionSelectionStore((state) => state.activateWorkspace);
+  const { beginPendingWorkspace } = useWorkspaceEntryFlow();
   const { agents } = useAgentCatalog();
   const { data: modelRegistries = EMPTY_MODEL_REGISTRIES } = useCloudLaunchModelRegistries();
   const preferences = useUserPreferencesStore(useShallow((state) => ({
@@ -88,7 +136,6 @@ export function useCoworkThreadWorkflow() {
   const { upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
   const setDraftText = useChatInputStore((state) => state.setDraftText);
   const clearDraft = useChatInputStore((state) => state.clearDraft);
-  const requestComposerFocus = useChatInputStore((state) => state.requestFocus);
   const createCoworkThreadMutation = useCreateCoworkThreadMutation();
 
   const navigateToWorkspaceShell = useCallback(() => {
@@ -127,8 +174,16 @@ export function useCoworkThreadWorkflow() {
       agentKind: input.agentKind,
       modelId: input.modelId,
     });
-    enterPendingWorkspaceShell(entry);
-    requestComposerFocus();
+    useWorkspaceUiStore.getState().setThreadsCollapsed(false);
+    const projectedSessionId = beginPendingWorkspace(entry, {
+      initialSession: {
+        kind: "session",
+        agentKind: input.agentKind,
+        modelId: input.modelId,
+        modeId,
+        displayTitle: input.modelId,
+      },
+    });
     navigateToWorkspaceShell();
 
     try {
@@ -212,12 +267,36 @@ export function useCoworkThreadWorkflow() {
 
       upsertLocalWorkspace(result.workspace);
       upsertWorkspaceSessionRecord(result.workspace.id, launchedSession);
-      putSessionRecord(
-        createSessionRecordFromSummary(launchedSession, result.workspace.id, {
-          transcriptHydrated: true,
-          sessionRelationship: { kind: "root" },
-        }),
-      );
+      const activeSessionId = projectedSessionId ?? launchedSession.id;
+      if (projectedSessionId) {
+        const projectedRecord = getSessionRecord(projectedSessionId);
+        const record = materializedCoworkSessionRecord({
+          clientSessionId: projectedSessionId,
+          session: launchedSession,
+          workspaceId: result.workspace.id,
+          fallbackAgentKind: input.agentKind,
+          fallbackModelId: input.modelId,
+          fallbackModeId: modeId ?? null,
+          fallbackTitle: projectedRecord?.title ?? input.modelId,
+        });
+        materializeSessionRecord(projectedSessionId, launchedSession.id, record);
+        useSessionIntentStore.getState().bindMaterializedSession(
+          projectedSessionId,
+          launchedSession.id,
+        );
+      } else {
+        putSessionRecord(
+          materializedCoworkSessionRecord({
+            clientSessionId: launchedSession.id,
+            session: launchedSession,
+            workspaceId: result.workspace.id,
+            fallbackAgentKind: input.agentKind,
+            fallbackModelId: input.modelId,
+            fallbackModeId: modeId ?? null,
+            fallbackTitle: input.modelId,
+          }),
+        );
+      }
       if (input.draftText?.length) {
         setDraftText(result.workspace.id, input.draftText);
         if (input.sourceWorkspaceId && input.sourceWorkspaceId !== result.workspace.id) {
@@ -235,7 +314,7 @@ export function useCoworkThreadWorkflow() {
         logicalWorkspaceId: null,
         workspaceId: result.workspace.id,
         clearPending: false,
-        initialActiveSessionId: launchedSession.id,
+        initialActiveSessionId: activeSessionId,
       });
       rememberLastViewedSession(result.workspace.id, launchedSession.id);
       trackWorkspaceInteraction(result.workspace.id, new Date().toISOString());
@@ -271,7 +350,10 @@ export function useCoworkThreadWorkflow() {
       if (isAttemptCurrent(entry.attemptId)) {
         setPendingWorkspaceEntry(null);
       }
-      return result;
+      return {
+        ...result,
+        projectedSessionId,
+      };
     } catch (error) {
       const message = resolveErrorMessage(error, "Couldn't start cowork thread.");
       logLatency("workspace.cowork.create.failed", {
@@ -295,15 +377,14 @@ export function useCoworkThreadWorkflow() {
     }
   }, [
     anyHarnessRuntime,
+    beginPendingWorkspace,
     clearDraft,
     createCoworkThreadMutation,
-    enterPendingWorkspaceShell,
     initForWorkspace,
     modelRegistries,
     navigateToWorkspaceShell,
     preferences.coworkWorkspaceDelegationEnabled,
     preferences.defaultLiveSessionControlValuesByAgentKind,
-    requestComposerFocus,
     runtimeUrl,
     setDraftText,
     activateWorkspace,

--- a/desktop/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/desktop/src/hooks/home/workflows/use-home-next-launch.ts
@@ -316,31 +316,47 @@ export function useHomeNextLaunch() {
 
     try {
       if (target.kind === "cowork") {
-        navigate("/");
-        const result = await createThreadFromSelection({
+        const resultPromise = createThreadFromSelection({
           agentKind: modelSelection.kind,
           modelId: modelSelection.modelId,
           modeId,
           draftText: null,
           sourceWorkspaceId: null,
         });
+        const queuedProjectedSessionId = await promptProjectedPendingWorkspaceSession({
+          text: prompt,
+          promptId,
+          launchIntentId,
+          waitUntil: resultPromise,
+        });
+        if (queuedProjectedSessionId) {
+          navigate("/");
+        }
+        const result = await resultPromise;
         if (!result) {
           throw new Error("Cowork thread creation was interrupted.");
         }
+        if (!queuedProjectedSessionId) {
+          navigate("/");
+        }
+        const projectedSessionId = queuedProjectedSessionId ?? result.projectedSessionId ?? null;
         markLaunchIntentMaterialized(launchIntentId, {
           workspaceId: result.workspace.id,
           sessionId: result.session.id,
+          clientSessionId: projectedSessionId,
         });
 
-        await promptSession({
-          sessionId: result.session.id,
-          text: prompt,
-          workspaceId: result.workspace.id,
-          promptId,
-          onBeforeOptimisticPrompt: () => {
-            markLaunchIntentSendAttempted(launchIntentId);
-          },
-        });
+        if (!queuedProjectedSessionId) {
+          await promptSession({
+            sessionId: projectedSessionId ?? result.session.id,
+            text: prompt,
+            workspaceId: result.workspace.id,
+            promptId,
+            onBeforeOptimisticPrompt: () => {
+              markLaunchIntentSendAttempted(launchIntentId);
+            },
+          });
+        }
         clearLaunchIntentIfActive(launchIntentId);
         return true;
       }

--- a/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
+++ b/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
@@ -12,8 +12,8 @@ const routerMocks = vi.hoisted(() => ({
 const harnessMocks = vi.hoisted(() => ({
   state: {
     pendingWorkspaceEntry: null as unknown,
+    selectedLogicalWorkspaceId: null as string | null,
     selectedWorkspaceId: null as string | null,
-    setPendingWorkspaceEntry: vi.fn(),
     deselectWorkspacePreservingSessions: vi.fn(),
   },
 }));
@@ -88,6 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   routerMocks.location.pathname = "/";
   harnessMocks.state.pendingWorkspaceEntry = null;
+  harnessMocks.state.selectedLogicalWorkspaceId = null;
   harnessMocks.state.selectedWorkspaceId = null;
   mobilityMocks.state.selectionLocked = false;
   mobilityMocks.state.selectedLogicalWorkspaceId = null;
@@ -102,19 +103,28 @@ describe("useWorkspaceNavigationWorkflow", () => {
     act(() => result.current.goToTopLevelRoute("/"));
 
     expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
-    expect(harnessMocks.state.setPendingWorkspaceEntry).not.toHaveBeenCalled();
     expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
     expect(routerMocks.navigate).toHaveBeenCalledWith("/");
   });
 
-  it("clears pending workspace state before top-level navigation", () => {
+  it("deselects pending workspace state before top-level navigation", () => {
     harnessMocks.state.pendingWorkspaceEntry = { id: "pending-1" };
     const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
 
     act(() => result.current.goToTopLevelRoute("/"));
 
-    expect(harnessMocks.state.setPendingWorkspaceEntry).toHaveBeenCalledWith(null);
-    expect(harnessMocks.state.deselectWorkspacePreservingSessions).not.toHaveBeenCalled();
+    expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
+    expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("deselects logical-only workspace state before top-level navigation", () => {
+    harnessMocks.state.selectedLogicalWorkspaceId = "logical-1";
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.goToTopLevelRoute("/"));
+
+    expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
     expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
     expect(routerMocks.navigate).toHaveBeenCalledWith("/");
   });

--- a/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
+++ b/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
@@ -14,12 +14,14 @@ import { useToastStore } from "@/stores/toast/toast-store";
 export function useWorkspaceNavigationWorkflow() {
   const location = useLocation();
   const navigate = useNavigate();
-  const setPendingWorkspaceEntry = useSessionSelectionStore((state) => state.setPendingWorkspaceEntry);
   const deselectWorkspacePreservingSessions = useSessionSelectionStore(
     (state) => state.deselectWorkspacePreservingSessions,
   );
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
   const mobility = useWorkspaceMobilityState();
   const { selectWorkspace } = useWorkspaceSelection();
   const showToast = useToastStore((state) => state.show);
@@ -36,11 +38,8 @@ export function useWorkspaceNavigationWorkflow() {
       return;
     }
 
-    if (selectedWorkspaceId) {
+    if (selectedWorkspaceId || selectedLogicalWorkspaceId || pendingWorkspaceEntry) {
       deselectWorkspacePreservingSessions();
-      resetWorkspaceEditorState();
-    } else if (pendingWorkspaceEntry) {
-      setPendingWorkspaceEntry(null);
       resetWorkspaceEditorState();
     }
     navigate(path);
@@ -49,8 +48,8 @@ export function useWorkspaceNavigationWorkflow() {
     mobility.selectionLocked,
     navigate,
     pendingWorkspaceEntry,
+    selectedLogicalWorkspaceId,
     selectedWorkspaceId,
-    setPendingWorkspaceEntry,
     showToast,
   ]);
 

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
@@ -311,7 +311,7 @@ describe("buildMobilityFooterContext", () => {
   });
 
   it("does not build a footer context for pending cowork threads", () => {
-    const cowork = buildPendingMobilityFooterContext(buildSubmittingPendingWorkspaceEntry({
+    const entry = buildSubmittingPendingWorkspaceEntry({
       attemptId: "cowork-attempt",
       selectedWorkspaceId: null,
       source: "cowork-created",
@@ -326,9 +326,14 @@ describe("buildMobilityFooterContext", () => {
           sourceWorkspaceId: null,
         },
       },
-    }));
+    });
 
-    expect(cowork).toBeNull();
+    expect(buildPendingMobilityFooterContext(entry)).toBeNull();
+    expect(buildPendingMobilityFooterContext({
+      ...entry,
+      workspaceId: "workspace-cowork",
+      request: { kind: "select-existing", workspaceId: "workspace-cowork" },
+    })).toBeNull();
   });
 
   it.each<{

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.test.ts
@@ -310,6 +310,27 @@ describe("buildMobilityFooterContext", () => {
     });
   });
 
+  it("does not build a footer context for pending cowork threads", () => {
+    const cowork = buildPendingMobilityFooterContext(buildSubmittingPendingWorkspaceEntry({
+      attemptId: "cowork-attempt",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Cowork thread",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "claude-sonnet-4.5",
+          modeId: "bypassPermissions",
+          draftText: null,
+          sourceWorkspaceId: null,
+        },
+      },
+    }));
+
+    expect(cowork).toBeNull();
+  });
+
   it.each<{
     effectiveOwner: LogicalWorkspace["effectiveOwner"];
     expected: string;

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
@@ -176,6 +176,10 @@ export function buildMobilityFooterContext(args: {
 export function buildPendingMobilityFooterContext(
   entry: PendingWorkspaceEntry,
 ): MobilityFooterContext | null {
+  if (entry.request.kind === "cowork") {
+    return null;
+  }
+
   const locationKind = pendingLocationKind(entry);
   const detailValue = pendingDetailValue(entry, locationKind);
   const branchValue = pendingBranchValue(entry);

--- a/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
+++ b/desktop/src/lib/domain/workspaces/mobility/mobility-footer-context.ts
@@ -176,7 +176,7 @@ export function buildMobilityFooterContext(args: {
 export function buildPendingMobilityFooterContext(
   entry: PendingWorkspaceEntry,
 ): MobilityFooterContext | null {
-  if (entry.request.kind === "cowork") {
+  if (entry.source === "cowork-created") {
     return null;
   }
 

--- a/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.test.ts
+++ b/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { APP_ROUTES } from "@/config/app-routes";
+import {
+  isWorkspaceProviderRoute,
+  resolveRouteScopedWorkspaceProviderId,
+} from "./workspace-provider-scope";
+
+describe("workspace provider scope", () => {
+  it("keeps the workspace provider active on workspace shell routes", () => {
+    expect(isWorkspaceProviderRoute(APP_ROUTES.home)).toBe(true);
+    expect(isWorkspaceProviderRoute(APP_ROUTES.settings)).toBe(true);
+  });
+
+  it("clears the workspace provider on top-level non-workspace routes", () => {
+    expect(resolveRouteScopedWorkspaceProviderId({
+      pathname: APP_ROUTES.plugins,
+      selectedLogicalWorkspaceId: "logical-workspace",
+      selectedWorkspaceId: "workspace-1",
+    })).toBeNull();
+
+    expect(resolveRouteScopedWorkspaceProviderId({
+      pathname: APP_ROUTES.automations,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: "workspace-1",
+    })).toBeNull();
+  });
+
+  it("prefers logical identity while a workspace route is active", () => {
+    expect(resolveRouteScopedWorkspaceProviderId({
+      pathname: APP_ROUTES.home,
+      selectedLogicalWorkspaceId: "logical-workspace",
+      selectedWorkspaceId: "workspace-1",
+    })).toBe("logical-workspace");
+  });
+
+  it("falls back to the materialized workspace while a workspace route is active", () => {
+    expect(resolveRouteScopedWorkspaceProviderId({
+      pathname: APP_ROUTES.home,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: "workspace-1",
+    })).toBe("workspace-1");
+  });
+});

--- a/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.ts
+++ b/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.ts
@@ -1,0 +1,17 @@
+import { APP_ROUTES } from "@/config/app-routes";
+
+export function isWorkspaceProviderRoute(pathname: string): boolean {
+  return pathname === APP_ROUTES.home || pathname === APP_ROUTES.settings;
+}
+
+export function resolveRouteScopedWorkspaceProviderId(args: {
+  pathname: string;
+  selectedLogicalWorkspaceId: string | null | undefined;
+  selectedWorkspaceId: string | null | undefined;
+}): string | null {
+  if (!isWorkspaceProviderRoute(args.pathname)) {
+    return null;
+  }
+
+  return args.selectedLogicalWorkspaceId ?? args.selectedWorkspaceId ?? null;
+}

--- a/desktop/src/providers/AppProviders.tsx
+++ b/desktop/src/providers/AppProviders.tsx
@@ -7,6 +7,7 @@ import type { CoworkStatus } from "@anyharness/sdk";
 import type { CloudMobilityWorkspaceSummary } from "@/lib/access/cloud/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { useCallback, type ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 import { appQueryClient } from "@/lib/infra/query/query-client";
 import { resolveWorkspaceConnection } from "@/lib/access/anyharness/resolve-workspace-connection";
 import {
@@ -23,6 +24,7 @@ import {
 import { buildStandardRepoProjection } from "@/lib/domain/workspaces/cloud/standard-projection";
 import { cloudMobilityWorkspacesKey } from "@/hooks/access/cloud/query-keys";
 import { cloudWorkspaceConnectionQueryOptions } from "@/hooks/access/cloud/use-cloud-workspace-connection";
+import { resolveRouteScopedWorkspaceProviderId } from "@/lib/domain/workspaces/selection/workspace-provider-scope";
 import { getWorkspaceCollectionsFromCache } from "@/hooks/workspaces/cache/query-keys";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
@@ -39,9 +41,15 @@ export function AppProviders({ children }: { children: ReactNode }) {
 }
 
 function WorkspaceProviders({ children }: { children: ReactNode }) {
+  const location = useLocation();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore((state) => state.selectedLogicalWorkspaceId);
+  const providerWorkspaceId = resolveRouteScopedWorkspaceProviderId({
+    pathname: location.pathname,
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+  });
   const resolveConnection = useCallback(
     (workspaceId: string) => {
       const workspaceCollections = getWorkspaceCollectionsFromCache(appQueryClient, runtimeUrl);
@@ -131,7 +139,7 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
   return (
     <AnyHarnessRuntime runtimeUrl={runtimeUrl}>
       <AnyHarnessWorkspace
-        workspaceId={selectedLogicalWorkspaceId ?? selectedWorkspaceId}
+        workspaceId={providerWorkspaceId}
         resolveConnection={resolveConnection}
       >
         {children}

--- a/desktop/src/stores/sessions/session-selection-store.test.ts
+++ b/desktop/src/stores/sessions/session-selection-store.test.ts
@@ -123,6 +123,7 @@ describe("session selection store invariants", () => {
       },
       activeSessionId: "session-a",
       activeSessionVersion: 7,
+      sessionActivationIntentEpochByWorkspace: { "workspace-a": 3 },
       hotPaintGate: hotGate({ workspaceId: "workspace-a", sessionId: "session-a", nonce: 12 }),
     });
 
@@ -136,6 +137,7 @@ describe("session selection store invariants", () => {
       workspaceArrivalEvent: null,
       activeSessionId: null,
       activeSessionVersion: 8,
+      sessionActivationIntentEpochByWorkspace: { "workspace-a": 3 },
       hotPaintGate: null,
     });
   });

--- a/desktop/src/stores/sessions/session-selection-store.test.ts
+++ b/desktop/src/stores/sessions/session-selection-store.test.ts
@@ -110,6 +110,36 @@ describe("session selection store invariants", () => {
     });
   });
 
+  it("deselects workspace shell state without clearing cached session metadata", () => {
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: pendingWorkspaceEntry(),
+      selectedLogicalWorkspaceId: "logical-a",
+      selectedWorkspaceId: "workspace-a",
+      workspaceSelectionNonce: 4,
+      workspaceArrivalEvent: {
+        workspaceId: "workspace-a",
+        source: "local-created",
+        createdAt: 100,
+      },
+      activeSessionId: "session-a",
+      activeSessionVersion: 7,
+      hotPaintGate: hotGate({ workspaceId: "workspace-a", sessionId: "session-a", nonce: 12 }),
+    });
+
+    useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
+
+    expect(useSessionSelectionStore.getState()).toMatchObject({
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: null,
+      workspaceSelectionNonce: 5,
+      workspaceArrivalEvent: null,
+      activeSessionId: null,
+      activeSessionVersion: 8,
+      hotPaintGate: null,
+    });
+  });
+
   it("bumps hot workspace intent only for hot activation and keeps session version stable for same session", () => {
     useSessionSelectionStore.setState({
       activeSessionId: "session-a",

--- a/desktop/src/stores/sessions/session-selection-store.ts
+++ b/desktop/src/stores/sessions/session-selection-store.ts
@@ -147,6 +147,7 @@ export const useSessionSelectionStore = create<SessionSelectionState>((set, get)
   deselectWorkspacePreservingSessions: () => set((state) => {
     return {
       pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: null,
       selectedWorkspaceId: null,
       workspaceSelectionNonce: state.workspaceSelectionNonce + 1,
       workspaceArrivalEvent: null,


### PR DESCRIPTION
## Summary
- Clear logical and materialized workspace selection when top-level navigation intentionally leaves the workspace shell.
- Scope the AnyHarness workspace provider to Home/Settings so Plugins and Automations cannot keep an old workspace active through direct routes or redirects.
- Suppress standard workspace composer chrome in cowork shells: mobility footer and workspace status/arrival panels.
- Keep pending launch Thinking on the assistant side instead of attaching it to the right-aligned user-message footer.
- Project cowork creation through the pending workspace session shell, so Home prompts render in the cowork surface immediately and bind to the real cowork thread after materialization.
- Render an optimistic pending cowork row in the Threads sidebar while the real thread list loads, expand Threads during cowork creation, and avoid duplicating the row after the backend thread appears.
- Skip the Home submitted-preview bubble and one-paint delay for cowork launches so the submitted message does not flash below the Home composer before the cowork shell appears.
- Add focused tests for selection clearing, route-scoped provider selection, cowork footer/status suppression, launch pending-status alignment, optimistic cowork sidebar projection, and cowork Home submit preview suppression.

## Root Cause
Home navigation only cleared materialized workspace selection or pending entries, but could leave selectedLogicalWorkspaceId set. Separately, the global AnyHarness provider still received the stored workspace id on non-workspace routes, so direct route entry could keep stale workspace context alive even while the shell was hidden.

Cowork chat reused standard chat composer slots. The first fix disabled the mobility footer, but the screenshot showed a different slot: WorkspaceArrivalAttachedPanel from useComposerDockSlots, backed by useWorkspaceStatusPanelState. Cowork shells now explicitly suppress both standard workspace footer and status/arrival panels. The pending footer guard also keys off the stable source: cowork-created signal rather than the initial request kind, which does not survive cowork handoff.

The right-side Thinking was from ChatLaunchIntentPane, not the transcript or composer dock. It rendered StreamingIndicator inside UserMessage.footer; UserMessage footers are right-aligned by design. Pending launch status now renders as a separate assistant-side row while failure/retry details remain attached to the user launch bubble.

The cowork launch gap was split across two handoff paths. Cowork creation used a pending workspace entry but did not create the projected session/sidebar identity before the backend thread was returned; it now uses the same pending session shell pattern as workspace creation, then materializes that projected client session onto the created cowork session and binds queued prompt intents to the real session. Home also rendered its own submitted-preview bubble and waited one paint before starting every launch, which caused the prompt to flash below the Home composer. Cowork launches now bypass that Home preview and let the cowork shell own the optimistic message immediately.

## Verification
- pnpm --filter ./desktop exec vitest run src/components/home/screen/HomeNextScreen.test.tsx src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx src/hooks/chat/ui/use-composer-dock-slots.test.tsx src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
- pnpm --dir desktop build
- git diff --check
