### PR TITLE
fix(product): polish cloud workspace launch surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyharness-credential-discovery",
  "base64 0.22.1",

--- a/cloud/sdk/src/client/support.ts
+++ b/cloud/sdk/src/client/support.ts
@@ -1,8 +1,11 @@
-import { getProliferateClient } from "./core.js";
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
 import type { SendSupportMessageRequest, SupportMessageContext } from "../types/index.js";
 
 export type { SupportMessageContext, SendSupportMessageRequest };
 
-export async function sendSupportMessage(input: SendSupportMessageRequest): Promise<void> {
-  await getProliferateClient().POST("/v1/support/messages", { body: input });
+export async function sendSupportMessage(
+  input: SendSupportMessageRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<void> {
+  await client.POST("/v1/support/messages", { body: input });
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4841,6 +4841,8 @@ export interface components {
             byoRuntimeAllowed: boolean;
             /** Legacycloudsubscription */
             legacyCloudSubscription: boolean;
+            /** Grantallocations */
+            grantAllocations?: components["schemas"]["GrantAllocationInfo"][];
         };
         /** CloudRepoConfigResponse */
         CloudRepoConfigResponse: {
@@ -5798,6 +5800,19 @@ export interface components {
             /** Title */
             title: string;
         };
+        /** GrantAllocationInfo */
+        GrantAllocationInfo: {
+            /** Granttype */
+            grantType: string;
+            /** Totalseconds */
+            totalSeconds: number;
+            /** Consumedseconds */
+            consumedSeconds: number;
+            /** Remainingseconds */
+            remainingSeconds: number;
+            /** Active */
+            active: boolean;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -5824,6 +5839,8 @@ export interface components {
             workspaceId?: string | null;
             /** Sessionid */
             sessionId: string;
+            /** Sourceagentkind */
+            sourceAgentKind?: string | null;
             /** Title */
             title?: string | null;
             /** Status */

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -98,6 +98,7 @@ export interface CloudWorkspaceLastSessionSummary {
   targetId: string;
   workspaceId?: string | null;
   sessionId: string;
+  sourceAgentKind?: string | null;
   title?: string | null;
   status: string;
   lastEventAt?: string | null;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proliferate",
   "private": true,
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-model build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proliferate"
-version = "0.1.37"
+version = "0.1.38"
 edition.workspace = true
 
 [build-dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Proliferate",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "identifier": "com.proliferate.app",
   "build": {
     "frontendDist": "../dist",

--- a/desktop/src/lib/domain/auth/desktop-navigation.test.ts
+++ b/desktop/src/lib/domain/auth/desktop-navigation.test.ts
@@ -27,6 +27,15 @@ describe("desktopNavigationTarget", () => {
     ).toBe("/plugins?source=mcp_oauth_callback&status=completed");
   });
 
+  it("routes workspace deep links to the desktop workspace opener", () => {
+    expect(desktopNavigationTarget("proliferate://workspaces/cloud-workspace-1")).toBe(
+      "/workspaces/cloud-workspace-1",
+    );
+    expect(desktopNavigationTarget("proliferate-local://workspaces/cloud%20workspace")).toBe(
+      "/workspaces/cloud%20workspace",
+    );
+  });
+
   it("routes legacy settings cloud deep links to billing", () => {
     expect(desktopNavigationTarget("proliferate://settings/cloud?checkout=done")).toBe(
       "/settings?checkout=done&section=billing",
@@ -54,5 +63,6 @@ describe("desktopNavigationTarget", () => {
   it("rejects unsupported desktop navigation links", () => {
     expect(desktopNavigationTarget("https://plugins?source=mcp_oauth_callback")).toBeNull();
     expect(desktopNavigationTarget("proliferate://plugins/extra")).toBeNull();
+    expect(desktopNavigationTarget("proliferate://workspaces/cloud-1/extra")).toBeNull();
   });
 });

--- a/desktop/src/lib/domain/auth/desktop-navigation.ts
+++ b/desktop/src/lib/domain/auth/desktop-navigation.ts
@@ -52,5 +52,20 @@ export function desktopNavigationTarget(url: string): string | null {
     return parsed.search ? `/plugins${parsed.search}` : "/plugins";
   }
 
+  if (parsed.hostname === "workspaces") {
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 1) {
+      return `/workspaces/${encodeURIComponent(decodeRoutePart(segments[0]))}${parsed.search}`;
+    }
+  }
+
   return null;
+}
+
+function decodeRoutePart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }

--- a/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
+++ b/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
@@ -241,13 +241,16 @@ export function buildSidebarGroupStates(args: {
         ? [pendingItem, ...visibleWorkspaceItems]
         : visibleWorkspaceItems;
       const visibleItems = items.filter((item) => {
-        if (item.active) {
-          return true;
-        }
         if (args.showArchived) {
           return item.archived && visibleWorkspaceTypes.has(item.variant);
         }
-        return !item.archived && visibleWorkspaceTypes.has(item.variant);
+        if (item.archived) {
+          return false;
+        }
+        if (item.active) {
+          return true;
+        }
+        return visibleWorkspaceTypes.has(item.variant);
       });
       const archiveHiddenItems = items.filter((item) =>
         !item.active

--- a/desktop/src/pages/AuthenticatedAppHost.tsx
+++ b/desktop/src/pages/AuthenticatedAppHost.tsx
@@ -4,6 +4,7 @@ import { APP_ROUTES, LEGACY_APP_ROUTES } from "@/config/app-routes";
 import { AutomationDetailPage } from "@/pages/AutomationDetailPage";
 import { AutomationsPage } from "@/pages/AutomationsPage";
 import { CloudWorkspacesPage } from "@/pages/CloudWorkspacesPage";
+import { DesktopWorkspaceDeepLinkPage } from "@/pages/DesktopWorkspaceDeepLinkPage";
 import { MainPage } from "@/pages/MainPage";
 import { PluginsPage } from "@/pages/PluginsPage";
 import { SettingsPage } from "@/pages/SettingsPage";
@@ -64,6 +65,7 @@ export function AuthenticatedAppHost({
           <Route path="automations" element={<AutomationsPage />} />
           <Route path="automations/:automationId" element={<AutomationDetailPage />} />
           <Route path="workspaces" element={<CloudWorkspacesPage />} />
+          <Route path="workspaces/:workspaceId" element={<DesktopWorkspaceDeepLinkPage />} />
           <Route path="*" element={<Navigate to={APP_ROUTES.home} replace />} />
         </Routes>
       )}

--- a/desktop/src/pages/DesktopWorkspaceDeepLinkPage.tsx
+++ b/desktop/src/pages/DesktopWorkspaceDeepLinkPage.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
+import { APP_ROUTES } from "@/config/app-routes";
+import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-workspace-actions";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+export function DesktopWorkspaceDeepLinkPage() {
+  const { workspaceId } = useParams();
+  const navigate = useNavigate();
+  const { refreshCloudWorkspace } = useCloudWorkspaceActions();
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
+  const showToast = useToastStore((state) => state.show);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      navigate(APP_ROUTES.workspaces, { replace: true });
+      return;
+    }
+
+    let active = true;
+    void refreshCloudWorkspace(workspaceId)
+      .then((workspace) => {
+        if (!active) {
+          return;
+        }
+        selectWorkspaceFromSurface(
+          cloudWorkspaceSyntheticId(workspace.id),
+          "desktop_deep_link",
+        );
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : "Failed to open workspace.";
+        showToast(message);
+        navigate(APP_ROUTES.workspaces, { replace: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    navigate,
+    refreshCloudWorkspace,
+    selectWorkspaceFromSurface,
+    showToast,
+    workspaceId,
+  ]);
+
+  return (
+    <RedirectCallbackScreen
+      title="Opening workspace"
+      description="Bringing this cloud workspace into Desktop."
+      statusLabel="Workspace deep link"
+      variant="handoff"
+    />
+  );
+}

--- a/mobile/src/components/home/MobileHomeScreen.tsx
+++ b/mobile/src/components/home/MobileHomeScreen.tsx
@@ -11,6 +11,7 @@ import type { CloudChatComposerControlView } from "@proliferate/product-model/ch
 
 import { useMobileHomeLaunchModel } from "../../hooks/home/derived/use-mobile-home-launch-model";
 import { useMobileHomeLaunchActions } from "../../hooks/home/workflows/use-mobile-home-launch-actions";
+import { useMobileWorkInventory } from "../../hooks/work/derived/use-mobile-work-inventory";
 import type { MobileCloudChat } from "../../navigation/navigation-model";
 import { MobileIcon, type MobileIconName } from "../primitives/MobileIcon";
 import { MobileTextInput } from "../primitives/MobileTextInput";
@@ -20,6 +21,7 @@ import { MobilePopoverDivider } from "../primitives/popover/MobilePopoverDivider
 import { MobilePopoverGroup } from "../primitives/popover/MobilePopoverGroup";
 import { MobilePopoverOption } from "../primitives/popover/MobilePopoverOption";
 import { MobilePopoverRow } from "../primitives/popover/MobilePopoverRow";
+import { MobileWorkspaceCard } from "../work/MobileWorkspaceCard";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 interface MobileHomeScreenProps {
@@ -29,7 +31,7 @@ interface MobileHomeScreenProps {
   onConfigureRepos: () => void;
 }
 
-type HomeSheet = "repo" | "runtime" | "config" | null;
+type HomeSheet = "repo" | "branch" | "runtime" | "config" | null;
 
 export function MobileHomeScreen({
   ownerUserId,
@@ -40,11 +42,14 @@ export function MobileHomeScreen({
   const [draft, setDraft] = useState("");
   const [sheet, setSheet] = useState<HomeSheet>(null);
   const launchModel = useMobileHomeLaunchModel();
+  const recentInventory = useMobileWorkInventory();
+  const recentItems = recentInventory.recentItems.slice(0, 2);
   const launchActions = useMobileHomeLaunchActions({
     ownerUserId,
     catalog: launchModel.agentCatalog.data,
     launchableAgentKinds: launchModel.launchableAgentKinds,
     selectedRepo: launchModel.selectedRepo,
+    selectedBaseBranch: launchModel.selectedBaseBranch,
     selectedRuntime: launchModel.selectedRuntime,
     selection: launchModel.resolvedLaunchSelection,
     onOpenChat,
@@ -139,6 +144,24 @@ export function MobileHomeScreen({
         </View>
       ) : null}
 
+      {recentItems.length > 0 ? (
+        <View style={styles.recentSection}>
+          <View style={styles.recentHeader}>
+            <Text style={styles.recentTitle}>Recent</Text>
+          </View>
+          <View style={styles.recentCards}>
+            {recentItems.map((item) => (
+              <MobileWorkspaceCard
+                key={item.view.id}
+                item={item}
+                compact
+                onPress={() => onOpenChat(item.chat)}
+              />
+            ))}
+          </View>
+        </View>
+      ) : null}
+
       <View style={styles.spacer} />
 
       {launchActions.status || launchActions.error || (!canStartCloudHarness && launchModel.harnessAvailability.message) ? (
@@ -149,21 +172,42 @@ export function MobileHomeScreen({
 
       <View style={styles.composer}>
         <View style={styles.composerCluster}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Choose repository"
-            onPress={() => setSheet("repo")}
-            style={({ pressed }) => [styles.repoPill, pressed && styles.pressed]}
-          >
-            <MobileIcon name="git-branch" size={15} color={colors.fg} />
-            <Text style={styles.repoPillText} numberOfLines={1}>
-              {launchModel.selectedRepo?.label ?? "Choose a GitHub repo"}
-            </Text>
-            <MobileIcon name="chevron-right" size={14} color={colors.faint} />
-          </Pressable>
+          <View style={styles.selectorRow}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Choose repository"
+              onPress={() => setSheet("repo")}
+              style={({ pressed }) => [styles.repoPill, styles.repoPillWide, pressed && styles.pressed]}
+            >
+              <MobileIcon name="git-branch" size={15} color={colors.fg} />
+              <Text style={styles.repoPillText} numberOfLines={1}>
+                {launchModel.selectedRepo?.label ?? "Choose a GitHub repo"}
+              </Text>
+              <MobileIcon name="chevron-right" size={14} color={colors.faint} />
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Choose branch"
+              disabled={!launchModel.selectedRepo || launchModel.repoBranches.isLoading}
+              onPress={() => setSheet("branch")}
+              style={({ pressed }) => [
+                styles.repoPill,
+                styles.branchPill,
+                (!launchModel.selectedRepo || launchModel.repoBranches.isLoading) && styles.disabledPill,
+                pressed && styles.pressed,
+              ]}
+            >
+              <MobileIcon name="git-branch" size={15} color={colors.fg} />
+              <Text style={styles.repoPillText} numberOfLines={1}>
+                {launchModel.selectedBaseBranch ?? (launchModel.repoBranches.isLoading ? "Loading" : "Branch")}
+              </Text>
+              <MobileIcon name="chevron-right" size={14} color={colors.faint} />
+            </Pressable>
+          </View>
 
           <View style={styles.composerCard}>
             <MobileTextInput
+              autoFocus
               multiline
               value={draft}
               onChangeText={setDraft}
@@ -234,6 +278,35 @@ export function MobileHomeScreen({
       </MobilePopover>
 
       <MobilePopover
+        visible={sheet === "branch"}
+        onClose={closeSheet}
+        anchor="bottom-left"
+        insetSide={20}
+        insetBottom={140}
+        width={260}
+      >
+        <MobilePopoverGroup>
+          {launchModel.repoBranches.isLoading ? (
+            <MobilePopoverRow id="loading" icon="git-branch" title="Loading branches..." disabled />
+          ) : launchModel.branchOptions.length === 0 ? (
+            <MobilePopoverRow id="empty" icon="git-branch" title="No branches found" disabled />
+          ) : (
+            launchModel.branchOptions.map((branch) => (
+              <MobilePopoverOption
+                key={branch}
+                title={branch}
+                selected={branch === launchModel.selectedBaseBranch}
+                onSelect={() => {
+                  launchModel.setBaseBranch(branch);
+                  closeSheet();
+                }}
+              />
+            ))
+          )}
+        </MobilePopoverGroup>
+      </MobilePopover>
+
+      <MobilePopover
         visible={sheet === "runtime"}
         onClose={closeSheet}
         anchor="top-center"
@@ -285,6 +358,7 @@ export function MobileHomeScreen({
                     disabled={option.disabled}
                     onSelect={() => {
                       control.onSelect?.(option.id);
+                      closeSheet();
                     }}
                   />
                 )),
@@ -460,6 +534,24 @@ const styles = StyleSheet.create({
     lineHeight: 16,
     fontWeight: "600",
   },
+  recentSection: {
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    marginTop: spacing[6],
+  },
+  recentHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  recentTitle: {
+    color: colors.faint,
+    fontSize: 12.5,
+    fontWeight: "600",
+  },
+  recentCards: {
+    gap: spacing[2],
+  },
   spacer: {
     flex: 1,
   },
@@ -472,9 +564,14 @@ const styles = StyleSheet.create({
   composerCluster: {
     gap: spacing[3],
   },
+  selectorRow: {
+    maxWidth: "100%",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[2],
+  },
   repoPill: {
     alignSelf: "flex-start",
-    maxWidth: "100%",
     minHeight: 36,
     flexDirection: "row",
     alignItems: "center",
@@ -484,6 +581,16 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     backgroundColor: colors.card,
     paddingHorizontal: spacing[3],
+  },
+  repoPillWide: {
+    flex: 1,
+    minWidth: 0,
+  },
+  branchPill: {
+    maxWidth: 140,
+  },
+  disabledPill: {
+    opacity: 0.55,
   },
   repoPillText: {
     minWidth: 0,

--- a/mobile/src/components/shell/MobileShell.tsx
+++ b/mobile/src/components/shell/MobileShell.tsx
@@ -411,6 +411,22 @@ function ShellWithDrawer({
     }),
     [translate],
   );
+  const contentRadius = useMemo(
+    () => translate.interpolate({
+      inputRange: [0, 36],
+      outputRange: [0, 30],
+      extrapolate: "clamp",
+    }),
+    [translate],
+  );
+  const edgeOpacity = useMemo(
+    () => translate.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 1],
+      extrapolate: "clamp",
+    }),
+    [translate],
+  );
 
   function animateTo(open: boolean, velocity = 0) {
     Animated.timing(translate, {
@@ -488,12 +504,39 @@ function ShellWithDrawer({
 
   return (
     <View style={styles.shellContainer} {...panResponder.panHandlers}>
+      <View
+        style={[
+          styles.staticDrawer,
+          { width: DRAWER_WIDTH },
+        ]}
+        pointerEvents={drawerOpen ? "auto" : "none"}
+      >
+        {drawer}
+      </View>
       <Animated.View
-        style={[styles.slidingContent, { transform: [{ translateX: translate }] }]}
+        style={[
+          styles.slidingContent,
+          {
+            borderTopLeftRadius: contentRadius,
+            borderBottomLeftRadius: contentRadius,
+            transform: [{ translateX: translate }],
+          },
+        ]}
       >
         <SafeAreaView style={styles.slidingSafeArea} edges={["top", "right", "bottom", "left"]}>
           {children}
         </SafeAreaView>
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.contentEdge,
+            {
+              borderTopLeftRadius: contentRadius,
+              borderBottomLeftRadius: contentRadius,
+              opacity: edgeOpacity,
+            },
+          ]}
+        />
         <Animated.View
           style={[styles.contentScrim, { opacity: scrimOpacity }]}
           pointerEvents={drawerOpen && scrimReady ? "auto" : "none"}
@@ -506,16 +549,6 @@ function ShellWithDrawer({
           />
         </Animated.View>
       </Animated.View>
-      <View
-        style={[
-          styles.staticDrawer,
-          drawerOpen && styles.staticDrawerOpen,
-          { width: DRAWER_WIDTH },
-        ]}
-        pointerEvents={drawerOpen ? "auto" : "none"}
-      >
-        {drawer}
-      </View>
     </View>
   );
 }
@@ -838,20 +871,28 @@ const styles = StyleSheet.create({
     left: 0,
     zIndex: 0,
   },
-  staticDrawerOpen: {
-    zIndex: 10,
-  },
   slidingContent: {
     flex: 1,
+    position: "relative",
     zIndex: 1,
     backgroundColor: colors.background,
-    borderTopLeftRadius: 22,
-    borderBottomLeftRadius: 22,
     overflow: "hidden",
   },
   slidingSafeArea: {
     flex: 1,
     backgroundColor: colors.background,
+  },
+  contentEdge: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 32,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderLeftWidth: 1,
+    borderColor: colors.borderHeavy,
+    zIndex: 4,
   },
   contentScrim: {
     ...StyleSheet.absoluteFillObject,

--- a/mobile/src/components/shell/drawer/MobileDrawer.tsx
+++ b/mobile/src/components/shell/drawer/MobileDrawer.tsx
@@ -169,8 +169,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[2],
     paddingBottom: Platform.OS === "web" ? 20 : spacing[4],
     backgroundColor: colors.sidebar,
-    borderRightWidth: 1,
-    borderRightColor: colors.borderHeavy,
     borderTopRightRadius: 22,
     borderBottomRightRadius: 22,
   },

--- a/mobile/src/components/work/MobileAllWorkScreen.tsx
+++ b/mobile/src/components/work/MobileAllWorkScreen.tsx
@@ -18,13 +18,13 @@ import type {
 import { useClaimCloudWorkspace } from "@proliferate/cloud-sdk-react";
 
 import { useMobileWorkInventory, type MobileWorkItem } from "../../hooks/work/derived/use-mobile-work-inventory";
-import { mobileIconForRuntimeLocation, mobileIconForWorkSourceKind } from "../../lib/domain/work/mobile-work-presentation";
 import type { MobileCloudChat } from "../../navigation/navigation-model";
 import { MobileIcon, type MobileIconName } from "../primitives/MobileIcon";
 import {
   MobileEmptyState,
   MobileScreen,
 } from "../primitives/MobileLayout";
+import { MobileWorkspaceCard } from "./MobileWorkspaceCard";
 import { colors, radius, spacing } from "../../styles/tokens";
 
 interface MobileWorkspacesScreenProps {
@@ -33,20 +33,27 @@ interface MobileWorkspacesScreenProps {
   onNewChat: () => void;
 }
 
-type SourceFilter = RecentWorkSourceKind | "all";
+type AgentFilter = "all" | "claude" | "codex" | "opencode" | "gemini";
+type WorkTypeFilter = "all" | "cloud" | "slack" | "personal_automation" | "team_automation" | "dispatch";
 type RuntimeFilter = RecentWorkRuntimeLocation | "all";
 type StatusFilter = CloudWorkStatusFilter | "all";
-type FilterPanel = "source" | "runtime" | "ownership" | "status" | "repo" | "sort";
+type FilterPanel = "type" | "runtime" | "ownership" | "status" | "repo" | "sort";
 
-const SOURCE_OPTIONS: readonly { id: SourceFilter; label: string; icon: MobileIconName }[] = [
-  { id: "all", label: "All sources", icon: "workspaces" },
-  { id: "cloud_sandbox", label: "Cloud", icon: "cloud" },
-  { id: "desktop_exposed", label: "Desktop", icon: "monitor" },
-  { id: "mobile", label: "Mobile", icon: "smartphone" },
+const AGENT_OPTIONS: readonly { id: AgentFilter; label: string; icon: MobileIconName }[] = [
+  { id: "all", label: "All", icon: "sparkles" },
+  { id: "claude", label: "Claude", icon: "claude" },
+  { id: "codex", label: "Codex", icon: "openai" },
+  { id: "opencode", label: "OpenCode", icon: "sparkles" },
+  { id: "gemini", label: "Gemini", icon: "gemini" },
+];
+
+const WORK_TYPE_OPTIONS: readonly { id: WorkTypeFilter; label: string; icon: MobileIconName }[] = [
+  { id: "all", label: "All", icon: "workspaces" },
+  { id: "cloud", label: "Cloud", icon: "cloud" },
   { id: "slack", label: "Slack", icon: "slack" },
   { id: "personal_automation", label: "Automation", icon: "calendar-clock" },
   { id: "team_automation", label: "Team automation", icon: "calendar-clock" },
-  { id: "api", label: "API", icon: "cloud" },
+  { id: "dispatch", label: "Dispatch", icon: "monitor" },
 ];
 
 const RUNTIME_OPTIONS: readonly { id: RuntimeFilter; label: string; icon: MobileIconName }[] = [
@@ -88,7 +95,8 @@ export function MobileWorkspacesScreen({
   onOpenDrawer,
   onNewChat,
 }: MobileWorkspacesScreenProps) {
-  const [source, setSource] = useState<SourceFilter>("all");
+  const [agent, setAgent] = useState<AgentFilter>("all");
+  const [workType, setWorkType] = useState<WorkTypeFilter>("all");
   const [runtime, setRuntime] = useState<RuntimeFilter>("all");
   const [ownership, setOwnership] = useState<CloudWorkOwnerFilter>("all");
   const [status, setStatus] = useState<StatusFilter>("all");
@@ -100,22 +108,33 @@ export function MobileWorkspacesScreen({
   const claimWorkspace = useClaimCloudWorkspace();
   const filters = useMemo(() => ({
     ownership,
-    semanticSources: source === "all" ? undefined : new Set<RecentWorkSourceKind>([source]),
+    semanticSources: semanticSourcesForWorkType(workType),
     runtimeLocations: runtime === "all" ? undefined : new Set<RecentWorkRuntimeLocation>([runtime]),
     statuses: status === "all" ? undefined : new Set<CloudWorkStatusFilter>([status]),
     repoLabels: repo === "all" ? undefined : new Set<string>([repo]),
     sort,
     needsAttention: attentionOnly,
-  }), [attentionOnly, ownership, repo, runtime, sort, source, status]);
+  }), [attentionOnly, ownership, repo, runtime, sort, status, workType]);
   const allInventory = useMobileWorkInventory();
   const inventory = useMobileWorkInventory(filters);
+  const visibleInventory = useMemo(() => {
+    const groups = inventory.groups.flatMap((group) => {
+      const items = group.items.filter((item) => workspaceMatchesAgent(item, agent));
+      return items.length > 0 ? [{ ...group, items }] : [];
+    });
+    return {
+      groups,
+      items: groups.flatMap((group) => group.items),
+    };
+  }, [agent, inventory.groups]);
   const repoOptions = useMemo(() => {
     return [...new Set(allInventory.items.map((item) => item.view.repoLabel))]
       .filter(Boolean)
       .sort((left, right) => left.localeCompare(right));
   }, [allInventory.items]);
   const activeFilterCount = [
-    source !== "all",
+    agent !== "all",
+    workType !== "all",
     runtime !== "all",
     ownership !== "all",
     status !== "all",
@@ -123,11 +142,6 @@ export function MobileWorkspacesScreen({
     sort !== "recent",
     attentionOnly,
   ].filter(Boolean).length;
-  const attentionCount = allInventory.items.filter((item) =>
-    item.view.status === "blocked" || item.view.unclaimed
-  ).length;
-  const readyCount = allInventory.items.filter((item) => item.view.status === "ready").length;
-
   async function claimListWorkspace(item: MobileWorkItem) {
     if (!item.view.unclaimed || claimingWorkspaceId) {
       return;
@@ -180,7 +194,8 @@ export function MobileWorkspacesScreen({
         contentContainerStyle={styles.pills}
       >
         <SummaryPill label={`All ${allInventory.items.length}`} selected={activeFilterCount === 0} onPress={() => {
-          setSource("all");
+          setAgent("all");
+          setWorkType("all");
           setRuntime("all");
           setOwnership("all");
           setStatus("all");
@@ -188,23 +203,31 @@ export function MobileWorkspacesScreen({
           setSort("recent");
           setAttentionOnly(false);
         }} />
-        <SummaryPill
-          label={`Needs input ${attentionCount}`}
-          selected={attentionOnly}
-          onPress={() => {
-            setAttentionOnly(!attentionOnly);
-            setStatus("all");
-            setOwnership("all");
-          }}
-        />
-        <SummaryPill
-          label={`Ready ${readyCount}`}
-          selected={status === "ready" && !attentionOnly}
-          onPress={() => {
-            setAttentionOnly(false);
-            setStatus(status === "ready" ? "all" : "ready");
-          }}
-        />
+        {AGENT_OPTIONS.filter((option) => option.id !== "all").map((option) => (
+          <SummaryPill
+            key={option.id}
+            label={option.label}
+            icon={option.icon}
+            selected={agent === option.id}
+            onPress={() => setAgent(agent === option.id ? "all" : option.id)}
+          />
+        ))}
+      </ScrollView>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={[styles.pills, styles.typePills]}
+      >
+        {WORK_TYPE_OPTIONS.map((option) => (
+          <SummaryPill
+            key={option.id}
+            label={option.label}
+            icon={option.icon}
+            selected={workType === option.id}
+            onPress={() => setWorkType(option.id)}
+          />
+        ))}
         <SummaryPill
           label={activeFilterCount ? `Filters ${activeFilterCount}` : "Filter"}
           icon="filter"
@@ -226,21 +249,21 @@ export function MobileWorkspacesScreen({
         <MobileEmptyState title="Loading workspaces" body="Fetching visible cloud workspaces." />
       ) : inventory.error && inventory.items.length === 0 ? (
         <MobileEmptyState title="Could not load workspaces" body="Pull to refresh or sign in again." />
-      ) : inventory.items.length === 0 ? (
+      ) : visibleInventory.items.length === 0 ? (
         <MobileEmptyState
           title="No matching workspaces"
           body="Adjust filters or start a new chat."
         />
       ) : (
         <View style={styles.groups}>
-          {inventory.groups.map((group) => (
+          {visibleInventory.groups.map((group) => (
             <View key={group.view.id} style={styles.group}>
               <View style={styles.sectionHeader}>
                 <Text style={styles.sectionTitle}>{group.view.label}</Text>
               </View>
               <View style={styles.cards}>
                 {group.items.map((item) => (
-                  <WorkspaceCard
+                  <MobileWorkspaceCard
                     key={item.view.id}
                     item={item}
                     claiming={claimingWorkspaceId === item.workspace.id}
@@ -258,14 +281,14 @@ export function MobileWorkspacesScreen({
 
       <FilterSheet
         visible={filterOpen}
-        source={source}
+        workType={workType}
         runtime={runtime}
         ownership={ownership}
         status={status}
         repo={repo}
         sort={sort}
         repoOptions={repoOptions}
-        onSource={setSource}
+        onWorkType={setWorkType}
         onRuntime={setRuntime}
         onOwnership={(value) => {
           setAttentionOnly(false);
@@ -278,7 +301,8 @@ export function MobileWorkspacesScreen({
         onRepo={setRepo}
         onSort={setSort}
         onClear={() => {
-          setSource("all");
+          setAgent("all");
+          setWorkType("all");
           setRuntime("all");
           setOwnership("all");
           setStatus("all");
@@ -322,111 +346,16 @@ function SummaryPill({
   );
 }
 
-function WorkspaceCard({
-  item,
-  claiming,
-  onPress,
-  onClaim,
-}: {
-  item: MobileWorkItem;
-  claiming: boolean;
-  onPress: () => void;
-  onClaim: () => void;
-}) {
-  const detailText = workspaceDetailText(item);
-  const blocked = item.view.status === "blocked" || item.view.status === "error";
-  const active = item.view.status === "active" || item.view.status === "running";
-  const unclaimed = item.view.unclaimed;
-
-  return (
-    <Pressable
-      accessibilityRole="button"
-      onPress={onPress}
-      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
-    >
-      <View style={styles.cardTop}>
-        <View style={styles.iconTile}>
-          <MobileIcon
-            name={mobileIconForWorkSourceKind(item.view.sourceKind)}
-            size={21}
-            color={item.view.sourceKind === "slack" ? colors.success : colors.fg}
-          />
-          <View
-            style={[
-              styles.stateDot,
-              active && styles.stateDotActive,
-              blocked && styles.stateDotBlocked,
-              unclaimed && styles.stateDotUnclaimed,
-            ]}
-          />
-        </View>
-        <View style={styles.cardTitleBlock}>
-          <View style={styles.cardTitleRow}>
-            <Text style={styles.cardTitle} numberOfLines={1}>{item.view.title}</Text>
-            <Text style={styles.cardTime}>{item.view.lastActivityLabel}</Text>
-          </View>
-          <View style={styles.cardMetaRow}>
-            <MobileIcon
-              name={mobileIconForRuntimeLocation(item.view.runtimeLocation)}
-              size={13}
-              color={colors.faint}
-            />
-            <Text style={styles.cardMeta} numberOfLines={1}>
-              {item.view.repoLabel} · {item.view.branchLabel}
-            </Text>
-          </View>
-        </View>
-      </View>
-      {detailText ? (
-        <View style={styles.promptBlock}>
-          <Text style={styles.promptText} numberOfLines={2}>
-            {detailText}
-          </Text>
-        </View>
-      ) : null}
-      {unclaimed ? (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Claim workspace"
-          accessibilityState={{ disabled: claiming }}
-          disabled={claiming}
-          onPress={onClaim}
-          style={({ pressed }) => [
-            styles.claimButton,
-            claiming && styles.claimButtonDisabled,
-            pressed && styles.pressed,
-          ]}
-        >
-          <Text style={styles.claimButtonText}>{claiming ? "Claiming" : "Claim workspace"}</Text>
-        </Pressable>
-      ) : null}
-    </Pressable>
-  );
-}
-
-function workspaceDetailText(item: MobileWorkItem): string | null {
-  if (item.view.unclaimed) {
-    return "Unclaimed workspace";
-  }
-  if (item.view.status === "blocked" || item.view.status === "error") {
-    return item.view.statusLabel;
-  }
-  if (item.view.commandability !== "commandable") {
-    return item.view.commandabilityLabel;
-  }
-  return null;
-}
-
 function FilterSheet({
   visible,
-  source,
+  workType,
   runtime,
   ownership,
   status,
   repo,
   sort,
   repoOptions,
-  onSource,
+  onWorkType,
   onRuntime,
   onOwnership,
   onStatus,
@@ -436,14 +365,14 @@ function FilterSheet({
   onClose,
 }: {
   visible: boolean;
-  source: SourceFilter;
+  workType: WorkTypeFilter;
   runtime: RuntimeFilter;
   ownership: CloudWorkOwnerFilter;
   status: StatusFilter;
   repo: string;
   sort: CloudWorkSort;
   repoOptions: readonly string[];
-  onSource: (value: SourceFilter) => void;
+  onWorkType: (value: WorkTypeFilter) => void;
   onRuntime: (value: RuntimeFilter) => void;
   onOwnership: (value: CloudWorkOwnerFilter) => void;
   onStatus: (value: StatusFilter) => void;
@@ -503,9 +432,9 @@ function FilterSheet({
               <>
                 <FilterSummaryRow
                   icon="workspaces"
-                  title="Source"
-                  value={optionLabel(SOURCE_OPTIONS, source)}
-                  onPress={() => setPanel("source")}
+                  title="Type"
+                  value={optionLabel(WORK_TYPE_OPTIONS, workType)}
+                  onPress={() => setPanel("type")}
                 />
                 <FilterSummaryRow
                   icon="cloud"
@@ -539,13 +468,13 @@ function FilterSheet({
                 />
               </>
             ) : null}
-            {panel === "source" ? SOURCE_OPTIONS.map((option) => (
+            {panel === "type" ? WORK_TYPE_OPTIONS.map((option) => (
                 <FilterChoice
                   key={option.id}
                   label={option.label}
                   icon={option.icon}
-                  selected={source === option.id}
-                  onPress={() => onSource(option.id)}
+                  selected={workType === option.id}
+                  onPress={() => onWorkType(option.id)}
                 />
               )) : null}
             {panel === "runtime" ? RUNTIME_OPTIONS.map((option) => (
@@ -637,8 +566,8 @@ function FilterSummaryRow({
 
 function filterPanelTitle(panel: FilterPanel): string {
   switch (panel) {
-    case "source":
-      return "Source";
+    case "type":
+      return "Type";
     case "runtime":
       return "Runtime";
     case "ownership":
@@ -650,6 +579,30 @@ function filterPanelTitle(panel: FilterPanel): string {
     case "sort":
       return "Sort";
   }
+}
+
+function semanticSourcesForWorkType(type: WorkTypeFilter): ReadonlySet<RecentWorkSourceKind> | undefined {
+  switch (type) {
+    case "cloud":
+      return new Set<RecentWorkSourceKind>(["cloud_sandbox", "web", "mobile", "api"]);
+    case "slack":
+      return new Set<RecentWorkSourceKind>(["slack"]);
+    case "personal_automation":
+      return new Set<RecentWorkSourceKind>(["personal_automation"]);
+    case "team_automation":
+      return new Set<RecentWorkSourceKind>(["team_automation"]);
+    case "dispatch":
+      return new Set<RecentWorkSourceKind>(["desktop_exposed"]);
+    case "all":
+      return undefined;
+  }
+}
+
+function workspaceMatchesAgent(item: MobileWorkItem, agent: AgentFilter): boolean {
+  if (agent === "all") {
+    return true;
+  }
+  return item.view.sourceAgentKind?.toLowerCase() === agent;
 }
 
 function optionLabel<T extends string>(
@@ -722,6 +675,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[4],
   },
+  typePills: {
+    paddingTop: 0,
+  },
   summaryPill: {
     minHeight: 38,
     flexDirection: "row",
@@ -783,113 +739,6 @@ const styles = StyleSheet.create({
   },
   cards: {
     gap: spacing[2],
-  },
-  card: {
-    borderRadius: 22,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-    backgroundColor: colors.card,
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[3],
-    gap: spacing[3],
-  },
-  cardPressed: {
-    opacity: 0.82,
-    backgroundColor: colors.accent,
-  },
-  cardTop: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing[3],
-  },
-  iconTile: {
-    width: 40,
-    height: 40,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: radius.full,
-    backgroundColor: colors.background,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-  },
-  stateDot: {
-    position: "absolute",
-    right: 4,
-    bottom: 4,
-    width: 7,
-    height: 7,
-    borderRadius: 4,
-    backgroundColor: colors.borderHeavy,
-  },
-  stateDotActive: {
-    backgroundColor: colors.info,
-  },
-  stateDotBlocked: {
-    backgroundColor: colors.destructive,
-  },
-  stateDotUnclaimed: {
-    backgroundColor: colors.success,
-  },
-  cardTitleBlock: {
-    flex: 1,
-    minWidth: 0,
-    gap: 5,
-  },
-  cardTitleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing[2],
-  },
-  cardTitle: {
-    flex: 1,
-    minWidth: 0,
-    color: colors.fg,
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  cardTime: {
-    color: colors.faint,
-    fontSize: 12,
-    fontWeight: "500",
-  },
-  cardMetaRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  cardMeta: {
-    flex: 1,
-    minWidth: 0,
-    color: colors.faint,
-    fontSize: 13.5,
-    lineHeight: 18,
-  },
-  promptBlock: {
-    borderRadius: 18,
-    backgroundColor: colors.background,
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[2],
-  },
-  promptText: {
-    color: colors.mutedForeground,
-    fontSize: 13,
-    lineHeight: 18,
-  },
-  claimButton: {
-    minHeight: 38,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: radius.full,
-    backgroundColor: colors.fg,
-    paddingHorizontal: spacing[4],
-  },
-  claimButtonDisabled: {
-    opacity: 0.62,
-  },
-  claimButtonText: {
-    color: colors.background,
-    fontSize: 13,
-    fontWeight: "600",
   },
   sheetLayer: {
     flex: 1,

--- a/mobile/src/components/work/MobileWorkspaceCard.tsx
+++ b/mobile/src/components/work/MobileWorkspaceCard.tsx
@@ -1,0 +1,236 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { mobileIconForRuntimeLocation, mobileIconForWorkSourceKind } from "../../lib/domain/work/mobile-work-presentation";
+import type { MobileWorkItem } from "../../hooks/work/derived/use-mobile-work-inventory";
+import { MobileIcon } from "../primitives/MobileIcon";
+import { colors, radius, spacing } from "../../styles/tokens";
+
+interface MobileWorkspaceCardProps {
+  item: MobileWorkItem;
+  compact?: boolean;
+  claiming?: boolean;
+  onPress: () => void;
+  onClaim?: () => void;
+}
+
+export function MobileWorkspaceCard({
+  item,
+  compact = false,
+  claiming = false,
+  onPress,
+  onClaim,
+}: MobileWorkspaceCardProps) {
+  const detailText = workspaceDetailText(item);
+  const blocked = item.view.status === "blocked" || item.view.status === "error";
+  const active = item.view.status === "active" || item.view.status === "running";
+  const unclaimed = item.view.unclaimed;
+  const canClaim = Boolean(onClaim) && unclaimed;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.card,
+        compact && styles.cardCompact,
+        pressed && styles.cardPressed,
+      ]}
+    >
+      <View style={styles.cardTop}>
+        <View style={[styles.iconTile, compact && styles.iconTileCompact]}>
+          <MobileIcon
+            name={mobileIconForWorkSourceKind(item.view.sourceKind)}
+            size={compact ? 18 : 21}
+            color={item.view.sourceKind === "slack" ? colors.success : colors.fg}
+          />
+          <View
+            style={[
+              styles.stateDot,
+              active && styles.stateDotActive,
+              blocked && styles.stateDotBlocked,
+              unclaimed && styles.stateDotUnclaimed,
+            ]}
+          />
+        </View>
+        <View style={styles.cardTitleBlock}>
+          <View style={styles.cardTitleRow}>
+            <Text style={[styles.cardTitle, compact && styles.cardTitleCompact]} numberOfLines={1}>
+              {item.view.title}
+            </Text>
+            <Text style={styles.cardTime}>{item.view.lastActivityLabel}</Text>
+          </View>
+          <View style={styles.cardMetaRow}>
+            <MobileIcon
+              name={mobileIconForRuntimeLocation(item.view.runtimeLocation)}
+              size={13}
+              color={colors.faint}
+            />
+            <Text style={styles.cardMeta} numberOfLines={1}>
+              {item.view.repoLabel} · {item.view.branchLabel}
+            </Text>
+          </View>
+        </View>
+      </View>
+      {detailText && !compact ? (
+        <View style={styles.promptBlock}>
+          <Text style={styles.promptText} numberOfLines={2}>
+            {detailText}
+          </Text>
+        </View>
+      ) : null}
+      {canClaim ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Claim workspace"
+          accessibilityState={{ disabled: claiming }}
+          disabled={claiming}
+          onPress={onClaim}
+          style={({ pressed }) => [
+            styles.claimButton,
+            claiming && styles.claimButtonDisabled,
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text style={styles.claimButtonText}>{claiming ? "Claiming" : "Claim workspace"}</Text>
+        </Pressable>
+      ) : null}
+    </Pressable>
+  );
+}
+
+function workspaceDetailText(item: MobileWorkItem): string | null {
+  if (item.view.unclaimed) {
+    return "Unclaimed workspace";
+  }
+  if (item.view.status === "blocked" || item.view.status === "error") {
+    return item.view.statusLabel;
+  }
+  if (item.view.commandability !== "commandable") {
+    return item.view.commandabilityLabel;
+  }
+  return null;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 22,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.card,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    gap: spacing[3],
+  },
+  cardCompact: {
+    borderRadius: 20,
+    paddingVertical: spacing[2],
+  },
+  cardPressed: {
+    opacity: 0.82,
+    backgroundColor: colors.accent,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[3],
+  },
+  iconTile: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.full,
+    backgroundColor: colors.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  iconTileCompact: {
+    width: 36,
+    height: 36,
+  },
+  stateDot: {
+    position: "absolute",
+    right: 4,
+    bottom: 4,
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+    backgroundColor: colors.borderHeavy,
+  },
+  stateDotActive: {
+    backgroundColor: colors.info,
+  },
+  stateDotBlocked: {
+    backgroundColor: colors.destructive,
+  },
+  stateDotUnclaimed: {
+    backgroundColor: colors.success,
+  },
+  cardTitleBlock: {
+    flex: 1,
+    minWidth: 0,
+    gap: 5,
+  },
+  cardTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[2],
+  },
+  cardTitle: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.fg,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  cardTitleCompact: {
+    fontSize: 15,
+  },
+  cardTime: {
+    color: colors.faint,
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  cardMetaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  cardMeta: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.faint,
+    fontSize: 13.5,
+    lineHeight: 18,
+  },
+  promptBlock: {
+    borderRadius: 18,
+    backgroundColor: colors.background,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  promptText: {
+    color: colors.mutedForeground,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  claimButton: {
+    minHeight: 38,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.full,
+    backgroundColor: colors.fg,
+    paddingHorizontal: spacing[4],
+  },
+  claimButtonDisabled: {
+    opacity: 0.62,
+  },
+  claimButtonText: {
+    color: colors.background,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+});

--- a/mobile/src/hooks/home/derived/use-mobile-home-launch-model.ts
+++ b/mobile/src/hooks/home/derived/use-mobile-home-launch-model.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   useCloudAgentCatalog,
   useCloudCapabilities,
+  useCloudRepoBranches,
   useCloudRepoConfigs,
   useCloudTargets,
   useAgentAuthCredentials,
@@ -21,11 +22,13 @@ import {
 
 import {
   buildMobileRepoOptions,
+  buildMobileBranchOptions,
   buildMobileRuntimeOptions,
 } from "../../../lib/domain/home/mobile-home-launch";
 
 export function useMobileHomeLaunchModel() {
   const [repoId, setRepoId] = useState("");
+  const [baseBranchByRepoId, setBaseBranchByRepoId] = useState<Record<string, string>>({});
   const [runtimeId, setRuntimeId] = useState("cloud");
   const [launchSelection, setLaunchSelection] = useState<CloudLaunchComposerSelection>({
     agentKind: DEFAULT_DIRECT_PROMPT_AGENT_KIND,
@@ -62,6 +65,25 @@ export function useMobileHomeLaunchModel() {
     [liveTargets],
   );
   const selectedRepo = repoOptions.find((repo) => repo.id === repoId) ?? repoOptions[0] ?? null;
+  const repoBranches = useCloudRepoBranches(
+    selectedRepo?.gitOwner,
+    selectedRepo?.gitRepoName,
+    Boolean(selectedRepo),
+  );
+  const selectedBaseBranchOverride = selectedRepo ? baseBranchByRepoId[selectedRepo.id] ?? null : null;
+  const branchOptions = useMemo(
+    () => buildMobileBranchOptions({
+      branches: repoBranches.data?.branches,
+      defaultBranch: repoBranches.data?.defaultBranch,
+      selectedBranch: selectedBaseBranchOverride,
+    }),
+    [repoBranches.data?.branches, repoBranches.data?.defaultBranch, selectedBaseBranchOverride],
+  );
+  const selectedBaseBranch =
+    selectedBaseBranchOverride
+    ?? repoBranches.data?.defaultBranch
+    ?? branchOptions[0]
+    ?? null;
   const selectedRuntime =
     runtimeOptions.find((runtime) => runtime.id === runtimeId) ?? runtimeOptions[0] ?? null;
   const agentGateway = cloudCapabilities.data?.agentGateway;
@@ -149,6 +171,8 @@ export function useMobileHomeLaunchModel() {
     harnessAvailability,
     launchableAgentKinds,
     launchComposerControls,
+    branchOptions,
+    repoBranches,
     repoConfigs,
     repoId,
     repoOptions,
@@ -156,7 +180,17 @@ export function useMobileHomeLaunchModel() {
     runtimeId,
     runtimeOptions,
     selectedRepo,
+    selectedBaseBranch,
     selectedRuntime,
+    setBaseBranch: (branch: string) => {
+      if (!selectedRepo) {
+        return;
+      }
+      setBaseBranchByRepoId((current) => ({
+        ...current,
+        [selectedRepo.id]: branch,
+      }));
+    },
     setRepoId,
     setRuntimeId,
     targetLive,

--- a/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
+++ b/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
@@ -26,6 +26,7 @@ export function useMobileHomeLaunchActions(input: {
   catalog?: CloudAgentCatalogResponse | null;
   launchableAgentKinds?: readonly string[] | null;
   selectedRepo: MobileRepoOption | null;
+  selectedBaseBranch: string | null;
   selectedRuntime: MobileRuntimeOption | null;
   selection: CloudLaunchComposerSelection;
   onOpenChat: (chat: MobileCloudChat) => void;
@@ -71,6 +72,7 @@ export function useMobileHomeLaunchActions(input: {
           gitProvider: "github",
           gitOwner: input.selectedRepo.gitOwner,
           gitRepoName: input.selectedRepo.gitRepoName,
+          baseBranch: input.selectedBaseBranch,
           branchName: buildBranchName(prompt),
           displayName: buildWorkspaceDisplayName(prompt),
           prompt,
@@ -110,6 +112,7 @@ export function useMobileHomeLaunchActions(input: {
         gitProvider: "github",
         gitOwner: input.selectedRepo.gitOwner,
         gitRepoName: input.selectedRepo.gitRepoName,
+        baseBranch: input.selectedBaseBranch,
         branchName: buildBranchName(prompt),
         displayName: buildWorkspaceDisplayName(prompt),
         ownerScope: "personal",

--- a/mobile/src/lib/domain/home/mobile-home-launch.ts
+++ b/mobile/src/lib/domain/home/mobile-home-launch.ts
@@ -56,6 +56,20 @@ export function buildMobileRepoOptions(
     }));
 }
 
+export function buildMobileBranchOptions(input: {
+  branches?: readonly string[] | null;
+  defaultBranch?: string | null;
+  selectedBranch?: string | null;
+}): string[] {
+  const options: string[] = [];
+  addUniqueBranch(options, input.defaultBranch);
+  addUniqueBranch(options, input.selectedBranch);
+  for (const branch of input.branches ?? []) {
+    addUniqueBranch(options, branch);
+  }
+  return options;
+}
+
 export function buildMobileRuntimeOptions(
   targets: readonly CloudTargetSummary[] | undefined,
 ): MobileRuntimeOption[] {
@@ -153,5 +167,12 @@ function targetIcon(target: CloudTargetSummary): MobileIconName {
       return "external";
     default:
       return "cloud";
+  }
+}
+
+function addUniqueBranch(options: string[], branch: string | null | undefined): void {
+  const trimmed = branch?.trim();
+  if (trimmed && !options.includes(trimmed)) {
+    options.push(trimmed);
   }
 }

--- a/packages/product-model/src/chats/session-controls/presentation.ts
+++ b/packages/product-model/src/chats/session-controls/presentation.ts
@@ -16,6 +16,7 @@ export type SessionControlTone =
   | "info";
 
 export type SessionControlIconKey =
+  | "branch"
   | "build"
   | "chat"
   | "claude"

--- a/packages/product-model/src/workspaces/cloud-work-inventory.test.ts
+++ b/packages/product-model/src/workspaces/cloud-work-inventory.test.ts
@@ -137,6 +137,23 @@ describe("cloud work inventory", () => {
     expect(groups[0]?.items.map((item) => item.id)).toEqual(["session-activity", "workspace-activity"]);
   });
 
+  it("carries the last session agent kind into workspace rows", () => {
+    const item = cloudWorkItemForWorkspace(workspace({
+      lastSessionSummary: {
+        targetId: "target",
+        workspaceId: "runtime",
+        sessionId: "session",
+        sourceAgentKind: "codex",
+        title: "Codex session",
+        status: "idle",
+        lastEventAt: "2026-05-23T11:57:00Z",
+      },
+    }), { nowMs: NOW });
+
+    expect(item.sourceAgentKind).toBe("codex");
+    expect(item.searchText).toContain("codex");
+  });
+
   it("dedupes duplicate rows while building the inventory", () => {
     const groups = buildCloudWorkInventory([
       workspace({ id: "same", displayName: "Sparse" }),
@@ -360,6 +377,48 @@ describe("cloud work inventory", () => {
       runtimeLocation: "cloud_sandbox",
       commandability: "commandable",
       state: "idle",
+    });
+  });
+
+  it("keeps the active workspace row even when that workspace has recent sessions", () => {
+    const rows = buildRecentWorkItems([
+      workspace({
+        id: "desktop",
+        displayName: "Bramble",
+        sandboxType: "local",
+        origin: { kind: "human", entrypoint: "desktop" },
+        lastSessionSummary: {
+          targetId: "target",
+          workspaceId: "runtime",
+          sessionId: "session",
+          title: "Fix cloud UI",
+          status: "running",
+          lastEventAt: "2026-05-23T11:58:00Z",
+        },
+      }),
+      workspace({
+        id: "empty",
+        displayName: "Empty cloud workspace",
+        sandboxType: "managed_personal",
+        origin: { kind: "human", entrypoint: "web" },
+        targetId: "cloud-target",
+        lastActivityAt: "2026-05-23T11:00:00Z",
+      }),
+    ], {
+      activeWorkspaceId: "desktop",
+      nowMs: NOW,
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "session:desktop:session",
+      "workspace:desktop",
+      "workspace:empty",
+    ]);
+    expect(rows[1]).toMatchObject({
+      rowKind: "workspace",
+      workspaceId: "desktop",
+      sessionId: null,
+      title: "Bramble",
     });
   });
 

--- a/packages/product-model/src/workspaces/cloud-work-inventory.ts
+++ b/packages/product-model/src/workspaces/cloud-work-inventory.ts
@@ -36,6 +36,7 @@ export interface CloudWorkItemView {
   id: string;
   title: string;
   subtitle: string;
+  sourceAgentKind: string | null;
   source: CloudWorkSource;
   sourceLabel: string;
   sourceKind: RecentWorkSourceKind;
@@ -171,6 +172,7 @@ export interface BuildCloudWorkInventoryOptions {
 }
 
 export interface BuildRecentWorkItemsOptions {
+  activeWorkspaceId?: string | null;
   activeWorkspaceSessions?: readonly CloudSessionProjection[];
   nowMs?: number;
   limit?: number;
@@ -260,6 +262,7 @@ export function buildRecentWorkItems(
   options: BuildRecentWorkItemsOptions = {},
 ): RecentWorkItemView[] {
   const nowMs = options.nowMs ?? Date.now();
+  const activeWorkspaceId = options.activeWorkspaceId ?? null;
   const workspaceRows = dedupeCloudWorkspaces(workspaces);
   const workspaceById = new Map(workspaceRows.map((workspace) => [workspace.id, workspace]));
   const rows = new Map<string, RecentWorkItemView>();
@@ -291,7 +294,7 @@ export function buildRecentWorkItems(
   }
 
   for (const workspace of workspaceRows) {
-    if (workspacesWithSessionRows.has(workspace.id)) {
+    if (workspacesWithSessionRows.has(workspace.id) && workspace.id !== activeWorkspaceId) {
       continue;
     }
     rows.set(recentWorkspaceRowId(workspace.id), recentWorkItemForWorkspace(workspace, { nowMs }));
@@ -324,6 +327,7 @@ export function cloudWorkItemForWorkspace(
   const branchLabel = workspace.repo.branch ?? workspace.repo.baseBranch ?? "main";
   const title = workspace.displayName ?? workspace.lastSessionSummary?.title ?? workspace.repo.name;
   const sessionTitle = workspace.lastSessionSummary?.title ?? null;
+  const sourceAgentKind = cloudWorkSourceAgentKind(workspace);
   const source = cloudWorkSourceForWorkspace(workspace);
   const sourceKind = recentWorkSourceForWorkspace(workspace);
   const runtimeLocation = recentWorkRuntimeLocationForWorkspace(workspace);
@@ -338,6 +342,7 @@ export function cloudWorkItemForWorkspace(
     id: workspace.id,
     title,
     subtitle: [repoLabel, branchLabel].filter(Boolean).join(" - "),
+    sourceAgentKind,
     source,
     sourceLabel: SOURCE_LABELS[source],
     sourceKind,
@@ -367,6 +372,7 @@ export function cloudWorkItemForWorkspace(
       sessionTitle,
       repoLabel,
       branchLabel,
+      sourceAgentKind,
       SOURCE_LABELS[source],
       cloudWorkOwnerLabel(workspace),
       STATUS_LABELS[status],
@@ -376,6 +382,13 @@ export function cloudWorkItemForWorkspace(
       sessionId: defaultSessionId,
     },
   };
+}
+
+export function cloudWorkSourceAgentKind(
+  workspace: Pick<CloudWorkspaceSummary, "lastSessionSummary">,
+): string | null {
+  const sourceAgentKind = workspace.lastSessionSummary?.sourceAgentKind?.trim();
+  return sourceAgentKind || null;
 }
 
 export function cloudWorkSourceForWorkspace(

--- a/packages/product-ui/src/billing/BillingSettingsPane.tsx
+++ b/packages/product-ui/src/billing/BillingSettingsPane.tsx
@@ -51,6 +51,15 @@ export interface BillingPlanView {
   overagePricePerHourCents?: number | null;
   repoEnvironmentLimit?: number | null;
   legacyCloudSubscription: boolean;
+  grantAllocations?: BillingGrantAllocationView[] | null;
+}
+
+export interface BillingGrantAllocationView {
+  grantType: string;
+  totalSeconds: number;
+  consumedSeconds: number;
+  remainingSeconds: number;
+  active: boolean;
 }
 
 export interface BillingActionView {
@@ -210,6 +219,8 @@ export function BillingOwnerCard({ view }: { view: BillingOwnerCardView }) {
           ) : null}
         </div>
 
+        <CreditGrantBreakdown plan={plan} />
+
         {overage ? (
           <div className="flex flex-col gap-3 border-t border-border-light pt-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0 space-y-1">
@@ -368,8 +379,8 @@ function CheckoutReturnNotice({ state }: { state: "success" | "cancel" }) {
           <div className="min-w-0">
             <div className="text-sm font-medium">Stripe checkout completed</div>
             <p className="mt-1 text-sm leading-5 text-muted-foreground">
-              Billing is refreshing from Stripe. If the relevant billing card has not updated yet,
-              wait a moment for the webhook to finish and refresh this page.
+              Billing is refreshing from Stripe. The relevant card will update automatically
+              as soon as the webhook lands.
             </p>
           </div>
         </div>
@@ -565,7 +576,11 @@ function runtimeUsage(plan: BillingPlanView): {
   const included = plan.proBillingEnabled && plan.isPaidCloud
     ? plan.includedManagedCloudHours
     : plan.freeSandboxHours;
-  const used = plan.usedSandboxHours ?? 0;
+  const grantUsage = grantUsageSummary(plan.grantAllocations);
+  const used = grantUsage?.consumedHours
+    ?? managedUsedHours(plan)
+    ?? plan.usedSandboxHours
+    ?? 0;
   const total = included ?? (remaining === null || remaining === undefined ? null : used + remaining);
   const percent = total && total > 0
     ? Math.min(100, Math.max(0, (used / total) * 100))
@@ -578,6 +593,124 @@ function runtimeUsage(plan: BillingPlanView): {
     percent,
     progressLabel: total ? `${Math.round(percent ?? 0)}% used this period` : "Usage is not capped for this plan",
   };
+}
+
+function CreditGrantBreakdown({ plan }: { plan: BillingPlanView }) {
+  const grants = visibleGrantAllocations(plan.grantAllocations);
+  if (grants.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 border-t border-border-light pt-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="text-sm font-medium text-foreground">Credit usage</div>
+          <p className="text-xs leading-5 text-muted-foreground">
+            Consumed hours across free trial, included, refill, and Team period grants.
+          </p>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {formatHours(grants.reduce((total, grant) => total + secondsToHours(grant.consumedSeconds), 0))} used
+        </div>
+      </div>
+      <div className="space-y-2">
+        {grants.map((grant) => {
+          const totalHours = secondsToHours(grant.totalSeconds);
+          const consumedHours = secondsToHours(grant.consumedSeconds);
+          const remainingHours = secondsToHours(grant.remainingSeconds);
+          const percent = totalHours > 0
+            ? Math.min(100, Math.max(0, (consumedHours / totalHours) * 100))
+            : 0;
+          return (
+            <div key={`${grant.grantType}:${grant.totalSeconds}:${grant.active}`} className="space-y-1.5">
+              <div className="flex items-center gap-2 text-xs">
+                <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+                  {grantTypeLabel(grant.grantType)}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {formatHours(consumedHours)} / {formatHours(totalHours)}
+                </span>
+                {!grant.active ? <Badge tone="neutral">Inactive</Badge> : null}
+              </div>
+              <div className="h-1 overflow-hidden rounded-full bg-foreground/10">
+                <div className="h-full rounded-full bg-foreground/70" style={{ width: `${percent}%` }} />
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {grant.active ? `${formatHours(remainingHours)} remaining` : "No longer active"}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function grantUsageSummary(
+  grants: readonly BillingGrantAllocationView[] | null | undefined,
+): { consumedHours: number } | null {
+  const visible = visibleGrantAllocations(grants);
+  if (visible.length === 0) {
+    return null;
+  }
+  return {
+    consumedHours: visible.reduce(
+      (total, grant) => total + secondsToHours(grant.consumedSeconds),
+      0,
+    ),
+  };
+}
+
+function visibleGrantAllocations(
+  grants: readonly BillingGrantAllocationView[] | null | undefined,
+): BillingGrantAllocationView[] {
+  return (grants ?? [])
+    .filter((grant) =>
+      grant.active
+      || grant.consumedSeconds > 0
+      || grant.remainingSeconds > 0
+    )
+    .sort((left, right) => Number(right.active) - Number(left.active)
+      || right.consumedSeconds - left.consumedSeconds);
+}
+
+function managedUsedHours(plan: BillingPlanView): number | null {
+  if (!plan.proBillingEnabled || !plan.isPaidCloud) {
+    return null;
+  }
+  if (
+    plan.includedManagedCloudHours === null
+    || plan.includedManagedCloudHours === undefined
+    || plan.remainingManagedCloudHours === null
+    || plan.remainingManagedCloudHours === undefined
+  ) {
+    return null;
+  }
+  return Math.max(plan.includedManagedCloudHours - plan.remainingManagedCloudHours, 0);
+}
+
+function secondsToHours(seconds: number | null | undefined): number {
+  return Math.max(seconds ?? 0, 0) / 3600;
+}
+
+function grantTypeLabel(grantType: string): string {
+  switch (grantType) {
+    case "free_trial_v2":
+      return "Free trial credits";
+    case "free_included":
+      return "Included free credits";
+    case "cloud_monthly":
+      return "Monthly cloud credits";
+    case "pro_period":
+      return "Team period credits";
+    case "pro_seat_proration":
+      return "Seat adjustment credits";
+    case "refill_10h":
+      return "Refill credits";
+    default:
+      return grantType.replace(/_/g, " ");
+  }
 }
 
 function overageSummary(plan: BillingPlanView): {

--- a/packages/product-ui/src/chat/CloudChatSurface.tsx
+++ b/packages/product-ui/src/chat/CloudChatSurface.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowLeft,
   ExternalLink,
-  MoreHorizontal,
+  MessagesSquare,
   Plus,
 } from "lucide-react";
 import { useState } from "react";
@@ -97,12 +97,14 @@ export function CloudChatSurface({
 }: CloudChatSurfaceProps) {
   return (
     <div className="flex h-full flex-col" data-telemetry-block={telemetryBlocked || undefined}>
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-border px-4">
         <IconButton title="Back" size="sm" onClick={onBack}>
           <ArrowLeft size={15} />
         </IconButton>
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <h1 className="truncate text-sm font-medium text-foreground">{title}</h1>
+          <h1 className="min-w-[7rem] max-w-[18rem] truncate text-sm font-medium text-foreground">
+            {title}
+          </h1>
           {sessionSwitcher ? (
             <CloudChatSessionSwitcher view={sessionSwitcher} />
           ) : eyebrowItems[0] ? (
@@ -140,12 +142,9 @@ export function CloudChatSurface({
             className="inline-flex h-8 items-center gap-2 rounded-md border border-input px-3 text-xs text-muted-foreground hover:bg-accent"
           >
             <ExternalLink size={14} />
-            Desktop
+            Open in Desktop
           </a>
         ) : null}
-        <IconButton title="Session menu" size="sm">
-          <MoreHorizontal size={15} />
-        </IconButton>
       </header>
       {topNotice ? (
         <div className="flex shrink-0 items-center gap-3 border-b border-warning/20 bg-warning-subtle px-4 py-2 text-sm text-warning">
@@ -203,9 +202,10 @@ function CloudChatSessionSwitcher({ view }: { view: CloudChatSessionSwitcherView
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((current) => !current)}
-        className="flex h-8 min-w-0 max-w-[18rem] items-center gap-2 rounded-lg border border-border/70 bg-foreground/[0.035] px-2.5 text-left text-sm text-foreground outline-none hover:bg-foreground/[0.055] disabled:text-muted-foreground"
+        className="flex h-8 min-w-0 max-w-[20rem] items-center gap-2 rounded-lg border border-border/70 bg-foreground/[0.035] px-2.5 text-left text-sm text-foreground outline-none hover:bg-foreground/[0.055] disabled:text-muted-foreground"
       >
-        <span className="size-4 shrink-0 rounded-full border border-border/80 bg-foreground/[0.04]" />
+        <MessagesSquare size={14} className="shrink-0 text-muted-foreground" />
+        <span className="shrink-0 text-xs text-muted-foreground">Session</span>
         <span className="min-w-0 truncate font-medium">{activeSession?.label ?? view.activeSessionLabel}</span>
       </button>
       <IconButton
@@ -220,6 +220,9 @@ function CloudChatSessionSwitcher({ view }: { view: CloudChatSessionSwitcherView
           role="menu"
           className="absolute left-0 top-[calc(100%+0.35rem)] z-50 w-72 rounded-lg border border-border bg-popover p-1.5 shadow-lg"
         >
+          <div className="px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
+            {view.sessions.length} {view.sessions.length === 1 ? "session" : "sessions"}
+          </div>
           {view.sessions.map((session) => (
             <button
               key={session.id}

--- a/packages/product-ui/src/chat/session-controls/SessionControlIcon.tsx
+++ b/packages/product-ui/src/chat/session-controls/SessionControlIcon.tsx
@@ -1,5 +1,6 @@
 import type { SessionControlIconKey } from "@proliferate/product-model/chats/session-controls/presentation";
 import type { ComponentType, SVGProps } from "react";
+import { GitBranch } from "lucide-react";
 
 type IconProps = SVGProps<SVGSVGElement>;
 
@@ -9,6 +10,7 @@ interface SessionControlIconProps {
 }
 
 const SESSION_CONTROL_ICONS: Record<SessionControlIconKey, ComponentType<IconProps>> = {
+  branch: GitBranch,
   build: BuildModeFilled,
   chat: MessageSquareFilled,
   claude: ClaudeProviderIcon,

--- a/packages/product-ui/src/support/SupportSurface.tsx
+++ b/packages/product-ui/src/support/SupportSurface.tsx
@@ -1,57 +1,108 @@
-import { CircleHelp, Mail, MessageSquare, Send } from "lucide-react";
+import { AlertCircle, CheckCircle2, CircleHelp, LifeBuoy, MessageSquare, Send } from "lucide-react";
+import { useState, type FormEvent } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Input } from "@proliferate/ui/primitives/Input";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 
 interface SupportSurfaceProps {
-  onSubmit?: () => void;
+  onSubmit?: (message: string) => Promise<void> | void;
 }
 
 export function SupportSurface({ onSubmit }: SupportSurfaceProps) {
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [notice, setNotice] = useState<{ tone: "success" | "error"; text: string } | null>(null);
+  const trimmedMessage = message.trim();
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!trimmedMessage || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setNotice(null);
+    try {
+      await onSubmit?.(trimmedMessage);
+      setMessage("");
+      setNotice({ tone: "success", text: "Support message sent." });
+    } catch (error) {
+      setNotice({
+        tone: "error",
+        text: error instanceof Error ? error.message : "Support message could not be sent.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
-    <div className="grid gap-4 lg:grid-cols-[0.8fr_1.2fr]">
+    <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
       <section className="space-y-3">
-        <article className="rounded-lg border border-border bg-card p-4">
+        <article className="border-b border-border-light pb-4">
           <div className="flex items-center gap-2 text-sm font-medium">
             <MessageSquare size={16} />
-            Product support
+            Product help
           </div>
           <p className="mt-2 text-sm leading-5 text-muted-foreground">
-            Send a message to the team with your current workspace context attached.
+            Cloud sessions, Desktop handoff, billing, and workspace dispatch issues.
           </p>
         </article>
-        <article className="rounded-lg border border-border bg-card p-4">
+        <article className="border-b border-border-light pb-4">
           <div className="flex items-center gap-2 text-sm font-medium">
             <CircleHelp size={16} />
-            Docs
+            Product docs
           </div>
           <p className="mt-2 text-sm leading-5 text-muted-foreground">
-            Setup, cloud sandbox, and automation guides stay grouped with product support.
+            Setup, cloud sandbox, automation, and environment guidance.
+          </p>
+        </article>
+        <article className="pb-2">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <LifeBuoy size={16} />
+            Account context
+          </div>
+          <p className="mt-2 text-sm leading-5 text-muted-foreground">
+            Messages include the current app location so the team can find the right account state.
           </p>
         </article>
       </section>
 
-      <section className="rounded-lg border border-border bg-card p-4">
-        <div className="mb-4 flex items-center gap-2 text-sm font-semibold">
-          <Mail size={16} />
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <LifeBuoy size={16} />
           Contact
         </div>
-        <div className="grid gap-3">
-          <Input placeholder="Email" />
-          <Input placeholder="Subject" />
-          <Textarea
-            rows={8}
-            className="w-full resize-none"
-            placeholder="What happened?"
-          />
-          <div className="flex justify-end">
-            <Button onClick={onSubmit}>
-              <Send size={15} />
-              Send
-            </Button>
+        <Textarea
+          rows={10}
+          value={message}
+          onChange={(event) => {
+            setMessage(event.currentTarget.value);
+            if (notice) {
+              setNotice(null);
+            }
+          }}
+          className="w-full resize-none"
+          placeholder="What happened?"
+          data-telemetry-mask
+        />
+        {notice ? (
+          <div
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+              notice.tone === "success"
+                ? "border-success/30 bg-success/10 text-success"
+                : "border-destructive/30 bg-destructive/10 text-destructive"
+            }`}
+          >
+            {notice.tone === "success" ? <CheckCircle2 size={15} /> : <AlertCircle size={15} />}
+            <span>{notice.text}</span>
           </div>
+        ) : null}
+        <div className="flex justify-end">
+          <Button type="submit" loading={submitting} disabled={!trimmedMessage || submitting}>
+            <Send size={15} />
+            Send
+          </Button>
         </div>
-      </section>
+      </form>
     </div>
   );
 }

--- a/server/proliferate/server/billing/models.py
+++ b/server/proliferate/server/billing/models.py
@@ -49,6 +49,7 @@ class BillingSnapshot:
     repo_environment_limit: int | None = None
     byo_runtime_allowed: bool = False
     legacy_cloud_subscription: bool = False
+    grant_allocations: tuple[GrantAllocation, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -104,6 +105,14 @@ class BillingBaseModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class GrantAllocationInfo(BillingBaseModel):
+    grant_type: str = Field(alias="grantType")
+    total_seconds: float = Field(alias="totalSeconds")
+    consumed_seconds: float = Field(alias="consumedSeconds")
+    remaining_seconds: float = Field(alias="remainingSeconds")
+    active: bool
+
+
 class PlanInfo(BillingBaseModel):
     plan: str
     usage_minutes: int = Field(alias="usageMinutes")
@@ -152,6 +161,10 @@ class CloudPlanInfo(BillingBaseModel):
     repo_environment_limit: int | None = Field(default=None, alias="repoEnvironmentLimit")
     byo_runtime_allowed: bool = Field(alias="byoRuntimeAllowed")
     legacy_cloud_subscription: bool = Field(alias="legacyCloudSubscription")
+    grant_allocations: list[GrantAllocationInfo] = Field(
+        default_factory=list,
+        alias="grantAllocations",
+    )
 
 
 class BillingOverview(BillingBaseModel):

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -112,6 +112,7 @@ from proliferate.errors import ProliferateError
 from proliferate.integrations import resend
 from proliferate.integrations.billing import stripe as stripe_billing
 from proliferate.server.billing.domain.accounting import (
+    ordered_accounting_grants,
     stripe_status_is_terminal,
     terminal_meter_event_error,
     usage_export_identifier,
@@ -152,6 +153,8 @@ from proliferate.server.billing.models import (
     BillingUrlResponse,
     CloudPlanInfo,
     CurrentTeamCheckoutResponse,
+    GrantAllocation,
+    GrantAllocationInfo,
     OverageSettingsResponse,
     PlanInfo,
     SandboxStartAuthorization,
@@ -270,6 +273,54 @@ def _grant_applies_to_paid_state(grant: BillingGrant, *, is_paid_cloud: bool) ->
     )
 
 
+def _grant_allocations_for_snapshot(
+    *,
+    eligible_grants: list[BillingGrant],
+    active_grants: list[BillingGrant],
+    is_paid_cloud: bool,
+    unaccounted_billable_seconds: float,
+    now: datetime,
+) -> tuple[GrantAllocation, ...]:
+    adjusted_remaining_by_id = {
+        grant.id: max(float(grant.remaining_seconds), 0.0) for grant in eligible_grants
+    }
+    uncovered_seconds = max(float(unaccounted_billable_seconds), 0.0)
+    for grant in ordered_accounting_grants(
+        active_grants,
+        pro_billing_enabled=settings.pro_billing_enabled,
+        is_paid_cloud=is_paid_cloud,
+        at=now,
+    ):
+        if uncovered_seconds <= 0:
+            break
+        available_seconds = adjusted_remaining_by_id.get(grant.id, 0.0)
+        consumed_seconds = min(available_seconds, uncovered_seconds)
+        if consumed_seconds <= 0:
+            continue
+        adjusted_remaining_by_id[grant.id] = max(available_seconds - consumed_seconds, 0.0)
+        uncovered_seconds -= consumed_seconds
+
+    allocations: list[GrantAllocation] = []
+    for grant in eligible_grants:
+        total_seconds = max(float(grant.hours_granted) * 3600.0, 0.0)
+        raw_remaining_seconds = max(float(grant.remaining_seconds), 0.0)
+        remaining_seconds = max(
+            adjusted_remaining_by_id.get(grant.id, raw_remaining_seconds),
+            0.0,
+        )
+        billable_remaining_seconds = min(remaining_seconds, total_seconds)
+        allocations.append(
+            GrantAllocation(
+                grant_type=grant.grant_type,
+                total_seconds=total_seconds,
+                consumed_seconds=max(total_seconds - billable_remaining_seconds, 0.0),
+                remaining_seconds=remaining_seconds,
+                active=_grant_is_active(grant, now),
+            )
+        )
+    return tuple(allocations)
+
+
 def _segment_seconds(segment: UsageSegment, now: datetime) -> float:
     return duration_seconds(
         started_at=segment.started_at,
@@ -355,6 +406,13 @@ def _build_billing_snapshot(state: BillingSnapshotState) -> BillingSnapshot:
 
     has_unlimited_cloud_hours = unlimited_state.has_unlimited_cloud_hours
     remaining_seconds_value = None if has_unlimited_cloud_hours else max(remaining_seconds, 0.0)
+    grant_allocations = _grant_allocations_for_snapshot(
+        eligible_grants=eligible_grants,
+        active_grants=active_grants,
+        is_paid_cloud=is_paid_cloud,
+        unaccounted_billable_seconds=state.unaccounted_billable_seconds,
+        now=now,
+    )
 
     active_sandbox_count = sum(
         1 for sandbox in state.sandboxes if sandbox.status in ACTIVE_SANDBOX_STATUSES
@@ -499,6 +557,7 @@ def _build_billing_snapshot(state: BillingSnapshotState) -> BillingSnapshot:
         repo_environment_limit=repo_environment_limit,
         byo_runtime_allowed=byo_runtime_allowed,
         legacy_cloud_subscription=legacy_cloud_subscription,
+        grant_allocations=grant_allocations,
     )
 
 
@@ -706,6 +765,20 @@ def _cloud_plan_from_snapshot(snapshot: BillingSnapshot) -> CloudPlanInfo:
         repo_environment_limit=snapshot.repo_environment_limit,
         byo_runtime_allowed=snapshot.byo_runtime_allowed,
         legacy_cloud_subscription=snapshot.legacy_cloud_subscription,
+        grant_allocations=[
+            _grant_allocation_info(allocation)
+            for allocation in snapshot.grant_allocations
+        ],
+    )
+
+
+def _grant_allocation_info(allocation: GrantAllocation) -> GrantAllocationInfo:
+    return GrantAllocationInfo(
+        grant_type=allocation.grant_type,
+        total_seconds=round(allocation.total_seconds, 4),
+        consumed_seconds=round(allocation.consumed_seconds, 4),
+        remaining_seconds=round(allocation.remaining_seconds, 4),
+        active=allocation.active,
     )
 
 

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -75,6 +75,7 @@ class WorkspaceSessionSummaryRecord(Protocol):
     target_id: UUID
     workspace_id: str | None
     session_id: str
+    source_agent_kind: str | None
     title: str | None
     status: str
     last_event_at: str | None
@@ -282,6 +283,7 @@ class LastSessionSummary(BaseModel):
     target_id: str = Field(serialization_alias="targetId")
     workspace_id: str | None = Field(default=None, serialization_alias="workspaceId")
     session_id: str = Field(serialization_alias="sessionId")
+    source_agent_kind: str | None = Field(default=None, serialization_alias="sourceAgentKind")
     title: str | None = None
     status: str
     last_event_at: str | None = Field(default=None, serialization_alias="lastEventAt")
@@ -730,6 +732,7 @@ def last_session_summary_payload(
         target_id=str(session.target_id),
         workspace_id=session.workspace_id,
         session_id=session.session_id,
+        source_agent_kind=getattr(session, "source_agent_kind", None),
         title=session.title,
         status=session.status,
         last_event_at=session.last_event_at,

--- a/web/src/components/app/navigation/WebSidebarController.tsx
+++ b/web/src/components/app/navigation/WebSidebarController.tsx
@@ -123,10 +123,11 @@ export function WebSidebarController({
   );
   const recentItems = useMemo(
     () => buildRecentWorkItems(cloudWorkspaces, {
+      activeWorkspaceId: routeState.sessionId ? null : routeState.workspaceId,
       activeWorkspaceSessions,
       nowMs: Date.now(),
     }),
-    [activeWorkspaceSessions, cloudWorkspaces],
+    [activeWorkspaceSessions, cloudWorkspaces, routeState.sessionId, routeState.workspaceId],
   );
   const visibleRecentItems = useMemo(
     () => recentItems.filter((item) =>

--- a/web/src/components/chat/screen/ChatScreen.tsx
+++ b/web/src/components/chat/screen/ChatScreen.tsx
@@ -478,7 +478,7 @@ export function ChatScreen() {
       setPendingHomePromptStatus(
         workspaceFailureMessage
           ?? pendingHomePrompt.errorMessage
-          ?? "Queued prompt could not be sent.",
+          ?? "Prompt could not be sent.",
       );
       setDraft((current) => current.trim() ? current : pendingHomePrompt.text);
       return;
@@ -510,7 +510,7 @@ export function ChatScreen() {
       }
     };
 
-    setPendingHomePromptStatus("Starting a session for the queued prompt.");
+    setPendingHomePromptStatus("Starting a session for this prompt.");
     const timeoutId = window.setTimeout(() => {
       if (!isCurrentRun()) {
         return;
@@ -565,7 +565,7 @@ export function ChatScreen() {
           if (!isCurrentRun()) {
             return;
           }
-          const message = error instanceof Error ? error.message : "Queued prompt could not be sent.";
+          const message = error instanceof Error ? error.message : "Prompt could not be sent.";
           const prompt: PendingHomePrompt = isWorkspacePreparationStatus(message)
             ? {
               ...pendingHomePrompt,
@@ -645,7 +645,7 @@ export function ChatScreen() {
       }
     };
 
-    setPendingHomePromptStatus("Session started; sending queued prompt.");
+    setPendingHomePromptStatus("Session started; sending prompt.");
     void resumePendingHomePromptInSession({
       client,
       workspace,
@@ -704,7 +704,7 @@ export function ChatScreen() {
         if (!isCurrentRun()) {
           return;
         }
-        const message = error instanceof Error ? error.message : "Queued prompt could not be sent.";
+        const message = error instanceof Error ? error.message : "Prompt could not be sent.";
         const prompt: PendingHomePrompt = {
           ...pendingHomePrompt,
           status: "failed",
@@ -1417,9 +1417,12 @@ export function ChatScreen() {
       && workspaceCommandReady
       && (session || canStartNewSession),
   );
-  const branchName = workspace.repo.branch ?? workspace.repo.baseBranch ?? "main";
   const repoLabel = `${workspace.repo.owner}/${workspace.repo.name}`;
-  const workspaceTitle = branchName || repoLabel;
+  const defaultBranchName = workspace.repo.baseBranch ?? "main";
+  const branchName = workspace.repo.branch ?? defaultBranchName;
+  const workspaceDisplayName = workspace.displayName?.trim() ?? "";
+  const workspaceTitle = workspaceDisplayName || branchName || repoLabel;
+  const showBranchChip = !workspaceDisplayName || branchName !== defaultBranchName;
   const activeSessionLabel = session
     ? sessionOptionLabel(session)
     : "New session";
@@ -1494,11 +1497,13 @@ export function ChatScreen() {
         commandabilityLabel,
       ]}
       chips={[
-        {
-          id: "branch",
-          label: branchName,
-          icon: "branch",
-        },
+        ...(showBranchChip
+          ? [{
+            id: "branch",
+            label: branchName,
+            icon: "branch" as const,
+          }]
+          : []),
         {
           id: "repo",
           label: repoLabel,
@@ -1756,7 +1761,7 @@ function commandStatusMessageForNotice(
   }
   switch (command.status) {
     case "queued":
-      return "Command queued; waiting for the cloud runtime.";
+      return "Loading...";
     case "leased":
       return "Cloud runtime is picking up the command.";
     case "delivered":
@@ -2032,15 +2037,13 @@ function buildOptimisticPromptRows(input: {
         kind: "user",
         body: prompt.text,
         status: optimisticPromptStatusLabel(prompt.status),
-        streaming: prompt.status !== "failed",
       });
     }
-    if (prompt.status !== "failed" && !agentStarted) {
+    if (prompt.status === "sending" && !agentStarted) {
       rows.push({
         id: `${prompt.id}:assistant-waiting`,
         kind: "assistant",
-        body: prompt.status === "sending" ? "Sending message..." : "Waiting for response...",
-        streaming: true,
+        body: "Loading...",
       });
     } else if (prompt.status === "failed" && (input.status || prompt.errorMessage)) {
       rows.push({
@@ -2078,27 +2081,23 @@ function buildPendingHomePromptRows(input: {
     && (input.pendingPrompt.status === "failed" || isFailureStatusText(input.status));
   const failureMessage = friendlyCommandStatusMessage(input.pendingPrompt.errorMessage)
     ?? input.status;
-  return [
+  const loading = preparationStatus;
+  const rows: CloudChatTranscriptRowView[] = [
     {
       id: `${input.pendingPrompt.id}:user`,
       kind: "user",
       body: input.pendingPrompt.text,
-      status: preparationStatus ? "Preparing" : failed ? "Failed" : "Queued",
-      streaming: !failed,
-    },
-    {
-      id: `${input.pendingPrompt.id}:assistant-waiting`,
-      kind: failed ? "error" : "assistant",
-      body: failed
-        ? failureMessage ?? "Queued prompt could not be sent."
-        : input.status ?? (
-          preparationStatus
-            ? "Preparing the selected runtime so this session can start."
-            : "Waiting for the workspace to be ready..."
-        ),
-      streaming: !failed,
+      status: loading ? "Loading" : failed ? "Failed" : null,
     },
   ];
+  if (loading || failed) {
+    rows.push({
+      id: `${input.pendingPrompt.id}:assistant-waiting`,
+      kind: failed ? "error" : "assistant",
+      body: failed ? failureMessage ?? "Prompt could not be sent." : "Loading...",
+    });
+  }
+  return rows;
 }
 
 function latestPendingPromptCommandId(
@@ -2200,15 +2199,15 @@ function removeRetryReplacedFailedPrompts(
   );
 }
 
-function optimisticPromptStatusLabel(status: OptimisticPrompt["status"]): string {
+function optimisticPromptStatusLabel(status: OptimisticPrompt["status"]): string | null {
   switch (status) {
     case "failed":
       return "Failed";
     case "queued":
-      return "Queued";
+      return null;
     case "sending":
     default:
-      return "Sending";
+      return "Loading";
   }
 }
 

--- a/web/src/components/home/screen/HomeScreen.tsx
+++ b/web/src/components/home/screen/HomeScreen.tsx
@@ -2,6 +2,7 @@ import { Bot, Cloud, GitBranch, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+  type CloudTargetSummary,
   listCloudWorkspaces,
   type CloudWorkspaceDetail,
   type CreateCloudWorkspaceRequest,
@@ -11,8 +12,12 @@ import {
   useCloudAgentCatalog,
   useCloudCapabilities,
   useCloudClient,
+  useCloudRepoBranches,
   useCloudRepoConfigs,
   useCreateCloudWorkspace,
+  useCloudTargets,
+  useLaunchCloudWorkspaceOnTarget,
+  useTargetLive,
   useAgentAuthCredentials,
 } from "@proliferate/cloud-sdk-react";
 import {
@@ -38,6 +43,7 @@ import type {
   NoticeView,
   PickerView,
 } from "@proliferate/product-ui/new-chat/NewChatSurface";
+import type { CloudChatComposerControlView } from "@proliferate/product-ui/chat/CloudChatComposer";
 import { NewChatSurface } from "@proliferate/product-ui/new-chat/NewChatSurface";
 import type { CloudChatTranscriptRowView } from "@proliferate/product-ui/chat/CloudChatTranscript";
 
@@ -47,6 +53,7 @@ import { ensurePersonalAgentAuthLaunchReady } from "../../../lib/access/cloud/ag
 import { isRecoverableCloudDispatchError } from "../../../lib/access/cloud/pending-home-prompt-dispatch";
 import { savePendingHomePrompt } from "../../../lib/access/cloud/pending-home-prompt-store";
 import { AddCloudEnvironmentDialogController } from "../../environments/screen/AddCloudEnvironmentDialogController";
+import { saveWebCloudPromptIntents } from "../../../stores/cloud/web-cloud-chat-state-store";
 
 const HOME_PLACEHOLDER = "Describe a quick remote task...";
 
@@ -65,6 +72,24 @@ interface HomePendingPrompt {
   detail?: string | null;
 }
 
+type RuntimeOption =
+  | {
+    id: "cloud";
+    kind: "cloud";
+    label: string;
+    description: string;
+    online: true;
+    targetId: null;
+  }
+  | {
+    id: string;
+    kind: "target";
+    label: string;
+    description: string;
+    online: boolean;
+    targetId: string;
+  };
+
 export function HomeScreen() {
   const navigate = useNavigate();
   const client = useCloudClient();
@@ -73,6 +98,8 @@ export function HomeScreen() {
   const [repoId, setRepoId] = useState(() =>
     readLastRepoId() ?? normalizeGitRepoId(webEnv.defaultCloudRepo) ?? ""
   );
+  const [baseBranchByRepoId, setBaseBranchByRepoId] = useState<Record<string, string>>({});
+  const [runtimeId, setRuntimeId] = useState("cloud");
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const [launchSelection, setLaunchSelection] = useState<CloudLaunchComposerSelection>({
     agentKind: DEFAULT_DIRECT_PROMPT_AGENT_KIND,
@@ -87,6 +114,10 @@ export function HomeScreen() {
   const cloudCapabilities = useCloudCapabilities();
   const agentAuthCredentials = useAgentAuthCredentials();
   const createWorkspace = useCreateCloudWorkspace();
+  const launchOnTarget = useLaunchCloudWorkspaceOnTarget();
+  const targets = useCloudTargets();
+  const liveTargetId = runtimeId === "cloud" ? null : runtimeId;
+  const targetLive = useTargetLive(liveTargetId, { enabled: Boolean(liveTargetId) });
   const repoOptions = useMemo(
     () => buildRepoOptions(repoConfigs.data?.configs ?? [], webEnv.defaultCloudRepo),
     [repoConfigs.data?.configs],
@@ -95,6 +126,46 @@ export function HomeScreen() {
     () => repoOptions.find((repo) => repo.id === repoId) ?? repoOptions[0] ?? null,
     [repoId, repoOptions],
   );
+  const liveTargets = useMemo(() => {
+    const liveTarget = targetLive.snapshot?.target;
+    if (!liveTarget) {
+      return targets.data;
+    }
+    const baseTargets = targets.data ?? [];
+    if (!baseTargets.some((target) => target.id === liveTarget.id)) {
+      return [...baseTargets, liveTarget];
+    }
+    return baseTargets.map((target) =>
+      target.id === liveTarget.id ? { ...target, ...liveTarget } : target
+    );
+  }, [targetLive.snapshot?.target, targets.data]);
+  const runtimeOptions = useMemo(
+    () => buildRuntimeOptions(liveTargets),
+    [liveTargets],
+  );
+  const selectedRuntime = useMemo(
+    () => runtimeOptions.find((runtime) => runtime.id === runtimeId) ?? runtimeOptions[0] ?? null,
+    [runtimeId, runtimeOptions],
+  );
+  const repoBranches = useCloudRepoBranches(
+    selectedRepo?.gitOwner,
+    selectedRepo?.gitRepoName,
+    Boolean(selectedRepo),
+  );
+  const selectedBaseBranchOverride = selectedRepo ? baseBranchByRepoId[selectedRepo.id] ?? null : null;
+  const branchOptions = useMemo(
+    () => buildBranchOptions({
+      branches: repoBranches.data?.branches,
+      defaultBranch: repoBranches.data?.defaultBranch,
+      selectedBranch: selectedBaseBranchOverride,
+    }),
+    [repoBranches.data?.branches, repoBranches.data?.defaultBranch, selectedBaseBranchOverride],
+  );
+  const selectedBaseBranch =
+    selectedBaseBranchOverride
+    ?? repoBranches.data?.defaultBranch
+    ?? branchOptions[0]
+    ?? null;
   const agentGateway = cloudCapabilities.data?.agentGateway;
   const readySyncedAgentKinds = useMemo(
     () => readySyncedCloudAgentKinds(agentAuthCredentials.data),
@@ -105,8 +176,11 @@ export function HomeScreen() {
   const catalogAgentKindsKey = agentCatalog.data?.agents.map((agent) => agent.kind).join("\0") ?? "";
   const harnessAvailability = useMemo(() => resolveCloudHarnessAvailability({
     catalogAgentKinds: agentCatalog.data?.agents.map((agent) => agent.kind),
-    readyAgentKinds: readySyncedAgentKinds,
-    agentGateway,
+    readyAgentKinds: selectedRuntime?.kind === "target"
+      ? agentCatalog.data?.agents.map((agent) => agent.kind)
+      : readySyncedAgentKinds,
+    agentGateway: selectedRuntime?.kind === "target" ? null : agentGateway,
+    assumeFallbackAgentKindsLaunchable: selectedRuntime?.kind === "target",
   }), [
     agentCatalog.data,
     readySyncedAgentKindsKey,
@@ -116,9 +190,11 @@ export function HomeScreen() {
     agentGateway?.opencodeGatewayEnabled,
     agentGatewayManagedCreditKindsKey,
     catalogAgentKindsKey,
+    selectedRuntime?.kind,
   ]);
   const launchableAgentKinds = harnessAvailability.launchableAgentKinds;
   const canStartCloudHarness = launchableAgentKinds.length > 0;
+  const selectedRuntimeReady = selectedRuntime?.kind !== "target" || selectedRuntime.online;
   const resolvedLaunchSelection = useMemo(
     () => resolveCloudLaunchSelection({
       catalog: agentCatalog.data,
@@ -157,12 +233,54 @@ export function HomeScreen() {
     }),
     [agentCatalog.data, launchableAgentKinds, resolvedLaunchSelection],
   );
+  const composerControls = useMemo(
+    () => [
+      buildBranchControl({
+        branchOptions,
+        loading: repoBranches.isLoading,
+        selectedBranch: selectedBaseBranch,
+        disabled: !selectedRepo,
+        onSelect: (branch) => {
+          if (!selectedRepo) {
+            return;
+          }
+          setBaseBranchByRepoId((current) => ({
+            ...current,
+            [selectedRepo.id]: branch,
+          }));
+        },
+      }),
+      buildRuntimeControl({
+        runtimeOptions,
+        loading: targets.isLoading,
+        selectedRuntime,
+        onSelect: setRuntimeId,
+      }),
+      ...launchComposerControls,
+    ],
+    [
+      branchOptions,
+      launchComposerControls,
+      repoBranches.isLoading,
+      runtimeOptions,
+      selectedBaseBranch,
+      selectedRepo,
+      selectedRuntime,
+      targets.isLoading,
+    ],
+  );
 
   useEffect(() => {
     if (!repoId && !selectedRepo && repoOptions[0]) {
       setRepoId(repoOptions[0].id);
     }
   }, [repoId, repoOptions, selectedRepo]);
+
+  useEffect(() => {
+    if (!runtimeOptions.some((runtime) => runtime.id === runtimeId)) {
+      setRuntimeId("cloud");
+    }
+  }, [runtimeId, runtimeOptions]);
 
   function handlePickerSelect(picker: NewChatPickerId, itemId: string) {
     if (picker === "target") {
@@ -187,6 +305,14 @@ export function HomeScreen() {
   async function handleSubmit() {
     const text = draft.trim();
     if (!text || !selectedRepo || submitInFlightRef.current) return;
+    if (!selectedRuntime) {
+      setSubmitError("Select a runtime before sending.");
+      return;
+    }
+    if (selectedRuntime.kind === "target" && !selectedRuntime.online) {
+      setSubmitError(`${selectedRuntime.label} is offline.`);
+      return;
+    }
     if (!canStartCloudHarness) {
       setSubmitError(
         harnessAvailability.message ?? "No cloud agent is ready to start this workspace.",
@@ -205,19 +331,52 @@ export function HomeScreen() {
     setDraft("");
     try {
       await waitForNextPaint();
+      const sessionConfigUpdates = buildLaunchSessionConfigUpdates({
+        catalog: agentCatalog.data,
+        launchableAgentKinds,
+        selection: resolvedLaunchSelection,
+      });
       const workspacePendingPrompt = {
         id: pendingPrompt.id,
         text,
         agentKind: resolvedLaunchSelection.agentKind,
         modelId: resolvedLaunchSelection.modelId,
         modeId: resolvedLaunchSelection.modeId,
-        sessionConfigUpdates: buildLaunchSessionConfigUpdates({
-          catalog: agentCatalog.data,
-          launchableAgentKinds,
-          selection: resolvedLaunchSelection,
-        }),
+        sessionConfigUpdates,
         createdAt: Date.now(),
       };
+      if (selectedRuntime.kind === "target") {
+        const result = await launchOnTarget.mutateAsync({
+          targetId: selectedRuntime.targetId,
+          gitProvider: "github",
+          gitOwner: selectedRepo.gitOwner,
+          gitRepoName: selectedRepo.gitRepoName,
+          baseBranch: selectedBaseBranch,
+          branchName: buildBranchName(text),
+          displayName: buildWorkspaceDisplayName(text),
+          prompt: text,
+          promptId: pendingPrompt.id,
+          agentKind: resolvedLaunchSelection.agentKind,
+          modelId: resolvedLaunchSelection.modelId,
+          modeId: resolvedLaunchSelection.modeId,
+          sessionConfigUpdates,
+          source: "web",
+        });
+        saveWebCloudPromptIntents(result.workspace.id, [
+          {
+            id: pendingPrompt.id,
+            workspaceId: result.workspace.id,
+            sessionId: result.sessionId,
+            text,
+            baseTranscriptSeq: 0,
+            status: "queued",
+            commandId: result.sendCommandId,
+            createdAt: Date.now(),
+          },
+        ]);
+        navigate(routes.chat(result.workspace.id, result.sessionId));
+        return;
+      }
       await ensurePersonalAgentAuthLaunchReady({
         client,
         agentKind: normalizeAgentAuthAgentKind(resolvedLaunchSelection.agentKind),
@@ -227,6 +386,7 @@ export function HomeScreen() {
         gitProvider: "github",
         gitOwner: selectedRepo.gitOwner,
         gitRepoName: selectedRepo.gitRepoName,
+        baseBranch: selectedBaseBranch,
         branchName: buildBranchName(text),
         displayName: buildWorkspaceDisplayName(text),
         ownerScope: "personal",
@@ -254,6 +414,7 @@ export function HomeScreen() {
   }
 
   const submitting = createWorkspace.isPending
+    || launchOnTarget.isPending
     || submitInFlightRef.current;
   const transcriptRows = useMemo(
     () => buildPendingPromptRows(pendingPrompt),
@@ -280,6 +441,13 @@ export function HomeScreen() {
       text: harnessAvailability.message,
     }
     : null;
+  const runtimeNotice: NoticeView | null = selectedRuntime?.kind === "target" && !selectedRuntime.online
+    ? {
+      id: "runtime-offline",
+      tone: "warning",
+      text: `${selectedRuntime.label} is offline.`,
+    }
+    : null;
   if (errorNotice && pendingPrompt?.status === "failed") {
     errorNotice.action = {
       label: "Retry",
@@ -292,6 +460,7 @@ export function HomeScreen() {
   }
   const notices: NoticeView[] = [];
   if (repoNotice) notices.push(repoNotice);
+  if (runtimeNotice) notices.push(runtimeNotice);
   if (harnessNotice) notices.push(harnessNotice);
   if (errorNotice) notices.push(errorNotice);
 
@@ -301,17 +470,26 @@ export function HomeScreen() {
         heading="What should we run?"
         draft={draft}
         placeholder={HOME_PLACEHOLDER}
-        canSubmit={Boolean(draft.trim()) && Boolean(selectedRepo) && canStartCloudHarness && !submitting}
+        canSubmit={
+          Boolean(draft.trim())
+          && Boolean(selectedRepo)
+          && Boolean(selectedRuntime)
+          && selectedRuntimeReady
+          && canStartCloudHarness
+          && !submitting
+        }
         submitting={submitting}
         target={buildTargetPicker(repoId, repoOptions, repoConfigs.isLoading)}
         model={buildModelPicker(resolvedLaunchSelection.modelId ?? DEFAULT_DIRECT_PROMPT_MODEL_ID)}
         mode={buildModePicker()}
-        extraComposerControls={launchComposerControls}
+        extraComposerControls={composerControls}
         notices={notices}
         transcriptRows={transcriptRows}
         commandMessage={
           pendingPrompt?.status === "creating"
-            ? "Creating a cloud workspace. The prompt will send as soon as the workspace is ready."
+            ? selectedRuntime?.kind === "target"
+              ? "Dispatching to Desktop. The prompt will send as soon as the session is ready."
+              : "Creating a cloud workspace. The prompt will send as soon as the workspace is ready."
             : null
         }
         actions={[
@@ -347,17 +525,14 @@ function buildPendingPromptRows(
       id: `${pendingPrompt.id}:user`,
       kind: "user",
       body: pendingPrompt.text,
-      status: isCreating ? "Creating workspace" : "Failed",
-      streaming: isCreating,
+      status: isCreating ? "Loading" : "Failed",
     },
     isCreating
       ? {
         id: `${pendingPrompt.id}:assistant`,
         kind: "assistant",
-        title: "Cloud setup",
-        body: "Preparing the workspace and queuing this prompt.",
-        status: "Waiting",
-        streaming: true,
+        title: "Workspace setup",
+        body: "Loading...",
       }
       : {
         id: `${pendingPrompt.id}:error`,
@@ -468,6 +643,51 @@ function buildTargetPicker(
   };
 }
 
+function buildRuntimeControl(input: {
+  runtimeOptions: readonly RuntimeOption[];
+  loading: boolean;
+  selectedRuntime: RuntimeOption | null;
+  onSelect: (runtimeId: string) => void;
+}): CloudChatComposerControlView {
+  const options = input.loading && input.runtimeOptions.length <= 1
+    ? [
+      {
+        id: "__loading__",
+        label: "Loading runtimes...",
+        disabled: true,
+        selected: true,
+      },
+    ]
+    : input.runtimeOptions.map((runtime) => ({
+      id: runtime.id,
+      label: runtime.label,
+      description: runtime.description,
+      selected: runtime.id === input.selectedRuntime?.id,
+      disabled: runtime.kind === "target" && !runtime.online,
+    }));
+
+  return {
+    id: "new-chat-runtime",
+    key: "runtime",
+    label: "Runtime",
+    icon: "build",
+    placement: "leading",
+    disabled: input.loading && input.runtimeOptions.length <= 1,
+    groups: [
+      {
+        id: "runtimes",
+        label: "Run destination",
+        options,
+      },
+    ],
+    onSelect: (optionId) => {
+      if (!optionId.startsWith("__")) {
+        input.onSelect(optionId);
+      }
+    },
+  };
+}
+
 function buildModelPicker(selectedId: string): PickerView {
   const models = [
     { id: "gpt-5.4", label: "GPT-5.4", description: "Balanced cloud work" },
@@ -511,6 +731,33 @@ function buildModePicker(): PickerView {
   };
 }
 
+function buildRuntimeOptions(
+  targets: readonly CloudTargetSummary[] | undefined,
+): RuntimeOption[] {
+  return [
+    {
+      id: "cloud",
+      kind: "cloud",
+      label: "Cloud sandbox",
+      description: "Run in managed cloud compute",
+      online: true,
+      targetId: null,
+    },
+    ...((targets ?? [])
+      .filter((target) => target.kind === "desktop_dispatch")
+      .map((target): RuntimeOption => ({
+        id: target.id,
+        kind: "target",
+        label: targetLabel(target),
+        description: target.status === "online"
+          ? "Dispatch to this connected Desktop"
+          : target.statusDetail?.statusDetail ?? "Desktop target is offline",
+        online: target.status === "online",
+        targetId: target.id,
+      }))),
+  ];
+}
+
 function buildRepoOptions(
   configs: readonly {
     gitOwner: string;
@@ -551,6 +798,81 @@ function buildRepoOptions(
     }
   }
   return Array.from(options.values());
+}
+
+function targetLabel(target: CloudTargetSummary): string {
+  const displayName = target.displayName?.trim();
+  return displayName || "Desktop Mac";
+}
+
+function buildBranchOptions(input: {
+  branches?: readonly string[] | null;
+  defaultBranch?: string | null;
+  selectedBranch?: string | null;
+}): string[] {
+  const options: string[] = [];
+  addUniqueBranch(options, input.defaultBranch);
+  addUniqueBranch(options, input.selectedBranch);
+  for (const branch of input.branches ?? []) {
+    addUniqueBranch(options, branch);
+  }
+  return options;
+}
+
+function buildBranchControl(input: {
+  branchOptions: readonly string[];
+  loading: boolean;
+  selectedBranch: string | null;
+  disabled: boolean;
+  onSelect: (branch: string) => void;
+}): CloudChatComposerControlView {
+  const options = input.loading && input.branchOptions.length === 0
+    ? [{
+      id: "__loading__",
+      label: "Loading branches...",
+      disabled: true,
+      selected: true,
+    }]
+    : input.branchOptions.length === 0
+      ? [{
+        id: "__empty__",
+        label: "No branches found",
+        disabled: true,
+        selected: true,
+      }]
+      : input.branchOptions.map((branch) => ({
+        id: branch,
+        label: branch,
+        selected: branch === input.selectedBranch,
+      }));
+
+  return {
+    id: "new-chat-base-branch",
+    key: "branch",
+    label: "Base branch",
+    icon: "branch",
+    placement: "leading",
+    disabled: input.disabled || (input.loading && input.branchOptions.length === 0),
+    groups: [
+      {
+        id: "branches",
+        label: "GitHub branches",
+        options,
+      },
+    ],
+    onSelect: (optionId) => {
+      if (!optionId.startsWith("__")) {
+        input.onSelect(optionId);
+      }
+    },
+  };
+}
+
+function addUniqueBranch(options: string[], branch: string | null | undefined): void {
+  const trimmed = branch?.trim();
+  if (trimmed && !options.includes(trimmed)) {
+    options.push(trimmed);
+  }
 }
 
 function buildBranchName(prompt: string): string {

--- a/web/src/components/settings/screen/BillingSettingsSection.tsx
+++ b/web/src/components/settings/screen/BillingSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import type { CloudOwnerSelection } from "@proliferate/cloud-sdk";
@@ -38,6 +38,13 @@ export function BillingSettingsSection() {
   const comparisonActions = useCloudBillingActions(comparisonOwner);
   const [comparisonActionError, setComparisonActionError] = useState<string | null>(null);
   const checkoutReturnState = checkoutReturnStateFromParams(searchParams);
+
+  useEffect(() => {
+    if (checkoutReturnState !== "success") {
+      return;
+    }
+    void comparisonBilling.refetch();
+  }, [checkoutReturnState, comparisonBilling.refetch]);
 
   async function openComparisonBillingAction() {
     setComparisonActionError(null);
@@ -95,6 +102,7 @@ export function BillingSettingsSection() {
           title="Account credits"
           description="Included cloud usage and onboarding credits for work you launch from this account."
           iconKind="personal"
+          checkoutReturnState={checkoutReturnState}
           accountCreditsOnly
         />
 
@@ -131,6 +139,7 @@ export function BillingSettingsSection() {
             description="Applies to shared cloud workspaces, team automations, Slack sessions, and shared sandbox usage."
             iconKind="organization"
             owner={{ ownerScope: "organization", organizationId: team.id }}
+            checkoutReturnState={checkoutReturnState}
           />
         ) : team ? (
           <SettingsCard>
@@ -161,12 +170,14 @@ function BillingOwnerController({
   description,
   iconKind,
   owner,
+  checkoutReturnState,
   accountCreditsOnly = false,
 }: {
   title: string;
   description: string;
   iconKind: "personal" | "organization";
   owner?: CloudOwnerSelection;
+  checkoutReturnState?: "success" | "cancel" | null;
   accountCreditsOnly?: boolean;
 }) {
   const billing = useCloudBilling(owner);
@@ -174,6 +185,23 @@ function BillingOwnerController({
   const billingPlan = billing.data;
   const [actionError, setActionError] = useState<string | null>(null);
   const invoiceUrl = billingPlan?.hostedInvoiceUrl ?? null;
+
+  useEffect(() => {
+    if (checkoutReturnState !== "success") {
+      return;
+    }
+    void billing.refetch();
+    const timers = [1500, 4500, 9000].map((delayMs) =>
+      window.setTimeout(() => {
+        void billing.refetch();
+      }, delayMs)
+    );
+    return () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [billing.refetch, checkoutReturnState]);
 
   async function openBillingAction(action: "checkout" | "portal" | "refill") {
     setActionError(null);

--- a/web/src/components/support/screen/SupportScreen.tsx
+++ b/web/src/components/support/screen/SupportScreen.tsx
@@ -1,14 +1,34 @@
+import { useLocation } from "react-router-dom";
+import { sendSupportMessage } from "@proliferate/cloud-sdk";
+import { useCloudClient } from "@proliferate/cloud-sdk-react";
 import { ProductPageShell } from "@proliferate/product-ui/layout/ProductPageShell";
 import { SupportSurface } from "@proliferate/product-ui/support/SupportSurface";
 
 export function SupportScreen() {
+  const client = useCloudClient();
+  const location = useLocation();
+
   return (
     <ProductPageShell
       title="Get help"
       description="Support for cloud sessions and Desktop handoff."
       telemetryBlocked
     >
-      <SupportSurface />
+      <SupportSurface
+        onSubmit={(message) =>
+          sendSupportMessage(
+            {
+              message,
+              context: {
+                source: "sidebar",
+                intent: "general",
+                pathname: `${location.pathname}${location.search}${location.hash}`,
+              },
+            },
+            client,
+          )
+        }
+      />
     </ProductPageShell>
   );
 }

--- a/web/src/lib/domain/sidebar/cloud-sidebar-model.ts
+++ b/web/src/lib/domain/sidebar/cloud-sidebar-model.ts
@@ -20,8 +20,7 @@ export function parseCloudSidebarRoute(pathname: string): CloudSidebarRouteState
     sessionId: match?.[2] ? decodeRoutePart(match[2]) : null,
     workspacesActive:
       normalizedPath === "/workspaces" ||
-      normalizedPath.startsWith("/workspaces/") ||
-      normalizedPath.startsWith("/cloud/workspaces/"),
+      normalizedPath === "/cloud/workspaces",
   };
 }
 

--- a/web/src/pages/SettingsModalPage.tsx
+++ b/web/src/pages/SettingsModalPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { X } from "lucide-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, type Location } from "react-router-dom";
 
 import { IconButton } from "@proliferate/ui/primitives/IconButton";
 
@@ -8,22 +8,25 @@ import { SettingsScreen } from "../components/settings/screen/SettingsScreen";
 import { routes } from "../config/routes";
 
 type SettingsRouteState = {
-  backgroundLocation?: unknown;
+  backgroundLocation?: Pick<Location, "pathname" | "search" | "hash">;
 };
 
 export function SettingsModalPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const hasBackground = Boolean((location.state as SettingsRouteState | null)?.backgroundLocation);
+  const backgroundLocation = (location.state as SettingsRouteState | null)?.backgroundLocation;
+  const backgroundPath = backgroundLocation
+    ? `${backgroundLocation.pathname}${backgroundLocation.search}${backgroundLocation.hash}`
+    : null;
 
   const closeSettings = useCallback(() => {
-    if (hasBackground) {
-      navigate(-1);
+    if (backgroundPath) {
+      navigate(backgroundPath, { replace: true });
       return;
     }
     navigate(routes.home, { replace: true });
-  }, [hasBackground, navigate]);
+  }, [backgroundPath, navigate]);
 
   useEffect(() => {
     dialogRef.current?.focus();
@@ -41,8 +44,13 @@ export function SettingsModalPage() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/48 p-4 backdrop-blur-[2px]"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/48 p-3 backdrop-blur-[2px] sm:p-5"
       data-telemetry-block
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          closeSettings();
+        }
+      }}
     >
       <div
         ref={dialogRef}
@@ -50,13 +58,13 @@ export function SettingsModalPage() {
         aria-modal="true"
         aria-label="Settings"
         tabIndex={-1}
-        className="relative h-[min(820px,calc(100vh-2rem))] w-[min(1120px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-border bg-background shadow-2xl outline-none"
+        className="relative h-[min(880px,calc(100vh-1.5rem))] w-[min(1180px,calc(100vw-1.5rem))] overflow-hidden rounded-2xl border border-border bg-background shadow-2xl outline-none"
       >
         <IconButton
           title="Close settings"
           aria-label="Close settings"
           onClick={closeSettings}
-          className="absolute right-3 top-3 z-10 bg-background/80"
+          className="absolute right-3 top-3 z-10 border border-border bg-background/90 shadow-sm"
         >
           <X size={16} />
         </IconButton>


### PR DESCRIPTION
## Summary
- polish web/mobile workspace launch and recent workspace surfaces
- improve billing/support/settings cloud UX and optimistic chat states
- add desktop workspace deep-link routing and bump desktop to 0.1.38

## Verification
- pnpm --filter @proliferate/web typecheck
- pnpm --filter @proliferate/web build
- pnpm --filter @proliferate/mobile typecheck
- uv run pytest tests/unit/test_billing_service_policy.py -q
- uv run ruff check proliferate/server/billing/models.py proliferate/server/billing/service.py proliferate/server/support proliferate/server/cloud/workspaces/models.py
- pnpm --dir desktop exec vitest run src/lib/domain/workspaces/sidebar/sidebar.test.ts src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts src/lib/domain/auth/desktop-navigation.test.ts
- pnpm --dir desktop build
- git diff --check