### PR TITLE
release(desktop): bump to 0.1.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyharness-credential-discovery",
  "base64 0.22.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proliferate",
   "private": true,
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proliferate"
-version = "0.1.40"
+version = "0.1.41"
 edition.workspace = true
 
 [build-dependencies]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Proliferate",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "identifier": "com.proliferate.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump desktop package/Tauri/Cargo versions to 0.1.41 for a production updater release

## Verification
- Local version consistency check for package.json, tauri.conf.json, and Cargo.toml