### PR TITLE
feat(cloud): unlock the web harness matrix

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth_config.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth_config.rs
@@ -10,7 +10,7 @@ use anyharness_contract::v1::{
 };
 use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 use crate::persistence::Db;
 use crate::sessions::mcp_bindings::crypto::{decrypt_bytes, encrypt_bytes, SessionDataCipher};
@@ -39,7 +39,7 @@ const CLAUDE_GATEWAY_PROTECTED_ENV: &[&str] = &[
     "ANTHROPIC_CUSTOM_HEADERS",
     "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
 ];
-const CODEX_GATEWAY_PROTECTED_ENV: &[&str] = &["CODEX_API_KEY", "CODEX_HOME"];
+const CODEX_GATEWAY_PROTECTED_ENV: &[&str] = &["CODEX_API_KEY", "OPENAI_API_KEY", "CODEX_HOME"];
 const OPENCODE_GATEWAY_PROTECTED_ENV: &[&str] = &["OPENAI_API_KEY", "OPENAI_BASE_URL"];
 const GEMINI_GATEWAY_PROTECTED_ENV: &[&str] = &["GEMINI_API_KEY", "GOOGLE_GEMINI_BASE_URL"];
 const CLAUDE_SYNCED_PROTECTED_ENV: &[&str] = &[];
@@ -391,7 +391,15 @@ impl AgentAuthConfigService {
             let Some(config) = selection.protected_config.get("codex") else {
                 continue;
             };
-            write_codex_config(&self.codex_home_dir(), config)?;
+            write_codex_config(
+                &self.codex_home_dir(),
+                config,
+                selection
+                    .protected_env
+                    .get("OPENAI_API_KEY")
+                    .or_else(|| selection.protected_env.get("CODEX_API_KEY"))
+                    .map(String::as_str),
+            )?;
         }
         Ok(())
     }
@@ -599,12 +607,17 @@ fn sanitize_scope_part(value: &str) -> String {
         .collect()
 }
 
-fn write_codex_config(codex_home: &PathBuf, config: &Value) -> anyhow::Result<()> {
+fn write_codex_config(
+    codex_home: &PathBuf,
+    config: &Value,
+    api_key: Option<&str>,
+) -> anyhow::Result<()> {
     let object = config
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("codex protectedConfig must be an object"))?;
-    let provider_id = string_value(object, "model_provider_id")
-        .ok_or_else(|| anyhow::anyhow!("codex protectedConfig missing model_provider_id"))?;
+    let provider_id = string_value(object, "model_provider")
+        .or_else(|| string_value(object, "model_provider_id"))
+        .ok_or_else(|| anyhow::anyhow!("codex protectedConfig missing model_provider"))?;
     let providers = object
         .get("model_providers")
         .and_then(Value::as_object)
@@ -625,7 +638,9 @@ fn write_codex_config(codex_home: &PathBuf, config: &Value) -> anyhow::Result<()
         .unwrap_or(false);
 
     let contents = format!(
-        "model_provider_id = {}\n\n[model_providers.{}]\nname = {}\nbase_url = {}\nenv_key = {}\nwire_api = {}\nrequires_openai_auth = {}\n",
+        "openai_base_url = {}\nenv_key = {}\n\nmodel_provider = {}\n\n[model_providers.{}]\nname = {}\nbase_url = {}\nenv_key = {}\nwire_api = {}\nrequires_openai_auth = {}\n",
+        toml_string(base_url),
+        toml_string(env_key),
         toml_string(provider_id),
         provider_id,
         toml_string(name),
@@ -636,6 +651,21 @@ fn write_codex_config(codex_home: &PathBuf, config: &Value) -> anyhow::Result<()
     );
     fs::create_dir_all(codex_home)?;
     let path = codex_home.join("config.toml");
+    fs::write(&path, contents)?;
+    set_private_file_permissions(&path)?;
+    if let Some(api_key) = api_key.map(str::trim).filter(|value| !value.is_empty()) {
+        write_codex_auth(codex_home, api_key)?;
+    }
+    Ok(())
+}
+
+fn write_codex_auth(codex_home: &PathBuf, api_key: &str) -> anyhow::Result<()> {
+    fs::create_dir_all(codex_home)?;
+    let path = codex_home.join("auth.json");
+    let contents = serde_json::to_vec_pretty(&json!({
+        "auth_mode": "apikey",
+        "OPENAI_API_KEY": api_key,
+    }))?;
     fs::write(&path, contents)?;
     set_private_file_permissions(&path)?;
     Ok(())

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth_config_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth_config_tests.rs
@@ -98,7 +98,7 @@ fn codex_launch_overlay_sets_managed_codex_home() {
                 protected_config: BTreeMap::from([(
                     "codex".to_string(),
                     json!({
-                        "model_provider_id": "proliferate",
+                        "model_provider": "proliferate",
                         "model_providers": {
                             "proliferate": {
                                 "name": "Proliferate Gateway",
@@ -126,6 +126,7 @@ fn codex_launch_overlay_sets_managed_codex_home() {
             .map(String::as_str),
         Some("runtime-token")
     );
+    assert_eq!(overlay.protected_env.get("OPENAI_API_KEY"), None);
     assert_eq!(
         overlay.protected_env.get("CODEX_HOME").map(String::as_str),
         Some(
@@ -140,6 +141,21 @@ fn codex_launch_overlay_sets_managed_codex_home() {
         .join("codex")
         .join("config.toml")
         .exists());
+    let codex_home = root.join("agent-auth").join("codex");
+    let config_toml =
+        std::fs::read_to_string(codex_home.join("config.toml")).expect("codex config");
+    assert!(config_toml.contains("openai_base_url = \"https://gateway.example/openai/v1\""));
+    assert!(config_toml.contains("env_key = \"CODEX_API_KEY\""));
+    assert!(config_toml.contains("model_provider = \"proliferate\""));
+    assert!(!config_toml.contains("model_provider_id"));
+    assert!(config_toml.contains("[model_providers.proliferate]"));
+    assert!(config_toml.contains("env_key = \"CODEX_API_KEY\""));
+
+    let auth_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(codex_home.join("auth.json")).expect("codex auth"))
+            .expect("parse codex auth");
+    assert_eq!(auth_json["auth_mode"], "apikey");
+    assert_eq!(auth_json["OPENAI_API_KEY"], "runtime-token");
 }
 
 #[test]

--- a/anyharness/crates/anyharness-lib/src/sessions/service.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/service.rs
@@ -325,11 +325,10 @@ impl SessionService {
                 .session_store
                 .list_events_after_oldest_limited(session_id, seq, limit)
                 .map(Some),
-            (Some(seq), None, Some(limit), None) => {
-                self.session_store
-                    .list_events_after_limited(session_id, seq, limit)
-                    .map(Some)
-            }
+            (Some(seq), None, Some(limit), None) => self
+                .session_store
+                .list_events_after_limited(session_id, seq, limit)
+                .map(Some),
             (Some(seq), None, None, None) => self
                 .session_store
                 .list_events_after(session_id, seq)

--- a/anyharness/crates/proliferate-worker/src/materialization/agent_auth.rs
+++ b/anyharness/crates/proliferate-worker/src/materialization/agent_auth.rs
@@ -17,7 +17,7 @@ const CLAUDE_GATEWAY_PROTECTED_ENV: &[&str] = &[
     "ANTHROPIC_CUSTOM_HEADERS",
     "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
 ];
-const CODEX_GATEWAY_PROTECTED_ENV: &[&str] = &["CODEX_API_KEY", "CODEX_HOME"];
+const CODEX_GATEWAY_PROTECTED_ENV: &[&str] = &["CODEX_API_KEY", "OPENAI_API_KEY", "CODEX_HOME"];
 const OPENCODE_GATEWAY_PROTECTED_ENV: &[&str] = &["OPENAI_API_KEY", "OPENAI_BASE_URL"];
 const GEMINI_GATEWAY_PROTECTED_ENV: &[&str] = &["GEMINI_API_KEY", "GOOGLE_GEMINI_BASE_URL"];
 const CLAUDE_SYNCED_PROTECTED_ENV: &[&str] = &[];
@@ -459,6 +459,48 @@ mod tests {
         assert_eq!(
             request["selections"][0]["expiresAt"],
             "2026-05-18T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn allows_codex_gateway_env_aliases() {
+        let plan: AgentAuthMaterializationPlan = serde_json::from_value(json!({
+            "applied": true,
+            "targetId": "target-1",
+            "sandboxProfileId": "profile-1",
+            "revision": 7,
+            "selections": [{
+                "agentKind": "codex",
+                "materializationMode": "gateway_env",
+                "credentialId": "credential-1",
+                "credentialRevision": 3,
+                "credentialShareId": null,
+                "gateway": {
+                    "protocolFacade": "openai",
+                    "baseUrls": { "openai": "https://gateway.example/openai/v1" },
+                    "runtimeGrantToken": "grant-token",
+                    "expiresAt": "2026-05-18T00:00:00Z",
+                    "protectedEnv": {
+                        "CODEX_API_KEY": "sk-codex",
+                        "OPENAI_API_KEY": "sk-codex",
+                        "CODEX_HOME": "/home/user/.proliferate/anyharness/agent-auth/codex"
+                    },
+                    "supportEnv": {},
+                    "protectedConfig": {},
+                    "supportConfig": {}
+                }
+            }]
+        }))
+        .expect("plan");
+
+        let (request, outcome) =
+            build_anyharness_agent_auth_request(None, "profile-1", "target-1", None, 7, &plan)
+                .expect("request");
+
+        assert!(outcome.applied);
+        assert_eq!(
+            request["selections"][0]["protectedEnv"]["OPENAI_API_KEY"],
+            "sk-codex"
         );
     }
 

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -125,10 +125,10 @@ export interface CloudWorkspaceRuntimeSummary {
   actionBlockReason?: string | null;
 }
 
-export type CloudAgentKind = "claude" | "codex" | "gemini";
+export type CloudAgentKind = "claude" | "codex" | "opencode" | "gemini";
 
 export function isCloudAgentKind(value: string): value is CloudAgentKind {
-  return value === "claude" || value === "codex" || value === "gemini";
+  return value === "claude" || value === "codex" || value === "opencode" || value === "gemini";
 }
 
 // Generated type aliases — names preserved so all existing import sites are unchanged.

--- a/docs/architecture/agent-llm-auth-gateway-spec.md
+++ b/docs/architecture/agent-llm-auth-gateway-spec.md
@@ -1711,7 +1711,7 @@ Claude:
 
 Codex:
   CODEX_API_KEY
-  model_provider_id
+  model_provider
   model_providers.proliferate.*
   Codex provider config files/env fragments
 
@@ -1764,7 +1764,7 @@ Use the OpenAI Responses-compatible facade.
 Expected config shape:
 
 ```text
-model_provider_id = "proliferate"
+model_provider = "proliferate"
 
 [model_providers.proliferate]
 name = "Proliferate Gateway"

--- a/docs/architecture/bifrost-byok-onboarding-spec.md
+++ b/docs/architecture/bifrost-byok-onboarding-spec.md
@@ -835,7 +835,7 @@ Claude Code in E2B
 Codex in E2B
   CODEX_API_KEY=sk-bf-...
   protected Codex config:
-    model_provider_id=proliferate
+    model_provider=proliferate
     model_providers.proliferate.base_url=https://llm.proliferate.ai/openai/v1
     model_providers.proliferate.env_key=CODEX_API_KEY
     model_providers.proliferate.wire_api=responses
@@ -1370,7 +1370,7 @@ claude
 
 codex
   CODEX_API_KEY = <virtual-key>
-  protectedConfig.codex.model_provider_id = proliferate
+  protectedConfig.codex.model_provider = proliferate
   protectedConfig.codex.model_providers.proliferate.base_url = <public>/openai/v1
   protectedConfig.codex.model_providers.proliferate.env_key = CODEX_API_KEY
   protectedConfig.codex.model_providers.proliferate.wire_api = responses

--- a/docs/current/implementation/02-agent-auth-config.md
+++ b/docs/current/implementation/02-agent-auth-config.md
@@ -766,7 +766,7 @@ protectedEnv:
   CODEX_API_KEY = {runtime_grant}
 
 protectedConfig.codex:
-  model_provider_id = "proliferate"
+  model_provider = "proliferate"
   model_providers.proliferate.base_url = {gateway}/openai/v1
   model_providers.proliferate.env_key = "CODEX_API_KEY"
   model_providers.proliferate.wire_api = "responses"
@@ -905,7 +905,7 @@ It sets CODEX_HOME to runtime_home/agent-auth/codex
 This matches Codex's provider config shape:
 
 ```toml
-model_provider_id = "proliferate"
+model_provider = "proliferate"
 
 [model_providers.proliferate]
 name = "Proliferate Gateway"

--- a/packages/product-model/package.json
+++ b/packages/product-model/package.json
@@ -55,6 +55,10 @@
       "types": "./dist/chats/cloud/composer-controls.d.ts",
       "import": "./dist/chats/cloud/composer-controls.js"
     },
+    "./chats/cloud/harness-availability": {
+      "types": "./dist/chats/cloud/harness-availability.d.ts",
+      "import": "./dist/chats/cloud/harness-availability.js"
+    },
     "./chats/cloud/transcript-view": {
       "types": "./dist/chats/cloud/transcript-view.d.ts",
       "import": "./dist/chats/cloud/transcript-view.js"

--- a/packages/product-model/src/chats/cloud/composer-controls.test.ts
+++ b/packages/product-model/src/chats/cloud/composer-controls.test.ts
@@ -7,6 +7,7 @@ import {
   resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "./composer-controls";
+import { resolveCloudHarnessAvailability } from "./harness-availability";
 
 type Catalog = NonNullable<Parameters<typeof buildCloudLaunchComposerControls>[0]["catalog"]>;
 type ChatControlsInput = Parameters<typeof buildCloudChatComposerControls>[0];
@@ -201,11 +202,22 @@ function multiAgentCatalog(): Catalog {
   const catalog = claudeCatalog() as unknown as {
     agents: Array<{
       session: {
+        modelDisplayPolicy: Catalog["agents"][number]["session"]["modelDisplayPolicy"];
         models: unknown[];
       };
     }>;
   };
 
+  if (catalog.agents[0]) {
+    catalog.agents[0].session.modelDisplayPolicy = {
+      defaultVisibleModelIds: [
+        "us.anthropic.claude-opus-4-6",
+        "us.anthropic.claude-sonnet-4-6",
+      ],
+      allowUserVisibleModelSelection: true,
+      moreModelsSource: "none",
+    };
+  }
   catalog.agents[0]?.session.models.push({
     id: "us.anthropic.claude-sonnet-4-6",
     displayName: "Claude Sonnet 4.6",
@@ -214,6 +226,20 @@ function multiAgentCatalog(): Catalog {
     status: "active",
     isDefault: false,
     defaultOptIn: null,
+    provider: "anthropic",
+    tags: [],
+    capabilities: null,
+    compatibility: null,
+    launchRemediation: null,
+  });
+  catalog.agents[0]?.session.models.push({
+    id: "us.anthropic.claude-hidden-4-6",
+    displayName: "Claude Hidden 4.6",
+    description: null,
+    aliases: [],
+    status: "active",
+    isDefault: false,
+    defaultOptIn: false,
     provider: "anthropic",
     tags: [],
     capabilities: null,
@@ -291,6 +317,15 @@ function claudeSession(modelId: string): NonNullable<ChatControlsInput["session"
   } as unknown as NonNullable<ChatControlsInput["session"]>;
 }
 
+function claudeSessionWithoutSourceAgentKind(
+  modelId: string,
+): NonNullable<ChatControlsInput["session"]> {
+  return {
+    sessionId: "session-1",
+    liveConfig: liveConfigWithModel(modelId),
+  } as unknown as NonNullable<ChatControlsInput["session"]>;
+}
+
 describe("buildCloudLaunchComposerControls", () => {
   it("shows queueable session controls before launch", () => {
     const catalog = claudeCatalog();
@@ -356,6 +391,83 @@ describe("buildCloudLaunchComposerControls", () => {
       agentKind: "claude",
       modelId: "us.anthropic.claude-opus-4-6",
     });
+  });
+
+  it("renders disabled launch controls when no cloud harness can start", () => {
+    const controls = buildCloudLaunchComposerControls({
+      catalog: multiAgentCatalog(),
+      launchableAgentKinds: [],
+      selection: {
+        agentKind: "claude",
+        modelId: "us.anthropic.claude-opus-4-6",
+        modeId: null,
+        controlValues: {},
+      },
+      onAgentModelSelect: () => {},
+      onControlSelect: () => {},
+    });
+
+    expect(controls.map((control) => [control.key, control.disabled])).toEqual([
+      ["model", true],
+      ["mode", true],
+    ]);
+    expect(controls[0]?.groups[0]?.options[0]).toMatchObject({
+      id: "unavailable",
+      label: "No cloud agents ready",
+      disabled: true,
+    });
+    expect(resolveCloudLaunchSelection({
+      catalog: multiAgentCatalog(),
+      launchableAgentKinds: [],
+      selection: {
+        agentKind: "claude",
+        modelId: "us.anthropic.claude-opus-4-6",
+        modeId: "default",
+        controlValues: {},
+      },
+    })).toMatchObject({
+      modelId: null,
+      modeId: null,
+    });
+  });
+});
+
+describe("resolveCloudHarnessAvailability", () => {
+  it("combines workspace-ready auth with managed-credit harnesses", () => {
+    expect(resolveCloudHarnessAvailability({
+      allowedAgentKinds: ["claude", "codex", "gemini", "opencode"],
+      readyAgentKinds: ["gemini"],
+      agentGateway: {
+        enabled: true,
+        managedCreditsPersonalEnabled: true,
+        managedCreditsOrganizationEnabled: false,
+        managedCreditAgentKinds: ["claude", "codex", "opencode"],
+        opencodeGatewayEnabled: false,
+      },
+    })).toMatchObject({
+      launchableAgentKinds: ["claude", "codex", "gemini"],
+      message: null,
+    });
+  });
+
+  it("returns a precise blocked state when gateway and synced auth are unavailable", () => {
+    const availability = resolveCloudHarnessAvailability({
+      allowedAgentKinds: ["claude", "codex"],
+      readyAgentKinds: [],
+      agentGateway: {
+        enabled: false,
+        managedCreditsPersonalEnabled: false,
+        managedCreditsOrganizationEnabled: false,
+        managedCreditAgentKinds: ["claude", "codex"],
+      },
+    });
+
+    expect(availability.launchableAgentKinds).toEqual([]);
+    expect(availability.unavailableAgentKinds.map((item) => item.reason)).toEqual([
+      "agent_gateway_disabled",
+      "agent_gateway_disabled",
+    ]);
+    expect(availability.message).toContain("Agent Gateway is disabled");
   });
 });
 
@@ -423,6 +535,64 @@ describe("buildCloudChatComposerControls", () => {
     expect(configUpdates).toEqual([]);
     expect(sessionSwitches).toEqual([
       { agentKind: "codex", modelId: "gpt-5-codex" },
+    ]);
+  });
+
+  it("infers session harness from the live model when sourceAgentKind is missing", () => {
+    const configUpdates: Array<{ rawConfigId: string; value: string }> = [];
+    const sessionSwitches: Array<{ agentKind: string; modelId: string }> = [];
+
+    const controls = buildCloudChatComposerControls({
+      session: claudeSessionWithoutSourceAgentKind("us.anthropic.claude-opus-4-6"),
+      liveConfig: liveConfigWithModel("us.anthropic.claude-opus-4-6"),
+      pendingConfigChanges: {},
+      launchCatalog: multiAgentCatalog(),
+      launchModelId: "us.anthropic.claude-opus-4-6",
+      onLaunchModelSelect: () => {},
+      onSessionConfigSelect: (rawConfigId, value) => {
+        configUpdates.push({ rawConfigId, value });
+      },
+      onSessionAgentModelSelect: (selection) => {
+        sessionSwitches.push(selection);
+      },
+    });
+
+    const modelControl = controls.find((control) => control.key === "model");
+    const codexGroup = modelControl?.groups.find((group) => group.id === "codex");
+    const codexOption = codexGroup?.options[0];
+
+    expect(codexOption).toBeDefined();
+    modelControl?.onSelect?.(codexOption!.id);
+
+    expect(configUpdates).toEqual([]);
+    expect(sessionSwitches).toEqual([
+      { agentKind: "codex", modelId: "gpt-5-codex" },
+    ]);
+  });
+
+  it("keeps cross-harness session model menus focused on catalog-default models", () => {
+    const controls = buildCloudChatComposerControls({
+      session: claudeSession("us.anthropic.claude-opus-4-6"),
+      liveConfig: liveConfigWithModel("us.anthropic.claude-opus-4-6"),
+      pendingConfigChanges: {},
+      launchCatalog: multiAgentCatalog(),
+      launchableAgentKinds: ["claude", "codex"],
+      launchModelId: "us.anthropic.claude-opus-4-6",
+      onLaunchModelSelect: () => {},
+      onSessionConfigSelect: () => {},
+      onSessionAgentModelSelect: () => {},
+    });
+
+    const modelControl = controls.find((control) => control.key === "model");
+    const claudeGroup = modelControl?.groups.find((group) => group.id === "claude");
+    const codexGroup = modelControl?.groups.find((group) => group.id === "codex");
+
+    expect(claudeGroup?.options.map((option) => option.label)).toEqual([
+      "Claude Opus 4.6",
+      "Claude Sonnet 4.6",
+    ]);
+    expect(codexGroup?.options.map((option) => option.label)).toEqual([
+      "GPT-5 Codex",
     ]);
   });
 

--- a/packages/product-model/src/chats/cloud/composer-controls.ts
+++ b/packages/product-model/src/chats/cloud/composer-controls.ts
@@ -16,6 +16,12 @@ import {
   type ConfiguredSessionControlKey,
   type SessionControlIconKey,
 } from "../session-controls/presentation";
+import {
+  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
+  normalizeCloudAgentKindList,
+} from "./harness-availability";
+
+export { DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS } from "./harness-availability";
 
 export interface CloudChatComposerControlOptionView {
   id: string;
@@ -65,7 +71,6 @@ export type PendingConfigChange = {
 
 export const DEFAULT_DIRECT_PROMPT_MODEL_ID = "us.anthropic.claude-sonnet-4-6";
 export const DEFAULT_DIRECT_PROMPT_AGENT_KIND = "claude";
-export const DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS = ["claude", "codex"] as const;
 
 const CLOUD_MODEL_OPTIONS = [
   {
@@ -167,6 +172,12 @@ export function buildCloudLaunchComposerControls(input: {
     launchableAgentKinds: input.launchableAgentKinds,
   });
   if (catalogAgents.length === 0) {
+    if (shouldShowUnavailableLaunchControls({
+      catalog: input.catalog,
+      launchableAgentKinds: input.launchableAgentKinds,
+    })) {
+      return unavailableLaunchComposerControls();
+    }
     return fallbackLaunchComposerControls({
       modelId: input.selection.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID,
       onModelSelect: (modelId) =>
@@ -206,6 +217,17 @@ export function resolveCloudLaunchSelection(input: {
   });
   const agent = selectLaunchAgent(agents, input.selection.agentKind);
   if (!agent) {
+    if (shouldShowUnavailableLaunchControls({
+      catalog: input.catalog,
+      launchableAgentKinds: input.launchableAgentKinds,
+    })) {
+      return {
+        ...input.selection,
+        agentKind: input.selection.agentKind || "",
+        modelId: null,
+        modeId: null,
+      };
+    }
     return {
       ...input.selection,
       agentKind: input.selection.agentKind || DEFAULT_DIRECT_PROMPT_AGENT_KIND,
@@ -481,6 +503,60 @@ function fallbackLaunchComposerControls(input: {
   ];
 }
 
+function unavailableLaunchComposerControls(): CloudChatComposerControlView[] {
+  return [
+    {
+      id: "launch-agent-unavailable",
+      key: "model",
+      label: "Agent",
+      detail: "Unavailable",
+      icon: "bot",
+      placement: "trailing",
+      disabled: true,
+      active: false,
+      groups: [
+        {
+          id: "agents",
+          label: "Cloud agents",
+          options: [
+            {
+              id: "unavailable",
+              label: "No cloud agents ready",
+              description: "Configure agent auth or managed credits before starting a session.",
+              disabled: true,
+              selected: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "launch-mode-unavailable",
+      key: "mode",
+      label: "Cloud task",
+      detail: "Waiting",
+      icon: "sparkles",
+      placement: "leading",
+      disabled: true,
+      active: false,
+      groups: [
+        {
+          id: "mode",
+          options: [
+            {
+              id: "cloud-task",
+              label: "Cloud task",
+              description: "Start a session in this workspace",
+              selected: true,
+              disabled: true,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
 function buildLaunchAgentModelControl(input: {
   agents: readonly CloudAgentCatalogAgent[];
   selectedAgentKind: string;
@@ -498,15 +574,16 @@ function buildLaunchAgentModelControl(input: {
     groups: input.agents.map((agent) => ({
       id: agent.kind,
       label: agent.displayName,
-      options: agent.session.models
-        .filter(isLaunchVisibleModel)
-        .map((model) => ({
-          id: launchAgentModelOptionId(agent.kind, model.id),
-          label: `${agent.displayName} · ${model.displayName}`,
-          description: model.description ?? agent.description ?? null,
-          icon: agentModelIcon(agent.kind),
-          selected: agent.kind === input.selectedAgentKind && model.id === input.selectedModelId,
-        })),
+      options: visibleComposerModels({
+        agent,
+        selectedModelId: agent.kind === input.selectedAgentKind ? input.selectedModelId : null,
+      }).map((model) => ({
+        id: launchAgentModelOptionId(agent.kind, model.id),
+        label: `${agent.displayName} · ${model.displayName}`,
+        description: model.description ?? agent.description ?? null,
+        icon: agentModelIcon(agent.kind),
+        selected: agent.kind === input.selectedAgentKind && model.id === input.selectedModelId,
+      })),
     })).filter((group) => group.options.length > 0),
     onSelect: (optionId) => {
       const parsed = parseLaunchAgentModelOptionId(optionId);
@@ -597,15 +674,25 @@ function launchableCatalogAgents(input: {
   launchableAgentKinds?: readonly string[] | null;
   includeAgentKind?: string | null;
 }): CloudAgentCatalogAgent[] {
-  const launchableKinds = input.launchableAgentKinds?.filter(Boolean) ?? [];
-  if (launchableKinds.length === 0) {
-    return [...input.agents];
-  }
+  const launchableKinds = normalizeCloudAgentKindList(
+    input.launchableAgentKinds ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
+  );
   const allowed = new Set(launchableKinds);
   if (input.includeAgentKind) {
     allowed.add(input.includeAgentKind);
   }
   return input.agents.filter((agent) => allowed.has(agent.kind));
+}
+
+function shouldShowUnavailableLaunchControls(input: {
+  catalog?: CloudAgentCatalogResponse | null;
+  launchableAgentKinds?: readonly string[] | null;
+}): boolean {
+  if (input.launchableAgentKinds !== undefined && input.launchableAgentKinds !== null) {
+    return normalizeCloudAgentKindList(input.launchableAgentKinds).length === 0
+      || Boolean(input.catalog?.agents?.length);
+  }
+  return Boolean(input.catalog?.agents?.length);
 }
 
 function selectLaunchModel(
@@ -658,6 +745,55 @@ function isLaunchComposerControl(control: CloudAgentCatalogControl): boolean {
 
 function isLaunchVisibleModel(model: CloudAgentCatalogAgent["session"]["models"][number]): boolean {
   return model.status === "active" || model.status === "candidate";
+}
+
+function visibleComposerModels(input: {
+  agent: CloudAgentCatalogAgent;
+  selectedModelId?: string | null;
+  selectedLabel?: string | null;
+  selectedValue?: string | null;
+}): CloudAgentCatalogAgent["session"]["models"] {
+  const selectedModelId = input.selectedModelId ?? null;
+  const selectedLabel = input.selectedLabel ?? null;
+  const selectedValue = input.selectedValue ?? selectedModelId;
+  const models = input.agent.session.models.filter((model) =>
+    isLaunchVisibleModel(model)
+    && (
+      isCatalogDefaultVisibleModel(input.agent, model)
+      || modelMatchesSelectedValue({
+        displayName: model.displayName,
+        id: model.id,
+        selectedLabel,
+        selectedValue,
+      })
+    )
+  );
+  const fallback = input.agent.session.models.find((model) =>
+    isLaunchVisibleModel(model)
+    && (
+      model.id === selectedModelId
+      || model.id === input.agent.session.defaultModelId
+      || model.isDefault
+    )
+  ) ?? input.agent.session.models.find(isLaunchVisibleModel) ?? null;
+  if (models.length === 0 && fallback) {
+    return [fallback];
+  }
+  return models;
+}
+
+function isCatalogDefaultVisibleModel(
+  agent: CloudAgentCatalogAgent,
+  model: CloudAgentCatalogAgent["session"]["models"][number],
+): boolean {
+  if (typeof model.defaultOptIn === "boolean") {
+    return model.defaultOptIn;
+  }
+  return Boolean(
+    agent.session.modelDisplayPolicy?.defaultVisibleModelIds.includes(model.id)
+    || model.isDefault
+    || model.tags.includes("recommended")
+  );
 }
 
 function isLaunchVisibleControlValue(
@@ -732,7 +868,15 @@ function buildSessionConfigComposerControl(input: {
   const selectedOption = input.control.values.find((option) => option.value === selectedValue)
     ?? input.control.values[0]
     ?? null;
-  const agentKind = input.agentKind ?? agentKindForSessionConfig(input.control);
+  const agentKind = input.agentKind
+    ?? agentKindForSessionConfig(input.control)
+    ?? (input.control.key === "model"
+      ? agentKindForSessionModelValue({
+        catalog: input.catalog ?? null,
+        selectedLabel: selectedOption?.label ?? null,
+        selectedValue,
+      })
+      : null);
   const controlKey = isConfiguredSessionControlKey(input.control.key) ? input.control.key : null;
   const selectedPresentation = controlKey
     ? resolveSessionControlPresentation(agentKind, controlKey, selectedValue)
@@ -776,8 +920,8 @@ function buildSessionConfigComposerControl(input: {
         : null;
       if (
         selectedModel
-        && input.agentKind
-        && selectedModel.agentKind !== input.agentKind
+        && agentKind
+        && selectedModel.agentKind !== agentKind
         && input.onAgentModelSelect
       ) {
         input.onAgentModelSelect(selectedModel);
@@ -833,8 +977,11 @@ function sessionModelGroupsFromCatalog(input: {
     includeAgentKind: input.agentKind,
   });
   const groups = agents.flatMap((agent) => {
-    const options = agent.session.models
-      .filter(isLaunchVisibleModel)
+    const options = visibleComposerModels({
+      agent,
+      selectedLabel: agent.kind === input.agentKind ? input.selectedLabel : null,
+      selectedValue: agent.kind === input.agentKind ? input.selectedValue : null,
+    })
       .map((model) => ({
         id: launchAgentModelOptionId(agent.kind, model.id),
         label: model.displayName,
@@ -935,6 +1082,29 @@ function agentKindForSessionConfig(control: NormalizedSessionControl): string | 
   const source = control.rawConfigId || control.key;
   const separator = source.indexOf(".");
   return separator > 0 ? source.slice(0, separator) : null;
+}
+
+function agentKindForSessionModelValue(input: {
+  catalog: CloudAgentCatalogResponse | null;
+  selectedLabel: string | null;
+  selectedValue: string | null;
+}): string | null {
+  const selectedValue = input.selectedValue?.trim().toLowerCase() ?? "";
+  const selectedLabel = input.selectedLabel?.trim().toLowerCase() ?? "";
+  if (!selectedValue && !selectedLabel) {
+    return null;
+  }
+  for (const agent of input.catalog?.agents ?? []) {
+    if (
+      agent.session.models.some((model) =>
+        model.id.toLowerCase() === selectedValue
+        || model.displayName.toLowerCase() === selectedLabel
+      )
+    ) {
+      return agent.kind;
+    }
+  }
+  return null;
 }
 
 function isLeadingModeControl(control: NormalizedSessionControl): boolean {

--- a/packages/product-model/src/chats/cloud/harness-availability.ts
+++ b/packages/product-model/src/chats/cloud/harness-availability.ts
@@ -1,0 +1,189 @@
+export const CLOUD_AGENT_KIND_ORDER = ["claude", "codex", "gemini", "opencode"] as const;
+export const DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS = ["claude", "codex"] as const;
+
+export type CloudHarnessUnavailableReason =
+  | "agent_gateway_disabled"
+  | "managed_credits_disabled"
+  | "missing_agent_auth"
+  | "opencode_gateway_disabled"
+  | "unsupported_cloud_agent";
+
+export interface CloudAgentGatewayCapabilitiesLike {
+  enabled?: boolean | null;
+  managedCreditsPersonalEnabled?: boolean | null;
+  managedCreditsOrganizationEnabled?: boolean | null;
+  managedCreditAgentKinds?: readonly string[] | null;
+  opencodeGatewayEnabled?: boolean | null;
+}
+
+export interface CloudHarnessUnavailableView {
+  agentKind: string;
+  label: string;
+  reason: CloudHarnessUnavailableReason;
+}
+
+export interface CloudHarnessAvailability {
+  launchableAgentKinds: string[];
+  unavailableAgentKinds: CloudHarnessUnavailableView[];
+  message: string | null;
+}
+
+export function resolveCloudHarnessAvailability(input: {
+  catalogAgentKinds?: readonly string[] | null;
+  allowedAgentKinds?: readonly string[] | null;
+  readyAgentKinds?: readonly string[] | null;
+  agentGateway?: CloudAgentGatewayCapabilitiesLike | null;
+  fallbackAgentKinds?: readonly string[] | null;
+  assumeFallbackAgentKindsLaunchable?: boolean;
+}): CloudHarnessAvailability {
+  const catalogAgentKinds = normalizeCloudAgentKindList(input.catalogAgentKinds);
+  const allowedAgentKinds = normalizeCloudAgentKindList(input.allowedAgentKinds);
+  const readyAgentKinds = normalizeCloudAgentKindList(input.readyAgentKinds);
+  const fallbackAgentKinds = normalizeCloudAgentKindList(
+    input.fallbackAgentKinds ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
+  );
+  const gateway = input.agentGateway;
+  const gatewayKnown = gateway !== undefined;
+  const managedCreditsEnabled = Boolean(
+    gateway?.enabled
+      && (
+        gateway.managedCreditsPersonalEnabled
+        || gateway.managedCreditsOrganizationEnabled
+      ),
+  );
+  const managedCreditAgentKinds = managedCreditsEnabled
+    ? normalizeCloudAgentKindList(gateway?.managedCreditAgentKinds)
+    : [];
+
+  const launchable = new Set<string>(readyAgentKinds);
+  for (const kind of managedCreditAgentKinds) {
+    launchable.add(kind);
+  }
+  if ((!gatewayKnown || input.assumeFallbackAgentKindsLaunchable) && launchable.size === 0) {
+    for (const kind of fallbackAgentKinds) {
+      launchable.add(kind);
+    }
+  }
+
+  const catalog = catalogAgentKinds.length > 0
+    ? new Set(catalogAgentKinds)
+    : new Set(CLOUD_AGENT_KIND_ORDER);
+  const allowed = new Set(
+    (allowedAgentKinds.length > 0 ? allowedAgentKinds : CLOUD_AGENT_KIND_ORDER)
+      .filter((kind) => catalog.has(kind)),
+  );
+  const ready = new Set(readyAgentKinds);
+  const launchableAgentKinds = CLOUD_AGENT_KIND_ORDER
+    .filter((kind) => allowed.has(kind) && launchable.has(kind))
+    .filter((kind) => kind !== "opencode" || ready.has(kind) || Boolean(gateway?.opencodeGatewayEnabled));
+  const launchableSet = new Set(launchableAgentKinds);
+  const unavailableAgentKinds = CLOUD_AGENT_KIND_ORDER.flatMap((kind) => {
+    if (!allowed.has(kind) || launchableSet.has(kind)) {
+      return [];
+    }
+    return [{
+      agentKind: kind,
+      label: cloudAgentKindLabel(kind),
+      reason: unavailableCloudHarnessReason({
+        agentKind: kind,
+        gateway,
+        ready: ready.has(kind),
+        managedCreditsEnabled,
+      }),
+    }];
+  });
+
+  return {
+    launchableAgentKinds,
+    unavailableAgentKinds,
+    message: launchableAgentKinds.length > 0
+      ? null
+      : cloudHarnessUnavailableMessage({ gateway, gatewayKnown, unavailableAgentKinds }),
+  };
+}
+
+export function normalizeCloudAgentKindList(
+  values: readonly string[] | null | undefined,
+): string[] {
+  if (!values) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of values) {
+    const kind = normalizeCloudAgentKind(value);
+    if (!kind || seen.has(kind)) {
+      continue;
+    }
+    seen.add(kind);
+    normalized.push(kind);
+  }
+  return normalized.sort((left, right) =>
+    cloudAgentKindSortIndex(left) - cloudAgentKindSortIndex(right)
+  );
+}
+
+export function normalizeCloudAgentKind(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && CLOUD_AGENT_KIND_ORDER.includes(normalized as never)
+    ? normalized
+    : null;
+}
+
+export function cloudAgentKindLabel(agentKind: string): string {
+  switch (agentKind) {
+    case "claude":
+      return "Claude";
+    case "codex":
+      return "Codex";
+    case "gemini":
+      return "Gemini";
+    case "opencode":
+      return "OpenCode";
+    default:
+      return agentKind;
+  }
+}
+
+function cloudAgentKindSortIndex(agentKind: string): number {
+  const index = CLOUD_AGENT_KIND_ORDER.indexOf(agentKind as never);
+  return index >= 0 ? index : CLOUD_AGENT_KIND_ORDER.length;
+}
+
+function unavailableCloudHarnessReason(input: {
+  agentKind: string;
+  gateway?: CloudAgentGatewayCapabilitiesLike | null;
+  ready: boolean;
+  managedCreditsEnabled: boolean;
+}): CloudHarnessUnavailableReason {
+  if (input.agentKind === "opencode" && !input.ready && !input.gateway?.opencodeGatewayEnabled) {
+    return "opencode_gateway_disabled";
+  }
+  if (!input.gateway?.enabled && !input.ready) {
+    return "agent_gateway_disabled";
+  }
+  if (!input.managedCreditsEnabled && !input.ready) {
+    return "managed_credits_disabled";
+  }
+  return "missing_agent_auth";
+}
+
+function cloudHarnessUnavailableMessage(input: {
+  gateway?: CloudAgentGatewayCapabilitiesLike | null;
+  gatewayKnown: boolean;
+  unavailableAgentKinds: readonly CloudHarnessUnavailableView[];
+}): string {
+  if (!input.gatewayKnown) {
+    return "Checking cloud agent availability.";
+  }
+  if (!input.gateway?.enabled) {
+    return "Agent Gateway is disabled. Configure a synced agent credential or enable managed credits before starting a new cloud session.";
+  }
+  if (input.unavailableAgentKinds.some((item) => item.reason === "opencode_gateway_disabled")) {
+    return "OpenCode gateway support is disabled. Choose Claude or Codex, or enable OpenCode gateway support before launching it.";
+  }
+  if (input.unavailableAgentKinds.some((item) => item.reason === "managed_credits_disabled")) {
+    return "Managed cloud agent credits are not enabled for this account. Configure agent auth before starting a cloud session.";
+  }
+  return "No cloud agent authentication is ready for this workspace. Configure Claude or Codex auth before starting a new session.";
+}

--- a/packages/product-model/src/workspaces/cloud-work-inventory.test.ts
+++ b/packages/product-model/src/workspaces/cloud-work-inventory.test.ts
@@ -423,6 +423,29 @@ describe("cloud work inventory", () => {
     }).state).toBe("workspace_not_ready");
   });
 
+  it("trusts active managed cloud exposure routing when runtime summary lags", () => {
+    const readiness = cloudCommandReadiness({
+      ...workspace({
+        sandboxType: "managed_personal",
+        targetId: "target",
+        runtime: runtime("pending"),
+        exposureState: "tracked",
+        exposure: {
+          id: "exposure",
+          visibility: "private",
+          claimedByUserId: null,
+          defaultProjectionLevel: "live",
+          commandable: true,
+          status: "active",
+        },
+      }),
+      anyharnessWorkspaceId: "runtime-workspace",
+    });
+
+    expect(readiness.state).toBe("ready");
+    expect(readiness.commandable).toBe(true);
+  });
+
   it("surfaces workspace provisioning errors before generic not-ready copy", () => {
     const readiness = cloudCommandReadiness(workspace({
       workspaceStatus: "error",

--- a/packages/product-model/src/workspaces/cloud-work-inventory.ts
+++ b/packages/product-model/src/workspaces/cloud-work-inventory.ts
@@ -558,6 +558,21 @@ export function cloudCommandReadiness(
       message: statusDetail ?? "Workspace runtime is not ready yet. Try again when setup finishes.",
     };
   }
+  const activeExposureCommandable =
+    workspace.exposure?.commandable === true &&
+    workspace.exposure.status === "active" &&
+    (workspace.exposureState === "live" || workspace.exposureState === "tracked");
+  const managedWorkspace =
+    workspace.sandboxType === "managed_personal" || workspace.sandboxType === "managed_shared";
+  const routedManagedWorkspace =
+    managedWorkspace && Boolean(workspace.targetId && workspace.anyharnessWorkspaceId);
+  if (activeExposureCommandable && (routedManagedWorkspace || !managedWorkspace)) {
+    return {
+      state: "ready",
+      commandable: true,
+      message: null,
+    };
+  }
   const runtimeLocation = recentWorkRuntimeLocationForWorkspace(workspace);
   if (runtimeLocation === "offline" || recentWorkCommandability(workspace) === "stale") {
     return {
@@ -581,17 +596,6 @@ export function cloudCommandReadiness(
         message: "Workspace is ready but missing runtime command routing.",
       };
     }
-    return {
-      state: "ready",
-      commandable: true,
-      message: null,
-    };
-  }
-  const activeExposureCommandable =
-    workspace.exposure?.commandable === true &&
-    workspace.exposure.status === "active" &&
-    (workspace.exposureState === "live" || workspace.exposureState === "tracked");
-  if (activeExposureCommandable) {
     return {
       state: "ready",
       commandable: true,

--- a/packages/product-ui/src/chat/CloudChatComposer.tsx
+++ b/packages/product-ui/src/chat/CloudChatComposer.tsx
@@ -679,6 +679,9 @@ function modelConfigSubmenuLabel(control: CloudChatComposerControlView): string 
     case "fast_mode":
       return "Speed";
     case "model":
+      if (control.groups.length > 1) {
+        return "Agent";
+      }
       return activeComposerModelGroup(control)?.label ?? selectedComposerOption(control)?.label ?? control.label;
     default:
       return control.label;

--- a/server/alembic/versions/0f1e2d3c4b5a_agent_gateway_budget_provider_keys.py
+++ b/server/alembic/versions/0f1e2d3c4b5a_agent_gateway_budget_provider_keys.py
@@ -1,0 +1,76 @@
+"""allow one managed provider key per budget subject provider
+
+Revision ID: 0f1e2d3c4b5a
+Revises: fa0b1c2d3e4f
+Create Date: 2026-05-27 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0f1e2d3c4b5a"
+down_revision: str | Sequence[str] | None = "fa0b1c2d3e4f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {
+        index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    }
+
+
+def _drop_index_once(table_name: str, index_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def upgrade() -> None:
+    if not _has_table("agent_gateway_router_materialization"):
+        return
+
+    _drop_index_once(
+        "agent_gateway_router_materialization",
+        "uq_agent_gateway_router_materialization_budget_object",
+    )
+    op.create_index(
+        "uq_agent_gateway_router_materialization_budget_object",
+        "agent_gateway_router_materialization",
+        [
+            "router_kind",
+            "router_object_kind",
+            "object_scope",
+            "budget_subject_id",
+            "router_object_id",
+        ],
+        unique=True,
+        postgresql_where=sa.text("object_scope = 'budget_subject' AND status != 'revoked'"),
+    )
+
+
+def downgrade() -> None:
+    if not _has_table("agent_gateway_router_materialization"):
+        return
+
+    _drop_index_once(
+        "agent_gateway_router_materialization",
+        "uq_agent_gateway_router_materialization_budget_object",
+    )
+    op.create_index(
+        "uq_agent_gateway_router_materialization_budget_object",
+        "agent_gateway_router_materialization",
+        ["router_kind", "router_object_kind", "object_scope", "budget_subject_id"],
+        unique=True,
+        postgresql_where=sa.text("object_scope = 'budget_subject' AND status != 'revoked'"),
+    )

--- a/server/proliferate/db/models/cloud/agent_auth.py
+++ b/server/proliferate/db/models/cloud/agent_auth.py
@@ -826,6 +826,7 @@ class AgentGatewayRouterMaterialization(Base):
             "router_object_kind",
             "object_scope",
             "budget_subject_id",
+            "router_object_id",
             unique=True,
             postgresql_where=text("object_scope = 'budget_subject' AND status != 'revoked'"),
         ),

--- a/server/proliferate/db/store/cloud_agent_auth/store.py
+++ b/server/proliferate/db/store/cloud_agent_auth/store.py
@@ -2180,6 +2180,7 @@ async def upsert_router_materialization(
         filters.append(AgentGatewayRouterMaterialization.policy_id == policy_id)
     elif object_scope == "budget_subject":
         filters.append(AgentGatewayRouterMaterialization.budget_subject_id == budget_subject_id)
+        filters.append(AgentGatewayRouterMaterialization.router_object_id == router_object_id)
     else:
         filters.append(AgentGatewayRouterMaterialization.id.is_(None))
     row = (

--- a/server/proliferate/integrations/anyharness/workspaces.py
+++ b/server/proliferate/integrations/anyharness/workspaces.py
@@ -11,6 +11,8 @@ from proliferate.integrations.anyharness.models import (
     ResolvedRemoteWorkspace,
 )
 
+_MOBILITY_DESTINATION_PREPARE_TIMEOUT_SECONDS = 180.0
+
 
 def _parse_resolved_workspace(
     payload: object,
@@ -89,7 +91,9 @@ async def prepare_runtime_mobility_destination(
     preferred_workspace_name: str | None = None,
 ) -> ResolvedRemoteWorkspace:
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            timeout=_MOBILITY_DESTINATION_PREPARE_TIMEOUT_SECONDS
+        ) as client:
             response = await client.post(
                 f"{runtime_url}/v1/repo-roots/{repo_root_id}/mobility/prepare-destination",
                 headers=auth_headers(access_token),

--- a/server/proliferate/server/cloud/agent_auth/protected_env.py
+++ b/server/proliferate/server/cloud/agent_auth/protected_env.py
@@ -16,7 +16,7 @@ _ALLOWLIST: dict[tuple[str, str], frozenset[str]] = {
             "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
         }
     ),
-    ("codex", "gateway_env"): frozenset({"CODEX_API_KEY", "CODEX_HOME"}),
+    ("codex", "gateway_env"): frozenset({"CODEX_API_KEY", "OPENAI_API_KEY", "CODEX_HOME"}),
     ("opencode", "gateway_env"): frozenset({"OPENAI_API_KEY", "OPENAI_BASE_URL"}),
     ("gemini", "gateway_env"): frozenset({"GEMINI_API_KEY", "GOOGLE_GEMINI_BASE_URL"}),
     ("claude", "synced_files"): frozenset(),

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -114,6 +114,7 @@ _CLEANUP_SELECTION_ERROR_CODES = {
     "credential_revoked",
     "credential_share_revoked",
 }
+_MANAGED_CODEX_HOME = "/home/user/.proliferate/anyharness/agent-auth/codex"
 _OPENCODE_ALLOWED_AUTH_FILES: frozenset[str] = frozenset({".config/opencode/auth.json"})
 _TERMINAL_AGENT_AUTH_REFRESH_COMMAND_STATUSES = frozenset(
     {
@@ -653,10 +654,7 @@ async def ensure_managed_credits_for_organization(
     managed_deployments = tuple(
         deployment
         for agent_kind in requested_agent_kinds
-        for deployment in _gateway_deployments_for_credential(
-            agent_kind=agent_kind,
-            provider_kind="proliferate_bedrock_pool",
-        )
+        for deployment in _managed_credit_deployments_for_agent(agent_kind)[1]
     )
     initial_error_code = (
         "managed_credit_models_not_configured"
@@ -692,10 +690,8 @@ async def ensure_managed_credits_for_organization(
     credentials: list[AgentAuthCredentialRecord] = []
     policies: list[AgentGatewayPolicyRecord] = []
     for agent_kind in requested_agent_kinds:
-        if not _gateway_deployments_for_credential(
-            agent_kind=agent_kind,
-            provider_kind="proliferate_bedrock_pool",
-        ):
+        provider_kind, deployments = _managed_credit_deployments_for_agent(agent_kind)
+        if not deployments:
             continue
         credential = await store.get_managed_gateway_credential(
             db,
@@ -714,7 +710,7 @@ async def ensure_managed_credits_for_organization(
                 display_name="Proliferate managed credits",
                 redacted_summary_json=json.dumps(
                     {
-                        "providerKind": "proliferate_bedrock_pool",
+                        "providerKind": provider_kind,
                         "budgetSubjectId": str(budget.id),
                     },
                     sort_keys=True,
@@ -882,10 +878,7 @@ async def ensure_free_managed_credits_for_user(
     managed_deployments = tuple(
         deployment
         for agent_kind in requested_agent_kinds
-        for deployment in _gateway_deployments_for_credential(
-            agent_kind=agent_kind,
-            provider_kind="proliferate_bedrock_pool",
-        )
+        for deployment in _managed_credit_deployments_for_agent(agent_kind)[1]
     )
     sync_status = "failed"
     status = "invalid"
@@ -897,7 +890,7 @@ async def ensure_free_managed_credits_for_user(
             policy_kind="proliferate_managed",
             router_object_id=existing_budget.litellm_team_id,
             budget_subject_id=None,
-            provider_kind="proliferate_bedrock_pool",
+            provider_kind="proliferate_managed",
             deployments=managed_deployments,
         )
         if (
@@ -961,10 +954,7 @@ async def ensure_free_managed_credits_for_user(
         for selection in await store.list_selections_for_profile(db, profile.id)
     }
     for agent_kind in requested_agent_kinds:
-        deployments = _gateway_deployments_for_credential(
-            agent_kind=agent_kind,
-            provider_kind="proliferate_bedrock_pool",
-        )
+        provider_kind, deployments = _managed_credit_deployments_for_agent(agent_kind)
         if not deployments:
             continue
         credential = await store.get_managed_gateway_credential_for_owner(
@@ -976,7 +966,7 @@ async def ensure_free_managed_credits_for_user(
         )
         redacted_summary_json = json.dumps(
             {
-                "providerKind": "proliferate_bedrock_pool",
+                "providerKind": provider_kind,
                 "budgetSubjectId": str(budget.id),
                 "freeCreditEntitlementId": str(entitlement.id),
             },
@@ -1045,15 +1035,31 @@ async def ensure_free_managed_credits_for_user(
             )
             existing_selection = existing_selections.get(agent_kind)
             should_select_managed_credential = existing_selection is None
-            if existing_selection is not None and body.agent_kind == agent_kind:
+            if existing_selection is not None:
                 existing_credential = await store.get_credential(
                     db,
                     existing_selection.credential_id,
                 )
-                should_select_managed_credential = (
+                existing_is_managed_gateway = (
+                    existing_credential is not None
+                    and existing_credential.credential_kind == "managed_gateway"
+                )
+                managed_selection_needs_refresh = existing_is_managed_gateway and (
+                    existing_selection.status != "active"
+                    or existing_selection.credential_id != credential.id
+                    or existing_selection.credential_share_id is not None
+                    or existing_selection.materialization_mode != "gateway_env"
+                    or existing_selection.selected_revision != credential.revision
+                    or existing_selection.last_error_code is not None
+                    or existing_selection.last_error_message is not None
+                )
+                explicit_agent_refresh = body.agent_kind == agent_kind and (
                     existing_credential is None
                     or existing_credential.credential_kind != "managed_gateway"
                     or existing_selection.credential_id != credential.id
+                )
+                should_select_managed_credential = (
+                    managed_selection_needs_refresh or explicit_agent_refresh
                 )
             if should_select_managed_credential:
                 await select_credential_for_profile(
@@ -2670,8 +2676,8 @@ async def _bifrost_provider_key_for_policy(
     policy: AgentGatewayPolicyRecord,
     agent_kind: str,
 ) -> dict[str, object]:
-    provider_kind = "proliferate_bedrock_pool"
     if policy.policy_kind == "proliferate_managed":
+        provider_kind = _managed_credit_provider_kind_for_agent(agent_kind)
         if policy.budget_subject_id is None:
             raise AgentAuthError(
                 "Managed gateway policy is missing a budget subject.",
@@ -2703,7 +2709,7 @@ async def _bifrost_provider_key_for_policy(
             )
         deployments = _gateway_deployments_for_credential(
             agent_kind=agent_kind,
-            provider_kind="proliferate_bedrock_pool",
+            provider_kind=provider_kind,
         )
         if not deployments:
             raise AgentAuthError(
@@ -2715,8 +2721,9 @@ async def _bifrost_provider_key_for_policy(
             db,
             budget=budget,
             deployments=deployments,
+            provider_kind=provider_kind,
         )
-        provider = _bifrost_managed_provider_name()
+        provider = _bifrost_provider_name_for_provider_kind(provider_kind)
     else:
         provider_credential = await store.get_provider_credential_for_policy(db, policy.id)
         if provider_credential is None:
@@ -2853,14 +2860,20 @@ async def _worker_gateway_config(
             baseUrls={"openai": facade_base},
             runtimeGrantToken=result.virtual_key,
             expiresAt=result.expires_at_iso,
-            protectedEnv={"CODEX_API_KEY": result.virtual_key},
+            protectedEnv={
+                "CODEX_API_KEY": result.virtual_key,
+                "OPENAI_API_KEY": result.virtual_key,
+                "CODEX_HOME": _MANAGED_CODEX_HOME,
+            },
             supportEnv={},
             protectedConfig={
                 "codex": {
-                    "model_provider_id": "proliferate-bifrost",
+                    "openai_base_url": facade_base,
+                    "env_key": "CODEX_API_KEY",
+                    "model_provider": "proliferate",
                     "model_providers": {
-                        "proliferate-bifrost": {
-                            "name": "Proliferate Bifrost",
+                        "proliferate": {
+                            "name": "Proliferate Gateway",
                             "base_url": facade_base,
                             "env_key": "CODEX_API_KEY",
                             "wire_api": "responses",
@@ -3033,8 +3046,22 @@ async def _reconcile_bifrost_managed_budget_subject(
         entitlement_period_key = budget.entitlement_period_key
         budget_duration = budget.budget_duration or AGENT_GATEWAY_BUDGET_DURATION_V1
 
-    deployments = _bifrost_deployments_for_managed_credits()
-    if not deployments:
+    managed_provider_plans: list[
+        tuple[str, tuple[GatewayModelDeploymentRequest, ...]]
+    ] = []
+    seen_provider_kinds: set[str] = set()
+    for agent_kind in _managed_credit_agent_kinds():
+        provider_kind = _managed_credit_provider_kind_for_agent(agent_kind)
+        if provider_kind in seen_provider_kinds:
+            continue
+        deployments = _gateway_deployments_for_credential(
+            agent_kind=agent_kind,
+            provider_kind=provider_kind,
+        )
+        if deployments:
+            managed_provider_plans.append((provider_kind, deployments))
+            seen_provider_kinds.add(provider_kind)
+    if not managed_provider_plans:
         return await _mark_bifrost_budget_failed(
             db,
             budget=budget,
@@ -3054,12 +3081,18 @@ async def _reconcile_bifrost_managed_budget_subject(
     router_object_id = budget.litellm_team_id
     if settings.agent_gateway_enabled and _bifrost_admin_ready():
         try:
-            materialization = await _ensure_bifrost_provider_key_for_managed_budget(
-                db,
-                budget=budget,
-                deployments=deployments,
+            materializations = [
+                await _ensure_bifrost_provider_key_for_managed_budget(
+                    db,
+                    budget=budget,
+                    deployments=deployments,
+                    provider_kind=provider_kind,
+                )
+                for provider_kind, deployments in managed_provider_plans
+            ]
+            router_object_id = (
+                materializations[0].router_object_id if materializations else None
             )
-            router_object_id = materialization.router_object_id
             used = await store.sum_llm_usage_cost_for_budget_subject(
                 db,
                 budget_subject_id=budget.id,
@@ -3070,7 +3103,9 @@ async def _reconcile_bifrost_managed_budget_subject(
                 if Decimal(included_budget_usd) <= 0 or used >= Decimal(included_budget_usd)
                 else "ready"
             )
-            fingerprint = materialization.sync_fingerprint
+            fingerprint = _managed_budget_provider_keys_fingerprint(
+                materializations
+            )
             error_code = None
             error_message = None
         except (BifrostIntegrationError, AgentAuthError) as exc:
@@ -3135,13 +3170,17 @@ async def _ensure_bifrost_provider_key_for_managed_budget(
     *,
     budget: AgentGatewayBudgetSubjectRecord,
     deployments: Sequence[GatewayModelDeploymentRequest],
+    provider_kind: str,
 ) -> store.AgentGatewayRouterMaterializationRecord:
     key_plan = _bifrost_provider_key_plan(
-        provider_kind="proliferate_bedrock_pool",
+        provider_kind=provider_kind,
         provider_payload={},
         deployments=deployments,
         object_id=str(budget.id),
-        display_name=f"Proliferate managed credits {budget.id}",
+        display_name=(
+            "Proliferate managed "
+            f"{_managed_provider_display_label(provider_kind)} credits {budget.id}"
+        ),
     )
     fingerprint = _bifrost_provider_key_fingerprint(key_plan)
     existing = await store.get_router_materialization_by_object_id(
@@ -3320,8 +3359,14 @@ def _bifrost_provider_key_plan(
     display_name: str,
 ) -> dict[str, object]:
     models = [deployment.provider_model for deployment in deployments]
-    if provider_kind == "proliferate_bedrock_pool":
+    if provider_kind in {
+        "proliferate_bedrock_pool",
+        "proliferate_managed_anthropic",
+        "proliferate_managed_openai",
+        "proliferate_managed_gemini",
+    }:
         return _bifrost_managed_provider_key_plan(
+            provider_kind=provider_kind,
             object_id=object_id,
             display_name=display_name,
             models=models,
@@ -3373,7 +3418,13 @@ def _bifrost_provider_key_plan(
 
 def _bifrost_provider_name_for_provider_kind(provider_kind: str) -> str:
     if provider_kind == "proliferate_bedrock_pool":
-        return _bifrost_managed_provider_name()
+        return "bedrock"
+    if provider_kind == "proliferate_managed_anthropic":
+        return "anthropic"
+    if provider_kind == "proliferate_managed_openai":
+        return "openai"
+    if provider_kind == "proliferate_managed_gemini":
+        return "gemini"
     if provider_kind == "anthropic_api_key":
         return "anthropic"
     if provider_kind == "openai_api_key":
@@ -3385,15 +3436,34 @@ def _bifrost_provider_name_for_provider_kind(provider_kind: str) -> str:
     raise BifrostIntegrationError(f"Provider kind is not supported by Bifrost: {provider_kind}.")
 
 
+def _managed_provider_display_label(provider_kind: str) -> str:
+    if provider_kind == "proliferate_bedrock_pool":
+        return "Bedrock"
+    if provider_kind == "proliferate_managed_anthropic":
+        return "Anthropic"
+    if provider_kind == "proliferate_managed_openai":
+        return "OpenAI"
+    if provider_kind == "proliferate_managed_gemini":
+        return "Gemini"
+    raise BifrostIntegrationError(
+        f"Provider kind is not supported by managed credits: {provider_kind}."
+    )
+
+
 def _bifrost_managed_provider_key_plan(
     *,
+    provider_kind: str,
     object_id: str,
     display_name: str,
     models: Sequence[str],
 ) -> dict[str, object]:
+    provider_slug = provider_kind.removeprefix("proliferate_managed_").replace("_", "-")
+    key_id_prefix = f"proliferate-managed-{provider_slug}"
+    if provider_kind == "proliferate_bedrock_pool":
+        key_id_prefix = "proliferate-managed-bedrock"
     region = settings.agent_gateway_managed_bedrock_region.strip()
     role_arn = settings.agent_gateway_managed_bedrock_role_arn.strip()
-    if region and role_arn:
+    if provider_kind == "proliferate_bedrock_pool" and region and role_arn:
         config: dict[str, object] = {
             "role_arn": bifrost_env_var(role_arn),
             "region": bifrost_env_var(region),
@@ -3404,41 +3474,52 @@ def _bifrost_managed_provider_key_plan(
             config["external_id"] = bifrost_env_var(external_id)
         return {
             "provider": "bedrock",
-            "key_id": f"proliferate-managed-{object_id}",
+            "key_id": f"{key_id_prefix}-{object_id}",
             "name": display_name,
             "value": None,
             "models": list(models),
             "aliases": {},
             "bedrock_key_config": config,
         }
-    if settings.agent_gateway_managed_anthropic_api_key.strip():
+    if (
+        provider_kind == "proliferate_managed_anthropic"
+        and settings.agent_gateway_managed_anthropic_api_key.strip()
+    ):
         return {
             "provider": "anthropic",
-            "key_id": f"proliferate-managed-{object_id}",
+            "key_id": f"{key_id_prefix}-{object_id}",
             "name": display_name,
             "value": settings.agent_gateway_managed_anthropic_api_key.strip(),
             "models": list(models),
             "aliases": {},
         }
-    if settings.agent_gateway_managed_openai_api_key.strip():
+    if (
+        provider_kind == "proliferate_managed_openai"
+        and settings.agent_gateway_managed_openai_api_key.strip()
+    ):
         return {
             "provider": "openai",
-            "key_id": f"proliferate-managed-{object_id}",
+            "key_id": f"{key_id_prefix}-{object_id}",
             "name": display_name,
             "value": settings.agent_gateway_managed_openai_api_key.strip(),
             "models": list(models),
             "aliases": {},
         }
-    if settings.agent_gateway_managed_gemini_api_key.strip():
+    if (
+        provider_kind == "proliferate_managed_gemini"
+        and settings.agent_gateway_managed_gemini_api_key.strip()
+    ):
         return {
             "provider": "gemini",
-            "key_id": f"proliferate-managed-{object_id}",
+            "key_id": f"{key_id_prefix}-{object_id}",
             "name": display_name,
             "value": settings.agent_gateway_managed_gemini_api_key.strip(),
             "models": list(models),
             "aliases": {},
         }
-    raise BifrostIntegrationError("No managed provider credential is configured for Bifrost.")
+    raise BifrostIntegrationError(
+        f"No managed provider credential is configured for Bifrost provider kind: {provider_kind}."
+    )
 
 
 def _bifrost_provider_key_fingerprint(plan: dict[str, object]) -> str:
@@ -3483,22 +3564,67 @@ def _bifrost_virtual_key_fingerprint(
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _bifrost_deployments_for_managed_credits() -> tuple[GatewayModelDeploymentRequest, ...]:
-    provider = _bifrost_managed_provider_name()
-    if provider == "openai":
-        model = "gpt-5.5"
-    elif provider == "gemini":
-        model = "gemini-2.5-pro"
-    elif provider == "anthropic":
-        model = "claude-sonnet-4-6"
-    else:
-        model = "us.anthropic.claude-sonnet-4-6"
-    return (
-        GatewayModelDeploymentRequest(
-            publicModelName=model,
-            providerModel=model,
-        ),
-    )
+def _managed_budget_provider_keys_fingerprint(
+    materializations: Sequence[store.AgentGatewayRouterMaterializationRecord],
+) -> str | None:
+    if not materializations:
+        return None
+    payload = [
+        {
+            "routerObjectId": materialization.router_object_id,
+            "syncFingerprint": materialization.sync_fingerprint,
+        }
+        for materialization in sorted(
+            materializations,
+            key=lambda item: item.router_object_id or "",
+        )
+    ]
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _bifrost_deployments_for_managed_credits(
+    *,
+    agent_kind: str,
+    provider_kind: str,
+) -> tuple[GatewayModelDeploymentRequest, ...]:
+    if agent_kind == "claude":
+        if provider_kind == "proliferate_bedrock_pool":
+            return (
+                GatewayModelDeploymentRequest(
+                    publicModelName="us.anthropic.claude-sonnet-4-6",
+                    providerModel="us.anthropic.claude-sonnet-4-6",
+                ),
+            )
+        if provider_kind == "proliferate_managed_anthropic":
+            return (
+                GatewayModelDeploymentRequest(
+                    publicModelName="claude-sonnet-4-6",
+                    providerModel="claude-sonnet-4-6",
+                ),
+            )
+    if agent_kind == "codex" and provider_kind == "proliferate_managed_openai":
+        return (
+            GatewayModelDeploymentRequest(
+                publicModelName="gpt-5.5",
+                providerModel="gpt-5.5",
+            ),
+        )
+    if agent_kind == "opencode" and provider_kind == "proliferate_managed_openai":
+        return (
+            GatewayModelDeploymentRequest(
+                publicModelName="opencode/big-pickle",
+                providerModel="gpt-5.5",
+            ),
+        )
+    if agent_kind == "gemini" and provider_kind == "proliferate_managed_gemini":
+        return (
+            GatewayModelDeploymentRequest(
+                publicModelName="gemini-2.5-pro",
+                providerModel="gemini-2.5-pro",
+            ),
+        )
+    return ()
 
 
 def _bifrost_managed_provider_name() -> str:
@@ -3891,13 +4017,16 @@ def _gateway_deployments_for_credential(
     agent_kind: str,
     provider_kind: str,
 ) -> tuple[GatewayModelDeploymentRequest, ...]:
-    if provider_kind == "proliferate_bedrock_pool" and agent_kind in {
-        "claude",
-        "codex",
-        "opencode",
-        "gemini",
+    if provider_kind in {
+        "proliferate_bedrock_pool",
+        "proliferate_managed_anthropic",
+        "proliferate_managed_openai",
+        "proliferate_managed_gemini",
     }:
-        return _bifrost_deployments_for_managed_credits()
+        return _bifrost_deployments_for_managed_credits(
+            agent_kind=agent_kind,
+            provider_kind=provider_kind,
+        )
     if agent_kind == "claude":
         if provider_kind in {"bedrock_assume_role", "proliferate_bedrock_pool"}:
             return (
@@ -4636,9 +4765,69 @@ def _managed_credit_agent_kinds() -> tuple[CloudAgentKind, ...]:
         if item.strip()
     ]
     agent_kinds = tuple(
-        item for item in configured if item in {"claude", "codex", "opencode", "gemini"}
+        item
+        for item in configured
+        if item in {"claude", "codex", "opencode", "gemini"}
+        and _managed_credit_agent_kind_has_provider(item)
     )
-    return agent_kinds or _DEFAULT_MANAGED_CREDIT_AGENT_KINDS
+    if agent_kinds:
+        return agent_kinds
+    if not configured:
+        return tuple(
+            item
+            for item in _DEFAULT_MANAGED_CREDIT_AGENT_KINDS
+            if _managed_credit_agent_kind_has_provider(item)
+        )
+    return ()
+
+
+def _managed_credit_agent_kind_has_provider(agent_kind: str) -> bool:
+    if agent_kind == "claude":
+        return bool(
+            (
+                settings.agent_gateway_managed_bedrock_region.strip()
+                and settings.agent_gateway_managed_bedrock_role_arn.strip()
+            )
+            or settings.agent_gateway_managed_anthropic_api_key.strip()
+        )
+    if agent_kind in {"codex", "opencode"}:
+        return bool(settings.agent_gateway_managed_openai_api_key.strip())
+    if agent_kind == "gemini":
+        return bool(settings.agent_gateway_managed_gemini_api_key.strip())
+    return False
+
+
+def _managed_credit_provider_kind_for_agent(agent_kind: str) -> str:
+    if agent_kind == "claude":
+        if (
+            settings.agent_gateway_managed_bedrock_region.strip()
+            and settings.agent_gateway_managed_bedrock_role_arn.strip()
+        ):
+            return "proliferate_bedrock_pool"
+        if settings.agent_gateway_managed_anthropic_api_key.strip():
+            return "proliferate_managed_anthropic"
+    elif agent_kind in {"codex", "opencode"}:
+        if settings.agent_gateway_managed_openai_api_key.strip():
+            return "proliferate_managed_openai"
+    elif agent_kind == "gemini":
+        if settings.agent_gateway_managed_gemini_api_key.strip():
+            return "proliferate_managed_gemini"
+    raise AgentAuthError(
+        "No managed-credit provider is configured for this agent.",
+        code="managed_credit_provider_not_configured",
+        status_code=409,
+    )
+
+
+def _managed_credit_deployments_for_agent(
+    agent_kind: str,
+) -> tuple[str, tuple[GatewayModelDeploymentRequest, ...]]:
+    provider_kind = _managed_credit_provider_kind_for_agent(agent_kind)
+    deployments = _gateway_deployments_for_credential(
+        agent_kind=agent_kind,
+        provider_kind=provider_kind,
+    )
+    return provider_kind, deployments
 
 
 def _user_free_credit_period_key() -> str:

--- a/server/proliferate/server/cloud/capabilities/service.py
+++ b/server/proliferate/server/cloud/capabilities/service.py
@@ -107,6 +107,29 @@ def _managed_credit_agent_kinds() -> list[str]:
         if item.strip()
     ]
     agent_kinds = [
-        item for item in configured if item in {"claude", "codex", "opencode", "gemini"}
+        item
+        for item in configured
+        if item in {"claude", "codex", "opencode", "gemini"}
+        and _managed_credit_agent_kind_has_provider(item)
     ]
-    return agent_kinds or ["claude"]
+    if agent_kinds:
+        return agent_kinds
+    if not configured and _managed_credit_agent_kind_has_provider("claude"):
+        return ["claude"]
+    return []
+
+
+def _managed_credit_agent_kind_has_provider(agent_kind: str) -> bool:
+    if agent_kind == "claude":
+        return bool(
+            (
+                settings.agent_gateway_managed_bedrock_region.strip()
+                and settings.agent_gateway_managed_bedrock_role_arn.strip()
+            )
+            or settings.agent_gateway_managed_anthropic_api_key.strip()
+        )
+    if agent_kind in {"codex", "opencode"}:
+        return bool(settings.agent_gateway_managed_openai_api_key.strip())
+    if agent_kind == "gemini":
+        return bool(settings.agent_gateway_managed_gemini_api_key.strip())
+    return False

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -1359,6 +1359,13 @@ async def _mark_pending_prompt_interaction_failed_for_command(
     )
 
 
+async def mark_pending_prompt_interaction_failed_for_command(
+    db: AsyncSession,
+    command: commands_store.CloudCommandSnapshot,
+) -> None:
+    await _mark_pending_prompt_interaction_failed_for_command(db, command)
+
+
 async def _validate_managed_runtime_config_current_for_command(
     db: AsyncSession,
     *,

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -671,6 +671,8 @@ def _session_projection_patch(
         return SessionProjectionPatch(status="running", phase="turn_running")
     if event_type_value == "turn_ended":
         return SessionProjectionPatch(status="idle", phase="idle")
+    if event_type_value == "error":
+        return SessionProjectionPatch(status="idle", phase="idle")
     if event_type_value == "session_info_update":
         return SessionProjectionPatch(title=_str_or_none(event.get("title")))
     if event_type_value == "config_option_update":

--- a/server/proliferate/server/cloud/runtime/wake.py
+++ b/server/proliferate/server/cloud/runtime/wake.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import timedelta
 from uuid import UUID
@@ -10,12 +11,13 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.cloud import CLOUD_TARGET_HEARTBEAT_STALE_SECONDS
+from proliferate.constants.cloud import CLOUD_TARGET_HEARTBEAT_STALE_SECONDS, CloudCommandKind
 from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.runtime_environments import CloudRuntimeEnvironment
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_sandbox_profiles import load_sandbox_profile_by_id
 from proliferate.db.store.cloud_sync import commands as commands_store
+from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.integrations.sentry import capture_server_sentry_exception
 from proliferate.server.billing.service import authorize_sandbox_start_for_billing_subject
@@ -86,6 +88,7 @@ async def run_managed_slot_wake_job(target_id: UUID, command_id: UUID | None = N
                 now=utcnow(),
             )
             for command in commands:
+                await _fail_pending_prompt_interaction_for_command(db, command)
                 await publish_command_status_after_commit(db, command)
             await db.commit()
             logger.info(
@@ -103,8 +106,51 @@ async def run_managed_slot_wake_job(target_id: UUID, command_id: UUID | None = N
     resumed = await _resume_target_runtime_environment(target_id, command_id=command_id)
     if resumed:
         return
-
     await perform_proliferate_owned_e2b_resume({"target_id": str(target_id)})
+
+
+async def _fail_pending_prompt_interaction_for_command(
+    db: AsyncSession,
+    command: commands_store.CloudCommandSnapshot,
+) -> None:
+    if command.kind != CloudCommandKind.send_prompt.value or command.session_id is None:
+        return
+    try:
+        payload = json.loads(command.payload_json or "{}")
+    except ValueError:
+        return
+    if not isinstance(payload, dict):
+        return
+    prompt_id = _str_or_none(payload.get("promptId"))
+    if not prompt_id:
+        return
+    await events_store.fail_existing_pending_interaction(
+        db,
+        target_id=command.target_id,
+        session_id=command.session_id,
+        request_id=prompt_id,
+        occurred_at=utcnow().isoformat(),
+        description=command.error_message or "Prompt could not be delivered.",
+        payload_json=_compact_json(
+            {
+                **payload,
+                "commandId": str(command.id),
+                "errorCode": command.error_code,
+                "errorMessage": command.error_message,
+                "status": command.status,
+            }
+        ),
+    )
+
+
+def _str_or_none(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _compact_json(value: dict[str, object]) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
 
 
 async def _resume_target_runtime_environment(

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -1131,6 +1131,8 @@ async def record_command_delivery(
         session_id=command.session_id,
         cloud_workspace_id=command.cloud_workspace_id,
     )
+    if _command_result_should_fail_pending_prompt(command):
+        await command_service.mark_pending_prompt_interaction_failed_for_command(db, command)
     await publish_command_status_after_commit(db, command)
     return WorkerCommandStatusResponse(
         command_id=str(command.id),
@@ -1274,12 +1276,24 @@ async def record_command_result(
         body=body,
         status=command.status,
     )
+    if _command_result_should_fail_pending_prompt(command):
+        await command_service.mark_pending_prompt_interaction_failed_for_command(db, command)
     await publish_command_status_after_commit(db, command)
     return WorkerCommandStatusResponse(
         command_id=str(command.id),
         status=command.status,
         updated=True,
     )
+
+
+def _command_result_should_fail_pending_prompt(
+    command: commands_store.CloudCommandSnapshot,
+) -> bool:
+    return command.kind == CloudCommandKind.send_prompt.value and command.status in {
+        CloudCommandStatus.rejected.value,
+        CloudCommandStatus.failed_delivery.value,
+        CloudCommandStatus.superseded.value,
+    }
 
 
 async def list_worker_exposures(

--- a/server/tests/integration/test_cloud_agent_auth_api.py
+++ b/server/tests/integration/test_cloud_agent_auth_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from base64 import b64encode
 from datetime import UTC, datetime
@@ -22,6 +23,7 @@ from proliferate.db.store.cloud_agent_auth import store
 from proliferate.db.store.cloud_sandboxes import ensure_profile_slot
 from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
 from proliferate.integrations.bifrost import (
+    BifrostIntegrationError,
     BifrostLogEntry,
     BifrostLogSearchResult,
     BifrostProviderKeyResult,
@@ -157,7 +159,23 @@ class _FakeBifrostAdminClient:
         self.log_calls: list[dict[str, object]] = []
 
     async def upsert_provider_key(self, **kwargs: object) -> BifrostProviderKeyResult:
-        self.provider_keys.append(dict(kwargs))
+        existing = next(
+            (
+                item
+                for item in self.provider_keys
+                if item["provider"] == kwargs["provider"] and item["key_id"] == kwargs["key_id"]
+            ),
+            None,
+        )
+        if existing is None and any(item["name"] == kwargs["name"] for item in self.provider_keys):
+            raise BifrostIntegrationError(
+                "Bifrost request failed with HTTP 500: API key names must be unique "
+                "across providers."
+            )
+        if existing is None:
+            self.provider_keys.append(dict(kwargs))
+        else:
+            existing.update(dict(kwargs))
         return BifrostProviderKeyResult(
             key_id=str(kwargs["key_id"]),
             provider=str(kwargs["provider"]),
@@ -943,7 +961,17 @@ async def test_free_managed_credits_use_bifrost_provider_key_materialization(
     monkeypatch.setattr(
         "proliferate.server.cloud.agent_auth.service.settings."
         "agent_gateway_managed_credit_agent_kinds",
-        "claude,gemini",
+        "claude,codex,gemini",
+    )
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_managed_openai_api_key",
+        "sk-openai-managed-test",
+    )
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_managed_gemini_api_key",
+        "sk-gemini-managed-test",
     )
 
     tokens = await _create_user_and_get_tokens(
@@ -964,15 +992,27 @@ async def test_free_managed_credits_use_bifrost_provider_key_materialization(
     assert body["launchEnabled"] is True
     assert body["budgetSubject"]["litellmSyncStatus"] == "synced"
     assert body["budgetSubject"]["litellmTeamId"].startswith("proliferate-managed-")
-    assert {item["agentKind"] for item in body["readyAgentModels"]} == {"claude", "gemini"}
-    assert {credential["agentKind"] for credential in body["credentials"]} == {
+    assert {item["agentKind"] for item in body["readyAgentModels"]} == {
         "claude",
+        "codex",
         "gemini",
     }
-    assert len(fake_bifrost.provider_keys) == 1
-    provider_key = fake_bifrost.provider_keys[0]
-    assert provider_key["provider"] == "anthropic"
-    assert provider_key["key_id"] == body["budgetSubject"]["litellmTeamId"]
+    assert {credential["agentKind"] for credential in body["credentials"]} == {
+        "claude",
+        "codex",
+        "gemini",
+    }
+    assert len(fake_bifrost.provider_keys) == 3
+    providers = {provider_key["provider"] for provider_key in fake_bifrost.provider_keys}
+    assert providers == {"anthropic", "openai", "gemini"}
+    provider_key_names = {str(provider_key["name"]) for provider_key in fake_bifrost.provider_keys}
+    assert len(provider_key_names) == 3
+    assert any("Anthropic" in name for name in provider_key_names)
+    assert any("OpenAI" in name for name in provider_key_names)
+    assert any("Gemini" in name for name in provider_key_names)
+    assert body["budgetSubject"]["litellmTeamId"] in {
+        provider_key["key_id"] for provider_key in fake_bifrost.provider_keys
+    }
     assert "sk-ant-managed-test" not in str(body)
 
     repeat = await client.post(
@@ -983,7 +1023,48 @@ async def test_free_managed_credits_use_bifrost_provider_key_materialization(
 
     assert repeat.status_code == 200
     assert repeat.json()["status"] == "ready"
-    assert len(fake_bifrost.provider_keys) == 1
+    assert len(fake_bifrost.provider_keys) == 3
+
+    profile = await store.get_active_personal_sandbox_profile_for_user(
+        db_session,
+        UUID(tokens["user_id"]),
+    )
+    assert profile is not None
+    codex_credential_id = next(
+        UUID(credential["id"])
+        for credential in body["credentials"]
+        if credential["agentKind"] == "codex"
+    )
+    stale_credential = await store.update_credential_status(
+        db_session,
+        credential_id=codex_credential_id,
+        status="ready",
+        redacted_summary_json=json.dumps({"stale": True}, sort_keys=True),
+    )
+    assert stale_credential is not None
+    stale_selection = next(
+        selection
+        for selection in await store.list_selections_for_profile(db_session, profile.id)
+        if selection.agent_kind == "codex"
+    )
+    assert stale_selection.selected_revision != stale_credential.revision
+    await db_session.commit()
+
+    selection_refresh = await client.post(
+        "/v1/cloud/agent-auth/free-credits/ensure",
+        headers=_headers(tokens),
+        json={},
+    )
+
+    assert selection_refresh.status_code == 200
+    refreshed_credential = await store.get_credential(db_session, codex_credential_id)
+    assert refreshed_credential is not None
+    refreshed_selection = next(
+        selection
+        for selection in await store.list_selections_for_profile(db_session, profile.id)
+        if selection.agent_kind == "codex"
+    )
+    assert refreshed_selection.selected_revision == refreshed_credential.revision
 
 
 @pytest.mark.asyncio
@@ -1005,7 +1086,17 @@ async def test_bifrost_worker_materialization_uses_direct_virtual_key_env(
     monkeypatch.setattr(
         "proliferate.server.cloud.agent_auth.service.settings."
         "agent_gateway_managed_credit_agent_kinds",
-        "claude,gemini",
+        "claude,codex,gemini",
+    )
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_managed_openai_api_key",
+        "sk-openai-managed-test",
+    )
+    monkeypatch.setattr(
+        "proliferate.server.cloud.agent_auth.service.settings."
+        "agent_gateway_managed_gemini_api_key",
+        "sk-gemini-managed-test",
     )
 
     tokens = await _create_user_and_get_tokens(
@@ -1102,19 +1193,48 @@ async def test_bifrost_worker_materialization_uses_direct_virtual_key_env(
     assert claude["runtimeGrantToken"] == "sk-bf-runtime-1"
     assert claude["protectedEnv"]["ANTHROPIC_AUTH_TOKEN"] == "sk-bf-runtime-1"
     assert claude["protectedEnv"]["ANTHROPIC_CUSTOM_HEADERS"] == "x-bf-vk: sk-bf-runtime-1"
+    codex = selections["codex"]["gateway"]
+    assert codex["protocolFacade"] == "openai"
+    assert codex["baseUrls"]["openai"] == "https://bifrost.test/openai/v1"
+    assert codex["runtimeGrantToken"] == "sk-bf-runtime-2"
+    assert codex["protectedEnv"] == {
+        "CODEX_API_KEY": "sk-bf-runtime-2",
+        "OPENAI_API_KEY": "sk-bf-runtime-2",
+        "CODEX_HOME": "/home/user/.proliferate/anyharness/agent-auth/codex",
+    }
+    assert codex["protectedConfig"]["codex"] == {
+        "openai_base_url": "https://bifrost.test/openai/v1",
+        "env_key": "CODEX_API_KEY",
+        "model_provider": "proliferate",
+        "model_providers": {
+            "proliferate": {
+                "name": "Proliferate Gateway",
+                "base_url": "https://bifrost.test/openai/v1",
+                "env_key": "CODEX_API_KEY",
+                "wire_api": "responses",
+                "requires_openai_auth": False,
+            }
+        },
+    }
     gemini = selections["gemini"]["gateway"]
     assert gemini["protocolFacade"] == "genai"
     assert gemini["baseUrls"]["genai"] == "https://bifrost.test/genai"
-    assert gemini["runtimeGrantToken"] == "sk-bf-runtime-2"
+    assert gemini["runtimeGrantToken"] == "sk-bf-runtime-3"
     assert gemini["protectedEnv"] == {
-        "GEMINI_API_KEY": "sk-bf-runtime-2",
+        "GEMINI_API_KEY": "sk-bf-runtime-3",
         "GOOGLE_GEMINI_BASE_URL": "https://bifrost.test/genai",
     }
-    assert len(fake_bifrost.virtual_keys) == 2
+    assert len(fake_bifrost.provider_keys) == 3
+    provider_key_ids_by_provider = {
+        str(provider_key["provider"]): str(provider_key["key_id"])
+        for provider_key in fake_bifrost.provider_keys
+    }
+    assert len(fake_bifrost.virtual_keys) == 3
     for virtual_key in fake_bifrost.virtual_keys:
         provider_configs = virtual_key["provider_configs"]
         assert isinstance(provider_configs, list)
-        assert provider_configs[0]["key_ids"] == [ensure.json()["budgetSubject"]["litellmTeamId"]]
+        provider = str(provider_configs[0]["provider"])
+        assert provider_configs[0]["key_ids"] == [provider_key_ids_by_provider[provider]]
         assert provider_configs[0]["allowed_models"] != ["*"]
         assert provider_configs[0]["budgets"][0]["max_limit"] == 5.0
 

--- a/server/tests/integration/test_cloud_capabilities_api.py
+++ b/server/tests/integration/test_cloud_capabilities_api.py
@@ -30,6 +30,7 @@ async def test_cloud_capabilities_response_shape(
     monkeypatch.setattr(settings, "agent_gateway_managed_budget_free_usd", "12.50")
     monkeypatch.setattr(settings, "agent_gateway_managed_budget_pro_usd", "0")
     monkeypatch.setattr(settings, "agent_gateway_managed_budget_unlimited_usd", "0")
+    monkeypatch.setattr(settings, "agent_gateway_managed_anthropic_api_key", "sk-ant-test")
     auth = await create_user_and_login(
         client,
         db_session,

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -1739,6 +1739,214 @@ class TestCloudCommandsApi:
         )
 
     @pytest.mark.asyncio
+    async def test_worker_rejected_web_send_prompt_fails_pending_prompt_interaction(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-pending-prompt-result",
+        )
+        target_id, worker_headers, profile = await _create_managed_profile_target(
+            client,
+            db_session,
+            auth,
+            suffix="pending-prompt-result",
+        )
+        target_uuid = UUID(target_id)
+        await _mark_agent_and_runtime_config_applied(
+            db_session,
+            target_id=target_uuid,
+            profile=profile,
+            user_id=UUID(auth.user_id),
+        )
+        cloud_workspace_id = await _create_ready_managed_cloud_workspace(
+            db_session,
+            profile_id=profile.id,
+            target_id=target_uuid,
+            user_id=UUID(auth.user_id),
+            suffix="pending-prompt-result",
+        )
+        await _seed_managed_session_projection(
+            db_session,
+            target_id=target_uuid,
+            cloud_workspace_id=cloud_workspace_id,
+            user_id=UUID(auth.user_id),
+            session_id="session-pending-prompt-result",
+        )
+        await db_session.commit()
+
+        monkeypatch.setattr(command_service, "kick_off_managed_slot_wake", lambda *_args: None)
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "web-pending-prompt-result",
+                "targetId": target_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "sessionId": "session-pending-prompt-result",
+                "kind": "send_prompt",
+                "source": "web",
+                "payload": {
+                    "text": "prompt that the worker rejects",
+                    "promptId": "web:pending-prompt-result",
+                },
+            },
+        )
+        assert created.status_code == 200
+        command_id = created.json()["commandId"]
+
+        lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["send_prompt", "refresh_agent_auth_config"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert lease.status_code == 200
+        leased_command = lease.json()["command"]
+        assert leased_command["commandId"] == command_id
+
+        result = await client.post(
+            f"/v1/cloud/worker/commands/{command_id}/result",
+            headers=worker_headers,
+            json={
+                "leaseId": leased_command["leaseId"],
+                "slotGeneration": leased_command["slotGeneration"],
+                "status": "rejected",
+                "errorCode": "runtime_rejected_prompt",
+                "errorMessage": "Runtime rejected the prompt.",
+            },
+        )
+        assert result.status_code == 200
+        assert result.json()["status"] == "rejected"
+
+        pending = (
+            await db_session.execute(
+                select(CloudPendingInteraction).where(
+                    CloudPendingInteraction.target_id == target_uuid,
+                    CloudPendingInteraction.session_id == "session-pending-prompt-result",
+                    CloudPendingInteraction.request_id == "web:pending-prompt-result",
+                )
+            )
+        ).scalar_one()
+        assert pending.status == "failed"
+        assert pending.description == "Runtime rejected the prompt."
+        assert pending.payload_json is not None
+        interaction_payload = json.loads(pending.payload_json)
+        assert interaction_payload["commandId"] == command_id
+        assert interaction_payload["status"] == "rejected"
+        assert interaction_payload["errorCode"] == "runtime_rejected_prompt"
+
+    @pytest.mark.asyncio
+    async def test_worker_failed_delivery_web_send_prompt_fails_pending_prompt_interaction(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-pending-prompt-delivery",
+        )
+        target_id, worker_headers, profile = await _create_managed_profile_target(
+            client,
+            db_session,
+            auth,
+            suffix="pending-prompt-delivery",
+        )
+        target_uuid = UUID(target_id)
+        await _mark_agent_and_runtime_config_applied(
+            db_session,
+            target_id=target_uuid,
+            profile=profile,
+            user_id=UUID(auth.user_id),
+        )
+        cloud_workspace_id = await _create_ready_managed_cloud_workspace(
+            db_session,
+            profile_id=profile.id,
+            target_id=target_uuid,
+            user_id=UUID(auth.user_id),
+            suffix="pending-prompt-delivery",
+        )
+        await _seed_managed_session_projection(
+            db_session,
+            target_id=target_uuid,
+            cloud_workspace_id=cloud_workspace_id,
+            user_id=UUID(auth.user_id),
+            session_id="session-pending-prompt-delivery",
+        )
+        await db_session.commit()
+
+        monkeypatch.setattr(command_service, "kick_off_managed_slot_wake", lambda *_args: None)
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "web-pending-prompt-delivery",
+                "targetId": target_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "sessionId": "session-pending-prompt-delivery",
+                "kind": "send_prompt",
+                "source": "web",
+                "payload": {
+                    "text": "prompt that the worker cannot deliver",
+                    "promptId": "web:pending-prompt-delivery",
+                },
+            },
+        )
+        assert created.status_code == 200
+        command_id = created.json()["commandId"]
+
+        lease = await client.post(
+            "/v1/cloud/worker/commands/lease",
+            headers=worker_headers,
+            json={
+                "supportedKinds": ["send_prompt", "refresh_agent_auth_config"],
+                "leaseTimeoutSeconds": 30,
+            },
+        )
+        assert lease.status_code == 200
+        leased_command = lease.json()["command"]
+        assert leased_command["commandId"] == command_id
+
+        delivery = await client.post(
+            f"/v1/cloud/worker/commands/{command_id}/delivery",
+            headers=worker_headers,
+            json={
+                "leaseId": leased_command["leaseId"],
+                "slotGeneration": leased_command["slotGeneration"],
+                "status": "failed_delivery",
+                "errorCode": "runtime_delivery_failed",
+                "errorMessage": "Runtime delivery failed.",
+            },
+        )
+        assert delivery.status_code == 200
+        assert delivery.json()["status"] == "failed_delivery"
+
+        pending = (
+            await db_session.execute(
+                select(CloudPendingInteraction).where(
+                    CloudPendingInteraction.request_id == "web:pending-prompt-delivery"
+                )
+            )
+        ).scalar_one()
+        assert pending.status == "failed"
+        assert pending.description == "Runtime delivery failed."
+        assert pending.payload_json is not None
+        interaction_payload = json.loads(pending.payload_json)
+        assert interaction_payload["commandId"] == command_id
+        assert interaction_payload["status"] == "failed_delivery"
+        assert interaction_payload["errorCode"] == "runtime_delivery_failed"
+
+    @pytest.mark.asyncio
     async def test_web_queued_command_status_expires_stale_command(
         self,
         client: AsyncClient,
@@ -2092,6 +2300,107 @@ class TestCloudCommandsApi:
                 "refresh_worker_enrollment_on_restart": True,
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_managed_slot_wake_billing_failure_fails_pending_prompt_interaction(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-command-wake-blocked",
+        )
+        target_id, _worker_headers, profile = await _create_managed_profile_target(
+            client,
+            db_session,
+            auth,
+            suffix="wake-blocked",
+        )
+        target_uuid = UUID(target_id)
+        await _mark_agent_and_runtime_config_applied(
+            db_session,
+            target_id=target_uuid,
+            profile=profile,
+            user_id=UUID(auth.user_id),
+        )
+        cloud_workspace_id = await _create_ready_managed_cloud_workspace(
+            db_session,
+            profile_id=profile.id,
+            target_id=target_uuid,
+            user_id=UUID(auth.user_id),
+            suffix="wake-blocked",
+        )
+        await _seed_managed_session_projection(
+            db_session,
+            target_id=target_uuid,
+            cloud_workspace_id=cloud_workspace_id,
+            user_id=UUID(auth.user_id),
+            session_id="session-wake-blocked",
+        )
+        await db_session.commit()
+        monkeypatch.setattr(
+            command_service,
+            "kick_off_managed_slot_wake",
+            lambda _target_id, _command_id=None: None,
+        )
+
+        created = await client.post(
+            "/v1/cloud/commands",
+            headers=auth.headers,
+            json={
+                "idempotencyKey": "managed-wake-blocked",
+                "targetId": target_id,
+                "cloudWorkspaceId": cloud_workspace_id,
+                "sessionId": "session-wake-blocked",
+                "kind": "send_prompt",
+                "source": "web",
+                "payload": {
+                    "text": "wake blocked prompt",
+                    "promptId": "web:wake-blocked-prompt",
+                },
+            },
+        )
+        assert created.status_code == 200, created.text
+        command_id = UUID(created.json()["commandId"])
+
+        class _Denied:
+            allowed = False
+            message = "Billing blocked sandbox wake."
+            start_block_reason = "usage_limit"
+
+        async def _deny_sandbox_start(**_kwargs: object) -> _Denied:
+            return _Denied()
+
+        monkeypatch.setattr(
+            runtime_wake,
+            "authorize_sandbox_start_for_billing_subject",
+            _deny_sandbox_start,
+        )
+
+        await runtime_wake.run_managed_slot_wake_job(target_uuid, command_id=command_id)
+
+        command = await db_session.get(CloudCommand, command_id)
+        assert command is not None
+        await db_session.refresh(command)
+        assert command.status == "failed_delivery"
+        assert command.error_code == "sandbox_wake_blocked"
+        pending = (
+            await db_session.execute(
+                select(CloudPendingInteraction).where(
+                    CloudPendingInteraction.request_id == "web:wake-blocked-prompt"
+                )
+            )
+        ).scalar_one()
+        assert pending.status == "failed"
+        assert pending.description == "Billing blocked sandbox wake."
+        assert pending.payload_json is not None
+        interaction_payload = json.loads(pending.payload_json)
+        assert interaction_payload["commandId"] == str(command_id)
+        assert interaction_payload["status"] == "failed_delivery"
+        assert interaction_payload["errorCode"] == "sandbox_wake_blocked"
 
     @pytest.mark.asyncio
     async def test_managed_slot_wake_hydrates_environment_from_runtime_access(

--- a/server/tests/integration/test_cloud_event_sync_api.py
+++ b/server/tests/integration/test_cloud_event_sync_api.py
@@ -231,6 +231,75 @@ class TestCloudEventSyncApi:
         assert duplicate_mismatch.json()["detail"]["code"] == "cloud_event_duplicate_mismatch"
 
     @pytest.mark.asyncio
+    async def test_worker_error_event_unblocks_session_projection(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await create_user_and_login(
+            client,
+            db_session,
+            email_prefix="cloud-event-sync-error",
+        )
+        target_id, worker_headers = await create_enrolled_target(client, db_session, auth)
+        await seed_exposed_session_projection(
+            db_session,
+            target_id=target_id,
+            auth=auth,
+            workspace_id="workspace-error",
+            session_id="session-error",
+        )
+
+        uploaded = await client.post(
+            "/v1/cloud/worker/events/batches",
+            headers=worker_headers,
+            json={
+                "events": [
+                    {
+                        "workspaceId": "workspace-error",
+                        "sessionId": "session-error",
+                        "seq": 1,
+                        "timestamp": "2026-05-13T00:00:00Z",
+                        "event": {
+                            "type": "session_started",
+                            "nativeSessionId": "native-error",
+                            "sourceAgentKind": "codex",
+                        },
+                    },
+                    {
+                        "workspaceId": "workspace-error",
+                        "sessionId": "session-error",
+                        "seq": 2,
+                        "timestamp": "2026-05-13T00:00:01Z",
+                        "event": {"type": "turn_started"},
+                    },
+                    {
+                        "workspaceId": "workspace-error",
+                        "sessionId": "session-error",
+                        "seq": 3,
+                        "timestamp": "2026-05-13T00:00:02Z",
+                        "event": {
+                            "type": "error",
+                            "message": "agent request failed",
+                        },
+                    },
+                ]
+            },
+        )
+        assert uploaded.status_code == 200
+        assert uploaded.json()["acceptedEvents"] == 3
+
+        snapshot = await client.get(
+            f"/v1/cloud/sessions/session-error/snapshot?targetId={target_id}",
+            headers=auth.headers,
+        )
+        assert snapshot.status_code == 200
+        session = snapshot.json()["session"]
+        assert session["status"] == "idle"
+        assert session["phase"] == "idle"
+        assert session["lastEventSeq"] == 3
+
+    @pytest.mark.asyncio
     async def test_worker_event_batch_discards_revoked_exposure_projection(
         self,
         client: AsyncClient,

--- a/server/tests/unit/test_cloud_capabilities.py
+++ b/server/tests/unit/test_cloud_capabilities.py
@@ -20,6 +20,11 @@ def test_cloud_capabilities_gate_gateway_byok(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(service.settings, "agent_gateway_managed_budget_free_usd", "12.50")
     monkeypatch.setattr(service.settings, "agent_gateway_managed_budget_pro_usd", "0")
     monkeypatch.setattr(service.settings, "agent_gateway_managed_budget_unlimited_usd", "0")
+    monkeypatch.setattr(
+        service.settings,
+        "agent_gateway_managed_anthropic_api_key",
+        "sk-ant-managed-test",
+    )
 
     capabilities = service.cloud_capabilities()
 

--- a/web/src/components/automations/screen/AutomationsScreen.tsx
+++ b/web/src/components/automations/screen/AutomationsScreen.tsx
@@ -40,12 +40,14 @@ import {
 import {
   buildCloudLaunchComposerControls,
   buildLaunchRunConfigControlValues,
-  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "@proliferate/product-model/chats/cloud/composer-controls";
+import {
+  resolveCloudHarnessAvailability,
+} from "@proliferate/product-model/chats/cloud/harness-availability";
 import {
   AutomationCreatePanel,
   type AutomationCreateFormValues,
@@ -181,13 +183,23 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     () => buildRepoOptions(repoConfigs.data?.configs ?? EMPTY_REPO_CONFIGS),
     [repoConfigs.data?.configs],
   );
-  const launchableAgentKinds = useMemo(() => {
-    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
-      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
-    return managedCreditKinds.length > 0
-      ? managedCreditKinds
-      : [DEFAULT_DIRECT_PROMPT_AGENT_KIND];
-  }, [cloudCapabilities.data?.agentGateway.managedCreditAgentKinds]);
+  const agentGateway = cloudCapabilities.data?.agentGateway;
+  const agentGatewayManagedCreditKindsKey = agentGateway?.managedCreditAgentKinds?.join("\0") ?? "";
+  const catalogAgentKindsKey = agentCatalog.data?.agents.map((agent) => agent.kind).join("\0") ?? "";
+  const harnessAvailability = useMemo(() => resolveCloudHarnessAvailability({
+    catalogAgentKinds: agentCatalog.data?.agents.map((agent) => agent.kind),
+    agentGateway,
+  }), [
+    agentCatalog.data,
+    agentGateway?.enabled,
+    agentGateway?.managedCreditsOrganizationEnabled,
+    agentGateway?.managedCreditsPersonalEnabled,
+    agentGateway?.opencodeGatewayEnabled,
+    agentGatewayManagedCreditKindsKey,
+    catalogAgentKindsKey,
+  ]);
+  const launchableAgentKinds = harnessAvailability.launchableAgentKinds;
+  const canStartCloudHarness = launchableAgentKinds.length > 0;
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
@@ -258,6 +270,12 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     setActionError(null);
     if (optionsUnavailable) {
       setCreateError(optionLoadError ?? "Automation options are still loading.");
+      return;
+    }
+    if (!canStartCloudHarness) {
+      setCreateError(
+        harnessAvailability.message ?? "No cloud agent is ready to create this automation.",
+      );
       return;
     }
     const title = createValues.title.trim();
@@ -381,11 +399,14 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
 
   const optionLoadError = repoConfigs.error || agentCatalog.error
     ? "Could not load repo or agent options. Retry from the page or refresh."
+    : !canStartCloudHarness && harnessAvailability.message
+      ? harnessAvailability.message
     : null;
   const optionsUnavailable = repoConfigs.isLoading
     || agentCatalog.isLoading
     || Boolean(repoConfigs.error)
-    || Boolean(agentCatalog.error);
+    || Boolean(agentCatalog.error)
+    || !canStartCloudHarness;
   const submitting = actions.creatingAutomation || runConfigActions.creatingAgentRunConfig;
   const busy = actions.creatingAutomation
     || actions.updatingAutomation

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -41,7 +41,6 @@ import {
 import {
   buildCloudChatComposerControls,
   buildLaunchSessionConfigUpdates,
-  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   getLiveConfigControlValue,
@@ -51,6 +50,9 @@ import {
   type CloudLaunchComposerSelection,
   type PendingConfigChange,
 } from "@proliferate/product-model/chats/cloud/composer-controls";
+import {
+  resolveCloudHarnessAvailability,
+} from "@proliferate/product-model/chats/cloud/harness-availability";
 import {
   cloudCommandReadiness,
   recentWorkCloudAccessState,
@@ -248,21 +250,27 @@ export function ChatScreen() {
   const isUnclaimed = workspace?.visibility === "shared_unclaimed";
   const workspaceReadyAgentKindsKey = workspace?.readyAgentKinds?.join("\0") ?? "";
   const workspaceAllowedAgentKindsKey = workspace?.allowedAgentKinds?.join("\0") ?? "";
-  const workspaceLaunchableAgentKinds = useMemo(() => {
-    const readyAgentKinds = workspace?.readyAgentKinds?.filter(Boolean) ?? [];
-    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
-      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
-    const allowedAgentKinds = workspace?.allowedAgentKinds?.filter(Boolean) ?? [];
-    const launchableKinds = new Set([...readyAgentKinds, ...managedCreditKinds]);
-    const filteredKinds = allowedAgentKinds.length > 0
-      ? [...launchableKinds].filter((kind) => allowedAgentKinds.includes(kind))
-      : [...launchableKinds];
-    return filteredKinds.length > 0 ? filteredKinds : null;
-  }, [
-    cloudCapabilities.data?.agentGateway.managedCreditAgentKinds,
+  const agentGateway = cloudCapabilities.data?.agentGateway;
+  const agentGatewayManagedCreditKindsKey = agentGateway?.managedCreditAgentKinds?.join("\0") ?? "";
+  const catalogAgentKindsKey = agentCatalog.data?.agents.map((agent) => agent.kind).join("\0") ?? "";
+  const workspaceHarnessAvailability = useMemo(() => resolveCloudHarnessAvailability({
+    catalogAgentKinds: agentCatalog.data?.agents.map((agent) => agent.kind),
+    allowedAgentKinds: workspace?.allowedAgentKinds,
+    readyAgentKinds: workspace?.readyAgentKinds,
+    agentGateway,
+  }), [
+    agentCatalog.data,
+    agentGateway?.enabled,
+    agentGateway?.managedCreditsOrganizationEnabled,
+    agentGateway?.managedCreditsPersonalEnabled,
+    agentGateway?.opencodeGatewayEnabled,
+    agentGatewayManagedCreditKindsKey,
+    catalogAgentKindsKey,
     workspaceAllowedAgentKindsKey,
     workspaceReadyAgentKindsKey,
   ]);
+  const workspaceLaunchableAgentKinds = workspaceHarnessAvailability.launchableAgentKinds;
+  const canStartNewSession = workspaceLaunchableAgentKinds.length > 0;
   const liveConfig = readSessionLiveConfig(session);
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
@@ -376,6 +384,9 @@ export function ChatScreen() {
     if (!pendingSessionDraft) {
       return;
     }
+    if (!canStartNewSession) {
+      return;
+    }
     const resolvedSelection = resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
       launchableAgentKinds: workspaceLaunchableAgentKinds,
@@ -401,6 +412,7 @@ export function ChatScreen() {
     launchSelection,
     pendingSessionDraft?.id,
     pendingSessionDraft?.workspaceId,
+    canStartNewSession,
     workspaceLaunchableAgentKinds,
   ]);
 
@@ -1038,6 +1050,13 @@ export function ChatScreen() {
       return;
     }
     if (!session) {
+      if (!canStartNewSession) {
+        setPendingHomePromptStatus(
+          workspaceHarnessAvailability.message
+            ?? "No cloud agent is ready to start a new session in this workspace.",
+        );
+        return;
+      }
       if (workspaceStatus !== "ready") {
         setPendingHomePromptStatus("Workspace is provisioning; the prompt will send when ready.");
         return;
@@ -1324,6 +1343,13 @@ export function ChatScreen() {
     if (!workspace) {
       return;
     }
+    if (!canStartNewSession) {
+      setPendingHomePromptStatus(
+        workspaceHarnessAvailability.message
+          ?? "No cloud agent is ready to start a new session in this workspace.",
+      );
+      return;
+    }
     if (pendingSessionDraft) {
       clearWebCloudSessionDraft(workspace.id, pendingSessionDraft.id);
     }
@@ -1372,7 +1398,8 @@ export function ChatScreen() {
     draft.trim()
       && !promptSubmitting
       && !isUnclaimed
-      && workspaceCommandReady,
+      && workspaceCommandReady
+      && (session || canStartNewSession),
   );
   const branchName = workspace.repo.branch ?? workspace.repo.baseBranch ?? "main";
   const repoLabel = `${workspace.repo.owner}/${workspace.repo.name}`;
@@ -1387,6 +1414,9 @@ export function ChatScreen() {
   const commandMessage =
     visiblePendingHomePromptStatus ??
     commandStatusMessage ??
+    (!session && workspaceCommandReady && !canStartNewSession
+      ? workspaceHarnessAvailability.message
+      : null) ??
     (!workspaceCommandReady
       ? friendlyCommandStatusMessage(commandReadiness.message)
         ?? commandReadiness.message
@@ -1540,7 +1570,7 @@ export function ChatScreen() {
         onSubmit: () => void submitPrompt(),
         controls: composerControls,
         footerControls: composerFooterControls,
-        disabled: !workspaceCommandReady || isUnclaimed,
+        disabled: !workspaceCommandReady || isUnclaimed || (!session && !canStartNewSession),
         canSubmit,
         isSubmitting: promptSubmitting,
         placeholder: isUnclaimed
@@ -1548,7 +1578,9 @@ export function ChatScreen() {
           : session
             ? "Describe a task"
             : workspaceCommandReady
-              ? "Describe a task"
+              ? canStartNewSession
+                ? "Describe a task"
+                : "No cloud agents ready"
               : workspaceCommandability === "stale"
                 ? "Desktop or remote runtime is offline"
                 : "Waiting for workspace",

--- a/web/src/components/home/screen/HomeScreen.tsx
+++ b/web/src/components/home/screen/HomeScreen.tsx
@@ -17,12 +17,14 @@ import {
 import {
   buildCloudLaunchComposerControls,
   buildLaunchSessionConfigUpdates,
-  DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS,
   DEFAULT_DIRECT_PROMPT_AGENT_KIND,
   DEFAULT_DIRECT_PROMPT_MODEL_ID,
   resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "@proliferate/product-model/chats/cloud/composer-controls";
+import {
+  resolveCloudHarnessAvailability,
+} from "@proliferate/product-model/chats/cloud/harness-availability";
 import {
   formatGitRepoId,
   normalizeGitRepoId,
@@ -90,13 +92,23 @@ export function HomeScreen() {
     () => repoOptions.find((repo) => repo.id === repoId) ?? repoOptions[0] ?? null,
     [repoId, repoOptions],
   );
-  const launchableAgentKinds = useMemo(() => {
-    const managedCreditKinds = cloudCapabilities.data?.agentGateway.managedCreditAgentKinds
-      ?? DEFAULT_CLOUD_LAUNCHABLE_AGENT_KINDS;
-    return managedCreditKinds.length > 0
-      ? managedCreditKinds
-      : [DEFAULT_DIRECT_PROMPT_AGENT_KIND];
-  }, [cloudCapabilities.data?.agentGateway.managedCreditAgentKinds]);
+  const agentGateway = cloudCapabilities.data?.agentGateway;
+  const agentGatewayManagedCreditKindsKey = agentGateway?.managedCreditAgentKinds?.join("\0") ?? "";
+  const catalogAgentKindsKey = agentCatalog.data?.agents.map((agent) => agent.kind).join("\0") ?? "";
+  const harnessAvailability = useMemo(() => resolveCloudHarnessAvailability({
+    catalogAgentKinds: agentCatalog.data?.agents.map((agent) => agent.kind),
+    agentGateway,
+  }), [
+    agentCatalog.data,
+    agentGateway?.enabled,
+    agentGateway?.managedCreditsOrganizationEnabled,
+    agentGateway?.managedCreditsPersonalEnabled,
+    agentGateway?.opencodeGatewayEnabled,
+    agentGatewayManagedCreditKindsKey,
+    catalogAgentKindsKey,
+  ]);
+  const launchableAgentKinds = harnessAvailability.launchableAgentKinds;
+  const canStartCloudHarness = launchableAgentKinds.length > 0;
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
@@ -165,6 +177,12 @@ export function HomeScreen() {
   async function handleSubmit() {
     const text = draft.trim();
     if (!text || !selectedRepo || submitInFlightRef.current) return;
+    if (!canStartCloudHarness) {
+      setSubmitError(
+        harnessAvailability.message ?? "No cloud agent is ready to start this workspace.",
+      );
+      return;
+    }
 
     submitInFlightRef.current = true;
     setSubmitError(null);
@@ -194,7 +212,6 @@ export function HomeScreen() {
         client,
         agentKind: normalizeAgentAuthAgentKind(resolvedLaunchSelection.agentKind),
         modelId: resolvedLaunchSelection.modelId,
-        allowUnavailableFreeCredits: true,
       });
       const workspaceRequest: CreateCloudWorkspaceRequest = {
         gitProvider: "github",
@@ -245,6 +262,13 @@ export function HomeScreen() {
       text: submitError,
     }
     : null;
+  const harnessNotice: NoticeView | null = !canStartCloudHarness && harnessAvailability.message
+    ? {
+      id: "harness-required",
+      tone: "warning",
+      text: harnessAvailability.message,
+    }
+    : null;
   if (errorNotice && pendingPrompt?.status === "failed") {
     errorNotice.action = {
       label: "Retry",
@@ -257,6 +281,7 @@ export function HomeScreen() {
   }
   const notices: NoticeView[] = [];
   if (repoNotice) notices.push(repoNotice);
+  if (harnessNotice) notices.push(harnessNotice);
   if (errorNotice) notices.push(errorNotice);
 
   return (
@@ -265,7 +290,7 @@ export function HomeScreen() {
         heading="What should we run?"
         draft={draft}
         placeholder={HOME_PLACEHOLDER}
-        canSubmit={Boolean(draft.trim()) && Boolean(selectedRepo) && !submitting}
+        canSubmit={Boolean(draft.trim()) && Boolean(selectedRepo) && canStartCloudHarness && !submitting}
         submitting={submitting}
         target={buildTargetPicker(repoId, repoOptions, repoConfigs.isLoading)}
         model={buildModelPicker(resolvedLaunchSelection.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID)}

--- a/web/src/lib/access/cloud/agent-auth-launch-readiness.ts
+++ b/web/src/lib/access/cloud/agent-auth-launch-readiness.ts
@@ -1,4 +1,5 @@
 import {
+  enableSandboxProfileCloud,
   ensureFreeManagedCredits,
   ensurePersonalSandboxProfile,
   getSandboxAgentAuthSelections,
@@ -26,6 +27,7 @@ export async function ensurePersonalAgentAuthLaunchReady(args: {
 }): Promise<PersonalAgentAuthLaunchReadiness> {
   if (args.agentKind && await hasReadyPersonalSelectionWithRetry(args.client, args.agentKind)) {
     args.onStatus?.("Using selected cloud agent credential.");
+    await ensurePersonalCloudTargetReady(args.client);
     return { source: "selected_credential" };
   }
 
@@ -39,7 +41,17 @@ export async function ensurePersonalAgentAuthLaunchReady(args: {
           : "Cloud agent credits are not ready yet. Please retry in a moment."),
     );
   }
+  await ensurePersonalCloudTargetReady(args.client);
   return { source: "free_credits", result };
+}
+
+async function ensurePersonalCloudTargetReady(
+  client: ProliferateCloudClient,
+): Promise<void> {
+  await withRecoverableRetry(async () => {
+    const profile = await ensurePersonalSandboxProfile(client);
+    await enableSandboxProfileCloud(profile.id, client);
+  });
 }
 
 async function hasReadyPersonalSelectionWithRetry(

--- a/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
+++ b/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
@@ -192,6 +192,7 @@ async function startSessionForPrompt(args: {
     targetId,
     fallbackWorkspaceId: anyharnessWorkspaceId,
     existingSessionIds,
+    expectedAgentKind: agentKind,
     shouldContinue: args.shouldContinue,
   });
 }
@@ -215,7 +216,12 @@ export async function prepareManagedWorkspaceForCloudCommands(args: {
       onStatus: args.onStatus,
     });
     assertStillCurrent(args.shouldContinue);
-    workspace = (await getWorkspaceSnapshot(workspace.id, args.client)).workspace;
+    workspace = await waitForManagedAgentAuthCurrent({
+      client: args.client,
+      workspaceId: workspace.id,
+      onStatus: args.onStatus,
+      shouldContinue: args.shouldContinue,
+    });
   }
   assertWorkspaceCanAcceptCloudCommands(workspace);
   await ensureManagedWorkspaceTargetConfigReady({
@@ -227,6 +233,37 @@ export async function prepareManagedWorkspaceForCloudCommands(args: {
     shouldContinue: args.shouldContinue,
   });
   return workspace;
+}
+
+async function waitForManagedAgentAuthCurrent(args: {
+  client: ProliferateCloudClient;
+  workspaceId: string;
+  onStatus: (status: string) => void;
+  shouldContinue: () => boolean;
+}): Promise<CloudWorkspaceDetail> {
+  const deadline = Date.now() + 120_000;
+  let delayMs = 500;
+  let latest = (await getWorkspaceSnapshot(args.workspaceId, args.client)).workspace;
+  while (true) {
+    assertStillCurrent(args.shouldContinue);
+    const runtimeAuth = latest.runtime?.runtimeAuth;
+    if (runtimeAuth?.targetCurrent === true) {
+      return latest;
+    }
+    if (runtimeAuth?.status === "apply_failed" || runtimeAuth?.status === "missing_credentials") {
+      throw new Error(
+        runtimeAuth.lastError
+          ?? "Cloud agent credentials are not ready for this workspace.",
+      );
+    }
+    args.onStatus("Applying cloud agent credentials.");
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for cloud agent credentials to apply.");
+    }
+    await sleep(delayMs);
+    delayMs = nextPollDelay(delayMs);
+    latest = (await getWorkspaceSnapshot(args.workspaceId, args.client)).workspace;
+  }
 }
 
 async function ensurePersonalManagedAgentAuthReady(args: {
@@ -502,6 +539,7 @@ async function waitForStartedSession(args: {
   targetId: string;
   fallbackWorkspaceId: string;
   existingSessionIds: Set<string>;
+  expectedAgentKind: string | null;
   shouldContinue: () => boolean;
 }): Promise<CloudSessionProjection> {
   const deadline = Date.now() + 240_000;
@@ -524,6 +562,8 @@ async function waitForStartedSession(args: {
       targetId: args.targetId,
       expectedSessionId,
       existingSessionIds: args.existingSessionIds,
+      expectedAgentKind: args.expectedAgentKind,
+      startedAfter: latestCommand.createdAt,
       shouldContinue: args.shouldContinue,
     });
     if (session) {
@@ -591,6 +631,8 @@ async function findStartedSession(args: {
   targetId: string;
   expectedSessionId: string | null;
   existingSessionIds: Set<string>;
+  expectedAgentKind: string | null;
+  startedAfter: string | null | undefined;
   shouldContinue: () => boolean;
 }): Promise<CloudSessionProjection | null> {
   assertStillCurrent(args.shouldContinue);
@@ -606,10 +648,34 @@ async function findStartedSession(args: {
     }
     return sessionsForTarget
       .filter((candidate) => !args.existingSessionIds.has(candidate.sessionId))
+      .filter((candidate) => sessionMatchesExpectedAgent(candidate, args.expectedAgentKind))
+      .filter((candidate) => sessionStartedAfter(candidate, args.startedAfter))
       .sort(compareSessionFreshness)[0] ?? null;
   } catch {
     return null;
   }
+}
+
+function sessionMatchesExpectedAgent(
+  session: CloudSessionProjection,
+  expectedAgentKind: string | null,
+): boolean {
+  return !expectedAgentKind || session.sourceAgentKind === expectedAgentKind;
+}
+
+function sessionStartedAfter(
+  session: CloudSessionProjection,
+  startedAfter: string | null | undefined,
+): boolean {
+  if (!startedAfter) {
+    return true;
+  }
+  const baseline = Date.parse(startedAfter);
+  if (!Number.isFinite(baseline)) {
+    return true;
+  }
+  const sessionTime = Date.parse(session.startedAt ?? session.lastEventAt ?? "");
+  return Number.isFinite(sessionTime) && sessionTime >= baseline;
 }
 
 function compareSessionFreshness(

--- a/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
+++ b/web/src/lib/access/cloud/pending-home-prompt-dispatch.ts
@@ -166,7 +166,7 @@ async function startSessionForPrompt(args: {
     client: args.client,
     workspaceId: workspace.id,
     targetId,
-  }).catch(() => new Set<string>());
+  });
   const command = await args.enqueueStartSession({
     idempotencyKey: `${args.pendingPrompt.id}:start-session`,
     targetId,
@@ -437,7 +437,13 @@ async function waitForCommandTerminal(
 ): Promise<CloudCommandResponse> {
   const deadline = Date.now() + 240_000;
   assertStillCurrent(shouldContinue);
-  let latest = await getCommandStatus(commandId, client);
+  let latest = await getCommandStatusWithRecoverableRetry({
+    commandId,
+    client,
+    shouldContinue,
+    deadline,
+  });
+  let delayMs = 500;
   let lastStatusMessage: string | null = null;
   while (!isTerminalStatus(latest.status)) {
     assertStillCurrent(shouldContinue);
@@ -449,12 +455,44 @@ async function waitForCommandTerminal(
       onStatus?.(nextStatusMessage);
       lastStatusMessage = nextStatusMessage;
     }
-    await sleep(500);
+    await sleep(delayMs);
+    delayMs = nextPollDelay(delayMs);
     assertStillCurrent(shouldContinue);
-    latest = await getCommandStatus(commandId, client);
+    latest = await getCommandStatusWithRecoverableRetry({
+      commandId,
+      client,
+      shouldContinue,
+      deadline,
+    });
   }
   assertStillCurrent(shouldContinue);
   return latest;
+}
+
+async function getCommandStatusWithRecoverableRetry(args: {
+  commandId: string;
+  client: ProliferateCloudClient;
+  shouldContinue: () => boolean;
+  deadline: number;
+}): Promise<CloudCommandResponse> {
+  let delayMs = 500;
+  let lastError: unknown = null;
+  while (Date.now() < args.deadline) {
+    assertStillCurrent(args.shouldContinue);
+    try {
+      return await getCommandStatus(args.commandId, args.client);
+    } catch (error) {
+      lastError = error;
+      if (!isRecoverableCloudDispatchError(error)) {
+        throw error;
+      }
+      await sleep(delayMs);
+      delayMs = nextPollDelay(delayMs);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Timed out waiting for the cloud command to finish.");
 }
 
 async function waitForStartedSession(args: {


### PR DESCRIPTION
## Summary
- harden managed cloud harness availability for web sessions and automations
- materialize Claude/Codex gateway auth cleanly through Bifrost virtual keys
- make web harness switching create clean distinct sessions and allow automation-created sessions to continue in web

## Verification
- pnpm --filter @proliferate/product-model test -- src/workspaces/cloud-work-inventory.test.ts src/chats/cloud/composer-controls.test.ts
- pnpm --filter @proliferate/web typecheck
- pnpm --filter @proliferate/product-ui build
- cargo test -p proliferate-worker allows_codex_gateway_env_aliases
- cargo test -p anyharness-lib codex_launch_overlay_sets_managed_codex_home
- cd server && uv run --extra dev pytest -q tests/integration/test_cloud_agent_auth_api.py::test_free_managed_credits_use_bifrost_provider_key_materialization tests/integration/test_cloud_agent_auth_api.py::test_bifrost_worker_materialization_uses_direct_virtual_key_env tests/integration/test_cloud_capabilities_api.py tests/integration/test_cloud_event_sync_api.py tests/unit/test_cloud_capabilities.py

## Manual QA
- Created a fresh managed web cloud workspace and verified Claude initial + follow-up prompts.
- Switched Claude to Codex in the same workspace and verified a distinct Codex session responded.
- Created and ran a web automation with Codex, then opened its cloud session in web and verified follow-up messaging.