### PR TITLE
feat(product): add personal cloud environments

### DIFF
--- a/cloud/sdk-react/src/hooks/repo-configs.ts
+++ b/cloud/sdk-react/src/hooks/repo-configs.ts
@@ -1,10 +1,16 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  getCloudRepoConfig,
   listCloudRepoConfigs,
   listOrganizationCloudRepoConfigs,
+  saveCloudRepoConfig,
+  type CloudRepoConfigResponse,
   type CloudRepoConfigsListResponse,
+  type SaveCloudRepoConfigRequest,
 } from "@proliferate/cloud-sdk";
 import {
+  cloudGitRepositoriesRootKey,
+  cloudRepoConfigKey,
   cloudRepoConfigsKey,
   organizationCloudRepoConfigsKey,
 } from "../lib/query-keys.js";
@@ -16,6 +22,58 @@ export function useCloudRepoConfigs(enabled = true) {
     queryKey: cloudRepoConfigsKey(),
     queryFn: () => listCloudRepoConfigs(client),
     enabled,
+  });
+}
+
+export function useCloudRepoConfig(
+  gitOwner: string | null | undefined,
+  gitRepoName: string | null | undefined,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  const resolvedGitOwner = gitOwner?.trim() ?? "";
+  const resolvedGitRepoName = gitRepoName?.trim() ?? "";
+  return useQuery<CloudRepoConfigResponse>({
+    queryKey: cloudRepoConfigKey(resolvedGitOwner, resolvedGitRepoName),
+    queryFn: () => getCloudRepoConfig(resolvedGitOwner, resolvedGitRepoName, client),
+    enabled: enabled && resolvedGitOwner.length > 0 && resolvedGitRepoName.length > 0,
+  });
+}
+
+export interface LoadCloudRepoConfigInput {
+  gitOwner: string;
+  gitRepoName: string;
+}
+
+export function useLoadCloudRepoConfig() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<CloudRepoConfigResponse, Error, LoadCloudRepoConfigInput>({
+    mutationFn: ({ gitOwner, gitRepoName }) =>
+      getCloudRepoConfig(gitOwner, gitRepoName, client),
+    onSuccess: (response, { gitOwner, gitRepoName }) => {
+      queryClient.setQueryData(cloudRepoConfigKey(gitOwner, gitRepoName), response);
+    },
+  });
+}
+
+export interface SaveCloudRepoConfigInput {
+  gitOwner: string;
+  gitRepoName: string;
+  body: SaveCloudRepoConfigRequest;
+}
+
+export function useSaveCloudRepoConfig() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<CloudRepoConfigResponse, Error, SaveCloudRepoConfigInput>({
+    mutationFn: ({ gitOwner, gitRepoName, body }) =>
+      saveCloudRepoConfig(gitOwner, gitRepoName, body, client),
+    onSuccess: (response, { gitOwner, gitRepoName }) => {
+      queryClient.setQueryData(cloudRepoConfigKey(gitOwner, gitRepoName), response);
+      void queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() });
+      void queryClient.invalidateQueries({ queryKey: cloudGitRepositoriesRootKey() });
+    },
   });
 }
 

--- a/cloud/sdk-react/src/hooks/repos.ts
+++ b/cloud/sdk-react/src/hooks/repos.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  listCloudGitRepositories,
+  listCloudRepoBranches,
+  type CloudGitRepositoriesResponse,
+  type CloudRepoBranchesResponse,
+  type ListCloudGitRepositoriesOptions,
+} from "@proliferate/cloud-sdk";
+
+import { useCloudClient } from "../context/CloudClientProvider.js";
+import {
+  cloudGitRepositoriesKey,
+  cloudRepoBranchesKey,
+} from "../lib/query-keys.js";
+
+export function useCloudGitRepositories(
+  options: ListCloudGitRepositoriesOptions = {},
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<CloudGitRepositoriesResponse>({
+    queryKey: cloudGitRepositoriesKey(options),
+    queryFn: () => listCloudGitRepositories(options, client),
+    enabled,
+  });
+}
+
+export function useCloudRepoBranches(
+  gitOwner: string | null | undefined,
+  gitRepoName: string | null | undefined,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  const resolvedGitOwner = gitOwner?.trim() ?? "";
+  const resolvedGitRepoName = gitRepoName?.trim() ?? "";
+  return useQuery<CloudRepoBranchesResponse>({
+    queryKey: cloudRepoBranchesKey(resolvedGitOwner, resolvedGitRepoName),
+    queryFn: () => listCloudRepoBranches(resolvedGitOwner, resolvedGitRepoName, client),
+    enabled: enabled && resolvedGitOwner.length > 0 && resolvedGitRepoName.length > 0,
+  });
+}
+
+export interface ValidateCloudRepoBranchesInput {
+  gitOwner: string;
+  gitRepoName: string;
+}
+
+export function useValidateCloudRepoBranches() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<CloudRepoBranchesResponse, Error, ValidateCloudRepoBranchesInput>({
+    mutationFn: ({ gitOwner, gitRepoName }) =>
+      listCloudRepoBranches(gitOwner, gitRepoName, client),
+    onSuccess: (response, { gitOwner, gitRepoName }) => {
+      queryClient.setQueryData(cloudRepoBranchesKey(gitOwner, gitRepoName), response);
+    },
+  });
+}

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -13,6 +13,7 @@ export * from "./hooks/live.js";
 export * from "./hooks/organizations.js";
 export * from "./hooks/runtime-config.js";
 export * from "./hooks/repo-configs.js";
+export * from "./hooks/repos.js";
 export * from "./hooks/sessions.js";
 export * from "./hooks/targets.js";
 export * from "./hooks/workspaces.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -78,6 +78,31 @@ export function cloudRepoBranchesKey(gitOwner: string, gitRepoName: string) {
   return [...cloudRootKey(), "repos", gitOwner, gitRepoName, "branches"] as const;
 }
 
+export function cloudGitRepositoriesRootKey() {
+  return [...cloudRootKey(), "git-repositories"] as const;
+}
+
+export interface CloudGitRepositoriesKeyOptions {
+  query?: string | null;
+  cursor?: string | null;
+  limit?: number | null;
+  affiliation?: string | null;
+  visibility?: string | null;
+}
+
+export function cloudGitRepositoriesKey(
+  options: CloudGitRepositoriesKeyOptions = {},
+) {
+  return [
+    ...cloudGitRepositoriesRootKey(),
+    options.query?.trim() || null,
+    options.cursor ?? null,
+    options.limit ?? null,
+    options.affiliation ?? null,
+    options.visibility ?? null,
+  ] as const;
+}
+
 export function cloudRepoConfigsKey() {
   return [...cloudRootKey(), "repo-configs"] as const;
 }

--- a/cloud/sdk/src/client/repo-configs.ts
+++ b/cloud/sdk/src/client/repo-configs.ts
@@ -30,9 +30,10 @@ export async function listOrganizationCloudRepoConfigs(
 export async function getCloudRepoConfig(
   gitOwner: string,
   gitRepoName: string,
+  client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudRepoConfigResponse> {
   return (
-    await getProliferateClient().GET("/v1/cloud/repos/{git_owner}/{git_repo_name}/config", {
+    await client.GET("/v1/cloud/repos/{git_owner}/{git_repo_name}/config", {
       params: { path: { git_owner: gitOwner, git_repo_name: gitRepoName } },
     })
   ).data!;
@@ -59,13 +60,39 @@ export async function saveCloudRepoConfig(
   gitOwner: string,
   gitRepoName: string,
   body: SaveCloudRepoConfigRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudRepoConfigResponse> {
   return (
-    await getProliferateClient().PUT("/v1/cloud/repos/{git_owner}/{git_repo_name}/config", {
+    await client.PUT("/v1/cloud/repos/{git_owner}/{git_repo_name}/config", {
       params: { path: { git_owner: gitOwner, git_repo_name: gitRepoName } },
       body,
     })
   ).data!;
+}
+
+export function buildMinimalCloudRepoConfigRequest(
+  defaultBranch: string | null,
+): SaveCloudRepoConfigRequest {
+  return {
+    configured: true,
+    defaultBranch,
+    envVars: {},
+    setupScript: "",
+    runCommand: "",
+  };
+}
+
+export function buildReenableCloudRepoConfigRequest(
+  config: CloudRepoConfigResponse,
+  defaultBranch: string | null,
+): SaveCloudRepoConfigRequest {
+  return {
+    configured: true,
+    defaultBranch: config.defaultBranch ?? defaultBranch,
+    envVars: config.envVars ?? {},
+    setupScript: config.setupScript ?? "",
+    runCommand: config.runCommand ?? "",
+  };
 }
 
 export async function saveOrganizationCloudRepoConfig(

--- a/cloud/sdk/src/client/repos.ts
+++ b/cloud/sdk/src/client/repos.ts
@@ -1,14 +1,44 @@
-import { getProliferateClient } from "./core.js";
-import type { CloudRepoBranchesResponse } from "../types/index.js";
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type {
+  CloudGitRepositoriesResponse,
+  CloudRepoBranchesResponse,
+} from "../types/index.js";
+
+export interface ListCloudGitRepositoriesOptions {
+  query?: string | null;
+  cursor?: string | null;
+  limit?: number;
+  affiliation?: string;
+  visibility?: string;
+}
+
+export async function listCloudGitRepositories(
+  options: ListCloudGitRepositoriesOptions = {},
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<CloudGitRepositoriesResponse> {
+  return (
+    await client.GET("/v1/cloud/repos", {
+      params: {
+        query: {
+          query: options.query,
+          cursor: options.cursor,
+          limit: options.limit,
+          affiliation: options.affiliation,
+          visibility: options.visibility,
+        },
+      },
+    })
+  ).data!;
+}
 
 export async function listCloudRepoBranches(
   gitOwner: string,
   gitRepoName: string,
+  client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudRepoBranchesResponse> {
   return (
-    await getProliferateClient().GET(
-      "/v1/cloud/repos/{git_owner}/{git_repo_name}/branches",
-      { params: { path: { git_owner: gitOwner, git_repo_name: gitRepoName } } },
-    )
+    await client.GET("/v1/cloud/repos/{git_owner}/{git_repo_name}/branches", {
+      params: { path: { git_owner: gitOwner, git_repo_name: gitRepoName } },
+    })
   ).data!;
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -450,6 +450,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/repos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Cloud Repositories Endpoint */
+        get: operations["list_cloud_repositories_endpoint_v1_cloud_repos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/repos/{git_owner}/{git_repo_name}/branches": {
         parameters: {
             query?: never;
@@ -4393,6 +4410,58 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** CloudGitRepositoriesResponse */
+        CloudGitRepositoriesResponse: {
+            /** Repositories */
+            repositories: components["schemas"]["CloudGitRepositorySummary"][];
+            /** Nextcursor */
+            nextCursor: string | null;
+        };
+        /** CloudGitRepositorySummary */
+        CloudGitRepositorySummary: {
+            /**
+             * Provider
+             * @default github
+             * @constant
+             */
+            provider: "github";
+            /** Gitowner */
+            gitOwner: string;
+            /** Gitreponame */
+            gitRepoName: string;
+            /** Fullname */
+            fullName: string;
+            /** Defaultbranch */
+            defaultBranch: string | null;
+            /** Private */
+            private: boolean;
+            /** Fork */
+            fork: boolean;
+            /** Archived */
+            archived: boolean;
+            /** Disabled */
+            disabled: boolean;
+            /** Htmlurl */
+            htmlUrl: string | null;
+            /** Owneravatarurl */
+            ownerAvatarUrl: string | null;
+            /** Pushedat */
+            pushedAt: string | null;
+            /** Updatedat */
+            updatedAt: string | null;
+            /** Permission */
+            permission?: string | null;
+            /**
+             * Configured
+             * @default false
+             */
+            configured: boolean;
+            /**
+             * Repoconfigstate
+             * @enum {string}
+             */
+            repoConfigState: "missing" | "disabled" | "configured";
+        };
         /** CloudMcpConnectionResponse */
         CloudMcpConnectionResponse: {
             /** Connectionid */
@@ -6259,6 +6328,16 @@ export interface components {
             defaultBranch: string;
             /** Branches */
             branches: string[];
+            /** Permission */
+            permission?: string | null;
+            /** Private */
+            private?: boolean | null;
+            /** Fork */
+            fork?: boolean | null;
+            /** Archived */
+            archived?: boolean | null;
+            /** Disabled */
+            disabled?: boolean | null;
         };
         /** RepoRef */
         RepoRef: {
@@ -6609,7 +6688,7 @@ export interface components {
              */
             runCommand: string;
             /** Files */
-            files: components["schemas"]["SaveCloudRepoConfigFile"][];
+            files?: components["schemas"]["SaveCloudRepoConfigFile"][] | null;
         };
         /** SaveOrganizationCloudRepoConfigRequest */
         SaveOrganizationCloudRepoConfigRequest: {
@@ -9388,6 +9467,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalyticsAcceptedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_cloud_repositories_endpoint_v1_cloud_repos_get: {
+        parameters: {
+            query?: {
+                query?: string | null;
+                cursor?: string | null;
+                limit?: number;
+                affiliation?: string;
+                visibility?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudGitRepositoriesResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -161,6 +161,9 @@ export type CloudWorkspaceCreatorContext =
 export type CloudWorkspaceDirectTargetContext =
   components["schemas"]["WorkspaceDirectTargetContext"];
 export type CloudConnectionInfo       = components["schemas"]["WorkspaceConnection"];
+export type CloudGitRepositorySummary = components["schemas"]["CloudGitRepositorySummary"];
+export type CloudGitRepositoriesResponse =
+  components["schemas"]["CloudGitRepositoriesResponse"];
 export type CloudRepoBranchesResponse = components["schemas"]["RepoBranchesResponse"];
 export type CloudRepoConfigSummary    = components["schemas"]["CloudRepoConfigSummary"];
 export type CloudRepoConfigsListResponse = components["schemas"]["CloudRepoConfigsListResponse"];

--- a/desktop/src/components/settings/panes/EnvironmentsPane.test.tsx
+++ b/desktop/src/components/settings/panes/EnvironmentsPane.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EnvironmentsPane } from "./EnvironmentsPane";
+import type { SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
+
+const cloudRepoConfigsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/access/cloud/use-cloud-repo-configs", () => ({
+  useCloudRepoConfigs: cloudRepoConfigsMock,
+}));
+
+vi.mock("./environments/AutomaticSyncSection", () => ({
+  AutomaticSyncSection: () => <div data-testid="automatic-sync" />,
+}));
+
+vi.mock("./environments/WorktreeStorageSection", () => ({
+  WorktreeStorageSection: () => <div data-testid="worktree-storage" />,
+}));
+
+vi.mock("./environments/AddCloudEnvironmentDialogController", () => ({
+  AddCloudEnvironmentDialogController: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-cloud-environment-dialog" /> : null,
+}));
+
+function repository(overrides: Partial<SettingsRepositoryEntry> = {}): SettingsRepositoryEntry {
+  return {
+    sourceRoot: "/Users/dev/project",
+    name: "project",
+    secondaryLabel: null,
+    workspaceCount: 1,
+    repoRootId: "repo-root",
+    localWorkspaceId: "workspace",
+    gitProvider: "github",
+    gitOwner: "octo",
+    gitRepoName: "desktop-cloud",
+    ...overrides,
+  };
+}
+
+describe("EnvironmentsPane", () => {
+  beforeEach(() => {
+    cloudRepoConfigsMock.mockReturnValue({
+      data: {
+        configs: [
+          {
+            gitOwner: "octo",
+            gitRepoName: "desktop-cloud",
+            configured: true,
+            configuredAt: "2026-05-24T09:00:00.000Z",
+            filesVersion: 0,
+          },
+          {
+            gitOwner: "octo",
+            gitRepoName: "desktop-only",
+            configured: false,
+            configuredAt: "2026-05-23T09:00:00.000Z",
+            filesVersion: 1,
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders local checkouts separately from cloud environments", () => {
+    render(
+      <EnvironmentsPane
+        repositories={[repository()]}
+        selectedRepository={null}
+        cloudEnabled
+        cloudActive
+        cloudSignInChecking={false}
+        cloudSignInAvailable
+        focus={{}}
+        onSelectRepository={vi.fn()}
+        onSelectCloudEnvironment={vi.fn()}
+        onBackToList={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Local checkouts")).not.toBeNull();
+    expect(screen.queryByText("Cloud environments")).not.toBeNull();
+    expect(screen.queryByText("project")).not.toBeNull();
+    expect(screen.queryByText("Cloud enabled")).not.toBeNull();
+    expect(screen.queryByText("octo/desktop-cloud")).not.toBeNull();
+    expect(screen.queryByText("octo/desktop-only")).not.toBeNull();
+    expect(screen.queryByText("Local + cloud")).not.toBeNull();
+    expect(screen.queryByText("Cloud only")).not.toBeNull();
+    expect(screen.queryByText("Disabled")).not.toBeNull();
+  });
+
+  it("selects cloud-only environments by owner and repo", () => {
+    const onSelectCloudEnvironment = vi.fn();
+    render(
+      <EnvironmentsPane
+        repositories={[repository()]}
+        selectedRepository={null}
+        cloudEnabled
+        cloudActive
+        cloudSignInChecking={false}
+        cloudSignInAvailable
+        focus={{}}
+        onSelectRepository={vi.fn()}
+        onSelectCloudEnvironment={onSelectCloudEnvironment}
+        onBackToList={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("octo/desktop-only")).not.toBeNull();
+    fireEvent.click(screen.getAllByRole("button", { name: "Configure" })[2]);
+
+    expect(onSelectCloudEnvironment).toHaveBeenCalledWith("octo", "desktop-only");
+  });
+});

--- a/desktop/src/components/settings/panes/EnvironmentsPane.tsx
+++ b/desktop/src/components/settings/panes/EnvironmentsPane.tsx
@@ -1,17 +1,24 @@
-import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { ChevronRight, Folder } from "@/components/ui/icons";
+import { CloudEnvironmentList } from "@proliferate/product-ui/environments/CloudEnvironmentList";
 import {
-  EnvironmentPanel,
-  EnvironmentPanelRow,
-  EnvironmentSection,
-} from "@/components/ui/EnvironmentLayout";
+  buildCloudEnvironmentListItems,
+} from "@proliferate/product-model/environments/cloud-environments";
+import {
+  formatGitRepoId,
+  parseGitRepoId,
+} from "@proliferate/product-model/repos/repo-id";
+import { ChevronRight } from "@/components/ui/icons";
 import type { SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
 import { SettingsPageHeader } from "@/components/settings/shared/SettingsPageHeader";
+import type { SettingsFocus } from "@/lib/domain/settings/navigation";
+import { useCloudRepoConfigs } from "@/hooks/access/cloud/use-cloud-repo-configs";
 import { LocalRepoSection } from "./repo/LocalRepoSection";
 import { CloudRepoSection } from "./repo/CloudRepoSection";
 import { AutomaticSyncSection } from "./environments/AutomaticSyncSection";
 import { WorktreeStorageSection } from "./environments/WorktreeStorageSection";
+import { AddCloudEnvironmentDialogController } from "./environments/AddCloudEnvironmentDialogController";
+import { CloudOnlyEnvironmentDetail } from "./environments/CloudOnlyEnvironmentDetail";
 
 interface EnvironmentsPaneProps {
   repositories: SettingsRepositoryEntry[];
@@ -20,33 +27,10 @@ interface EnvironmentsPaneProps {
   cloudActive: boolean;
   cloudSignInChecking: boolean;
   cloudSignInAvailable: boolean;
+  focus: SettingsFocus;
   onSelectRepository: (sourceRoot: string) => void;
+  onSelectCloudEnvironment: (gitOwner: string, gitRepoName: string) => void;
   onBackToList: () => void;
-}
-
-function RepositoryIdentityRow({
-  repository,
-  action,
-}: {
-  repository: SettingsRepositoryEntry;
-  action?: ReactNode;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <div className="flex min-w-0 items-center gap-3">
-        <Folder className="size-5 shrink-0 text-muted-foreground" />
-        <div className="min-w-0 space-y-0.5">
-          <div className="truncate text-sm font-medium text-foreground">
-            {repository.name}
-          </div>
-          <div className="truncate text-xs text-muted-foreground">
-            {repository.secondaryLabel ?? repository.sourceRoot}
-          </div>
-        </div>
-      </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
-    </div>
-  );
 }
 
 export function EnvironmentsPane({
@@ -56,55 +40,121 @@ export function EnvironmentsPane({
   cloudActive,
   cloudSignInChecking,
   cloudSignInAvailable,
+  focus,
   onSelectRepository,
+  onSelectCloudEnvironment,
   onBackToList,
 }: EnvironmentsPaneProps) {
-  if (!selectedRepository) {
-    return (
-      <section className="space-y-6">
-        <SettingsPageHeader
-          title="Environments"
-          description="Per-repo configuration for local worktrees and personal cloud workspaces."
-        />
+  const [addCloudEnvironmentOpen, setAddCloudEnvironmentOpen] = useState(false);
+  const cloudRepoConfigs = useCloudRepoConfigs(cloudActive);
+  const selectedCloudRepo = focus.cloudRepoOwner && focus.cloudRepoName
+    ? {
+      gitOwner: focus.cloudRepoOwner,
+      gitRepoName: focus.cloudRepoName,
+    }
+    : null;
+  const cloudConfigByRepoId = useMemo(() => {
+    const byId = new Map<string, { configured: boolean }>();
+    for (const config of cloudRepoConfigs.data?.configs ?? []) {
+      byId.set(formatGitRepoId({
+        gitOwner: config.gitOwner,
+        gitRepoName: config.gitRepoName,
+      }), config);
+    }
+    return byId;
+  }, [cloudRepoConfigs.data?.configs]);
+  const cloudEnvironmentItems = useMemo(() => buildCloudEnvironmentListItems({
+    configs: cloudRepoConfigs.data?.configs ?? [],
+    localCheckouts: repositories
+      .filter((repository) => repository.gitOwner && repository.gitRepoName)
+      .map((repository) => ({
+        gitOwner: repository.gitOwner!,
+        gitRepoName: repository.gitRepoName!,
+        sourceRoot: repository.sourceRoot,
+        name: repository.name,
+        secondaryLabel: repository.secondaryLabel,
+      })),
+  }), [cloudRepoConfigs.data?.configs, repositories]);
 
-        <EnvironmentSection
-          title="Your repositories"
-          description="Click a repository to configure its environment."
-        >
-          <EnvironmentPanel>
-            {repositories.length === 0 ? (
-              <EnvironmentPanelRow>
-                <p className="text-sm text-muted-foreground">
-                  No local environments are available yet.
-                </p>
-              </EnvironmentPanelRow>
-            ) : (
-              repositories.map((repository) => (
-                <EnvironmentPanelRow key={`${repository.sourceRoot}:${repository.repoRootId}`}>
-                  <RepositoryIdentityRow
-                    repository={repository}
-                    action={(
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={() => onSelectRepository(repository.sourceRoot)}
-                        className="px-2"
-                      >
-                        Configure
-                        <ChevronRight className="size-4" />
-                      </Button>
-                    )}
-                  />
-                </EnvironmentPanelRow>
-              ))
-            )}
-          </EnvironmentPanel>
-      </EnvironmentSection>
-      <WorktreeStorageSection />
-      <AutomaticSyncSection repositories={repositories} />
-    </section>
-  );
-}
+  if (!selectedRepository && selectedCloudRepo && cloudActive) {
+    return (
+      <CloudOnlyEnvironmentDetail
+        gitOwner={selectedCloudRepo.gitOwner}
+        gitRepoName={selectedCloudRepo.gitRepoName}
+        cloudActive={cloudActive}
+        onBack={onBackToList}
+        onSaved={() => { void cloudRepoConfigs.refetch(); }}
+      />
+    );
+  }
+
+  if (!selectedRepository) {
+    const cloudUnavailableReason = cloudUnavailableDescription({
+      cloudEnabled,
+      cloudActive,
+      cloudSignInChecking,
+      cloudSignInAvailable,
+    });
+
+    return (
+      <>
+        <CloudEnvironmentList
+          title="Environments"
+          description="Configure local checkouts and personal Cloud environments."
+          localCheckouts={repositories.map((repository) => {
+            const repoId = repository.gitOwner && repository.gitRepoName
+              ? formatGitRepoId({
+                gitOwner: repository.gitOwner,
+                gitRepoName: repository.gitRepoName,
+              })
+              : null;
+            const cloudConfig = repoId ? cloudConfigByRepoId.get(repoId) : null;
+            return {
+              id: repository.sourceRoot,
+              name: repository.name,
+              description: repository.secondaryLabel ?? repository.sourceRoot,
+              cloudStatusLabel: cloudConfig
+                ? cloudConfig.configured
+                  ? "Cloud enabled"
+                  : "Cloud disabled"
+                : null,
+            };
+          })}
+          cloudEnvironments={cloudEnvironmentItems.map((environment) => ({
+            id: environment.id,
+            fullName: environment.fullName,
+            description: environment.description,
+            configured: environment.configured,
+            localState: environment.localState,
+          }))}
+          loadingCloudEnvironments={cloudRepoConfigs.isLoading}
+          cloudUnavailableReason={cloudUnavailableReason}
+          onSelectLocalCheckout={onSelectRepository}
+          onSelectCloudEnvironment={(repoId) => {
+            const parsed = parseGitRepoId(repoId);
+            if (parsed) {
+              onSelectCloudEnvironment(parsed.gitOwner, parsed.gitRepoName);
+            }
+          }}
+          onAddCloudEnvironment={cloudActive ? () => setAddCloudEnvironmentOpen(true) : undefined}
+          onRetryCloudEnvironments={cloudRepoConfigs.isError ? () => { void cloudRepoConfigs.refetch(); } : undefined}
+        />
+        <WorktreeStorageSection />
+        <AutomaticSyncSection repositories={repositories} />
+        <AddCloudEnvironmentDialogController
+          open={addCloudEnvironmentOpen}
+          onClose={() => setAddCloudEnvironmentOpen(false)}
+          onEnvironmentAdded={(repoId) => {
+            const parsed = parseGitRepoId(repoId);
+            if (parsed) {
+              onSelectCloudEnvironment(parsed.gitOwner, parsed.gitRepoName);
+              void cloudRepoConfigs.refetch();
+            }
+          }}
+        />
+      </>
+    );
+  }
 
   return (
     <section className="space-y-6">
@@ -135,4 +185,29 @@ export function EnvironmentsPane({
       />
     </section>
   );
+}
+
+function cloudUnavailableDescription({
+  cloudEnabled,
+  cloudActive,
+  cloudSignInChecking,
+  cloudSignInAvailable,
+}: {
+  cloudEnabled: boolean;
+  cloudActive: boolean;
+  cloudSignInChecking: boolean;
+  cloudSignInAvailable: boolean;
+}): string | null {
+  if (cloudActive) {
+    return null;
+  }
+  if (!cloudEnabled) {
+    return "Cloud environments are unavailable in this build or deployment.";
+  }
+  if (cloudSignInChecking) {
+    return "Checking cloud sign-in before loading personal Cloud environments.";
+  }
+  return cloudSignInAvailable
+    ? "Sign in to configure personal Cloud environments."
+    : "GitHub sign-in is unavailable, so Cloud environments cannot load.";
 }

--- a/desktop/src/components/settings/panes/environments/AddCloudEnvironmentDialogController.tsx
+++ b/desktop/src/components/settings/panes/environments/AddCloudEnvironmentDialogController.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from "react";
+import { AddCloudEnvironmentDialog } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+import type { AddCloudEnvironmentRepositoryView } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+import type { CloudGitRepositorySummary } from "@proliferate/cloud-sdk";
+import {
+  useCloudGitRepositories,
+  useLoadCloudRepoConfig,
+  useSaveCloudRepoConfig,
+  useValidateCloudRepoBranches,
+} from "@proliferate/cloud-sdk-react";
+import {
+  blockedCloudRepositoryBranchReason,
+  blockedCloudRepositoryReason,
+  buildMinimalCloudEnvironmentConfigRequest,
+  buildReenableCloudEnvironmentConfigRequest,
+} from "@proliferate/product-model/environments/cloud-environments";
+import {
+  formatGitRepoId,
+  parseGitRepoId,
+  type GitRepoIdentity,
+} from "@proliferate/product-model/repos/repo-id";
+
+const REPO_PAGE_LIMIT = 50;
+
+interface AddCloudEnvironmentDialogControllerProps {
+  open: boolean;
+  onClose: () => void;
+  onEnvironmentAdded: (repoId: string) => void;
+}
+
+export function AddCloudEnvironmentDialogController({
+  open,
+  onClose,
+  onEnvironmentAdded,
+}: AddCloudEnvironmentDialogControllerProps) {
+  const actions = useCloudEnvironmentAddActions({
+    open,
+    onEnvironmentAdded: (repoId) => {
+      onEnvironmentAdded(repoId);
+      onClose();
+    },
+  });
+
+  const repositories: AddCloudEnvironmentRepositoryView[] = actions.repositories.map((repo) => ({
+    id: formatGitRepoId(repo),
+    fullName: repo.fullName,
+    defaultBranch: repo.defaultBranch,
+    private: repo.private,
+    fork: repo.fork,
+    archived: repo.archived,
+    disabled: repo.disabled,
+    permission: repo.permission ?? null,
+    configured: repo.configured,
+    repoConfigState: repo.repoConfigState,
+    ownerAvatarUrl: repo.ownerAvatarUrl,
+    pushedAt: repo.pushedAt,
+    updatedAt: repo.updatedAt,
+    disabledReason: blockedCloudRepositoryReason(repo),
+  }));
+
+  return (
+    <AddCloudEnvironmentDialog
+      open={open}
+      query={actions.query}
+      manualValue={actions.manualValue}
+      repositories={repositories}
+      loading={actions.loading}
+      loadingMore={actions.loadingMore}
+      addingRepoId={actions.addingRepoId}
+      error={actions.error}
+      nextCursor={actions.nextCursor}
+      onQueryChange={actions.setQuery}
+      onManualValueChange={actions.setManualValue}
+      onAddRepository={(repo) => void actions.addCatalogRepository(repo.id)}
+      onAddManual={() => void actions.addManualRepository()}
+      onLoadMore={actions.loadMore}
+      onRetry={() => void actions.retry()}
+      onClose={onClose}
+    />
+  );
+}
+
+interface UseCloudEnvironmentAddActionsInput {
+  open: boolean;
+  onEnvironmentAdded: (repoId: string) => void;
+}
+
+function useCloudEnvironmentAddActions({
+  open,
+  onEnvironmentAdded,
+}: UseCloudEnvironmentAddActionsInput) {
+  const [query, setQuery] = useState("");
+  const [manualValue, setManualValue] = useState("");
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [repositories, setRepositories] = useState<CloudGitRepositorySummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [addingRepoId, setAddingRepoId] = useState<string | null>(null);
+  const debouncedQuery = useDebouncedValue(query.trim(), 250);
+  const catalog = useCloudGitRepositories(
+    {
+      query: debouncedQuery || null,
+      cursor,
+      limit: REPO_PAGE_LIMIT,
+    },
+    open,
+  );
+  const validateBranches = useValidateCloudRepoBranches();
+  const loadConfig = useLoadCloudRepoConfig();
+  const saveConfig = useSaveCloudRepoConfig();
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setManualValue("");
+      setCursor(null);
+      setRepositories([]);
+      setError(null);
+      setAddingRepoId(null);
+      return;
+    }
+    setCursor(null);
+    setRepositories([]);
+    setError(null);
+  }, [debouncedQuery, open]);
+
+  useEffect(() => {
+    if (!catalog.data) {
+      return;
+    }
+    setRepositories((current) =>
+      cursor
+        ? mergeRepositories(current, catalog.data.repositories)
+        : catalog.data.repositories
+    );
+  }, [catalog.data, cursor]);
+
+  useEffect(() => {
+    if (catalog.error) {
+      setError(catalog.error instanceof Error ? catalog.error.message : "Could not load GitHub repositories.");
+    }
+  }, [catalog.error]);
+
+  const repositoryById = useMemo(() => {
+    const byId = new Map<string, CloudGitRepositorySummary>();
+    for (const repo of repositories) {
+      byId.set(formatGitRepoId(repo), repo);
+    }
+    return byId;
+  }, [repositories]);
+
+  async function addCatalogRepository(repoId: string) {
+    const repo = repositoryById.get(repoId);
+    if (!repo) {
+      setError("Repository is no longer available in this list.");
+      return;
+    }
+    await addRepository(repo);
+  }
+
+  async function addManualRepository() {
+    const parsed = parseGitRepoId(manualValue);
+    if (!parsed) {
+      setError("Enter a GitHub repository as owner/repo or a GitHub URL.");
+      return;
+    }
+    await addRepository(parsed);
+  }
+
+  async function addRepository(repo: CloudGitRepositorySummary | GitRepoIdentity) {
+    const repoId = formatGitRepoId(repo);
+    setAddingRepoId(repoId);
+    setError(null);
+    try {
+      if ("repoConfigState" in repo && repo.repoConfigState === "configured") {
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      const catalogBlockedReason = "repoConfigState" in repo ? blockedCloudRepositoryReason(repo) : null;
+      if (catalogBlockedReason) {
+        throw new Error(catalogBlockedReason);
+      }
+
+      const branches = await validateBranches.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+      });
+      const branchBlockedReason = blockedCloudRepositoryBranchReason(branches);
+      if (branchBlockedReason) {
+        throw new Error(branchBlockedReason);
+      }
+
+      if ("repoConfigState" in repo && repo.repoConfigState === "missing") {
+        await saveConfig.mutateAsync({
+          gitOwner: repo.gitOwner,
+          gitRepoName: repo.gitRepoName,
+          body: buildMinimalCloudEnvironmentConfigRequest(branches.defaultBranch),
+        });
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      const existingConfig = await loadConfig.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+      });
+      if (existingConfig.configured) {
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      await saveConfig.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        body: buildReenableCloudEnvironmentConfigRequest(existingConfig, branches.defaultBranch),
+      });
+      onEnvironmentAdded(repoId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not add cloud environment.");
+    } finally {
+      setAddingRepoId(null);
+    }
+  }
+
+  return {
+    query,
+    manualValue,
+    repositories,
+    error,
+    addingRepoId,
+    nextCursor: catalog.data?.nextCursor ?? null,
+    loading: catalog.isLoading,
+    loadingMore: catalog.isFetching && cursor !== null,
+    setQuery,
+    setManualValue,
+    addCatalogRepository,
+    addManualRepository,
+    retry: catalog.refetch,
+    loadMore: () => {
+      const nextCursor = catalog.data?.nextCursor ?? null;
+      if (nextCursor && !catalog.isFetching) {
+        setCursor(nextCursor);
+      }
+    },
+  };
+}
+
+function mergeRepositories(
+  current: CloudGitRepositorySummary[],
+  incoming: CloudGitRepositorySummary[],
+): CloudGitRepositorySummary[] {
+  const byId = new Map<string, CloudGitRepositorySummary>();
+  for (const repo of current) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  for (const repo of incoming) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  return Array.from(byId.values());
+}
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, value]);
+  return debounced;
+}

--- a/desktop/src/components/settings/panes/environments/CloudOnlyEnvironmentDetail.test.tsx
+++ b/desktop/src/components/settings/panes/environments/CloudOnlyEnvironmentDetail.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudOnlyEnvironmentDetail } from "./CloudOnlyEnvironmentDetail";
+import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
+
+const hooks = vi.hoisted(() => ({
+  useCloudRepoConfig: vi.fn(),
+  useCloudRepoBranches: vi.fn(),
+  useSavePersonalCloudRepoConfig: vi.fn(),
+  saveMutateAsync: vi.fn(),
+}));
+
+vi.mock("@/hooks/access/cloud/use-cloud-repo-config", () => ({
+  useCloudRepoConfig: hooks.useCloudRepoConfig,
+}));
+
+vi.mock("@/hooks/access/cloud/use-cloud-repo-branches", () => ({
+  useCloudRepoBranches: hooks.useCloudRepoBranches,
+}));
+
+vi.mock("@/hooks/access/cloud/use-save-personal-cloud-repo-config", () => ({
+  useSavePersonalCloudRepoConfig: hooks.useSavePersonalCloudRepoConfig,
+}));
+
+function disabledConfig(): CloudRepoConfig {
+  return {
+    configured: false,
+    configuredAt: "2026-05-23T09:00:00.000Z",
+    defaultBranch: "main",
+    envVars: { FEATURE_FLAG: "1" },
+    setupScript: "npm ci",
+    runCommand: "",
+    filesVersion: 1,
+    trackedFiles: [{
+      relativePath: ".env.desktop",
+      contentSha256: "abc",
+      byteSize: 20,
+      updatedAt: "2026-05-23T09:00:00.000Z",
+      lastSyncedAt: "2026-05-23T09:00:00.000Z",
+    }],
+  };
+}
+
+describe("CloudOnlyEnvironmentDetail", () => {
+  beforeEach(() => {
+    hooks.saveMutateAsync.mockResolvedValue({
+      ...disabledConfig(),
+      configured: true,
+      configuredAt: "2026-05-24T09:00:00.000Z",
+    });
+    hooks.useCloudRepoConfig.mockReturnValue({
+      data: disabledConfig(),
+      isLoading: false,
+    });
+    hooks.useCloudRepoBranches.mockReturnValue({
+      data: {
+        defaultBranch: "main",
+        branches: ["main", "develop"],
+      },
+      isLoading: false,
+      error: null,
+    });
+    hooks.useSavePersonalCloudRepoConfig.mockReturnValue({
+      mutateAsync: hooks.saveMutateAsync,
+      isPending: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("opens disabled cloud-only configs ready to enable and saves without files", async () => {
+    render(
+      <CloudOnlyEnvironmentDetail
+        gitOwner="octo"
+        gitRepoName="desktop-disabled"
+        cloudActive
+        onBack={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Ready to enable")).not.toBeNull();
+    expect(screen.queryByText(/1 tracked file is saved/u)).not.toBeNull();
+    expect(screen.queryByText("Sync tracked files")).toBeNull();
+
+    const save = screen.getByRole("button", { name: "Save" });
+    expect((save as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      expect(hooks.saveMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(hooks.saveMutateAsync).toHaveBeenCalledWith({
+      gitOwner: "octo",
+      gitRepoName: "desktop-disabled",
+      body: {
+        configured: true,
+        defaultBranch: "main",
+        envVars: { FEATURE_FLAG: "1" },
+        setupScript: "npm ci",
+        runCommand: "",
+      },
+    });
+    expect(hooks.saveMutateAsync.mock.calls[0][0].body).not.toHaveProperty("files");
+  });
+});

--- a/desktop/src/components/settings/panes/environments/CloudOnlyEnvironmentDetail.tsx
+++ b/desktop/src/components/settings/panes/environments/CloudOnlyEnvironmentDetail.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { CloudEnvironmentEditor } from "@proliferate/product-ui/environments/CloudEnvironmentEditor";
+import type { CloudEnvironmentEnvVarRowView } from "@proliferate/product-ui/environments/CloudEnvironmentEditor";
+import { buildCoreCloudEnvironmentSaveRequest } from "@proliferate/product-model/environments/cloud-environments";
+import { formatGitRepoId } from "@proliferate/product-model/repos/repo-id";
+import { useCloudRepoBranches } from "@/hooks/access/cloud/use-cloud-repo-branches";
+import { useCloudRepoConfig } from "@/hooks/access/cloud/use-cloud-repo-config";
+import { useSavePersonalCloudRepoConfig } from "@/hooks/access/cloud/use-save-personal-cloud-repo-config";
+import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
+
+interface CloudOnlyEnvironmentDetailProps {
+  gitOwner: string;
+  gitRepoName: string;
+  cloudActive: boolean;
+  onBack: () => void;
+  onSaved: () => void;
+}
+
+interface CloudEnvironmentDraftState {
+  configured: boolean;
+  defaultBranch: string | null;
+  setupScript: string;
+  runCommand: string;
+  envVarRows: CloudEnvironmentEnvVarRowView[];
+}
+
+export function CloudOnlyEnvironmentDetail({
+  gitOwner,
+  gitRepoName,
+  cloudActive,
+  onBack,
+  onSaved,
+}: CloudOnlyEnvironmentDetailProps) {
+  const repoId = formatGitRepoId({ gitOwner, gitRepoName });
+  const config = useCloudRepoConfig(gitOwner, gitRepoName, cloudActive);
+  const branches = useCloudRepoBranches(gitOwner, gitRepoName, cloudActive);
+  const saveConfig = useSavePersonalCloudRepoConfig();
+  const draft = useCloudEnvironmentCoreDraft(config.data, repoId);
+  const savedConfigured = config.data?.configured ?? false;
+  const statusLabel = !draft.configured && savedConfigured
+    ? "Will disable"
+    : savedConfigured
+      ? draft.dirty
+        ? "Unsaved changes"
+        : "Saved"
+      : draft.configured
+        ? "Ready to enable"
+        : "Disabled";
+
+  async function handleSave() {
+    const response = await saveConfig.mutateAsync({
+      gitOwner,
+      gitRepoName,
+      body: buildCoreCloudEnvironmentSaveRequest({
+        configured: draft.configured,
+        defaultBranch: draft.defaultBranch,
+        envVars: draft.envVars,
+        setupScript: draft.setupScript,
+        runCommand: draft.runCommand,
+      }),
+    });
+    draft.reset(response);
+    onSaved();
+  }
+
+  return (
+    <CloudEnvironmentEditor
+      title={repoId}
+      description="Personal Cloud environment. This repo does not need to be cloned locally."
+      statusLabel={statusLabel}
+      statusTone={savedConfigured ? (draft.dirty ? "warning" : "success") : "warning"}
+      defaultBranch={draft.defaultBranch}
+      githubDefaultBranch={branches.data?.defaultBranch ?? null}
+      branches={branches.data?.branches ?? []}
+      branchesLoading={branches.isLoading || config.isLoading}
+      branchError={branches.error instanceof Error ? branches.error.message : null}
+      setupScript={draft.setupScript}
+      runCommand={draft.runCommand}
+      envVarRows={draft.envVarRows}
+      saving={saveConfig.isPending}
+      saveDisabled={!cloudActive || config.isLoading || saveConfig.isPending || !draft.canSave}
+      revertDisabled={saveConfig.isPending || !draft.dirty}
+      disableDisabled={!draft.configured}
+      error={saveConfig.error?.message ?? null}
+      trackedFileCount={config.data?.trackedFiles.length ?? 0}
+      trackedFilesReadOnly
+      breadcrumb={(
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onBack}
+          className="h-auto px-0 py-0 text-sm hover:bg-transparent"
+        >
+          Environments / {repoId}
+        </Button>
+      )}
+      onDefaultBranchChange={draft.setDefaultBranch}
+      onSetupScriptChange={draft.setSetupScript}
+      onRunCommandChange={draft.setRunCommand}
+      onAddEnvVar={draft.addEnvVar}
+      onUpdateEnvVar={draft.updateEnvVar}
+      onRemoveEnvVar={draft.removeEnvVar}
+      onSave={() => { void handleSave(); }}
+      onRevert={draft.revert}
+      onDisable={savedConfigured ? draft.disable : undefined}
+    />
+  );
+}
+
+function useCloudEnvironmentCoreDraft(
+  config: CloudRepoConfig | null | undefined,
+  sourceKey: string,
+) {
+  const initial = useMemo(() => buildInitialDraftState(config), [config]);
+  const [state, setState] = useState(() => ({
+    sourceKey,
+    baseline: initial.baseline,
+    revertDraft: initial.revertDraft,
+    draft: initial.draft,
+  }));
+
+  useEffect(() => {
+    const sourceChanged = state.sourceKey !== sourceKey;
+    if (sourceChanged || !isDraftDirty(state.draft, state.revertDraft)) {
+      setState({
+        sourceKey,
+        baseline: initial.baseline,
+        revertDraft: initial.revertDraft,
+        draft: initial.draft,
+      });
+    }
+  }, [initial, sourceKey, state.draft, state.revertDraft, state.sourceKey]);
+
+  const envVars = useMemo(() => rowsToEnvVars(state.draft.envVarRows), [state.draft.envVarRows]);
+  const normalizedDraft = useMemo(() => ({
+    ...state.draft,
+    envVarRows: buildEnvVarRows(envVars),
+  }), [envVars, state.draft]);
+  const dirty = isDraftDirty(normalizedDraft, state.revertDraft);
+  const configurable = !state.baseline.configured && normalizedDraft.configured;
+
+  function patch(patch: Partial<Omit<CloudEnvironmentDraftState, "envVarRows">>) {
+    setState((current) => ({
+      ...current,
+      draft: {
+        ...current.draft,
+        ...patch,
+        configured: patch.configured ?? true,
+      },
+    }));
+  }
+
+  return {
+    configured: normalizedDraft.configured,
+    defaultBranch: normalizedDraft.defaultBranch,
+    setupScript: normalizedDraft.setupScript,
+    runCommand: normalizedDraft.runCommand,
+    envVarRows: state.draft.envVarRows,
+    envVars,
+    dirty,
+    canSave: dirty || configurable,
+    setDefaultBranch: (defaultBranch: string | null) => patch({ defaultBranch }),
+    setSetupScript: (setupScript: string) => patch({ setupScript }),
+    setRunCommand: (runCommand: string) => patch({ runCommand }),
+    addEnvVar: () => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: [...current.draft.envVarRows, { id: createRowId(), key: "", value: "" }],
+        },
+      }));
+    },
+    updateEnvVar: (
+      rowId: string,
+      rowPatch: Partial<Pick<CloudEnvironmentEnvVarRowView, "key" | "value">>,
+    ) => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: current.draft.envVarRows.map((row) =>
+            row.id === rowId ? { ...row, ...rowPatch } : row),
+        },
+      }));
+    },
+    removeEnvVar: (rowId: string) => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: current.draft.envVarRows.filter((row) => row.id !== rowId),
+        },
+      }));
+    },
+    revert: () => {
+      setState((current) => ({
+        ...current,
+        draft: current.revertDraft,
+      }));
+    },
+    disable: () => patch({ configured: false }),
+    reset: (nextConfig: CloudRepoConfig) => {
+      const next = buildInitialDraftState(nextConfig);
+      setState({
+        sourceKey,
+        baseline: next.baseline,
+        revertDraft: next.revertDraft,
+        draft: next.draft,
+      });
+    },
+  };
+}
+
+function buildInitialDraftState(
+  config: CloudRepoConfig | null | undefined,
+): {
+  baseline: CloudEnvironmentDraftState;
+  revertDraft: CloudEnvironmentDraftState;
+  draft: CloudEnvironmentDraftState;
+} {
+  const baseline = buildSavedDraft(config);
+  if (baseline.configured) {
+    return {
+      baseline,
+      revertDraft: baseline,
+      draft: baseline,
+    };
+  }
+  const draft = {
+    ...baseline,
+    configured: true,
+  };
+  return {
+    baseline,
+    revertDraft: draft,
+    draft,
+  };
+}
+
+function buildSavedDraft(
+  config: CloudRepoConfig | null | undefined,
+): CloudEnvironmentDraftState {
+  return {
+    configured: config?.configured ?? false,
+    defaultBranch: config?.defaultBranch ?? null,
+    setupScript: config?.setupScript ?? "",
+    runCommand: config?.runCommand ?? "",
+    envVarRows: buildEnvVarRows(config?.envVars ?? {}),
+  };
+}
+
+function buildEnvVarRows(envVars: Record<string, string>): CloudEnvironmentEnvVarRowView[] {
+  return Object.entries(envVars)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ({ id: createRowId(), key, value }));
+}
+
+function isDraftDirty(
+  draft: CloudEnvironmentDraftState,
+  baseline: CloudEnvironmentDraftState,
+): boolean {
+  return draft.configured !== baseline.configured
+    || draft.defaultBranch !== baseline.defaultBranch
+    || draft.setupScript !== baseline.setupScript
+    || draft.runCommand !== baseline.runCommand
+    || JSON.stringify(rowsToEnvVars(draft.envVarRows)) !== JSON.stringify(rowsToEnvVars(baseline.envVarRows));
+}
+
+function rowsToEnvVars(rows: readonly CloudEnvironmentEnvVarRowView[]): Record<string, string> {
+  return Object.fromEntries(
+    rows
+      .map((row) => [row.key.trim(), row.value] as const)
+      .filter(([key]) => key.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function createRowId(): string {
+  return crypto.randomUUID();
+}

--- a/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -37,6 +37,7 @@ interface SettingsScreenProps {
   onNavigateHome: () => void;
   onSelectSection: (section: SettingsSection) => void;
   onSelectRepo: (sourceRoot: string) => void;
+  onSelectCloudEnvironment: (gitOwner: string, gitRepoName: string) => void;
 }
 
 function renderSettingsSection(
@@ -52,6 +53,7 @@ function renderSettingsSection(
   focus: SettingsFocus,
   onSelectSection: (section: SettingsSection) => void,
   onSelectRepo: (sourceRoot: string) => void,
+  onSelectCloudEnvironment: (gitOwner: string, gitRepoName: string) => void,
 ): ReactNode {
   if (activeSection === "agents") {
     return <AgentsPane />;
@@ -158,7 +160,9 @@ function renderSettingsSection(
       cloudActive={cloudActive}
       cloudSignInChecking={cloudSignInChecking}
       cloudSignInAvailable={cloudSignInAvailable}
+      focus={focus}
       onSelectRepository={onSelectRepo}
+      onSelectCloudEnvironment={onSelectCloudEnvironment}
       onBackToList={() => onSelectSection("environments")}
     />
   );
@@ -172,6 +176,7 @@ export function SettingsScreen({
   onNavigateHome,
   onSelectSection,
   onSelectRepo,
+  onSelectCloudEnvironment,
 }: SettingsScreenProps) {
   const { cloudActive, cloudEnabled, cloudSignInAvailable, cloudSignInChecking } = useCloudAvailabilityState();
   const { activeOrganizationId } = useActiveOrganization();
@@ -245,6 +250,7 @@ export function SettingsScreen({
                   focus,
                   onSelectSection,
                   onSelectRepo,
+                  onSelectCloudEnvironment,
                 )}
               </SettingsContentBoundary>
             </div>

--- a/desktop/src/hooks/access/cloud/use-save-personal-cloud-repo-config.ts
+++ b/desktop/src/hooks/access/cloud/use-save-personal-cloud-repo-config.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+import { saveCloudRepoConfig } from "@proliferate/cloud-sdk/client/repo-configs";
+import type { SaveCloudRepoConfigRequest } from "@proliferate/cloud-sdk/types";
+import type { CloudRepoConfig } from "@/lib/domain/cloud/repo-configs";
+import { useCloudRepoConfigCache } from "./use-cloud-repo-config-cache";
+
+interface SavePersonalCloudRepoConfigInput {
+  gitOwner: string;
+  gitRepoName: string;
+  body: SaveCloudRepoConfigRequest;
+}
+
+export function useSavePersonalCloudRepoConfig() {
+  const { invalidateCloudRepoConfigs } = useCloudRepoConfigCache();
+
+  return useMutation<CloudRepoConfig, Error, SavePersonalCloudRepoConfigInput>({
+    mutationFn: async ({ gitOwner, gitRepoName, body }) =>
+      await saveCloudRepoConfig(gitOwner, gitRepoName, body),
+    onSuccess: async (_response, variables) => {
+      await invalidateCloudRepoConfigs(variables);
+    },
+  });
+}

--- a/desktop/src/hooks/settings/workflows/use-settings-navigation.ts
+++ b/desktop/src/hooks/settings/workflows/use-settings-navigation.ts
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { type SettingsSection } from "@/config/settings";
 import { type SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
 import {
+  buildCloudRepoSettingsHref,
   buildSettingsHref,
   resolveSettingsSelection,
 } from "@/lib/domain/settings/navigation";
@@ -95,9 +96,14 @@ export function useSettingsNavigation({
     });
   }, [navigateTo]);
 
+  const selectCloudEnvironment = useCallback((gitOwner: string, gitRepoName: string) => {
+    navigate(buildCloudRepoSettingsHref(gitOwner, gitRepoName));
+  }, [navigate]);
+
   return {
     ...selection,
     selectSection,
     selectRepo,
+    selectCloudEnvironment,
   };
 }

--- a/desktop/src/lib/domain/settings/navigation.test.ts
+++ b/desktop/src/lib/domain/settings/navigation.test.ts
@@ -150,6 +150,41 @@ describe("settings navigation", () => {
     });
   });
 
+  it("keeps modern cloud repo settings links keyed by owner and repo", () => {
+    expect(resolveSettingsSelection({
+      rawSection: "environments",
+      rawCloudRepoOwner: "owner",
+      rawCloudRepoName: "name",
+      repositories: [repo({ sourceRoot: "/repo-a" })],
+    })).toEqual({
+      activeSection: "environments",
+      activeRepoSourceRoot: null,
+      focus: {
+        cloudRepoOwner: "owner",
+        cloudRepoName: "name",
+      },
+      inviteHandoff: null,
+    });
+  });
+
+  it("prefers explicit local repo settings links when both local and cloud focus are present", () => {
+    expect(resolveSettingsSelection({
+      rawSection: "environments",
+      rawRepo: "/repo-a",
+      rawCloudRepoOwner: "owner",
+      rawCloudRepoName: "name",
+      repositories: [repo({ sourceRoot: "/repo-a" })],
+    })).toEqual({
+      activeSection: "environments",
+      activeRepoSourceRoot: "/repo-a",
+      focus: {
+        cloudRepoOwner: "owner",
+        cloudRepoName: "name",
+      },
+      inviteHandoff: null,
+    });
+  });
+
   it("falls legacy cloudRepo links back to environments when multiple local repos match", () => {
     expect(resolveSettingsSelection({
       rawSection: "cloudRepo",

--- a/desktop/src/lib/domain/settings/navigation.ts
+++ b/desktop/src/lib/domain/settings/navigation.ts
@@ -187,15 +187,7 @@ export function resolveSettingsSelection({
     repoSourceRoot = rawRepo;
   }
 
-  if (
-    rawSection === "cloudRepo"
-    || (
-      section === "environments"
-      && rawCloudRepoOwner
-      && rawCloudRepoName
-      && !repoSourceRoot
-    )
-  ) {
+  if (rawSection === "cloudRepo") {
     const cloudRepoKey = rawCloudRepoOwner && rawCloudRepoName
       ? cloudRepositoryKey(rawCloudRepoOwner, rawCloudRepoName)
       : null;

--- a/desktop/src/pages/SettingsPage.tsx
+++ b/desktop/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ export function SettingsPage({ returnTo = "/" }: { returnTo?: string }) {
     focus,
     selectSection,
     selectRepo,
+    selectCloudEnvironment,
   } = useSettingsNavigation({ repositories });
 
   return (
@@ -23,6 +24,7 @@ export function SettingsPage({ returnTo = "/" }: { returnTo?: string }) {
       onNavigateHome={() => navigate(returnTo || "/")}
       onSelectSection={selectSection}
       onSelectRepo={selectRepo}
+      onSelectCloudEnvironment={selectCloudEnvironment}
     />
   );
 }

--- a/docs/architecture/personal-cloud-environments-ux-restructure-spec.md
+++ b/docs/architecture/personal-cloud-environments-ux-restructure-spec.md
@@ -1,0 +1,223 @@
+# Personal Cloud Environments UX Restructure Spec
+
+Status: implemented implementation spec
+
+Date: 2026-05-24
+
+Branch: `codex/cloud-web-repo-add-spec`
+
+## Purpose
+
+Proliferate has two related but distinct repository concepts:
+
+- A local checkout is a folder or repo root present on the current Desktop
+  computer.
+- A Cloud environment is durable personal cloud configuration for
+  `github:owner/repo`, usable by web, mobile, and Desktop even when no local
+  checkout exists.
+
+This slice makes `Settings > Environments` the canonical surface for Cloud
+environment configuration and keeps Desktop's local checkout flow separate.
+Web Home keeps a shortcut, but it opens the same Cloud environment add flow.
+
+The implementation is personal-scope only. Organization/shared environment
+authoring, public repo search, Desktop GitHub-to-local clone, and cloud tracked
+file editing are intentionally deferred.
+
+## Docs Read
+
+This implementation follows:
+
+- `docs/README.md`
+- `docs/frontend/README.md`
+- `docs/frontend/guides/access.md`
+- `docs/frontend/guides/components.md`
+- `docs/frontend/guides/config.md`
+- `docs/frontend/guides/copy.md`
+- `docs/frontend/guides/hooks.md`
+- `docs/frontend/guides/lib.md`
+- `docs/frontend/guides/state.md`
+- `docs/frontend/guides/styling.md`
+- `docs/server/README.md`
+- `docs/sdk/README.md`
+- `docs/architecture/cloud-surfaces-launch-plan.md`
+- `docs/architecture/cloud-work-launch-model-spec.md`
+- `docs/architecture/web-desktop-parity-spec.md`
+
+## Current Model
+
+`CloudRepoConfig` is the durable cloud record keyed by owner scope plus
+GitHub identity:
+
+```text
+owner_scope        personal | organization
+user_id            required for personal
+organization_id    required for organization
+git_owner
+git_repo_name
+```
+
+For this pass, only personal configs are surfaced by the new UI. Existing
+organization config APIs remain in place.
+
+The core editable fields are:
+
+```text
+configured
+default_branch
+setup_script
+run_command
+env_vars
+```
+
+Tracked files remain supported for local checkout flows, but cloud-only core
+edits do not send `files`. This preserves any existing tracked files while
+avoiding a cloud/web UI that pretends it can edit local file material.
+
+## UX Contract
+
+### Desktop Settings > Environments
+
+The Desktop pane has two sections:
+
+```text
+Local checkouts
+  Local repo roots and folders present on this computer.
+  Selecting one opens the existing local detail flow.
+
+Cloud environments
+  Personal GitHub repo configs returned by useCloudRepoConfigs().
+  Selecting one opens cloud detail by owner/repo and does not require a local
+  checkout.
+```
+
+If a local checkout has GitHub identity and a matching Cloud environment, the
+local row labels its cloud state. Selecting the local checkout still opens the
+existing local detail page and includes the local checkout's Cloud section,
+including tracked-file sync.
+
+If a Cloud environment has no matching local checkout, selecting it opens a
+cloud-only detail page keyed by `cloudRepoOwner/cloudRepoName`. The page shows
+default branch, setup script, run command, and env vars. It supports Save,
+Revert, and Disable. It hides local tracked-file sync controls. If tracked files
+already exist, it shows a read-only count and save omits `files`.
+
+`buildCloudRepoSettingsHref(owner, repo)` resolves to:
+
+```text
+/settings?section=environments&cloudRepoOwner=<owner>&cloudRepoName=<repo>
+```
+
+That route must open the cloud-only detail instead of falling back to the local
+repo list. Legacy `section=cloudRepo` links still try to resolve a local repo
+for backwards compatibility.
+
+### Web Settings > Environments
+
+Web now has `Settings > Environments`. The Web page shows only Cloud
+environments. It uses the shared list/editor components and the same add dialog
+controller pattern as Desktop. There is no local checkout section in Web.
+
+### Web Home Shortcut
+
+Web Home retains a shortcut action labeled `Add cloud environment`. It opens
+the same Cloud environment add dialog/controller. After the selected repo is
+created, enabled, or reused, Home selects that repo in the target picker and
+existing workspace creation proceeds through `createCloudWorkspace`.
+
+## Add Dialog Contract
+
+The dialog is framed as `Add cloud environment`, not ambiguous repository
+addition. It supports:
+
+- GitHub catalog rows from `GET /v1/cloud/repos`.
+- Manual `owner/repo` or GitHub URL entry.
+- Existing configured rows as `Use`.
+- Existing disabled rows as `Enable`.
+- Missing rows as `Add`.
+
+Public search is not a V1 tab. The catalog is based on the connected GitHub
+grant, and manual entry still requires GitHub access plus write-capable
+permission.
+
+Blocked rows and manual validation use shared product-model helpers:
+
+```text
+archived repo      -> blocked
+disabled repo      -> blocked
+empty repo         -> blocked
+missing default    -> blocked
+read-only access   -> blocked
+```
+
+## Persistence Contract
+
+Core cloud-only saves use:
+
+```http
+PUT /v1/cloud/repos/{git_owner}/{git_repo_name}/config
+```
+
+with:
+
+```json
+{
+  "configured": true,
+  "defaultBranch": "main",
+  "envVars": {},
+  "setupScript": "",
+  "runCommand": ""
+}
+```
+
+`files` is omitted. The server preserves existing tracked files when `files` is
+absent.
+
+Local checkout tracked-file sync may still call the same save path with
+`files`. That is the only UI path that should send tracked file material in
+this pass.
+
+Re-enable flows load existing config when needed and preserve default branch,
+env vars, setup script, run command, and tracked files.
+
+## Shared Packages
+
+`@proliferate/product-model` owns pure planning and projection:
+
+- `repos/repo-id`
+- `environments/cloud-environments`
+
+`@proliferate/product-ui` owns reusable presentation:
+
+- `environments/AddCloudEnvironmentDialog`
+- `environments/CloudEnvironmentList`
+- `environments/CloudEnvironmentEditor`
+
+App-specific controllers stay in Web/Desktop because they own React Query,
+navigation, refetch, and route selection.
+
+## Backend And SDK Contract
+
+The backend/SDK slice keeps:
+
+- `GET /v1/cloud/repos`
+- branch metadata on `GET /v1/cloud/repos/{owner}/{repo}/branches`
+- optional `files` in personal config save
+- repo access validation when enabling a repo
+- SDK and React hooks for catalog, branches, config load/save
+
+The GitHub catalog endpoint is admission/discovery only. It does not clone.
+Cloud workspaces still clone/materialize during workspace creation.
+
+## Verification Plan
+
+Targeted checks:
+
+- Product-model tests for parsing, list projection, blocked repo reasons, and
+  save planning.
+- Product-ui tests for add dialog copy, two-section list rendering, cloud-only
+  editor behavior, and Save/Revert/Disable state.
+- Desktop settings navigation tests for cloud-only owner/repo routes and local
+  repo routes.
+- Web build and manual smoke for Settings > Environments and Home shortcut.
+- Server tests for catalog/config save behavior and optional `files`.

--- a/packages/product-model/package.json
+++ b/packages/product-model/package.json
@@ -171,6 +171,14 @@
       "types": "./dist/telemetry/scrub.d.ts",
       "import": "./dist/telemetry/scrub.js"
     },
+    "./repos/repo-id": {
+      "types": "./dist/repos/repo-id.d.ts",
+      "import": "./dist/repos/repo-id.js"
+    },
+    "./environments/cloud-environments": {
+      "types": "./dist/environments/cloud-environments.d.ts",
+      "import": "./dist/environments/cloud-environments.js"
+    },
     "./workspaces/model": {
       "types": "./dist/workspaces/model.d.ts",
       "import": "./dist/workspaces/model.js"

--- a/packages/product-model/src/environments/cloud-environments.test.ts
+++ b/packages/product-model/src/environments/cloud-environments.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  blockedCloudRepositoryBranchReason,
+  blockedCloudRepositoryReason,
+  buildCloudEnvironmentListItems,
+  buildCoreCloudEnvironmentSaveRequest,
+  buildMinimalCloudEnvironmentConfigRequest,
+  buildReenableCloudEnvironmentConfigRequest,
+} from "./cloud-environments";
+
+describe("cloud environment helpers", () => {
+  it("projects configured and disabled cloud environments with local checkout state", () => {
+    expect(buildCloudEnvironmentListItems({
+      configs: [
+        { gitOwner: "acme", gitRepoName: "cloud-only", configured: true, filesVersion: 2 },
+        { gitOwner: "acme", gitRepoName: "disabled", configured: false, filesVersion: 3 },
+        { gitOwner: "acme", gitRepoName: "local", configured: true, filesVersion: 1 },
+      ],
+      localCheckouts: [
+        {
+          gitOwner: "acme",
+          gitRepoName: "local",
+          sourceRoot: "/repos/local",
+          name: "local",
+          secondaryLabel: null,
+        },
+      ],
+    })).toMatchObject([
+      {
+        id: "acme/local",
+        configState: "configured",
+        localState: "local_and_cloud",
+        localSourceRoot: "/repos/local",
+      },
+      {
+        id: "acme/cloud-only",
+        configState: "configured",
+        localState: "cloud_only",
+        description: "Cloud-only environment",
+      },
+      {
+        id: "acme/disabled",
+        configState: "disabled",
+        localState: "cloud_only",
+      },
+    ]);
+  });
+
+  it("explains repositories that cannot be cloud environments", () => {
+    expect(blockedCloudRepositoryReason({ disabled: true, defaultBranch: "main", permission: "push" }))
+      .toBe("Repository is disabled on GitHub.");
+    expect(blockedCloudRepositoryReason({ archived: true, defaultBranch: "main", permission: "push" }))
+      .toBe("Archived repositories cannot be used for cloud environments.");
+    expect(blockedCloudRepositoryReason({ defaultBranch: null, permission: "push" }))
+      .toBe("Repository does not have a default branch yet.");
+    expect(blockedCloudRepositoryReason({ defaultBranch: "main", permission: "pull" }))
+      .toBe("GitHub write access is required for cloud environments.");
+    expect(blockedCloudRepositoryReason({ defaultBranch: "main", permission: "maintain" }))
+      .toBeNull();
+  });
+
+  it("checks branch metadata without requiring a default branch field", () => {
+    expect(blockedCloudRepositoryBranchReason({ permission: "pull" }))
+      .toBe("GitHub write access is required for cloud environments.");
+    expect(blockedCloudRepositoryBranchReason({ permission: "admin" })).toBeNull();
+  });
+
+  it("builds add and re-enable requests without tracked files", () => {
+    expect(buildMinimalCloudEnvironmentConfigRequest("main")).toEqual({
+      configured: true,
+      defaultBranch: "main",
+      envVars: {},
+      setupScript: "",
+      runCommand: "",
+    });
+
+    expect(buildReenableCloudEnvironmentConfigRequest({
+      configured: false,
+      defaultBranch: "release",
+      envVars: { API_BASE_URL: "https://api.example" },
+      setupScript: "pnpm install",
+      runCommand: "pnpm dev",
+    }, "main")).toEqual({
+      configured: true,
+      defaultBranch: "release",
+      envVars: { API_BASE_URL: "https://api.example" },
+      setupScript: "pnpm install",
+      runCommand: "pnpm dev",
+    });
+  });
+
+  it("builds core editor save requests without files and normalizes env keys", () => {
+    expect(buildCoreCloudEnvironmentSaveRequest({
+      defaultBranch: null,
+      envVars: { " B ": "2", "": "ignored", A: "1" },
+      setupScript: "pnpm install",
+      runCommand: "pnpm dev",
+    })).toEqual({
+      configured: true,
+      defaultBranch: null,
+      envVars: { A: "1", B: "2" },
+      setupScript: "pnpm install",
+      runCommand: "pnpm dev",
+    });
+
+    expect(buildCoreCloudEnvironmentSaveRequest({
+      configured: false,
+      defaultBranch: "main",
+      envVars: { A: "1" },
+      setupScript: "x",
+      runCommand: "y",
+    })).toEqual({
+      configured: false,
+      defaultBranch: null,
+      envVars: {},
+      setupScript: "",
+      runCommand: "",
+    });
+  });
+});

--- a/packages/product-model/src/environments/cloud-environments.ts
+++ b/packages/product-model/src/environments/cloud-environments.ts
@@ -1,0 +1,203 @@
+import type { SaveCloudRepoConfigRequest } from "@proliferate/cloud-sdk";
+import { formatGitRepoId } from "../repos/repo-id";
+
+const WRITE_PERMISSIONS = new Set(["admin", "maintain", "push"]);
+
+export interface CloudEnvironmentRepoIdentity {
+  gitOwner: string;
+  gitRepoName: string;
+}
+
+export interface CloudEnvironmentConfigSummaryInput extends CloudEnvironmentRepoIdentity {
+  configured: boolean;
+  configuredAt?: string | null;
+  filesVersion?: number | null;
+}
+
+export interface CloudEnvironmentSavedConfigInput {
+  configured?: boolean | null;
+  defaultBranch?: string | null;
+  envVars?: Record<string, string> | null;
+  setupScript?: string | null;
+  runCommand?: string | null;
+}
+
+export interface CloudEnvironmentLocalCheckoutInput extends CloudEnvironmentRepoIdentity {
+  sourceRoot: string;
+  name: string;
+  secondaryLabel?: string | null;
+}
+
+export type CloudEnvironmentLocalState = "cloud_only" | "local_and_cloud";
+export type CloudEnvironmentConfigState = "configured" | "disabled";
+
+export interface CloudEnvironmentListItem {
+  id: string;
+  gitOwner: string;
+  gitRepoName: string;
+  fullName: string;
+  label: string;
+  description: string;
+  configured: boolean;
+  configState: CloudEnvironmentConfigState;
+  localState: CloudEnvironmentLocalState;
+  localSourceRoot: string | null;
+  filesVersion: number | null;
+}
+
+export interface CloudRepositoryAccessInput {
+  defaultBranch?: string | null;
+  permission?: string | null;
+  archived?: boolean | null;
+  disabled?: boolean | null;
+}
+
+export interface CoreCloudEnvironmentDraftInput {
+  configured?: boolean;
+  defaultBranch: string | null;
+  envVars: Record<string, string>;
+  setupScript: string;
+  runCommand: string;
+}
+
+function normalizedRepoKey(input: CloudEnvironmentRepoIdentity): string {
+  return formatGitRepoId(input).toLowerCase();
+}
+
+function repoFullName(input: CloudEnvironmentRepoIdentity): string {
+  return formatGitRepoId(input);
+}
+
+export function hasCloudEnvironmentWritePermission(permission: string | null | undefined): boolean {
+  return permission ? WRITE_PERMISSIONS.has(permission) : false;
+}
+
+export function blockedCloudRepositoryReason(repo: CloudRepositoryAccessInput): string | null {
+  if (repo.disabled) {
+    return "Repository is disabled on GitHub.";
+  }
+  if (repo.archived) {
+    return "Archived repositories cannot be used for cloud environments.";
+  }
+  if (!repo.defaultBranch) {
+    return "Repository does not have a default branch yet.";
+  }
+  if (!hasCloudEnvironmentWritePermission(repo.permission)) {
+    return "GitHub write access is required for cloud environments.";
+  }
+  return null;
+}
+
+export function blockedCloudRepositoryBranchReason(repo: Omit<CloudRepositoryAccessInput, "defaultBranch">): string | null {
+  if (repo.disabled) {
+    return "Repository is disabled on GitHub.";
+  }
+  if (repo.archived) {
+    return "Archived repositories cannot be used for cloud environments.";
+  }
+  if (!hasCloudEnvironmentWritePermission(repo.permission)) {
+    return "GitHub write access is required for cloud environments.";
+  }
+  return null;
+}
+
+export function buildMinimalCloudEnvironmentConfigRequest(
+  defaultBranch: string | null,
+): SaveCloudRepoConfigRequest {
+  return {
+    configured: true,
+    defaultBranch,
+    envVars: {},
+    setupScript: "",
+    runCommand: "",
+  };
+}
+
+export function buildReenableCloudEnvironmentConfigRequest(
+  config: CloudEnvironmentSavedConfigInput,
+  defaultBranch: string | null,
+): SaveCloudRepoConfigRequest {
+  return {
+    configured: true,
+    defaultBranch: config.defaultBranch ?? defaultBranch,
+    envVars: config.envVars ?? {},
+    setupScript: config.setupScript ?? "",
+    runCommand: config.runCommand ?? "",
+  };
+}
+
+export function buildCoreCloudEnvironmentSaveRequest(
+  draft: CoreCloudEnvironmentDraftInput,
+): SaveCloudRepoConfigRequest {
+  if (draft.configured === false) {
+    return {
+      configured: false,
+      defaultBranch: null,
+      envVars: {},
+      setupScript: "",
+      runCommand: "",
+    };
+  }
+
+  return {
+    configured: true,
+    defaultBranch: draft.defaultBranch,
+    envVars: normalizeEnvVars(draft.envVars),
+    setupScript: draft.setupScript,
+    runCommand: draft.runCommand,
+  };
+}
+
+export function buildCloudEnvironmentListItems(input: {
+  configs: readonly CloudEnvironmentConfigSummaryInput[];
+  localCheckouts?: readonly CloudEnvironmentLocalCheckoutInput[];
+}): CloudEnvironmentListItem[] {
+  const localByRepo = new Map<string, CloudEnvironmentLocalCheckoutInput>();
+  for (const local of input.localCheckouts ?? []) {
+    localByRepo.set(normalizedRepoKey(local), local);
+  }
+
+  return input.configs
+    .map((config) => {
+      const fullName = repoFullName(config);
+      const local = localByRepo.get(normalizedRepoKey(config)) ?? null;
+      return {
+        id: fullName,
+        gitOwner: config.gitOwner,
+        gitRepoName: config.gitRepoName,
+        fullName,
+        label: fullName,
+        description: local
+          ? local.secondaryLabel || local.sourceRoot
+          : "Cloud-only environment",
+        configured: config.configured,
+        configState: config.configured ? "configured" : "disabled",
+        localState: local ? "local_and_cloud" : "cloud_only",
+        localSourceRoot: local?.sourceRoot ?? null,
+        filesVersion: config.filesVersion ?? null,
+      } satisfies CloudEnvironmentListItem;
+    })
+    .sort(compareCloudEnvironmentListItems);
+}
+
+function compareCloudEnvironmentListItems(
+  left: CloudEnvironmentListItem,
+  right: CloudEnvironmentListItem,
+): number {
+  if (left.configured !== right.configured) {
+    return left.configured ? -1 : 1;
+  }
+  if (left.localState !== right.localState) {
+    return left.localState === "local_and_cloud" ? -1 : 1;
+  }
+  return left.fullName.localeCompare(right.fullName);
+}
+
+function normalizeEnvVars(envVars: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(envVars)
+      .map(([key, value]) => [key.trim(), value] as const)
+      .filter(([key]) => key.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/packages/product-model/src/repos/repo-id.test.ts
+++ b/packages/product-model/src/repos/repo-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeGitRepoId, parseGitRepoId } from "./repo-id";
+
+describe("parseGitRepoId", () => {
+  it("parses owner/name repo ids", () => {
+    expect(parseGitRepoId("proliferate-ai/proliferate")).toEqual({
+      gitOwner: "proliferate-ai",
+      gitRepoName: "proliferate",
+    });
+  });
+
+  it("parses GitHub URLs and ssh remotes", () => {
+    expect(normalizeGitRepoId("https://github.com/proliferate-ai/proliferate.git")).toBe(
+      "proliferate-ai/proliferate",
+    );
+    expect(normalizeGitRepoId("git@github.com:proliferate-ai/proliferate.git")).toBe(
+      "proliferate-ai/proliferate",
+    );
+  });
+
+  it("rejects unsupported or ambiguous values", () => {
+    expect(parseGitRepoId("https://example.com/proliferate-ai/proliferate")).toBeNull();
+    expect(parseGitRepoId("proliferate-ai/proliferate/extra")).toBeNull();
+    expect(parseGitRepoId("missing-owner")).toBeNull();
+  });
+});

--- a/packages/product-model/src/repos/repo-id.ts
+++ b/packages/product-model/src/repos/repo-id.ts
@@ -1,0 +1,66 @@
+export interface GitRepoIdentity {
+  gitOwner: string;
+  gitRepoName: string;
+}
+
+export function formatGitRepoId(repo: GitRepoIdentity): string {
+  return `${repo.gitOwner}/${repo.gitRepoName}`;
+}
+
+export function gitRepoKey(gitOwner: string, gitRepoName: string): string {
+  return formatGitRepoId({ gitOwner, gitRepoName });
+}
+
+export function normalizeGitRepoId(value: string | null | undefined): string | null {
+  const parsed = parseGitRepoId(value);
+  return parsed ? formatGitRepoId(parsed) : null;
+}
+
+export function parseGitRepoId(value: string | null | undefined): GitRepoIdentity | null {
+  const candidate = extractGitHubRepoCandidate(value);
+  if (!candidate) {
+    return null;
+  }
+
+  const normalized = candidate
+    .replace(/^\/+/u, "")
+    .replace(/\/+$/u, "")
+    .replace(/\.git$/iu, "");
+  const [gitOwner, gitRepoName, ...rest] = normalized.split("/");
+  if (
+    !gitOwner
+    || !gitRepoName
+    || rest.length > 0
+    || !isValidGitHubOwner(gitOwner)
+    || !isValidGitHubRepoName(gitRepoName)
+  ) {
+    return null;
+  }
+  return { gitOwner, gitRepoName };
+}
+
+function extractGitHubRepoCandidate(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("git@github.com:")) {
+    return trimmed.slice("git@github.com:".length);
+  }
+
+  if (/^https?:\/\//iu.test(trimmed)) {
+    const match = /^https?:\/\/github\.com\/([^/?#]+\/[^/?#]+)/iu.exec(trimmed);
+    return match?.[1] ?? null;
+  }
+
+  return trimmed;
+}
+
+function isValidGitHubOwner(value: string): boolean {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u.test(value);
+}
+
+function isValidGitHubRepoName(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/u.test(value) && value !== "." && value !== "..";
+}

--- a/packages/product-ui/package.json
+++ b/packages/product-ui/package.json
@@ -159,6 +159,22 @@
       "types": "./dist/new-chat/NewChatSurface.d.ts",
       "import": "./dist/new-chat/NewChatSurface.js"
     },
+    "./repos/AddCloudRepoDialog": {
+      "types": "./dist/repos/AddCloudRepoDialog.d.ts",
+      "import": "./dist/repos/AddCloudRepoDialog.js"
+    },
+    "./environments/AddCloudEnvironmentDialog": {
+      "types": "./dist/environments/AddCloudEnvironmentDialog.d.ts",
+      "import": "./dist/environments/AddCloudEnvironmentDialog.js"
+    },
+    "./environments/CloudEnvironmentList": {
+      "types": "./dist/environments/CloudEnvironmentList.d.ts",
+      "import": "./dist/environments/CloudEnvironmentList.js"
+    },
+    "./environments/CloudEnvironmentEditor": {
+      "types": "./dist/environments/CloudEnvironmentEditor.d.ts",
+      "import": "./dist/environments/CloudEnvironmentEditor.js"
+    },
     "./workspaces/WorkspaceRow": {
       "types": "./dist/workspaces/WorkspaceRow.d.ts",
       "import": "./dist/workspaces/WorkspaceRow.js"

--- a/packages/product-ui/src/environments/AddCloudEnvironmentDialog.tsx
+++ b/packages/product-ui/src/environments/AddCloudEnvironmentDialog.tsx
@@ -1,0 +1,280 @@
+import { useEffect, type FormEvent } from "react";
+import {
+  Archive,
+  Check,
+  ChevronDown,
+  Cloud,
+  GitBranch,
+  Lock,
+  Plus,
+  RotateCw,
+  Search,
+  ShieldAlert,
+  X,
+} from "lucide-react";
+
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+
+export type AddCloudEnvironmentConfigState = "missing" | "disabled" | "configured";
+
+export interface AddCloudEnvironmentRepositoryView {
+  id: string;
+  fullName: string;
+  defaultBranch: string | null;
+  private: boolean;
+  fork: boolean;
+  archived: boolean;
+  disabled: boolean;
+  permission: string | null;
+  configured: boolean;
+  repoConfigState: AddCloudEnvironmentConfigState;
+  ownerAvatarUrl?: string | null;
+  pushedAt?: string | null;
+  updatedAt?: string | null;
+  disabledReason?: string | null;
+}
+
+interface AddCloudEnvironmentDialogProps {
+  open: boolean;
+  query: string;
+  manualValue: string;
+  repositories: readonly AddCloudEnvironmentRepositoryView[];
+  loading?: boolean;
+  loadingMore?: boolean;
+  addingRepoId?: string | null;
+  error?: string | null;
+  nextCursor?: string | null;
+  onQueryChange: (value: string) => void;
+  onManualValueChange: (value: string) => void;
+  onAddRepository: (repo: AddCloudEnvironmentRepositoryView) => void;
+  onAddManual: () => void;
+  onLoadMore: () => void;
+  onRetry?: () => void;
+  onClose: () => void;
+}
+
+export function AddCloudEnvironmentDialog({
+  open,
+  query,
+  manualValue,
+  repositories,
+  loading = false,
+  loadingMore = false,
+  addingRepoId = null,
+  error = null,
+  nextCursor = null,
+  onQueryChange,
+  onManualValueChange,
+  onAddRepository,
+  onAddManual,
+  onLoadMore,
+  onRetry,
+  onClose,
+}: AddCloudEnvironmentDialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleManualSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onAddManual();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 px-4 py-6 backdrop-blur-sm"
+      role="presentation"
+      data-telemetry-block
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section
+        aria-modal="true"
+        aria-labelledby="add-cloud-environment-title"
+        role="dialog"
+        className="flex max-h-[min(42rem,calc(100vh-3rem))] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-2xl"
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-border-light px-4 py-3">
+          <div className="min-w-0">
+            <h2 id="add-cloud-environment-title" className="text-sm font-medium text-foreground">
+              Add cloud environment
+            </h2>
+            <p className="mt-1 text-xs leading-4 text-muted-foreground">
+              Choose a GitHub repository. This creates cloud configuration and does not clone locally.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Close add cloud environment"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </Button>
+        </header>
+
+        <div className="grid gap-3 border-b border-border-light px-4 py-3">
+          <form className="flex min-w-0 gap-2" onSubmit={handleManualSubmit}>
+            <div className="relative min-w-0 flex-1">
+              <GitBranch className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                aria-label="GitHub repository"
+                value={manualValue}
+                placeholder="owner/repo or GitHub URL"
+                className="pl-8"
+                onChange={(event) => onManualValueChange(event.currentTarget.value)}
+              />
+            </div>
+            <Button type="submit" variant="primary" disabled={manualValue.trim().length === 0}>
+              <Plus size={14} />
+              Add
+            </Button>
+          </form>
+
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              aria-label="Search GitHub repositories"
+              value={query}
+              placeholder="Search repositories your GitHub account can access"
+              className="pl-8"
+              onChange={(event) => onQueryChange(event.currentTarget.value)}
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <div className="flex items-start gap-2 border-b border-destructive/20 bg-destructive-subtle px-4 py-3 text-sm text-destructive">
+            <ShieldAlert className="mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0 flex-1">{error}</div>
+            {onRetry ? (
+              <Button type="button" variant="secondary" size="sm" onClick={onRetry}>
+                <RotateCw size={13} />
+                Retry
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="web-scrollbar min-h-0 flex-1 overflow-y-auto">
+          {loading && repositories.length === 0 ? (
+            <div className="grid gap-2 px-4 py-4">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-14 animate-pulse rounded-lg border border-border-light bg-background/50"
+                />
+              ))}
+            </div>
+          ) : repositories.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No repositories found.
+            </div>
+          ) : (
+            <div className="divide-y divide-border-light">
+              {repositories.map((repo) => (
+                <RepositoryRow
+                  key={repo.id}
+                  repo={repo}
+                  adding={addingRepoId === repo.id}
+                  onAdd={onAddRepository}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {nextCursor ? (
+          <div className="border-t border-border-light px-4 py-3">
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full"
+              loading={loadingMore}
+              onClick={onLoadMore}
+            >
+              <ChevronDown size={14} />
+              Load more
+            </Button>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function RepositoryRow({
+  repo,
+  adding,
+  onAdd,
+}: {
+  repo: AddCloudEnvironmentRepositoryView;
+  adding: boolean;
+  onAdd: (repo: AddCloudEnvironmentRepositoryView) => void;
+}) {
+  const blocked = Boolean(repo.disabledReason);
+  const actionLabel = repo.repoConfigState === "configured"
+    ? "Use"
+    : repo.repoConfigState === "disabled"
+      ? "Enable"
+      : "Add";
+
+  return (
+    <div className="flex min-w-0 items-center gap-3 px-4 py-3">
+      <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-background">
+        {repo.ownerAvatarUrl ? (
+          <img src={repo.ownerAvatarUrl} alt="" className="size-full object-cover" />
+        ) : (
+          <Cloud size={14} className="text-muted-foreground" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+            {repo.fullName}
+          </span>
+          {repo.private ? <Lock className="size-3.5 shrink-0 text-muted-foreground" /> : null}
+          {repo.archived ? <Archive className="size-3.5 shrink-0 text-warning" /> : null}
+          {repo.repoConfigState === "configured" ? (
+            <Check className="size-3.5 shrink-0 text-success" />
+          ) : null}
+        </div>
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span className="truncate">
+            {repo.defaultBranch ? `default: ${repo.defaultBranch}` : "no default branch"}
+          </span>
+          {repo.permission ? <span>{repo.permission}</span> : null}
+          {repo.fork ? <span>fork</span> : null}
+          {repo.disabledReason ? <span className="text-warning">{repo.disabledReason}</span> : null}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant={repo.repoConfigState === "configured" ? "secondary" : "primary"}
+        loading={adding}
+        disabled={blocked}
+        onClick={() => onAdd(repo)}
+      >
+        {actionLabel}
+      </Button>
+    </div>
+  );
+}

--- a/packages/product-ui/src/environments/CloudEnvironmentEditor.tsx
+++ b/packages/product-ui/src/environments/CloudEnvironmentEditor.tsx
@@ -1,0 +1,282 @@
+import type { ChangeEvent, ReactNode } from "react";
+import { Cloud, Plus, Trash } from "lucide-react";
+
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Select } from "@proliferate/ui/primitives/Select";
+import { Textarea } from "@proliferate/ui/primitives/Textarea";
+import { SettingsCard } from "../settings/SettingsCard";
+import { SettingsCardRow } from "../settings/SettingsCardRow";
+import { SettingsPageHeader } from "../settings/SettingsPageHeader";
+
+export interface CloudEnvironmentEnvVarRowView {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface CloudEnvironmentEditorProps {
+  title: string;
+  description: string;
+  statusLabel: string;
+  statusTone?: "neutral" | "success" | "info" | "warning" | "destructive";
+  defaultBranch: string | null;
+  githubDefaultBranch: string | null;
+  branches: readonly string[];
+  branchesLoading?: boolean;
+  branchError?: string | null;
+  setupScript: string;
+  runCommand: string;
+  envVarRows: readonly CloudEnvironmentEnvVarRowView[];
+  saving?: boolean;
+  saveDisabled?: boolean;
+  revertDisabled?: boolean;
+  disableDisabled?: boolean;
+  error?: string | null;
+  trackedFileCount?: number;
+  trackedFilesReadOnly?: boolean;
+  onDefaultBranchChange: (value: string | null) => void;
+  onSetupScriptChange: (value: string) => void;
+  onRunCommandChange: (value: string) => void;
+  onAddEnvVar: () => void;
+  onUpdateEnvVar: (
+    rowId: string,
+    patch: Partial<Pick<CloudEnvironmentEnvVarRowView, "key" | "value">>,
+  ) => void;
+  onRemoveEnvVar: (rowId: string) => void;
+  onSave: () => void;
+  onRevert: () => void;
+  onDisable?: () => void;
+  breadcrumb?: ReactNode;
+}
+
+export function CloudEnvironmentEditor({
+  title,
+  description,
+  statusLabel,
+  statusTone = "neutral",
+  defaultBranch,
+  githubDefaultBranch,
+  branches,
+  branchesLoading = false,
+  branchError = null,
+  setupScript,
+  runCommand,
+  envVarRows,
+  saving = false,
+  saveDisabled = false,
+  revertDisabled = false,
+  disableDisabled = false,
+  error = null,
+  trackedFileCount = 0,
+  trackedFilesReadOnly = false,
+  onDefaultBranchChange,
+  onSetupScriptChange,
+  onRunCommandChange,
+  onAddEnvVar,
+  onUpdateEnvVar,
+  onRemoveEnvVar,
+  onSave,
+  onRevert,
+  onDisable,
+  breadcrumb = null,
+}: CloudEnvironmentEditorProps) {
+  const hasStaleSavedBranch = Boolean(defaultBranch && !branches.includes(defaultBranch));
+  const branchOptions = [
+    {
+      value: "__github__",
+      label: githubDefaultBranch
+        ? `GitHub default (${githubDefaultBranch})`
+        : "GitHub default",
+    },
+    ...(hasStaleSavedBranch && defaultBranch ? [{
+      value: defaultBranch,
+      label: `${defaultBranch} (saved, missing on GitHub)`,
+    }] : []),
+    ...branches.map((branch) => ({ value: branch, label: branch })),
+  ];
+
+  return (
+    <section className="space-y-6">
+      <div className="space-y-3">
+        {breadcrumb}
+        <div className="flex items-start justify-between gap-3">
+          <SettingsPageHeader title={title} description={description} />
+          <Badge tone={statusTone}>{statusLabel}</Badge>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/25 bg-destructive-subtle px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <SettingsCard>
+        <SettingsCardRow
+          label={(
+            <span className="flex items-center gap-2">
+              <Cloud size={14} className="text-muted-foreground" />
+              Default branch
+            </span>
+          )}
+          description={branchHelperText({
+            branchesLoading,
+            branchError,
+            githubDefaultBranch,
+          })}
+        >
+          <Select
+            aria-label="Cloud environment default branch"
+            value={defaultBranch ?? "__github__"}
+            disabled={branchesLoading}
+            className="w-72"
+            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+              const next = event.currentTarget.value;
+              onDefaultBranchChange(next === "__github__" ? null : next);
+            }}
+          >
+            {branchOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </SettingsCardRow>
+
+        <SettingsCardRow
+          label="Cloud action command"
+          description="Command launched by the workspace Run action for cloud workspaces in this environment."
+        >
+          <Input
+            aria-label="Cloud action command"
+            value={runCommand}
+            placeholder="make dev"
+            className="w-72 font-mono text-sm"
+            onChange={(event: ChangeEvent<HTMLInputElement>) => onRunCommandChange(event.currentTarget.value)}
+          />
+        </SettingsCardRow>
+
+        <SettingsCardRow
+          label="Setup script"
+          description="Runs after a new cloud workspace reaches ready."
+          className="sm:items-start"
+        >
+          <Textarea
+            aria-label="Cloud setup script"
+            value={setupScript}
+            placeholder={"pnpm install\npnpm prisma generate"}
+            className="h-36 w-96 font-mono text-sm"
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSetupScriptChange(event.currentTarget.value)}
+          />
+        </SettingsCardRow>
+      </SettingsCard>
+
+      <SettingsCard>
+        <SettingsCardRow
+          label="Environment variables"
+          description="Injected into new cloud workspaces for this environment."
+          className="sm:items-start"
+        >
+          <div className="w-full max-w-xl space-y-3">
+            {envVarRows.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No environment variables yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {envVarRows.map((row) => (
+                  <div key={row.id} className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+                    <Input
+                      aria-label="Environment variable key"
+                      value={row.key}
+                      placeholder="API_BASE_URL"
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        onUpdateEnvVar(row.id, { key: event.currentTarget.value })}
+                    />
+                    <Input
+                      aria-label="Environment variable value"
+                      value={row.value}
+                      placeholder="https://example.internal"
+                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                        onUpdateEnvVar(row.id, { value: event.currentTarget.value })}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Remove environment variable"
+                      onClick={() => onRemoveEnvVar(row.id)}
+                    >
+                      <Trash size={14} />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <Button type="button" variant="secondary" size="sm" onClick={onAddEnvVar}>
+              <Plus size={14} />
+              Add variable
+            </Button>
+          </div>
+        </SettingsCardRow>
+
+        {trackedFilesReadOnly && trackedFileCount > 0 ? (
+          <SettingsCardRow
+            label="Tracked files"
+            description={`${trackedFileCount} tracked file${trackedFileCount === 1 ? "" : "s"} ${trackedFileCount === 1 ? "is" : "are"} saved for this environment. Cloud-only edits preserve them; local file sync requires a local checkout.`}
+          />
+        ) : null}
+      </SettingsCard>
+
+      <div className="flex justify-end gap-2">
+        {onDisable ? (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={disableDisabled || saving}
+            onClick={onDisable}
+          >
+            Disable cloud environment
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={revertDisabled || saving}
+          onClick={onRevert}
+        >
+          Revert
+        </Button>
+        <Button
+          type="button"
+          loading={saving}
+          disabled={saveDisabled}
+          onClick={onSave}
+        >
+          Save
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function branchHelperText({
+  branchesLoading,
+  branchError,
+  githubDefaultBranch,
+}: {
+  branchesLoading: boolean;
+  branchError: string | null;
+  githubDefaultBranch: string | null;
+}): string {
+  if (branchError) {
+    return branchError;
+  }
+  if (branchesLoading) {
+    return "Loading GitHub branches...";
+  }
+  if (githubDefaultBranch) {
+    return `Leaving this on GitHub default follows ${githubDefaultBranch}.`;
+  }
+  return "Leaving this on GitHub default follows the repo's current default branch.";
+}

--- a/packages/product-ui/src/environments/CloudEnvironmentList.tsx
+++ b/packages/product-ui/src/environments/CloudEnvironmentList.tsx
@@ -1,0 +1,193 @@
+import type { ReactNode } from "react";
+import { Cloud, Folder, Plus } from "lucide-react";
+
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { SettingsCard } from "../settings/SettingsCard";
+import { SettingsCardRow } from "../settings/SettingsCardRow";
+import { SettingsPageHeader } from "../settings/SettingsPageHeader";
+
+export interface LocalCheckoutEnvironmentView {
+  id: string;
+  name: string;
+  description: string;
+  cloudStatusLabel?: string | null;
+}
+
+export interface CloudEnvironmentListItemView {
+  id: string;
+  fullName: string;
+  description: string;
+  configured: boolean;
+  localState: "cloud_only" | "local_and_cloud";
+  trackedFileCount?: number | null;
+}
+
+export interface CloudEnvironmentListProps {
+  title?: string;
+  description?: string;
+  localCheckouts?: readonly LocalCheckoutEnvironmentView[];
+  cloudEnvironments: readonly CloudEnvironmentListItemView[];
+  loadingCloudEnvironments?: boolean;
+  cloudUnavailableReason?: string | null;
+  onSelectLocalCheckout?: (id: string) => void;
+  onSelectCloudEnvironment: (id: string) => void;
+  onAddCloudEnvironment?: () => void;
+  onRetryCloudEnvironments?: () => void;
+}
+
+export function CloudEnvironmentList({
+  title = "Environments",
+  description = "Configure local checkouts and personal cloud environments.",
+  localCheckouts = [],
+  cloudEnvironments,
+  loadingCloudEnvironments = false,
+  cloudUnavailableReason = null,
+  onSelectLocalCheckout,
+  onSelectCloudEnvironment,
+  onAddCloudEnvironment,
+  onRetryCloudEnvironments,
+}: CloudEnvironmentListProps) {
+  return (
+    <section className="space-y-6">
+      <SettingsPageHeader title={title} description={description} />
+
+      {onSelectLocalCheckout ? (
+        <section className="space-y-3">
+          <SectionHeading
+            title="Local checkouts"
+            description="Folders present on this computer."
+          />
+          <SettingsCard>
+            {localCheckouts.length === 0 ? (
+              <SettingsCardRow
+                label="No local checkouts"
+                description="Add a folder from Desktop to configure local defaults."
+              />
+            ) : (
+              localCheckouts.map((checkout) => (
+                <SettingsCardRow
+                  key={checkout.id}
+                  label={(
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Folder size={14} className="shrink-0 text-muted-foreground" />
+                      <span className="truncate">{checkout.name}</span>
+                    </span>
+                  )}
+                  description={checkout.description}
+                >
+                  <div className="flex items-center gap-2">
+                    {checkout.cloudStatusLabel ? (
+                      <Badge tone="info">{checkout.cloudStatusLabel}</Badge>
+                    ) : null}
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => onSelectLocalCheckout(checkout.id)}
+                    >
+                      Configure
+                    </Button>
+                  </div>
+                </SettingsCardRow>
+              ))
+            )}
+          </SettingsCard>
+        </section>
+      ) : null}
+
+      <section className="space-y-3">
+        <SectionHeading
+          title="Cloud environments"
+          description="GitHub repositories configured for Proliferate Cloud. These do not have to be cloned locally."
+          action={onAddCloudEnvironment ? (
+            <Button type="button" size="sm" onClick={onAddCloudEnvironment}>
+              <Plus size={14} />
+              Add GitHub repo
+            </Button>
+          ) : null}
+        />
+        <SettingsCard>
+          {cloudUnavailableReason ? (
+            <SettingsCardRow
+              label="Cloud environments unavailable"
+              description={cloudUnavailableReason}
+            />
+          ) : loadingCloudEnvironments && cloudEnvironments.length === 0 ? (
+            <SettingsCardRow label="Cloud environments" description="Loading..." />
+          ) : cloudEnvironments.length === 0 ? (
+            <SettingsCardRow
+              label="No cloud environments"
+              description="Add a GitHub repo to use it from web, mobile, or Desktop cloud workspaces."
+            />
+          ) : (
+            cloudEnvironments.map((environment) => (
+              <SettingsCardRow
+                key={environment.id}
+                label={(
+                  <span className="flex min-w-0 items-center gap-2">
+                    <Cloud size={14} className="shrink-0 text-muted-foreground" />
+                    <span className="truncate">{environment.fullName}</span>
+                  </span>
+                )}
+                description={environmentDescription(environment)}
+              >
+                <div className="flex items-center gap-2">
+                  <Badge tone={environment.configured ? "success" : "warning"}>
+                    {environment.configured ? "Enabled" : "Disabled"}
+                  </Badge>
+                  <Badge tone={environment.localState === "local_and_cloud" ? "info" : "neutral"}>
+                    {environment.localState === "local_and_cloud" ? "Local + cloud" : "Cloud only"}
+                  </Badge>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => onSelectCloudEnvironment(environment.id)}
+                  >
+                    Configure
+                  </Button>
+                </div>
+              </SettingsCardRow>
+            ))
+          )}
+          {onRetryCloudEnvironments ? (
+            <SettingsCardRow label="Refresh" description="Reload cloud environment records.">
+              <Button type="button" variant="secondary" size="sm" onClick={onRetryCloudEnvironments}>
+                Retry
+              </Button>
+            </SettingsCardRow>
+          ) : null}
+        </SettingsCard>
+      </section>
+    </section>
+  );
+}
+
+function SectionHeading({
+  title,
+  description,
+  action = null,
+}: {
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex items-end justify-between gap-3">
+      <div className="min-w-0 space-y-1">
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        <p className="text-xs leading-4 text-muted-foreground">{description}</p>
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}
+
+function environmentDescription(environment: CloudEnvironmentListItemView): string {
+  const parts = [environment.description];
+  if ((environment.trackedFileCount ?? 0) > 0) {
+    parts.push(`${environment.trackedFileCount} tracked file${environment.trackedFileCount === 1 ? "" : "s"}`);
+  }
+  return parts.join(" · ");
+}

--- a/packages/product-ui/src/repos/AddCloudRepoDialog.tsx
+++ b/packages/product-ui/src/repos/AddCloudRepoDialog.tsx
@@ -1,0 +1,5 @@
+export {
+  AddCloudEnvironmentDialog as AddCloudRepoDialog,
+  type AddCloudEnvironmentConfigState as AddCloudRepoConfigState,
+  type AddCloudEnvironmentRepositoryView as AddCloudRepoDialogRepositoryView,
+} from "../environments/AddCloudEnvironmentDialog";

--- a/packages/product-ui/test/CloudEnvironments.test.tsx
+++ b/packages/product-ui/test/CloudEnvironments.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AddCloudEnvironmentDialog } from "../src/environments/AddCloudEnvironmentDialog";
+import { CloudEnvironmentEditor } from "../src/environments/CloudEnvironmentEditor";
+import { CloudEnvironmentList } from "../src/environments/CloudEnvironmentList";
+
+describe("cloud environment product UI", () => {
+  afterEach(cleanup);
+
+  it("labels the add dialog as a cloud environment flow", () => {
+    render(
+      <AddCloudEnvironmentDialog
+        open
+        query=""
+        manualValue=""
+        repositories={[]}
+        onQueryChange={vi.fn()}
+        onManualValueChange={vi.fn()}
+        onAddRepository={vi.fn()}
+        onAddManual={vi.fn()}
+        onLoadMore={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Add cloud environment")).toBeTruthy();
+    expect(screen.getByText(/does not clone locally/u)).toBeTruthy();
+    expect(screen.getByLabelText("GitHub repository")).toBeTruthy();
+  });
+
+  it("renders local checkouts separately from cloud environments", () => {
+    const onSelectLocal = vi.fn();
+    const onSelectCloud = vi.fn();
+
+    render(
+      <CloudEnvironmentList
+        localCheckouts={[{
+          id: "/repo",
+          name: "repo",
+          description: "/repo",
+          cloudStatusLabel: "Cloud configured",
+        }]}
+        cloudEnvironments={[{
+          id: "acme/rocket",
+          fullName: "acme/rocket",
+          description: "Cloud-only environment",
+          configured: true,
+          localState: "cloud_only",
+        }]}
+        onSelectLocalCheckout={onSelectLocal}
+        onSelectCloudEnvironment={onSelectCloud}
+      />,
+    );
+
+    expect(screen.getByText("Local checkouts")).toBeTruthy();
+    expect(screen.getByText("Cloud environments")).toBeTruthy();
+    fireEvent.click(screen.getAllByText("Configure")[0]!);
+    expect(onSelectLocal).toHaveBeenCalledWith("/repo");
+    fireEvent.click(screen.getAllByText("Configure")[1]!);
+    expect(onSelectCloud).toHaveBeenCalledWith("acme/rocket");
+  });
+
+  it("hides local file sync and shows tracked files as read-only in cloud-only editor", () => {
+    render(
+      <CloudEnvironmentEditor
+        title="acme/rocket"
+        description="Cloud-only environment"
+        statusLabel="Saved"
+        statusTone="success"
+        defaultBranch={null}
+        githubDefaultBranch="main"
+        branches={["main"]}
+        setupScript=""
+        runCommand=""
+        envVarRows={[]}
+        trackedFileCount={2}
+        trackedFilesReadOnly
+        onDefaultBranchChange={vi.fn()}
+        onSetupScriptChange={vi.fn()}
+        onRunCommandChange={vi.fn()}
+        onAddEnvVar={vi.fn()}
+        onUpdateEnvVar={vi.fn()}
+        onRemoveEnvVar={vi.fn()}
+        onSave={vi.fn()}
+        onRevert={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Tracked files")).toBeTruthy();
+    expect(screen.getByText(/Cloud-only edits preserve them/u)).toBeTruthy();
+    expect(screen.queryByText("Choose tracked files")).toBeNull();
+  });
+
+  it("emits editor save, revert, disable, and env var actions", () => {
+    const onSave = vi.fn();
+    const onRevert = vi.fn();
+    const onDisable = vi.fn();
+    const onAddEnvVar = vi.fn();
+
+    render(
+      <CloudEnvironmentEditor
+        title="acme/rocket"
+        description="Cloud-only environment"
+        statusLabel="Unsaved changes"
+        defaultBranch="main"
+        githubDefaultBranch="main"
+        branches={["main"]}
+        setupScript=""
+        runCommand=""
+        envVarRows={[]}
+        onDefaultBranchChange={vi.fn()}
+        onSetupScriptChange={vi.fn()}
+        onRunCommandChange={vi.fn()}
+        onAddEnvVar={onAddEnvVar}
+        onUpdateEnvVar={vi.fn()}
+        onRemoveEnvVar={vi.fn()}
+        onSave={onSave}
+        onRevert={onRevert}
+        onDisable={onDisable}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Add variable"));
+    fireEvent.click(screen.getByText("Revert"));
+    fireEvent.click(screen.getByText("Disable cloud environment"));
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onAddEnvVar).toHaveBeenCalledTimes(1);
+    expect(onRevert).toHaveBeenCalledTimes(1);
+    expect(onDisable).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/proliferate/db/store/cloud_repo_config.py
+++ b/server/proliferate/db/store/cloud_repo_config.py
@@ -540,7 +540,7 @@ async def save_cloud_repo_config(
     env_vars: dict[str, str],
     setup_script: str,
     run_command: str,
-    files: list[CloudRepoFileInput],
+    files: list[CloudRepoFileInput] | None,
 ) -> CloudRepoConfigValue:
     record = await _get_or_create_repo_config_record(
         db,

--- a/server/proliferate/integrations/github.py
+++ b/server/proliferate/integrations/github.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import re
 from dataclasses import dataclass, field
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, NoReturn
 
 import httpx
 
@@ -13,6 +17,34 @@ class GitHubRepoBranches:
     default_branch: str
     branches: list[str]
     branch_heads_by_name: dict[str, str] = field(default_factory=dict)
+    permission: str | None = None
+    private: bool = False
+    fork: bool = False
+    archived: bool = False
+    disabled: bool = False
+
+
+@dataclass(frozen=True)
+class GitHubRepositorySummary:
+    owner: str
+    name: str
+    full_name: str
+    default_branch: str | None
+    private: bool
+    fork: bool
+    archived: bool
+    disabled: bool
+    html_url: str | None
+    owner_avatar_url: str | None
+    pushed_at: str | None
+    updated_at: str | None
+    permission: str | None
+
+
+@dataclass(frozen=True)
+class GitHubRepositoryPage:
+    repositories: list[GitHubRepositorySummary]
+    next_cursor: str | None
 
 
 @dataclass(frozen=True)
@@ -30,12 +62,211 @@ class GitHubRepoAccessRequired(GitHubIntegrationError):
     pass
 
 
+class GitHubRateLimited(GitHubIntegrationError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after_seconds: int | None = None,
+        rate_limit_reset_at: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+        self.rate_limit_reset_at = rate_limit_reset_at
+
+
+class GitHubRepoEmpty(GitHubIntegrationError):
+    pass
+
+
+class GitHubInvalidCursor(GitHubIntegrationError):
+    pass
+
+
 def _github_headers(access_token: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
+
+
+def _parse_retry_after_seconds(response: httpx.Response) -> int | None:
+    value = response.headers.get("retry-after")
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _parse_rate_limit_reset_at(response: httpx.Response) -> str | None:
+    value = response.headers.get("x-ratelimit-reset")
+    if value is None:
+        return None
+    try:
+        timestamp = int(value)
+    except ValueError:
+        return None
+    return datetime.fromtimestamp(timestamp, tz=UTC).isoformat()
+
+
+def _is_rate_limited_response(response: httpx.Response) -> bool:
+    if response.status_code == 429:
+        return True
+    if response.status_code != 403:
+        return False
+    if response.headers.get("x-ratelimit-remaining") == "0":
+        return True
+    return response.headers.get("retry-after") is not None
+
+
+def _raise_github_response_error(
+    response: httpx.Response,
+    *,
+    access_message: str,
+    fallback_message: str,
+) -> NoReturn:
+    if _is_rate_limited_response(response):
+        raise GitHubRateLimited(
+            "GitHub is rate limiting repository access. Try again later.",
+            retry_after_seconds=_parse_retry_after_seconds(response),
+            rate_limit_reset_at=_parse_rate_limit_reset_at(response),
+        )
+    if response.status_code in {401, 403, 404}:
+        raise GitHubRepoAccessRequired(access_message)
+    raise GitHubIntegrationError(fallback_message)
+
+
+def _json_payload(response: httpx.Response) -> object:
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise GitHubIntegrationError("GitHub returned an invalid response.") from exc
+
+
+def _permission_from_payload(payload: dict[str, Any]) -> str | None:
+    permissions = payload.get("permissions")
+    if not isinstance(permissions, dict):
+        return None
+    for permission in ("admin", "maintain", "push", "triage", "pull"):
+        if permissions.get(permission) is True:
+            return permission
+    return None
+
+
+def _repo_summary_from_payload(payload: dict[str, Any]) -> GitHubRepositorySummary | None:
+    owner_payload = payload.get("owner")
+    if not isinstance(owner_payload, dict):
+        return None
+    owner = owner_payload.get("login")
+    name = payload.get("name")
+    if not isinstance(owner, str) or not owner.strip():
+        return None
+    if not isinstance(name, str) or not name.strip():
+        return None
+    full_name = payload.get("full_name")
+    default_branch = payload.get("default_branch")
+    html_url = payload.get("html_url")
+    owner_avatar_url = owner_payload.get("avatar_url")
+    pushed_at = payload.get("pushed_at")
+    updated_at = payload.get("updated_at")
+    return GitHubRepositorySummary(
+        owner=owner.strip(),
+        name=name.strip(),
+        full_name=full_name.strip()
+        if isinstance(full_name, str) and full_name.strip()
+        else f"{owner.strip()}/{name.strip()}",
+        default_branch=default_branch.strip()
+        if isinstance(default_branch, str) and default_branch.strip()
+        else None,
+        private=payload.get("private") is True,
+        fork=payload.get("fork") is True,
+        archived=payload.get("archived") is True,
+        disabled=payload.get("disabled") is True,
+        html_url=html_url.strip() if isinstance(html_url, str) and html_url.strip() else None,
+        owner_avatar_url=owner_avatar_url.strip()
+        if isinstance(owner_avatar_url, str) and owner_avatar_url.strip()
+        else None,
+        pushed_at=pushed_at.strip() if isinstance(pushed_at, str) and pushed_at.strip() else None,
+        updated_at=(
+            updated_at.strip() if isinstance(updated_at, str) and updated_at.strip() else None
+        ),
+        permission=_permission_from_payload(payload),
+    )
+
+
+def _encode_repo_cursor(
+    *,
+    page: int,
+    limit: int,
+    affiliation: str,
+    visibility: str,
+    sort: str,
+    direction: str,
+) -> str:
+    payload = {
+        "source": "github-user-repos-v1",
+        "page": page,
+        "limit": limit,
+        "affiliation": affiliation,
+        "visibility": visibility,
+        "sort": sort,
+        "direction": direction,
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_repo_cursor(
+    cursor: str,
+    *,
+    limit: int,
+    affiliation: str,
+    visibility: str,
+    sort: str,
+    direction: str,
+) -> int:
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8"))
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise GitHubInvalidCursor("Invalid GitHub repository cursor.") from exc
+    if not isinstance(payload, dict):
+        raise GitHubInvalidCursor("Invalid GitHub repository cursor.")
+    expected = {
+        "source": "github-user-repos-v1",
+        "limit": limit,
+        "affiliation": affiliation,
+        "visibility": visibility,
+        "sort": sort,
+        "direction": direction,
+    }
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise GitHubInvalidCursor("GitHub repository cursor does not match this request.")
+    page = payload.get("page")
+    if not isinstance(page, int) or page < 1:
+        raise GitHubInvalidCursor("Invalid GitHub repository cursor.")
+    return page
+
+
+_NEXT_LINK_RE = re.compile(r'<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="next"')
+
+
+def _next_page_from_link_header(response: httpx.Response) -> int | None:
+    link_header = response.headers.get("link")
+    if not link_header:
+        return None
+    match = _NEXT_LINK_RE.search(link_header)
+    if match is None:
+        return None
+    try:
+        page = int(match.group(1))
+    except ValueError:
+        return None
+    return page if page >= 1 else None
 
 
 async def _fetch_github_repo_response(
@@ -53,21 +284,94 @@ async def _fetch_github_repo_response(
         ) from exc
 
     if response.status_code < 300:
-        payload = response.json()
+        payload = _json_payload(response)
         if isinstance(payload, dict):
             return payload
         raise GitHubIntegrationError(
             "Could not verify GitHub repository access for this cloud workspace."
         )
 
-    if response.status_code in {401, 403, 404}:
-        raise GitHubRepoAccessRequired(
+    _raise_github_response_error(
+        response,
+        access_message=(
             "Reconnect GitHub and grant repository access before creating a cloud workspace."
+        ),
+        fallback_message="Could not verify GitHub repository access for this cloud workspace.",
+    )
+
+
+async def list_github_repositories(
+    access_token: str,
+    *,
+    cursor: str | None,
+    limit: int,
+    affiliation: str,
+    visibility: str,
+) -> GitHubRepositoryPage:
+    sort = "pushed"
+    direction = "desc"
+    page = (
+        _decode_repo_cursor(
+            cursor,
+            limit=limit,
+            affiliation=affiliation,
+            visibility=visibility,
+            sort=sort,
+            direction=direction,
+        )
+        if cursor
+        else 1
+    )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(
+                "https://api.github.com/user/repos",
+                headers=_github_headers(access_token),
+                params={
+                    "per_page": limit,
+                    "page": page,
+                    "affiliation": affiliation,
+                    "visibility": visibility,
+                    "sort": sort,
+                    "direction": direction,
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise GitHubIntegrationError("Could not list GitHub repositories.") from exc
+
+    if response.status_code >= 300:
+        _raise_github_response_error(
+            response,
+            access_message="Reconnect GitHub and grant repository access before browsing repos.",
+            fallback_message="Could not list GitHub repositories.",
         )
 
-    raise GitHubIntegrationError(
-        "Could not verify GitHub repository access for this cloud workspace."
+    payload = _json_payload(response)
+    if not isinstance(payload, list):
+        raise GitHubIntegrationError("Could not list GitHub repositories.")
+
+    repositories: list[GitHubRepositorySummary] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        summary = _repo_summary_from_payload(item)
+        if summary is not None:
+            repositories.append(summary)
+
+    next_page = _next_page_from_link_header(response)
+    next_cursor = (
+        _encode_repo_cursor(
+            page=next_page,
+            limit=limit,
+            affiliation=affiliation,
+            visibility=visibility,
+            sort=sort,
+            direction=direction,
+        )
+        if next_page is not None
+        else None
     )
+    return GitHubRepositoryPage(repositories=repositories, next_cursor=next_cursor)
 
 
 async def get_github_repo_branches(
@@ -76,7 +380,12 @@ async def get_github_repo_branches(
     git_repo_name: str,
 ) -> GitHubRepoBranches:
     repo_payload = await _fetch_github_repo_response(access_token, git_owner, git_repo_name)
-    default_branch = str(repo_payload.get("default_branch") or "main")
+    default_branch_payload = repo_payload.get("default_branch")
+    default_branch = (
+        default_branch_payload.strip()
+        if isinstance(default_branch_payload, str) and default_branch_payload.strip()
+        else None
+    )
     repo_url = f"https://api.github.com/repos/{git_owner}/{git_repo_name}/branches"
     branches: list[str] = []
     branch_heads_by_name: dict[str, str] = {}
@@ -90,17 +399,17 @@ async def get_github_repo_branches(
                     headers=_github_headers(access_token),
                     params={"per_page": 100, "page": page},
                 )
-                if response.status_code in {401, 403, 404}:
-                    raise GitHubRepoAccessRequired(
-                        "Reconnect GitHub and grant repository access"
-                        " before creating a cloud workspace."
-                    )
                 if response.status_code >= 300:
-                    raise GitHubIntegrationError(
-                        "Could not load GitHub branches for this repository."
+                    _raise_github_response_error(
+                        response,
+                        access_message=(
+                            "Reconnect GitHub and grant repository access"
+                            " before creating a cloud workspace."
+                        ),
+                        fallback_message="Could not load GitHub branches for this repository.",
                     )
 
-                payload = response.json()
+                payload = _json_payload(response)
                 if not isinstance(payload, list):
                     raise GitHubIntegrationError(
                         "Could not load GitHub branches for this repository."
@@ -127,6 +436,8 @@ async def get_github_repo_branches(
         ) from exc
 
     ordered = sorted(set(branches))
+    if not ordered or default_branch is None:
+        raise GitHubRepoEmpty("This repository does not have a branch yet.")
     if default_branch in ordered:
         ordered.remove(default_branch)
     ordered.insert(0, default_branch)
@@ -134,6 +445,11 @@ async def get_github_repo_branches(
         default_branch=default_branch,
         branches=ordered,
         branch_heads_by_name=branch_heads_by_name,
+        permission=_permission_from_payload(repo_payload),
+        private=repo_payload.get("private") is True,
+        fork=repo_payload.get("fork") is True,
+        archived=repo_payload.get("archived") is True,
+        disabled=repo_payload.get("disabled") is True,
     )
 
 

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -107,14 +107,17 @@ async def _proliferate_error_handler(
     _request: Request,
     error: ProliferateError,
 ) -> JSONResponse:
+    detail = {
+        "code": error.code,
+        "message": error.message,
+    }
+    extra_detail = getattr(error, "extra_detail", None)
+    if isinstance(extra_detail, dict):
+        detail.update(extra_detail)
     return JSONResponse(
         status_code=error.status_code,
-        content={
-            "detail": {
-                "code": error.code,
-                "message": error.message,
-            }
-        },
+        content={"detail": detail},
+        headers=getattr(error, "headers", None),
     )
 
 

--- a/server/proliferate/server/cloud/errors.py
+++ b/server/proliferate/server/cloud/errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import NoReturn
 
 from fastapi import HTTPException
@@ -12,8 +13,18 @@ from proliferate.errors import ProliferateError
 class CloudApiError(ProliferateError):
     """Raised when a cloud workspace operation fails with a client-facing error."""
 
-    def __init__(self, code: str, message: str, *, status_code: int) -> None:
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int,
+        extra_detail: Mapping[str, object] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
         super().__init__(message=message, code=code, status_code=status_code)
+        self.extra_detail = dict(extra_detail or {})
+        self.headers = dict(headers or {})
 
 
 def raise_cloud_error(error: CloudApiError) -> NoReturn:
@@ -21,5 +32,6 @@ def raise_cloud_error(error: CloudApiError) -> NoReturn:
 
     raise HTTPException(
         status_code=error.status_code,
-        detail={"code": error.code, "message": error.message},
+        detail={"code": error.code, "message": error.message, **error.extra_detail},
+        headers=error.headers or None,
     )

--- a/server/proliferate/server/cloud/repo_config/models.py
+++ b/server/proliferate/server/cloud/repo_config/models.py
@@ -66,7 +66,7 @@ class SaveCloudRepoConfigRequest(BaseModel):
     env_vars: dict[str, str] = Field(default_factory=dict, alias="envVars")
     setup_script: str = Field(default="", alias="setupScript")
     run_command: str = Field(default="", alias="runCommand")
-    files: list[SaveCloudRepoConfigFile]
+    files: list[SaveCloudRepoConfigFile] | None = None
 
 
 class SaveOrganizationCloudRepoConfigRequest(BaseModel):

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -238,16 +238,17 @@ def _normalize_files(files: list[CloudRepoFileInput]) -> list[CloudRepoFileInput
     return normalized
 
 
-async def _validate_default_branch(
+async def _validate_repo_access_and_default_branch(
     db: AsyncSession,
     user_id: UUID,
     *,
     git_owner: str,
     git_repo_name: str,
     default_branch: str | None,
+    require_access: bool,
 ) -> str | None:
     normalized_default_branch = (default_branch or "").strip() or None
-    if normalized_default_branch is None:
+    if normalized_default_branch is None and not require_access:
         return None
 
     github_grant = await get_ready_github_grant_for_user(db, user_id=user_id)
@@ -267,6 +268,9 @@ async def _validate_default_branch(
             "Reconnect GitHub and grant repository access before setting a cloud default branch."
         ),
     )
+    if normalized_default_branch is None:
+        return repo_branches.default_branch
+
     if normalized_default_branch not in repo_branches.branches:
         raise CloudApiError(
             "github_branch_not_found",
@@ -286,18 +290,23 @@ async def save_repo_config(
     body: SaveCloudRepoConfigRequest,
 ) -> CloudRepoConfigValue:
     env_vars = normalize_env_vars(body.env_vars)
-    default_branch = await _validate_default_branch(
+    default_branch = await _validate_repo_access_and_default_branch(
         db,
         user_id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         default_branch=body.default_branch,
+        require_access=body.configured,
     )
-    files = _normalize_files(
-        [
-            CloudRepoFileInput(relative_path=item.relative_path, content=item.content)
-            for item in body.files
-        ]
+    files = (
+        _normalize_files(
+            [
+                CloudRepoFileInput(relative_path=item.relative_path, content=item.content)
+                for item in body.files
+            ]
+        )
+        if body.files is not None
+        else None
     )
     billing_snapshot = await get_billing_snapshot_for_request(db, user_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
@@ -343,12 +352,13 @@ async def save_organization_repo_config(
         organization_id=organization_id,
     )
     env_vars = normalize_env_vars(body.env_vars)
-    default_branch = await _validate_default_branch(
+    default_branch = await _validate_repo_access_and_default_branch(
         db,
         user_id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         default_branch=body.default_branch,
+        require_access=body.configured,
     )
     files = (
         _normalize_files(

--- a/server/proliferate/server/cloud/repos/api.py
+++ b/server/proliferate/server/cloud/repos/api.py
@@ -1,12 +1,52 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.repos.access import CloudRepoGitHubCredentialsDependency
-from proliferate.server.cloud.repos.models import RepoBranchesResponse
-from proliferate.server.cloud.repos.service import get_cloud_repo_branches
+from proliferate.server.cloud.repos.models import (
+    CloudGitRepositoriesResponse,
+    RepoBranchesResponse,
+    cloud_git_repositories_payload,
+)
+from proliferate.server.cloud.repos.service import (
+    DEFAULT_REPO_AFFILIATION,
+    DEFAULT_REPO_VISIBILITY,
+    get_cloud_repo_branches,
+    list_cloud_repositories,
+)
 
 router = APIRouter()
+
+
+@router.get("/repos", response_model=CloudGitRepositoriesResponse)
+async def list_cloud_repositories_endpoint(
+    response: Response,
+    credentials: CloudRepoGitHubCredentialsDependency,
+    db: AsyncSession = Depends(get_async_session),
+    query: str | None = None,
+    cursor: str | None = None,
+    limit: int = 50,
+    affiliation: str = DEFAULT_REPO_AFFILIATION,
+    visibility: str = DEFAULT_REPO_VISIBILITY,
+) -> CloudGitRepositoriesResponse:
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Vary"] = "Authorization, Cookie"
+    try:
+        page = await list_cloud_repositories(
+            db,
+            credentials,
+            query=query,
+            cursor=cursor,
+            limit=limit,
+            affiliation=affiliation,
+            visibility=visibility,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return cloud_git_repositories_payload(page)
 
 
 @router.get("/repos/{git_owner}/{git_repo_name}/branches", response_model=RepoBranchesResponse)
@@ -15,8 +55,11 @@ async def get_cloud_repo_branches_endpoint(
     git_repo_name: str,
     credentials: CloudRepoGitHubCredentialsDependency,
 ) -> RepoBranchesResponse:
-    return await get_cloud_repo_branches(
-        credentials,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
+    try:
+        return await get_cloud_repo_branches(
+            credentials,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/repos/domain/catalog.py
+++ b/server/proliferate/server/cloud/repos/domain/catalog.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+RepoConfigState = Literal["missing", "disabled", "configured"]
+
+
+@dataclass(frozen=True)
+class CloudGitRepositoryRecord:
+    provider: Literal["github"]
+    git_owner: str
+    git_repo_name: str
+    full_name: str
+    default_branch: str | None
+    private: bool
+    fork: bool
+    archived: bool
+    disabled: bool
+    html_url: str | None
+    owner_avatar_url: str | None
+    pushed_at: str | None
+    updated_at: str | None
+    permission: str | None
+    configured: bool
+    repo_config_state: RepoConfigState
+
+
+@dataclass(frozen=True)
+class CloudGitRepositoriesPageRecord:
+    repositories: tuple[CloudGitRepositoryRecord, ...]
+    next_cursor: str | None
+
+
+def normalized_repo_key(git_owner: str, git_repo_name: str) -> str:
+    return f"{git_owner.strip().lower()}/{git_repo_name.strip().lower()}"

--- a/server/proliferate/server/cloud/repos/models.py
+++ b/server/proliferate/server/cloud/repos/models.py
@@ -2,9 +2,73 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
+
+from proliferate.server.cloud.repos.domain.catalog import CloudGitRepositoriesPageRecord
 
 
 class RepoBranchesResponse(BaseModel):
     default_branch: str = Field(serialization_alias="defaultBranch")
     branches: list[str]
+    permission: str | None = None
+    private: bool | None = None
+    fork: bool | None = None
+    archived: bool | None = None
+    disabled: bool | None = None
+
+
+class CloudGitRepositorySummary(BaseModel):
+    provider: Literal["github"] = "github"
+    git_owner: str = Field(serialization_alias="gitOwner")
+    git_repo_name: str = Field(serialization_alias="gitRepoName")
+    full_name: str = Field(serialization_alias="fullName")
+    default_branch: str | None = Field(serialization_alias="defaultBranch")
+    private: bool
+    fork: bool
+    archived: bool
+    disabled: bool
+    html_url: str | None = Field(serialization_alias="htmlUrl")
+    owner_avatar_url: str | None = Field(serialization_alias="ownerAvatarUrl")
+    pushed_at: str | None = Field(serialization_alias="pushedAt")
+    updated_at: str | None = Field(serialization_alias="updatedAt")
+    permission: str | None = None
+    configured: bool = False
+    repo_config_state: Literal["missing", "disabled", "configured"] = Field(
+        serialization_alias="repoConfigState"
+    )
+
+
+class CloudGitRepositoriesResponse(BaseModel):
+    repositories: list[CloudGitRepositorySummary]
+    next_cursor: str | None = Field(serialization_alias="nextCursor")
+
+
+def cloud_git_repositories_payload(
+    page: CloudGitRepositoriesPageRecord,
+) -> CloudGitRepositoriesResponse:
+    return CloudGitRepositoriesResponse(
+        repositories=[
+            CloudGitRepositorySummary(
+                provider=repo.provider,
+                git_owner=repo.git_owner,
+                git_repo_name=repo.git_repo_name,
+                full_name=repo.full_name,
+                default_branch=repo.default_branch,
+                private=repo.private,
+                fork=repo.fork,
+                archived=repo.archived,
+                disabled=repo.disabled,
+                html_url=repo.html_url,
+                owner_avatar_url=repo.owner_avatar_url,
+                pushed_at=repo.pushed_at,
+                updated_at=repo.updated_at,
+                permission=repo.permission,
+                configured=repo.configured,
+                repo_config_state=repo.repo_config_state,
+            )
+            for repo in page.repositories
+        ],
+        next_cursor=page.next_cursor,
+    )

--- a/server/proliferate/server/cloud/repos/service.py
+++ b/server/proliferate/server/cloud/repos/service.py
@@ -5,15 +5,28 @@ from collections.abc import Iterable
 from typing import Protocol
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.constants.cloud import SUPPORTED_GIT_PROVIDER
+from proliferate.db.store.cloud_repo_config import list_cloud_repo_configs
 from proliferate.integrations.github import (
     GitHubIntegrationError,
+    GitHubInvalidCursor,
+    GitHubRateLimited,
     GitHubRepoAccessRequired,
     GitHubRepoBranches,
+    GitHubRepoEmpty,
     get_github_repo_branches,
+    list_github_repositories,
 )
 from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repos.domain.catalog import (
+    CloudGitRepositoriesPageRecord,
+    CloudGitRepositoryRecord,
+    RepoConfigState,
+    normalized_repo_key,
+)
 from proliferate.server.cloud.repos.domain.github_credentials import (
     CloudRepoGitHubCredentials,
     OAuthAccountLike,
@@ -22,6 +35,11 @@ from proliferate.server.cloud.repos.domain.github_credentials import (
 )
 from proliferate.server.cloud.repos.models import RepoBranchesResponse
 from proliferate.utils.time import duration_ms
+
+SUPPORTED_VISIBILITIES = {"all", "public", "private"}
+SUPPORTED_AFFILIATIONS = {"owner", "collaborator", "organization_member"}
+DEFAULT_REPO_AFFILIATION = "owner,collaborator,organization_member"
+DEFAULT_REPO_VISIBILITY = "all"
 
 
 class CloudRepoUserLike(Protocol):
@@ -59,6 +77,70 @@ def _require_github_access_token(
     return credentials.access_token
 
 
+def _rate_limit_detail(exc: GitHubRateLimited) -> dict[str, object]:
+    detail: dict[str, object] = {}
+    if exc.retry_after_seconds is not None:
+        detail["retryAfterSeconds"] = exc.retry_after_seconds
+    if exc.rate_limit_reset_at is not None:
+        detail["rateLimitResetAt"] = exc.rate_limit_reset_at
+    return detail
+
+
+def _rate_limit_headers(exc: GitHubRateLimited) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if exc.retry_after_seconds is not None:
+        headers["Retry-After"] = str(exc.retry_after_seconds)
+    return headers
+
+
+def _github_rate_limited_error(exc: GitHubRateLimited) -> CloudApiError:
+    return CloudApiError(
+        "github_rate_limited",
+        "GitHub is rate limiting repository browsing. Try again later.",
+        status_code=429,
+        extra_detail=_rate_limit_detail(exc),
+        headers=_rate_limit_headers(exc),
+    )
+
+
+def _validate_repo_catalog_params(
+    *,
+    query: str | None,
+    limit: int,
+    affiliation: str,
+    visibility: str,
+) -> tuple[str | None, int, str, str]:
+    if limit < 1 or limit > 100:
+        raise CloudApiError(
+            "invalid_repo_catalog_query",
+            "Repository catalog limit must be between 1 and 100.",
+            status_code=400,
+        )
+    normalized_visibility = visibility.strip().lower()
+    if normalized_visibility not in SUPPORTED_VISIBILITIES:
+        raise CloudApiError(
+            "invalid_repo_catalog_query",
+            "Repository catalog visibility is invalid.",
+            status_code=400,
+        )
+    affiliation_parts = [part.strip().lower() for part in affiliation.split(",") if part.strip()]
+    has_invalid_affiliation = any(part not in SUPPORTED_AFFILIATIONS for part in affiliation_parts)
+    if not affiliation_parts or has_invalid_affiliation:
+        raise CloudApiError(
+            "invalid_repo_catalog_query",
+            "Repository catalog affiliation is invalid.",
+            status_code=400,
+        )
+    normalized_query = (query or "").strip().lower() or None
+    if normalized_query is not None and len(normalized_query) > 120:
+        raise CloudApiError(
+            "invalid_repo_catalog_query",
+            "Repository catalog query is too long.",
+            status_code=400,
+        )
+    return normalized_query, limit, ",".join(affiliation_parts), normalized_visibility
+
+
 async def get_repo_branches_for_credentials(
     credentials: CloudRepoGitHubCredentials,
     *,
@@ -71,10 +153,18 @@ async def get_repo_branches_for_credentials(
     lookup_started = time.perf_counter()
     try:
         branch_info = await get_github_repo_branches(access_token, git_owner, git_repo_name)
+    except GitHubRateLimited as exc:
+        raise _github_rate_limited_error(exc) from exc
     except GitHubRepoAccessRequired as exc:
         raise CloudApiError(
             "github_repo_access_required",
             repo_access_required_message or str(exc),
+            status_code=400,
+        ) from exc
+    except GitHubRepoEmpty as exc:
+        raise CloudApiError(
+            "github_repo_empty",
+            str(exc),
             status_code=400,
         ) from exc
     except GitHubIntegrationError as exc:
@@ -91,6 +181,110 @@ async def get_repo_branches_for_credentials(
         elapsed_ms=duration_ms(lookup_started),
     )
     return branch_info
+
+
+async def list_cloud_repositories(
+    db: AsyncSession,
+    credentials: CloudRepoGitHubCredentials,
+    *,
+    query: str | None = None,
+    cursor: str | None = None,
+    limit: int = 50,
+    affiliation: str = DEFAULT_REPO_AFFILIATION,
+    visibility: str = DEFAULT_REPO_VISIBILITY,
+) -> CloudGitRepositoriesPageRecord:
+    access_token = _require_github_access_token(
+        credentials,
+        "Connect a GitHub account before browsing cloud repositories.",
+    )
+    normalized_query, normalized_limit, normalized_affiliation, normalized_visibility = (
+        _validate_repo_catalog_params(
+            query=query,
+            limit=limit,
+            affiliation=affiliation,
+            visibility=visibility,
+        )
+    )
+    lookup_started = time.perf_counter()
+    try:
+        github_page = await list_github_repositories(
+            access_token,
+            cursor=cursor,
+            limit=normalized_limit,
+            affiliation=normalized_affiliation,
+            visibility=normalized_visibility,
+        )
+    except GitHubInvalidCursor as exc:
+        raise CloudApiError(
+            "invalid_repo_catalog_query",
+            str(exc),
+            status_code=400,
+        ) from exc
+    except GitHubRateLimited as exc:
+        raise _github_rate_limited_error(exc) from exc
+    except GitHubRepoAccessRequired as exc:
+        raise CloudApiError(
+            "github_repo_access_required",
+            str(exc),
+            status_code=400,
+        ) from exc
+    except GitHubIntegrationError as exc:
+        raise CloudApiError(
+            "github_repo_list_failed",
+            str(exc),
+            status_code=502,
+        ) from exc
+
+    config_states: dict[str, RepoConfigState] = {
+        normalized_repo_key(config.git_owner, config.git_repo_name): (
+            "configured" if config.configured else "disabled"
+        )
+        for config in await list_cloud_repo_configs(db, credentials.user_id)
+    }
+    records: list[CloudGitRepositoryRecord] = []
+    for repo in github_page.repositories:
+        if normalized_query and (
+            normalized_query not in repo.full_name.lower()
+            and normalized_query not in repo.owner.lower()
+            and normalized_query not in repo.name.lower()
+        ):
+            continue
+        config_state = config_states.get(
+            normalized_repo_key(repo.owner, repo.name),
+            "missing",
+        )
+        records.append(
+            CloudGitRepositoryRecord(
+                provider="github",
+                git_owner=repo.owner,
+                git_repo_name=repo.name,
+                full_name=repo.full_name,
+                default_branch=repo.default_branch,
+                private=repo.private,
+                fork=repo.fork,
+                archived=repo.archived,
+                disabled=repo.disabled,
+                html_url=repo.html_url,
+                owner_avatar_url=repo.owner_avatar_url,
+                pushed_at=repo.pushed_at,
+                updated_at=repo.updated_at,
+                permission=repo.permission,
+                configured=config_state == "configured",
+                repo_config_state=config_state,
+            )
+        )
+    log_cloud_event(
+        "cloud github repos listed",
+        user_id=credentials.user_id,
+        repo_count=len(records),
+        has_next_cursor=github_page.next_cursor is not None,
+        query_present=normalized_query is not None,
+        elapsed_ms=duration_ms(lookup_started),
+    )
+    return CloudGitRepositoriesPageRecord(
+        repositories=tuple(records),
+        next_cursor=github_page.next_cursor,
+    )
 
 
 async def get_repo_branches_for_user(
@@ -135,4 +329,9 @@ async def get_cloud_repo_branches(
     return RepoBranchesResponse(
         default_branch=branch_info.default_branch,
         branches=branch_info.branches,
+        permission=branch_info.permission,
+        private=branch_info.private,
+        fork=branch_info.fork,
+        archived=branch_info.archived,
+        disabled=branch_info.disabled,
     )

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -33,7 +33,11 @@ from proliferate.db.store.cloud_mcp.oauth_flows import (
 )
 from proliferate.db.store.cloud_mcp.oauth_clients import upsert_oauth_client
 from proliferate.db.store.billing import ensure_personal_billing_subject
-from proliferate.integrations.github import GitHubRepoBranches
+from proliferate.integrations.github import (
+    GitHubRepositoryPage,
+    GitHubRepositorySummary,
+    GitHubRepoBranches,
+)
 from proliferate.integrations.mcp_oauth import TokenResponse
 from proliferate.integrations.sandbox.base import ProviderSandboxState
 from proliferate.server.cloud.errors import CloudApiError
@@ -806,6 +810,13 @@ class TestCloudRepoConfig:
         client: AsyncClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        async def _repo_branches(*_args, **_kwargs) -> GitHubRepoBranches:
+            return GitHubRepoBranches(
+                default_branch="main",
+                branches=["main", "release"],
+            )
+
+        _patch_repo_branches_lookup(monkeypatch, _repo_branches)
         monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_OBSERVE)
         monkeypatch.setattr(settings, "cloud_free_repo_limit", 1)
 
@@ -1034,7 +1045,125 @@ class TestCloudRepoBranches:
         assert response.json() == {
             "defaultBranch": "main",
             "branches": ["main", "release", "stable"],
+            "permission": None,
+            "private": False,
+            "fork": False,
+            "archived": False,
+            "disabled": False,
         }
+
+
+class TestCloudRepoCatalog:
+    @pytest.mark.asyncio
+    async def test_list_cloud_repositories_marks_repo_config_state(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _repo_branches(*_args, **_kwargs) -> GitHubRepoBranches:
+            return GitHubRepoBranches(
+                default_branch="main",
+                branches=["main", "release"],
+                permission="push",
+                private=True,
+            )
+
+        async def _github_repositories(*_args, **_kwargs) -> GitHubRepositoryPage:
+            return GitHubRepositoryPage(
+                repositories=[
+                    GitHubRepositorySummary(
+                        owner="acme",
+                        name="rocket",
+                        full_name="acme/rocket",
+                        default_branch="main",
+                        private=True,
+                        fork=False,
+                        archived=False,
+                        disabled=False,
+                        html_url="https://github.com/acme/rocket",
+                        owner_avatar_url=None,
+                        pushed_at="2026-05-01T00:00:00Z",
+                        updated_at="2026-05-02T00:00:00Z",
+                        permission="push",
+                    ),
+                    GitHubRepositorySummary(
+                        owner="acme",
+                        name="disabled",
+                        full_name="acme/disabled",
+                        default_branch="main",
+                        private=False,
+                        fork=False,
+                        archived=False,
+                        disabled=False,
+                        html_url=None,
+                        owner_avatar_url=None,
+                        pushed_at=None,
+                        updated_at=None,
+                        permission="admin",
+                    ),
+                    GitHubRepositorySummary(
+                        owner="acme",
+                        name="missing",
+                        full_name="acme/missing",
+                        default_branch="main",
+                        private=False,
+                        fork=False,
+                        archived=False,
+                        disabled=False,
+                        html_url=None,
+                        owner_avatar_url=None,
+                        pushed_at=None,
+                        updated_at=None,
+                        permission="pull",
+                    ),
+                ],
+                next_cursor="cursor-2",
+            )
+
+        _patch_repo_branches_lookup(monkeypatch, _repo_branches)
+        monkeypatch.setattr(
+            repos_service,
+            "list_github_repositories",
+            _github_repositories,
+        )
+
+        session = await _register_and_login(client, "cloud-repo-catalog@example.com")
+        headers = {"Authorization": f"Bearer {session['access_token']}"}
+        await _link_github_account(db_session, session["user_id"])
+        await _configure_repo(client, headers, git_owner="acme", git_repo_name="rocket")
+        disabled = await client.put(
+            "/v1/cloud/repos/acme/disabled/config",
+            headers=headers,
+            json={
+                "configured": False,
+                "defaultBranch": None,
+                "envVars": {},
+                "setupScript": "",
+                "runCommand": "",
+            },
+        )
+        assert disabled.status_code == 200
+
+        response = await client.get(
+            "/v1/cloud/repos",
+            headers=headers,
+            params={"limit": 25},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-store, private"
+        assert response.headers["vary"] == "Authorization, Cookie"
+        payload = response.json()
+        assert payload["nextCursor"] == "cursor-2"
+        assert [
+            (repo["fullName"], repo["repoConfigState"], repo["configured"])
+            for repo in payload["repositories"]
+        ] == [
+            ("acme/rocket", "configured", True),
+            ("acme/disabled", "disabled", False),
+            ("acme/missing", "missing", False),
+        ]
 
 
 class TestCloudWorkspaces:

--- a/server/tests/integration/test_cloud_target_config_api.py
+++ b/server/tests/integration/test_cloud_target_config_api.py
@@ -6,6 +6,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.integrations.github import GitHubRepoBranches
+from proliferate.server.cloud.repo_config import service as repo_config_service
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 
@@ -45,7 +47,19 @@ async def _create_enrolled_target(
 async def test_target_config_materialization_command_is_secret_safe(
     client: AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    async def _repo_branches(*_args, **_kwargs) -> GitHubRepoBranches:
+        return GitHubRepoBranches(
+            default_branch="main",
+            branches=["main", "release"],
+        )
+
+    monkeypatch.setattr(
+        repo_config_service,
+        "get_repo_branches_for_credentials",
+        _repo_branches,
+    )
     auth = await create_user_and_login(
         client,
         db_session,

--- a/server/tests/unit/test_github_integration.py
+++ b/server/tests/unit/test_github_integration.py
@@ -6,7 +6,11 @@ import httpx
 import pytest
 
 from proliferate.integrations import github
-from proliferate.integrations.github import GitHubIntegrationError
+from proliferate.integrations.github import (
+    GitHubIntegrationError,
+    GitHubInvalidCursor,
+    GitHubRateLimited,
+)
 
 
 class _FakeGitHubClient:
@@ -38,6 +42,127 @@ def _github_response(status_code: int, payload: object) -> httpx.Response:
         json=payload,
         request=httpx.Request("GET", "https://api.github.com/user"),
     )
+
+
+def _github_response_with_headers(
+    status_code: int,
+    payload: object,
+    *,
+    headers: dict[str, str],
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        headers=headers,
+        request=httpx.Request("GET", "https://api.github.com/user/repos"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_github_repositories_shapes_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeGitHubClient(
+        _github_response_with_headers(
+            200,
+            [
+                {
+                    "owner": {
+                        "login": " acme ",
+                        "avatar_url": " https://avatars.example/acme ",
+                    },
+                    "name": " rocket ",
+                    "full_name": " acme/rocket ",
+                    "default_branch": " main ",
+                    "private": True,
+                    "fork": False,
+                    "archived": False,
+                    "disabled": False,
+                    "html_url": " https://github.com/acme/rocket ",
+                    "pushed_at": "2026-05-01T00:00:00Z",
+                    "updated_at": "2026-05-02T00:00:00Z",
+                    "permissions": {"pull": True, "push": True},
+                }
+            ],
+            headers={"link": '<https://api.github.com/user/repos?page=2>; rel="next"'},
+        )
+    )
+    monkeypatch.setattr(github.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    page = await github.list_github_repositories(
+        "token-1",
+        cursor=None,
+        limit=25,
+        affiliation="owner,collaborator",
+        visibility="all",
+    )
+
+    assert page.next_cursor is not None
+    assert len(page.repositories) == 1
+    repo = page.repositories[0]
+    assert repo.owner == "acme"
+    assert repo.name == "rocket"
+    assert repo.full_name == "acme/rocket"
+    assert repo.default_branch == "main"
+    assert repo.private is True
+    assert repo.permission == "push"
+    assert client.calls == [
+        (
+            "https://api.github.com/user/repos",
+            {
+                "headers": {
+                    "Authorization": "Bearer token-1",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                "params": {
+                    "per_page": 25,
+                    "page": 1,
+                    "affiliation": "owner,collaborator",
+                    "visibility": "all",
+                    "sort": "pushed",
+                    "direction": "desc",
+                },
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_github_repositories_rejects_invalid_cursor() -> None:
+    with pytest.raises(GitHubInvalidCursor):
+        await github.list_github_repositories(
+            "token-1",
+            cursor="not-base64",
+            limit=25,
+            affiliation="owner",
+            visibility="all",
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_github_repositories_maps_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeGitHubClient(
+        httpx.Response(
+            403,
+            json={"message": "rate limited"},
+            headers={"x-ratelimit-remaining": "0", "retry-after": "30"},
+            request=httpx.Request("GET", "https://api.github.com/user/repos"),
+        )
+    )
+    monkeypatch.setattr(github.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    with pytest.raises(GitHubRateLimited) as exc_info:
+        await github.list_github_repositories(
+            "token-1",
+            cursor=None,
+            limit=25,
+            affiliation="owner",
+            visibility="all",
+        )
+    assert exc_info.value.retry_after_seconds == 30
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_repos_service.py
+++ b/server/tests/unit/test_repos_service.py
@@ -13,10 +13,14 @@ import pytest
 
 from proliferate.integrations.github import (
     GitHubIntegrationError,
+    GitHubRepositoryPage,
+    GitHubRepositorySummary,
     GitHubRepoBranches,
     GitHubRepoAccessRequired,
+    GitHubRateLimited,
     list_branches,
 )
+from proliferate.db.store.cloud_repo_config import CloudRepoConfigSummaryValue
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.repos.domain.github_credentials import (
     CloudRepoGitHubCredentials,
@@ -26,6 +30,7 @@ from proliferate.server.cloud.repos.service import (
     build_cloud_repo_credentials_for_user,
     get_cloud_repo_branches,
     get_linked_github_account,
+    list_cloud_repositories,
     get_repo_branches_for_credentials,
     get_repo_branches_for_user,
 )
@@ -237,7 +242,134 @@ class TestGetCloudRepoBranches:
             assert result.model_dump(by_alias=True) == {
                 "defaultBranch": "main",
                 "branches": ["main", "release", "stable"],
+                "permission": None,
+                "private": False,
+                "fork": False,
+                "archived": False,
+                "disabled": False,
             }
+
+
+class TestListCloudRepositories:
+    @pytest.mark.asyncio
+    async def test_maps_github_repositories_and_existing_config_state(self) -> None:
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token="gh-token",
+        )
+        github_page = GitHubRepositoryPage(
+            repositories=[
+                GitHubRepositorySummary(
+                    owner="acme",
+                    name="rocket",
+                    full_name="acme/rocket",
+                    default_branch="main",
+                    private=True,
+                    fork=False,
+                    archived=False,
+                    disabled=False,
+                    html_url="https://github.com/acme/rocket",
+                    owner_avatar_url=None,
+                    pushed_at="2026-05-01T00:00:00Z",
+                    updated_at="2026-05-02T00:00:00Z",
+                    permission="push",
+                ),
+                GitHubRepositorySummary(
+                    owner="acme",
+                    name="disabled",
+                    full_name="acme/disabled",
+                    default_branch="main",
+                    private=False,
+                    fork=False,
+                    archived=False,
+                    disabled=False,
+                    html_url=None,
+                    owner_avatar_url=None,
+                    pushed_at=None,
+                    updated_at=None,
+                    permission="admin",
+                ),
+            ],
+            next_cursor="cursor-2",
+        )
+        configs = [
+            CloudRepoConfigSummaryValue(
+                id=uuid.uuid4(),
+                owner_scope="personal",
+                user_id=credentials.user_id,
+                organization_id=None,
+                git_owner="acme",
+                git_repo_name="rocket",
+                configured=True,
+                configured_at=None,
+                files_version=0,
+            ),
+            CloudRepoConfigSummaryValue(
+                id=uuid.uuid4(),
+                owner_scope="personal",
+                user_id=credentials.user_id,
+                organization_id=None,
+                git_owner="acme",
+                git_repo_name="disabled",
+                configured=False,
+                configured_at=None,
+                files_version=0,
+            ),
+        ]
+
+        with (
+            patch(
+                "proliferate.server.cloud.repos.service.list_github_repositories",
+                new_callable=AsyncMock,
+                return_value=github_page,
+            ) as list_github,
+            patch(
+                "proliferate.server.cloud.repos.service.list_cloud_repo_configs",
+                new_callable=AsyncMock,
+                return_value=configs,
+            ),
+        ):
+            result = await list_cloud_repositories(
+                object(),  # type: ignore[arg-type]
+                credentials,
+                query=None,
+                limit=25,
+            )
+
+        list_github.assert_awaited_once_with(
+            "gh-token",
+            cursor=None,
+            limit=25,
+            affiliation="owner,collaborator,organization_member",
+            visibility="all",
+        )
+        assert result.next_cursor == "cursor-2"
+        assert [repo.repo_config_state for repo in result.repositories] == [
+            "configured",
+            "disabled",
+        ]
+        assert result.repositories[0].configured is True
+        assert result.repositories[1].configured is False
+
+    @pytest.mark.asyncio
+    async def test_maps_github_rate_limits(self) -> None:
+        credentials = CloudRepoGitHubCredentials(
+            user_id=uuid.uuid4(),
+            access_token="gh-token",
+        )
+        with patch(
+            "proliferate.server.cloud.repos.service.list_github_repositories",
+            new_callable=AsyncMock,
+            side_effect=GitHubRateLimited("slow down", retry_after_seconds=30),
+        ), pytest.raises(CloudApiError) as exc_info:
+            await list_cloud_repositories(
+                object(),  # type: ignore[arg-type]
+                credentials,
+            )
+        assert exc_info.value.code == "github_rate_limited"
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.extra_detail == {"retryAfterSeconds": 30}
+        assert exc_info.value.headers == {"Retry-After": "30"}
 
 
 class TestListBranchesAlias:

--- a/web/src/components/environments/screen/AddCloudEnvironmentDialogController.tsx
+++ b/web/src/components/environments/screen/AddCloudEnvironmentDialogController.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from "react";
+import { AddCloudEnvironmentDialog } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+import type { AddCloudEnvironmentRepositoryView } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+import type { CloudGitRepositorySummary } from "@proliferate/cloud-sdk";
+import {
+  useCloudGitRepositories,
+  useLoadCloudRepoConfig,
+  useSaveCloudRepoConfig,
+  useValidateCloudRepoBranches,
+} from "@proliferate/cloud-sdk-react";
+import {
+  blockedCloudRepositoryBranchReason,
+  blockedCloudRepositoryReason,
+  buildMinimalCloudEnvironmentConfigRequest,
+  buildReenableCloudEnvironmentConfigRequest,
+} from "@proliferate/product-model/environments/cloud-environments";
+import {
+  formatGitRepoId,
+  parseGitRepoId,
+  type GitRepoIdentity,
+} from "@proliferate/product-model/repos/repo-id";
+
+const REPO_PAGE_LIMIT = 50;
+
+interface AddCloudEnvironmentDialogControllerProps {
+  open: boolean;
+  onClose: () => void;
+  onEnvironmentAdded: (repoId: string) => void;
+}
+
+export function AddCloudEnvironmentDialogController({
+  open,
+  onClose,
+  onEnvironmentAdded,
+}: AddCloudEnvironmentDialogControllerProps) {
+  const actions = useCloudEnvironmentAddActions({
+    open,
+    onEnvironmentAdded: (repoId) => {
+      onEnvironmentAdded(repoId);
+      onClose();
+    },
+  });
+
+  const repositories: AddCloudEnvironmentRepositoryView[] = actions.repositories.map((repo) => ({
+    id: formatGitRepoId(repo),
+    fullName: repo.fullName,
+    defaultBranch: repo.defaultBranch,
+    private: repo.private,
+    fork: repo.fork,
+    archived: repo.archived,
+    disabled: repo.disabled,
+    permission: repo.permission ?? null,
+    configured: repo.configured,
+    repoConfigState: repo.repoConfigState,
+    ownerAvatarUrl: repo.ownerAvatarUrl,
+    pushedAt: repo.pushedAt,
+    updatedAt: repo.updatedAt,
+    disabledReason: blockedCloudRepositoryReason(repo),
+  }));
+
+  return (
+    <AddCloudEnvironmentDialog
+      open={open}
+      query={actions.query}
+      manualValue={actions.manualValue}
+      repositories={repositories}
+      loading={actions.loading}
+      loadingMore={actions.loadingMore}
+      addingRepoId={actions.addingRepoId}
+      error={actions.error}
+      nextCursor={actions.nextCursor}
+      onQueryChange={actions.setQuery}
+      onManualValueChange={actions.setManualValue}
+      onAddRepository={(repo) => void actions.addCatalogRepository(repo.id)}
+      onAddManual={() => void actions.addManualRepository()}
+      onLoadMore={actions.loadMore}
+      onRetry={() => void actions.retry()}
+      onClose={onClose}
+    />
+  );
+}
+
+interface UseCloudEnvironmentAddActionsInput {
+  open: boolean;
+  onEnvironmentAdded: (repoId: string) => void;
+}
+
+function useCloudEnvironmentAddActions({
+  open,
+  onEnvironmentAdded,
+}: UseCloudEnvironmentAddActionsInput) {
+  const [query, setQuery] = useState("");
+  const [manualValue, setManualValue] = useState("");
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [repositories, setRepositories] = useState<CloudGitRepositorySummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [addingRepoId, setAddingRepoId] = useState<string | null>(null);
+  const debouncedQuery = useDebouncedValue(query.trim(), 250);
+  const catalog = useCloudGitRepositories(
+    {
+      query: debouncedQuery || null,
+      cursor,
+      limit: REPO_PAGE_LIMIT,
+    },
+    open,
+  );
+  const validateBranches = useValidateCloudRepoBranches();
+  const loadConfig = useLoadCloudRepoConfig();
+  const saveConfig = useSaveCloudRepoConfig();
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setManualValue("");
+      setCursor(null);
+      setRepositories([]);
+      setError(null);
+      setAddingRepoId(null);
+      return;
+    }
+    setCursor(null);
+    setRepositories([]);
+    setError(null);
+  }, [debouncedQuery, open]);
+
+  useEffect(() => {
+    if (!catalog.data) {
+      return;
+    }
+    setRepositories((current) =>
+      cursor
+        ? mergeRepositories(current, catalog.data.repositories)
+        : catalog.data.repositories
+    );
+  }, [catalog.data, cursor]);
+
+  useEffect(() => {
+    if (catalog.error) {
+      setError(catalog.error instanceof Error ? catalog.error.message : "Could not load GitHub repositories.");
+    }
+  }, [catalog.error]);
+
+  const repositoryById = useMemo(() => {
+    const byId = new Map<string, CloudGitRepositorySummary>();
+    for (const repo of repositories) {
+      byId.set(formatGitRepoId(repo), repo);
+    }
+    return byId;
+  }, [repositories]);
+
+  async function addCatalogRepository(repoId: string) {
+    const repo = repositoryById.get(repoId);
+    if (!repo) {
+      setError("Repository is no longer available in this list.");
+      return;
+    }
+    await addRepository(repo);
+  }
+
+  async function addManualRepository() {
+    const parsed = parseGitRepoId(manualValue);
+    if (!parsed) {
+      setError("Enter a GitHub repository as owner/repo or a GitHub URL.");
+      return;
+    }
+    await addRepository(parsed);
+  }
+
+  async function addRepository(repo: CloudGitRepositorySummary | GitRepoIdentity) {
+    const repoId = formatGitRepoId(repo);
+    setAddingRepoId(repoId);
+    setError(null);
+    try {
+      if ("repoConfigState" in repo && repo.repoConfigState === "configured") {
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      const catalogBlockedReason = "repoConfigState" in repo ? blockedCloudRepositoryReason(repo) : null;
+      if (catalogBlockedReason) {
+        throw new Error(catalogBlockedReason);
+      }
+
+      const branches = await validateBranches.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+      });
+      const branchBlockedReason = blockedCloudRepositoryBranchReason(branches);
+      if (branchBlockedReason) {
+        throw new Error(branchBlockedReason);
+      }
+
+      if ("repoConfigState" in repo && repo.repoConfigState === "missing") {
+        await saveConfig.mutateAsync({
+          gitOwner: repo.gitOwner,
+          gitRepoName: repo.gitRepoName,
+          body: buildMinimalCloudEnvironmentConfigRequest(branches.defaultBranch),
+        });
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      const existingConfig = await loadConfig.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+      });
+      if (existingConfig.configured) {
+        onEnvironmentAdded(repoId);
+        return;
+      }
+
+      await saveConfig.mutateAsync({
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        body: buildReenableCloudEnvironmentConfigRequest(existingConfig, branches.defaultBranch),
+      });
+      onEnvironmentAdded(repoId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not add cloud environment.");
+    } finally {
+      setAddingRepoId(null);
+    }
+  }
+
+  return {
+    query,
+    manualValue,
+    repositories,
+    error,
+    addingRepoId,
+    nextCursor: catalog.data?.nextCursor ?? null,
+    loading: catalog.isLoading,
+    loadingMore: catalog.isFetching && cursor !== null,
+    setQuery,
+    setManualValue,
+    addCatalogRepository,
+    addManualRepository,
+    retry: catalog.refetch,
+    loadMore: () => {
+      const nextCursor = catalog.data?.nextCursor ?? null;
+      if (nextCursor && !catalog.isFetching) {
+        setCursor(nextCursor);
+      }
+    },
+  };
+}
+
+function mergeRepositories(
+  current: CloudGitRepositorySummary[],
+  incoming: CloudGitRepositorySummary[],
+): CloudGitRepositorySummary[] {
+  const byId = new Map<string, CloudGitRepositorySummary>();
+  for (const repo of current) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  for (const repo of incoming) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  return Array.from(byId.values());
+}
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, value]);
+  return debounced;
+}

--- a/web/src/components/home/screen/HomeScreen.tsx
+++ b/web/src/components/home/screen/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { Bot, Cloud, GitBranch } from "lucide-react";
+import { Bot, Cloud, GitBranch, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
@@ -14,6 +14,11 @@ import {
   resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "@proliferate/product-model/chats/cloud/composer-controls";
+import {
+  formatGitRepoId,
+  normalizeGitRepoId,
+  parseGitRepoId,
+} from "@proliferate/product-model/repos/repo-id";
 
 import type {
   NewChatPickerId,
@@ -26,6 +31,7 @@ import type { CloudChatTranscriptRowView } from "@proliferate/product-ui/chat/Cl
 import { webEnv } from "../../../config/env";
 import { routes } from "../../../config/routes";
 import { savePendingHomePrompt } from "../../../lib/access/cloud/pending-home-prompt-store";
+import { AddCloudEnvironmentDialogController } from "../../environments/screen/AddCloudEnvironmentDialogController";
 
 const HOME_PLACEHOLDER = "Describe a quick remote task...";
 
@@ -49,8 +55,9 @@ export function HomeScreen() {
   const submitInFlightRef = useRef(false);
   const [draft, setDraft] = useState("");
   const [repoId, setRepoId] = useState(() =>
-    readLastRepoId() ?? normalizeRepoId(webEnv.defaultCloudRepo) ?? ""
+    readLastRepoId() ?? normalizeGitRepoId(webEnv.defaultCloudRepo) ?? ""
   );
+  const [addRepoOpen, setAddRepoOpen] = useState(false);
   const [launchSelection, setLaunchSelection] = useState<CloudLaunchComposerSelection>({
     agentKind: DEFAULT_DIRECT_PROMPT_AGENT_KIND,
     modelId: DEFAULT_DIRECT_PROMPT_MODEL_ID,
@@ -108,10 +115,10 @@ export function HomeScreen() {
   );
 
   useEffect(() => {
-    if (!selectedRepo && repoOptions[0]) {
+    if (!repoId && !selectedRepo && repoOptions[0]) {
       setRepoId(repoOptions[0].id);
     }
-  }, [repoOptions, selectedRepo]);
+  }, [repoId, repoOptions, selectedRepo]);
 
   function handlePickerSelect(picker: NewChatPickerId, itemId: string) {
     if (picker === "target") {
@@ -119,6 +126,18 @@ export function HomeScreen() {
       writeLastRepoId(itemId);
       return;
     }
+  }
+
+  function handleAction(actionId: string) {
+    if (actionId === "add-repo") {
+      setAddRepoOpen(true);
+    }
+  }
+
+  function handleRepoSelected(nextRepoId: string) {
+    setRepoId(nextRepoId);
+    writeLastRepoId(nextRepoId);
+    void repoConfigs.refetch();
   }
 
   async function handleSubmit() {
@@ -223,10 +242,22 @@ export function HomeScreen() {
             ? "Creating a cloud workspace. The prompt will send as soon as the workspace is ready."
             : null
         }
-        actions={[]}
+        actions={[
+          {
+            id: "add-repo",
+            label: "Add cloud environment",
+            icon: <Plus size={13} />,
+          },
+        ]}
         onDraftChange={setDraft}
         onSubmit={() => void handleSubmit()}
         onPickerSelect={handlePickerSelect}
+        onAction={handleAction}
+      />
+      <AddCloudEnvironmentDialogController
+        open={addRepoOpen}
+        onClose={() => setAddRepoOpen(false)}
+        onEnvironmentAdded={handleRepoSelected}
       />
     </div>
   );
@@ -357,7 +388,10 @@ function buildRepoOptions(
     if (!config.configured) {
       continue;
     }
-    const id = repoId(config.gitOwner, config.gitRepoName);
+    const id = formatGitRepoId({
+      gitOwner: config.gitOwner,
+      gitRepoName: config.gitRepoName,
+    });
     options.set(id, {
       id,
       gitOwner: config.gitOwner,
@@ -367,9 +401,9 @@ function buildRepoOptions(
     });
   }
 
-  const normalizedDefault = normalizeRepoId(defaultRepo);
+  const normalizedDefault = normalizeGitRepoId(defaultRepo);
   if (normalizedDefault && !options.has(normalizedDefault)) {
-    const parsed = parseRepoId(normalizedDefault);
+    const parsed = parseGitRepoId(normalizedDefault);
     if (parsed) {
       options.set(normalizedDefault, {
         id: normalizedDefault,
@@ -398,33 +432,9 @@ function buildWorkspaceDisplayName(prompt: string): string {
   return firstLine.length > 120 ? `${firstLine.slice(0, 117)}...` : firstLine;
 }
 
-function repoId(gitOwner: string, gitRepoName: string): string {
-  return `${gitOwner}/${gitRepoName}`;
-}
-
-function normalizeRepoId(value: string | null | undefined): string | null {
-  const parsed = parseRepoId(value);
-  return parsed ? repoId(parsed.gitOwner, parsed.gitRepoName) : null;
-}
-
-function parseRepoId(value: string | null | undefined): {
-  gitOwner: string;
-  gitRepoName: string;
-} | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const [gitOwner, gitRepoName, ...rest] = trimmed.split("/");
-  if (!gitOwner || !gitRepoName || rest.length > 0) {
-    return null;
-  }
-  return { gitOwner, gitRepoName };
-}
-
 function readLastRepoId(): string | null {
   try {
-    return normalizeRepoId(window.localStorage.getItem("proliferate.web.homeRepo"));
+    return normalizeGitRepoId(window.localStorage.getItem("proliferate.web.homeRepo"));
   } catch {
     return null;
   }

--- a/web/src/components/settings/screen/EnvironmentsSettingsSection.tsx
+++ b/web/src/components/settings/screen/EnvironmentsSettingsSection.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  useCloudRepoBranches,
+  useCloudRepoConfig,
+  useCloudRepoConfigs,
+  useSaveCloudRepoConfig,
+} from "@proliferate/cloud-sdk-react";
+import type { CloudRepoConfigResponse } from "@proliferate/cloud-sdk";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { CloudEnvironmentEditor } from "@proliferate/product-ui/environments/CloudEnvironmentEditor";
+import type { CloudEnvironmentEnvVarRowView } from "@proliferate/product-ui/environments/CloudEnvironmentEditor";
+import { CloudEnvironmentList } from "@proliferate/product-ui/environments/CloudEnvironmentList";
+import {
+  buildCloudEnvironmentListItems,
+  buildCoreCloudEnvironmentSaveRequest,
+} from "@proliferate/product-model/environments/cloud-environments";
+import {
+  formatGitRepoId,
+} from "@proliferate/product-model/repos/repo-id";
+
+import { AddCloudEnvironmentDialogController } from "../../environments/screen/AddCloudEnvironmentDialogController";
+
+interface CloudEnvironmentDraftState {
+  configured: boolean;
+  defaultBranch: string | null;
+  setupScript: string;
+  runCommand: string;
+  envVarRows: CloudEnvironmentEnvVarRowView[];
+}
+
+export function EnvironmentsSettingsSection() {
+  const [addOpen, setAddOpen] = useState(false);
+  const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
+  const repoConfigs = useCloudRepoConfigs();
+  const environments = useMemo(
+    () => buildCloudEnvironmentListItems({
+      configs: repoConfigs.data?.configs ?? [],
+    }),
+    [repoConfigs.data?.configs],
+  );
+  const selectedEnvironment = useMemo(
+    () => environments.find((environment) => environment.id === selectedRepoId) ?? null,
+    [environments, selectedRepoId],
+  );
+
+  if (selectedEnvironment) {
+    return (
+      <CloudEnvironmentDetail
+        gitOwner={selectedEnvironment.gitOwner}
+        gitRepoName={selectedEnvironment.gitRepoName}
+        onBack={() => setSelectedRepoId(null)}
+        onSaved={() => void repoConfigs.refetch()}
+      />
+    );
+  }
+
+  return (
+    <>
+      <CloudEnvironmentList
+        title="Environments"
+        description="Personal Cloud environments are GitHub repositories Proliferate can run without a local clone."
+        cloudEnvironments={environments.map((environment) => ({
+          id: environment.id,
+          fullName: environment.fullName,
+          description: environment.description,
+          configured: environment.configured,
+          localState: environment.localState,
+        }))}
+        loadingCloudEnvironments={repoConfigs.isLoading}
+        cloudUnavailableReason={repoConfigs.isError ? "Cloud environments could not be loaded." : null}
+        onSelectCloudEnvironment={setSelectedRepoId}
+        onAddCloudEnvironment={() => setAddOpen(true)}
+        onRetryCloudEnvironments={repoConfigs.isError ? () => void repoConfigs.refetch() : undefined}
+      />
+      <AddCloudEnvironmentDialogController
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onEnvironmentAdded={(repoId) => {
+          setSelectedRepoId(repoId);
+          void repoConfigs.refetch();
+        }}
+      />
+    </>
+  );
+}
+
+function CloudEnvironmentDetail({
+  gitOwner,
+  gitRepoName,
+  onBack,
+  onSaved,
+}: {
+  gitOwner: string;
+  gitRepoName: string;
+  onBack: () => void;
+  onSaved: () => void;
+}) {
+  const config = useCloudRepoConfig(gitOwner, gitRepoName, true);
+  const branches = useCloudRepoBranches(gitOwner, gitRepoName, true);
+  const saveConfig = useSaveCloudRepoConfig();
+  const draft = useCloudEnvironmentCoreDraft(config.data, formatGitRepoId({ gitOwner, gitRepoName }));
+  const repoId = formatGitRepoId({ gitOwner, gitRepoName });
+  const errorMessage = saveConfig.error?.message ?? null;
+  const savedConfigured = config.data?.configured ?? false;
+  const statusLabel = !draft.configured && savedConfigured
+    ? "Will disable"
+    : savedConfigured
+      ? draft.dirty
+        ? "Unsaved changes"
+        : "Saved"
+      : draft.configured
+        ? "Ready to enable"
+        : "Disabled";
+
+  async function handleSave() {
+    const response = await saveConfig.mutateAsync({
+      gitOwner,
+      gitRepoName,
+      body: buildCoreCloudEnvironmentSaveRequest({
+        configured: draft.configured,
+        defaultBranch: draft.defaultBranch,
+        envVars: draft.envVars,
+        setupScript: draft.setupScript,
+        runCommand: draft.runCommand,
+      }),
+    });
+    draft.reset(response);
+    onSaved();
+  }
+
+  return (
+    <CloudEnvironmentEditor
+      title={repoId}
+      description="Personal Cloud environment. This does not create or require a local checkout."
+      statusLabel={statusLabel}
+      statusTone={savedConfigured ? (draft.dirty ? "warning" : "success") : "warning"}
+      defaultBranch={draft.defaultBranch}
+      githubDefaultBranch={branches.data?.defaultBranch ?? null}
+      branches={branches.data?.branches ?? []}
+      branchesLoading={branches.isLoading || config.isLoading}
+      branchError={branches.error instanceof Error ? branches.error.message : null}
+      setupScript={draft.setupScript}
+      runCommand={draft.runCommand}
+      envVarRows={draft.envVarRows}
+      saving={saveConfig.isPending}
+      saveDisabled={config.isLoading || saveConfig.isPending || !draft.canSave}
+      revertDisabled={saveConfig.isPending || !draft.dirty}
+      disableDisabled={!draft.configured}
+      error={errorMessage}
+      trackedFileCount={config.data?.trackedFiles.length ?? 0}
+      trackedFilesReadOnly
+      breadcrumb={(
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-auto px-0 py-0 text-sm hover:bg-transparent"
+          onClick={onBack}
+        >
+          Environments / {repoId}
+        </Button>
+      )}
+      onDefaultBranchChange={draft.setDefaultBranch}
+      onSetupScriptChange={draft.setSetupScript}
+      onRunCommandChange={draft.setRunCommand}
+      onAddEnvVar={draft.addEnvVar}
+      onUpdateEnvVar={draft.updateEnvVar}
+      onRemoveEnvVar={draft.removeEnvVar}
+      onSave={() => { void handleSave(); }}
+      onRevert={draft.revert}
+      onDisable={savedConfigured ? draft.disable : undefined}
+    />
+  );
+}
+
+function useCloudEnvironmentCoreDraft(
+  config: CloudRepoConfigResponse | null | undefined,
+  sourceKey: string,
+) {
+  const initial = useMemo(() => buildInitialDraftState(config), [config]);
+  const [state, setState] = useState(() => ({
+    sourceKey,
+    baseline: initial.baseline,
+    revertDraft: initial.revertDraft,
+    draft: initial.draft,
+  }));
+
+  useEffect(() => {
+    const sourceChanged = state.sourceKey !== sourceKey;
+    if (!sourceChanged && !isDraftDirty(state.draft, state.revertDraft)) {
+      setState({
+        sourceKey,
+        baseline: initial.baseline,
+        revertDraft: initial.revertDraft,
+        draft: initial.draft,
+      });
+      return;
+    }
+    if (sourceChanged) {
+      setState({
+        sourceKey,
+        baseline: initial.baseline,
+        revertDraft: initial.revertDraft,
+        draft: initial.draft,
+      });
+    }
+  }, [initial, sourceKey, state.draft, state.revertDraft, state.sourceKey]);
+
+  const envVars = useMemo(() => (
+    Object.fromEntries(
+      state.draft.envVarRows
+        .map((row) => [row.key.trim(), row.value] as const)
+        .filter(([key]) => key.length > 0),
+    )
+  ), [state.draft.envVarRows]);
+  const normalizedDraft = useMemo(() => ({
+    ...state.draft,
+    envVarRows: buildEnvVarRows(envVars),
+  }), [envVars, state.draft]);
+  const dirty = isDraftDirty(normalizedDraft, state.revertDraft);
+  const configurable = !state.baseline.configured && normalizedDraft.configured;
+
+  function patch(patch: Partial<Omit<CloudEnvironmentDraftState, "envVarRows">>) {
+    setState((current) => ({
+      ...current,
+      draft: {
+        ...current.draft,
+        ...patch,
+        configured: patch.configured ?? true,
+      },
+    }));
+  }
+
+  return {
+    configured: normalizedDraft.configured,
+    defaultBranch: normalizedDraft.defaultBranch,
+    setupScript: normalizedDraft.setupScript,
+    runCommand: normalizedDraft.runCommand,
+    envVarRows: state.draft.envVarRows,
+    envVars,
+    dirty,
+    canSave: dirty || configurable,
+    setDefaultBranch: (defaultBranch: string | null) => patch({ defaultBranch }),
+    setSetupScript: (setupScript: string) => patch({ setupScript }),
+    setRunCommand: (runCommand: string) => patch({ runCommand }),
+    addEnvVar: () => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: [...current.draft.envVarRows, { id: createRowId(), key: "", value: "" }],
+        },
+      }));
+    },
+    updateEnvVar: (
+      rowId: string,
+      rowPatch: Partial<Pick<CloudEnvironmentEnvVarRowView, "key" | "value">>,
+    ) => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: current.draft.envVarRows.map((row) =>
+            row.id === rowId ? { ...row, ...rowPatch } : row),
+        },
+      }));
+    },
+    removeEnvVar: (rowId: string) => {
+      setState((current) => ({
+        ...current,
+        draft: {
+          ...current.draft,
+          configured: true,
+          envVarRows: current.draft.envVarRows.filter((row) => row.id !== rowId),
+        },
+      }));
+    },
+    revert: () => {
+      setState((current) => ({
+        ...current,
+        draft: current.revertDraft,
+      }));
+    },
+    disable: () => patch({ configured: false }),
+    reset: (nextConfig: CloudRepoConfigResponse) => {
+      const next = buildInitialDraftState(nextConfig);
+      setState({
+        sourceKey,
+        baseline: next.baseline,
+        revertDraft: next.revertDraft,
+        draft: next.draft,
+      });
+    },
+  };
+}
+
+function buildInitialDraftState(
+  config: CloudRepoConfigResponse | null | undefined,
+): {
+  baseline: CloudEnvironmentDraftState;
+  revertDraft: CloudEnvironmentDraftState;
+  draft: CloudEnvironmentDraftState;
+} {
+  const baseline = buildSavedDraft(config);
+  if (baseline.configured) {
+    return {
+      baseline,
+      revertDraft: baseline,
+      draft: baseline,
+    };
+  }
+  const draft = {
+    ...baseline,
+    configured: true,
+  };
+  return {
+    baseline,
+    revertDraft: draft,
+    draft,
+  };
+}
+
+function buildSavedDraft(
+  config: CloudRepoConfigResponse | null | undefined,
+): CloudEnvironmentDraftState {
+  return {
+    configured: config?.configured ?? false,
+    defaultBranch: config?.defaultBranch ?? null,
+    setupScript: config?.setupScript ?? "",
+    runCommand: config?.runCommand ?? "",
+    envVarRows: buildEnvVarRows(config?.envVars ?? {}),
+  };
+}
+
+function buildEnvVarRows(envVars: Record<string, string>): CloudEnvironmentEnvVarRowView[] {
+  return Object.entries(envVars)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ({ id: createRowId(), key, value }));
+}
+
+function isDraftDirty(
+  draft: CloudEnvironmentDraftState,
+  baseline: CloudEnvironmentDraftState,
+): boolean {
+  return draft.configured !== baseline.configured
+    || draft.defaultBranch !== baseline.defaultBranch
+    || draft.setupScript !== baseline.setupScript
+    || draft.runCommand !== baseline.runCommand
+    || JSON.stringify(rowsToEnvVars(draft.envVarRows)) !== JSON.stringify(rowsToEnvVars(baseline.envVarRows));
+}
+
+function rowsToEnvVars(rows: readonly CloudEnvironmentEnvVarRowView[]): Record<string, string> {
+  return Object.fromEntries(
+    rows
+      .map((row) => [row.key.trim(), row.value] as const)
+      .filter(([key]) => key.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function createRowId(): string {
+  return crypto.randomUUID();
+}

--- a/web/src/components/settings/screen/SettingsScreen.tsx
+++ b/web/src/components/settings/screen/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { Apple, CircleUserRound, CreditCard, Github, LifeBuoy, UsersRound } from "lucide-react";
+import { Apple, CircleUserRound, CreditCard, Github, GitBranch, LifeBuoy, UsersRound } from "lucide-react";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -24,8 +24,9 @@ import { routes } from "../../../config/routes";
 import { startWebAuthFlow } from "../../../lib/access/cloud/auth/web-auth-flow";
 import { useAuthToken } from "../../../providers/WebCloudProvider";
 import { BillingSettingsSection } from "./BillingSettingsSection";
+import { EnvironmentsSettingsSection } from "./EnvironmentsSettingsSection";
 
-type SettingsSectionId = "account" | "teams" | "billing" | "support";
+type SettingsSectionId = "account" | "environments" | "teams" | "billing" | "support";
 const SETTINGS_ICON_SIZE = 14;
 
 export function SettingsScreen() {
@@ -77,6 +78,11 @@ export function SettingsScreen() {
                 icon: <CircleUserRound size={SETTINGS_ICON_SIZE} />,
               },
               {
+                id: "environments",
+                label: "Environments",
+                icon: <GitBranch size={SETTINGS_ICON_SIZE} />,
+              },
+              {
                 id: "teams",
                 label: "Teams",
                 icon: <UsersRound size={SETTINGS_ICON_SIZE} />,
@@ -113,6 +119,8 @@ export function SettingsScreen() {
               signOut: () => void signOut(),
             })}
           />
+        ) : activeSection === "environments" ? (
+          <EnvironmentsSettingsSection />
         ) : activeSection === "teams" ? (
           <TeamsSection />
         ) : activeSection === "billing" ? (
@@ -126,7 +134,11 @@ export function SettingsScreen() {
 }
 
 function isSettingsSectionId(value: string | undefined): value is SettingsSectionId {
-  return value === "account" || value === "teams" || value === "billing" || value === "support";
+  return value === "account"
+    || value === "environments"
+    || value === "teams"
+    || value === "billing"
+    || value === "support";
 }
 
 function AccountSection({ props }: { props: AccountSettingsPaneProps }) {


### PR DESCRIPTION
## Summary
- Adds personal cloud environment targets as the canonical Settings > Environments flow for web and desktop.
- Adds shared product-model planning/projection helpers and shared product-ui environment components.
- Adds GitHub repo catalog/config SDK hooks and server validation for branch/config saves with optional tracked files.

## Verification
- pnpm --filter @proliferate/product-model test -- src/environments/cloud-environments.test.ts src/repos/repo-id.test.ts
- pnpm --filter @proliferate/product-ui typecheck
- pnpm --filter @proliferate/product-ui test -- CloudEnvironments.test.tsx
- pnpm --filter @proliferate/web build
- pnpm --filter @proliferate/cloud-sdk-react typecheck
- pnpm --filter proliferate build
- pnpm -C desktop exec vitest run src/lib/domain/settings/navigation.test.ts src/hooks/cloud/workflows/use-save-cloud-repo-config.test.ts
- pnpm -C desktop exec vitest run src/components/settings/panes/EnvironmentsPane.test.tsx src/components/settings/panes/environments/CloudOnlyEnvironmentDetail.test.tsx
- DEBUG=1 JWT_SECRET=test CLOUD_SECRET_KEY=test GITHUB_OAUTH_CLIENT_ID=test GITHUB_OAUTH_CLIENT_SECRET=test uv run --extra dev pytest -q tests/unit/test_repos_service.py tests/unit/test_github_integration.py tests/integration/test_cloud_api.py::TestCloudRepoCatalog::test_list_cloud_repositories_marks_repo_config_state tests/integration/test_cloud_api.py::TestCloudRepoConfig::test_free_plan_repo_config_limit_blocks_second_configured_repo tests/integration/test_cloud_target_config_api.py
- git diff --check

Manual smoke covered Web Settings > Environments and Home shortcut with the mock API. Desktop coverage is via focused component/navigation tests.
