### PR TITLE
feat(desktop): slim updater UI

### DIFF
--- a/apps/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
+++ b/apps/desktop/src/components/feedback/UpdateNotificationCard.test.tsx
@@ -8,6 +8,7 @@ const updaterMocks = vi.hoisted(() => ({
   phase: "available",
   availableVersion: "0.1.24",
   downloadProgress: null as number | null,
+  restartPromptOpen: false,
   downloadUpdate: vi.fn(),
   openRestartPrompt: vi.fn(),
 }));
@@ -30,6 +31,7 @@ afterEach(() => {
   updaterMocks.phase = "available";
   updaterMocks.availableVersion = "0.1.24";
   updaterMocks.downloadProgress = null;
+  updaterMocks.restartPromptOpen = false;
 });
 
 describe("UpdateNotificationCard", () => {
@@ -37,7 +39,8 @@ describe("UpdateNotificationCard", () => {
     render(<UpdateNotificationCard />);
 
     expect(screen.getByLabelText("Desktop update is available")).toBeTruthy();
-    expect(screen.getByText("New update available")).toBeTruthy();
+    expect(screen.getByText("Update available")).toBeTruthy();
+    expect(screen.getByText("Proliferate 0.1.24 is ready to download.")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "See changes" }));
     expect(shellMocks.openExternal).toHaveBeenCalledWith(
@@ -56,11 +59,48 @@ describe("UpdateNotificationCard", () => {
     expect(screen.queryByLabelText("Desktop update is available")).toBeNull();
   });
 
+  it("renders downloading state without progress or duplicate update actions", () => {
+    updaterMocks.phase = "downloading";
+    updaterMocks.downloadProgress = 68;
+
+    render(<UpdateNotificationCard />);
+
+    expect(screen.getByLabelText("Desktop update is downloading")).toBeTruthy();
+    expect(screen.getByText("Downloading update")).toBeTruthy();
+    expect(screen.getByText("Preparing the update in the background.")).toBeTruthy();
+    expect(screen.queryByText("68%")).toBeNull();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss update notification" })).toBeNull();
+  });
+
+  it("shows a ready reminder when the restart prompt is closed", () => {
+    updaterMocks.phase = "ready";
+    updaterMocks.restartPromptOpen = false;
+
+    render(<UpdateNotificationCard />);
+
+    expect(screen.getByLabelText("Desktop update is ready to install")).toBeTruthy();
+    expect(screen.getByText("Update ready")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+    expect(updaterMocks.openRestartPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the ready reminder behind the restart prompt", () => {
+    updaterMocks.phase = "ready";
+    updaterMocks.restartPromptOpen = true;
+
+    render(<UpdateNotificationCard />);
+
+    expect(screen.queryByLabelText("Desktop update is ready to install")).toBeNull();
+  });
+
   it("does not render when no update is available", () => {
     updaterMocks.phase = "current";
 
     render(<UpdateNotificationCard />);
 
-    expect(screen.queryByText("New update available")).toBeNull();
+    expect(screen.queryByText("Update available")).toBeNull();
   });
 });

--- a/apps/desktop/src/components/feedback/UpdateNotificationCard.tsx
+++ b/apps/desktop/src/components/feedback/UpdateNotificationCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { ProgressBar } from "@proliferate/ui/primitives/ProgressBar";
 import { X } from "@proliferate/ui/icons";
 import { useUpdater, type UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
@@ -17,97 +16,106 @@ export function UpdateNotificationCard() {
   const {
     phase,
     availableVersion,
-    downloadProgress,
+    restartPromptOpen,
     downloadUpdate,
     openRestartPrompt,
   } = useUpdater();
   const { openExternal } = useTauriShellActions();
   const [dismissedKey, setDismissedKey] = useState<string | null>(null);
-  const visibleKey = `${phase}:${availableVersion ?? "unknown"}`;
+  const visibleKey = [
+    phase,
+    availableVersion ?? "unknown",
+    restartPromptOpen ? "prompt-open" : "prompt-closed",
+  ].join(":");
 
   useEffect(() => {
     setDismissedKey(null);
   }, [visibleKey]);
 
-  if (!UPDATE_CARD_PHASES.has(phase) || dismissedKey === visibleKey) {
+  if (
+    !UPDATE_CARD_PHASES.has(phase)
+    || dismissedKey === visibleKey
+    || (phase === "ready" && restartPromptOpen)
+  ) {
     return null;
   }
 
-  const card = updateCardPresentation(phase, downloadProgress);
+  const card = updateCardPresentation(phase, availableVersion);
+  const canDismiss = phase !== "downloading";
 
   return (
     <aside
       aria-label={card.ariaLabel}
-      className="relative flex w-[min(22rem,calc(100vw-2rem))] flex-wrap items-start gap-2 rounded-lg border border-border bg-background px-3 py-3 pr-10 text-sm text-foreground shadow-floating-dark animate-toast-in"
+      className="relative w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-border/80 bg-card px-3 py-2.5 text-sm text-card-foreground shadow-floating-dark animate-toast-in"
     >
-      <Button
-        type="button"
-        variant="unstyled"
-        size="unstyled"
-        aria-label="Dismiss update notification"
-        className="absolute right-2 top-2 flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-        onClick={() => setDismissedKey(visibleKey)}
-      >
-        <X className="size-3" />
-      </Button>
+      {canDismiss ? (
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          aria-label="Dismiss update notification"
+          className="absolute right-2 top-2 flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={() => setDismissedKey(visibleKey)}
+        >
+          <X className="size-3" />
+        </Button>
+      ) : null}
 
-      <div className="w-full min-w-0">
-        <h2 className="select-text truncate text-sm font-medium leading-5 text-foreground">
+      <div className={`${canDismiss ? "pr-7" : ""}`}>
+        <h2 className="select-text truncate text-[13px] font-medium leading-5 text-card-foreground">
           {card.title}
         </h2>
+        <p className="mt-0.5 text-xs leading-4 text-muted-foreground">
+          {card.description}
+        </p>
       </div>
 
-      {phase === "downloading" && typeof downloadProgress === "number" && (
-        <ProgressBar
-          value={downloadProgress}
-          className="h-1 w-full bg-muted"
-          indicatorClassName="h-full bg-foreground transition-[width]"
-        />
-      )}
-
-      <div className="flex items-center gap-2 pt-1">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-7 rounded-md border-input bg-background px-2.5 text-xs font-normal"
-          onClick={() => { void openExternal(CHANGELOG_URL); }}
-        >
-          See changes
-        </Button>
-        <Button
-          type="button"
-          variant="inverted"
-          size="sm"
-          disabled={phase === "downloading"}
-          className="h-7 rounded-md px-2.5 text-xs font-medium"
-          onClick={() => {
-            if (phase === "available") {
-              void downloadUpdate();
-              return;
-            }
-            if (phase === "ready") {
-              openRestartPrompt();
-            }
-          }}
-        >
-          {card.actionLabel}
-        </Button>
-      </div>
+      {phase !== "downloading" ? (
+        <div className="mt-2 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2.5 text-xs"
+            onClick={() => { void openExternal(CHANGELOG_URL); }}
+          >
+            See changes
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            className="h-7 px-2.5 text-xs"
+            onClick={() => {
+              if (phase === "available") {
+                void downloadUpdate();
+                return;
+              }
+              if (phase === "ready") {
+                openRestartPrompt();
+              }
+            }}
+          >
+            {card.actionLabel}
+          </Button>
+        </div>
+      ) : null}
     </aside>
   );
 }
 
 function updateCardPresentation(
   phase: UpdaterPhase,
-  downloadProgress: number | null,
+  availableVersion: string | null,
 ) {
+  const versionLabel = availableVersion ? ` ${availableVersion}` : "";
+
   if (phase === "downloading") {
-    const progressLabel = typeof downloadProgress === "number" ? ` ${downloadProgress}%` : "";
     return {
       phase,
-      ariaLabel: `Desktop update is downloading${progressLabel}`,
+      ariaLabel: "Desktop update is downloading",
       title: "Downloading update",
+      description: "Preparing the update in the background.",
       actionLabel: "Downloading",
     } as const;
   }
@@ -116,7 +124,8 @@ function updateCardPresentation(
     return {
       phase,
       ariaLabel: "Desktop update is ready to install",
-      title: "New update available",
+      title: "Update ready",
+      description: `Restart to finish installing Proliferate${versionLabel}.`,
       actionLabel: "Restart",
     } as const;
   }
@@ -124,7 +133,8 @@ function updateCardPresentation(
   return {
     phase: "available",
     ariaLabel: "Desktop update is available",
-    title: "New update available",
+    title: "Update available",
+    description: `Proliferate${versionLabel} is ready to download.`,
     actionLabel: "Download",
   } as const;
 }

--- a/apps/desktop/src/components/feedback/UpdateRestartDialog.test.tsx
+++ b/apps/desktop/src/components/feedback/UpdateRestartDialog.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpdateRestartDialog } from "./UpdateRestartDialog";
+
+const updaterMocks = vi.hoisted(() => ({
+  phase: "ready",
+  availableVersion: "0.1.42",
+  restartPromptOpen: true,
+  closeRestartPrompt: vi.fn(),
+  restartNow: vi.fn(),
+}));
+
+vi.mock("@/hooks/access/tauri/use-updater", () => ({
+  useUpdater: () => updaterMocks,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  updaterMocks.phase = "ready";
+  updaterMocks.availableVersion = "0.1.42";
+  updaterMocks.restartPromptOpen = true;
+});
+
+describe("UpdateRestartDialog", () => {
+  it("renders the compact restart prompt when the update is ready", () => {
+    render(<UpdateRestartDialog />);
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getAllByText("Restart to finish updating").length).toBeGreaterThan(0);
+    expect(screen.getByText("Proliferate 0.1.42 is installed and ready.")).toBeTruthy();
+    expect(screen.getByText(/Anything running locally will stop/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+
+  it("closes from Later and restarts from Restart now", () => {
+    render(<UpdateRestartDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Later" }));
+    expect(updaterMocks.closeRestartPrompt).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+    expect(updaterMocks.restartNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render when the ready prompt is closed", () => {
+    updaterMocks.restartPromptOpen = false;
+
+    render(<UpdateRestartDialog />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("does not render before the update is ready", () => {
+    updaterMocks.phase = "available";
+
+    render(<UpdateRestartDialog />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/feedback/UpdateRestartDialog.tsx
+++ b/apps/desktop/src/components/feedback/UpdateRestartDialog.tsx
@@ -16,30 +16,49 @@ export function UpdateRestartDialog() {
       open={restartPromptOpen && phase === "ready"}
       onClose={closeRestartPrompt}
       title="Restart to finish updating"
-      description={
-        availableVersion
-          ? `Version ${availableVersion} has been installed and is ready to use.`
-          : "The update has been installed and is ready to use."
-      }
+      showCloseButton={false}
+      sizeClassName="max-w-[420px]"
+      overlayClassName="bg-black/70"
+      panelClassName="!rounded-lg border-border/80 bg-card shadow-floating-dark"
+      bodyClassName="px-5 pb-0 pt-0"
+      footerClassName="flex shrink-0 items-center justify-end gap-2 px-5 pb-4 pt-5"
+      headerContent={(
+        <div>
+          <h2 className="text-base font-medium leading-6 text-foreground">
+            Restart to finish updating
+          </h2>
+          <p className="mt-1.5 text-[13px] leading-5 text-muted-foreground">
+            {availableVersion
+              ? `Proliferate ${availableVersion} is installed and ready.`
+              : "Proliferate is installed and ready."}
+          </p>
+        </div>
+      )}
       footer={(
         <>
-          <Button variant="ghost" onClick={closeRestartPrompt}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-[34px] px-3.5 text-[13px]"
+            onClick={closeRestartPrompt}
+          >
             Later
           </Button>
-          <Button variant="primary" onClick={() => void restartNow()}>
+          <Button
+            variant="primary"
+            size="sm"
+            className="h-[34px] px-4 text-[13px]"
+            onClick={() => void restartNow()}
+          >
             Restart now
           </Button>
         </>
       )}
     >
-      <div className="space-y-2">
-        <p className="text-sm text-foreground">
-          Restarting closes Proliferate and starts the new version.
-        </p>
-        <p className="text-xs text-muted-foreground">
-          If you have local work in progress, wait until you are ready before restarting.
-        </p>
-      </div>
+      <p className="text-[13px] leading-[1.55] text-muted-foreground">
+        Restarting closes Proliferate and reopens on the new version. Anything running locally
+        will stop, so finish in-progress work first.
+      </p>
     </ModalShell>
   );
 }

--- a/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
+++ b/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { Badge, type BadgeTone } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ProgressBar } from "@proliferate/ui/primitives/ProgressBar";
@@ -13,6 +13,34 @@ import {
   type UpdatePreviewPhase,
   type UpdatePreviewState,
 } from "@/config/update-playground";
+
+type ProductionSurfacePreview =
+  | "available"
+  | "downloading"
+  | "ready-reminder"
+  | "restart-dialog";
+
+interface DevUpdaterMockState {
+  phase: "available" | "downloading" | "ready";
+  version: string;
+  downloadProgress: number | null;
+  restartPromptOpen: boolean;
+  lastCheckedAt: string | null;
+  errorMessage: string | null;
+}
+
+const DEV_UPDATER_MOCK_KEY = "proliferate.dev.updaterMock";
+const DEV_UPDATER_MOCK_EVENT = "proliferate:dev-updater-mock";
+const PREVIEW_VERSION = "0.1.42";
+const PRODUCTION_SURFACE_PREVIEWS: {
+  id: ProductionSurfacePreview;
+  label: string;
+}[] = [
+  { id: "available", label: "Available" },
+  { id: "downloading", label: "Downloading" },
+  { id: "ready-reminder", label: "Ready reminder" },
+  { id: "restart-dialog", label: "Restart dialog" },
+];
 
 const PHASE_LABELS: Record<UpdatePreviewPhase, string> = {
   checking: "Checking",
@@ -47,6 +75,16 @@ const PHASE_BADGE_TONES: Record<UpdatePreviewPhase, BadgeTone> = {
 };
 
 export function UpdateUiPlayground() {
+  const [productionSurfacePreview, setProductionSurfacePreview] =
+    useState<ProductionSurfacePreview>("available");
+
+  useEffect(() => {
+    writeDevUpdaterMock(buildProductionSurfaceMock(productionSurfacePreview));
+    return () => {
+      clearDevUpdaterMock();
+    };
+  }, [productionSurfacePreview]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-border/60 px-7 py-5">
@@ -67,6 +105,24 @@ export function UpdateUiPlayground() {
       </header>
 
       <main className="mx-auto grid max-w-6xl gap-8 px-7 py-7">
+        <PreviewSection
+          title="Production Surfaces"
+          description="Live updater components driven by the dev updater mock. The toast renders in the app toast position; the restart dialog renders as the real app modal."
+        >
+          <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card/60 p-3">
+            {PRODUCTION_SURFACE_PREVIEWS.map((preview) => (
+              <Button
+                key={preview.id}
+                variant={productionSurfacePreview === preview.id ? "primary" : "secondary"}
+                size="sm"
+                onClick={() => setProductionSurfacePreview(preview.id)}
+              >
+                {preview.label}
+              </Button>
+            ))}
+          </div>
+        </PreviewSection>
+
         <PreviewSection
           title="Variant A: Workspace Banner"
           description="A compact global surface for active workspaces. It should tell the user enough without stealing the main task."
@@ -91,6 +147,58 @@ export function UpdateUiPlayground() {
       </main>
     </div>
   );
+}
+
+function buildProductionSurfaceMock(preview: ProductionSurfacePreview): DevUpdaterMockState {
+  const baseState = {
+    version: PREVIEW_VERSION,
+    lastCheckedAt: new Date().toISOString(),
+    errorMessage: null,
+  };
+
+  if (preview === "downloading") {
+    return {
+      ...baseState,
+      phase: "downloading",
+      downloadProgress: 68,
+      restartPromptOpen: false,
+    };
+  }
+
+  if (preview === "ready-reminder") {
+    return {
+      ...baseState,
+      phase: "ready",
+      downloadProgress: null,
+      restartPromptOpen: false,
+    };
+  }
+
+  if (preview === "restart-dialog") {
+    return {
+      ...baseState,
+      phase: "ready",
+      downloadProgress: null,
+      restartPromptOpen: true,
+    };
+  }
+
+  return {
+    ...baseState,
+    phase: "available",
+    downloadProgress: null,
+    restartPromptOpen: false,
+  };
+}
+
+function writeDevUpdaterMock(state: DevUpdaterMockState): void {
+  window.localStorage.setItem(DEV_UPDATER_MOCK_KEY, JSON.stringify(state));
+  window.dispatchEvent(new Event(DEV_UPDATER_MOCK_EVENT));
+}
+
+function clearDevUpdaterMock(): void {
+  window.localStorage.removeItem(DEV_UPDATER_MOCK_KEY);
+  window.dispatchEvent(new Event(DEV_UPDATER_MOCK_EVENT));
 }
 
 function PreviewSection({

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -187,12 +187,8 @@ export function SettingsScreen({
   const admin = useIsAdmin(activeOrganizationId);
   const {
     phase,
-    availableVersion,
     checkNow,
-    downloadProgress,
-    downloadUpdate,
     updatesSupported,
-    openRestartPrompt,
   } = useUpdater();
   const activeRepository = repositories.find(
     (repository) => repository.sourceRoot === activeRepoSourceRoot,
@@ -216,15 +212,11 @@ export function SettingsScreen({
         }}
         onCheckForUpdates={() => { void checkNow(); }}
         updateActionState={{
-          availableVersion,
-          downloadProgress,
           isChecking: phase === "checking",
           hasAvailableUpdate: phase === "available" || phase === "ready",
           phase,
           updatesSupported,
         }}
-        onDownloadUpdate={() => { void downloadUpdate(); }}
-        onOpenRestartPrompt={openRestartPrompt}
       />
 
       <div className="relative flex-1 bg-background">

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
@@ -44,11 +44,20 @@ function renderSettingsSidebar({
   disabledSections,
   onNavigateHome = vi.fn(),
   onSelectSection = vi.fn(),
+  onCheckForUpdates = vi.fn(),
+  updateActionState,
 }: {
   adminAccess?: { isAdmin: boolean; isLoading?: boolean };
   disabledSections?: Partial<Record<SettingsSection, boolean>>;
   onNavigateHome?: () => void;
   onSelectSection?: (section: SettingsSection) => void;
+  onCheckForUpdates?: () => void;
+  updateActionState?: Partial<{
+    isChecking: boolean;
+    hasAvailableUpdate: boolean;
+    phase: "idle" | "checking" | "current" | "available" | "downloading" | "ready" | "error";
+    updatesSupported: boolean;
+  }>;
 } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -66,16 +75,13 @@ function renderSettingsSidebar({
           disabledSections={disabledSections}
           onNavigateHome={onNavigateHome}
           onSelectSection={onSelectSection}
-          onCheckForUpdates={vi.fn()}
-          onDownloadUpdate={vi.fn()}
-          onOpenRestartPrompt={vi.fn()}
+          onCheckForUpdates={onCheckForUpdates}
           updateActionState={{
-            availableVersion: null,
-            downloadProgress: null,
             isChecking: false,
             hasAvailableUpdate: false,
             phase: "idle",
             updatesSupported: true,
+            ...updateActionState,
           }}
         />
       </MemoryRouter>
@@ -181,6 +187,25 @@ describe("SettingsSidebar layout and shortcuts", () => {
     const backRow = screen.getByRole("button", { name: "Back to app" });
     expect(backRow.className).toContain("w-full");
     expect(backRow.className).not.toContain("w-fit");
+  });
+
+  it("keeps desktop update actions on the single settings row", () => {
+    const onCheckForUpdates = vi.fn();
+    renderSettingsSidebar({
+      onCheckForUpdates,
+      updateActionState: {
+        hasAvailableUpdate: true,
+        phase: "ready",
+      },
+    });
+
+    const desktopUpdates = screen.getByRole("button", { name: /Desktop updates/ });
+    expect(desktopUpdates.textContent).toContain("Available");
+    expect(screen.queryByRole("button", { name: /Restart to update/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Download update/ })).toBeNull();
+
+    fireEvent.click(desktopUpdates);
+    expect(onCheckForUpdates).toHaveBeenCalledTimes(1);
   });
 
   it("uses the product sidebar rail width", () => {

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -31,11 +31,7 @@ interface SettingsSidebarProps {
   onNavigateHome: () => void;
   onSelectSection: (section: SettingsSection) => void;
   onCheckForUpdates: () => void;
-  onDownloadUpdate: () => void;
-  onOpenRestartPrompt: () => void;
   updateActionState: {
-    availableVersion: string | null;
-    downloadProgress: number | null;
     isChecking: boolean;
     hasAvailableUpdate: boolean;
     phase: UpdaterPhase;
@@ -103,6 +99,9 @@ function settingsItemStatus(
   if (updateActionState.isChecking) {
     return "Checking...";
   }
+  if (updateActionState.phase === "downloading") {
+    return "Downloading";
+  }
   if (updateActionState.hasAvailableUpdate) {
     return "Available";
   }
@@ -142,8 +141,6 @@ export function SettingsSidebar({
   onNavigateHome,
   onSelectSection,
   onCheckForUpdates,
-  onDownloadUpdate,
-  onOpenRestartPrompt,
   updateActionState,
 }: SettingsSidebarProps) {
   const location = useLocation();
@@ -202,51 +199,6 @@ export function SettingsSidebar({
     }
 
     onSelectSection(item.id);
-  }
-
-  function renderUpdateCommand() {
-    if (
-      updateActionState.phase !== "available"
-      && updateActionState.phase !== "downloading"
-      && updateActionState.phase !== "ready"
-    ) {
-      return null;
-    }
-
-    const disabled = updateActionState.phase === "downloading";
-    const label =
-      updateActionState.phase === "ready"
-        ? "Restart to update"
-        : updateActionState.phase === "downloading"
-          ? "Downloading update"
-          : "Download update";
-    const status =
-      updateActionState.phase === "ready"
-        ? "Ready"
-        : updateActionState.phase === "downloading"
-          ? `${updateActionState.downloadProgress ?? 0}%`
-          : updateActionState.availableVersion
-            ? `v${updateActionState.availableVersion}`
-            : "Available";
-
-    return (
-      <SidebarNavRow
-        onPress={() => {
-          if (disabled) {
-            return;
-          }
-          if (updateActionState.phase === "ready") {
-            onOpenRestartPrompt();
-            return;
-          }
-          onDownloadUpdate();
-        }}
-        disabled={disabled}
-        label={label}
-        status={status}
-        className={settingsRowClass(false, disabled)}
-      />
-    );
   }
 
   return (
@@ -317,9 +269,6 @@ export function SettingsSidebar({
                       className={settingsRowClass(active, disabled)}
                       shortcutRevealVisible={shortcutRevealVisible}
                     />
-                    {item.kind === "action" && item.id === "checkForUpdates"
-                      ? renderUpdateCommand()
-                      : null}
                   </Fragment>
                 );
               })}

--- a/apps/packages/ui/src/primitives/ModalShell.tsx
+++ b/apps/packages/ui/src/primitives/ModalShell.tsx
@@ -17,6 +17,7 @@ export interface ModalShellProps {
   footerClassName?: string;
   overlayClassName?: string;
   panelClassName?: string;
+  showCloseButton?: boolean;
   telemetryBlocked?: boolean;
 }
 
@@ -34,6 +35,7 @@ export function ModalShell({
   footerClassName = "flex shrink-0 items-center justify-end gap-2 border-t border-border/60 px-5 py-3",
   overlayClassName = "bg-black/70 backdrop-blur-sm",
   panelClassName = "border-border bg-background shadow-lg",
+  showCloseButton = true,
   telemetryBlocked = false,
 }: ModalShellProps) {
   const titleId = useId();
@@ -82,15 +84,17 @@ export function ModalShell({
           className={`relative flex w-full flex-col overflow-hidden rounded-2xl border ${panelClassName} ${sizeClassName}`}
           onClick={(event) => event.stopPropagation()}
         >
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={disableClose}
-            aria-label="Close"
-            className="absolute right-4 top-4 z-10 rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 disabled:opacity-30"
-          >
-            <X className="size-4" />
-          </button>
+          {showCloseButton ? (
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={disableClose}
+              aria-label="Close"
+              className="absolute right-4 top-4 z-10 rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 disabled:opacity-30"
+            >
+              <X className="size-4" />
+            </button>
+          ) : null}
 
           {headerContent ? (
             <>
@@ -102,12 +106,12 @@ export function ModalShell({
                   {description}
                 </p>
               )}
-              <div className="shrink-0 px-5 py-3 pr-12">
+              <div className={`shrink-0 px-5 py-3 ${showCloseButton ? "pr-12" : ""}`}>
                 {headerContent}
               </div>
             </>
           ) : (
-            <div className="shrink-0 px-5 pb-3 pr-10 pt-5">
+            <div className={`shrink-0 px-5 pb-3 pt-5 ${showCloseButton ? "pr-10" : ""}`}>
               <h2 id={titleId} className="text-lg font-medium tracking-tight text-foreground">
                 {title}
               </h2>

--- a/apps/packages/ui/test/ModalShell.test.tsx
+++ b/apps/packages/ui/test/ModalShell.test.tsx
@@ -54,4 +54,14 @@ describe("ModalShell", () => {
 
     expect(screen.getByRole("dialog").getAttribute("data-telemetry-block")).toBe("true");
   });
+
+  it("can hide the close button for focused system prompts", () => {
+    render(
+      <ModalShell open title="Restart" onClose={vi.fn()} showCloseButton={false}>
+        Content
+      </ModalShell>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- slim the desktop updater toast and make Download/Restart use primary actions
- replace the restart prompt with a compact mockup-inspired dialog
- remove the extra settings-sidebar updater command row
- add dev playground controls for the real updater surfaces

## Tests
- `git diff --check origin/main..HEAD`
- `pnpm --dir apps/packages/ui exec vitest run test/ModalShell.test.tsx`
- `pnpm --dir apps/desktop exec vitest run src/components/feedback/UpdateNotificationCard.test.tsx src/components/feedback/UpdateRestartDialog.test.tsx src/components/settings/sidebar/SettingsSidebar.test.tsx src/config/playground.test.ts`
