### PR TITLE
feat(desktop): clean up plugins catalog

### DIFF
--- a/desktop/src/components/plugins/catalog/ConnectorCatalogPage.test.tsx
+++ b/desktop/src/components/plugins/catalog/ConnectorCatalogPage.test.tsx
@@ -21,14 +21,6 @@ const connectorsCatalogState = vi.hoisted(() => {
     searchQuery: "",
     setActiveTab: vi.fn(),
     setSearchQuery: vi.fn(),
-    sharedExposure: {
-      activeOrganizationId: "org_1",
-      activeOrganizationName: "Acme",
-      canManage: true,
-      currentUserId: "user_1",
-      hasOrganization: true,
-      isLoading: false,
-    },
   });
 
   return {
@@ -81,16 +73,12 @@ vi.mock("./PluginPackageRow", () => ({
     { "data-testid": "available-plugin-row" },
     model.entry.id,
   ),
-  ConnectedPluginPackageRow: ({
-    canManageSharedExposure,
-    model,
-  }: {
-    canManageSharedExposure: boolean;
+  ConnectedPluginPackageRow: ({ model }: {
     model: { record: { metadata: { connectionId: string } } };
   }) => createElement(
     "div",
     { "data-testid": "connected-plugin-row" },
-    `${model.record.metadata.connectionId}:${canManageSharedExposure ? "can-share" : "cannot-share"}`,
+    model.record.metadata.connectionId,
   ),
 }));
 
@@ -146,23 +134,7 @@ describe("ConnectorCatalogPage", () => {
     expect(html).not.toContain("No plugins are available right now.");
   });
 
-  it("lets personal source owners publish their plugin package without being org admins", () => {
-    connectorsCatalogState.state.sharedExposure.canManage = false;
-    connectorsCatalogState.state.connected = [
-      {
-        record: {
-          metadata: { connectionId: "conn-1", ownerScope: "personal", ownerUserId: "user_1" },
-        },
-      },
-    ] as never[];
-
-    const html = renderToStaticMarkup(createElement(ConnectorCatalogPage));
-
-    expect(html).toContain("conn-1:can-share");
-  });
-
-  it("lets organization admins publish personal source plugin packages", () => {
-    connectorsCatalogState.state.sharedExposure.canManage = true;
+  it("renders connected and available plugin cards", () => {
     connectorsCatalogState.state.connected = [
       {
         record: {
@@ -170,24 +142,43 @@ describe("ConnectorCatalogPage", () => {
         },
       },
     ] as never[];
-
-    const html = renderToStaticMarkup(createElement(ConnectorCatalogPage));
-
-    expect(html).toContain("conn-1:can-share");
-  });
-
-  it("blocks shared exposure actions for non-admins who do not own the personal source", () => {
-    connectorsCatalogState.state.sharedExposure.canManage = false;
-    connectorsCatalogState.state.connected = [
+    connectorsCatalogState.state.availableCards = [
       {
-        record: {
-          metadata: { connectionId: "conn-1", ownerScope: "personal", ownerUserId: "user_2" },
+        entry: {
+          id: "context7",
         },
       },
     ] as never[];
 
     const html = renderToStaticMarkup(createElement(ConnectorCatalogPage));
 
-    expect(html).toContain("conn-1:cannot-share");
+    expect(html).toContain("Installed");
+    expect(html).toContain("Available");
+    expect(html).toContain("conn-1");
+    expect(html).toContain("context7");
+  });
+
+  it("does not render shared or team access controls on the plugins page", () => {
+    connectorsCatalogState.state.connected = [
+      {
+        record: {
+          metadata: {
+            connectionId: "conn-1",
+            ownerScope: "personal",
+            ownerUserId: "user_2",
+            publicToOrg: true,
+            publicStatus: "public",
+          },
+        },
+      },
+    ] as never[];
+
+    const html = renderToStaticMarkup(createElement(ConnectorCatalogPage));
+
+    expect(html).not.toContain("Shared cloud access");
+    expect(html).not.toContain("Make public");
+    expect(html).not.toContain("Make private");
+    expect(html).not.toContain("team automations");
+    expect(html).not.toContain("Slack");
   });
 });

--- a/desktop/src/components/plugins/catalog/ConnectorCatalogPage.tsx
+++ b/desktop/src/components/plugins/catalog/ConnectorCatalogPage.tsx
@@ -3,7 +3,7 @@ import { useConnectorsCatalogState } from "@/hooks/mcp/ui/use-connectors-catalog
 import { LoadingState } from "@/components/feedback/LoadingIllustration";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { Globe, Search } from "@/components/ui/icons";
+import { Search } from "@/components/ui/icons";
 import {
   AvailablePluginPackageRow,
   ConnectedPluginPackageRow,
@@ -77,19 +77,14 @@ export function ConnectorCatalogPage() {
           </div>
         ) : (
           <>
-            <SharedCloudExposureNotice
-              activeOrganizationName={state.sharedExposure.activeOrganizationName}
-              canManage={state.sharedExposure.canManage}
-              hasOrganization={state.sharedExposure.hasOrganization}
-              isLoading={state.sharedExposure.isLoading}
-            />
-
             {state.connected.length > 0 && (
-              <section className="space-y-4">
+              <section className="space-y-3">
                 <div className="border-b border-border/60 pb-2">
-                  <h3 className="text-lg leading-6 text-foreground">Installed</h3>
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Installed
+                  </h3>
                 </div>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                   {state.connected.map((model) => (
                     <ConnectedPluginPackageRow
                       key={model.record.metadata.connectionId}
@@ -97,28 +92,9 @@ export function ConnectorCatalogPage() {
                       pending={actions.installedConnectorActions.isPending(
                         model.record.metadata.connectionId,
                       )}
-                      canManageSharedExposure={
-                        state.sharedExposure.canManage
-                        || canManageOwnSharedExposure(
-                          model.record.metadata.ownerScope,
-                          model.record.metadata.ownerUserId,
-                          state.sharedExposure.currentUserId,
-                        )
-                      }
-                      organizationId={state.sharedExposure.activeOrganizationId}
                       onDelete={() => actions.requestDelete(model.record)}
                       onManage={() => state.openManage(model.record.metadata.connectionId)}
                       onReconnect={() => state.openManage(model.record.metadata.connectionId)}
-                      onSetSharedExposure={(publicToOrg) => {
-                        if (!state.sharedExposure.activeOrganizationId) {
-                          return;
-                        }
-                        void actions.installedConnectorActions.onSetSharedExposure(
-                          model.record,
-                          state.sharedExposure.activeOrganizationId,
-                          publicToOrg,
-                        );
-                      }}
                       onStatusClick={() => state.openRecovery(model.record)}
                       onToggle={(enabled) => {
                         void actions.installedConnectorActions.onToggle(model.record, enabled);
@@ -129,23 +105,25 @@ export function ConnectorCatalogPage() {
               </section>
             )}
 
-            <section className="space-y-4">
+            <section className="space-y-3">
               <div className="border-b border-border/60 pb-2">
-                <h3 className="text-lg leading-6 text-foreground">Available</h3>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Available
+                </h3>
               </div>
               {state.firstRunEmpty && state.availableCards.length > 0 && (
-                <div className="rounded-2xl border border-border/40 bg-foreground/5 px-4 py-3">
+                <div className="rounded-lg border border-border/40 bg-foreground/5 px-4 py-3">
                   <div className="text-sm font-medium text-foreground">
                     No plugins installed
                   </div>
                   <p className="mt-1 text-sm text-muted-foreground">
                     Install a package below. Enabled packages add MCP tools and
-                    plugin skills to managed cloud sandbox runtime config.
+                    plugin skills to your sessions.
                   </p>
                 </div>
               )}
               {state.availableCards.length > 0 ? (
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                   {state.availableCards.map((model) => (
                     <AvailablePluginPackageRow
                       key={model.entry.id}
@@ -188,57 +166,5 @@ export function ConnectorCatalogPage() {
         />
       )}
     </>
-  );
-}
-
-function canManageOwnSharedExposure(
-  ownerScope: string,
-  ownerUserId: string | null | undefined,
-  currentUserId: string | null,
-): boolean {
-  return ownerScope !== "organization"
-    && Boolean(currentUserId)
-    && ownerUserId === currentUserId;
-}
-
-function SharedCloudExposureNotice({
-  activeOrganizationName,
-  canManage,
-  hasOrganization,
-  isLoading,
-}: {
-  activeOrganizationName: string | null;
-  canManage: boolean;
-  hasOrganization: boolean;
-  isLoading: boolean;
-}) {
-  const title = canManage
-    ? `Shared cloud access${activeOrganizationName ? ` for ${activeOrganizationName}` : ""}`
-    : "Shared cloud access";
-  const description = !hasOrganization
-    ? "Join an organization before making MCPs, plugins, and skills available to shared cloud."
-    : canManage
-      ? "Make installed MCP, plugin, and skill items public here. Public items can be used by team automations, Slack, and shared cloud work; shared environments inherit this sandbox-wide set."
-      : "Installed items show whether they are private or public. Organization owners and admins can make them public for team automations, Slack, and shared cloud work.";
-
-  return (
-    <div className="rounded-lg border border-border/60 bg-surface-elevated-secondary px-4 py-3">
-      <div className="flex gap-3">
-        <span
-          aria-hidden="true"
-          className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/20 text-muted-foreground"
-        >
-          <Globe className="size-4" />
-        </span>
-        <div className="min-w-0">
-          <div className="text-sm font-medium text-foreground">
-            {isLoading ? "Checking shared cloud access" : title}
-          </div>
-          <p className="mt-1 text-sm leading-5 text-muted-foreground">
-            {description}
-          </p>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/desktop/src/components/plugins/catalog/PluginPackageRow.tsx
+++ b/desktop/src/components/plugins/catalog/PluginPackageRow.tsx
@@ -7,21 +7,18 @@ import type { PluginPackagePresentation } from "@/lib/domain/plugins/plugin-pack
 import {
   buildAvailablePluginPresentation,
   buildConnectedPluginPresentation,
-  buildPluginSharedExposurePresentation,
-  type PluginSharedExposurePresentation,
 } from "@/lib/domain/plugins/plugin-package-view-model";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Switch } from "@/components/ui/Switch";
 import { ConnectorIcon } from "@/components/plugins/status/ConnectorIcon";
 import { ConnectorOverflowMenu } from "@/components/plugins/status/ConnectorOverflowMenu";
-import { ConnectorStatusChip } from "@/components/plugins/status/ConnectorStatusChip";
-import { Globe, Plus } from "@/components/ui/icons";
+import { Plus } from "@/components/ui/icons";
 
-const SHARED_EXPOSURE_TONE_CLASSES: Record<PluginSharedExposurePresentation["sharedCloudTone"], string> = {
-  neutral: "border-border/50 bg-muted/20 text-muted-foreground",
-  success: "border-success/25 bg-success/10 text-success",
+const STATUS_TONE_CLASSES: Record<PluginPackagePresentation["statusTone"], string> = {
+  neutral: "border-border/50 bg-muted/30 text-muted-foreground",
+  muted: "border-border/40 bg-muted/20 text-muted-foreground/80",
   warning: "border-warning/30 bg-warning/10 text-warning",
-  muted: "border-border/50 bg-muted/30 text-muted-foreground",
+  error: "border-destructive/40 bg-destructive/10 text-destructive",
 };
 
 export function AvailablePluginPackageRow({
@@ -35,19 +32,23 @@ export function AvailablePluginPackageRow({
 
   return (
     <PluginPackageCard
-      icon={<ConnectorIcon entry={model.entry} size="md" />}
+      icon={<ConnectorIcon entry={model.entry} size="sm" />}
       presentation={presentation}
       onOpen={onConnect}
-      controls={(
+      trailing={(
         <Button
-          variant="ghost"
+          type="button"
+          variant="outline"
           size="icon"
-          onClick={onConnect}
+          onClick={(event) => {
+            event.stopPropagation();
+            onConnect();
+          }}
           aria-label={`Install ${presentation.name}`}
           title={`Install ${presentation.name}`}
-          className="h-7 w-7 shrink-0 rounded-full bg-foreground/5 p-0.5 text-foreground hover:bg-foreground/10"
+          className="size-7 shrink-0 rounded-md"
         >
-          <Plus className="size-4" />
+          <Plus className="size-3.5" />
         </Button>
       )}
     />
@@ -59,58 +60,50 @@ export function ConnectedPluginPackageRow({
   onDelete,
   onManage,
   onReconnect,
-  onSetSharedExposure,
   onStatusClick,
   onToggle,
   pending,
-  canManageSharedExposure,
-  organizationId,
 }: {
   model: ConnectedCardModel;
   onDelete: () => void;
   onManage: () => void;
   onReconnect?: () => void;
-  onSetSharedExposure: (publicToOrg: boolean) => void;
   onStatusClick: () => void;
   onToggle: (enabled: boolean) => void;
   pending: boolean;
-  canManageSharedExposure: boolean;
-  organizationId: string | null;
 }) {
   const presentation = buildConnectedPluginPresentation(model.record, model.status);
-  const exposure = buildPluginSharedExposurePresentation(model.record);
   const enabled = model.record.metadata.enabled;
-  const nextPublicToOrg = !exposure.isFullyPublic;
-  const canShowSharedAction =
-    canManageSharedExposure
-    && Boolean(organizationId)
-    && exposure.configuredItemCount > 0
-    && model.record.metadata.ownerScope !== "organization";
 
   return (
     <PluginPackageCard
-      icon={<ConnectorIcon entry={model.record.catalogEntry} size="md" />}
+      icon={<ConnectorIcon entry={model.record.catalogEntry} size="sm" />}
       presentation={presentation}
-      sharedExposure={exposure}
       onOpen={model.status.actionable ? onStatusClick : onManage}
-      status={<ConnectorStatusChip status={model.status} onClick={onStatusClick} />}
-      controls={(
-        <div className="flex shrink-0 items-center gap-1">
-          {canShowSharedAction && (
+      trailing={(
+        <>
+          {presentation.recoveryActionLabel ? (
             <Button
               type="button"
-              variant={exposure.isFullyPublic ? "ghost" : "outline"}
+              variant="outline"
               size="sm"
               loading={pending}
-              onClick={() => onSetSharedExposure(nextPublicToOrg)}
-              title={nextPublicToOrg
-                ? "Make configured MCP, plugin, and skill items public to shared cloud."
-                : "Make configured MCP, plugin, and skill items private to personal cloud."}
-              className="h-7 px-2"
+              onClick={(event) => {
+                event.stopPropagation();
+                onStatusClick();
+              }}
+              className="h-7 px-2 text-[11px]"
             >
-              <Globe className="size-3.5" />
-              {nextPublicToOrg ? "Make public" : "Make private"}
+              {presentation.recoveryActionLabel}
             </Button>
+          ) : (
+            <Switch
+              checked={enabled}
+              disabled={pending}
+              onChange={onToggle}
+              size="compact"
+              aria-label={`${enabled ? "Disable" : "Enable"} ${presentation.name}`}
+            />
           )}
           <div className="pointer-events-none opacity-0 transition-opacity group-hover/plugin-package:pointer-events-auto group-hover/plugin-package:opacity-100 group-focus-within/plugin-package:pointer-events-auto group-focus-within/plugin-package:opacity-100">
             <ConnectorOverflowMenu
@@ -122,84 +115,69 @@ export function ConnectedPluginPackageRow({
               record={model.record}
             />
           </div>
-          <Switch
-            checked={enabled}
-            disabled={pending}
-            onChange={onToggle}
-            size="compact"
-            aria-label={`${enabled ? "Disable" : "Enable"} ${presentation.name}`}
-          />
-        </div>
+        </>
       )}
     />
   );
 }
 
 function PluginPackageCard({
-  controls,
   icon,
   onOpen,
   presentation,
-  sharedExposure,
-  status,
+  trailing,
 }: {
-  controls: ReactNode;
   icon: ReactNode;
   onOpen: () => void;
   presentation: PluginPackagePresentation;
-  sharedExposure?: PluginSharedExposurePresentation;
-  status?: ReactNode;
+  trailing: ReactNode;
 }) {
   return (
-    <div className="group/plugin-package flex min-h-[60px] flex-col justify-center gap-2.5 rounded-2xl border border-transparent p-2.5 transition-colors hover:bg-foreground/5">
-      <div className="flex items-center gap-3">
+    <article className="group/plugin-package flex min-h-[96px] flex-col gap-2 rounded-lg border border-border/60 bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.075]">
+      <div className="flex min-w-0 items-start gap-3">
         <Button
           variant="unstyled"
           size="unstyled"
           type="button"
           onClick={onOpen}
-          className="flex min-w-0 flex-1 items-center gap-3 rounded-xl text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-w-0 flex-1 items-start gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {icon}
-          <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
-            <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2 pr-1">
               <div className="truncate text-sm font-medium text-foreground">
                 {presentation.name}
               </div>
+              <PluginStatusPill presentation={presentation} />
             </div>
-            <div className="line-clamp-1 text-sm leading-relaxed text-muted-foreground">
+            <div className="line-clamp-1 text-xs leading-5 text-muted-foreground">
               {presentation.description}
             </div>
-            <div className="line-clamp-1 text-xs text-muted-foreground/80">
-              {presentation.includesLabel}
-            </div>
-            {sharedExposure && (
-              <div className="mt-1 flex flex-wrap gap-1.5">
-                <span className="rounded-full border border-border/50 bg-muted/20 px-2 py-0.5 text-[11px] text-muted-foreground">
-                  {sharedExposure.personalCloudLabel}
-                </span>
-                <span className="rounded-full border border-border/50 bg-muted/20 px-2 py-0.5 text-[11px] text-muted-foreground">
-                  {sharedExposure.sourceLabel}
-                </span>
-                <span
-                  className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${SHARED_EXPOSURE_TONE_CLASSES[sharedExposure.sharedCloudTone]}`}
-                  title={sharedExposure.sharedCloudDescription}
-                >
-                  {sharedExposure.sharedCloudLabel}
-                </span>
-              </div>
-            )}
           </div>
         </Button>
-        {status && (
-          <div className="shrink-0">
-            {status}
-          </div>
-        )}
-        <div className="flex shrink-0 items-center">
-          {controls}
+      </div>
+      <div className="flex min-w-0 items-center gap-2 pl-11">
+        <div className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground/80">
+          {presentation.capabilitySummary}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {trailing}
         </div>
       </div>
-    </div>
+    </article>
+  );
+}
+
+function PluginStatusPill({
+  presentation,
+}: {
+  presentation: PluginPackagePresentation;
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${STATUS_TONE_CLASSES[presentation.statusTone]}`}
+    >
+      {presentation.statusLabel}
+    </span>
   );
 }

--- a/desktop/src/hooks/mcp/ui/use-connectors-catalog-state.ts
+++ b/desktop/src/hooks/mcp/ui/use-connectors-catalog-state.ts
@@ -14,11 +14,8 @@ import type {
   InstalledConnectorRecord,
 } from "@/lib/domain/mcp/types";
 import { useConnectors } from "@/hooks/access/mcp/connectors/use-connectors";
-import { useIsAdmin } from "@/hooks/access/cloud/organizations/use-is-admin";
 import { useConnectorsCatalogViewTelemetry } from "@/hooks/mcp/lifecycle/use-connectors-catalog-view-telemetry";
-import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { trackProductEvent } from "@/lib/integrations/telemetry/client";
-import { useAuthStore } from "@/stores/auth/auth-store";
 
 const EMPTY_INSTALLED: InstalledConnectorRecord[] = [];
 const EMPTY_AVAILABLE: readonly ConnectorCatalogEntry[] = [];
@@ -26,14 +23,6 @@ const EMPTY_AVAILABLE: readonly ConnectorCatalogEntry[] = [];
 // Owns connector catalog search/modal UI state. Does not own connector mutations.
 export function useConnectorsCatalogState() {
   const connectorsQuery = useConnectors();
-  const {
-    activeOrganization,
-    activeOrganizationId,
-    organizations,
-    organizationsQuery,
-  } = useActiveOrganization();
-  const currentUserId = useAuthStore((state) => state.user?.id ?? null);
-  const admin = useIsAdmin(activeOrganizationId);
   const [searchQuery, setSearchQuery] = useState("");
   const [modal, setModal] = useState<ConnectorCatalogModalState>(null);
 
@@ -126,13 +115,5 @@ export function useConnectorsCatalogState() {
     searchQuery,
     setActiveTab,
     setSearchQuery,
-    sharedExposure: {
-      activeOrganizationId,
-      activeOrganizationName: activeOrganization?.name ?? null,
-      canManage: admin.isAdmin,
-      currentUserId,
-      hasOrganization: organizations.length > 0,
-      isLoading: organizationsQuery.isLoading || admin.isLoading,
-    },
   };
 }

--- a/desktop/src/lib/domain/plugins/plugin-package-view-model.test.ts
+++ b/desktop/src/lib/domain/plugins/plugin-package-view-model.test.ts
@@ -21,6 +21,8 @@ describe("buildConnectedPluginPresentation", () => {
       .toBe("Connected");
     expect(presentation.components.find((row) => row.kind === "mcp")?.stateLabel)
       .toBe("Off");
+    expect(presentation.statusLabel).toBe("Off");
+    expect(presentation.capabilitySummary).toBe("MCP · no setup");
   });
 
   it("shows broken credential state on the connection row", () => {
@@ -36,6 +38,26 @@ describe("buildConnectedPluginPresentation", () => {
 
     expect(presentation.components.find((row) => row.kind === "app")?.stateLabel)
       .toBe("Needs token");
+    expect(presentation.recoveryActionLabel).toBe("Add token");
+  });
+
+  it("keeps shared/public labels out of the plugin presentation", () => {
+    const presentation = buildConnectedPluginPresentation(
+      installedRecord({
+        enabled: true,
+        broken: false,
+        publicToOrg: true,
+        publicStatus: "public",
+      }),
+      {
+        intent: "connected",
+        label: "Connected",
+        actionable: false,
+        tone: "neutral",
+      },
+    );
+
+    expect(presentation.components.some((row) => row.publicLabel)).toBe(false);
   });
 });
 

--- a/desktop/src/lib/domain/plugins/plugin-package-view-model.ts
+++ b/desktop/src/lib/domain/plugins/plugin-package-view-model.ts
@@ -33,8 +33,12 @@ export interface PluginPackagePresentation {
   id: string;
   name: string;
   description: string;
+  capabilitySummary: string;
   includesLabel: string;
   enabledScopesLabel: string;
+  statusLabel: string;
+  statusTone: "neutral" | "muted" | "warning" | "error";
+  recoveryActionLabel: string | null;
   components: PluginComponentRowModel[];
 }
 
@@ -54,8 +58,12 @@ export function buildConnectedPluginPresentation(
     id: entry.id,
     name: entry.name,
     description: entry.oneLiner,
+    capabilitySummary: summarizeCapabilities(entry),
     includesLabel: summarizeComponents(components),
     enabledScopesLabel: record.metadata.enabled ? "New sessions" : "Disabled",
+    statusLabel: status.label,
+    statusTone: status.tone,
+    recoveryActionLabel: recoveryActionLabel(status),
     components,
   };
 }
@@ -151,8 +159,12 @@ export function buildAvailablePluginPresentation(
     id: entry.id,
     name: entry.name,
     description: entry.oneLiner,
+    capabilitySummary: summarizeCapabilities(entry),
     includesLabel: summarizeComponents(components),
     enabledScopesLabel: "Not installed",
+    statusLabel: "Not installed",
+    statusTone: "muted",
+    recoveryActionLabel: null,
     components,
   };
 }
@@ -169,9 +181,6 @@ function buildPluginComponents(
   const configuredSkillItemsBySourceId = new Map(
     state.record?.metadata.configuredSkills.map((item) => [item.sourceId, item]) ?? [],
   );
-  const mcpPublicLabel = state.record
-    ? configuredItemPublicLabel(buildConfiguredCapabilityItems(state.record)[0])
-    : undefined;
   const components: PluginComponentRowModel[] = [
     {
       kind: "app",
@@ -186,8 +195,6 @@ function buildPluginComponents(
       description: "MCP tools mounted into compatible sessions.",
       stateLabel: state.mcpState,
       stateTone: state.mcpState === "Enabled" ? "success" : "muted",
-      publicLabel: mcpPublicLabel,
-      publicTone: publicLabelTone(mcpPublicLabel),
     },
   ];
 
@@ -196,17 +203,12 @@ function buildPluginComponents(
     const skillStateLabel = configuredSkill
       ? configuredSkill.enabled ? state.skillState : "Off"
       : "Not configured";
-    const publicLabel = configuredSkill
-      ? configuredItemPublicLabel(configuredSkill)
-      : undefined;
     components.push({
       kind: "skill",
       label: skill.displayName,
       description: skill.description || "Reviewed markdown instructions agents can activate when relevant.",
       stateLabel: skillStateLabel,
       stateTone: skillStateLabel === "Enabled" ? "success" : "muted",
-      publicLabel,
-      publicTone: publicLabelTone(publicLabel),
     });
   }
 
@@ -221,39 +223,6 @@ function buildPluginComponents(
   );
 
   return components;
-}
-
-function configuredItemPublicLabel(
-  item: ConfiguredCapabilityItemState | undefined,
-): string | undefined {
-  if (!item) {
-    return undefined;
-  }
-  if (item.ownerScope === "organization") {
-    return "Organization";
-  }
-  if (!item.publicToOrg) {
-    return "Private";
-  }
-  if (item.publicStatus === "public") {
-    return "Public";
-  }
-  return item.publicStatus;
-}
-
-function publicLabelTone(
-  publicLabel: string | undefined,
-): PluginComponentRowModel["publicTone"] {
-  if (!publicLabel) {
-    return undefined;
-  }
-  if (publicLabel === "Public" || publicLabel === "Organization") {
-    return "success";
-  }
-  if (publicLabel === "Private") {
-    return "muted";
-  }
-  return "warning";
 }
 
 function configuredSourceLabel(
@@ -307,6 +276,44 @@ function summarizeComponents(components: readonly PluginComponentRowModel[]): st
     skillLabel ?? null,
   ].filter(Boolean);
   return parts.join(" + ");
+}
+
+function summarizeCapabilities(entry: ConnectorCatalogEntry): string {
+  const skillCount = entry.pluginPackage?.skills.length ?? 0;
+  const parts = [
+    "MCP",
+    skillCount > 0 ? `${skillCount} ${skillCount === 1 ? "skill" : "skills"}` : null,
+    authSummaryLabel(entry),
+  ].filter(Boolean);
+
+  return parts.join(" · ");
+}
+
+function authSummaryLabel(entry: ConnectorCatalogEntry): string {
+  if (entry.setupKind === "local_oauth") {
+    return "local auth";
+  }
+  if (entry.transport === "stdio") {
+    return "local";
+  }
+  if (entry.authKind === "oauth") {
+    return "OAuth";
+  }
+  if (entry.authKind === "secret" || entry.requiredFields.length > 0) {
+    return "API key";
+  }
+  return "no setup";
+}
+
+function recoveryActionLabel(status: ConnectorCardStatus): string | null {
+  switch (status.intent) {
+    case "needs_reconnect":
+      return "Reconnect";
+    case "needs_token":
+      return "Add token";
+    default:
+      return null;
+  }
 }
 
 function setupLabel(entry: ConnectorCatalogEntry): string {


### PR DESCRIPTION
## Summary
- Redesign the Desktop Plugins base page as a compact personal capability catalog.
- Remove shared/team/public exposure controls and copy from the Desktop Plugins surface.
- Keep the existing modal, install/OAuth/reconnect/token/toggle/delete/search/loading/error flows intact.

## Verification
- `node_modules/.bin/tsc --noEmit` from `desktop/` passed.
- `desktop/node_modules/.bin/vitest run ConnectorCatalogPage plugin-package-view-model` could not start because the local Rollup native optional dependency failed to load due a macOS code-signature mismatch.