### PR TITLE
fix(desktop): keep cloud-synced workspaces local

### DIFF
--- a/desktop/src/hooks/workspaces/use-selected-cloud-runtime-state.ts
+++ b/desktop/src/hooks/workspaces/use-selected-cloud-runtime-state.ts
@@ -12,6 +12,7 @@ import {
   buildSelectedCloudRuntimeViewModel,
   type SelectedCloudRuntimeViewModel,
 } from "@/lib/domain/workspaces/cloud/cloud-runtime-state";
+import { cloudWorkspaceUsesCloudRuntime } from "@/lib/domain/workspaces/cloud/cloud-runtime-kind";
 import { useCloudWorkspaceConnectionCache } from "@/hooks/access/cloud/use-cloud-workspace-connection-cache";
 import { useCloudWorkspaceConnection } from "@/hooks/access/cloud/use-cloud-workspace-connection";
 import { useCloudWorkspaceClaimMutation } from "@/hooks/access/cloud/use-cloud-workspace-claim-mutation";
@@ -73,7 +74,10 @@ export function useSelectedCloudRuntimeState(): SelectedCloudRuntimeState {
   });
   const claimMutation = useCloudWorkspaceClaimMutation();
   const persistedStatus = (selectedCloudWorkspace?.status ?? null) as CloudWorkspaceStatus | null;
-  const usesDirectAttach = selectedCloudWorkspace?.visibility === "claimed";
+  const usesCloudRuntime = cloudWorkspaceUsesCloudRuntime(selectedCloudWorkspace);
+  const usesDirectAttach = selectedCloudWorkspace
+    ? selectedCloudWorkspace.visibility === "claimed" || !usesCloudRuntime
+    : false;
   const needsClaim = selectedCloudWorkspace?.visibility === "shared_unclaimed";
   const isWarm = selectedWorkspaceId !== null && hasWorkspaceBootstrappedInSession(selectedWorkspaceId);
   const connectionQuery = useCloudWorkspaceConnection(
@@ -110,9 +114,11 @@ export function useSelectedCloudRuntimeState(): SelectedCloudRuntimeState {
     persistedStatus,
     visibility: selectedCloudWorkspace?.visibility ?? null,
     connectionState,
-    runtimeAuth: connectionQuery.data?.runtimeAuth
-      ?? selectedCloudWorkspace?.runtime?.runtimeAuth
-      ?? null,
+    runtimeAuth: usesCloudRuntime
+      ? connectionQuery.data?.runtimeAuth
+        ?? selectedCloudWorkspace?.runtime?.runtimeAuth
+        ?? null
+      : null,
     isWarm,
   }), [
     connectionState,
@@ -121,6 +127,7 @@ export function useSelectedCloudRuntimeState(): SelectedCloudRuntimeState {
     persistedStatus,
     selectedCloudWorkspace?.runtime?.runtimeAuth,
     selectedCloudWorkspace?.visibility,
+    usesCloudRuntime,
   ]);
 
   return {

--- a/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-kind.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-kind.ts
@@ -1,0 +1,17 @@
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+export function cloudWorkspaceUsesCloudRuntime(
+  workspace: Pick<CloudWorkspaceSummary, "directTargetContext" | "sandboxType"> | null | undefined,
+): boolean {
+  if (!workspace) {
+    return false;
+  }
+
+  const targetKind = workspace?.directTargetContext?.targetKind ?? null;
+  if (targetKind === "desktop_dispatch" || targetKind === "local_direct" || targetKind === "ssh") {
+    return false;
+  }
+
+  const sandboxType = workspace?.sandboxType ?? "managed_personal";
+  return sandboxType !== "local" && sandboxType !== "ssh";
+}

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
@@ -1,5 +1,6 @@
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { targetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
+import { cloudWorkspaceUsesCloudRuntime } from "@/lib/domain/workspaces/cloud/cloud-runtime-kind";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 
 export function logicalWorkspaceTargetMaterializationId(
@@ -26,14 +27,23 @@ export function resolvePreferredLogicalWorkspaceMaterialization(
   currentSelectionId: string | null,
   effectiveOwnerHint: "local" | "cloud" | null,
 ): { workspaceId: string | null; owner: "local" | "cloud" } {
+  const cloudWorkspaceUsesRuntime = cloudWorkspace
+    ? cloudWorkspaceUsesCloudRuntime(cloudWorkspace)
+    : false;
   const directTargetId = cloudWorkspace
     ? logicalWorkspaceTargetMaterializationId({ cloudWorkspace })
     : null;
-  const cloudId = directTargetId ?? (cloudWorkspace
-    ? cloudWorkspaceSyntheticId(cloudWorkspace.id)
+  const managedCloudId = cloudWorkspace
+    ? cloudWorkspaceUsesRuntime
+      ? cloudWorkspaceSyntheticId(cloudWorkspace.id)
+      : null
     : mobilityWorkspace?.cloudWorkspaceId
       ? cloudWorkspaceSyntheticId(mobilityWorkspace.cloudWorkspaceId)
-      : null);
+      : null;
+  const cloudId = directTargetId ?? managedCloudId;
+  const fallbackOwner = cloudWorkspace && !cloudWorkspaceUsesRuntime
+    ? "local"
+    : "cloud";
 
   if (effectiveOwnerHint === "local" && localWorkspace) {
     return { workspaceId: localWorkspace.id, owner: "local" };
@@ -62,7 +72,7 @@ export function resolvePreferredLogicalWorkspaceMaterialization(
 
   return {
     workspaceId: cloudId,
-    owner: "cloud",
+    owner: fallbackOwner,
   };
 }
 
@@ -92,4 +102,13 @@ export function logicalWorkspaceCloudMaterializationId(
     return cloudWorkspaceSyntheticId(workspace.mobilityWorkspace.cloudWorkspaceId);
   }
   return null;
+}
+
+export function logicalWorkspaceCloudRuntimeMaterializationId(
+  workspace: Pick<LogicalWorkspace, "cloudWorkspace" | "mobilityWorkspace">,
+): string | null {
+  if (workspace.cloudWorkspace && !cloudWorkspaceUsesCloudRuntime(workspace.cloudWorkspace)) {
+    return null;
+  }
+  return logicalWorkspaceCloudMaterializationId(workspace);
 }

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
@@ -18,6 +18,7 @@ import {
   replaceLogicalWorkspaceBranch,
 } from "@/lib/domain/workspaces/cloud/logical-workspace-id";
 import {
+  logicalWorkspaceCloudRuntimeMaterializationId,
   resolveLogicalWorkspaceMaterializationId,
 } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
@@ -29,7 +30,7 @@ import {
 
 function makeMobilityWorkspace(args: {
   id?: string;
-  owner: "local" | "cloud";
+  owner: "local" | "cloud" | "personal_cloud";
   branch?: string;
   cloudWorkspaceId?: string | null;
 }): CloudMobilityWorkspaceSummary {
@@ -482,6 +483,62 @@ describe("logical workspaces", () => {
       "cloud:cloud-1",
       targetMaterializationId,
     ]);
+  });
+
+  it("keeps cloud-synced local workspaces on the local materialization", () => {
+    const localWorkspace = makeWorkspace({
+      id: "local-main",
+      branch: "main",
+    });
+    const cloudWorkspace = makeCloudWorkspace({
+      id: "cloud-main",
+      branch: "main",
+      sandboxType: "local",
+    });
+    const cloudAliasId = cloudWorkspaceSyntheticId(cloudWorkspace.id);
+
+    const logicalWorkspace = buildLogicalWorkspaces({
+      localWorkspaces: [localWorkspace],
+      repoRoots: [],
+      cloudWorkspaces: [cloudWorkspace],
+      cloudMobilityWorkspaces: [
+        makeMobilityWorkspace({
+          owner: "personal_cloud",
+          branch: "main",
+          cloudWorkspaceId: cloudWorkspace.id,
+        }),
+      ],
+      currentSelectionId: cloudAliasId,
+    })[0]!;
+
+    expect(logicalWorkspace.preferredMaterializationId).toBe(localWorkspace.id);
+    expect(logicalWorkspace.effectiveOwner).toBe("local");
+    expect(resolveLogicalWorkspaceMaterializationId(logicalWorkspace, cloudAliasId))
+      .toBe(localWorkspace.id);
+    expect(logicalWorkspaceCloudRuntimeMaterializationId(logicalWorkspace)).toBeNull();
+    expect(logicalWorkspaceRelatedIds(logicalWorkspace)).toContain(cloudAliasId);
+  });
+
+  it("does not materialize a cloud-only local sync record as a cloud runtime", () => {
+    const cloudWorkspace = makeCloudWorkspace({
+      id: "cloud-main",
+      branch: "main",
+      sandboxType: "local",
+    });
+    const cloudAliasId = cloudWorkspaceSyntheticId(cloudWorkspace.id);
+
+    const logicalWorkspace = buildLogicalWorkspaces({
+      localWorkspaces: [],
+      repoRoots: [],
+      cloudWorkspaces: [cloudWorkspace],
+      currentSelectionId: cloudAliasId,
+    })[0]!;
+
+    expect(logicalWorkspace.preferredMaterializationId).toBeNull();
+    expect(logicalWorkspace.effectiveOwner).toBe("local");
+    expect(resolveLogicalWorkspaceMaterializationId(logicalWorkspace, cloudAliasId)).toBeNull();
+    expect(logicalWorkspaceCloudRuntimeMaterializationId(logicalWorkspace)).toBeNull();
+    expect(logicalWorkspaceRelatedIds(logicalWorkspace)).toContain(cloudAliasId);
   });
 
   it("replaces the branch segment while preserving logical workspace identity", () => {

--- a/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -3,6 +3,7 @@ import type {
   CloudMobilityWorkspaceSummary,
   CloudWorkspaceSummary,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { cloudWorkspaceUsesCloudRuntime } from "@/lib/domain/workspaces/cloud/cloud-runtime-kind";
 import {
   humanizeBranchName,
   workspaceCurrentBranchName,
@@ -165,6 +166,16 @@ function effectiveOwnerFromMobilityOwner(
   }
 }
 
+function effectiveOwnerHintForWorkspace(
+  mobilityOwner: string | null | undefined,
+  cloudWorkspace: CloudWorkspaceSummary | null,
+): "local" | "cloud" | null {
+  if (cloudWorkspace && !cloudWorkspaceUsesCloudRuntime(cloudWorkspace)) {
+    return null;
+  }
+  return effectiveOwnerFromMobilityOwner(mobilityOwner);
+}
+
 export function buildLogicalWorkspaces(args: {
   localWorkspaces: Workspace[];
   repoRoots: RepoRoot[];
@@ -252,12 +263,16 @@ export function buildLogicalWorkspaces(args: {
 
   return Array.from(byId.entries())
     .map(([id, entry]) => {
+      const effectiveOwnerHint = effectiveOwnerHintForWorkspace(
+        entry.mobilityWorkspace?.owner,
+        entry.cloudWorkspace,
+      );
       const materialization = resolvePreferredLogicalWorkspaceMaterialization(
         entry.localWorkspace,
         entry.cloudWorkspace,
         entry.mobilityWorkspace,
         args.currentSelectionId ?? null,
-        effectiveOwnerFromMobilityOwner(entry.mobilityWorkspace?.owner),
+        effectiveOwnerHint,
       );
       const repoKey = entry.localWorkspace
         ? localWorkspaceGroupKey(entry.localWorkspace)
@@ -326,9 +341,7 @@ export function buildLogicalWorkspaces(args: {
         cloudWorkspace: entry.cloudWorkspace,
         mobilityWorkspace: entry.mobilityWorkspace,
         preferredMaterializationId: materialization.workspaceId,
-        effectiveOwner:
-          effectiveOwnerFromMobilityOwner(entry.mobilityWorkspace?.owner)
-          ?? materialization.owner,
+        effectiveOwner: effectiveOwnerHint ?? materialization.owner,
         lifecycle: inferLifecycle(
           entry.localWorkspace,
           entry.cloudWorkspace,

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
@@ -102,6 +102,7 @@ export function makeCloudWorkspace(args: {
   origin?: SidebarCloudWorkspaceSummary["origin"];
   creatorContext?: SidebarCloudWorkspaceSummary["creatorContext"];
   directTargetContext?: SidebarCloudWorkspaceSummary["directTargetContext"];
+  sandboxType?: SidebarCloudWorkspaceSummary["sandboxType"];
   status?: SidebarCloudWorkspaceSummary["status"];
   updatedAt?: string;
 }): SidebarCloudWorkspaceSummary {
@@ -113,6 +114,7 @@ export function makeCloudWorkspace(args: {
     origin = null,
     creatorContext = null,
     directTargetContext = null,
+    sandboxType,
     status = "ready",
     updatedAt = DEFAULT_UPDATED_AT,
   } = args;
@@ -151,6 +153,7 @@ export function makeCloudWorkspace(args: {
     postReadyStartedAt: null,
     postReadyCompletedAt: null,
     visibility: "private",
+    sandboxType,
   };
 }
 

--- a/desktop/src/providers/AppProviders.tsx
+++ b/desktop/src/providers/AppProviders.tsx
@@ -17,7 +17,7 @@ import {
   findLogicalWorkspace,
 } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
-  logicalWorkspaceCloudMaterializationId,
+  logicalWorkspaceCloudRuntimeMaterializationId,
   logicalWorkspaceTargetMaterializationId,
   resolveLogicalWorkspaceMaterializationId,
 } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
@@ -77,12 +77,13 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
         : [];
       const logicalWorkspace = findLogicalWorkspace(logicalWorkspaces, workspaceId);
       if (logicalWorkspace) {
-        const explicitCloudMaterializationId = logicalWorkspaceCloudMaterializationId(logicalWorkspace);
+        const explicitCloudRuntimeMaterializationId =
+          logicalWorkspaceCloudRuntimeMaterializationId(logicalWorkspace);
         const explicitTargetMaterializationId = logicalWorkspaceTargetMaterializationId(logicalWorkspace);
         const explicitLocalMaterializationId = logicalWorkspace.localWorkspace?.id ?? null;
         const materializationId = (
           (
-            workspaceId === explicitCloudMaterializationId
+            workspaceId === explicitCloudRuntimeMaterializationId
             && !explicitTargetMaterializationId
           )
           || workspaceId === explicitTargetMaterializationId
@@ -99,10 +100,10 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
         }
 
         if (
-          explicitCloudMaterializationId
-          && materializationId === explicitCloudMaterializationId
+          explicitCloudRuntimeMaterializationId
+          && materializationId === explicitCloudRuntimeMaterializationId
         ) {
-          return resolveWorkspaceConnection(runtimeUrl, explicitCloudMaterializationId);
+          return resolveWorkspaceConnection(runtimeUrl, explicitCloudRuntimeMaterializationId);
         }
 
         if (

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -851,11 +851,7 @@ async def ensure_managed_budget_subject_for_owner(
             ]
         )
     row = (
-        await db.execute(
-            select(AgentGatewayBudgetSubject)
-            .where(*owner_filters)
-            .with_for_update()
-        )
+        await db.execute(select(AgentGatewayBudgetSubject).where(*owner_filters).with_for_update())
     ).scalar_one_or_none()
     now = utcnow()
     if row is None:
@@ -953,9 +949,7 @@ async def get_managed_budget_subject_for_owner(
             ]
         )
     row = (
-        await db.execute(
-            select(AgentGatewayBudgetSubject).where(*owner_filters)
-        )
+        await db.execute(select(AgentGatewayBudgetSubject).where(*owner_filters))
     ).scalar_one_or_none()
     return _budget_subject_record(row) if row is not None else None
 
@@ -1073,12 +1067,16 @@ async def get_free_credit_entitlement_for_budget(
     if period_key is not None:
         filters.append(AgentGatewayFreeCreditEntitlement.period_key == period_key)
     row = (
-        await db.execute(
-            select(AgentGatewayFreeCreditEntitlement)
-            .where(*filters)
-            .order_by(AgentGatewayFreeCreditEntitlement.updated_at.desc())
+        (
+            await db.execute(
+                select(AgentGatewayFreeCreditEntitlement)
+                .where(*filters)
+                .order_by(AgentGatewayFreeCreditEntitlement.updated_at.desc())
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     return _free_credit_entitlement_record(row) if row is not None else None
 
 

--- a/server/proliferate/server/billing/stripe_webhooks.py
+++ b/server/proliferate/server/billing/stripe_webhooks.py
@@ -230,9 +230,10 @@ async def _handle_checkout_session_completed(
     *,
     event_id: object = None,
 ) -> None:
-    if session.get("mode") == "subscription" and _metadata(session).get(
-        "purpose"
-    ) == "team_subscription":
+    if (
+        session.get("mode") == "subscription"
+        and _metadata(session).get("purpose") == "team_subscription"
+    ):
         await activate_team_checkout_from_stripe_session(
             session=session,
             webhook_event_id=event_id if isinstance(event_id, str) else None,

--- a/server/proliferate/server/cloud/backfill/service.py
+++ b/server/proliferate/server/cloud/backfill/service.py
@@ -16,6 +16,7 @@ from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import exposures as exposures_store
 from proliferate.db.store.cloud_sync import projections as projections_store
 from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.backfill.models import (
     WorkerBackfillRequest,
     WorkerBackfillResponse,
@@ -23,7 +24,6 @@ from proliferate.server.cloud.backfill.models import (
     WorkerBackfillWorkspace,
     WorkerBackfillWorkspaceMapping,
 )
-from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.worker.domain.rules import compact_json
 from proliferate.server.cloud.worker.domain.types import WorkerAuthContext

--- a/server/proliferate/server/cloud/capabilities/service.py
+++ b/server/proliferate/server/cloud/capabilities/service.py
@@ -45,9 +45,7 @@ def cloud_capabilities() -> CloudCapabilitiesResponse:
         ),
     )
     org_byok_enabled = (
-        gateway_enabled
-        and settings.agent_gateway_byok_enabled
-        and route_isolation_ready
+        gateway_enabled and settings.agent_gateway_byok_enabled and route_isolation_ready
     )
     personal_byok_enabled = (
         gateway_enabled

--- a/server/proliferate/server/cloud/commands/api.py
+++ b/server/proliferate/server/cloud/commands/api.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.dependencies import current_active_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.commands.models import (
     CloudCommandResponse,
     CreateCloudCommandRequest,
@@ -19,7 +20,6 @@ from proliferate.server.cloud.commands.service import (
     enqueue_command_and_commit,
     get_command_status,
 )
-from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 
 router = APIRouter(prefix="/commands", tags=["cloud-commands"])

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -28,8 +28,8 @@ from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import exposures as exposures_store
 from proliferate.db.store.cloud_sync import target_config as target_config_store
 from proliferate.db.store.cloud_sync import targets as targets_store
-from proliferate.server.cloud.claims.access import require_workspace_interact
 from proliferate.server.cloud._logging import log_cloud_event
+from proliferate.server.cloud.claims.access import require_workspace_interact
 from proliferate.server.cloud.commands.domain.rules import (
     compact_command_json,
     validate_active_command_kind,

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -13,11 +13,11 @@ from proliferate.db import engine as db_engine
 from proliferate.db.store import cloud_workspaces
 from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.claims.access import (
     load_workspace_exposure_and_claim,
     require_workspace_view,
 )
-from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.events.domain.cursors import advance_contiguous_cursor
 from proliferate.server.cloud.events.domain.payload_policy import retained_payload

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -32,8 +32,8 @@ from proliferate.db.store.cloud_sync import projections as projections_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
 from proliferate.db.store.users import get_user_with_oauth_accounts_by_id
-from proliferate.server.cloud.commands import service as command_service
 from proliferate.server.cloud._logging import log_cloud_event
+from proliferate.server.cloud.commands import service as command_service
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.events.models import (
     WorkerEventBatchRequest,

--- a/server/tests/unit/test_repos_service.py
+++ b/server/tests/unit/test_repos_service.py
@@ -357,11 +357,14 @@ class TestListCloudRepositories:
             user_id=uuid.uuid4(),
             access_token="gh-token",
         )
-        with patch(
-            "proliferate.server.cloud.repos.service.list_github_repositories",
-            new_callable=AsyncMock,
-            side_effect=GitHubRateLimited("slow down", retry_after_seconds=30),
-        ), pytest.raises(CloudApiError) as exc_info:
+        with (
+            patch(
+                "proliferate.server.cloud.repos.service.list_github_repositories",
+                new_callable=AsyncMock,
+                side_effect=GitHubRateLimited("slow down", retry_after_seconds=30),
+            ),
+            pytest.raises(CloudApiError) as exc_info,
+        ):
             await list_cloud_repositories(
                 object(),  # type: ignore[arg-type]
                 credentials,


### PR DESCRIPTION
## Summary
- keep desktop-dispatch/local cloud sync records on local materialization instead of cloud runtime resolution
- treat local/ssh cloud workspace records as direct attach for runtime state so the resume-cloud panel does not appear in desktop
- add regression coverage for cloud aliases that point at local workspaces
- clean up cloud server import ordering from the previous CI lint failure

## Verification
- pnpm --filter proliferate exec vitest run src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
- pnpm --filter proliferate exec tsc --noEmit --pretty false
- cd server && uv run ruff check proliferate/server/cloud/backfill/service.py proliferate/server/cloud/commands/api.py proliferate/server/cloud/commands/service.py proliferate/server/cloud/events/service.py proliferate/server/cloud/worker/service.py
- cd server && uv run ruff format --check proliferate/server/cloud/backfill/service.py proliferate/server/cloud/commands/api.py proliferate/server/cloud/commands/service.py proliferate/server/cloud/events/service.py proliferate/server/cloud/worker/service.py