### PR TITLE
fix(desktop): preserve sidebar row spacing

### DIFF
--- a/apps/packages/product-ui/test/ProductSidebar.test.tsx
+++ b/apps/packages/product-ui/test/ProductSidebar.test.tsx
@@ -38,6 +38,7 @@ describe("ProductSidebar", () => {
                 subtitle: "proliferate-ai/proliferate",
                 active: false,
                 status: <span aria-label="running" />,
+                detail: <span aria-label="detail">D</span>,
                 trailingLabel: "Slack",
                 shortcutLabel: "⌥⌘1",
                 actions: [{ id: "more", label: "More" }],
@@ -82,6 +83,7 @@ describe("ProductSidebar", () => {
     expect(screen.getByText("Pablo")).toBeTruthy();
     expect(screen.getByText("⌘B").className).toContain("opacity-100");
     expect(screen.getByText("⌥⌘1").className).toContain("opacity-100");
+    expect(screen.getByText("Slack").parentElement?.className).toContain("ml-[5px]");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
     expect(onAction).toHaveBeenCalledWith({ scope: "header", actionId: "toggle-sidebar" });

--- a/apps/packages/ui/src/layout/SidebarNavRow.tsx
+++ b/apps/packages/ui/src/layout/SidebarNavRow.tsx
@@ -23,6 +23,7 @@ export function SidebarNavRow({
   shortcutLabel,
   shortcutRevealVisible,
   onPress,
+  className = "",
   ...props
 }: SidebarNavRowProps) {
   return (
@@ -31,7 +32,7 @@ export function SidebarNavRow({
       active={active}
       disabled={disabled}
       onPress={onPress}
-      className="h-[30px] gap-2 px-2 py-1 text-sm leading-4 focus-visible:outline-offset-[-2px]"
+      className={`h-[30px] gap-2 px-2 py-1 text-sm leading-4 focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       <div className="flex size-5 shrink-0 items-center justify-center">

--- a/apps/packages/ui/test/SidebarNavRow.test.tsx
+++ b/apps/packages/ui/test/SidebarNavRow.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SidebarNavRow } from "../src/layout/SidebarNavRow";
+
+afterEach(cleanup);
+
+describe("SidebarNavRow", () => {
+  it("merges caller classes without dropping base row spacing", () => {
+    render(
+      <SidebarNavRow
+        label="General"
+        icon={<span>G</span>}
+        onPress={vi.fn()}
+        className="!text-sidebar-foreground"
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: "G General" });
+    expect(row.className).toContain("h-[30px]");
+    expect(row.className).toContain("gap-2");
+    expect(row.className).toContain("px-2");
+    expect(row.className).toContain("!text-sidebar-foreground");
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve shared SidebarNavRow base spacing when callers pass state classes
- Add regression coverage for settings sidebar row spacing and workspace date gap behavior

## Verification
- pnpm --filter @proliferate/ui test -- SidebarNavRow
- pnpm --filter @proliferate/product-ui test -- ProductSidebar
- pnpm --dir apps/desktop exec vitest run src/components/settings/sidebar/SettingsSidebar.test.tsx

Note: a broad desktop vitest run also executed and hit two unrelated existing domain test failures outside this change.