### PR TITLE
feat(cloud): edit shared environment files

### DIFF
--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -1810,6 +1810,15 @@
               "type": "integer",
               "format": "int64"
             }
+          },
+          {
+            "name": "oldest_first",
+            "in": "query",
+            "description": "When after_seq and limit are set, page from the oldest matching event instead of the newest matching window",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -5781,6 +5781,8 @@ export interface operations {
                 limit?: number;
                 /** @description Return complete newest turns, bounded by the limit event budget */
                 turn_limit?: number;
+                /** @description When after_seq and limit are set, page from the oldest matching event instead of the newest matching window */
+                oldest_first?: boolean;
             };
             header?: never;
             path: {

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4496,6 +4496,8 @@ export interface components {
             updatedAt: string;
             /** Lastsyncedat */
             lastSyncedAt: string;
+            /** Content */
+            content?: string | null;
         };
         /** CloudSessionEventResponse */
         CloudSessionEventResponse: {

--- a/desktop/src/components/cloud/repo-settings/RepoSharedEnvFilesCard.tsx
+++ b/desktop/src/components/cloud/repo-settings/RepoSharedEnvFilesCard.tsx
@@ -1,0 +1,171 @@
+import type { ChangeEvent } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@/components/ui/Label";
+import { Plus, Trash } from "@/components/ui/icons";
+import {
+  EnvironmentField,
+  EnvironmentPanel,
+  EnvironmentPanelRow,
+} from "@/components/ui/EnvironmentLayout";
+import type {
+  CloudRepoEnvVarRow,
+  CloudRepoSharedEnvFile,
+} from "@/hooks/cloud/ui/use-cloud-repo-config-draft";
+
+interface RepoSharedEnvFilesCardProps {
+  files: CloudRepoSharedEnvFile[];
+  onAddFile: () => void;
+  onUpdateFilePath: (fileId: string, relativePath: string) => void;
+  onAddRow: (fileId: string) => void;
+  onUpdateRow: (
+    fileId: string,
+    rowId: string,
+    patch: Partial<Pick<CloudRepoEnvVarRow, "key" | "value">>,
+  ) => void;
+  onRemoveRow: (fileId: string, rowId: string) => void;
+  onRemoveFile: (fileId: string) => void;
+}
+
+export function RepoSharedEnvFilesCard({
+  files,
+  onAddFile,
+  onUpdateFilePath,
+  onAddRow,
+  onUpdateRow,
+  onRemoveRow,
+  onRemoveFile,
+}: RepoSharedEnvFilesCardProps) {
+  return (
+    <EnvironmentField
+      label="Shared env files"
+      description="Admin-authored .env-style files written into new shared cloud workspaces."
+    >
+      <div className="space-y-3">
+        {files.length === 0 ? (
+          <EnvironmentPanel>
+            <EnvironmentPanelRow>
+              <p className="text-sm text-muted-foreground">
+                No shared env files yet. Add one to write stable key/value files such as <code>.env.shared</code> into newly created shared workspaces.
+              </p>
+            </EnvironmentPanelRow>
+          </EnvironmentPanel>
+        ) : (
+          <div className="space-y-3">
+            {files.map((file) => (
+              <EnvironmentPanel key={file.id}>
+                <EnvironmentPanelRow>
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-end">
+                      <div className="min-w-0 flex-1 space-y-1.5">
+                        <Label htmlFor={`shared-env-file-path-${file.id}`}>File path</Label>
+                        <Input
+                          id={`shared-env-file-path-${file.id}`}
+                          value={file.relativePath}
+                          placeholder=".env.shared"
+                          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                            onUpdateFilePath(file.id, event.target.value)}
+                          className="h-8 px-2.5 py-1.5 font-mono text-sm leading-[var(--readable-code-line-height)]"
+                        />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => onRemoveFile(file.id)}
+                      >
+                        <Trash className="mr-2 size-4" />
+                        Remove file
+                      </Button>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="hidden grid-cols-[minmax(12rem,0.8fr)_minmax(16rem,1.2fr)_auto] gap-3 px-0.5 text-xs font-medium uppercase text-muted-foreground md:grid">
+                        <span>Key</span>
+                        <span>Value</span>
+                        <span className="sr-only">Actions</span>
+                      </div>
+
+                      {file.rows.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                          This file has no variables. Add a row to write values into it.
+                        </p>
+                      ) : (
+                        <div className="space-y-2">
+                          {file.rows.map((row) => (
+                            <div
+                              key={row.id}
+                              className="grid gap-3 md:grid-cols-[minmax(12rem,0.8fr)_minmax(16rem,1.2fr)_auto]"
+                            >
+                              <div className="space-y-1.5">
+                                <Label
+                                  className="md:sr-only"
+                                  htmlFor={`shared-env-file-key-${file.id}-${row.id}`}
+                                >
+                                  Key
+                                </Label>
+                                <Input
+                                  id={`shared-env-file-key-${file.id}-${row.id}`}
+                                  value={row.key}
+                                  placeholder="API_BASE_URL"
+                                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                                    onUpdateRow(file.id, row.id, { key: event.target.value })}
+                                  className="h-8 px-2.5 py-1.5 font-mono text-sm leading-[var(--readable-code-line-height)]"
+                                />
+                              </div>
+                              <div className="space-y-1.5">
+                                <Label
+                                  className="md:sr-only"
+                                  htmlFor={`shared-env-file-value-${file.id}-${row.id}`}
+                                >
+                                  Value
+                                </Label>
+                                <Input
+                                  id={`shared-env-file-value-${file.id}-${row.id}`}
+                                  value={row.value}
+                                  placeholder="https://example.internal"
+                                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                                    onUpdateRow(file.id, row.id, { value: event.target.value })}
+                                  className="h-8 px-2.5 py-1.5 font-mono text-sm leading-[var(--readable-code-line-height)]"
+                                />
+                              </div>
+                              <div className="flex items-end">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  aria-label="Remove variable"
+                                  onClick={() => onRemoveRow(file.id, row.id)}
+                                >
+                                  <Trash className="size-4" />
+                                </Button>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    <div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => onAddRow(file.id)}
+                      >
+                        <Plus className="mr-2 size-4" />
+                        Add variable
+                      </Button>
+                    </div>
+                  </div>
+                </EnvironmentPanelRow>
+              </EnvironmentPanel>
+            ))}
+          </div>
+        )}
+
+        <Button type="button" variant="outline" onClick={onAddFile}>
+          <Plus className="mr-2 size-4" />
+          Add shared env file
+        </Button>
+      </div>
+    </EnvironmentField>
+  );
+}

--- a/desktop/src/components/settings/panes/SharedEnvironmentsPane.tsx
+++ b/desktop/src/components/settings/panes/SharedEnvironmentsPane.tsx
@@ -7,12 +7,11 @@ import { Badge } from "@/components/ui/Badge";
 import { CloudIcon } from "@/components/ui/icons";
 import {
   EnvironmentField,
-  EnvironmentPanel,
-  EnvironmentPanelRow,
   EnvironmentSection,
 } from "@/components/ui/EnvironmentLayout";
 import { RepoEnvVarsCard } from "@/components/cloud/repo-settings/RepoEnvVarsCard";
 import { RepoRunCommandCard } from "@/components/cloud/repo-settings/RepoRunCommandCard";
+import { RepoSharedEnvFilesCard } from "@/components/cloud/repo-settings/RepoSharedEnvFilesCard";
 import { RepoSetupScriptCard } from "@/components/cloud/repo-settings/RepoSetupScriptCard";
 import { AdminOnlyPlaceholder } from "@/components/settings/shared/AdminOnlyPlaceholder";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
@@ -271,6 +270,7 @@ function SharedEnvironmentDetail({
       envVars: draft.savePayload.envVars,
       setupScript: draft.savePayload.setupScript,
       runCommand: draft.savePayload.runCommand,
+      files: draft.sharedEnvFilePayloads,
     });
     const profile = await authMutations.ensureOrganizationProfile({ organizationId });
     await authMutations.enableProfileCloud({ sandboxProfileId: profile.id });
@@ -359,18 +359,15 @@ function SharedEnvironmentDetail({
           onRemoveRow={draft.removeEnvVarRow}
         />
 
-        <EnvironmentField
-          label="Shared env files"
-          description="Shared files are admin-authored and written into newly created shared workspaces."
-        >
-          <EnvironmentPanel>
-            <EnvironmentPanelRow>
-              <p className="text-sm text-muted-foreground">
-                Existing shared file metadata is preserved by this editor. File content editing needs the follow-up shared-file content API, since current cloud repo responses intentionally return metadata rather than plaintext.
-              </p>
-            </EnvironmentPanelRow>
-          </EnvironmentPanel>
-        </EnvironmentField>
+        <RepoSharedEnvFilesCard
+          files={draft.sharedEnvFiles}
+          onAddFile={draft.addSharedEnvFile}
+          onUpdateFilePath={draft.updateSharedEnvFilePath}
+          onAddRow={draft.addSharedEnvFileRow}
+          onUpdateRow={draft.updateSharedEnvFileRow}
+          onRemoveRow={draft.removeSharedEnvFileRow}
+          onRemoveFile={draft.removeSharedEnvFile}
+        />
       </EnvironmentSection>
     </section>
   );

--- a/desktop/src/hooks/access/cloud/use-save-organization-cloud-repo-config.ts
+++ b/desktop/src/hooks/access/cloud/use-save-organization-cloud-repo-config.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   saveOrganizationCloudRepoConfig,
 } from "@proliferate/cloud-sdk/client/repo-configs";
+import type { SaveCloudRepoConfigRequest } from "@proliferate/cloud-sdk/types";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
 import {
   organizationCloudRepoConfigKey,
@@ -17,6 +18,7 @@ interface SaveOrganizationCloudRepoConfigInput {
   envVars: Record<string, string>;
   setupScript: string;
   runCommand: string;
+  files?: SaveCloudRepoConfigRequest["files"];
 }
 
 export function useSaveOrganizationCloudRepoConfig() {
@@ -32,6 +34,7 @@ export function useSaveOrganizationCloudRepoConfig() {
       envVars,
       setupScript,
       runCommand,
+      files,
     }) => await saveOrganizationCloudRepoConfig(
       organizationId,
       gitOwner,
@@ -42,6 +45,7 @@ export function useSaveOrganizationCloudRepoConfig() {
         envVars,
         setupScript,
         runCommand,
+        ...(files ? { files } : {}),
       },
     ),
     onSuccess: async (_response, variables) => {

--- a/desktop/src/hooks/cloud/ui/use-cloud-repo-config-draft.ts
+++ b/desktop/src/hooks/cloud/ui/use-cloud-repo-config-draft.ts
@@ -11,12 +11,29 @@ import {
   type CloudEnvironmentDraft,
   type CloudEnvironmentDraftState,
 } from "@/lib/domain/settings/environment-draft";
+import {
+  envFileVariablesEqual,
+  parseEnvFileVariables,
+  serializeEnvFileVariables,
+  type EnvFileVariable,
+} from "@/lib/domain/settings/env-file-draft";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
 
 export interface CloudRepoEnvVarRow {
   id: string;
   key: string;
   value: string;
+}
+
+export interface CloudRepoSharedEnvFile {
+  id: string;
+  relativePath: string;
+  rows: CloudRepoEnvVarRow[];
+}
+
+export interface CloudRepoSharedEnvFilePayload {
+  relativePath: string;
+  content: string;
 }
 
 function createRowId(): string {
@@ -33,6 +50,77 @@ function buildEnvVarRows(envVars: Record<string, string>): CloudRepoEnvVarRow[] 
     }));
 }
 
+function buildEnvVarRowsFromVariables(variables: readonly EnvFileVariable[]): CloudRepoEnvVarRow[] {
+  return variables.map((row) => ({
+    id: createRowId(),
+    key: row.key,
+    value: row.value,
+  }));
+}
+
+function buildSharedEnvFiles(savedConfig: CloudRepoConfig | null | undefined): CloudRepoSharedEnvFile[] {
+  return (savedConfig?.trackedFiles ?? [])
+    .filter((file) => typeof file.content === "string")
+    .map((file) => ({
+      id: createRowId(),
+      relativePath: file.relativePath,
+      rows: buildEnvVarRowsFromVariables(parseEnvFileVariables(file.content)),
+    }));
+}
+
+function normalizeSharedEnvFilePath(relativePath: string): string {
+  return relativePath.trim().replaceAll("\\", "/");
+}
+
+function normalizeSharedEnvFiles(files: readonly CloudRepoSharedEnvFile[]): CloudRepoSharedEnvFile[] {
+  return files
+    .map((file) => ({
+      ...file,
+      relativePath: normalizeSharedEnvFilePath(file.relativePath),
+      rows: file.rows.filter((row) => row.key.trim().length > 0),
+    }))
+    .filter((file) => file.relativePath.length > 0);
+}
+
+function buildSharedEnvFilePayloads(
+  files: readonly CloudRepoSharedEnvFile[],
+): CloudRepoSharedEnvFilePayload[] {
+  return normalizeSharedEnvFiles(files).map((file) => ({
+    relativePath: file.relativePath,
+    content: serializeEnvFileVariables(file.rows),
+  }));
+}
+
+function sharedEnvFilesEqual(
+  left: readonly CloudRepoSharedEnvFile[],
+  right: readonly CloudRepoSharedEnvFile[],
+): boolean {
+  const leftNormalized = normalizeSharedEnvFiles(left);
+  const rightNormalized = normalizeSharedEnvFiles(right);
+  if (leftNormalized.length !== rightNormalized.length) {
+    return false;
+  }
+  return leftNormalized.every((leftFile, index) => {
+    const rightFile = rightNormalized[index];
+    return rightFile?.relativePath === leftFile.relativePath
+      && envFileVariablesEqual(leftFile.rows, rightFile.rows);
+  });
+}
+
+function nextDefaultSharedEnvFilePath(files: readonly CloudRepoSharedEnvFile[]): string {
+  const existing = new Set(files.map((file) => normalizeSharedEnvFilePath(file.relativePath)));
+  if (!existing.has(".env.shared")) {
+    return ".env.shared";
+  }
+  for (let index = 2; index < 100; index += 1) {
+    const candidate = `.env.shared.${index}`;
+    if (!existing.has(candidate)) {
+      return candidate;
+    }
+  }
+  return ".env.shared";
+}
+
 interface UseCloudRepoConfigDraftArgs {
   savedConfig: CloudRepoConfig | null | undefined;
   localSetupScript: string;
@@ -44,6 +132,8 @@ interface CloudRepoDraftViewState {
   draftState: CloudEnvironmentDraftState;
   activeSourceKey: string;
   envVarRows: CloudRepoEnvVarRow[];
+  sharedEnvFiles: CloudRepoSharedEnvFile[];
+  revertSharedEnvFiles: CloudRepoSharedEnvFile[];
 }
 
 export function useCloudRepoConfigDraft({
@@ -64,6 +154,8 @@ export function useCloudRepoConfigDraft({
     draftState: initialDraftState,
     activeSourceKey: sourceKey,
     envVarRows: buildEnvVarRows(initialDraftState.draft.envVars),
+    sharedEnvFiles: buildSharedEnvFiles(savedConfig),
+    revertSharedEnvFiles: buildSharedEnvFiles(savedConfig),
   }));
 
   const envVars = useMemo(() => (
@@ -83,7 +175,12 @@ export function useCloudRepoConfigDraft({
     }),
     [state.draftState.draft, envVars],
   );
-  const dirty = isCloudEnvironmentDraftDirty(currentDraft, state.draftState.revertDraft);
+  const sharedEnvFilesDirty = !sharedEnvFilesEqual(
+    state.sharedEnvFiles,
+    state.revertSharedEnvFiles,
+  );
+  const dirty = isCloudEnvironmentDraftDirty(currentDraft, state.draftState.revertDraft)
+    || sharedEnvFilesDirty;
   const configurable = isCloudEnvironmentDraftConfigurable(currentDraft, state.draftState.baseline);
   const savePayload = useMemo(
     () => buildCloudEnvironmentSavePayload(currentDraft),
@@ -100,8 +197,10 @@ export function useCloudRepoConfigDraft({
       draftState: initialDraftState,
       activeSourceKey: sourceKey,
       envVarRows: buildEnvVarRows(initialDraftState.draft.envVars),
+      sharedEnvFiles: buildSharedEnvFiles(savedConfig),
+      revertSharedEnvFiles: buildSharedEnvFiles(savedConfig),
     });
-  }, [dirty, initialDraftState, sourceKey, state.activeSourceKey]);
+  }, [dirty, initialDraftState, savedConfig, sourceKey, state.activeSourceKey]);
 
   const updateDraft = useCallback((patch: Partial<CloudEnvironmentDraft>) => {
     setState((current) => ({
@@ -153,6 +252,100 @@ export function useCloudRepoConfigDraft({
     }));
   }, []);
 
+  const addSharedEnvFile = useCallback(() => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: [
+        ...current.sharedEnvFiles,
+        {
+          id: createRowId(),
+          relativePath: nextDefaultSharedEnvFilePath(current.sharedEnvFiles),
+          rows: [{ id: createRowId(), key: "", value: "" }],
+        },
+      ],
+    }));
+  }, []);
+
+  const updateSharedEnvFilePath = useCallback((fileId: string, relativePath: string) => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: current.sharedEnvFiles.map((file) =>
+        file.id === fileId ? { ...file, relativePath } : file),
+    }));
+  }, []);
+
+  const addSharedEnvFileRow = useCallback((fileId: string) => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: current.sharedEnvFiles.map((file) => (
+        file.id === fileId
+          ? { ...file, rows: [...file.rows, { id: createRowId(), key: "", value: "" }] }
+          : file
+      )),
+    }));
+  }, []);
+
+  const updateSharedEnvFileRow = useCallback((
+    fileId: string,
+    rowId: string,
+    patch: Partial<Pick<CloudRepoEnvVarRow, "key" | "value">>,
+  ) => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: current.sharedEnvFiles.map((file) => (
+        file.id === fileId
+          ? {
+              ...file,
+              rows: file.rows.map((row) =>
+                row.id === rowId ? { ...row, ...patch } : row),
+            }
+          : file
+      )),
+    }));
+  }, []);
+
+  const removeSharedEnvFileRow = useCallback((fileId: string, rowId: string) => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: current.sharedEnvFiles.map((file) => (
+        file.id === fileId
+          ? { ...file, rows: file.rows.filter((row) => row.id !== rowId) }
+          : file
+      )),
+    }));
+  }, []);
+
+  const removeSharedEnvFile = useCallback((fileId: string) => {
+    setState((current) => ({
+      ...current,
+      draftState: {
+        ...current.draftState,
+        draft: buildConfiguredCloudEnvironmentDraft(current.draftState.draft),
+      },
+      sharedEnvFiles: current.sharedEnvFiles.filter((file) => file.id !== fileId),
+    }));
+  }, []);
+
   const addTrackedFile = useCallback((relativePath: string) => {
     const normalizedPath = relativePath.trim();
     if (!normalizedPath) {
@@ -200,6 +393,7 @@ export function useCloudRepoConfigDraft({
         draft: current.draftState.revertDraft,
       },
       envVarRows: buildEnvVarRows(current.draftState.revertDraft.envVars),
+      sharedEnvFiles: current.revertSharedEnvFiles,
     }));
   }, []);
 
@@ -211,6 +405,7 @@ export function useCloudRepoConfigDraft({
         draft: buildDisabledCloudEnvironmentDraft(),
       },
       envVarRows: [],
+      sharedEnvFiles: [],
     }));
   }, []);
 
@@ -220,6 +415,8 @@ export function useCloudRepoConfigDraft({
       ...current,
       draftState: nextState,
       envVarRows: buildEnvVarRows(nextState.draft.envVars),
+      sharedEnvFiles: buildSharedEnvFiles(nextSavedConfig),
+      revertSharedEnvFiles: buildSharedEnvFiles(nextSavedConfig),
     }));
   }, []);
 
@@ -229,6 +426,8 @@ export function useCloudRepoConfigDraft({
     setDefaultBranch: (defaultBranch: string | null) => updateDraft({ defaultBranch }),
     envVarRows: state.envVarRows,
     envVars,
+    sharedEnvFiles: state.sharedEnvFiles,
+    sharedEnvFilePayloads: buildSharedEnvFilePayloads(state.sharedEnvFiles),
     trackedFilePaths: currentDraft.trackedFilePaths,
     setupScript: currentDraft.setupScript,
     setSetupScript: (setupScript: string) => updateDraft({ setupScript }),
@@ -241,6 +440,12 @@ export function useCloudRepoConfigDraft({
     addEnvVarRow,
     updateEnvVarRow,
     removeEnvVarRow,
+    addSharedEnvFile,
+    updateSharedEnvFilePath,
+    addSharedEnvFileRow,
+    updateSharedEnvFileRow,
+    removeSharedEnvFileRow,
+    removeSharedEnvFile,
     addTrackedFile,
     removeTrackedFile,
     revert,

--- a/desktop/src/lib/domain/cloud/repo-configs.ts
+++ b/desktop/src/lib/domain/cloud/repo-configs.ts
@@ -4,6 +4,7 @@ export interface CloudRepoFileMetadata {
   byteSize: number;
   updatedAt: string;
   lastSyncedAt: string;
+  content?: string | null;
 }
 
 export interface CloudRepoConfig {

--- a/desktop/src/lib/domain/settings/env-file-draft.test.ts
+++ b/desktop/src/lib/domain/settings/env-file-draft.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  envFileVariablesEqual,
+  parseEnvFileVariables,
+  serializeEnvFileVariables,
+} from "@/lib/domain/settings/env-file-draft";
+
+describe("env file draft helpers", () => {
+  it("parses editable key/value rows from .env-style content", () => {
+    expect(parseEnvFileVariables([
+      "# shared values",
+      "API_BASE_URL=https://example.internal",
+      "export SHARED_TOKEN=\"with spaces\"",
+      "IGNORED_LINE",
+      "EMPTY=",
+    ].join("\n"))).toEqual([
+      { key: "API_BASE_URL", value: "https://example.internal" },
+      { key: "SHARED_TOKEN", value: "with spaces" },
+      { key: "EMPTY", value: "" },
+    ]);
+  });
+
+  it("serializes rows back to deterministic .env content", () => {
+    expect(serializeEnvFileVariables([
+      { key: " API_BASE_URL ", value: "https://example.internal" },
+      { key: "SHARED_TOKEN", value: "with spaces" },
+      { key: "", value: "ignored" },
+    ])).toBe("API_BASE_URL=https://example.internal\nSHARED_TOKEN=\"with spaces\"\n");
+  });
+
+  it("compares rows by serialized content", () => {
+    expect(envFileVariablesEqual(
+      [{ key: "API_BASE_URL", value: "https://example.internal" }],
+      [{ key: " API_BASE_URL ", value: "https://example.internal" }],
+    )).toBe(true);
+  });
+});

--- a/desktop/src/lib/domain/settings/env-file-draft.ts
+++ b/desktop/src/lib/domain/settings/env-file-draft.ts
@@ -1,0 +1,72 @@
+export interface EnvFileVariable {
+  key: string;
+  value: string;
+}
+
+const SAFE_UNQUOTED_ENV_VALUE_RE = /^[A-Za-z0-9_./:@%+=,-]*$/;
+
+function unquoteEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+    try {
+      return JSON.parse(trimmed) as string;
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  return value;
+}
+
+function serializeEnvValue(value: string): string {
+  if (SAFE_UNQUOTED_ENV_VALUE_RE.test(value)) {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+export function parseEnvFileVariables(content: string | null | undefined): EnvFileVariable[] {
+  const rows: EnvFileVariable[] = [];
+  for (const rawLine of (content ?? "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const normalizedLine = line.startsWith("export ") ? line.slice("export ".length).trim() : line;
+    const equalsIndex = normalizedLine.indexOf("=");
+    if (equalsIndex <= 0) {
+      continue;
+    }
+    const key = normalizedLine.slice(0, equalsIndex).trim();
+    if (!key) {
+      continue;
+    }
+    rows.push({
+      key,
+      value: unquoteEnvValue(normalizedLine.slice(equalsIndex + 1)),
+    });
+  }
+  return rows;
+}
+
+export function serializeEnvFileVariables(rows: readonly EnvFileVariable[]): string {
+  const lines = rows
+    .map((row) => ({
+      key: row.key.trim(),
+      value: row.value,
+    }))
+    .filter((row) => row.key.length > 0)
+    .map((row) => `${row.key}=${serializeEnvValue(row.value)}`);
+  return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}
+
+export function envFileVariablesEqual(
+  left: readonly EnvFileVariable[],
+  right: readonly EnvFileVariable[],
+): boolean {
+  const leftContent = serializeEnvFileVariables(left);
+  const rightContent = serializeEnvFileVariables(right);
+  return leftContent === rightContent;
+}

--- a/server/proliferate/server/cloud/repo_config/api.py
+++ b/server/proliferate/server/cloud/repo_config/api.py
@@ -119,7 +119,11 @@ async def get_organization_cloud_repo_config_endpoint(
         )
     except CloudApiError as error:
         raise_cloud_error(error)
-    return _default_repo_config_response() if value is None else repo_config_payload(value)
+    return (
+        _default_repo_config_response()
+        if value is None
+        else repo_config_payload(value, include_file_content=True)
+    )
 
 
 @router.put("/repos/{git_owner}/{git_repo_name}/config", response_model=CloudRepoConfigResponse)
@@ -166,7 +170,7 @@ async def save_organization_cloud_repo_config_endpoint(
         )
     except CloudApiError as error:
         raise_cloud_error(error)
-    return repo_config_payload(value)
+    return repo_config_payload(value, include_file_content=True)
 
 
 @router.put("/repos/{git_owner}/{git_repo_name}/files", response_model=CloudRepoConfigResponse)

--- a/server/proliferate/server/cloud/repo_config/models.py
+++ b/server/proliferate/server/cloud/repo_config/models.py
@@ -41,6 +41,7 @@ class CloudRepoFileMetadata(BaseModel):
     byte_size: int = Field(serialization_alias="byteSize")
     updated_at: str = Field(serialization_alias="updatedAt")
     last_synced_at: str = Field(serialization_alias="lastSyncedAt")
+    content: str | None = None
 
 
 class CloudRepoConfigResponse(BaseModel):
@@ -113,6 +114,8 @@ def repo_config_summary_payload(value: CloudRepoConfigSummaryValue) -> CloudRepo
 
 def repo_file_metadata_payload(
     value: CloudRepoFileValue | RepoConfigTrackedFileStatus,
+    *,
+    include_content: bool = False,
 ) -> CloudRepoFileMetadata:
     return CloudRepoFileMetadata(
         relative_path=value.relative_path,
@@ -120,10 +123,15 @@ def repo_file_metadata_payload(
         byte_size=value.byte_size,
         updated_at=value.updated_at.isoformat(),
         last_synced_at=value.last_synced_at.isoformat(),
+        content=value.content if include_content and isinstance(value, CloudRepoFileValue) else None,
     )
 
 
-def repo_config_payload(value: CloudRepoConfigValue) -> CloudRepoConfigResponse:
+def repo_config_payload(
+    value: CloudRepoConfigValue,
+    *,
+    include_file_content: bool = False,
+) -> CloudRepoConfigResponse:
     return CloudRepoConfigResponse(
         configured=value.configured,
         configured_at=_to_iso(value.configured_at),
@@ -132,7 +140,10 @@ def repo_config_payload(value: CloudRepoConfigValue) -> CloudRepoConfigResponse:
         setup_script=value.setup_script,
         run_command=value.run_command,
         files_version=value.files_version,
-        tracked_files=[repo_file_metadata_payload(item) for item in value.tracked_files],
+        tracked_files=[
+            repo_file_metadata_payload(item, include_content=include_file_content)
+            for item in value.tracked_files
+        ],
     )
 
 

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -668,13 +668,20 @@ class TestCloudRepoConfig:
                 "envVars": {"API_BASE_URL": "https://example.internal"},
                 "setupScript": "pnpm install",
                 "runCommand": "make dev",
-                "files": [],
+                "files": [
+                    {
+                        "relativePath": ".env.shared",
+                        "content": "API_BASE_URL=https://example.internal\nSHARED_TOKEN=dev\n",
+                    },
+                ],
             },
         )
 
         assert save_response.status_code == 200
         assert save_response.json()["defaultBranch"] == "release"
         assert save_response.json()["runCommand"] == "make dev"
+        assert save_response.json()["trackedFiles"][0]["relativePath"] == ".env.shared"
+        assert save_response.json()["trackedFiles"][0].get("content") is None
 
         get_response = await client.get(
             "/v1/cloud/repos/proliferate-ai/proliferate/config",
@@ -683,6 +690,8 @@ class TestCloudRepoConfig:
         assert get_response.status_code == 200
         assert get_response.json()["defaultBranch"] == "release"
         assert get_response.json()["runCommand"] == "make dev"
+        assert get_response.json()["trackedFiles"][0]["relativePath"] == ".env.shared"
+        assert get_response.json()["trackedFiles"][0].get("content") is None
 
         record = (
             await db_session.execute(
@@ -695,6 +704,51 @@ class TestCloudRepoConfig:
         ).scalar_one()
         assert record.default_branch == "release"
         assert record.run_command == "make dev"
+
+        organizations_response = await client.get("/v1/organizations", headers=headers)
+        assert organizations_response.status_code == 200
+        organization_id = organizations_response.json()["organizations"][0]["id"]
+
+        organization_save_response = await client.put(
+            (
+                f"/v1/cloud/organizations/{organization_id}/repos/"
+                "proliferate-ai/proliferate/config"
+            ),
+            headers=headers,
+            json={
+                "configured": True,
+                "defaultBranch": "release",
+                "envVars": {"API_BASE_URL": "https://example.internal"},
+                "setupScript": "pnpm install",
+                "runCommand": "make dev",
+                "files": [
+                    {
+                        "relativePath": ".env.shared",
+                        "content": "API_BASE_URL=https://example.internal\nSHARED_TOKEN=team\n",
+                    },
+                ],
+            },
+        )
+        assert organization_save_response.status_code == 200
+        assert organization_save_response.json()["trackedFiles"][0]["relativePath"] == ".env.shared"
+        assert (
+            organization_save_response.json()["trackedFiles"][0]["content"]
+            == "API_BASE_URL=https://example.internal\nSHARED_TOKEN=team\n"
+        )
+
+        organization_get_response = await client.get(
+            (
+                f"/v1/cloud/organizations/{organization_id}/repos/"
+                "proliferate-ai/proliferate/config"
+            ),
+            headers=headers,
+        )
+        assert organization_get_response.status_code == 200
+        assert organization_get_response.json()["trackedFiles"][0]["relativePath"] == ".env.shared"
+        assert (
+            organization_get_response.json()["trackedFiles"][0]["content"]
+            == "API_BASE_URL=https://example.internal\nSHARED_TOKEN=team\n"
+        )
 
     @pytest.mark.asyncio
     async def test_free_plan_repo_config_limit_blocks_second_configured_repo(


### PR DESCRIPTION
## Summary
- add an admin editor for shared environment files in Shared Environments
- preserve metadata-only responses for personal repo config while returning shared file content for org admin editing
- persist shared file key/value rows as concrete env file contents
- refresh generated AnyHarness SDK schema after local dev bootstrap

## Validation
- `pnpm --dir desktop build`
- `pnpm --dir desktop exec tsc --noEmit`
- `pnpm --dir cloud/sdk exec tsc --noEmit`
- `pnpm --dir desktop exec vitest run src/lib/domain/settings/env-file-draft.test.ts`
- `cd server && DEBUG=1 uv run --extra dev python -m pytest -q tests/integration/test_cloud_api.py::TestCloudRepoConfig::test_save_and_get_repo_config_persists_default_branch`
- `python3 -m py_compile server/proliferate/server/cloud/repo_config/models.py server/proliferate/server/cloud/repo_config/api.py server/proliferate/server/cloud/repo_config/service.py`
- local `sharedenv` profile booted successfully; API, web, and desktop renderer returned `200`
