### PR TITLE
refactor(anyharness): clean up session store live boundary

### DIFF
--- a/anyharness/crates/anyharness-lib/src/acp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/mod.rs
@@ -1,4 +1,3 @@
 pub(crate) mod permission_context;
 pub(crate) mod permission_payload;
-pub mod persistence_sanitizer;
 pub mod provider_errors;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
@@ -7,7 +7,6 @@ use anyharness_contract::v1::{
 };
 use tokio::sync::Mutex;
 
-use crate::acp::persistence_sanitizer::sanitize_raw_notification_for_sqlite;
 use crate::domains::plans::service::PlanService;
 use crate::domains::reviews::service::ReviewService;
 use crate::live::sessions::actor::config::apply::set_select_option_current_value_for_purpose;
@@ -334,7 +333,7 @@ pub(in crate::live::sessions::actor) fn persist_raw_notification(
     kind: &str,
     notif: &acp::SessionNotification,
 ) -> anyhow::Result<()> {
-    let payload_json = serde_json::to_string(&sanitize_raw_notification_for_sqlite(notif))?;
+    let payload_json = serde_json::to_string(notif)?;
     session_store.append_raw_notification(
         session_id,
         kind,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/event_sink/publish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/event_sink/publish.rs
@@ -1,7 +1,6 @@
 use tokio::sync::broadcast;
 
 use super::SessionEventSink;
-use crate::acp::persistence_sanitizer::sanitize_session_event_for_sqlite;
 use crate::sessions::model::SessionEventRecord;
 use crate::sessions::runtime_event::RuntimeEventInjectionError;
 use crate::sessions::store::SessionStore;
@@ -55,8 +54,7 @@ pub(crate) fn publish_session_event(
         event,
     };
 
-    let persisted_event = sanitize_session_event_for_sqlite(&envelope.event);
-    let payload_json = serde_json::to_string(&persisted_event).unwrap_or_default();
+    let payload_json = serde_json::to_string(&envelope.event).unwrap_or_default();
     tracing::debug!(session_id = %session_id, seq = seq, "event_sink: event persisted");
     let record = SessionEventRecord {
         id: 0,
@@ -97,8 +95,7 @@ pub(super) fn publish_session_event_strict(
         item_id: item_id.clone(),
         event,
     };
-    let persisted_event = sanitize_session_event_for_sqlite(&envelope.event);
-    let payload_json = serde_json::to_string(&persisted_event)
+    let payload_json = serde_json::to_string(&envelope.event)
         .map_err(|error| RuntimeEventInjectionError::PersistenceFailed(error.to_string()))?;
     let record = SessionEventRecord {
         id: 0,

--- a/anyharness/crates/anyharness-lib/src/sessions/store/events.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/events.rs
@@ -1,7 +1,7 @@
 use rusqlite::params;
 
+use super::persisted_payloads::sanitize_session_event_for_sqlite;
 use super::SessionStore;
-use crate::acp::persistence_sanitizer::sanitize_session_event_for_sqlite;
 use crate::sessions::model::SessionEventRecord;
 
 impl SessionStore {

--- a/anyharness/crates/anyharness-lib/src/sessions/store/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/mod.rs
@@ -7,6 +7,7 @@ mod links;
 mod live_config;
 mod notifications;
 mod pending_prompts;
+pub(crate) mod persisted_payloads;
 pub(crate) mod sessions;
 
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/sessions/store/notifications.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/notifications.rs
@@ -1,7 +1,7 @@
 use rusqlite::params;
 
+use super::persisted_payloads::sanitize_raw_notification_json_for_sqlite;
 use super::SessionStore;
-use crate::acp::persistence_sanitizer::sanitize_raw_notification_json_for_sqlite;
 use crate::sessions::model::SessionRawNotificationRecord;
 
 impl SessionStore {

--- a/anyharness/crates/anyharness-lib/src/sessions/store/persisted_payloads.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/persisted_payloads.rs
@@ -1,4 +1,3 @@
-use agent_client_protocol as acp;
 use anyharness_contract::v1::{
     ContentPart, ItemCompletedEvent, ItemDeltaEvent, ItemStartedEvent, SessionEvent,
     TranscriptItemDeltaPayload, TranscriptItemPayload,
@@ -7,7 +6,7 @@ use anyharness_contract::v1::{
 const MAX_PERSISTED_OUTPUT_BYTES: usize = 16 * 1024;
 const TRUNCATION_MARKER: &str = "\n[truncated for storage]";
 
-pub fn sanitize_session_event_for_sqlite(event: &SessionEvent) -> SessionEvent {
+pub(crate) fn sanitize_session_event_for_sqlite(event: &SessionEvent) -> SessionEvent {
     let mut event = event.clone();
     match &mut event {
         SessionEvent::ItemStarted(ItemStartedEvent { item }) => sanitize_item_payload(item),
@@ -18,15 +17,7 @@ pub fn sanitize_session_event_for_sqlite(event: &SessionEvent) -> SessionEvent {
     event
 }
 
-pub fn sanitize_raw_notification_for_sqlite(
-    notification: &acp::SessionNotification,
-) -> serde_json::Value {
-    let mut value = serde_json::to_value(notification).unwrap_or_else(|_| serde_json::Value::Null);
-    sanitize_generated_output_json(&mut value);
-    value
-}
-
-pub fn sanitize_raw_notification_json_for_sqlite(payload_json: &str) -> String {
+pub(crate) fn sanitize_raw_notification_json_for_sqlite(payload_json: &str) -> String {
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(payload_json) else {
         return payload_json.to_string();
     };

--- a/anyharness/crates/anyharness-lib/src/sessions/store/tests/events.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/tests/events.rs
@@ -33,6 +33,51 @@ fn detects_when_a_session_has_started_a_turn() {
 }
 
 #[test]
+fn append_event_sanitizes_large_persisted_payloads() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    let oversized_text = "x".repeat(16 * 1024 + 128);
+    let payload_json = serde_json::json!({
+        "type": "item_delta",
+        "delta": {
+            "appendContentParts": [
+                {
+                    "type": "tool_result_text",
+                    "text": oversized_text,
+                }
+            ]
+        }
+    })
+    .to_string();
+
+    store
+        .append_event(&SessionEventRecord {
+            id: 0,
+            session_id: "session-1".to_string(),
+            seq: 1,
+            timestamp: "2026-03-25T00:01:00Z".to_string(),
+            event_type: "item_delta".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            item_id: Some("item-1".to_string()),
+            payload_json,
+        })
+        .expect("append event");
+
+    let events = store.list_events("session-1").expect("list events");
+    let persisted: serde_json::Value =
+        serde_json::from_str(&events[0].payload_json).expect("parse event payload");
+    let content_part = &persisted["delta"]["appendContentParts"][0];
+
+    assert_eq!(content_part["textTruncated"], true);
+    assert_eq!(content_part["textOriginalBytes"], 16 * 1024 + 128);
+    assert!(content_part["text"].as_str().unwrap().len() <= 16 * 1024);
+}
+
+#[test]
 fn limited_event_reads_return_newest_events_in_ascending_order() {
     let db = Db::open_in_memory().expect("open db");
     seed_workspace(&db);

--- a/anyharness/crates/anyharness-lib/src/sessions/store/tests/notifications.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/store/tests/notifications.rs
@@ -41,3 +41,50 @@ fn raw_notifications_are_persisted_in_seq_order() {
     assert_eq!(tail.len(), 1);
     assert_eq!(tail[0].seq, 2);
 }
+
+#[test]
+fn append_raw_notification_sanitizes_large_persisted_payloads() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    let oversized_output = "x".repeat(16 * 1024 + 128);
+    let payload_json = serde_json::json!({
+        "_anyharness": {
+            "aggregated_output": oversized_output.clone(),
+        },
+        "aggregated_output": oversized_output,
+    })
+    .to_string();
+
+    store
+        .append_raw_notification(
+            "session-1",
+            "tool_call",
+            "2026-03-25T00:00:01Z",
+            &payload_json,
+        )
+        .expect("append raw notification");
+
+    let raw = store
+        .list_raw_notifications("session-1")
+        .expect("list raw notifications");
+    let persisted: serde_json::Value =
+        serde_json::from_str(&raw[0].payload_json).expect("parse raw payload");
+
+    assert_eq!(
+        persisted["_anyharness"]["aggregated_output"]
+            .as_str()
+            .unwrap()
+            .len(),
+        16 * 1024 + 128
+    );
+    assert_eq!(persisted["aggregated_output_truncated"], true);
+    assert_eq!(
+        persisted["aggregated_output_original_bytes"],
+        16 * 1024 + 128
+    );
+    assert!(persisted["aggregated_output"].as_str().unwrap().len() <= 16 * 1024);
+}

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -6,8 +6,6 @@
 # This is migration debt, not permission for new code. If a cleanup reduces a
 # count, update this file in the same PR.
 
-SESSION_STORE_LIVE_IMPORT anyharness/crates/anyharness-lib/src/sessions/store/events.rs 1 transitional session event sanitizer still lives under live session event sink
-SESSION_STORE_LIVE_IMPORT anyharness/crates/anyharness-lib/src/sessions/store/notifications.rs 1 transitional raw notification sanitizer still lives under live session event sink
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/injection.rs 2 transitional session MCP injection still imports product MCP modules
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_catalog.rs 2 transitional session MCP catalog still imports product MCP auth modules
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs 2 transitional session MCP selection still imports product MCP modules


### PR DESCRIPTION
## Summary
- move persisted session event/raw-notification sanitization from the transitional `acp` root into `sessions/store/persisted_payloads.rs`
- let session store append paths enforce persisted payload truncation while live event sink/actor code serializes raw payloads and delegates durable projection to the store
- remove the two `SESSION_STORE_LIVE_IMPORT` allowlist entries and add store-focused sanitizer coverage

## Verification
- `python3 scripts/check_anyharness_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_anyharness_old_paths.py`
- `git diff --check`
- `cargo check -p anyharness-lib`
- `cargo test -p anyharness-lib sessions::store::tests`
- `cargo test -p anyharness-lib live::sessions::event_sink`
- `cargo test -p anyharness-lib live::sessions::actor::tests::notifications`
