### PR TITLE
fix(cloud): load backfilled remote sessions

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
@@ -883,10 +883,17 @@ pub async fn list_sessions(
         }
         _ => query.workspace_id.as_deref(),
     };
+    let include_dismissed = query.include_dismissed.unwrap_or(false);
     let records = state
         .session_service
-        .list_sessions(workspace_id, query.include_dismissed.unwrap_or(false))
+        .list_sessions(workspace_id, include_dismissed)
         .map_err(|e| ApiError::internal(e.to_string()))?;
+    tracing::debug!(
+        workspace_id = workspace_id.unwrap_or("<all>"),
+        include_dismissed,
+        session_count = records.len(),
+        "session.http.list.completed"
+    );
     let mut sessions = Vec::with_capacity(records.len());
     for record in &records {
         sessions.push(session_to_contract(&state, record).await?);
@@ -963,7 +970,7 @@ pub async fn list_session_events(
             "UNSUPPORTED_EVENT_HISTORY_WINDOW",
         ));
     }
-    tracing::info!(
+    tracing::debug!(
         session_id = %session_id,
         after_seq,
         before_seq,
@@ -1009,20 +1016,37 @@ pub async fn list_session_events(
         })
         .collect();
 
-    tracing::info!(
-        session_id = %session_id,
-        event_count = envelopes.len(),
-        after_seq,
-        before_seq,
-        limit,
-        turn_limit,
-        elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.events.completed"
-    );
+    if envelopes.is_empty() {
+        tracing::debug!(
+            session_id = %session_id,
+            event_count = envelopes.len(),
+            after_seq,
+            before_seq,
+            limit,
+            turn_limit,
+            elapsed_ms = started.elapsed().as_millis(),
+            flow_id = latency_fields.flow_id,
+                flow_kind = latency_fields.flow_kind,
+                flow_source = latency_fields.flow_source,
+                prompt_id = latency_fields.prompt_id,
+            "[workspace-latency] session.http.events.completed"
+        );
+    } else {
+        tracing::info!(
+            session_id = %session_id,
+            event_count = envelopes.len(),
+            after_seq,
+            before_seq,
+            limit,
+            turn_limit,
+            elapsed_ms = started.elapsed().as_millis(),
+            flow_id = latency_fields.flow_id,
+                flow_kind = latency_fields.flow_kind,
+                flow_source = latency_fields.flow_source,
+                prompt_id = latency_fields.prompt_id,
+            "[workspace-latency] session.http.events.completed"
+        );
+    }
 
     Ok(Json(envelopes))
 }

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 use serde_json::Value;
+use tracing::debug;
 
 use crate::error::WorkerError;
 
@@ -93,6 +94,13 @@ impl AnyHarnessClient {
                 .collect::<std::collections::HashSet<_>>();
             sessions.retain(|session| workspace_ids.contains(session.workspace_id.as_str()));
         }
+        debug!(
+            workspace_id = workspace_id.unwrap_or("<all>"),
+            repo_root_count = repo_roots_by_id.len(),
+            workspace_count = workspaces.len(),
+            session_count = sessions.len(),
+            "anyharness backfill snapshot fetched"
+        );
         Ok(AnyHarnessBackfillSnapshot {
             workspaces,
             repo_roots_by_id,

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/events.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/events.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::debug;
 
 use crate::error::WorkerError;
 
@@ -42,6 +43,18 @@ impl AnyHarnessClient {
             let body = response.text().await.unwrap_or_default();
             return Err(WorkerError::Cloud { status, body });
         }
-        Ok(response.json().await?)
+        let events = response.json::<Vec<SessionEventEnvelope>>().await?;
+        let first_seq = events.first().map(|event| event.seq);
+        let last_seq = events.last().map(|event| event.seq);
+        debug!(
+            session_id,
+            after_seq,
+            limit = ?limit,
+            event_count = events.len(),
+            first_seq = ?first_seq,
+            last_seq = ?last_seq,
+            "anyharness session events fetched"
+        );
+        Ok(events)
     }
 }

--- a/anyharness/crates/proliferate-worker/src/sync/backfill.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/backfill.rs
@@ -40,14 +40,46 @@ pub async fn backfill_exposed_workspace(
     identity: &WorkerIdentity,
     workspace_id: Option<&str>,
 ) -> Result<BackfillResult, WorkerError> {
+    info!(
+        workspace_id = workspace_id.unwrap_or("<all>"),
+        "worker backfill starting"
+    );
     let snapshot = anyharness.backfill_snapshot(workspace_id).await?;
     let request = backfill_request(&snapshot);
+    let requested_workspace_count = request.workspaces.len();
+    let requested_session_count = request.sessions.len();
+    let chunks = backfill_chunks(request);
+    let chunk_count = chunks.len();
+    info!(
+        workspace_id = workspace_id.unwrap_or("<all>"),
+        requested_workspace_count,
+        requested_session_count,
+        chunk_count,
+        "worker backfill snapshot prepared"
+    );
     let mut mapped_workspace_count = 0;
     let mut mapped_session_count = 0;
-    for chunk in backfill_chunks(request) {
+    for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+        let chunk_workspace_count = chunk.workspaces.len();
+        let chunk_session_count = chunk.sessions.len();
+        info!(
+            workspace_id = workspace_id.unwrap_or("<all>"),
+            chunk_index,
+            chunk_count,
+            chunk_workspace_count,
+            chunk_session_count,
+            "worker backfill uploading chunk"
+        );
         let response = cloud
             .upload_backfill(&identity.worker_token, &chunk)
             .await?;
+        info!(
+            workspace_id = workspace_id.unwrap_or("<all>"),
+            chunk_index,
+            mapped_workspace_count = response.mapped_workspaces.len(),
+            mapped_session_count = response.mapped_sessions.len(),
+            "worker backfill chunk mapped"
+        );
         let workspace_mappings = response
             .mapped_workspaces
             .iter()
@@ -68,8 +100,12 @@ pub async fn backfill_exposed_workspace(
         mapped_session_count += response.mapped_sessions.len();
     }
     info!(
+        workspace_id = workspace_id.unwrap_or("<all>"),
+        requested_workspace_count,
+        requested_session_count,
         mapped_workspace_count,
-        mapped_session_count, "worker backfill completed"
+        mapped_session_count,
+        "worker backfill completed"
     );
     Ok(BackfillResult {
         mapped_workspace_count,

--- a/anyharness/crates/proliferate-worker/src/sync/tailer.rs
+++ b/anyharness/crates/proliferate-worker/src/sync/tailer.rs
@@ -93,14 +93,23 @@ async fn reconcile_projection_cursors(
         .exposures
         .first()
         .map(|snapshot| snapshot.cloud_workspace_id.as_str());
+    let exposure_count = response.exposures.len();
+    let workspace_exposure_count = response
+        .exposures
+        .iter()
+        .filter(|snapshot| snapshot.anyharness_session_id.is_none())
+        .count();
     let cursors = response
         .exposures
         .iter()
         .filter_map(projection_cursor_upsert)
         .collect::<Vec<_>>();
+    let session_cursor_count = cursors.len();
     store.reconcile_projection_cursors(&cursors)?;
     debug!(
-        active_exposure_count = cursors.len(),
+        exposure_count,
+        workspace_exposure_count,
+        session_cursor_count,
         max_revision,
         first_target_id,
         first_cloud_workspace_id,
@@ -170,6 +179,15 @@ async fn discover_workspace_sessions_for_exposure(
         .filter(|session| session.workspace_id == workspace_id)
         .filter(|session| !known_sessions.contains(&session.id))
         .count();
+    debug!(
+        exposure_id = %exposure.exposure_id,
+        cloud_workspace_id = %exposure.cloud_workspace_id,
+        workspace_id,
+        snapshot_session_count = snapshot.sessions.len(),
+        known_session_count = known_sessions.len(),
+        missing_session_count,
+        "worker checked exposed workspace for unmapped sessions"
+    );
     if missing_session_count == 0 {
         return Ok(());
     }
@@ -218,6 +236,19 @@ async fn sync_projection_cursor(
     if events.is_empty() {
         return Ok(());
     }
+    let event_count = events.len();
+    let first_seq = events.first().map(|event| event.seq);
+    let last_seq = events.last().map(|event| event.seq);
+    info!(
+        exposure_id = %cursor.exposure_id,
+        session_projection_id = %cursor.session_projection_id,
+        session_id = %cursor.anyharness_session_id,
+        last_uploaded_seq = cursor.last_uploaded_seq,
+        event_count,
+        first_seq = ?first_seq,
+        last_seq = ?last_seq,
+        "worker fetched anyharness events for projection cursor"
+    );
     if let Some(gap) = first_sequence_gap(cursor.last_uploaded_seq, &events) {
         let response = cloud
             .report_projection_gap(
@@ -253,14 +284,20 @@ async fn sync_projection_cursor(
             .map(|event| worker_event(cursor, event))
             .collect(),
     };
+    let upload_event_count = request.events.len();
     let response = cloud
         .upload_event_batch(&identity.worker_token, &request)
         .await?;
-    debug!(
+    let session_ack_count = response.session_acks.len();
+    info!(
+        exposure_id = %cursor.exposure_id,
+        session_projection_id = %cursor.session_projection_id,
+        session_id = %cursor.anyharness_session_id,
+        event_count = upload_event_count,
         accepted_events = response.accepted_events,
         duplicate_events = response.duplicate_events,
         live_only_events = response.live_only_events,
-        session_ack_count = response.session_acks.len(),
+        session_ack_count,
         "uploaded worker event batch"
     );
     for ack in response.session_acks {

--- a/desktop/src/hooks/workspaces/remote-access/use-workspace-remote-access-actions.ts
+++ b/desktop/src/hooks/workspaces/remote-access/use-workspace-remote-access-actions.ts
@@ -44,12 +44,63 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
-async function waitForOnlineDispatchTarget(targetId: string): Promise<CloudTargetSummary> {
+interface WorkerSignalBaseline {
+  workerId: string | null;
+  readyAt: number | null;
+}
+
+function newestTimestamp(...values: Array<string | null | undefined>): number | null {
+  const timestamps = values
+    .map((value) => value ? Date.parse(value) : Number.NaN)
+    .filter(Number.isFinite);
+  return timestamps.length > 0 ? Math.max(...timestamps) : null;
+}
+
+function workerSignalTimestamp(target: CloudTargetSummary): number | null {
+  return newestTimestamp(
+    target.update?.currentVersions?.reportedAt,
+    target.statusDetail?.lastHeartbeatAt,
+    target.statusDetail?.updatedAt,
+  );
+}
+
+function workerSignalBaseline(target: CloudTargetSummary): WorkerSignalBaseline {
+  return {
+    workerId: target.update?.currentVersions?.workerId ?? null,
+    readyAt: workerSignalTimestamp(target),
+  };
+}
+
+function isFreshOnlineDispatchTarget(
+  target: CloudTargetSummary,
+  baseline: WorkerSignalBaseline | null,
+): boolean {
+  if (target.kind !== "desktop_dispatch" || target.status !== "online") {
+    return false;
+  }
+  if (baseline === null) {
+    return true;
+  }
+  const workerId = target.update?.currentVersions?.workerId ?? null;
+  if (baseline.workerId && workerId && workerId !== baseline.workerId) {
+    return true;
+  }
+  const readyAt = workerSignalTimestamp(target);
+  return readyAt !== null && (
+    baseline.readyAt === null
+    || readyAt > baseline.readyAt
+  );
+}
+
+async function waitForOnlineDispatchTarget(
+  targetId: string,
+  baseline: WorkerSignalBaseline | null = null,
+): Promise<CloudTargetSummary> {
   let last: CloudTargetSummary | null = null;
   for (let attempt = 0; attempt < 120; attempt += 1) {
     const target = await getTarget(targetId);
     last = target;
-    if (target.kind === "desktop_dispatch" && target.status === "online") {
+    if (isFreshOnlineDispatchTarget(target, baseline)) {
       return target;
     }
     await sleep(500);
@@ -112,7 +163,14 @@ export function useWorkspaceRemoteAccessActions() {
 
   const ensureDispatchTarget = useCallback(async () => {
     if (dispatchTarget) {
-      return dispatchTarget;
+      const baseline = workerSignalBaseline(dispatchTarget);
+      await ensureDesktopDispatchWorker({
+        targetId: dispatchTarget.id,
+        enrollmentToken: null,
+      });
+      const target = await waitForOnlineDispatchTarget(dispatchTarget.id, baseline);
+      void targetsQuery.refetch();
+      return target;
     }
     const runtime = await getRuntimeInfo();
     if (runtime.status !== "healthy") {

--- a/desktop/src/lib/access/cloud/session-commands.test.ts
+++ b/desktop/src/lib/access/cloud/session-commands.test.ts
@@ -1,0 +1,73 @@
+import { enqueueCommand, getCommandStatus } from "@proliferate/cloud-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startCloudSessionCommand } from "@/lib/access/cloud/session-commands";
+
+vi.mock("@proliferate/cloud-sdk", () => ({
+  enqueueCommand: vi.fn(),
+  getCommandStatus: vi.fn(),
+}));
+
+const enqueueCommandMock = vi.mocked(enqueueCommand);
+const getCommandStatusMock = vi.mocked(getCommandStatus);
+
+describe("startCloudSessionCommand", () => {
+  beforeEach(() => {
+    enqueueCommandMock.mockReset();
+    getCommandStatusMock.mockReset();
+  });
+
+  it("routes desktop-dispatch session starts through the payload workspace id", async () => {
+    enqueueCommandMock.mockResolvedValue({
+      commandId: "command-1",
+      idempotencyKey: "start-session-1",
+      targetId: "target-1",
+      kind: "start_session",
+      source: "desktop_cloud_view",
+      status: "queued",
+      createdAt: "2026-05-25T00:00:00Z",
+      updatedAt: "2026-05-25T00:00:00Z",
+    } as Awaited<ReturnType<typeof enqueueCommand>>);
+    getCommandStatusMock.mockResolvedValue({
+      commandId: "command-1",
+      idempotencyKey: "start-session-1",
+      targetId: "target-1",
+      kind: "start_session",
+      source: "desktop_cloud_view",
+      status: "accepted",
+      createdAt: "2026-05-25T00:00:00Z",
+      updatedAt: "2026-05-25T00:00:01Z",
+      result: { sessionId: "session-1" },
+    } as Awaited<ReturnType<typeof getCommandStatus>>);
+
+    const sessionId = await startCloudSessionCommand({
+      idempotencyKey: "start-session-1",
+      targetId: "target-1",
+      cloudWorkspaceId: "cloud-workspace-1",
+      anyharnessWorkspaceId: "anyharness-workspace-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+      modeId: "default",
+      subagentsEnabled: true,
+    });
+
+    expect(sessionId).toBe("session-1");
+    expect(enqueueCommandMock).toHaveBeenCalledTimes(1);
+    const request = enqueueCommandMock.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      idempotencyKey: "start-session-1",
+      targetId: "target-1",
+      cloudWorkspaceId: "cloud-workspace-1",
+      kind: "start_session",
+      source: "desktop_cloud_view",
+      payload: {
+        workspaceId: "anyharness-workspace-1",
+        agentKind: "claude",
+        modelId: "sonnet",
+        modeId: "default",
+        subagentsEnabled: true,
+      },
+    });
+    expect(request).not.toHaveProperty("workspaceId");
+  });
+});

--- a/desktop/src/lib/access/cloud/session-commands.ts
+++ b/desktop/src/lib/access/cloud/session-commands.ts
@@ -24,7 +24,6 @@ export async function startCloudSessionCommand(
   const command = await enqueueCommand({
     idempotencyKey: input.idempotencyKey,
     targetId: input.targetId,
-    workspaceId: input.anyharnessWorkspaceId,
     cloudWorkspaceId: input.cloudWorkspaceId,
     kind: "start_session",
     source: "desktop_cloud_view",

--- a/mobile/src/lib/access/cloud/pending-mobile-prompt-dispatch.ts
+++ b/mobile/src/lib/access/cloud/pending-mobile-prompt-dispatch.ts
@@ -333,7 +333,6 @@ async function enqueueStartSessionWithRetryableReadiness(input: {
     return await input.args.enqueueStartSession({
       idempotencyKey: `${input.args.pendingPrompt.id}:start-session`,
       targetId: input.targetId,
-      workspaceId: input.anyharnessWorkspaceId,
       cloudWorkspaceId: input.args.workspace.id,
       kind: "start_session",
       source: "mobile",

--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -10,7 +10,11 @@ from sqlalchemy.orm import Session
 
 from proliferate.config import settings
 
-engine = create_async_engine(settings.database_url, echo=settings.database_echo)
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.database_echo,
+    pool_pre_ping=True,
+)
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 _AFTER_COMMIT_CALLBACKS_KEY = "proliferate_after_commit_callbacks"
 _AFTER_COMMIT_LISTENERS_KEY = "proliferate_after_commit_listeners"

--- a/server/proliferate/server/cloud/backfill/service.py
+++ b/server/proliferate/server/cloud/backfill/service.py
@@ -23,6 +23,7 @@ from proliferate.server.cloud.backfill.models import (
     WorkerBackfillWorkspace,
     WorkerBackfillWorkspaceMapping,
 )
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.worker.domain.rules import compact_json
 from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
@@ -55,6 +56,13 @@ async def record_worker_backfill(
             status_code=401,
         )
     await require_current_managed_worker_slot(db, auth=auth, target=target)
+    log_cloud_event(
+        "cloud worker backfill received",
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        workspace_count=len(body.workspaces),
+        session_count=len(body.sessions),
+    )
     billing_subject = (
         await ensure_organization_billing_subject(db, target.organization_id)
         if target.owner_scope == "organization" and target.organization_id is not None
@@ -62,6 +70,8 @@ async def record_worker_backfill(
     )
     workspace_mappings: dict[str, UUID] = {}
     mapped_workspaces: list[WorkerBackfillWorkspaceMapping] = []
+    skipped_workspace_missing_mapping = 0
+    skipped_workspace_inactive_exposure = 0
     for workspace in body.workspaces:
         existing_cloud_workspace_id = await events_store.resolve_cloud_workspace_id(
             db,
@@ -69,6 +79,7 @@ async def record_worker_backfill(
             workspace_id=workspace.workspace_id,
         )
         if existing_cloud_workspace_id is None:
+            skipped_workspace_missing_mapping += 1
             continue
         exposure = await exposures_store.get_active_workspace_exposure(
             db,
@@ -80,6 +91,7 @@ async def record_worker_backfill(
             or exposure.status != "active"
             or exposure.anyharness_workspace_id != workspace.workspace_id
         ):
+            skipped_workspace_inactive_exposure += 1
             continue
         repo = _normalize_repo(workspace)
         mapped = await backfill_store.upsert_synced_workspace(
@@ -109,6 +121,8 @@ async def record_worker_backfill(
         )
 
     mapped_sessions: list[WorkerBackfillSessionMapping] = []
+    skipped_session_missing_cloud_workspace = 0
+    skipped_session_inactive_exposure = 0
     for session in body.sessions:
         cloud_workspace_id = workspace_mappings.get(session.workspace_id or "")
         if cloud_workspace_id is None:
@@ -117,18 +131,20 @@ async def record_worker_backfill(
                 target_id=auth.target_id,
                 workspace_id=session.workspace_id,
             )
-        exposure = None
-        if cloud_workspace_id is not None:
-            exposure = await exposures_store.get_active_workspace_exposure(
-                db,
-                target_id=auth.target_id,
-                cloud_workspace_id=cloud_workspace_id,
-            )
+        if cloud_workspace_id is None:
+            skipped_session_missing_cloud_workspace += 1
+            continue
+        exposure = await exposures_store.get_active_workspace_exposure(
+            db,
+            target_id=auth.target_id,
+            cloud_workspace_id=cloud_workspace_id,
+        )
         if (
             exposure is None
             or exposure.status != "active"
             or exposure.anyharness_workspace_id != session.workspace_id
         ):
+            skipped_session_inactive_exposure += 1
             continue
         projection = await events_store.upsert_session_projection(
             db,
@@ -195,6 +211,19 @@ async def record_worker_backfill(
                 ),
             )
         )
+    log_cloud_event(
+        "cloud worker backfill mapped",
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        received_workspace_count=len(body.workspaces),
+        mapped_workspace_count=len(mapped_workspaces),
+        skipped_workspace_missing_mapping=skipped_workspace_missing_mapping,
+        skipped_workspace_inactive_exposure=skipped_workspace_inactive_exposure,
+        received_session_count=len(body.sessions),
+        mapped_session_count=len(mapped_sessions),
+        skipped_session_missing_cloud_workspace=skipped_session_missing_cloud_workspace,
+        skipped_session_inactive_exposure=skipped_session_inactive_exposure,
+    )
     return WorkerBackfillResponse(
         mapped_workspaces=mapped_workspaces,
         mapped_sessions=mapped_sessions,

--- a/server/proliferate/server/cloud/commands/api.py
+++ b/server/proliferate/server/cloud/commands/api.py
@@ -19,6 +19,7 @@ from proliferate.server.cloud.commands.service import (
     enqueue_command_and_commit,
     get_command_status,
 )
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 
 router = APIRouter(prefix="/commands", tags=["cloud-commands"])
@@ -33,6 +34,17 @@ async def enqueue_command_endpoint(
     try:
         command = await enqueue_command_and_commit(db, user=user, body=body)
     except CloudApiError as error:
+        log_cloud_event(
+            "cloud command enqueue rejected",
+            error_code=error.code,
+            status_code=error.status_code,
+            target_id=body.target_id,
+            kind=body.kind,
+            source=body.source,
+            workspace_id=body.workspace_id,
+            cloud_workspace_id=body.cloud_workspace_id,
+            session_id=body.session_id,
+        )
         raise_cloud_error(error)
     return command_response_payload(command)
 

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -29,6 +29,7 @@ from proliferate.db.store.cloud_sync import exposures as exposures_store
 from proliferate.db.store.cloud_sync import target_config as target_config_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.cloud.claims.access import require_workspace_interact
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.commands.domain.rules import (
     compact_command_json,
     validate_active_command_kind,
@@ -769,6 +770,17 @@ async def enqueue_command(
         idempotency_key=body.idempotency_key,
     )
     if existing is not None:
+        log_cloud_event(
+            "cloud command enqueue reused existing",
+            command_id=existing.id,
+            target_id=target.id,
+            kind=kind,
+            source=source,
+            workspace_id=resolved_workspace_id,
+            session_id=body.session_id,
+            cloud_workspace_id=cloud_workspace_id,
+            status=existing.status,
+        )
         await _record_pending_prompt_interaction_for_command(db, existing)
         await publish_command_status_after_commit(db, existing)
         await kick_off_command_wake_after_commit_if_required(
@@ -808,6 +820,17 @@ async def enqueue_command(
                 authorization_context_json=authorization_context_json,
             )
             await _record_pending_prompt_interaction_for_command(db, command)
+        log_cloud_event(
+            "cloud command queued",
+            command_id=command.id,
+            target_id=target.id,
+            kind=kind,
+            source=source,
+            workspace_id=resolved_workspace_id,
+            session_id=body.session_id,
+            cloud_workspace_id=cloud_workspace_id,
+            status=command.status,
+        )
         await publish_command_status_after_commit(db, command)
         await kick_off_command_wake_after_commit_if_required(
             db,

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -17,6 +17,7 @@ from proliferate.server.cloud.claims.access import (
     load_workspace_exposure_and_claim,
     require_workspace_view,
 )
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.events.domain.cursors import advance_contiguous_cursor
 from proliferate.server.cloud.events.domain.payload_policy import retained_payload
@@ -347,6 +348,18 @@ async def ingest_worker_event_batch(
     if slack_outbound_queued:
         db_engine.defer_after_commit(db, process_due_outbound_messages)
 
+    log_cloud_event(
+        "cloud worker event batch ingested",
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        event_count=len(body.events),
+        session_count=len(processed_by_session),
+        first_session_id=body.events[0].session_id if body.events else None,
+        accepted_events=accepted_events,
+        duplicate_events=duplicate_events,
+        live_only_events=live_only_events,
+        session_ack_count=len(session_acks),
+    )
     return WorkerEventBatchResponse(
         accepted_events=accepted_events,
         duplicate_events=duplicate_events,

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -33,6 +33,7 @@ from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
 from proliferate.db.store.users import get_user_with_oauth_accounts_by_id
 from proliferate.server.cloud.commands import service as command_service
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.events.models import (
     WorkerEventBatchRequest,
@@ -904,6 +905,18 @@ async def lease_worker_command(
         now=now,
     )
     if command is not None:
+        log_cloud_event(
+            "cloud worker command leased",
+            command_id=command.id,
+            target_id=auth.target_id,
+            worker_id=auth.worker_id,
+            kind=command.kind,
+            workspace_id=command.workspace_id,
+            session_id=command.session_id,
+            cloud_workspace_id=command.cloud_workspace_id,
+            attempt_count=command.attempt_count,
+            lease_expires_at=command.lease_expires_at,
+        )
         await publish_command_status_after_commit(db, command)
         # Workers report delivery immediately after receiving a lease. The lease
         # must be committed before the HTTP response is returned, otherwise the
@@ -952,6 +965,18 @@ async def record_command_delivery(
             "Command is not leased by this worker.",
             status_code=404,
         )
+    log_cloud_event(
+        "cloud worker command delivery recorded",
+        command_id=command.id,
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        kind=command.kind,
+        status=command.status,
+        error_code=command.error_code,
+        workspace_id=command.workspace_id,
+        session_id=command.session_id,
+        cloud_workspace_id=command.cloud_workspace_id,
+    )
     await publish_command_status_after_commit(db, command)
     return WorkerCommandStatusResponse(
         command_id=str(command.id),
@@ -1076,6 +1101,18 @@ async def record_command_result(
             "Command is not leased by this worker.",
             status_code=404,
         )
+    log_cloud_event(
+        "cloud worker command result recorded",
+        command_id=command.id,
+        target_id=auth.target_id,
+        worker_id=auth.worker_id,
+        kind=command.kind,
+        status=command.status,
+        error_code=command.error_code,
+        workspace_id=command.workspace_id,
+        session_id=command.session_id,
+        cloud_workspace_id=command.cloud_workspace_id,
+    )
     await _record_agent_auth_state_from_command_result(
         db,
         auth=auth,

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   desktopWorkspaceDeepLink,
   getCommandStatus,
@@ -90,6 +90,7 @@ const EMPTY_PENDING_INTERACTIONS: CloudPendingInteraction[] = [];
 export function ChatScreen() {
   const { workspaceId, chatId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const client = useCloudClient();
   const [draft, setDraft] = useState("");
   const [launchSelection, setLaunchSelection] = useState<CloudLaunchComposerSelection>({
@@ -123,6 +124,7 @@ export function ChatScreen() {
     () => [...(snapshot?.sessions ?? [])].sort(compareSessions),
     [snapshot?.sessions],
   );
+  const suppressSessionRedirect = shouldSuppressWorkspaceSessionRedirect(location.state);
   const session = chatId
     ? sessions.find((candidate) => candidate.sessionId === chatId) ?? null
     : null;
@@ -273,6 +275,31 @@ export function ChatScreen() {
       window.clearInterval(interval);
     };
   }, [workspace, workspaceStatus, workspaceId, workspaceQuery.refetch]);
+
+  useEffect(() => {
+    if (
+      !workspaceId
+      || chatId
+      || pendingHomePrompt
+      || directPromptDispatching
+      || suppressSessionRedirect
+    ) {
+      return;
+    }
+    const latestSession = sessions[0];
+    if (!latestSession) {
+      return;
+    }
+    navigate(routes.chat(workspaceId, latestSession.sessionId), { replace: true });
+  }, [
+    chatId,
+    directPromptDispatching,
+    navigate,
+    pendingHomePrompt,
+    sessions,
+    suppressSessionRedirect,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     if (!pendingHomePrompt || !workspace) {
@@ -982,7 +1009,9 @@ export function ChatScreen() {
           id: "new-session",
           label: "New chat",
           kind: "new-session",
-          onClick: () => navigate(routes.workspace(workspace.id)),
+          onClick: () => navigate(routes.workspace(workspace.id), {
+            state: { startNewSession: true },
+          }),
         }]
         : []}
       topNotice={isUnclaimed
@@ -1036,6 +1065,15 @@ function MissingState({ title }: { title: string }) {
 
 function compareSessions(left: CloudSessionProjection, right: CloudSessionProjection): number {
   return (right.lastEventSeq ?? 0) - (left.lastEventSeq ?? 0);
+}
+
+function shouldSuppressWorkspaceSessionRedirect(state: unknown): boolean {
+  return Boolean(
+    state
+      && typeof state === "object"
+      && "startNewSession" in state
+      && (state as { startNewSession?: unknown }).startNewSession === true,
+  );
 }
 
 function effectiveWorkspaceStatus(

--- a/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
+++ b/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
@@ -127,7 +127,6 @@ async function startSessionForPrompt(args: {
   const command = await args.enqueueStartSession({
     idempotencyKey: `${args.pendingPrompt.id}:start-session`,
     targetId,
-    workspaceId: anyharnessWorkspaceId,
     cloudWorkspaceId: args.workspace.id,
     kind: "start_session",
     source: "web",


### PR DESCRIPTION
## Summary
- restart/reconfirm the desktop dispatch worker before enabling remote access against an existing target
- stop sending local AnyHarness workspace ids as top-level Cloud command workspace ids
- select an existing backfilled session when opening a cloud workspace without a chat id
- add targeted sync/command diagnostics and reduce empty AnyHarness event polling noise

## Verification
- pnpm --filter proliferate exec vitest run src/lib/access/cloud/session-commands.test.ts
- pnpm --filter proliferate exec tsc --noEmit --pretty false
- pnpm --filter @proliferate/web typecheck
- pnpm --filter @proliferate/mobile typecheck
- cd server && uv run python -m py_compile proliferate/db/engine.py proliferate/server/cloud/commands/api.py proliferate/server/cloud/commands/service.py proliferate/server/cloud/worker/service.py proliferate/server/cloud/backfill/service.py proliferate/server/cloud/events/service.py
- rustfmt --edition 2021 --check anyharness/crates/anyharness-lib/src/api/http/sessions.rs anyharness/crates/proliferate-worker/src/anyharness_client/backfill.rs anyharness/crates/proliferate-worker/src/anyharness_client/events.rs anyharness/crates/proliferate-worker/src/sync/backfill.rs anyharness/crates/proliferate-worker/src/sync/tailer.rs
- cargo check -p proliferate-worker -p anyharness-lib

Browser verification was blocked locally by ERR_BLOCKED_BY_CLIENT, but the local DB confirmed Cloud had the backfilled transcript rows and the route-selection fix displayed them.