### PR TITLE
refactor(anyharness): decouple session product MCP launch

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -44,7 +44,6 @@ use crate::sessions::links::completions::LinkCompletionStore;
 use crate::sessions::links::service::SessionLinkService;
 use crate::sessions::links::store::SessionLinkStore;
 use crate::sessions::mcp_bindings::crypto::{load_data_cipher_from_env, DATA_KEY_ENV_VAR};
-use crate::sessions::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
 use crate::sessions::mcp_bindings::product_registry::ProductMcpEndpointRegistry;
 use crate::sessions::runtime::SessionRuntime;
 use crate::sessions::service::SessionService;
@@ -288,16 +287,17 @@ impl AppState {
                 bearer_token.clone(),
                 skills_mcp_auth.clone(),
             ));
-        let product_mcp_launch_catalog = ProductMcpLaunchCatalog::new(
-            runtime_base_url.clone(),
-            bearer_token.clone(),
-            review_mcp_auth.clone(),
-            subagent_mcp_auth.clone(),
-            workspace_naming_mcp_auth.clone(),
-            cowork_mcp_auth.clone(),
-            subagent_service.clone(),
-            SessionStore::new(db.clone()),
-        );
+        let product_mcp_launch_catalog =
+            product_mcp::build_product_mcp_launch_catalog(product_mcp::LaunchCatalogDeps {
+                runtime_base_url: runtime_base_url.clone(),
+                bearer_token: bearer_token.clone(),
+                review_mcp_auth: review_mcp_auth.clone(),
+                subagent_mcp_auth: subagent_mcp_auth.clone(),
+                workspace_naming_mcp_auth: workspace_naming_mcp_auth.clone(),
+                cowork_mcp_auth: cowork_mcp_auth.clone(),
+                subagent_service: subagent_service.clone(),
+                session_store: SessionStore::new(db.clone()),
+            });
         let session_extensions: Vec<Arc<dyn crate::sessions::extensions::SessionExtension>> = vec![
             cowork_session_hooks.clone(),
             subagent_session_hooks.clone(),

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -2,16 +2,20 @@ use std::sync::Arc;
 
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::mcp::{
-    auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
+    self as cowork_mcp, auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
 };
 use crate::domains::cowork::runtime::CoworkRuntime;
 use crate::domains::plugins::mcp::{auth::SkillsMcpAuth, SkillsProductMcpServer};
 use crate::domains::reviews::mcp::{
-    auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
+    self as review_mcp, auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
 };
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::domains::runtime_config::service::RuntimeConfigService;
 use crate::persistence::Db;
+use crate::sessions::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
+use crate::sessions::mcp_bindings::product_launch::{
+    ProductMcpLaunchRegistration, ProductMcpSelectionContext,
+};
 use crate::sessions::mcp_bindings::product_registry::{
     ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
 };
@@ -28,6 +32,17 @@ use crate::workspaces::access_gate::WorkspaceAccessGate;
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
 use crate::workspaces::runtime::WorkspaceRuntime;
 
+pub(super) struct LaunchCatalogDeps {
+    pub(super) runtime_base_url: String,
+    pub(super) bearer_token: Option<String>,
+    pub(super) review_mcp_auth: Arc<ReviewMcpAuth>,
+    pub(super) subagent_mcp_auth: Arc<SubagentMcpAuth>,
+    pub(super) workspace_naming_mcp_auth: Arc<WorkspaceNamingMcpAuth>,
+    pub(super) cowork_mcp_auth: Arc<CoworkMcpAuth>,
+    pub(super) subagent_service: Arc<SubagentService>,
+    pub(super) session_store: SessionStore,
+}
+
 pub(super) struct EndpointRegistryDeps {
     pub(super) db: Db,
     pub(super) review_runtime: Arc<ReviewRuntime>,
@@ -43,6 +58,93 @@ pub(super) struct EndpointRegistryDeps {
     pub(super) cowork_mcp_auth: Arc<CoworkMcpAuth>,
     pub(super) runtime_config_service: Arc<RuntimeConfigService>,
     pub(super) skills_mcp_auth: Arc<SkillsMcpAuth>,
+}
+
+pub(super) fn build_product_mcp_launch_catalog(deps: LaunchCatalogDeps) -> ProductMcpLaunchCatalog {
+    let LaunchCatalogDeps {
+        runtime_base_url,
+        bearer_token,
+        review_mcp_auth,
+        subagent_mcp_auth,
+        workspace_naming_mcp_auth,
+        cowork_mcp_auth,
+        subagent_service,
+        session_store,
+    } = deps;
+
+    let review_auth = review_mcp_auth.clone();
+    let subagent_auth = subagent_mcp_auth.clone();
+    let workspace_naming_auth = workspace_naming_mcp_auth.clone();
+    let cowork_auth = cowork_mcp_auth.clone();
+    let subagent_selector_service = subagent_service.clone();
+    let workspace_naming_session_store = session_store.clone();
+    let workspace_naming_prompts =
+        crate::sessions::workspace_naming::mcp::definition::system_prompt_append();
+
+    ProductMcpLaunchCatalog::new(
+        runtime_base_url,
+        bearer_token,
+        vec![
+            ProductMcpLaunchRegistration::new(
+                &review_mcp::definition::DEFINITION,
+                Arc::new(|ctx: ProductMcpSelectionContext<'_>| {
+                    // Reviews intentionally preload on standard sessions. A parent session can
+                    // start unrelated and become a review parent later; without live MCP refresh,
+                    // the endpoint resolves the current review role on each request.
+                    Ok(ctx.workspace.surface == "standard")
+                }),
+                Arc::new(move |workspace_id: &str, session_id: &str| {
+                    review_auth.mint_capability_token(workspace_id, session_id)
+                }),
+            )
+            .with_binding_summary(review_mcp::definition::binding_summary()),
+            ProductMcpLaunchRegistration::new(
+                &crate::sessions::subagents::mcp::definition::DEFINITION,
+                Arc::new(move |ctx: ProductMcpSelectionContext<'_>| {
+                    if ctx.workspace.surface != "standard" || !ctx.session.subagents_enabled {
+                        return Ok(false);
+                    }
+                    Ok(subagent_selector_service
+                        .find_subagent_parent(&ctx.session.id)?
+                        .is_none())
+                }),
+                Arc::new(move |workspace_id: &str, session_id: &str| {
+                    subagent_auth.mint_capability_token(workspace_id, session_id)
+                }),
+            )
+            .with_binding_summary(crate::sessions::subagents::mcp::definition::binding_summary()),
+            ProductMcpLaunchRegistration::new(
+                &crate::sessions::workspace_naming::mcp::definition::DEFINITION,
+                Arc::new(move |ctx: ProductMcpSelectionContext<'_>| {
+                    crate::sessions::workspace_naming::eligibility::eligible_for_launch(
+                        &workspace_naming_session_store,
+                        ctx.workspace,
+                        ctx.session,
+                    )
+                }),
+                Arc::new(move |workspace_id: &str, session_id: &str| {
+                    workspace_naming_auth.mint_capability_token(workspace_id, session_id)
+                }),
+            )
+            .with_system_prompt_append(workspace_naming_prompts.clone())
+            .with_first_prompt_system_prompt_append(workspace_naming_prompts)
+            .with_binding_summary(
+                crate::sessions::workspace_naming::mcp::definition::binding_summary(),
+            ),
+            ProductMcpLaunchRegistration::new(
+                &cowork_mcp::definition::DEFINITION,
+                Arc::new(|ctx: ProductMcpSelectionContext<'_>| {
+                    Ok(ctx.workspace.surface == "cowork"
+                        && !cowork_mcp::definition::launch_disabled())
+                }),
+                Arc::new(move |workspace_id: &str, session_id: &str| {
+                    cowork_auth.mint_capability_token(workspace_id, session_id)
+                }),
+            )
+            .with_system_prompt_append(cowork_mcp::definition::system_prompt_append())
+            .with_binding_summary(cowork_mcp::definition::binding_summary()),
+        ],
+    )
 }
 
 pub(super) fn build_product_mcp_endpoint_registry(

--- a/anyharness/crates/anyharness-lib/src/domains/plans/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plans/service.rs
@@ -12,6 +12,7 @@ use super::model::{
 };
 use super::store::PlanStore;
 use crate::sessions::model::SessionEventRecord;
+use crate::sessions::plan_references::{PlanReferenceResolver, ResolvedPlanReference};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanCreateError {
@@ -416,6 +417,30 @@ impl PlanService {
                 created_at: now.clone(),
                 updated_at: now,
             })
+    }
+}
+
+impl PlanReferenceResolver for PlanService {
+    fn resolve_plan_reference(
+        &self,
+        plan_id: &str,
+    ) -> anyhow::Result<Option<ResolvedPlanReference>> {
+        Ok(self.get(plan_id)?.map(plan_reference_from_record))
+    }
+}
+
+fn plan_reference_from_record(plan: PlanRecord) -> ResolvedPlanReference {
+    ResolvedPlanReference {
+        id: plan.id,
+        workspace_id: plan.workspace_id,
+        title: plan.title,
+        body_markdown: plan.body_markdown,
+        snapshot_hash: plan.snapshot_hash,
+        source_session_id: plan.source_session_id,
+        source_turn_id: plan.source_turn_id,
+        source_item_id: plan.source_item_id,
+        source_kind: plan.source_kind,
+        source_tool_call_id: plan.source_tool_call_id,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/injection.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/injection.rs
@@ -1,5 +1,3 @@
-use crate::domains::cowork::mcp as cowork_mcp;
-use crate::domains::reviews::mcp as reviews_mcp;
 use crate::integrations::mcp::product_server::{
     ProductMcpDefinition, PRODUCT_MCP_TOKEN_HEADER_NAME,
 };
@@ -9,53 +7,27 @@ use crate::sessions::mcp_bindings::model::{
 };
 use crate::sessions::mcp_bindings::selection::{product_mcp_prompt_extras, SelectedProductMcp};
 use crate::sessions::model::SessionRecord;
-use crate::sessions::subagents::mcp as subagents_mcp;
-use crate::sessions::workspace_naming::mcp as workspace_naming_mcp;
 use crate::workspaces::model::WorkspaceRecord;
 
 pub struct ProductMcpInjectionContext<'a> {
     pub runtime_base_url: &'a str,
     pub runtime_bearer_token: Option<&'a str>,
-    pub review_auth: &'a reviews_mcp::auth::ReviewMcpAuth,
-    pub subagent_auth: &'a subagents_mcp::auth::SubagentMcpAuth,
-    pub workspace_naming_auth: &'a workspace_naming_mcp::auth::WorkspaceNamingMcpAuth,
-    pub cowork_auth: &'a cowork_mcp::auth::CoworkMcpAuth,
     pub workspace: &'a WorkspaceRecord,
     pub session: &'a SessionRecord,
 }
 
 pub fn inject_product_mcps(
-    selected: &[SelectedProductMcp],
+    selected: &[SelectedProductMcp<'_>],
     ctx: ProductMcpInjectionContext<'_>,
 ) -> anyhow::Result<SessionLaunchExtras> {
     let mut extras = product_mcp_prompt_extras(selected);
     for product in selected {
-        extras.mcp_servers.push(match product {
-            SelectedProductMcp::Reviews => build_http_server(
-                &reviews_mcp::definition::DEFINITION,
-                &ctx,
-                ctx.review_auth
-                    .mint_capability_token(&ctx.workspace.id, &ctx.session.id)?,
-            ),
-            SelectedProductMcp::Subagents => build_http_server(
-                &subagents_mcp::definition::DEFINITION,
-                &ctx,
-                ctx.subagent_auth
-                    .mint_capability_token(&ctx.workspace.id, &ctx.session.id)?,
-            ),
-            SelectedProductMcp::WorkspaceNaming => build_http_server(
-                &workspace_naming_mcp::definition::DEFINITION,
-                &ctx,
-                ctx.workspace_naming_auth
-                    .mint_capability_token(&ctx.workspace.id, &ctx.session.id)?,
-            ),
-            SelectedProductMcp::Cowork => build_http_server(
-                &cowork_mcp::definition::DEFINITION,
-                &ctx,
-                ctx.cowork_auth
-                    .mint_capability_token(&ctx.workspace.id, &ctx.session.id)?,
-            ),
-        });
+        let registration = product.registration;
+        extras.mcp_servers.push(build_http_server(
+            registration.definition(),
+            &ctx,
+            registration.mint_capability_token(&ctx.workspace.id, &ctx.session.id)?,
+        ));
     }
     Ok(extras)
 }
@@ -91,23 +63,18 @@ fn build_http_server(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::sync::Arc;
 
+    use crate::integrations::mcp::product_server::{ProductMcpPromptPolicy, ProductMcpVisibility};
     use crate::origin::OriginContext;
+    use crate::sessions::mcp_bindings::product_launch::{
+        ProductMcpLaunchRegistration, ProductMcpSelectionContext,
+    };
     use crate::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
     use crate::sessions::workspace_naming::mcp::auth::LEGACY_CAPABILITY_HEADER_NAME;
     use crate::workspaces::model::WorkspaceRecord;
 
     use super::*;
-
-    fn runtime_home(test_name: &str) -> PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "anyharness-product-mcp-injection-{test_name}-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let _ = std::fs::remove_dir_all(&path);
-        path
-    }
 
     fn workspace(id: &str) -> WorkspaceRecord {
         WorkspaceRecord {
@@ -135,6 +102,28 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:00Z".to_string(),
         }
+    }
+
+    static TEST_DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
+        id: "workspace_naming",
+        route_slug: "workspace_naming",
+        acp_server_name: "workspace_naming",
+        server_info_name: "proliferate-workspace-naming",
+        display_name: "Workspace naming",
+        description: "Name workspaces",
+        visibility: ProductMcpVisibility::Internal,
+        instructions: "Name the workspace",
+        unauthorized_code: "WORKSPACE_NAMING_UNAUTHORIZED",
+        request_invalid_code: "WORKSPACE_NAMING_INVALID",
+        prompt_policy: ProductMcpPromptPolicy::SystemAndFirstPrompt,
+    };
+
+    fn selected_registration(token: &'static str) -> ProductMcpLaunchRegistration {
+        ProductMcpLaunchRegistration::new(
+            &TEST_DEFINITION,
+            Arc::new(|_ctx: ProductMcpSelectionContext<'_>| Ok(true)),
+            Arc::new(move |_workspace_id: &str, _session_id: &str| Ok(token.to_string())),
+        )
     }
 
     fn session(id: &str, workspace_id: &str) -> SessionRecord {
@@ -170,24 +159,18 @@ mod tests {
 
     #[test]
     fn fresh_product_injection_uses_generic_route_and_product_token_header() {
-        let home = runtime_home("fresh");
-        let review_auth = reviews_mcp::auth::ReviewMcpAuth::new(home.clone());
-        let subagent_auth = subagents_mcp::auth::SubagentMcpAuth::new(home.clone());
-        let workspace_naming_auth =
-            workspace_naming_mcp::auth::WorkspaceNamingMcpAuth::new(home.clone());
-        let cowork_auth = cowork_mcp::auth::CoworkMcpAuth::new(home.clone());
         let workspace = workspace("workspace-1");
         let session = session("session-1", &workspace.id);
+        let registration = selected_registration("product-token");
+        let selected = [SelectedProductMcp {
+            registration: &registration,
+        }];
 
         let extras = inject_product_mcps(
-            &[SelectedProductMcp::WorkspaceNaming],
+            &selected,
             ProductMcpInjectionContext {
                 runtime_base_url: "http://127.0.0.1:4317",
                 runtime_bearer_token: Some("runtime-token"),
-                review_auth: &review_auth,
-                subagent_auth: &subagent_auth,
-                workspace_naming_auth: &workspace_naming_auth,
-                cowork_auth: &cowork_auth,
                 workspace: &workspace,
                 session: &session,
             },
@@ -217,7 +200,5 @@ mod tests {
             .headers
             .iter()
             .any(|header| header.name == LEGACY_CAPABILITY_HEADER_NAME));
-
-        let _ = std::fs::remove_dir_all(home);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/mod.rs
@@ -5,6 +5,7 @@ pub mod crypto;
 pub mod injection;
 pub mod model;
 pub mod product_catalog;
+pub mod product_launch;
 pub mod product_registry;
 pub mod selection;
 pub mod summaries;

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_catalog.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use crate::domains::cowork::mcp::auth::CoworkMcpAuth;
-use crate::domains::reviews::mcp::auth::ReviewMcpAuth;
 use crate::sessions::extensions::SessionLaunchExtras;
 use crate::sessions::mcp_bindings::injection::{inject_product_mcps, ProductMcpInjectionContext};
-use crate::sessions::mcp_bindings::selection::{select_product_mcps, ProductMcpSelectionContext};
+use crate::sessions::mcp_bindings::product_launch::ProductMcpLaunchRegistration;
+use crate::sessions::mcp_bindings::selection::select_product_mcps;
 use crate::sessions::model::SessionRecord;
-use crate::sessions::store::SessionStore;
-use crate::sessions::subagents::mcp::auth::SubagentMcpAuth;
-use crate::sessions::subagents::service::SubagentService;
-use crate::sessions::workspace_naming::mcp::auth::WorkspaceNamingMcpAuth;
 use crate::workspaces::model::WorkspaceRecord;
 
 #[derive(Clone)]
@@ -20,35 +15,20 @@ pub struct ProductMcpLaunchCatalog {
 struct ProductMcpLaunchCatalogInner {
     runtime_base_url: String,
     runtime_bearer_token: Option<String>,
-    review_auth: Arc<ReviewMcpAuth>,
-    subagent_auth: Arc<SubagentMcpAuth>,
-    workspace_naming_auth: Arc<WorkspaceNamingMcpAuth>,
-    cowork_auth: Arc<CoworkMcpAuth>,
-    subagent_service: Arc<SubagentService>,
-    session_store: SessionStore,
+    registrations: Vec<ProductMcpLaunchRegistration>,
 }
 
 impl ProductMcpLaunchCatalog {
     pub fn new(
         runtime_base_url: String,
         runtime_bearer_token: Option<String>,
-        review_auth: Arc<ReviewMcpAuth>,
-        subagent_auth: Arc<SubagentMcpAuth>,
-        workspace_naming_auth: Arc<WorkspaceNamingMcpAuth>,
-        cowork_auth: Arc<CoworkMcpAuth>,
-        subagent_service: Arc<SubagentService>,
-        session_store: SessionStore,
+        registrations: Vec<ProductMcpLaunchRegistration>,
     ) -> Self {
         Self {
             inner: Some(Arc::new(ProductMcpLaunchCatalogInner {
                 runtime_base_url,
                 runtime_bearer_token,
-                review_auth,
-                subagent_auth,
-                workspace_naming_auth,
-                cowork_auth,
-                subagent_service,
-                session_store,
+                registrations,
             })),
         }
     }
@@ -65,21 +45,12 @@ impl ProductMcpLaunchCatalog {
         let Some(inner) = self.inner.as_ref() else {
             return Ok(SessionLaunchExtras::default());
         };
-        let selected = select_product_mcps(ProductMcpSelectionContext {
-            workspace,
-            session,
-            subagent_service: &inner.subagent_service,
-            session_store: &inner.session_store,
-        })?;
+        let selected = select_product_mcps(workspace, session, &inner.registrations)?;
         inject_product_mcps(
             &selected,
             ProductMcpInjectionContext {
                 runtime_base_url: &inner.runtime_base_url,
                 runtime_bearer_token: inner.runtime_bearer_token.as_deref(),
-                review_auth: &inner.review_auth,
-                subagent_auth: &inner.subagent_auth,
-                workspace_naming_auth: &inner.workspace_naming_auth,
-                cowork_auth: &inner.cowork_auth,
                 workspace,
                 session,
             },

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_launch.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_launch.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use anyharness_contract::v1::SessionMcpBindingSummary;
+
+use crate::integrations::mcp::product_server::ProductMcpDefinition;
+use crate::sessions::extensions::SessionLaunchExtras;
+use crate::sessions::model::SessionRecord;
+use crate::workspaces::model::WorkspaceRecord;
+
+pub struct ProductMcpSelectionContext<'a> {
+    pub workspace: &'a WorkspaceRecord,
+    pub session: &'a SessionRecord,
+}
+
+pub trait ProductMcpLaunchSelector: Send + Sync {
+    fn should_attach(&self, ctx: ProductMcpSelectionContext<'_>) -> anyhow::Result<bool>;
+}
+
+impl<F> ProductMcpLaunchSelector for F
+where
+    F: for<'a> Fn(ProductMcpSelectionContext<'a>) -> anyhow::Result<bool> + Send + Sync,
+{
+    fn should_attach(&self, ctx: ProductMcpSelectionContext<'_>) -> anyhow::Result<bool> {
+        self(ctx)
+    }
+}
+
+pub trait ProductMcpCapabilityTokenMinter: Send + Sync {
+    fn mint_capability_token(&self, workspace_id: &str, session_id: &str)
+        -> anyhow::Result<String>;
+}
+
+impl<F> ProductMcpCapabilityTokenMinter for F
+where
+    F: Fn(&str, &str) -> anyhow::Result<String> + Send + Sync,
+{
+    fn mint_capability_token(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+    ) -> anyhow::Result<String> {
+        self(workspace_id, session_id)
+    }
+}
+
+#[derive(Clone)]
+pub struct ProductMcpLaunchRegistration {
+    definition: &'static ProductMcpDefinition,
+    selector: Arc<dyn ProductMcpLaunchSelector>,
+    token_minter: Arc<dyn ProductMcpCapabilityTokenMinter>,
+    launch_extras: SessionLaunchExtras,
+}
+
+impl ProductMcpLaunchRegistration {
+    pub fn new(
+        definition: &'static ProductMcpDefinition,
+        selector: Arc<dyn ProductMcpLaunchSelector>,
+        token_minter: Arc<dyn ProductMcpCapabilityTokenMinter>,
+    ) -> Self {
+        Self {
+            definition,
+            selector,
+            token_minter,
+            launch_extras: SessionLaunchExtras::default(),
+        }
+    }
+
+    pub fn with_binding_summary(mut self, summary: SessionMcpBindingSummary) -> Self {
+        self.launch_extras.mcp_binding_summaries.push(summary);
+        self
+    }
+
+    pub fn with_system_prompt_append(mut self, prompt: Vec<String>) -> Self {
+        self.launch_extras.system_prompt_append.extend(prompt);
+        self
+    }
+
+    pub fn with_first_prompt_system_prompt_append(mut self, prompt: Vec<String>) -> Self {
+        self.launch_extras
+            .first_prompt_system_prompt_append
+            .extend(prompt);
+        self
+    }
+
+    pub fn definition(&self) -> &'static ProductMcpDefinition {
+        self.definition
+    }
+
+    pub fn launch_extras(&self) -> &SessionLaunchExtras {
+        &self.launch_extras
+    }
+
+    pub fn should_attach(&self, ctx: ProductMcpSelectionContext<'_>) -> anyhow::Result<bool> {
+        self.selector.should_attach(ctx)
+    }
+
+    pub fn mint_capability_token(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+    ) -> anyhow::Result<String> {
+        self.token_minter
+            .mint_capability_token(workspace_id, session_id)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs
@@ -1,115 +1,73 @@
-use crate::domains::cowork::mcp as cowork_mcp;
-use crate::domains::reviews::mcp as reviews_mcp;
 use crate::sessions::extensions::SessionLaunchExtras;
+use crate::sessions::mcp_bindings::product_launch::{
+    ProductMcpLaunchRegistration, ProductMcpSelectionContext,
+};
 use crate::sessions::model::SessionRecord;
-use crate::sessions::store::SessionStore;
-use crate::sessions::subagents::service::SubagentService;
-use crate::sessions::workspace_naming::{eligibility, mcp as workspace_naming_mcp};
 use crate::workspaces::model::WorkspaceRecord;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SelectedProductMcp {
-    Reviews,
-    Subagents,
-    WorkspaceNaming,
-    Cowork,
+pub struct SelectedProductMcp<'a> {
+    pub registration: &'a ProductMcpLaunchRegistration,
 }
 
-pub struct ProductMcpSelectionContext<'a> {
-    pub workspace: &'a WorkspaceRecord,
-    pub session: &'a SessionRecord,
-    pub subagent_service: &'a SubagentService,
-    pub session_store: &'a SessionStore,
-}
-
-pub fn select_product_mcps(
-    ctx: ProductMcpSelectionContext<'_>,
-) -> anyhow::Result<Vec<SelectedProductMcp>> {
+pub fn select_product_mcps<'a>(
+    workspace: &'a WorkspaceRecord,
+    session: &'a SessionRecord,
+    registrations: &'a [ProductMcpLaunchRegistration],
+) -> anyhow::Result<Vec<SelectedProductMcp<'a>>> {
     let mut selected = Vec::new();
-
-    // Reviews intentionally preload on standard sessions. A parent session can
-    // start unrelated and become a review parent later; without live MCP refresh,
-    // the review MCP must already be attached for that later parent tool surface.
-    // The endpoint resolves the current review role on each request, so unrelated
-    // sessions receive no review tools even though the server is attached.
-    if should_preload_reviews_mcp_until_live_refresh(ctx.workspace) {
-        selected.push(SelectedProductMcp::Reviews);
+    for registration in registrations {
+        if registration.should_attach(ProductMcpSelectionContext { workspace, session })? {
+            selected.push(SelectedProductMcp { registration });
+        }
     }
-
-    if ctx.workspace.surface == "standard"
-        && ctx.session.subagents_enabled
-        && ctx
-            .subagent_service
-            .find_subagent_parent(&ctx.session.id)?
-            .is_none()
-    {
-        selected.push(SelectedProductMcp::Subagents);
-    }
-
-    if eligibility::eligible_for_launch(ctx.session_store, ctx.workspace, ctx.session)? {
-        selected.push(SelectedProductMcp::WorkspaceNaming);
-    }
-
-    if should_attach_cowork_mcp(ctx.workspace) {
-        selected.push(SelectedProductMcp::Cowork);
-    }
-
     Ok(selected)
 }
 
-fn should_preload_reviews_mcp_until_live_refresh(workspace: &WorkspaceRecord) -> bool {
-    workspace.surface == "standard"
-}
-
-fn should_attach_cowork_mcp(workspace: &WorkspaceRecord) -> bool {
-    workspace.surface == "cowork" && !cowork_mcp::definition::launch_disabled()
-}
-
-pub fn product_mcp_prompt_extras(selected: &[SelectedProductMcp]) -> SessionLaunchExtras {
+pub fn product_mcp_prompt_extras(selected: &[SelectedProductMcp<'_>]) -> SessionLaunchExtras {
     let mut extras = SessionLaunchExtras::default();
     for product in selected {
-        match product {
-            SelectedProductMcp::Reviews => {
-                // The review MCP server is preloaded broadly so parent sessions
-                // can become review parents after launch. Do not also preload
-                // review-specific prompt text into unrelated sessions; review
-                // runtime prompts add role-specific instructions when review
-                // work actually starts.
-                extras
-                    .mcp_binding_summaries
-                    .push(reviews_mcp::definition::binding_summary());
-            }
-            SelectedProductMcp::Subagents => {
-                extras
-                    .mcp_binding_summaries
-                    .push(crate::sessions::subagents::mcp::definition::binding_summary());
-            }
-            SelectedProductMcp::WorkspaceNaming => {
-                let prompts = workspace_naming_mcp::definition::system_prompt_append();
-                extras.system_prompt_append.extend(prompts.clone());
-                extras.first_prompt_system_prompt_append.extend(prompts);
-                extras
-                    .mcp_binding_summaries
-                    .push(workspace_naming_mcp::definition::binding_summary());
-            }
-            SelectedProductMcp::Cowork => {
-                extras
-                    .system_prompt_append
-                    .extend(cowork_mcp::definition::system_prompt_append());
-                extras
-                    .mcp_binding_summaries
-                    .push(cowork_mcp::definition::binding_summary());
-            }
-        }
+        merge_launch_extras(&mut extras, product.registration.launch_extras());
     }
     extras
 }
 
+fn merge_launch_extras(target: &mut SessionLaunchExtras, source: &SessionLaunchExtras) {
+    target
+        .system_prompt_append
+        .extend(source.system_prompt_append.clone());
+    target
+        .first_prompt_system_prompt_append
+        .extend(source.first_prompt_system_prompt_append.clone());
+    target
+        .mcp_binding_summaries
+        .extend(source.mcp_binding_summaries.clone());
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::integrations::mcp::product_server::{
+        ProductMcpDefinition, ProductMcpPromptPolicy, ProductMcpVisibility,
+    };
     use crate::origin::OriginContext;
+    use crate::sessions::model::SessionMcpBindingPolicy;
 
     use super::*;
+
+    static TEST_DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
+        id: "test",
+        route_slug: "test",
+        acp_server_name: "test",
+        server_info_name: "proliferate-test",
+        display_name: "Test",
+        description: "Test",
+        visibility: ProductMcpVisibility::Internal,
+        instructions: "Test",
+        unauthorized_code: "TEST_UNAUTHORIZED",
+        request_invalid_code: "TEST_INVALID",
+        prompt_policy: ProductMcpPromptPolicy::System,
+    };
 
     fn workspace(id: &str, surface: &str) -> WorkspaceRecord {
         WorkspaceRecord {
@@ -139,64 +97,101 @@ mod tests {
         }
     }
 
-    #[test]
-    fn reviews_mcp_broadly_attaches_to_standard_workspaces_only() {
-        assert!(should_preload_reviews_mcp_until_live_refresh(&workspace(
-            "standard-1",
-            "standard"
-        )));
-        assert!(!should_preload_reviews_mcp_until_live_refresh(&workspace(
-            "cowork-1", "cowork"
-        )));
+    fn session(id: &str, workspace_id: &str) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            agent_kind: "codex".to_string(),
+            native_session_id: None,
+            agent_auth_scope: None,
+            required_agent_auth_revision: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: Some(OriginContext::human_desktop()),
+        }
+    }
+
+    fn registration(
+        should_attach: bool,
+        extras: SessionLaunchExtras,
+    ) -> ProductMcpLaunchRegistration {
+        ProductMcpLaunchRegistration::new(
+            &TEST_DEFINITION,
+            Arc::new(move |_ctx: ProductMcpSelectionContext<'_>| Ok(should_attach)),
+            Arc::new(|_workspace_id: &str, _session_id: &str| Ok("token".to_string())),
+        )
+        .with_system_prompt_append(extras.system_prompt_append)
+        .with_first_prompt_system_prompt_append(extras.first_prompt_system_prompt_append)
     }
 
     #[test]
-    fn cowork_mcp_attaches_to_cowork_workspaces_only() {
-        assert!(should_attach_cowork_mcp(&workspace("cowork-1", "cowork")));
-        assert!(!should_attach_cowork_mcp(&workspace(
-            "standard-1",
-            "standard"
-        )));
+    fn selection_uses_app_wired_product_capabilities() {
+        let workspace = workspace("workspace-1", "standard");
+        let session = session("session-1", &workspace.id);
+        let registrations = [registration(true, SessionLaunchExtras::default())];
+        let selected =
+            select_product_mcps(&workspace, &session, &registrations).expect("select product MCPs");
+
+        assert_eq!(selected.len(), 1);
     }
 
     #[test]
-    fn broad_reviews_selection_does_not_add_review_prompt_text() {
-        let extras = product_mcp_prompt_extras(&[SelectedProductMcp::Reviews]);
+    fn selection_skips_unavailable_app_wired_capabilities() {
+        let workspace = workspace("workspace-1", "standard");
+        let session = session("session-1", &workspace.id);
+        let registrations = [registration(false, SessionLaunchExtras::default())];
+        let selected =
+            select_product_mcps(&workspace, &session, &registrations).expect("select product MCPs");
 
-        assert!(extras.system_prompt_append.is_empty());
-        assert_eq!(extras.mcp_binding_summaries.len(), 1);
+        assert!(selected.is_empty());
     }
 
     #[test]
-    fn subagents_selection_adds_binding_summary_without_prompt_text() {
-        let extras = product_mcp_prompt_extras(&[SelectedProductMcp::Subagents]);
+    fn selected_product_extras_merge_in_launch_order() {
+        let workspace = workspace("workspace-1", "standard");
+        let session = session("session-1", &workspace.id);
+        let registrations = [
+            registration(
+                true,
+                SessionLaunchExtras {
+                    system_prompt_append: vec!["system-a".to_string()],
+                    first_prompt_system_prompt_append: Vec::new(),
+                    mcp_servers: Vec::new(),
+                    mcp_binding_summaries: Vec::new(),
+                },
+            ),
+            registration(
+                true,
+                SessionLaunchExtras {
+                    system_prompt_append: vec!["system-b".to_string()],
+                    first_prompt_system_prompt_append: vec!["first-b".to_string()],
+                    mcp_servers: Vec::new(),
+                    mcp_binding_summaries: Vec::new(),
+                },
+            ),
+        ];
+        let selected =
+            select_product_mcps(&workspace, &session, &registrations).expect("select product MCPs");
+        let extras = product_mcp_prompt_extras(&selected);
 
-        assert!(extras.system_prompt_append.is_empty());
-        assert_eq!(extras.mcp_binding_summaries.len(), 1);
-    }
-
-    #[test]
-    fn workspace_naming_selection_adds_prompt_text_and_binding_summary() {
-        let extras = product_mcp_prompt_extras(&[SelectedProductMcp::WorkspaceNaming]);
-
-        assert!(!extras.system_prompt_append.is_empty());
-        assert!(!extras.first_prompt_system_prompt_append.is_empty());
-        assert_eq!(extras.mcp_binding_summaries.len(), 1);
-        assert_eq!(
-            extras.mcp_binding_summaries[0].server_name,
-            workspace_naming_mcp::definition::ACP_SERVER_NAME
-        );
-    }
-
-    #[test]
-    fn cowork_selection_adds_prompt_text_and_binding_summary() {
-        let extras = product_mcp_prompt_extras(&[SelectedProductMcp::Cowork]);
-
-        assert!(!extras.system_prompt_append.is_empty());
-        assert_eq!(extras.mcp_binding_summaries.len(), 1);
-        assert_eq!(
-            extras.mcp_binding_summaries[0].server_name,
-            cowork_mcp::definition::ACP_SERVER_NAME
-        );
+        assert_eq!(extras.system_prompt_append, ["system-a", "system-b"]);
+        assert_eq!(extras.first_prompt_system_prompt_append, ["first-b"]);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mod.rs
@@ -7,6 +7,7 @@ pub mod links;
 pub mod live_config;
 pub mod mcp_bindings;
 pub mod model;
+pub mod plan_references;
 pub mod prompt;
 pub mod replay;
 pub mod runtime;

--- a/anyharness/crates/anyharness-lib/src/sessions/plan_references.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/plan_references.rs
@@ -1,0 +1,58 @@
+#[derive(Debug, Clone)]
+pub struct ResolvedPlanReference {
+    pub id: String,
+    pub workspace_id: String,
+    pub title: String,
+    pub body_markdown: String,
+    pub snapshot_hash: String,
+    pub source_session_id: String,
+    pub source_turn_id: Option<String>,
+    pub source_item_id: Option<String>,
+    pub source_kind: String,
+    pub source_tool_call_id: Option<String>,
+}
+
+pub trait PlanReferenceResolver {
+    fn resolve_plan_reference(
+        &self,
+        plan_id: &str,
+    ) -> anyhow::Result<Option<ResolvedPlanReference>>;
+}
+
+pub fn render_plan_reference_markdown(title: &str, body_markdown: &str) -> String {
+    let title = title.trim();
+    let body = body_markdown.trim_end();
+    if body_starts_with_title_heading(body, title) {
+        format!("{body}\n")
+    } else {
+        format!("# {title}\n\n{body}\n")
+    }
+}
+
+fn body_starts_with_title_heading(body: &str, title: &str) -> bool {
+    let Some(first_line) = body.lines().next() else {
+        return false;
+    };
+    let Some(heading) = first_line.trim().strip_prefix("# ") else {
+        return false;
+    };
+    heading.trim() == title
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_plan_reference_markdown;
+
+    #[test]
+    fn render_markdown_does_not_duplicate_matching_h1() {
+        let markdown =
+            render_plan_reference_markdown("README pass", "# README pass\n\n- Tighten intro.");
+        assert_eq!(markdown, "# README pass\n\n- Tighten intro.\n");
+    }
+
+    #[test]
+    fn render_markdown_adds_title_when_body_has_no_matching_h1() {
+        let markdown = render_plan_reference_markdown("README pass", "Review the desktop folder.");
+        assert_eq!(markdown, "# README pass\n\nReview the desktop folder.\n");
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/sessions/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/prompt.rs
@@ -9,11 +9,11 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::domains::plans::{document, model::PlanRecord};
 use crate::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::sessions::model::{
     PromptAttachmentKind, PromptAttachmentRecord, PromptAttachmentSource, PromptAttachmentState,
 };
+use crate::sessions::plan_references::{render_plan_reference_markdown, PlanReferenceResolver};
 use crate::sessions::service::read_prompt_attachment_content_with_legacy_fallback;
 use crate::sessions::store::SessionStore;
 
@@ -27,10 +27,6 @@ pub const MAX_TEXT_RESOURCE_BYTES: usize = 256 * 1024;
 pub const MAX_TOTAL_ATTACHMENT_BYTES: usize = 8 * 1024 * 1024;
 pub const MAX_TOTAL_PLAN_REFERENCE_BYTES: usize = 512 * 1024;
 pub const MAX_RESOURCE_PREVIEW_CHARS: usize = 2_000;
-
-pub trait PlanReferenceResolver {
-    fn resolve_plan_reference(&self, plan_id: &str) -> anyhow::Result<Option<PlanRecord>>;
-}
 
 pub struct PromptPrepareContext<'a> {
     pub store: &'a SessionStore,
@@ -260,7 +256,7 @@ impl PromptPayload {
                     as_resource,
                     ..
                 } => {
-                    let markdown = document::render_markdown_snapshot(title, body_markdown);
+                    let markdown = render_plan_reference_markdown(title, body_markdown);
                     if *as_resource {
                         let uri = format!("plan://{plan_id}?snapshot={snapshot_hash}");
                         let resource = acp::TextResourceContents::new(markdown, uri)
@@ -1214,18 +1210,20 @@ fn bounded_preview(text: &str) -> Option<String> {
 mod tests {
     use std::collections::HashMap;
 
-    use anyharness_contract::v1::{ProposedPlanDecisionState, ProposedPlanNativeResolutionState};
-
     use super::*;
     use crate::persistence::Db;
+    use crate::sessions::plan_references::ResolvedPlanReference;
     use crate::sessions::store::SessionStore;
 
     struct TestPlanResolver {
-        plans: HashMap<String, PlanRecord>,
+        plans: HashMap<String, ResolvedPlanReference>,
     }
 
     impl PlanReferenceResolver for TestPlanResolver {
-        fn resolve_plan_reference(&self, plan_id: &str) -> anyhow::Result<Option<PlanRecord>> {
+        fn resolve_plan_reference(
+            &self,
+            plan_id: &str,
+        ) -> anyhow::Result<Option<ResolvedPlanReference>> {
             Ok(self.plans.get(plan_id).cloned())
         }
     }
@@ -1407,26 +1405,17 @@ mod tests {
         let mut plans = HashMap::new();
         plans.insert(
             "plan-1".to_string(),
-            PlanRecord {
+            ResolvedPlanReference {
                 id: "plan-1".to_string(),
                 workspace_id: workspace_id.to_string(),
-                session_id: "session-1".to_string(),
-                item_id: "item-1".to_string(),
                 title: "Plan".to_string(),
                 body_markdown: body_markdown.to_string(),
                 snapshot_hash: "hash-1".to_string(),
-                decision_state: ProposedPlanDecisionState::Pending,
-                native_resolution_state: ProposedPlanNativeResolutionState::None,
-                decision_version: 1,
-                source_agent_kind: "codex".to_string(),
                 source_kind: "codex_turn_plan".to_string(),
                 source_session_id: "session-1".to_string(),
                 source_turn_id: Some("turn-1".to_string()),
                 source_item_id: Some("item-1".to_string()),
                 source_tool_call_id: None,
-                superseded_by_plan_id: None,
-                created_at: "now".to_string(),
-                updated_at: "now".to_string(),
             },
         );
         (store, TestPlanResolver { plans })

--- a/anyharness/crates/anyharness-lib/src/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/runtime/prompt.rs
@@ -2,26 +2,17 @@ use std::time::Instant;
 
 use anyharness_contract::v1::PromptInputBlock;
 
-use crate::domains::plans::model::PlanRecord;
-use crate::domains::plans::service::PlanService;
 use crate::live::sessions::{LiveSessionCommandError, PromptAcceptError, PromptAcceptance};
 use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::sessions::mcp_bindings::assembly::SESSION_RESTART_REQUIRED_DETAIL;
 use crate::sessions::model::PromptAttachmentState;
 use crate::sessions::prompt::{
-    capabilities_from_live_config, prepare_prompt, PlanReferenceResolver, PromptPrepareContext,
-    PromptProvenance,
+    capabilities_from_live_config, prepare_prompt, PromptPrepareContext, PromptProvenance,
 };
 
 use super::{
     SendPromptError, SendPromptOutcome, SessionLifecycleError, SessionRuntime, StartSessionError,
 };
-
-impl PlanReferenceResolver for PlanService {
-    fn resolve_plan_reference(&self, plan_id: &str) -> anyhow::Result<Option<PlanRecord>> {
-        self.get(plan_id)
-    }
-}
 
 impl SessionRuntime {
     pub async fn send_prompt(

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -6,12 +6,7 @@
 # This is migration debt, not permission for new code. If a cleanup reduces a
 # count, update this file in the same PR.
 
-CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/injection.rs 2 transitional session MCP injection still imports product MCP modules
-CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_catalog.rs 2 transitional session MCP catalog still imports product MCP auth modules
-CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/selection.rs 2 transitional session MCP selection still imports product MCP modules
-CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/prompt.rs 2 transitional session prompt projection still imports plan types
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/runtime/mod.rs 1 transitional session runtime still owns plan service wiring
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/runtime/plans.rs 2 transitional session runtime still coordinates plan domain directly
-CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/runtime/prompt.rs 2 transitional session prompt runtime still coordinates plan domain directly
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/sessions/service.rs 1 transitional session service still accepts mobility attachment domain data
 CORE_DOMAIN_PRODUCT_IMPORT anyharness/crates/anyharness-lib/src/workspaces/files_runtime.rs 1 transitional workspace files runtime still serves cowork artifact files directly


### PR DESCRIPTION
## Summary
- Move session product MCP launch selection/injection behind app-wired launch registrations instead of concrete product-domain imports.
- Add a session-owned plan-reference DTO/resolver so prompt preparation no longer imports plan domain records or rendering.
- Ratchet AnyHarness boundary allowlist counts for the removed CORE_DOMAIN_PRODUCT_IMPORT debt.

## Verification
- python3 scripts/check_anyharness_boundaries.py
- python3 scripts/check_max_lines.py
- python3 scripts/check_anyharness_old_paths.py
- git diff --check
- cargo check -p anyharness-lib
- cargo test -p anyharness-lib sessions::mcp_bindings
- cargo test -p anyharness-lib sessions::prompt
- cargo test -p anyharness-lib sessions::plan_references
- cargo test -p anyharness-lib domains::plans::service