### PR TITLE
release(mobile): bump iOS build number

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -24,7 +24,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   ios: {
     bundleIdentifier: BUNDLE_ID,
-    buildNumber: "28",
+    buildNumber: "29",
     supportsTablet: true,
     usesAppleSignIn: true,
     associatedDomains: ["applinks:app.proliferate.ai"],


### PR DESCRIPTION
## Summary\n- bump the production iOS build number from 28 to 29 so TestFlight submit can accept a new build\n\n## Verification\n- node check confirmed apps/mobile/app.config.ts contains buildNumber 29\n\n## Release notes\n- Mobile production release metadata only; no user-facing behavior change.