### PR TITLE
fix(ci): clean up cloud workspace lint checks

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -55,6 +55,7 @@ desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
 desktop/src/hooks/home/workflows/use-home-next-launch.ts
 desktop/src/lib/integrations/auth/orchestration.ts
 desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
+desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
 desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
 desktop/src-tauri/src/commands/ssh_tunnel.rs
 desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
@@ -63,7 +64,6 @@ desktop/src/lib/integrations/auth/orchestration.ts
 server/tests/integration/test_cloud_api.py
 server/tests/integration/test_auth_flow.py
 server/tests/integration/test_cloud_agent_auth_api.py
-server/tests/integration/test_agent_gateway_api.py
 server/tests/integration/test_billing_accounting.py
 server/tests/integration/test_billing_api.py
 server/tests/integration/test_stripe_webhooks.py
@@ -97,6 +97,7 @@ server/proliferate/server/cloud/events/service.py
 server/proliferate/server/cloud/mobility/service.py
 server/proliferate/server/cloud/slack/service.py
 server/proliferate/server/cloud/workspaces/models.py
+server/proliferate/auth/identity/service.py
 server/tests/integration/schema_migration_assertions.py
 server/tests/integration/test_schema_migrations.py
 server/tests/integration/test_cloud_commands_api.py
@@ -107,5 +108,4 @@ server/proliferate/server/cloud/agent_auth/service.py
 server/tests/integration/test_cloud_agent_auth_api.py
 server/tests/unit/test_cloud_runtime_ensure_running.py
 server/tests/integration/test_sandbox_profile_foundation.py
-server/proliferate/server/agent_gateway/service.py
 server/proliferate/server/organizations/service.py

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -20,8 +20,8 @@ from proliferate.server.cloud.workspaces.models import (
     UpdateCloudWorkspaceDisplayNameRequest,
     WorkspaceConnection,
     WorkspaceDetail,
-    WorkspaceTargetLaunchResponse,
     WorkspaceSummary,
+    WorkspaceTargetLaunchResponse,
 )
 from proliferate.server.cloud.workspaces.service import (
     archive_cloud_workspace,

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -96,6 +96,10 @@ from proliferate.db.store.cloud_workspaces import (
 )
 from proliferate.integrations.anyharness import CloudRuntimeReconnectError
 from proliferate.integrations.sandbox import get_configured_sandbox_provider, get_sandbox_provider
+from proliferate.server.automations.domain.claim_lifecycle import (
+    CLOUD_WORKSPACE_CREATION_TRANSITION,
+    claim_is_active,
+)
 from proliferate.server.automations.worker.cloud_execution.command_models import (
     EnsureRepoCheckoutPayload,
     MaterializeWorkspacePayload,
@@ -107,11 +111,8 @@ from proliferate.server.automations.worker.cloud_execution.commands import (
     parse_start_session_result,
 )
 from proliferate.server.automations.worker.cloud_executor_commands import (
+    AutomationCommandResult,
     wait_for_command_result,
-)
-from proliferate.server.automations.domain.claim_lifecycle import (
-    CLOUD_WORKSPACE_CREATION_TRANSITION,
-    claim_is_active,
 )
 from proliferate.server.billing.models import BillingSnapshot, SandboxStartAuthorization
 from proliferate.server.billing.service import (
@@ -167,9 +168,9 @@ from proliferate.server.cloud.workspaces.models import (
     WorkspaceCreatorContext,
     WorkspaceDetail,
     WorkspaceDirectTargetContext,
+    WorkspaceSummary,
     WorkspaceTargetLaunchCommandIds,
     WorkspaceTargetLaunchResponse,
-    WorkspaceSummary,
     runtime_auth_payload,
     workspace_detail_payload,
     workspace_summary_payload,
@@ -1096,7 +1097,7 @@ async def _enqueue_target_launch_command(
     idempotency_key: str,
     source: str,
     session_id: str | None = None,
-):
+) -> command_store.CloudCommandSnapshot:
     command = await enqueue_command(
         db,
         user=user,
@@ -1116,7 +1117,11 @@ async def _enqueue_target_launch_command(
     return command
 
 
-async def _wait_for_target_launch_command(command, *, workspace_id: UUID):
+async def _wait_for_target_launch_command(
+    command: command_store.CloudCommandSnapshot,
+    *,
+    workspace_id: UUID,
+) -> AutomationCommandResult:
     del workspace_id
     return await wait_for_command_result(
         command,


### PR DESCRIPTION
## Summary
- refresh max-lines allowlist entries after the cloud workspace/auth merge
- fix Ruff import ordering and annotations in cloud workspace launch helpers

## Verification
- python3 scripts/check_max_lines.py
- cd server && uv run ruff check proliferate tests