### PR TITLE
ci(release): route desktop through production promote

### DIFF
--- a/.github/workflows/_deploy-desktop.yml
+++ b/.github/workflows/_deploy-desktop.yml
@@ -12,6 +12,15 @@ on:
       enabled:
         default: true
         type: boolean
+      dry_run:
+        default: false
+        type: boolean
+      publish_updater:
+        default: false
+        type: boolean
+      target_os:
+        default: all
+        type: string
 
 permissions:
   contents: read
@@ -20,39 +29,71 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  deploy:
+  plan:
     if: ${{ inputs.enabled }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    outputs:
+      enabled: ${{ steps.meta.outputs.enabled }}
+      version: ${{ steps.meta.outputs.version }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
     env:
       DESKTOP_DEPLOY_ENABLED: ${{ vars.DESKTOP_DEPLOY_ENABLED || 'false' }}
-      DESKTOP_RELEASE_WORKFLOW: ${{ vars.DESKTOP_RELEASE_WORKFLOW || 'release-desktop.yml' }}
-      DESKTOP_RELEASE_REF: ${{ vars.DESKTOP_RELEASE_REF }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_sha }}
 
-      - name: Validate desktop deploy config
+      - name: Resolve desktop release metadata
+        id: meta
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          GIT_SHA: ${{ inputs.git_sha }}
         run: |
           set -euo pipefail
           if [[ "$DESKTOP_DEPLOY_ENABLED" != "true" ]]; then
             echo "Desktop deploy is intentionally disabled for this environment."
-            echo "Set DESKTOP_DEPLOY_ENABLED=true after the beta/stable channel is ready."
+            echo "Set DESKTOP_DEPLOY_ENABLED=true to build from the promoted SHA."
+            {
+              echo "enabled=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          : "${DESKTOP_RELEASE_REF:?Set DESKTOP_RELEASE_REF to the desktop tag/ref to release.}"
 
-      - name: Dispatch desktop release workflow
-        if: ${{ env.DESKTOP_DEPLOY_ENABLED == 'true' }}
-        run: |
-          set -euo pipefail
-          gh workflow run "$DESKTOP_RELEASE_WORKFLOW" \
-            --ref "$DESKTOP_RELEASE_REF" \
-            -f dry_run=false \
-            -f publish_updater=true
-        env:
-          GH_TOKEN: ${{ github.token }}
+          package_version="$(node -p "require('./apps/desktop/package.json').version")"
+          tauri_version="$(node -p "JSON.parse(require('fs').readFileSync('./apps/desktop/src-tauri/tauri.conf.json','utf8')).version")"
+          cargo_version="$(grep '^version' apps/desktop/src-tauri/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
+          if [[ "$package_version" == "$tauri_version" && "$package_version" == "$cargo_version" ]]; then
+            :
+          else
+            echo "::error::Desktop version mismatch: package=$package_version tauri=$tauri_version cargo=$cargo_version"
+            exit 1
+          fi
+
+          tag_name="desktop-v$package_version"
+          tag_target="$(git ls-remote --tags origin "refs/tags/$tag_name" | awk '{ print $1 }' | head -n 1)"
+          if [[ -n "$tag_target" && "$tag_target" == "$GIT_SHA" && "$DRY_RUN" != "true" ]]; then
+            echo "Desktop tag $tag_name already points at $GIT_SHA; skipping duplicate release."
+            {
+              echo "enabled=false"
+              echo "version=$package_version"
+              echo "tag_name=$tag_name"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -n "$tag_target" && "$tag_target" != "$GIT_SHA" && "$DRY_RUN" != "true" ]]; then
+            echo "::error::Desktop tag $tag_name already exists at $tag_target, not $GIT_SHA. Bump the desktop version before publishing desktop from this SHA."
+            exit 1
+          fi
+          if [[ -n "$tag_target" && "$DRY_RUN" == "true" ]]; then
+            echo "::warning::Desktop tag $tag_name already exists at $tag_target; dry run will build without publishing."
+          fi
+
+          {
+            echo "enabled=true"
+            echo "version=$package_version"
+            echo "tag_name=$tag_name"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Summarize desktop deploy
         run: |
@@ -60,8 +101,27 @@ jobs:
             echo "### Desktop"
             echo "- Environment: ${{ inputs.environment }}"
             echo "- Enabled: \`$DESKTOP_DEPLOY_ENABLED\`"
-            if [[ "$DESKTOP_DEPLOY_ENABLED" == "true" ]]; then
-              echo "- Dispatched workflow: \`$DESKTOP_RELEASE_WORKFLOW\`"
-              echo "- Ref: \`$DESKTOP_RELEASE_REF\`"
+            echo "- Git SHA: \`${{ inputs.git_sha }}\`"
+            if [[ "${{ steps.meta.outputs.enabled }}" == "true" ]]; then
+              echo "- Version: \`${{ steps.meta.outputs.version }}\`"
+              echo "- Tag: \`${{ steps.meta.outputs.tag_name }}\`"
+              echo "- Dry run: \`${{ inputs.dry_run }}\`"
+              echo "- Publish updater: \`${{ inputs.publish_updater }}\`"
+              echo "- Target OS: \`${{ inputs.target_os }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    needs: [plan]
+    if: ${{ needs.plan.outputs.enabled == 'true' }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      git_sha: ${{ inputs.git_sha }}
+      version: ${{ needs.plan.outputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+      publish_updater: ${{ inputs.publish_updater }}
+      target_os: ${{ inputs.target_os }}
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -213,11 +213,16 @@ jobs:
   deploy-desktop:
     needs: [plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/_deploy-desktop.yml
     with:
       environment: staging
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.desktop == 'true' }}
+      dry_run: true
+      publish_updater: false
     secrets: inherit
 
   summary:

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -185,11 +185,16 @@ jobs:
   deploy-desktop:
     needs: [plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/_deploy-desktop.yml
     with:
       environment: production
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.desktop == 'true' }}
+      dry_run: false
+      publish_updater: true
     secrets: inherit
 
   summary:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -21,6 +21,28 @@ on:
           - all
           - macos
         default: all
+  workflow_call:
+    inputs:
+      git_sha:
+        description: "Commit SHA to package. Defaults to the caller ref."
+        required: false
+        type: string
+      version:
+        description: "Desktop version to release. Required for non-tag reusable releases."
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run (skip GitHub release creation and updater publish)"
+        type: boolean
+        default: false
+      publish_updater:
+        description: "Publish updater/download assets to S3 and CloudFront"
+        type: boolean
+        default: false
+      target_os:
+        description: "Target OS"
+        type: string
+        default: all
 
 permissions:
   contents: write
@@ -64,8 +86,10 @@ jobs:
       - name: Decide whether to build this matrix entry
         id: filter
         shell: bash
+        env:
+          TARGET_OS: ${{ inputs.target_os || 'all' }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ inputs.target_os }}" != "all" ]] && [[ "${{ inputs.target_os }}" != "${{ matrix.runner_os }}" ]]; then
+          if [[ "${{ github.event_name }}" != "push" ]] && [[ "$TARGET_OS" != "all" ]] && [[ "$TARGET_OS" != "${{ matrix.runner_os }}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -83,17 +107,29 @@ jobs:
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - name: Validate version consistency
-        if: steps.filter.outputs.skip != 'true' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
+        if: steps.filter.outputs.skip != 'true' && (github.event_name == 'push' || (github.event_name != 'push' && !inputs.dry_run))
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#desktop-v}"
+          if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
+            RELEASE_VERSION="${GITHUB_REF_NAME#desktop-v}"
+          else
+            RELEASE_VERSION="$INPUT_VERSION"
+          fi
+          if [[ -z "$RELEASE_VERSION" ]]; then
+            echo "::error::A desktop version input is required for non-tag releases."
+            exit 1
+          fi
           PKG_VERSION=$(node -p "require('./apps/desktop/package.json').version")
           TAURI_VERSION=$(node -p "JSON.parse(require('fs').readFileSync('./apps/desktop/src-tauri/tauri.conf.json','utf8')).version")
           CARGO_VERSION=$(grep '^version' apps/desktop/src-tauri/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]] || [[ "$TAG_VERSION" != "$TAURI_VERSION" ]] || [[ "$TAG_VERSION" != "$CARGO_VERSION" ]]; then
-            echo "::error::Version mismatch: tag=$TAG_VERSION pkg=$PKG_VERSION tauri=$TAURI_VERSION cargo=$CARGO_VERSION"
+          if [[ "$RELEASE_VERSION" != "$PKG_VERSION" ]] || [[ "$RELEASE_VERSION" != "$TAURI_VERSION" ]] || [[ "$RELEASE_VERSION" != "$CARGO_VERSION" ]]; then
+            echo "::error::Version mismatch: release=$RELEASE_VERSION pkg=$PKG_VERSION tauri=$TAURI_VERSION cargo=$CARGO_VERSION"
             exit 1
           fi
 
@@ -106,10 +142,14 @@ jobs:
       - name: Resolve release metadata
         if: steps.filter.outputs.skip != 'true'
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
           package_version=$(node -p "require('./apps/desktop/package.json').version")
           if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
             release_version="${GITHUB_REF_NAME#desktop-v}"
+          elif [[ -n "$INPUT_VERSION" ]]; then
+            release_version="$INPUT_VERSION"
           else
             safe_ref=$(printf '%s' "${GITHUB_REF_NAME:-$GITHUB_SHA}" | sed 's/[^A-Za-z0-9._-]/-/g')
             release_version="${package_version}-${safe_ref}-${GITHUB_SHA::12}"
@@ -448,7 +488,7 @@ jobs:
   create-release:
     needs: build-desktop
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    if: github.event_name == 'push' || (github.event_name != 'push' && !inputs.dry_run)
     steps:
       - name: Validate release ref
         if: github.event_name == 'workflow_dispatch'
@@ -472,10 +512,11 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Proliferate Desktop ${{ github.ref_name }}
+          name: Proliferate Desktop ${{ startsWith(github.ref_name, 'desktop-v') && github.ref_name || format('desktop-v{0}', inputs.version) }}
           draft: true
           generate_release_notes: true
+          target_commitish: ${{ inputs.git_sha || github.sha }}
+          tag_name: ${{ startsWith(github.ref_name, 'desktop-v') && github.ref_name || format('desktop-v{0}', inputs.version) }}
           files: all-artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -483,13 +524,15 @@ jobs:
   publish-updater:
     needs: [build-desktop, create-release]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.publish_updater)
+    if: github.event_name == 'push' || (github.event_name != 'push' && !inputs.dry_run && inputs.publish_updater)
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - name: Setup Node 22
         uses: actions/setup-node@v4
@@ -513,17 +556,31 @@ jobs:
           aws-region: us-east-1
 
       - name: Generate updater manifest
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
+          version="$INPUT_VERSION"
+          if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
+            version="${GITHUB_REF_NAME#desktop-v}"
+          fi
+          : "${version:?Missing desktop release version.}"
           node scripts/generate-updater-manifest.mjs \
-            --version "${GITHUB_REF_NAME#desktop-v}" \
+            --version "$version" \
             --artifacts-dir all-artifacts \
             --base-url "${{ vars.DESKTOP_DOWNLOADS_BASE_URL }}/desktop/stable" \
             --output latest.json
 
       - name: Generate installer manifest
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
+          version="$INPUT_VERSION"
+          if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
+            version="${GITHUB_REF_NAME#desktop-v}"
+          fi
+          : "${version:?Missing desktop release version.}"
           node scripts/generate-desktop-installer-manifest.mjs \
-            --version "${GITHUB_REF_NAME#desktop-v}" \
+            --version "$version" \
             --artifacts-dir all-artifacts \
             --base-url "${{ vars.DESKTOP_DOWNLOADS_BASE_URL }}/desktop/stable" \
             --output installers.json

--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -15,7 +15,7 @@ publishing, or the desktop in-app update flow.
   _deploy-workers.yml        # reusable hosted worker lane, gated until workers are enabled
   _deploy-web.yml            # reusable Vercel deploy/alias/smoke lane
   _deploy-mobile.yml         # reusable EAS/TestFlight lane, gated until app identity is ready
-  _deploy-desktop.yml        # reusable desktop release dispatch lane, gated until beta/stable channel split
+  _deploy-desktop.yml        # reusable desktop release lane, gated until beta/stable channel split
   cloud-tests.yml            # real-provider cloud lifecycle + cloud-backed runtime suites
   cloud-live-webhook.yml     # manual/nightly live E2B webhook delivery smoke
   release-cloud-template.yml # public E2B cloud template build + publish + staging promote
@@ -53,14 +53,14 @@ vercel.json                  # web app deploy config (Vercel project proliferate
 
 - Treat workflows, release scripts, infra, and updater config as one delivery
   surface. Do not update one without checking the others.
-- Desktop releases ship off the `desktop-v*` tag line. Runtime releases ship off
-  the `runtime-v*` tag line.
+- Desktop releases create/use the `desktop-v*` tag line. Runtime releases ship
+  off the `runtime-v*` tag line.
 - Cloud template releases are manually dispatched. They publish immutable
   `sha-*` tags, then move rolling `staging` and `production` tags separately.
 - Desktop versioning must stay consistent across
   `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`, and
   `apps/desktop/src-tauri/Cargo.toml`. The desktop release workflow enforces this on
-  tagged releases.
+  tagged and production-promoted releases.
 - Do not change updater endpoints, publish paths, or signing behavior in only
   one place. Keep these aligned:
   - `.github/workflows/release-desktop.yml`
@@ -238,18 +238,21 @@ Flow:
    - `apps/desktop/src-tauri/tauri.conf.json`
    - `apps/desktop/src-tauri/Cargo.toml`
 2. Commit and merge the version bump to `main`.
-3. From updated `main`, create and push a tag like `desktop-v0.1.0`. The
-   workflow triggers automatically.
-4. Treat pushing the `desktop-v*` tag as the shipping action. The tag-push
-   workflow publishes updater/download assets after the build succeeds, even
-   though the GitHub Release remains a draft.
+3. Preferred production path: run `promote-production.yml` for the merged SHA.
+   When the desktop surface is enabled and `DESKTOP_DEPLOY_ENABLED=true` for
+   the target environment, the promote workflow derives `desktop-v<VERSION>`
+   from the promoted SHA and calls `release-desktop.yml` directly.
+4. Low-level/manual path: from updated `main`, create and push a tag like
+   `desktop-v0.1.0`. The tag-push workflow still triggers automatically and
+   publishes updater/download assets after the build succeeds.
 5. After the workflow succeeds, manually review the draft GitHub Release:
    - add a short highlights section at the top
    - clean up generated release notes if needed
    - publish the GitHub Release as the human-facing release page
-6. If you must trigger manually, use `--ref desktop-v<VERSION>` — **never
-   trigger on `main`**, because the updater manifest version is derived from
-   `GITHUB_REF_NAME` and resolves to `"main"` instead of valid semver.
+6. If you must trigger the desktop workflow manually, use
+   `--ref desktop-v<VERSION>` for non-dry-run releases. Reusable calls from
+   production promote pass `git_sha` and `version` explicitly, so they do not
+   depend on `GITHUB_REF_NAME`.
 7. The workflow:
    - validates version consistency on tag pushes
    - builds the AnyHarness sidecar for each desktop target
@@ -314,11 +317,17 @@ Note:
 - `dry_run: true` exercises the build matrix but skips `create-release` and
   `publish-updater`.
 - Manual non-dry-run desktop releases must run from a `desktop-v*` tag ref.
+  Production promote is the exception: it calls the reusable desktop workflow
+  with an explicit promoted SHA and version, after `_deploy-desktop.yml`
+  validates that the version matches package/Tauri/Cargo metadata.
 - Manual runs default `publish_updater` to false. Use this to test draft
   GitHub release creation and generated notes without uploading updater assets
   to S3 or invalidating CloudFront.
 - Real `desktop-v*` tag pushes still publish updater and download assets
   automatically after the draft GitHub release is created.
+- `_deploy-desktop.yml` refuses to publish a desktop version if the derived
+  `desktop-v<VERSION>` tag already exists at a different SHA. Bump the desktop
+  version before publishing a new desktop build from a new commit.
 - Publishing the GitHub Release does not make the updater live. The updater is
   made live by the tag-push workflow's S3/CloudFront publish step. The GitHub
   Release is the public release-notes and artifact archive surface.
@@ -500,7 +509,9 @@ Trigger model:
 4. Production is promoted manually through `Promote Production` and should be
    protected by the GitHub `production` environment.
 5. Tags are release artifacts or channel pointers, not the primary hosted deploy
-   trigger.
+   trigger. Desktop still produces `desktop-v*` release tags, but production
+   promote owns deriving and invoking that desktop release from the promoted
+   SHA.
 
 Deploy graph:
 
@@ -524,8 +535,9 @@ Deploy graph:
    - server deploys ECR/ECS, runs Alembic, and smokes health
    - web deploys through Vercel, aliases the environment URL, and smokes it
    - mobile uses EAS build/submit when `MOBILE_DEPLOY_ENABLED=true`
-   - desktop dispatches the desktop release workflow when
-     `DESKTOP_DEPLOY_ENABLED=true`
+   - desktop calls the reusable desktop release workflow when
+     `DESKTOP_DEPLOY_ENABLED=true`; the desktop version is derived from the
+     promoted SHA, and no static `DESKTOP_RELEASE_REF` is used
    - workers are intentionally gated until the hosted worker ECS command/service
      is canonical
 4. Upload a deploy summary artifact.
@@ -571,8 +583,6 @@ EAS_SUBMIT_ENABLED
 
 # desktop, when enabled
 DESKTOP_DEPLOY_ENABLED
-DESKTOP_RELEASE_WORKFLOW
-DESKTOP_RELEASE_REF
 ```
 
 For staging, the canonical values are expected to point at staging resources
@@ -630,11 +640,12 @@ DESKTOP_CHANNEL=beta
 
 The production GitHub environment currently exists as `Production`; the
 workflow input still uses `production`, which GitHub resolves to that existing
-environment. Production should keep `MOBILE_DEPLOY_ENABLED=false`,
-`WORKERS_DEPLOY_ENABLED=false`, and `DESKTOP_DEPLOY_ENABLED=false` until those
-lanes are explicitly ready. Keep `VERCEL_TOKEN` as an environment secret, and
-keep E2B API credentials as repo or environment secrets; do not document secret
-values here.
+environment. Production should keep `MOBILE_DEPLOY_ENABLED=false` and
+`WORKERS_DEPLOY_ENABLED=false` until those lanes are explicitly ready.
+`DESKTOP_DEPLOY_ENABLED=true` enables production promote to publish the desktop
+updater for SHAs that include a desktop version bump. Keep `VERCEL_TOKEN` as an
+environment secret, and keep E2B API credentials as repo or environment
+secrets; do not document secret values here.
 
 ## 5. Source of Truth
 


### PR DESCRIPTION
## Summary

- route the production desktop lane through `_deploy-desktop.yml` instead of a static `DESKTOP_RELEASE_REF` dispatch
- let production promote derive `desktop-v<VERSION>` from the promoted SHA and call `release-desktop.yml` directly
- keep staging desktop deploys build-only via dry run, and document the new release path

## Verification

- `actionlint .github/workflows/*.yml`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/*.yml`\n- `node --check scripts/ci-cd/detect-deploy-surfaces.mjs`\n- `node --check scripts/ci-cd/resolve-deploy-base.mjs`\n- `node scripts/ci-cd/detect-deploy-surfaces.mjs --base origin/main --head HEAD`\n- `git diff --check -- .github/workflows/release-desktop.yml .github/workflows/_deploy-desktop.yml .github/workflows/promote-production.yml .github/workflows/deploy-staging.yml docs/dev/ci-cd.md`