### PR TITLE
fix(cloud): harden shared environment config saves

### DIFF
--- a/anyharness/sdk/src/client/sessions.test.ts
+++ b/anyharness/sdk/src/client/sessions.test.ts
@@ -111,3 +111,31 @@ describe("SessionsClient.resume", () => {
     }]);
   });
 });
+
+describe("SessionsClient.listEvents", () => {
+  it("serializes oldest-first pagination", async () => {
+    const calls: Array<{ path: string; options: AnyHarnessRequestOptions | undefined }> = [];
+    const transport = {
+      get: async (path: string, options?: AnyHarnessRequestOptions) => {
+        calls.push({ path, options });
+        return [];
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new SessionsClient(transport);
+
+    await client.listEvents("session-1", {
+      afterSeq: 10,
+      limit: 25,
+      oldestFirst: true,
+      request: { headers: { "x-trace": "trace-events" } },
+    });
+
+    expect(calls).toEqual([{
+      path: "/v1/sessions/session-1/events?after_seq=10&limit=25&oldest_first=true",
+      options: {
+        headers: { "x-trace": "trace-events" },
+        timingCategory: "session.events.list",
+      },
+    }]);
+  });
+});

--- a/anyharness/sdk/src/client/sessions.ts
+++ b/anyharness/sdk/src/client/sessions.ts
@@ -289,6 +289,9 @@ export class SessionsClient {
     if (options?.limit != null) {
       params.set("limit", String(options.limit));
     }
+    if (options?.oldestFirst != null) {
+      params.set("oldest_first", String(options.oldestFirst));
+    }
     if (options?.turnLimit != null) {
       params.set("turn_limit", String(options.turnLimit));
     }

--- a/anyharness/sdk/src/types/sessions.ts
+++ b/anyharness/sdk/src/types/sessions.ts
@@ -131,6 +131,7 @@ export interface ListSessionEventsOptions {
   afterSeq?: number;
   beforeSeq?: number;
   limit?: number;
+  oldestFirst?: boolean;
   turnLimit?: number;
 }
 

--- a/cloud/sdk/src/client/repo-configs.ts
+++ b/cloud/sdk/src/client/repo-configs.ts
@@ -6,6 +6,7 @@ import type {
   PutCloudRepoFileRequest,
   RunCloudWorkspaceSetupResponse,
   SaveCloudRepoConfigRequest,
+  SaveOrganizationCloudRepoConfigRequest,
   ResyncCloudWorkspaceFilesResponse,
 } from "../types/index.js";
 
@@ -69,9 +70,7 @@ export async function saveOrganizationCloudRepoConfig(
   organizationId: string,
   gitOwner: string,
   gitRepoName: string,
-  body: Omit<SaveCloudRepoConfigRequest, "files"> & {
-    files?: SaveCloudRepoConfigRequest["files"];
-  },
+  body: SaveOrganizationCloudRepoConfigRequest,
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudRepoConfigResponse> {
   return client.requestJson<CloudRepoConfigResponse>({

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -484,6 +484,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/organizations/{organization_id}/repos/configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Organization Cloud Repo Configs Endpoint */
+        get: operations["list_organization_cloud_repo_configs_endpoint_v1_cloud_organizations__organization_id__repos_configs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/repos/{git_owner}/{git_repo_name}/config": {
         parameters: {
             query?: never;
@@ -495,6 +512,24 @@ export interface paths {
         get: operations["get_cloud_repo_config_endpoint_v1_cloud_repos__git_owner___git_repo_name__config_get"];
         /** Save Cloud Repo Config Endpoint */
         put: operations["save_cloud_repo_config_endpoint_v1_cloud_repos__git_owner___git_repo_name__config_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/organizations/{organization_id}/repos/{git_owner}/{git_repo_name}/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Organization Cloud Repo Config Endpoint */
+        get: operations["get_organization_cloud_repo_config_endpoint_v1_cloud_organizations__organization_id__repos__git_owner___git_repo_name__config_get"];
+        /** Save Organization Cloud Repo Config Endpoint */
+        put: operations["save_organization_cloud_repo_config_endpoint_v1_cloud_organizations__organization_id__repos__git_owner___git_repo_name__config_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -623,6 +658,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/workspaces/remote-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bootstrap Workspace Remote Access Endpoint */
+        post: operations["bootstrap_workspace_remote_access_endpoint_v1_cloud_workspaces_remote_access_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workspaces/{workspace_id}": {
         parameters: {
             query?: never;
@@ -652,6 +704,40 @@ export interface paths {
         get: operations["get_cloud_workspace_connection_endpoint_v1_cloud_workspaces__workspace_id__connection_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/workspaces/{workspace_id}/remote-access/enable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Enable Cloud Workspace Remote Access Endpoint */
+        post: operations["enable_cloud_workspace_remote_access_endpoint_v1_cloud_workspaces__workspace_id__remote_access_enable_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/workspaces/{workspace_id}/remote-access/disable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Disable Cloud Workspace Remote Access Endpoint */
+        post: operations["disable_cloud_workspace_remote_access_endpoint_v1_cloud_workspaces__workspace_id__remote_access_disable_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4186,6 +4272,21 @@ export interface components {
             /** User */
             user?: string | null;
         };
+        /** BootstrapWorkspaceRemoteAccessRequest */
+        BootstrapWorkspaceRemoteAccessRequest: {
+            /**
+             * Targetid
+             * Format: uuid
+             */
+            targetId: string;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId: string;
+            /** Anyharnesssessionid */
+            anyharnessSessionId?: string | null;
+            /** Displayname */
+            displayName?: string | null;
+            repo?: components["schemas"]["RemoteAccessRepoRef"] | null;
+        };
         /** ClaimWorkspaceRequest */
         ClaimWorkspaceRequest: {
             /**
@@ -5511,6 +5612,14 @@ export interface components {
         /** MaterializeTargetConfigRequest */
         MaterializeTargetConfigRequest: {
             /**
+             * Ownerscope
+             * @default personal
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
+            /**
              * Gitprovider
              * @default github
              * @constant
@@ -6090,6 +6199,28 @@ export interface components {
              */
             reason: string;
         };
+        /** RemoteAccessRepoRef */
+        RemoteAccessRepoRef: {
+            /**
+             * Provider
+             * @default local
+             */
+            provider: string;
+            /**
+             * Owner
+             * @default local
+             */
+            owner: string;
+            /** Name */
+            name: string;
+            /**
+             * Branch
+             * @default default
+             */
+            branch: string;
+            /** Basebranch */
+            baseBranch?: string | null;
+        };
         /** RepairWorkspaceMobilityHandoffRequest */
         RepairWorkspaceMobilityHandoffRequest: {
             /** Action */
@@ -6453,7 +6584,30 @@ export interface components {
              */
             runCommand: string;
             /** Files */
-            files?: components["schemas"]["SaveCloudRepoConfigFile"][];
+            files: components["schemas"]["SaveCloudRepoConfigFile"][];
+        };
+        /** SaveOrganizationCloudRepoConfigRequest */
+        SaveOrganizationCloudRepoConfigRequest: {
+            /** Configured */
+            configured: boolean;
+            /** Defaultbranch */
+            defaultBranch?: string | null;
+            /** Envvars */
+            envVars?: {
+                [key: string]: string;
+            };
+            /**
+             * Setupscript
+             * @default
+             */
+            setupScript: string;
+            /**
+             * Runcommand
+             * @default
+             */
+            runCommand: string;
+            /** Files */
+            files?: components["schemas"]["SaveCloudRepoConfigFile"][] | null;
         };
         /** SelectAgentAuthCredentialRequest */
         SelectAgentAuthCredentialRequest: {
@@ -6644,6 +6798,10 @@ export interface components {
             cloudRepoConfigId: string;
             /** Organizationid */
             organizationId: string;
+            /** Gitowner */
+            gitOwner?: string | null;
+            /** Gitreponame */
+            gitRepoName?: string | null;
             /** Displayname */
             displayName: string | null;
             /** Description */
@@ -7972,6 +8130,8 @@ export interface components {
         WorkspaceDetail: {
             /** Id */
             id: string;
+            /** Targetid */
+            targetId?: string | null;
             /** Displayname */
             displayName: string | null;
             repo: components["schemas"]["RepoRef"];
@@ -8147,6 +8307,8 @@ export interface components {
         WorkspaceSummary: {
             /** Id */
             id: string;
+            /** Targetid */
+            targetId?: string | null;
             /** Displayname */
             displayName: string | null;
             repo: components["schemas"]["RepoRef"];
@@ -9266,6 +9428,37 @@ export interface operations {
             };
         };
     };
+    list_organization_cloud_repo_configs_endpoint_v1_cloud_organizations__organization_id__repos_configs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudRepoConfigsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_cloud_repo_config_endpoint_v1_cloud_repos__git_owner___git_repo_name__config_get: {
         parameters: {
             query?: never;
@@ -9311,6 +9504,76 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["SaveCloudRepoConfigRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudRepoConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_organization_cloud_repo_config_endpoint_v1_cloud_organizations__organization_id__repos__git_owner___git_repo_name__config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+                git_owner: string;
+                git_repo_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudRepoConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_organization_cloud_repo_config_endpoint_v1_cloud_organizations__organization_id__repos__git_owner___git_repo_name__config_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+                git_owner: string;
+                git_repo_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveOrganizationCloudRepoConfigRequest"];
             };
         };
         responses: {
@@ -9602,6 +9865,39 @@ export interface operations {
             };
         };
     };
+    bootstrap_workspace_remote_access_endpoint_v1_cloud_workspaces_remote_access_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BootstrapWorkspaceRemoteAccessRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_cloud_workspace_endpoint_v1_cloud_workspaces__workspace_id__get: {
         parameters: {
             query?: never;
@@ -9684,6 +9980,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspaceConnection"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enable_cloud_workspace_remote_access_endpoint_v1_cloud_workspaces__workspace_id__remote_access_enable_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    disable_cloud_workspace_remote_access_endpoint_v1_cloud_workspaces__workspace_id__remote_access_disable_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceDetail"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -167,6 +167,8 @@ export type CloudRepoConfigsListResponse = components["schemas"]["CloudRepoConfi
 export type CloudRepoFileMetadata     = components["schemas"]["CloudRepoFileMetadata"];
 export type CloudRepoConfigResponse   = components["schemas"]["CloudRepoConfigResponse"];
 export type SaveCloudRepoConfigRequest = components["schemas"]["SaveCloudRepoConfigRequest"];
+export type SaveOrganizationCloudRepoConfigRequest =
+  components["schemas"]["SaveOrganizationCloudRepoConfigRequest"];
 export type AutomationOwnerScope = "personal" | "organization";
 export type AutomationTargetMode = "local" | "personal_cloud" | "shared_cloud";
 export type AutomationRunStatus =

--- a/desktop/src/components/settings/panes/SharedEnvironmentsPane.tsx
+++ b/desktop/src/components/settings/panes/SharedEnvironmentsPane.tsx
@@ -270,7 +270,7 @@ function SharedEnvironmentDetail({
       envVars: draft.savePayload.envVars,
       setupScript: draft.savePayload.setupScript,
       runCommand: draft.savePayload.runCommand,
-      files: draft.sharedEnvFilePayloads,
+      files: draft.sharedEnvFilesDirty ? draft.sharedEnvFilePayloads : undefined,
     });
     const profile = await authMutations.ensureOrganizationProfile({ organizationId });
     await authMutations.enableProfileCloud({ sandboxProfileId: profile.id });

--- a/desktop/src/hooks/access/cloud/use-save-organization-cloud-repo-config.ts
+++ b/desktop/src/hooks/access/cloud/use-save-organization-cloud-repo-config.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   saveOrganizationCloudRepoConfig,
 } from "@proliferate/cloud-sdk/client/repo-configs";
-import type { SaveCloudRepoConfigRequest } from "@proliferate/cloud-sdk/types";
+import type { SaveOrganizationCloudRepoConfigRequest } from "@proliferate/cloud-sdk/types";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
 import {
   organizationCloudRepoConfigKey,
@@ -18,7 +18,7 @@ interface SaveOrganizationCloudRepoConfigInput {
   envVars: Record<string, string>;
   setupScript: string;
   runCommand: string;
-  files?: SaveCloudRepoConfigRequest["files"];
+  files?: NonNullable<SaveOrganizationCloudRepoConfigRequest["files"]>;
 }
 
 export function useSaveOrganizationCloudRepoConfig() {

--- a/desktop/src/hooks/cloud/ui/use-cloud-repo-config-draft.ts
+++ b/desktop/src/hooks/cloud/ui/use-cloud-repo-config-draft.ts
@@ -14,7 +14,7 @@ import {
 import {
   envFileVariablesEqual,
   parseEnvFileVariables,
-  serializeEnvFileVariables,
+  serializeEnvFileVariablesPreservingOriginal,
   type EnvFileVariable,
 } from "@/lib/domain/settings/env-file-draft";
 import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
@@ -29,6 +29,8 @@ export interface CloudRepoSharedEnvFile {
   id: string;
   relativePath: string;
   rows: CloudRepoEnvVarRow[];
+  originalContent: string | null;
+  originalVariables: EnvFileVariable[];
 }
 
 export interface CloudRepoSharedEnvFilePayload {
@@ -61,11 +63,17 @@ function buildEnvVarRowsFromVariables(variables: readonly EnvFileVariable[]): Cl
 function buildSharedEnvFiles(savedConfig: CloudRepoConfig | null | undefined): CloudRepoSharedEnvFile[] {
   return (savedConfig?.trackedFiles ?? [])
     .filter((file) => typeof file.content === "string")
-    .map((file) => ({
-      id: createRowId(),
-      relativePath: file.relativePath,
-      rows: buildEnvVarRowsFromVariables(parseEnvFileVariables(file.content)),
-    }));
+    .map((file) => {
+      const originalContent = file.content ?? "";
+      const originalVariables = parseEnvFileVariables(originalContent);
+      return {
+        id: createRowId(),
+        relativePath: file.relativePath,
+        rows: buildEnvVarRowsFromVariables(originalVariables),
+        originalContent,
+        originalVariables,
+      };
+    });
 }
 
 function normalizeSharedEnvFilePath(relativePath: string): string {
@@ -87,7 +95,11 @@ function buildSharedEnvFilePayloads(
 ): CloudRepoSharedEnvFilePayload[] {
   return normalizeSharedEnvFiles(files).map((file) => ({
     relativePath: file.relativePath,
-    content: serializeEnvFileVariables(file.rows),
+    content: serializeEnvFileVariablesPreservingOriginal(
+      file.rows,
+      file.originalVariables,
+      file.originalContent,
+    ),
   }));
 }
 
@@ -265,6 +277,8 @@ export function useCloudRepoConfigDraft({
           id: createRowId(),
           relativePath: nextDefaultSharedEnvFilePath(current.sharedEnvFiles),
           rows: [{ id: createRowId(), key: "", value: "" }],
+          originalContent: null,
+          originalVariables: [],
         },
       ],
     }));
@@ -427,6 +441,7 @@ export function useCloudRepoConfigDraft({
     envVarRows: state.envVarRows,
     envVars,
     sharedEnvFiles: state.sharedEnvFiles,
+    sharedEnvFilesDirty,
     sharedEnvFilePayloads: buildSharedEnvFilePayloads(state.sharedEnvFiles),
     trackedFilePaths: currentDraft.trackedFilePaths,
     setupScript: currentDraft.setupScript,

--- a/desktop/src/lib/domain/settings/env-file-draft.test.ts
+++ b/desktop/src/lib/domain/settings/env-file-draft.test.ts
@@ -3,6 +3,7 @@ import {
   envFileVariablesEqual,
   parseEnvFileVariables,
   serializeEnvFileVariables,
+  serializeEnvFileVariablesPreservingOriginal,
 } from "@/lib/domain/settings/env-file-draft";
 
 describe("env file draft helpers", () => {
@@ -33,5 +34,32 @@ describe("env file draft helpers", () => {
       [{ key: "API_BASE_URL", value: "https://example.internal" }],
       [{ key: " API_BASE_URL ", value: "https://example.internal" }],
     )).toBe(true);
+  });
+
+  it("preserves original content when editable rows have not changed", () => {
+    const originalContent = [
+      "# keep this comment",
+      "export API_BASE_URL='https://example.internal'",
+      "UNSUPPORTED_LINE",
+      "",
+    ].join("\n");
+    const originalRows = parseEnvFileVariables(originalContent);
+
+    expect(serializeEnvFileVariablesPreservingOriginal(
+      [{ key: "API_BASE_URL", value: "https://example.internal" }],
+      originalRows,
+      originalContent,
+    )).toBe(originalContent);
+  });
+
+  it("serializes deterministic content once editable rows change", () => {
+    const originalContent = "# keep this comment\nAPI_BASE_URL=https://example.internal\n";
+    const originalRows = parseEnvFileVariables(originalContent);
+
+    expect(serializeEnvFileVariablesPreservingOriginal(
+      [{ key: "API_BASE_URL", value: "https://example.test" }],
+      originalRows,
+      originalContent,
+    )).toBe("API_BASE_URL=https://example.test\n");
   });
 });

--- a/desktop/src/lib/domain/settings/env-file-draft.ts
+++ b/desktop/src/lib/domain/settings/env-file-draft.ts
@@ -70,3 +70,14 @@ export function envFileVariablesEqual(
   const rightContent = serializeEnvFileVariables(right);
   return leftContent === rightContent;
 }
+
+export function serializeEnvFileVariablesPreservingOriginal(
+  rows: readonly EnvFileVariable[],
+  originalRows: readonly EnvFileVariable[],
+  originalContent: string | null | undefined,
+): string {
+  if (originalContent != null && envFileVariablesEqual(rows, originalRows)) {
+    return originalContent;
+  }
+  return serializeEnvFileVariables(rows);
+}

--- a/server/proliferate/server/cloud/repo_config/access.py
+++ b/server/proliferate/server/cloud/repo_config/access.py
@@ -1,0 +1,39 @@
+"""Access checks for cloud repo configuration APIs."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_ROLE_ADMIN,
+    ORGANIZATION_ROLE_OWNER,
+)
+from proliferate.db.store.organizations import get_active_membership
+from proliferate.server.cloud.errors import CloudApiError
+
+
+async def require_organization_repo_config_admin(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    membership = await get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    if membership is None:
+        raise CloudApiError(
+            "organization_repo_config_not_found",
+            "Organization repo configuration not found.",
+            status_code=404,
+        )
+    if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
+        raise CloudApiError(
+            "organization_repo_config_permission_denied",
+            "You do not have permission to manage shared environments for this organization.",
+            status_code=403,
+        )

--- a/server/proliferate/server/cloud/repo_config/api.py
+++ b/server/proliferate/server/cloud/repo_config/api.py
@@ -17,6 +17,7 @@ from proliferate.server.cloud.repo_config.models import (
     ResyncCloudWorkspaceFilesResponse,
     RunCloudWorkspaceSetupResponse,
     SaveCloudRepoConfigRequest,
+    SaveOrganizationCloudRepoConfigRequest,
     repo_config_payload,
     repo_config_summary_payload,
     resync_cloud_workspace_files_payload,
@@ -155,7 +156,7 @@ async def save_organization_cloud_repo_config_endpoint(
     organization_id: UUID,
     git_owner: str,
     git_repo_name: str,
-    body: SaveCloudRepoConfigRequest,
+    body: SaveOrganizationCloudRepoConfigRequest,
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> CloudRepoConfigResponse:

--- a/server/proliferate/server/cloud/repo_config/models.py
+++ b/server/proliferate/server/cloud/repo_config/models.py
@@ -66,7 +66,16 @@ class SaveCloudRepoConfigRequest(BaseModel):
     env_vars: dict[str, str] = Field(default_factory=dict, alias="envVars")
     setup_script: str = Field(default="", alias="setupScript")
     run_command: str = Field(default="", alias="runCommand")
-    files: list[SaveCloudRepoConfigFile] = Field(default_factory=list)
+    files: list[SaveCloudRepoConfigFile]
+
+
+class SaveOrganizationCloudRepoConfigRequest(BaseModel):
+    configured: bool
+    default_branch: str | None = Field(default=None, alias="defaultBranch")
+    env_vars: dict[str, str] = Field(default_factory=dict, alias="envVars")
+    setup_script: str = Field(default="", alias="setupScript")
+    run_command: str = Field(default="", alias="runCommand")
+    files: list[SaveCloudRepoConfigFile] | None = None
 
 
 class PutCloudRepoFileRequest(BaseModel):

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -22,8 +22,9 @@ from proliferate.db.store.cloud_repo_config import (
     save_cloud_repo_file,
     save_organization_cloud_repo_config,
 )
-from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
-from proliferate.db.store.organizations import load_active_membership
+from proliferate.db.store.cloud_slack import repo_routing_profiles as slack_routing_profile_store
+from proliferate.db.store.cloud_workspaces import get_cloud_workspace_by_id
+from proliferate.db.store.organizations import get_active_membership
 from proliferate.integrations.anyharness import CloudRuntimeOperationError
 from proliferate.server.billing.service import (
     get_billing_snapshot,
@@ -31,6 +32,7 @@ from proliferate.server.billing.service import (
     repo_limit_for_billing_snapshot,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repo_config.access import require_organization_repo_config_admin
 from proliferate.server.cloud.repo_config.domain.workspace_status import (
     RepoConfigTrackedFileStatus,
     ResyncWorkspaceRepoConfigStatus,
@@ -40,6 +42,7 @@ from proliferate.server.cloud.repo_config.domain.workspace_status import (
 from proliferate.server.cloud.repo_config.models import (
     PutCloudRepoFileRequest,
     SaveCloudRepoConfigRequest,
+    SaveOrganizationCloudRepoConfigRequest,
 )
 from proliferate.server.cloud.repo_config.validation import (
     normalize_env_vars,
@@ -56,8 +59,6 @@ from proliferate.server.cloud.runtime.repo_config_apply import (
     run_workspace_saved_setup,
 )
 from proliferate.server.cloud.runtime.service import get_workspace_connection
-from proliferate.server.cloud.targets.domain.policy import require_target_admin_membership
-from proliferate.db.store.cloud_slack import repo_routing_profiles as slack_routing_profile_store
 
 
 class _WorkspaceRepoConfigRecord(Protocol):
@@ -91,12 +92,14 @@ def _raise_org_cloud_not_ready() -> NoReturn:
 
 
 async def _load_authorized_workspace_for_repo_config(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> _WorkspaceRepoConfigRecord:
-    workspace = await load_cloud_workspace_by_id(workspace_id)
+    workspace = await get_cloud_workspace_by_id(db, workspace_id)
     if workspace is None:
         _raise_workspace_not_found()
+    await db.refresh(workspace)
 
     if workspace.owner_scope == "personal":
         if workspace.owner_user_id != user_id:
@@ -104,7 +107,8 @@ async def _load_authorized_workspace_for_repo_config(
         return workspace
 
     if workspace.owner_scope == "organization" and workspace.organization_id is not None:
-        membership = await load_active_membership(
+        membership = await get_active_membership(
+            db,
             organization_id=workspace.organization_id,
             user_id=user_id,
         )
@@ -169,20 +173,16 @@ async def list_repo_configs(
     return await list_cloud_repo_configs(db, user_id)
 
 
-async def _require_organization_admin(user_id: UUID, organization_id: UUID) -> None:
-    membership = await load_active_membership(
-        organization_id=organization_id,
-        user_id=user_id,
-    )
-    require_target_admin_membership(membership)
-
-
 async def list_organization_repo_configs(
     db: AsyncSession,
     user_id: UUID,
     organization_id: UUID,
 ) -> list[CloudRepoConfigValue]:
-    await _require_organization_admin(user_id, organization_id)
+    await require_organization_repo_config_admin(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
     return await list_organization_cloud_repo_configs(db, organization_id=organization_id)
 
 
@@ -209,7 +209,11 @@ async def get_organization_repo_config(
     git_owner: str,
     git_repo_name: str,
 ) -> CloudRepoConfigValue | None:
-    await _require_organization_admin(user_id, organization_id)
+    await require_organization_repo_config_admin(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
     return await get_organization_cloud_repo_config(
         db,
         organization_id=organization_id,
@@ -332,9 +336,13 @@ async def save_organization_repo_config(
     *,
     git_owner: str,
     git_repo_name: str,
-    body: SaveCloudRepoConfigRequest,
+    body: SaveOrganizationCloudRepoConfigRequest,
 ) -> CloudRepoConfigValue:
-    await _require_organization_admin(user_id, organization_id)
+    await require_organization_repo_config_admin(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
     env_vars = normalize_env_vars(body.env_vars)
     default_branch = await _validate_default_branch(
         db,
@@ -350,7 +358,7 @@ async def save_organization_repo_config(
                 for item in body.files
             ]
         )
-        if "files" in body.model_fields_set
+        if body.files is not None
         else None
     )
     value = await save_organization_cloud_repo_config(
@@ -442,7 +450,7 @@ async def get_workspace_repo_config_status(
     user_id: UUID,
     workspace_id: UUID,
 ) -> WorkspaceRepoConfigStatus:
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
     repo_config = await get_cloud_repo_config(
         db,
         user_id=user_id,
@@ -457,7 +465,7 @@ async def build_resync_workspace_repo_config_status(
     user_id: UUID,
     workspace_id: UUID,
 ) -> ResyncWorkspaceRepoConfigStatus:
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
     repo_config = await get_cloud_repo_config(
         db,
         user_id=user_id,
@@ -488,7 +496,7 @@ async def resync_workspace_files(
     user_id: UUID,
     workspace_id: UUID,
 ) -> ResyncWorkspaceRepoConfigStatus:
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
     target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
@@ -511,7 +519,7 @@ async def resync_workspace_files(
             status_code=502,
         ) from error
 
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
     repo_config = await get_cloud_repo_config(
         db,
         user_id=user_id,
@@ -526,7 +534,7 @@ async def run_workspace_setup(
     user_id: UUID,
     workspace_id: UUID,
 ) -> RunWorkspaceSetupStatus:
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
     target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
@@ -548,7 +556,7 @@ async def run_workspace_setup(
             status_code=502,
         ) from error
 
-    workspace = await _load_authorized_workspace_for_repo_config(user_id, workspace_id)
+    workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
     return RunWorkspaceSetupStatus(
         workspace_id=workspace.id,
         command=started.command,

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -12,12 +12,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.constants.billing import BILLING_MODE_OBSERVE
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+)
 from proliferate.db.models.auth import OAuthAccount
 from proliferate.db.models.cloud.mcp import CloudMcpConnection, CloudMcpConnectionAuth
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.models.cloud.worktree_policy import CloudWorktreeRetentionPolicy
+from proliferate.db.models.organizations import OrganizationMembership
 from proliferate.db.store.cloud_mcp.auth import (
     update_connection_auth_if_version,
     upsert_connection_auth,
@@ -749,6 +754,62 @@ class TestCloudRepoConfig:
             organization_get_response.json()["trackedFiles"][0]["content"]
             == "API_BASE_URL=https://example.internal\nSHARED_TOKEN=team\n"
         )
+
+        organization_preserve_response = await client.put(
+            (
+                f"/v1/cloud/organizations/{organization_id}/repos/"
+                "proliferate-ai/proliferate/config"
+            ),
+            headers=headers,
+            json={
+                "configured": True,
+                "defaultBranch": "release",
+                "envVars": {"API_BASE_URL": "https://example.internal"},
+                "setupScript": "pnpm install",
+                "runCommand": "make dev --shared",
+            },
+        )
+        assert organization_preserve_response.status_code == 200
+        assert organization_preserve_response.json()["runCommand"] == "make dev --shared"
+        assert (
+            organization_preserve_response.json()["trackedFiles"][0]["content"]
+            == "API_BASE_URL=https://example.internal\nSHARED_TOKEN=team\n"
+        )
+
+        member_session = await _register_and_login(client, "cloud-member@example.com")
+        db_session.add(
+            OrganizationMembership(
+                organization_id=uuid.UUID(organization_id),
+                user_id=uuid.UUID(member_session["user_id"]),
+                role=ORGANIZATION_ROLE_MEMBER,
+                status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            )
+        )
+        await db_session.commit()
+        member_headers = {"Authorization": f"Bearer {member_session['access_token']}"}
+        member_get_response = await client.get(
+            (
+                f"/v1/cloud/organizations/{organization_id}/repos/"
+                "proliferate-ai/proliferate/config"
+            ),
+            headers=member_headers,
+        )
+        assert member_get_response.status_code == 403
+        assert member_get_response.json()["detail"]["code"] == (
+            "organization_repo_config_permission_denied"
+        )
+
+        outsider_session = await _register_and_login(client, "cloud-outsider@example.com")
+        outsider_headers = {"Authorization": f"Bearer {outsider_session['access_token']}"}
+        outsider_get_response = await client.get(
+            (
+                f"/v1/cloud/organizations/{organization_id}/repos/"
+                "proliferate-ai/proliferate/config"
+            ),
+            headers=outsider_headers,
+        )
+        assert outsider_get_response.status_code == 404
+        assert outsider_get_response.json()["detail"]["code"] == "organization_repo_config_not_found"
 
     @pytest.mark.asyncio
     async def test_free_plan_repo_config_limit_blocks_second_configured_repo(


### PR DESCRIPTION
## Summary
- preserve original shared env file content unless the shared-file editor changes it
- split personal vs organization repo config save request shapes so org saves can omit files to preserve them
- move organization repo config admin checks onto the request DB session and add member/outsider denial coverage
- pass AnyHarness oldest-first event pagination through the curated SDK wrapper

## Verification
- pnpm --dir desktop exec vitest run src/lib/domain/settings/env-file-draft.test.ts
- pnpm --dir anyharness/sdk exec vitest run src/client/sessions.test.ts
- pnpm --dir cloud/sdk exec tsc --noEmit
- pnpm --dir anyharness/sdk exec tsc --noEmit
- pnpm --dir desktop exec tsc --noEmit
- cd server && DEBUG=1 uv run python -m py_compile proliferate/server/cloud/repo_config/access.py proliferate/server/cloud/repo_config/api.py proliferate/server/cloud/repo_config/models.py proliferate/server/cloud/repo_config/service.py
- cd server && DEBUG=1 uv run --extra dev python -m pytest -q tests/integration/test_cloud_api.py::TestCloudRepoConfig::test_save_and_get_repo_config_persists_default_branch (test passed; local teardown failed because the Postgres user cannot terminate a superuser backend)