### PR TITLE
refactor(anyharness): thin workspace and agent HTTP handlers

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/agents.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agents.rs
@@ -11,18 +11,17 @@ use axum::{
 };
 
 use crate::app::AppState;
-use crate::domains::agents::installer::{
-    self, InstallError, InstallOptions, InstalledArtifactResult,
-};
+use crate::domains::agents::installer::{InstallError, InstalledArtifactResult};
 use crate::domains::agents::model::*;
-use crate::domains::agents::readiness::resolver::resolve_agent;
 use crate::domains::agents::reconcile::execution::{
     AgentReconcileJobSnapshot, AgentReconcileJobStatus,
 };
 use crate::domains::agents::reconcile::{
     AgentReconcileOutcome, AgentReconcileResult as InternalAgentReconcileResult,
 };
-use crate::domains::agents::registry::built_in_registry;
+use crate::domains::agents::runtime::{
+    AgentInstallRequest as DomainInstallAgentRequest, AgentRuntimeError,
+};
 
 type ProblemResponse = (StatusCode, Json<ProblemDetails>);
 
@@ -57,6 +56,25 @@ fn agent_not_found(kind: &str) -> ProblemResponse {
     )
 }
 
+fn agent_runtime_error_to_problem(error: AgentRuntimeError) -> ProblemResponse {
+    match error {
+        AgentRuntimeError::NotFound(kind) => agent_not_found(&kind),
+        AgentRuntimeError::LoginNotSupported(kind) => problem(
+            400,
+            "Login not supported",
+            Some(format!("Agent {kind} does not support native login")),
+            Some("LOGIN_NOT_SUPPORTED"),
+        ),
+        AgentRuntimeError::InstallTaskFailed(error) => problem(
+            500,
+            "Install failed",
+            Some(format!("Agent install task failed: {error}")),
+            Some("INSTALL_FAILED"),
+        ),
+        AgentRuntimeError::Install(error) => install_error_to_problem(error),
+    }
+}
+
 #[utoipa::path(
     get,
     path = "/v1/agents",
@@ -66,16 +84,11 @@ fn agent_not_found(kind: &str) -> ProblemResponse {
     tag = "agents"
 )]
 pub async fn list_agents(State(state): State<AppState>) -> Json<Vec<AgentSummary>> {
-    let registry = built_in_registry();
-    let reconcile_snapshot = state.agent_reconcile_service.snapshot().await;
-    let summaries: Vec<AgentSummary> = registry
+    let snapshot = state.agent_runtime.list_agents().await;
+    let summaries: Vec<AgentSummary> = snapshot
+        .agents
         .iter()
-        .map(|desc| {
-            to_summary(
-                &resolve_agent(desc, &state.runtime_home),
-                Some(&reconcile_snapshot),
-            )
-        })
+        .map(|agent| to_summary(agent, Some(&snapshot.reconcile_snapshot)))
         .collect();
     Json(summaries)
 }
@@ -94,16 +107,15 @@ pub async fn get_agent(
     State(state): State<AppState>,
     Path(kind): Path<String>,
 ) -> Result<Json<AgentSummary>, ProblemResponse> {
-    let registry = built_in_registry();
-    let desc = registry.iter().find(|d| d.kind.as_str() == kind);
-    let reconcile_snapshot = state.agent_reconcile_service.snapshot().await;
-    match desc {
-        Some(desc) => Ok(Json(to_summary(
-            &resolve_agent(desc, &state.runtime_home),
-            Some(&reconcile_snapshot),
-        ))),
-        None => Err(agent_not_found(&kind)),
-    }
+    let snapshot = state
+        .agent_runtime
+        .get_agent(&kind)
+        .await
+        .map_err(agent_runtime_error_to_problem)?;
+    Ok(Json(to_summary(
+        &snapshot.agent,
+        Some(&snapshot.reconcile_snapshot),
+    )))
 }
 
 #[utoipa::path(
@@ -124,82 +136,23 @@ pub async fn install_agent(
     Path(kind): Path<String>,
     Json(req): Json<InstallAgentRequest>,
 ) -> Result<Json<InstallAgentResponse>, ProblemResponse> {
-    let registry = built_in_registry();
-    let desc = registry.iter().find(|d| d.kind.as_str() == kind);
-    let desc = match desc {
-        Some(d) => d,
-        None => return Err(agent_not_found(&kind)),
-    };
-
-    let options = InstallOptions {
-        reinstall: req.reinstall,
-        native_version: req.native_version,
-        agent_process_version: req.agent_process_version,
-    };
-
-    tracing::info!(
-        agent = %kind,
-        reinstall = options.reinstall,
-        native_version = ?options.native_version,
-        agent_process_version = ?options.agent_process_version,
-        runtime_home = %state.runtime_home.display(),
-        "installing agent"
-    );
-
-    let install_runtime_home = state.runtime_home.clone();
-    let install_desc = desc.clone();
-    let install_options = options.clone();
-    let installed_artifacts = tokio::task::spawn_blocking(move || {
-        installer::install_agent(&install_desc, &install_runtime_home, &install_options)
-    })
-    .await
-    .map_err(|error| {
-        tracing::error!(
-            agent = %kind,
-            reinstall = options.reinstall,
-            native_version = ?options.native_version,
-            agent_process_version = ?options.agent_process_version,
-            runtime_home = %state.runtime_home.display(),
-            error = %error,
-            "agent install task failed"
-        );
-        problem(
-            500,
-            "Install failed",
-            Some(format!("Agent install task failed: {error}")),
-            Some("INSTALL_FAILED"),
+    let outcome = state
+        .agent_runtime
+        .install_agent(
+            &kind,
+            DomainInstallAgentRequest {
+                reinstall: req.reinstall,
+                native_version: req.native_version,
+                agent_process_version: req.agent_process_version,
+            },
         )
-    })?
-    .map_err(|error| {
-        tracing::error!(
-            agent = %kind,
-            reinstall = options.reinstall,
-            native_version = ?options.native_version,
-            agent_process_version = ?options.agent_process_version,
-            runtime_home = %state.runtime_home.display(),
-            error = %error,
-            "agent install failed"
-        );
-        install_error_to_problem(error)
-    })?;
-    state
-        .agent_seed_store
-        .refresh_from_state(&state.runtime_home);
-    let resolved = resolve_agent(desc, &state.runtime_home);
-    let summary = to_summary(&resolved, None);
-    let already_installed = installed_artifacts.is_empty();
-
-    tracing::info!(
-        agent = %kind,
-        already_installed,
-        installed_artifact_count = installed_artifacts.len(),
-        "agent install completed"
-    );
-
+        .await
+        .map_err(agent_runtime_error_to_problem)?;
     Ok(Json(InstallAgentResponse {
-        agent: summary,
-        already_installed,
-        installed_artifacts: installed_artifacts
+        agent: to_summary(&outcome.agent, None),
+        already_installed: outcome.already_installed,
+        installed_artifacts: outcome
+            .installed_artifacts
             .iter()
             .map(to_installed_artifact_status)
             .collect(),
@@ -223,51 +176,22 @@ pub async fn start_agent_login(
     Path(kind): Path<String>,
     Json(_req): Json<StartAgentLoginRequest>,
 ) -> Result<Json<StartAgentLoginResponse>, ProblemResponse> {
-    let registry = built_in_registry();
-    let desc = registry.iter().find(|d| d.kind.as_str() == kind);
-    let desc = match desc {
-        Some(d) => d,
-        None => return Err(agent_not_found(&kind)),
-    };
-
-    match &desc.auth.login {
-        Some(login) => Ok(Json(StartAgentLoginResponse {
-            kind: desc.kind.as_str().into(),
-            label: login.label.clone(),
-            mode: "terminal_command".into(),
-            command: managed_login_command(desc, &state.runtime_home).unwrap_or_else(|| {
-                LoginCommand {
-                    program: login.command.program.clone(),
-                    args: login.command.args.clone(),
-                }
-            }),
-            reuses_user_state: login.reuses_user_state,
-            message: login.message.clone(),
-        })),
-        None => Err(problem(
-            400,
-            "Login not supported",
-            Some(format!("Agent {kind} does not support native login")),
-            Some("LOGIN_NOT_SUPPORTED"),
-        )),
-    }
-}
-
-fn managed_login_command(
-    desc: &AgentDescriptor,
-    runtime_home: &std::path::Path,
-) -> Option<LoginCommand> {
-    let login = desc.auth.login.as_ref()?;
-    let resolved = resolve_agent(desc, runtime_home);
-    let native = resolved.native.as_ref()?;
-    if native.source.as_deref() == Some("path") {
-        return None;
-    }
-    let path = native.path.as_ref()?;
-    Some(LoginCommand {
-        program: path.display().to_string(),
-        args: login.command.args.clone(),
-    })
+    let login = state
+        .agent_runtime
+        .start_login(&kind)
+        .await
+        .map_err(agent_runtime_error_to_problem)?;
+    Ok(Json(StartAgentLoginResponse {
+        kind: login.kind,
+        label: login.label,
+        mode: "terminal_command".into(),
+        command: LoginCommand {
+            program: login.command.program,
+            args: login.command.args,
+        },
+        reuses_user_state: login.reuses_user_state,
+        message: login.message,
+    }))
 }
 
 #[utoipa::path(
@@ -279,7 +203,7 @@ fn managed_login_command(
     tag = "agents"
 )]
 pub async fn get_reconcile_status(State(state): State<AppState>) -> Json<ReconcileAgentsResponse> {
-    let snapshot = state.agent_reconcile_service.snapshot().await;
+    let snapshot = state.agent_runtime.reconcile_status().await;
     Json(reconcile_snapshot_to_contract(&snapshot))
 }
 
@@ -296,15 +220,7 @@ pub async fn reconcile_agents(
     State(state): State<AppState>,
     Json(req): Json<ReconcileAgentsRequest>,
 ) -> (StatusCode, Json<ReconcileAgentsResponse>) {
-    let snapshot = state
-        .agent_reconcile_service
-        .start_or_get(
-            built_in_registry(),
-            state.runtime_home.clone(),
-            req.reinstall,
-            Some(state.agent_seed_store.clone()),
-        )
-        .await;
+    let snapshot = state.agent_runtime.start_reconcile(req.reinstall).await;
     (
         StatusCode::ACCEPTED,
         Json(reconcile_snapshot_to_contract(&snapshot)),

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
@@ -39,6 +39,10 @@ use crate::workspaces::operation_gate::WorkspaceOperationKind;
 use crate::workspaces::purge::WorkspacePurgeServiceOutcome;
 use crate::workspaces::retire_preflight::RetirePreflightMode;
 use crate::workspaces::runtime::WorkspaceResolution;
+use crate::workspaces::setup_runtime::{StartWorkspaceSetupInput, WorkspaceSetupError};
+use crate::workspaces::worktree_runtime::{
+    CreateWorktreeWorkflowError, CreateWorktreeWorkflowInput,
+};
 
 #[utoipa::path(
     post,
@@ -127,17 +131,15 @@ pub async fn create_worktree(
     let latency = LatencyRequestContext::from_headers(&headers);
     let latency_fields = latency_trace_fields(latency.as_ref());
     let started = Instant::now();
-    let workspace_runtime = state.workspace_runtime.clone();
     let repo_root_id = req.repo_root_id;
     let target_path = req.target_path;
     let new_branch_name = req.new_branch_name;
     let base_branch = req.base_branch.clone();
-    let setup_script = req.setup_script.clone();
+    let setup_script = req.setup_script;
     let origin = request_origin_or_api_default(req.origin, "create_worktree");
     let creator_context = req
         .creator_context
         .map(WorkspaceCreatorContext::from_contract);
-    let repo_root_id_for_task = repo_root_id.clone();
     let has_setup_script = setup_script
         .as_deref()
         .map(str::trim)
@@ -158,60 +160,26 @@ pub async fn create_worktree(
         .assert_can_mutate_for_repo_root(&repo_root_id)
         .map_err(map_access_error)?;
 
-    let result = run_blocking("worktree", {
-        let base_branch = base_branch.clone();
-        move || {
-            workspace_runtime.create_worktree_with_surface(
-                &repo_root_id_for_task,
-                &target_path,
-                &new_branch_name,
-                base_branch.as_deref(),
-                None,
-                "standard",
-                origin,
-                creator_context,
-            )
-        }
-    })
-    .await?
-    .map_err(|e| ApiError::bad_request(e.to_string(), "WORKTREE_CREATE_FAILED"))?;
-
-    if let Some(script) = setup_script
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let _lease = state
-            .workspace_operation_gate
-            .acquire_shared(&result.workspace.id, WorkspaceOperationKind::SetupCommand)
-            .await;
-        let workspace_runtime_for_env = state.workspace_runtime.clone();
-        let env_vars = tokio::task::spawn_blocking({
-            let record = result.workspace.clone();
-            let base_branch = base_branch.clone();
-            move || workspace_runtime_for_env.build_workspace_env(&record, base_branch.as_deref())
+    let result = state
+        .workspace_worktree_runtime
+        .create_worktree(CreateWorktreeWorkflowInput {
+            repo_root_id: repo_root_id.clone(),
+            target_path,
+            new_branch_name,
+            base_branch: base_branch.clone(),
+            setup_script,
+            surface: "standard".to_string(),
+            origin,
+            creator_context,
         })
         .await
-        .map_err(|e| ApiError::internal(format!("env build task failed: {e}")))?
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-
-        state
-            .terminal_service
-            .start_setup_command(
-                &result.workspace.id,
-                &result.workspace.path,
-                script.to_string(),
-                env_vars,
-                None,
-            )
-            .await
-            .map_err(|e| ApiError::internal(e.to_string()))?;
-    }
+        .map_err(map_create_worktree_error)?;
 
     tracing::info!(
-        workspace_id = %result.workspace.id,
+        workspace_id = %result.worktree.workspace.id,
         repo_root_id = %repo_root_id,
         has_setup_script,
+        setup_started = result.setup_started,
         elapsed_ms = started.elapsed().as_millis(),
         flow_id = latency_fields.flow_id,
         flow_kind = latency_fields.flow_kind,
@@ -220,13 +188,8 @@ pub async fn create_worktree(
         "[workspace-latency] workspace.http.worktree.completed"
     );
 
-    state
-        .workspace_retention_service
-        .clone()
-        .spawn_post_create_pass(result.workspace.id.clone());
-
     Ok(Json(CreateWorktreeWorkspaceResponse {
-        workspace: workspace_to_contract(&state, result.workspace).await?,
+        workspace: workspace_to_contract(&state, result.worktree.workspace).await?,
         setup_script: None,
     }))
 }
@@ -914,9 +877,9 @@ pub async fn get_setup_status(
     Path(workspace_id): Path<String>,
 ) -> Result<Json<GetSetupStatusResponse>, ApiError> {
     let run = state
-        .terminal_service
+        .workspace_setup_runtime
         .latest_setup_run(&workspace_id)
-        .map_err(|e| ApiError::internal(e.to_string()))?
+        .map_err(map_workspace_setup_error)?
         .ok_or_else(|| {
             ApiError::not_found(
                 "No setup execution found for this workspace".to_string(),
@@ -942,20 +905,12 @@ pub async fn rerun_setup(
     State(state): State<AppState>,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<GetSetupStatusResponse>, ApiError> {
-    assert_workspace_mutable(&state, &workspace_id)?;
-    let previous = state
-        .terminal_service
-        .latest_setup_run(&workspace_id)
-        .map_err(|e| ApiError::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::not_found(
-                "No previous setup execution found for this workspace".to_string(),
-                "SETUP_NOT_FOUND",
-            )
-        })?;
-
-    let snapshot = start_setup_for_workspace(&state, workspace_id, previous.command, None).await?;
-    Ok(Json(snapshot))
+    let run = state
+        .workspace_setup_runtime
+        .rerun_setup(workspace_id)
+        .await
+        .map_err(map_workspace_setup_error)?;
+    Ok(Json(setup_command_run_to_contract(run)))
 }
 
 #[utoipa::path(
@@ -975,58 +930,48 @@ pub async fn start_setup(
     Path(workspace_id): Path<String>,
     Json(req): Json<StartWorkspaceSetupRequest>,
 ) -> Result<Json<GetSetupStatusResponse>, ApiError> {
-    assert_workspace_mutable(&state, &workspace_id)?;
-    let command = req.command.trim().to_string();
-    if command.is_empty() {
-        return Err(ApiError::bad_request(
-            "Setup command must not be empty.",
-            "INVALID_SETUP_COMMAND",
-        ));
-    }
-
-    let snapshot = start_setup_for_workspace(&state, workspace_id, command, req.base_ref).await?;
-    Ok(Json(snapshot))
-}
-
-async fn start_setup_for_workspace(
-    state: &AppState,
-    workspace_id: String,
-    command: String,
-    base_ref: Option<String>,
-) -> Result<GetSetupStatusResponse, ApiError> {
-    let _lease = state
-        .workspace_operation_gate
-        .acquire_shared(&workspace_id, WorkspaceOperationKind::SetupCommand)
-        .await;
-    assert_workspace_mutable(state, &workspace_id)?;
-    let workspace_runtime = state.workspace_runtime.clone();
-    let ws_id = workspace_id.clone();
-    let record = run_blocking("workspace lookup", move || {
-        workspace_runtime.get_workspace(&ws_id)
-    })
-    .await?
-    .map_err(|e| ApiError::internal(e.to_string()))?
-    .ok_or_else(|| ApiError::not_found("Workspace not found".to_string(), "WORKSPACE_NOT_FOUND"))?;
-
-    let env_vars = {
-        let workspace_runtime = state.workspace_runtime.clone();
-        let rec = record.clone();
-        let base_ref = base_ref.clone();
-        tokio::task::spawn_blocking(move || {
-            workspace_runtime.build_workspace_env(&rec, base_ref.as_deref())
+    let run = state
+        .workspace_setup_runtime
+        .start_setup(StartWorkspaceSetupInput {
+            workspace_id,
+            command: req.command,
+            base_ref: req.base_ref,
         })
         .await
-        .map_err(|e| ApiError::internal(format!("env build failed: {e}")))?
-        .map_err(|e| ApiError::internal(e.to_string()))?
-    };
+        .map_err(map_workspace_setup_error)?;
+    Ok(Json(setup_command_run_to_contract(run)))
+}
 
-    let run = state
-        .terminal_service
-        .start_setup_command(&workspace_id, &record.path, command, env_vars, None)
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+fn map_create_worktree_error(error: CreateWorktreeWorkflowError) -> ApiError {
+    match error {
+        CreateWorktreeWorkflowError::CreateTaskFailed(error) => {
+            ApiError::internal(format!("worktree task failed: {error}"))
+        }
+        CreateWorktreeWorkflowError::Create(error) => {
+            ApiError::bad_request(error.to_string(), "WORKTREE_CREATE_FAILED")
+        }
+        CreateWorktreeWorkflowError::Setup(error) => map_workspace_setup_error(error),
+    }
+}
 
-    Ok(setup_command_run_to_contract(run))
+fn map_workspace_setup_error(error: WorkspaceSetupError) -> ApiError {
+    match error {
+        WorkspaceSetupError::InvalidCommand => {
+            ApiError::bad_request("Setup command must not be empty.", "INVALID_SETUP_COMMAND")
+        }
+        WorkspaceSetupError::WorkspaceNotFound(_) => {
+            ApiError::not_found("Workspace not found".to_string(), "WORKSPACE_NOT_FOUND")
+        }
+        WorkspaceSetupError::SetupNotFound => ApiError::not_found(
+            "No previous setup execution found for this workspace".to_string(),
+            "SETUP_NOT_FOUND",
+        ),
+        WorkspaceSetupError::Access(error) => map_access_error(error),
+        WorkspaceSetupError::TaskFailed(error) => {
+            ApiError::internal(format!("workspace setup task failed: {error}"))
+        }
+        WorkspaceSetupError::Unexpected(error) => ApiError::internal(error.to_string()),
+    }
 }
 
 async fn resolve_workspace_response_to_contract(

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -1,3 +1,5 @@
+mod product_mcp;
+
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -13,9 +15,7 @@ use crate::domains::agents::runtime::AgentRuntime;
 use crate::domains::agents::seed::AgentSeedStore;
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::delegation::service::CoworkDelegationService;
-use crate::domains::cowork::mcp::{
-    auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
-};
+use crate::domains::cowork::mcp::auth::CoworkMcpAuth;
 use crate::domains::cowork::runtime::{CoworkRuntime, CoworkSessionHooks};
 use crate::domains::cowork::service::CoworkService;
 use crate::domains::cowork::store::CoworkStore;
@@ -24,11 +24,9 @@ use crate::domains::mobility::store::MobilityStore;
 use crate::domains::plans::runtime::PlanRuntime;
 use crate::domains::plans::service::PlanService;
 use crate::domains::plans::store::PlanStore;
-use crate::domains::plugins::mcp::{auth::SkillsMcpAuth, SkillsProductMcpServer};
+use crate::domains::plugins::mcp::auth::SkillsMcpAuth;
 use crate::domains::reviews::hooks::ReviewSessionHooks;
-use crate::domains::reviews::mcp::{
-    auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
-};
+use crate::domains::reviews::mcp::auth::ReviewMcpAuth;
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::domains::reviews::service::ReviewService;
 use crate::domains::reviews::store::ReviewStore;
@@ -43,21 +41,15 @@ use crate::sessions::links::service::SessionLinkService;
 use crate::sessions::links::store::SessionLinkStore;
 use crate::sessions::mcp_bindings::crypto::{load_data_cipher_from_env, DATA_KEY_ENV_VAR};
 use crate::sessions::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
-use crate::sessions::mcp_bindings::product_registry::{
-    ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
-};
+use crate::sessions::mcp_bindings::product_registry::ProductMcpEndpointRegistry;
 use crate::sessions::runtime::SessionRuntime;
 use crate::sessions::service::SessionService;
 use crate::sessions::store::SessionStore;
 use crate::sessions::subagents::hooks::SubagentSessionHooks;
-use crate::sessions::subagents::mcp::{
-    auth::SubagentMcpAuth, tools as subagent_mcp_tools, SubagentProductMcpServer,
-};
+use crate::sessions::subagents::mcp::auth::SubagentMcpAuth;
 use crate::sessions::subagents::service::SubagentService;
 use crate::sessions::subagents::store::SubagentStore;
-use crate::sessions::workspace_naming::mcp::{
-    auth::WorkspaceNamingMcpAuth, WorkspaceNamingProductMcpServer,
-};
+use crate::sessions::workspace_naming::mcp::auth::WorkspaceNamingMcpAuth;
 use crate::terminals::store::TerminalStore;
 use crate::terminals::TerminalService;
 use crate::workspaces::access_gate::WorkspaceAccessGate;
@@ -65,7 +57,7 @@ use crate::workspaces::access_store::WorkspaceAccessStore;
 use crate::workspaces::checkout_gate::CheckoutDeletionGate;
 use crate::workspaces::files_runtime::WorkspaceFilesRuntime;
 use crate::workspaces::inventory::WorktreeInventoryService;
-use crate::workspaces::operation_gate::{WorkspaceOperationGate, WorkspaceOperationKind};
+use crate::workspaces::operation_gate::WorkspaceOperationGate;
 use crate::workspaces::purge::WorkspacePurgeService;
 use crate::workspaces::retention::WorkspaceRetentionService;
 use crate::workspaces::retention_policy::WorktreeRetentionPolicyStore;
@@ -373,57 +365,24 @@ impl AppState {
         review_runtime
             .clone()
             .spawn_background_tasks(review_hook_event_rx);
-        let product_mcp_endpoint_registrations = vec![
-            ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(ReviewProductMcpServer::new(
-                    review_runtime.clone(),
-                    review_mcp_auth,
-                )),
-                Some(WorkspaceOperationKind::ReviewWrite),
-                review_mcp_tools::MUTATING_TOOL_NAMES,
-            ))),
-            ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(SubagentProductMcpServer::new(
-                    subagent_service.clone(),
-                    session_runtime.clone(),
-                    workspace_runtime.clone(),
-                    subagent_mcp_auth,
-                )),
-                Some(WorkspaceOperationKind::SubagentWrite),
-                subagent_mcp_tools::MUTATING_TOOL_NAMES,
-            ))),
-            ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(WorkspaceNamingProductMcpServer::new(
-                    workspace_runtime.clone(),
-                    workspace_access_gate.clone(),
-                    SessionStore::new(db.clone()),
-                    workspace_naming_mcp_auth,
-                )),
-                None,
-                &[],
-            ))),
-            ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(CoworkProductMcpServer::new(
-                    cowork_artifact_runtime.clone(),
-                    cowork_runtime.clone(),
-                    cowork_mcp_auth,
-                )),
-                Some(WorkspaceOperationKind::CoworkWrite),
-                cowork_mcp_tools::MUTATING_TOOL_NAMES,
-            ))),
-            ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(SkillsProductMcpServer::new(
-                    runtime_config_service.clone(),
-                    skills_mcp_auth,
-                )),
-                None,
-                &[],
-            ))),
-        ];
-        let product_mcp_endpoint_registry = Arc::new(
-            ProductMcpEndpointRegistry::new(product_mcp_endpoint_registrations)
-                .map_err(AppStateInitError::InvalidProductMcpRegistry)?,
-        );
+        let product_mcp_endpoint_registry =
+            product_mcp::build_product_mcp_endpoint_registry(product_mcp::EndpointRegistryDeps {
+                db: db.clone(),
+                review_runtime: review_runtime.clone(),
+                review_mcp_auth,
+                subagent_service: subagent_service.clone(),
+                session_runtime: session_runtime.clone(),
+                workspace_runtime: workspace_runtime.clone(),
+                subagent_mcp_auth,
+                workspace_access_gate: workspace_access_gate.clone(),
+                workspace_naming_mcp_auth,
+                cowork_artifact_runtime: cowork_artifact_runtime.clone(),
+                cowork_runtime: cowork_runtime.clone(),
+                cowork_mcp_auth,
+                runtime_config_service: runtime_config_service.clone(),
+                skills_mcp_auth,
+            })
+            .map_err(AppStateInitError::InvalidProductMcpRegistry)?;
         #[cfg(not(test))]
         workspace_retention_service.clone().spawn_startup_pass();
         Ok(Self {

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -9,6 +9,7 @@ use crate::domains::agents::auth_config::{AgentAuthConfigService, AgentAuthConfi
 use crate::domains::agents::model_registry::service::DynamicModelRegistryService;
 use crate::domains::agents::model_registry::store::DynamicModelRegistryStore;
 use crate::domains::agents::reconcile::execution::AgentReconcileService;
+use crate::domains::agents::runtime::AgentRuntime;
 use crate::domains::agents::seed::AgentSeedStore;
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::delegation::service::CoworkDelegationService;
@@ -71,7 +72,9 @@ use crate::workspaces::retention_policy::WorktreeRetentionPolicyStore;
 use crate::workspaces::retire_preflight::RetirePreflightChecker;
 use crate::workspaces::runtime::WorkspaceRuntime;
 use crate::workspaces::service::WorkspaceService;
+use crate::workspaces::setup_runtime::WorkspaceSetupRuntime;
 use crate::workspaces::store::WorkspaceStore;
+use crate::workspaces::worktree_runtime::WorkspaceWorktreeRuntime;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AppStateInitError {
@@ -94,12 +97,15 @@ pub struct AppState {
     pub bearer_token: Option<String>,
     pub auth_manager: AuthManager,
     pub agent_seed_store: AgentSeedStore,
+    pub agent_runtime: Arc<AgentRuntime>,
     pub agent_auth_config_service: Arc<AgentAuthConfigService>,
     pub agent_reconcile_service: Arc<AgentReconcileService>,
     pub dynamic_model_registry_service: Arc<DynamicModelRegistryService>,
     pub runtime_config_service: Arc<RuntimeConfigService>,
     pub repo_root_service: Arc<RepoRootService>,
     pub workspace_runtime: Arc<WorkspaceRuntime>,
+    pub workspace_setup_runtime: Arc<WorkspaceSetupRuntime>,
+    pub workspace_worktree_runtime: Arc<WorkspaceWorktreeRuntime>,
     pub files_runtime: Arc<WorkspaceFilesRuntime>,
     pub process_service: Arc<ProcessService>,
     pub workspace_file_search_cache: Arc<WorkspaceFileSearchCache>,
@@ -153,6 +159,11 @@ impl AppState {
             runtime_home.clone(),
         ));
         let agent_reconcile_service = Arc::new(AgentReconcileService::new());
+        let agent_runtime = Arc::new(AgentRuntime::new(
+            runtime_home.clone(),
+            agent_reconcile_service.clone(),
+            agent_seed_store.clone(),
+        ));
         let agent_auth_config_service = Arc::new(AgentAuthConfigService::new(
             AgentAuthConfigStore::new(db.clone()),
             session_data_cipher.clone(),
@@ -207,6 +218,12 @@ impl AppState {
             SessionStore::new(db.clone()),
             WorkspaceAccessStore::new(db.clone()),
             terminal_service.clone(),
+        ));
+        let workspace_setup_runtime = Arc::new(WorkspaceSetupRuntime::new(
+            workspace_runtime.clone(),
+            terminal_service.clone(),
+            workspace_access_gate.clone(),
+            workspace_operation_gate.clone(),
         ));
         let session_link_service = SessionLinkService::new(
             SessionLinkStore::new(db.clone()),
@@ -317,6 +334,11 @@ impl AppState {
             checkout_deletion_gate.clone(),
             runtime_home.clone(),
         ));
+        let workspace_worktree_runtime = Arc::new(WorkspaceWorktreeRuntime::new(
+            workspace_runtime.clone(),
+            workspace_setup_runtime.clone(),
+            workspace_retention_service.clone(),
+        ));
         let cowork_runtime = Arc::new(CoworkRuntime::new(
             (*cowork_service).clone(),
             cowork_delegation_service,
@@ -411,12 +433,15 @@ impl AppState {
             bearer_token,
             auth_manager,
             agent_seed_store,
+            agent_runtime,
             agent_auth_config_service,
             agent_reconcile_service,
             dynamic_model_registry_service,
             runtime_config_service,
             repo_root_service,
             workspace_runtime,
+            workspace_setup_runtime,
+            workspace_worktree_runtime,
             files_runtime,
             process_service,
             workspace_file_search_cache,

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
+use crate::domains::cowork::mcp::{
+    auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
+};
+use crate::domains::cowork::runtime::CoworkRuntime;
+use crate::domains::plugins::mcp::{auth::SkillsMcpAuth, SkillsProductMcpServer};
+use crate::domains::reviews::mcp::{
+    auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
+};
+use crate::domains::reviews::runtime::ReviewRuntime;
+use crate::domains::runtime_config::service::RuntimeConfigService;
+use crate::persistence::Db;
+use crate::sessions::mcp_bindings::product_registry::{
+    ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
+};
+use crate::sessions::runtime::SessionRuntime;
+use crate::sessions::store::SessionStore;
+use crate::sessions::subagents::mcp::{
+    auth::SubagentMcpAuth, tools as subagent_mcp_tools, SubagentProductMcpServer,
+};
+use crate::sessions::subagents::service::SubagentService;
+use crate::sessions::workspace_naming::mcp::{
+    auth::WorkspaceNamingMcpAuth, WorkspaceNamingProductMcpServer,
+};
+use crate::workspaces::access_gate::WorkspaceAccessGate;
+use crate::workspaces::operation_gate::WorkspaceOperationKind;
+use crate::workspaces::runtime::WorkspaceRuntime;
+
+pub(super) struct EndpointRegistryDeps {
+    pub(super) db: Db,
+    pub(super) review_runtime: Arc<ReviewRuntime>,
+    pub(super) review_mcp_auth: Arc<ReviewMcpAuth>,
+    pub(super) subagent_service: Arc<SubagentService>,
+    pub(super) session_runtime: Arc<SessionRuntime>,
+    pub(super) workspace_runtime: Arc<WorkspaceRuntime>,
+    pub(super) subagent_mcp_auth: Arc<SubagentMcpAuth>,
+    pub(super) workspace_access_gate: Arc<WorkspaceAccessGate>,
+    pub(super) workspace_naming_mcp_auth: Arc<WorkspaceNamingMcpAuth>,
+    pub(super) cowork_artifact_runtime: Arc<CoworkArtifactRuntime>,
+    pub(super) cowork_runtime: Arc<CoworkRuntime>,
+    pub(super) cowork_mcp_auth: Arc<CoworkMcpAuth>,
+    pub(super) runtime_config_service: Arc<RuntimeConfigService>,
+    pub(super) skills_mcp_auth: Arc<SkillsMcpAuth>,
+}
+
+pub(super) fn build_product_mcp_endpoint_registry(
+    deps: EndpointRegistryDeps,
+) -> anyhow::Result<Arc<ProductMcpEndpointRegistry>> {
+    let EndpointRegistryDeps {
+        db,
+        review_runtime,
+        review_mcp_auth,
+        subagent_service,
+        session_runtime,
+        workspace_runtime,
+        subagent_mcp_auth,
+        workspace_access_gate,
+        workspace_naming_mcp_auth,
+        cowork_artifact_runtime,
+        cowork_runtime,
+        cowork_mcp_auth,
+        runtime_config_service,
+        skills_mcp_auth,
+    } = deps;
+
+    let product_mcp_endpoint_registrations = vec![
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(ReviewProductMcpServer::new(review_runtime, review_mcp_auth)),
+            Some(WorkspaceOperationKind::ReviewWrite),
+            review_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(SubagentProductMcpServer::new(
+                subagent_service.clone(),
+                session_runtime,
+                workspace_runtime.clone(),
+                subagent_mcp_auth,
+            )),
+            Some(WorkspaceOperationKind::SubagentWrite),
+            subagent_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(WorkspaceNamingProductMcpServer::new(
+                workspace_runtime,
+                workspace_access_gate,
+                SessionStore::new(db),
+                workspace_naming_mcp_auth,
+            )),
+            None,
+            &[],
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(CoworkProductMcpServer::new(
+                cowork_artifact_runtime,
+                cowork_runtime,
+                cowork_mcp_auth,
+            )),
+            Some(WorkspaceOperationKind::CoworkWrite),
+            cowork_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(SkillsProductMcpServer::new(
+                runtime_config_service,
+                skills_mcp_auth,
+            )),
+            None,
+            &[],
+        ))),
+    ];
+    ProductMcpEndpointRegistry::new(product_mcp_endpoint_registrations).map(Arc::new)
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/mod.rs
@@ -9,4 +9,5 @@ pub mod portability;
 pub mod readiness;
 pub mod reconcile;
 pub mod registry;
+pub mod runtime;
 pub mod seed;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
@@ -1,0 +1,238 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::installer::{self, InstallError, InstallOptions, InstalledArtifactResult};
+use super::model::*;
+use super::readiness::resolver::resolve_agent;
+use super::reconcile::execution::{AgentReconcileJobSnapshot, AgentReconcileService};
+use super::registry::built_in_registry;
+use super::seed::AgentSeedStore;
+
+#[derive(Clone)]
+pub struct AgentRuntime {
+    runtime_home: PathBuf,
+    reconcile_service: Arc<AgentReconcileService>,
+    seed_store: AgentSeedStore,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentListSnapshot {
+    pub agents: Vec<ResolvedAgent>,
+    pub reconcile_snapshot: AgentReconcileJobSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentReadinessSnapshot {
+    pub agent: ResolvedAgent,
+    pub reconcile_snapshot: AgentReconcileJobSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentInstallRequest {
+    pub reinstall: bool,
+    pub native_version: Option<String>,
+    pub agent_process_version: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentInstallOutcome {
+    pub agent: ResolvedAgent,
+    pub already_installed: bool,
+    pub installed_artifacts: Vec<InstalledArtifactResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentLoginCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentLoginStart {
+    pub kind: String,
+    pub label: String,
+    pub command: AgentLoginCommand,
+    pub reuses_user_state: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AgentRuntimeError {
+    #[error("No built-in agent with kind: {0}")]
+    NotFound(String),
+    #[error("Agent {0} does not support native login")]
+    LoginNotSupported(String),
+    #[error("Agent install task failed: {0}")]
+    InstallTaskFailed(tokio::task::JoinError),
+    #[error(transparent)]
+    Install(#[from] InstallError),
+}
+
+impl AgentRuntime {
+    pub fn new(
+        runtime_home: PathBuf,
+        reconcile_service: Arc<AgentReconcileService>,
+        seed_store: AgentSeedStore,
+    ) -> Self {
+        Self {
+            runtime_home,
+            reconcile_service,
+            seed_store,
+        }
+    }
+
+    pub async fn list_agents(&self) -> AgentListSnapshot {
+        let registry = built_in_registry();
+        let reconcile_snapshot = self.reconcile_service.snapshot().await;
+        let agents = registry
+            .iter()
+            .map(|desc| resolve_agent(desc, &self.runtime_home))
+            .collect();
+        AgentListSnapshot {
+            agents,
+            reconcile_snapshot,
+        }
+    }
+
+    pub async fn get_agent(&self, kind: &str) -> Result<AgentReadinessSnapshot, AgentRuntimeError> {
+        let descriptor = descriptor_for_kind(kind)?;
+        let reconcile_snapshot = self.reconcile_service.snapshot().await;
+        Ok(AgentReadinessSnapshot {
+            agent: resolve_agent(&descriptor, &self.runtime_home),
+            reconcile_snapshot,
+        })
+    }
+
+    pub async fn install_agent(
+        &self,
+        kind: &str,
+        request: AgentInstallRequest,
+    ) -> Result<AgentInstallOutcome, AgentRuntimeError> {
+        let descriptor = descriptor_for_kind(kind)?;
+        let options = InstallOptions {
+            reinstall: request.reinstall,
+            native_version: request.native_version,
+            agent_process_version: request.agent_process_version,
+        };
+
+        tracing::info!(
+            agent = %kind,
+            reinstall = options.reinstall,
+            native_version = ?options.native_version,
+            agent_process_version = ?options.agent_process_version,
+            runtime_home = %self.runtime_home.display(),
+            "installing agent"
+        );
+
+        let install_runtime_home = self.runtime_home.clone();
+        let install_descriptor = descriptor.clone();
+        let install_options = options.clone();
+        let installed_artifacts = tokio::task::spawn_blocking(move || {
+            installer::install_agent(&install_descriptor, &install_runtime_home, &install_options)
+        })
+        .await
+        .map_err(|error| {
+            tracing::error!(
+                agent = %kind,
+                reinstall = options.reinstall,
+                native_version = ?options.native_version,
+                agent_process_version = ?options.agent_process_version,
+                runtime_home = %self.runtime_home.display(),
+                error = %error,
+                "agent install task failed"
+            );
+            AgentRuntimeError::InstallTaskFailed(error)
+        })?
+        .map_err(|error| {
+            tracing::error!(
+                agent = %kind,
+                reinstall = options.reinstall,
+                native_version = ?options.native_version,
+                agent_process_version = ?options.agent_process_version,
+                runtime_home = %self.runtime_home.display(),
+                error = %error,
+                "agent install failed"
+            );
+            AgentRuntimeError::Install(error)
+        })?;
+
+        self.seed_store.refresh_from_state(&self.runtime_home);
+        let agent = resolve_agent(&descriptor, &self.runtime_home);
+        let already_installed = installed_artifacts.is_empty();
+
+        tracing::info!(
+            agent = %kind,
+            already_installed,
+            installed_artifact_count = installed_artifacts.len(),
+            "agent install completed"
+        );
+
+        Ok(AgentInstallOutcome {
+            agent,
+            already_installed,
+            installed_artifacts,
+        })
+    }
+
+    pub async fn start_login(&self, kind: &str) -> Result<AgentLoginStart, AgentRuntimeError> {
+        let descriptor = descriptor_for_kind(kind)?;
+        let login = descriptor
+            .auth
+            .login
+            .as_ref()
+            .ok_or_else(|| AgentRuntimeError::LoginNotSupported(kind.to_string()))?;
+        let command = managed_login_command(&descriptor, &self.runtime_home).unwrap_or_else(|| {
+            AgentLoginCommand {
+                program: login.command.program.clone(),
+                args: login.command.args.clone(),
+            }
+        });
+
+        Ok(AgentLoginStart {
+            kind: descriptor.kind.as_str().to_string(),
+            label: login.label.clone(),
+            command,
+            reuses_user_state: login.reuses_user_state,
+            message: login.message.clone(),
+        })
+    }
+
+    pub async fn reconcile_status(&self) -> AgentReconcileJobSnapshot {
+        self.reconcile_service.snapshot().await
+    }
+
+    pub async fn start_reconcile(&self, reinstall: bool) -> AgentReconcileJobSnapshot {
+        self.reconcile_service
+            .start_or_get(
+                built_in_registry(),
+                self.runtime_home.clone(),
+                reinstall,
+                Some(self.seed_store.clone()),
+            )
+            .await
+    }
+}
+
+fn descriptor_for_kind(kind: &str) -> Result<AgentDescriptor, AgentRuntimeError> {
+    built_in_registry()
+        .into_iter()
+        .find(|descriptor| descriptor.kind.as_str() == kind)
+        .ok_or_else(|| AgentRuntimeError::NotFound(kind.to_string()))
+}
+
+fn managed_login_command(
+    descriptor: &AgentDescriptor,
+    runtime_home: &Path,
+) -> Option<AgentLoginCommand> {
+    let login = descriptor.auth.login.as_ref()?;
+    let resolved = resolve_agent(descriptor, runtime_home);
+    let native = resolved.native.as_ref()?;
+    if native.source.as_deref() == Some("path") {
+        return None;
+    }
+    let path = native.path.as_ref()?;
+    Some(AgentLoginCommand {
+        program: path.display().to_string(),
+        args: login.command.args.clone(),
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/workspaces/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/mod.rs
@@ -18,5 +18,7 @@ pub mod retention_policy;
 pub mod retire_preflight;
 pub mod runtime;
 pub mod service;
+pub mod setup_runtime;
 pub mod store;
 pub mod types;
+pub mod worktree_runtime;

--- a/anyharness/crates/anyharness-lib/src/workspaces/setup_runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/setup_runtime.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+
+use crate::terminals::model::TerminalCommandRunRecord;
+use crate::terminals::TerminalService;
+use crate::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
+use crate::workspaces::model::WorkspaceRecord;
+use crate::workspaces::operation_gate::{WorkspaceOperationGate, WorkspaceOperationKind};
+use crate::workspaces::runtime::WorkspaceRuntime;
+
+#[derive(Clone)]
+pub struct WorkspaceSetupRuntime {
+    workspace_runtime: Arc<WorkspaceRuntime>,
+    terminal_service: Arc<TerminalService>,
+    access_gate: Arc<WorkspaceAccessGate>,
+    operation_gate: Arc<WorkspaceOperationGate>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StartWorkspaceSetupInput {
+    pub workspace_id: String,
+    pub command: String,
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceSetupError {
+    #[error("Setup command must not be empty.")]
+    InvalidCommand,
+    #[error("Workspace not found: {0}")]
+    WorkspaceNotFound(String),
+    #[error("No previous setup execution found for this workspace")]
+    SetupNotFound,
+    #[error(transparent)]
+    Access(#[from] WorkspaceAccessError),
+    #[error("workspace setup task failed: {0}")]
+    TaskFailed(#[from] tokio::task::JoinError),
+    #[error(transparent)]
+    Unexpected(#[from] anyhow::Error),
+}
+
+impl WorkspaceSetupRuntime {
+    pub fn new(
+        workspace_runtime: Arc<WorkspaceRuntime>,
+        terminal_service: Arc<TerminalService>,
+        access_gate: Arc<WorkspaceAccessGate>,
+        operation_gate: Arc<WorkspaceOperationGate>,
+    ) -> Self {
+        Self {
+            workspace_runtime,
+            terminal_service,
+            access_gate,
+            operation_gate,
+        }
+    }
+
+    pub fn latest_setup_run(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<TerminalCommandRunRecord>, WorkspaceSetupError> {
+        Ok(self.terminal_service.latest_setup_run(workspace_id)?)
+    }
+
+    pub async fn start_setup(
+        &self,
+        input: StartWorkspaceSetupInput,
+    ) -> Result<TerminalCommandRunRecord, WorkspaceSetupError> {
+        let command = normalize_setup_command(input.command)?;
+        let _lease = self
+            .operation_gate
+            .acquire_shared(&input.workspace_id, WorkspaceOperationKind::SetupCommand)
+            .await;
+        self.access_gate
+            .assert_can_mutate_for_workspace(&input.workspace_id)?;
+        let record = self.load_workspace(input.workspace_id).await?;
+        self.start_setup_for_record(record, command, input.base_ref)
+            .await
+    }
+
+    pub async fn rerun_setup(
+        &self,
+        workspace_id: String,
+    ) -> Result<TerminalCommandRunRecord, WorkspaceSetupError> {
+        let previous = self
+            .terminal_service
+            .latest_setup_run(&workspace_id)?
+            .ok_or(WorkspaceSetupError::SetupNotFound)?;
+        self.start_setup(StartWorkspaceSetupInput {
+            workspace_id,
+            command: previous.command,
+            base_ref: None,
+        })
+        .await
+    }
+
+    pub async fn start_setup_for_created_workspace(
+        &self,
+        workspace: WorkspaceRecord,
+        command: String,
+        base_ref: Option<String>,
+    ) -> Result<TerminalCommandRunRecord, WorkspaceSetupError> {
+        let command = normalize_setup_command(command)?;
+        let _lease = self
+            .operation_gate
+            .acquire_shared(&workspace.id, WorkspaceOperationKind::SetupCommand)
+            .await;
+        self.start_setup_for_record(workspace, command, base_ref)
+            .await
+    }
+
+    async fn load_workspace(
+        &self,
+        workspace_id: String,
+    ) -> Result<WorkspaceRecord, WorkspaceSetupError> {
+        let runtime = self.workspace_runtime.clone();
+        let lookup_id = workspace_id.clone();
+        let record = tokio::task::spawn_blocking(move || runtime.get_workspace(&lookup_id))
+            .await??
+            .ok_or(WorkspaceSetupError::WorkspaceNotFound(workspace_id))?;
+        Ok(record)
+    }
+
+    async fn start_setup_for_record(
+        &self,
+        record: WorkspaceRecord,
+        command: String,
+        base_ref: Option<String>,
+    ) -> Result<TerminalCommandRunRecord, WorkspaceSetupError> {
+        let env_vars = {
+            let workspace_runtime = self.workspace_runtime.clone();
+            let record = record.clone();
+            let base_ref = base_ref.clone();
+            tokio::task::spawn_blocking(move || {
+                workspace_runtime.build_workspace_env(&record, base_ref.as_deref())
+            })
+            .await??
+        };
+
+        Ok(self
+            .terminal_service
+            .start_setup_command(&record.id, &record.path, command, env_vars, None)
+            .await?)
+    }
+}
+
+fn normalize_setup_command(command: String) -> Result<String, WorkspaceSetupError> {
+    let command = command.trim().to_string();
+    if command.is_empty() {
+        return Err(WorkspaceSetupError::InvalidCommand);
+    }
+    Ok(command)
+}

--- a/anyharness/crates/anyharness-lib/src/workspaces/worktree_runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/worktree_runtime.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+
+use crate::origin::OriginContext;
+use crate::workspaces::creator_context::WorkspaceCreatorContext;
+use crate::workspaces::retention::WorkspaceRetentionService;
+use crate::workspaces::runtime::WorkspaceRuntime;
+use crate::workspaces::setup_runtime::{WorkspaceSetupError, WorkspaceSetupRuntime};
+use crate::workspaces::types::CreateWorktreeResult;
+
+#[derive(Clone)]
+pub struct WorkspaceWorktreeRuntime {
+    workspace_runtime: Arc<WorkspaceRuntime>,
+    setup_runtime: Arc<WorkspaceSetupRuntime>,
+    retention_service: Arc<WorkspaceRetentionService>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateWorktreeWorkflowInput {
+    pub repo_root_id: String,
+    pub target_path: String,
+    pub new_branch_name: String,
+    pub base_branch: Option<String>,
+    pub setup_script: Option<String>,
+    pub surface: String,
+    pub origin: OriginContext,
+    pub creator_context: Option<WorkspaceCreatorContext>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateWorktreeWorkflowResult {
+    pub worktree: CreateWorktreeResult,
+    pub setup_started: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreateWorktreeWorkflowError {
+    #[error("worktree create task failed: {0}")]
+    CreateTaskFailed(tokio::task::JoinError),
+    #[error(transparent)]
+    Create(anyhow::Error),
+    #[error(transparent)]
+    Setup(#[from] WorkspaceSetupError),
+}
+
+impl WorkspaceWorktreeRuntime {
+    pub fn new(
+        workspace_runtime: Arc<WorkspaceRuntime>,
+        setup_runtime: Arc<WorkspaceSetupRuntime>,
+        retention_service: Arc<WorkspaceRetentionService>,
+    ) -> Self {
+        Self {
+            workspace_runtime,
+            setup_runtime,
+            retention_service,
+        }
+    }
+
+    pub async fn create_worktree(
+        &self,
+        input: CreateWorktreeWorkflowInput,
+    ) -> Result<CreateWorktreeWorkflowResult, CreateWorktreeWorkflowError> {
+        let workspace_runtime = self.workspace_runtime.clone();
+        let repo_root_id = input.repo_root_id.clone();
+        let target_path = input.target_path.clone();
+        let new_branch_name = input.new_branch_name.clone();
+        let base_branch = input.base_branch.clone();
+        let surface = input.surface.clone();
+        let origin = input.origin;
+        let creator_context = input.creator_context;
+        let worktree = tokio::task::spawn_blocking(move || {
+            workspace_runtime.create_worktree_with_surface(
+                &repo_root_id,
+                &target_path,
+                &new_branch_name,
+                base_branch.as_deref(),
+                None,
+                &surface,
+                origin,
+                creator_context,
+            )
+        })
+        .await
+        .map_err(CreateWorktreeWorkflowError::CreateTaskFailed)?
+        .map_err(CreateWorktreeWorkflowError::Create)?;
+
+        let setup_started = if let Some(script) = normalized_setup_script(input.setup_script) {
+            self.setup_runtime
+                .start_setup_for_created_workspace(
+                    worktree.workspace.clone(),
+                    script,
+                    input.base_branch.clone(),
+                )
+                .await?;
+            true
+        } else {
+            false
+        };
+
+        self.retention_service
+            .clone()
+            .spawn_post_create_pass(worktree.workspace.id.clone());
+
+        Ok(CreateWorktreeWorkflowResult {
+            worktree,
+            setup_started,
+        })
+    }
+}
+
+fn normalized_setup_script(script: Option<String>) -> Option<String> {
+    script
+        .map(|script| script.trim().to_string())
+        .filter(|script| !script.is_empty())
+}


### PR DESCRIPTION
## Summary
- Move workspace worktree/setup orchestration out of HTTP handlers into workspace runtimes.
- Move agent catalog/readiness/install orchestration out of API handlers into `AgentRuntime`.
- Keep HTTP handlers focused on request extraction, auth, owner calls, and response/error mapping.

## Checks
- `cargo fmt --package anyharness-lib`
- `cargo check -p anyharness-lib`
- `cargo test -p anyharness-lib domains::agents`
- `cargo test -p anyharness-lib workspaces::`
- `git diff --check`
