### PR TITLE
fix(desktop): respect right-panel tab shortcuts

### DIFF
--- a/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/desktop/src/components/workspace/chat/ChatView.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   useCallback,
   useMemo,
+  useRef,
   useState,
   type DragEvent,
   type JSX,
@@ -26,6 +27,7 @@ import {
 import { useChatAvailabilityState } from "@/hooks/chat/derived/use-chat-availability-state";
 import { useChatDockInset } from "@/hooks/chat/ui/use-chat-dock-inset";
 import { useChatPromptAttachments } from "@/hooks/chat/ui/use-chat-prompt-attachments";
+import { useChatRootFocus } from "@/hooks/chat/ui/use-chat-root-focus";
 import { useCloudWorkspacePolling } from "@/hooks/chat/use-cloud-workspace-polling";
 import { useComposerDockSlots } from "@/hooks/chat/ui/use-composer-dock-slots";
 import { useQueuedPromptEditStatus } from "@/hooks/chat/use-queued-prompt-edit";
@@ -137,6 +139,7 @@ export const ChatView = memo(function ChatView({
     canAttachFiles: canAcceptFileDrop,
   });
   const [fileDragOver, setFileDragOver] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
   const {
     dockRef,
     dockSafeAreaPx,
@@ -192,11 +195,16 @@ export const ChatView = memo(function ChatView({
     }
     setFileDragOver(false);
   }, []);
+  const handleRootPointerDownCapture = useChatRootFocus(rootRef);
 
   return (
     <DebugProfiler id="chat-surface">
       <div
-        className="chat-selection-root relative flex h-full min-h-0 flex-1 flex-col select-none overflow-hidden"
+        ref={rootRef}
+        data-focus-zone="chat"
+        tabIndex={-1}
+        className="chat-selection-root relative flex h-full min-h-0 flex-1 flex-col select-none overflow-hidden outline-none"
+        onPointerDownCapture={handleRootPointerDownCapture}
         onDragEnter={handleFileDrag}
         onDragOver={handleFileDrag}
         onDragLeave={handleDragLeave}

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -23,7 +23,7 @@ import {
 import {
   requestRightPanelRelativeTab,
   requestRightPanelTabByIndex,
-} from "@/lib/infra/right-panel-shortcuts";
+} from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 
 const terminalActionsMocks = vi.hoisted(() => ({
@@ -396,11 +396,13 @@ describe("RightPanel viewer routing", () => {
 describe("RightPanel tab shortcuts", () => {
   it("activates right-panel entries by option-number shortcut requests", async () => {
     render(<RightPanelHarness isWorkspaceReady />);
+    let handled = false;
 
     act(() => {
-      requestRightPanelTabByIndex(2);
+      handled = requestRightPanelTabByIndex(2);
     });
 
+    expect(handled).toBe(true);
     await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
   });
 
@@ -423,6 +425,18 @@ describe("RightPanel tab shortcuts", () => {
 
     expect(screen.getByRole("tab", { name: "Changes" }).getAttribute("aria-selected"))
       .toBe("true");
+  });
+
+  it("leaves routed shortcuts unhandled when the right panel is closed", async () => {
+    render(<RightPanelHarness isWorkspaceReady isOpen={false} />);
+    let handled = true;
+
+    act(() => {
+      handled = requestRightPanelTabByIndex(2);
+    });
+
+    expect(handled).toBe(false);
+    expect(screen.queryByTestId("git-panel")).toBeNull();
   });
 
   it("does not intercept primary-number shell shortcuts after clicking panel content", async () => {

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -176,8 +176,12 @@ describe("RightPanel terminal activation", () => {
 
     expect(screen.queryByTestId("browser-panel")).toBeNull();
 
-    requestRightPanelBrowserTab();
+    let handled = false;
+    act(() => {
+      handled = requestRightPanelBrowserTab();
+    });
 
+    expect(handled).toBe(true);
     await waitFor(() => {
       expect(screen.getByTestId("browser-panel").dataset.visible).toBe("true");
     });
@@ -193,8 +197,12 @@ describe("RightPanel terminal activation", () => {
       />,
     );
 
-    requestRightPanelBrowserTab();
+    let handled = false;
+    act(() => {
+      handled = requestRightPanelBrowserTab();
+    });
 
+    expect(handled).toBe(true);
     await waitFor(() => expect(onOpenPanel).toHaveBeenCalledTimes(1));
   });
 
@@ -395,7 +403,11 @@ describe("RightPanel viewer routing", () => {
 
 describe("RightPanel tab shortcuts", () => {
   it("activates right-panel entries by option-number shortcut requests", async () => {
-    render(<RightPanelHarness isWorkspaceReady />);
+    const { container } = render(<RightPanelHarness isWorkspaceReady />);
+    const root = container.querySelector("[data-right-panel-root='true']");
+    if (!(root instanceof HTMLElement)) {
+      throw new Error("Expected right panel root");
+    }
     let handled = false;
 
     act(() => {
@@ -403,6 +415,7 @@ describe("RightPanel tab shortcuts", () => {
     });
 
     expect(handled).toBe(true);
+    expect(document.activeElement).toBe(root);
     await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
   });
 

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useState, type Dispatch, type SetStateAction } from "react";
 import type { TerminalRecord } from "@anyharness/sdk";
@@ -20,6 +20,10 @@ import {
   requestRightPanelBrowserTab,
   requestRightPanelNewTabMenu,
 } from "@/lib/infra/right-panel-new-tab-menu";
+import {
+  requestRightPanelRelativeTab,
+  requestRightPanelTabByIndex,
+} from "@/lib/infra/right-panel-shortcuts";
 import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-tabs-store";
 
 const terminalActionsMocks = vi.hoisted(() => ({
@@ -390,6 +394,37 @@ describe("RightPanel viewer routing", () => {
 });
 
 describe("RightPanel tab shortcuts", () => {
+  it("activates right-panel entries by option-number shortcut requests", async () => {
+    render(<RightPanelHarness isWorkspaceReady />);
+
+    act(() => {
+      requestRightPanelTabByIndex(2);
+    });
+
+    await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
+  });
+
+  it("cycles right-panel entries by routed tab-cycle shortcut requests", async () => {
+    const { container } = render(<RightPanelHarness isWorkspaceReady />);
+    const root = container.querySelector("[data-right-panel-root='true']");
+    if (!(root instanceof HTMLElement)) {
+      throw new Error("Expected right panel root");
+    }
+
+    fireEvent.pointerDown(root);
+    expect(document.activeElement).toBe(root);
+    expect(root.getAttribute("data-focus-zone")).toBe("right-panel");
+
+    act(() => {
+      requestRightPanelRelativeTab(1);
+    });
+
+    await waitFor(() => expect(screen.getByTestId("git-panel")).toBeTruthy());
+
+    expect(screen.getByRole("tab", { name: "Changes" }).getAttribute("aria-selected"))
+      .toBe("true");
+  });
+
   it("does not intercept primary-number shell shortcuts after clicking panel content", async () => {
     const { container } = render(<RightPanelHarness isWorkspaceReady />);
     const root = container.querySelector("[data-right-panel-root='true']");

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -25,6 +25,10 @@ import {
   type RightPanelTool,
   type RightPanelWorkspaceState,
 } from "@/lib/domain/workspaces/shell/right-panel-model";
+import {
+  resolveRelativeRightPanelHeaderEntryKey,
+  resolveRightPanelHeaderEntryKeyByShortcutIndex,
+} from "@/lib/domain/workspaces/shell/right-panel-shortcuts";
 import { createRightPanelBrowserTabId } from "@/lib/domain/workspaces/shell/right-panel-browser-tabs";
 import {
   createOrActivateBrowserTabInRightPanelState,
@@ -45,6 +49,10 @@ import {
   rightPanelNewTabMenuDefaultFromEvent,
   type RightPanelNewTabMenuDefault,
 } from "@/lib/infra/right-panel-new-tab-menu";
+import {
+  RIGHT_PANEL_SHORTCUT_EVENT,
+  rightPanelShortcutRequestFromEvent,
+} from "@/lib/infra/right-panel-shortcuts";
 import {
   viewerTargetEditablePath,
   viewerTargetKey,
@@ -356,6 +364,67 @@ export const RightPanel = memo(function RightPanel({
         : [...previous.headerOrder, targetKey],
     }));
   }, [openViewerTargets, setActiveViewerTarget, updateState]);
+
+  const activateRightPanelEntry = useCallback((entryKey: RightPanelHeaderEntryKey) => {
+    const entry = parseRightPanelHeaderEntryKey(entryKey);
+    if (!entry) {
+      return false;
+    }
+
+    if (entry.kind === "tool") {
+      activateTool(entry.tool);
+      return true;
+    }
+    if (entry.kind === "terminal") {
+      selectTerminal(entry.terminalId);
+      return true;
+    }
+    if (entry.kind === "browser") {
+      selectBrowser(entry.browserId);
+      return true;
+    }
+    if (entry.kind === "viewer") {
+      selectViewer(entry.targetKey);
+      return true;
+    }
+    return false;
+  }, [activateTool, selectBrowser, selectTerminal, selectViewer]);
+
+  useEffect(() => {
+    const handleShortcutRequest = (event: Event) => {
+      if (!isOpen) {
+        return;
+      }
+
+      const request = rightPanelShortcutRequestFromEvent(event);
+      if (!request) {
+        return;
+      }
+
+      const nextEntryKey = request.kind === "relative-tab"
+        ? resolveRelativeRightPanelHeaderEntryKey({
+            entries: headerEntries,
+            activeEntryKey: state.activeEntryKey,
+            delta: request.delta,
+          })
+        : resolveRightPanelHeaderEntryKeyByShortcutIndex(headerEntries, request.digit);
+      if (!nextEntryKey) {
+        return;
+      }
+
+      activateRightPanelEntry(nextEntryKey);
+    };
+
+    window.addEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
+    return () => {
+      window.removeEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
+    };
+  }, [
+    activateRightPanelEntry,
+    headerEntries,
+    isOpen,
+    state.activeEntryKey,
+  ]);
 
   const handleRootPointerDownCapture = useRightPanelRootFocus({
     rootRef,

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -382,12 +382,16 @@ export const RightPanel = memo(function RightPanel({
     }
     return false;
   }, [activateTool, selectBrowser, selectTerminal, selectViewer]);
+  const focusRightPanelRoot = useCallback(() => {
+    rootRef.current?.focus({ preventScroll: true });
+  }, []);
 
   useRightPanelShortcutRequests({
     activeEntryKey: state.activeEntryKey,
     entries: headerEntries,
     isOpen,
     onActivateEntry: activateRightPanelEntry,
+    onHandledRequest: focusRightPanelRoot,
   });
 
   const handleRootPointerDownCapture = useRightPanelRootFocus({
@@ -433,7 +437,7 @@ export const RightPanel = memo(function RightPanel({
 
   const handleCreateBrowser = useCallback(() => {
     if (!workspaceId || !shouldRenderContent) {
-      return;
+      return false;
     }
     updateState((previous) =>
       createOrActivateBrowserTabInRightPanelState(
@@ -443,6 +447,7 @@ export const RightPanel = memo(function RightPanel({
       ),
     );
     onOpenPanel();
+    return true;
   }, [
     isCloudWorkspaceSelected,
     onOpenPanel,
@@ -452,8 +457,10 @@ export const RightPanel = memo(function RightPanel({
   ]);
 
   useEffect(() => {
-    const handleBrowserTabRequest = () => {
-      handleCreateBrowser();
+    const handleBrowserTabRequest = (event: Event) => {
+      if (handleCreateBrowser()) {
+        event.preventDefault();
+      }
     };
 
     window.addEventListener(RIGHT_PANEL_BROWSER_TAB_EVENT, handleBrowserTabRequest);

--- a/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -13,6 +13,7 @@ import { RightPanelFrame } from "@/components/workspace/shell/right-panel/RightP
 import { useTerminalActions } from "@/hooks/terminals/workflows/use-terminal-actions";
 import { useRightPanelHeaderEntries } from "@/hooks/workspaces/derived/use-right-panel-header-entries";
 import { useRightPanelRootFocus } from "@/hooks/workspaces/ui/use-right-panel-root-focus";
+import { useRightPanelShortcutRequests } from "@/hooks/workspaces/ui/use-right-panel-shortcut-requests";
 import { useRightPanelStateUpdater } from "@/hooks/workspaces/ui/use-right-panel-state-updater";
 import {
   parseRightPanelHeaderEntryKey,
@@ -25,10 +26,6 @@ import {
   type RightPanelTool,
   type RightPanelWorkspaceState,
 } from "@/lib/domain/workspaces/shell/right-panel-model";
-import {
-  resolveRelativeRightPanelHeaderEntryKey,
-  resolveRightPanelHeaderEntryKeyByShortcutIndex,
-} from "@/lib/domain/workspaces/shell/right-panel-shortcuts";
 import { createRightPanelBrowserTabId } from "@/lib/domain/workspaces/shell/right-panel-browser-tabs";
 import {
   createOrActivateBrowserTabInRightPanelState,
@@ -49,10 +46,6 @@ import {
   rightPanelNewTabMenuDefaultFromEvent,
   type RightPanelNewTabMenuDefault,
 } from "@/lib/infra/right-panel-new-tab-menu";
-import {
-  RIGHT_PANEL_SHORTCUT_EVENT,
-  rightPanelShortcutRequestFromEvent,
-} from "@/lib/infra/right-panel-shortcuts";
 import {
   viewerTargetEditablePath,
   viewerTargetKey,
@@ -390,41 +383,12 @@ export const RightPanel = memo(function RightPanel({
     return false;
   }, [activateTool, selectBrowser, selectTerminal, selectViewer]);
 
-  useEffect(() => {
-    const handleShortcutRequest = (event: Event) => {
-      if (!isOpen) {
-        return;
-      }
-
-      const request = rightPanelShortcutRequestFromEvent(event);
-      if (!request) {
-        return;
-      }
-
-      const nextEntryKey = request.kind === "relative-tab"
-        ? resolveRelativeRightPanelHeaderEntryKey({
-            entries: headerEntries,
-            activeEntryKey: state.activeEntryKey,
-            delta: request.delta,
-          })
-        : resolveRightPanelHeaderEntryKeyByShortcutIndex(headerEntries, request.digit);
-      if (!nextEntryKey) {
-        return;
-      }
-
-      activateRightPanelEntry(nextEntryKey);
-    };
-
-    window.addEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
-    return () => {
-      window.removeEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
-    };
-  }, [
-    activateRightPanelEntry,
-    headerEntries,
+  useRightPanelShortcutRequests({
+    activeEntryKey: state.activeEntryKey,
+    entries: headerEntries,
     isOpen,
-    state.activeEntryKey,
-  ]);
+    onActivateEntry: activateRightPanelEntry,
+  });
 
   const handleRootPointerDownCapture = useRightPanelRootFocus({
     rootRef,

--- a/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -113,6 +113,7 @@ export function RightPanelFrame({
     <div
       ref={rootRef}
       data-right-panel-root="true"
+      data-focus-zone="right-panel"
       data-group="true"
       tabIndex={-1}
       onPointerDownCapture={onPointerDownCapture}

--- a/desktop/src/components/workspace/shell/right-panel/TerminalHeaderButton.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/TerminalHeaderButton.tsx
@@ -78,7 +78,10 @@ export function TerminalHeaderButton({
       }}
       className={HEADER_TERMINAL_TAB_CLASS}
     >
-      <span className="ui-tab-system-tab__content">
+      <span
+        className="ui-tab-system-tab__content"
+        data-shortcut-reveal={shortcutRevealVisible ? true : undefined}
+      >
         <AppShellTerminalIcon className="ui-tab-system-tab__icon" />
         <span className="ui-tab-system-tab__label">
           <span className="ui-tab-system-tab__label-primary">{displayTitle}</span>

--- a/desktop/src/components/workspace/shell/right-panel/TerminalHeaderIcon.tsx
+++ b/desktop/src/components/workspace/shell/right-panel/TerminalHeaderIcon.tsx
@@ -161,7 +161,10 @@ export function TerminalHeaderIcon({
       onContextMenuCapture={onContextMenuCapture}
       className={HEADER_TERMINAL_TAB_CLASS}
     >
-      <span className="ui-tab-system-tab__content">
+      <span
+        className="ui-tab-system-tab__content"
+        data-shortcut-reveal={shortcutRevealVisible ? true : undefined}
+      >
         <AppShellTerminalIcon className="ui-tab-system-tab__icon" />
         <span className="ui-tab-system-tab__label">
           <span className="ui-tab-system-tab__label-primary">{displayTitle}</span>

--- a/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -3,21 +3,32 @@
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppCommandActions } from "@/hooks/app/workflows/use-app-command-actions";
+import { useAppShortcuts } from "@/hooks/app/lifecycle/use-app-shortcuts";
 import {
   clearShortcutHandlerRegistryForTests,
   runShortcutHandler,
 } from "@/lib/domain/shortcuts/registry";
 import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-import { useAppShortcuts } from "./use-app-shortcuts";
+import { requestRightPanelTabByIndex } from "@/lib/infra/right-panel-shortcuts";
+
+const navigationMocks = vi.hoisted(() => ({
+  selectWorkspaceFromSurface: vi.fn(),
+}));
+
+const harnessState = vi.hoisted(() => ({
+  selectedWorkspaceId: null as string | null,
+  selectedLogicalWorkspaceId: null as string | null,
+  sidebarShortcutTargets: [] as string[],
+}));
 
 vi.mock("@/hooks/workspaces/derived/use-sidebar-shortcut-targets", () => ({
-  useSidebarShortcutTargets: () => [],
+  useSidebarShortcutTargets: () => harnessState.sidebarShortcutTargets,
 }));
 
 vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
   useWorkspaceNavigationWorkflow: () => ({
-    selectWorkspaceFromSurface: vi.fn(),
+    selectWorkspaceFromSurface: navigationMocks.selectWorkspaceFromSurface,
   }),
 }));
 
@@ -29,33 +40,20 @@ vi.mock("@/stores/sessions/session-selection-store", () => ({
     }) => unknown,
   ) =>
     selector({
-      selectedWorkspaceId: null,
-      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: harnessState.selectedWorkspaceId,
+      selectedLogicalWorkspaceId: harnessState.selectedLogicalWorkspaceId,
     }),
 }));
 
-function buildCommandActions(): AppCommandActions {
-  const action = {
-    execute: vi.fn(),
-    disabledReason: null,
-  };
-
-  return {
-    openSettings: action,
-    showKeyboardShortcuts: action,
-    goHome: action,
-    goPlugins: action,
-    goAutomations: action,
-    openSupport: action,
-    addRepository: action,
-    newLocalWorkspace: action,
-    newWorktreeWorkspace: action,
-    newCloudWorkspace: action,
-  };
-}
+vi.mock("@/lib/infra/right-panel-shortcuts", () => ({
+  requestRightPanelTabByIndex: vi.fn(() => true),
+}));
 
 describe("useAppShortcuts", () => {
   beforeEach(() => {
+    harnessState.selectedWorkspaceId = null;
+    harnessState.selectedLogicalWorkspaceId = null;
+    harnessState.sidebarShortcutTargets = [];
     clearShortcutHandlerRegistryForTests();
     useUserPreferencesStore.setState({
       ...USER_PREFERENCE_DEFAULTS,
@@ -67,11 +65,12 @@ describe("useAppShortcuts", () => {
   afterEach(() => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
+    document.body.innerHTML = "";
     vi.clearAllMocks();
   });
 
   it("steps appearance font sizes through the registered app shortcuts", () => {
-    renderHook(() => useAppShortcuts(buildCommandActions()));
+    renderHook(() => useAppShortcuts(commandActions()));
 
     useUserPreferencesStore.setState({
       uiFontSizeId: "xsmall",
@@ -95,4 +94,67 @@ describe("useAppShortcuts", () => {
     expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxxlarge");
     expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xlarge");
   });
+
+  it("routes option-number shortcuts to the right panel when right-panel focus is active", () => {
+    harnessState.selectedWorkspaceId = "workspace-1";
+    harnessState.selectedLogicalWorkspaceId = "workspace-1";
+    harnessState.sidebarShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+
+    renderHook(() => useAppShortcuts(commandActions()));
+
+    expect(runShortcutHandler("workspace.by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
+    expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+  });
+
+  it("falls back to workspace selection when a stale right-panel focus request is unhandled", () => {
+    harnessState.selectedWorkspaceId = "workspace-1";
+    harnessState.selectedLogicalWorkspaceId = "workspace-1";
+    harnessState.sidebarShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+    vi.mocked(requestRightPanelTabByIndex).mockReturnValueOnce(false);
+
+    renderHook(() => useAppShortcuts(commandActions()));
+
+    expect(runShortcutHandler("workspace.by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
+    expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
+      "workspace-2",
+      "shortcut",
+    );
+  });
 });
+
+function commandActions(): AppCommandActions {
+  const action = () => ({
+    disabledReason: null,
+    execute: vi.fn(),
+  });
+  return {
+    openSettings: action(),
+    showKeyboardShortcuts: action(),
+    goHome: action(),
+    goPlugins: action(),
+    goAutomations: action(),
+    openSupport: action(),
+    addRepository: action(),
+    newLocalWorkspace: action(),
+    newWorktreeWorkspace: action(),
+    newCloudWorkspace: action(),
+  };
+}

--- a/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/domain/shortcuts/registry";
 import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-import { requestRightPanelTabByIndex } from "@/lib/infra/right-panel-shortcuts";
+import { requestRightPanelTabByIndex } from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
 
 const navigationMocks = vi.hoisted(() => ({
   selectWorkspaceFromSurface: vi.fn(),
@@ -45,7 +45,7 @@ vi.mock("@/stores/sessions/session-selection-store", () => ({
     }),
 }));
 
-vi.mock("@/lib/infra/right-panel-shortcuts", () => ({
+vi.mock("@/lib/workflows/workspaces/right-panel-shortcut-requests", () => ({
   requestRightPanelTabByIndex: vi.fn(() => true),
 }));
 

--- a/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -2,10 +2,12 @@ import { useShortcutHandler } from "@/hooks/shortcuts/lifecycle/use-shortcut-han
 import type { AppCommandActions } from "@/hooks/app/workflows/use-app-command-actions";
 import { useSidebarShortcutTargets } from "@/hooks/workspaces/derived/use-sidebar-shortcut-targets";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { getFocusZone, isRightPanelFocusZone } from "@/lib/domain/focus-zone";
 import {
   resolveAdjacentSidebarShortcutTarget,
   resolveSidebarShortcutDigitTarget,
 } from "@/lib/domain/workspaces/sidebar/sidebar-shortcut-targets";
+import { requestRightPanelTabByIndex } from "@/lib/infra/right-panel-shortcuts";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
@@ -73,6 +75,10 @@ export function useAppShortcuts(actions: AppCommandActions): void {
   useShortcutHandler("workspace.by-index", ({ digit }) => {
     if (!digit) {
       return false;
+    }
+
+    if (isRightPanelFocusZone(getFocusZone())) {
+      return requestRightPanelTabByIndex(digit);
     }
 
     const targetId = resolveSidebarShortcutDigitTarget(sidebarShortcutTargetIds, digit);

--- a/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -7,7 +7,7 @@ import {
   resolveAdjacentSidebarShortcutTarget,
   resolveSidebarShortcutDigitTarget,
 } from "@/lib/domain/workspaces/sidebar/sidebar-shortcut-targets";
-import { requestRightPanelTabByIndex } from "@/lib/infra/right-panel-shortcuts";
+import { requestRightPanelTabByIndex } from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
@@ -78,7 +78,10 @@ export function useAppShortcuts(actions: AppCommandActions): void {
     }
 
     if (isRightPanelFocusZone(getFocusZone())) {
-      return requestRightPanelTabByIndex(digit);
+      const handled = requestRightPanelTabByIndex(digit);
+      if (handled) {
+        return true;
+      }
     }
 
     const targetId = resolveSidebarShortcutDigitTarget(sidebarShortcutTargetIds, digit);

--- a/desktop/src/hooks/chat/ui/use-chat-root-focus.test.tsx
+++ b/desktop/src/hooks/chat/ui/use-chat-root-focus.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useRef } from "react";
+import { useChatRootFocus } from "@/hooks/chat/ui/use-chat-root-focus";
+
+function ChatRootFocusHarness() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const transcriptRootRef = useRef<HTMLDivElement>(null);
+  const handlePointerDownCapture = useChatRootFocus(rootRef);
+
+  return (
+    <div>
+      <button type="button" data-testid="before-chat">Before chat</button>
+      <div
+        ref={rootRef}
+        data-testid="chat-root"
+        data-focus-zone="chat"
+        tabIndex={-1}
+        onPointerDownCapture={handlePointerDownCapture}
+      >
+        <div data-testid="plain-chat-surface">Plain chat surface</div>
+        <div
+          ref={transcriptRootRef}
+          data-testid="transcript-root"
+          data-chat-transcript-root="true"
+          tabIndex={-1}
+        >
+          <div data-testid="transcript-row">Transcript row</div>
+        </div>
+        <button type="button">Composer action</button>
+      </div>
+    </div>
+  );
+}
+
+describe("useChatRootFocus", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("focuses the chat root when a plain chat surface is clicked", () => {
+    render(<ChatRootFocusHarness />);
+
+    fireEvent.pointerDown(screen.getByTestId("plain-chat-surface"));
+
+    expect(document.activeElement).toBe(screen.getByTestId("chat-root"));
+  });
+
+  it("preserves transcript-root focus for transcript clicks", () => {
+    render(<ChatRootFocusHarness />);
+    const transcriptRoot = screen.getByTestId("transcript-root");
+    transcriptRoot.focus();
+
+    fireEvent.pointerDown(screen.getByTestId("transcript-row"));
+
+    expect(document.activeElement).toBe(transcriptRoot);
+  });
+
+  it("does not steal focus from interactive chat controls", () => {
+    render(<ChatRootFocusHarness />);
+    const existingFocus = screen.getByTestId("before-chat");
+    existingFocus.focus();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Composer action" }));
+
+    expect(document.activeElement).toBe(existingFocus);
+  });
+});

--- a/desktop/src/hooks/chat/ui/use-chat-root-focus.ts
+++ b/desktop/src/hooks/chat/ui/use-chat-root-focus.ts
@@ -1,0 +1,40 @@
+import {
+  useCallback,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from "react";
+
+function shouldPreservePointerFocus(target: EventTarget): boolean {
+  if (!(target instanceof Element)) {
+    return true;
+  }
+
+  return Boolean(target.closest(
+    [
+      "a",
+      "button",
+      "input",
+      "select",
+      "textarea",
+      "iframe",
+      "[contenteditable='true']",
+      "[role='button']",
+      "[tabindex]:not([tabindex='-1'])",
+      "[data-chat-transcript-root='true']",
+      "[data-focus-zone='terminal']",
+      "[data-focus-zone='browser']",
+    ].join(","),
+  ));
+}
+
+export function useChatRootFocus(
+  rootRef: RefObject<HTMLDivElement | null>,
+) {
+  return useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (shouldPreservePointerFocus(event.target)) {
+      return;
+    }
+
+    rootRef.current?.focus({ preventScroll: true });
+  }, [rootRef]);
+}

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import {
+  resolveRelativeRightPanelHeaderEntryKey,
+  resolveRightPanelHeaderEntryKeyByShortcutIndex,
+} from "@/lib/domain/workspaces/shell/right-panel-shortcuts";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel-model";
+import {
+  RIGHT_PANEL_SHORTCUT_EVENT,
+  rightPanelShortcutRequestFromEvent,
+} from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
+
+export function useRightPanelShortcutRequests({
+  activeEntryKey,
+  entries,
+  isOpen,
+  onActivateEntry,
+}: {
+  activeEntryKey: RightPanelHeaderEntryKey;
+  entries: readonly RightPanelHeaderEntry[];
+  isOpen: boolean;
+  onActivateEntry: (entryKey: RightPanelHeaderEntryKey) => boolean;
+}): void {
+  useEffect(() => {
+    const handleShortcutRequest = (event: Event) => {
+      if (!isOpen) {
+        return;
+      }
+
+      const request = rightPanelShortcutRequestFromEvent(event);
+      if (!request) {
+        return;
+      }
+
+      const nextEntryKey = request.kind === "relative-tab"
+        ? resolveRelativeRightPanelHeaderEntryKey({
+            entries,
+            activeEntryKey,
+            delta: request.delta,
+          })
+        : resolveRightPanelHeaderEntryKeyByShortcutIndex(entries, request.digit);
+      if (!nextEntryKey) {
+        return;
+      }
+
+      if (onActivateEntry(nextEntryKey)) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
+    return () => {
+      window.removeEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handleShortcutRequest);
+    };
+  }, [
+    activeEntryKey,
+    entries,
+    isOpen,
+    onActivateEntry,
+  ]);
+}

--- a/desktop/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts
+++ b/desktop/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts
@@ -15,11 +15,13 @@ export function useRightPanelShortcutRequests({
   entries,
   isOpen,
   onActivateEntry,
+  onHandledRequest,
 }: {
   activeEntryKey: RightPanelHeaderEntryKey;
   entries: readonly RightPanelHeaderEntry[];
   isOpen: boolean;
   onActivateEntry: (entryKey: RightPanelHeaderEntryKey) => boolean;
+  onHandledRequest?: () => void;
 }): void {
   useEffect(() => {
     const handleShortcutRequest = (event: Event) => {
@@ -44,6 +46,7 @@ export function useRightPanelShortcutRequests({
       }
 
       if (onActivateEntry(nextEntryKey)) {
+        onHandledRequest?.();
         event.preventDefault();
       }
     };
@@ -57,5 +60,6 @@ export function useRightPanelShortcutRequests({
     entries,
     isOpen,
     onActivateEntry,
+    onHandledRequest,
   ]);
 }

--- a/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
+++ b/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
@@ -7,6 +7,27 @@ import {
   runShortcutHandler,
 } from "@/lib/domain/shortcuts/registry";
 import { useWorkspaceContentShortcuts } from "@/hooks/workspaces/ui/use-workspace-content-shortcuts";
+import {
+  requestRightPanelRelativeTab,
+  requestRightPanelTabByIndex,
+} from "@/lib/infra/right-panel-shortcuts";
+
+function createActions(overrides: Partial<{
+  activateRelativeTab: ReturnType<typeof vi.fn>;
+  activateTabByShortcutIndex: ReturnType<typeof vi.fn>;
+  closeActiveWorkspaceTab: ReturnType<typeof vi.fn>;
+  openNewSessionTab: ReturnType<typeof vi.fn>;
+  restoreLastDismissedTab: ReturnType<typeof vi.fn>;
+}> = {}) {
+  return {
+    activateRelativeTab: vi.fn(() => true),
+    activateTabByShortcutIndex: vi.fn(),
+    closeActiveWorkspaceTab: vi.fn(() => "closed" as const),
+    openNewSessionTab: vi.fn(() => true),
+    restoreLastDismissedTab: vi.fn(),
+    ...overrides,
+  };
+}
 
 const harnessState = vi.hoisted(() => ({
   selectedWorkspaceId: "workspace-1" as string | null,
@@ -15,6 +36,11 @@ const harnessState = vi.hoisted(() => ({
 vi.mock("@/stores/sessions/session-selection-store", () => ({
   useSessionSelectionStore: (selector: (state: { selectedWorkspaceId: string | null }) => unknown) =>
     selector(harnessState),
+}));
+
+vi.mock("@/lib/infra/right-panel-shortcuts", () => ({
+  requestRightPanelRelativeTab: vi.fn(() => true),
+  requestRightPanelTabByIndex: vi.fn(() => true),
 }));
 
 describe("useWorkspaceContentShortcuts", () => {
@@ -26,17 +52,12 @@ describe("useWorkspaceContentShortcuts", () => {
   afterEach(() => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
+    document.body.innerHTML = "";
     vi.clearAllMocks();
   });
 
   it("uses Cmd+T for a new chat tab", () => {
-    const actions = {
-      activateRelativeTab: vi.fn(),
-      activateTabByShortcutIndex: vi.fn(),
-      closeActiveWorkspaceTab: vi.fn(() => "closed" as const),
-      openNewSessionTab: vi.fn(() => true),
-      restoreLastDismissedTab: vi.fn(),
-    };
+    const actions = createActions();
 
     renderHook(() => useWorkspaceContentShortcuts(actions));
 
@@ -44,5 +65,91 @@ describe("useWorkspaceContentShortcuts", () => {
 
     expect(runShortcutHandler("workspace.new-session-tab", { source: "keyboard" })).toBe(true);
     expect(actions.openNewSessionTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes tab cycling to the right panel when focus is in the right panel", () => {
+    const actions = createActions();
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+
+    renderHook(() => useWorkspaceContentShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.next-tab", { source: "keyboard" })).toBe(true);
+    expect(requestRightPanelRelativeTab).toHaveBeenCalledWith(1);
+    expect(actions.activateRelativeTab).not.toHaveBeenCalled();
+  });
+
+  it("falls back to workspace tab cycling when a stale right-panel focus request is unhandled", () => {
+    const actions = createActions();
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+    vi.mocked(requestRightPanelRelativeTab).mockReturnValueOnce(false);
+
+    renderHook(() => useWorkspaceContentShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.next-tab", { source: "keyboard" })).toBe(true);
+    expect(requestRightPanelRelativeTab).toHaveBeenCalledWith(1);
+    expect(actions.activateRelativeTab).toHaveBeenCalledWith(1);
+  });
+
+  it("routes chat-tab number shortcuts to the right panel when focus is in the right panel", () => {
+    const actions = createActions();
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+
+    renderHook(() => useWorkspaceContentShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.tab-by-index", {
+      source: "keyboard",
+      digit: 3,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(3);
+    expect(actions.activateTabByShortcutIndex).not.toHaveBeenCalled();
+  });
+
+  it("falls back to chat-tab number shortcuts when a stale right-panel focus request is unhandled", () => {
+    const actions = createActions();
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+    vi.mocked(requestRightPanelTabByIndex).mockReturnValueOnce(false);
+
+    renderHook(() => useWorkspaceContentShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.tab-by-index", {
+      source: "keyboard",
+      digit: 3,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(3);
+    expect(actions.activateTabByShortcutIndex).toHaveBeenCalledWith("3");
+  });
+
+  it("keeps chat-tab number shortcuts in chat when chat owns focus", () => {
+    const actions = createActions();
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "chat");
+    document.body.append(zone);
+    zone.focus();
+
+    renderHook(() => useWorkspaceContentShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.tab-by-index", {
+      source: "keyboard",
+      digit: 3,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).not.toHaveBeenCalled();
+    expect(actions.activateTabByShortcutIndex).toHaveBeenCalledWith("3");
   });
 });

--- a/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
+++ b/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
@@ -10,7 +10,7 @@ import { useWorkspaceContentShortcuts } from "@/hooks/workspaces/ui/use-workspac
 import {
   requestRightPanelRelativeTab,
   requestRightPanelTabByIndex,
-} from "@/lib/infra/right-panel-shortcuts";
+} from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
 
 function createActions(overrides: Partial<{
   activateRelativeTab: ReturnType<typeof vi.fn>;
@@ -38,7 +38,7 @@ vi.mock("@/stores/sessions/session-selection-store", () => ({
     selector(harnessState),
 }));
 
-vi.mock("@/lib/infra/right-panel-shortcuts", () => ({
+vi.mock("@/lib/workflows/workspaces/right-panel-shortcut-requests", () => ({
   requestRightPanelRelativeTab: vi.fn(() => true),
   requestRightPanelTabByIndex: vi.fn(() => true),
 }));

--- a/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
+++ b/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
@@ -4,7 +4,7 @@ import { getFocusZone, isRightPanelFocusZone } from "@/lib/domain/focus-zone";
 import {
   requestRightPanelRelativeTab,
   requestRightPanelTabByIndex,
-} from "@/lib/infra/right-panel-shortcuts";
+} from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
 import type { WorkspaceTabActions } from "@/hooks/workspaces/tabs/use-workspace-tab-actions";
 
 type WorkspaceContentShortcutActions = Pick<

--- a/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
+++ b/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
@@ -1,5 +1,10 @@
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useShortcutHandler } from "@/hooks/shortcuts/lifecycle/use-shortcut-handler";
+import { getFocusZone, isRightPanelFocusZone } from "@/lib/domain/focus-zone";
+import {
+  requestRightPanelRelativeTab,
+  requestRightPanelTabByIndex,
+} from "@/lib/infra/right-panel-shortcuts";
 import type { WorkspaceTabActions } from "@/hooks/workspaces/tabs/use-workspace-tab-actions";
 
 type WorkspaceContentShortcutActions = Pick<
@@ -26,10 +31,24 @@ export function useWorkspaceContentShortcuts(
   } = actions;
 
   useShortcutHandler("workspace.previous-tab", () => {
+    if (isRightPanelFocusZone(getFocusZone())) {
+      const handled = requestRightPanelRelativeTab(-1);
+      if (handled) {
+        return true;
+      }
+    }
+
     return activateRelativeTab(-1);
   }, { enabled });
 
   useShortcutHandler("workspace.next-tab", () => {
+    if (isRightPanelFocusZone(getFocusZone())) {
+      const handled = requestRightPanelRelativeTab(1);
+      if (handled) {
+        return true;
+      }
+    }
+
     return activateRelativeTab(1);
   }, { enabled });
 
@@ -40,6 +59,13 @@ export function useWorkspaceContentShortcuts(
   useShortcutHandler("workspace.tab-by-index", ({ digit }) => {
     if (!digit) {
       return false;
+    }
+
+    if (isRightPanelFocusZone(getFocusZone())) {
+      const handled = requestRightPanelTabByIndex(digit);
+      if (handled) {
+        return true;
+      }
     }
 
     return activateTabByShortcutIndex(String(digit));

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -2286,7 +2286,7 @@ body {
 
 /* ---- Right panel tabs ---- */
 .right-panel-tab-system {
-  --tab-system-height: var(--workspace-shell-header-height);
+  --tab-system-height: 2.5rem; /* Align with the main sidebar header. */
   --tab-max-width: 156px;
   --tab-shell-max-width: 160px;
   --tab-height: 30px;
@@ -2329,6 +2329,7 @@ body {
   flex-direction: column;
   width: 100%;
   height: var(--tab-system-height);
+  box-sizing: border-box;
   flex-shrink: 0;
   min-width: 0;
   background-color: var(--right-panel-tab-surface);
@@ -2629,6 +2630,10 @@ body {
   font-size: var(--right-panel-tab-font-size);
   line-height: var(--right-panel-tab-line-height);
   font-weight: var(--right-panel-tab-font-weight);
+}
+
+.right-panel-tab-system .ui-tab-system-tab__content[data-shortcut-reveal="true"] {
+  padding-right: 1.65rem;
 }
 
 .right-panel-tab-system .ui-tab-system-tab[data-stable] .ui-tab-system-tab__content,

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -2289,13 +2289,13 @@ body {
   --tab-system-height: var(--workspace-shell-header-height);
   --tab-max-width: 156px;
   --tab-shell-max-width: 160px;
-  --tab-height: var(--workspace-shell-action-size);
+  --tab-height: 30px;
   --tab-container-padding: calc((var(--tab-system-height) - var(--tab-height) - 2px) / 2);
   --tab-stable-end-margin: 0px;
   --tab-gap: 3px;
   --tab-bar-mask-size: 28px;
   --right-panel-tab-leading-inset: 0px;
-  --right-panel-tab-radius: 10px;
+  --right-panel-tab-radius: 8px;
   --right-panel-tab-overlay-radius: 8px;
   --right-panel-tab-surface: transparent;
   --right-panel-tab-hover-bg: color-mix(
@@ -2700,7 +2700,12 @@ body {
 }
 
 .right-panel-tab-system .right-panel-shortcut-badge {
-  flex-shrink: 0;
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  z-index: 2;
+  transform: translateY(-50%);
+  pointer-events: none;
   color: var(--right-panel-tab-text-tertiary);
 }
 

--- a/desktop/src/lib/domain/focus-zone.test.ts
+++ b/desktop/src/lib/domain/focus-zone.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { focusChatInput, focusTerminal, getFocusZone } from "@/lib/domain/focus-zone";
+import {
+  focusChatInput,
+  focusTerminal,
+  getFocusZone,
+  isRightPanelFocusZone,
+} from "@/lib/domain/focus-zone";
 
 describe("focus-zone helpers", () => {
   afterEach(() => {
@@ -16,6 +21,13 @@ describe("focus-zone helpers", () => {
     });
 
     expect(getFocusZone()).toBe("terminal");
+  });
+
+  it("classifies the right panel and its hosted surfaces as right-panel focus", () => {
+    expect(isRightPanelFocusZone("right-panel")).toBe(true);
+    expect(isRightPanelFocusZone("terminal")).toBe(true);
+    expect(isRightPanelFocusZone("browser")).toBe(true);
+    expect(isRightPanelFocusZone("chat")).toBe(false);
   });
 
   it("focuses the chat composer editor when the chat focus zone exists", () => {

--- a/desktop/src/lib/domain/focus-zone.ts
+++ b/desktop/src/lib/domain/focus-zone.ts
@@ -1,10 +1,11 @@
-export type FocusZone = "browser" | "chat" | "terminal" | "unknown";
+export type FocusZone = "browser" | "chat" | "right-panel" | "terminal" | "unknown";
 
 const FOCUS_ZONE_ATTR = "data-focus-zone";
 
 /**
  * Derives the current focus zone from the DOM (no store).
- * Components mark their focusable regions with `data-focus-zone="browser" | "chat" | "terminal"`.
+ * Components mark their focusable regions with
+ * `data-focus-zone="browser" | "chat" | "right-panel" | "terminal"`.
  */
 export function getFocusZone(): FocusZone {
   const active = document.activeElement;
@@ -14,8 +15,17 @@ export function getFocusZone(): FocusZone {
   if (!zone) return "unknown";
 
   const value = zone.getAttribute(FOCUS_ZONE_ATTR);
-  if (value === "browser" || value === "chat" || value === "terminal") return value;
+  if (
+    value === "browser"
+    || value === "chat"
+    || value === "right-panel"
+    || value === "terminal"
+  ) return value;
   return "unknown";
+}
+
+export function isRightPanelFocusZone(zone: FocusZone): boolean {
+  return zone === "right-panel" || zone === "browser" || zone === "terminal";
 }
 
 export function focusChatInput(): boolean {

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.test.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel-model";
+import {
+  resolveRelativeRightPanelHeaderEntryKey,
+  resolveRightPanelHeaderEntryKeyByShortcutIndex,
+} from "@/lib/domain/workspaces/shell/right-panel-shortcuts";
+
+describe("right panel shortcut resolution", () => {
+  const entries = [
+    entry("tool:scratch"),
+    entry("tool:git"),
+    entry("terminal:t1"),
+    entry("browser:b1"),
+  ];
+
+  it("cycles through visible right-panel header entries", () => {
+    expect(resolveRelativeRightPanelHeaderEntryKey({
+      entries,
+      activeEntryKey: "tool:git",
+      delta: 1,
+    })).toBe("terminal:t1");
+
+    expect(resolveRelativeRightPanelHeaderEntryKey({
+      entries,
+      activeEntryKey: "tool:scratch",
+      delta: -1,
+    })).toBe("browser:b1");
+  });
+
+  it("uses the first or last entry when the active entry is stale", () => {
+    expect(resolveRelativeRightPanelHeaderEntryKey({
+      entries,
+      activeEntryKey: "terminal:missing",
+      delta: 1,
+    })).toBe("tool:scratch");
+
+    expect(resolveRelativeRightPanelHeaderEntryKey({
+      entries,
+      activeEntryKey: "terminal:missing",
+      delta: -1,
+    })).toBe("browser:b1");
+  });
+
+  it("resolves digit shortcuts against all right-panel header entries", () => {
+    expect(resolveRightPanelHeaderEntryKeyByShortcutIndex(entries, 2)).toBe("tool:git");
+    expect(resolveRightPanelHeaderEntryKeyByShortcutIndex(entries, 4)).toBe("browser:b1");
+    expect(resolveRightPanelHeaderEntryKeyByShortcutIndex(entries, 9)).toBe("browser:b1");
+  });
+});
+
+function entry(key: RightPanelHeaderEntryKey): RightPanelHeaderEntry {
+  return { kind: "tool", key, tool: "scratch" } as RightPanelHeaderEntry;
+}

--- a/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.ts
+++ b/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.ts
@@ -1,0 +1,42 @@
+import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
+import type { RightPanelHeaderEntry } from "@/lib/domain/workspaces/shell/right-panel-header-entry";
+import type { RightPanelHeaderEntryKey } from "@/lib/domain/workspaces/shell/right-panel-model";
+
+export function resolveRelativeRightPanelHeaderEntryKey({
+  activeEntryKey,
+  delta,
+  entries,
+}: {
+  activeEntryKey: RightPanelHeaderEntryKey;
+  delta: -1 | 1;
+  entries: readonly RightPanelHeaderEntry[];
+}): RightPanelHeaderEntryKey | null {
+  const keys = entries.map((entry) => entry.key);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  const activeIndex = keys.indexOf(activeEntryKey);
+  if (activeIndex < 0) {
+    return delta < 0 ? keys[keys.length - 1] ?? null : keys[0] ?? null;
+  }
+
+  const nextIndex = (activeIndex + delta + keys.length) % keys.length;
+  return keys[nextIndex] ?? null;
+}
+
+export function resolveRightPanelHeaderEntryKeyByShortcutIndex(
+  entries: readonly RightPanelHeaderEntry[],
+  digit: ShortcutDigit,
+): RightPanelHeaderEntryKey | null {
+  const keys = entries.map((entry) => entry.key);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  if (digit === 9) {
+    return keys[keys.length - 1] ?? null;
+  }
+
+  return keys[digit - 1] ?? null;
+}

--- a/desktop/src/lib/infra/right-panel-new-tab-menu.test.ts
+++ b/desktop/src/lib/infra/right-panel-new-tab-menu.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RIGHT_PANEL_BROWSER_TAB_EVENT,
+  requestRightPanelBrowserTab,
+} from "@/lib/infra/right-panel-new-tab-menu";
+
+describe("right panel browser tab requests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports unhandled requests when no right panel listener accepts them", () => {
+    expect(requestRightPanelBrowserTab()).toBe(false);
+  });
+
+  it("reports handled requests only when the listener cancels the request event", () => {
+    const handler = vi.fn((event: Event) => {
+      expect(event.cancelable).toBe(true);
+      event.preventDefault();
+    });
+    window.addEventListener(RIGHT_PANEL_BROWSER_TAB_EVENT, handler);
+
+    try {
+      expect(requestRightPanelBrowserTab()).toBe(true);
+    } finally {
+      window.removeEventListener(RIGHT_PANEL_BROWSER_TAB_EVENT, handler);
+    }
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/lib/infra/right-panel-new-tab-menu.ts
+++ b/desktop/src/lib/infra/right-panel-new-tab-menu.ts
@@ -18,8 +18,9 @@ export function requestRightPanelNewTabMenu(
 }
 
 export function requestRightPanelBrowserTab(): boolean {
-  window.dispatchEvent(new Event(RIGHT_PANEL_BROWSER_TAB_EVENT));
-  return true;
+  return !window.dispatchEvent(new Event(RIGHT_PANEL_BROWSER_TAB_EVENT, {
+    cancelable: true,
+  }));
 }
 
 export function rightPanelNewTabMenuDefaultFromEvent(

--- a/desktop/src/lib/infra/right-panel-shortcuts.ts
+++ b/desktop/src/lib/infra/right-panel-shortcuts.ts
@@ -1,0 +1,53 @@
+import type { ShortcutDigit } from "@/lib/domain/shortcuts/matching";
+
+export const RIGHT_PANEL_SHORTCUT_EVENT = "proliferate:right-panel-shortcut";
+
+export type RightPanelShortcutRequest =
+  | { kind: "relative-tab"; delta: -1 | 1 }
+  | { kind: "tab-by-index"; digit: ShortcutDigit };
+
+export function requestRightPanelRelativeTab(delta: -1 | 1): boolean {
+  window.dispatchEvent(new CustomEvent<RightPanelShortcutRequest>(
+    RIGHT_PANEL_SHORTCUT_EVENT,
+    { detail: { kind: "relative-tab", delta } },
+  ));
+  return true;
+}
+
+export function requestRightPanelTabByIndex(digit: ShortcutDigit): boolean {
+  window.dispatchEvent(new CustomEvent<RightPanelShortcutRequest>(
+    RIGHT_PANEL_SHORTCUT_EVENT,
+    { detail: { kind: "tab-by-index", digit } },
+  ));
+  return true;
+}
+
+export function rightPanelShortcutRequestFromEvent(
+  event: Event,
+): RightPanelShortcutRequest | null {
+  if (!(event instanceof CustomEvent)) {
+    return null;
+  }
+
+  const detail = event.detail as Partial<RightPanelShortcutRequest> | undefined;
+  if (detail?.kind === "relative-tab") {
+    return detail.delta === -1 || detail.delta === 1
+      ? { kind: "relative-tab", delta: detail.delta }
+      : null;
+  }
+
+  if (detail?.kind === "tab-by-index") {
+    return isShortcutDigit(detail.digit)
+      ? { kind: "tab-by-index", digit: detail.digit }
+      : null;
+  }
+
+  return null;
+}
+
+function isShortcutDigit(value: unknown): value is ShortcutDigit {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= 1
+    && value <= 9;
+}

--- a/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.test.ts
+++ b/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RIGHT_PANEL_SHORTCUT_EVENT,
+  requestRightPanelRelativeTab,
+  requestRightPanelTabByIndex,
+  rightPanelShortcutRequestFromEvent,
+} from "@/lib/workflows/workspaces/right-panel-shortcut-requests";
+
+describe("right panel shortcut requests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports unhandled requests when no right panel listener accepts them", () => {
+    expect(requestRightPanelRelativeTab(1)).toBe(false);
+    expect(requestRightPanelTabByIndex(2)).toBe(false);
+  });
+
+  it("reports handled requests only when the listener cancels the request event", () => {
+    const handler = vi.fn((event: Event) => {
+      event.preventDefault();
+    });
+    window.addEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handler);
+
+    try {
+      expect(requestRightPanelRelativeTab(-1)).toBe(true);
+    } finally {
+      window.removeEventListener(RIGHT_PANEL_SHORTCUT_EVENT, handler);
+    }
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(rightPanelShortcutRequestFromEvent(handler.mock.calls[0]![0])).toEqual({
+      kind: "relative-tab",
+      delta: -1,
+    });
+  });
+});

--- a/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.ts
+++ b/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.ts
@@ -7,19 +7,11 @@ export type RightPanelShortcutRequest =
   | { kind: "tab-by-index"; digit: ShortcutDigit };
 
 export function requestRightPanelRelativeTab(delta: -1 | 1): boolean {
-  window.dispatchEvent(new CustomEvent<RightPanelShortcutRequest>(
-    RIGHT_PANEL_SHORTCUT_EVENT,
-    { detail: { kind: "relative-tab", delta } },
-  ));
-  return true;
+  return dispatchRightPanelShortcutRequest({ kind: "relative-tab", delta });
 }
 
 export function requestRightPanelTabByIndex(digit: ShortcutDigit): boolean {
-  window.dispatchEvent(new CustomEvent<RightPanelShortcutRequest>(
-    RIGHT_PANEL_SHORTCUT_EVENT,
-    { detail: { kind: "tab-by-index", digit } },
-  ));
-  return true;
+  return dispatchRightPanelShortcutRequest({ kind: "tab-by-index", digit });
 }
 
 export function rightPanelShortcutRequestFromEvent(
@@ -50,4 +42,15 @@ function isShortcutDigit(value: unknown): value is ShortcutDigit {
     && Number.isInteger(value)
     && value >= 1
     && value <= 9;
+}
+
+function dispatchRightPanelShortcutRequest(request: RightPanelShortcutRequest): boolean {
+  const event = new CustomEvent<RightPanelShortcutRequest>(
+    RIGHT_PANEL_SHORTCUT_EVENT,
+    {
+      cancelable: true,
+      detail: request,
+    },
+  );
+  return !window.dispatchEvent(event);
 }


### PR DESCRIPTION
## Summary
- Adds a right-panel focus zone so clicks inside the panel make right-panel shortcuts active.
- Routes Cmd+Opt+<, Cmd+Opt+>, and Cmd+Opt+1-9 to right-panel tabs when focus is inside the panel, terminal, or browser-hosted right-panel DOM.
- Tightens right-panel terminal tab sizing/alignment and removes hidden shortcut badge layout reservation.
- Hardens stale-focus behavior so closed-panel shortcut requests fall back to the normal workspace shortcuts instead of being consumed as no-ops.

## Review follow-up
- Extracted the right-panel shortcut event subscription into a focused workspace UI hook.
- Moved the product-specific right-panel shortcut request bridge out of generic infra.
- Aligned the right-panel tab strip with the main sidebar header and kept revealed shortcut badges from overlapping titles.

## Validation
- pnpm exec vitest run src/lib/domain/focus-zone.test.ts src/lib/domain/workspaces/shell/right-panel-shortcuts.test.ts src/lib/workflows/workspaces/right-panel-shortcut-requests.test.ts src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx src/hooks/app/lifecycle/use-app-shortcuts.test.tsx src/components/workspace/shell/right-panel/RightPanel.test.tsx
- pnpm exec tsc --noEmit (in desktop/)
- git diff --check
