### PR TITLE
fix(cloud): forge reliable web workspace sessions

### DIFF
--- a/cloud/sdk-react/src/hooks/live.ts
+++ b/cloud/sdk-react/src/hooks/live.ts
@@ -255,7 +255,12 @@ export function useWorkspaceLive(
               setState((current) => {
                 const snapshot = reduceWorkspaceSnapshot(current.snapshot, event);
                 if (snapshot) {
-                  queryClient.setQueryData(cloudWorkspaceSnapshotKey(workspaceId), snapshot);
+                  queryClient.setQueryData<CloudWorkspaceSnapshot>(
+                    cloudWorkspaceSnapshotKey(workspaceId),
+                    (cached) => cached
+                      ? { ...cached, sessions: snapshot.sessions }
+                      : snapshot,
+                  );
                 }
                 return {
                   client,
@@ -266,6 +271,17 @@ export function useWorkspaceLive(
                   error: undefined,
                 };
               });
+              return;
+            }
+            if (isCloudCommandStatusPatch(event)) {
+              queryClient.setQueryData(cloudCommandKey(event.command.commandId), event.command);
+              setState((current) => ({
+                ...current,
+                client,
+                liveKey,
+                isConnected: true,
+                error: undefined,
+              }));
             }
           },
           onError(error) {

--- a/cloud/sdk/src/client/live.ts
+++ b/cloud/sdk/src/client/live.ts
@@ -49,7 +49,7 @@ export function subscribeWorkspace(
   workspaceId: string,
   options: SubscribeCloudLiveOptions<
     CloudWorkspaceLiveEvent,
-    CloudWorkspaceProjectionPatch
+    CloudWorkspaceProjectionPatch | CloudCommandStatusPatch
   >,
   client: ProliferateCloudClient = getProliferateClient(),
 ): CloudSseSubscription<CloudWorkspaceLiveEvent> {

--- a/cloud/sdk/src/types/live.ts
+++ b/cloud/sdk/src/types/live.ts
@@ -86,6 +86,7 @@ export type CloudSessionLiveEvent =
 export type CloudWorkspaceLiveEvent =
   | CloudWorkspaceSnapshot
   | CloudWorkspaceProjectionPatch
+  | CloudCommandStatusPatch
   | CloudLiveHeartbeat;
 
 export type CloudTargetLiveEvent =

--- a/docs/architecture/bifrost-byok-onboarding-spec.md
+++ b/docs/architecture/bifrost-byok-onboarding-spec.md
@@ -733,10 +733,11 @@ This matches the major harness conventions:
 
 - Codex/OpenAI-compatible clients can use the existing Codex provider config
   with `CODEX_API_KEY`.
-- Claude/Anthropic-compatible clients should prefer
-  `ANTHROPIC_CUSTOM_HEADERS=x-bf-vk: <virtual-key>`, which Claude Code forwards
-  to the Anthropic client and Bifrost records as the virtual-key identity for
-  usage attribution.
+- Claude/Anthropic-compatible clients should send
+  `ANTHROPIC_CUSTOM_HEADERS=x-bf-vk: <virtual-key>` and may also materialize
+  `ANTHROPIC_AUTH_TOKEN=<virtual-key>` for client builds that do not reliably
+  forward custom headers. Bifrost records the `x-bf-vk` identity for usage
+  attribution and also accepts the bearer token fallback in local cloud QA.
 - Gemini-style clients can use `x-goog-api-key` if the CLI can be pointed at a
   compatible base URL.
 
@@ -827,7 +828,7 @@ Claude Code in E2B
   ANTHROPIC_BASE_URL=https://llm.proliferate.ai/anthropic
   CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1
   ANTHROPIC_CUSTOM_HEADERS="x-bf-vk: sk-bf-..."
-  ANTHROPIC_AUTH_TOKEN=
+  ANTHROPIC_AUTH_TOKEN=sk-bf-...
   -> Bifrost
   -> Anthropic or Bedrock
 
@@ -1353,7 +1354,7 @@ Example plan:
   "env": {
     "ANTHROPIC_BASE_URL": "https://llm.proliferate.ai/anthropic",
     "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: <resolved in worker>",
-    "ANTHROPIC_AUTH_TOKEN": ""
+    "ANTHROPIC_AUTH_TOKEN": "<resolved in worker>"
   }
 }
 ```
@@ -1364,7 +1365,7 @@ Harness env mapping:
 claude
   ANTHROPIC_BASE_URL
   ANTHROPIC_CUSTOM_HEADERS = x-bf-vk: <virtual-key>
-  ANTHROPIC_AUTH_TOKEN = ""
+  ANTHROPIC_AUTH_TOKEN = <virtual-key>
   CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = 1
 
 codex

--- a/packages/product-model/src/automations/inventory.test.ts
+++ b/packages/product-model/src/automations/inventory.test.ts
@@ -302,6 +302,7 @@ describe("automation inventory", () => {
       run("dispatched", { id: "run-ssh", anyharnessWorkspaceId: "aw-1", cloudTargetKindSnapshot: "ssh" }),
       run("failed", { lastErrorMessage: "Boom" }),
       run("cancelled"),
+      run("queued_elsewhere" as AutomationRunInventoryRecord["status"], { id: "run-unknown" }),
     ]);
 
     expect(items.map((item) => [item.statusLabel, item.statusKind, item.openState, item.targetLabel])).toEqual([
@@ -312,6 +313,7 @@ describe("automation inventory", () => {
       ["Session started", "done", "openable", "SSH target"],
       ["Failed", "blocked", "none", "Personal cloud"],
       ["Cancelled", "done", "none", "Personal cloud"],
+      ["Status unavailable", "waiting", "none", "Personal cloud"],
     ]);
   });
 

--- a/packages/product-model/src/automations/inventory.ts
+++ b/packages/product-model/src/automations/inventory.ts
@@ -571,7 +571,7 @@ function automationRunStatusLabel(run: AutomationRunInventoryRecord): string {
     case "cancelled":
       return "Cancelled";
     default:
-      return `Unknown status: ${run.status}`;
+      return "Status unavailable";
   }
 }
 

--- a/packages/product-model/src/chats/cloud/composer-controls.test.ts
+++ b/packages/product-model/src/chats/cloud/composer-controls.test.ts
@@ -4,6 +4,7 @@ import {
   buildCloudLaunchComposerControls,
   buildLaunchRunConfigControlValues,
   buildLaunchSessionConfigUpdates,
+  resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "./composer-controls";
 
@@ -324,6 +325,38 @@ describe("buildCloudLaunchComposerControls", () => {
       placement: "trailing",
     });
   });
+
+  it("filters launch agent options to launchable agent kinds", () => {
+    const controls = buildCloudLaunchComposerControls({
+      catalog: multiAgentCatalog(),
+      launchableAgentKinds: ["claude"],
+      selection: {
+        agentKind: "codex",
+        modelId: "gpt-5-codex",
+        modeId: null,
+        controlValues: {},
+      },
+      onAgentModelSelect: () => {},
+      onControlSelect: () => {},
+    });
+
+    const modelControl = controls.find((control) => control.key === "model");
+
+    expect(modelControl?.groups.map((group) => group.id)).toEqual(["claude"]);
+    expect(resolveCloudLaunchSelection({
+      catalog: multiAgentCatalog(),
+      launchableAgentKinds: ["claude"],
+      selection: {
+        agentKind: "codex",
+        modelId: "gpt-5-codex",
+        modeId: null,
+        controlValues: {},
+      },
+    })).toMatchObject({
+      agentKind: "claude",
+      modelId: "us.anthropic.claude-opus-4-6",
+    });
+  });
 });
 
 describe("buildCloudChatComposerControls", () => {
@@ -391,6 +424,24 @@ describe("buildCloudChatComposerControls", () => {
     expect(sessionSwitches).toEqual([
       { agentKind: "codex", modelId: "gpt-5-codex" },
     ]);
+  });
+
+  it("filters cross-harness session model options to launchable agent kinds", () => {
+    const controls = buildCloudChatComposerControls({
+      session: claudeSession("us.anthropic.claude-opus-4-6"),
+      liveConfig: liveConfigWithModel("us.anthropic.claude-opus-4-6"),
+      pendingConfigChanges: {},
+      launchCatalog: multiAgentCatalog(),
+      launchableAgentKinds: ["claude"],
+      launchModelId: "us.anthropic.claude-opus-4-6",
+      onLaunchModelSelect: () => {},
+      onSessionConfigSelect: () => {},
+      onSessionAgentModelSelect: () => {},
+    });
+
+    const modelControl = controls.find((control) => control.key === "model");
+
+    expect(modelControl?.groups.map((group) => group.id)).toEqual(["claude"]);
   });
 });
 

--- a/packages/product-model/src/chats/cloud/composer-controls.ts
+++ b/packages/product-model/src/chats/cloud/composer-controls.ts
@@ -65,6 +65,7 @@ export type PendingConfigChange = {
 
 export const DEFAULT_DIRECT_PROMPT_MODEL_ID = "us.anthropic.claude-sonnet-4-6";
 export const DEFAULT_DIRECT_PROMPT_AGENT_KIND = "claude";
+export const DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS = ["claude", "codex"] as const;
 
 const CLOUD_MODEL_OPTIONS = [
   {
@@ -111,6 +112,7 @@ export function buildCloudChatComposerControls(input: {
   liveConfig: SessionLiveConfigSnapshot | null;
   pendingConfigChanges: Record<string, PendingConfigChange>;
   launchCatalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   launchSelection?: CloudLaunchComposerSelection;
   launchModelId: string;
   onLaunchAgentModelSelect?: (agentKind: string, modelId: string) => void;
@@ -122,6 +124,7 @@ export function buildCloudChatComposerControls(input: {
   if (!input.session) {
     return buildCloudLaunchComposerControls({
       catalog: input.launchCatalog,
+      launchableAgentKinds: input.launchableAgentKinds,
       selection: input.launchSelection ?? {
         agentKind: DEFAULT_DIRECT_PROMPT_AGENT_KIND,
         modelId: input.launchModelId,
@@ -143,6 +146,7 @@ export function buildCloudChatComposerControls(input: {
       agentKind: input.session!.sourceAgentKind ?? null,
       control,
       catalog: input.launchCatalog ?? null,
+      launchableAgentKinds: input.launchableAgentKinds,
       placement: control.rawConfigId === leadingModeControl?.rawConfigId ? "leading" : "trailing",
       pendingConfigChanges: input.pendingConfigChanges,
       onSelect: input.onSessionConfigSelect,
@@ -153,11 +157,15 @@ export function buildCloudChatComposerControls(input: {
 
 export function buildCloudLaunchComposerControls(input: {
   catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   selection: CloudLaunchComposerSelection;
   onAgentModelSelect: (agentKind: string, modelId: string) => void;
   onControlSelect: (selection: CloudLaunchComposerControlSelection) => void;
 }): CloudChatComposerControlView[] {
-  const catalogAgents = input.catalog?.agents ?? [];
+  const catalogAgents = launchableCatalogAgents({
+    agents: input.catalog?.agents ?? [],
+    launchableAgentKinds: input.launchableAgentKinds,
+  });
   if (catalogAgents.length === 0) {
     return fallbackLaunchComposerControls({
       modelId: input.selection.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID,
@@ -189,9 +197,13 @@ export function buildCloudLaunchComposerControls(input: {
 
 export function resolveCloudLaunchSelection(input: {
   catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   selection: CloudLaunchComposerSelection;
 }): CloudLaunchComposerSelection {
-  const agents = input.catalog?.agents ?? [];
+  const agents = launchableCatalogAgents({
+    agents: input.catalog?.agents ?? [],
+    launchableAgentKinds: input.launchableAgentKinds,
+  });
   const agent = selectLaunchAgent(agents, input.selection.agentKind);
   if (!agent) {
     return {
@@ -221,9 +233,16 @@ export function resolveCloudLaunchSelection(input: {
 
 export function buildLaunchSessionConfigUpdates(input: {
   catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   selection: CloudLaunchComposerSelection;
 }): LaunchSessionConfigUpdate[] {
-  const agent = selectLaunchAgent(input.catalog?.agents ?? [], input.selection.agentKind);
+  const agent = selectLaunchAgent(
+    launchableCatalogAgents({
+      agents: input.catalog?.agents ?? [],
+      launchableAgentKinds: input.launchableAgentKinds,
+    }),
+    input.selection.agentKind,
+  );
   if (!agent) {
     return [];
   }
@@ -238,9 +257,16 @@ export function buildLaunchSessionConfigUpdates(input: {
 
 export function buildLaunchRunConfigControlValues(input: {
   catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   selection: CloudLaunchComposerSelection;
 }): Record<string, string> {
-  const agent = selectLaunchAgent(input.catalog?.agents ?? [], input.selection.agentKind);
+  const agent = selectLaunchAgent(
+    launchableCatalogAgents({
+      agents: input.catalog?.agents ?? [],
+      launchableAgentKinds: input.launchableAgentKinds,
+    }),
+    input.selection.agentKind,
+  );
   if (!agent) {
     return {};
   }
@@ -566,6 +592,22 @@ function selectLaunchAgent(
     ?? null;
 }
 
+function launchableCatalogAgents(input: {
+  agents: readonly CloudAgentCatalogAgent[];
+  launchableAgentKinds?: readonly string[] | null;
+  includeAgentKind?: string | null;
+}): CloudAgentCatalogAgent[] {
+  const launchableKinds = input.launchableAgentKinds?.filter(Boolean) ?? [];
+  if (launchableKinds.length === 0) {
+    return [...input.agents];
+  }
+  const allowed = new Set(launchableKinds);
+  if (input.includeAgentKind) {
+    allowed.add(input.includeAgentKind);
+  }
+  return input.agents.filter((agent) => allowed.has(agent.kind));
+}
+
 function selectLaunchModel(
   agent: CloudAgentCatalogAgent,
   modelId: string | null | undefined,
@@ -677,6 +719,7 @@ function buildSessionConfigComposerControl(input: {
   agentKind: string | null;
   control: NormalizedSessionControl;
   catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   placement: "leading" | "trailing";
   pendingConfigChanges: Record<string, PendingConfigChange>;
   onSelect: (rawConfigId: string, value: string) => void;
@@ -698,6 +741,7 @@ function buildSessionConfigComposerControl(input: {
     ? sessionModelGroupsFromCatalog({
       agentKind,
       catalog: input.catalog ?? null,
+      launchableAgentKinds: input.launchableAgentKinds,
       selectedLabel: selectedOption?.label ?? null,
       selectedValue,
     }) ?? sessionControlGroups({
@@ -779,10 +823,15 @@ function sessionControlGroups(input: {
 function sessionModelGroupsFromCatalog(input: {
   agentKind: string | null;
   catalog: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
   selectedLabel: string | null;
   selectedValue: string | null;
 }): CloudChatComposerControlGroupView[] | null {
-  const agents = input.catalog?.agents ?? [];
+  const agents = launchableCatalogAgents({
+    agents: input.catalog?.agents ?? [],
+    launchableAgentKinds: input.launchableAgentKinds,
+    includeAgentKind: input.agentKind,
+  });
   const groups = agents.flatMap((agent) => {
     const options = agent.session.models
       .filter(isLaunchVisibleModel)

--- a/server/proliferate/db/store/cloud_sync/commands.py
+++ b/server/proliferate/db/store/cloud_sync/commands.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import (
+    SUPPORTED_CLOUD_AGENTS,
     CloudCommandKind,
     CloudCommandStatus,
     CloudWorkspaceCleanupState,
@@ -1463,6 +1464,7 @@ async def _record_started_cloud_session_projection(
     )
     if exposure is None or exposure.status != "active" or not exposure.anyharness_workspace_id:
         return
+    source_agent_kind = _start_session_agent_kind(row.payload_json)
     projection = (
         await db.execute(
             select(CloudSessionProjection)
@@ -1479,6 +1481,7 @@ async def _record_started_cloud_session_projection(
             cloud_workspace_id=row.cloud_workspace_id,
             workspace_id=row.workspace_id,
             session_id=session_id,
+            source_agent_kind=source_agent_kind,
             status="running",
             projection_level=(
                 exposure.default_projection_level if exposure is not None else "live"
@@ -1494,12 +1497,27 @@ async def _record_started_cloud_session_projection(
         projection.exposure_id = exposure.id if exposure is not None else projection.exposure_id
         projection.cloud_workspace_id = row.cloud_workspace_id
         projection.workspace_id = row.workspace_id
+        projection.source_agent_kind = source_agent_kind or projection.source_agent_kind
         projection.status = projection.status or "running"
         if exposure is not None:
             projection.projection_level = exposure.default_projection_level
             projection.commandable = exposure.commandable
         projection.updated_at = now
     await db.flush()
+
+
+def _start_session_agent_kind(payload_json: str | None) -> str | None:
+    try:
+        payload = json.loads(payload_json or "{}")
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("agentKind")
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if normalized in SUPPORTED_CLOUD_AGENTS else None
 
 
 async def _load_active_workspace_exposure(

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -2834,7 +2834,7 @@ async def _worker_gateway_config(
                 "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": "1",
                 "ANTHROPIC_BASE_URL": facade_base,
                 "ANTHROPIC_CUSTOM_HEADERS": f"x-bf-vk: {result.virtual_key}",
-                "ANTHROPIC_AUTH_TOKEN": "",
+                "ANTHROPIC_AUTH_TOKEN": result.virtual_key,
             },
             supportEnv={},
             protectedConfig={},

--- a/server/proliferate/server/cloud/live/service.py
+++ b/server/proliferate/server/cloud/live/service.py
@@ -139,6 +139,11 @@ async def publish_command_status(command: commands_store.CloudCommandSnapshot) -
         target_channel(target_id=command.target_id),
         PubSubMessage(event="command_status", event_id=event_id, data=data),
     )
+    if command.cloud_workspace_id is not None:
+        await _live_bus.publish(
+            workspace_channel(workspace_id=command.cloud_workspace_id),
+            PubSubMessage(event="command_status", event_id=event_id, data=data),
+        )
     if command.session_id is not None:
         await _live_bus.publish(
             session_channel(target_id=command.target_id, session_id=command.session_id),
@@ -245,6 +250,13 @@ async def stream_workspace_events(
                     event="heartbeat",
                     event_id=str(cursor),
                     data=CloudStreamHeartbeatResponse().model_dump(by_alias=True),
+                )
+                continue
+            if message.event != "patch":
+                yield _sse_event(
+                    event=message.event,
+                    event_id=message.event_id,
+                    data=message.data,
                 )
                 continue
             message_seq = _int_or_zero(message.event_id)

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -1100,7 +1100,7 @@ async def test_bifrost_worker_materialization_uses_direct_virtual_key_env(
     claude = selections["claude"]["gateway"]
     assert claude["baseUrls"]["anthropic"] == "https://bifrost.test/anthropic"
     assert claude["runtimeGrantToken"] == "sk-bf-runtime-1"
-    assert claude["protectedEnv"]["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert claude["protectedEnv"]["ANTHROPIC_AUTH_TOKEN"] == "sk-bf-runtime-1"
     assert claude["protectedEnv"]["ANTHROPIC_CUSTOM_HEADERS"] == "x-bf-vk: sk-bf-runtime-1"
     gemini = selections["gemini"]["gateway"]
     assert gemini["protocolFacade"] == "genai"

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -18,7 +18,7 @@ from proliferate.constants.cloud import (
 from proliferate.db.models.cloud.agent_auth import SandboxProfileTargetState
 from proliferate.db.models.cloud.commands import CloudCommand
 from proliferate.db.models.cloud.exposures import CloudWorkspaceExposure
-from proliferate.db.models.cloud.sync import CloudPendingInteraction
+from proliferate.db.models.cloud.sync import CloudPendingInteraction, CloudSessionProjection
 from proliferate.db.store import cloud_runtime_environments, cloud_workspaces
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_runtime_config import revisions as runtime_config_store
@@ -2435,6 +2435,113 @@ class TestCloudCommandsApi:
         assert cursors[0].exposure_id == exposure.id
         assert cursors[0].anyharness_workspace_id == "workspace-exposure-cursor"
         assert cursors[0].anyharness_session_id == "session-exposure-cursor"
+        session_projection = (
+            await db_session.execute(
+                select(CloudSessionProjection).where(
+                    CloudSessionProjection.session_id == "session-exposure-cursor",
+                )
+            )
+        ).scalar_one()
+        assert session_projection.source_agent_kind == "claude"
+
+        codex_start = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "managed-start-session-exposure-cursor-codex",
+                "targetId": target_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "kind": "start_session",
+                "payload": {"agentKind": "codex"},
+            },
+        )
+        assert codex_start.status_code == 200
+        codex_start_id = codex_start.json()["commandId"]
+        codex_start_lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["start_session", "refresh_agent_auth_config"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert codex_start_lease.status_code == 200
+        leased_codex_start = codex_start_lease.json()["command"]
+        assert leased_codex_start["commandId"] == codex_start_id
+        codex_start_result = await client.post(
+            f"/v1/cloud/worker/commands/{codex_start_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": leased_codex_start["leaseId"],
+                "slotGeneration": leased_codex_start["slotGeneration"],
+                "cloudWorkspaceId": cloud_workspace_id,
+                "status": "accepted",
+                "result": {"body": {"sessionId": "session-exposure-cursor-codex"}},
+            },
+        )
+        assert codex_start_result.status_code == 200
+        session_projections = (
+            (
+                await db_session.execute(
+                    select(CloudSessionProjection).where(
+                        CloudSessionProjection.cloud_workspace_id == UUID(cloud_workspace_id),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        projection_agents = {
+            projection.session_id: projection.source_agent_kind
+            for projection in session_projections
+        }
+        assert projection_agents["session-exposure-cursor"] == "claude"
+        assert projection_agents["session-exposure-cursor-codex"] == "codex"
+
+        invalid_start = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "managed-start-session-exposure-cursor-invalid-agent",
+                "targetId": target_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "kind": "start_session",
+                "payload": {"agentKind": "not-a-supported-agent-kind" * 8},
+            },
+        )
+        assert invalid_start.status_code == 200
+        invalid_start_id = invalid_start.json()["commandId"]
+        invalid_start_lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["start_session", "refresh_agent_auth_config"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert invalid_start_lease.status_code == 200
+        leased_invalid_start = invalid_start_lease.json()["command"]
+        assert leased_invalid_start["commandId"] == invalid_start_id
+        invalid_start_result = await client.post(
+            f"/v1/cloud/worker/commands/{invalid_start_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": leased_invalid_start["leaseId"],
+                "slotGeneration": leased_invalid_start["slotGeneration"],
+                "cloudWorkspaceId": cloud_workspace_id,
+                "status": "accepted",
+                "result": {"body": {"sessionId": "session-exposure-cursor-invalid-agent"}},
+            },
+        )
+        assert invalid_start_result.status_code == 200
+        invalid_agent_projection = (
+            await db_session.execute(
+                select(CloudSessionProjection).where(
+                    CloudSessionProjection.session_id == "session-exposure-cursor-invalid-agent",
+                )
+            )
+        ).scalar_one()
+        assert invalid_agent_projection.source_agent_kind is None
 
         revoked_cloud_workspace_id = await _create_ready_managed_cloud_workspace(
             db_session,

--- a/server/tests/integration/test_cloud_event_streams_api.py
+++ b/server/tests/integration/test_cloud_event_streams_api.py
@@ -455,22 +455,12 @@ class TestCloudEventStreamsApi:
                 mapping(session)["sessionId"] for session in workspace_snapshot["sessions"]
             ] == ["session-live"]
 
-            workspace_patch_task: asyncio.Task[str] = asyncio.create_task(
-                next_stream_frame(workspace_stream)
-            )
+            workspace_patch_task = _next_workspace_stream_frame(workspace_stream)
             live_uploaded = await client.post(
                 "/v1/cloud/worker/events/batches",
                 headers=worker_headers,
                 json={
-                    "events": [
-                        {
-                            "workspaceId": "workspace-live",
-                            "sessionId": "session-live",
-                            "seq": 2,
-                            "timestamp": "2026-05-13T00:00:01Z",
-                            "event": {"type": "turn_started"},
-                        }
-                    ]
+                    "events": [_live_turn_started_event(seq=2, timestamp="2026-05-13T00:00:01Z")]
                 },
             )
             assert live_uploaded.status_code == 200
@@ -482,9 +472,50 @@ class TestCloudEventStreamsApi:
             workspace_patch = mapping(patch_envelope["patch"])
             assert workspace_patch["eventType"] == "turn_started"
             assert mapping(workspace_patch["envelope"])["sessionId"] == "session-live"
-            assert mapping(mapping(workspace_patch["envelope"])["event"])["type"] == (
-                "turn_started"
+            workspace_patch_event = mapping(mapping(workspace_patch["envelope"])["event"])
+            assert workspace_patch_event["type"] == "turn_started"
+
+            command_status_task = _next_workspace_stream_frame(workspace_stream)
+            command = await client.post(
+                "/v1/cloud/commands",
+                headers=auth.headers,
+                json={
+                    "idempotencyKey": "workspace-stream-command",
+                    "targetId": target_id,
+                    "workspaceId": "workspace-live",
+                    "cloudWorkspaceId": cloud_workspace_id,
+                    "sessionId": "session-live",
+                    "kind": "send_prompt",
+                    "payload": {"text": "hi"},
+                    "source": "web",
+                },
             )
+            assert command.status_code == 200
+            command_status_frame = await asyncio.wait_for(command_status_task, timeout=2)
+            assert sse_event(command_status_frame) == "command_status"
+            command_status = sse_data(command_status_frame)
+            assert command_status["kind"] == "command_status"
+            assert mapping(command_status["command"])["status"] == "queued"
+
+            workspace_patch_after_command_task = _next_workspace_stream_frame(workspace_stream)
+            live_uploaded_after_command = await client.post(
+                "/v1/cloud/worker/events/batches",
+                headers=worker_headers,
+                json={
+                    "events": [_live_turn_started_event(seq=3, timestamp="2026-05-13T00:00:02Z")]
+                },
+            )
+            assert live_uploaded_after_command.status_code == 200
+
+            workspace_patch_after_command_frame = await asyncio.wait_for(
+                workspace_patch_after_command_task,
+                timeout=2,
+            )
+            assert sse_event(workspace_patch_after_command_frame) == "patch"
+            patch_after_command_envelope = sse_data(workspace_patch_after_command_frame)
+            patch_after_command = mapping(patch_after_command_envelope["patch"])
+            assert patch_after_command["eventType"] == "turn_started"
+            assert mapping(patch_after_command["envelope"])["seq"] == 3
         finally:
             await workspace_stream.aclose()
 
@@ -551,3 +582,19 @@ class _ClosingPubSubBus:
 async def _closed_message_iterator() -> AsyncIterator[PubSubMessage]:
     return
     yield PubSubMessage(event="patch", event_id="1", data={})
+
+
+def _next_workspace_stream_frame(
+    workspace_stream: AsyncGenerator[str, None],
+) -> asyncio.Task[str]:
+    return asyncio.create_task(next_stream_frame(workspace_stream))
+
+
+def _live_turn_started_event(seq: int, timestamp: str) -> dict[str, object]:
+    return {
+        "workspaceId": "workspace-live",
+        "sessionId": "session-live",
+        "seq": seq,
+        "timestamp": timestamp,
+        "event": {"type": "turn_started"},
+    }

--- a/web/src/components/app/navigation/WebSidebarController.tsx
+++ b/web/src/components/app/navigation/WebSidebarController.tsx
@@ -444,7 +444,6 @@ function RecentSourceIndicator({ item }: { item: RecentWorkItemView }) {
 
 function sourceIcon(source: RecentWorkSourceKind): ReactNode {
   switch (source) {
-    case "web":
     case "mobile":
       return <Smartphone className="size-3.5" />;
     case "slack":
@@ -454,6 +453,7 @@ function sourceIcon(source: RecentWorkSourceKind): ReactNode {
       return <CalendarClock className="size-3.5" />;
     case "desktop_exposed":
     case "cloud_sandbox":
+    case "web":
     case "api":
     case "unknown":
       return <Cloud className="size-3.5" />;
@@ -462,9 +462,12 @@ function sourceIcon(source: RecentWorkSourceKind): ReactNode {
 
 function sourceIndicatorLabel(item: RecentWorkItemView): string {
   switch (item.sourceKind) {
-    case "web":
     case "mobile":
       return "Mobile dispatch";
+    case "web":
+      return item.ownership === "unclaimed"
+        ? "Cloud workspace, unclaimed"
+        : "Cloud workspace";
     case "slack":
       return "Slack";
     case "personal_automation":

--- a/web/src/components/automations/screen/AutomationsScreen.tsx
+++ b/web/src/components/automations/screen/AutomationsScreen.tsx
@@ -14,6 +14,7 @@ import {
   useAutomationRuns,
   useAutomations,
   useCloudAgentCatalog,
+  useCloudCapabilities,
   useCloudRepoConfigs,
   useOrganizations,
 } from "@proliferate/cloud-sdk-react";
@@ -39,6 +40,7 @@ import {
 import {
   buildCloudLaunchComposerControls,
   buildLaunchRunConfigControlValues,
+  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   resolveCloudLaunchSelection,
@@ -90,6 +92,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
   });
   const repoConfigs = useCloudRepoConfigs();
   const agentCatalog = useCloudAgentCatalog();
+  const cloudCapabilities = useCloudCapabilities();
   const actions = useAutomationActions();
   const runConfigActions = useAgentRunConfigActions();
   const [createOpen, setCreateOpen] = useState(false);
@@ -178,16 +181,25 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     () => buildRepoOptions(repoConfigs.data?.configs ?? EMPTY_REPO_CONFIGS),
     [repoConfigs.data?.configs],
   );
+  const launchableAgentKinds = useMemo(() => {
+    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
+      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
+    return managedCreditKinds.length > 0
+      ? managedCreditKinds
+      : [DEFAULT_DIRECT_PROMPT_AGENT_KIND];
+  }, [cloudCapabilities.data?.agentGateway.managedCreditAgentKinds]);
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
+      launchableAgentKinds,
       selection: launchSelection,
     }),
-    [agentCatalog.data, launchSelection],
+    [agentCatalog.data, launchSelection, launchableAgentKinds],
   );
   const agentControls = useMemo(
     () => buildCloudLaunchComposerControls({
       catalog: agentCatalog.data,
+      launchableAgentKinds,
       selection: resolvedLaunchSelection,
       onAgentModelSelect: (agentKind, modelId) => {
         setLaunchSelection((current) => ({
@@ -212,7 +224,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
         });
       },
     }),
-    [agentCatalog.data, resolvedLaunchSelection],
+    [agentCatalog.data, launchableAgentKinds, resolvedLaunchSelection],
   );
   const timezoneOptions = useMemo(
     () => automationTimezoneOptions(createValues.timezone),
@@ -297,6 +309,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
       modelId: resolvedLaunchSelection.modelId,
       controlValues: buildLaunchRunConfigControlValues({
         catalog: agentCatalog.data,
+        launchableAgentKinds,
         selection: resolvedLaunchSelection,
       }),
       usableInPersonalSandboxes: true,

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -14,6 +14,7 @@ import {
 import {
   useClaimCloudWorkspace,
   useCloudAgentCatalog,
+  useCloudCapabilities,
   useCloudClient,
   useCloudSessionEvents,
   useCloudTranscriptSnapshot,
@@ -40,6 +41,7 @@ import {
 import {
   buildCloudChatComposerControls,
   buildLaunchSessionConfigUpdates,
+  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   getLiveConfigControlValue,
@@ -59,7 +61,9 @@ import {
 import { routes } from "../../../config/routes";
 import {
   dispatchPendingHomePrompt,
+  enqueuePromptCommandWithRetry,
   prepareManagedWorkspaceForCloudCommands,
+  resumePendingHomePromptInSession,
   type SendPromptPayload,
   type StartSessionPayload,
   type UpdateSessionConfigPayload,
@@ -70,6 +74,22 @@ import {
   savePendingHomePrompt,
   type PendingHomePrompt,
 } from "../../../lib/access/cloud/pending-home-prompt-store";
+import {
+  clearWebCloudSessionDraft,
+  createWebCloudSessionDraft,
+  loadWebCloudPendingConfigChanges,
+  loadWebCloudPromptIntents,
+  loadWebCloudSessionDraftFromSearch,
+  saveWebCloudPendingConfigChanges,
+  saveWebCloudPromptIntents,
+  saveWebCloudSessionDraft,
+  webCloudSessionDraftIdFromOptionId,
+  webCloudSessionDraftIdFromSearch,
+  webCloudSessionDraftOptionId,
+  webCloudSessionDraftSearch,
+  type WebCloudPromptIntent,
+  type WebCloudSessionDraft,
+} from "../../../stores/cloud/web-cloud-chat-state-store";
 
 type PendingHomePromptDispatchRun = {
   key: string;
@@ -77,17 +97,7 @@ type PendingHomePromptDispatchRun = {
   started: boolean;
 };
 
-type OptimisticPromptStatus = "sending" | "queued" | "failed";
-
-type OptimisticPrompt = {
-  id: string;
-  workspaceId: string;
-  sessionId: string | null;
-  text: string;
-  baseTranscriptSeq: number;
-  status: OptimisticPromptStatus;
-  commandId?: string | null;
-};
+type OptimisticPrompt = WebCloudPromptIntent;
 
 const EMPTY_SESSION_EVENTS: CloudSessionEvent[] = [];
 const EMPTY_TRANSCRIPT_ITEMS: CloudTranscriptItem[] = [];
@@ -107,19 +117,26 @@ export function ChatScreen() {
   });
   const [latestCommandId, setLatestCommandId] = useState<string | null>(null);
   const [directPromptDispatching, setDirectPromptDispatching] = useState(false);
-  const [optimisticPrompts, setOptimisticPrompts] = useState<OptimisticPrompt[]>([]);
+  const [optimisticPrompts, setOptimisticPrompts] = useState<OptimisticPrompt[]>(() =>
+    workspaceId ? loadWebCloudPromptIntents(workspaceId) : []
+  );
   const [pendingConfigChanges, setPendingConfigChanges] = useState<
     Record<string, PendingConfigChange>
-  >({});
+  >(() => workspaceId ? loadWebCloudPendingConfigChanges(workspaceId) : {});
+  const [pendingSessionDraft, setPendingSessionDraft] = useState<WebCloudSessionDraft | null>(() =>
+    workspaceId ? loadWebCloudSessionDraftFromSearch(workspaceId, location.search) : null
+  );
   const [pendingHomePrompt, setPendingHomePrompt] = useState<PendingHomePrompt | null>(() =>
     workspaceId ? loadPendingHomePrompt(workspaceId) : null
   );
   const [pendingHomePromptStatus, setPendingHomePromptStatus] = useState<string | null>(null);
   const pendingHomePromptDispatchRunRef = useRef<PendingHomePromptDispatchRun | null>(null);
+  const pendingHomePromptResumeAttemptsRef = useRef<Set<string>>(new Set());
   const pendingConfigMutationIdRef = useRef(0);
   const mountedRef = useRef(true);
   const workspaceQuery = useCloudWorkspaceSnapshot(workspaceId ?? null, Boolean(workspaceId));
   const agentCatalog = useCloudAgentCatalog();
+  const cloudCapabilities = useCloudCapabilities();
   const workspaceLive = useWorkspaceLive(workspaceId ?? null, { enabled: Boolean(workspaceId) });
   const snapshot = useMemo(
     () => mergeWorkspaceSnapshot(workspaceQuery.data, workspaceLive.snapshot),
@@ -131,7 +148,9 @@ export function ChatScreen() {
     () => [...(snapshot?.sessions ?? [])].sort(compareSessions),
     [snapshot?.sessions],
   );
-  const suppressSessionRedirect = shouldSuppressWorkspaceSessionRedirect(location.state);
+  const routeSessionDraftId = workspaceId ? webCloudSessionDraftIdFromSearch(location.search) : null;
+  const suppressSessionRedirect = Boolean(routeSessionDraftId && pendingSessionDraft)
+    || shouldSuppressWorkspaceSessionRedirect(location.state);
   const session = chatId
     ? sessions.find((candidate) => candidate.sessionId === chatId) ?? null
     : null;
@@ -168,6 +187,11 @@ export function ChatScreen() {
     [pendingInteractions],
   );
   const pendingPromptCommandIdsKey = pendingPromptCommandIds.join("\0");
+  const optimisticPromptCommandIds = useMemo(
+    () => optimisticPromptCommandIdsFromPrompts(optimisticPrompts),
+    [optimisticPrompts],
+  );
+  const optimisticPromptCommandIdsKey = optimisticPromptCommandIds.join("\0");
   const pendingConfigCommandIds = useMemo(
     () => pendingConfigCommandIdsFromChanges(pendingConfigChanges),
     [pendingConfigChanges],
@@ -224,13 +248,29 @@ export function ChatScreen() {
   const isUnclaimed = workspace?.visibility === "shared_unclaimed";
   const workspaceReadyAgentKindsKey = workspace?.readyAgentKinds?.join("\0") ?? "";
   const workspaceAllowedAgentKindsKey = workspace?.allowedAgentKinds?.join("\0") ?? "";
+  const workspaceLaunchableAgentKinds = useMemo(() => {
+    const readyAgentKinds = workspace?.readyAgentKinds?.filter(Boolean) ?? [];
+    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
+      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
+    const allowedAgentKinds = workspace?.allowedAgentKinds?.filter(Boolean) ?? [];
+    const launchableKinds = new Set([...readyAgentKinds, ...managedCreditKinds]);
+    const filteredKinds = allowedAgentKinds.length > 0
+      ? [...launchableKinds].filter((kind) => allowedAgentKinds.includes(kind))
+      : [...launchableKinds];
+    return filteredKinds.length > 0 ? filteredKinds : null;
+  }, [
+    cloudCapabilities.data?.agentGateway.managedCreditAgentKinds,
+    workspaceAllowedAgentKindsKey,
+    workspaceReadyAgentKindsKey,
+  ]);
   const liveConfig = readSessionLiveConfig(session);
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
+      launchableAgentKinds: workspaceLaunchableAgentKinds,
       selection: launchSelection,
     }),
-    [agentCatalog.data, launchSelection],
+    [agentCatalog.data, launchSelection, workspaceLaunchableAgentKinds],
   );
   const sessionModelId = session && liveConfig ? getLiveConfigControlValue(liveConfig, "model") : null;
   const composerControls = buildCloudChatComposerControls({
@@ -238,6 +278,7 @@ export function ChatScreen() {
     liveConfig,
     pendingConfigChanges,
     launchCatalog: agentCatalog.data,
+    launchableAgentKinds: workspaceLaunchableAgentKinds,
     launchSelection: resolvedLaunchSelection,
     launchModelId: resolvedLaunchSelection.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID,
     onLaunchAgentModelSelect: (agentKind, modelId) => {
@@ -269,18 +310,12 @@ export function ChatScreen() {
       void submitSessionConfig(rawConfigId, value);
     },
     onSessionAgentModelSelect: ({ agentKind, modelId }) => {
-      setLaunchSelection({
+      openNewSessionDraft({
         agentKind,
         modelId,
         modeId: null,
         controlValues: {},
       });
-      setPendingConfigChanges({});
-      if (workspaceId) {
-        navigate(routes.workspace(workspaceId), {
-          state: { startNewSession: true },
-        });
-      }
     },
   });
 
@@ -297,9 +332,77 @@ export function ChatScreen() {
   useEffect(() => {
     setPendingHomePrompt(workspaceId ? loadPendingHomePrompt(workspaceId) : null);
     setPendingHomePromptStatus(null);
-    setOptimisticPrompts([]);
-    setPendingConfigChanges({});
+    setOptimisticPrompts(workspaceId ? loadWebCloudPromptIntents(workspaceId) : []);
+    setPendingConfigChanges(workspaceId ? loadWebCloudPendingConfigChanges(workspaceId) : {});
+    pendingHomePromptResumeAttemptsRef.current.clear();
   }, [workspaceId]);
+
+  useEffect(() => {
+    setPendingSessionDraft(
+      workspaceId ? loadWebCloudSessionDraftFromSearch(workspaceId, location.search) : null,
+    );
+  }, [location.search, workspaceId]);
+
+  useEffect(() => {
+    if (!workspaceId || optimisticPrompts.some((prompt) => prompt.workspaceId !== workspaceId)) {
+      return;
+    }
+    saveWebCloudPromptIntents(workspaceId, optimisticPrompts);
+  }, [optimisticPrompts, workspaceId]);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+    saveWebCloudPendingConfigChanges(workspaceId, pendingConfigChanges);
+  }, [pendingConfigChanges, workspaceId]);
+
+  useEffect(() => {
+    if (!pendingSessionDraft) {
+      return;
+    }
+    setLaunchSelection(pendingSessionDraft.selection);
+  }, [pendingSessionDraft?.id]);
+
+  useEffect(() => {
+    if (!workspaceId || !routeSessionDraftId || pendingSessionDraft) {
+      return;
+    }
+    clearWebCloudSessionDraft(workspaceId, routeSessionDraftId);
+    navigate(routes.workspace(workspaceId), { replace: true });
+  }, [navigate, pendingSessionDraft, routeSessionDraftId, workspaceId]);
+
+  useEffect(() => {
+    if (!pendingSessionDraft) {
+      return;
+    }
+    const resolvedSelection = resolveCloudLaunchSelection({
+      catalog: agentCatalog.data,
+      launchableAgentKinds: workspaceLaunchableAgentKinds,
+      selection: launchSelection,
+    });
+    const sessionConfigUpdates = buildLaunchSessionConfigUpdates({
+      catalog: agentCatalog.data,
+      launchableAgentKinds: workspaceLaunchableAgentKinds,
+      selection: resolvedSelection,
+    });
+    if (sessionDraftMatchesSelection(pendingSessionDraft, resolvedSelection, sessionConfigUpdates)) {
+      return;
+    }
+    const nextDraft = {
+      ...pendingSessionDraft,
+      selection: resolvedSelection,
+      sessionConfigUpdates,
+    };
+    saveWebCloudSessionDraft(nextDraft);
+    setPendingSessionDraft(nextDraft);
+  }, [
+    agentCatalog.data,
+    launchSelection,
+    pendingSessionDraft?.id,
+    pendingSessionDraft?.workspaceId,
+    workspaceLaunchableAgentKinds,
+  ]);
 
   useEffect(() => {
     if (!workspaceId || !workspace || workspaceStatus === "ready" || workspaceStatus === "error") {
@@ -418,10 +521,13 @@ export function ChatScreen() {
                   baseTranscriptSeq: 0,
                   status: "queued",
                   commandId: result.sendCommandId,
+                  createdAt: Date.now(),
                 },
               ]
           );
           clearPendingHomePrompt(workspace.id);
+          clearWebCloudSessionDraft(workspace.id, pendingSessionDraft?.id ?? routeSessionDraftId);
+          setPendingSessionDraft(null);
           setPendingHomePrompt(null);
           setPendingHomePromptStatus(null);
           void workspaceQuery.refetch();
@@ -467,12 +573,140 @@ export function ChatScreen() {
     enqueueConfig.mutateAsync,
     navigate,
     pendingHomePrompt,
+    routeSessionDraftId,
     workspace?.anyharnessWorkspaceId,
     workspace?.id,
     workspace?.targetId,
     workspaceStatus,
     workspaceAllowedAgentKindsKey,
     workspaceReadyAgentKindsKey,
+    workspaceQuery.refetch,
+  ]);
+
+  useEffect(() => {
+    if (
+      !workspace
+      || chatId
+      || !pendingHomePrompt
+      || pendingHomePrompt.status !== "failed"
+      || directPromptDispatching
+    ) {
+      return;
+    }
+    const recoverableSession = findRecoverableSessionForPendingPrompt(sessions, pendingHomePrompt);
+    if (!recoverableSession) {
+      return;
+    }
+    const runKey = `${workspace.id}:${pendingHomePrompt.id}:resume:${recoverableSession.sessionId}`;
+    if (pendingHomePromptResumeAttemptsRef.current.has(runKey)) {
+      return;
+    }
+    const currentRun = pendingHomePromptDispatchRunRef.current;
+    if (currentRun?.key === runKey && currentRun.active) {
+      return;
+    }
+
+    pendingHomePromptResumeAttemptsRef.current.add(runKey);
+    const run: PendingHomePromptDispatchRun = { key: runKey, active: true, started: true };
+    pendingHomePromptDispatchRunRef.current = run;
+    const isCurrentRun = () =>
+      mountedRef.current && pendingHomePromptDispatchRunRef.current === run && run.active;
+    const setCurrentStatus = (status: string) => {
+      if (isCurrentRun()) {
+        setPendingHomePromptStatus(status);
+      }
+    };
+
+    setPendingHomePromptStatus("Session started; sending queued prompt.");
+    void resumePendingHomePromptInSession({
+      client,
+      workspace,
+      session: recoverableSession,
+      pendingPrompt: pendingHomePrompt,
+      enqueueConfig: enqueueConfig.mutateAsync,
+      enqueuePrompt: enqueuePrompt.mutateAsync,
+      setLatestCommandId: (commandId) => {
+        if (isCurrentRun()) {
+          setLatestCommandId(commandId);
+        }
+      },
+      onStatus: setCurrentStatus,
+      shouldContinue: isCurrentRun,
+    })
+      .then((result) => {
+        if (!isCurrentRun()) {
+          return;
+        }
+        setOptimisticPrompts((current) => {
+          const updated = current.map((prompt) =>
+            prompt.id === pendingHomePrompt.id
+              ? {
+                ...prompt,
+                sessionId: result.sessionId,
+                status: "queued" as const,
+                commandId: result.sendCommandId,
+                errorMessage: null,
+              }
+              : prompt
+          );
+          return updated.some((prompt) => prompt.id === pendingHomePrompt.id)
+            ? updated
+            : [
+              ...updated,
+              {
+                id: pendingHomePrompt.id,
+                workspaceId: workspace.id,
+                sessionId: result.sessionId,
+                text: pendingHomePrompt.text,
+                baseTranscriptSeq: 0,
+                status: "queued",
+                commandId: result.sendCommandId,
+                createdAt: Date.now(),
+              },
+            ];
+        });
+        clearPendingHomePrompt(workspace.id);
+        setPendingHomePrompt(null);
+        setPendingHomePromptStatus(null);
+        setDraft((current) => textMatches(current, pendingHomePrompt.text) ? "" : current);
+        void workspaceQuery.refetch();
+        navigate(routes.chat(workspace.id, result.sessionId), { replace: true });
+      })
+      .catch((error: unknown) => {
+        if (!isCurrentRun()) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Queued prompt could not be sent.";
+        const prompt: PendingHomePrompt = {
+          ...pendingHomePrompt,
+          status: "failed",
+          errorMessage: message,
+        };
+        savePendingHomePrompt(workspace.id, prompt);
+        setPendingHomePrompt(prompt);
+        setPendingHomePromptStatus(message);
+        setDraft((current) => current.trim() ? current : pendingHomePrompt.text);
+      })
+      .finally(() => {
+        if (pendingHomePromptDispatchRunRef.current === run) {
+          pendingHomePromptDispatchRunRef.current = null;
+        }
+      });
+    return () => {
+      if (!run.started) {
+        run.active = false;
+      }
+    };
+  }, [
+    chatId,
+    client,
+    directPromptDispatching,
+    enqueueConfig.mutateAsync,
+    enqueuePrompt.mutateAsync,
+    navigate,
+    pendingHomePrompt,
+    sessions,
+    workspace,
     workspaceQuery.refetch,
   ]);
 
@@ -544,7 +778,10 @@ export function ChatScreen() {
     if (!hasMatchingOptimisticPrompt && !isPersistedPendingPromptCommand) {
       return;
     }
-    const message = command.errorMessage || promptCommandFailureMessage(command.status);
+    const message = commandStatusFailureMessage(
+      command,
+      promptCommandFailureMessage(command.status),
+    ) ?? promptCommandFailureMessage(command.status);
     const isPreparing = isWorkspacePreparationStatus(message);
     if (hasMatchingOptimisticPrompt) {
       setOptimisticPrompts((current) =>
@@ -564,6 +801,7 @@ export function ChatScreen() {
     }
   }, [
     commandStatus.data?.commandId,
+    commandStatus.data?.errorCode,
     commandStatus.data?.errorMessage,
     commandStatus.data?.status,
     pendingPromptCommandId,
@@ -616,6 +854,75 @@ export function ChatScreen() {
   ]);
 
   useEffect(() => {
+    if (optimisticPromptCommandIds.length === 0) {
+      return;
+    }
+    let active = true;
+    let timeoutId: number | undefined;
+
+    const pollOptimisticPromptCommands = async () => {
+      let sawTerminalCommand = false;
+      let failureMessage: string | null = null;
+      for (const commandId of optimisticPromptCommandIds) {
+        try {
+          const command = await getCommandStatus(commandId, client);
+          if (isTerminalCommandStatus(command.status)) {
+            sawTerminalCommand = true;
+          }
+          if (isRejectedCommandStatus(command.status)) {
+            const message = commandStatusFailureMessage(
+              command,
+              promptCommandFailureMessage(command.status),
+            );
+            failureMessage = failureMessage ?? message;
+            setOptimisticPrompts((current) =>
+              current.map((prompt) =>
+                prompt.commandId === command.commandId
+                  ? { ...prompt, status: "failed", errorMessage: message }
+                  : prompt
+              )
+            );
+          } else if (command.status === "accepted" || command.status === "accepted_but_queued") {
+            setOptimisticPrompts((current) =>
+              current.map((prompt) =>
+                prompt.commandId === command.commandId && prompt.status === "sending"
+                  ? { ...prompt, status: "queued" }
+                  : prompt
+              )
+            );
+          }
+        } catch {
+          // Keep polling other commands; a transient read should not strand prompt echoes.
+        }
+      }
+      if (!active) {
+        return;
+      }
+      if (failureMessage) {
+        setPendingHomePromptStatus(failureMessage);
+      }
+      if (sawTerminalCommand) {
+        void transcriptQuery.refetch();
+        void sessionEventsQuery.refetch();
+      }
+      timeoutId = window.setTimeout(pollOptimisticPromptCommands, 3000);
+    };
+
+    timeoutId = window.setTimeout(pollOptimisticPromptCommands, 0);
+    return () => {
+      active = false;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [
+    client,
+    optimisticPromptCommandIdsKey,
+    sessionEventsQuery.refetch,
+    transcriptQuery.refetch,
+  ]);
+
+  useEffect(() => {
     const command = commandStatus.data;
     if (!command || command.commandId !== pendingPromptCommandId) {
       return;
@@ -653,7 +960,10 @@ export function ChatScreen() {
               removePendingConfigCommand(current, command.commandId)
             );
             setPendingHomePromptStatus(
-              command.errorMessage || sessionConfigCommandFailureMessage(command.status),
+              commandStatusFailureMessage(
+                command,
+                sessionConfigCommandFailureMessage(command.status),
+              ) ?? sessionConfigCommandFailureMessage(command.status),
             );
           }
         } catch {
@@ -692,7 +1002,10 @@ export function ChatScreen() {
     )) {
       return;
     }
-    const message = command.errorMessage || promptCommandFailureMessage(command.status);
+    const message = commandStatusFailureMessage(
+      command,
+      promptCommandFailureMessage(command.status),
+    ) ?? promptCommandFailureMessage(command.status);
     const isPreparing = isWorkspacePreparationStatus(message);
     setOptimisticPrompts((current) =>
       current.map((prompt) =>
@@ -704,6 +1017,7 @@ export function ChatScreen() {
     setPendingHomePromptStatus(message);
   }, [
     commandStatus.data?.commandId,
+    commandStatus.data?.errorCode,
     commandStatus.data?.errorMessage,
     commandStatus.data?.status,
     optimisticPrompts,
@@ -739,6 +1053,7 @@ export function ChatScreen() {
         text,
         baseTranscriptSeq: 0,
         status: "sending",
+        createdAt: Date.now(),
       };
       setOptimisticPrompts((current) => [
         ...removeRetryReplacedFailedPrompts(current, optimisticPrompt),
@@ -747,16 +1062,24 @@ export function ChatScreen() {
       setDraft("");
       setDirectPromptDispatching(true);
       setPendingHomePromptStatus("Starting a session for this prompt.");
+      const promptSelection = resolveCloudLaunchSelection({
+        catalog: agentCatalog.data,
+        launchableAgentKinds: workspaceLaunchableAgentKinds,
+        selection: pendingSessionDraft?.selection ?? resolvedLaunchSelection,
+      });
+      const promptConfigUpdates = pendingSessionDraft?.sessionConfigUpdates
+        ?? buildLaunchSessionConfigUpdates({
+          catalog: agentCatalog.data,
+          launchableAgentKinds: workspaceLaunchableAgentKinds,
+          selection: promptSelection,
+        });
       const pendingPrompt: PendingHomePrompt = {
         id: promptId,
         text,
-        agentKind: resolvedLaunchSelection.agentKind,
-        modelId: resolvedLaunchSelection.modelId,
-        modeId: resolvedLaunchSelection.modeId,
-        sessionConfigUpdates: buildLaunchSessionConfigUpdates({
-          catalog: agentCatalog.data,
-          selection: resolvedLaunchSelection,
-        }),
+        agentKind: promptSelection.agentKind,
+        modelId: promptSelection.modelId,
+        modeId: promptSelection.modeId,
+        sessionConfigUpdates: promptConfigUpdates,
         createdAt: Date.now(),
       };
       savePendingHomePrompt(workspace.id, pendingPrompt);
@@ -786,6 +1109,8 @@ export function ChatScreen() {
           )
         );
         clearPendingHomePrompt(workspace.id);
+        clearWebCloudSessionDraft(workspace.id, pendingSessionDraft?.id ?? routeSessionDraftId);
+        setPendingSessionDraft(null);
         setPendingHomePrompt(null);
         setPendingHomePromptStatus(null);
         await workspaceQuery.refetch();
@@ -821,6 +1146,7 @@ export function ChatScreen() {
       text,
       baseTranscriptSeq: latestCloudTranscriptSeq(transcriptItems, transcriptView.rows),
       status: "sending",
+      createdAt: Date.now(),
     };
     setOptimisticPrompts((current) => [
       ...removeRetryReplacedFailedPrompts(current, optimisticPrompt),
@@ -839,22 +1165,29 @@ export function ChatScreen() {
         onStatus: setPendingHomePromptStatus,
         shouldContinue: () => mountedRef.current,
       });
-      const command = await enqueuePrompt.mutateAsync({
-        idempotencyKey: optimisticPrompt.id,
-        targetId: session.targetId,
-        workspaceId: session.workspaceId,
-        cloudWorkspaceId: commandWorkspace.id,
-        sessionId: session.sessionId,
-        kind: "send_prompt",
-        source: "web",
-        payload: { text, promptId: optimisticPrompt.id },
+      const command = await enqueuePromptCommandWithRetry({
+        envelope: {
+          idempotencyKey: optimisticPrompt.id,
+          targetId: session.targetId,
+          workspaceId: session.workspaceId,
+          cloudWorkspaceId: commandWorkspace.id,
+          sessionId: session.sessionId,
+          kind: "send_prompt",
+          source: "web",
+          payload: { text, promptId: optimisticPrompt.id },
+        },
+        enqueuePrompt: enqueuePrompt.mutateAsync,
+        shouldContinue: () => mountedRef.current,
       });
       if (!mountedRef.current) {
         return;
       }
       setLatestCommandId(command.commandId);
       if (isRejectedCommandStatus(command.status)) {
-        throw new Error(command.errorMessage || promptCommandFailureMessage(command.status));
+        throw new Error(
+          commandStatusFailureMessage(command, promptCommandFailureMessage(command.status))
+            ?? promptCommandFailureMessage(command.status),
+        );
       }
       setOptimisticPrompts((current) =>
         current.map((prompt) =>
@@ -987,6 +1320,35 @@ export function ChatScreen() {
     }
   }
 
+  function openNewSessionDraft(selection: CloudLaunchComposerSelection = resolvedLaunchSelection) {
+    if (!workspace) {
+      return;
+    }
+    if (pendingSessionDraft) {
+      clearWebCloudSessionDraft(workspace.id, pendingSessionDraft.id);
+    }
+    const resolvedSelection = resolveCloudLaunchSelection({
+      catalog: agentCatalog.data,
+      launchableAgentKinds: workspaceLaunchableAgentKinds,
+      selection,
+    });
+    const draft = createWebCloudSessionDraft({
+      workspaceId: workspace.id,
+      selection: resolvedSelection,
+      sessionConfigUpdates: buildLaunchSessionConfigUpdates({
+        catalog: agentCatalog.data,
+        launchableAgentKinds: workspaceLaunchableAgentKinds,
+        selection: resolvedSelection,
+      }),
+    });
+    saveWebCloudSessionDraft(draft);
+    setPendingSessionDraft(draft);
+    setLaunchSelection(resolvedSelection);
+    setPendingConfigChanges({});
+    setPendingHomePromptStatus(null);
+    navigate(`${routes.workspace(workspace.id)}${webCloudSessionDraftSearch(draft.id)}`);
+  }
+
   if (!workspaceId) {
     return <MissingState title="Workspace not found" />;
   }
@@ -1075,7 +1437,7 @@ export function ChatScreen() {
     ? `Start the first session in ${workspaceTitle}`
     : sessionEventsQuery.isLoading && transcriptView.source === "empty"
       ? "Loading transcript"
-      : "Waiting for the first projected transcript event.";
+      : "No transcript yet";
 
   return (
     <CloudChatSurface
@@ -1129,19 +1491,35 @@ export function ChatScreen() {
         : null}
       sessionSwitcher={{
         workspaceLabel: workspaceTitle,
-        activeSessionId: session?.sessionId ?? null,
+        activeSessionId: session?.sessionId
+          ?? (pendingSessionDraft ? webCloudSessionDraftOptionId(pendingSessionDraft.id) : null),
         activeSessionLabel,
-        sessions: sessions.map((candidate) => ({
-          id: candidate.sessionId,
-          label: sessionOptionLabel(candidate),
-          detail: relativeSessionTime(candidate.lastEventAt ?? candidate.startedAt ?? null),
-          statusLabel: sessionStatusLabel(candidate.status),
-        })),
+        sessions: [
+          ...(pendingSessionDraft
+            ? [{
+              id: webCloudSessionDraftOptionId(pendingSessionDraft.id),
+              label: "New session",
+              detail: pendingSessionDraft.selection.agentKind,
+              statusLabel: "Draft",
+            }]
+            : []),
+          ...sessions.map((candidate) => ({
+            id: candidate.sessionId,
+            label: sessionOptionLabel(candidate),
+            detail: relativeSessionTime(candidate.lastEventAt ?? candidate.startedAt ?? null),
+            statusLabel: sessionStatusLabel(candidate.status),
+          })),
+        ],
         newSessionLabel: "New session",
-        onSelectSession: (sessionId: string) => navigate(routes.chat(workspace.id, sessionId)),
-        onNewSession: () => navigate(routes.workspace(workspace.id), {
-          state: { startNewSession: true },
-        }),
+        onSelectSession: (sessionId: string) => {
+          const draftId = webCloudSessionDraftIdFromOptionId(sessionId);
+          if (draftId) {
+            navigate(`${routes.workspace(workspace.id)}${webCloudSessionDraftSearch(draftId)}`);
+            return;
+          }
+          navigate(routes.chat(workspace.id, sessionId));
+        },
+        onNewSession: () => openNewSessionDraft(),
       }}
       topNotice={isUnclaimed
         ? {
@@ -1203,6 +1581,51 @@ function sessionRecencyMs(
   session: Pick<CloudSessionProjection, "lastEventAt" | "startedAt">,
 ): number {
   return Date.parse(session.lastEventAt ?? session.startedAt ?? "") || 0;
+}
+
+function findRecoverableSessionForPendingPrompt(
+  sessions: readonly CloudSessionProjection[],
+  prompt: PendingHomePrompt,
+): CloudSessionProjection | null {
+  if (Date.now() - prompt.createdAt > 30 * 60 * 1000) {
+    return null;
+  }
+  const earliestStartMs = prompt.createdAt - 30_000;
+  return sessions
+    .filter((session) =>
+      sessionStartedMs(session) >= earliestStartMs
+      && (
+        !prompt.agentKind
+        || !session.sourceAgentKind
+        || session.sourceAgentKind === prompt.agentKind
+      )
+    )
+    .sort(compareSessions)[0] ?? null;
+}
+
+function sessionStartedMs(
+  session: Pick<CloudSessionProjection, "lastEventAt" | "startedAt">,
+): number {
+  return Date.parse(session.startedAt ?? "") || Date.parse(session.lastEventAt ?? "") || 0;
+}
+
+function sessionDraftMatchesSelection(
+  draft: WebCloudSessionDraft,
+  selection: CloudLaunchComposerSelection,
+  sessionConfigUpdates: WebCloudSessionDraft["sessionConfigUpdates"],
+): boolean {
+  return launchSelectionsEqual(draft.selection, selection)
+    && JSON.stringify(draft.sessionConfigUpdates) === JSON.stringify(sessionConfigUpdates);
+}
+
+function launchSelectionsEqual(
+  left: CloudLaunchComposerSelection,
+  right: CloudLaunchComposerSelection,
+): boolean {
+  return left.agentKind === right.agentKind
+    && left.modelId === right.modelId
+    && left.modeId === right.modeId
+    && JSON.stringify(left.controlValues) === JSON.stringify(right.controlValues);
 }
 
 function sessionOptionLabel(session: Pick<CloudSessionProjection, "sessionId" | "title">): string {
@@ -1279,9 +1702,9 @@ function commandStatusMessageForNotice(
   if (!command) {
     return null;
   }
-  const errorMessage = friendlyCommandStatusMessage(command.errorMessage);
-  if (errorMessage) {
-    return errorMessage;
+  const failureMessage = commandStatusFailureMessage(command, null);
+  if (failureMessage) {
+    return failureMessage;
   }
   switch (command.status) {
     case "queued":
@@ -1302,12 +1725,72 @@ function commandStatusMessageForNotice(
   }
 }
 
+function commandStatusFailureMessage(
+  command: Pick<CloudCommandResponse, "errorCode" | "errorMessage" | "status">,
+  fallback: string | null,
+): string | null {
+  const codeMessage = friendlyCommandErrorCodeMessage(command.errorCode);
+  if (codeMessage) {
+    return codeMessage;
+  }
+  const errorMessage = friendlyCommandStatusMessage(command.errorMessage);
+  if (errorMessage) {
+    return errorMessage;
+  }
+  return fallback;
+}
+
+function friendlyCommandErrorCodeMessage(code: string | null | undefined): string | null {
+  switch (code) {
+    case "cloud_command_exposure_not_active":
+    case "cloud_exposure_not_active":
+      return "Workspace access is no longer active. Refresh the workspace, then retry.";
+    case "cloud_command_exposure_not_commandable":
+    case "cloud_exposure_not_commandable":
+      return "This workspace is read-only from Cloud right now.";
+    case "cloud_command_workspace_not_found":
+      return "Workspace no longer exists.";
+    case "cloud_command_workspace_target_mismatch":
+    case "cloud_command_agent_auth_target_mismatch":
+      return "Workspace is attached to a different runtime target. Refresh the workspace, then retry.";
+    case "cloud_command_cloud_workspace_required":
+    case "cloud_workspace_required":
+      return "Workspace accepted. Preparing the selected runtime so this session can start.";
+    case "runtime_config_not_ready":
+      return "Workspace accepted. Preparing cloud runtime access for this target.";
+    case "web_command_queue_timeout":
+      return "Cloud runtime did not pick up the command in time. Check that the runtime is online, then retry.";
+    case "sandbox_wake_blocked":
+      return "Cloud runtime needs billing or quota attention before it can wake.";
+    case "sandbox_wake_failed":
+      return "Cloud runtime wake failed. Retry after the runtime is healthy.";
+    case "sandbox_wake_timeout":
+      return "Cloud runtime did not wake in time. Retry shortly.";
+    case "quota_exceeded":
+    case "cloud_repo_limit_reached":
+      return "Cloud limit reached. Disable another cloud repo or upgrade before creating this workspace.";
+    case "missing_supported_credentials":
+    case "agent_auth_credentials_missing":
+      return "Add credentials for the selected agent before starting this session.";
+    default:
+      return null;
+  }
+}
+
 function workspaceFailureStatusMessage(
   workspace: { lastError?: string | null; statusDetail?: string | null },
 ): string | null {
   return friendlyCommandStatusMessage(workspace.lastError)
-    ?? friendlyCommandStatusMessage(workspace.statusDetail)
+    ?? friendlyWorkspaceStatusDetailMessage(workspace.statusDetail)
     ?? null;
+}
+
+function friendlyWorkspaceStatusDetailMessage(message: string | null | undefined): string | null {
+  const trimmed = message?.trim();
+  if (!trimmed || /^ready$/i.test(trimmed) || /^synced from target\.?$/i.test(trimmed)) {
+    return null;
+  }
+  return friendlyCommandStatusMessage(trimmed);
 }
 
 function isManagedCloudWorkerBaseUrlMessage(message: string): boolean {
@@ -1510,11 +1993,11 @@ function buildOptimisticPromptRows(input: {
         body: prompt.status === "sending" ? "Sending message..." : "Waiting for response...",
         streaming: true,
       });
-    } else if (prompt.status === "failed" && input.status) {
+    } else if (prompt.status === "failed" && (input.status || prompt.errorMessage)) {
       rows.push({
         id: `${prompt.id}:assistant-error`,
         kind: "error",
-        body: input.status,
+        body: input.status ?? prompt.errorMessage ?? "Prompt could not be sent.",
       });
     }
   }
@@ -1594,6 +2077,17 @@ function pendingPromptCommandIdsFromInteractions(
     .map((candidate) => candidate.commandId);
 }
 
+function optimisticPromptCommandIdsFromPrompts(
+  prompts: readonly OptimisticPrompt[],
+): string[] {
+  return [...new Set(
+    prompts
+      .filter((prompt) => prompt.status !== "failed")
+      .map((prompt) => prompt.commandId?.trim() ?? "")
+      .filter((commandId) => commandId.length > 0),
+  )];
+}
+
 function pendingConfigCommandIdsFromChanges(
   pendingConfigChanges: Record<string, PendingConfigChange>,
 ): string[] {
@@ -1657,7 +2151,7 @@ function removeRetryReplacedFailedPrompts(
   );
 }
 
-function optimisticPromptStatusLabel(status: OptimisticPromptStatus): string {
+function optimisticPromptStatusLabel(status: OptimisticPrompt["status"]): string {
   switch (status) {
     case "failed":
       return "Failed";

--- a/web/src/components/home/screen/HomeScreen.tsx
+++ b/web/src/components/home/screen/HomeScreen.tsx
@@ -2,7 +2,14 @@ import { Bot, Cloud, GitBranch, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+  listCloudWorkspaces,
+  type CloudWorkspaceDetail,
+  type CreateCloudWorkspaceRequest,
+  type ProliferateCloudClient,
+} from "@proliferate/cloud-sdk";
+import {
   useCloudAgentCatalog,
+  useCloudCapabilities,
   useCloudClient,
   useCloudRepoConfigs,
   useCreateCloudWorkspace,
@@ -10,6 +17,7 @@ import {
 import {
   buildCloudLaunchComposerControls,
   buildLaunchSessionConfigUpdates,
+  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   resolveCloudLaunchSelection,
@@ -32,6 +40,7 @@ import type { CloudChatTranscriptRowView } from "@proliferate/product-ui/chat/Cl
 import { webEnv } from "../../../config/env";
 import { routes } from "../../../config/routes";
 import { ensurePersonalAgentAuthLaunchReady } from "../../../lib/access/cloud/agent-auth-launch-readiness";
+import { isRecoverableCloudDispatchError } from "../../../lib/access/cloud/pending-home-prompt-dispatch";
 import { savePendingHomePrompt } from "../../../lib/access/cloud/pending-home-prompt-store";
 import { AddCloudEnvironmentDialogController } from "../../environments/screen/AddCloudEnvironmentDialogController";
 
@@ -71,6 +80,7 @@ export function HomeScreen() {
   const [pendingPrompt, setPendingPrompt] = useState<HomePendingPrompt | null>(null);
   const repoConfigs = useCloudRepoConfigs();
   const agentCatalog = useCloudAgentCatalog();
+  const cloudCapabilities = useCloudCapabilities();
   const createWorkspace = useCreateCloudWorkspace();
   const repoOptions = useMemo(
     () => buildRepoOptions(repoConfigs.data?.configs ?? [], webEnv.defaultCloudRepo),
@@ -80,16 +90,25 @@ export function HomeScreen() {
     () => repoOptions.find((repo) => repo.id === repoId) ?? repoOptions[0] ?? null,
     [repoId, repoOptions],
   );
+  const launchableAgentKinds = useMemo(() => {
+    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
+      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
+    return managedCreditKinds.length > 0
+      ? managedCreditKinds
+      : [DEFAULT_DIRECT_PROMPT_AGENT_KIND];
+  }, [cloudCapabilities.data?.agentGateway.managedCreditAgentKinds]);
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
+      launchableAgentKinds,
       selection: launchSelection,
     }),
-    [agentCatalog.data, launchSelection],
+    [agentCatalog.data, launchSelection, launchableAgentKinds],
   );
   const launchComposerControls = useMemo(
     () => buildCloudLaunchComposerControls({
       catalog: agentCatalog.data,
+      launchableAgentKinds,
       selection: resolvedLaunchSelection,
       onAgentModelSelect: (agentKind, modelId) => {
         setLaunchSelection((current) => ({
@@ -114,7 +133,7 @@ export function HomeScreen() {
         });
       },
     }),
-    [agentCatalog.data, resolvedLaunchSelection],
+    [agentCatalog.data, launchableAgentKinds, resolvedLaunchSelection],
   );
 
   useEffect(() => {
@@ -166,6 +185,7 @@ export function HomeScreen() {
         modeId: resolvedLaunchSelection.modeId,
         sessionConfigUpdates: buildLaunchSessionConfigUpdates({
           catalog: agentCatalog.data,
+          launchableAgentKinds,
           selection: resolvedLaunchSelection,
         }),
         createdAt: Date.now(),
@@ -176,7 +196,7 @@ export function HomeScreen() {
         modelId: resolvedLaunchSelection.modelId,
         allowUnavailableFreeCredits: true,
       });
-      const workspace = await createWorkspace.mutateAsync({
+      const workspaceRequest: CreateCloudWorkspaceRequest = {
         gitProvider: "github",
         gitOwner: selectedRepo.gitOwner,
         gitRepoName: selectedRepo.gitRepoName,
@@ -184,6 +204,11 @@ export function HomeScreen() {
         displayName: buildWorkspaceDisplayName(text),
         ownerScope: "personal",
         requiredAgentKind: resolvedLaunchSelection.agentKind,
+      };
+      const workspace = await createCloudWorkspaceWithTransientRecovery({
+        client,
+        request: workspaceRequest,
+        createWorkspace: createWorkspace.mutateAsync,
       });
       savePendingHomePrompt(workspace.id, workspacePendingPrompt);
       navigate(routes.workspace(workspace.id));
@@ -316,6 +341,61 @@ function waitForNextPaint(): Promise<void> {
       });
     });
   });
+}
+
+async function createCloudWorkspaceWithTransientRecovery(args: {
+  client: ProliferateCloudClient;
+  request: CreateCloudWorkspaceRequest;
+  createWorkspace: (request: CreateCloudWorkspaceRequest) => Promise<CloudWorkspaceDetail>;
+}): Promise<Pick<CloudWorkspaceDetail, "id">> {
+  let lastError: unknown = null;
+  for (const delayMs of [0, 750, 1500]) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+    try {
+      return await args.createWorkspace(args.request);
+    } catch (error) {
+      lastError = error;
+      const recovered = await recoverCreatedWorkspaceByBranch(args).catch(() => null);
+      if (recovered) {
+        return recovered;
+      }
+      if (!isRecoverableCloudDispatchError(error) && !isDuplicateBranchError(error)) {
+        throw error;
+      }
+    }
+  }
+  const recovered = await recoverCreatedWorkspaceByBranch(args).catch(() => null);
+  if (recovered) {
+    return recovered;
+  }
+  throw lastError instanceof Error ? lastError : new Error("Could not create workspace.");
+}
+
+async function recoverCreatedWorkspaceByBranch(args: {
+  client: ProliferateCloudClient;
+  request: CreateCloudWorkspaceRequest;
+}): Promise<Pick<CloudWorkspaceDetail, "id"> | null> {
+  const workspaces = await listCloudWorkspaces(
+    undefined,
+    { ownerScope: args.request.ownerScope ?? "personal", scope: "my" },
+    args.client,
+  );
+  return workspaces.find((workspace) =>
+    workspace.repo.owner === args.request.gitOwner
+    && workspace.repo.name === args.request.gitRepoName
+    && workspace.repo.branch === args.request.branchName
+  ) ?? null;
+}
+
+function isDuplicateBranchError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /\bcloud_branch_already_exists\b|\bbranch\b.*\balready exists\b/i.test(message);
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, delayMs));
 }
 
 function normalizeAgentAuthAgentKind(agentKind: string) {

--- a/web/src/lib/access/cloud/agent-auth-launch-readiness.ts
+++ b/web/src/lib/access/cloud/agent-auth-launch-readiness.ts
@@ -24,16 +24,13 @@ export async function ensurePersonalAgentAuthLaunchReady(args: {
   allowUnavailableFreeCredits?: boolean;
   onStatus?: (status: string) => void;
 }): Promise<PersonalAgentAuthLaunchReadiness> {
-  if (args.agentKind && await hasReadyPersonalSelection(args.client, args.agentKind)) {
+  if (args.agentKind && await hasReadyPersonalSelectionWithRetry(args.client, args.agentKind)) {
     args.onStatus?.("Using selected cloud agent credential.");
     return { source: "selected_credential" };
   }
 
   args.onStatus?.("Checking cloud agent credits.");
-  const result = await ensureFreeManagedCredits({
-    agentKind: args.agentKind,
-    modelId: args.modelId,
-  }, args.client);
+  const result = await ensureFreeManagedCreditsWithRetry(args);
   if (!result.launchEnabled && !freeCreditFailureCanFallThrough(result, args.allowUnavailableFreeCredits)) {
     throw new Error(
       result.lastErrorMessage
@@ -43,6 +40,13 @@ export async function ensurePersonalAgentAuthLaunchReady(args: {
     );
   }
   return { source: "free_credits", result };
+}
+
+async function hasReadyPersonalSelectionWithRetry(
+  client: ProliferateCloudClient,
+  agentKind: AgentAuthAgentKind,
+): Promise<boolean> {
+  return withRecoverableRetry(() => hasReadyPersonalSelection(client, agentKind));
 }
 
 async function hasReadyPersonalSelection(
@@ -62,6 +66,49 @@ async function hasReadyPersonalSelection(
   }
   const credential = credentials.find((candidate) => candidate.id === selection.credentialId);
   return credential?.status === "ready";
+}
+
+async function ensureFreeManagedCreditsWithRetry(args: {
+  client: ProliferateCloudClient;
+  agentKind: AgentAuthAgentKind | null;
+  modelId?: string | null;
+}): Promise<EnsureFreeManagedCreditsResponse> {
+  return withRecoverableRetry(() =>
+    ensureFreeManagedCredits({
+      agentKind: args.agentKind,
+      modelId: args.modelId,
+    }, args.client)
+  );
+}
+
+async function withRecoverableRetry<T>(operation: () => Promise<T>): Promise<T> {
+  let lastError: unknown = null;
+  for (const delayMs of [0, 500, 1_250]) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isRecoverableLaunchReadinessError(error)) {
+        throw error;
+      }
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Cloud agent launch readiness could not be checked.");
+}
+
+function isRecoverableLaunchReadinessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /\b(failed to fetch|network|load failed|connection|aborted|timeout|timed out)\b/i
+    .test(message);
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, delayMs));
 }
 
 function freeCreditFailureCanFallThrough(

--- a/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
+++ b/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
@@ -73,18 +73,12 @@ export async function dispatchPendingHomePrompt(args: {
   });
   assertStillCurrent(args.shouldContinue);
   args.onStatus("Sending queued prompt.");
-  const command = await args.enqueuePrompt({
-    idempotencyKey: `${args.pendingPrompt.id}:send`,
-    targetId: session.targetId,
-    workspaceId: session.workspaceId,
-    cloudWorkspaceId: args.workspace.id,
-    sessionId: session.sessionId,
-    kind: "send_prompt",
-    source: "web",
-    payload: {
-      text: args.pendingPrompt.text,
-      promptId: args.pendingPrompt.id,
-    },
+  const command = await enqueuePromptWithRetry({
+    workspace: args.workspace,
+    session,
+    pendingPrompt: args.pendingPrompt,
+    enqueuePrompt: args.enqueuePrompt,
+    shouldContinue: args.shouldContinue,
   });
   args.setLatestCommandId(command.commandId);
   if (isRejectedCommandStatus(command.status)) {
@@ -93,6 +87,47 @@ export async function dispatchPendingHomePrompt(args: {
   args.onStatus("Queued prompt; waiting for transcript.");
   return {
     sessionId: session.sessionId,
+    sendCommandId: command.commandId,
+  };
+}
+
+export async function resumePendingHomePromptInSession(args: {
+  client: ProliferateCloudClient;
+  workspace: CloudWorkspaceDetail;
+  session: CloudSessionProjection;
+  pendingPrompt: PendingHomePrompt;
+  enqueueConfig: EnqueueCloudCommand<UpdateSessionConfigPayload>;
+  enqueuePrompt: EnqueueCloudCommand<SendPromptPayload>;
+  setLatestCommandId: (commandId: string) => void;
+  onStatus: (status: string) => void;
+  shouldContinue: () => boolean;
+}): Promise<PendingHomePromptDispatchResult> {
+  await applyPendingSessionConfigUpdates({
+    client: args.client,
+    workspace: args.workspace,
+    session: args.session,
+    pendingPrompt: args.pendingPrompt,
+    enqueueConfig: args.enqueueConfig,
+    setLatestCommandId: args.setLatestCommandId,
+    onStatus: args.onStatus,
+    shouldContinue: args.shouldContinue,
+  });
+  assertStillCurrent(args.shouldContinue);
+  args.onStatus("Sending queued prompt.");
+  const command = await enqueuePromptWithRetry({
+    workspace: args.workspace,
+    session: args.session,
+    pendingPrompt: args.pendingPrompt,
+    enqueuePrompt: args.enqueuePrompt,
+    shouldContinue: args.shouldContinue,
+  });
+  args.setLatestCommandId(command.commandId);
+  if (isRejectedCommandStatus(command.status)) {
+    assertCommandAccepted(command);
+  }
+  args.onStatus("Queued prompt; waiting for transcript.");
+  return {
+    sessionId: args.session.sessionId,
     sendCommandId: command.commandId,
   };
 }
@@ -131,7 +166,7 @@ async function startSessionForPrompt(args: {
     client: args.client,
     workspaceId: workspace.id,
     targetId,
-  });
+  }).catch(() => new Set<string>());
   const command = await args.enqueueStartSession({
     idempotencyKey: `${args.pendingPrompt.id}:start-session`,
     targetId,
@@ -335,6 +370,63 @@ function normalizeAgentAuthAgentKind(agentKind: string): AgentAuthAgentKind | nu
     || agentKind === "gemini"
     ? agentKind
     : null;
+}
+
+async function enqueuePromptWithRetry(args: {
+  workspace: CloudWorkspaceDetail;
+  session: CloudSessionProjection;
+  pendingPrompt: PendingHomePrompt;
+  enqueuePrompt: EnqueueCloudCommand<SendPromptPayload>;
+  shouldContinue: () => boolean;
+}): Promise<CloudCommandResponse> {
+  const envelope: CloudCommandEnvelope<SendPromptPayload> = {
+    idempotencyKey: `${args.pendingPrompt.id}:send`,
+    targetId: args.session.targetId,
+    workspaceId: args.session.workspaceId,
+    cloudWorkspaceId: args.workspace.id,
+    sessionId: args.session.sessionId,
+    kind: "send_prompt",
+    source: "web",
+    payload: {
+      text: args.pendingPrompt.text,
+      promptId: args.pendingPrompt.id,
+    },
+  };
+  return enqueuePromptCommandWithRetry({
+    envelope,
+    enqueuePrompt: args.enqueuePrompt,
+    shouldContinue: args.shouldContinue,
+  });
+}
+
+export async function enqueuePromptCommandWithRetry(args: {
+  envelope: CloudCommandEnvelope<SendPromptPayload>;
+  enqueuePrompt: EnqueueCloudCommand<SendPromptPayload>;
+  shouldContinue: () => boolean;
+}): Promise<CloudCommandResponse> {
+  let lastError: unknown = null;
+  for (const delayMs of [0, 750, 1500]) {
+    assertStillCurrent(args.shouldContinue);
+    if (delayMs > 0) {
+      await sleep(delayMs);
+      assertStillCurrent(args.shouldContinue);
+    }
+    try {
+      return await args.enqueuePrompt(args.envelope);
+    } catch (error) {
+      lastError = error;
+      if (!isRecoverableCloudDispatchError(error)) {
+        throw error;
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Prompt could not be sent.");
+}
+
+export function isRecoverableCloudDispatchError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /\b(failed to fetch|network|load failed|connection|aborted|timeout|timed out)\b/i
+    .test(message);
 }
 
 async function waitForCommandTerminal(

--- a/web/src/lib/access/cloud/pending-home-prompt-store.ts
+++ b/web/src/lib/access/cloud/pending-home-prompt-store.ts
@@ -16,6 +16,8 @@ export interface PendingHomePrompt {
 }
 
 const PENDING_HOME_PROMPT_KEY_PREFIX = "proliferate.web.pendingHomePrompt:";
+const MAX_PENDING_HOME_PROMPT_AGE_MS = 6 * 60 * 60 * 1000;
+const MAX_FAILED_HOME_PROMPT_AGE_MS = 10 * 60 * 1000;
 const memoryPendingHomePrompts = new Map<string, PendingHomePrompt>();
 
 export function savePendingHomePrompt(
@@ -36,6 +38,10 @@ export function savePendingHomePrompt(
 export function loadPendingHomePrompt(workspaceId: string): PendingHomePrompt | null {
   const memoryPrompt = memoryPendingHomePrompts.get(workspaceId);
   if (memoryPrompt) {
+    if (!isFreshPrompt(memoryPrompt)) {
+      clearPendingHomePrompt(workspaceId);
+      return null;
+    }
     return memoryPrompt;
   }
   let raw: string | null = null;
@@ -52,7 +58,7 @@ export function loadPendingHomePrompt(workspaceId: string): PendingHomePrompt | 
     if (typeof parsed.id !== "string" || typeof parsed.text !== "string") {
       return null;
     }
-    return {
+    const prompt: PendingHomePrompt = {
       id: parsed.id,
       text: parsed.text,
       agentKind: typeof parsed.agentKind === "string" ? parsed.agentKind : null,
@@ -63,6 +69,12 @@ export function loadPendingHomePrompt(workspaceId: string): PendingHomePrompt | 
       status: parsed.status === "failed" ? "failed" : "pending",
       errorMessage: typeof parsed.errorMessage === "string" ? parsed.errorMessage : null,
     };
+    if (!isFreshPrompt(prompt)) {
+      clearPendingHomePrompt(workspaceId);
+      return null;
+    }
+    memoryPendingHomePrompts.set(workspaceId, prompt);
+    return prompt;
   } catch {
     return null;
   }
@@ -79,6 +91,13 @@ export function clearPendingHomePrompt(workspaceId: string): void {
 
 function pendingHomePromptKey(workspaceId: string): string {
   return `${PENDING_HOME_PROMPT_KEY_PREFIX}${workspaceId}`;
+}
+
+function isFreshPrompt(prompt: PendingHomePrompt): boolean {
+  const maxAgeMs = prompt.status === "failed"
+    ? MAX_FAILED_HOME_PROMPT_AGE_MS
+    : MAX_PENDING_HOME_PROMPT_AGE_MS;
+  return Date.now() - prompt.createdAt < maxAgeMs;
 }
 
 function parseSessionConfigUpdates(value: unknown): PendingHomePromptSessionConfigUpdate[] {

--- a/web/src/stores/cloud/web-cloud-chat-state-store.ts
+++ b/web/src/stores/cloud/web-cloud-chat-state-store.ts
@@ -1,0 +1,436 @@
+import {
+  DEFAULT_DIRECT_PROMPT_AGENT_KIND,
+  DEFAULT_DIRECT_PROMPT_MODEL_ID,
+  type CloudLaunchComposerSelection,
+  type LaunchSessionConfigUpdate,
+  type PendingConfigChange,
+} from "@proliferate/product-model/chats/cloud/composer-controls";
+
+export type WebCloudPromptIntentStatus = "sending" | "queued" | "failed";
+
+export interface WebCloudPromptIntent {
+  id: string;
+  workspaceId: string;
+  sessionId: string | null;
+  text: string;
+  baseTranscriptSeq: number;
+  status: WebCloudPromptIntentStatus;
+  commandId?: string | null;
+  errorMessage?: string | null;
+  createdAt: number;
+}
+
+export interface WebCloudSessionDraft {
+  id: string;
+  workspaceId: string;
+  selection: CloudLaunchComposerSelection;
+  sessionConfigUpdates: LaunchSessionConfigUpdate[];
+  createdAt: number;
+}
+
+type StoredPendingConfigChange = PendingConfigChange & { storedAt: number };
+
+export const WEB_CLOUD_SESSION_DRAFT_QUERY_PARAM = "newSession";
+
+const PROMPT_INTENTS_KEY_PREFIX = "proliferate.web.cloudPromptIntents:";
+const PENDING_CONFIG_CHANGES_KEY_PREFIX = "proliferate.web.cloudPendingConfigChanges:";
+const SESSION_DRAFT_KEY_PREFIX = "proliferate.web.cloudSessionDraft:";
+const MAX_PROMPT_INTENT_AGE_MS = 6 * 60 * 60 * 1000;
+const MAX_PENDING_CONFIG_CHANGE_AGE_MS = 30 * 60 * 1000;
+const MAX_SESSION_DRAFT_AGE_MS = 24 * 60 * 60 * 1000;
+
+const memoryPromptIntents = new Map<string, WebCloudPromptIntent[]>();
+const memoryPendingConfigChanges = new Map<string, Record<string, StoredPendingConfigChange>>();
+const memorySessionDrafts = new Map<string, WebCloudSessionDraft>();
+
+export function saveWebCloudPromptIntents(
+  workspaceId: string,
+  prompts: readonly WebCloudPromptIntent[],
+): void {
+  const freshPrompts = freshPromptIntents(workspaceId, prompts).slice(-20);
+  memoryPromptIntents.set(workspaceId, [...freshPrompts]);
+  try {
+    window.sessionStorage.setItem(promptIntentsKey(workspaceId), JSON.stringify(freshPrompts));
+  } catch {
+    // The in-memory copy still carries state across same-tab navigation.
+  }
+}
+
+export function loadWebCloudPromptIntents(workspaceId: string): WebCloudPromptIntent[] {
+  const memoryValue = memoryPromptIntents.get(workspaceId);
+  if (memoryValue) {
+    const fresh = freshPromptIntents(workspaceId, memoryValue);
+    memoryPromptIntents.set(workspaceId, fresh);
+    return [...fresh];
+  }
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(promptIntentsKey(workspaceId));
+  } catch {
+    return [];
+  }
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    const prompts = freshPromptIntents(workspaceId, parsed.flatMap(parsePromptIntent));
+    memoryPromptIntents.set(workspaceId, prompts);
+    return [...prompts];
+  } catch {
+    return [];
+  }
+}
+
+export function clearWebCloudPromptIntents(workspaceId: string): void {
+  memoryPromptIntents.delete(workspaceId);
+  try {
+    window.sessionStorage.removeItem(promptIntentsKey(workspaceId));
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}
+
+export function saveWebCloudPendingConfigChanges(
+  workspaceId: string,
+  changes: Record<string, PendingConfigChange>,
+): void {
+  const now = Date.now();
+  const storedEntries = Object.entries(changes)
+    .filter(([, change]) => isPendingConfigChange(change))
+    .map(([key, change]) => [key, { ...change, storedAt: now }] as const);
+  const stored = Object.fromEntries(storedEntries);
+  memoryPendingConfigChanges.set(workspaceId, stored);
+  try {
+    if (storedEntries.length === 0) {
+      window.sessionStorage.removeItem(pendingConfigChangesKey(workspaceId));
+      return;
+    }
+    window.sessionStorage.setItem(pendingConfigChangesKey(workspaceId), JSON.stringify(stored));
+  } catch {
+    // The in-memory copy still carries state across same-tab navigation.
+  }
+}
+
+export function loadWebCloudPendingConfigChanges(
+  workspaceId: string,
+): Record<string, PendingConfigChange> {
+  const memoryValue = memoryPendingConfigChanges.get(workspaceId);
+  if (memoryValue) {
+    const fresh = parsePendingConfigChanges(memoryValue);
+    memoryPendingConfigChanges.set(workspaceId, stampPendingConfigChanges(fresh));
+    return fresh;
+  }
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(pendingConfigChangesKey(workspaceId));
+  } catch {
+    return {};
+  }
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    const changes = parsePendingConfigChanges(parsed);
+    memoryPendingConfigChanges.set(workspaceId, stampPendingConfigChanges(changes));
+    return changes;
+  } catch {
+    return {};
+  }
+}
+
+export function createWebCloudSessionDraft(input: {
+  workspaceId: string;
+  selection: CloudLaunchComposerSelection;
+  sessionConfigUpdates: LaunchSessionConfigUpdate[];
+}): WebCloudSessionDraft {
+  return {
+    id: `draft:${Date.now().toString(36)}:${randomSuffix()}`,
+    workspaceId: input.workspaceId,
+    selection: normalizeSelection(input.selection),
+    sessionConfigUpdates: input.sessionConfigUpdates,
+    createdAt: Date.now(),
+  };
+}
+
+export function saveWebCloudSessionDraft(draft: WebCloudSessionDraft): void {
+  memorySessionDrafts.set(draftKey(draft.workspaceId, draft.id), draft);
+  try {
+    window.sessionStorage.setItem(sessionDraftKey(draft.workspaceId, draft.id), JSON.stringify(draft));
+  } catch {
+    // The in-memory copy still carries state across same-tab navigation.
+  }
+}
+
+export function loadWebCloudSessionDraft(
+  workspaceId: string,
+  draftId: string | null,
+): WebCloudSessionDraft | null {
+  if (!draftId) {
+    return null;
+  }
+  const key = draftKey(workspaceId, draftId);
+  const memoryValue = memorySessionDrafts.get(key);
+  if (memoryValue) {
+    if (isFresh(memoryValue.createdAt, MAX_SESSION_DRAFT_AGE_MS)) {
+      return memoryValue;
+    }
+    memorySessionDrafts.delete(key);
+  }
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(sessionDraftKey(workspaceId, draftId));
+  } catch {
+    return null;
+  }
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = parseSessionDraft(JSON.parse(raw), workspaceId, draftId);
+    if (!parsed || !isFresh(parsed.createdAt, MAX_SESSION_DRAFT_AGE_MS)) {
+      return null;
+    }
+    memorySessionDrafts.set(key, parsed);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function loadWebCloudSessionDraftFromSearch(
+  workspaceId: string,
+  search: string,
+): WebCloudSessionDraft | null {
+  return loadWebCloudSessionDraft(workspaceId, webCloudSessionDraftIdFromSearch(search));
+}
+
+export function clearWebCloudSessionDraft(workspaceId: string, draftId: string | null): void {
+  if (!draftId) {
+    return;
+  }
+  memorySessionDrafts.delete(draftKey(workspaceId, draftId));
+  try {
+    window.sessionStorage.removeItem(sessionDraftKey(workspaceId, draftId));
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}
+
+export function webCloudSessionDraftIdFromSearch(search: string): string | null {
+  const value = new URLSearchParams(search).get(WEB_CLOUD_SESSION_DRAFT_QUERY_PARAM);
+  return value?.trim() || null;
+}
+
+export function webCloudSessionDraftSearch(draftId: string): string {
+  const params = new URLSearchParams();
+  params.set(WEB_CLOUD_SESSION_DRAFT_QUERY_PARAM, draftId);
+  return `?${params.toString()}`;
+}
+
+export function webCloudSessionDraftOptionId(draftId: string): string {
+  return `session-draft:${draftId}`;
+}
+
+export function isWebCloudSessionDraftOptionId(value: string): boolean {
+  return value.startsWith("session-draft:");
+}
+
+export function webCloudSessionDraftIdFromOptionId(value: string): string | null {
+  return isWebCloudSessionDraftOptionId(value) ? value.slice("session-draft:".length) : null;
+}
+
+function promptIntentsKey(workspaceId: string): string {
+  return `${PROMPT_INTENTS_KEY_PREFIX}${workspaceId}`;
+}
+
+function pendingConfigChangesKey(workspaceId: string): string {
+  return `${PENDING_CONFIG_CHANGES_KEY_PREFIX}${workspaceId}`;
+}
+
+function sessionDraftKey(workspaceId: string, draftId: string): string {
+  return `${SESSION_DRAFT_KEY_PREFIX}${workspaceId}:${draftId}`;
+}
+
+function draftKey(workspaceId: string, draftId: string): string {
+  return `${workspaceId}:${draftId}`;
+}
+
+function freshPromptIntents(
+  workspaceId: string,
+  prompts: readonly WebCloudPromptIntent[],
+): WebCloudPromptIntent[] {
+  return prompts
+    .filter((prompt) => prompt.workspaceId === workspaceId)
+    .filter((prompt) => isFresh(prompt.createdAt, MAX_PROMPT_INTENT_AGE_MS));
+}
+
+function parsePromptIntent(value: unknown): WebCloudPromptIntent[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const id = stringOrNull(record.id);
+  const workspaceId = stringOrNull(record.workspaceId);
+  const text = stringOrNull(record.text);
+  if (!id || !workspaceId || !text) {
+    return [];
+  }
+  return [{
+    id,
+    workspaceId,
+    sessionId: stringOrNull(record.sessionId),
+    text,
+    baseTranscriptSeq: numberOrDefault(record.baseTranscriptSeq, 0),
+    status: parsePromptStatus(record.status),
+    commandId: stringOrNull(record.commandId),
+    errorMessage: stringOrNull(record.errorMessage),
+    createdAt: numberOrDefault(record.createdAt, Date.now()),
+  }];
+}
+
+function parseSessionDraft(
+  value: unknown,
+  workspaceId: string,
+  draftId: string,
+): WebCloudSessionDraft | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (stringOrNull(record.id) !== draftId || stringOrNull(record.workspaceId) !== workspaceId) {
+    return null;
+  }
+  return {
+    id: draftId,
+    workspaceId,
+    selection: normalizeSelection(parseSelection(record.selection)),
+    sessionConfigUpdates: parseSessionConfigUpdates(record.sessionConfigUpdates),
+    createdAt: numberOrDefault(record.createdAt, Date.now()),
+  };
+}
+
+function parseSelection(value: unknown): CloudLaunchComposerSelection {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return normalizeSelection({});
+  }
+  const record = value as Record<string, unknown>;
+  const rawControlValues = record.controlValues;
+  const controlValues: Record<string, string> = {};
+  if (rawControlValues && typeof rawControlValues === "object" && !Array.isArray(rawControlValues)) {
+    for (const [key, item] of Object.entries(rawControlValues)) {
+      const value = stringOrNull(item);
+      if (value) {
+        controlValues[key] = value;
+      }
+    }
+  }
+  return {
+    agentKind: stringOrNull(record.agentKind) ?? DEFAULT_DIRECT_PROMPT_AGENT_KIND,
+    modelId: stringOrNull(record.modelId),
+    modeId: stringOrNull(record.modeId),
+    controlValues,
+  };
+}
+
+function normalizeSelection(value: Partial<CloudLaunchComposerSelection>): CloudLaunchComposerSelection {
+  return {
+    agentKind: value.agentKind || DEFAULT_DIRECT_PROMPT_AGENT_KIND,
+    modelId: value.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID,
+    modeId: value.modeId ?? null,
+    controlValues: value.controlValues ?? {},
+  };
+}
+
+function parseSessionConfigUpdates(value: unknown): LaunchSessionConfigUpdate[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return [];
+    }
+    const record = item as Record<string, unknown>;
+    const configId = stringOrNull(record.configId);
+    const updateValue = stringOrNull(record.value);
+    return configId && updateValue ? [{ configId, value: updateValue }] : [];
+  });
+}
+
+function parsePromptStatus(value: unknown): WebCloudPromptIntentStatus {
+  return value === "queued" || value === "failed" ? value : "sending";
+}
+
+function parsePendingConfigChanges(value: unknown): Record<string, PendingConfigChange> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const changes: Record<string, PendingConfigChange> = {};
+  for (const [key, item] of Object.entries(value)) {
+    const change = parsePendingConfigChange(item);
+    if (change) {
+      changes[key] = change;
+    }
+  }
+  return changes;
+}
+
+function stampPendingConfigChanges(
+  changes: Record<string, PendingConfigChange>,
+): Record<string, StoredPendingConfigChange> {
+  const now = Date.now();
+  return Object.fromEntries(
+    Object.entries(changes).map(([key, change]) => [key, { ...change, storedAt: now }]),
+  );
+}
+
+function parsePendingConfigChange(value: unknown): PendingConfigChange | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (!isFresh(numberOrDefault(record.storedAt, 0), MAX_PENDING_CONFIG_CHANGE_AGE_MS)) {
+    return null;
+  }
+  const sessionId = stringOrNull(record.sessionId);
+  const rawConfigId = stringOrNull(record.rawConfigId);
+  const updateValue = stringOrNull(record.value);
+  if (!sessionId || !rawConfigId || !updateValue) {
+    return null;
+  }
+  return {
+    sessionId,
+    rawConfigId,
+    value: updateValue,
+    status: record.status === "sending" ? "sending" : "queued",
+    mutationId: numberOrDefault(record.mutationId, 0),
+    commandId: stringOrNull(record.commandId),
+  };
+}
+
+function isPendingConfigChange(value: PendingConfigChange): boolean {
+  return Boolean(value.sessionId && value.rawConfigId && value.value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function isFresh(createdAt: number, maxAgeMs: number): boolean {
+  return Date.now() - createdAt < maxAgeMs;
+}
+
+function randomSuffix(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID().slice(0, 8);
+  }
+  return Math.random().toString(36).slice(2, 10);
+}


### PR DESCRIPTION
## Summary
- Harden web cloud workspace/session sending with URL-backed new-session drafts, prompt intent persistence, retry/recovery, and clean top-level status handling.
- Keep workspace live streams and SDK React caches in sync for command status, while stamping started sessions with the selected source harness.
- Limit launch controls to cloud-launchable harnesses, improve sidebar/automation affordances, and send Bifrost Claude virtual keys through the expected custom header.

## Testing
- `git diff --check`
- `pnpm --filter @proliferate/product-model test -- chats/cloud/composer-controls.test.ts automations/inventory.test.ts workspaces/cloud-work-inventory.test.ts`
- `pnpm --filter @proliferate/web typecheck`
- `pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build`
- `cd server && uv run pytest -q tests/integration/test_cloud_agent_auth_api.py -k materialization tests/integration/test_cloud_event_streams_api.py -k workspace_stream tests/integration/test_cloud_commands_api.py -k managed_materialize_and_start_session_create_exposure_cursor`
- `pnpm --filter @proliferate/web build`

## Manual QA
- Created a web cloud workspace from the home prompt and received `pr1-postpatch-home-ok`.
- Sent a message in an existing web session and received `pr1-existing-ok`.
- Created a new session inside an existing workspace and received `pr1-new-session-ok`.
- Switched Claude to Codex in the web composer, sent a prompt, verified the new session is stamped `sourceAgentKind: "codex"`, and received `pr1-codex-ok`.
- Verified the web automations model picker only exposes cloud-launchable Claude/Codex options.
