### PR TITLE
feat(mobile): refine chat configuration controls

### DIFF
--- a/apps/mobile/src/components/chat/MobileChatScreen.tsx
+++ b/apps/mobile/src/components/chat/MobileChatScreen.tsx
@@ -68,6 +68,7 @@ import {
   type RecentWorkRuntimeLocation,
 } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
 
+import { useVisualViewportKeyboardInset } from "../../hooks/ui/keyboard/use-visual-viewport-keyboard-inset";
 import { MobileIcon, type MobileIconName } from "../primitives/MobileIcon";
 import { MobileStatusDot } from "../primitives/MobileStatusDot";
 import { MobileTextInput } from "../primitives/MobileTextInput";
@@ -143,6 +144,7 @@ export function MobileChatScreen({
   onInitialPendingPromptConsumed,
   onSessionSelected,
 }: MobileChatScreenProps) {
+  const keyboardInset = useVisualViewportKeyboardInset();
   const queryClient = useQueryClient();
   const client = useCloudClient();
   const agentCatalog = useCloudAgentCatalog();
@@ -1456,7 +1458,7 @@ export function MobileChatScreen({
         }
       />
 
-      <View style={styles.composer}>
+      <View style={[styles.composer, keyboardInset > 0 && { marginBottom: keyboardInset }]}>
         <View style={styles.composerCard}>
           <MobileTextInput
             multiline
@@ -2992,10 +2994,10 @@ const styles = StyleSheet.create({
   configLinkText: {
     flexShrink: 1,
     minWidth: 0,
-    color: colors.faint,
-    fontSize: 13.5,
-    lineHeight: 18,
-    fontWeight: "600",
+    color: colors.mutedForeground,
+    fontSize: 14,
+    lineHeight: 19,
+    fontWeight: "400",
     includeFontPadding: false,
   },
   send: {

--- a/apps/mobile/src/components/home/MobileHomeScreen.tsx
+++ b/apps/mobile/src/components/home/MobileHomeScreen.tsx
@@ -21,6 +21,7 @@ import {
 
 import { useMobileHomeLaunchModel } from "../../hooks/home/derived/use-mobile-home-launch-model";
 import { useMobileHomeLaunchActions } from "../../hooks/home/workflows/use-mobile-home-launch-actions";
+import { useVisualViewportKeyboardInset } from "../../hooks/ui/keyboard/use-visual-viewport-keyboard-inset";
 import { useMobileWorkInventory } from "../../hooks/work/derived/use-mobile-work-inventory";
 import type { MobileRuntimeOption } from "../../lib/domain/home/mobile-home-launch";
 import type { MobileCloudChat } from "../../navigation/navigation-model";
@@ -50,6 +51,7 @@ export function MobileHomeScreen({
   onOpenDrawer,
   onConfigureRepos,
 }: MobileHomeScreenProps) {
+  const keyboardInset = useVisualViewportKeyboardInset();
   const [draft, setDraft] = useState("");
   const [sheet, setSheet] = useState<HomeSheet>(null);
   const launchModel = useMobileHomeLaunchModel();
@@ -142,7 +144,7 @@ export function MobileHomeScreen({
         </Text>
       ) : null}
 
-      <View style={styles.composer}>
+      <View style={[styles.composer, keyboardInset > 0 && { marginBottom: keyboardInset }]}>
         <View style={styles.composerCluster}>
           <View style={styles.selectorRow}>
             <Pressable
@@ -625,23 +627,23 @@ const styles = StyleSheet.create({
     minHeight: 40,
     flexDirection: "row",
     alignItems: "center",
-    gap: spacing[2],
+    gap: spacing[1],
     borderRadius: radius.full,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: colors.border,
     backgroundColor: colors.card,
-    paddingHorizontal: spacing[3],
+    paddingHorizontal: spacing[2],
     overflow: "hidden",
   },
   repoPillWide: {
-    flex: 1,
     flexShrink: 1,
     minWidth: 0,
+    maxWidth: "68%",
   },
   branchPill: {
-    width: 148,
-    maxWidth: "42%",
-    flexShrink: 0,
+    minWidth: 92,
+    maxWidth: "36%",
+    flexShrink: 1,
   },
   disabledPill: {
     opacity: 0.55,
@@ -703,10 +705,10 @@ const styles = StyleSheet.create({
   configLinkText: {
     flexShrink: 1,
     minWidth: 0,
-    color: colors.faint,
-    fontSize: 13.5,
-    lineHeight: 18,
-    fontWeight: "600",
+    color: colors.mutedForeground,
+    fontSize: 14,
+    lineHeight: 19,
+    fontWeight: "400",
     includeFontPadding: false,
   },
   send: {

--- a/apps/mobile/src/hooks/ui/keyboard/use-visual-viewport-keyboard-inset.ts
+++ b/apps/mobile/src/hooks/ui/keyboard/use-visual-viewport-keyboard-inset.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { Platform } from "react-native";
+
+const MIN_SOFT_KEYBOARD_INSET = 80;
+
+export function useVisualViewportKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    if (Platform.OS !== "web" || typeof window === "undefined") {
+      return;
+    }
+
+    const viewport = window.visualViewport;
+    if (!viewport) {
+      return;
+    }
+    const visualViewport = viewport;
+
+    let frame: number | null = null;
+    let lastInset = -1;
+
+    function readInset() {
+      const nextInset = calculateKeyboardInset(visualViewport);
+      if (nextInset === lastInset) {
+        return;
+      }
+      lastInset = nextInset;
+      setInset(nextInset);
+    }
+
+    function scheduleRead() {
+      if (frame !== null) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        readInset();
+      });
+    }
+
+    readInset();
+    visualViewport.addEventListener("resize", scheduleRead);
+    visualViewport.addEventListener("scroll", scheduleRead);
+    window.addEventListener("resize", scheduleRead);
+    window.addEventListener("orientationchange", scheduleRead);
+
+    return () => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+      visualViewport.removeEventListener("resize", scheduleRead);
+      visualViewport.removeEventListener("scroll", scheduleRead);
+      window.removeEventListener("resize", scheduleRead);
+      window.removeEventListener("orientationchange", scheduleRead);
+    };
+  }, []);
+
+  return inset;
+}
+
+function calculateKeyboardInset(viewport: VisualViewport): number {
+  const layoutHeight = Math.max(window.innerHeight, document.documentElement.clientHeight);
+  const viewportBottom = viewport.offsetTop + viewport.height;
+  const rawInset = Math.max(0, layoutHeight - viewportBottom);
+
+  if (rawInset < MIN_SOFT_KEYBOARD_INSET) {
+    return 0;
+  }
+
+  return Math.round(rawInset);
+}


### PR DESCRIPTION
## Summary

- Move mobile chat/workspace controls into a bottom-sheet configuration surface.
- Add runtime context into the composer summary on chat and home.
- Show the session count fused next to the workspace actions button in the chat header.

## PR Metadata

- release:minor-feature
- area:product

## Verification

- pnpm --filter @proliferate/mobile typecheck
- Verified locally in the in-app browser at http://localhost:5254/