### PR TITLE
fix(desktop): polish git diff UI

### DIFF
--- a/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/files.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/files.rs
@@ -5,6 +5,7 @@ use super::file_references::{
     determine_file_read_scope, extract_location_line, normalize_file_reference,
     resolve_file_references,
 };
+use super::synthesized_patch::{extract_diff_start_line, synthesize_patch};
 use super::text::{count_lines, extract_preview};
 use anyharness_contract::v1::{ContentPart, FileChangeOperation, FileOpenTarget};
 
@@ -37,24 +38,35 @@ pub(in crate::acp::event_sink) fn normalize_file_parts(
                 .get("newText")
                 .and_then(serde_json::Value::as_str)
                 .map(String::from);
-            let patch = item
+            let raw_patch = item
                 .get("patch")
                 .and_then(serde_json::Value::as_str)
-                .map(String::from)
-                .or_else(|| {
-                    synthesize_patch(
-                        diff_path.as_deref(),
-                        old_text.as_deref(),
-                        new_text.as_deref(),
-                    )
-                });
-            let additions = item
-                .get("additions")
-                .and_then(serde_json::Value::as_i64)
+                .map(String::from);
+            let synthesized_patch = if raw_patch.is_none() {
+                let start_line = extract_diff_start_line(item, raw_input, locations);
+                synthesize_patch(
+                    diff_path.as_deref(),
+                    old_text.as_deref(),
+                    new_text.as_deref(),
+                    start_line,
+                )
+            } else {
+                None
+            };
+            let patch = raw_patch.or_else(|| {
+                synthesized_patch
+                    .as_ref()
+                    .map(|synthesized| synthesized.patch.clone())
+            });
+            let additions = synthesized_patch
+                .as_ref()
+                .map(|patch| patch.additions)
+                .or_else(|| item.get("additions").and_then(serde_json::Value::as_i64))
                 .or_else(|| new_text.as_ref().map(|text| count_lines(text)));
-            let deletions = item
-                .get("deletions")
-                .and_then(serde_json::Value::as_i64)
+            let deletions = synthesized_patch
+                .as_ref()
+                .map(|patch| patch.deletions)
+                .or_else(|| item.get("deletions").and_then(serde_json::Value::as_i64))
                 .or_else(|| old_text.as_ref().map(|text| count_lines(text)));
 
             let (path, new_path) =
@@ -244,35 +256,4 @@ fn determine_file_operation(
         (Some(old), Some(new)) if !old.is_empty() && new.is_empty() => FileChangeOperation::Delete,
         _ => FileChangeOperation::Edit,
     }
-}
-
-fn synthesize_patch(
-    path: Option<&str>,
-    old_text: Option<&str>,
-    new_text: Option<&str>,
-) -> Option<String> {
-    if old_text.is_none() && new_text.is_none() {
-        return None;
-    }
-
-    let path = path.unwrap_or("file");
-    let mut patch = format!("--- a/{path}\n+++ b/{path}\n");
-
-    if let Some(old_text) = old_text {
-        for line in old_text.lines() {
-            patch.push('-');
-            patch.push_str(line);
-            patch.push('\n');
-        }
-    }
-
-    if let Some(new_text) = new_text {
-        for line in new_text.lines() {
-            patch.push('+');
-            patch.push_str(line);
-            patch.push('\n');
-        }
-    }
-
-    Some(patch)
 }

--- a/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/mod.rs
@@ -2,5 +2,6 @@ pub(in crate::acp::event_sink) mod file_references;
 pub(in crate::acp::event_sink) mod files;
 pub(in crate::acp::event_sink) mod meta;
 pub(in crate::acp::event_sink) mod snapshots;
+pub(in crate::acp::event_sink) mod synthesized_patch;
 pub(in crate::acp::event_sink) mod terminals;
 pub(in crate::acp::event_sink) mod text;

--- a/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/synthesized_patch.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/event_sink/normalization/synthesized_patch.rs
@@ -1,0 +1,388 @@
+pub(in crate::acp::event_sink) fn synthesize_patch(
+    path: Option<&str>,
+    old_text: Option<&str>,
+    new_text: Option<&str>,
+    start_line: Option<i64>,
+) -> Option<SynthesizedPatch> {
+    if old_text.is_none() && new_text.is_none() {
+        return None;
+    }
+
+    let old_lines = split_lines(old_text.unwrap_or_default());
+    let new_lines = split_lines(new_text.unwrap_or_default());
+    let ops = diff_line_ops(&old_lines, &new_lines);
+    let additions = ops
+        .iter()
+        .filter(|op| matches!(op, LineDiffOp::Insert(_)))
+        .count() as i64;
+    let deletions = ops
+        .iter()
+        .filter(|op| matches!(op, LineDiffOp::Delete(_)))
+        .count() as i64;
+    if additions == 0 && deletions == 0 {
+        return None;
+    }
+
+    let path = path.unwrap_or("file");
+    let mut patch = format!("--- a/{path}\n+++ b/{path}\n");
+    let numbered_ops = number_diff_ops(&ops, start_line.unwrap_or(1).max(1));
+    for hunk in build_unified_hunks(&numbered_ops) {
+        let old_start = hunk_old_start(&hunk);
+        let new_start = hunk_new_start(&hunk);
+        let old_count = hunk
+            .iter()
+            .filter(|op| !matches!(op.op, LineDiffOp::Insert(_)))
+            .count();
+        let new_count = hunk
+            .iter()
+            .filter(|op| !matches!(op.op, LineDiffOp::Delete(_)))
+            .count();
+
+        patch.push_str(&format!(
+            "@@ -{},{} +{},{} @@\n",
+            old_start, old_count, new_start, new_count
+        ));
+        for op in hunk {
+            match op.op {
+                LineDiffOp::Equal(line) => {
+                    patch.push(' ');
+                    patch.push_str(line);
+                }
+                LineDiffOp::Delete(line) => {
+                    patch.push('-');
+                    patch.push_str(line);
+                }
+                LineDiffOp::Insert(line) => {
+                    patch.push('+');
+                    patch.push_str(line);
+                }
+            }
+            patch.push('\n');
+        }
+    }
+
+    Some(SynthesizedPatch {
+        patch,
+        additions,
+        deletions,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::acp::event_sink) struct SynthesizedPatch {
+    pub patch: String,
+    pub additions: i64,
+    pub deletions: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineDiffOp<'a> {
+    Equal(&'a str),
+    Delete(&'a str),
+    Insert(&'a str),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NumberedLineDiffOp<'a> {
+    op: LineDiffOp<'a>,
+    old_line: Option<i64>,
+    new_line: Option<i64>,
+}
+
+fn split_lines(text: &str) -> Vec<&str> {
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        text.lines().collect()
+    }
+}
+
+fn diff_line_ops<'a>(old_lines: &'a [&'a str], new_lines: &'a [&'a str]) -> Vec<LineDiffOp<'a>> {
+    let mut prefix_len = 0;
+    while prefix_len < old_lines.len()
+        && prefix_len < new_lines.len()
+        && old_lines[prefix_len] == new_lines[prefix_len]
+    {
+        prefix_len += 1;
+    }
+
+    let mut old_suffix_start = old_lines.len();
+    let mut new_suffix_start = new_lines.len();
+    while old_suffix_start > prefix_len
+        && new_suffix_start > prefix_len
+        && old_lines[old_suffix_start - 1] == new_lines[new_suffix_start - 1]
+    {
+        old_suffix_start -= 1;
+        new_suffix_start -= 1;
+    }
+
+    let mut ops = old_lines[..prefix_len]
+        .iter()
+        .map(|line| LineDiffOp::Equal(*line))
+        .collect::<Vec<_>>();
+    ops.extend(diff_middle_lines(
+        &old_lines[prefix_len..old_suffix_start],
+        &new_lines[prefix_len..new_suffix_start],
+    ));
+    ops.extend(
+        old_lines[old_suffix_start..]
+            .iter()
+            .map(|line| LineDiffOp::Equal(*line)),
+    );
+    ops
+}
+
+fn diff_middle_lines<'a>(
+    old_lines: &'a [&'a str],
+    new_lines: &'a [&'a str],
+) -> Vec<LineDiffOp<'a>> {
+    const MAX_LCS_CELLS: usize = 1_000_000;
+    if old_lines.is_empty() {
+        return new_lines
+            .iter()
+            .map(|line| LineDiffOp::Insert(*line))
+            .collect();
+    }
+    if new_lines.is_empty() {
+        return old_lines
+            .iter()
+            .map(|line| LineDiffOp::Delete(*line))
+            .collect();
+    }
+    if old_lines.len().saturating_mul(new_lines.len()) > MAX_LCS_CELLS {
+        return old_lines
+            .iter()
+            .map(|line| LineDiffOp::Delete(*line))
+            .chain(new_lines.iter().map(|line| LineDiffOp::Insert(*line)))
+            .collect();
+    }
+
+    let width = new_lines.len() + 1;
+    let mut lcs = vec![0usize; (old_lines.len() + 1) * width];
+    for old_index in (0..old_lines.len()).rev() {
+        for new_index in (0..new_lines.len()).rev() {
+            let cell = old_index * width + new_index;
+            lcs[cell] = if old_lines[old_index] == new_lines[new_index] {
+                lcs[(old_index + 1) * width + new_index + 1] + 1
+            } else {
+                lcs[(old_index + 1) * width + new_index].max(lcs[old_index * width + new_index + 1])
+            };
+        }
+    }
+
+    let mut ops = Vec::new();
+    let mut old_index = 0;
+    let mut new_index = 0;
+    while old_index < old_lines.len() && new_index < new_lines.len() {
+        if old_lines[old_index] == new_lines[new_index] {
+            ops.push(LineDiffOp::Equal(old_lines[old_index]));
+            old_index += 1;
+            new_index += 1;
+        } else if lcs[(old_index + 1) * width + new_index] >= lcs[old_index * width + new_index + 1]
+        {
+            ops.push(LineDiffOp::Delete(old_lines[old_index]));
+            old_index += 1;
+        } else {
+            ops.push(LineDiffOp::Insert(new_lines[new_index]));
+            new_index += 1;
+        }
+    }
+    ops.extend(
+        old_lines[old_index..]
+            .iter()
+            .map(|line| LineDiffOp::Delete(*line)),
+    );
+    ops.extend(
+        new_lines[new_index..]
+            .iter()
+            .map(|line| LineDiffOp::Insert(*line)),
+    );
+    ops
+}
+
+fn number_diff_ops<'a>(ops: &[LineDiffOp<'a>], start_line: i64) -> Vec<NumberedLineDiffOp<'a>> {
+    let mut old_line = start_line;
+    let mut new_line = start_line;
+    ops.iter()
+        .map(|op| match *op {
+            LineDiffOp::Equal(_) => {
+                let numbered = NumberedLineDiffOp {
+                    op: *op,
+                    old_line: Some(old_line),
+                    new_line: Some(new_line),
+                };
+                old_line += 1;
+                new_line += 1;
+                numbered
+            }
+            LineDiffOp::Delete(_) => {
+                let numbered = NumberedLineDiffOp {
+                    op: *op,
+                    old_line: Some(old_line),
+                    new_line: None,
+                };
+                old_line += 1;
+                numbered
+            }
+            LineDiffOp::Insert(_) => {
+                let numbered = NumberedLineDiffOp {
+                    op: *op,
+                    old_line: None,
+                    new_line: Some(new_line),
+                };
+                new_line += 1;
+                numbered
+            }
+        })
+        .collect()
+}
+
+fn build_unified_hunks<'a>(ops: &[NumberedLineDiffOp<'a>]) -> Vec<Vec<NumberedLineDiffOp<'a>>> {
+    const CONTEXT_LINES: usize = 3;
+    let mut hunks = Vec::new();
+    let mut index = 0;
+
+    while let Some(relative_change_index) = ops[index..]
+        .iter()
+        .position(|op| !matches!(op.op, LineDiffOp::Equal(_)))
+    {
+        let change_index = index + relative_change_index;
+        let hunk_start = change_index.saturating_sub(CONTEXT_LINES);
+        let mut hunk_end = change_index;
+        let mut trailing_context = 0;
+
+        while hunk_end < ops.len() {
+            if matches!(ops[hunk_end].op, LineDiffOp::Equal(_)) {
+                trailing_context += 1;
+                if trailing_context > CONTEXT_LINES {
+                    break;
+                }
+            } else {
+                trailing_context = 0;
+            }
+            hunk_end += 1;
+        }
+
+        hunks.push(ops[hunk_start..hunk_end].to_vec());
+        index = hunk_end;
+    }
+
+    hunks
+}
+
+fn hunk_old_start(hunk: &[NumberedLineDiffOp<'_>]) -> i64 {
+    hunk.iter()
+        .find_map(|op| op.old_line)
+        .or_else(|| hunk.iter().find_map(|op| op.new_line).map(|line| line - 1))
+        .unwrap_or(0)
+        .max(0)
+}
+
+fn hunk_new_start(hunk: &[NumberedLineDiffOp<'_>]) -> i64 {
+    hunk.iter()
+        .find_map(|op| op.new_line)
+        .or_else(|| hunk.iter().find_map(|op| op.old_line).map(|line| line - 1))
+        .unwrap_or(0)
+        .max(0)
+}
+
+pub(in crate::acp::event_sink) fn extract_diff_start_line(
+    diff_item: &serde_json::Value,
+    raw_input: Option<&serde_json::Value>,
+    locations: Option<&Vec<serde_json::Value>>,
+) -> Option<i64> {
+    const START_LINE_KEYS: &[&str] = &[
+        "startLine",
+        "start_line",
+        "lineStart",
+        "line_start",
+        "oldStart",
+        "old_start",
+        "oldLine",
+        "old_line",
+        "line",
+    ];
+
+    extract_i64_keys(Some(diff_item), START_LINE_KEYS)
+        .or_else(|| extract_i64_keys(raw_input, START_LINE_KEYS))
+        .or_else(|| {
+            locations.and_then(|items| {
+                items
+                    .iter()
+                    .find_map(|item| extract_i64_keys(Some(item), START_LINE_KEYS))
+            })
+        })
+}
+
+fn extract_i64_keys(value: Option<&serde_json::Value>, keys: &[&str]) -> Option<i64> {
+    let value = value?;
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(read_i64_value)
+}
+
+fn read_i64_value(value: &serde_json::Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|raw| i64::try_from(raw).ok()))
+        .or_else(|| value.as_str().and_then(|raw| raw.parse::<i64>().ok()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthesized_patch_uses_minimal_hunk_and_start_line() {
+        let old_text = [
+            "line 1",
+            "line 2",
+            "line 3",
+            "line 4",
+            "old value",
+            "line 6",
+            "line 7",
+            "line 8",
+            "line 9",
+        ]
+        .join("\n");
+        let new_text = [
+            "line 1",
+            "line 2",
+            "line 3",
+            "line 4",
+            "new value",
+            "line 6",
+            "line 7",
+            "line 8",
+            "line 9",
+        ]
+        .join("\n");
+
+        let patch = synthesize_patch(
+            Some("README.md"),
+            Some(&old_text),
+            Some(&new_text),
+            Some(100),
+        )
+        .expect("patch");
+
+        assert_eq!(patch.additions, 1);
+        assert_eq!(patch.deletions, 1);
+        assert!(patch.patch.contains("--- a/README.md\n+++ b/README.md\n"));
+        assert!(patch.patch.contains("@@ -101,7 +101,7 @@"));
+        assert!(patch.patch.contains("-old value\n+new value"));
+        assert!(!patch.patch.contains(" line 1\n"));
+    }
+
+    #[test]
+    fn synthesized_patch_extracts_start_line_from_diff_payload() {
+        let line = extract_diff_start_line(
+            &serde_json::json!({ "type": "diff", "startLine": "42" }),
+            None,
+            None,
+        );
+
+        assert_eq!(line, Some(42));
+    }
+}

--- a/desktop/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
+++ b/desktop/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
@@ -11,7 +11,13 @@ describe("PlaygroundSidebarGitDiff", () => {
     expect(html).toContain("data-diff-surface=\"sidebar\"");
     expect(html).toContain("data-diff=\"\"");
     expect(html).toContain("composer-diff-simple-line");
-    expect(html).toContain("px-2 pb-2");
+    expect(html).toContain("id=\"review-diffs-collapsed\"");
+    expect(html).toContain("data-app-action-review-scroll=\"\"");
+    expect(html).toContain("data-thread-find-target=\"review\"");
+    expect(html).toContain("data-app-action-review-metrics-probe=\"\"");
+    expect(html).toContain("data-review-path=");
+    expect(html).toContain("codex-review-diff-card");
+    expect(html).toContain("px-2 pb-3");
     expect(html).toContain("pt-2");
     expect(html).not.toContain("px-2 py-2");
     expect(html).toContain("Binary file changed");

--- a/desktop/src/components/playground/PlaygroundSidebarGitDiff.tsx
+++ b/desktop/src/components/playground/PlaygroundSidebarGitDiff.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
 import { FileDiffCard } from "@/components/ui/content/FileDiffCard";
+import { CheckCircleFilled } from "@/components/ui/icons";
+import { GitReviewEmptyState } from "@/components/workspace/git/GitReviewEmptyState";
 import {
   PLAYGROUND_SIDEBAR_GIT_DIFF_FILES,
   PLAYGROUND_SIDEBAR_GIT_DIFF_SECTIONS,
@@ -8,6 +10,9 @@ import {
 } from "@/lib/domain/chat/__fixtures__/playground/git-diff-fixtures";
 
 const SIDEBAR_DIFF_VIEWPORT_CLASS = "max-h-[calc(var(--diffs-line-height)*18)]";
+const SIDEBAR_DIFF_SURFACE_STYLE = {
+  "--codex-diffs-surface-override": "var(--color-diff-surface)",
+} as CSSProperties;
 
 export function PlaygroundSidebarGitDiff() {
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(
@@ -31,15 +36,25 @@ export function PlaygroundSidebarGitDiff() {
       <div className="shrink-0 border-b border-sidebar-border/70 px-3 py-2">
         <p className="text-xs text-sidebar-muted-foreground">Git diff sidebar</p>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
-        <div className="flex flex-col gap-3 pt-2">
+      <div
+        id="review-diffs-collapsed"
+        data-app-action-review-scroll=""
+        data-thread-find-target="review"
+        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2 pb-3"
+      >
+        <div className="relative flex flex-col gap-1.5 pt-2">
+          <span
+            aria-hidden="true"
+            data-app-action-review-metrics-probe=""
+            className="pointer-events-none absolute left-0 top-0 size-px opacity-0"
+          />
           {PLAYGROUND_SIDEBAR_GIT_DIFF_SECTIONS.map((section) => {
             const files = PLAYGROUND_SIDEBAR_GIT_DIFF_FILES.filter(
               (file) => file.section === section,
             );
             return (
-              <section key={section} className="flex flex-col gap-2">
-                <h2 className="px-1 text-xs font-medium text-sidebar-muted-foreground">
+              <section key={section} className="flex flex-col gap-1">
+                <h2 className="px-1.5 text-[10px] font-medium uppercase tracking-wide text-sidebar-muted-foreground">
                   {section}
                 </h2>
                 {files.length > 0 ? (
@@ -52,9 +67,12 @@ export function PlaygroundSidebarGitDiff() {
                     />
                   ))
                 ) : (
-                  <p className="rounded-lg bg-sidebar-accent px-3 py-4 text-center text-xs text-sidebar-muted-foreground">
-                    Working tree clean
-                  </p>
+                  <GitReviewEmptyState
+                    variant="inline"
+                    icon={<CheckCircleFilled className="size-3.5" />}
+                    title="Working tree clean"
+                    description="No files to review in this section."
+                  />
                 )}
               </section>
             );
@@ -75,33 +93,38 @@ function PlaygroundSidebarGitDiffCard({
   onToggle: () => void;
 }) {
   return (
-    <FileDiffCard
-      filePath={file.displayPath}
-      additions={file.additions}
-      deletions={file.deletions}
-      isExpanded={isExpanded}
-      onToggleExpand={onToggle}
-      surface="sidebar"
+    <div
+      data-review-path={file.displayPath}
+      style={SIDEBAR_DIFF_SURFACE_STYLE}
     >
-      {file.binary ? (
-        <p className="px-3 py-2 text-xs text-sidebar-muted-foreground">
-          Binary file changed
-        </p>
-      ) : file.patch ? (
-        <div>
-          <DiffViewer
-            patch={file.patch}
-            filePath={file.displayPath}
-            viewportClassName={SIDEBAR_DIFF_VIEWPORT_CLASS}
-            variant="chat"
-          />
-          {file.truncated && (
-            <p className="px-3 pb-1 text-[10px] text-sidebar-muted-foreground">
-              Diff truncated
-            </p>
-          )}
-        </div>
-      ) : null}
-    </FileDiffCard>
+      <FileDiffCard
+        filePath={file.displayPath}
+        additions={file.additions}
+        deletions={file.deletions}
+        isExpanded={isExpanded}
+        onToggleExpand={onToggle}
+        surface="sidebar"
+      >
+        {file.binary ? (
+          <p className="px-3 py-2 text-xs text-sidebar-muted-foreground">
+            Binary file changed
+          </p>
+        ) : file.patch ? (
+          <div>
+            <DiffViewer
+              patch={file.patch}
+              filePath={file.displayPath}
+              viewportClassName={SIDEBAR_DIFF_VIEWPORT_CLASS}
+              variant="chat"
+            />
+            {file.truncated && (
+              <p className="px-3 pb-1 text-[10px] text-sidebar-muted-foreground">
+                Diff truncated
+              </p>
+            )}
+          </div>
+        ) : null}
+      </FileDiffCard>
+    </div>
   );
 }

--- a/desktop/src/components/ui/content/DiffViewer.test.tsx
+++ b/desktop/src/components/ui/content/DiffViewer.test.tsx
@@ -37,13 +37,19 @@ describe("DiffViewer chat variant", () => {
     expect(html).toContain("data-gutter=\"\"");
     expect(html).toContain("sticky left-0 z-10");
     expect(html).toContain("data-content=\"\"");
+    expect(html.match(/data-gutter=\"\"/g)).toHaveLength(1);
+    expect(html.match(/data-content=\"\"/g)).toHaveLength(1);
+    expect(html).toContain("grid-row:1 / span 4");
+    expect(html).toContain("grid-template-rows:repeat(4, auto)");
+    expect(html).toContain("[grid-template-rows:subgrid]");
     expect(html).toContain("--diffs-min-number-column-width:4ch");
     expect(html).toContain("--diffs-min-number-column-width-default:3ch");
     expect(html).toContain("--diffs-addition-color:var(--diffs-addition-color-override)");
     expect(html).toContain("--diffs-deletion-color:var(--diffs-deletion-color-override)");
     expect(html).toContain(
-      "--diffs-column-number-width:max(24px, 5ch)",
+      "--diffs-column-number-width:max(40px, calc(4ch + 1.5rem))",
     );
+    expect(html).toContain("pr-2 pl-3");
     expect(html).toContain("diff-content-cell relative min-h");
     expect(html).not.toContain("thread-diff-virtualized");
   });
@@ -110,6 +116,35 @@ describe("DiffViewer chat variant", () => {
     expect(splitHtml).toContain("overscroll-behavior:none");
     expect(splitHtml).toContain("overscroll-behavior-x:none");
     expect(splitHtml).toContain("overscroll-behavior-y:none");
+  });
+
+  it("renders split diffs with Codex-style paired code columns", () => {
+    const html = renderToStaticMarkup(
+      createElement(DiffViewer, {
+        patch: PATCH,
+        filePath: "src/example.ts",
+        layout: "split",
+      }),
+    );
+
+    expect(html).toContain("composer-diff-simple-line");
+    expect(html).toContain("data-diff-type=\"split\"");
+    expect(html).toContain("data-deletions=\"\"");
+    expect(html).toContain("data-additions=\"\"");
+    expect(html).toContain("data-container-size=\"\"");
+    expect(html).toContain("data-line-type=\"change-deletion\"");
+    expect(html).toContain("data-line-type=\"change-addition\"");
+    expect(html).toContain("--diffs-column-content-width:360px");
+    expect(html).toContain("--diffs-column-number-width:max(40px, calc(4ch + 1.5rem))");
+    expect(html).toContain("[grid-template-rows:subgrid]");
+    expect(html).toContain("overflow-x-hidden");
+    expect(html).toContain("overflow-x-auto overflow-y-hidden");
+    expect(html).toContain("grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
+    expect(html).toContain("data-empty-side=\"change-deletion\"");
+    expect(html).toContain("data-empty-side=\"change-addition\"");
+    expect(html).toContain("data-gutter-buffer=\"buffer\"");
+    expect(html).toContain("w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)]");
+    expect(html).not.toContain("w-max min-w-full");
   });
 
   it("keeps diff viewer overscroll non-chaining by default", () => {

--- a/desktop/src/components/ui/content/DiffViewer.tsx
+++ b/desktop/src/components/ui/content/DiffViewer.tsx
@@ -72,6 +72,7 @@ export function DiffViewer({
           tokens={tokens}
           className={rootClass}
           viewportClassName={viewportClassName}
+          wrapLongLines={wrapLongLines}
           overscrollBehavior={overscrollBehavior}
           overscrollBehaviorX={overscrollBehaviorX}
           overscrollBehaviorY={overscrollBehaviorY}

--- a/desktop/src/components/ui/content/FileDiffCard.test.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.test.tsx
@@ -25,15 +25,17 @@ describe("FileChangesCard and FileDiffCard", () => {
 
     expect(html).toContain("2 files changed");
     expect(html).not.toContain("+7");
-    expect(html).not.toContain("text-git-red\">-3</span>");
-    expect(html).toContain('text-right">+</span><span class="text-right">4');
-    expect(html).toContain('text-right">-</span><span class="text-right">1');
-    expect(html).toContain("grid-cols-[0.65ch_minmax(1ch,max-content)]");
+    expect(html).not.toContain(">-3</span>");
+    expect(html).toContain(">+4</span>");
+    expect(html).toContain(">-1</span>");
     expect(html).toContain("bg-[var(--color-diff-panel-surface)]");
     expect(html).toContain("text-chat leading-[var(--text-chat--line-height)]");
-    expect(html).toContain("thread-diff-virtualized");
+    expect(html).not.toContain("thread-diff-virtualized");
     expect(html).toContain("--codex-diffs-surface:var(--codex-diffs-surface-override, var(--color-diff-surface))");
     expect(html).toContain("data-diff-surface=\"sidebar\"");
+    expect(html).toContain("codex-review-diff-card");
+    expect(html).toContain("data-app-action-review-file-expanded=\"true\"");
+    expect(html).toContain("data-app-action-review-file-toggle=\"\"");
     expect(html).toContain("text-sidebar-foreground");
     expect(html).toContain("hover:bg-sidebar-accent");
     expect(html).toContain("diff body");
@@ -55,7 +57,8 @@ describe("FileChangesCard and FileDiffCard", () => {
     expect(html).toContain(">.claude/plans/sorry-im-eant-liek-moonlit-goose.md</span>");
     expect(html).not.toContain(">/Users/pablo/.claude/plans/sorry-im-eant-liek-moonlit-goose.md</span>");
     expect(html).not.toContain("hover:underline");
-    expect(html).toContain("opacity-0");
+    expect(html).toContain("thread-diff-virtualized");
+    expect(html).toContain("group-hover/diff-header:block");
   });
 
   it("marks truncated absolute path prefixes with an ellipsis", () => {

--- a/desktop/src/components/ui/content/FileDiffCard.tsx
+++ b/desktop/src/components/ui/content/FileDiffCard.tsx
@@ -19,6 +19,7 @@ export function FileChangeStats({
 
   return (
     <span
+      data-thread-find-skip="true"
       className={`inline-flex shrink-0 items-baseline gap-1 tabular-nums tracking-tight ${className ?? ""}`}
     >
       {additions > 0 && (
@@ -41,9 +42,9 @@ function FileChangeStat({
   className: string;
 }) {
   return (
-    <span className={`inline-grid shrink-0 grid-cols-[0.65ch_minmax(1ch,max-content)] items-baseline ${className}`}>
-      <span className="text-right">{sign}</span>
-      <span className="text-right">{value}</span>
+    <span className={`shrink-0 leading-none ${className}`}>
+      {sign}
+      {value}
     </span>
   );
 }
@@ -183,6 +184,8 @@ interface FileDiffCardProps {
   filePath: string;
   additions: number;
   deletions: number;
+  displayLabel?: string;
+  showStats?: boolean;
   isExpanded: boolean;
   onToggleExpand?: () => void;
   onOpenFile?: () => void;
@@ -201,6 +204,8 @@ export function FileDiffCard({
   filePath,
   additions,
   deletions,
+  displayLabel,
+  showStats = true,
   isExpanded,
   onToggleExpand,
   onOpenFile,
@@ -222,147 +227,176 @@ export function FileDiffCard({
   const showChildren = !!children && (!collapsible || isExpanded);
   const basename = extractBasename(filePath);
   const displayPath = formatDiffHeaderPath(filePath);
-  const surfaceTextClass = surface === "sidebar" ? "text-sidebar-foreground" : "text-foreground";
-  const surfaceActionClass = surface === "sidebar"
+  const compactLabel = displayLabel ?? basename;
+  const fullLabel = displayLabel ?? displayPath;
+  const isSidebar = surface === "sidebar";
+  const surfaceTextClass = isSidebar ? "text-sidebar-foreground" : "text-foreground";
+  const surfaceActionClass = isSidebar
     ? "text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-sidebar-ring"
     : "text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-border";
-  const cardClass = surface === "sidebar"
-    ? "codex-review-diff-card rounded-lg ring-[0.5px] ring-sidebar-border/70"
+  const cardClass = isSidebar
+    ? "codex-review-diff-card rounded-lg"
     : embedded ? "" : "rounded-lg";
   const cardStyle = {
     "--codex-diffs-surface":
       "var(--codex-diffs-surface-override, var(--color-diff-surface))",
-    "--codex-diffs-header-surface": "var(--codex-diffs-surface)",
+    "--codex-diffs-header-surface": isSidebar
+      ? "color-mix(in srgb, var(--codex-diffs-surface) 98%, var(--color-foreground))"
+      : "var(--codex-diffs-surface)",
+    ...(isSidebar
+      ? {
+          "--codex-diffs-separator-surface":
+            "color-mix(in srgb, var(--codex-diffs-surface) 94%, var(--color-foreground))",
+        }
+      : {}),
     backgroundColor: "var(--codex-diffs-surface)",
   } as CSSProperties;
+  const headerShellClass = isSidebar
+    ? "bg-[var(--codex-diffs-header-surface)]"
+    : "bg-[var(--codex-diffs-header-surface)]";
+  const headerInnerClass = isSidebar
+    ? "group/diff-header @container/diff-header relative flex min-h-9 items-center gap-2.5 px-[calc(var(--codex-diffs-header-padding-x,0.75rem)+0.5rem)] py-1.5 text-chat leading-[var(--text-chat--line-height)] hover:bg-[var(--codex-diffs-separator-surface)]"
+    : "group/diff-header @container/diff-header relative flex min-h-8 items-center gap-2.5 px-[var(--codex-diffs-header-padding-x,1rem)] py-[var(--codex-diffs-header-padding-y,0.5rem)] text-chat leading-[var(--text-chat--line-height)] hover:bg-foreground/5";
+  const actionRevealClass = isSidebar
+    ? "opacity-0 transition-opacity duration-200 group-hover/file-diff:opacity-100 group-focus-within/file-diff:opacity-100"
+    : "hidden group-hover/diff-header:block group-focus-within/diff-header:block";
+  const statsClass = isSidebar
+    ? "leading-none"
+    : "leading-none group-hover/diff-header:hidden group-focus-within/diff-header:hidden";
   const pathContent = (
     <>
       <span className="min-w-0 truncate text-chat leading-[var(--text-chat--line-height)] [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:hidden">
-        {basename}
+        {compactLabel}
       </span>
       <span className="hidden min-w-0 truncate text-chat leading-[var(--text-chat--line-height)] [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:inline">
-        {displayPath}
+        {fullLabel}
       </span>
     </>
   );
 
-  return (
-    <div className="thread-diff-virtualized">
+  const card = (
+    <div
+      data-diff-surface={surface}
+      style={cardStyle}
+      className={`group/file-diff flex flex-col overflow-clip bg-[var(--codex-diffs-surface)] ${cardClass}`}
+    >
       <div
-        data-diff-surface={surface}
-        style={cardStyle}
-        className={`group/file-diff flex flex-col overflow-clip bg-[var(--codex-diffs-surface)] ${cardClass}`}
-      >
-        <div
-          role={canExpand ? "button" : undefined}
-          tabIndex={canExpand ? 0 : undefined}
-          onClick={canExpand ? onToggleExpand : undefined}
-          onKeyDown={
-            canExpand
-              ? (e) => {
-                  if (
-                    e.target === e.currentTarget
-                    && (e.key === "Enter" || e.key === " ")
-                  ) {
-                    e.preventDefault();
-                    onToggleExpand();
-                  }
+        role={canExpand ? "button" : undefined}
+        tabIndex={canExpand ? 0 : undefined}
+        aria-expanded={canExpand ? isExpanded : undefined}
+        onClick={canExpand ? onToggleExpand : undefined}
+        onKeyDown={
+          canExpand
+            ? (e) => {
+                if (
+                  e.target === e.currentTarget
+                  && (e.key === "Enter" || e.key === " ")
+                ) {
+                  e.preventDefault();
+                  onToggleExpand();
                 }
-              : undefined
-          }
-          className={`z-10 select-none bg-[var(--codex-diffs-surface)] ${surface === "sidebar" ? "sticky top-0" : ""} ${canExpand ? "cursor-pointer" : ""}`}
-        >
-          <div className="bg-[var(--codex-diffs-header-surface)] px-2 py-[2px]">
-            <div className="group/diff-header @container/diff-header relative flex items-center gap-2 rounded-[6px] px-1 py-0.5 text-chat leading-[var(--text-chat--line-height)] hover:bg-[var(--codex-diffs-separator-surface)]">
-              <div className={`flex min-w-0 flex-1 items-center gap-2 ${surfaceTextClass}`}>
-                {onOpenFile ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    title={filePath}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenFile();
-                    }}
-                    className={`h-auto min-w-0 truncate rounded-none border-0 bg-transparent p-0 text-start text-chat font-normal leading-[var(--text-chat--line-height)] shadow-none select-text [direction:rtl] hover:bg-transparent focus-visible:ring-1 ${
-                      surface === "sidebar" ? "text-sidebar-foreground hover:text-sidebar-foreground focus-visible:ring-sidebar-ring" : "text-foreground hover:text-foreground focus-visible:ring-border"
-                    }`}
-                  >
-                    {pathContent}
-                  </Button>
-                ) : (
-                  <span
-                    className="min-w-0 truncate text-start text-chat leading-[var(--text-chat--line-height)] [direction:rtl]"
-                    title={filePath}
-                  >
-                    {pathContent}
-                  </span>
-                )}
-              </div>
+              }
+            : undefined
+        }
+        className={`z-10 select-none bg-[var(--codex-diffs-surface)] ${isSidebar ? "sticky top-0" : ""} ${canExpand ? "cursor-pointer" : ""}`}
+      >
+        <div className={headerShellClass}>
+          <div className={headerInnerClass}>
+            <div className={`flex min-w-0 flex-1 items-center gap-2 ${surfaceTextClass}`}>
+              {onOpenFile ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  title={filePath}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenFile();
+                  }}
+                  className={`h-auto min-w-0 truncate rounded-none border-0 bg-transparent p-0 text-start text-chat font-normal leading-[var(--text-chat--line-height)] shadow-none select-text [direction:rtl] hover:bg-transparent focus-visible:ring-1 ${
+                    isSidebar ? "text-sidebar-foreground hover:text-sidebar-foreground focus-visible:ring-sidebar-ring" : "text-foreground hover:text-foreground focus-visible:ring-border"
+                  }`}
+                >
+                  {pathContent}
+                </Button>
+              ) : (
+                <span
+                  className="min-w-0 truncate text-start text-chat leading-[var(--text-chat--line-height)] [direction:rtl]"
+                  title={filePath}
+                >
+                  {pathContent}
+                </span>
+              )}
+            </div>
 
-              <div className="ms-auto flex shrink-0 items-center gap-1">
-                {actions && (
-                  <div className="flex items-center opacity-0 transition-opacity duration-200 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100">
-                    {actions}
-                  </div>
-                )}
+            <div className="ms-auto flex shrink-0 items-center gap-1.5">
+              {actions && (
+                <div className={`flex items-center ${actionRevealClass}`}>
+                  {actions}
+                </div>
+              )}
+              {showStats && (
                 <FileChangeStats
                   additions={additions}
                   deletions={deletions}
-                  className="leading-none"
+                  className={statsClass}
                 />
-                {!additions && !deletions && metadata}
-                {handleOpenAction && (
-                  <div className="shrink-0 opacity-0 transition-opacity duration-200 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        handleOpenAction();
-                      }}
-                      className={`size-5 rounded-lg border-0 bg-transparent p-0 transition-colors focus-visible:ring-1 ${surfaceActionClass}`}
-                      aria-label={openActionLabel ?? `Open ${filePath}`}
-                      title={openActionTitle ?? "Open file"}
-                    >
-                      <ArrowUpRight className="size-3" />
-                    </Button>
-                  </div>
-                )}
-                {canExpand && (
+              )}
+              {!additions && !deletions && metadata}
+              {handleOpenAction && (
+                <div className={`shrink-0 ${actionRevealClass}`}>
                   <Button
                     type="button"
                     variant="ghost"
                     size="icon-sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onToggleExpand();
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleOpenAction();
                     }}
-                    className={`size-5 shrink-0 rounded-lg border-0 bg-transparent p-0 transition-colors focus-visible:ring-1 ${surfaceActionClass}`}
-                    aria-label="Toggle file diff"
+                    className={`size-6 rounded-lg border-0 bg-transparent p-0 transition-colors focus-visible:ring-1 ${surfaceActionClass}`}
+                    aria-label={openActionLabel ?? `Open ${filePath}`}
+                    title={openActionTitle ?? "Open file"}
                   >
-                    <ChevronDown
-                      className={`size-3 transition-transform duration-200 ${
-                        isExpanded ? "rotate-180" : "rotate-0"
-                      }`}
-                    />
+                    <ArrowUpRight className="size-3.5" />
                   </Button>
-                )}
-              </div>
+                </div>
+              )}
+              {canExpand && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleExpand();
+                  }}
+                  className={`size-6 shrink-0 rounded-lg border-0 bg-transparent p-0 transition-colors focus-visible:ring-1 ${surfaceActionClass}`}
+                  aria-label="Toggle file diff"
+                  aria-expanded={isExpanded}
+                  data-app-action-review-file-expanded={isExpanded ? "true" : "false"}
+                  data-app-action-review-file-toggle=""
+                >
+                  <ChevronDown
+                    className={`size-3.5 transition-transform duration-200 ${
+                      isExpanded ? "rotate-180" : "rotate-0"
+                    }`}
+                  />
+                </Button>
+              )}
             </div>
           </div>
         </div>
-
-        {showChildren && (
-          <div className="relative overflow-hidden">
-            {children}
-          </div>
-        )}
       </div>
+
+      {showChildren && (
+        <div className="relative overflow-hidden">
+          {children}
+        </div>
+      )}
     </div>
   );
+
+  return isSidebar ? card : <div className="thread-diff-virtualized">{card}</div>;
 }
 
 function extractBasename(path: string): string {

--- a/desktop/src/components/ui/content/diff/ChatDiffViewer.tsx
+++ b/desktop/src/components/ui/content/diff/ChatDiffViewer.tsx
@@ -1,5 +1,4 @@
 import {
-  Fragment,
   useEffect,
   useId,
   useMemo,
@@ -108,24 +107,36 @@ function getChatLineNumberDigits(rows: ChatDiffRow[]): number {
   return Math.max(String(maxLineNumber).length, 1);
 }
 
-function ChatGutterCell({ line }: { line: DiffLine }) {
+function getDiffLineNumberColumnWidth(lineNumberDigits: number): string {
+  return `max(40px, calc(${lineNumberDigits}ch + 1.5rem))`;
+}
+
+function ChatGutterLine({ line }: { line: DiffLine }) {
   const lineType = getChatLineType(line);
   const lineNumber = getChatLineNumber(line);
 
   return (
     <div
-      data-gutter=""
       data-line-type={lineType}
       data-column-number={lineNumber ?? undefined}
       data-line-index={getChatLineIndex(line)}
-      className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] px-2 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
+      className="diff-gutter-cell box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
     >
       <span data-line-number-content="">{lineNumber ?? ""}</span>
     </div>
   );
 }
 
-function ChatContentCell({
+function ChatGutterSeparatorLine() {
+  return (
+    <div
+      data-separator="simple"
+      className="diff-gutter-cell min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
+    />
+  );
+}
+
+function ChatContentLine({
   line,
   tokens,
   wrapLongLines,
@@ -146,7 +157,6 @@ function ChatContentCell({
 
   return (
     <div
-      data-content=""
       data-line={lineNumber ?? undefined}
       data-alt-line={altLineNumber}
       data-line-type={lineType}
@@ -178,7 +188,6 @@ function ChatCollapsedRow({
   return (
     <button
       type="button"
-      data-content=""
       data-separator="simple"
       onClick={onExpand}
       aria-label={`Show ${section.lineCount} unmodified lines`}
@@ -191,6 +200,78 @@ function ChatCollapsedRow({
       </span>
       <span className="h-px min-w-4 flex-1 bg-border/60" />
     </button>
+  );
+}
+
+function ChatGutterColumn({
+  rows,
+  rowCount,
+}: {
+  rows: ChatDiffRow[];
+  rowCount: number;
+}) {
+  return (
+    <div
+      data-gutter=""
+      style={{ gridColumn: "1", gridRow: `1 / span ${rowCount}` }}
+      className="sticky left-0 z-10 grid [grid-template-rows:subgrid]"
+    >
+      {rows.map((row) =>
+        row.kind === "line" ? (
+          <ChatGutterLine key={row.key} line={row.line} />
+        ) : (
+          <ChatGutterSeparatorLine key={row.key} />
+        )
+      )}
+    </div>
+  );
+}
+
+function ChatContentColumn({
+  rows,
+  rowCount,
+  tokens,
+  wrapLongLines,
+  contentSearchQuery,
+  activeMatchId,
+  contentSearchUnitId,
+  onExpandCollapsedRow,
+}: {
+  rows: ChatDiffRow[];
+  rowCount: number;
+  tokens: HighlightedToken[][] | null;
+  wrapLongLines: boolean;
+  contentSearchQuery: string;
+  activeMatchId: string | null;
+  contentSearchUnitId: string;
+  onExpandCollapsedRow: (key: string) => void;
+}) {
+  return (
+    <div
+      data-content=""
+      style={{ gridColumn: "2", gridRow: `1 / span ${rowCount}` }}
+      className="grid [grid-template-rows:subgrid]"
+    >
+      {rows.map((row) =>
+        row.kind === "line" ? (
+          <ChatContentLine
+            key={row.key}
+            line={row.line}
+            tokens={tokens}
+            wrapLongLines={wrapLongLines}
+            contentSearchQuery={contentSearchQuery}
+            activeMatchId={activeMatchId}
+            contentSearchUnitId={contentSearchUnitId}
+          />
+        ) : (
+          <ChatCollapsedRow
+            key={row.key}
+            section={row.section}
+            onExpand={() => onExpandCollapsedRow(row.key)}
+          />
+        )
+      )}
+    </div>
   );
 }
 
@@ -258,13 +339,15 @@ export function ChatDiffViewer({
     },
     [contentSearchQuery, contentSearchUnitId, parsed.allCodeLines, tokens],
   );
+  const rowCount = Math.max(rows.length, 1);
   const lineNumberDigits = getChatLineNumberDigits(rows);
   const codeStyle = useMemo(
     () => ({
       ...CHAT_DIFF_CODE_BASE_STYLE,
-      "--diffs-column-number-width": `max(24px, ${lineNumberDigits + 1}ch)`,
+      "--diffs-column-number-width": getDiffLineNumberColumnWidth(lineNumberDigits),
+      gridTemplateRows: `repeat(${rowCount}, auto)`,
     }) as CSSProperties,
-    [lineNumberDigits],
+    [lineNumberDigits, rowCount],
   );
   const viewportStyle = useMemo(
     () => ({
@@ -345,33 +428,17 @@ export function ChatDiffViewer({
                 : "grid-cols-[var(--diffs-column-number-width)_minmax(max-content,1fr)]"
             }`}
           >
-            {rows.map((row) =>
-              row.kind === "line" ? (
-                <Fragment key={row.key}>
-                  <ChatGutterCell line={row.line} />
-                  <ChatContentCell
-                    line={row.line}
-                    tokens={tokens}
-                    wrapLongLines={wrapLongLines}
-                    contentSearchQuery={contentSearchQuery}
-                    activeMatchId={activeMatchId}
-                    contentSearchUnitId={contentSearchUnitId}
-                  />
-                </Fragment>
-              ) : (
-                <Fragment key={row.key}>
-                  <div
-                    data-gutter=""
-                    data-separator="simple"
-                    className="diff-gutter-cell sticky left-0 z-10 min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
-                  />
-                  <ChatCollapsedRow
-                    section={row.section}
-                    onExpand={() => expandCollapsedRow(row.key)}
-                  />
-                </Fragment>
-              )
-            )}
+            <ChatGutterColumn rows={rows} rowCount={rowCount} />
+            <ChatContentColumn
+              rows={rows}
+              rowCount={rowCount}
+              tokens={tokens}
+              wrapLongLines={wrapLongLines}
+              contentSearchQuery={contentSearchQuery}
+              activeMatchId={activeMatchId}
+              contentSearchUnitId={contentSearchUnitId}
+              onExpandCollapsedRow={expandCollapsedRow}
+            />
           </code>
         </pre>
       </div>

--- a/desktop/src/components/ui/content/diff/SplitDiffViewer.tsx
+++ b/desktop/src/components/ui/content/diff/SplitDiffViewer.tsx
@@ -1,53 +1,300 @@
-import type { CSSProperties } from "react";
-import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
-import type { DiffLine, ParsedPatch } from "@/lib/domain/files/diff-parser";
+import {
+  Fragment,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+import { DiffLineContent } from "@/components/ui/content/diff/DiffLineContent";
+import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
+import { chainVerticalWheelScroll } from "@/lib/infra/dom/scroll-chain";
+import type {
+  CollapsedContext,
+  DiffLine,
+  ParsedPatch,
+} from "@/lib/domain/files/diff-parser";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 
 type SplitDiffRow =
-  | { key: string; oldLine: null; newLine: null; label: string }
-  | { key: string; oldLine: DiffLine | null; newLine: DiffLine | null; label: null };
+  | { kind: "line"; key: string; oldLine: DiffLine | null; newLine: DiffLine | null }
+  | { kind: "collapsed"; key: string; section: CollapsedContext };
 
-function tokenContent(line: DiffLine, tokens: HighlightedToken[][] | null) {
-  const lineTokens = tokens?.[line.tokenIndex];
-  if (!lineTokens) {
-    return line.content || " ";
+type SplitSide = "old" | "new";
+
+const SPLIT_DIFF_PRE_STYLE = {
+  color: "var(--diffs-fg)",
+  backgroundColor: "var(--diffs-bg)",
+  "--diffs-bg": "var(--codex-diffs-surface)",
+  "--diffs-addition-color": "var(--diffs-addition-color-override)",
+  "--diffs-deletion-color": "var(--diffs-deletion-color-override)",
+  "--diffs-min-number-column-width": "4ch",
+  "--diffs-min-number-column-width-default": "3ch",
+} as CSSProperties;
+
+const SPLIT_DIFF_CODE_BASE_STYLE = {
+  "--diffs-column-content-width": "360px",
+  "--diffs-column-width": "360px",
+} as CSSProperties;
+
+function getSplitLineType(line: DiffLine): "context" | "change-addition" | "change-deletion" {
+  switch (line.type) {
+    case "added":
+      return "change-addition";
+    case "removed":
+      return "change-deletion";
+    case "context":
+      return "context";
   }
-  return lineTokens.map((token, index) => (
-    <span key={index} style={token.color ? { color: token.color } : undefined}>
-      {token.content}
-    </span>
-  ));
 }
 
-function SplitCell({
+function getSplitEmptyLineType(
+  peerLine: DiffLine | null,
+): "change-addition" | "change-deletion" | undefined {
+  if (!peerLine || peerLine.type === "context") {
+    return undefined;
+  }
+  return peerLine.type === "added" ? "change-addition" : "change-deletion";
+}
+
+function getSplitLineNumber(line: DiffLine, side: SplitSide): number | null {
+  return side === "old" ? line.oldLineNum : line.newLineNum;
+}
+
+function getSplitAltLineNumber(line: DiffLine, side: SplitSide): number | undefined {
+  if (line.type !== "context") {
+    return undefined;
+  }
+  return side === "old" ? line.newLineNum ?? undefined : line.oldLineNum ?? undefined;
+}
+
+function getSplitLineIndex(line: DiffLine): string {
+  return `${line.oldLineNum ?? ""},${line.newLineNum ?? ""}`;
+}
+
+function getSplitRows(
+  parsed: ParsedPatch,
+  expandedCollapsedKeys: Set<string>,
+): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = [];
+
+  parsed.hunks.forEach((hunk, hunkIndex) => {
+    hunk.items.forEach((item, itemIndex) => {
+      const key = `${hunkIndex}-${itemIndex}`;
+      if ("kind" in item && item.kind === "collapsed") {
+        if (expandedCollapsedKeys.has(key)) {
+          item.lines.forEach((line) => {
+            rows.push({
+              kind: "line",
+              key: `${key}-${line.tokenIndex}`,
+              oldLine: line,
+              newLine: line,
+            });
+          });
+        } else {
+          rows.push({ kind: "collapsed", key, section: item });
+        }
+        return;
+      }
+
+      const line = item as DiffLine;
+      rows.push({
+        kind: "line",
+        key: `${key}-${line.tokenIndex}`,
+        oldLine: line.type === "added" ? null : line,
+        newLine: line.type === "removed" ? null : line,
+      });
+    });
+  });
+
+  return rows;
+}
+
+function getSplitLineNumberDigits(rows: SplitDiffRow[], side: SplitSide): number {
+  let maxLineNumber = 0;
+  for (const row of rows) {
+    if (row.kind !== "line") continue;
+    const line = side === "old" ? row.oldLine : row.newLine;
+    if (!line) continue;
+    maxLineNumber = Math.max(maxLineNumber, getSplitLineNumber(line, side) ?? 0);
+  }
+  return Math.max(String(maxLineNumber).length, 1);
+}
+
+function getDiffLineNumberColumnWidth(lineNumberDigits: number): string {
+  return `max(40px, calc(${lineNumberDigits}ch + 1.5rem))`;
+}
+
+function SplitEmptyCell({
+  emptyLineType,
+}: {
+  emptyLineType: "change-addition" | "change-deletion" | undefined;
+}) {
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-empty-side={emptyLineType}
+        data-gutter-buffer="buffer"
+        data-buffer-size="1"
+        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--diffs-bg)]"
+      />
+      <div
+        data-content=""
+        data-empty-side={emptyLineType}
+        className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
+      />
+    </>
+  );
+}
+
+function SplitLineCells({
   line,
+  peerLine,
   tokens,
   side,
+  wrapLongLines,
 }: {
   line: DiffLine | null;
+  peerLine: DiffLine | null;
   tokens: HighlightedToken[][] | null;
-  side: "old" | "new";
+  side: SplitSide;
+  wrapLongLines: boolean;
 }) {
   if (!line) {
-    return <div className="min-h-[var(--readable-code-line-height)] border-l border-border/40" />;
+    return <SplitEmptyCell emptyLineType={getSplitEmptyLineType(peerLine)} />;
   }
-  const lineNumber = side === "old"
-    ? line.oldLineNum
-    : line.newLineNum;
-  const bg = line.type === "added"
-    ? "bg-[var(--color-diff-added-bg)]"
-    : line.type === "removed"
-      ? "bg-[var(--color-diff-deleted-bg)]"
-      : "";
+
+  const lineType = getSplitLineType(line);
+  const lineNumber = getSplitLineNumber(line, side);
+  const altLineNumber = getSplitAltLineNumber(line, side);
+
   return (
-    <div className={`grid min-h-[var(--readable-code-line-height)] grid-cols-[4ch_minmax(0,1fr)] border-l border-border/40 ${bg}`}>
-      <span className="select-none pr-1 text-right text-[10px] text-muted-foreground/40">
-        {lineNumber ?? ""}
-      </span>
-      <span className="min-w-0 whitespace-pre-wrap break-words px-2">
-        {tokenContent(line, tokens)}
-      </span>
-    </div>
+    <>
+      <div
+        data-gutter=""
+        data-line-type={lineType}
+        data-column-number={lineNumber ?? undefined}
+        data-line-index={getSplitLineIndex(line)}
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
+      >
+        <span data-line-number-content="">{lineNumber ?? ""}</span>
+      </div>
+      <div
+        data-content=""
+        data-line={lineNumber ?? undefined}
+        data-alt-line={altLineNumber}
+        data-line-type={lineType}
+        data-line-index={getSplitLineIndex(line)}
+        className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
+          wrapLongLines
+            ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
+            : "flex min-w-max items-center whitespace-pre"
+        }`}
+      >
+        <DiffLineContent line={line} tokens={tokens} />
+      </div>
+    </>
+  );
+}
+
+function SplitCollapsedCells({
+  section,
+  onExpand,
+}: {
+  section: CollapsedContext;
+  onExpand: () => void;
+}) {
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-separator="line-info"
+        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--diffs-bg)]"
+      />
+      <button
+        type="button"
+        data-content=""
+        data-separator="line-info"
+        onClick={onExpand}
+        aria-label={`Show ${section.lineCount} unmodified lines`}
+        title={`${section.lineCount} unmodified lines`}
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center gap-2 border-0 bg-transparent px-2 py-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/70 hover:text-muted-foreground"
+      >
+        <span className="h-px min-w-4 flex-1 bg-border/60" />
+        <span data-unmodified-lines="" className="shrink-0 text-[10px] leading-none">
+          Show {section.lineCount} unchanged line{section.lineCount === 1 ? "" : "s"}
+        </span>
+        <span className="h-px min-w-4 flex-1 bg-border/60" />
+      </button>
+    </>
+  );
+}
+
+function SplitCodeColumn({
+  side,
+  rows,
+  rowCount,
+  tokens,
+  wrapLongLines,
+  lineNumberDigits,
+  onExpandCollapsed,
+}: {
+  side: SplitSide;
+  rows: SplitDiffRow[];
+  rowCount: number;
+  tokens: HighlightedToken[][] | null;
+  wrapLongLines: boolean;
+  lineNumberDigits: number;
+  onExpandCollapsed: (key: string) => void;
+}) {
+  const codeStyle = useMemo(
+    () => ({
+      ...SPLIT_DIFF_CODE_BASE_STYLE,
+      "--diffs-column-number-width": getDiffLineNumberColumnWidth(lineNumberDigits),
+    }) as CSSProperties,
+    [lineNumberDigits],
+  );
+
+  return (
+    <code
+      data-code=""
+      data-deletions={side === "old" ? "" : undefined}
+      data-additions={side === "new" ? "" : undefined}
+      data-container-size=""
+      style={{
+        ...codeStyle,
+        gridColumn: side === "old" ? "1" : "2",
+        gridRow: `1 / span ${rowCount}`,
+      }}
+      className={`grid border-border/60 ${
+        side === "old" ? "border-r" : ""
+      } [grid-template-rows:subgrid] ${
+        wrapLongLines
+          ? "min-w-0 max-w-full overflow-hidden grid-cols-[var(--diffs-column-number-width)_minmax(0,1fr)]"
+          : "min-w-0 max-w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] grid-cols-[var(--diffs-column-number-width)_minmax(max-content,1fr)]"
+      }`}
+    >
+      {rows.map((row) =>
+        row.kind === "line" ? (
+          <Fragment key={row.key}>
+            <SplitLineCells
+              line={side === "old" ? row.oldLine : row.newLine}
+              peerLine={side === "old" ? row.newLine : row.oldLine}
+              tokens={tokens}
+              side={side}
+              wrapLongLines={wrapLongLines}
+            />
+          </Fragment>
+        ) : (
+          <Fragment key={row.key}>
+            <SplitCollapsedCells
+              section={row.section}
+              onExpand={() => onExpandCollapsed(row.key)}
+            />
+          </Fragment>
+        )
+      )}
+    </code>
   );
 }
 
@@ -56,70 +303,111 @@ export function SplitDiffViewer({
   tokens,
   className,
   viewportClassName,
-  overscrollBehavior,
+  wrapLongLines,
+  overscrollBehavior = "none",
   overscrollBehaviorX,
   overscrollBehaviorY,
-  chainVerticalWheel,
+  chainVerticalWheel = false,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
   className?: string;
   viewportClassName?: string;
+  wrapLongLines: boolean;
   overscrollBehavior?: CSSProperties["overscrollBehavior"];
   overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
 }) {
-  const rows: SplitDiffRow[] = [];
-  parsed.hunks.forEach((hunk, hunkIndex) => {
-    hunk.items.forEach((item, itemIndex) => {
-      if ("kind" in item && item.kind === "collapsed") {
-        rows.push({
-          key: `collapsed-${hunkIndex}-${itemIndex}`,
-          oldLine: null,
-          newLine: null,
-          label: `${item.lineCount} unmodified lines`,
-        });
-        return;
-      }
-      const line = item as DiffLine;
-      rows.push({
-        key: `line-${line.tokenIndex}`,
-        oldLine: line.type === "added" ? null : line,
-        newLine: line.type === "removed" ? null : line,
-        label: null,
-      });
+  const resolvedMode = useResolvedMode();
+  const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const rows = useMemo(
+    () => getSplitRows(parsed, expandedCollapsedKeys),
+    [parsed, expandedCollapsedKeys],
+  );
+  const rowCount = Math.max(rows.length, 1);
+  const oldLineNumberDigits = getSplitLineNumberDigits(rows, "old");
+  const newLineNumberDigits = getSplitLineNumberDigits(rows, "new");
+  const viewportStyle = useMemo(
+    () => ({
+      overscrollBehavior,
+      ...(overscrollBehaviorX ? { overscrollBehaviorX } : {}),
+      ...(overscrollBehaviorY ? { overscrollBehaviorY } : {}),
+    }) as CSSProperties,
+    [overscrollBehavior, overscrollBehaviorX, overscrollBehaviorY],
+  );
+  const preStyle = useMemo(
+    () => ({
+      ...SPLIT_DIFF_PRE_STYLE,
+      gridTemplateRows: `repeat(${rowCount}, auto)`,
+    }) as CSSProperties,
+    [rowCount],
+  );
+
+  const expandCollapsedRow = (key: string) => {
+    setExpandedCollapsedKeys((prev) => {
+      const next = new Set(prev);
+      next.add(key);
+      return next;
     });
-  });
+  };
+  const handleViewportWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    if (!chainVerticalWheel) {
+      return;
+    }
+    if (chainVerticalWheelScroll(event.currentTarget, event.deltaY)) {
+      event.preventDefault();
+    }
+  };
 
   return (
-    <AutoHideScrollArea
-      className={`font-mono text-[length:var(--readable-code-font-size)] leading-[var(--readable-code-line-height)] ${className ?? ""}`}
-      viewportClassName={`bg-[var(--codex-diffs-surface)] ${viewportClassName ?? ""}`}
-      contentClassName="min-h-full bg-[var(--codex-diffs-surface)]"
-      allowHorizontal={false}
-      overscrollBehavior={overscrollBehavior}
-      overscrollBehaviorX={overscrollBehaviorX}
-      overscrollBehaviorY={overscrollBehaviorY}
-      chainVerticalWheel={chainVerticalWheel}
-    >
-      <div className="grid min-w-0 grid-cols-2">
-        {rows.map((row) =>
-          row.label ? (
-            <div
-              key={row.key}
-              className="col-span-2 border-y border-border/50 bg-muted/20 px-3 py-1 text-center text-[10px] text-muted-foreground"
-            >
-              {row.label}
-            </div>
-          ) : (
-            <div key={row.key} className="contents">
-              <SplitCell line={row.oldLine} tokens={tokens} side="old" />
-              <SplitCell line={row.newLine} tokens={tokens} side="new" />
-            </div>
-          )
-        )}
+    <div className={className ?? ""}>
+      <div
+        style={viewportStyle}
+        onWheel={handleViewportWheel}
+        className={`relative [contain:content] composer-diff-simple-line overflow-y-auto overflow-x-hidden ${
+          viewportClassName ?? ""
+        }`}
+      >
+        <pre
+          data-diff=""
+          data-theme-type={resolvedMode === "dark" ? "dark" : "light"}
+          data-indicators="bars"
+          data-background=""
+          data-diff-type="split"
+          data-overflow="scroll"
+          data-interactive-lines=""
+          data-interactive-line-numbers=""
+          tabIndex={0}
+          style={preStyle}
+          className={`m-0 grid bg-[var(--codex-diffs-surface)] p-0 font-[family:var(--diffs-font-family)] text-[length:var(--diffs-font-size)] leading-[var(--diffs-line-height)] text-[color:var(--diffs-fg)] ${
+            wrapLongLines
+              ? "w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
+              : "w-full min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
+          }`}
+        >
+          <SplitCodeColumn
+            side="old"
+            rows={rows}
+            rowCount={rowCount}
+            tokens={tokens}
+            wrapLongLines={wrapLongLines}
+            lineNumberDigits={oldLineNumberDigits}
+            onExpandCollapsed={expandCollapsedRow}
+          />
+          <SplitCodeColumn
+            side="new"
+            rows={rows}
+            rowCount={rowCount}
+            tokens={tokens}
+            wrapLongLines={wrapLongLines}
+            lineNumberDigits={newLineNumberDigits}
+            onExpandCollapsed={expandCollapsedRow}
+          />
+        </pre>
       </div>
-    </AutoHideScrollArea>
+    </div>
   );
 }

--- a/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
@@ -19,18 +19,21 @@ describe("TurnDiffPanel", () => {
       }),
     );
 
-    expect(html).toContain("2 files changed");
-    expect(html).not.toContain("+4");
-    expect(html).not.toContain("text-git-red\">-2</span>");
-    expect(html).toContain('text-right">+</span><span class="text-right">2');
-    expect(html).toContain('text-right">-</span><span class="text-right">1');
-    expect(html).toContain("grid-cols-[0.65ch_minmax(1ch,max-content)]");
+    expect(html).toContain("Edited 2 files");
+    expect(html).toContain("bg-[var(--color-diff-panel-surface)]");
+    expect(html).toContain("border border-border");
+    expect(html).toContain(">+2</span>");
+    expect(html).toContain(">-1</span>");
     expect(html).toContain("data-diff-surface=\"chat\"");
+    expect(html).toContain("thread-diff-virtualized");
+    expect(html).toContain("data-app-action-review-file-expanded=\"false\"");
+    expect(html).not.toContain("data-gutter=\"\"");
+    expect(html).not.toContain("data-content=\"\"");
     expect(html).toContain("README.md");
     expect(html).toContain("GitPanel.tsx");
   });
 
-  it("labels the file card action as a changes review entry point", () => {
+  it("keeps the aggregate review entry point invisible while file rows keep their action", () => {
     const turn = PLAYGROUND_END_TURN_DIFF_TRANSCRIPT.turnsById["turn-end-diff"];
     const html = renderToStaticMarkup(
       createElement(TurnDiffPanel, {
@@ -42,6 +45,43 @@ describe("TurnDiffPanel", () => {
     );
 
     expect(html).toContain("Open changes review");
+    expect(html).toContain("--turn-diff-header-hover-surface");
+    expect(html).toContain("var(--color-diff-panel-surface)_96%");
+    expect(html).toContain("var(--color-background)");
+    expect(html).toContain("hover:bg-[var(--turn-diff-header-hover-surface)]");
+    expect(html).not.toContain(">Review</button>");
+    expect(html).toContain("Show file in review");
+    expect(html).toContain("data-app-action-review-file-toggle");
+  });
+
+  it("uses file-specific single-file end-turn copy without repeating row stats", () => {
+    const transcript = structuredClone(PLAYGROUND_END_TURN_DIFF_TRANSCRIPT);
+    transcript.turnsById["turn-end-diff"].itemOrder = [
+      "assistant-end-diff",
+      "tool-end-diff-readme",
+    ];
+    transcript.turnsById["turn-end-diff"].fileBadges = [
+      { path: "README.md", additions: 2, deletions: 1 },
+    ];
+
+    const html = renderToStaticMarkup(
+      createElement(TurnDiffPanel, {
+        turn: transcript.turnsById["turn-end-diff"],
+        transcript,
+        onOpenFile: () => {},
+        onOpenReviewPane: () => {},
+      }),
+    );
+
+    expect(html).toContain("Edited README.md");
+    expect(html).not.toContain("Edited 1 file");
+    expect(html).toContain(">README.md</span>");
+    expect(html).not.toContain(">Details</span>");
+    expect(html.match(/>\+2<\/span>/g)).toHaveLength(1);
+    expect(html.match(/>-1<\/span>/g)).toHaveLength(1);
+    expect(html).toContain("data-app-action-review-file-expanded=\"false\"");
+    expect(html).not.toContain("data-gutter=\"\"");
+    expect(html).not.toContain("data-content=\"\"");
   });
 
   it("does not render chat diff cards for blank file patches", () => {
@@ -102,10 +142,10 @@ describe("TurnDiffPanel", () => {
       }),
     );
 
-    expect(html).toContain("5 files changed");
+    expect(html).toContain("Edited 5 files");
     expect(html).toContain("src/file-0.ts");
     expect(html).toContain("src/file-2.ts");
     expect(html).not.toContain("src/file-3.ts");
-    expect(html).toContain("Show 2 more");
+    expect(html).toContain("Show 2 more files");
   });
 });

--- a/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
 import {
-  FileChangesCard,
+  FileChangeStats,
   FileDiffCard,
 } from "@/components/ui/content/FileDiffCard";
 import { collectTurnFilePatches } from "@/lib/domain/chat/transcript/turn-file-patches";
@@ -50,6 +50,12 @@ export function TurnDiffPanel({
     : filePatches.slice(0, CHAT_VISIBLE_FILE_CHANGE_LIMIT);
   const canToggleVisibleFiles = filePatches.length > CHAT_VISIBLE_FILE_CHANGE_LIMIT;
   const hiddenFileCount = filePatches.length - visibleFilePatches.length;
+  const totalAdditions = filePatches.reduce((total, fp) => total + fp.additions, 0);
+  const totalDeletions = filePatches.reduce((total, fp) => total + fp.deletions, 0);
+  const singleFilePatch = fileCount === 1 ? filePatches[0] : null;
+  const title = singleFilePatch
+    ? `Edited ${extractBasename(singleFilePatch.path)}`
+    : `Edited ${fileCount} files`;
 
   const toggleExpanded = (path: string) => {
     setExpandedPaths((prev) => {
@@ -64,64 +70,95 @@ export function TurnDiffPanel({
   };
 
   return (
-    <FileChangesCard
-      fileCount={fileCount}
-      className="mt-2"
+    <div
+      className="mb-2 flex max-w-full flex-col overflow-hidden rounded-lg border border-border bg-[var(--color-diff-panel-surface)] text-base text-foreground shadow-sm [--turn-diff-header-hover-surface:color-mix(in_oklab,var(--color-diff-panel-surface)_96%,var(--color-background))] [--turn-diff-row-padding-x:0.75rem] [--turn-diff-row-padding-y:0.5rem]"
     >
-      {visibleFilePatches.map((fp) => {
-        const isExpanded = expandedPaths.has(fp.path);
-        const combinedPatch = fp.patches.join("\n");
-        const displayPolicy = resolveDiffDisplayPolicy({
-          path: fp.path,
-          additions: fp.additions,
-          deletions: fp.deletions,
-          patch: combinedPatch,
-        });
+      <div className="relative">
+        {onOpenReviewPane && (
+          <button
+            type="button"
+            aria-label="Open changes review"
+            onClick={onOpenReviewPane}
+            className="absolute inset-0 cursor-pointer bg-transparent hover:bg-[var(--turn-diff-header-hover-surface)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border focus-visible:ring-inset"
+          />
+        )}
+        <div className="pointer-events-none relative z-10 flex min-w-0 items-center px-[var(--turn-diff-row-padding-x)] py-3 text-left">
+          <span className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-chat font-medium leading-[var(--text-chat--line-height)] text-foreground">
+              {title}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              <FileChangeStats
+                additions={totalAdditions}
+                deletions={totalDeletions}
+                className="text-xs"
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col border-t border-border [--codex-diffs-header-padding-x:var(--turn-diff-row-padding-x)] [--codex-diffs-header-padding-y:var(--turn-diff-row-padding-y)] [--codex-diffs-surface-override:color-mix(in_oklab,var(--color-diff-panel-surface)_50%,transparent)]">
+        {visibleFilePatches.map((fp) => {
+          const isExpanded = expandedPaths.has(fp.path);
+          const combinedPatch = fp.patches.join("\n");
+          const displayPolicy = resolveDiffDisplayPolicy({
+            path: fp.path,
+            additions: fp.additions,
+            deletions: fp.deletions,
+            patch: combinedPatch,
+          });
 
-        return (
-          <FileDiffCard
-            key={fp.path}
-            filePath={fp.path}
-            additions={fp.additions}
-            deletions={fp.deletions}
-            isExpanded={isExpanded}
-            onToggleExpand={() => toggleExpanded(fp.path)}
-            onOpenFile={() => onOpenFile(fp.path)}
-            onOpenAction={onOpenReviewPane}
-            openActionLabel={onOpenReviewPane ? "Open changes review" : undefined}
-            openActionTitle={onOpenReviewPane ? "Open changes review" : undefined}
-            embedded
+          return (
+            <FileDiffCard
+              key={fp.path}
+              filePath={fp.path}
+              additions={fp.additions}
+              deletions={fp.deletions}
+              showStats={fileCount !== 1}
+              isExpanded={isExpanded}
+              onToggleExpand={() => toggleExpanded(fp.path)}
+              onOpenFile={() => onOpenFile(fp.path)}
+              onOpenAction={onOpenReviewPane}
+              openActionLabel={onOpenReviewPane ? "Show file in review" : undefined}
+              openActionTitle={onOpenReviewPane ? "Show file in review" : undefined}
+              embedded
+            >
+              {combinedPatch && !displayPolicy.canRenderInline ? (
+                <DiffDisplayPolicyPlaceholder
+                  title={displayPolicy.placeholderTitle}
+                  description={displayPolicy.placeholderDescription}
+                />
+              ) : combinedPatch ? (
+                <DiffViewer
+                  patch={combinedPatch}
+                  filePath={fp.path}
+                  contentSearchUnitId={`diff:${turn.turnId}:${fp.path}`}
+                  viewportClassName={TURN_DIFF_VIEWPORT_CLASS}
+                  variant="chat"
+                />
+              ) : null}
+            </FileDiffCard>
+          );
+        })}
+        {canToggleVisibleFiles && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowAllFiles((value) => !value)}
+            className="flex h-9 w-full justify-start rounded-none px-[var(--turn-diff-row-padding-x)] py-[var(--turn-diff-row-padding-y)] text-left text-chat leading-[var(--text-chat--line-height)] text-foreground hover:bg-foreground/5"
           >
-            {combinedPatch && !displayPolicy.canRenderInline ? (
-              <DiffDisplayPolicyPlaceholder
-                title={displayPolicy.placeholderTitle}
-                description={displayPolicy.placeholderDescription}
-              />
-            ) : combinedPatch ? (
-              <DiffViewer
-                patch={combinedPatch}
-                filePath={fp.path}
-                contentSearchUnitId={`diff:${turn.turnId}:${fp.path}`}
-                viewportClassName={TURN_DIFF_VIEWPORT_CLASS}
-                variant="chat"
-              />
-            ) : null}
-          </FileDiffCard>
-        );
-      })}
-      {canToggleVisibleFiles && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => setShowAllFiles((value) => !value)}
-          className="h-8 w-full justify-center rounded-none px-3 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          {showAllFiles ? "Show less" : `Show ${hiddenFileCount} more`}
-        </Button>
-      )}
-    </FileChangesCard>
+            {showAllFiles ? "Show fewer files" : `Show ${hiddenFileCount} more files`}
+          </Button>
+        )}
+      </div>
+    </div>
   );
+}
+
+function extractBasename(path: string): string {
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? path;
 }
 
 function DiffDisplayPolicyPlaceholder({

--- a/desktop/src/components/workspace/git/GitPanel.test.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.test.tsx
@@ -2,6 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitPanel } from "./GitPanel";
+import { GitPanelHeader } from "./GitPanelHeader";
 
 const mockGitPanelState = vi.hoisted(() => vi.fn());
 const gitDiffQuery = vi.hoisted(() => ({
@@ -113,18 +114,74 @@ describe("GitPanel", () => {
 
     expect(html).toContain("Unstaged");
     expect(html).toContain(">1<");
-    expect(html).toContain("Working tree");
+    expect(html).not.toContain("Working tree");
     expect(html).toContain("Git review options");
     expect(html).toContain("Show files");
     expect(html).toContain("data-diff-surface=\"sidebar\"");
-    expect(html).toContain("px-2 pb-2");
+    expect(html).toContain("codex-review-diff-card");
+    expect(html).toContain("data-review-path=\"desktop/src/components/workspace/git/GitPanel.tsx\"");
+    expect(html).toContain("id=\"review-diffs-collapsed\"");
+    expect(html).toContain("data-app-action-review-scroll=\"\"");
+    expect(html).toContain("data-thread-find-target=\"review\"");
+    expect(html).toContain("data-app-action-review-metrics-probe=\"\"");
+    expect(html).toContain("[container-name:review-header]");
+    expect(html).toContain("grid-cols-[minmax(0,1fr)_auto]");
+    expect(html).toContain("min-h-9");
+    expect(html).toContain("px-2 pb-3");
     expect(html).toContain("pt-2");
-    expect(html).not.toContain("px-2 py-2");
     expect(html).not.toContain("No diff available");
     expect(html).toContain("GitPanel.tsx");
+    expect(html).toContain("aria-expanded=\"false\"");
+    expect(html).not.toContain("new line");
+    expect(gitDiffQuery.calls[0]).toMatchObject({
+      path: "desktop/src/components/workspace/git/GitPanel.tsx",
+      enabled: false,
+    });
   });
 
-  it("keeps the Changes header options before the file sidebar toggle", () => {
+  it("shows the branch target selector only in branch review mode", () => {
+    const baseProps = {
+      visibleChangedCount: 1,
+      additions: 1,
+      deletions: 1,
+      isRuntimeReady: true,
+      branchRefs: [{ name: "origin/main", isDefault: true, isHead: false, isRemote: true, upstream: null }],
+      baseRef: "origin/main",
+      layout: "unified" as const,
+      wrapLongLines: true,
+      fileTreeOpen: false,
+      allFilesCollapsed: false,
+      onFilterChange: vi.fn(),
+      onBaseRefChange: vi.fn(),
+      onToggleLayout: vi.fn(),
+      onToggleWrap: vi.fn(),
+      onToggleFileTree: vi.fn(),
+      onToggleAllFiles: vi.fn(),
+      onRefresh: vi.fn(),
+    };
+
+    const unstagedHtml = renderToStaticMarkup(
+      createElement(GitPanelHeader, {
+        ...baseProps,
+        changesFilter: "unstaged",
+      }),
+    );
+    const branchHtml = renderToStaticMarkup(
+      createElement(GitPanelHeader, {
+        ...baseProps,
+        changesFilter: "branch",
+      }),
+    );
+
+    expect(unstagedHtml).not.toContain("origin/main");
+    expect(unstagedHtml).toContain("min-h-9");
+    expect(branchHtml).toContain("origin/main");
+    expect(branchHtml).toContain("min-h-9");
+    expect(branchHtml).not.toContain("min-h-[68px]");
+    expect(branchHtml).not.toContain("col-span-2");
+  });
+
+  it("keeps the Changes header options before the sidebar controls", () => {
     const html = renderToStaticMarkup(createElement(GitPanel));
     const layoutIndex = html.indexOf("Use split diff");
     const optionsIndex = html.indexOf("Git review options");
@@ -133,8 +190,8 @@ describe("GitPanel", () => {
     expect(layoutIndex).toBeGreaterThanOrEqual(0);
     expect(optionsIndex).toBeGreaterThanOrEqual(0);
     expect(sidebarIndex).toBeGreaterThanOrEqual(0);
-    expect(layoutIndex).toBeLessThan(optionsIndex);
-    expect(optionsIndex).toBeLessThan(sidebarIndex);
+    expect(optionsIndex).toBeLessThan(layoutIndex);
+    expect(layoutIndex).toBeLessThan(sidebarIndex);
   });
 
   it("renders a compact empty state when there are no changes", () => {
@@ -149,6 +206,24 @@ describe("GitPanel", () => {
     expect(html).toContain("No unstaged changes");
     expect(html).toContain("Edit files in the workspace and they will appear here.");
     expect(html).toContain("Refresh");
+  });
+
+  it("renders the empty state when the active section has no files", () => {
+    mockGitPanelState.mockReturnValue(createGitPanelState({
+      sections: [{
+        scope: "unstaged",
+        label: "Unstaged",
+        files: [],
+      }],
+      totalChangedCount: 0,
+      visibleChangedCount: 0,
+    }));
+
+    const html = renderToStaticMarkup(createElement(GitPanel));
+
+    expect(html).toContain("No unstaged changes");
+    expect(html).toContain("Edit files in the workspace and they will appear here.");
+    expect(html).not.toContain("data-diff-surface=\"sidebar\"");
   });
 
   it("renders last-turn current diffs without stage actions", () => {
@@ -179,11 +254,11 @@ describe("GitPanel", () => {
     const html = renderToStaticMarkup(createElement(GitPanel));
 
     expect(html).toContain("README.md");
-    expect(html).toContain('text-right">+</span><span class="text-right">1');
+    expect(html).toContain(">+1</span>");
     expect(html).not.toContain("Stage README.md");
   });
 
-  it("keeps zero-stat rows expanded so empty status entries can resolve", () => {
+  it("starts zero-stat rows collapsed until the user expands them", () => {
     const files = Array.from({ length: 4 }, (_, index) => {
       const path = index === 3 ? "src/unknown-stat.ts" : `src/file-${index}.ts`;
       const diff = {
@@ -214,10 +289,12 @@ describe("GitPanel", () => {
     const html = renderToStaticMarkup(createElement(GitPanel));
 
     expect(html).toContain("src/unknown-stat.ts");
-    expect(html.match(/new line/g)).toHaveLength(4);
+    expect(html).not.toContain("new line");
+    expect(gitDiffQuery.calls.map((call) => (call as { enabled?: boolean }).enabled))
+      .toEqual([false, false, false, false]);
   });
 
-  it("skips loaded changed-file rows that have no renderable diff", () => {
+  it("keeps collapsed changed-file rows visible until their diff is expanded", () => {
     gitDiffQuery.state = {
       data: {
         patch: null,
@@ -235,11 +312,16 @@ describe("GitPanel", () => {
 
     expect(html).toContain("Unstaged");
     expect(html).not.toContain("No diff available");
-    expect(html).not.toContain("data-diff-surface=\"sidebar\"");
-    expect(html).not.toContain("GitPanel.tsx");
+    expect(html).toContain("data-diff-surface=\"sidebar\"");
+    expect(html).toContain("GitPanel.tsx");
+    expect(html).toContain("aria-label=\"Modified\"");
+    expect(gitDiffQuery.calls[0]).toMatchObject({
+      path: "desktop/src/components/workspace/git/GitPanel.tsx",
+      enabled: false,
+    });
   });
 
-  it("renders diff load errors explicitly", () => {
+  it("does not render diff load errors before collapsed rows are expanded", () => {
     gitDiffQuery.state = {
       data: null,
       error: new Error("pathspec did not match any files"),
@@ -249,7 +331,12 @@ describe("GitPanel", () => {
 
     const html = renderToStaticMarkup(createElement(GitPanel));
 
-    expect(html).toContain("Diff unavailable: pathspec did not match any files");
+    expect(html).not.toContain("Diff unavailable: pathspec did not match any files");
+    expect(html).toContain("aria-expanded=\"false\"");
+    expect(gitDiffQuery.calls[0]).toMatchObject({
+      path: "desktop/src/components/workspace/git/GitPanel.tsx",
+      enabled: false,
+    });
   });
 
   it("does not auto-fetch oversized generated diffs on first render", () => {
@@ -286,7 +373,7 @@ describe("GitPanel", () => {
     });
   });
 
-  it("limits initial expanded diff fetches", () => {
+  it("does not fetch file diffs before the user expands rows", () => {
     const files = Array.from({ length: 4 }, (_, index) => {
       const path = `src/file-${index}.ts`;
       const diff = {
@@ -318,6 +405,6 @@ describe("GitPanel", () => {
 
     expect(gitDiffQuery.calls).toHaveLength(4);
     expect(gitDiffQuery.calls.map((call) => (call as { enabled?: boolean }).enabled))
-      .toEqual([true, true, false, false]);
+      .toEqual([false, false, false, false]);
   });
 });

--- a/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/desktop/src/components/workspace/git/GitPanel.tsx
@@ -3,11 +3,14 @@ import {
   useStageGitPathsMutation,
   useUnstageGitPathsMutation,
 } from "@anyharness/sdk-react";
+import {
+  GitReviewEmptyState,
+  GitReviewEmptyStateAction,
+} from "./GitReviewEmptyState";
 import { GitPanelHeader } from "./GitPanelHeader";
 import { GitReviewFileRow } from "./GitReviewFileRow";
 import { GitReviewFileTree } from "./GitReviewFileTree";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { AutoHideScrollArea } from "@/components/ui/layout/AutoHideScrollArea";
 import { CheckCircleFilled, ChevronRight, GitBranchIcon, RefreshCw } from "@/components/ui/icons";
 import { PaneSideOverlay } from "@/components/workspace/pane/PaneSideOverlay";
 import { useDiffReviewMeasurement } from "@/hooks/workspaces/files/use-diff-review-measurement";
@@ -34,7 +37,6 @@ import {
 } from "@/lib/domain/workspaces/changes/git-review-entries";
 import { useGitPanelUiStore } from "@/stores/editor/git-panel-ui-store";
 
-const INITIAL_EXPANDED_DIFF_FILE_LIMIT = 3;
 const EMPTY_COLLAPSED_FILE_KEYS = new Set<string>();
 
 export function GitPanel() {
@@ -62,7 +64,7 @@ function GitPanelContent({
   const [changesFilter, setChangesFilter] = useState<GitPanelMode>("unstaged");
   const [selectedBaseRef, setSelectedBaseRef] = useState<string | null>(null);
   const [layout, setLayout] = useState<"unified" | "split">("unified");
-  const [wrapLongLines, setWrapLongLines] = useState(true);
+  const [wrapLongLines, setWrapLongLines] = useState(false);
   const [fileTreeOpen, setFileTreeOpen] = useState(false);
   const [collapsedSections, setCollapsedSections] = useState<Set<GitPanelReviewScope>>(new Set());
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
@@ -93,42 +95,25 @@ function GitPanelContent({
   });
   const stageMutation = useStageGitPathsMutation({ workspaceId: activeWorkspaceId });
   const unstageMutation = useUnstageGitPathsMutation({ workspaceId: activeWorkspaceId });
+  const reviewEntries = useMemo(
+    () => buildGitReviewFileEntries(sections),
+    [sections],
+  );
+  const hasReviewEntries = reviewEntries.length > 0;
   const canShowFileTree = fileTreeOpen
     && !isLoading
     && !errorMessage
     && !runtimeBlockedReason
-    && sections.length > 0;
-
-  const reviewEntries = useMemo(
-    () => buildGitReviewFileEntries(sections),
+    && hasReviewEntries;
+  const aggregateStats = useMemo(
+    () => summarizeGitPanelSectionStats(sections),
     [sections],
   );
   const autoCollapsedFiles = useMemo<ReadonlySet<string>>(() => {
     if (fileCollapseTouched) {
       return EMPTY_COLLAPSED_FILE_KEYS;
     }
-    const collapsedKeys = reviewEntries.flatMap((entry, index) => {
-      const currentDiff = entry.file.currentDiff;
-      const displayPolicy = currentDiff
-        ? resolveDiffDisplayPolicy({
-            path: currentDiff.path,
-            additions: currentDiff.additions,
-            deletions: currentDiff.deletions,
-          })
-        : null;
-      const hasKnownChangedLines = currentDiff
-        ? currentDiff.additions + currentDiff.deletions > 0
-        : false;
-      const shouldResolveInline = Boolean(
-        currentDiff
-        && !hasKnownChangedLines
-        && !displayPolicy?.shouldAutoCollapse,
-      );
-      return Boolean(displayPolicy?.shouldAutoCollapse)
-        || (index >= INITIAL_EXPANDED_DIFF_FILE_LIMIT && !shouldResolveInline)
-        ? [entry.key]
-        : [];
-    });
+    const collapsedKeys = reviewEntries.map((entry) => entry.key);
     return collapsedKeys.length === 0
       ? EMPTY_COLLAPSED_FILE_KEYS
       : new Set(collapsedKeys);
@@ -286,6 +271,8 @@ function GitPanelContent({
       <GitPanelHeader
         changesFilter={changesFilter}
         visibleChangedCount={visibleChangedCount}
+        additions={aggregateStats.additions}
+        deletions={aggregateStats.deletions}
         isRuntimeReady={isRuntimeReady}
         branchRefs={branchRefs}
         baseRef={baseRef}
@@ -303,79 +290,87 @@ function GitPanelContent({
       />
 
       <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
-        <AutoHideScrollArea
-          className="h-full min-h-0 min-w-0"
-          viewportClassName="px-2 pb-2"
-          contentClassName="pt-2"
+        <div
+          id="review-diffs-collapsed"
+          data-app-action-review-scroll=""
+          data-thread-find-target="review"
+          className="h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-2 pb-3"
         >
-          {isLoading && (
-            <div className="space-y-2 px-2 py-4">
-              <div className="h-3 w-32 animate-pulse rounded bg-sidebar-accent" />
-              <div className="h-3 w-48 animate-pulse rounded bg-sidebar-accent" />
-              <div className="h-3 w-40 animate-pulse rounded bg-sidebar-accent" />
-            </div>
-          )}
-          {errorMessage && (
-            <p className="px-2 py-4 text-xs text-destructive">{errorMessage}</p>
-          )}
-          {!errorMessage && runtimeBlockedReason && (
-            <p className="px-2 py-4 text-xs text-sidebar-muted-foreground">
-              {runtimeBlockedReason}
-            </p>
-          )}
-          {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length === 0 && (
-            <GitReviewEmptyState
-              mode={changesFilter}
-              baseRef={baseRef}
-              onRefresh={() => void refetch()}
+          <div className="relative flex min-h-full flex-col pt-2">
+            <span
+              aria-hidden="true"
+              data-app-action-review-metrics-probe=""
+              className="pointer-events-none absolute left-0 top-0 size-px opacity-0"
             />
-          )}
+            {isLoading && (
+              <div className="space-y-2 px-2 py-4">
+                <div className="h-3 w-32 animate-pulse rounded bg-sidebar-accent" />
+                <div className="h-3 w-48 animate-pulse rounded bg-sidebar-accent" />
+                <div className="h-3 w-40 animate-pulse rounded bg-sidebar-accent" />
+              </div>
+            )}
+            {errorMessage && (
+              <p className="px-2 py-4 text-xs text-destructive">{errorMessage}</p>
+            )}
+            {!errorMessage && runtimeBlockedReason && (
+              <p className="px-2 py-4 text-xs text-sidebar-muted-foreground">
+                {runtimeBlockedReason}
+              </p>
+            )}
+            {!isLoading && !errorMessage && !runtimeBlockedReason && !hasReviewEntries && (
+              <GitReviewNoChangesState
+                mode={changesFilter}
+                baseRef={baseRef}
+                onRefresh={() => void refetch()}
+              />
+            )}
 
-          {!isLoading && !errorMessage && !runtimeBlockedReason && sections.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {diffPolicySummary.total > 0 && (
-                <GitReviewDiffPolicyNotice summary={diffPolicySummary} />
-              )}
-              {sections.map((section) => (
-                <div key={section.scope} className="flex flex-col gap-1.5">
-                  {changesFilter === "working_tree_composite" && (
-                    <GitReviewSectionHeader
-                      section={section}
-                      collapsed={collapsedSections.has(section.scope)}
-                      onToggle={() => toggleSectionCollapsed(section.scope)}
-                    />
-                  )}
-                  {visibleSections.some((visibleSection) => visibleSection.scope === section.scope)
-                    && section.files.map((file) => {
-                      const entry = gitReviewEntryForFile(section.scope, file);
-                      return (
-                        <GitReviewFileRow
-                          key={entry.key}
-                          id={entry.id}
-                          workspaceId={activeWorkspaceId}
-                          sectionScope={section.scope}
-                          file={file}
-                          baseRef={baseRef}
-                          layout={layout}
-                          wrapLongLines={wrapLongLines}
-                          collapsed={effectiveCollapsedFiles.has(entry.key)}
-                          isRuntimeReady={isRuntimeReady}
-                          fetchDiff={permittedDiffFetchKeys.has(entry.key)}
-                          onToggleCollapsed={() => toggleFileCollapsed(entry.key)}
-                          onDiffFetchSettled={() => markDiffFetchSettled(entry.key)}
-                          openFile={openFile}
-                          stagePath={(path) => stageMutation.mutateAsync([path])}
-                          unstagePath={(path) => unstageMutation.mutateAsync([path])}
-                          diffTimingOptions={diffReviewMeasurement.diffTimingOptions}
-                          measurementOperationId={diffReviewMeasurement.operationId}
-                        />
-                      );
-                    })}
-                </div>
-              ))}
-            </div>
-          )}
-        </AutoHideScrollArea>
+            {!isLoading && !errorMessage && !runtimeBlockedReason && hasReviewEntries && (
+              <div className="flex flex-col gap-1.5">
+                {diffPolicySummary.total > 0 && (
+                  <GitReviewDiffPolicyNotice summary={diffPolicySummary} />
+                )}
+                {sections.map((section) => (
+                  <div key={section.scope} className="flex flex-col gap-1">
+                    {changesFilter === "working_tree_composite" && (
+                      <GitReviewSectionHeader
+                        section={section}
+                        collapsed={collapsedSections.has(section.scope)}
+                        onToggle={() => toggleSectionCollapsed(section.scope)}
+                      />
+                    )}
+                    {visibleSections.some((visibleSection) => visibleSection.scope === section.scope)
+                      && section.files.map((file) => {
+                        const entry = gitReviewEntryForFile(section.scope, file);
+                        return (
+                          <GitReviewFileRow
+                            key={entry.key}
+                            id={entry.id}
+                            workspaceId={activeWorkspaceId}
+                            sectionScope={section.scope}
+                            file={file}
+                            baseRef={baseRef}
+                            layout={layout}
+                            wrapLongLines={wrapLongLines}
+                            collapsed={effectiveCollapsedFiles.has(entry.key)}
+                            isRuntimeReady={isRuntimeReady}
+                            fetchDiff={permittedDiffFetchKeys.has(entry.key)}
+                            onToggleCollapsed={() => toggleFileCollapsed(entry.key)}
+                            onDiffFetchSettled={() => markDiffFetchSettled(entry.key)}
+                            openFile={openFile}
+                            stagePath={(path) => stageMutation.mutateAsync([path])}
+                            unstagePath={(path) => unstageMutation.mutateAsync([path])}
+                            diffTimingOptions={diffReviewMeasurement.diffTimingOptions}
+                            measurementOperationId={diffReviewMeasurement.operationId}
+                          />
+                        );
+                      })}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
         <PaneSideOverlay
           open={canShowFileTree}
           label="Changed files"
@@ -391,6 +386,22 @@ function GitPanelContent({
         </PaneSideOverlay>
       </div>
     </div>
+  );
+}
+
+function summarizeGitPanelSectionStats(sections: readonly GitPanelSection[]): {
+  additions: number;
+  deletions: number;
+} {
+  return sections.reduce(
+    (stats, section) => {
+      for (const file of section.files) {
+        stats.additions += file.currentDiff?.additions ?? 0;
+        stats.deletions += file.currentDiff?.deletions ?? 0;
+      }
+      return stats;
+    },
+    { additions: 0, deletions: 0 },
   );
 }
 
@@ -411,7 +422,7 @@ function GitReviewDiffPolicyNotice({ summary }: { summary: DiffDisplayPolicySumm
   );
 }
 
-function GitReviewEmptyState({
+function GitReviewNoChangesState({
   mode,
   baseRef,
   onRefresh,
@@ -422,29 +433,17 @@ function GitReviewEmptyState({
 }) {
   const Icon = mode === "branch" ? GitBranchIcon : CheckCircleFilled;
   return (
-    <div className="flex min-h-[260px] items-center justify-center px-4 py-8">
-      <div className="flex max-w-[280px] flex-col items-center text-center">
-        <div className="mb-3 flex size-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-foreground/5 text-sidebar-muted-foreground">
-          <Icon className="size-4" />
-        </div>
-        <p className="text-sm font-medium text-sidebar-foreground">
-          {gitPanelEmptyMessage(mode)}
-        </p>
-        <p className="mt-1 text-pretty text-xs leading-5 text-sidebar-muted-foreground">
-          {gitPanelEmptyDescription(mode, baseRef)}
-        </p>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onRefresh}
-          className="mt-4 h-7 gap-1.5 rounded-md border border-sidebar-border/70 px-2.5 text-xs text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-        >
+    <GitReviewEmptyState
+      icon={<Icon className="size-4" />}
+      title={gitPanelEmptyMessage(mode)}
+      description={gitPanelEmptyDescription(mode, baseRef)}
+      action={
+        <GitReviewEmptyStateAction onClick={onRefresh}>
           <RefreshCw className="size-3" />
           Refresh
-        </Button>
-      </div>
-    </div>
+        </GitReviewEmptyStateAction>
+      }
+    />
   );
 }
 

--- a/desktop/src/components/workspace/git/GitPanelHeader.tsx
+++ b/desktop/src/components/workspace/git/GitPanelHeader.tsx
@@ -2,13 +2,15 @@ import type { GitBranchRef } from "@anyharness/sdk";
 import { GitReviewOptionsMenu } from "./GitReviewOptionsMenu";
 import { GitReviewBaseSelector } from "./GitReviewBaseSelector";
 import { GitReviewTargetSelector } from "./GitReviewTargetSelector";
-import { ArrowRight, FileCode, SplitPanel } from "@/components/ui/icons";
-import { PaneHeader, PaneIconButton } from "@/components/workspace/pane/PaneHeader";
+import { FileCode, SplitPanel } from "@/components/ui/icons";
+import { PaneIconButton } from "@/components/workspace/pane/PaneHeader";
 import type { GitPanelMode } from "@/lib/domain/workspaces/changes/git-panel-diff";
 
 interface GitPanelHeaderProps {
   changesFilter: GitPanelMode;
   visibleChangedCount: number;
+  additions: number;
+  deletions: number;
   isRuntimeReady: boolean;
   branchRefs: readonly GitBranchRef[];
   baseRef: string | null;
@@ -28,6 +30,8 @@ interface GitPanelHeaderProps {
 export function GitPanelHeader({
   changesFilter,
   visibleChangedCount,
+  additions,
+  deletions,
   isRuntimeReady,
   branchRefs,
   baseRef,
@@ -43,51 +47,77 @@ export function GitPanelHeader({
   onToggleAllFiles,
   onRefresh,
 }: GitPanelHeaderProps) {
+  const showTargetSelector = changesFilter === "branch";
+
   return (
-    <PaneHeader
-      left={(
-        <>
+    <div
+      className="z-20 grid min-h-9 shrink-0 [container-name:review-header] [container-type:inline-size] grid-cols-[minmax(0,1fr)_auto] items-center gap-1 border-b border-sidebar-border/70 bg-sidebar-background px-2 py-1 text-sidebar-muted-foreground"
+    >
+      <div className="flex w-full min-w-0 flex-col overflow-hidden text-base">
+        <div className="flex min-w-0 items-center gap-1 overflow-hidden">
           <GitReviewBaseSelector
             activeMode={changesFilter}
             changedCount={visibleChangedCount}
             onSelect={onFilterChange}
           />
-          <ArrowRight className="size-3 shrink-0 text-sidebar-muted-foreground" />
-          <GitReviewTargetSelector
-            mode={changesFilter}
-            baseRef={baseRef}
-            branchRefs={branchRefs}
-            isRuntimeReady={isRuntimeReady}
-            onSelect={onBaseRefChange}
-          />
-        </>
-      )}
-      right={(
-        <>
-          <PaneIconButton
-            label={layout === "split" ? "Use unified diff" : "Use split diff"}
-            onClick={onToggleLayout}
-          >
-            <SplitPanel className="size-3.5" />
-          </PaneIconButton>
-          <GitReviewOptionsMenu
-            allFilesCollapsed={allFilesCollapsed}
-            wrapLongLines={wrapLongLines}
-            isRuntimeReady={isRuntimeReady}
-            onToggleAllFiles={onToggleAllFiles}
-            onToggleWrap={onToggleWrap}
-            onRefresh={onRefresh}
-          />
-          <PaneIconButton
-            label={fileTreeOpen ? "Hide files" : "Show files"}
-            aria-pressed={fileTreeOpen}
-            active={fileTreeOpen}
-            onClick={onToggleFileTree}
-          >
-            <FileCode className="size-3.5" />
-          </PaneIconButton>
-        </>
-      )}
-    />
+          {showTargetSelector && (
+            <GitReviewTargetSelector
+              mode={changesFilter}
+              baseRef={baseRef}
+              branchRefs={branchRefs}
+              isRuntimeReady={isRuntimeReady}
+              onSelect={onBaseRefChange}
+            />
+          )}
+          <GitPanelAggregateStats additions={additions} deletions={deletions} />
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-px">
+        <GitReviewOptionsMenu
+          allFilesCollapsed={allFilesCollapsed}
+          wrapLongLines={wrapLongLines}
+          isRuntimeReady={isRuntimeReady}
+          onToggleAllFiles={onToggleAllFiles}
+          onToggleWrap={onToggleWrap}
+          onRefresh={onRefresh}
+        />
+        <PaneIconButton
+          label={layout === "split" ? "Use unified diff" : "Use split diff"}
+          onClick={onToggleLayout}
+        >
+          <SplitPanel className="size-3.5" />
+        </PaneIconButton>
+        <PaneIconButton
+          label={fileTreeOpen ? "Hide files" : "Show files"}
+          aria-pressed={fileTreeOpen}
+          active={fileTreeOpen}
+          onClick={onToggleFileTree}
+        >
+          <FileCode className="size-3.5" />
+        </PaneIconButton>
+      </div>
+    </div>
+  );
+}
+
+function GitPanelAggregateStats({
+  additions,
+  deletions,
+}: {
+  additions: number;
+  deletions: number;
+}) {
+  return (
+    <div
+      className="flex shrink-0 items-center gap-1 text-[10px] font-medium leading-none tabular-nums"
+      aria-label={`${additions} additions, ${deletions} deletions`}
+    >
+      <span className={additions > 0 ? "text-git-green" : "text-sidebar-muted-foreground/70"}>
+        +{additions}
+      </span>
+      <span className={deletions > 0 ? "text-git-red" : "text-sidebar-muted-foreground/70"}>
+        -{deletions}
+      </span>
+    </div>
   );
 }

--- a/desktop/src/components/workspace/git/GitReviewEmptyState.tsx
+++ b/desktop/src/components/workspace/git/GitReviewEmptyState.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+
+export function GitReviewEmptyState({
+  icon,
+  title,
+  description,
+  action,
+  variant = "panel",
+}: {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  variant?: "panel" | "inline";
+}) {
+  const isPanel = variant === "panel";
+
+  return (
+    <div
+      className={
+        isPanel
+          ? "flex min-h-[260px] items-center justify-center px-4 py-8"
+          : "flex min-h-28 items-center justify-center px-4 py-5"
+      }
+    >
+      <div
+        className={`flex w-full flex-col items-center text-center ${
+          isPanel ? "max-w-[300px]" : "max-w-[260px]"
+        }`}
+      >
+        <div
+          className={`mb-3 flex items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/45 text-sidebar-muted-foreground shadow-[inset_0_1px_0_color-mix(in_srgb,var(--color-foreground)_7%,transparent)] ${
+            isPanel ? "size-10" : "size-8"
+          }`}
+        >
+          {icon}
+        </div>
+        <p
+          className={`font-medium text-sidebar-foreground ${
+            isPanel ? "text-sm" : "text-xs"
+          }`}
+        >
+          {title}
+        </p>
+        {description && (
+          <p className="mt-1 text-pretty text-xs leading-5 text-sidebar-muted-foreground">
+            {description}
+          </p>
+        )}
+        {action && (
+          <div className={isPanel ? "mt-4" : "mt-3"}>
+            {action}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function GitReviewEmptyStateAction({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="h-7 gap-1.5 rounded-md border border-sidebar-border/70 bg-sidebar-background/40 px-2.5 text-xs text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+    >
+      {children}
+    </Button>
+  );
+}

--- a/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
 import {
   type AnyHarnessQueryTimingOptions,
   useGitDiffQuery,
@@ -6,7 +6,18 @@ import {
 import { Button } from "@proliferate/ui/primitives/Button";
 import { DiffViewer } from "@/components/ui/content/DiffViewer";
 import { FileDiffCard } from "@/components/ui/content/FileDiffCard";
-import { Minus, Plus } from "@/components/ui/icons";
+import {
+  CircleAlert,
+  FileCode,
+  FileIcon,
+  Minus,
+  Plus,
+  RefreshCw,
+} from "@/components/ui/icons";
+import {
+  GitReviewEmptyState,
+  GitReviewEmptyStateAction,
+} from "./GitReviewEmptyState";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
@@ -18,6 +29,10 @@ import type {
 
 type StagePath = (path: string) => Promise<unknown>;
 type OpenFile = (path: string) => Promise<void>;
+
+const SIDEBAR_DIFF_SURFACE_STYLE = {
+  "--codex-diffs-surface-override": "var(--color-diff-surface)",
+} as CSSProperties;
 
 export function GitReviewFileRow({
   id,
@@ -102,14 +117,13 @@ export function GitReviewFileRow({
   const waitingForDiffPermit = Boolean(
     currentDiff
     && isRuntimeReady
-    && !collapsed
     && metadataPolicy?.canFetchInline
     && !fetchDiff
     && !patch
     && !diffQuery.data
     && !diffQuery.isError,
   );
-  const emptyDiffMessage = formatEmptyDiffMessage({
+  const emptyDiffState = formatEmptyDiffState({
     binary: Boolean(diffQuery.data?.binary || currentDiff?.binary),
     truncated: Boolean(diffQuery.data?.truncated && !patch),
   });
@@ -129,7 +143,7 @@ export function GitReviewFileRow({
     && !patch
     && !diffQuery.isLoading
     && !diffErrorMessage
-    && !emptyDiffMessage
+    && !emptyDiffState
   ) {
     return null;
   }
@@ -137,7 +151,8 @@ export function GitReviewFileRow({
   return (
     <div
       id={id}
-      className="[--codex-diffs-surface-override:var(--color-diff-surface)]"
+      data-review-path={file.path}
+      style={SIDEBAR_DIFF_SURFACE_STYLE}
     >
       <FileDiffCard
         filePath={file.displayPath}
@@ -166,25 +181,28 @@ export function GitReviewFileRow({
               }}
               disabled={!isRuntimeReady}
               aria-label={shouldUnstage ? `Unstage ${file.displayPath}` : `Stage ${file.displayPath}`}
-              className={`size-5 rounded-full border-0 bg-transparent p-0 ${
+              className={`size-6 rounded-full border-0 bg-transparent p-0 ${
                 shouldUnstage
                   ? "text-git-green hover:bg-sidebar-accent"
                   : "text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
               }`}
             >
               {shouldUnstage ? (
-                <Minus className="size-3" />
+                <Minus className="size-3.5" />
               ) : (
-                <Plus className="size-3" />
+                <Plus className="size-3.5" />
               )}
             </Button>
           </Tooltip>
         )}
       >
         {!currentDiff ? (
-          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
-            No current diff against base
-          </p>
+          <GitReviewInlineEmptyState
+            icon={<FileIcon className="size-3.5" />}
+            title="No current diff"
+            description="This file was touched, but there are no current changes to review against the selected base."
+            onOpenFile={() => void openFile(file.path)}
+          />
         ) : !metadataPolicy?.canFetchInline ? (
           <DiffDisplayPolicyPlaceholder
             title={metadataPolicy?.placeholderTitle ?? "Too large to render inline"}
@@ -192,17 +210,24 @@ export function GitReviewFileRow({
             onOpenFile={() => void openFile(file.path)}
           />
         ) : waitingForDiffPermit ? (
-          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
-            Waiting to load diff
-          </p>
+          <GitReviewInlineEmptyState
+            icon={<RefreshCw className="size-3.5" />}
+            title="Waiting to load diff"
+            description="This file will load when review capacity is available."
+          />
         ) : diffQuery.isLoading ? (
-          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
-            Loading diff
-          </p>
+          <GitReviewInlineEmptyState
+            icon={<RefreshCw className="size-3.5 animate-spin" />}
+            title="Loading diff"
+            description="Fetching the latest file patch."
+          />
         ) : diffErrorMessage ? (
-          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
-            Diff unavailable: {diffErrorMessage}
-          </p>
+          <GitReviewInlineEmptyState
+            icon={<CircleAlert className="size-3.5" />}
+            title="Diff unavailable"
+            description={diffErrorMessage}
+            onOpenFile={() => void openFile(file.path)}
+          />
         ) : patch ? (
           patchPolicy && !patchPolicy.canRenderInline ? (
             <DiffDisplayPolicyPlaceholder
@@ -231,10 +256,13 @@ export function GitReviewFileRow({
               ) : null}
             </>
           )
-        ) : emptyDiffMessage ? (
-          <p className="px-3 py-5 text-center text-xs text-sidebar-muted-foreground">
-            {emptyDiffMessage}
-          </p>
+        ) : emptyDiffState ? (
+          <GitReviewInlineEmptyState
+            icon={emptyDiffState.icon}
+            title={emptyDiffState.title}
+            description={emptyDiffState.description}
+            onOpenFile={() => void openFile(file.path)}
+          />
         ) : null}
       </FileDiffCard>
     </div>
@@ -311,21 +339,12 @@ function DiffDisplayPolicyPlaceholder({
   onOpenFile: () => void;
 }) {
   return (
-    <div className="flex items-center gap-3 px-3 py-4 text-xs text-sidebar-muted-foreground">
-      <div className="min-w-0 flex-1">
-        <p className="font-medium text-sidebar-foreground">{title}</p>
-        <p className="mt-0.5 leading-5">{description}</p>
-      </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        onClick={onOpenFile}
-        className="h-7 shrink-0 rounded-md border border-sidebar-border/70 px-2.5 text-xs text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-      >
-        Open file
-      </Button>
-    </div>
+    <GitReviewInlineEmptyState
+      icon={<CircleAlert className="size-3.5" />}
+      title={title}
+      description={description}
+      onOpenFile={onOpenFile}
+    />
   );
 }
 
@@ -339,18 +358,56 @@ function formatDiffErrorMessage(error: unknown): string {
   return "Failed to load diff";
 }
 
-function formatEmptyDiffMessage({
+function GitReviewInlineEmptyState({
+  icon,
+  title,
+  description,
+  onOpenFile,
+}: {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  onOpenFile?: () => void;
+}) {
+  return (
+    <GitReviewEmptyState
+      variant="inline"
+      icon={icon}
+      title={title}
+      description={description}
+      action={onOpenFile ? (
+        <GitReviewEmptyStateAction onClick={onOpenFile}>
+          Open file
+        </GitReviewEmptyStateAction>
+      ) : null}
+    />
+  );
+}
+
+function formatEmptyDiffState({
   binary,
   truncated,
 }: {
   binary: boolean;
   truncated: boolean;
-}): string | null {
+}): {
+  title: string;
+  description: string;
+  icon: ReactNode;
+} | null {
   if (binary) {
-    return "Binary file changed";
+    return {
+      title: "Binary file changed",
+      description: "Open the file to inspect this change.",
+      icon: <FileCode className="size-3.5" />,
+    };
   }
   if (truncated) {
-    return "Diff unavailable because it is too large";
+    return {
+      title: "Diff too large",
+      description: "Open the file to inspect the full change.",
+      icon: <CircleAlert className="size-3.5" />,
+    };
   }
   return null;
 }

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -1433,6 +1433,7 @@ mark.codex-thread-find-active {
 .composer-diff-simple-line {
   --codex-diffs-surface: var(--color-diff-code-surface);
   --codex-diffs-header-surface: var(--codex-diffs-surface);
+  --codex-diffs-empty-surface: color-mix(in srgb, var(--codex-diffs-surface) 96%, var(--color-foreground));
   --diffs-bg: var(--codex-diffs-surface);
   background-color: var(--codex-diffs-surface);
   scrollbar-color: var(--color-scrollbar-thumb) transparent;
@@ -1467,6 +1468,14 @@ mark.codex-thread-find-active {
   background-color: var(--diffs-bg-separator-override);
 }
 
+.composer-diff-simple-line .diff-content-cell[data-empty-side] {
+  background-color: var(--codex-diffs-empty-surface);
+}
+
+.composer-diff-simple-line .diff-gutter-cell[data-empty-side] {
+  background-color: var(--codex-diffs-context-number);
+}
+
 .composer-diff-simple-line .diff-gutter-cell[data-line-type="context"] {
   background-color: var(--codex-diffs-context-number);
   color: color-mix(in srgb, var(--diffs-fg) 35%, transparent);
@@ -1484,7 +1493,14 @@ mark.codex-thread-find-active {
 
 .composer-diff-simple-line .diff-gutter-cell[data-line-type="change-addition"],
 .composer-diff-simple-line .diff-gutter-cell[data-line-type="change-deletion"] {
+  position: sticky;
+  inset-inline-start: 0;
+  z-index: 10;
+}
+
+.composer-diff-simple-line [data-line-number-content] {
   position: relative;
+  z-index: 1;
 }
 
 .composer-diff-simple-line .diff-gutter-cell[data-line-type="change-addition"]::before,

--- a/desktop/src/lib/domain/workspaces/changes/git-panel-diff.test.ts
+++ b/desktop/src/lib/domain/workspaces/changes/git-panel-diff.test.ts
@@ -75,7 +75,7 @@ describe("git panel diff domain", () => {
     });
   });
 
-  it("omits last-turn touched files that no longer have a current diff", () => {
+  it("keeps last-turn touched files even when they no longer have a current diff", () => {
     const sections = buildGitPanelSections({
       mode: "last_turn",
       statusFiles: [],
@@ -104,7 +104,33 @@ describe("git panel diff domain", () => {
     });
 
     expect(sections).toHaveLength(1);
-    expect(sections[0].files.map((file) => file.path)).toEqual(["dirty.md"]);
+    expect(sections[0].files.map((file) => file.path)).toEqual([
+      "clean.md",
+      "dirty.md",
+    ]);
+    expect(sections[0].files[0]).toMatchObject({
+      key: ":clean.md:edit",
+      path: "clean.md",
+      displayPath: "clean.md",
+      currentDiff: null,
+      touched: {
+        path: "clean.md",
+        operation: "edit",
+      },
+    });
+    expect(sections[0].files[1]).toMatchObject({
+      key: ":dirty.md:edit",
+      path: "dirty.md",
+      displayPath: "dirty.md",
+      currentDiff: {
+        path: "dirty.md",
+        additions: 2,
+      },
+      touched: {
+        path: "dirty.md",
+        operation: "edit",
+      },
+    });
   });
 
   it("resolves branch base-ref precedence", () => {

--- a/desktop/src/lib/domain/workspaces/changes/git-panel-diff.ts
+++ b/desktop/src/lib/domain/workspaces/changes/git-panel-diff.ts
@@ -118,9 +118,9 @@ export function buildGitPanelSections(input: BuildGitPanelFilesInput): GitPanelS
       label: "Last turn",
       files: (input.lastTurnFiles ?? [])
         .filter((file) => isVisibleGitPath(file.path))
-        .map((file) => currentByPath.get(file.path) ?? null)
-        .filter((file): file is GitPanelFile => Boolean(file))
-        .map(toReviewFile),
+        .map((file) =>
+          toLastTurnReviewFile(file, currentByPath.get(file.path) ?? null)
+        ),
     }];
   }
   const scope: GitPanelSectionScope = input.mode;
@@ -229,6 +229,20 @@ export function toReviewFile(file: GitPanelFile): GitPanelReviewFile {
     oldPath: file.oldPath,
     displayPath: file.displayPath,
     currentDiff: file,
+  };
+}
+
+function toLastTurnReviewFile(
+  touched: LastTurnTouchedFile,
+  currentDiff: GitPanelFile | null,
+): GitPanelReviewFile {
+  return {
+    key: touched.key,
+    path: touched.path,
+    oldPath: currentDiff?.oldPath ?? touched.oldPath,
+    displayPath: touched.displayPath,
+    currentDiff,
+    touched,
   };
 }
 


### PR DESCRIPTION
## Summary
- polish the end-turn diff card and git sidebar diff cards toward the reference styling
- keep end-turn diff headers visually quiet while preserving review-pane click/hover behavior
- improve split diff scrolling, sticky gutters, empty-side rendering, and empty git review states
- synthesize tighter AnyHarness file patches with line-aware hunks for cleaner rendered diffs

## Validation
- pnpm -C desktop exec vitest run src/components/workspace/git/GitPanel.test.tsx src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx src/components/ui/content/DiffViewer.test.tsx src/components/ui/content/FileDiffCard.test.tsx src/components/playground/PlaygroundSidebarGitDiff.test.tsx src/lib/domain/workspaces/changes/git-panel-diff.test.ts --pool=threads --poolOptions.threads.singleThread=true
- pnpm -C desktop exec tsc --noEmit --pretty false
- cargo test -p anyharness-lib acp::event_sink::normalization::files::tests --lib
- cargo fmt --all --check
- git diff --check