### PR TITLE
docs(frontend): codify app package standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ at the start of the task, not halfway through implementation.
 
 ## Area Read Order
 
-### Frontend (`desktop/src/**`)
+### Frontend (`apps/desktop/src/**`, `apps/web/src/**`, `apps/mobile/src/**`, `apps/packages/**`)
 
 1. `docs/frontend/README.md`
 2. The focused frontend doc for the layer being changed:
@@ -75,6 +75,9 @@ at the start of the task, not halfway through implementation.
    - `docs/frontend/guides/config.md`
    - `docs/frontend/guides/copy.md`
    - `docs/frontend/guides/access.md`
+   - `docs/frontend/packages/README.md` for shared frontend packages, package
+     dependency direction, shared product rules, product UI, or connected
+     product surfaces
 3. Specialized docs when relevant:
    - `docs/frontend/guides/styling.md` for styling, primitives, tokens, or
      theme usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,21 +31,9 @@ start of the task, not after implementation has already started.
   - styling, theme token, and UI primitive rules
 - `docs/frontend/guides/telemetry.md`
   - analytics, Sentry, replay masking, and telemetry payload rules
-- `docs/frontend/specs/chat-composer.md`
-  - chat composer and composer-adjacent surfaces
-- `docs/frontend/specs/chat-transcript.md`
-  - transcript streaming, replay, row models, and long-history rendering
-- `docs/frontend/specs/mobile-cloud-client.md`
-  - mobile cloud client parity, native chat UI, workspace/session workflows,
-    automations, and settings
-- `docs/frontend/specs/mobile-claude-ui-alignment.md`
-  - screenshot-backed mobile UI alignment against Claude mobile for drawer,
-    home/new chat, workspaces, chat, automations, and settings
-- `docs/frontend/specs/web-cloud-local-parity.md`
-  - Web cloud/local workspace identity, recents/sidebar, session switching,
-    settings modal migration, and mobile cloud UI alignment
-- `docs/frontend/specs/workspace-files.md`
-  - workspace file browsing, file viewing, diff viewing, and Changes
+- `docs/frontend/packages/README.md`
+  - shared frontend package ownership for design, UI primitives, product-domain
+    rules, product UI, and connected product surfaces
 
 ## Authoritative server standards
 

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,117 +1,69 @@
 # Frontend Standards
 
-Status: authoritative for frontend code in this repo.
+Status: authoritative for Desktop, Web, Mobile, and shared frontend packages.
 
-Scope:
+## Scope
 
-- `desktop/src/**`
-- `web/src/**`
-- `mobile/src/**`
-- shared frontend packages under `packages/design/**`, `packages/ui/**`, and
-  `packages/product-ui/**`, and `packages/product-model/**` where explicitly
-  noted by the focused guides
+These standards apply to all frontend app logic and shared frontend packages:
 
-Use this doc first to understand the frontend ownership model. Then read the
-layer doc and any surface spec that applies to the code you are changing.
+- `apps/desktop/src/**`
+- `apps/web/src/**`
+- `apps/mobile/src/**`
+- `apps/packages/design/**`
+- `apps/packages/ui/**`
+- `apps/packages/product-domain/**`
+- `apps/packages/product-ui/**`
+- `apps/packages/product-surfaces/**`
 
-## North Star
+Desktop, Web, and Mobile use the same folder logic. Platform-specific folders
+exist only where the platform genuinely differs: Desktop has Tauri and local
+AnyHarness runtime access, Web has browser/cloud access, and Mobile has native
+navigation, native styling, and React Native UI.
 
-The frontend is organized for legibility by file path. When a developer sees a
-file location, they should know what kind of logic is allowed there before
-opening the file. When something breaks or needs to change, they should know
-where to look first.
+## Goal
 
-Structural rules are not aesthetic. They prevent mixed-ownership files from
-becoming god modules that nobody can change confidently.
+The frontend is organized into distinct folders and subfolders for UI, state,
+long-lived client state, access, reusable product logic, workflows, providers,
+and shared packages.
 
-The single rule behind this guide:
+The explicit goals are:
 
-> A file should be readable cold. A contributor should be able to open the top
-> file in a feature and understand what it owns, what it exposes, and where the
-> real work lives. If understanding the file requires following imports through
-> unrelated layers, the structure is wrong.
+- make it predictable where UI, state, logic, access, and shared code live
+- make complicated product work legible, decomposed, and reviewable
+- make it easy to build broadly without re-learning the app structure per app
 
-## Read Order
-
-Always start here.
-
-Guides define reusable engineering standards: where code goes, what each layer
-may own, and which patterns are allowed.
-
-Guides:
-
-- [guides/components.md](guides/components.md) for component ownership, UI
-  primitives, and component folder hierarchy.
-- [guides/hooks.md](guides/hooks.md) for hook taxonomy, hook organization, and
-  React behavior ownership.
-- [guides/state.md](guides/state.md) for Zustand stores, React Query,
-  providers, and local state.
-- [guides/lib.md](guides/lib.md) for pure product logic, workflows, infra
-  utilities, and side-effect planners.
-- [guides/config.md](guides/config.md) for static constants, limits, option
-  sets, route ids, defaults, and ordering.
-- [guides/copy.md](guides/copy.md) for authored user-facing copy and reusable
-  presentation mappings.
-- [guides/access.md](guides/access.md) for cloud, AnyHarness, and Tauri access
-  boundaries.
-- [guides/styling.md](guides/styling.md) for styling, theme tokens,
-  primitives, and theme usage.
-- [guides/telemetry.md](guides/telemetry.md) for analytics, Sentry, replay
-  masking, or telemetry payloads.
-
-Specs define product/surface contracts: UX invariants, performance invariants,
-edge cases, and focused verification for a specific product surface.
-
-Specs:
-
-- [specs/delegated-work.md](specs/delegated-work.md) for subagents, cowork
-  agents, plan review agents, code review agents, tab indicators, delegated
-  work popovers, and delegated-work delete semantics.
-- [specs/chat-composer.md](specs/chat-composer.md) for the chat composer area.
-- [specs/chat-transcript.md](specs/chat-transcript.md) for transcript
-  streaming, replay, row models, or long-history rendering.
-- [specs/pending-workspace-shell.md](specs/pending-workspace-shell.md) for
-  pending workspace entry, projected session shell, optimistic prompts, and
-  workspace/session materialization handoff.
-- [specs/web-chat-home-component-audit.md](specs/web-chat-home-component-audit.md)
-  for the current Web chat/home component inventory and Desktop extraction
-  classification.
-- [specs/web-desktop-parity.md](specs/web-desktop-parity.md) for Web matching
-  Desktop chat/workspace UX through shared product-ui/product-model surfaces.
-- [specs/web-cloud-local-parity.md](specs/web-cloud-local-parity.md) for Web
-  cloud/local workspace identity, recents/sidebar, session switching, settings
-  modal migration, and mobile cloud UI alignment.
-- [specs/mobile-cloud-client.md](specs/mobile-cloud-client.md) for the mobile
-  cloud client, native chat parity, workspace/session flows, automations, and
-  settings.
-- [specs/mobile-claude-ui-alignment.md](specs/mobile-claude-ui-alignment.md)
-  for the screenshot-backed mobile UI alignment pass against Claude mobile.
-- [specs/workspace-files.md](specs/workspace-files.md) for workspace file
-  browsing, file viewing, diff viewing, Changes, or all-changes review.
+A file path should tell a developer what kind of code is allowed there before
+they open the file. If understanding a feature requires following imports
+through unrelated layers, the structure is wrong.
 
 ## Target Shape
 
-This is the target architecture. Some existing code is still transitional; new
-code and cleanup work should move toward this shape.
+The app tree is relative to each app source root:
+
+- `apps/desktop/src/`
+- `apps/web/src/`
+- `apps/mobile/src/`
+
+Each app starts from this shape and omits folders it does not need.
 
 ```text
-desktop/src/
+<app>/src/
   App.tsx
   main.tsx
+
   assets/
+
   components/
-    ui/
     <domain>/
       <surface>/
         <role>/
+
   config/
   copy/
+
   hooks/
     access/
-      anyharness/
-      cloud/
-      mcp/
-      tauri/
+      <external-system>/
     ui/
     <domain>/
       derived/
@@ -120,11 +72,10 @@ desktop/src/
       ui/
       cache/
       facade/
+
   lib/
     access/
-      anyharness/
-      cloud/
-      tauri/
+      <external-system>/
     domain/
       <domain>/
         <subdomain>/
@@ -132,157 +83,186 @@ desktop/src/
       <domain>/
     infra/
       <technical-concern>/
-  pages/
-  providers/
-  stores/
-    <domain>/
-  index.css
 
-web/src/
-  App.tsx
-  main.tsx
-  components/
-    <domain>/
-      <surface>/
-        <ControllerOrScreen>.tsx
-  config/
-  lib/
-    access/
-      cloud/
-    infra/
-  pages/
-  providers/
-  index.css
-
-mobile/src/
-  App.tsx
-  components/
-    <domain>/
-  config/
-  hooks/
-    <domain>/
-  lib/
-    access/
-      cloud/
-    domain/
-    infra/
   navigation/
+  pages/
   providers/
+
   stores/
     <domain>/
-  styles/
 
-packages/
+  styles/
+  index.css
+```
+
+Shared package shape:
+
+```text
+apps/packages/
   design/
     src/
       tokens.ts
       dom.css
+      react-native.ts
+
   ui/
     src/
       layout/
       primitives/
+
+  product-domain/
+    src/
+      <domain>/
+
   product-ui/
     src/
       <domain>/
+        <surface>/
+
+  product-surfaces/
+    src/
+      <domain>/
+        <surface>/
 ```
 
-Do not add new top-level frontend folders without updating this doc and the
-focused doc that owns the layer. And only update this after getting permission from a human.
+Platform notes:
+
+- Desktop uses `hooks/access/{anyharness,cloud,mcp,tauri}/**` and
+  `lib/access/{anyharness,cloud,tauri}/**` when it needs local runtime, native
+  shell, and Cloud attachment behavior.
+- Web uses Cloud/browser access and shared DOM packages. It should not rebuild
+  Desktop/Web product presentation locally when `product-ui` or
+  `product-surfaces` can own it.
+- Mobile uses Cloud/native access, native navigation, React Native components,
+  `design/react-native`, and `product-domain`. It does not import DOM packages:
+  `ui`, `product-ui`, or `product-surfaces`.
+
+## What Goes Where
+
+Use the lowest layer that can own the logic cleanly.
+
+| Area | Path | Owns | Must Not Own | Canon |
+| --- | --- | --- | --- | --- |
+| App entry | `<app>/src/App.tsx`, `<app>/src/main.tsx` | App bootstrap, provider composition, root shell mounting. | Product workflows, reusable rules, remote cache shape. | This doc |
+| Pages | `<app>/src/pages/**` | Desktop/Web route entrypoints: params, navigation state, page-level screen render. | Product visuals, access details, heavy orchestration. | This doc |
+| Navigation | `<app>/src/navigation/**` | Mobile navigation model and route typing. | Product business logic or remote access. | This doc |
+| Components | `<app>/src/components/<domain>/<surface>/<role>/**` | App-local product UI. Components render, call hooks, and forward callbacks. | Raw access, query invalidation, multi-step workflows, reusable product rules. | [guides/components.md](guides/components.md) |
+| Access hooks | `<app>/src/hooks/access/<system>/**` | React Query/mutation wrappers, query keys, invalidation, retry policy, UI-safe access state. | Product workflow branching or JSX. | [guides/hooks.md](guides/hooks.md), [guides/access.md](guides/access.md), [guides/state.md](guides/state.md) |
+| Generic UI hooks | `<app>/src/hooks/ui/<mechanic>/**` | Generic UI mechanics: keyboard, pointer, layout, measurement. | Product concepts. | [guides/hooks.md](guides/hooks.md) |
+| Derived hooks | `<app>/src/hooks/<domain>/derived/**` | UI-ready state computed from stores, providers, and queries. | Writes, effects, access construction, navigation, telemetry. | [guides/hooks.md](guides/hooks.md) |
+| Workflow hooks | `<app>/src/hooks/<domain>/workflows/**` | User-action callbacks and React-facing orchestration. | Large algorithms, raw clients, query key definitions. | [guides/hooks.md](guides/hooks.md) |
+| Lifecycle hooks | `<app>/src/hooks/<domain>/lifecycle/**` | Mounted background behavior: streams, dispatchers, polling, reconciliation, persistence bootstrap. | Render logic or click-driven branching. | [guides/hooks.md](guides/hooks.md) |
+| Product UI hooks | `<app>/src/hooks/<domain>/ui/**` | Product-specific UI mechanics. | Generic UI mechanics or product workflows. | [guides/hooks.md](guides/hooks.md) |
+| Product cache hooks | `<app>/src/hooks/<domain>/cache/**` | Product-composed caches combining multiple external/local sources. | Simple one-resource external queries. | [guides/hooks.md](guides/hooks.md), [guides/state.md](guides/state.md) |
+| Facade hooks | `<app>/src/hooks/<domain>/facade/**` | Thin composition wrappers that simplify a component API. | New product behavior or business branching. | [guides/hooks.md](guides/hooks.md) |
+| Raw access | `<app>/src/lib/access/<system>/**` | App-local raw client setup, platform bridges, native wrappers, auth/storage integration. | Product UI state, product branching, shared package logic. | [guides/access.md](guides/access.md) |
+| App product rules | `<app>/src/lib/domain/<domain>/<subdomain>/**` | Pure app-local product rules. | React, stores, query clients, access helpers, platform APIs. | [guides/lib.md](guides/lib.md) |
+| App workflows | `<app>/src/lib/workflows/<domain>/**` | Non-React product sequences with dependencies passed in. | React hooks, hidden singletons, raw endpoint construction. | [guides/lib.md](guides/lib.md) |
+| Infra | `<app>/src/lib/infra/<technical-concern>/**` | Generic technical machinery: persistence, scheduling, ids, batching, measurement. | Product-domain behavior. | [guides/lib.md](guides/lib.md) |
+| Providers | `<app>/src/providers/**` | Scoped dependencies and app/subtree boundaries. | General mutable UI state. | [guides/state.md](guides/state.md) |
+| Stores | `<app>/src/stores/<domain>/**` | Shared client-only state: selected ids, drafts, panels, local UI preferences. | Remote caches, APIs, navigation, telemetry, multi-store orchestration. | [guides/state.md](guides/state.md) |
+| Config | `<app>/src/config/**` | Static constants, limits, option sets, default ids, ordering. | Copy, presentation mappings, runtime state. | [guides/config.md](guides/config.md) |
+| Copy | `<app>/src/copy/**` | Authored user-facing copy and prompt/content strings. | Logic, access, status-to-style mappings. | [guides/copy.md](guides/copy.md) |
+| Styling | `<app>/src/styles/**`, `<app>/src/index.css` | App-local style entrypoints, native token bridge, app-specific third-party CSS. | Shared tokens or reusable DOM primitives. | [guides/styling.md](guides/styling.md) |
+| Telemetry | `<app>/src/hooks/**`, `<app>/src/lib/**`, `<app>/src/providers/**` | Product event wiring and replay/privacy boundaries at the owning app layer. | Hidden tracking inside shared product UI. | [guides/telemetry.md](guides/telemetry.md) |
+| Design package | `apps/packages/design/**` | Shared tokens, DOM CSS entrypoint, React Native-safe token values. | Product concepts, app code, SDK clients. | [packages/README.md](packages/README.md) |
+| UI package | `apps/packages/ui/**` | Canonical Desktop/Web DOM primitives and layout components. | Product concepts, app code, SDK clients, stores, React Native. | [packages/README.md](packages/README.md) |
+| Product domain package | `apps/packages/product-domain/**` | Pure shared product rules, vocabulary, validation, projections, view models. | React, DOM, React Native components, SDK clients, query clients, stores, access. | [packages/README.md](packages/README.md) |
+| Product UI package | `apps/packages/product-ui/src/<domain>/<surface>/**` | Shared Desktop/Web product presentation. Props in, callbacks out. | SDK clients, access helpers, query hooks, app stores, routes, Tauri, React Native, custom primitive redefinitions. | [packages/README.md](packages/README.md) |
+| Product surfaces package | `apps/packages/product-surfaces/src/<domain>/<surface>/**` | Shared connected Desktop/Web Cloud surfaces with SDK/query wiring and product UI composition. | Desktop/Web app internals, Tauri, AnyHarness runtime wiring, app stores, app routes, React Native, custom primitive redefinitions. | [packages/README.md](packages/README.md) |
+
+## Read Order
+
+Always start with this file. Then read the focused guide or package doc for the
+layer you are changing:
+
+- [guides/components.md](guides/components.md)
+- [guides/hooks.md](guides/hooks.md)
+- [guides/state.md](guides/state.md)
+- [guides/lib.md](guides/lib.md)
+- [guides/access.md](guides/access.md)
+- [guides/config.md](guides/config.md)
+- [guides/copy.md](guides/copy.md)
+- [guides/styling.md](guides/styling.md)
+- [guides/telemetry.md](guides/telemetry.md)
+- [packages/README.md](packages/README.md)
 
 ## Hard Rules
 
-- Use `@/` imports for app-root paths under `desktop/src/**`.
-- Keep imports direct and concrete. No barrel files or convenience re-export
-  modules.
+- Keep imports direct and concrete. Do not add barrel files or convenience
+  re-export modules.
+- Use `@/` imports for app-root paths in apps where the alias is configured.
 - `components/**` is `.tsx` only.
 - `hooks/**`, `lib/**`, `stores/**`, `config/**`, `copy/**`, and
   `providers/**` are `.ts` only unless a file must render JSX.
 - Pages are route entrypoints only: read params/navigation state, call
   page-level hooks, and render a screen component.
-- Hooks are not the default extraction unit. Use hooks for React behavior; use
-  plain functions for pure logic, product workflows, access helpers, and infra
-  utilities.
-- Product hook domains are organized by responsibility folders. New
-  non-migration hook files should not sit directly under `hooks/<domain>/`.
-- Web may own routes, providers, access/config helpers, and controller
-  components that map cloud data into shared view models. Web must not create
-  parallel product visual components when the same surface can be shared with
-  Desktop through `packages/product-ui/**`.
+- Product hook domains use responsibility folders. Hook files should not sit
+  directly under `hooks/<domain>/`.
+- Components render. Hooks own React behavior. Stores hold shared client-only
+  state. `lib/domain` and `product-domain` hold pure product rules.
+- Desktop, Web, `product-ui`, and `product-surfaces` use
+  `apps/packages/ui/**` for DOM primitives.
+- Do not define DOM primitive components outside `apps/packages/ui/**`. This
+  includes differently named local wrappers around buttons, inputs, dialogs,
+  menus, tabs, tooltips, badges, layout shells, or similar reusable controls.
+- Desktop and Web share product presentation through `product-ui` and connected
+  Cloud surfaces through `product-surfaces` when sharing keeps the product more
+  legible.
+- Mobile shares product rules through `product-domain` and renders native UI in
+  the app.
 - Preserve current UI and behavior unless an explicit behavior change is
   requested.
 - Delete dead code when replacing an implementation.
-- Move toward the target architecture incrementally. Do not create empty
-  folder trees or speculative abstractions.
-- Cleanup PRs should state whether they are behavior-preserving extractions or
-  behavior changes. Do not mix both unless the task explicitly requires it.
+- Do not create empty folder trees or speculative abstractions.
 - Avoid god modules and god stores. Prefer splitting before roughly 400 lines.
   Files at 600+ lines need a strong reason to stay whole. Mixed ownership
   should be split even below those thresholds.
 - Colocate types with the code that owns them. Generated API types live with
   the generated client. App-defined domain models live with their owning
-  domain logic. Store types live with their store. Do not create shared type
-  buckets.
-
-## Ownership Model
-
-Use the lowest layer that can own the logic cleanly.
-
-| Concern | Path | Put it here when | Do not put here | Details |
-| --- | --- | --- | --- | --- |
-| Product UI | `desktop/src/components/<domain>/<surface>/<role>/**` or `packages/product-ui/**` | It renders product-specific UI. Use `packages/product-ui/**` when the component is shared by Desktop and Web and accepts data/callback props instead of calling app access directly. | Raw access, query invalidation, multi-step workflows, reusable product rules, Web-local product visuals. | [guides/components.md](guides/components.md) |
-| UI primitives | `desktop/src/components/ui/**` or `packages/ui/**` | It is reusable without product knowledge. Use `packages/ui/**` only when the primitive is useful to both Desktop and Web and has no Desktop-only runtime dependencies. | Product-specific copy, stores, access, or workflow behavior. | [guides/components.md](guides/components.md), [guides/styling.md](guides/styling.md) |
-| Generic UI hooks | `hooks/ui/<mechanic>/**` | It wraps browser/UI mechanics with no product concepts. | Sessions, workspaces, cloud, agents, billing, or other product concepts. | [guides/hooks.md](guides/hooks.md) |
-| Access hooks | `hooks/access/<system>/**` | It is a React Query/mutation wrapper around cloud, AnyHarness, or Tauri. | Product workflow branching or JSX. | [guides/hooks.md](guides/hooks.md), [guides/access.md](guides/access.md), [guides/state.md](guides/state.md) |
-| Product derived hooks | `hooks/<domain>/derived/**` | It computes UI-ready state from stores, providers, and queries. | Writes, effects, raw access, navigation, or telemetry. | [guides/hooks.md](guides/hooks.md) |
-| Product workflow hooks | `hooks/<domain>/workflows/**` | It exposes user-action callbacks and coordinates React dependencies. | Large business algorithms or raw clients. | [guides/hooks.md](guides/hooks.md) |
-| Product lifecycle hooks | `hooks/<domain>/lifecycle/**` | It owns mounted effects, streams, dispatchers, polling, or reconciliation. | Render logic or user-click workflow branching. | [guides/hooks.md](guides/hooks.md) |
-| Product UI-mechanic hooks | `hooks/<domain>/ui/**` | It wraps UI mechanics that are specific to one product domain. | Generic browser mechanics or product workflows. | [guides/hooks.md](guides/hooks.md) |
-| Product cache hooks | `hooks/<domain>/cache/**` | It owns a product-composed cache that combines multiple external/local sources. | One-resource external query wrappers or raw access. | [guides/hooks.md](guides/hooks.md), [guides/access.md](guides/access.md), [guides/state.md](guides/state.md) |
-| Shared client state | `stores/<domain>/<concern>-store.ts` | It is client-only state such as selected ids, drafts, panels, or active UI. | Server/runtime caches, API calls, navigation, telemetry, or multi-store orchestration. | [guides/state.md](guides/state.md) |
-| Scoped dependencies | `providers/**` | It defines an app/subtree context boundary. | General mutable UI state. | [guides/state.md](guides/state.md) |
-| Pure product rules | `lib/domain/<domain>/<subdomain>/**` | It is deterministic product logic with no React or external access. | Hooks, stores, clients, query invalidation, platform APIs. | [guides/lib.md](guides/lib.md) |
-| Plain product workflows | `lib/workflows/<domain>/**` | It is a non-React sequence coordinating dependencies passed by a hook. | React hooks or hidden singleton client construction. | [guides/lib.md](guides/lib.md) |
-| Raw external access | `lib/access/<system>/**` | `lib/access` owns raw cloud, AnyHarness desktop wiring, and Tauri native wrappers. | Product UI state, product branching, or components. | [guides/access.md](guides/access.md) |
-| Technical utilities | `lib/infra/<technical-concern>/**` | It is generic machinery such as persistence, scheduling, ids, batching, or measurement. | Product-domain behavior. | [guides/lib.md](guides/lib.md) |
-| Static constants | `config/**` | It is a real constant, limit, option set, default id, or ordering. | Copy, status labels, presentation metadata, or runtime state. | [guides/config.md](guides/config.md) |
-| Product copy | `copy/<domain>/**` | It is user-facing text or authored prompt content. | Logic, access, or status-to-style mappings. | [guides/copy.md](guides/copy.md) |
-| Presentation mappings | `lib/domain/<domain>/<subdomain>/presentation.ts` | It maps product state to labels, tone, icons, descriptions, or visibility. | Transport access or mutable UI state. | [guides/copy.md](guides/copy.md) |
+  domain logic. Store types live with their store.
 
 ## Dependency Direction
 
-- Components may call hooks and render UI primitives.
-- Product hooks may read stores/providers, call access hooks, and call
-  `lib/domain` or `lib/workflows` functions.
-- Product hooks do not own React Query key definitions or query cache shape.
-  They call access hooks/cache callbacks when a workflow needs remote state
-  invalidated or updated.
-- Stores do not call hooks, clients, query invalidation, navigation, telemetry,
-  or other stores.
-- `lib/domain` does not import React, stores, query clients, access helpers, or
-  platform APIs.
-- `lib/workflows` may coordinate multiple dependencies, but those dependencies
-  are passed in. It does not import React hooks.
-- Raw cloud, AnyHarness, and Tauri access stays behind the access boundary.
-
-Dependency direction is one-way:
+App dependency direction:
 
 ```text
-components -> hooks -> lib/workflows -> lib/domain/lib/infra -> lib/access
+components -> hooks
+hooks -> hooks/access -> lib/access -> external SDK/platform
+hooks -> lib/workflows -> lib/domain/lib/infra
+hooks -> stores/providers
 ```
 
-Stores are read by hooks. `lib/**` files do not read stores directly unless a
-focused area doc explicitly marks the file as a transitional state adapter.
+Stores are read by hooks. `lib/**` files do not call hooks or read stores
+directly. Product workflows receive access calls, store setters, navigation,
+telemetry, and cache callbacks through dependency arguments.
+
+Shared package dependency direction:
+
+```text
+apps
+  -> product-surfaces
+  -> product-ui
+  -> ui
+  -> design
+
+apps
+  -> product-domain
+product-surfaces -> product-domain
+product-ui -> product-domain
+```
+
+`product-domain` is pure. It does not import React, DOM, React Native, SDK
+clients, access helpers, stores, or query clients. `product-ui` is
+presentational DOM UI. It does not import app code, raw access, stores, routes,
+or SDK clients. `product-surfaces` may use shared Cloud SDK React hooks for
+Desktop/Web surfaces, but it must not import app internals.
 
 ## CI-Enforced Repo Shape
 
 Frontend ownership boundaries are enforced by
-`scripts/check_frontend_boundaries.py` in CI. The check is a ratchet: existing
-violations live in `scripts/frontend_boundaries_allowlist.txt`, and new
-violations fail the repo-shape job.
-
-The allowlist is temporary migration debt. Cleanup PRs should remove allowlist
-entries whenever they move a path to the target architecture or reduce the
-number of violations in that file.
+`scripts/check_frontend_boundaries.py` in CI. The repo-shape job should enforce
+the ownership rules in this document.
 
 React Query cache shape is owned by access hooks by default. The only
 product-domain exception is a product-composed cache under
@@ -290,15 +270,14 @@ product-domain exception is a product-composed cache under
 files should call access/cache callbacks instead of importing `useQueryClient`
 or hand-editing query keys.
 
-## Cleanup Discipline
+## Change Discipline
 
-- Move ownership violations before introducing new abstractions.
-- Do not leave duplicate old and new paths behind after a migration.
+- Keep ownership boundaries intact before introducing new abstractions.
+- Do not leave duplicate code paths behind.
 - Do not create one-file folders or empty target trees to satisfy a diagram.
 - Prefer one bounded product area per PR.
-- Keep public hook/component APIs stable unless the cleanup explicitly changes
+- Keep public hook/component APIs stable unless the task explicitly changes
   callsites.
-- When splitting a file, preserve behavior first; improve behavior in a
-  separate PR.
+- When splitting a file, preserve behavior first; improve behavior separately.
 - Use focused tests around moved domain/workflow logic when the logic is
   meaningful or risky.

--- a/docs/frontend/guides/access.md
+++ b/docs/frontend/guides/access.md
@@ -1,59 +1,74 @@
 # Frontend Access Boundaries
 
-External systems should have one clear access boundary. Product components and
-product hooks should not construct clients, call raw endpoint paths, or invoke
-platform APIs directly.
+External systems have one clear access boundary. Components and product hooks
+do not construct clients, call raw endpoint paths, or invoke platform APIs
+directly.
 
-## Target Shape
+## Shape
 
 ```text
 lib/access/
-  cloud/
-    client.ts
-    agent-auth-sync.ts
-    agent-auth-recovery.ts
-    health.ts
-    timing.ts
-  anyharness/
-    runtime-target.ts
-    runtime-bootstrap.ts
-    workspace-connection.ts
-    session-stream-transport.ts
-  tauri/
+  <external-system>/
     <capability>.ts
+
 hooks/access/
-  cloud/
+  <external-system-or-capability>/
     <resource>/
       query-keys.ts
       use-<resource>.ts
       use-<action>-mutation.ts
-  anyharness/
-    <desktop-runtime-concern>/
-      use-<concern>.ts
-  tauri/
-    <capability>/
-      query-keys.ts
-      use-<capability>-actions.ts
-  mcp/
-    connectors/
-      query-keys.ts
-      use-connectors.ts
-      use-connector-mutations.ts
 ```
 
-Existing code may still live under older transitional paths such as
-`lib/integrations/**` or domain hook folders. New code and cleanup work should
-move toward the access shape above.
+Common external systems:
 
-## Query Key Ownership
+- `cloud`
+- `anyharness`
+- `tauri`
+- `browser`
+- `native`
 
-Query keys are part of the React-facing access contract. They should live next
-to the access hook that owns the same external resource cache:
+Folder names under `hooks/access/**` describe the external system or cached
+access capability, not the product screen that happens to render the data. A
+capability folder such as `mcp` is allowed when one React-facing access API
+intentionally coordinates more than one external boundary, such as cloud
+connector records plus local OAuth/native setup.
+
+Illustrative examples only, not a complete inventory:
 
 ```text
 hooks/access/cloud/automations/query-keys.ts
 hooks/access/cloud/automations/use-automations.ts
 hooks/access/cloud/automations/use-automation-mutations.ts
+
+hooks/access/cloud/billing/query-keys.ts
+hooks/access/cloud/billing/use-cloud-billing.ts
+hooks/access/cloud/billing/use-cloud-billing-mutations.ts
+
+hooks/access/tauri/updater/query-keys.ts
+hooks/access/tauri/updater/use-updater.ts
+
+hooks/access/mcp/connectors/query-keys.ts
+hooks/access/mcp/connectors/use-connectors.ts
+hooks/access/mcp/connectors/use-connector-mutations.ts
+```
+
+Do not create access folders just to mirror another app. Each app only has the
+external systems it actually uses:
+
+- Desktop may use `cloud`, `anyharness`, `tauri`, `browser`, and capability
+  folders such as `mcp`.
+- Web usually uses `cloud` and browser auth/storage helpers.
+- Mobile usually uses `cloud` and native auth/storage helpers.
+
+## Query Key Ownership
+
+Query keys are part of the React-facing access contract. They live beside the
+access hook that owns the same remote resource cache.
+
+```text
+hooks/access/<system>/<resource>/query-keys.ts
+hooks/access/<system>/<resource>/use-<resource>.ts
+hooks/access/<system>/<resource>/use-<action>-mutation.ts
 ```
 
 Do not put React Query key factories in `lib/access/**`; that layer owns raw
@@ -61,124 +76,8 @@ transport, not React cache identity. Do not define remote-resource query keys
 inside product hook folders such as `hooks/automations/**`,
 `hooks/workspaces/**`, or `hooks/sessions/**`.
 
-Product hook folders may keep a key helper only when the cache is genuinely
-product-composed state rather than one external resource. If that exception is
-used, the file should make the product ownership obvious and should not call
-raw endpoint helpers.
-
-Cleanup audits should start with:
-
-```bash
-rg "query-keys" desktop/src/hooks --glob '!access/**'
-```
-
-Every hit should be either migration debt or a documented product-composed
-cache.
-
-## Desktop Access Folder Shape
-
-Use resource folders under `hooks/access/**`. The folder name should describe
-the external boundary or access capability being cached, not the product screen
-that happens to use it. Most folders map directly to an external system
-(`cloud`, `anyharness`, `tauri`). A capability folder such as `mcp` is allowed
-when one React-facing access API intentionally coordinates more than one
-external boundary, such as cloud connector records plus local OAuth/native
-setup.
-
-```text
-hooks/access/
-  cloud/
-    auth/
-      query-keys.ts
-      use-github-auth-availability.ts
-    automations/
-      query-keys.ts
-      use-automations.ts
-      use-automation-mutations.ts
-    billing/
-      query-keys.ts
-      use-cloud-billing.ts
-      use-cloud-billing-mutations.ts
-    agent-auth/
-      query-keys.ts
-      use-agent-auth.ts
-      use-agent-auth-mutations.ts
-    mobility/
-      query-keys.ts
-      use-cloud-mobility-workspaces.ts
-      use-cloud-mobility-workspace.ts
-      use-cloud-mobility-mutations.ts
-      cache.ts
-    organizations/
-      query-keys.ts
-      use-organizations.ts
-      use-organization-members.ts
-      use-organization-invitations.ts
-      use-organization-mutations.ts
-    repo-configs/
-      query-keys.ts
-      use-cloud-repo-config.ts
-      use-cloud-repo-configs.ts
-      use-cloud-repo-config-mutations.ts
-    repos/
-      query-keys.ts
-      use-cloud-repo-branches.ts
-    runtime/
-      query-keys.ts
-      use-control-plane-health.ts
-      use-cloud-workspace-connection.ts
-    workspaces/
-      query-keys.ts
-      use-cloud-workspace-repo-config-status.ts
-      use-cloud-workspace-mutations.ts
-    worktree-policy/
-      query-keys.ts
-      use-cloud-worktree-retention-policy.ts
-      use-cloud-worktree-retention-policy-mutation.ts
-  anyharness/
-    runtime/
-      use-runtime-health.ts
-    sessions/
-      use-prompt-attachment-url.ts
-    worktrees/
-      use-dynamic-worktree-inventory.ts
-      use-dynamic-worktree-policy.ts
-  tauri/
-    app/
-      query-keys.ts
-      use-app-version.ts
-    credentials/
-      query-keys.ts
-      use-local-agent-credentials.ts
-    shell/
-      query-keys.ts
-      use-available-editors.ts
-      use-shell-actions.ts
-    updater/
-      query-keys.ts
-      use-updater.ts
-    window/
-      use-window-actions.ts
-    diagnostics/
-      use-diagnostics-actions.ts
-  mcp/
-    connectors/
-      query-keys.ts
-      use-connectors.ts
-      use-connector-mutations.ts
-```
-
-`hooks/access/anyharness/**` should stay rare. Prefer importing
-`@anyharness/sdk-react` hooks directly for normal AnyHarness resources. Do not
-wrap SDK React hooks just for symmetry with cloud or Tauri access. Add a
-desktop AnyHarness access hook only when the hook needs selected-runtime
-resolution, desktop connection state, or a local/cloud runtime target that SDK
-React cannot know.
-
-Product-composed caches do not move here just because they use React Query. For
-example, workspace collections combine local runtime workspaces, cloud
-workspaces, repository roots, cleanup state, and product latency diagnostics.
-That cache should live under a product-owned cache folder such as:
+Product hook folders may keep key helpers only for product-composed caches
+that combine multiple sources into one product-owned projection.
 
 ```text
 hooks/workspaces/cache/workspace-collections-query.ts
@@ -190,33 +89,23 @@ cross-boundary product projections.
 
 ## Cloud
 
-`@proliferate/cloud-sdk` owns shared raw Proliferate Cloud API resource
-helpers. Desktop code should import reusable request helpers directly from the
-SDK, such as `@proliferate/cloud-sdk/client/workspaces`, instead of adding
-Desktop re-export wrappers.
+`@proliferate/cloud-sdk` owns shared raw Proliferate Cloud API helpers.
+`@proliferate/cloud-sdk-react` owns generic React Query hooks and providers for
+Cloud resources. App code imports reusable SDK helpers directly instead of
+adding app-local re-export wrappers.
 
-`lib/access/cloud/**` owns Desktop-specific Cloud access setup and native
-bridges:
+`lib/access/cloud/**` owns app-specific Cloud setup and platform bridges the
+shared SDK cannot know:
 
-- singleton OpenAPI client setup
-- auth/refresh middleware
-- Desktop auth/session storage integration
-- Desktop base-url resolution
+- app-specific auth/session storage integration
+- base-url resolution
+- token refresh or pending prompt persistence when platform-specific
 - Desktop-only agent-auth sync/recovery helpers
 - control-plane health checks used during Desktop startup
-- request timing integration
+- request timing or telemetry integration
 
-File naming:
-
-- `client.ts` for client setup, auth/refresh middleware, and shared transport
-  error types
-- `agent-auth-sync.ts` and `agent-auth-recovery.ts` for Desktop-native
-  agent-auth export/import coordination
-- `health.ts` for Desktop control-plane reachability checks
-- `timing.ts` for Desktop request measurement wiring
-- no React hooks, Zustand stores, query invalidation, navigation, or JSX
-
-`hooks/access/cloud/**` owns React-facing access:
+`hooks/access/cloud/**` owns app-local React-facing access that is not already
+generic enough for `@proliferate/cloud-sdk-react`:
 
 - query keys
 - `useQuery` and `useMutation`
@@ -225,40 +114,24 @@ File naming:
 - request telemetry
 - UI-safe error handling
 
-File naming:
+If a hook wraps a Cloud endpoint with `useQuery` or `useMutation`, it belongs
+under `hooks/access/cloud/**` even when the resource is product-specific.
+Product hooks consume the access hook and derive product state in their own
+domain folder.
 
-- `<resource>/query-keys.ts` for cloud query key factories
-- `use-<resource>.ts` for list or summary queries
-- `use-<resource>-detail.ts` for single-entity queries
-- `use-<action>-mutation.ts` for one mutation
-- `use-<resource>-actions.ts` only for a tight mutation group
-
-New cloud query/mutation wrappers belong in `hooks/access/cloud/**`. Existing
-`hooks/cloud/**` is transitional; product workflow hooks should migrate to
-their owning product hook domain.
-
-If a hook wraps a cloud endpoint with `useQuery` or `useMutation`, it belongs
-here even when the resource is product-specific. For example:
-
-```text
-hooks/access/cloud/mobility/query-keys.ts
-hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
-```
-
-Product hooks should consume this access hook and derive product state in their
-own domain folder. They should not define cloud query keys or call cloud raw
-helpers directly.
-
-Do not create ad hoc `openapi-fetch` clients outside the cloud access layer.
+Do not create ad hoc `openapi-fetch` clients outside the Cloud access layer.
 Do not call raw `client.GET`, `client.POST`, `client.PUT`, or `client.DELETE`
 from product hooks or components.
+
+`apps/packages/product-surfaces/**` may call `@proliferate/cloud-sdk-react`
+directly for shared Desktop/Web connected surfaces. It must not import app
+access folders or app-specific clients.
 
 ## AnyHarness
 
 Generic AnyHarness React access goes through `@anyharness/sdk-react`.
-Product hooks should not call `getAnyHarnessClient` directly except in
-transitional code. Put normal AnyHarness resource operations behind
-`@anyharness/sdk-react` or `hooks/access/anyharness/**`.
+Product hooks should not call `getAnyHarnessClient` directly for normal
+resource operations.
 
 Prefer direct SDK React imports for generic resources:
 
@@ -266,8 +139,9 @@ Prefer direct SDK React imports for generic resources:
 import { useAnyHarnessRuntimeWorkspaces } from "@anyharness/sdk-react";
 ```
 
-Create a desktop access hook only when desktop adds connection/runtime
-selection, local/cloud bridging, or cache behavior the SDK cannot provide.
+Create a Desktop AnyHarness access hook only when Desktop adds
+connection/runtime selection, local/cloud bridging, or cache behavior the SDK
+cannot provide.
 
 Low-level framework-agnostic primitives, such as streams, transcript reducers,
 and terminal connections, belong in `@anyharness/sdk`.
@@ -278,14 +152,9 @@ generic SDK cannot know:
 - resolving the selected workspace to the correct runtime target
 - local/cloud runtime connection mapping
 - runtime bootstrap and credentials
-- desktop-specific compatibility adapters
+- Desktop-specific compatibility adapters
 
-File naming should name the desktop wiring concern, such as
-`runtime-target.ts`, `runtime-bootstrap.ts`, or `workspace-connection.ts`.
-Do not name files after generic AnyHarness resources if the SDK can own that
-resource.
-
-Do not add a parallel generic AnyHarness request layer in desktop. If the
+Do not add a parallel generic AnyHarness request layer in Desktop. If the
 operation is a normal AnyHarness resource operation, prefer the SDK or SDK
 React hook.
 
@@ -296,7 +165,7 @@ Raw Tauri access belongs behind the Tauri access boundary.
 `@tauri-apps/api` or call native `invoke` directly. `hooks/access/tauri/**` is
 the React-facing access boundary.
 
-Use wrappers for:
+Use wrappers for native capabilities such as:
 
 - `invoke`
 - native events
@@ -305,18 +174,13 @@ Use wrappers for:
 - native window operations
 - shell/open-in-editor operations
 
-File naming should name the native capability, such as `updater.ts`,
-`filesystem.ts`, `window.ts`, `shell.ts`, or `diagnostics.ts`.
-
 React-facing Tauri behavior belongs in `hooks/access/tauri/**` or a product
 workflow hook that calls the wrapper. Components should not call raw Tauri APIs
 directly.
 
 ## Product Usage Pattern
 
-Product hooks should compose access instead of owning it directly. The product
-hook is the React boundary: it may call access hooks, read stores, and pass the
-resulting callbacks into plain workflow functions.
+Product hooks compose access instead of owning it directly.
 
 ```text
 Component
@@ -326,12 +190,11 @@ Component
     -> lib/workflows function receives access callbacks as dependencies
 ```
 
-Keep business rules in `lib/domain` or `lib/workflows`. Keep transport details
-in access. Keep rendering in components. Do not call React hooks from
-`lib/workflows`.
+Business rules live in `lib/domain/**` or `lib/workflows/**`. Transport
+details live in access. Rendering lives in components. Plain `lib/**`
+functions do not call React hooks.
 
-Query cache ownership follows the same boundary. Access hooks own query keys,
-cache object shape, invalidation, and `setQueryData` for remote resources.
-Product workflow hooks may decide that a resource should be refreshed or
-updated, but they should do that through access-owned callbacks rather than
-constructing query keys or writing cache objects inline.
+Access hooks own query keys, cache object shape, invalidation, and
+`setQueryData` for remote resources. Product workflow hooks request refresh or
+update through access-owned callbacks instead of constructing query keys or
+writing cache objects inline.

--- a/docs/frontend/guides/components.md
+++ b/docs/frontend/guides/components.md
@@ -1,190 +1,132 @@
 # Frontend Components
 
-Components render UI. They should be easy to scan: props in, hook calls for
-state/actions, tiny local UI callbacks, JSX out.
+Components render UI. Hooks own React behavior, `lib/**` owns reusable logic,
+and access layers own external systems.
 
 ## Ownership
 
-- Components render. They do not fetch, orchestrate workflows, or own reusable
-  product logic.
-- Components may call hooks. Hooks should provide the data, callbacks, and
-  state needed for rendering.
-- Components may import small pure domain/presentation helpers directly when
-  the helper only builds local render metadata, such as a row label, tone, or
-  icon choice. If the composition reads multiple stores/queries or combines
-  several product concerns, put it behind a derived hook instead.
-- Components may own local presentational state that only their subtree needs.
-- If a component has real computation in `useMemo`, move the computation into a
-  derived hook or `lib/domain` helper.
-- If a component defines several callbacks that coordinate stores, query
-  invalidation, navigation, or API calls, move that orchestration into a
-  workflow hook.
-- Use error boundaries around major sections so one crash does not kill the
-  entire app.
-
-Allowed component logic:
-
-- choosing which child component to render from hook-provided state
-- tiny local UI callbacks such as `setOpen(false)` or forwarding an event to a
-  prop callback
-- local-only measurement, hover, drag, focus, and menu state
-- simple formatting that is truly local and not a repeated product rule
-- small calls to pure presentation/domain helpers for local render metadata
+- Components may render, call hooks, forward callbacks, and own local
+  presentation state for their subtree.
+- Components must not fetch, invalidate queries, construct clients, call raw
+  Tauri/Cloud/AnyHarness helpers, coordinate multi-step workflows, or own
+  reusable product rules.
+- Product conditions reused across components belong in `lib/domain/**` or
+  `apps/packages/product-domain/**`.
+- A component callback that coordinates stores, queries, navigation, or remote
+  mutations belongs in a workflow hook.
 
 Red flags:
 
-- raw cloud, AnyHarness, or Tauri calls
-- `queryClient.invalidateQueries`
-- multiple store setters in one event handler
-- duplicated product conditions across components
+- raw Cloud, AnyHarness, MCP, or Tauri calls
+- `queryClient.invalidateQueries` or direct query-key construction
+- multiple store setters in one component callback
+- repeated status-to-label/tone/icon maps
 - non-trivial `useMemo` or `useEffect`
-- inline status-to-label/tone/icon maps
-- callbacks that read like workflows
-- imperative UI engine setup, subscriptions, or cleanup, such as xterm,
-  Monaco, canvas, media players, or map engines
-- async mutations, file parsing, sorting/filtering product models, or
-  multi-step state transitions
+- async mutations, file parsing, product sorting/filtering, or multi-step state
+  transitions
 
 ## Folder Shape
 
-Organize product components by domain, surface, then role by default:
-
-```text
-components/
-  ui/
-    Button.tsx
-    ConfirmationDialog.tsx
-    ModalShell.tsx
-  workspace/
-    shell/
-      topbar/
-      sidebar/
-    chat/
-      input/
-      transcript/
-    git/
-  settings/
-    panes/
-```
-
-Default path:
+Organize app product components by domain, surface, then role:
 
 ```text
 components/<domain>/<surface>/<role>/<Component>.tsx
 ```
 
-Use fewer levels only when the domain is genuinely small. Domain folders answer
-"what product area owns this?" Surface folders answer "where does this render?"
-Role folders answer "what part of the surface is this?"
+Use fewer levels only when the domain is small. Domain answers "what product
+area owns this?" Surface answers "where does this render?" Role answers "what
+part of the surface is this?"
 
-Examples:
+Rules:
 
-```text
-components/workspace/chat/input/ChatInput.tsx
-components/workspace/chat/transcript/MessageList.tsx
-components/workspace/shell/topbar/TopBar.tsx
-components/settings/panes/cloud/CloudPane.tsx
-```
-
-Avoid new root buckets like `modals`, `panels`, `sidebar`, or `topbar`.
-Domain-aware dialogs, panels, sidebars, and toolbars stay inside their owning
-product area (under the hoo  using the components from the `ui` folder for shared UI structure for modals, buttons, etc.)
-
-Folder hygiene:
-
-- A top-level `components/<domain>/` folder should represent a real product
-  area, not a UI shape or transport boundary.
-- Single-file folders are usually not worth it. Keep the file in its parent
-  unless the folder is clearly about to hold a cohesive surface/role.
-- Pick one shape per parent. A folder should not mix many direct component
-  files with some nested role folders unless the direct files are the surface
-  entrypoints.
-- Avoid `shared/` and `common/` inside surfaces. Reuse moves up to
-  `components/ui/**` for generic primitives or to a domain root when it remains
-  product-aware.
+- Top-level `components/<domain>/` folders are product areas, not UI shapes or
+  transport boundaries.
+- Avoid root buckets like `modals`, `panels`, `sidebar`, `topbar`, `shared`, or
+  `common`.
+- Single-file folders are usually noise unless the folder is the start of a
+  cohesive surface or role.
+- Pick one shape per parent. Do not mix many direct component files with nested
+  role folders unless the direct files are surface entrypoints.
 - When a flat component folder grows past roughly ten files, introduce
-  surface/role folders before adding more unrelated components.
-
-## UI Primitives
-
-- Put Desktop-only foundational primitives and shells in
-  `desktop/src/components/ui/**`.
-- Put cross-client DOM primitives in `packages/ui/**` only when they are useful
-  to both Desktop and Web and do not import `@/`, Tauri APIs, stores, product
-  hooks, access helpers, or Desktop overlay/runtime mechanics.
-- Put cross-client Desktop/Web product components in `packages/product-ui/**`
-  only when they accept data and callbacks as props and do not construct SDK
-  clients, call app access helpers, or own query/mutation wiring.
-- Web product surfaces should be controllers over `packages/product-ui/**`.
-  `web/src/components/**` may map cloud data, fixture data, route params, auth
-  state, and callbacks into shared view models, but it should not define
-  product visual rows, cards, banners, sidebars, settings panes, or chat
-  surfaces locally.
-- Desktop product surfaces should use the same `packages/product-ui/**`
-  components whenever Web needs the surface too. Desktop keeps the controller:
-  stores, hooks, AnyHarness/Tauri/cloud access, navigation, native menus, and
-  workflow callbacks stay in `desktop/src/**`.
-- Do not promote product-aware components into `components/ui/**`.
-- Do not render raw `<button>`, `<input>`, `<label>`, `<select>`, or
-  `<textarea>` outside approved primitives in `components/ui/**`.
-- Reusable icons belong in `components/ui/icons.tsx`, not inline inside
-  feature components.
-- `packages/ui/**` exports concrete subpaths such as
-  `@proliferate/ui/primitives/Button`; do not add barrel imports.
-- `packages/product-ui/**` follows the same concrete subpath rule for shared
-  product components, such as `@proliferate/product-ui/auth/AuthLayout`.
-- Preserve UI behavior and layout unless an explicit redesign is requested.
-- Product copy should come from `copy/**` or a domain/presentation helper when
-  it is reused or conditional.
-
-## Component Patterns
-
-- Functions flow down; events flow up through callbacks.
-- Push state down. Lift state only when siblings need to share it.
-- Split components at data boundaries: if a child needs guarded data, make the
-  guard the parent and the data consumer the child.
-- Use `React.memo` only when props are reference-stable and the component
-  demonstrably re-renders due to parent state churn.
+  surface/role folders before adding unrelated components.
 - Component files use `PascalCase.tsx`.
-- Do not put `.ts` files under `components/**`. Static metadata, copy,
-  config, and pure presentation helpers belong in `config/**`, `copy/**`, or
+- Do not put `.ts` files under `components/**`. Static metadata, copy, config,
+  and pure presentation helpers belong in `config/**`, `copy/**`, or
   `lib/domain/**`.
-- Component names should describe the product surface or UI primitive they own.
-- Avoid generic names like `Panel`, `Modal`, `Content`, or `Row` unless the
-  folder path already makes the ownership unambiguous.
 
-## Imperative UI Engines
+## Shared UI
 
-Components may render the host element for imperative UI engines, such as
-xterm, Monaco, canvas, media players, or map engines. The setup and lifecycle
-for those engines belongs in hooks:
+`apps/packages/ui/**` is the only DOM primitive layer.
 
-```text
-components/workspace/terminals/TerminalViewport.tsx
-hooks/terminals/lifecycle/use-xterm-viewport.ts
-hooks/terminals/lifecycle/use-terminal-stream-replay.ts
-```
+Hard invariant: do not define DOM primitive components anywhere else.
 
-The component should provide refs, props, and render shell. The lifecycle hook
-should own dynamic imports, engine construction, subscriptions, observers,
-stream handles, event wiring, focus retries, and cleanup. Pure presentation
-rules, such as labels or replay-entry decisions, still belong in `lib/domain/**`
-when they can be expressed without DOM or engine instances.
+A primitive component is any generic reusable control, shell, or low-level UI
+building block: `Button`, `IconButton`, `Input`, `Textarea`, `Label`, `Select`,
+`Checkbox`, `Switch`, `Tabs`, `Menu`, `Popover`, `Tooltip`, `Dialog`, `Modal`,
+`Badge`, `Pill`, `Separator`, `ScrollArea`, layout shell, or a differently
+named component that wraps/restyles the same raw DOM control.
 
-File size guidance:
+New primitive definitions are forbidden in:
 
-- Prefer splitting product component files before roughly 300 lines.
-- Component files around 500 lines need a strong reason to stay whole.
-- Size alone is not the only signal. Split earlier when a component mixes
-  rendering with workflows, product-model construction, repeated presentation
-  maps, or non-trivial effects.
+- `apps/desktop/src/**`
+- `apps/web/src/**`
+- `apps/packages/product-ui/**`
+- `apps/packages/product-surfaces/**`
 
-## Settings
+Primitive definitions outside `apps/packages/ui/**` violate this standard. Do
+not add them, copy them, or create local variants beside them. Put the
+primitive in `apps/packages/ui/**`, add the needed variant/prop there, and
+update callsites to import it.
 
-- Settings routes use flat section ids.
-- Visual sidebar groups, such as Configuration, are headings only and must not
-  introduce nested route state.
-- Settings panes live under `components/settings/panes/**`; each pane owns one
-  product area.
-- Repo settings compose local and cloud repo sections inside the repo pane
-  instead of growing one mixed pane.
+### `apps/packages/ui`
+
+- Owns base DOM controls and layout primitives: buttons, icon buttons, inputs,
+  textareas, labels, selects, checkboxes, switches, tabs, menus, popovers,
+  dialogs, tooltips, badges, separators, scroll areas, and layout shells.
+- Must not import app code, SDK clients, stores, product hooks, access helpers,
+  Tauri APIs, React Native, routes, or product concepts.
+- Must expose variants/props for repeated visual treatments. Do not create a
+  one-off restyled button/input/dialog at the callsite.
+- Is the only place in DOM frontend code that should define the base visual
+  contract for raw controls.
+
+### Desktop, Web, `product-ui`, and `product-surfaces`
+
+- Must use primitives from `apps/packages/ui/**` for base controls.
+- Must not define or redefine primitive components, even with different names.
+- Must not render raw `<button>`, `<input>`, `<label>`, `<select>`, or
+  `<textarea>` outside `apps/packages/ui/**`.
+- May pass layout/sizing classes when the primitive API allows it, but must not
+  rebuild color, border, radius, typography, focus, disabled, or hover behavior
+  at the callsite.
+- If a needed primitive variant does not exist, add it to
+  `apps/packages/ui/**` and then consume it everywhere.
+
+### `apps/packages/product-ui`
+
+- Owns shared Desktop/Web product presentation under
+  `apps/packages/product-ui/src/<domain>/<surface>/**`.
+- Receives data and callbacks as props.
+- Composes `apps/packages/ui/**` primitives and
+  `apps/packages/product-domain/**` view models.
+- Must not import SDK clients, SDK React hooks, access helpers, app stores,
+  routes, Tauri, AnyHarness runtime wiring, or React Native.
+
+### `apps/packages/product-surfaces`
+
+- Owns shared connected Desktop/Web Cloud surfaces under
+  `apps/packages/product-surfaces/src/<domain>/<surface>/**`.
+- May use shared Cloud SDK React hooks and render `product-ui`.
+- Must still use `apps/packages/ui/**` for base controls.
+- Must not import Desktop/Web app internals, Tauri, local AnyHarness runtime
+  wiring, app stores, app routes, or React Native.
+
+### Mobile
+
+- Renders native components under `apps/mobile/src/components/**`.
+- May share `apps/packages/product-domain/**` view models and
+  `apps/packages/design/src/react-native.ts` tokens.
+- Must not import DOM packages: `ui`, `product-ui`, or `product-surfaces`.
+
+Use concrete package subpaths such as `@proliferate/ui/primitives/Button` or
+`@proliferate/product-ui/settings/account/AccountPane`; do not add barrels.

--- a/docs/frontend/guides/copy.md
+++ b/docs/frontend/guides/copy.md
@@ -32,7 +32,9 @@ Presentation mappings convert product state to display metadata: labels, tones,
 icons, descriptions, ordering, and visibility flags.
 
 Put reusable mappings in `lib/domain/<domain>/<subdomain>/presentation.ts`.
-Keep them component-local only when they are purely visual and not reused.
+Move them to `apps/packages/product-domain/**` when the same mapping is shared
+by Desktop, Web, or Mobile. Keep them component-local only when they are purely
+visual and not reused.
 
 Examples:
 

--- a/docs/frontend/guides/hooks.md
+++ b/docs/frontend/guides/hooks.md
@@ -1,15 +1,13 @@
 # Frontend Hooks
 
-Hooks own React behavior. A hook should have one clear responsibility, a clear
-folder kind, and a name that tells the reader what it returns or owns.
+Hooks own React behavior: effects, refs, context, query/mutation wiring,
+subscriptions, local UI mechanics, and UI-facing orchestration.
 
 ## Hook Types
 
 ### UI Hooks
 
-Tiny reusable browser/UI mechanics with no product concepts.
-
-Path:
+Generic UI mechanics with no product concepts.
 
 ```text
 hooks/ui/keyboard/use-keyboard-shortcut.ts
@@ -17,15 +15,13 @@ hooks/ui/pointer/use-click-outside.ts
 hooks/ui/layout/use-element-size.ts
 ```
 
-UI hooks may use refs, local state, effects, DOM subscriptions, timers, and
-browser APIs. They should not know about sessions, workspaces, agents, billing,
-or cloud.
+UI hooks may use refs, local state, effects, DOM/native subscriptions, timers,
+and platform UI APIs. They must not know about sessions, workspaces, agents,
+billing, repositories, or cloud.
 
 ### Access Hooks
 
-React Query or mutation wrappers around external systems.
-
-Path:
+React Query and mutation wrappers around external systems.
 
 ```text
 hooks/access/cloud/billing/use-cloud-billing.ts
@@ -34,249 +30,87 @@ hooks/access/anyharness/runtime/use-runtime-workspaces.ts
 hooks/access/tauri/updater/use-updater-actions.ts
 ```
 
-Access hooks own query keys, `useQuery`, `useMutation`, retries, invalidation,
-and request telemetry. Product hooks should use access hooks instead of
-constructing clients or calling raw endpoint helpers directly.
+Access hooks own query keys, `useQuery`, `useMutation`, retry policy,
+invalidation, cache shape, and request telemetry. If a hook directly wraps an
+external request, it belongs under `hooks/access/<system>/**`.
 
-If a hook directly wraps an external request with `useQuery` or `useMutation`,
-it belongs under `hooks/access/<boundary>/**`. Do not put query/mutation hooks
-inside product-domain folders such as `hooks/workspaces/**`, `hooks/agents/**`,
-or `hooks/sessions/**`.
-
-Query keys live with the access hooks for the same external boundary and
-resource:
-
-```text
-hooks/access/cloud/mobility/query-keys.ts
-hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
-```
-
-The concrete access folder map lives in `docs/frontend/guides/access.md`.
-Follow that map before inventing a new access folder or leaving query keys in a
-product hook directory.
-
-For example, automation list/detail/run keys belong with the cloud automation
-access hooks, not in `hooks/automations/query-keys.ts`:
+Query keys live beside the access hook that owns the resource:
 
 ```text
 hooks/access/cloud/automations/query-keys.ts
 hooks/access/cloud/automations/use-automations.ts
-hooks/access/cloud/automations/use-automation-mutations.ts
 ```
 
-Do not create `hooks/<domain>/access/**` by default. Product domains consume
-access hooks; they do not own raw external access. If a product domain needs a
-local cache adapter over remote data, name that folder by the product
-responsibility, such as `derived/`, `workflows/`, or `cache/`, not `access/`.
-
-Access hook naming:
-
-- `use-<resource>.ts` for queries
-- `use-<resource>-detail.ts` for one entity
-- `use-<action>-mutation.ts` for one mutation
-- `use-<resource>-actions.ts` only for a tight group of related mutations
-- `query-keys.ts` for key factories in the same access domain
-
-Access hooks may call `lib/access/**`, `@anyharness/sdk-react`, or
-`@anyharness/sdk`. They should not contain product workflow branching.
-
-Query cache writes belong here too. Access hooks own query cache shape,
-`queryClient.invalidateQueries`, and `queryClient.setQueryData` for their
-resource. Product workflow hooks may call access-provided callbacks such as
-`invalidateWorkspaceSessions` or `upsertSession`, but should not hand-edit
-query cache keys or cache object shapes directly.
+Access hooks may call `lib/access/**`, SDK clients, SDK React hooks, or shared
+Cloud SDK React hooks. They must not contain product workflow branching.
 
 ### Product Cache Hooks
 
-Product cache hooks are rare React Query caches that combine multiple
-external/local sources into one product-owned data model. They are not raw
-access wrappers.
-
-Path:
+Rare React Query caches that combine multiple external/local sources into one
+product-owned data model.
 
 ```text
 hooks/<domain>/cache/<cache-name>-query.ts
 hooks/<domain>/cache/<cache-name>-cache.ts
 ```
 
-Use this only when the cache is genuinely product-composed rather than one
-external resource. For example, a workspace collection cache may combine local
-runtime workspaces, cloud workspaces, repository roots, cleanup state, and
-diagnostics. A simple cloud endpoint query still belongs in `hooks/access/**`.
+Use this for product-composed state, not simple endpoint queries. One external
+resource still belongs in `hooks/access/**`.
 
 ### Derived Hooks
 
-Read store/provider/query state and return UI-ready state. They should not
-write, fetch, invalidate, navigate, or emit telemetry.
-
-Use derived hooks when a component needs one stable answer from many inputs,
-such as "what chat surface should render?"
-
-Path:
+Read stores, providers, and queries; return UI-ready state.
 
 ```text
 hooks/<domain>/derived/use-<thing>-state.ts
 hooks/<domain>/derived/use-<thing>-model.ts
 ```
 
-Derived hooks may call other derived hooks and read access hooks. They must not
-call mutation hooks except to read stable status that is already exposed as
-state.
-
-Derived hooks are read-only. A hook named `use-*-state`, `use-*-model`, or
-living under `derived/` must not return mutating callbacks such as `save`,
-`submit`, `update`, `set`, `dismiss`, or `retry`. Split actions into a workflow
-hook and compose them with a facade only when a component genuinely benefits
-from one combined interface.
+Derived hooks must not write, fetch, invalidate, navigate, emit telemetry, or
+return mutating callbacks. If the component needs actions too, compose a
+derived hook and workflow hook behind a facade.
 
 ### Workflow Hooks
 
-User-action controllers. They gather dependencies, expose callbacks, and call
-domain/workflow/access functions.
-
-Workflow hooks should read like route handlers:
-
-- collect current state and dependencies
-- validate inputs
-- call a plain workflow function or access hook
-- update stores or invalidate queries in one readable path
-- handle user-facing errors
-
-They should not bury large product algorithms inline. Move reusable logic to
-`lib/domain` or `lib/workflows`.
-
-Do not create more hooks just to hide complexity. Extract to another hook only
-when the extracted code genuinely owns React state, effects, context,
-subscriptions, or query behavior. Otherwise extract a plain function into
-`lib/domain`, `lib/workflows`, `lib/access`, or `lib/infra`.
-
-Path:
+User-action callbacks and React-facing orchestration.
 
 ```text
 hooks/<domain>/workflows/use-<workflow>-actions.ts
 hooks/<domain>/workflows/use-<workflow>-workflow.ts
 ```
 
-Workflow hooks may:
+Workflow hooks may read stores/providers/access hooks, expose callbacks, call
+`lib/domain/**` for pure decisions, call `lib/workflows/**` for sequences, and
+use access-owned cache/invalidation callbacks.
 
-- read stores, providers, and access hooks
-- expose callbacks used by components
-- call `lib/domain` for pure decisions
-- call `lib/workflows` for multi-step product sequences
-- pass access-hook callbacks, store setters, and other side-effect functions
-  into `lib/workflows`
-- call access-owned invalidation/cache callbacks and store setters at the
-  React boundary
+Workflow hooks must not construct raw clients, call raw endpoint paths, define
+query keys, hand-edit cache object shapes, or bury large reusable algorithms.
 
-Workflow hooks must not:
-
-- construct raw clients
-- call raw endpoint paths or raw Tauri invoke wrappers
-- contain large reusable algorithms inline
-- define query keys or hand-edit React Query cache object shapes
-- become a grab bag of unrelated actions
-
-The workflow hook is the React boundary. It is allowed to call hooks. Plain
-`lib/workflows` functions are not.
-
-The default split is:
+Default split:
 
 ```text
 workflow hook = gathers React/store/query/provider deps + returns callbacks
 lib/workflows function = receives input + deps and runs the product sequence
 ```
 
-Default shape:
-
-```text
-Component
-  -> useProductWorkflowActions()
-    -> useAccessMutation()
-    -> useStore(selector)
-    -> runPlainWorkflow(input, {
-         accessCall: mutation.mutateAsync,
-         storeSetter,
-       })
-```
-
 ### Actions vs. Workflows
 
-Most exposed callbacks are actions, not workflows.
+Keep a callback inline in the workflow hook when it is one short user intent:
+validate a snapshot, call one access function/mutation, update owned local
+state/cache, and return.
 
-An action is one user intent with a short, mostly linear body: validate a
-snapshot, call one access function or mutation, update local state/cache through
-owned callbacks, and return. Keep actions inline in the workflow hook when they
-are easy to scan.
+Move a sequence to `lib/workflows/<domain>/**` when it has ordering
+invariants, branching on fetched data, rollback, retries, multi-step error
+recovery, or a useful unit-test boundary. Dependency objects should be narrow;
+large `EverythingDeps` types usually mean the boundary is too broad.
 
-A workflow earns `lib/workflows/<domain>/**` only when it has sequencing worth
-testing: ordering invariants, branching on fetched data, rollback, retries,
-multi-step error recovery, or a body that keeps growing past the point where
-the hook remains readable.
-
-Before extracting to `lib/workflows`, check:
-
-1. It is a sequence, not a single action.
-2. The dependency object is narrow, usually five capabilities or fewer.
-3. The sequence is reused, likely to be reused, or naturally unit-testable with
-   fake deps.
-
-If any answer is no, leave it in the hook and instead extract pure decisions to
-`lib/domain/**` or repeated access/cache details to access hooks.
-
-Do not extract actions just to make files look layered. Thin wrappers with no
-information value make the code harder to read.
-
-Workflow shape:
-
-```ts
-export interface DoThingInput {
-  workspaceId: string;
-  promptText: string;
-}
-
-export interface DoThingDeps {
-  createSession(input: CreateSessionInput): Promise<Session>;
-  promptSession(sessionId: string, prompt: PromptInput): Promise<void>;
-  rollbackSession(sessionId: string): Promise<void>;
-}
-
-export type DoThingResult =
-  | { kind: "completed" }
-  | { kind: "interrupted" }
-  | { kind: "failed"; message: string };
-
-export async function doThing(
-  input: DoThingInput,
-  deps: DoThingDeps,
-): Promise<DoThingResult> {
-  // Ordered product sequence.
-}
-```
-
-State values that change per call belong in `input`. Stable capabilities belong
-in `deps`. Do not pass state snapshots, pure helpers, constants, or formatting
-functions as deps.
-
-If a workflow appears to need many deps, investigate before accepting it:
-
-- State values may belong in `input`.
-- Several setters for one store may be one writer capability.
-- One function may really be two workflows.
-- Heavy branching may want a pure `plan(input) -> Command[]` domain planner
-  plus a small executor.
-- Some callbacks should return tagged results so the hook can decide whether
-  to toast, navigate, or call `onCompleted`.
+State values that change per call belong in `input`. Stable capabilities such
+as access calls, store setters, cache invalidation, navigation, toasts,
+telemetry, clocks, or id generation belong in `deps`.
 
 ### Lifecycle Hooks
 
-Mounted background behavior: streams, dispatchers, subscriptions, polling,
-bootstrap, cleanup, and cross-store reconciliation.
-
-Lifecycle hooks are effect-driven. Keep their ownership comments explicit:
-"Owns X. Does not own Y." They should be mounted once at the correct boundary
-and should clean up every subscription or timer they create.
-
-Path:
+Mounted background behavior.
 
 ```text
 hooks/<domain>/lifecycle/use-<thing>-lifecycle.ts
@@ -284,37 +118,33 @@ hooks/<domain>/lifecycle/use-<thing>-dispatcher.ts
 hooks/<domain>/lifecycle/use-<thing>-reconciler.ts
 ```
 
-Use lifecycle hooks for background behavior triggered by mounting or external
-events, not direct user clicks.
+Use lifecycle hooks for streams, dispatchers, subscriptions, polling,
+bootstrap, teardown, cross-store reconciliation, imperative controllers, and
+external-event-driven behavior. They should be mounted at the owning boundary
+and clean up every timer, listener, observer, handle, or subscription they
+create.
 
-Lifecycle hooks may manage imperative controllers, not only passive
-`useEffect` blocks. Streams, reconnect loops, background dispatchers, hot
-session ingest, xterm or Monaco instances, canvas controllers, media players,
-and long-lived subscriptions are lifecycle concerns when their main trigger is
-mounting or external events. The hook should make the owned system obvious and
-keep timers, handles, observers, event wiring, and cleanup in one readable
-place.
+### Product UI Hooks
 
-If extracting lifecycle logic creates one giant dependency interface, the
-extraction boundary is too large. Keep the lifecycle hook as the readable
-orchestrator and extract smaller substeps instead.
+Product-specific UI mechanics.
+
+```text
+hooks/<domain>/ui/use-<mechanic>.ts
+```
+
+Use this when the hook is UI behavior but needs product vocabulary. Generic
+mechanics stay in `hooks/ui/**`; workflows stay in `workflows/**`.
 
 ### Facade Hooks
 
-Thin composition wrappers around several hooks. Facades are acceptable when
-they create a simpler interface for a component or preserve compatibility
-during a migration. If a facade grows large or contains branching business
-logic, split the underlying responsibilities.
-
-Path:
+Thin composition wrappers around several hooks.
 
 ```text
 hooks/<domain>/facade/use-<surface>.ts
 ```
 
-Facade hooks should mostly rename and group values. They should not introduce
-new product behavior. A facade that only re-exports one or two callbacks is
-usually noise; keep the public hook or use a plain function instead.
+Facades may group and rename values for a component. They must not introduce
+new product behavior, raw access, query keys, or business branching.
 
 ## Folder Shape
 
@@ -337,103 +167,33 @@ hooks/
     facade/
 ```
 
-Existing domain folders may still be transitional. New hooks and cleanup work
-should move toward the taxonomy above.
+Product hook files belong in a responsibility folder, not directly under
+`hooks/<domain>/`. Do not create empty folders; add folders when real files need
+them.
 
-For product domains, responsibility folders are mandatory for new
-non-migration files. A tiny domain does not need every folder, but it should
-still use the folder for the kind it has:
+## Placement Rules
 
-```text
-hooks/automations/workflows/use-automation-actions.ts
-hooks/chat/derived/use-chat-surface-state.ts
-hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts
-hooks/workspaces/cache/workspace-collections-query.ts
-```
-
-Do not add new flat files directly under `hooks/<domain>/`. During migrations,
-flat files should be treated as transitional and moved into the appropriate
-responsibility folder as the area is touched.
-
-Do not create empty or speculative folder trees. Add the folders needed for the
-files being moved now, and let later cleanup passes add more responsibility
-folders as real files need them.
-
-## Hook Cleanup Playbook
-
-Use this sequence when cleaning an existing hook:
-
-1. Classify the hook as access, UI, derived, workflow, lifecycle, or facade.
-2. Write the ownership boundary first: "Owns X. Does not own Y."
-3. Preserve the public hook API unless the task explicitly changes callsites.
-4. Extract non-React code before creating more hooks.
-5. Move pure product decisions to `lib/domain/**`.
-6. Move multi-step product sequences to `lib/workflows/**`.
-7. Move raw external calls to `lib/access/**` or `hooks/access/**`.
-8. Create another hook only when the extracted code owns React behavior.
-9. Keep dependency objects narrow; giant `EverythingDeps` types usually mean
-   the workflow boundary is too broad.
-10. Add or adjust focused tests around moved domain/workflow logic.
-
-Prefer modest cleanup passes over idealized rewrites. The target architecture
-guides direction; it is not a request to introduce every possible future file
-or split a stable hook only to match a diagram. Preserve behavior, move the
-obvious ownership violations first, and leave invasive rewrites explicit for a
-separate plan.
-
-When reading a hook, separate three regions:
-
-```text
-1. React reads: stores, queries, context, access hooks
-2. Pure logic: inline if tiny, otherwise `lib/domain/**`
-3. Async glue: inline if linear, `lib/workflows/**` if sequenced/branchy
-```
-
-Most god hooks are not solved by immediately creating workflows. First look for
-pure decisions trapped in hooks, repeated selector boilerplate, and raw access
-or cache code in the wrong layer.
-
-Action bundle hooks are junctions, not homes for every concern behind the
-actions. A bundle hook exposes callbacks for one product capability. It may
-inline simple actions and call access hooks, derived hooks, lifecycle or
-registry helpers, and real `lib/workflows/**` functions. It should not own raw
-access, query keys, remote cache shape, module-level coordination state, or
-long-lived registry behavior.
-
-Do not re-export pure stateless functions through action hooks. If a function
-does not need React state or hook-owned dependencies, import it from the module
-that owns it.
-
-Example: prompt outbox dispatch should stay as one app-mounted lifecycle hook.
-The hook owns singleton mount behavior, store subscription, and in-flight loop
-coordination. It should extract focused substeps such as block preparation,
-failure classification, runtime prompt access, and history reconciliation. Do
-not replace it with one mega-workflow that needs every outbox, session,
-latency, title, and access dependency in the app.
+- Raw external calls live in `lib/access/**` or `hooks/access/**`.
+- Pure product decisions live in `lib/domain/**` or `product-domain`.
+- Real multi-step sequences live in `lib/workflows/**`.
+- Another hook is only warranted when the extracted code owns React behavior.
+- Focused tests belong next to risky or meaningful domain/workflow logic.
 
 ## Rules
 
-- Product hooks should not construct raw cloud clients, AnyHarness clients, or
-  Tauri invocations directly.
+- Product hooks should not construct raw Cloud, AnyHarness, MCP, or Tauri
+  clients directly.
 - Components should not call `queryClient.invalidateQueries` directly.
 - Product hooks should not define query keys or own cache object shape.
 - Components should not call multiple store setters in sequence; put that in a
   workflow hook.
-- Product workflow hooks should read like route handlers. If the middle of the
-  hook is the business algorithm, extract that algorithm to `lib/domain` or
-  `lib/workflows`.
 - Hooks may call hooks. Plain functions in `lib/**` must not call hooks.
-- Query key helpers live alongside their access/query hooks.
-- Product-domain `query-keys.ts` files are migration debt unless they cache
-  product-composed state rather than one external resource.
 - Query/mutation wrappers for external systems live in `hooks/access/**`, not
   product-domain hook folders.
 - Reducers are pure functions, not hooks. Do not use a `use-` prefix for pure
   reducers.
 - Non-trivial hooks should start with a short ownership comment when the name
   alone is not enough.
-- Avoid god hooks. A hook that mixes five mutations, retry logic, telemetry,
-  route changes, and store coordination needs to be split.
 
 ## Effects
 
@@ -441,7 +201,7 @@ Valid `useEffect` ownership:
 
 - SSE/WebSocket connections
 - Tauri IPC listeners
-- DOM event subscriptions
+- DOM/native event subscriptions
 - resize/intersection observers
 - timers, debouncing, and polling
 - one-time app initialization
@@ -453,5 +213,5 @@ Invalid `useEffect` ownership:
 - deriving state from other state
 - watching one state value only to set another state value
 
-Always include a dependency array. `useEffect(fn)` with no dependency array
-runs every render and is almost always a bug.
+Avoid `useEffect(fn)` with no dependency array unless every-render execution is
+intentional and documented.

--- a/docs/frontend/guides/lib.md
+++ b/docs/frontend/guides/lib.md
@@ -1,279 +1,119 @@
 # Frontend Lib
 
-`lib/**` is for non-component logic. Keep React behavior in hooks and raw
-external access in `lib/access/**`.
+`lib/**` is non-component logic. Hooks own React behavior. Access layers own
+external systems.
 
 ## `lib/domain/**`
 
-Pure product logic.
+Pure product logic for one app.
 
-Use this for rules that understand Proliferate concepts but do not need React,
-stores, query clients, platform APIs, or external clients.
+Use app-local `lib/domain/**` when the rule is platform/app-specific. Move the
+rule to `apps/packages/product-domain/**` when Desktop, Web, or Mobile need the
+same decision or view model.
 
-Examples:
+Owns:
 
-- chat surface mode transitions
-- session status labels
-- workspace display names
-- prompt outbox reconciliation
-- validation rules for product models
+- product validation and normalization
+- status labels, tones, icons, and display metadata
+- workspace/session/chat projection models
+- pure reducers
+- pure side-effect planners
 
-Rules:
+Must not import:
 
-- No React, JSX, hooks, stores, query clients, telemetry, or raw access.
-- Keep functions deterministic when possible.
-- Organize large domains by subdomain and product purpose, not by generic file
-  types like `utils` or `helpers`.
-- Pure side-effect planners belong here when the decision is product logic.
-  They inspect state/events and return an explicit plan; they do not execute
-  the effects.
+- React, JSX, hooks, stores, providers, query clients
+- DOM, React Native components, Tauri, or platform APIs
+- SDK clients, raw access helpers, or app code from another boundary
 
-Target shape:
+Shape:
 
 ```text
-lib/domain/
-  chat/
-    composer/
-    launch/
-    models/
-    outbox/
-    session-controls/
-    subagents/
-    surface/
-    tools/
-    transcript/
-  workspaces/
-    changes/
-    cloud/
-    creation/
-    display/
-    mobility/
-    selection/
-    shell/
-    sidebar/
-    tabs/
-    viewer/
+lib/domain/<domain>/<subdomain>/<rule>.ts
 ```
 
-File naming:
-
-- `<specific-rule>.ts` for pure decisions and computations
-- `<thing>-model.ts` for model construction
-- `<thing>-reducer.ts` for pure reducers
-- `<thing>-effect-plan.ts` for pure side-effect planning
-- `<thing>-presentation.ts` or `presentation.ts` for state-to-display metadata
-- `<thing>.test.ts` next to meaningful pure logic when coverage is useful
-
-Avoid names like `utils.ts`, `helpers.ts`, or `types.ts` unless the file is
-truly tiny and local to one subdomain. Prefer names that state the product rule.
+Name files for the product rule: `<specific-rule>.ts`,
+`<thing>-model.ts`, `<thing>-reducer.ts`, `<thing>-effect-plan.ts`, or
+`<thing>-presentation.ts`. Avoid `utils.ts`, `helpers.ts`, and broad
+`types.ts` files unless the scope is tiny and local.
 
 ### Side-Effect Planners
 
-Use this pattern when product logic needs to decide what effects should happen
-but should not execute those effects directly.
+A planner decides what effects should happen and returns an explicit plan. It
+does not execute effects. The executor belongs in a workflow hook, lifecycle
+hook, or `lib/workflows/**`.
 
-Domain planner:
-
-```ts
-export function planSessionStreamEffects(input): SessionStreamEffectPlan {
-  return {
-    refreshSummary: true,
-    playTurnEndSound: false,
-    mountLinkedSessionIds: [],
-  };
-}
-```
-
-Workflow or lifecycle hook executor:
-
-```ts
-const plan = planSessionStreamEffects(snapshot);
-if (plan.refreshSummary) {
-  await deps.refreshSummary();
-}
-if (plan.playTurnEndSound) {
-  deps.playTurnEndSound();
-}
-```
-
-The planner belongs in `lib/domain/**` because it is pure product decision
-logic. The executor belongs in a workflow hook, lifecycle hook, or
-`lib/workflows/**` because it performs side effects.
+Use planners when product decisions are pure but the resulting effects are not,
+such as stream refresh decisions, toast decisions, or reconciliation commands.
 
 ## `lib/workflows/**`
 
 Plain non-React product sequences.
 
-Use this when logic coordinates multiple dependencies but should not be tied to
-React. The hook gathers dependencies and passes them in; the workflow runs the
-sequence.
+Use this when a user or lifecycle action coordinates multiple dependencies and
+the sequence should be readable/testable outside React. The owning hook gathers
+dependencies and calls the workflow.
 
-Examples:
+Owns:
 
-- create workspace then create initial session
-- prepare prompt payload then dispatch
-- reconcile materialized workspace metadata
+- ordered product sequences
+- branching across fetched/local data
+- retries, rollback, and multi-step error recovery
+- app-local orchestration that should not call hooks directly
 
-Rules:
+Must not import:
 
-- No React hooks.
-- Dependencies are passed in as arguments.
-- Keep side effects explicit in the dependency interface.
-- Workflow hooks should remain thin controllers around these functions.
-- Do not import access hooks, stores, query clients, or React providers.
-- Do not construct raw clients or call raw endpoint paths unless the workflow is
-  explicitly designed as an access-layer helper. Product workflows should
-  receive access callbacks from the hook that calls them.
+- React hooks, providers, stores, or query clients
+- hidden singletons for app state
+- raw endpoint paths or client construction for product workflows
 
-Target shape:
+Shape:
 
 ```text
-lib/workflows/
-  sessions/
-    create-session-workflow.ts
-    prompt-session-workflow.ts
-  workspaces/
-    materialize-workspace-workflow.ts
+lib/workflows/<domain>/<workflow>.ts
 ```
 
-Workflow functions should accept a small dependency object instead of importing
-singletons. That keeps the sequence testable and makes side effects visible.
-Use an `(input, deps)` shape by default. The dependency object should expose
-side effects as named callbacks, not hidden imports.
+Use an `(input, deps)` shape. Per-call values belong in `input`. Live
+capabilities belong in `deps`: access calls, store setters, cache invalidation,
+navigation, toasts, telemetry, runtime resolution, clocks, and id generation.
 
-### Workflow Dependency Interfaces
+Do not pass pure helpers, constants, or formatting functions as deps. Import
+pure domain helpers and static config directly.
 
-Dependencies are for live side effects and runtime collaborators: access
-calls, store setters, cache invalidation, navigation, toasts, telemetry,
-runtime connection resolution, clocks, and id generation when testability
-requires it.
+Keep a sequence in the workflow hook when it is a short single action. Move it
+to `lib/workflows/**` when ordering, branching, rollback, retry, or testability
+is the reason for the extraction.
 
-Do not pass pure helpers, constants, or simple formatting functions as
-dependencies. Import pure domain helpers and static config directly.
+## `lib/access/**`
 
-Prefer small capability interfaces and compose narrow workflow deps:
+Raw app-local access helpers.
 
-```ts
-interface TerminalRuntimeDeps {
-  getWorkspaceRuntimeBlockReason(workspaceId: string): string | null;
-  resolveWorkspaceConnection(workspaceId: string): Promise<TerminalConnection>;
-}
+Use this for client setup, platform bridges, native wrappers, auth/storage
+integration, and thin app-specific adapters around SDK clients. Query/mutation
+hooks that expose this access to React live in `hooks/access/**`.
 
-interface TerminalCacheDeps {
-  invalidateWorkspaceTerminals(workspaceId: string): Promise<void>;
-}
+Must not own product workflow branching, UI state, stores, or reusable shared
+package logic.
 
-interface TerminalRecordAccessDeps {
-  createTerminal(
-    connection: TerminalConnection,
-    input: CreateTerminalRequest,
-  ): Promise<TerminalRecord>;
-  closeTerminal(connection: TerminalConnection, terminalId: string): Promise<void>;
-  isMissingTerminalError(error: unknown): boolean;
-}
-
-type CreateTerminalDeps =
-  TerminalRuntimeDeps
-  & Pick<TerminalRecordAccessDeps, "createTerminal">
-  & TerminalCacheDeps;
-```
-
-Each workflow should receive only the capabilities it uses. Avoid one giant
-`TerminalEverythingDeps` or `PromptOutboxEverythingDeps` object. If a workflow
-needs a very large dependency type, split the workflow into smaller substeps or
-keep the owning hook as the readable orchestrator.
-
-Use one workflow file per cohesive family at first:
-
-```text
-lib/workflows/terminals/
-  terminal-record-workflows.ts
-  terminal-stream-workflows.ts
-```
-
-Split into per-action files only when a family file becomes too large or mixes
-unrelated ownership:
-
-```text
-lib/workflows/terminals/
-  create-terminal-workflow.ts
-  close-terminal-workflow.ts
-```
-
-Example shape:
-
-```ts
-export async function createWorkspaceWorkflow(input, deps) {
-  const workspace = await deps.createWorkspace(input.workspace);
-  const session = await deps.createSession({ workspaceId: workspace.id });
-  deps.activateWorkspace({ workspaceId: workspace.id, sessionId: session.id });
-  return { workspace, session };
-}
-```
-
-Another example:
-
-```ts
-export async function closeTerminalWorkflow(input, deps) {
-  const blockedReason = deps.getBlockReason(input.workspaceId);
-  if (blockedReason) {
-    deps.showToast(blockedReason);
-    return "blocked";
-  }
-
-  try {
-    await deps.closeTerminal(input.terminalId, input.workspaceId);
-    deps.clearTerminalState(input.terminalId, input.workspaceId);
-    return "closed";
-  } finally {
-    await deps.invalidateTerminals(input.workspaceId);
-  }
-}
-```
-
-The corresponding hook wires the dependencies:
-
-```ts
-export function useCreateWorkspaceActions() {
-  const createWorkspace = useCreateWorkspaceMutation();
-  const createSession = useCreateSessionMutation();
-  const activateWorkspace = useSelectionStore((state) => state.activateWorkspace);
-
-  return {
-    create: (input) => createWorkspaceWorkflow(input, {
-      createWorkspace: createWorkspace.mutateAsync,
-      createSession: createSession.mutateAsync,
-      activateWorkspace,
-    }),
-  };
-}
-```
+See [access.md](access.md) for the concrete system map.
 
 ## `lib/infra/**`
 
-Generic technical machinery that does not care about product domains.
+Generic technical machinery with no product-domain vocabulary.
 
-Examples:
+Owns:
 
 - persistence helpers
-- scheduling and batching
-- ids and stable key helpers
+- scheduling, batching, and timers
+- ids and stable keys
 - measurement plumbing
 - safe JSON parsing
 - logging utilities
 
-If a function knows about chats, sessions, workspaces, agents, billing, or
-repositories, it is not infra.
+If a function knows about chats, sessions, workspaces, agents, billing,
+repositories, or prompts, it is not infra.
 
-Target shape:
+Shape:
 
 ```text
-lib/infra/
-  persistence/
-  scheduling/
-  measurement/
-  ids/
-  logging/
+lib/infra/<technical-concern>/<helper>.ts
 ```
-
-Organize infra by technical mechanism, not by product domain.

--- a/docs/frontend/guides/state.md
+++ b/docs/frontend/guides/state.md
@@ -4,210 +4,137 @@ Use the smallest state owner that can solve the problem.
 
 ## Local State
 
-Use component state for local presentational concerns that only one subtree
-needs: open/closed menus, hover state, temporary input state, local measurement,
-or drag state.
+Use component state for local presentation state that only one subtree needs:
+menus, hover, temporary input, local measurement, drag state, and one-off
+visibility toggles.
 
-Do not lift state unless two siblings need to share it.
+Lift state only when another component needs to read or write the same state.
 
 ## Stores
 
-Zustand stores hold shared client-only state: selected ids, active panels,
-drafts, resize state, local UI preferences, and approved local runtime/editor
-state.
-
-Path:
+Zustand stores hold shared client-only state.
 
 ```text
 stores/<domain>/<concern>-store.ts
 ```
 
-Store rules:
+Owns:
 
-- Always use selectors: `useStore((state) => state.field)`.
-- Use `useShallow` when selecting multiple fields into an object.
-- Store setters should be single `set()` calls.
-- Stores do not call APIs, query invalidation, navigation, telemetry, toasts,
-  or other stores.
-- Stores do not own persistence bootstrap or persistence subscriptions.
-- If an operation needs multiple store writes or coordinates with React Query,
-  it belongs in a workflow hook.
-- Pure domain helpers do not belong in store files.
+- selected ids
+- active panels and tabs
+- drafts
+- resize/editor/runtime UI state
+- local preferences
+- synchronous multi-field local invariants
 
-Stores should expose simple verbs such as `setActiveSessionId`, `patchDraft`,
-or `clearSelection`. Avoid verbs that imply orchestration, such as `submit`,
-`sync`, `load`, `refresh`, or `bootstrap`.
-
-Atomic local transactions are allowed. A setter such as `activateWorkspace`
-may update several fields when those fields form one local invariant and the
-operation is synchronous with no external side effects. Do not move atomic
-local state transitions to `lib/workflows/**` just because they touch multiple
-fields.
-
-Dangerous primitive setters need narrow names or comments. If a setter updates
-one piece of a larger invariant, such as a selected id without clearing related
-state, either expose a more specific intent method or mark the primitive as
-internal to lifecycle/workflow code.
-
-### Store Persistence
-
-Persistence belongs outside the store file. Stores should not export
-`bootstrapX()`, call `readPersistedValue`, call `persistValue`, or subscribe to
-themselves at module scope.
-
-Target shape:
-
-```text
-stores/<domain>/<concern>-store.ts
-hooks/<domain>/lifecycle/use-<concern>-lifecycle.ts
-```
-
-The lifecycle hook owns:
-
-- loading persisted state on mount
-- hydrating the store
-- subscribing after hydration
-- persisting selected store slices
-- cleaning up subscriptions on unmount
-
-Stores with persisted metadata should make that metadata explicit local state,
-not module-level mutable state:
-
-```ts
-_hydrated: boolean;
-_persistedMetadata: PersistedXMetadata;
-hydrate(...);
-setPersistedMetadata(...);
-```
-
-`hydrate` and metadata setters are internal. UI code should call user-facing
-setters such as `set` or `setMultiple`; lifecycle/workflow hooks call the
-internal hydration and metadata methods.
-
-Do not create generic persistence infrastructure on the first cleanup. Build
-one or two concrete lifecycle hooks first. Generalize only after the repeated
-shape is clear.
-
-Keep read normalization and write eligibility separate. A value may normalize
-to `null` when loaded from disk but still be skipped, not overwritten, when it
-appears in live UI state. For example, transient pending workspace ids should
-not replace the last persisted stable workspace id.
-
-### Store Cleanup Playbook
-
-When cleaning a store, move ownership violations in this order:
-
-1. Move async bootstrap, persistence reads/writes, and subscriptions to a
-   lifecycle hook.
-2. Move timers, waits, listeners, and retry loops to lifecycle/workflow hooks.
-3. Move pure normalization, equality, migration, persisted-slice selection,
-   and index helpers to `lib/domain/<domain>/<subdomain>/**` once they are
-   non-trivial or make the store hard to read.
-4. Keep synchronous multi-field local transactions in the store when they
-   preserve one local invariant.
-5. Split the store only when ownership is mixed; do not split only because the
-   store contains legitimate local state transitions.
-
-Examples:
-
-- `user-preferences-store`: persistence bootstrap and metadata adoption move to
-  lifecycle/workflow hooks; persisted metadata becomes explicit store state.
-- `session-selection-store`: persisted selected workspace loading/saving moves
-  to a lifecycle hook; pure hot-paint helpers move to domain logic.
-- `repo-preferences-store`: persisted repo config loading/saving moves to a
-  lifecycle hook while `setRepoConfig` remains a local state transaction.
-
-### Store Facades
-
-Cross-store facades are allowed only as local state adapters. Use them when a
-domain has split stores but callers need one narrow way to read or patch the
-local state model.
-
-Allowed:
-
-- read from multiple stores
-- write to multiple stores with simple local setters
-- hide storage layout during a store split
-- expose local state helpers with no remote side effects
-
-Not allowed:
+Must not own:
 
 - API calls
 - React Query invalidation or cache writes
 - navigation
 - telemetry
 - toasts
-- timers, streams, or subscriptions
+- persistence bootstrap/subscriptions
+- timers, listeners, streams, or retry loops
+- cross-store/product workflows
+
+Rules:
+
+- Always use selectors: `useStore((state) => state.field)`.
+- Use `useShallow` when selecting multiple fields into an object.
+- Store setters should be single `set()` calls.
+- Name setters as local state intents, such as `setActiveSessionId`,
+  `patchDraft`, or `clearSelection`.
+- Avoid setter names that imply orchestration, such as `submit`, `sync`,
+  `load`, `refresh`, or `bootstrap`.
+- Non-trivial normalization, equality, schema upgrade, and indexing helpers
+  live in `lib/domain/**`.
+
+## Store Persistence
+
+Persistence belongs outside the store file.
+
+```text
+stores/<domain>/<concern>-store.ts
+hooks/<domain>/lifecycle/use-<concern>-lifecycle.ts
+```
+
+The lifecycle hook owns loading, hydration, subscriptions, writes, and teardown.
+The store may expose explicit hydration metadata such as `_hydrated` or
+`_persistedMetadata`, but UI code should use normal user-facing setters.
+
+Keep read normalization and write eligibility separate. A loaded value may
+normalize to `null` without meaning live transient state should overwrite the
+last persisted stable value.
+
+## Store Facades
+
+Cross-store facades are allowed only as local state adapters.
+
+Allowed:
+
+- read from multiple stores
+- write to multiple stores with simple local setters
+- hide storage layout during a store split
+
+Not allowed:
+
+- API calls
+- query invalidation or cache writes
+- navigation, telemetry, or toasts
+- timers, streams, subscriptions, or wait loops
 - raw client construction
 
-If a facade starts coordinating external work or product sequences, move that
-logic to a workflow hook or `lib/workflows/**`.
-
-Facades may coordinate local reads and synchronous writes, but they must not
-wait for state changes, set timeouts, install listeners, or subscribe for
-completion. Wait-or-timeout behavior belongs in a lifecycle hook, workflow
-hook, or explicitly dependency-injected `lib/workflows/**` function.
+If a facade coordinates external work or product sequencing, move that logic to
+a workflow hook or `lib/workflows/**`.
 
 ## Remote State
 
-TanStack Query owns authoritative remote state from cloud, AnyHarness, and
+TanStack Query owns authoritative remote state from Cloud, AnyHarness, and
 other external systems.
 
-Path:
-
 ```text
-hooks/access/<system>/**       # app-owned query and mutation hooks
+hooks/access/<system>/**       # app-owned query/mutation hooks
 @anyharness/sdk-react          # generic AnyHarness query/mutation hooks
+@proliferate/cloud-sdk-react   # generic Cloud query/mutation hooks
+product-surfaces               # shared Desktop/Web Cloud surfaces
 ```
 
 - Do not copy refetchable server/runtime data into Zustand as a cache.
-- Access hooks own query keys, queries, mutations, invalidation, and retry
-  policy.
-- Use generated response types or SDK types as the source of truth for remote
+- Access hooks own query keys, queries, mutations, invalidation, cache shape,
+  and retry policy.
+- Product workflow hooks may request refresh/update through access-owned
+  callbacks; they should not construct query keys or write cache objects
+  directly.
+- Generated response types or SDK types are the source of truth for remote
   transport shapes.
-- Product workflow hooks may decide that remote state needs refreshing or
-  updating, but access hooks own the query keys and cache shape. Product
-  workflow hooks should call access-owned callbacks instead of constructing
-  query keys or writing cache objects directly.
 
 ## Providers
 
-Providers define scoped dependencies and app boundaries: query client, auth,
-telemetry, theme, runtime context, or a subtree-specific service.
-
-Path:
+Providers define scoped dependencies and app/subtree boundaries.
 
 ```text
 providers/<ProviderName>.tsx
 providers/<domain>/<ProviderName>.tsx
 ```
 
-Use a provider when consumers need a scoped dependency or context value that
-should not be globally addressable through a store.
+Use providers for query clients, auth, telemetry, theme, runtime context, and
+subtree-specific services. Do not use providers as a general mutable state
+store.
 
-Provider rules:
+Provider values that are objects or callback bundles should be stable.
 
-- Keep provider values small and stable.
-- `useMemo` provider values that are objects or callback bundles.
-- Do not use providers as a generic state store.
-- Do not stack providers casually; each provider should represent a real
-  boundary.
+## Derived State
 
-Derived UI state belongs in components for trivial expressions or
-`hooks/<domain>/derived/**` for non-trivial composition. Do not store derived
-values in Zustand.
-
-## Reference Stability
+Do not store derived values in Zustand. Use component expressions for trivial
+derived state and `hooks/<domain>/derived/**` for non-trivial composition.
 
 Avoid inline fallback defaults in query destructuring:
 
 ```ts
 const EMPTY_ITEMS: Item[] = [];
-
 const { data: items = EMPTY_ITEMS } = useItems();
 ```
 
-Inline defaults like `{ data: items = [] }` create new references while loading
-and break downstream `useMemo`, `React.memo`, and shallow comparisons.
-
-The same rule applies to object defaults.
+Inline object/array defaults create new references while loading and break
+`useMemo`, `React.memo`, and shallow comparisons.

--- a/docs/frontend/guides/styling.md
+++ b/docs/frontend/guides/styling.md
@@ -2,10 +2,11 @@
 
 Scope:
 
-- `desktop/src/**`
-- `web/src/**`
-- shared DOM styling under `packages/design/**`, `packages/ui/**`, and
-  `packages/product-ui/**`
+- `apps/desktop/src/**`
+- `apps/web/src/**`
+- `apps/mobile/src/**`
+- shared styling under `apps/packages/design/**`, `apps/packages/ui/**`,
+  `apps/packages/product-ui/**`, and `apps/packages/product-surfaces/**`
 
 This file covers styling-only rules. Read
 [README.md](../README.md) for structure, ownership, and data-flow guidance.
@@ -27,14 +28,12 @@ supported themes instead of dropping palette classes into a component.
 
 Shared token ownership:
 
-- `packages/design/src/tokens.ts` owns serializable cross-client token values.
-- `packages/design/dist/theme.css` is generated from those tokens and exposes
+- `apps/packages/design/src/tokens.ts` owns serializable cross-client token
+  values.
+- `apps/packages/design/dist/theme.css` is generated from those tokens and exposes
   shared CSS theme variables plus shared non-product animation utilities for
-  Desktop/Web. Do not hand-edit generated theme output. Desktop currently
-  imports this generated CSS while still owning its full product theme presets
-  in `desktop/src/index.css`; moving those presets into generated shared tokens
-  is a later migration, not part of the foundation package.
-- `packages/design/src/dom.css` owns the shared Desktop/Web DOM entrypoint:
+  Desktop/Web. Do not hand-edit generated theme output.
+- `apps/packages/design/src/dom.css` owns the shared Desktop/Web DOM entrypoint:
   Tailwind setup, shared package `@source` entries, shared reset/root/body
   defaults, shared scrollbar utilities, and shared Proliferate global classes.
   Apps import this as `@proliferate/design/dom.css`.
@@ -42,10 +41,10 @@ Shared token ownership:
   under `[data-proliferate-client="desktop"]` or
   `[data-proliferate-client="web"]`.
 - Desktop keeps Desktop-only global CSS, third-party overrides, and theme
-  runtime behavior in `desktop/src/**`.
+  runtime behavior in `apps/desktop/src/**`.
 - Third-party dependency CSS, such as `@xterm/xterm/css/xterm.css`, is imported
   by the owning app directly. Do not put third-party dependency CSS in
-  `packages/design`.
+  `apps/packages/design`.
 - Mobile consumes React Native-safe values from
   `@proliferate/design/react-native`, not DOM CSS.
 
@@ -160,7 +159,16 @@ the tokens.
 
 ## UI Primitives First
 
-Outside `components/ui/**`, do not render raw:
+In DOM apps/packages, `apps/packages/ui/**` owns the primitive visual contract.
+Do not define primitive components outside that folder.
+
+Forbidden outside `apps/packages/ui/**`:
+
+- defining a local `Button`, `IconButton`, `Input`, `Dialog`, `Menu`, `Select`,
+  `Tabs`, `Tooltip`, `Badge`, layout shell, or equivalent lookalike
+- wrapping raw DOM controls in a reusable locally styled primitive
+- restyling raw controls at callsites to mimic a primitive
+- rendering raw controls directly:
 
 - `<button>`
 - `<input>`
@@ -168,16 +176,18 @@ Outside `components/ui/**`, do not render raw:
 - `<select>`
 - `<textarea>`
 
-Use an existing primitive when possible. If the visual treatment is genuinely
-new, extend the primitive cleanly or add a new dedicated primitive in
-`components/ui/**`.
+If a visual treatment is missing, extend the primitive API or add a dedicated
+primitive in `apps/packages/ui/**`. Callsite classes may handle layout,
+spacing, and sizing; primitives own color, border, radius, typography, focus,
+hover, disabled, and loading states.
 
-When using primitives from `packages/ui/**` or shared product components from
-`packages/product-ui/**`, import `@proliferate/design/dom.css`; that shared
-entrypoint owns the Tailwind package source scanning.
+When using primitives from `apps/packages/ui/**`, shared product components
+from `apps/packages/product-ui/**`, or connected surfaces from
+`apps/packages/product-surfaces/**`, import `@proliferate/design/dom.css`;
+that shared entrypoint owns the Tailwind package source scanning.
 
-Reusable icons belong in `components/ui/icons.tsx`, not inline inside feature
-components.
+Reusable icons belong in app/package primitive icon modules, not inline inside
+feature components.
 
 ## Callsite Styling
 
@@ -211,7 +221,8 @@ Global CSS is for:
 Component-specific styling belongs with the component or primitive, not in
 `index.css`.
 
-App stylesheets should be import-only where possible. `web/src/index.css`
-imports only `@proliferate/design/dom.css`. `desktop/src/index.css` imports
-the shared DOM entrypoint plus Desktop-owned third-party CSS and remaining
-legacy Desktop-specific theme/runtime CSS.
+App stylesheets should be import-only where possible. `apps/web/src/index.css`
+imports only `@proliferate/design/dom.css`. `apps/desktop/src/index.css`
+imports the shared DOM entrypoint plus Desktop-owned third-party CSS and
+Desktop-specific theme/runtime CSS. Mobile uses `apps/mobile/src/styles/**`
+and `@proliferate/design/react-native`, not DOM CSS.

--- a/docs/frontend/guides/telemetry.md
+++ b/docs/frontend/guides/telemetry.md
@@ -1,7 +1,7 @@
 # Frontend Telemetry Standards
 
-Status: authoritative for frontend telemetry in `desktop/src/**`, `web/src/**`,
-and `mobile/src/**`.
+Status: authoritative for frontend telemetry in `apps/desktop/src/**`,
+`apps/web/src/**`, and `apps/mobile/src/**`.
 
 Use this doc for analytics events, exception capture, anonymous telemetry,
 session replay, and telemetry-related provider and hook ownership.
@@ -29,9 +29,9 @@ session replay, and telemetry-related provider and hook ownership.
 - `trackProductEvent(...)` remains the frontend fanout seam. Hooks continue to
   emit typed product events, and the telemetry client decides whether they go to
   vendor telemetry, anonymous telemetry, or both.
-- Web and mobile do not yet use the desktop typed product-event catalog. Their
-  current PostHog telemetry is limited to coarse route/screen events plus
-  hosted authenticated identity sync.
+- Web and Mobile telemetry stays coarse unless a typed product event is added:
+  route/screen events, hosted authenticated identity sync, and reviewed product
+  events only.
 - Vendor telemetry is enabled only in `hosted_product`.
 - Anonymous telemetry may be enabled in all runtime modes unless explicitly
   disabled.
@@ -53,9 +53,9 @@ session replay, and telemetry-related provider and hook ownership.
   `lib/domain/telemetry/events.ts`.
 - Event names should stay stable when possible. Prefer changing payload shape
   and ownership over renaming events.
-- Hosted-product PostHog should stay intentionally allowlisted. If an event is
-  not in the vendor allowlist, it may still produce Sentry breadcrumbs without
-  becoming a PostHog event.
+- Hosted-product PostHog events should stay explicitly permitted. If an event
+  is not permitted for the vendor backend, it may still produce Sentry
+  breadcrumbs without becoming a PostHog event.
 - Event payloads must be low-risk and structured: enums, booleans, counts,
   versions, provider kinds, workspace kind, and similar fields.
 - Do not send prompts, transcript content, terminal output, file contents,

--- a/docs/frontend/packages/README.md
+++ b/docs/frontend/packages/README.md
@@ -1,0 +1,240 @@
+# Frontend Packages
+
+Status: authoritative for shared frontend package ownership.
+
+## Scope
+
+- `apps/packages/design/**`
+- `apps/packages/ui/**`
+- `apps/packages/product-domain/**`
+- `apps/packages/product-ui/**`
+- `apps/packages/product-surfaces/**`
+
+Use app-local code first. Put code in a package only when shared ownership
+makes Desktop/Web/Mobile easier to keep in sync.
+
+## Package Map
+
+| Package | Owns | May Import | Must Not Import |
+| --- | --- | --- | --- |
+| `design` | Shared tokens, DOM CSS, React Native-safe token values. | Token/build tooling. | Product concepts, app code, SDK clients, hooks, stores. |
+| `ui` | Canonical Desktop/Web DOM primitives and layout components. | `design`, React, DOM-safe libraries. | Product concepts, app code, SDK clients, hooks, stores, Tauri, React Native. |
+| `product-domain` | Pure shared product rules, vocabulary, validation, projections, and view models. | Generated/SDK contract types, pure utilities. | React, DOM, React Native components, SDK clients, query clients, stores, app code, raw access. |
+| `product-ui` | Shared Desktop/Web product presentation by domain and surface. Props in, callbacks out. | `design`, `ui`, `product-domain`, React, DOM-safe rendering libraries. | SDK clients, access helpers, query hooks, stores, routes, Tauri, AnyHarness runtime wiring, React Native, custom primitive redefinitions. |
+| `product-surfaces` | Shared connected Desktop/Web Cloud surfaces with SDK/query wiring and product UI composition. | Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, `design`. | Desktop/Web app internals, Tauri, AnyHarness runtime wiring, app stores, app routes, React Native, custom primitive redefinitions. |
+
+## Package Shape
+
+```text
+apps/packages/
+  design/
+    src/
+      tokens.ts
+      dom.css
+      react-native.ts
+
+  ui/
+    src/
+      layout/
+      primitives/
+
+  product-domain/
+    src/
+      <domain>/
+
+  product-ui/
+    src/
+      <domain>/
+        <surface>/
+
+  product-surfaces/
+    src/
+      <domain>/
+        <surface>/
+```
+
+## Dependency Direction
+
+```text
+apps
+  -> product-surfaces
+  -> product-ui
+  -> ui
+  -> design
+
+apps
+  -> product-domain
+product-surfaces -> product-domain
+product-ui -> product-domain
+```
+
+Mobile may import `design/react-native`, `product-domain`, and SDK packages.
+Mobile must not import DOM packages: `ui`, `product-ui`, or
+`product-surfaces`.
+
+## DOM UI Contract
+
+`apps/packages/ui/**` is the single DOM primitive system for Desktop, Web,
+`product-ui`, and `product-surfaces`.
+
+Hard invariant: no DOM primitive component may be defined outside
+`apps/packages/ui/**`.
+
+A primitive component is any generic reusable control, shell, or low-level UI
+building block, including a wrapper around a raw DOM control. This applies even
+when the component has a different name but still behaves like a local button,
+input, dialog, menu, tab, tooltip, badge, or layout primitive.
+
+Primitives that belong in `ui`:
+
+- `Button`, `IconButton`, button groups
+- `Input`, `Textarea`, `Label`, `Select`
+- `Checkbox`, `Switch`, radio controls
+- `Tabs`, segmented controls
+- `Menu`, `Popover`, `Tooltip`
+- `Dialog`, modal shells, confirmation dialogs
+- badges, pills, separators, scroll areas, layout shells
+
+Rules:
+
+- Do not define primitive components in `apps/desktop/src/**`,
+  `apps/web/src/**`, `apps/packages/product-ui/**`, or
+  `apps/packages/product-surfaces/**`.
+- Do not define a second button/input/dialog/menu/select/tabs primitive with a
+  different name.
+- Do not restyle raw DOM controls at callsites to mimic a primitive.
+- Do not render raw `<button>`, `<input>`, `<label>`, `<select>`, or
+  `<textarea>` outside `apps/packages/ui/**`.
+- If the primitive needs a new size, tone, density, icon position, loading
+  state, destructive state, or layout mode, add that API to `ui` first.
+- Callsite classes may handle layout and spacing. The primitive owns color,
+  border, radius, typography, focus, hover, disabled, and loading behavior.
+- `product-ui` composes `ui` primitives with product view models.
+- `product-surfaces` composes Cloud SDK React hooks, `product-ui`, and `ui`
+  primitives. It does not create its own primitive layer.
+- Mobile has a separate native component layer and does not import DOM
+  primitives.
+- Primitive definitions outside `apps/packages/ui/**` violate this standard.
+  Do not add them or copy them; put them in `ui`.
+
+## When To Share
+
+- Put a rule in `product-domain` when the same product decision or view
+  model is needed by more than one app.
+- Put a component in `product-ui` when Desktop and Web should render the
+  same product presentation and data/callback props are enough.
+- Put a surface in `product-surfaces` when Desktop and Web should share the
+  same connected Cloud CRUD surface, including SDK React hooks and mutation
+  wiring.
+- Keep code app-local when it depends on Tauri, local AnyHarness runtime
+  selection, native mobile navigation/storage, browser route state, app-local
+  stores, or one-off UI.
+
+## Package Rules
+
+- Use concrete export-map subpaths such as
+  `@proliferate/ui/primitives/Button`; do not add barrels.
+- Package code must not import app code through `@/` or relative paths into an
+  app.
+- Package code must not import app stores, app providers, app routes, Tauri
+  wrappers, or local AnyHarness runtime wiring unless the package table above
+  explicitly allows it.
+- Do not add `shared`, `common`, `types`, or `utils` buckets.
+- Name package files for the rule, primitive, component, or surface they own.
+- Tests live with shared logic when the logic is meaningful or risky.
+- If sharing requires many app-specific branches, keep the code app-local and
+  extract only the pure `product-domain` rule.
+
+## Responsibilities
+
+### `design`
+
+Owns serializable design values and generated CSS.
+
+```text
+apps/packages/design/src/tokens.ts
+apps/packages/design/src/dom.css
+apps/packages/design/src/react-native.ts
+apps/packages/design/dist/theme.css
+```
+
+Do not put product copy, product status colors, route concepts, or component
+behavior here.
+
+May import token source files and build tooling. Must not import React, app
+code, SDK clients, stores, providers, query clients, or product concepts.
+
+### `ui`
+
+Owns canonical DOM primitives.
+
+```text
+apps/packages/ui/src/primitives/**
+apps/packages/ui/src/layout/**
+```
+
+Use this for reusable controls and layout helpers with no Proliferate product
+concepts. This is where primitive variants are added; apps and product
+packages consume those variants instead of redefining primitives locally.
+
+May import `design`, React, and DOM-safe libraries. Must not import product
+concepts, app code, SDK clients, hooks, stores, Tauri, or React Native.
+
+### `product-domain`
+
+Owns pure product rules and view models.
+
+```text
+apps/packages/product-domain/src/<domain>/**
+```
+
+This is the primary sharing point for Mobile. If Mobile and Web need the same
+behavior, share the rule here and render it separately in native and DOM UI.
+
+May import generated or SDK types only when they are contract shapes. Must not
+import SDK clients, SDK React hooks, React, DOM components, React Native
+components, app code, stores, query clients, or access helpers.
+
+### `product-ui`
+
+Owns Desktop/Web DOM product components.
+
+```text
+apps/packages/product-ui/src/<domain>/<surface>/<Component>.tsx
+```
+
+Use this for product-specific rows, cards, panes, chat pieces, settings
+sections, account/billing views, and other shared Desktop/Web presentation.
+It must compose `ui` primitives for controls and must not create local
+primitive lookalikes.
+
+May import `design`, `ui`, `product-domain`, React, and DOM-safe rendering
+libraries. Must not import SDK clients, SDK React hooks, access helpers, app
+stores, app providers, app routes, Tauri, local AnyHarness runtime wiring, or
+React Native.
+
+Components here are UI-only: data in, callbacks out. If the component needs
+query/mutation state, client construction, route state, or app store state, it
+does not belong in `product-ui`.
+
+### `product-surfaces`
+
+Owns fully connected Desktop/Web Cloud surfaces.
+
+```text
+apps/packages/product-surfaces/src/<domain>/<surface>/**
+```
+
+A surface may call shared Cloud SDK React hooks and render `product-ui`.
+App-specific routing, shell placement, Tauri/AnyHarness access, app stores,
+telemetry wiring, and native mobile UI stay outside. Base controls still come
+from `ui`.
+
+May import Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, and
+`design`. Must not import Desktop/Web app internals, app stores, app providers,
+app routes, Tauri, local AnyHarness runtime wiring, or React Native.
+
+Use this for shared connected Cloud surfaces where duplicating SDK/query wiring
+in Desktop and Web would make the product harder to keep consistent. Do not
+put Desktop-only runtime access, local workspace logic, or app shell behavior
+in `product-surfaces`; pass app-specific callbacks or adapters from the app.


### PR DESCRIPTION
## Summary
- codify shared Desktop/Web/Mobile frontend folder ownership
- add explicit package ownership rules for design, ui, product-domain, product-ui, and product-surfaces
- tighten hook, access, state, lib, styling, and telemetry guide language into steady-state rules

## Verification
- git diff --check