### PR TITLE
feat(desktop): show workspace activity in Dock badge

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -45,9 +45,13 @@ uuid.workspace = true
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = [
   "NSApplication",
+  "NSDockTile",
   "NSMenu",
   "NSMenuItem",
   "NSView",
   "NSWindow",
 ] }
-objc2-foundation = { version = "0.3.2", features = ["NSProcessInfo", "NSString"] }
+objc2-foundation = { version = "0.3.2", features = [
+  "NSProcessInfo",
+  "NSString",
+] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod sidecar;
 mod state;
 mod telemetry;
 mod telemetry_file_logging;
+mod workspace_activity_indicator;
 
 use commands::{
     anonymous_telemetry, cloud_worker, config, diagnostics as diagnostics_commands,
@@ -20,7 +21,7 @@ use tauri::Manager;
 #[cfg(target_os = "macos")]
 use tauri::{
     menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder},
-    AppHandle, Emitter, Runtime,
+    AppHandle, Emitter, RunEvent, Runtime,
 };
 #[cfg(any(target_os = "linux", windows))]
 use tauri_plugin_deep_link::DeepLinkExt;
@@ -212,6 +213,7 @@ pub fn run() {
         .manage(sc.clone())
         .manage(cloud_worker_state)
         .manage(QuitFlowState::default())
+        .manage(workspace_activity_indicator::WorkspaceActivityIndicatorStore::default())
         .manage(ssh_tunnel::SshTunnelState::default())
         .invoke_handler(tauri::generate_handler![
             anonymous_telemetry::load_anonymous_telemetry_bootstrap,
@@ -228,6 +230,7 @@ pub fn run() {
             workspace_scratch::read_workspace_scratch_pad,
             workspace_scratch::write_workspace_scratch_pad,
             quit_flow::set_running_agent_count,
+            workspace_activity_indicator::set_workspace_activity_indicator,
             shell::pick_folder,
             shell::copy_text,
             shell::list_available_editors,
@@ -311,6 +314,16 @@ pub fn run() {
         .expect("error while running tauri application")
         .run(|_app_handle, _event| {
             #[cfg(target_os = "macos")]
-            quit_flow::handle_run_event(_app_handle, _event);
+            {
+                if matches!(_event, RunEvent::Ready) {
+                    if let Err(error) = workspace_activity_indicator::setup(_app_handle) {
+                        tracing::warn!(
+                            %error,
+                            "failed to initialize workspace activity indicator on app ready"
+                        );
+                    }
+                }
+                quit_flow::handle_run_event(_app_handle, _event);
+            }
         });
 }

--- a/desktop/src-tauri/src/workspace_activity_indicator.rs
+++ b/desktop/src-tauri/src/workspace_activity_indicator.rs
@@ -1,0 +1,213 @@
+use serde::Deserialize;
+use std::sync::Mutex;
+
+#[cfg(target_os = "macos")]
+use objc2::MainThreadMarker;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSApplication;
+#[cfg(target_os = "macos")]
+use objc2_foundation::NSString;
+#[cfg(target_os = "macos")]
+use tauri::Manager;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceActivityIndicatorState {
+    Idle,
+    Attention,
+}
+
+#[derive(Debug, Default)]
+struct WorkspaceActivityIndicatorCache {
+    state: Option<WorkspaceActivityIndicatorState>,
+    attention_count: Option<u32>,
+}
+
+impl WorkspaceActivityIndicatorCache {
+    fn needs_update(
+        &self,
+        state: WorkspaceActivityIndicatorState,
+        attention_count: Option<u32>,
+    ) -> bool {
+        self.state != Some(state) || self.attention_count != attention_count
+    }
+
+    fn remember(&mut self, state: WorkspaceActivityIndicatorState, attention_count: Option<u32>) {
+        self.state = Some(state);
+        self.attention_count = attention_count;
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct WorkspaceActivityIndicatorStore {
+    cache: Mutex<WorkspaceActivityIndicatorCache>,
+}
+
+impl WorkspaceActivityIndicatorStore {
+    #[cfg(target_os = "macos")]
+    fn apply_macos_dock_badge(
+        state: WorkspaceActivityIndicatorState,
+        attention_count: Option<u32>,
+        mtm: MainThreadMarker,
+    ) -> Result<(), String> {
+        let app = NSApplication::sharedApplication(mtm);
+        let dock_tile = app.dockTile();
+        match dock_badge_label(state, attention_count) {
+            Some(label) => {
+                let label = NSString::from_str(&label);
+                dock_tile.setBadgeLabel(Some(&label));
+            }
+            None => dock_tile.setBadgeLabel(None),
+        }
+        dock_tile.display();
+        Ok(())
+    }
+
+    fn cached_payload_or_default(
+        &self,
+    ) -> Result<(WorkspaceActivityIndicatorState, Option<u32>), String> {
+        let mut cache = self
+            .cache
+            .lock()
+            .map_err(|_| "workspace activity indicator cache lock poisoned".to_string())?;
+        let state = cache.state.unwrap_or(WorkspaceActivityIndicatorState::Idle);
+        let attention_count = cache.attention_count;
+        cache.remember(state, attention_count);
+        Ok((state, attention_count))
+    }
+}
+
+pub fn setup(app: &tauri::AppHandle) -> tauri::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let store = app.state::<WorkspaceActivityIndicatorStore>();
+        let mtm = MainThreadMarker::new().ok_or_else(|| {
+            std::io::Error::other("workspace activity indicator setup must run on the main thread")
+        })?;
+        let (state, attention_count) = store
+            .cached_payload_or_default()
+            .map_err(std::io::Error::other)?;
+        WorkspaceActivityIndicatorStore::apply_macos_dock_badge(state, attention_count, mtm)
+            .map_err(std::io::Error::other)?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+    }
+
+    Ok(())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn set_workspace_activity_indicator(
+    app: tauri::AppHandle,
+    store: tauri::State<'_, WorkspaceActivityIndicatorStore>,
+    state: WorkspaceActivityIndicatorState,
+    attention_count: Option<u32>,
+) -> Result<(), String> {
+    let mut cache = store
+        .cache
+        .lock()
+        .map_err(|_| "workspace activity indicator cache lock poisoned".to_string())?;
+    if !cache.needs_update(state, attention_count) {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        app.run_on_main_thread(move || {
+            let result = MainThreadMarker::new()
+                .ok_or_else(|| {
+                    "workspace activity indicator update must run on the main thread".to_string()
+                })
+                .and_then(|mtm| {
+                    WorkspaceActivityIndicatorStore::apply_macos_dock_badge(
+                        state,
+                        attention_count,
+                        mtm,
+                    )
+                });
+            let _ = sender.send(result);
+        })
+        .map_err(|error| error.to_string())?;
+        receiver
+            .recv()
+            .map_err(|_| "workspace activity indicator update did not complete".to_string())??;
+        tracing::info!(
+            ?state,
+            attention_count = attention_count.unwrap_or(0),
+            "updated workspace activity Dock badge"
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+    }
+
+    cache.remember(state, attention_count);
+    Ok(())
+}
+
+fn dock_badge_label(
+    state: WorkspaceActivityIndicatorState,
+    attention_count: Option<u32>,
+) -> Option<String> {
+    match state {
+        WorkspaceActivityIndicatorState::Idle => None,
+        WorkspaceActivityIndicatorState::Attention => {
+            Some(attention_count.unwrap_or(1).max(1).to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_known_indicator_states() {
+        let idle: WorkspaceActivityIndicatorState = serde_json::from_str("\"idle\"").unwrap();
+        let attention: WorkspaceActivityIndicatorState =
+            serde_json::from_str("\"attention\"").unwrap();
+
+        assert_eq!(idle, WorkspaceActivityIndicatorState::Idle);
+        assert_eq!(attention, WorkspaceActivityIndicatorState::Attention);
+    }
+
+    #[test]
+    fn rejects_unknown_indicator_states() {
+        let parsed = serde_json::from_str::<WorkspaceActivityIndicatorState>("\"busy\"");
+
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn repeated_identical_state_does_not_need_an_update() {
+        let mut cache = WorkspaceActivityIndicatorCache::default();
+
+        assert!(cache.needs_update(WorkspaceActivityIndicatorState::Idle, None));
+        cache.remember(WorkspaceActivityIndicatorState::Idle, Some(0));
+
+        assert!(!cache.needs_update(WorkspaceActivityIndicatorState::Idle, Some(0)));
+        assert!(cache.needs_update(WorkspaceActivityIndicatorState::Attention, Some(1)));
+    }
+
+    #[test]
+    fn formats_dock_badge_label() {
+        assert_eq!(
+            dock_badge_label(WorkspaceActivityIndicatorState::Idle, Some(3)),
+            None
+        );
+        assert_eq!(
+            dock_badge_label(WorkspaceActivityIndicatorState::Attention, Some(3)),
+            Some("3".to_string())
+        );
+        assert_eq!(
+            dock_badge_label(WorkspaceActivityIndicatorState::Attention, Some(0)),
+            Some("1".to_string())
+        );
+    }
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import { UpdateRestartDialog } from "@/components/feedback/UpdateRestartDialog"
 import { MacWindowControlsSafeArea } from "@/components/ui/MacWindowControlsSafeArea"
 import { applyAppearancePreference, initializeTheme } from "@/config/theme"
 import { useExportRunningAgentCount } from "@/hooks/app/lifecycle/use-export-running-agent-count"
+import { useWorkspaceActivityIndicator } from "@/hooks/app/lifecycle/use-workspace-activity-indicator"
 import { useAppShortcuts } from "@/hooks/app/lifecycle/use-app-shortcuts"
 import { useAppCommandActions } from "@/hooks/app/workflows/use-app-command-actions"
 import { useAuthBootstrap } from "@/hooks/auth/lifecycle/use-auth-bootstrap"
@@ -280,6 +281,7 @@ function AppRuntime() {
         <ShortcutRevealProvider>
           <MacWindowControlsSafeArea />
           <UpdateRestartDialog />
+          <WorkspaceActivityIndicatorMount />
           <RuntimeInputSyncGate />
           <WorktreeCleanupPolicySyncGate />
           <InstrumentedRoutes>
@@ -325,6 +327,13 @@ function AppRuntime() {
       </AppCommandActionsProvider>
     </>
   )
+}
+
+function WorkspaceActivityIndicatorMount() {
+  recordBootDiagnosticOnce("app_runtime.render.before.use_workspace_activity_indicator")
+  useWorkspaceActivityIndicator()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_workspace_activity_indicator")
+  return null
 }
 
 function RuntimeInputSyncGate() {

--- a/desktop/src/hooks/access/tauri/dock/use-dock-actions.ts
+++ b/desktop/src/hooks/access/tauri/dock/use-dock-actions.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+import {
+  setWorkspaceActivityIndicator,
+} from "@/lib/access/tauri/dock";
+
+export function useTauriDockActions() {
+  return useMemo(() => ({
+    setWorkspaceActivityIndicator,
+  }), []);
+}

--- a/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.test.tsx
+++ b/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetWorkspaceActivityIndicatorExportForTests,
+  useWorkspaceActivityIndicator,
+} from "@/hooks/app/lifecycle/use-workspace-activity-indicator";
+import { createDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
+import {
+  makeLocalLogicalWorkspace,
+} from "@/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
+
+const tauriMocks = vi.hoisted(() => ({
+  setWorkspaceActivityIndicator: vi.fn(async () => undefined),
+}));
+
+const harnessState = vi.hoisted(() => ({
+  logicalWorkspaces: [] as unknown[],
+  logicalWorkspacesLoading: false,
+  workspaceActivities: {} as Record<string, string>,
+  workspaceUi: {
+    _hydrated: true,
+    archivedWorkspaceIds: [] as string[],
+    hiddenRepoRootIds: [] as string[],
+    lastViewedAt: {} as Record<string, string>,
+    lastViewedSessionErrorAtBySession: {} as Record<string, string>,
+    sessionLastInteracted: {} as Record<string, string>,
+    sessionLastViewedAt: {} as Record<string, string>,
+    workspaceLastInteracted: {} as Record<string, string>,
+    workspaceTypes: ["local", "worktree", "cloud", "ssh"],
+  },
+  deferredHome: {
+    launches: {} as Record<string, { workspaceId: string }>,
+  },
+  sessionSelection: {
+    _hydrated: true,
+    selectedLogicalWorkspaceId: null as string | null,
+  },
+  sessionDirectory: {
+    entriesById: {} as Record<string, ReturnType<typeof createDirectoryEntry>>,
+  },
+}));
+
+vi.mock("@/hooks/access/tauri/dock/use-dock-actions", () => ({
+  useTauriDockActions: () => ({
+    setWorkspaceActivityIndicator: tauriMocks.setWorkspaceActivityIndicator,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-logical-workspaces", () => ({
+  useLogicalWorkspaces: () => ({
+    logicalWorkspaces: harnessState.logicalWorkspaces,
+    isLoading: harnessState.logicalWorkspacesLoading,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-sidebar-activities", () => ({
+  useWorkspaceSidebarActivityStatesWithErrorAttention: () =>
+    harnessState.workspaceActivities,
+}));
+
+vi.mock("@/stores/preferences/workspace-ui-store", () => ({
+  useWorkspaceUiStore: (selector: (state: typeof harnessState.workspaceUi) => unknown) =>
+    selector(harnessState.workspaceUi),
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: typeof harnessState.sessionSelection) => unknown,
+  ) => selector(harnessState.sessionSelection),
+}));
+
+vi.mock("@/stores/sessions/session-directory-store", () => ({
+  useSessionDirectoryStore: (
+    selector: (state: typeof harnessState.sessionDirectory) => unknown,
+  ) => selector(harnessState.sessionDirectory),
+}));
+
+vi.mock("@/stores/home/deferred-home-launch-store", () => ({
+  useDeferredHomeLaunchStore: (
+    selector: (state: typeof harnessState.deferredHome) => unknown,
+  ) => selector(harnessState.deferredHome),
+}));
+
+describe("useWorkspaceActivityIndicator", () => {
+  beforeEach(() => {
+    harnessState.logicalWorkspaces = [];
+    harnessState.logicalWorkspacesLoading = false;
+    harnessState.workspaceActivities = {};
+    harnessState.workspaceUi = {
+      _hydrated: true,
+      archivedWorkspaceIds: [],
+      hiddenRepoRootIds: [],
+      lastViewedAt: {},
+      lastViewedSessionErrorAtBySession: {},
+      sessionLastInteracted: {},
+      sessionLastViewedAt: {},
+      workspaceLastInteracted: {},
+      workspaceTypes: ["local", "worktree", "cloud", "ssh"],
+    };
+    harnessState.deferredHome = {
+      launches: {},
+    };
+    harnessState.sessionSelection = {
+      _hydrated: true,
+      selectedLogicalWorkspaceId: null,
+    };
+    harnessState.sessionDirectory = {
+      entriesById: {},
+    };
+    tauriMocks.setWorkspaceActivityIndicator.mockReset();
+    tauriMocks.setWorkspaceActivityIndicator.mockResolvedValue(undefined);
+    resetWorkspaceActivityIndicatorExportForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("exports native state only when the aggregate payload changes", async () => {
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "review-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.workspaceUi.workspaceLastInteracted = {
+      "review-workspace-materialization": "2026-04-13T10:00:00.000Z",
+    };
+    harnessState.workspaceUi.lastViewedAt = {
+      "review-workspace": "2026-04-13T10:05:00.000Z",
+    };
+
+    const { rerender } = renderHook(() => useWorkspaceActivityIndicator());
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "idle",
+      attentionCount: 0,
+    });
+
+    rerender();
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+
+    harnessState.workspaceUi = {
+      ...harnessState.workspaceUi,
+      workspaceLastInteracted: {
+        "review-workspace-materialization": "2026-04-13T10:10:00.000Z",
+      },
+      lastViewedAt: {
+        "review-workspace": "2026-04-13T10:05:00.000Z",
+      },
+    };
+    rerender();
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(2);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+
+    rerender();
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for workspace UI hydration before exporting native state", async () => {
+    harnessState.workspaceUi = {
+      ...harnessState.workspaceUi,
+      _hydrated: false,
+    };
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "deferred-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.workspaceActivities = {
+      "deferred-workspace-materialization": "waiting_input",
+    };
+
+    const { rerender } = renderHook(() => useWorkspaceActivityIndicator());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tauriMocks.setWorkspaceActivityIndicator).not.toHaveBeenCalled();
+
+    harnessState.workspaceUi = {
+      ...harnessState.workspaceUi,
+      _hydrated: true,
+    };
+    rerender();
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("waits for session selection hydration before exporting native state", async () => {
+    harnessState.sessionSelection = {
+      ...harnessState.sessionSelection,
+      _hydrated: false,
+    };
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "selected-filtered-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.workspaceUi.workspaceTypes = ["cloud"];
+    harnessState.workspaceActivities = {
+      "selected-filtered-workspace-materialization": "waiting_input",
+    };
+
+    const { rerender } = renderHook(() => useWorkspaceActivityIndicator());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tauriMocks.setWorkspaceActivityIndicator).not.toHaveBeenCalled();
+
+    harnessState.sessionSelection = {
+      _hydrated: true,
+      selectedLogicalWorkspaceId: "selected-filtered-workspace",
+    };
+    rerender();
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("waits for logical workspaces to finish loading before exporting native state", async () => {
+    harnessState.logicalWorkspacesLoading = true;
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "loading-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.workspaceActivities = {
+      "loading-workspace-materialization": "waiting_input",
+    };
+
+    const { rerender } = renderHook(() => useWorkspaceActivityIndicator());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tauriMocks.setWorkspaceActivityIndicator).not.toHaveBeenCalled();
+
+    harnessState.logicalWorkspacesLoading = false;
+    rerender();
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("exports attention for unread session activity", async () => {
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "session-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.sessionDirectory.entriesById = {
+      "session-1": createDirectoryEntry({
+        sessionId: "session-1",
+        workspaceId: "session-workspace-materialization",
+        agentKind: "codex",
+      }),
+    };
+    harnessState.workspaceUi.sessionLastInteracted = {
+      "session-1": "2026-04-13T10:10:00.000Z",
+    };
+    harnessState.workspaceUi.sessionLastViewedAt = {
+      "session-1": "2026-04-13T10:00:00.000Z",
+    };
+
+    renderHook(() => useWorkspaceActivityIndicator());
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("does not cache failed native exports as completed", async () => {
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "retry-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+    harnessState.workspaceActivities = {
+      "retry-workspace-materialization": "waiting_input",
+    };
+    tauriMocks.setWorkspaceActivityIndicator.mockRejectedValueOnce(new Error("native failed"));
+
+    const first = renderHook(() => useWorkspaceActivityIndicator());
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    first.unmount();
+
+    renderHook(() => useWorkspaceActivityIndicator());
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(2);
+    });
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenLastCalledWith({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("does not re-export the same payload after remounting", async () => {
+    harnessState.logicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "quiet-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+    ];
+
+    const first = renderHook(() => useWorkspaceActivityIndicator());
+
+    await waitFor(() => {
+      expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+    });
+    first.unmount();
+
+    renderHook(() => useWorkspaceActivityIndicator());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tauriMocks.setWorkspaceActivityIndicator).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.ts
+++ b/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.ts
@@ -1,0 +1,168 @@
+import { useEffect, useMemo } from "react";
+import { resolveSessionSidebarActivityState } from "@proliferate/product-model/sessions/activity";
+import { useShallow } from "zustand/react/shallow";
+import { useTauriDockActions } from "@/hooks/access/tauri/dock/use-dock-actions";
+import { useLogicalWorkspaces } from "@/hooks/workspaces/derived/use-logical-workspaces";
+import { useWorkspaceSidebarActivityStatesWithErrorAttention } from "@/hooks/workspaces/derived/use-workspace-sidebar-activities";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import {
+  buildWorkspaceActivityIndicatorSnapshot,
+} from "@/lib/domain/workspaces/sidebar/workspace-activity-indicator";
+import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+const EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION: Record<string, string> = {};
+let lastWorkspaceActivityIndicatorPayloadSignature: string | null = null;
+let pendingWorkspaceActivityIndicatorPayloadSignature: string | null = null;
+
+export function resetWorkspaceActivityIndicatorExportForTests(): void {
+  lastWorkspaceActivityIndicatorPayloadSignature = null;
+  pendingWorkspaceActivityIndicatorPayloadSignature = null;
+}
+
+export function useWorkspaceActivityIndicator(): void {
+  const { setWorkspaceActivityIndicator } = useTauriDockActions();
+  const {
+    logicalWorkspaces,
+    isLoading: logicalWorkspacesLoading,
+  } = useLogicalWorkspaces();
+  const {
+    archivedWorkspaceIds,
+    hiddenRepoRootIds,
+    hydrated: workspaceUiHydrated,
+    lastViewedAt,
+    lastViewedSessionErrorAtBySession,
+    sessionLastInteracted,
+    sessionLastViewedAt,
+    workspaceLastInteracted,
+    workspaceTypes,
+  } = useWorkspaceUiStore(useShallow((state) => ({
+    archivedWorkspaceIds: state.archivedWorkspaceIds,
+    hiddenRepoRootIds: state.hiddenRepoRootIds,
+    hydrated: state._hydrated,
+    lastViewedAt: state.lastViewedAt,
+    lastViewedSessionErrorAtBySession:
+      state.lastViewedSessionErrorAtBySession
+      ?? EMPTY_LAST_VIEWED_SESSION_ERROR_AT_BY_SESSION,
+    sessionLastInteracted: state.sessionLastInteracted,
+    sessionLastViewedAt: state.sessionLastViewedAt,
+    workspaceLastInteracted: state.workspaceLastInteracted,
+    workspaceTypes: state.workspaceTypes,
+  })));
+  const {
+    hydrated: sessionSelectionHydrated,
+    selectedLogicalWorkspaceId,
+  } = useSessionSelectionStore(useShallow((state) => ({
+    hydrated: state._hydrated,
+    selectedLogicalWorkspaceId: state.selectedLogicalWorkspaceId,
+  })));
+  const workspaceActivities = useWorkspaceSidebarActivityStatesWithErrorAttention(
+    lastViewedSessionErrorAtBySession,
+  );
+  const sessionEntriesById = useSessionDirectoryStore((state) => state.entriesById);
+  const deferredLaunchesById = useDeferredHomeLaunchStore((state) => state.launches);
+
+  const archivedSet = useMemo(
+    () => new Set(archivedWorkspaceIds),
+    [archivedWorkspaceIds],
+  );
+  const hiddenRepoRootSet = useMemo(
+    () => new Set(hiddenRepoRootIds),
+    [hiddenRepoRootIds],
+  );
+  const pendingPromptCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const launch of Object.values(deferredLaunchesById)) {
+      counts[launch.workspaceId] = (counts[launch.workspaceId] ?? 0) + 1;
+    }
+    return counts;
+  }, [deferredLaunchesById]);
+  const sessionActivityInputs = useMemo(() => {
+    const sessionWorkspaceIds: Record<string, string | null> = {};
+    const sessionActivities: Record<string, ReturnType<typeof resolveSessionSidebarActivityState>> = {};
+    for (const entry of Object.values(sessionEntriesById)) {
+      sessionWorkspaceIds[entry.sessionId] = entry.workspaceId;
+      const activity = resolveSessionSidebarActivityState(
+        activitySnapshotFromDirectoryEntry(entry),
+      );
+      sessionActivities[entry.sessionId] =
+        activity === "error"
+          && entry.activity.errorAttentionKey !== null
+          && lastViewedSessionErrorAtBySession[entry.sessionId] === entry.activity.errorAttentionKey
+          ? "idle"
+          : activity;
+    }
+    return { sessionActivities, sessionWorkspaceIds };
+  }, [lastViewedSessionErrorAtBySession, sessionEntriesById]);
+
+  const snapshot = useMemo(() => buildWorkspaceActivityIndicatorSnapshot({
+    logicalWorkspaces,
+    workspaceActivities,
+    pendingPromptCounts,
+    archivedSet,
+    hiddenRepoRootIds: hiddenRepoRootSet,
+    selectedLogicalWorkspaceId,
+    workspaceTypes,
+    lastViewedAt,
+    workspaceLastInteracted,
+    sessionWorkspaceIds: sessionActivityInputs.sessionWorkspaceIds,
+    sessionActivities: sessionActivityInputs.sessionActivities,
+    sessionLastInteracted,
+    sessionLastViewedAt,
+  }), [
+    archivedSet,
+    hiddenRepoRootSet,
+    lastViewedAt,
+    logicalWorkspaces,
+    pendingPromptCounts,
+    selectedLogicalWorkspaceId,
+    sessionActivityInputs.sessionActivities,
+    sessionActivityInputs.sessionWorkspaceIds,
+    sessionLastInteracted,
+    sessionLastViewedAt,
+    workspaceActivities,
+    workspaceLastInteracted,
+    workspaceTypes,
+  ]);
+
+  useEffect(() => {
+    if (!workspaceUiHydrated || !sessionSelectionHydrated || logicalWorkspacesLoading) {
+      return;
+    }
+
+    const signature = `${snapshot.state}\u001f${snapshot.attentionCount}`;
+    if (
+      lastWorkspaceActivityIndicatorPayloadSignature === signature
+      || pendingWorkspaceActivityIndicatorPayloadSignature === signature
+    ) {
+      return;
+    }
+
+    pendingWorkspaceActivityIndicatorPayloadSignature = signature;
+    const payload = {
+      state: snapshot.state,
+      attentionCount: snapshot.attentionCount,
+    };
+    void setWorkspaceActivityIndicator(payload)
+      .then(() => {
+        if (pendingWorkspaceActivityIndicatorPayloadSignature === signature) {
+          lastWorkspaceActivityIndicatorPayloadSignature = signature;
+          pendingWorkspaceActivityIndicatorPayloadSignature = null;
+        }
+      })
+      .catch(() => {
+        if (pendingWorkspaceActivityIndicatorPayloadSignature === signature) {
+          pendingWorkspaceActivityIndicatorPayloadSignature = null;
+        }
+      });
+  }, [
+    setWorkspaceActivityIndicator,
+    logicalWorkspacesLoading,
+    snapshot.attentionCount,
+    snapshot.state,
+    sessionSelectionHydrated,
+    workspaceUiHydrated,
+  ]);
+}

--- a/desktop/src/lib/access/tauri/dock.test.ts
+++ b/desktop/src/lib/access/tauri/dock.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  setWorkspaceActivityIndicator,
+} from "@/lib/access/tauri/dock";
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriMocks.invoke,
+}));
+
+describe("setWorkspaceActivityIndicator", () => {
+  beforeEach(() => {
+    tauriMocks.invoke.mockReset();
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("does nothing outside the Tauri desktop runtime", async () => {
+    await setWorkspaceActivityIndicator({
+      state: "attention",
+      attentionCount: 1,
+    });
+
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+  });
+
+  it("invokes the native Dock badge command when Tauri is available", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+
+    await setWorkspaceActivityIndicator({
+      state: "attention",
+      attentionCount: 1,
+    });
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith(
+      "set_workspace_activity_indicator",
+      {
+        state: "attention",
+        attentionCount: 1,
+      },
+    );
+  });
+});

--- a/desktop/src/lib/access/tauri/dock.ts
+++ b/desktop/src/lib/access/tauri/dock.ts
@@ -1,0 +1,25 @@
+export type WorkspaceActivityIndicatorState = "idle" | "attention";
+
+export interface WorkspaceActivityIndicatorPayload {
+  state: WorkspaceActivityIndicatorState;
+  attentionCount: number;
+}
+
+export function isTauriDockApiAvailable(): boolean {
+  return typeof window !== "undefined"
+    && "__TAURI_INTERNALS__" in (window as unknown as Record<string, unknown>);
+}
+
+export async function setWorkspaceActivityIndicator(
+  payload: WorkspaceActivityIndicatorPayload,
+): Promise<void> {
+  if (!isTauriDockApiAvailable()) {
+    return;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("set_workspace_activity_indicator", {
+    state: payload.state,
+    attentionCount: payload.attentionCount,
+  });
+}

--- a/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkspaceActivityIndicatorSnapshot,
+} from "@/lib/domain/workspaces/sidebar/workspace-activity-indicator";
+import {
+  DEFAULT_SIDEBAR_WORKSPACE_TYPES,
+} from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import {
+  makeLocalLogicalWorkspace,
+} from "@/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
+
+function buildSnapshot(
+  overrides: Partial<Parameters<typeof buildWorkspaceActivityIndicatorSnapshot>[0]> = {},
+) {
+  return buildWorkspaceActivityIndicatorSnapshot({
+    logicalWorkspaces: [],
+    workspaceActivities: {},
+    archivedSet: new Set(),
+    hiddenRepoRootIds: new Set(),
+    workspaceTypes: DEFAULT_SIDEBAR_WORKSPACE_TYPES,
+    lastViewedAt: {},
+    workspaceLastInteracted: {},
+    ...overrides,
+  });
+}
+
+describe("workspace activity indicator", () => {
+  it("is idle when all visible workspaces are viewed and idle", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "quiet-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      workspaceLastInteracted: {
+        "quiet-workspace-materialization": "2026-04-13T10:00:00.000Z",
+      },
+      lastViewedAt: {
+        "quiet-workspace": "2026-04-13T10:05:00.000Z",
+      },
+    })).toEqual({
+      state: "idle",
+      attentionCount: 0,
+    });
+  });
+
+  it("reports attention for unread workspace activity", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "unread-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      workspaceLastInteracted: {
+        "unread-workspace-materialization": "2026-04-13T10:10:00.000Z",
+      },
+      lastViewedAt: {
+        "unread-workspace": "2026-04-13T10:00:00.000Z",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("reports attention for waiting input and plan approval", () => {
+    const inputWorkspace = makeLocalLogicalWorkspace({
+      id: "input-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+    const planWorkspace = makeLocalLogicalWorkspace({
+      id: "plan-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [inputWorkspace, planWorkspace],
+      workspaceActivities: {
+        "input-workspace-materialization": "waiting_input",
+        "plan-workspace-materialization": "waiting_plan",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 2,
+    });
+  });
+
+  it("reports attention for active iterating workspace activity", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "iterating-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      workspaceActivities: {
+        "iterating-workspace-materialization": "iterating",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("reports attention for active session activity on the workspace", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "session-active-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      sessionWorkspaceIds: {
+        "session-1": "session-active-workspace-materialization",
+      },
+      sessionActivities: {
+        "session-1": "waiting_input",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("reports attention for unread session activity on the workspace", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "session-unread-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      sessionWorkspaceIds: {
+        "session-1": "session-unread-workspace-materialization",
+      },
+      sessionLastInteracted: {
+        "session-1": "2026-04-13T10:10:00.000Z",
+      },
+      sessionLastViewedAt: {
+        "session-1": "2026-04-13T10:00:00.000Z",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+
+  it("reports attention for errors and queued prompts", () => {
+    const errorWorkspace = makeLocalLogicalWorkspace({
+      id: "error-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+    const queuedWorkspace = makeLocalLogicalWorkspace({
+      id: "queued-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [errorWorkspace, queuedWorkspace],
+      workspaceActivities: {
+        "error-workspace-materialization": "error",
+      },
+      pendingPromptCounts: {
+        "queued-workspace": 1,
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 2,
+    });
+  });
+
+  it("ignores archived workspaces", () => {
+    const workspace = makeLocalLogicalWorkspace({
+      id: "archived-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [workspace],
+      workspaceActivities: {
+        "archived-workspace-materialization": "error",
+      },
+      archivedSet: new Set(["archived-workspace"]),
+    })).toMatchObject({
+      state: "idle",
+      attentionCount: 0,
+    });
+  });
+
+  it("includes the active non-archived workspace even when its variant is filtered out", () => {
+    const activeWorkspace = makeLocalLogicalWorkspace({
+      id: "active-local-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+    const filteredWorkspace = makeLocalLogicalWorkspace({
+      id: "filtered-local-workspace",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+    });
+
+    expect(buildSnapshot({
+      logicalWorkspaces: [activeWorkspace, filteredWorkspace],
+      selectedLogicalWorkspaceId: "active-local-workspace",
+      workspaceTypes: ["cloud"],
+      workspaceActivities: {
+        "active-local-workspace-materialization": "waiting_input",
+        "filtered-local-workspace-materialization": "error",
+      },
+    })).toMatchObject({
+      state: "attention",
+      attentionCount: 1,
+    });
+  });
+});

--- a/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts
@@ -1,0 +1,181 @@
+import type { SidebarSessionActivityState } from "@proliferate/product-model/sessions/activity";
+import {
+  latestLogicalWorkspaceTimestamp,
+  logicalWorkspaceMatchesId,
+  logicalWorkspaceRelatedIds,
+} from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
+import {
+  activeWorkspaceActivity,
+  sidebarStatusIndicatorFromActivity,
+  sidebarWorkspaceVariantForLogicalWorkspace,
+  type SidebarStatusIndicator,
+  type SidebarWorkspaceVariant,
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
+import { isWorkspaceNeedsReview } from "@/lib/domain/workspaces/sidebar/sidebar-review";
+import { resolveLogicalWorkspaceRecency } from "@/lib/domain/workspaces/sidebar/recency";
+import { resolveSidebarWorkspaceTypes } from "@/lib/domain/workspaces/sidebar/sidebar-workspace-types";
+
+export type WorkspaceActivityIndicatorState = "idle" | "attention";
+
+export interface WorkspaceActivityIndicatorSnapshot {
+  state: WorkspaceActivityIndicatorState;
+  attentionCount: number;
+}
+
+export interface BuildWorkspaceActivityIndicatorSnapshotArgs {
+  logicalWorkspaces: readonly LogicalWorkspace[];
+  workspaceActivities: Record<string, SidebarSessionActivityState>;
+  pendingPromptCounts?: Record<string, number>;
+  archivedSet: ReadonlySet<string>;
+  hiddenRepoRootIds: ReadonlySet<string>;
+  selectedLogicalWorkspaceId?: string | null;
+  workspaceTypes: readonly SidebarWorkspaceVariant[] | null | undefined;
+  lastViewedAt: Record<string, string>;
+  workspaceLastInteracted: Record<string, string>;
+  sessionWorkspaceIds?: Readonly<Record<string, string | null | undefined>>;
+  sessionActivities?: Readonly<Record<string, SidebarSessionActivityState>>;
+  sessionLastInteracted?: Readonly<Record<string, string>>;
+  sessionLastViewedAt?: Readonly<Record<string, string>>;
+}
+
+const ATTENTION_STATUS_KINDS: ReadonlySet<SidebarStatusIndicator["kind"]> = new Set([
+  "error",
+  "iterating",
+  "waiting_input",
+  "waiting_plan",
+  "queued_prompt",
+  "needs_review",
+]);
+
+const ATTENTION_SESSION_ACTIVITY_STATES: ReadonlySet<SidebarSessionActivityState> = new Set([
+  "error",
+  "iterating",
+  "waiting_input",
+  "waiting_plan",
+]);
+
+export function buildWorkspaceActivityIndicatorSnapshot(
+  args: BuildWorkspaceActivityIndicatorSnapshotArgs,
+): WorkspaceActivityIndicatorSnapshot {
+  const visibleWorkspaceTypes = new Set(resolveSidebarWorkspaceTypes(args.workspaceTypes));
+  let attentionCount = 0;
+
+  for (const workspace of args.logicalWorkspaces) {
+    const relatedIds = logicalWorkspaceRelatedIds(workspace);
+    const relatedIdSet = new Set(relatedIds);
+    const archived = isLogicalWorkspaceArchived(relatedIds, args.archivedSet);
+    const active = logicalWorkspaceMatchesId(workspace, args.selectedLogicalWorkspaceId);
+    const variant = sidebarWorkspaceVariantForLogicalWorkspace(workspace);
+    if (
+      archived
+      || isLogicalWorkspaceRepoHidden(workspace, args.hiddenRepoRootIds)
+      || (!active && !visibleWorkspaceTypes.has(variant))
+    ) {
+      continue;
+    }
+
+    const recency = resolveLogicalWorkspaceRecency(workspace, args.workspaceLastInteracted);
+    const needsReview = isWorkspaceNeedsReview({
+      isArchived: archived,
+      lastInteracted: recency.displayAt,
+      lastViewedAt: latestLogicalWorkspaceTimestamp(args.lastViewedAt, workspace),
+    });
+    const statusIndicator = sidebarStatusIndicatorFromActivity({
+      activity: activeWorkspaceActivity(workspace, args.workspaceActivities),
+      needsReview,
+      pendingPromptCount: logicalWorkspaceRelatedCount(args.pendingPromptCounts, workspace),
+    });
+
+    if (
+      needsReview
+      || (statusIndicator && ATTENTION_STATUS_KINDS.has(statusIndicator.kind))
+      || logicalWorkspaceHasAttentionSessionActivity(relatedIdSet, args)
+      || logicalWorkspaceHasUnreadSessionActivity(relatedIdSet, args)
+    ) {
+      attentionCount += 1;
+    }
+  }
+
+  return {
+    state: attentionCount > 0 ? "attention" : "idle",
+    attentionCount,
+  };
+}
+
+function isLogicalWorkspaceArchived(
+  relatedIds: readonly string[],
+  archivedSet: ReadonlySet<string>,
+): boolean {
+  return relatedIds.some((id) => archivedSet.has(id));
+}
+
+function isLogicalWorkspaceRepoHidden(
+  workspace: LogicalWorkspace,
+  hiddenRepoRootIds: ReadonlySet<string>,
+): boolean {
+  return !!workspace.repoRoot?.id && hiddenRepoRootIds.has(workspace.repoRoot.id);
+}
+
+function logicalWorkspaceHasAttentionSessionActivity(
+  relatedIds: ReadonlySet<string>,
+  args: Pick<
+    BuildWorkspaceActivityIndicatorSnapshotArgs,
+    "sessionWorkspaceIds" | "sessionActivities"
+  >,
+): boolean {
+  if (!args.sessionWorkspaceIds || !args.sessionActivities) {
+    return false;
+  }
+
+  for (const [sessionId, workspaceId] of Object.entries(args.sessionWorkspaceIds)) {
+    if (!workspaceId || !relatedIds.has(workspaceId)) {
+      continue;
+    }
+    const activity = args.sessionActivities[sessionId];
+    if (activity && ATTENTION_SESSION_ACTIVITY_STATES.has(activity)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function logicalWorkspaceHasUnreadSessionActivity(
+  relatedIds: ReadonlySet<string>,
+  args: Pick<
+    BuildWorkspaceActivityIndicatorSnapshotArgs,
+    "sessionWorkspaceIds" | "sessionLastInteracted" | "sessionLastViewedAt"
+  >,
+): boolean {
+  if (!args.sessionWorkspaceIds || !args.sessionLastInteracted) {
+    return false;
+  }
+
+  for (const [sessionId, workspaceId] of Object.entries(args.sessionWorkspaceIds)) {
+    if (!workspaceId || !relatedIds.has(workspaceId)) {
+      continue;
+    }
+    const lastInteracted = args.sessionLastInteracted[sessionId];
+    if (!lastInteracted) {
+      continue;
+    }
+    const lastViewed = args.sessionLastViewedAt?.[sessionId];
+    if (!lastViewed || new Date(lastInteracted).getTime() > new Date(lastViewed).getTime()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function logicalWorkspaceRelatedCount(
+  counts: Record<string, number> | undefined,
+  workspace: LogicalWorkspace,
+): number {
+  if (!counts) {
+    return 0;
+  }
+  return logicalWorkspaceRelatedIds(workspace).reduce(
+    (total, id) => total + (counts[id] ?? 0),
+    0,
+  );
+}


### PR DESCRIPTION
## Summary
- add a macOS Dock badge command for workspace activity
- aggregate unread/attention-worthy workspace state in the renderer
- export badge updates from app lifecycle with focused unit coverage

## Verification
- cargo test -p proliferate workspace_activity_indicator
- pnpm --dir desktop exec vitest run src/lib/domain/workspaces/sidebar/workspace-activity-indicator.test.ts src/lib/access/tauri/dock.test.ts src/hooks/app/lifecycle/use-workspace-activity-indicator.test.tsx
- pnpm --dir desktop build
- git diff --check