### PR TITLE
refactor(anyharness): move domain response DTOs to API mappers

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
@@ -1,7 +1,10 @@
 use anyharness_contract::v1::{
-    CoworkArtifactDetailResponse, CoworkArtifactManifestResponse, CoworkManagedWorkspacesResponse,
+    CoworkArtifactDetailResponse, CoworkArtifactManifestResponse,
+    CoworkArtifactSummary as ContractCoworkArtifactSummary,
+    CoworkArtifactType as ContractCoworkArtifactType, CoworkCodingCompletionSummary,
+    CoworkCodingSessionSummary, CoworkManagedWorkspaceSummary, CoworkManagedWorkspacesResponse,
     CoworkRoot, CoworkStatus, CoworkThread, CreateCoworkThreadRequest, CreateCoworkThreadResponse,
-    Workspace,
+    SessionStatus, Workspace,
 };
 use axum::{
     extract::{Path, State},
@@ -12,9 +15,14 @@ use super::blocking::run_blocking;
 use super::error::ApiError;
 use super::workspaces_contract::workspace_to_contract_with_summary;
 use crate::app::AppState;
+use crate::domains::cowork::artifacts::{CoworkArtifactDetail, CoworkArtifactManifest};
 use crate::domains::cowork::manifest::CoworkArtifactError;
+use crate::domains::cowork::manifest::{CoworkArtifactSummary, CoworkArtifactType};
 use crate::domains::cowork::model::CoworkRootRecord;
-use crate::domains::cowork::runtime::{CoworkCreateThreadError, CoworkThreadSummary};
+use crate::domains::cowork::runtime::{
+    CoworkCodingCompletion, CoworkCodingSessionContext, CoworkCreateThreadError,
+    CoworkManagedWorkspaceContext, CoworkManagedWorkspacesContext, CoworkThreadSummary,
+};
 use crate::repo_roots::model::RepoRootRecord;
 use crate::sessions::mcp_bindings::crypto::SessionMcpBindingsError;
 use crate::workspaces::model::WorkspaceRecord;
@@ -140,7 +148,7 @@ pub async fn get_cowork_manifest(
     })
     .await?
     .map_err(map_cowork_artifact_error)?;
-    Ok(Json(manifest))
+    Ok(Json(cowork_artifact_manifest_to_contract(manifest)))
 }
 
 #[utoipa::path(
@@ -168,7 +176,7 @@ pub async fn get_cowork_artifact(
     })
     .await?
     .map_err(map_cowork_artifact_error)?;
-    Ok(Json(artifact))
+    Ok(Json(cowork_artifact_detail_to_contract(artifact)))
 }
 
 #[utoipa::path(
@@ -185,7 +193,7 @@ pub async fn get_cowork_managed_workspaces(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<Json<CoworkManagedWorkspacesResponse>, ApiError> {
-    let response = state
+    let context = state
         .cowork_runtime
         .managed_workspaces_context(&session_id)
         .await
@@ -195,7 +203,7 @@ pub async fn get_cowork_managed_workspaces(
             }
             other => ApiError::internal(other.to_string()),
         })?;
-    Ok(Json(response))
+    Ok(Json(cowork_managed_workspaces_to_contract(context)))
 }
 
 fn map_create_cowork_thread_error(error: CoworkCreateThreadError) -> ApiError {
@@ -247,6 +255,135 @@ fn map_create_cowork_thread_error(error: CoworkCreateThreadError) -> ApiError {
             }
         },
         CoworkCreateThreadError::Internal(error) => ApiError::internal(error.to_string()),
+    }
+}
+
+fn cowork_artifact_manifest_to_contract(
+    manifest: CoworkArtifactManifest,
+) -> CoworkArtifactManifestResponse {
+    CoworkArtifactManifestResponse {
+        version: manifest.version,
+        artifacts: manifest
+            .artifacts
+            .into_iter()
+            .map(cowork_artifact_summary_to_contract)
+            .collect(),
+    }
+}
+
+fn cowork_artifact_detail_to_contract(
+    detail: CoworkArtifactDetail,
+) -> CoworkArtifactDetailResponse {
+    CoworkArtifactDetailResponse {
+        artifact: cowork_artifact_summary_to_contract(detail.artifact),
+        content: detail.content,
+    }
+}
+
+fn cowork_artifact_summary_to_contract(
+    artifact: CoworkArtifactSummary,
+) -> ContractCoworkArtifactSummary {
+    ContractCoworkArtifactSummary {
+        id: artifact.id,
+        path: artifact.path,
+        r#type: cowork_artifact_type_to_contract(artifact.r#type),
+        title: artifact.title,
+        description: artifact.description,
+        created_at: artifact.created_at,
+        updated_at: artifact.updated_at,
+        exists: artifact.exists,
+        size_bytes: artifact.size_bytes,
+        modified_at: artifact.modified_at,
+    }
+}
+
+fn cowork_artifact_type_to_contract(
+    artifact_type: CoworkArtifactType,
+) -> ContractCoworkArtifactType {
+    match artifact_type {
+        CoworkArtifactType::TextMarkdown => ContractCoworkArtifactType::TextMarkdown,
+        CoworkArtifactType::TextHtml => ContractCoworkArtifactType::TextHtml,
+        CoworkArtifactType::ImageSvgXml => ContractCoworkArtifactType::ImageSvgXml,
+        CoworkArtifactType::ApplicationVndProliferateReact => {
+            ContractCoworkArtifactType::ApplicationVndProliferateReact
+        }
+    }
+}
+
+fn cowork_managed_workspaces_to_contract(
+    context: CoworkManagedWorkspacesContext,
+) -> CoworkManagedWorkspacesResponse {
+    CoworkManagedWorkspacesResponse {
+        workspaces: context
+            .workspaces
+            .into_iter()
+            .map(cowork_managed_workspace_to_contract)
+            .collect(),
+    }
+}
+
+fn cowork_managed_workspace_to_contract(
+    workspace: CoworkManagedWorkspaceContext,
+) -> CoworkManagedWorkspaceSummary {
+    CoworkManagedWorkspaceSummary {
+        cowork_workspace_id: workspace.cowork_workspace_id,
+        ownership_id: workspace.ownership_id,
+        workspace_id: workspace.workspace_id,
+        source_workspace_id: workspace.source_workspace_id,
+        label: workspace.label,
+        created_at: workspace.created_at,
+        closed_at: workspace.closed_at,
+        sessions: workspace
+            .sessions
+            .into_iter()
+            .map(cowork_coding_session_to_contract)
+            .collect(),
+    }
+}
+
+fn cowork_coding_session_to_contract(
+    session: CoworkCodingSessionContext,
+) -> CoworkCodingSessionSummary {
+    CoworkCodingSessionSummary {
+        cowork_agent_id: session.cowork_agent_id,
+        session_link_id: session.session_link_id,
+        coding_session_id: session.coding_session_id,
+        title: session.title,
+        label: session.label,
+        status: session_status_to_contract(&session.status),
+        agent_kind: session.agent_kind,
+        model_id: session.model_id,
+        mode_id: session.mode_id,
+        wake_scheduled: session.wake_scheduled,
+        latest_completion: session.latest_completion.map(cowork_completion_to_contract),
+        link_created_at: session.link_created_at,
+        link_closed_at: session.link_closed_at,
+        session_created_at: session.session_created_at,
+    }
+}
+
+fn cowork_completion_to_contract(
+    completion: CoworkCodingCompletion,
+) -> CoworkCodingCompletionSummary {
+    CoworkCodingCompletionSummary {
+        completion_id: completion.completion_id,
+        child_turn_id: completion.child_turn_id,
+        child_last_event_seq: completion.child_last_event_seq,
+        outcome: completion.outcome,
+        parent_event_seq: completion.parent_event_seq,
+        parent_prompt_seq: completion.parent_prompt_seq,
+        created_at: completion.created_at,
+    }
+}
+
+fn session_status_to_contract(status: &str) -> SessionStatus {
+    match status {
+        "starting" => SessionStatus::Starting,
+        "idle" => SessionStatus::Idle,
+        "running" => SessionStatus::Running,
+        "completed" => SessionStatus::Completed,
+        "closed" => SessionStatus::Closed,
+        _ => SessionStatus::Errored,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
@@ -1156,7 +1156,7 @@ pub async fn reveal_mcp_elicitation_url(
     ApiError,
 > {
     assert_session_auth_scope(&state, &auth, &session_id)?;
-    let response = state
+    let reveal = state
         .session_runtime
         .reveal_mcp_elicitation_url(&session_id, &request_id)
         .await
@@ -1164,7 +1164,10 @@ pub async fn reveal_mcp_elicitation_url(
 
     let mut headers = HeaderMap::new();
     headers.insert("cache-control", HeaderValue::from_static("no-store"));
-    Ok((headers, Json(response)))
+    Ok((
+        headers,
+        Json(anyharness_contract::v1::McpElicitationUrlRevealResponse { url: reveal.url }),
+    ))
 }
 
 fn raw_notification_record_to_envelope(

--- a/anyharness/crates/anyharness-lib/src/api/http/subagents.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/subagents.rs
@@ -1,6 +1,7 @@
 use anyharness_contract::v1::{
-    ProblemDetails, ScheduleSubagentWakeRequest, ScheduleSubagentWakeResponse,
-    SessionSubagentsResponse,
+    ChildSubagentSummary, ParentSubagentLinkSummary, ProblemDetails, ScheduleSubagentWakeRequest,
+    ScheduleSubagentWakeResponse, SessionStatus, SessionSubagentsResponse,
+    SubagentCompletionSummary as ContractSubagentCompletionSummary, SubagentTurnOutcome,
 };
 use axum::{
     extract::{Path, State},
@@ -11,6 +12,11 @@ use super::access::{assert_session_auth_scope, assert_workspace_mutable};
 use super::error::ApiError;
 use crate::api::auth::AuthContext;
 use crate::app::AppState;
+use crate::sessions::extensions::SessionTurnOutcome;
+use crate::sessions::subagents::model::{
+    ChildSubagentContext, ParentSubagentLinkContext, SessionSubagentsContext,
+    SubagentCompletionSummary,
+};
 use crate::sessions::subagents::service::SubagentError;
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
 
@@ -34,7 +40,7 @@ pub async fn get_session_subagents(
         .subagent_service
         .subagent_context(&session_id)
         .map_err(map_subagent_error)?;
-    Ok(Json(context))
+    Ok(Json(session_subagents_to_contract(context)))
 }
 
 #[utoipa::path(
@@ -88,6 +94,79 @@ pub async fn schedule_subagent_wake(
 
 #[allow(dead_code)]
 fn _problem_details_reference(_: ProblemDetails) {}
+
+fn session_subagents_to_contract(context: SessionSubagentsContext) -> SessionSubagentsResponse {
+    SessionSubagentsResponse {
+        parent: context.parent.map(parent_subagent_to_contract),
+        children: context
+            .children
+            .into_iter()
+            .map(child_subagent_to_contract)
+            .collect(),
+    }
+}
+
+fn parent_subagent_to_contract(parent: ParentSubagentLinkContext) -> ParentSubagentLinkSummary {
+    ParentSubagentLinkSummary {
+        subagent_id: parent.subagent_id,
+        session_link_id: parent.session_link_id,
+        parent_session_id: parent.parent_session_id,
+        parent_title: parent.parent_title,
+        parent_agent_kind: parent.parent_agent_kind,
+        parent_model_id: parent.parent_model_id,
+        label: parent.label,
+        link_created_at: parent.link_created_at,
+        link_closed_at: parent.link_closed_at,
+    }
+}
+
+fn child_subagent_to_contract(child: ChildSubagentContext) -> ChildSubagentSummary {
+    ChildSubagentSummary {
+        subagent_id: child.subagent_id,
+        session_link_id: child.session_link_id,
+        child_session_id: child.child_session_id,
+        title: child.title,
+        label: child.label,
+        status: session_status_to_contract(&child.status),
+        agent_kind: child.agent_kind,
+        model_id: child.model_id,
+        mode_id: child.mode_id,
+        link_created_at: child.link_created_at,
+        link_closed_at: child.link_closed_at,
+        child_created_at: child.child_created_at,
+        latest_completion: child.latest_completion.map(subagent_completion_to_contract),
+        wake_scheduled: child.wake_scheduled,
+    }
+}
+
+fn subagent_completion_to_contract(
+    completion: SubagentCompletionSummary,
+) -> ContractSubagentCompletionSummary {
+    ContractSubagentCompletionSummary {
+        completion_id: completion.completion_id,
+        child_turn_id: completion.child_turn_id,
+        outcome: match completion.outcome {
+            SessionTurnOutcome::Completed => SubagentTurnOutcome::Completed,
+            SessionTurnOutcome::Failed => SubagentTurnOutcome::Failed,
+            SessionTurnOutcome::Cancelled => SubagentTurnOutcome::Cancelled,
+        },
+        child_last_event_seq: completion.child_last_event_seq,
+        created_at: completion.created_at,
+        parent_event_seq: completion.parent_event_seq,
+        parent_prompt_seq: completion.parent_prompt_seq,
+    }
+}
+
+fn session_status_to_contract(status: &str) -> SessionStatus {
+    match status {
+        "starting" => SessionStatus::Starting,
+        "idle" => SessionStatus::Idle,
+        "running" => SessionStatus::Running,
+        "completed" => SessionStatus::Completed,
+        "closed" => SessionStatus::Closed,
+        _ => SessionStatus::Errored,
+    }
+}
 
 fn map_subagent_error(error: SubagentError) -> ApiError {
     match error {

--- a/anyharness/crates/anyharness-lib/src/api/http/worktrees.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/worktrees.rs
@@ -1,11 +1,23 @@
 use anyharness_contract::v1::{
     PruneOrphanWorktreeRequest, RunWorktreeRetentionResponse, UpdateWorktreeRetentionPolicyRequest,
-    WorktreeInventoryResponse, WorktreeRetentionPolicy, WorktreeRetentionRunRow,
+    WorkspaceCleanupOperation as ContractWorkspaceCleanupOperation,
+    WorkspaceCleanupState as ContractWorkspaceCleanupState, WorkspaceKind as ContractWorkspaceKind,
+    WorkspaceLifecycleState as ContractWorkspaceLifecycleState, WorkspaceRetireBlocker,
+    WorktreeInventoryAction as ContractWorktreeInventoryAction, WorktreeInventoryResponse,
+    WorktreeInventoryRow as ContractWorktreeInventoryRow,
+    WorktreeInventoryState as ContractWorktreeInventoryState,
+    WorktreeInventoryWorkspaceSummary as ContractWorktreeInventoryWorkspaceSummary,
+    WorktreeRetentionPolicy, WorktreeRetentionRunRow,
 };
 use axum::{extract::State, Json};
 
 use super::error::ApiError;
 use crate::app::AppState;
+use crate::workspaces::inventory::{
+    WorkspaceCleanupOperation, WorkspaceCleanupState, WorkspaceKind, WorkspaceLifecycleState,
+    WorktreeInventory, WorktreeInventoryAction, WorktreeInventoryRow, WorktreeInventoryState,
+    WorktreeInventoryWorkspaceSummary,
+};
 
 #[utoipa::path(
     get,
@@ -19,6 +31,7 @@ pub async fn get_worktree_inventory(
     state
         .worktree_inventory_service
         .inventory()
+        .map(worktree_inventory_to_contract)
         .map(Json)
         .map_err(|error| ApiError::internal(error.to_string()))
 }
@@ -38,6 +51,7 @@ pub async fn prune_orphan_worktree(
     tokio::task::spawn_blocking(move || service.prune_orphan(&request.path))
         .await
         .map_err(|error| ApiError::internal(format!("worktree prune task failed: {error}")))?
+        .map(worktree_inventory_to_contract)
         .map(Json)
         .map_err(|error| ApiError::bad_request(error.to_string(), "WORKTREE_PRUNE_FAILED"))
 }
@@ -134,5 +148,124 @@ fn run_result_to_contract(
                 message: row.message,
             })
             .collect(),
+    }
+}
+
+fn worktree_inventory_to_contract(inventory: WorktreeInventory) -> WorktreeInventoryResponse {
+    WorktreeInventoryResponse {
+        rows: inventory
+            .rows
+            .into_iter()
+            .map(worktree_inventory_row_to_contract)
+            .collect(),
+    }
+}
+
+fn worktree_inventory_row_to_contract(row: WorktreeInventoryRow) -> ContractWorktreeInventoryRow {
+    ContractWorktreeInventoryRow {
+        id: row.id,
+        state: worktree_inventory_state_to_contract(row.state),
+        path: row.path,
+        canonical_path: row.canonical_path,
+        managed: row.managed,
+        materialized: row.materialized,
+        repo_root_id: row.repo_root_id,
+        repo_root_name: row.repo_root_name,
+        branch: row.branch,
+        associated_workspaces: row
+            .associated_workspaces
+            .into_iter()
+            .map(worktree_inventory_workspace_to_contract)
+            .collect(),
+        total_session_count: row.total_session_count,
+        blockers: Vec::<WorkspaceRetireBlocker>::new(),
+        cleanup_operation: row
+            .cleanup_operation
+            .map(workspace_cleanup_operation_to_contract),
+        cleanup_state: row.cleanup_state.map(workspace_cleanup_state_to_contract),
+        available_actions: row
+            .available_actions
+            .into_iter()
+            .map(worktree_inventory_action_to_contract)
+            .collect(),
+    }
+}
+
+fn worktree_inventory_workspace_to_contract(
+    workspace: WorktreeInventoryWorkspaceSummary,
+) -> ContractWorktreeInventoryWorkspaceSummary {
+    ContractWorktreeInventoryWorkspaceSummary {
+        id: workspace.id,
+        kind: workspace_kind_to_contract(workspace.kind),
+        lifecycle_state: workspace_lifecycle_state_to_contract(workspace.lifecycle_state),
+        cleanup_state: workspace_cleanup_state_to_contract(workspace.cleanup_state),
+        cleanup_operation: workspace
+            .cleanup_operation
+            .map(workspace_cleanup_operation_to_contract),
+        display_name: workspace.display_name,
+        branch: workspace.branch,
+        session_count: workspace.session_count,
+    }
+}
+
+fn worktree_inventory_state_to_contract(
+    state: WorktreeInventoryState,
+) -> ContractWorktreeInventoryState {
+    match state {
+        WorktreeInventoryState::Associated => ContractWorktreeInventoryState::Associated,
+        WorktreeInventoryState::OrphanCheckout => ContractWorktreeInventoryState::OrphanCheckout,
+        WorktreeInventoryState::MissingCheckout => ContractWorktreeInventoryState::MissingCheckout,
+        WorktreeInventoryState::Conflict => ContractWorktreeInventoryState::Conflict,
+    }
+}
+
+fn worktree_inventory_action_to_contract(
+    action: WorktreeInventoryAction,
+) -> ContractWorktreeInventoryAction {
+    match action {
+        WorktreeInventoryAction::PruneCheckout => ContractWorktreeInventoryAction::PruneCheckout,
+        WorktreeInventoryAction::DeleteWorkspaceHistory => {
+            ContractWorktreeInventoryAction::DeleteWorkspaceHistory
+        }
+        WorktreeInventoryAction::RetryPurge => ContractWorktreeInventoryAction::RetryPurge,
+        WorktreeInventoryAction::DeleteOrphanCheckout => {
+            ContractWorktreeInventoryAction::DeleteOrphanCheckout
+        }
+    }
+}
+
+fn workspace_kind_to_contract(kind: WorkspaceKind) -> ContractWorkspaceKind {
+    match kind {
+        WorkspaceKind::Worktree => ContractWorkspaceKind::Worktree,
+        WorkspaceKind::Local => ContractWorkspaceKind::Local,
+    }
+}
+
+fn workspace_lifecycle_state_to_contract(
+    state: WorkspaceLifecycleState,
+) -> ContractWorkspaceLifecycleState {
+    match state {
+        WorkspaceLifecycleState::Active => ContractWorkspaceLifecycleState::Active,
+        WorkspaceLifecycleState::Retired => ContractWorkspaceLifecycleState::Retired,
+    }
+}
+
+fn workspace_cleanup_state_to_contract(
+    state: WorkspaceCleanupState,
+) -> ContractWorkspaceCleanupState {
+    match state {
+        WorkspaceCleanupState::None => ContractWorkspaceCleanupState::None,
+        WorkspaceCleanupState::Pending => ContractWorkspaceCleanupState::Pending,
+        WorkspaceCleanupState::Complete => ContractWorkspaceCleanupState::Complete,
+        WorkspaceCleanupState::Failed => ContractWorkspaceCleanupState::Failed,
+    }
+}
+
+fn workspace_cleanup_operation_to_contract(
+    operation: WorkspaceCleanupOperation,
+) -> ContractWorkspaceCleanupOperation {
+    match operation {
+        WorkspaceCleanupOperation::Retire => ContractWorkspaceCleanupOperation::Retire,
+        WorkspaceCleanupOperation::Purge => ContractWorkspaceCleanupOperation::Purge,
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/artifacts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/artifacts.rs
@@ -2,15 +2,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use anyharness_contract::v1::{
-    CoworkArtifactDetailResponse, CoworkArtifactManifestResponse, CoworkArtifactSummary,
-};
+use serde::Serialize;
 use uuid::Uuid;
 
 use super::manifest::{
     artifact_type_from_path, enrich_manifest_entry, load_manifest_if_present,
     load_manifest_or_empty, manifest_path, validate_relative_artifact_path,
-    ArtifactManifestDocument, ArtifactManifestEntry, CoworkArtifactError,
+    ArtifactManifestDocument, ArtifactManifestEntry, CoworkArtifactError, CoworkArtifactSummary,
     COWORK_ARTIFACT_MANIFEST_RELATIVE_PATH, COWORK_ARTIFACT_MANIFEST_VERSION,
 };
 use crate::workspaces::model::WorkspaceRecord;
@@ -36,6 +34,20 @@ pub struct UpdateCoworkArtifactInput {
     pub description: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkArtifactManifest {
+    pub version: u32,
+    pub artifacts: Vec<CoworkArtifactSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkArtifactDetail {
+    pub artifact: CoworkArtifactSummary,
+    pub content: String,
+}
+
 impl CoworkArtifactRuntime {
     pub fn new() -> Self {
         Self::default()
@@ -44,7 +56,7 @@ impl CoworkArtifactRuntime {
     pub fn get_manifest(
         &self,
         workspace: &WorkspaceRecord,
-    ) -> Result<CoworkArtifactManifestResponse, CoworkArtifactError> {
+    ) -> Result<CoworkArtifactManifest, CoworkArtifactError> {
         ensure_cowork_workspace(workspace)?;
         let workspace_root = Path::new(&workspace.path);
         let manifest = load_manifest_or_empty(workspace_root)?;
@@ -54,7 +66,7 @@ impl CoworkArtifactRuntime {
             .map(|entry| enrich_manifest_entry(workspace_root, entry))
             .collect();
         artifacts.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
-        Ok(CoworkArtifactManifestResponse {
+        Ok(CoworkArtifactManifest {
             version: COWORK_ARTIFACT_MANIFEST_VERSION,
             artifacts,
         })
@@ -64,7 +76,7 @@ impl CoworkArtifactRuntime {
         &self,
         workspace: &WorkspaceRecord,
         artifact_id: &str,
-    ) -> Result<CoworkArtifactDetailResponse, CoworkArtifactError> {
+    ) -> Result<CoworkArtifactDetail, CoworkArtifactError> {
         ensure_cowork_workspace(workspace)?;
         let workspace_root = Path::new(&workspace.path);
         let manifest = load_manifest_or_empty(workspace_root)?;
@@ -78,7 +90,7 @@ impl CoworkArtifactRuntime {
         }
         let content = std::fs::read_to_string(workspace_root.join(&entry.path))
             .map_err(|error| CoworkArtifactError::ArtifactFileInvalid(error.to_string()))?;
-        Ok(CoworkArtifactDetailResponse { artifact, content })
+        Ok(CoworkArtifactDetail { artifact, content })
     }
 
     pub fn create_artifact(

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/manifest.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/manifest.rs
@@ -1,11 +1,40 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
-use anyharness_contract::v1::{CoworkArtifactSummary, CoworkArtifactType};
 use serde::{Deserialize, Serialize};
 
 pub const COWORK_ARTIFACT_MANIFEST_VERSION: u32 = 1;
 pub const COWORK_ARTIFACT_MANIFEST_RELATIVE_PATH: &str = ".proliferate/artifacts.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CoworkArtifactType {
+    #[serde(rename = "text/markdown")]
+    TextMarkdown,
+    #[serde(rename = "text/html")]
+    TextHtml,
+    #[serde(rename = "image/svg+xml")]
+    ImageSvgXml,
+    #[serde(rename = "application/vnd.proliferate.react")]
+    ApplicationVndProliferateReact,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkArtifactSummary {
+    pub id: String,
+    pub path: String,
+    pub r#type: CoworkArtifactType,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified_at: Option<String>,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum CoworkArtifactError {

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
@@ -6,10 +6,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use anyharness_contract::v1::{
-    ContentPart, CoworkCodingCompletionSummary, CoworkCodingSessionSummary,
-    CoworkManagedWorkspaceSummary, CoworkManagedWorkspacesResponse, SessionEvent,
-    SessionLinkTurnCompletedPayload, SubagentTurnOutcome,
+    ContentPart, SessionEvent, SessionLinkTurnCompletedPayload, SubagentTurnOutcome,
 };
+use serde::Serialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -120,6 +119,69 @@ pub struct CoworkCodingStatusResult {
     pub session_link: crate::sessions::links::model::SessionLinkRecord,
     pub wake_scheduled: bool,
     pub latest_completion: Option<LinkCompletionRecord>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkManagedWorkspacesContext {
+    pub workspaces: Vec<CoworkManagedWorkspaceContext>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkManagedWorkspaceContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cowork_workspace_id: Option<String>,
+    pub ownership_id: String,
+    pub workspace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_workspace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closed_at: Option<String>,
+    pub sessions: Vec<CoworkCodingSessionContext>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkCodingSessionContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cowork_agent_id: Option<String>,
+    pub session_link_id: String,
+    pub coding_session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub status: String,
+    pub agent_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
+    pub wake_scheduled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_completion: Option<CoworkCodingCompletion>,
+    pub link_created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_closed_at: Option<String>,
+    pub session_created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoworkCodingCompletion {
+    pub completion_id: String,
+    pub child_turn_id: String,
+    pub child_last_event_seq: i64,
+    pub outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_event_seq: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_prompt_seq: Option<i64>,
+    pub created_at: String,
 }
 
 const DEFAULT_CODING_WORKSPACE_NAME: &str = "coding-workspace";
@@ -1225,7 +1287,7 @@ impl CoworkRuntime {
     pub async fn managed_workspaces_context(
         &self,
         parent_session_id: &str,
-    ) -> Result<CoworkManagedWorkspacesResponse, CoworkDelegationError> {
+    ) -> Result<CoworkManagedWorkspacesContext, CoworkDelegationError> {
         let workspaces = self
             .delegation_service
             .list_managed_workspaces(parent_session_id)?;
@@ -1252,11 +1314,11 @@ impl CoworkRuntime {
             let sessions = linked_sessions
                 .into_iter()
                 .map(|(link, session)| {
-                    let status = session.to_contract().status;
+                    let status = normalized_session_status(&session.status).to_string();
                     let latest_completion = self
                         .delegation_service
                         .latest_completion_for_link(&link.id)?
-                        .map(|record| CoworkCodingCompletionSummary {
+                        .map(|record| CoworkCodingCompletion {
                             completion_id: record.completion_id,
                             child_turn_id: record.child_turn_id,
                             child_last_event_seq: record.child_last_event_seq,
@@ -1265,7 +1327,7 @@ impl CoworkRuntime {
                             parent_prompt_seq: record.parent_prompt_seq,
                             created_at: record.created_at,
                         });
-                    Ok(CoworkCodingSessionSummary {
+                    Ok(CoworkCodingSessionContext {
                         cowork_agent_id: link.public_id.clone(),
                         session_link_id: link.id.clone(),
                         coding_session_id: session.id,
@@ -1283,7 +1345,7 @@ impl CoworkRuntime {
                     })
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
-            summaries.push(CoworkManagedWorkspaceSummary {
+            summaries.push(CoworkManagedWorkspaceContext {
                 cowork_workspace_id: managed.public_id,
                 ownership_id: managed.id,
                 workspace_id: managed.workspace_id,
@@ -1294,7 +1356,7 @@ impl CoworkRuntime {
                 sessions,
             });
         }
-        Ok(CoworkManagedWorkspacesResponse {
+        Ok(CoworkManagedWorkspacesContext {
             workspaces: summaries,
         })
     }
@@ -1430,6 +1492,18 @@ fn normalize_optional_text(value: Option<String>) -> Option<String> {
 
 fn normalize_optional_ref(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn normalized_session_status(status: &str) -> &'static str {
+    match status {
+        "starting" => "starting",
+        "idle" => "idle",
+        "running" => "running",
+        "completed" => "completed",
+        "closed" => "closed",
+        "errored" => "errored",
+        _ => "errored",
+    }
 }
 
 fn cowork_transcript_search_text(record: &crate::sessions::model::SessionEventRecord) -> String {

--- a/anyharness/crates/anyharness-lib/src/sessions/runtime/interactions.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/runtime/interactions.rs
@@ -1,4 +1,4 @@
-use anyharness_contract::v1::{InteractionKind, McpElicitationUrlRevealResponse};
+use anyharness_contract::v1::InteractionKind;
 
 use crate::live::sessions::{
     InteractionResolution, PermissionDecision, ResolveInteractionCommandError,
@@ -6,8 +6,8 @@ use crate::live::sessions::{
 };
 
 use super::{
-    InteractionPermissionDecision, InteractionResolutionRequest, ResolveInteractionError,
-    SessionRuntime,
+    InteractionPermissionDecision, InteractionResolutionRequest, McpElicitationUrlReveal,
+    ResolveInteractionError, SessionRuntime,
 };
 
 impl SessionRuntime {
@@ -147,7 +147,7 @@ impl SessionRuntime {
         &self,
         session_id: &str,
         request_id: &str,
-    ) -> Result<McpElicitationUrlRevealResponse, ResolveInteractionError> {
+    ) -> Result<McpElicitationUrlReveal, ResolveInteractionError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
             .map_err(|error| ResolveInteractionError::SessionNotLive(error.to_string()))?;
@@ -192,6 +192,6 @@ impl SessionRuntime {
                 }
             })?;
 
-        Ok(McpElicitationUrlRevealResponse { url })
+        Ok(McpElicitationUrlReveal { url })
     }
 }

--- a/anyharness/crates/anyharness-lib/src/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/runtime/mod.rs
@@ -227,6 +227,11 @@ pub enum ResolveInteractionError {
     Internal(anyhow::Error),
 }
 
+#[derive(Debug, Clone)]
+pub struct McpElicitationUrlReveal {
+    pub url: String,
+}
+
 #[derive(Debug)]
 pub(super) enum StartSessionError {
     WorkspaceNotFound,

--- a/anyharness/crates/anyharness-lib/src/sessions/subagents/model.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/subagents/model.rs
@@ -3,6 +3,8 @@ pub use crate::sessions::links::completions::{
     LinkWakeScheduleRecord as SubagentWakeScheduleRecord,
 };
 
+use crate::sessions::extensions::SessionTurnOutcome;
+
 #[derive(Debug, Clone)]
 pub struct SubagentSummary {
     pub subagent_id: Option<String>,
@@ -15,6 +17,66 @@ pub struct SubagentSummary {
     pub mode_id: Option<String>,
     pub created_at: String,
     pub closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionSubagentsContext {
+    pub parent: Option<ParentSubagentLinkContext>,
+    pub children: Vec<ChildSubagentContext>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParentSubagentLinkContext {
+    pub subagent_id: Option<String>,
+    pub session_link_id: String,
+    pub parent_session_id: String,
+    pub parent_title: Option<String>,
+    pub parent_agent_kind: String,
+    pub parent_model_id: Option<String>,
+    pub label: Option<String>,
+    pub link_created_at: String,
+    pub link_closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChildSubagentContext {
+    pub subagent_id: Option<String>,
+    pub session_link_id: String,
+    pub child_session_id: String,
+    pub title: Option<String>,
+    pub label: Option<String>,
+    pub status: String,
+    pub agent_kind: String,
+    pub model_id: Option<String>,
+    pub mode_id: Option<String>,
+    pub link_created_at: String,
+    pub link_closed_at: Option<String>,
+    pub child_created_at: String,
+    pub latest_completion: Option<SubagentCompletionSummary>,
+    pub wake_scheduled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubagentCompletionSummary {
+    pub completion_id: String,
+    pub child_turn_id: String,
+    pub outcome: SessionTurnOutcome,
+    pub child_last_event_seq: i64,
+    pub created_at: String,
+    pub parent_event_seq: Option<i64>,
+    pub parent_prompt_seq: Option<i64>,
+}
+
+pub fn normalized_session_status(status: &str) -> &'static str {
+    match status {
+        "starting" => "starting",
+        "idle" => "idle",
+        "running" => "running",
+        "completed" => "completed",
+        "closed" => "closed",
+        "errored" => "errored",
+        _ => "errored",
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/anyharness/crates/anyharness-lib/src/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/subagents/service.rs
@@ -1,9 +1,10 @@
 use super::model::{
-    SubagentCompletionRecord, SubagentEventSlice, SubagentLatestTurn, SubagentSummary,
-    SubagentTranscriptSearchMatch, SubagentWakeScheduleRecord,
+    normalized_session_status, ChildSubagentContext, ParentSubagentLinkContext,
+    SessionSubagentsContext, SubagentCompletionRecord, SubagentEventSlice, SubagentLatestTurn,
+    SubagentSummary, SubagentTranscriptSearchMatch, SubagentWakeScheduleRecord,
 };
 use super::store::{SubagentCompletionInsert, SubagentStore};
-use super::summary::completion_to_contract;
+use super::summary::completion_to_summary;
 use super::transcript::{
     search_match_for_record, summarize_turn_events, LATEST_TURN_EVENT_BUDGET,
     READ_LATEST_TURNS_DEFAULT_LIMIT, READ_LATEST_TURNS_MAX_LIMIT, SEARCH_EVENT_BUDGET,
@@ -22,9 +23,6 @@ use crate::sessions::prompt::PromptPayload;
 use crate::sessions::store::SessionStore;
 use crate::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
 use crate::workspaces::runtime::WorkspaceRuntime;
-use anyharness_contract::v1::{
-    ChildSubagentSummary, ParentSubagentLinkSummary, SessionSubagentsResponse,
-};
 use std::collections::HashSet;
 
 pub const MAX_SUBAGENTS_PER_PARENT: usize = 8;
@@ -286,7 +284,7 @@ impl SubagentService {
     pub fn subagent_context(
         &self,
         session_id: &str,
-    ) -> Result<SessionSubagentsResponse, SubagentError> {
+    ) -> Result<SessionSubagentsContext, SubagentError> {
         self.session_store
             .find_by_id(session_id)?
             .ok_or_else(|| SubagentError::ParentNotFound(session_id.to_string()))?;
@@ -294,7 +292,7 @@ impl SubagentService {
         let parent = if let Some(link) = self.link_service.find_subagent_parent(session_id)? {
             self.session_store
                 .find_by_id(&link.parent_session_id)?
-                .map(|parent| ParentSubagentLinkSummary {
+                .map(|parent| ParentSubagentLinkContext {
                     subagent_id: link.public_id.clone(),
                     session_link_id: link.id,
                     parent_session_id: parent.id,
@@ -326,15 +324,15 @@ impl SubagentService {
             let latest_completion = self
                 .subagent_store
                 .latest_completion_for_link(&link.id)?
-                .map(completion_to_contract);
+                .map(completion_to_summary);
             let wake_scheduled = scheduled_link_ids.contains(&link.id);
-            children.push(ChildSubagentSummary {
+            children.push(ChildSubagentContext {
                 subagent_id: link.public_id.clone(),
                 session_link_id: link.id,
                 child_session_id: child.id.clone(),
                 title: child.title.clone(),
                 label: link.label,
-                status: child.to_contract().status,
+                status: normalized_session_status(&child.status).to_string(),
                 agent_kind: child.agent_kind,
                 model_id: child.current_model_id.or(child.requested_model_id),
                 mode_id: child.current_mode_id.or(child.requested_mode_id),
@@ -346,7 +344,7 @@ impl SubagentService {
             });
         }
 
-        Ok(SessionSubagentsResponse { parent, children })
+        Ok(SessionSubagentsContext { parent, children })
     }
 
     pub fn find_subagent_parent(

--- a/anyharness/crates/anyharness-lib/src/sessions/subagents/summary.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/subagents/summary.rs
@@ -1,17 +1,10 @@
-use anyharness_contract::v1::{SubagentCompletionSummary, SubagentTurnOutcome};
+use super::model::{SubagentCompletionRecord, SubagentCompletionSummary};
 
-use super::model::SubagentCompletionRecord;
-use crate::sessions::extensions::SessionTurnOutcome;
-
-pub(super) fn completion_to_contract(wake: SubagentCompletionRecord) -> SubagentCompletionSummary {
+pub(super) fn completion_to_summary(wake: SubagentCompletionRecord) -> SubagentCompletionSummary {
     SubagentCompletionSummary {
         completion_id: wake.completion_id,
         child_turn_id: wake.child_turn_id,
-        outcome: match wake.outcome {
-            SessionTurnOutcome::Completed => SubagentTurnOutcome::Completed,
-            SessionTurnOutcome::Failed => SubagentTurnOutcome::Failed,
-            SessionTurnOutcome::Cancelled => SubagentTurnOutcome::Cancelled,
-        },
+        outcome: wake.outcome,
         child_last_event_seq: wake.child_last_event_seq,
         created_at: wake.created_at,
         parent_event_seq: wake.parent_event_seq,

--- a/anyharness/crates/anyharness-lib/src/workspaces/inventory.rs
+++ b/anyharness/crates/anyharness-lib/src/workspaces/inventory.rs
@@ -2,16 +2,87 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyharness_contract::v1::{
-    WorkspaceCleanupOperation, WorkspaceCleanupState, WorkspaceKind, WorkspaceLifecycleState,
-    WorktreeInventoryAction, WorktreeInventoryResponse, WorktreeInventoryRow,
-    WorktreeInventoryState, WorktreeInventoryWorkspaceSummary,
-};
-
 use crate::sessions::store::SessionStore;
 use crate::workspaces::checkout_gate::{CheckoutDeletionGate, CheckoutPathLockKey};
 use crate::workspaces::managed_root::canonical_managed_worktrees_root;
 use crate::workspaces::store::WorkspaceStore;
+
+#[derive(Debug, Clone)]
+pub struct WorktreeInventory {
+    pub rows: Vec<WorktreeInventoryRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeInventoryState {
+    Associated,
+    OrphanCheckout,
+    MissingCheckout,
+    Conflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeInventoryAction {
+    PruneCheckout,
+    DeleteWorkspaceHistory,
+    RetryPurge,
+    DeleteOrphanCheckout,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeInventoryWorkspaceSummary {
+    pub id: String,
+    pub kind: WorkspaceKind,
+    pub lifecycle_state: WorkspaceLifecycleState,
+    pub cleanup_state: WorkspaceCleanupState,
+    pub cleanup_operation: Option<WorkspaceCleanupOperation>,
+    pub display_name: Option<String>,
+    pub branch: Option<String>,
+    pub session_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeInventoryRow {
+    pub id: String,
+    pub state: WorktreeInventoryState,
+    pub path: String,
+    pub canonical_path: Option<String>,
+    pub managed: bool,
+    pub materialized: bool,
+    pub repo_root_id: Option<String>,
+    pub repo_root_name: Option<String>,
+    pub branch: Option<String>,
+    pub associated_workspaces: Vec<WorktreeInventoryWorkspaceSummary>,
+    pub total_session_count: usize,
+    pub cleanup_operation: Option<WorkspaceCleanupOperation>,
+    pub cleanup_state: Option<WorkspaceCleanupState>,
+    pub available_actions: Vec<WorktreeInventoryAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceKind {
+    Worktree,
+    Local,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceLifecycleState {
+    Active,
+    Retired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceCleanupState {
+    None,
+    Pending,
+    Complete,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceCleanupOperation {
+    Retire,
+    Purge,
+}
 
 #[derive(Clone)]
 pub struct WorktreeInventoryService {
@@ -36,7 +107,7 @@ impl WorktreeInventoryService {
         }
     }
 
-    pub fn inventory(&self) -> anyhow::Result<WorktreeInventoryResponse> {
+    pub fn inventory(&self) -> anyhow::Result<WorktreeInventory> {
         let workspaces = self.workspace_store.list_all()?;
         let mut by_path: BTreeMap<String, Vec<_>> = BTreeMap::new();
         for workspace in workspaces
@@ -79,12 +150,10 @@ impl WorktreeInventoryService {
                         .unwrap_or(0);
                     WorktreeInventoryWorkspaceSummary {
                         id: workspace.id.clone(),
-                        kind: workspace_kind_to_contract(&workspace.kind),
-                        lifecycle_state: workspace_lifecycle_to_contract(
-                            &workspace.lifecycle_state,
-                        ),
-                        cleanup_state: workspace_cleanup_to_contract(&workspace.cleanup_state),
-                        cleanup_operation: workspace_cleanup_operation_to_contract(
+                        kind: workspace_kind(&workspace.kind),
+                        lifecycle_state: workspace_lifecycle(&workspace.lifecycle_state),
+                        cleanup_state: workspace_cleanup(&workspace.cleanup_state),
+                        cleanup_operation: workspace_cleanup_operation(
                             workspace.cleanup_operation.as_deref(),
                         ),
                         display_name: workspace.display_name.clone(),
@@ -122,14 +191,13 @@ impl WorktreeInventoryService {
                     .first()
                     .and_then(|workspace| workspace.current_branch.clone()),
                 cleanup_operation: associated.first().and_then(|workspace| {
-                    workspace_cleanup_operation_to_contract(workspace.cleanup_operation.as_deref())
+                    workspace_cleanup_operation(workspace.cleanup_operation.as_deref())
                 }),
                 cleanup_state: associated
                     .first()
-                    .map(|workspace| workspace_cleanup_to_contract(&workspace.cleanup_state)),
+                    .map(|workspace| workspace_cleanup(&workspace.cleanup_state)),
                 associated_workspaces: summaries,
                 total_session_count,
-                blockers: Vec::new(),
                 available_actions: actions,
             });
             known_paths.insert(path);
@@ -160,7 +228,6 @@ impl WorktreeInventoryService {
                     branch: None,
                     associated_workspaces: Vec::new(),
                     total_session_count: 0,
-                    blockers: Vec::new(),
                     cleanup_operation: None,
                     cleanup_state: None,
                     available_actions: vec![WorktreeInventoryAction::DeleteOrphanCheckout],
@@ -168,10 +235,10 @@ impl WorktreeInventoryService {
             }
         }
 
-        Ok(WorktreeInventoryResponse { rows })
+        Ok(WorktreeInventory { rows })
     }
 
-    pub fn prune_orphan(&self, path: &str) -> anyhow::Result<WorktreeInventoryResponse> {
+    pub fn prune_orphan(&self, path: &str) -> anyhow::Result<WorktreeInventory> {
         let canonical_root = canonical_managed_worktrees_root(&self.runtime_home)?;
         let canonical_path = std::fs::canonicalize(path)
             .map_err(|error| anyhow::anyhow!("canonicalizing orphan worktree: {error}"))?;
@@ -279,21 +346,21 @@ fn git_worktree_paths(worktree: &Path) -> anyhow::Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
-fn workspace_kind_to_contract(kind: &str) -> WorkspaceKind {
+fn workspace_kind(kind: &str) -> WorkspaceKind {
     match kind {
         "worktree" => WorkspaceKind::Worktree,
         _ => WorkspaceKind::Local,
     }
 }
 
-fn workspace_lifecycle_to_contract(state: &str) -> WorkspaceLifecycleState {
+fn workspace_lifecycle(state: &str) -> WorkspaceLifecycleState {
     match state {
         "retired" => WorkspaceLifecycleState::Retired,
         _ => WorkspaceLifecycleState::Active,
     }
 }
 
-fn workspace_cleanup_to_contract(state: &str) -> WorkspaceCleanupState {
+fn workspace_cleanup(state: &str) -> WorkspaceCleanupState {
     match state {
         "pending" => WorkspaceCleanupState::Pending,
         "complete" => WorkspaceCleanupState::Complete,
@@ -302,9 +369,7 @@ fn workspace_cleanup_to_contract(state: &str) -> WorkspaceCleanupState {
     }
 }
 
-fn workspace_cleanup_operation_to_contract(
-    operation: Option<&str>,
-) -> Option<WorkspaceCleanupOperation> {
+fn workspace_cleanup_operation(operation: Option<&str>) -> Option<WorkspaceCleanupOperation> {
     match operation {
         Some("retire") => Some(WorkspaceCleanupOperation::Retire),
         Some("purge") => Some(WorkspaceCleanupOperation::Purge),

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -17,8 +17,3 @@ CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/runtime
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/runtime/prompt.rs 2 transitional session prompt runtime still coordinates plan domain directly
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/service.rs 1 transitional session service still accepts mobility attachment domain data
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/workspaces/files_runtime.rs 1 transitional workspace files runtime still serves cowork artifact files directly
-DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/cowork/artifacts.rs 2 transitional cowork artifact domain still returns API contract responses
-DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1 transitional cowork runtime still returns API contract managed-workspace response
-DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/sessions/runtime/interactions.rs 1 transitional session runtime interactions still returns API contract elicitation response
-DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/sessions/subagents/service.rs 1 transitional subagent service still returns API contract subagents response
-DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/workspaces/inventory.rs 1 transitional workspace inventory still returns API contract response


### PR DESCRIPTION
## Summary
- Move cowork artifact, cowork managed-workspace, subagent context, MCP URL reveal, and worktree inventory response DTO mapping to HTTP API handlers.
- Add internal AnyHarness result/context structs for the affected domain/runtime services while preserving serialized response shape at the API/MCP boundaries.
- Remove the stale DOMAIN_CONTRACT_REQUEST_RESPONSE allowlist rows for the cleaned modules.

## Verification
- python3 scripts/check_anyharness_boundaries.py
- python3 scripts/check_max_lines.py
- python3 scripts/check_anyharness_old_paths.py
- git diff --check
- cargo check -p anyharness-lib
- cargo test -p anyharness-lib cowork --lib
- cargo test -p anyharness-lib subagent --lib
- cargo test -p anyharness-lib inventory --lib
- cargo test -p anyharness-lib interaction --lib