### PR TITLE
fix(cloud): enforce archive purge invariants

### DIFF
--- a/server/proliferate/db/store/cloud_sync/commands.py
+++ b/server/proliferate/db/store/cloud_sync/commands.py
@@ -1309,7 +1309,7 @@ async def _record_pruned_cloud_workspace(
         row.error_code = "stale_materialization"
         row.error_message = "Prune result does not match the current workspace materialization."
         row.accepted_at = None
-        row.rejected_at = now
+        row.rejected_at = None
         row.updated_at = now
         await db.flush()
         return

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -1798,6 +1798,12 @@ async def purge_cloud_workspace(
             "Only personal cloud workspaces can be purged from this surface.",
             status_code=409,
         )
+    if workspace.archived_at is None:
+        raise CloudApiError(
+            "workspace_purge_requires_archive",
+            "Archive this Cloud workspace before purging it.",
+            status_code=409,
+        )
     await _revoke_claim_tokens_for_workspace(workspace, reason="workspace_purged")
     await command_store.supersede_workspace_commands(
         db,

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -683,6 +683,106 @@ class TestCloudCommandsApi:
         assert exposure.commandable is False
 
     @pytest.mark.asyncio
+    async def test_worker_prune_command_result_supersedes_stale_materialization_without_rejection(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-prune-stale",
+        )
+        target_id, worker_headers, profile = await _create_managed_profile_target(
+            client,
+            db_session,
+            auth,
+            suffix="prune-stale",
+        )
+        target_uuid = UUID(target_id)
+        cloud_workspace_id = await _create_ready_managed_cloud_workspace(
+            db_session,
+            profile_id=profile.id,
+            target_id=target_uuid,
+            user_id=UUID(auth.user_id),
+            suffix="prune-stale",
+        )
+        await db_session.commit()
+
+        current_workspace_id = "anyharness-managed-prune-stale"
+        stale_workspace_id = "anyharness-managed-prune-stale-old"
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "prune-worktree-stale-materialization",
+                "targetId": target_id,
+                "workspaceId": current_workspace_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "kind": CloudCommandKind.prune_workspace_worktree.value,
+                "payload": {
+                    "workspaceId": current_workspace_id,
+                    "cloudWorkspaceId": cloud_workspace_id,
+                    "reason": "test",
+                },
+            },
+        )
+        assert created.status_code == 200, created.text
+        command_id = created.json()["commandId"]
+
+        lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": [CloudCommandKind.prune_workspace_worktree.value],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert lease.status_code == 200
+        leased = lease.json()["command"]
+        assert leased["commandId"] == command_id
+
+        result = await client.post(
+            f"/v1/cloud/worker/commands/{command_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": leased["leaseId"],
+                "slotGeneration": leased["slotGeneration"],
+                "status": "accepted",
+                "result": {
+                    "cloudWorkspaceId": cloud_workspace_id,
+                    "anyharnessWorkspaceId": stale_workspace_id,
+                    "materializationState": "dehydrated",
+                    "cleanupStatus": "completed",
+                    "anyharnessStatusCode": 200,
+                    "body": {
+                        "workspace": {"id": stale_workspace_id},
+                    },
+                },
+            },
+        )
+        assert result.status_code == 200, result.text
+        payload = result.json()
+        assert payload["status"] == CloudCommandStatus.superseded.value
+
+        row = (
+            await db_session.execute(
+                select(CloudCommand).where(CloudCommand.id == UUID(command_id))
+            )
+        ).scalar_one()
+        assert row.status == CloudCommandStatus.superseded.value
+        assert row.error_code == "stale_materialization"
+        assert row.accepted_at is None
+        assert row.rejected_at is None
+
+        workspace = await cloud_workspaces.get_cloud_workspace_by_id(
+            db_session,
+            UUID(cloud_workspace_id),
+        )
+        assert workspace is not None
+        assert workspace.anyharness_workspace_id == current_workspace_id
+
+    @pytest.mark.asyncio
     async def test_archive_supersedes_pending_workspace_commands(
         self,
         client: AsyncClient,

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -482,6 +482,64 @@ async def test_purge_cloud_workspace_is_idempotent_when_record_is_missing(
 
 
 @pytest.mark.asyncio
+async def test_purge_cloud_workspace_requires_archived_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    workspace_id = uuid4()
+    workspace = SimpleNamespace(
+        id=workspace_id,
+        owner_scope="personal",
+        archived_at=None,
+    )
+
+    async def _get_cloud_workspace_by_id(_db, _workspace_id):
+        assert _workspace_id == workspace_id
+        return workspace
+
+    async def _cloud_workspace_user_can_archive_with_db(_db, _user_id, _workspace_id):
+        assert _user_id == user_id
+        assert _workspace_id == workspace_id
+        return workspace
+
+    async def _unexpected(*_args, **_kwargs):
+        raise AssertionError("active workspace purge must stop before destructive work")
+
+    db = SimpleNamespace(commit=_unexpected)
+    monkeypatch.setattr(
+        workspace_service,
+        "get_cloud_workspace_by_id",
+        _get_cloud_workspace_by_id,
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "cloud_workspace_user_can_archive_with_db",
+        _cloud_workspace_user_can_archive_with_db,
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "_revoke_claim_tokens_for_workspace",
+        _unexpected,
+    )
+    monkeypatch.setattr(
+        workspace_service.command_store,
+        "supersede_workspace_commands",
+        _unexpected,
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "purge_cloud_workspace_record",
+        _unexpected,
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await workspace_service.purge_cloud_workspace(db, user_id, workspace_id)
+
+    assert exc_info.value.code == "workspace_purge_requires_archive"
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_destroy_workspace_runtime_skips_shared_profile_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Summary
- require Cloud workspaces to be archived before purge can hard-delete them
- keep stale prune/materialization command results terminally superseded without rejected_at
- add regression coverage for both Greptile findings

Verification
- server ruff check on touched files
- server targeted purge/prune regression tests
- server command prune result tests
- server boundary and max-lines checks