### PR TITLE
fix(desktop): polish sidebar and chat actions

### DIFF
--- a/desktop/src/components/workspace/chat/transcript/CopyMessageButton.test.tsx
+++ b/desktop/src/components/workspace/chat/transcript/CopyMessageButton.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CopyMessageButton } from "./CopyMessageButton";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CopyMessageButton", () => {
+  it("renders the timestamp before the copy button by default", () => {
+    const { container } = render(
+      <CopyMessageButton
+        content="hello"
+        timestampLabel="9:41 AM"
+        visibilityClassName=""
+      />,
+    );
+
+    const root = container.firstElementChild;
+    expect(root?.children[0]?.tagName).toBe("SPAN");
+    expect(root?.children[0]?.textContent).toBe("9:41 AM");
+    expect(root?.children[1]?.tagName).toBe("BUTTON");
+  });
+
+  it("can render the copy button before the timestamp", () => {
+    const { container } = render(
+      <CopyMessageButton
+        content="hello"
+        timestampLabel="9:41 AM"
+        timestampPosition="after"
+        visibilityClassName=""
+      />,
+    );
+
+    const root = container.firstElementChild;
+    expect(root?.children[0]?.tagName).toBe("BUTTON");
+    expect(root?.children[1]?.tagName).toBe("SPAN");
+    expect(root?.children[1]?.textContent).toBe("9:41 AM");
+  });
+});

--- a/desktop/src/components/workspace/chat/transcript/CopyMessageButton.tsx
+++ b/desktop/src/components/workspace/chat/transcript/CopyMessageButton.tsx
@@ -5,10 +5,12 @@ import { Check, Copy } from "@/components/ui/icons";
 export function CopyMessageButton({
   content,
   timestampLabel = null,
+  timestampPosition = "before",
   visibilityClassName,
 }: {
   content: string;
   timestampLabel?: string | null;
+  timestampPosition?: "before" | "after";
   visibilityClassName: string;
 }) {
   const [copied, setCopied] = useState(false);
@@ -20,21 +22,27 @@ export function CopyMessageButton({
     }).catch(() => {});
   };
 
+  const timestamp = timestampLabel
+    ? <span className="tabular-nums">{timestampLabel}</span>
+    : null;
+  const copyButton = (
+    <IconButton
+      data-chat-transcript-ignore
+      onClick={handleCopy}
+      title={copied ? "Copied" : "Copy message"}
+      className="rounded-md text-muted-foreground hover:text-foreground"
+    >
+      {copied
+        ? <Check className="size-3" />
+        : <Copy className="size-3" />}
+    </IconButton>
+  );
+
   return (
     <span className={`inline-flex items-center gap-1 text-xs text-muted-foreground transition-opacity duration-200 ${visibilityClassName}`}>
-      {timestampLabel && (
-        <span className="tabular-nums">{timestampLabel}</span>
-      )}
-      <IconButton
-        data-chat-transcript-ignore
-        onClick={handleCopy}
-        title={copied ? "Copied" : "Copy message"}
-        className="rounded-md text-muted-foreground hover:text-foreground"
-      >
-        {copied
-          ? <Check className="size-3" />
-          : <Copy className="size-3" />}
-      </IconButton>
+      {timestampPosition === "before" && timestamp}
+      {copyButton}
+      {timestampPosition === "after" && timestamp}
     </span>
   );
 }

--- a/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
+++ b/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
@@ -51,6 +51,7 @@ export function TurnAssistantActionRow({
           <CopyMessageButton
             content={content}
             timestampLabel={timestampLabel}
+            timestampPosition="after"
             visibilityClassName="opacity-0 group-hover/turn:opacity-100"
           />
         )}

--- a/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -20,7 +20,12 @@ import {
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
 
-type GlyphTestKind = "waiting_input" | "waiting_plan" | "iterating" | "queued_prompt";
+type GlyphTestKind =
+  | "waiting_input"
+  | "waiting_plan"
+  | "iterating"
+  | "queued_prompt"
+  | "needs_review";
 
 function countElementsByType(node: ReactNode, targetType: unknown): number {
   if (Array.isArray(node)) {
@@ -72,6 +77,13 @@ describe("SidebarStatusGlyph", () => {
     const glyph = renderGlyph("queued_prompt");
 
     expect(countElementsByType(glyph, Spinner)).toBe(1);
+  });
+
+  it("uses an unread dot for needs-review work", () => {
+    const glyph = renderGlyph("needs_review");
+
+    expect(countElementsByType(glyph, Clock)).toBe(0);
+    expect(countElementsByType(glyph, "span")).toBe(1);
   });
 });
 

--- a/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -45,8 +45,9 @@ export function SidebarStatusGlyph({
       return <CircleAlert className="size-3 text-destructive" />;
     case "waiting_input":
     case "waiting_plan":
-    case "needs_review":
       return <Clock className="size-3 text-info" />;
+    case "needs_review":
+      return <span aria-hidden="true" className="block size-1.5 rounded-full bg-info" />;
     case "iterating":
     case "queued_prompt":
       return <Spinner className="size-3.5 text-sidebar-foreground" />;

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -234,6 +234,59 @@ describe("sidebar indicators", () => {
     )).toEqual(["materialization"]);
   });
 
+  it("keeps cloud exposure visible for locally running remote-access workspaces", () => {
+    const localWorkspace = makeWorkspace({
+      id: "remote-access-local-materialization",
+      repoName: "repo-a",
+      sourceRoot: "/tmp/repo-a",
+      kind: "local",
+      branch: "feature/local",
+    });
+    const cloudWorkspace = makeCloudWorkspace({
+      id: "remote-access-cloud-record",
+      repoName: "repo-a",
+      branch: "feature/local",
+      directTargetContext: {
+        targetId: "desktop-target",
+        targetKind: "desktop_dispatch",
+        anyharnessWorkspaceId: localWorkspace.id,
+      },
+      exposureState: "live",
+      sandboxType: "local",
+    });
+    const base = makeLocalLogicalWorkspace({
+      id: "remote-access-local-effective",
+      repoKey: "/tmp/repo-a",
+      repoName: "repo-a",
+      kind: "local",
+      branch: "feature/local",
+    });
+    const localEffective: LogicalWorkspace = {
+      ...base,
+      localWorkspace,
+      cloudWorkspace,
+      effectiveOwner: "local",
+      preferredMaterializationId: localWorkspace.id,
+      lifecycle: "local_active",
+    };
+
+    const groups = buildGroups({
+      logicalWorkspaces: [localEffective],
+    });
+
+    expect(groups[0]?.items[0]?.detailIndicators).toMatchObject([
+      {
+        kind: "cloud_exposure",
+        tone: "neutral",
+        tooltip: "Cloud projection live",
+      },
+      {
+        kind: "materialization",
+        variant: "local",
+      },
+    ]);
+  });
+
   it("uses cloud activity for dual rows when cloud is the effective materialization", () => {
     const localWorkspace = makeWorkspace({
       id: "dual-local-materialization",

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
@@ -434,7 +434,7 @@ function cloudAccessDetailIndicator(workspace: LogicalWorkspace): SidebarDetailI
 }
 
 function cloudExposureDetailIndicator(workspace: LogicalWorkspace): SidebarDetailIndicator | null {
-  const exposureState = activeCloudWorkspace(workspace)?.exposureState;
+  const exposureState = workspace.cloudWorkspace?.exposureState;
   if (!exposureState) {
     return null;
   }
@@ -501,7 +501,7 @@ function cloudExposureTone(
   switch (exposureState) {
     case "live":
     case "tracked":
-      return "success";
+      return "neutral";
     case "paused":
     case "stale":
       return "warning";

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
@@ -102,6 +102,7 @@ export function makeCloudWorkspace(args: {
   origin?: SidebarCloudWorkspaceSummary["origin"];
   creatorContext?: SidebarCloudWorkspaceSummary["creatorContext"];
   directTargetContext?: SidebarCloudWorkspaceSummary["directTargetContext"];
+  exposureState?: SidebarCloudWorkspaceSummary["exposureState"];
   sandboxType?: SidebarCloudWorkspaceSummary["sandboxType"];
   status?: SidebarCloudWorkspaceSummary["status"];
   updatedAt?: string;
@@ -114,6 +115,7 @@ export function makeCloudWorkspace(args: {
     origin = null,
     creatorContext = null,
     directTargetContext = null,
+    exposureState,
     sandboxType,
     status = "ready",
     updatedAt = DEFAULT_UPDATED_AT,
@@ -153,6 +155,7 @@ export function makeCloudWorkspace(args: {
     postReadyStartedAt: null,
     postReadyCompletedAt: null,
     visibility: "private",
+    exposureState,
     sandboxType,
   };
 }


### PR DESCRIPTION
## Summary
- keep remote-access cloud projection visible in the sidebar while preserving local runtime materialization
- show live/tracked cloud projection badges with neutral sidebar tone instead of green success
- use a smaller unread dot for needs-review work and put assistant copy controls before the timestamp

## Verification
- pnpm --filter proliferate exec vitest run src/components/workspace/chat/transcript/CopyMessageButton.test.tsx src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts