### PR TITLE
fix(desktop): match terminal pane background to right panel surfaces

### DIFF
--- a/desktop/src/components/workspace/pane/PaneHeader.tsx
+++ b/desktop/src/components/workspace/pane/PaneHeader.tsx
@@ -17,7 +17,7 @@ export function PaneHeader({
   return (
     <div
       className={twMerge(
-        "z-20 flex h-10 min-h-10 shrink-0 items-center gap-1 border-b border-sidebar-border/70 bg-sidebar px-2 text-sidebar-foreground",
+        "z-20 flex h-10 min-h-10 shrink-0 items-center gap-1 border-b border-sidebar-border/70 px-2 text-sidebar-foreground",
         className,
       )}
     >

--- a/desktop/src/components/workspace/terminals/TerminalPanel.tsx
+++ b/desktop/src/components/workspace/terminals/TerminalPanel.tsx
@@ -57,7 +57,7 @@ export function TerminalPanel({
           onNewTerminal={onNewTerminal}
         />
       )}
-      <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-background">
+      <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-sidebar">
         {isLoading ? (
           <TerminalEmptyState label="Loading terminals" />
         ) : errorMessage ? (

--- a/desktop/src/config/theme.ts
+++ b/desktop/src/config/theme.ts
@@ -169,7 +169,7 @@ export function getTerminalTheme(): Record<string, string> {
   const s = getComputedStyle(document.documentElement);
   const v = (name: string) => s.getPropertyValue(name).trim();
   return {
-    background: v("--color-background"),
+    background: v("--color-sidebar"),
     foreground: v("--color-foreground"),
     cursor: v("--color-foreground"),
     selectionBackground: v("--color-input"),


### PR DESCRIPTION
## Summary

The terminal pane in the right panel rendered on `--color-background`, a deeper dark than the `--color-sidebar` surface used by the Scratch and Git panes. This switches the terminal pane to `--color-sidebar` so the whole right panel reads as one surface.

## Changes

- `TerminalPanel.tsx` — pane container `bg-background` -> `bg-sidebar` (covers the empty / loading / error states and the padding around xterm).
- `config/theme.ts` — xterm canvas `background` `--color-background` -> `--color-sidebar`, so a running terminal matches too. Re-applies on theme change via `use-terminal-viewport.ts`.
- `PaneHeader.tsx` — drop the now-redundant `bg-sidebar` class; the shared header inherits the panel surface.

## Context

The rest of the right-panel surface alignment already landed via #296. This is the remaining piece.

## Verification

- Visual: terminal pane (empty and with a live terminal) now matches the Scratch and Git panes.