### PR TITLE
feat(cloud): wire web mobile dispatch surfaces

### DIFF
--- a/cloud/sdk-react/src/hooks/claims.ts
+++ b/cloud/sdk-react/src/hooks/claims.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  claimCloudWorkspace,
+  type ClaimWorkspaceRequest,
+  type ClaimWorkspaceResponse,
+} from "@proliferate/cloud-sdk";
+import {
+  cloudWorkspaceSnapshotKey,
+  cloudWorkspacesKey,
+  personalCloudOwnerKey,
+} from "../lib/query-keys.js";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+
+export function useClaimCloudWorkspace() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<ClaimWorkspaceResponse, Error, {
+    workspaceId: string;
+    body?: ClaimWorkspaceRequest;
+  }>({
+    mutationFn: ({ workspaceId, body }) => claimCloudWorkspace(workspaceId, body, client),
+    onSuccess(_result, variables) {
+      void queryClient.invalidateQueries({
+        queryKey: cloudWorkspacesKey(personalCloudOwnerKey(), "exposed"),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: cloudWorkspaceSnapshotKey(variables.workspaceId),
+      });
+    },
+  });
+}

--- a/cloud/sdk-react/src/hooks/live-reducer.ts
+++ b/cloud/sdk-react/src/hooks/live-reducer.ts
@@ -1,0 +1,121 @@
+import type {
+  CloudCommandStatusPatch,
+  CloudSessionLiveEvent,
+  CloudSessionProjectionPatch,
+  CloudSessionSnapshot,
+  CloudTargetLiveEvent,
+  CloudTargetPatch,
+  CloudWorkspaceLiveEvent,
+  CloudWorkspaceProjectionPatch,
+  CloudWorkspaceSnapshot,
+} from "@proliferate/cloud-sdk";
+
+export function isCloudHeartbeat(event: unknown): event is { kind: "heartbeat" } {
+  return eventKind(event) === "heartbeat";
+}
+
+export function isCloudCommandStatusPatch(event: unknown): event is CloudCommandStatusPatch {
+  return eventKind(event) === "command_status";
+}
+
+export function isCloudSessionSnapshot(event: CloudSessionLiveEvent): event is CloudSessionSnapshot {
+  return isRecord(event) && "session" in event && "transcriptItems" in event;
+}
+
+export function isCloudWorkspaceSnapshot(
+  event: CloudWorkspaceLiveEvent,
+): event is CloudWorkspaceSnapshot {
+  return isRecord(event) && "workspace" in event && "sessions" in event;
+}
+
+export function isCloudTargetSnapshot(
+  event: CloudTargetLiveEvent,
+): event is Extract<CloudTargetLiveEvent, { target: unknown }> {
+  return isRecord(event) && "target" in event && eventKind(event) === undefined;
+}
+
+export function isCloudSessionProjectionPatch(
+  event: CloudSessionLiveEvent,
+): event is CloudSessionProjectionPatch {
+  return eventKind(event) === "projection_patch";
+}
+
+export function isCloudWorkspaceProjectionPatch(
+  event: CloudWorkspaceLiveEvent,
+): event is CloudWorkspaceProjectionPatch {
+  return eventKind(event) === "workspace_projection_patch";
+}
+
+export function isCloudTargetPatch(event: CloudTargetLiveEvent): event is CloudTargetPatch {
+  return eventKind(event) === "target_projection_patch";
+}
+
+export function reduceSessionSnapshot(
+  snapshot: CloudSessionSnapshot | undefined,
+  event: CloudSessionProjectionPatch,
+): CloudSessionSnapshot | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+  const patch = event.patch;
+  return {
+    ...snapshot,
+    session: patch.session,
+    transcriptItems: upsertByKey(
+      snapshot.transcriptItems,
+      patch.transcriptItem ?? null,
+      (item) => item.itemId,
+    ),
+    pendingInteractions: upsertByKey(
+      snapshot.pendingInteractions,
+      patch.pendingInteraction ?? null,
+      (interaction) => interaction.requestId,
+    ),
+  };
+}
+
+export function reduceWorkspaceSnapshot(
+  snapshot: CloudWorkspaceSnapshot | undefined,
+  event: CloudWorkspaceProjectionPatch,
+): CloudWorkspaceSnapshot | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+  const patch = event.patch;
+  return {
+    ...snapshot,
+    sessions: upsertByKey(snapshot.sessions, patch.session, (session) => session.sessionId),
+  };
+}
+
+function upsertByKey<T>(
+  items: readonly T[],
+  nextItem: T | null,
+  keyFor: (item: T) => string,
+): T[] {
+  if (nextItem === null) {
+    return [...items];
+  }
+  const nextKey = keyFor(nextItem);
+  let replaced = false;
+  const nextItems = items.map((item) => {
+    if (keyFor(item) !== nextKey) {
+      return item;
+    }
+    replaced = true;
+    return nextItem;
+  });
+  return replaced ? nextItems : [...nextItems, nextItem];
+}
+
+function eventKind(event: unknown): string | undefined {
+  if (!isRecord(event)) {
+    return undefined;
+  }
+  const kind = event.kind;
+  return typeof kind === "string" ? kind : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/cloud/sdk-react/src/hooks/live.ts
+++ b/cloud/sdk-react/src/hooks/live.ts
@@ -1,3 +1,367 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import {
+  getCommandStatus,
+  subscribeSession,
+  subscribeTarget,
+  subscribeWorkspace,
+  type CloudCommandResponse,
+  type CloudSessionSnapshot,
+  type CloudTargetDetail,
+  type CloudWorkspaceSnapshot,
+} from "@proliferate/cloud-sdk";
+import {
+  cloudCommandKey,
+  cloudSessionSnapshotKey,
+  cloudTargetKey,
+  cloudWorkspaceSnapshotKey,
+} from "../lib/query-keys.js";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+import {
+  isCloudCommandStatusPatch,
+  isCloudHeartbeat,
+  isCloudSessionProjectionPatch,
+  isCloudSessionSnapshot,
+  isCloudTargetPatch,
+  isCloudTargetSnapshot,
+  isCloudWorkspaceProjectionPatch,
+  isCloudWorkspaceSnapshot,
+  reduceSessionSnapshot,
+  reduceWorkspaceSnapshot,
+} from "./live-reducer.js";
+
+const MIN_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 8_000;
+
+export interface CloudLiveHookOptions {
+  enabled?: boolean;
+}
+
+export interface UseSessionLiveOptions extends CloudLiveHookOptions {
+  targetId: string | null;
+}
+
+export interface CloudLiveState<TSnapshot> {
+  snapshot: TSnapshot | undefined;
+  lastPatchAt: Date | undefined;
+  isConnected: boolean;
+  error: Error | undefined;
+}
+
+export interface CloudTargetLiveState extends CloudLiveState<{ target: CloudTargetDetail }> {}
+
+export function useSessionLive(
+  sessionId: string | null,
+  options: UseSessionLiveOptions,
+): CloudLiveState<CloudSessionSnapshot> {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<CloudLiveState<CloudSessionSnapshot>>(emptyLiveState);
+  const cursorRef = useRef(0);
+  const targetId = options.targetId;
+  const enabled = options.enabled ?? true;
+
+  useEffect(() => {
+    if (!enabled || !sessionId || !targetId) {
+      setState(emptyLiveState());
+      cursorRef.current = 0;
+      return;
+    }
+
+    let active = true;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let attempt = 0;
+    let subscription: { close: () => void } | undefined;
+
+    const connect = () => {
+      if (!active) {
+        return;
+      }
+      subscription?.close();
+      subscription = subscribeSession(sessionId, {
+        targetId,
+        afterSeq: cursorRef.current,
+        onEvent(event) {
+          if (!active) {
+            return;
+          }
+          if (isCloudHeartbeat(event)) {
+            setState((current) => ({ ...current, isConnected: true, error: undefined }));
+            return;
+          }
+          attempt = 0;
+          if (isCloudSessionSnapshot(event)) {
+            cursorRef.current = event.session.lastEventSeq;
+            queryClient.setQueryData(cloudSessionSnapshotKey(targetId, sessionId), event);
+            setState({
+              snapshot: event,
+              lastPatchAt: new Date(),
+              isConnected: true,
+              error: undefined,
+            });
+            return;
+          }
+          if (isCloudSessionProjectionPatch(event)) {
+            cursorRef.current = Math.max(cursorRef.current, event.patch.seq);
+            setState((current) => {
+              const snapshot = reduceSessionSnapshot(current.snapshot, event);
+              if (snapshot) {
+                queryClient.setQueryData(cloudSessionSnapshotKey(targetId, sessionId), snapshot);
+              }
+              return {
+                snapshot,
+                lastPatchAt: new Date(),
+                isConnected: true,
+                error: undefined,
+              };
+            });
+            return;
+          }
+          if (isCloudCommandStatusPatch(event)) {
+            queryClient.setQueryData(cloudCommandKey(event.command.commandId), event.command);
+            setState((current) => ({ ...current, isConnected: true, error: undefined }));
+          }
+        },
+        onError(error) {
+          if (!active) {
+            return;
+          }
+          setState((current) => ({
+            ...current,
+            isConnected: false,
+            error: normalizeStreamError(error),
+          }));
+          reconnectTimer = setTimeout(connect, reconnectDelay(attempt++));
+        },
+      });
+    };
+
+    connect();
+    return () => {
+      active = false;
+      subscription?.close();
+      if (reconnectTimer !== undefined) {
+        clearTimeout(reconnectTimer);
+      }
+    };
+  }, [enabled, queryClient, sessionId, targetId]);
+
+  return state;
+}
+
+export function useWorkspaceLive(
+  workspaceId: string | null,
+  options: CloudLiveHookOptions = {},
+): CloudLiveState<CloudWorkspaceSnapshot> {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<CloudLiveState<CloudWorkspaceSnapshot>>(emptyLiveState);
+  const cursorRef = useRef(0);
+  const enabled = options.enabled ?? true;
+
+  useEffect(() => {
+    if (!enabled || !workspaceId) {
+      setState(emptyLiveState());
+      cursorRef.current = 0;
+      return;
+    }
+
+    let active = true;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let attempt = 0;
+    let subscription: { close: () => void } | undefined;
+
+    const connect = () => {
+      if (!active) {
+        return;
+      }
+      subscription?.close();
+      subscription = subscribeWorkspace(workspaceId, {
+        afterSeq: cursorRef.current,
+        onEvent(event) {
+          if (!active) {
+            return;
+          }
+          if (isCloudHeartbeat(event)) {
+            setState((current) => ({ ...current, isConnected: true, error: undefined }));
+            return;
+          }
+          attempt = 0;
+          if (isCloudWorkspaceSnapshot(event)) {
+            cursorRef.current = Math.max(
+              0,
+              ...event.sessions.map((session) => session.lastEventSeq),
+            );
+            queryClient.setQueryData(cloudWorkspaceSnapshotKey(workspaceId), event);
+            setState({
+              snapshot: event,
+              lastPatchAt: new Date(),
+              isConnected: true,
+              error: undefined,
+            });
+            return;
+          }
+          if (isCloudWorkspaceProjectionPatch(event)) {
+            cursorRef.current = Math.max(cursorRef.current, event.patch.seq);
+            setState((current) => {
+              const snapshot = reduceWorkspaceSnapshot(current.snapshot, event);
+              if (snapshot) {
+                queryClient.setQueryData(cloudWorkspaceSnapshotKey(workspaceId), snapshot);
+              }
+              return {
+                snapshot,
+                lastPatchAt: new Date(),
+                isConnected: true,
+                error: undefined,
+              };
+            });
+          }
+        },
+        onError(error) {
+          if (!active) {
+            return;
+          }
+          setState((current) => ({
+            ...current,
+            isConnected: false,
+            error: normalizeStreamError(error),
+          }));
+          reconnectTimer = setTimeout(connect, reconnectDelay(attempt++));
+        },
+      });
+    };
+
+    connect();
+    return () => {
+      active = false;
+      subscription?.close();
+      if (reconnectTimer !== undefined) {
+        clearTimeout(reconnectTimer);
+      }
+    };
+  }, [enabled, queryClient, workspaceId]);
+
+  return state;
+}
+
+export function useTargetLive(
+  targetId: string | null,
+  options: CloudLiveHookOptions = {},
+): CloudTargetLiveState {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<CloudTargetLiveState>(emptyLiveState);
+  const cursorRef = useRef(0);
+  const enabled = options.enabled ?? true;
+
+  useEffect(() => {
+    if (!enabled || !targetId) {
+      setState(emptyLiveState());
+      cursorRef.current = 0;
+      return;
+    }
+
+    let active = true;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let attempt = 0;
+    let subscription: { close: () => void } | undefined;
+
+    const connect = () => {
+      if (!active) {
+        return;
+      }
+      subscription?.close();
+      subscription = subscribeTarget(targetId, {
+        afterSeq: cursorRef.current,
+        onEvent(event) {
+          if (!active) {
+            return;
+          }
+          if (isCloudHeartbeat(event)) {
+            setState((current) => ({ ...current, isConnected: true, error: undefined }));
+            return;
+          }
+          attempt = 0;
+          if (isCloudTargetPatch(event)) {
+            queryClient.setQueryData(cloudTargetKey(targetId), event.target);
+            setState({
+              snapshot: { target: event.target },
+              lastPatchAt: new Date(),
+              isConnected: true,
+              error: undefined,
+            });
+            return;
+          }
+          if (isCloudTargetSnapshot(event)) {
+            queryClient.setQueryData(cloudTargetKey(targetId), event.target);
+            setState({
+              snapshot: event,
+              lastPatchAt: new Date(),
+              isConnected: true,
+              error: undefined,
+            });
+            return;
+          }
+          if (isCloudCommandStatusPatch(event)) {
+            queryClient.setQueryData(cloudCommandKey(event.command.commandId), event.command);
+            setState((current) => ({ ...current, isConnected: true, error: undefined }));
+          }
+        },
+        onError(error) {
+          if (!active) {
+            return;
+          }
+          setState((current) => ({
+            ...current,
+            isConnected: false,
+            error: normalizeStreamError(error),
+          }));
+          reconnectTimer = setTimeout(connect, reconnectDelay(attempt++));
+        },
+      });
+    };
+
+    connect();
+    return () => {
+      active = false;
+      subscription?.close();
+      if (reconnectTimer !== undefined) {
+        clearTimeout(reconnectTimer);
+      }
+    };
+  }, [enabled, queryClient, targetId]);
+
+  return state;
+}
+
+export function useCommandStatus(commandId: string | null, options: CloudLiveHookOptions = {}) {
+  const client = useCloudClient();
+  return useQuery<CloudCommandResponse>({
+    queryKey: cloudCommandKey(commandId),
+    queryFn: () => getCommandStatus(commandId!, client),
+    enabled: (options.enabled ?? true) && commandId !== null,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && !["queued", "leased", "delivered"].includes(status) ? false : 2_000;
+    },
+  });
+}
+
+function emptyLiveState<TSnapshot>(): CloudLiveState<TSnapshot> {
+  return {
+    snapshot: undefined,
+    lastPatchAt: undefined,
+    isConnected: false,
+    error: undefined,
+  };
+}
+
+function reconnectDelay(attempt: number): number {
+  const exponentialDelay = MIN_RECONNECT_DELAY_MS * 2 ** Math.min(attempt, 5);
+  return Math.min(exponentialDelay, MAX_RECONNECT_DELAY_MS);
+}
+
+function normalizeStreamError(error: Event): Error {
+  return new Error(error.type || "Cloud live stream disconnected.");
+}
+
 export type {
   CloudCommandStatusPatch,
   CloudLivePatch,

--- a/cloud/sdk-react/src/hooks/workspaces.ts
+++ b/cloud/sdk-react/src/hooks/workspaces.ts
@@ -4,19 +4,41 @@ import {
   getWorkspaceSnapshot,
   type CloudWorkspaceSummary,
   type CloudWorkspaceSnapshot,
+  type CloudWorkspaceListSelection,
+  type CloudWorkspaceListScope,
 } from "@proliferate/cloud-sdk";
 import {
   cloudWorkspacesKey,
   cloudWorkspaceSnapshotKey,
+  personalCloudOwnerKey,
+  type CloudOwnerScope,
 } from "../lib/query-keys.js";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 
-export function useCloudWorkspaces(enabled = true) {
+export interface UseCloudWorkspacesOptions {
+  enabled?: boolean;
+  ownerScope?: CloudOwnerScope;
+  organizationId?: string | null;
+  scope?: CloudWorkspaceListScope | null;
+}
+
+export function useCloudWorkspaces(options: UseCloudWorkspacesOptions | boolean = {}) {
   const client = useCloudClient();
+  const normalizedOptions = typeof options === "boolean" ? { enabled: options } : options;
+  const owner = {
+    ...personalCloudOwnerKey(),
+    ownerScope: normalizedOptions.ownerScope ?? "personal",
+    organizationId: normalizedOptions.organizationId ?? null,
+  };
+  const selection: CloudWorkspaceListSelection = {
+    ownerScope: owner.ownerScope,
+    organizationId: owner.organizationId,
+    scope: normalizedOptions.scope ?? undefined,
+  };
   return useQuery<CloudWorkspaceSummary[]>({
-    queryKey: cloudWorkspacesKey(),
-    queryFn: () => listCloudWorkspaces(undefined, undefined, client),
-    enabled,
+    queryKey: cloudWorkspacesKey(owner, normalizedOptions.scope ?? null),
+    queryFn: () => listCloudWorkspaces(undefined, selection, client),
+    enabled: normalizedOptions.enabled ?? true,
   });
 }
 

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -4,6 +4,7 @@ export * from "./hooks/automations.js";
 export * from "./hooks/agent-auth.js";
 export * from "./hooks/commands.js";
 export * from "./hooks/config.js";
+export * from "./hooks/claims.js";
 export * from "./hooks/events.js";
 export * from "./hooks/live.js";
 export * from "./hooks/organizations.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -118,8 +118,18 @@ export function cloudWorkspaceConnectionKey(
   ] as const;
 }
 
-export function cloudWorkspacesKey() {
-  return [...cloudRootKey(), "workspaces", "list"] as const;
+export function cloudWorkspacesKey(
+  owner: CloudOwnerSelectionKey = personalCloudOwnerKey(),
+  scope: string | null = null,
+) {
+  return [
+    ...cloudRootKey(),
+    "workspaces",
+    "list",
+    owner.ownerScope,
+    owner.organizationId,
+    scope,
+  ] as const;
 }
 
 export function isCloudWorkspaceConnectionQueryKey(

--- a/cloud/sdk/src/client/deep-links.ts
+++ b/cloud/sdk/src/client/deep-links.ts
@@ -1,0 +1,19 @@
+const DEFAULT_WEB_APP_BASE_URL = "https://app.proliferate.ai";
+
+export function webWorkspaceDeepLink(
+  workspaceId: string,
+  baseUrl = DEFAULT_WEB_APP_BASE_URL,
+): string {
+  return `${baseUrl.replace(/\/+$/u, "")}/workspaces/${encodeURIComponent(workspaceId)}`;
+}
+
+export function mobileWorkspaceDeepLink(
+  workspaceId: string,
+  baseUrl = DEFAULT_WEB_APP_BASE_URL,
+): string {
+  return webWorkspaceDeepLink(workspaceId, baseUrl);
+}
+
+export function desktopWorkspaceDeepLink(workspaceId: string): string {
+  return `proliferate://workspaces/${encodeURIComponent(workspaceId)}`;
+}

--- a/cloud/sdk/src/client/workspaces.ts
+++ b/cloud/sdk/src/client/workspaces.ts
@@ -12,7 +12,12 @@ import type {
 } from "../types/index.js";
 import type { CloudOwnerSelection } from "./billing.js";
 
-export type CloudWorkspaceListScope = "my" | "unclaimed" | "claimable" | "org-all";
+export type CloudWorkspaceListScope =
+  | "my"
+  | "unclaimed"
+  | "claimable"
+  | "org-all"
+  | "exposed";
 export type CloudWorkspaceListSelection = CloudOwnerSelection & {
   scope?: CloudWorkspaceListScope;
 };
@@ -72,18 +77,17 @@ export async function listCloudWorkspaces(
     operationId: options?.measurementOperationId,
     category: "cloud.workspace.list",
     method: "GET",
-    run: async () => (
-      await client.GET("/v1/cloud/workspaces", {
-        params: {
-          query: {
-            ownerScope: owner?.ownerScope ?? "personal",
-            organizationId: owner?.organizationId ?? undefined,
-            scope: owner?.scope,
-          },
+    run: async () =>
+      client.requestJson<CloudWorkspaceTransport[]>({
+        method: "GET",
+        path: "/v1/cloud/workspaces",
+        query: {
+          ownerScope: owner?.ownerScope ?? "personal",
+          organizationId: owner?.organizationId ?? undefined,
+          scope: owner?.scope,
         },
         signal: options?.signal,
-      })
-    ).data!,
+      }),
   });
   return data.map((workspace) => normalizeCloudWorkspace(workspace) as CloudWorkspaceSummary);
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1202,6 +1202,77 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/agent-run-configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Run Configs Endpoint */
+        get: operations["list_agent_run_configs_endpoint_v1_cloud_agent_run_configs_get"];
+        put?: never;
+        /** Create Agent Run Config Endpoint */
+        post: operations["create_agent_run_config_endpoint_v1_cloud_agent_run_configs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-run-configs/defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Run Config Defaults Endpoint */
+        get: operations["list_agent_run_config_defaults_endpoint_v1_cloud_agent_run_configs_defaults_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-run-configs/defaults/{agent_kind}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set Agent Run Config Default Endpoint */
+        put: operations["set_agent_run_config_default_endpoint_v1_cloud_agent_run_configs_defaults__agent_kind__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-run-configs/{config_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Agent Run Config Endpoint */
+        get: operations["get_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__get"];
+        put?: never;
+        post?: never;
+        /** Archive Agent Run Config Endpoint */
+        delete: operations["archive_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Agent Run Config Endpoint */
+        patch: operations["update_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__patch"];
+        trace?: never;
+    };
     "/v1/cloud/mcp/catalog": {
         parameters: {
             query?: never;
@@ -1460,6 +1531,144 @@ export interface paths {
         head?: never;
         /** Patch Configured Skill Endpoint */
         patch: operations["patch_configured_skill_endpoint_v1_cloud_skills__item_id__patch"];
+        trace?: never;
+    };
+    "/v1/cloud/slack/oauth/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Start Slack Oauth Endpoint */
+        get: operations["start_slack_oauth_endpoint_v1_cloud_slack_oauth_start_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/oauth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Slack Oauth Callback Endpoint */
+        get: operations["slack_oauth_callback_endpoint_v1_cloud_slack_oauth_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/disconnect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Disconnect Slack Endpoint */
+        post: operations["disconnect_slack_endpoint_v1_cloud_slack_disconnect_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/bot-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Slack Bot Config Endpoint */
+        get: operations["get_slack_bot_config_endpoint_v1_cloud_slack_bot_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Slack Bot Config Endpoint */
+        patch: operations["update_slack_bot_config_endpoint_v1_cloud_slack_bot_config_patch"];
+        trace?: never;
+    };
+    "/v1/cloud/slack/bot-config/validate-connection": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Validate Slack Connection Endpoint */
+        post: operations["validate_slack_connection_endpoint_v1_cloud_slack_bot_config_validate_connection_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Slack Channels Endpoint */
+        get: operations["list_slack_channels_endpoint_v1_cloud_slack_channels_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/repo-routing-profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Slack Repo Routing Profiles Endpoint */
+        get: operations["list_slack_repo_routing_profiles_endpoint_v1_cloud_slack_repo_routing_profiles_get"];
+        /** Upsert Slack Repo Routing Profile Endpoint */
+        put: operations["upsert_slack_repo_routing_profile_endpoint_v1_cloud_slack_repo_routing_profiles_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/slack/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Slack Events Endpoint */
+        post: operations["slack_events_endpoint_v1_cloud_slack_events_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/v1/cloud/webhooks/e2b": {
@@ -3298,6 +3507,156 @@ export interface components {
             /** Revision */
             revision: number;
         };
+        /** AgentRunConfigCreateRequest */
+        AgentRunConfigCreateRequest: {
+            /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "system" | "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Name */
+            name: string;
+            /** Agentkind */
+            agentKind: string;
+            /** Modelid */
+            modelId: string;
+            /** Controlvalues */
+            controlValues?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Usableinpersonalsandboxes
+             * @default true
+             */
+            usableInPersonalSandboxes: boolean;
+            /**
+             * Usableinsharedsandboxes
+             * @default false
+             */
+            usableInSharedSandboxes: boolean;
+        };
+        /** AgentRunConfigDefaultRequest */
+        AgentRunConfigDefaultRequest: {
+            /**
+             * Configid
+             * Format: uuid
+             */
+            configId: string;
+        };
+        /** AgentRunConfigDefaultResponse */
+        AgentRunConfigDefaultResponse: {
+            /** Id */
+            id: string;
+            /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Agentkind */
+            agentKind: string;
+            /** Configid */
+            configId: string;
+            /** Createdbyuserid */
+            createdByUserId: string;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** AgentRunConfigDefaultsResponse */
+        AgentRunConfigDefaultsResponse: {
+            /** Defaults */
+            defaults: components["schemas"]["AgentRunConfigDefaultResponse"][];
+        };
+        /** AgentRunConfigListResponse */
+        AgentRunConfigListResponse: {
+            /** Configs */
+            configs: components["schemas"]["AgentRunConfigResponse"][];
+        };
+        /** AgentRunConfigResolvedSnapshot */
+        AgentRunConfigResolvedSnapshot: {
+            /** Configid */
+            configId: string;
+            /** Configname */
+            configName: string;
+            /** Agentkind */
+            agentKind: string;
+            /** Modelid */
+            modelId: string;
+            /** Controlvalues */
+            controlValues: {
+                [key: string]: unknown;
+            };
+            /** Ignoredkeys */
+            ignoredKeys: string[];
+        };
+        /** AgentRunConfigResponse */
+        AgentRunConfigResponse: {
+            /** Id */
+            id: string;
+            /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "system" | "personal" | "organization";
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Createdbyuserid */
+            createdByUserId: string;
+            /** Name */
+            name: string;
+            /** Agentkind */
+            agentKind: string;
+            /** Modelid */
+            modelId: string;
+            /** Controlvalues */
+            controlValues: {
+                [key: string]: unknown;
+            };
+            /** Usableinpersonalsandboxes */
+            usableInPersonalSandboxes: boolean;
+            /** Usableinsharedsandboxes */
+            usableInSharedSandboxes: boolean;
+            /** Seedkey */
+            seedKey: string | null;
+            /** Systemdefaultrank */
+            systemDefaultRank: number | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "archived";
+            resolved?: components["schemas"]["AgentRunConfigResolvedSnapshot"] | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+            /** Archivedat */
+            archivedAt: string | null;
+        };
+        /** AgentRunConfigUpdateRequest */
+        AgentRunConfigUpdateRequest: {
+            /** Name */
+            name?: string | null;
+            /** Modelid */
+            modelId?: string | null;
+            /** Controlvalues */
+            controlValues?: {
+                [key: string]: unknown;
+            } | null;
+            /** Usableinpersonalsandboxes */
+            usableInPersonalSandboxes?: boolean | null;
+            /** Usableinsharedsandboxes */
+            usableInSharedSandboxes?: boolean | null;
+        };
         /** AnonymousTelemetryAcceptedResponse */
         AnonymousTelemetryAcceptedResponse: {
             /**
@@ -3472,6 +3831,17 @@ export interface components {
         AutomationResponse: {
             /** Id */
             id: string;
+            /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Createdbyuserid */
+            createdByUserId: string;
             /** Gitowner */
             gitOwner: string;
             /** Gitreponame */
@@ -3482,22 +3852,12 @@ export interface components {
             prompt: string;
             schedule: components["schemas"]["AutomationScheduleResponse"];
             /**
-             * Executiontarget
+             * Targetmode
              * @enum {string}
              */
-            executionTarget: "cloud" | "local";
-            /** Targetid */
-            targetId: string | null;
-            /** Targetkind */
-            targetKind: string | null;
-            /** Agentkind */
-            agentKind: string | null;
-            /** Modelid */
-            modelId: string | null;
-            /** Modeid */
-            modeId: string | null;
-            /** Reasoningeffort */
-            reasoningEffort: string | null;
+            targetMode: "local" | "personal_cloud" | "shared_cloud";
+            /** Cloudagentrunconfigid */
+            cloudAgentRunConfigId: string;
             /** Enabled */
             enabled: boolean;
             /** Pausedat */
@@ -3521,6 +3881,17 @@ export interface components {
             /** Automationid */
             automationId: string;
             /**
+             * Ownerscope
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Owneruserid */
+            ownerUserId: string | null;
+            /** Organizationid */
+            organizationId: string | null;
+            /** Createdbyuserid */
+            createdByUserId: string;
+            /**
              * Triggerkind
              * @enum {string}
              */
@@ -3528,14 +3899,10 @@ export interface components {
             /** Scheduledfor */
             scheduledFor: string | null;
             /**
-             * Executiontarget
+             * Targetmode
              * @enum {string}
              */
-            executionTarget: "cloud" | "local";
-            /** Targetidsnapshot */
-            targetIdSnapshot: string | null;
-            /** Targetkindsnapshot */
-            targetKindSnapshot: string | null;
+            targetMode: "local" | "personal_cloud" | "shared_cloud";
             /**
              * Status
              * @enum {string}
@@ -3543,14 +3910,34 @@ export interface components {
             status: "queued" | "claimed" | "creating_workspace" | "provisioning_workspace" | "creating_session" | "dispatching" | "dispatched" | "failed" | "cancelled";
             /** Titlesnapshot */
             titleSnapshot: string;
-            /** Agentkindsnapshot */
-            agentKindSnapshot: string | null;
-            /** Modelidsnapshot */
-            modelIdSnapshot: string | null;
-            /** Modeidsnapshot */
-            modeIdSnapshot: string | null;
-            /** Reasoningeffortsnapshot */
-            reasoningEffortSnapshot: string | null;
+            /** Promptsnapshot */
+            promptSnapshot: string;
+            /** Gitprovidersnapshot */
+            gitProviderSnapshot: string;
+            /** Gitownersnapshot */
+            gitOwnerSnapshot: string;
+            /** Gitreponamesnapshot */
+            gitRepoNameSnapshot: string;
+            /** Cloudrepoconfigidsnapshot */
+            cloudRepoConfigIdSnapshot: string;
+            /** Cloudtargetidsnapshot */
+            cloudTargetIdSnapshot: string | null;
+            /** Cloudtargetkindsnapshot */
+            cloudTargetKindSnapshot: string | null;
+            /** Sandboxprofileid */
+            sandboxProfileId: string | null;
+            /** Cloudworkspaceexposureid */
+            cloudWorkspaceExposureId: string | null;
+            /** Agentrunconfigsnapshot */
+            agentRunConfigSnapshot: {
+                [key: string]: unknown;
+            } | null;
+            /** Cascadeattempt */
+            cascadeAttempt: number;
+            /** Lastcascadecommandid */
+            lastCascadeCommandId: string | null;
+            /** Lastcascadereason */
+            lastCascadeReason: string | null;
             /** Claimexpiresat */
             claimExpiresAt: string | null;
             /** Dispatchstartedat */
@@ -4567,26 +4954,30 @@ export interface components {
             title: string;
             /** Prompt */
             prompt: string;
+            /**
+             * Ownerscope
+             * @default personal
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
             /** Gitowner */
             gitOwner: string;
             /** Gitreponame */
             gitRepoName: string;
             schedule: components["schemas"]["AutomationScheduleRequest"];
             /**
-             * Executiontarget
+             * Targetmode
+             * @default personal_cloud
              * @enum {string}
              */
-            executionTarget: "cloud" | "local";
-            /** Targetid */
-            targetId?: string | null;
-            /** Agentkind */
-            agentKind?: string | null;
-            /** Modelid */
-            modelId?: string | null;
-            /** Modeid */
-            modeId?: string | null;
-            /** Reasoningeffort */
-            reasoningEffort?: string | null;
+            targetMode: "local" | "personal_cloud" | "shared_cloud";
+            /**
+             * Cloudagentrunconfigid
+             * Format: uuid
+             */
+            cloudAgentRunConfigId: string;
         };
         /** CreateCloudCommandRequest */
         CreateCloudCommandRequest: {
@@ -4835,6 +5226,23 @@ export interface components {
              */
             version: string;
         };
+        /** LastSessionSummary */
+        LastSessionSummary: {
+            /** Targetid */
+            targetId: string;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Sessionid */
+            sessionId: string;
+            /** Title */
+            title?: string | null;
+            /** Status */
+            status: string;
+            /** Lasteventat */
+            lastEventAt?: string | null;
+            /** Preview */
+            preview?: string | null;
+        };
         /** LocalAutomationAttachSessionRequest */
         LocalAutomationAttachSessionRequest: {
             /** Executorid */
@@ -4921,10 +5329,10 @@ export interface components {
              */
             status: "queued" | "claimed" | "creating_workspace" | "provisioning_workspace" | "creating_session" | "dispatching" | "dispatched" | "failed" | "cancelled";
             /**
-             * Executiontarget
+             * Targetmode
              * @enum {string}
              */
-            executionTarget: "cloud" | "local";
+            targetMode: "local" | "personal_cloud" | "shared_cloud";
             /** Titlesnapshot */
             titleSnapshot: string;
             /** Promptsnapshot */
@@ -4935,6 +5343,8 @@ export interface components {
             gitOwnerSnapshot: string;
             /** Gitreponamesnapshot */
             gitRepoNameSnapshot: string;
+            /** Cloudagentrunconfigidsnapshot */
+            cloudAgentRunConfigIdSnapshot: string | null;
             /** Agentkindsnapshot */
             agentKindSnapshot: string | null;
             /** Modelidsnapshot */
@@ -5271,7 +5681,7 @@ export interface components {
              * Entrypoint
              * @enum {string}
              */
-            entrypoint: "desktop" | "cloud" | "local_runtime" | "cowork";
+            entrypoint: "desktop" | "web" | "mobile" | "cloud" | "local_runtime" | "cowork" | "slack" | "api";
         };
         /** OverageSettingsRequest */
         OverageSettingsRequest: {
@@ -5944,6 +6354,157 @@ export interface components {
             /** Skills */
             skills: components["schemas"]["SkillConfiguredItemResponse"][];
         };
+        /** SlackBotConfigEnvelopeResponse */
+        SlackBotConfigEnvelopeResponse: {
+            connection: components["schemas"]["SlackConnectionResponse"] | null;
+            config: components["schemas"]["SlackBotConfigResponse"] | null;
+        };
+        /** SlackBotConfigResponse */
+        SlackBotConfigResponse: {
+            /** Id */
+            id: string;
+            /** Organizationid */
+            organizationId: string;
+            /** Slackworkspaceconnectionid */
+            slackWorkspaceConnectionId: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Repomode */
+            repoMode: string;
+            /** Fixedcloudrepoconfigid */
+            fixedCloudRepoConfigId: string | null;
+            /** Allowedcloudrepoconfigids */
+            allowedCloudRepoConfigIds: string[];
+            /** Defaultagentkind */
+            defaultAgentKind: string | null;
+            /** Defaultagentrunconfigid */
+            defaultAgentRunConfigId: string | null;
+            /** Allowedslackchannelids */
+            allowedSlackChannelIds: string[];
+            /** Ackmessagetemplate */
+            ackMessageTemplate: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** SlackBotConfigUpdateRequest */
+        SlackBotConfigUpdateRequest: {
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Repomode */
+            repoMode?: string | null;
+            /** Fixedcloudrepoconfigid */
+            fixedCloudRepoConfigId?: string | null;
+            /** Allowedcloudrepoconfigids */
+            allowedCloudRepoConfigIds?: string[] | null;
+            /** Defaultagentkind */
+            defaultAgentKind?: string | null;
+            /** Defaultagentrunconfigid */
+            defaultAgentRunConfigId?: string | null;
+            /** Allowedslackchannelids */
+            allowedSlackChannelIds?: string[] | null;
+            /** Ackmessagetemplate */
+            ackMessageTemplate?: string | null;
+        };
+        /** SlackChannelResponse */
+        SlackChannelResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Isprivate */
+            isPrivate: boolean;
+            /** Isarchived */
+            isArchived: boolean;
+        };
+        /** SlackChannelsResponse */
+        SlackChannelsResponse: {
+            /** Channels */
+            channels: components["schemas"]["SlackChannelResponse"][];
+        };
+        /** SlackConnectionResponse */
+        SlackConnectionResponse: {
+            /** Id */
+            id: string;
+            /** Organizationid */
+            organizationId: string;
+            /** Slackteamid */
+            slackTeamId: string;
+            /** Slackteamname */
+            slackTeamName: string;
+            /** Slackbotuserid */
+            slackBotUserId: string;
+            /** Botscopes */
+            botScopes: string;
+            /** Status */
+            status: string;
+            /** Installedbyuserid */
+            installedByUserId: string;
+            /** Installedat */
+            installedAt: string;
+            /** Lastvalidatedat */
+            lastValidatedAt: string | null;
+            /** Revokedat */
+            revokedAt: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** SlackRepoRoutingProfileResponse */
+        SlackRepoRoutingProfileResponse: {
+            /** Id */
+            id: string;
+            /** Cloudrepoconfigid */
+            cloudRepoConfigId: string;
+            /** Organizationid */
+            organizationId: string;
+            /** Displayname */
+            displayName: string | null;
+            /** Description */
+            description?: string | null;
+            /** Readmesummary */
+            readmeSummary: string | null;
+            /** Languages */
+            languages: string[];
+            /** Topics */
+            topics: string[];
+            /** Cachedat */
+            cachedAt: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** SlackRepoRoutingProfileUpsertRequest */
+        SlackRepoRoutingProfileUpsertRequest: {
+            /**
+             * Cloudrepoconfigid
+             * Format: uuid
+             */
+            cloudRepoConfigId: string;
+            /** Displayname */
+            displayName?: string | null;
+            /** Description */
+            description?: string | null;
+        };
+        /** SlackRepoRoutingProfilesResponse */
+        SlackRepoRoutingProfilesResponse: {
+            /** Profiles */
+            profiles: components["schemas"]["SlackRepoRoutingProfileResponse"][];
+        };
+        /** SlackValidateConnectionResponse */
+        SlackValidateConnectionResponse: {
+            /** Ok */
+            ok: boolean;
+            /** Status */
+            status: string;
+            /** Teamname */
+            teamName?: string | null;
+            /** Errorcode */
+            errorCode?: string | null;
+        };
         /** StartAuthRequest */
         StartAuthRequest: {
             /**
@@ -6048,7 +6609,7 @@ export interface components {
             /** Workspacename */
             workspaceName?: string | null;
             /** Workspacelocation */
-            workspaceLocation?: ("cloud" | "local") | null;
+            workspaceLocation?: ("local" | "cloud") | null;
         };
         /** SupportMessageRequest */
         SupportMessageRequest: {
@@ -6268,18 +6829,10 @@ export interface components {
             /** Gitreponame */
             gitRepoName?: string | null;
             schedule?: components["schemas"]["AutomationScheduleRequest"] | null;
-            /** Executiontarget */
-            executionTarget?: ("cloud" | "local") | null;
-            /** Targetid */
-            targetId?: string | null;
-            /** Agentkind */
-            agentKind?: string | null;
-            /** Modelid */
-            modelId?: string | null;
-            /** Modeid */
-            modeId?: string | null;
-            /** Reasoningeffort */
-            reasoningEffort?: string | null;
+            /** Targetmode */
+            targetMode?: ("local" | "personal_cloud" | "shared_cloud") | null;
+            /** Cloudagentrunconfigid */
+            cloudAgentRunConfigId?: string | null;
         };
         /** UpdateCloudWorkspaceBranchRequest */
         UpdateCloudWorkspaceBranchRequest: {
@@ -7241,6 +7794,22 @@ export interface components {
              * @enum {string}
              */
             visibility: "private" | "shared_unclaimed" | "claimed" | "archived";
+            exposure?: components["schemas"]["WorkspaceExposureSummary"] | null;
+            /**
+             * Exposurestate
+             * @default untracked
+             * @enum {string}
+             */
+            exposureState: "untracked" | "tracked" | "live" | "paused" | "stale" | "revoked";
+            /**
+             * Sandboxtype
+             * @default managed_personal
+             * @enum {string}
+             */
+            sandboxType: "local" | "ssh" | "managed_personal" | "managed_shared" | "self_hosted";
+            /** Lastactivityat */
+            lastActivityAt?: string | null;
+            lastSessionSummary?: components["schemas"]["LastSessionSummary"] | null;
             /** Claimedbyuserid */
             claimedByUserId?: string | null;
             /** Claimid */
@@ -7267,6 +7836,27 @@ export interface components {
             targetKind: string;
             /** Anyharnessworkspaceid */
             anyharnessWorkspaceId: string;
+        };
+        /** WorkspaceExposureSummary */
+        WorkspaceExposureSummary: {
+            /** Id */
+            id: string;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            visibility: "private" | "shared_unclaimed" | "claimed" | "archived";
+            /** Claimedbyuserid */
+            claimedByUserId?: string | null;
+            /** Defaultprojectionlevel */
+            defaultProjectionLevel: string;
+            /** Commandable */
+            commandable: boolean;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "paused" | "stale" | "revoked";
         };
         /** WorkspaceMobilityPreflightRequest */
         WorkspaceMobilityPreflightRequest: {
@@ -7378,6 +7968,22 @@ export interface components {
              * @enum {string}
              */
             visibility: "private" | "shared_unclaimed" | "claimed" | "archived";
+            exposure?: components["schemas"]["WorkspaceExposureSummary"] | null;
+            /**
+             * Exposurestate
+             * @default untracked
+             * @enum {string}
+             */
+            exposureState: "untracked" | "tracked" | "live" | "paused" | "stale" | "revoked";
+            /**
+             * Sandboxtype
+             * @default managed_personal
+             * @enum {string}
+             */
+            sandboxType: "local" | "ssh" | "managed_personal" | "managed_shared" | "self_hosted";
+            /** Lastactivityat */
+            lastActivityAt?: string | null;
+            lastSessionSummary?: components["schemas"]["LastSessionSummary"] | null;
             /** Claimedbyuserid */
             claimedByUserId?: string | null;
             /** Claimid */
@@ -8678,7 +9284,7 @@ export interface operations {
             query?: {
                 ownerScope?: "personal" | "organization";
                 organizationId?: string | null;
-                scope?: ("my" | "unclaimed" | "claimable" | "org-all") | null;
+                scope?: ("my" | "unclaimed" | "claimable" | "org-all" | "exposed") | null;
             };
             header?: never;
             path?: never;
@@ -9907,6 +10513,241 @@ export interface operations {
             };
         };
     };
+    list_agent_run_configs_endpoint_v1_cloud_agent_run_configs_get: {
+        parameters: {
+            query?: {
+                ownerScope?: string | null;
+                organizationId?: string | null;
+                agentKind?: string | null;
+                usableIn?: string | null;
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_agent_run_config_endpoint_v1_cloud_agent_run_configs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentRunConfigCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_run_config_defaults_endpoint_v1_cloud_agent_run_configs_defaults_get: {
+        parameters: {
+            query?: {
+                ownerScope?: string;
+                organizationId?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigDefaultsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_agent_run_config_default_endpoint_v1_cloud_agent_run_configs_defaults__agent_kind__put: {
+        parameters: {
+            query?: {
+                ownerScope?: string;
+                organizationId?: string | null;
+            };
+            header?: never;
+            path: {
+                agent_kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentRunConfigDefaultRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigDefaultResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentRunConfigUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_cloud_mcp_catalog_endpoint_v1_cloud_mcp_catalog_get: {
         parameters: {
             query?: never;
@@ -10496,6 +11337,329 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SkillConfiguredItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    start_slack_oauth_endpoint_v1_cloud_slack_oauth_start_get: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    slack_oauth_callback_endpoint_v1_cloud_slack_oauth_callback_get: {
+        parameters: {
+            query?: {
+                code?: string | null;
+                state?: string | null;
+                error?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    disconnect_slack_endpoint_v1_cloud_slack_disconnect_post: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackBotConfigEnvelopeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_slack_bot_config_endpoint_v1_cloud_slack_bot_config_get: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackBotConfigEnvelopeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_slack_bot_config_endpoint_v1_cloud_slack_bot_config_patch: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SlackBotConfigUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackBotConfigEnvelopeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    validate_slack_connection_endpoint_v1_cloud_slack_bot_config_validate_connection_post: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackValidateConnectionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_slack_channels_endpoint_v1_cloud_slack_channels_get: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackChannelsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_slack_repo_routing_profiles_endpoint_v1_cloud_slack_repo_routing_profiles_get: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackRepoRoutingProfilesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upsert_slack_repo_routing_profile_endpoint_v1_cloud_slack_repo_routing_profiles_put: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SlackRepoRoutingProfileUpsertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackRepoRoutingProfilesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    slack_events_endpoint_v1_cloud_slack_events_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-slack-request-timestamp"?: string | null;
+                "x-slack-signature"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -12791,7 +13955,10 @@ export interface operations {
     };
     list_automations_endpoint_v1_automations_get: {
         parameters: {
-            query?: never;
+            query?: {
+                ownerScope?: string;
+                organizationId?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -12805,6 +13972,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AutomationListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -12,6 +12,7 @@ export * from "./client/commands.js";
 export * from "./client/compute.js";
 export * from "./client/config.js";
 export * from "./client/events.js";
+export * from "./client/deep-links.js";
 export * from "./client/live.js";
 export * from "./client/mcp_catalog.js";
 export * from "./client/mcp_connections.js";

--- a/cloud/sdk/src/streams/sse.ts
+++ b/cloud/sdk/src/streams/sse.ts
@@ -34,11 +34,17 @@ export function subscribeCloudSse<TEvent>(
   options.signal?.addEventListener("abort", close, { once: true });
   void pumpCloudSse(options, controller.signal, (nextReader) => {
     reader = nextReader;
-  }).catch((error) => {
-    if (!closed && !controller.signal.aborted) {
-      options.onError?.(error instanceof Event ? error : new Event("error"));
-    }
-  });
+  })
+    .then(() => {
+      if (!closed && !controller.signal.aborted) {
+        options.onError?.(new Event("eof"));
+      }
+    })
+    .catch((error) => {
+      if (!closed && !controller.signal.aborted) {
+        options.onError?.(error instanceof Event ? error : new Event("error"));
+      }
+    });
 
   return {
     close,

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -16,6 +16,38 @@ export type CloudWorkspaceVisibility =
   | "claimed"
   | "archived";
 
+export type CloudWorkspaceExposureState =
+  | "untracked"
+  | "tracked"
+  | "live"
+  | "paused"
+  | "stale"
+  | "revoked";
+
+export type CloudWorkspaceSandboxType =
+  | "local"
+  | "ssh"
+  | "managed_personal"
+  | "managed_shared"
+  | "self_hosted";
+
+export interface CloudWorkspaceExposureSummary {
+  id: string;
+  visibility: CloudWorkspaceVisibility;
+  claimedByUserId?: string | null;
+  defaultProjectionLevel: string;
+  commandable: boolean;
+  status: "active" | "paused" | "stale" | "revoked";
+}
+
+export interface CloudWorkspaceLastSessionSummary {
+  sessionId: string;
+  title?: string | null;
+  status: string;
+  lastEventAt?: string | null;
+  preview?: string | null;
+}
+
 export type CloudRuntimeStatus =
   | "pending"
   | "provisioning"
@@ -84,6 +116,11 @@ export type CloudWorkspaceSummary = Omit<
   actionBlockKind?: string | null;
   actionBlockReason?: string | null;
   visibility: CloudWorkspaceVisibility;
+  exposure?: CloudWorkspaceExposureSummary | null;
+  exposureState?: CloudWorkspaceExposureState;
+  sandboxType?: CloudWorkspaceSandboxType;
+  lastActivityAt?: string | null;
+  lastSessionSummary?: CloudWorkspaceLastSessionSummary | null;
 };
 export type CloudWorkspaceDetail = Omit<
   components["schemas"]["WorkspaceDetail"],
@@ -100,6 +137,11 @@ export type CloudWorkspaceDetail = Omit<
   actionBlockKind?: string | null;
   actionBlockReason?: string | null;
   visibility: CloudWorkspaceVisibility;
+  exposure?: CloudWorkspaceExposureSummary | null;
+  exposureState?: CloudWorkspaceExposureState;
+  sandboxType?: CloudWorkspaceSandboxType;
+  lastActivityAt?: string | null;
+  lastSessionSummary?: CloudWorkspaceLastSessionSummary | null;
 };
 export type ClaimWorkspaceRequest = components["schemas"]["ClaimWorkspaceRequest"];
 export type ClaimWorkspaceResponse = components["schemas"]["ClaimWorkspaceResponse"];

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -41,6 +41,8 @@ export interface CloudWorkspaceExposureSummary {
 }
 
 export interface CloudWorkspaceLastSessionSummary {
+  targetId: string;
+  workspaceId?: string | null;
   sessionId: string;
   title?: string | null;
   status: string;

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -21,6 +21,9 @@
       "buildNumber": "4",
       "supportsTablet": true,
       "usesAppleSignIn": true,
+      "associatedDomains": [
+        "applinks:app.proliferate.ai"
+      ],
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
@@ -33,7 +36,24 @@
         "backgroundColor": "#181818"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "app.proliferate.ai",
+              "pathPrefix": "/workspaces/"
+            }
+          ],
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,9 +18,11 @@
   },
   "dependencies": {
     "@proliferate/cloud-sdk": "workspace:*",
+    "@proliferate/cloud-sdk-react": "workspace:*",
     "@proliferate/design": "workspace:*",
     "@proliferate/product-model": "workspace:*",
     "@sentry/react-native": "^8.11.1",
+    "@tanstack/react-query": "^5.95.2",
     "expo": "~54.0.33",
     "expo-apple-authentication": "~8.0.7",
     "expo-application": "~7.0.8",

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -2,6 +2,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { MobileShell } from "./components/shell/MobileShell";
 import { MobileAuthProvider } from "./providers/MobileAuthProvider";
+import { MobileCloudProvider } from "./providers/MobileCloudProvider";
 import { MobileTelemetryProvider } from "./providers/MobileTelemetryProvider";
 
 export default function App() {
@@ -9,7 +10,9 @@ export default function App() {
     <SafeAreaProvider>
       <MobileAuthProvider>
         <MobileTelemetryProvider>
-          <MobileShell />
+          <MobileCloudProvider>
+            <MobileShell />
+          </MobileCloudProvider>
         </MobileTelemetryProvider>
       </MobileAuthProvider>
     </SafeAreaProvider>

--- a/mobile/src/components/chat/MobileChatScreen.tsx
+++ b/mobile/src/components/chat/MobileChatScreen.tsx
@@ -8,30 +8,60 @@ import {
   Text,
   View,
 } from "react-native";
-
-import { deriveClaimState, getPrimaryChatAction } from "@proliferate/product-model/chats/claiming";
-import { chatKindPresentation } from "@proliferate/product-model/chats/presentation";
-import type { ProductChat } from "@proliferate/product-model/chats/model";
+import {
+  useCloudTranscriptSnapshot,
+  useCommandStatus,
+  useEnqueueCloudCommand,
+  useSessionLive,
+} from "@proliferate/cloud-sdk-react";
+import type { CloudTranscriptItem } from "@proliferate/cloud-sdk";
 
 import { MobileIcon } from "../primitives/MobileIcon";
 import { MobileStatusDot } from "../primitives/MobileStatusDot";
 import { MobileTextInput } from "../primitives/MobileTextInput";
 import { MobileTopBar, MobileTopBarIconButton } from "../primitives/MobileTopBar";
-import { chatMessages, currentUser, workspaceForChat } from "../../lib/fixtures/mobile-fixtures";
+import type { MobileCloudChat } from "../../navigation/navigation-model";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 interface MobileChatScreenProps {
-  chat: ProductChat;
+  chat: MobileCloudChat;
   onBack: () => void;
 }
 
+type SendPromptPayload = {
+  text: string;
+};
+
 export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
   const [draft, setDraft] = useState("");
-  const workspace = workspaceForChat(chat);
-  const presentation = chatKindPresentation(chat.kind);
-  const claimState = deriveClaimState(chat, currentUser);
-  const action = getPrimaryChatAction(chat, currentUser);
-  const canSubmit = action.kind === "claim" || Boolean(draft.trim());
+  const [latestCommandId, setLatestCommandId] = useState<string | null>(null);
+  const sessionLive = useSessionLive(chat.sessionId, {
+    targetId: chat.targetId,
+  });
+  const transcript = useCloudTranscriptSnapshot(chat.targetId, chat.sessionId);
+  const enqueuePrompt = useEnqueueCloudCommand<SendPromptPayload>();
+  const commandStatus = useCommandStatus(latestCommandId);
+  const messages = sessionLive.snapshot?.transcriptItems ?? transcript.data?.transcriptItems ?? [];
+  const canSubmit = Boolean(draft.trim() && !enqueuePrompt.isPending);
+
+  async function submitPrompt() {
+    const text = draft.trim();
+    if (!text) {
+      return;
+    }
+    const command = await enqueuePrompt.mutateAsync({
+      idempotencyKey: `mobile:${chat.workspaceId}:${chat.sessionId}:${Date.now()}`,
+      targetId: chat.targetId,
+      workspaceId: chat.workspaceRuntimeId,
+      cloudWorkspaceId: chat.workspaceId,
+      sessionId: chat.sessionId,
+      kind: "send_prompt",
+      source: "mobile",
+      payload: { text },
+    });
+    setLatestCommandId(command.commandId);
+    setDraft("");
+  }
 
   return (
     <KeyboardAvoidingView
@@ -42,11 +72,11 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
       <View style={styles.headerWrapper}>
         <MobileTopBar
           title={chat.title}
-          subtitle={`${workspace?.name ?? "Unknown"} · ${presentation.label}`}
+          subtitle={`${chat.workspaceName} · ${chat.repoLabel}`}
           leading={{ kind: "back", onPress: onBack }}
           trailing={
             <View style={styles.headerStatus}>
-              <MobileStatusDot status={chat.status} />
+              <MobileStatusDot status={mobileStatus(chat.status)} />
               <MobileTopBarIconButton name="more" accessibilityLabel="Chat menu" />
             </View>
           }
@@ -58,7 +88,7 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        {claimState.kind === "unclaimed" ? (
+        {chat.visibility === "shared_unclaimed" ? (
           <View style={styles.claimBanner}>
             <View style={styles.claimIcon}>
               <MobileIcon name="hand" size={16} color={colors.success} />
@@ -66,29 +96,36 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
             <View style={styles.claimText}>
               <Text style={styles.claimTitle}>Unclaimed shared chat</Text>
               <Text style={styles.claimBody}>
-                Claim this to take control. Anyone on the team can pick it up
-                until then.
+                Claim from web or Desktop before taking direct control.
               </Text>
             </View>
           </View>
         ) : null}
 
-        {claimState.kind === "claimed_by_me" ? (
-          <View style={styles.controlNote}>
-            <Text style={styles.controlNoteText}>You control this chat.</Text>
-          </View>
-        ) : null}
+        <View style={styles.controlNote}>
+          <Text style={styles.controlNoteText}>
+            {sessionLive.isConnected ? "Live cloud projection" : "Snapshot projection"}
+          </Text>
+        </View>
 
         <View style={styles.messages}>
-          {chatMessages.map((message) => (
-            <Message key={message.id} role={message.role} body={message.body} />
-          ))}
+          {messages.length > 0 ? (
+            messages.map((message) => <Message key={message.itemId} item={message} />)
+          ) : (
+            <View style={styles.message}>
+              <Text style={styles.messageRole}>system</Text>
+              <Text style={styles.messageBody}>Waiting for projected transcript events.</Text>
+            </View>
+          )}
         </View>
 
-        <View style={styles.actionChips}>
-          <ActionChip icon="git-branch" label="Diff" />
-          <ActionChip icon="external" label="Create PR" />
-        </View>
+        {commandStatus.data?.status ? (
+          <View style={styles.controlNote}>
+            <Text style={styles.controlNoteText}>
+              {commandStatus.data.errorMessage ?? `Command ${commandStatus.data.status}`}
+            </Text>
+          </View>
+        ) : null}
       </ScrollView>
 
       <View style={styles.composer}>
@@ -96,37 +133,30 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
           multiline
           value={draft}
           onChangeText={setDraft}
-          placeholder={
-            action.kind === "claim"
-              ? "Claim and reply..."
-              : "Message this session"
-          }
+          placeholder="Message this session"
           style={styles.composerInput}
         />
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={action.kind === "claim" ? "Claim" : "Send"}
+          accessibilityLabel="Send"
           accessibilityState={{ disabled: !canSubmit }}
           disabled={!canSubmit}
-          onPress={() => setDraft("")}
+          onPress={() => void submitPrompt()}
           style={({ pressed }) => [
             styles.send,
             !canSubmit && styles.sendDisabled,
             pressed && styles.sendPressed,
           ]}
         >
-          <MobileIcon
-            name={action.kind === "claim" ? "hand" : "send"}
-            size={16}
-            color={canSubmit ? colors.background : colors.faint}
-          />
+          <MobileIcon name="send" size={16} color={canSubmit ? colors.background : colors.faint} />
         </Pressable>
       </View>
     </KeyboardAvoidingView>
   );
 }
 
-function Message({ role, body }: { role: string; body: string }) {
+function Message({ item }: { item: CloudTranscriptItem }) {
+  const role = transcriptRole(item);
   const isAssistant = role === "assistant";
   const isSystem = role === "system";
   return (
@@ -138,23 +168,37 @@ function Message({ role, body }: { role: string; body: string }) {
       ]}
     >
       <Text style={styles.messageRole}>{role}</Text>
-      <Text style={styles.messageBody}>{body}</Text>
+      <Text style={styles.messageBody}>
+        {item.text ?? item.title ?? item.kind ?? "Projected event"}
+      </Text>
     </View>
   );
 }
 
-function ActionChip({ icon, label }: { icon: "git-branch" | "external"; label: string }) {
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={{ disabled: true }}
-      disabled
-      style={styles.chip}
-    >
-      <MobileIcon name={icon} size={13} color={colors.mutedForeground} />
-      <Text style={styles.chipText}>{label}</Text>
-    </Pressable>
-  );
+function transcriptRole(item: CloudTranscriptItem): "user" | "assistant" | "system" {
+  if (item.kind === "user_message" || item.kind === "prompt") {
+    return "user";
+  }
+  if (item.kind === "system" || item.kind === "tool") {
+    return "system";
+  }
+  return "assistant";
+}
+
+function mobileStatus(status: string): "running" | "idle" | "paused" | "failed" | "done" {
+  if (status === "running") {
+    return "running";
+  }
+  if (status === "failed" || status === "error") {
+    return "failed";
+  }
+  if (status === "paused") {
+    return "paused";
+  }
+  if (status === "ended" || status === "done" || status === "completed") {
+    return "done";
+  }
+  return "idle";
 }
 
 const styles = StyleSheet.create({
@@ -247,7 +291,7 @@ const styles = StyleSheet.create({
     color: colors.faint,
     fontSize: 10.5,
     fontWeight: "600",
-    letterSpacing: 0.6,
+    letterSpacing: 0,
     textTransform: "uppercase",
     marginBottom: 6,
   },
@@ -255,30 +299,6 @@ const styles = StyleSheet.create({
     color: colors.fg,
     fontSize: 14.5,
     lineHeight: 21,
-  },
-  actionChips: {
-    flexDirection: "row",
-    gap: spacing[2],
-    marginTop: spacing[1],
-  },
-  chip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    paddingHorizontal: spacing[3],
-    paddingVertical: 7,
-    borderRadius: radius.full,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-    backgroundColor: colors.card,
-  },
-  chipPressed: {
-    opacity: 0.78,
-  },
-  chipText: {
-    color: colors.mutedForeground,
-    fontSize: 12.5,
-    fontWeight: "500",
   },
   composer: {
     flexDirection: "row",

--- a/mobile/src/components/chat/MobileChatScreen.tsx
+++ b/mobile/src/components/chat/MobileChatScreen.tsx
@@ -11,6 +11,7 @@ import {
 import {
   useCloudTranscriptSnapshot,
   useCommandStatus,
+  useClaimCloudWorkspace,
   useEnqueueCloudCommand,
   useSessionLive,
 } from "@proliferate/cloud-sdk-react";
@@ -35,14 +36,17 @@ type SendPromptPayload = {
 export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
   const [draft, setDraft] = useState("");
   const [latestCommandId, setLatestCommandId] = useState<string | null>(null);
+  const [claimedLocally, setClaimedLocally] = useState(false);
   const sessionLive = useSessionLive(chat.sessionId, {
     targetId: chat.targetId,
   });
   const transcript = useCloudTranscriptSnapshot(chat.targetId, chat.sessionId);
   const enqueuePrompt = useEnqueueCloudCommand<SendPromptPayload>();
+  const claimWorkspace = useClaimCloudWorkspace();
   const commandStatus = useCommandStatus(latestCommandId);
   const messages = sessionLive.snapshot?.transcriptItems ?? transcript.data?.transcriptItems ?? [];
-  const canSubmit = Boolean(draft.trim() && !enqueuePrompt.isPending);
+  const isUnclaimed = chat.visibility === "shared_unclaimed" && !claimedLocally;
+  const canSubmit = Boolean(draft.trim() && !enqueuePrompt.isPending && !isUnclaimed);
 
   async function submitPrompt() {
     const text = draft.trim();
@@ -61,6 +65,11 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
     });
     setLatestCommandId(command.commandId);
     setDraft("");
+  }
+
+  async function claimChat() {
+    await claimWorkspace.mutateAsync({ workspaceId: chat.workspaceId });
+    setClaimedLocally(true);
   }
 
   return (
@@ -88,7 +97,7 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        {chat.visibility === "shared_unclaimed" ? (
+        {isUnclaimed ? (
           <View style={styles.claimBanner}>
             <View style={styles.claimIcon}>
               <MobileIcon name="hand" size={16} color={colors.success} />
@@ -96,9 +105,25 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
             <View style={styles.claimText}>
               <Text style={styles.claimTitle}>Unclaimed shared chat</Text>
               <Text style={styles.claimBody}>
-                Claim from web or Desktop before taking direct control.
+                Claim this work before sending prompts from mobile.
               </Text>
             </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Claim shared chat"
+              accessibilityState={{ disabled: claimWorkspace.isPending }}
+              disabled={claimWorkspace.isPending}
+              onPress={() => void claimChat()}
+              style={({ pressed }) => [
+                styles.claimButton,
+                claimWorkspace.isPending && styles.claimButtonDisabled,
+                pressed && styles.claimButtonPressed,
+              ]}
+            >
+              <Text style={styles.claimButtonText}>
+                {claimWorkspace.isPending ? "Claiming" : "Claim"}
+              </Text>
+            </Pressable>
           </View>
         ) : null}
 
@@ -133,7 +158,7 @@ export function MobileChatScreen({ chat, onBack }: MobileChatScreenProps) {
           multiline
           value={draft}
           onChangeText={setDraft}
-          placeholder="Message this session"
+          placeholder={isUnclaimed ? "Claim this chat to reply" : "Message this session"}
           style={styles.composerInput}
         />
         <Pressable
@@ -255,6 +280,23 @@ const styles = StyleSheet.create({
     color: colors.mutedForeground,
     fontSize: 12.5,
     lineHeight: 17,
+  },
+  claimButton: {
+    borderRadius: radius.md,
+    backgroundColor: colors.success,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  claimButtonPressed: {
+    opacity: 0.82,
+  },
+  claimButtonDisabled: {
+    opacity: 0.56,
+  },
+  claimButtonText: {
+    color: colors.background,
+    fontSize: 12,
+    fontWeight: "700",
   },
   controlNote: {
     paddingVertical: spacing[2],

--- a/mobile/src/components/home/MobileHomeScreen.tsx
+++ b/mobile/src/components/home/MobileHomeScreen.tsx
@@ -9,7 +9,6 @@ import {
 } from "../primitives/MobileLayout";
 import { MobileIcon, type MobileIconName } from "../primitives/MobileIcon";
 import { MobileTextInput } from "../primitives/MobileTextInput";
-import { workspaces } from "../../lib/fixtures/mobile-fixtures";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 type Mode = "dispatch" | "shared" | "personal";
@@ -58,7 +57,6 @@ export function MobileHomeScreen({ onOpenSessions }: MobileHomeScreenProps) {
   const [mode, setMode] = useState<Mode>("dispatch");
   const [draft, setDraft] = useState("");
   const meta = MODES.find((m) => m.id === mode) ?? MODES[0];
-  const workspace = workspaces[0];
 
   return (
     <MobileScreen>
@@ -114,11 +112,11 @@ export function MobileHomeScreen({ onOpenSessions }: MobileHomeScreenProps) {
               style={styles.composerInput}
             />
             <View style={styles.composerFooter}>
-              {mode === "personal" && workspace ? (
+              {mode === "personal" ? (
                 <View style={styles.context}>
-                  <MobileIcon name="git-branch" size={13} color={colors.faint} />
+                  <MobileIcon name="cloud" size={13} color={colors.faint} />
                   <Text style={styles.contextText} numberOfLines={1}>
-                    {workspace.repoLabel} · {workspace.branchLabel}
+                    Personal cloud sandbox
                   </Text>
                 </View>
               ) : (

--- a/mobile/src/components/sessions/MobileSessionsScreen.tsx
+++ b/mobile/src/components/sessions/MobileSessionsScreen.tsx
@@ -1,51 +1,58 @@
 import { StyleSheet, Text, View } from "react-native";
-
-import { deriveClaimState, isTeamChat } from "@proliferate/product-model/chats/claiming";
-import { chatKindPresentation } from "@proliferate/product-model/chats/presentation";
-import type { ProductChat } from "@proliferate/product-model/chats/model";
+import { useCloudWorkspaces } from "@proliferate/cloud-sdk-react";
+import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
 
 import { MobileIcon } from "../primitives/MobileIcon";
 import { MobileKindIcon } from "../primitives/MobileKindIcon";
 import { MobileListRow } from "../primitives/MobileListRow";
-import { MobileScreen } from "../primitives/MobileLayout";
+import { MobileEmptyState, MobileScreen } from "../primitives/MobileLayout";
 import { MobileStatusDot } from "../primitives/MobileStatusDot";
-import { chats, currentUser, workspaceForChat } from "../../lib/fixtures/mobile-fixtures";
+import type { MobileCloudChat } from "../../navigation/navigation-model";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 interface MobileSessionsScreenProps {
-  onOpenChat: (chat: ProductChat) => void;
+  onOpenChat: (chat: MobileCloudChat) => void;
 }
 
 export function MobileSessionsScreen({ onOpenChat }: MobileSessionsScreenProps) {
+  const workspaces = useCloudWorkspaces({ scope: "exposed" });
+  const chats = (workspaces.data ?? []).flatMap(cloudChatsForWorkspace);
+
   return (
     <MobileScreen contentStyle={styles.screenContent}>
-      <View style={styles.list}>
-        {chats.map((chat) => (
-          <SessionRow
-            key={chat.id}
-            chat={chat}
-            onPress={() => onOpenChat(chat)}
-          />
-        ))}
-      </View>
+      {workspaces.isLoading ? (
+        <MobileEmptyState title="Loading sessions" body="Fetching projected cloud sessions." />
+      ) : workspaces.error ? (
+        <MobileEmptyState title="Could not load sessions" body="Refresh or sign in again." />
+      ) : chats.length === 0 ? (
+        <MobileEmptyState
+          title="No projected sessions"
+          body="Cloud sessions appear here after a workspace has live projection."
+        />
+      ) : (
+        <View style={styles.list}>
+          {chats.map((chat) => (
+            <SessionRow
+              key={`${chat.workspaceId}:${chat.sessionId}`}
+              chat={chat}
+              onPress={() => onOpenChat(chat)}
+            />
+          ))}
+        </View>
+      )}
     </MobileScreen>
   );
 }
 
-function SessionRow({ chat, onPress }: { chat: ProductChat; onPress: () => void }) {
-  const presentation = chatKindPresentation(chat.kind);
-  const workspace = workspaceForChat(chat);
-  const claim = deriveClaimState(chat, currentUser);
-  const unclaimed = isTeamChat(chat.kind) && claim.kind === "unclaimed";
+function SessionRow({ chat, onPress }: { chat: MobileCloudChat; onPress: () => void }) {
+  const unclaimed = chat.visibility === "shared_unclaimed";
 
   return (
     <MobileListRow
       onPress={onPress}
-      leading={<MobileKindIcon kind={chat.kind} />}
+      leading={<MobileKindIcon kind={unclaimed ? "shared-chat" : "cloud"} />}
       title={chat.title}
-      subtitle={`${presentation.label} · ${workspace?.name ?? "Unknown"}${
-        claim.kind === "claimed_by_other" ? ` · ${claim.claimantName}` : ""
-      }`}
+      subtitle={`${chat.workspaceName} · ${chat.repoLabel}`}
       trailing={
         <View style={styles.trailing}>
           {unclaimed ? (
@@ -55,8 +62,8 @@ function SessionRow({ chat, onPress }: { chat: ProductChat; onPress: () => void 
             </View>
           ) : null}
           <View style={styles.statusGroup}>
-            <MobileStatusDot status={chat.status} />
-            <Text style={styles.statusText}>{chatStatusLabel(chat.status)}</Text>
+            <MobileStatusDot status={mobileStatus(chat.status)} />
+            <Text style={styles.statusText}>{chat.status}</Text>
           </View>
         </View>
       }
@@ -64,19 +71,41 @@ function SessionRow({ chat, onPress }: { chat: ProductChat; onPress: () => void 
   );
 }
 
-function chatStatusLabel(status: ProductChat["status"]): string {
-  switch (status) {
-    case "running":
-      return "Running";
-    case "idle":
-      return "Idle";
-    case "paused":
-      return "Paused";
-    case "failed":
-      return "Failed";
-    case "done":
-      return "Done";
+function cloudChatsForWorkspace(workspace: CloudWorkspaceSummary): MobileCloudChat[] {
+  const session = workspace.lastSessionSummary;
+  if (!session) {
+    return [];
   }
+  return [
+    {
+      workspaceId: workspace.id,
+      workspaceName: workspace.displayName ?? workspace.repo.name,
+      repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
+      branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+      targetId: session.targetId,
+      workspaceRuntimeId: session.workspaceId ?? null,
+      sessionId: session.sessionId,
+      title: session.title ?? workspace.displayName ?? workspace.repo.name,
+      status: session.status,
+      visibility: workspace.visibility,
+    },
+  ];
+}
+
+function mobileStatus(status: string): "running" | "idle" | "paused" | "failed" | "done" {
+  if (status === "running") {
+    return "running";
+  }
+  if (status === "failed" || status === "error") {
+    return "failed";
+  }
+  if (status === "paused") {
+    return "paused";
+  }
+  if (status === "ended" || status === "done" || status === "completed") {
+    return "done";
+  }
+  return "idle";
 }
 
 const styles = StyleSheet.create({

--- a/mobile/src/components/shell/MobileShell.tsx
+++ b/mobile/src/components/shell/MobileShell.tsx
@@ -1,8 +1,9 @@
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   BackHandler,
+  Linking,
   Pressable,
   StyleSheet,
   Text,
@@ -10,7 +11,8 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import type { AuthUser } from "@proliferate/cloud-sdk";
+import type { AuthUser, CloudSessionProjection, CloudWorkspaceDetail } from "@proliferate/cloud-sdk";
+import { useCloudWorkspaceSnapshot } from "@proliferate/cloud-sdk-react";
 
 import { MobileAuthScreen } from "../auth/MobileAuthScreen";
 import { MobileConnectGitHubScreen } from "../auth/MobileConnectGitHubScreen";
@@ -48,6 +50,11 @@ export function MobileShell() {
   const [route, setRoute] = useState<RouteId>("home");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedChat, setSelectedChat] = useState<MobileCloudChat | null>(null);
+  const [linkedWorkspaceId, setLinkedWorkspaceId] = useState<string | null>(null);
+  const linkedWorkspace = useCloudWorkspaceSnapshot(
+    linkedWorkspaceId,
+    authState === "active" && linkedWorkspaceId !== null,
+  );
 
   const subtitle = useMemo(() => routeSubtitle(route), [route]);
   const account = useMemo(() => accountSummary(user), [user]);
@@ -61,6 +68,45 @@ export function MobileShell() {
     routeOrScreen: authState === "needs_github" ? "connect_github" : telemetryScreen,
     viewingChat: authState === "active" && selectedChat !== null,
   });
+  const applyWorkspaceLink = useCallback((url: string | null) => {
+    const workspaceId = workspaceIdFromUrl(url);
+    if (!workspaceId) {
+      return;
+    }
+    setLinkedWorkspaceId(workspaceId);
+    setRoute("workspaces");
+    setSelectedChat(null);
+    setDrawerOpen(false);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    void Linking.getInitialURL().then((url) => {
+      if (active) {
+        applyWorkspaceLink(url);
+      }
+    });
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      applyWorkspaceLink(url);
+    });
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, [applyWorkspaceLink]);
+
+  useEffect(() => {
+    if (!linkedWorkspaceId || !linkedWorkspace.data) {
+      return;
+    }
+    const chat = linkedChatForWorkspace(linkedWorkspace.data.workspace, linkedWorkspace.data.sessions);
+    if (chat) {
+      setSelectedChat(chat);
+    } else {
+      setRoute("workspaces");
+    }
+    setLinkedWorkspaceId(null);
+  }, [linkedWorkspace.data, linkedWorkspaceId]);
 
   useEffect(() => {
     const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
@@ -241,6 +287,40 @@ function routeSubtitle(route: RouteId): string | undefined {
     case "settings":
       return "Account · device";
   }
+}
+
+function workspaceIdFromUrl(url: string | null): string | null {
+  if (!url) {
+    return null;
+  }
+  const match = url.match(
+    /^(?:proliferate:\/\/workspaces\/|https:\/\/app\.proliferate\.ai\/workspaces\/)([^/?#]+)/u,
+  );
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+function linkedChatForWorkspace(
+  workspace: CloudWorkspaceDetail,
+  sessions: readonly CloudSessionProjection[],
+): MobileCloudChat | null {
+  const session = [...sessions].sort((left, right) =>
+    (right.lastEventSeq ?? 0) - (left.lastEventSeq ?? 0)
+  )[0];
+  if (!session) {
+    return null;
+  }
+  return {
+    workspaceId: workspace.id,
+    workspaceName: workspace.displayName ?? workspace.repo.name,
+    repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
+    branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+    targetId: session.targetId,
+    workspaceRuntimeId: session.workspaceId ?? null,
+    sessionId: session.sessionId,
+    title: session.title ?? workspace.displayName ?? workspace.repo.name,
+    status: session.status,
+    visibility: workspace.visibility,
+  };
 }
 
 interface DrawerProps {

--- a/mobile/src/components/shell/MobileShell.tsx
+++ b/mobile/src/components/shell/MobileShell.tsx
@@ -10,7 +10,6 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import type { ProductChat } from "@proliferate/product-model/chats/model";
 import type { AuthUser } from "@proliferate/cloud-sdk";
 
 import { MobileAuthScreen } from "../auth/MobileAuthScreen";
@@ -25,8 +24,13 @@ import { MobileSettingsScreen } from "../settings/MobileSettingsScreen";
 import { MobileTopBar, MobileTopBarIconButton } from "../primitives/MobileTopBar";
 import { MobileWorkspacesScreen } from "../workspaces/MobileWorkspacesScreen";
 import { useMobileClientDailyActivity } from "../../hooks/telemetry/use-mobile-client-daily-activity";
-import { drawerRoutes, routeTitle, type RouteId } from "../../navigation/navigation-model";
 import { useMobileScreenTelemetry } from "../../hooks/telemetry/use-mobile-screen-telemetry";
+import {
+  drawerRoutes,
+  routeTitle,
+  type MobileCloudChat,
+  type RouteId,
+} from "../../navigation/navigation-model";
 import { useMobileAuth } from "../../providers/MobileAuthProvider";
 import { colors, radius, shadow, spacing } from "../../styles/tokens";
 
@@ -43,7 +47,7 @@ export function MobileShell() {
   } = useMobileAuth();
   const [route, setRoute] = useState<RouteId>("home");
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedChat, setSelectedChat] = useState<ProductChat | null>(null);
+  const [selectedChat, setSelectedChat] = useState<MobileCloudChat | null>(null);
 
   const subtitle = useMemo(() => routeSubtitle(route), [route]);
   const account = useMemo(() => accountSummary(user), [user]);
@@ -84,7 +88,7 @@ export function MobileShell() {
     setDrawerOpen(false);
   }
 
-  function openChat(chat: ProductChat) {
+  function openChat(chat: MobileCloudChat) {
     setSelectedChat(chat);
     setDrawerOpen(false);
   }

--- a/mobile/src/components/workspaces/MobileWorkspacesScreen.tsx
+++ b/mobile/src/components/workspaces/MobileWorkspacesScreen.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, Text, View } from "react-native";
-
-import type { ProductChat, ProductWorkspace } from "@proliferate/product-model/chats/model";
-import { isTeamChat } from "@proliferate/product-model/chats/claiming";
+import type { ReactNode } from "react";
+import { useCloudWorkspaces } from "@proliferate/cloud-sdk-react";
+import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
 
 import { MobileIcon } from "../primitives/MobileIcon";
 import { MobileListRow } from "../primitives/MobileListRow";
@@ -10,19 +10,26 @@ import {
   MobileScreen,
   MobileSectionLabel,
 } from "../primitives/MobileLayout";
-import { chats, workspaces } from "../../lib/fixtures/mobile-fixtures";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 export function MobileWorkspacesScreen() {
-  const shared = workspaces.filter((workspace) => workspace.kind === "shared");
-  const personal = workspaces.filter((workspace) => workspace.kind !== "shared");
+  const workspaces = useCloudWorkspaces({ scope: "exposed" });
+  const shared = (workspaces.data ?? []).filter((workspace) => workspace.visibility !== "private");
+  const personal = (workspaces.data ?? []).filter((workspace) => workspace.visibility === "private");
 
   return (
     <MobileScreen contentStyle={styles.screenContent}>
-      {workspaces.length === 0 ? (
+      {workspaces.isLoading ? (
+        <MobileEmptyState title="Loading workspaces" body="Fetching cloud workspaces." />
+      ) : workspaces.error ? (
         <MobileEmptyState
-          title="No workspaces yet"
-          body="Create or join a workspace from the desktop app."
+          title="Could not load workspaces"
+          body="Refresh from Desktop or sign in again."
+        />
+      ) : (workspaces.data ?? []).length === 0 ? (
+        <MobileEmptyState
+          title="No cloud workspaces yet"
+          body="Continue a workspace remotely from Desktop to see it here."
         />
       ) : (
         <View style={styles.stack}>
@@ -49,8 +56,11 @@ function Section({
 }: {
   label: string;
   count: number;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
+  if (count === 0) {
+    return null;
+  }
   return (
     <View style={styles.section}>
       <View style={styles.sectionHeader}>
@@ -62,40 +72,37 @@ function Section({
   );
 }
 
-function WorkspaceRow({ workspace }: { workspace: ProductWorkspace }) {
-  const ws = workspace;
-  const wsChats = chats.filter((c) => c.workspaceId === ws.id);
-  const running = wsChats.filter((c) => c.status === "running").length;
-  const unclaimed = wsChats.filter((c: ProductChat) => isTeamChat(c.kind) && !c.claimantUserId).length;
-
+function WorkspaceRow({ workspace }: { workspace: CloudWorkspaceSummary }) {
+  const lastSession = workspace.lastSessionSummary;
   return (
     <MobileListRow
       leading={
         <View style={styles.icon}>
           <MobileIcon
-            name={ws.kind === "shared" ? "users" : "folder"}
+            name={workspace.visibility === "private" ? "folder" : "users"}
             size={17}
             color={colors.mutedForeground}
           />
         </View>
       }
-      title={ws.name}
-      subtitle={`${ws.repoLabel} · ${ws.branchLabel}`}
+      title={workspace.displayName ?? workspace.repo.name}
+      subtitle={`${workspace.repo.owner}/${workspace.repo.name} · ${
+        workspace.repo.branch ?? workspace.repo.baseBranch ?? "main"
+      }`}
       trailing={
         <View style={styles.trailing}>
-          {unclaimed > 0 ? (
+          {workspace.visibility === "shared_unclaimed" ? (
             <View style={styles.unclaimed}>
               <MobileIcon name="hand" size={11} color={colors.success} />
-              <Text style={styles.unclaimedText}>{unclaimed}</Text>
+              <Text style={styles.unclaimedText}>Claim</Text>
             </View>
           ) : null}
           <Text style={styles.meta}>
-            {wsChats.length} chat{wsChats.length === 1 ? "" : "s"}
-            {running ? ` · ${running} running` : ""}
+            {lastSession?.title ?? workspace.exposureState ?? workspace.status}
           </Text>
         </View>
       }
-      showChevron
+      showChevron={Boolean(lastSession)}
     />
   );
 }

--- a/mobile/src/navigation/navigation-model.ts
+++ b/mobile/src/navigation/navigation-model.ts
@@ -8,6 +8,19 @@ export interface DrawerRoute {
   icon: MobileIconName;
 }
 
+export interface MobileCloudChat {
+  workspaceId: string;
+  workspaceName: string;
+  repoLabel: string;
+  branchLabel: string;
+  targetId: string;
+  workspaceRuntimeId: string | null;
+  sessionId: string;
+  title: string;
+  status: string;
+  visibility: string;
+}
+
 export const drawerRoutes: DrawerRoute[] = [
   { id: "home", label: "Home", icon: "home" },
   { id: "workspaces", label: "Workspaces", icon: "workspaces" },

--- a/mobile/src/providers/MobileCloudProvider.tsx
+++ b/mobile/src/providers/MobileCloudProvider.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CloudClientProvider } from "@proliferate/cloud-sdk-react";
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
 
 import { mobileEnv } from "../config/env";
 import { createMobileCloudClient } from "../lib/access/cloud/client";
@@ -10,10 +10,18 @@ const queryClient = new QueryClient();
 
 export function MobileCloudProvider({ children }: { children: ReactNode }) {
   const { accessToken } = useMobileAuth();
+  const previousAccessToken = useRef<string | null>(null);
   const client = useMemo(
     () => createMobileCloudClient(mobileEnv.apiBaseUrl, accessToken),
     [accessToken],
   );
+
+  useEffect(() => {
+    if (previousAccessToken.current !== accessToken) {
+      queryClient.clear();
+      previousAccessToken.current = accessToken;
+    }
+  }, [accessToken]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/mobile/src/providers/MobileCloudProvider.tsx
+++ b/mobile/src/providers/MobileCloudProvider.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CloudClientProvider } from "@proliferate/cloud-sdk-react";
+import { type ReactNode, useMemo } from "react";
+
+import { mobileEnv } from "../config/env";
+import { createMobileCloudClient } from "../lib/access/cloud/client";
+import { useMobileAuth } from "./MobileAuthProvider";
+
+const queryClient = new QueryClient();
+
+export function MobileCloudProvider({ children }: { children: ReactNode }) {
+  const { accessToken } = useMobileAuth();
+  const client = useMemo(
+    () => createMobileCloudClient(mobileEnv.apiBaseUrl, accessToken),
+    [accessToken],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CloudClientProvider client={client}>{children}</CloudClientProvider>
+    </QueryClientProvider>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       '@proliferate/cloud-sdk':
         specifier: workspace:*
         version: link:../cloud/sdk
+      '@proliferate/cloud-sdk-react':
+        specifier: workspace:*
+        version: link:../cloud/sdk-react
       '@proliferate/design':
         specifier: workspace:*
         version: link:../packages/design
@@ -308,6 +311,9 @@ importers:
       '@sentry/react-native':
         specifier: ^8.11.1
         version: 8.11.1(@expo/env@2.0.11)(dotenv@16.6.1)(expo@54.0.34(@babel/core@7.29.0)(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-query':
+        specifier: ^5.95.2
+        version: 5.95.2(react@19.1.0)
       expo:
         specifier: ~54.0.33
         version: 54.0.34(@babel/core@7.29.0)(graphql@16.8.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -19,7 +19,11 @@ from proliferate.constants.cloud import (
     WorkspacePostReadyPhase,
     WorkspaceStatus,
 )
-from proliferate.constants.organizations import ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_ADMIN,
+    ORGANIZATION_ROLE_OWNER,
+)
 from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.exposures import CloudWorkspaceExposure
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
@@ -144,6 +148,76 @@ async def list_claimed_organization_workspaces_for_user(
         .scalars()
         .all()
     )
+
+
+async def list_exposed_cloud_workspaces_for_user(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    organization_id: UUID | None = None,
+) -> list[CloudWorkspace]:
+    personal_query = (
+        select(CloudWorkspace)
+        .join(
+            CloudWorkspaceExposure,
+            CloudWorkspaceExposure.cloud_workspace_id == CloudWorkspace.id,
+        )
+        .where(
+            CloudWorkspace.owner_scope == "personal",
+            CloudWorkspace.owner_user_id == user_id,
+            CloudWorkspace.archived_at.is_(None),
+            CloudWorkspaceExposure.owner_scope == "personal",
+            CloudWorkspaceExposure.owner_user_id == user_id,
+            CloudWorkspaceExposure.archived_at.is_(None),
+            CloudWorkspaceExposure.status == "active",
+        )
+        .order_by(CloudWorkspace.updated_at.desc())
+    )
+    if organization_id is not None:
+        personal_rows: list[CloudWorkspace] = []
+    else:
+        personal_rows = list((await db.execute(personal_query)).scalars().all())
+
+    organization_query = (
+        select(CloudWorkspace)
+        .join(
+            CloudWorkspaceExposure,
+            CloudWorkspaceExposure.cloud_workspace_id == CloudWorkspace.id,
+        )
+        .join(
+            OrganizationMembership,
+            OrganizationMembership.organization_id == CloudWorkspace.organization_id,
+        )
+        .where(
+            CloudWorkspace.owner_scope == "organization",
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            CloudWorkspace.archived_at.is_(None),
+            CloudWorkspaceExposure.owner_scope == "organization",
+            CloudWorkspaceExposure.archived_at.is_(None),
+            CloudWorkspaceExposure.status == "active",
+            (
+                (CloudWorkspaceExposure.visibility == "shared_unclaimed")
+                | (CloudWorkspaceExposure.claimed_by_user_id == user_id)
+                | (
+                    OrganizationMembership.role.in_(
+                        (ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN),
+                    )
+                )
+            ),
+        )
+        .order_by(CloudWorkspace.updated_at.desc())
+    )
+    if organization_id is not None:
+        organization_query = organization_query.where(
+            CloudWorkspace.organization_id == organization_id,
+        )
+    organization_rows = list((await db.execute(organization_query)).scalars().all())
+
+    by_id: dict[UUID, CloudWorkspace] = {}
+    for workspace in [*personal_rows, *organization_rows]:
+        by_id[workspace.id] = workspace
+    return sorted(by_id.values(), key=lambda workspace: workspace.updated_at, reverse=True)
 
 
 async def list_unclaimed_organization_workspaces(

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -38,7 +38,9 @@ router = APIRouter()
 async def list_cloud_workspaces_endpoint(
     owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
     organization_id: UUID | None = Query(default=None, alias="organizationId"),
-    scope: Literal["my", "unclaimed", "claimable", "org-all"] | None = Query(default=None),
+    scope: Literal["my", "unclaimed", "claimable", "org-all", "exposed"] | None = Query(
+        default=None,
+    ),
     user: User = Depends(current_product_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> list[WorkspaceSummary]:

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -29,6 +29,7 @@ class WorkspaceRecord(Protocol):
     git_repo_name: str
     git_branch: str
     git_base_branch: str | None
+    origin: str
     origin_json: str | None
     status: str
     status_detail: str | None
@@ -126,7 +127,16 @@ class OriginContext(BaseModel):
     """Advisory provenance metadata; not authoritative for policy decisions."""
 
     kind: Literal["human", "cowork", "api", "system"]
-    entrypoint: Literal["desktop", "cloud", "local_runtime", "cowork"]
+    entrypoint: Literal[
+        "desktop",
+        "web",
+        "mobile",
+        "cloud",
+        "local_runtime",
+        "cowork",
+        "slack",
+        "api",
+    ]
 
 
 class WorkspaceCreatorContext(BaseModel):
@@ -293,7 +303,7 @@ def _repo_ref(workspace: WorkspaceRecord) -> RepoRef:
 
 def _origin_payload(workspace: WorkspaceRecord) -> OriginContext | None:
     if not workspace.origin_json:
-        return None
+        return _origin_context_from_legacy_origin(workspace.origin)
     try:
         raw = json.loads(workspace.origin_json)
         if not isinstance(raw, dict):
@@ -304,7 +314,23 @@ def _origin_payload(workspace: WorkspaceRecord) -> OriginContext | None:
             "invalid cloud workspace origin JSON",
             extra={"table": "cloud_workspace", "row_id": str(workspace.id), "error": str(exc)},
         )
-        return None
+        return _origin_context_from_legacy_origin(workspace.origin)
+
+
+def _origin_context_from_legacy_origin(origin: str | None) -> OriginContext | None:
+    if origin == "manual_desktop":
+        return OriginContext(kind="human", entrypoint="desktop")
+    if origin == "manual_web":
+        return OriginContext(kind="human", entrypoint="web")
+    if origin == "manual_mobile":
+        return OriginContext(kind="human", entrypoint="mobile")
+    if origin == "automation":
+        return OriginContext(kind="system", entrypoint="cloud")
+    if origin == "slack":
+        return OriginContext(kind="system", entrypoint="slack")
+    if origin == "cowork_api":
+        return OriginContext(kind="api", entrypoint="api")
+    return None
 
 
 def runtime_auth_payload(
@@ -365,7 +391,13 @@ def exposure_state_payload(exposure: WorkspaceExposureRecord | None) -> str:
     return "tracked"
 
 
-def sandbox_type_payload(workspace: WorkspaceRecord) -> str:
+def sandbox_type_payload(workspace: WorkspaceRecord, target_kind: str | None) -> str:
+    if target_kind == "ssh":
+        return "ssh"
+    if target_kind in {"desktop_dispatch", "local_direct"}:
+        return "local"
+    if target_kind == "self_hosted_cloud":
+        return "self_hosted"
     return (
         "managed_shared"
         if getattr(workspace, "owner_scope", None) == "organization"
@@ -401,6 +433,7 @@ def workspace_summary_payload(
     exposure: WorkspaceExposureRecord | None = None,
     claim: WorkspaceClaimRecord | None = None,
     last_session_summary: WorkspaceSessionSummaryRecord | None = None,
+    target_kind: str | None = None,
 ) -> WorkspaceSummary:
     runtime_status = (
         runtime_environment.status
@@ -451,7 +484,7 @@ def workspace_summary_payload(
         visibility=exposure.visibility if exposure is not None else "private",
         exposure=exposure_payload(exposure),
         exposure_state=exposure_state_payload(exposure),
-        sandbox_type=sandbox_type_payload(workspace),
+        sandbox_type=sandbox_type_payload(workspace, target_kind),
         last_activity_at=(
             session_summary.last_event_at
             if session_summary is not None and session_summary.last_event_at is not None
@@ -482,6 +515,7 @@ def workspace_detail_payload(
     exposure: WorkspaceExposureRecord | None = None,
     claim: WorkspaceClaimRecord | None = None,
     last_session_summary: WorkspaceSessionSummaryRecord | None = None,
+    target_kind: str | None = None,
 ) -> WorkspaceDetail:
     summary = workspace_summary_payload(
         workspace,
@@ -494,6 +528,7 @@ def workspace_detail_payload(
         exposure=exposure,
         claim=claim,
         last_session_summary=last_session_summary,
+        target_kind=target_kind,
     )
     return WorkspaceDetail(
         **summary.model_dump(),

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -47,8 +47,13 @@ class WorkspaceRecord(Protocol):
 
 
 class WorkspaceExposureRecord(Protocol):
+    id: UUID
     visibility: str
     claimed_by_user_id: UUID | None
+    default_projection_level: str
+    commandable: bool
+    status: str
+    last_projected_at: datetime | None
 
 
 class WorkspaceClaimRecord(Protocol):
@@ -56,6 +61,13 @@ class WorkspaceClaimRecord(Protocol):
     claimed_by_user_id: UUID | None
     claimed_at: datetime
     source_kind: str
+
+
+class WorkspaceSessionSummaryRecord(Protocol):
+    session_id: str
+    title: str | None
+    status: str
+    last_event_at: str | None
 
 
 class RuntimeEnvironmentRecord(Protocol):
@@ -139,6 +151,23 @@ class WorkspaceDirectTargetContext(BaseModel):
     anyharness_workspace_id: str = Field(serialization_alias="anyharnessWorkspaceId")
 
 
+class WorkspaceExposureSummary(BaseModel):
+    id: str
+    visibility: Literal["private", "shared_unclaimed", "claimed", "archived"]
+    claimed_by_user_id: str | None = Field(default=None, serialization_alias="claimedByUserId")
+    default_projection_level: str = Field(serialization_alias="defaultProjectionLevel")
+    commandable: bool
+    status: Literal["active", "paused", "stale", "revoked"]
+
+
+class LastSessionSummary(BaseModel):
+    session_id: str = Field(serialization_alias="sessionId")
+    title: str | None = None
+    status: str
+    last_event_at: str | None = Field(default=None, serialization_alias="lastEventAt")
+    preview: str | None = None
+
+
 class WorkspaceSummary(BaseModel):
     id: str
     display_name: str | None = Field(serialization_alias="displayName")
@@ -173,6 +202,23 @@ class WorkspaceSummary(BaseModel):
         serialization_alias="directTargetContext",
     )
     visibility: Literal["private", "shared_unclaimed", "claimed", "archived"] = "private"
+    exposure: WorkspaceExposureSummary | None = None
+    exposure_state: Literal["untracked", "tracked", "live", "paused", "stale", "revoked"] = Field(
+        default="untracked",
+        serialization_alias="exposureState",
+    )
+    sandbox_type: Literal[
+        "local",
+        "ssh",
+        "managed_personal",
+        "managed_shared",
+        "self_hosted",
+    ] = Field(default="managed_personal", serialization_alias="sandboxType")
+    last_activity_at: str | None = Field(default=None, serialization_alias="lastActivityAt")
+    last_session_summary: LastSessionSummary | None = Field(
+        default=None,
+        serialization_alias="lastSessionSummary",
+    )
     claimed_by_user_id: str | None = Field(default=None, serialization_alias="claimedByUserId")
     claim_id: str | None = Field(default=None, serialization_alias="claimId")
     claimed_at: str | None = Field(default=None, serialization_alias="claimedAt")
@@ -276,6 +322,67 @@ def runtime_auth_payload(
     )
 
 
+def exposure_payload(exposure: WorkspaceExposureRecord | None) -> WorkspaceExposureSummary | None:
+    if exposure is None:
+        return None
+    visibility = (
+        exposure.visibility
+        if exposure.visibility
+        in {
+            "private",
+            "shared_unclaimed",
+            "claimed",
+            "archived",
+        }
+        else "private"
+    )
+    status = (
+        exposure.status if exposure.status in {"active", "paused", "stale", "revoked"} else "stale"
+    )
+    return WorkspaceExposureSummary(
+        id=str(exposure.id),
+        visibility=visibility,
+        claimed_by_user_id=(
+            str(exposure.claimed_by_user_id) if exposure.claimed_by_user_id is not None else None
+        ),
+        default_projection_level=exposure.default_projection_level,
+        commandable=exposure.commandable,
+        status=status,
+    )
+
+
+def exposure_state_payload(exposure: WorkspaceExposureRecord | None) -> str:
+    if exposure is None:
+        return "untracked"
+    if exposure.status in {"paused", "stale", "revoked"}:
+        return exposure.status
+    if exposure.status == "active" and exposure.last_projected_at is not None:
+        return "live"
+    return "tracked"
+
+
+def sandbox_type_payload(workspace: WorkspaceRecord) -> str:
+    return (
+        "managed_shared"
+        if getattr(workspace, "owner_scope", None) == "organization"
+        else "managed_personal"
+    )
+
+
+def last_session_summary_payload(
+    session: WorkspaceSessionSummaryRecord | None,
+) -> LastSessionSummary | None:
+    if session is None:
+        return None
+    return LastSessionSummary(
+        session_id=session.session_id,
+        title=session.title,
+        status=session.status,
+        last_event_at=session.last_event_at,
+        preview=session.title,
+    )
+
+
 def workspace_summary_payload(
     workspace: WorkspaceRecord,
     *,
@@ -287,6 +394,7 @@ def workspace_summary_payload(
     direct_target_context: WorkspaceDirectTargetContext | None = None,
     exposure: WorkspaceExposureRecord | None = None,
     claim: WorkspaceClaimRecord | None = None,
+    last_session_summary: WorkspaceSessionSummaryRecord | None = None,
 ) -> WorkspaceSummary:
     runtime_status = (
         runtime_environment.status
@@ -298,6 +406,7 @@ def workspace_summary_payload(
     workspace_status = workspace.status
     if workspace_status not in {"pending", "materializing", "ready", "archived", "error"}:
         workspace_status = CloudWorkspaceStatus.error.value
+    session_summary = last_session_summary_payload(last_session_summary)
     return WorkspaceSummary(
         id=str(workspace.id),
         display_name=workspace.display_name,
@@ -334,6 +443,15 @@ def workspace_summary_payload(
         creator_context=creator_context,
         direct_target_context=direct_target_context,
         visibility=exposure.visibility if exposure is not None else "private",
+        exposure=exposure_payload(exposure),
+        exposure_state=exposure_state_payload(exposure),
+        sandbox_type=sandbox_type_payload(workspace),
+        last_activity_at=(
+            session_summary.last_event_at
+            if session_summary is not None and session_summary.last_event_at is not None
+            else _to_iso(workspace.updated_at)
+        ),
+        last_session_summary=session_summary,
         claimed_by_user_id=(
             str(exposure.claimed_by_user_id)
             if exposure is not None and exposure.claimed_by_user_id is not None
@@ -357,6 +475,7 @@ def workspace_detail_payload(
     direct_target_context: WorkspaceDirectTargetContext | None = None,
     exposure: WorkspaceExposureRecord | None = None,
     claim: WorkspaceClaimRecord | None = None,
+    last_session_summary: WorkspaceSessionSummaryRecord | None = None,
 ) -> WorkspaceDetail:
     summary = workspace_summary_payload(
         workspace,
@@ -368,6 +487,7 @@ def workspace_detail_payload(
         direct_target_context=direct_target_context,
         exposure=exposure,
         claim=claim,
+        last_session_summary=last_session_summary,
     )
     return WorkspaceDetail(
         **summary.model_dump(),

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -64,6 +64,8 @@ class WorkspaceClaimRecord(Protocol):
 
 
 class WorkspaceSessionSummaryRecord(Protocol):
+    target_id: UUID
+    workspace_id: str | None
     session_id: str
     title: str | None
     status: str
@@ -161,6 +163,8 @@ class WorkspaceExposureSummary(BaseModel):
 
 
 class LastSessionSummary(BaseModel):
+    target_id: str = Field(serialization_alias="targetId")
+    workspace_id: str | None = Field(default=None, serialization_alias="workspaceId")
     session_id: str = Field(serialization_alias="sessionId")
     title: str | None = None
     status: str
@@ -375,6 +379,8 @@ def last_session_summary_payload(
     if session is None:
         return None
     return LastSessionSummary(
+        target_id=str(session.target_id),
+        workspace_id=session.workspace_id,
         session_id=session.session_id,
         title=session.title,
         status=session.status,

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -45,6 +45,7 @@ from proliferate.db.store.cloud_runtime_environments import (
     load_runtime_environment_for_workspace,
 )
 from proliferate.db.store.cloud_sync import events as events_store
+from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_workspaces import (
     CloudRepoLimitExceededError,
     create_cloud_workspace_for_user,
@@ -336,6 +337,11 @@ async def _workspace_summaries_for_request(
             cloud_workspace_id=workspace.id,
             limit=1,
         )
+        target = (
+            await targets_store.get_target_by_id(db, workspace.target_id)
+            if workspace.target_id is not None
+            else None
+        )
         billing_subject_id = (
             runtime_environment.billing_subject_id
             if runtime_environment is not None
@@ -362,6 +368,7 @@ async def _workspace_summaries_for_request(
                 exposure=exposure,
                 claim=claim,
                 last_session_summary=latest_sessions[0] if latest_sessions else None,
+                target_kind=target.kind if target is not None else None,
             )
         )
     return summaries
@@ -505,6 +512,11 @@ async def _build_workspace_detail_for_request(
         cloud_workspace_id=workspace.id,
         limit=1,
     )
+    target = (
+        await targets_store.get_target_by_id(db, workspace.target_id)
+        if workspace.target_id is not None
+        else None
+    )
     billing = await get_billing_snapshot_for_subject(
         runtime_environment.billing_subject_id
         if runtime_environment is not None
@@ -531,6 +543,7 @@ async def _build_workspace_detail_for_request(
         exposure=exposure,
         claim=claim,
         last_session_summary=latest_sessions[0] if latest_sessions else None,
+        target_kind=target.kind if target is not None else None,
     )
 
 
@@ -552,11 +565,17 @@ async def _build_workspace_detail(
     )
     ready_agent_kind_values = await _load_agent_auth_agent_kinds_for_workspace(workspace)
     latest_sessions = ()
+    target = None
     async with db_engine.async_session_factory() as db:
         latest_sessions = await events_store.list_session_projections_for_workspace(
             db,
             cloud_workspace_id=workspace.id,
             limit=1,
+        )
+        target = (
+            await targets_store.get_target_by_id(db, workspace.target_id)
+            if workspace.target_id is not None
+            else None
         )
     billing = await get_billing_snapshot_for_subject(
         runtime_environment.billing_subject_id
@@ -584,6 +603,7 @@ async def _build_workspace_detail(
         exposure=exposure,
         claim=claim,
         last_session_summary=latest_sessions[0] if latest_sessions else None,
+        target_kind=target.kind if target is not None else None,
     )
 
 

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -44,11 +44,13 @@ from proliferate.db.store.cloud_runtime_environments import (
     get_runtime_environment_for_workspace,
     load_runtime_environment_for_workspace,
 )
+from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_workspaces import (
     CloudRepoLimitExceededError,
     create_cloud_workspace_for_user,
     delete_cloud_workspace_records_for_workspace,
     list_claimed_organization_workspaces_for_user,
+    list_exposed_cloud_workspaces_for_user,
     list_organization_workspaces_for_admin_audit,
     list_unclaimed_organization_workspaces,
     load_active_sandbox_for_workspace,
@@ -272,12 +274,26 @@ async def list_cloud_workspaces_for_user(
             )
         return await _workspace_summaries_for_request(db, user_id=user_id, workspaces=workspaces)
 
+    if list_scope == "exposed":
+        organization_id = (
+            owner_selection.organization_id
+            if owner_selection is not None and owner_selection.owner_scope == "organization"
+            else None
+        )
+        workspaces = await list_exposed_cloud_workspaces_for_user(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        return await _workspace_summaries_for_request(db, user_id=user_id, workspaces=workspaces)
+
     if list_scope != "my":
         raise CloudApiError(
             "invalid_workspace_scope",
             "Unsupported workspace scope.",
             status_code=400,
         )
+
     workspaces = await list_cloud_workspaces_store(db, user_id)
     claimed_workspaces = await list_claimed_organization_workspaces_for_user(
         db,
@@ -315,6 +331,11 @@ async def _workspace_summaries_for_request(
             workspace=workspace,
             runtime_environment=runtime_environment,
         )
+        latest_sessions = await events_store.list_session_projections_for_workspace(
+            db,
+            cloud_workspace_id=workspace.id,
+            limit=1,
+        )
         billing_subject_id = (
             runtime_environment.billing_subject_id
             if runtime_environment is not None
@@ -340,6 +361,7 @@ async def _workspace_summaries_for_request(
                 ),
                 exposure=exposure,
                 claim=claim,
+                last_session_summary=latest_sessions[0] if latest_sessions else None,
             )
         )
     return summaries
@@ -478,6 +500,11 @@ async def _build_workspace_detail_for_request(
         runtime_environment=runtime_environment,
     )
     ready_agent_kind_values = await _agent_auth_agent_kinds_for_workspace_request(db, workspace)
+    latest_sessions = await events_store.list_session_projections_for_workspace(
+        db,
+        cloud_workspace_id=workspace.id,
+        limit=1,
+    )
     billing = await get_billing_snapshot_for_subject(
         runtime_environment.billing_subject_id
         if runtime_environment is not None
@@ -503,6 +530,7 @@ async def _build_workspace_detail_for_request(
         ),
         exposure=exposure,
         claim=claim,
+        last_session_summary=latest_sessions[0] if latest_sessions else None,
     )
 
 
@@ -523,6 +551,13 @@ async def _build_workspace_detail(
         runtime_environment=runtime_environment,
     )
     ready_agent_kind_values = await _load_agent_auth_agent_kinds_for_workspace(workspace)
+    latest_sessions = ()
+    async with db_engine.async_session_factory() as db:
+        latest_sessions = await events_store.list_session_projections_for_workspace(
+            db,
+            cloud_workspace_id=workspace.id,
+            limit=1,
+        )
     billing = await get_billing_snapshot_for_subject(
         runtime_environment.billing_subject_id
         if runtime_environment is not None
@@ -548,6 +583,7 @@ async def _build_workspace_detail(
         ),
         exposure=exposure,
         claim=claim,
+        last_session_summary=latest_sessions[0] if latest_sessions else None,
     )
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ export function App() {
         <Route path="plugins" element={<PluginsPage />} />
         <Route path="support" element={<SupportPage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="workspaces/:workspaceId" element={<ChatPage />} />
         <Route path="workspaces/:workspaceId/chats/:chatId" element={<ChatPage />} />
         <Route path="*" element={<Navigate to={routes.home} replace />} />
       </Route>

--- a/web/src/components/app/navigation/WebSidebarController.tsx
+++ b/web/src/components/app/navigation/WebSidebarController.tsx
@@ -1,55 +1,31 @@
 import {
   Calendar,
-  ChevronRight,
   CircleHelp,
-  Folder,
-  FolderOpen,
   Grid2X2,
   Home,
-  MoreHorizontal,
   Settings,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import type {
   SidebarActionEvent,
-  SidebarChatRowView,
   SidebarNavItemView,
-  SidebarWorkspaceGroupView,
-  SidebarWorkspaceRowView,
 } from "@proliferate/product-ui/sidebar/ProductSidebar";
 import { ProductSidebar } from "@proliferate/product-ui/sidebar/ProductSidebar";
-import {
-  deriveClaimState,
-  isTeamChat,
-} from "@proliferate/product-model/chats/claiming";
-import type { ProductChat, ProductWorkspace } from "@proliferate/product-model/chats/model";
 
 import { routes } from "../../../config/routes";
-import {
-  chats,
-  currentUser,
-  workspaceForChat,
-} from "../../../lib/fixtures/web-fixtures";
 
 export function WebSidebarController() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
 
   const navItems = useMemo(
     () => buildNavItems(location.pathname),
     [location.pathname],
   );
-  const workspaceGroups = useMemo(
-    () => buildWorkspaceGroups(location.pathname, collapsedGroups),
-    [collapsedGroups, location.pathname],
-  );
-  const chatRows = useMemo(
-    () => buildUnclaimedRows(location.pathname),
-    [location.pathname],
-  );
+  const workspaceGroups = useMemo(() => [], []);
+  const chatRows = useMemo(() => [], []);
 
   function navigateByNavId(id: string) {
     switch (id) {
@@ -68,18 +44,6 @@ export function WebSidebarController() {
       default:
         return;
     }
-  }
-
-  function handleGroupToggle(id: string) {
-    setCollapsedGroups((current) => {
-      const next = new Set(current);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
   }
 
   function handleAction(event: SidebarActionEvent) {
@@ -102,19 +66,9 @@ export function WebSidebarController() {
           },
         ]}
         onNavSelect={navigateByNavId}
-        onWorkspaceSelect={(chatId) => {
-          const chat = chats.find((item) => item.id === chatId);
-          if (chat) {
-            navigate(routes.chat(chat.workspaceId, chat.id));
-          }
-        }}
-        onChatSelect={(chatId) => {
-          const chat = chats.find((item) => item.id === chatId);
-          if (chat) {
-            navigate(routes.chat(chat.workspaceId, chat.id));
-          }
-        }}
-        onGroupToggle={handleGroupToggle}
+        onWorkspaceSelect={() => undefined}
+        onChatSelect={() => undefined}
+        onGroupToggle={() => undefined}
         onAction={handleAction}
       />
     </div>
@@ -148,114 +102,4 @@ function buildNavItems(pathname: string): SidebarNavItemView[] {
       active: pathname.startsWith(routes.support),
     },
   ];
-}
-
-function buildWorkspaceGroups(
-  pathname: string,
-  collapsedGroups: Set<string>,
-): SidebarWorkspaceGroupView[] {
-  const groupsByRepo = new Map<string, {
-    id: string;
-    label: string;
-    chats: Array<{ chat: ProductChat; workspace: ProductWorkspace }>;
-  }>();
-
-  for (const chat of chats) {
-    const workspace = workspaceForChat(chat);
-    if (!workspace) {
-      continue;
-    }
-    const repoKey = repoNameFromLabel(workspace.repoLabel);
-    const existing = groupsByRepo.get(repoKey);
-    if (existing) {
-      existing.chats.push({ chat, workspace });
-      continue;
-    }
-    groupsByRepo.set(repoKey, {
-      id: repoKey,
-      label: repoKey,
-      chats: [{ chat, workspace }],
-    });
-  }
-
-  return [...groupsByRepo.values()].map((group) => ({
-    id: group.id,
-    label: group.label,
-    count: group.chats.length,
-    collapsed: collapsedGroups.has(group.id),
-    icon: <Folder className="size-3.5 shrink-0" />,
-    expandedIcon: <FolderOpen className="size-3.5 shrink-0" />,
-    hoverIcon: (
-      <ChevronRight
-        className={`size-3 transition-transform ${collapsedGroups.has(group.id) ? "" : "rotate-90"}`}
-      />
-    ),
-    rows: group.chats.map(({ chat }) => buildChatWorkspaceRow(chat, pathname)),
-    actions: [],
-  }));
-}
-
-function repoNameFromLabel(repoLabel: string): string {
-  const normalized = repoLabel.trim();
-  const parts = normalized.split("/").filter(Boolean);
-  return parts.at(-1) ?? normalized;
-}
-
-function buildChatWorkspaceRow(
-  chat: ProductChat,
-  pathname: string,
-): SidebarWorkspaceRowView {
-  return {
-    id: chat.id,
-    label: chat.title,
-    subtitle: null,
-    active: pathname === routes.chat(chat.workspaceId, chat.id),
-    status: <StatusDot status={chat.status} />,
-    trailingLabel: compactRecencyLabel(chat.id),
-    actions: [
-      {
-        id: "more",
-        label: "More actions",
-        icon: <MoreHorizontal className="size-3.5" />,
-      },
-    ],
-  };
-}
-
-function buildUnclaimedRows(pathname: string): SidebarChatRowView[] {
-  return chats
-    .filter((chat) => isTeamChat(chat.kind) && deriveClaimState(chat, currentUser).kind === "unclaimed")
-    .map((chat) => ({
-      id: chat.id,
-      label: chat.title,
-      subtitle: null,
-      active: pathname === routes.chat(chat.workspaceId, chat.id),
-      status: <StatusDot status={chat.status} />,
-      trailingLabel: compactRecencyLabel(chat.id),
-    }));
-}
-
-function compactRecencyLabel(chatId: string): string {
-  const labels: Record<string, string> = {
-    "slack-1": "2w",
-    "automation-1": "2w",
-    "shared-chat-1": "1m",
-    "slack-2": "23h",
-    "cloud-1": "1d",
-    "dispatch-1": "2d",
-    "cloud-2": "2d",
-  };
-  return labels[chatId] ?? "2w";
-}
-
-function StatusDot({ status }: { status: ProductChat["status"] }) {
-  const className =
-    status === "running"
-      ? "bg-success"
-      : status === "failed"
-        ? "bg-destructive"
-        : status === "done"
-          ? "bg-info"
-          : "bg-muted-foreground/60";
-  return <span className={`block size-1.5 rounded-full ${className}`} />;
 }

--- a/web/src/components/automations/screen/AutomationsScreen.tsx
+++ b/web/src/components/automations/screen/AutomationsScreen.tsx
@@ -20,7 +20,7 @@ export function AutomationsScreen() {
           title: automation.title,
           repo: `${automation.gitOwner}/${automation.gitRepoName}`,
           schedule: automation.schedule.summary,
-          target: automation.executionTarget,
+          target: automation.targetMode,
           lastRun: automation.lastScheduledAt,
           enabled: automation.enabled,
         }))}

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -1,109 +1,248 @@
-import { useMemo } from "react";
+import {
+  ArrowLeft,
+  ExternalLink,
+  GitBranch,
+  MoreHorizontal,
+  Send,
+  Users,
+} from "lucide-react";
+import { useMemo, useState, type FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import {
+  desktopWorkspaceDeepLink,
+  type CloudSessionProjection,
+  type CloudTranscriptItem,
+} from "@proliferate/cloud-sdk";
+import {
+  useClaimCloudWorkspace,
+  useCloudTranscriptSnapshot,
+  useCloudWorkspaceSnapshot,
+  useCommandStatus,
+  useEnqueueCloudCommand,
+  useSessionLive,
+  useWorkspaceLive,
+} from "@proliferate/cloud-sdk-react";
 
-import { ChatPreviewSurface, type ChatPreviewMessageView } from "@proliferate/product-ui/chat/ChatPreviewSurface";
-import type { ClaimBannerView } from "@proliferate/product-ui/chat/ClaimBanner";
-import { ProductPageShell } from "@proliferate/product-ui/layout/ProductPageShell";
-import { EmptyState } from "@proliferate/ui/layout/EmptyState";
-import { deriveClaimState, getPrimaryChatAction } from "@proliferate/product-model/chats/claiming";
-import type { ClaimState } from "@proliferate/product-model/chats/model";
-import { chatKindPresentation, claimStateLabel } from "@proliferate/product-model/chats/presentation";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { IconButton } from "@proliferate/ui/primitives/IconButton";
+import { Textarea } from "@proliferate/ui/primitives/Textarea";
 
 import { routes } from "../../../config/routes";
-import {
-  chatMessages,
-  chats,
-  currentUser,
-  workspaces,
-  workspaceForChat,
-} from "../../../lib/fixtures/web-fixtures";
 
-function statusLabel(status: string) {
-  return status.charAt(0).toUpperCase() + status.slice(1);
-}
+type SendPromptPayload = {
+  text: string;
+};
 
 export function ChatScreen() {
   const { workspaceId, chatId } = useParams();
   const navigate = useNavigate();
-  const chat = chats.find((candidate) => candidate.id === chatId && candidate.workspaceId === workspaceId);
-  const workspace = chat ? workspaceForChat(chat) : workspaces[0];
-  const messages = useMemo(() => (chat ? chatMessages[chat.id] ?? [] : []), [chat]);
+  const [draft, setDraft] = useState("");
+  const [latestCommandId, setLatestCommandId] = useState<string | null>(null);
+  const workspaceQuery = useCloudWorkspaceSnapshot(workspaceId ?? null, Boolean(workspaceId));
+  const workspaceLive = useWorkspaceLive(workspaceId ?? null, { enabled: Boolean(workspaceId) });
+  const snapshot = workspaceLive.snapshot ?? workspaceQuery.data;
+  const workspace = snapshot?.workspace;
+  const sessions = useMemo(
+    () => [...(snapshot?.sessions ?? [])].sort(compareSessions),
+    [snapshot?.sessions],
+  );
+  const session =
+    sessions.find((candidate) => candidate.sessionId === chatId) ?? sessions[0] ?? null;
+  const sessionLive = useSessionLive(session?.sessionId ?? null, {
+    targetId: session?.targetId ?? null,
+    enabled: Boolean(session),
+  });
+  const transcriptQuery = useCloudTranscriptSnapshot(
+    session?.targetId ?? null,
+    session?.sessionId ?? null,
+    Boolean(session),
+  );
+  const transcriptItems =
+    sessionLive.snapshot?.transcriptItems ?? transcriptQuery.data?.transcriptItems ?? [];
+  const enqueuePrompt = useEnqueueCloudCommand<SendPromptPayload>();
+  const claimWorkspace = useClaimCloudWorkspace();
+  const commandStatus = useCommandStatus(latestCommandId);
 
-  if (!chat || !workspace) {
-    return (
-      <ProductPageShell
-        title="Session not found"
-        description="The mocked session route does not exist."
-        telemetryBlocked
-      >
-        <EmptyState title="Session not found" description="Go home and choose another session." />
-      </ProductPageShell>
-    );
+  async function submitPrompt(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const text = draft.trim();
+    if (!text || !workspace || !session) {
+      return;
+    }
+    const command = await enqueuePrompt.mutateAsync({
+      idempotencyKey: `web:${workspace.id}:${session.sessionId}:${Date.now()}`,
+      targetId: session.targetId,
+      workspaceId: session.workspaceId,
+      cloudWorkspaceId: workspace.id,
+      sessionId: session.sessionId,
+      kind: "send_prompt",
+      source: "web",
+      payload: { text },
+    });
+    setLatestCommandId(command.commandId);
+    setDraft("");
   }
 
-  const presentation = chatKindPresentation(chat.kind);
-  const claimState = deriveClaimState(chat, currentUser);
-  const primaryAction = getPrimaryChatAction(chat, currentUser);
+  if (!workspaceId) {
+    return <MissingState title="Workspace not found" />;
+  }
+
+  if (workspaceQuery.isLoading && !snapshot) {
+    return <MissingState title="Loading workspace" />;
+  }
+
+  if (workspaceQuery.error || !workspace) {
+    return <MissingState title="Workspace not available" />;
+  }
+
+  const canSubmit = Boolean(draft.trim() && session && !enqueuePrompt.isPending);
+  const sessionTitle = session?.title ?? workspace.displayName ?? workspace.repo.name;
+  const commandMessage =
+    commandStatus.data?.errorMessage ??
+    (commandStatus.data?.status ? `Command ${commandStatus.data.status}` : null);
 
   return (
-    <ChatPreviewSurface
-      title={chat.title}
-      eyebrowItems={[presentation.label, claimStateLabel(claimState), statusLabel(chat.status)]}
-      branchLabel={workspace.branchLabel}
-      repoLabel={workspace.repoLabel}
-      descriptionLabel={presentation.description}
-      claimBanner={buildClaimBannerView(claimState)}
-      messages={buildMessages(messages)}
-      primaryAction={
-        primaryAction.kind === "none"
-          ? null
-          : {
-              label: primaryAction.label,
-              kind: primaryAction.kind === "claim" ? "claim" : "continue",
-            }
-      }
-      telemetryBlocked
-      onBack={() => navigate(routes.home)}
-    />
+    <div className="flex h-full flex-col">
+      <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border px-4">
+        <IconButton title="Back" onClick={() => navigate(routes.workspaces)}>
+          <ArrowLeft size={16} />
+        </IconButton>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{workspace.sandboxType ?? "cloud"}</span>
+            <span>-</span>
+            <span>{workspace.exposureState ?? "tracked"}</span>
+            <span>-</span>
+            <span>{session?.status ?? workspace.status}</span>
+          </div>
+          <h1 className="truncate text-sm font-semibold">{sessionTitle}</h1>
+        </div>
+        {workspace.visibility === "shared_unclaimed" && (
+          <Button
+            variant="secondary"
+            size="sm"
+            loading={claimWorkspace.isPending}
+            onClick={() => claimWorkspace.mutate({ workspaceId: workspace.id })}
+          >
+            <Users size={14} />
+            Claim
+          </Button>
+        )}
+        <a
+          href={desktopWorkspaceDeepLink(workspace.id)}
+          className="inline-flex h-8 items-center gap-2 rounded-md border border-input px-3 text-xs text-muted-foreground hover:bg-accent"
+        >
+          <ExternalLink size={14} />
+          Desktop
+        </a>
+        <IconButton title="Session menu">
+          <MoreHorizontal size={16} />
+        </IconButton>
+      </header>
+
+      <div className="web-scrollbar min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-3xl px-6 py-6">
+          <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1">
+              <GitBranch size={13} />
+              {workspace.repo.branch ?? workspace.repo.baseBranch ?? "main"}
+            </span>
+            <span className="rounded-md border border-border px-2 py-1">
+              {workspace.repo.owner}/{workspace.repo.name}
+            </span>
+            {workspace.visibility !== "private" && (
+              <span className="rounded-md border border-border px-2 py-1">
+                {workspace.visibility}
+              </span>
+            )}
+            <span className="rounded-md border border-border px-2 py-1">
+              {sessionLive.isConnected ? "Live" : "Snapshot"}
+            </span>
+          </div>
+
+          {!session ? (
+            <div className="rounded-lg border border-dashed border-border bg-card p-5 text-sm text-muted-foreground">
+              No projected sessions are available for this workspace yet.
+            </div>
+          ) : transcriptItems.length > 0 ? (
+            <div className="space-y-3">
+              {transcriptItems.map((item) => (
+                <TranscriptMessage key={item.itemId} item={item} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground">
+              Waiting for the first projected transcript event.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <footer className="shrink-0 border-t border-border p-4">
+        <form
+          onSubmit={(event) => void submitPrompt(event)}
+          className="mx-auto flex max-w-3xl items-end gap-2 rounded-lg border border-input bg-card p-2"
+        >
+          <Textarea
+            rows={2}
+            value={draft}
+            onChange={(event) => setDraft(event.currentTarget.value)}
+            disabled={!session}
+            className="min-h-10 flex-1 resize-none bg-transparent px-2 py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            placeholder={session ? "Message this session" : "No active projected session"}
+          />
+          <Button size="icon" aria-label="Send message" disabled={!canSubmit}>
+            <Send size={15} />
+          </Button>
+        </form>
+        {commandMessage && (
+          <p className="mx-auto mt-2 max-w-3xl text-xs text-muted-foreground">{commandMessage}</p>
+        )}
+      </footer>
+    </div>
   );
 }
 
-function buildClaimBannerView(claimState: ClaimState): ClaimBannerView {
-  if (claimState.kind === "unclaimed") {
-    return {
-      kind: "unclaimed",
-      title: "Unclaimed shared session",
-      description: "Claim this session before continuing it from Desktop.",
-      actionLabel: "Claim",
-    };
-  }
-
-  if (claimState.kind === "claimed_by_other") {
-    return {
-      kind: "claimed_by_other",
-      claimantName: claimState.claimantName,
-      description: "Only the current claimant can continue this shared session from Desktop.",
-    };
-  }
-
-  return { kind: "hidden" };
+function TranscriptMessage({ item }: { item: CloudTranscriptItem }) {
+  const role = transcriptRole(item);
+  return (
+    <article
+      className={`rounded-lg border border-border p-4 ${
+        role === "assistant" ? "bg-card" : "bg-background"
+      }`}
+    >
+      <div className="mb-2 text-xs font-medium uppercase text-muted-foreground">{role}</div>
+      <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+        {item.text ?? item.title ?? item.kind ?? "Projected event"}
+      </p>
+    </article>
+  );
 }
 
-function buildMessages(messages: typeof chatMessages[string]): ChatPreviewMessageView[] {
-  if (messages.length > 0) {
-    return messages;
-  }
+function MissingState({ title }: { title: string }) {
+  const navigate = useNavigate();
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="rounded-lg border border-border bg-card p-6 text-center">
+        <h1 className="text-lg font-semibold">{title}</h1>
+        <Button className="mt-4" onClick={() => navigate(routes.workspaces)}>
+          Go to workspaces
+        </Button>
+      </div>
+    </div>
+  );
+}
 
-  return [
-    {
-      id: "fallback-user",
-      role: "user",
-      body: "Open this session and show the latest mocked workspace context.",
-    },
-    {
-      id: "fallback-assistant",
-      role: "assistant",
-      body: "Loaded the workspace state, active branch, and claim metadata for this preview session.",
-    },
-  ];
+function compareSessions(left: CloudSessionProjection, right: CloudSessionProjection): number {
+  return (right.lastEventSeq ?? 0) - (left.lastEventSeq ?? 0);
+}
+
+function transcriptRole(item: CloudTranscriptItem): "user" | "assistant" | "system" {
+  if (item.kind === "user_message" || item.kind === "prompt") {
+    return "user";
+  }
+  if (item.kind === "system" || item.kind === "tool") {
+    return "system";
+  }
+  return "assistant";
 }

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -62,6 +62,7 @@ export function ChatScreen() {
   const enqueuePrompt = useEnqueueCloudCommand<SendPromptPayload>();
   const claimWorkspace = useClaimCloudWorkspace();
   const commandStatus = useCommandStatus(latestCommandId);
+  const isUnclaimed = workspace?.visibility === "shared_unclaimed";
 
   async function submitPrompt(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -95,7 +96,7 @@ export function ChatScreen() {
     return <MissingState title="Workspace not available" />;
   }
 
-  const canSubmit = Boolean(draft.trim() && session && !enqueuePrompt.isPending);
+  const canSubmit = Boolean(draft.trim() && session && !enqueuePrompt.isPending && !isUnclaimed);
   const sessionTitle = session?.title ?? workspace.displayName ?? workspace.repo.name;
   const commandMessage =
     commandStatus.data?.errorMessage ??
@@ -117,7 +118,7 @@ export function ChatScreen() {
           </div>
           <h1 className="truncate text-sm font-semibold">{sessionTitle}</h1>
         </div>
-        {workspace.visibility === "shared_unclaimed" && (
+        {isUnclaimed && (
           <Button
             variant="secondary"
             size="sm"
@@ -189,7 +190,13 @@ export function ChatScreen() {
             onChange={(event) => setDraft(event.currentTarget.value)}
             disabled={!session}
             className="min-h-10 flex-1 resize-none bg-transparent px-2 py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground"
-            placeholder={session ? "Message this session" : "No active projected session"}
+            placeholder={
+              isUnclaimed
+                ? "Claim this workspace to reply"
+                : session
+                  ? "Message this session"
+                  : "No active projected session"
+            }
           />
           <Button size="icon" aria-label="Send message" disabled={!canSubmit}>
             <Send size={15} />

--- a/web/src/components/home/screen/HomeScreen.tsx
+++ b/web/src/components/home/screen/HomeScreen.tsx
@@ -4,8 +4,6 @@ import { useState } from "react";
 import type { NewChatPickerId, PickerView } from "@proliferate/product-ui/new-chat/NewChatSurface";
 import { NewChatSurface } from "@proliferate/product-ui/new-chat/NewChatSurface";
 
-import { workspaces } from "../../../lib/fixtures/web-fixtures";
-
 type ModeId = "dispatch" | "shared" | "personal";
 
 const MODE_PLACEHOLDERS: Record<ModeId, string> = {
@@ -16,7 +14,7 @@ const MODE_PLACEHOLDERS: Record<ModeId, string> = {
 
 export function HomeScreen() {
   const [draft, setDraft] = useState("");
-  const [targetId, setTargetId] = useState(workspaces[0]?.id ?? "shared-cloud");
+  const [targetId, setTargetId] = useState("personal-cloud");
   const [modelId, setModelId] = useState("gpt-5.4");
   const [modeId, setModeId] = useState<ModeId>("dispatch");
   const [submitting, setSubmitting] = useState(false);
@@ -53,13 +51,7 @@ export function HomeScreen() {
         target={buildTargetPicker(targetId)}
         model={buildModelPicker(modelId)}
         mode={buildModePicker(modeId)}
-        notices={[
-          {
-            id: "mock-cloud",
-            tone: "neutral",
-            text: "Cloud API wiring is intentionally light in this PR; this surface is using shared UI and fixture targets.",
-          },
-        ]}
+        notices={[]}
         actions={[
           {
             id: "branch",
@@ -86,6 +78,20 @@ export function HomeScreen() {
 }
 
 function buildTargetPicker(selectedId: string): PickerView {
+  const targets = [
+    {
+      id: "personal-cloud",
+      label: "Personal cloud",
+      description: "Your cloud sandbox",
+      icon: <Cloud size={13} />,
+    },
+    {
+      id: "shared-cloud",
+      label: "Shared cloud",
+      description: "Team sandbox",
+      icon: <Users size={13} />,
+    },
+  ];
   return {
     label: "Target",
     icon: <Cloud size={13} />,
@@ -93,12 +99,9 @@ function buildTargetPicker(selectedId: string): PickerView {
       {
         id: "targets",
         label: "Cloud targets",
-        items: workspaces.map((workspace) => ({
-          id: workspace.id,
-          label: workspace.name,
-          description: `${workspace.repoLabel} · ${workspace.branchLabel}`,
-          selected: workspace.id === selectedId,
-          icon: workspace.kind === "shared" ? <Users size={13} /> : <Cloud size={13} />,
+        items: targets.map((target) => ({
+          ...target,
+          selected: target.id === selectedId,
         })),
       },
     ],

--- a/web/src/components/workspaces/screen/WorkspacesScreen.tsx
+++ b/web/src/components/workspaces/screen/WorkspacesScreen.tsx
@@ -1,12 +1,15 @@
-import { RefreshCw } from "lucide-react";
+import { Cloud, GitBranch, RefreshCw, Users } from "lucide-react";
+import { Link } from "react-router-dom";
 import { useCloudWorkspaces } from "@proliferate/cloud-sdk-react";
 
 import { ProductPageShell } from "@proliferate/product-ui/layout/ProductPageShell";
-import { CloudWorkspaceList } from "@proliferate/product-ui/workspaces/CloudWorkspaceList";
+import { EmptyState } from "@proliferate/ui/layout/EmptyState";
 import { Button } from "@proliferate/ui/primitives/Button";
 
+import { routes } from "../../../config/routes";
+
 export function WorkspacesScreen() {
-  const workspaces = useCloudWorkspaces();
+  const workspaces = useCloudWorkspaces({ scope: "exposed" });
 
   return (
     <ProductPageShell
@@ -20,18 +23,79 @@ export function WorkspacesScreen() {
       }
       telemetryBlocked
     >
-      <CloudWorkspaceList
-        loading={workspaces.isLoading}
-        error={Boolean(workspaces.error)}
-        items={(workspaces.data ?? []).map((workspace) => ({
-          id: workspace.id,
-          name: workspace.displayName ?? workspace.repo.name,
-          repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-          branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
-          originLabel: workspace.origin?.kind ?? "personal",
-          statusLabel: workspace.status,
-        }))}
-      />
+      {workspaces.isLoading ? (
+        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+          Loading workspaces
+        </div>
+      ) : workspaces.error ? (
+        <EmptyState
+          title="Could not load workspaces"
+          description="Refresh the page or sign in again."
+        />
+      ) : workspaces.data?.length ? (
+        <div className="grid gap-3">
+          {workspaces.data.map((workspace) => (
+            <Link
+              key={workspace.id}
+              to={routes.workspace(workspace.id)}
+              className="rounded-lg border border-border bg-card p-4 text-left transition hover:border-ring/50 hover:bg-accent/30"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="flex size-8 items-center justify-center rounded-md bg-accent text-foreground">
+                      <Cloud size={15} />
+                    </span>
+                    <div className="min-w-0">
+                      <h2 className="truncate text-sm font-semibold">
+                        {workspace.displayName ?? workspace.repo.name}
+                      </h2>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {workspace.repo.owner}/{workspace.repo.name}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-wrap justify-end gap-2">
+                  <span className="rounded-full border border-border bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                    {workspace.exposureState ?? "tracked"}
+                  </span>
+                  <span className="rounded-full border border-border bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                    {workspace.status}
+                  </span>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1">
+                  <GitBranch size={13} />
+                  {workspace.repo.branch ?? workspace.repo.baseBranch ?? "main"}
+                </span>
+                {workspace.visibility !== "private" && (
+                  <span className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1">
+                    <Users size={13} />
+                    {workspace.visibility === "shared_unclaimed"
+                      ? "Unclaimed"
+                      : workspace.visibility}
+                  </span>
+                )}
+                <span className="rounded-md border border-border px-2 py-1">
+                  {workspace.origin?.kind ?? "personal"}
+                </span>
+                {workspace.lastSessionSummary && (
+                  <span className="rounded-md border border-border px-2 py-1">
+                    {workspace.lastSessionSummary.title ?? workspace.lastSessionSummary.status}
+                  </span>
+                )}
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          title="No cloud workspaces"
+          description="Create a workspace from Desktop or the cloud setup flow."
+        />
+      )}
     </ProductPageShell>
   );
 }

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -10,5 +10,6 @@ export const routes = {
   connectGitHub: "/connect-github",
   desktopHandoff: "/auth/desktop/handoff",
   authError: "/auth/error",
+  workspace: (workspaceId: string) => `/workspaces/${workspaceId}`,
   chat: (workspaceId: string, chatId: string) => `/workspaces/${workspaceId}/chats/${chatId}`,
 } as const;


### PR DESCRIPTION
## Summary

- adds exposed workspace listing support and last-session metadata for Cloud-mediated clients
- adds SDK React live hooks for session/workspace/target streams plus command status tracking
- wires web and mobile workspace/chat screens to live Cloud data and command-based prompt dispatch
- adds shared workspace deep-link helpers and mobile universal/app link configuration

## Validation

- DEBUG=1 uv run ruff check proliferate/server/cloud/workspaces proliferate/db/store/cloud_workspaces.py
- DEBUG=1 uv run ruff check server/proliferate/server/cloud/workspaces/models.py
- pnpm web:typecheck
- pnpm mobile:typecheck

## Notes

This PR implements the web/mobile dispatch slice of spec 08 on top of the Cloud Running, Claiming, Automations, and Slack stack. Desktop context-menu verbs and Cowork API-key management remain separate larger chunks.