### PR TITLE
fix(product): smooth auth loading mark handoff

### DIFF
--- a/apps/desktop/src/components/auth/AuthGate.test.tsx
+++ b/apps/desktop/src/components/auth/AuthGate.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { BootstrappedRoute } from "@/components/auth/AuthGate";
 import { LoginScreen } from "@/components/auth/LoginScreen";
 import { SessionCheckScreen } from "@/components/auth/SessionCheckScreen";
+import { BRAILLE_SWEEP_FRAMES } from "@/hooks/ui/use-braille-sweep";
 import {
   buildUiTextScaleCssVariables,
   DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES,
@@ -16,6 +17,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   for (const property of Object.keys(DEFAULT_UI_TEXT_SCALE_CSS_VARIABLES)) {
     document.documentElement.style.removeProperty(property);
   }
@@ -51,6 +53,30 @@ describe("SessionCheckScreen", () => {
     expect(html).toContain("Checking your session");
     expect(html).toContain("Proliferate is restoring your account");
     expect(html).not.toContain("data-jank-canary=\"braille\"");
+  });
+
+  it("fades the branded mark through the outgoing braille sweep", () => {
+    vi.useFakeTimers();
+
+    const { container } = render(<SessionCheckScreen />);
+    const seenFrames = new Set<string>();
+
+    act(() => {
+      for (let frame = 0; frame < BRAILLE_SWEEP_FRAMES.length; frame += 1) {
+        const currentFrame = BRAILLE_SWEEP_FRAMES[frame];
+        seenFrames.add(currentFrame);
+        vi.advanceTimersByTime(60);
+      }
+    });
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(container.querySelector(".animate-resolve-0")).toBeTruthy();
+    expect(seenFrames).toContain("⣿⣿");
+    expect(seenFrames).toContain("⣾⣿");
+    expect(seenFrames).toContain("⣴⣿");
+    expect(BRAILLE_SWEEP_FRAMES).not.toContain("⠀⠀");
   });
 
   it("ignores user appearance text-size preferences", () => {

--- a/apps/desktop/src/hooks/ui/use-braille-sweep.ts
+++ b/apps/desktop/src/hooks/ui/use-braille-sweep.ts
@@ -2,8 +2,8 @@
  * Auth-only brand transition frames for ProliferateLivingMark.
  */
 export const BRAILLE_SWEEP_FRAMES = [
-  "⠁⠀", "⠋⠀", "⠟⠁", "⡿⠋", "⣿⠟", "⣿⡿", "⣿⣿", "⣿⣿",
-  "⣾⣿", "⣴⣿", "⣠⣾", "⢀⣴", "⠀⣠", "⠀⢀", "⠀⠀", "⠀⠀",
+  "⠁⠀", "⠋⠀", "⠟⠁", "⡿⠋", "⣿⠟", "⣿⡿", "⣿⣿",
+  "⣾⣿", "⣴⣿", "⣠⣾", "⢀⣴", "⠀⣠", "⠀⢀",
 ] as const;
 
 export const BRAILLE_SWEEP_FRAME_INTERVAL_MS = 60;

--- a/apps/packages/product-ui/src/auth/RedirectCallbackScreen.tsx
+++ b/apps/packages/product-ui/src/auth/RedirectCallbackScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { Button } from "@proliferate/ui/primitives/Button";
+import { ProliferateIcon, ProliferateIconResolve } from "@proliferate/ui/proliferate-icons";
 
 export type RedirectCallbackTone = "neutral" | "success" | "error";
 
@@ -47,7 +48,6 @@ const BRAILLE_SWEEP_FRAMES = [
   "⢀⣴",
   "⠀⣠",
   "⠀⢀",
-  "⠀⠀",
 ] as const;
 
 const BRAILLE_FRAME_INTERVAL_MS = 60;
@@ -55,6 +55,7 @@ const ICON_ENTER_MS = 700;
 const ICON_HOLD_MS = 950;
 const ICON_EXIT_MS = 220;
 const BRAILLE_END_HOLD_MS = 120;
+const REDIRECT_MARK_LAYER_CLASS = "absolute inset-0 flex items-center justify-center";
 
 export function RedirectCallbackScreen({
   title,
@@ -200,6 +201,8 @@ function RedirectCallbackLivingMark() {
   );
   const [cycle, setCycle] = useState(0);
   const [brailleIndex, setBrailleIndex] = useState(0);
+  const iconClassName = "size-12 text-foreground";
+  const brailleFrame = BRAILLE_SWEEP_FRAMES[brailleIndex] ?? BRAILLE_SWEEP_FRAMES[0];
 
   useEffect(() => {
     if (phase !== "braille") {
@@ -260,56 +263,46 @@ function RedirectCallbackLivingMark() {
     return () => window.clearTimeout(timer);
   }, [phase]);
 
-  if (phase === "braille") {
-    return (
-      <span
-        aria-hidden="true"
-        className="inline-block w-[1em] shrink-0 font-mono text-5xl leading-none tracking-[-0.18em] text-foreground"
-      >
-        {BRAILLE_SWEEP_FRAMES[brailleIndex] ?? BRAILLE_SWEEP_FRAMES[0]}
-      </span>
-    );
-  }
-
   return (
-    <div className={phase === "icon-exit" ? "opacity-0 transition-opacity duration-200" : ""}>
-      <RedirectCallbackMark key={cycle} className="size-12 text-foreground" />
-    </div>
-  );
-}
-
-function RedirectCallbackMark({ className }: { className?: string }) {
-  const nodes = [
-    { x: 375, y: 375, size: 50 },
-    { x: 387.67, y: 305, size: 24.67 },
-    { x: 429, y: 346.33, size: 24.67 },
-    { x: 470.33, y: 387.67, size: 24.67 },
-    { x: 429, y: 429, size: 24.67 },
-    { x: 387.67, y: 470.33, size: 24.67 },
-    { x: 346.33, y: 429, size: 24.67 },
-    { x: 305, y: 387.67, size: 24.67 },
-    { x: 346.33, y: 346.33, size: 24.67 },
-  ];
-
-  return (
-    <svg
-      className={className}
-      viewBox="300 300 200 200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      shapeRendering="crispEdges"
+    <div
       aria-hidden="true"
+      className="relative size-12 shrink-0 overflow-hidden"
+      data-testid="redirect-callback-living-mark"
     >
-      {nodes.map((node, index) => (
-        <rect
-          key={`redirect-callback-mark-${index}`}
-          x={node.x}
-          y={node.y}
-          width={node.size}
-          height={node.size}
-          fill="currentColor"
-        />
-      ))}
-    </svg>
+      {phase === "braille" ? (
+        <div
+          className={REDIRECT_MARK_LAYER_CLASS}
+          data-testid="redirect-callback-braille-layer"
+        >
+          <span className="inline-block w-[1em] shrink-0 font-mono text-5xl leading-none tracking-[-0.18em] text-foreground">
+            {brailleFrame}
+          </span>
+        </div>
+      ) : null}
+      {phase === "icon-enter" ? (
+        <div
+          className={REDIRECT_MARK_LAYER_CLASS}
+          data-testid="redirect-callback-icon-layer"
+        >
+          <ProliferateIconResolve key={cycle} className={iconClassName} />
+        </div>
+      ) : null}
+      {phase === "icon-hold" ? (
+        <div
+          className={REDIRECT_MARK_LAYER_CLASS}
+          data-testid="redirect-callback-icon-layer"
+        >
+          <ProliferateIcon className={iconClassName} />
+        </div>
+      ) : null}
+      {phase === "icon-exit" ? (
+        <div
+          className={twMerge(REDIRECT_MARK_LAYER_CLASS, "animate-brand-mark-fade-out")}
+          data-testid="redirect-callback-icon-layer"
+        >
+          <ProliferateIcon className={iconClassName} />
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/packages/product-ui/test/AuthPanels.test.tsx
+++ b/apps/packages/product-ui/test/AuthPanels.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AUTH_PROVIDER_ORDER,
@@ -14,7 +14,10 @@ import { ConnectGitHubRequiredPanel } from "../src/auth/ConnectGitHubRequiredPan
 import { RedirectCallbackScreen } from "../src/auth/RedirectCallbackScreen";
 
 describe("auth product panels", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   it("renders the shared provider order and sign-in copy", () => {
     render(
@@ -86,5 +89,49 @@ describe("auth product panels", () => {
     );
     expect(screen.getByText("Sign-in failed")).toBeTruthy();
     expect(screen.getByText("access_denied")).toBeTruthy();
+  });
+
+  it("resolves the handoff mark after the outgoing braille sweep", () => {
+    vi.useFakeTimers();
+
+    const { container } = render(
+      <RedirectCallbackScreen
+        title="Checking your session"
+        description="Opening Proliferate."
+        statusLabel="Desktop handoff"
+        variant="handoff"
+      />,
+    );
+
+    const mark = screen.getByTestId("redirect-callback-living-mark");
+    expect(mark.className).toContain("relative size-12");
+    expect(mark.className).toContain("overflow-hidden");
+    expect(screen.getByTestId("redirect-callback-braille-layer").className).toContain(
+      "absolute inset-0 flex items-center justify-center",
+    );
+
+    const seenFrames = new Set<string>();
+    const readBrailleFrame = () =>
+      screen.queryByTestId("redirect-callback-braille-layer")?.textContent ?? "";
+    seenFrames.add(readBrailleFrame());
+    for (let frame = 1; frame < 13; frame += 1) {
+      act(() => {
+        vi.advanceTimersByTime(60);
+      });
+      seenFrames.add(readBrailleFrame());
+    }
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(screen.getByTestId("redirect-callback-icon-layer").className).toContain(
+      "absolute inset-0 flex items-center justify-center",
+    );
+    expect(screen.queryByTestId("redirect-callback-braille-layer")).toBeNull();
+    expect(seenFrames).toContain("⣿⣿");
+    expect(seenFrames).toContain("⣾⣿");
+    expect(seenFrames).toContain("⣴⣿");
+    expect(seenFrames).not.toContain("⠀⠀");
+    expect(container.querySelector(".animate-resolve-0")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- keep the auth braille loading mark in a stable overlay slot before resolving to the Proliferate mark
- replace the lower braille drain frames with a reverse sweep so the dots fade out without dropping stray blocks underneath
- cover both desktop session checking and shared redirect callback handoff behavior

## Verification
- pnpm --dir apps/packages/product-ui exec vitest run test/AuthPanels.test.tsx
- pnpm --filter @proliferate/product-ui build
- pnpm --dir apps/desktop exec vitest run src/components/auth/AuthGate.test.tsx
- pnpm --dir apps/desktop exec tsc --noEmit
- git diff --check -- apps/desktop/src/components/auth/AuthGate.test.tsx apps/desktop/src/hooks/ui/use-braille-sweep.ts apps/packages/product-ui/src/auth/RedirectCallbackScreen.tsx apps/packages/product-ui/test/AuthPanels.test.tsx