### PR TITLE
ci(release): build E2B when bypassing staging

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -139,7 +139,7 @@ jobs:
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.e2b == 'true' }}
       rolling_tag: production
-      mode: promote_only
+      mode: ${{ github.event.inputs.require_staging_success == 'true' && 'promote_only' || 'build_and_promote' }}
     secrets: inherit
 
   deploy-server:

--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -519,6 +519,8 @@ Deploy graph:
    - E2B builds immutable `sha-*` tags for staging, then moves the rolling
      `staging` tag after smoke
    - production E2B promotes the already-built `sha-*` tag to `production`
+     when staging success is required; if staging is explicitly bypassed, it
+     builds and smokes the immutable `sha-*` tag before promotion
    - server deploys ECR/ECS, runs Alembic, and smokes health
    - web deploys through Vercel, aliases the environment URL, and smokes it
    - mobile uses EAS build/submit when `MOBILE_DEPLOY_ENABLED=true`


### PR DESCRIPTION
## Summary
- Build and smoke the production E2B immutable tag when staging success is explicitly bypassed
- Document the bypass behavior in the CI/CD deploy graph

## Verification
- actionlint .github/workflows/promote-production.yml