### PR TITLE
feat(product): surface cloud workspace activity status

### DIFF
--- a/apps/mobile/src/components/work/MobileWorkspaceCard.tsx
+++ b/apps/mobile/src/components/work/MobileWorkspaceCard.tsx
@@ -1,6 +1,10 @@
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
-import { mobileIconForRuntimeLocation, mobileIconForWorkSourceKind } from "../../lib/domain/work/mobile-work-presentation";
+import {
+  mobileColorKeyForWorkStatusTone,
+  mobileIconForRuntimeLocation,
+  mobileIconForWorkSourceKind,
+} from "../../lib/domain/work/mobile-work-presentation";
 import type { MobileWorkItem } from "../../hooks/work/derived/use-mobile-work-inventory";
 import { MobileIcon } from "../primitives/MobileIcon";
 import { colors, radius, spacing } from "../../styles/tokens";
@@ -21,14 +25,14 @@ export function MobileWorkspaceCard({
   onClaim,
 }: MobileWorkspaceCardProps) {
   const detailText = workspaceDetailText(item);
-  const blocked = item.view.status === "blocked" || item.view.status === "error";
-  const active = item.view.status === "active" || item.view.status === "running";
+  const statusColor = colors[mobileColorKeyForWorkStatusTone(item.view.statusIndicator.tone)];
   const unclaimed = item.view.unclaimed;
   const canClaim = Boolean(onClaim) && unclaimed;
 
   return (
     <Pressable
       accessibilityRole="button"
+      accessibilityLabel={`${item.view.title}, ${item.view.statusIndicator.label}`}
       onPress={onPress}
       style={({ pressed }) => [
         styles.card,
@@ -46,9 +50,9 @@ export function MobileWorkspaceCard({
           <View
             style={[
               styles.stateDot,
-              active && styles.stateDotActive,
-              blocked && styles.stateDotBlocked,
-              unclaimed && styles.stateDotUnclaimed,
+              item.view.statusIndicator.hollow
+                ? [styles.stateDotHollow, { borderColor: statusColor }]
+                : { backgroundColor: statusColor },
             ]}
           />
         </View>
@@ -103,7 +107,13 @@ function workspaceDetailText(item: MobileWorkItem): string | null {
     return item.view.activityPreview;
   }
   if (item.view.unclaimed) {
-    return "Unclaimed workspace";
+    return item.view.statusIndicator.label;
+  }
+  if (
+    item.view.statusIndicator.kind !== "idle" &&
+    item.view.statusIndicator.kind !== "ready"
+  ) {
+    return item.view.statusIndicator.label;
   }
   if (item.view.commandability !== "commandable") {
     return item.view.commandabilityLabel;
@@ -157,14 +167,9 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     backgroundColor: colors.borderHeavy,
   },
-  stateDotActive: {
-    backgroundColor: colors.info,
-  },
-  stateDotBlocked: {
-    backgroundColor: colors.destructive,
-  },
-  stateDotUnclaimed: {
-    backgroundColor: colors.success,
+  stateDotHollow: {
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: "transparent",
   },
   cardTitleBlock: {
     flex: 1,

--- a/apps/mobile/src/lib/domain/work/mobile-work-presentation.ts
+++ b/apps/mobile/src/lib/domain/work/mobile-work-presentation.ts
@@ -2,6 +2,7 @@ import type {
   CloudWorkStatusFilter,
   RecentWorkRuntimeLocation,
   RecentWorkSourceKind,
+  RecentWorkStatusIndicatorTone,
 } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
 
 import type { MobileIconName } from "../../../components/primitives/MobileIcon";
@@ -58,5 +59,29 @@ export function mobileIconForWorkStatus(status: CloudWorkStatusFilter): MobileIc
     case "ready":
     default:
       return "check";
+  }
+}
+
+export type MobileWorkStatusColorKey =
+  | "warning"
+  | "info"
+  | "success"
+  | "destructive"
+  | "borderHeavy";
+
+export function mobileColorKeyForWorkStatusTone(
+  tone: RecentWorkStatusIndicatorTone,
+): MobileWorkStatusColorKey {
+  switch (tone) {
+    case "attention":
+      return "warning";
+    case "progress":
+      return "info";
+    case "success":
+      return "success";
+    case "danger":
+      return "destructive";
+    case "muted":
+      return "borderHeavy";
   }
 }

--- a/apps/packages/product-domain/src/workspaces/cloud-work-inventory.test.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-inventory.test.ts
@@ -15,6 +15,7 @@ import {
   recentWorkCommandability,
   recentWorkRuntimeLocationForWorkspace,
   recentWorkSourceForWorkspace,
+  recentWorkStatusIndicatorForWorkspace,
 } from "./cloud-work-inventory";
 
 const NOW = Date.parse("2026-05-23T12:00:00Z");
@@ -69,6 +70,56 @@ describe("cloud work inventory", () => {
       },
     }))).toBe("blocked");
     expect(cloudWorkStatusForWorkspace(workspace({ workspaceStatus: "ready", runtime: runtime("paused") }))).toBe("ready");
+  });
+
+  it("derives a shared status indicator without requiring server UI fields", () => {
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      workspaceStatus: "error",
+      lastError: "Runtime failed",
+    }))).toMatchObject({ kind: "error", tone: "danger", label: "Error", hollow: false });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      lastSessionSummary: {
+        targetId: "target",
+        workspaceId: "runtime",
+        sessionId: "session",
+        title: "Awaiting approval",
+        status: "idle",
+        phase: "awaiting_interaction",
+        pendingInteractionCount: 1,
+        lastEventAt: "2026-05-23T11:56:00Z",
+      },
+    }))).toMatchObject({ kind: "needs_input", tone: "attention", label: "Needs input" });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      workspaceStatus: "materializing",
+      status: "materializing",
+      runtime: runtime("provisioning"),
+    }))).toMatchObject({ kind: "running", tone: "progress", label: "In progress", live: true });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      lastSessionSummary: {
+        targetId: "target",
+        workspaceId: "runtime",
+        sessionId: "session",
+        title: "Review",
+        status: "ready_for_review",
+        lastEventAt: "2026-05-23T11:56:00Z",
+      },
+    }))).toMatchObject({ kind: "review_ready", tone: "success", label: "Ready for review" });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      sandboxType: "managed_personal",
+      targetId: "target",
+      runtime: runtime("running"),
+    }))).toMatchObject({ kind: "ready", tone: "success", label: "Ready" });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      sandboxType: "local",
+      exposureState: "untracked",
+      exposure: null,
+      runtime: runtime("running"),
+    }))).toMatchObject({ kind: "idle", tone: "muted", label: "Idle", hollow: true });
   });
 
   it("dedupes duplicate workspace rows by merging complementary details", () => {
@@ -184,6 +235,7 @@ describe("cloud work inventory", () => {
 
     expect(item.activityPreview).toBe("I fixed the mobile workspace list preview.");
     expect(item.searchText).toContain("mobile workspace list");
+    expect(item.statusIndicator.kind).toBe("ready");
   });
 
   it("falls back to specific blocker detail instead of blunt status copy", () => {
@@ -409,6 +461,7 @@ describe("cloud work inventory", () => {
       cloudAccessState: "enabled",
       commandability: "commandable",
       state: "running",
+      statusIndicator: { kind: "running", label: "In progress" },
       lastActivityLabel: "2m",
     });
     expect(rows[1]).toMatchObject({
@@ -419,7 +472,33 @@ describe("cloud work inventory", () => {
       runtimeLocation: "cloud_sandbox",
       commandability: "commandable",
       state: "idle",
+      statusIndicator: { kind: "ready", label: "Ready" },
     });
+  });
+
+  it("carries latest session previews into recent work rows", () => {
+    const rows = buildRecentWorkItems([
+      workspace({
+        id: "with-preview",
+        displayName: "Preview workspace",
+        lastSessionSummary: {
+          targetId: "target",
+          workspaceId: "runtime",
+          sessionId: "session",
+          title: "Session title",
+          status: "idle",
+          lastEventAt: "2026-05-23T11:58:00Z",
+          preview: "Want me to drill into one zone?",
+        },
+      }),
+    ], { nowMs: NOW });
+
+    expect(rows[0]).toMatchObject({
+      id: "session:with-preview:session",
+      activityPreview: "Want me to drill into one zone?",
+      statusIndicator: { kind: "ready" },
+    });
+    expect(rows[0]?.searchText).toContain("drill into one zone");
   });
 
   it("keeps the active workspace row even when that workspace has recent sessions", () => {

--- a/apps/packages/product-domain/src/workspaces/cloud-work-inventory.test.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-inventory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
+import type { CloudSessionProjection, CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
 
 import {
   buildCloudWorkInventory,
@@ -111,8 +111,26 @@ describe("cloud work inventory", () => {
     expect(recentWorkStatusIndicatorForWorkspace(workspace({
       sandboxType: "managed_personal",
       targetId: "target",
+      anyharnessWorkspaceId: "runtime-workspace",
       runtime: runtime("running"),
     }))).toMatchObject({ kind: "ready", tone: "success", label: "Ready" });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      sandboxType: "managed_personal",
+      targetId: "target",
+      runtime: runtime("running"),
+    }))).toMatchObject({ kind: "idle", tone: "muted", label: "Idle" });
+
+    expect(recentWorkStatusIndicatorForWorkspace(workspace({
+      lastSessionSummary: {
+        targetId: "target",
+        workspaceId: "runtime",
+        sessionId: "session",
+        title: "Failed session",
+        status: "failed",
+        lastEventAt: "2026-05-23T11:56:00Z",
+      },
+    }))).toMatchObject({ kind: "error", tone: "danger", label: "Error" });
 
     expect(recentWorkStatusIndicatorForWorkspace(workspace({
       sandboxType: "local",
@@ -177,6 +195,40 @@ describe("cloud work inventory", () => {
     expect(groups[1]?.items[0]?.lastActivityLabel).toBe("2m");
   });
 
+  it("includes billing-blocked work in needs-attention filters", () => {
+    const groups = buildCloudWorkInventory([
+      workspace({
+        id: "billing-blocked",
+        displayName: "Billing blocked",
+        billing: {
+          plan: "free",
+          billingMode: "free",
+          blockStatus: "allowed",
+          overageEnabled: false,
+          overageUsedCentsThisPeriod: 0,
+          startBlocked: true,
+          activeSpendHold: false,
+          activeSandboxCount: 0,
+        },
+      }),
+      workspace({
+        id: "quiet",
+        displayName: "Quiet",
+      }),
+    ], {
+      filters: { needsAttention: true },
+      nowMs: NOW,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items).toHaveLength(1);
+    expect(groups[0]?.items[0]).toMatchObject({
+      id: "billing-blocked",
+      status: "ready",
+      statusIndicator: { kind: "needs_input", label: "Needs input" },
+    });
+  });
+
   it("uses latest session activity before workspace activity", () => {
     const groups = buildCloudWorkInventory([
       workspace({
@@ -235,7 +287,7 @@ describe("cloud work inventory", () => {
 
     expect(item.activityPreview).toBe("I fixed the mobile workspace list preview.");
     expect(item.searchText).toContain("mobile workspace list");
-    expect(item.statusIndicator.kind).toBe("ready");
+    expect(item.statusIndicator.kind).toBe("idle");
   });
 
   it("falls back to specific blocker detail instead of blunt status copy", () => {
@@ -472,7 +524,7 @@ describe("cloud work inventory", () => {
       runtimeLocation: "cloud_sandbox",
       commandability: "commandable",
       state: "idle",
-      statusIndicator: { kind: "ready", label: "Ready" },
+      statusIndicator: { kind: "idle", label: "Idle" },
     });
   });
 
@@ -496,7 +548,7 @@ describe("cloud work inventory", () => {
     expect(rows[0]).toMatchObject({
       id: "session:with-preview:session",
       activityPreview: "Want me to drill into one zone?",
-      statusIndicator: { kind: "ready" },
+      statusIndicator: { kind: "idle" },
     });
     expect(rows[0]?.searchText).toContain("drill into one zone");
   });
@@ -541,6 +593,43 @@ describe("cloud work inventory", () => {
       sessionId: null,
       title: "Bramble",
     });
+  });
+
+  it("keeps active session projection status separate from the workspace last session", () => {
+    const rows = buildRecentWorkItems([
+      workspace({
+        id: "multi-session",
+        displayName: "Multi session",
+        lastSessionSummary: {
+          targetId: "target",
+          workspaceId: "runtime",
+          sessionId: "needs-input-session",
+          title: "Needs input session",
+          status: "idle",
+          phase: "awaiting_interaction",
+          pendingInteractionCount: 1,
+          lastEventAt: "2026-05-23T11:58:00Z",
+        },
+      }),
+    ], {
+      activeWorkspaceSessions: [
+        sessionProjection({
+          cloudWorkspaceId: "multi-session",
+          sessionId: "running-session",
+          title: "Running session",
+          status: "running",
+          pendingInteractionCount: 0,
+          lastEventAt: "2026-05-23T11:59:00Z",
+        }),
+      ],
+      nowMs: NOW,
+    });
+
+    const runningSession = rows.find((row) => row.sessionId === "running-session");
+    const needsInputSession = rows.find((row) => row.sessionId === "needs-input-session");
+
+    expect(runningSession?.statusIndicator).toMatchObject({ kind: "running", label: "In progress" });
+    expect(needsInputSession?.statusIndicator).toMatchObject({ kind: "needs_input", label: "Needs input" });
   });
 
   it("distinguishes cloud access from cloud runtime", () => {
@@ -661,6 +750,27 @@ function runtime(status: RuntimeSummary["status"]): RuntimeSummary {
     runtimeAuth: null,
     actionBlockKind: null,
     actionBlockReason: null,
+  };
+}
+
+function sessionProjection(overrides: Partial<CloudSessionProjection> = {}): CloudSessionProjection {
+  return {
+    targetId: "target",
+    cloudWorkspaceId: "workspace",
+    workspaceId: "runtime",
+    sessionId: "session",
+    nativeSessionId: null,
+    sourceAgentKind: "codex",
+    title: "Session",
+    status: "idle",
+    phase: null,
+    pendingInteractionCount: 0,
+    liveConfig: null,
+    lastEventSeq: 1,
+    lastEventAt: "2026-05-23T11:45:00Z",
+    startedAt: "2026-05-23T11:00:00Z",
+    endedAt: null,
+    ...overrides,
   };
 }
 

--- a/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
@@ -15,6 +15,29 @@ export type CloudWorkSort = "recent" | "created" | "name" | "repo" | "status";
 
 export type CloudWorkOwnerKind = "private" | "claimed" | "unclaimed" | "archived";
 
+export type RecentWorkStatusIndicatorKind =
+  | "needs_input"
+  | "running"
+  | "review_ready"
+  | "ready"
+  | "error"
+  | "idle";
+
+export type RecentWorkStatusIndicatorTone =
+  | "attention"
+  | "progress"
+  | "success"
+  | "danger"
+  | "muted";
+
+export interface RecentWorkStatusIndicatorView {
+  kind: RecentWorkStatusIndicatorKind;
+  tone: RecentWorkStatusIndicatorTone;
+  label: string;
+  hollow: boolean;
+  live: boolean;
+}
+
 export interface CloudWorkFilters {
   ownership?: CloudWorkOwnerFilter;
   sources?: ReadonlySet<CloudWorkSource>;
@@ -51,6 +74,7 @@ export interface CloudWorkItemView {
   ownerLabel: string;
   status: CloudWorkStatusFilter;
   statusLabel: string;
+  statusIndicator: RecentWorkStatusIndicatorView;
   activityPreview: string | null;
   branchLabel: string;
   repoLabel: string;
@@ -150,6 +174,8 @@ export interface RecentWorkItemView {
   lastActivityLabel: string;
   state: RecentWorkState;
   stateLabel: string;
+  statusIndicator: RecentWorkStatusIndicatorView;
+  activityPreview: string | null;
   searchText: string;
 }
 
@@ -335,6 +361,7 @@ export function cloudWorkItemForWorkspace(
   const cloudAccessState = recentWorkCloudAccessState(workspace);
   const commandability = recentWorkCommandability(workspace);
   const status = cloudWorkStatusForWorkspace(workspace);
+  const statusIndicator = recentWorkStatusIndicatorForWorkspace(workspace);
   const ownerKind = cloudWorkOwnerKind(workspace);
   const lastActivityMs = cloudWorkLastActivityMs(workspace);
   const createdAtMs = parseTime(workspace.createdAt) || lastActivityMs;
@@ -359,6 +386,7 @@ export function cloudWorkItemForWorkspace(
     ownerLabel: cloudWorkOwnerLabel(workspace),
     status,
     statusLabel: STATUS_LABELS[status],
+    statusIndicator,
     activityPreview,
     branchLabel,
     repoLabel,
@@ -649,6 +677,34 @@ export function cloudCommandReadiness(
   };
 }
 
+export function recentWorkStatusIndicatorForWorkspace(
+  workspace: CloudWorkspaceStatusIndicatorFacts,
+): RecentWorkStatusIndicatorView {
+  return recentWorkStatusIndicatorForSession(workspace, workspace.lastSessionSummary?.status);
+}
+
+export function recentWorkStatusIndicatorForSession(
+  workspace: CloudWorkspaceStatusIndicatorFacts,
+  sessionStatus: string | null | undefined,
+): RecentWorkStatusIndicatorView {
+  if (workspaceHasErrorStatus(workspace)) {
+    return STATUS_INDICATORS.error;
+  }
+  if (workspaceNeedsInput(workspace)) {
+    return STATUS_INDICATORS.needs_input;
+  }
+  if (sessionIsReviewReady(sessionStatus)) {
+    return STATUS_INDICATORS.review_ready;
+  }
+  if (sessionIsRunning(sessionStatus) || workspaceIsInProgress(workspace)) {
+    return STATUS_INDICATORS.running;
+  }
+  if (workspaceIsCommandReady(workspace)) {
+    return STATUS_INDICATORS.ready;
+  }
+  return STATUS_INDICATORS.idle;
+}
+
 function commandStatusDetailMessage(statusDetail: string | null | undefined): string | null {
   const trimmed = statusDetail?.trim();
   if (!trimmed || /^ready$/i.test(trimmed)) {
@@ -674,6 +730,24 @@ type CloudWorkspaceCommandFacts = Pick<
     | "status"
   > &
   Partial<Pick<CloudWorkspaceSummary, "lastError" | "statusDetail">> &
+  Partial<Pick<CloudWorkspaceDetail, "anyharnessWorkspaceId">>;
+
+type CloudWorkspaceStatusIndicatorFacts = Pick<
+  CloudWorkspaceSummary,
+  | "actionBlockKind"
+  | "actionBlockReason"
+  | "billing"
+  | "exposure"
+  | "exposureState"
+  | "lastError"
+  | "lastSessionSummary"
+  | "runtime"
+  | "sandboxType"
+  | "status"
+  | "targetId"
+  | "visibility"
+  | "workspaceStatus"
+> &
   Partial<Pick<CloudWorkspaceDetail, "anyharnessWorkspaceId">>;
 
 export function cloudWorkStatusForWorkspace(
@@ -713,6 +787,110 @@ export function cloudWorkStatusForWorkspace(
     return "active";
   }
   return "ready";
+}
+
+const STATUS_INDICATORS: Record<RecentWorkStatusIndicatorKind, RecentWorkStatusIndicatorView> = {
+  needs_input: {
+    kind: "needs_input",
+    tone: "attention",
+    label: "Needs input",
+    hollow: false,
+    live: false,
+  },
+  running: {
+    kind: "running",
+    tone: "progress",
+    label: "In progress",
+    hollow: false,
+    live: true,
+  },
+  review_ready: {
+    kind: "review_ready",
+    tone: "success",
+    label: "Ready for review",
+    hollow: false,
+    live: false,
+  },
+  ready: {
+    kind: "ready",
+    tone: "success",
+    label: "Ready",
+    hollow: false,
+    live: false,
+  },
+  error: {
+    kind: "error",
+    tone: "danger",
+    label: "Error",
+    hollow: false,
+    live: false,
+  },
+  idle: {
+    kind: "idle",
+    tone: "muted",
+    label: "Idle",
+    hollow: true,
+    live: false,
+  },
+};
+
+function workspaceHasErrorStatus(
+  workspace: Pick<CloudWorkspaceSummary, "lastError" | "runtime" | "status" | "workspaceStatus">,
+): boolean {
+  return Boolean(workspace.lastError)
+    || workspace.workspaceStatus === "error"
+    || workspace.status === "error"
+    || workspace.runtime?.status === "error"
+    || workspace.runtime?.status === "disabled";
+}
+
+function workspaceNeedsInput(
+  workspace: Pick<
+    CloudWorkspaceSummary,
+    | "actionBlockKind"
+    | "actionBlockReason"
+    | "billing"
+    | "lastSessionSummary"
+    | "visibility"
+  >,
+): boolean {
+  return workspace.visibility === "shared_unclaimed"
+    || workspaceHasPendingSessionInput(workspace)
+    || Boolean(workspace.actionBlockKind || workspace.actionBlockReason)
+    || workspace.billing?.blockStatus === "blocked"
+    || workspace.billing?.startBlocked === true
+    || workspace.billing?.activeSpendHold === true;
+}
+
+function workspaceIsInProgress(
+  workspace: Pick<CloudWorkspaceSummary, "runtime" | "status" | "workspaceStatus">,
+): boolean {
+  return workspace.workspaceStatus === "pending"
+    || workspace.workspaceStatus === "materializing"
+    || workspace.workspaceStatus === "needs_rematerialization"
+    || workspace.status === "pending"
+    || workspace.status === "materializing"
+    || workspace.status === "needs_rematerialization"
+    || workspace.runtime?.status === "pending"
+    || workspace.runtime?.status === "provisioning";
+}
+
+function workspaceIsCommandReady(workspace: CloudWorkspaceStatusIndicatorFacts): boolean {
+  return recentWorkCommandability(workspace) === "commandable";
+}
+
+function sessionIsRunning(status: string | null | undefined): boolean {
+  const normalized = normalizedStatusToken(status);
+  return normalized === "running" || normalized === "queued";
+}
+
+function sessionIsReviewReady(status: string | null | undefined): boolean {
+  const normalized = normalizedStatusToken(status);
+  return normalized === "review" || normalized === "ready_for_review";
+}
+
+function normalizedStatusToken(value: string | null | undefined): string {
+  return value?.toLowerCase().replace(/[\s-]+/gu, "_") ?? "";
 }
 
 function workspaceHasPendingSessionInput(
@@ -852,6 +1030,7 @@ function recentWorkItemForWorkspace(
   options: { nowMs: number },
 ): RecentWorkItemView {
   const base = recentWorkBase(workspace, { nowMs: options.nowMs, rowActivityAt: cloudWorkLastActivityIso(workspace) });
+  const state = workspaceState(workspace);
   return {
     ...base,
     id: recentWorkspaceRowId(workspace.id),
@@ -861,8 +1040,10 @@ function recentWorkItemForWorkspace(
     openTarget: { kind: "workspace", workspaceId: workspace.id },
     title: workspace.displayName ?? workspace.repo.name,
     subtitle: "Workspace",
-    state: workspaceState(workspace),
-    stateLabel: recentWorkStateLabel(workspaceState(workspace)),
+    state,
+    stateLabel: recentWorkStateLabel(state),
+    statusIndicator: recentWorkStatusIndicatorForWorkspace(workspace),
+    activityPreview: cloudWorkActivityPreview(workspace),
     searchText: recentSearchText(base, [workspace.displayName, workspace.repo.name, "workspace"]),
   };
 }
@@ -874,6 +1055,7 @@ function recentWorkItemForSessionSummary(
 ): RecentWorkItemView {
   const base = recentWorkBase(workspace, { nowMs: options.nowMs, rowActivityAt: summary.lastEventAt ?? cloudWorkLastActivityIso(workspace) });
   const state = sessionState(summary.status, workspace);
+  const activityPreview = compactPreviewText(summary.preview);
   return {
     ...base,
     id: recentSessionRowId(workspace.id, summary.sessionId),
@@ -885,7 +1067,9 @@ function recentWorkItemForSessionSummary(
     subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
-    searchText: recentSearchText(base, [summary.title, summary.preview, workspace.displayName, workspace.repo.name, "session"]),
+    statusIndicator: recentWorkStatusIndicatorForSession(workspace, summary.status),
+    activityPreview,
+    searchText: recentSearchText(base, [summary.title, activityPreview, workspace.displayName, workspace.repo.name, "session"]),
   };
 }
 
@@ -907,6 +1091,8 @@ function recentWorkItemForSessionProjection(
     subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
+    statusIndicator: recentWorkStatusIndicatorForSession(workspace, session.status),
+    activityPreview: null,
     searchText: recentSearchText(base, [session.title, session.sourceAgentKind, workspace.displayName, workspace.repo.name, "session"]),
   };
 }
@@ -926,6 +1112,8 @@ function recentWorkBase(
   | "subtitle"
   | "state"
   | "stateLabel"
+  | "statusIndicator"
+  | "activityPreview"
   | "searchText"
 > {
   const sourceKind = recentWorkSourceForWorkspace(workspace);

--- a/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
@@ -148,6 +148,11 @@ export type RecentWorkOpenTarget =
   | { kind: "session"; workspaceId: string; sessionId: string }
   | { kind: "pending-session"; workspaceId: string; pendingSessionKey: string };
 
+type RecentWorkSessionInteractionFacts = Pick<
+  CloudWorkspaceLastSessionSummary,
+  "phase" | "pendingInteractionCount"
+>;
+
 export interface RecentWorkItemView {
   id: string;
   rowKind: RecentWorkRowKind;
@@ -680,17 +685,25 @@ export function cloudCommandReadiness(
 export function recentWorkStatusIndicatorForWorkspace(
   workspace: CloudWorkspaceStatusIndicatorFacts,
 ): RecentWorkStatusIndicatorView {
-  return recentWorkStatusIndicatorForSession(workspace, workspace.lastSessionSummary?.status);
+  return recentWorkStatusIndicatorForSession(
+    workspace,
+    workspace.lastSessionSummary?.status,
+    workspace.lastSessionSummary,
+  );
 }
 
 export function recentWorkStatusIndicatorForSession(
   workspace: CloudWorkspaceStatusIndicatorFacts,
   sessionStatus: string | null | undefined,
+  sessionInteraction?: RecentWorkSessionInteractionFacts | null,
 ): RecentWorkStatusIndicatorView {
   if (workspaceHasErrorStatus(workspace)) {
     return STATUS_INDICATORS.error;
   }
-  if (workspaceNeedsInput(workspace)) {
+  if (sessionIsError(sessionStatus)) {
+    return STATUS_INDICATORS.error;
+  }
+  if (workspaceNeedsInput(workspace, sessionInteraction)) {
     return STATUS_INDICATORS.needs_input;
   }
   if (sessionIsReviewReady(sessionStatus)) {
@@ -853,9 +866,10 @@ function workspaceNeedsInput(
     | "lastSessionSummary"
     | "visibility"
   >,
+  sessionInteraction: RecentWorkSessionInteractionFacts | null | undefined = workspace.lastSessionSummary,
 ): boolean {
   return workspace.visibility === "shared_unclaimed"
-    || workspaceHasPendingSessionInput(workspace)
+    || sessionHasPendingInput(sessionInteraction)
     || Boolean(workspace.actionBlockKind || workspace.actionBlockReason)
     || workspace.billing?.blockStatus === "blocked"
     || workspace.billing?.startBlocked === true
@@ -876,7 +890,12 @@ function workspaceIsInProgress(
 }
 
 function workspaceIsCommandReady(workspace: CloudWorkspaceStatusIndicatorFacts): boolean {
-  return recentWorkCommandability(workspace) === "commandable";
+  return cloudCommandReadiness(workspace).commandable;
+}
+
+function sessionIsError(status: string | null | undefined): boolean {
+  const normalized = normalizedStatusToken(status);
+  return normalized === "error" || normalized === "failed";
 }
 
 function sessionIsRunning(status: string | null | undefined): boolean {
@@ -896,7 +915,12 @@ function normalizedStatusToken(value: string | null | undefined): string {
 function workspaceHasPendingSessionInput(
   workspace: Pick<CloudWorkspaceSummary, "lastSessionSummary">,
 ): boolean {
-  const summary = workspace.lastSessionSummary;
+  return sessionHasPendingInput(workspace.lastSessionSummary);
+}
+
+function sessionHasPendingInput(
+  summary: RecentWorkSessionInteractionFacts | null | undefined,
+): boolean {
   if (!summary) {
     return false;
   }
@@ -973,7 +997,7 @@ export function filterCloudWorkItems(
     if (filters.repoLabels?.size && !filters.repoLabels.has(item.repoLabel)) {
       return false;
     }
-    if (filters.needsAttention && item.status !== "blocked" && !item.unclaimed) {
+    if (filters.needsAttention && !cloudWorkItemNeedsAttention(item)) {
       return false;
     }
     if (query && !matchesSearch(item, query)) {
@@ -981,6 +1005,12 @@ export function filterCloudWorkItems(
     }
     return true;
   });
+}
+
+function cloudWorkItemNeedsAttention(item: CloudWorkItemView): boolean {
+  return item.status === "blocked"
+    || item.unclaimed
+    || item.statusIndicator.kind === "needs_input";
 }
 
 const RECENCY_GROUPS = [
@@ -1067,7 +1097,7 @@ function recentWorkItemForSessionSummary(
     subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
-    statusIndicator: recentWorkStatusIndicatorForSession(workspace, summary.status),
+    statusIndicator: recentWorkStatusIndicatorForSession(workspace, summary.status, summary),
     activityPreview,
     searchText: recentSearchText(base, [summary.title, activityPreview, workspace.displayName, workspace.repo.name, "session"]),
   };
@@ -1091,7 +1121,7 @@ function recentWorkItemForSessionProjection(
     subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
-    statusIndicator: recentWorkStatusIndicatorForSession(workspace, session.status),
+    statusIndicator: recentWorkStatusIndicatorForSession(workspace, session.status, session),
     activityPreview: null,
     searchText: recentSearchText(base, [session.title, session.sourceAgentKind, workspace.displayName, workspace.repo.name, "session"]),
   };

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -215,6 +215,10 @@
       "types": "./dist/workspaces/WorkspaceRow.d.ts",
       "import": "./dist/workspaces/WorkspaceRow.js"
     },
+    "./workspaces/RecentWorkStatusDot": {
+      "types": "./dist/workspaces/RecentWorkStatusDot.d.ts",
+      "import": "./dist/workspaces/RecentWorkStatusDot.js"
+    },
     "./workspaces/CloudWorkspaceList": {
       "types": "./dist/workspaces/CloudWorkspaceList.d.ts",
       "import": "./dist/workspaces/CloudWorkspaceList.js"

--- a/apps/packages/product-ui/src/new-chat/NewChatSurface.tsx
+++ b/apps/packages/product-ui/src/new-chat/NewChatSurface.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
+import { ChevronRight } from "lucide-react";
 
+import type { RecentWorkItemView } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
 import { Button } from "@proliferate/ui/primitives/Button";
 import {
   CloudChatComposer,
@@ -9,6 +11,7 @@ import {
   CloudChatTranscript,
   type CloudChatTranscriptRowView,
 } from "../chat/CloudChatTranscript";
+import { RecentWorkStatusDot } from "../workspaces/RecentWorkStatusDot";
 
 export interface PickerItemView {
   id: string;
@@ -67,6 +70,8 @@ export interface NewChatSurfaceProps {
   actions: ActionRowView[];
   extraComposerControls?: readonly CloudChatComposerControlView[];
   transcriptRows?: readonly CloudChatTranscriptRowView[];
+  recentItems?: readonly RecentWorkItemView[];
+  recentLoading?: boolean;
   emptyTitle?: string;
   emptyDescription?: string;
   commandMessage?: string | null;
@@ -75,6 +80,7 @@ export interface NewChatSurfaceProps {
   onCancel?: () => void;
   onPickerSelect?: (picker: NewChatPickerId, itemId: string) => void;
   onAction?: (id: string) => void;
+  onRecentSelect?: (item: RecentWorkItemView) => void;
 }
 
 export function NewChatSurface({
@@ -90,6 +96,8 @@ export function NewChatSurface({
   actions,
   extraComposerControls,
   transcriptRows = [],
+  recentItems = [],
+  recentLoading = false,
   emptyTitle = "No transcript",
   emptyDescription,
   commandMessage = null,
@@ -98,6 +106,7 @@ export function NewChatSurface({
   onCancel,
   onPickerSelect,
   onAction,
+  onRecentSelect,
 }: NewChatSurfaceProps) {
   const composerControls = [
     pickerToComposerControl("target", target, "sparkles", "leading", onPickerSelect),
@@ -197,6 +206,14 @@ export function NewChatSurface({
               </div>
             </div>
           ) : null}
+
+          {recentItems.length > 0 || recentLoading ? (
+            <RecentWorkList
+              items={recentItems}
+              loading={recentLoading}
+              onSelect={onRecentSelect}
+            />
+          ) : null}
         </div>
       </main>
     </div>
@@ -256,4 +273,108 @@ function NoticeRow({ notice }: { notice: NoticeView }) {
       ) : null}
     </div>
   );
+}
+
+function RecentWorkList({
+  items,
+  loading,
+  onSelect,
+}: {
+  items: readonly RecentWorkItemView[];
+  loading: boolean;
+  onSelect?: (item: RecentWorkItemView) => void;
+}) {
+  return (
+    <section className="mx-auto mt-8 max-w-3xl">
+      <header className="mb-2 flex items-center px-1">
+        <h2 className="text-sm font-medium leading-5 text-muted-foreground">
+          Recent work
+        </h2>
+      </header>
+      <div className="flex flex-col gap-1">
+        {items.map((item) => (
+          <RecentWorkRow
+            key={item.id}
+            item={item}
+            onSelect={onSelect}
+          />
+        ))}
+        {loading && items.length === 0 ? (
+          <>
+            <RecentWorkSkeleton />
+            <RecentWorkSkeleton />
+            <RecentWorkSkeleton />
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function RecentWorkRow({
+  item,
+  onSelect,
+}: {
+  item: RecentWorkItemView;
+  onSelect?: (item: RecentWorkItemView) => void;
+}) {
+  const preview = recentWorkPreview(item);
+
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      onClick={() => onSelect?.(item)}
+      className="group flex h-10 w-full min-w-0 items-center justify-between gap-3 rounded-lg bg-foreground/5 px-3 text-left text-sm leading-5 text-foreground whitespace-normal hover:bg-foreground/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-3">
+        <span className="flex w-[6.75rem] shrink-0 items-center">
+          <RecentWorkStatusDot indicator={item.statusIndicator} showLabel />
+        </span>
+        <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+          <span className="min-w-0 truncate text-foreground">
+            {item.title}
+          </span>
+          {preview ? (
+            <span className="min-w-0 flex-[2] truncate text-muted-foreground">
+              {preview}
+            </span>
+          ) : null}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-2 text-muted-foreground">
+        {item.repoLabel ? (
+          <span className="hidden max-w-[11rem] truncate text-xs sm:block">
+            {item.repoLabel}
+          </span>
+        ) : null}
+        <span className="min-w-6 text-right text-xs tabular-nums">
+          {item.lastActivityLabel}
+        </span>
+        <ChevronRight className="size-3.5 transition-colors group-hover:text-foreground" />
+      </span>
+    </Button>
+  );
+}
+
+function RecentWorkSkeleton() {
+  return (
+    <div className="h-10 rounded-lg bg-foreground/5 px-3">
+      <div className="flex h-full items-center gap-3">
+        <div className="h-2 w-24 rounded-full bg-foreground/10" />
+        <div className="h-2 flex-1 rounded-full bg-foreground/10" />
+        <div className="h-2 w-10 rounded-full bg-foreground/10" />
+      </div>
+    </div>
+  );
+}
+
+function recentWorkPreview(item: RecentWorkItemView): string | null {
+  const preview = item.activityPreview?.trim();
+  if (preview) {
+    return preview;
+  }
+  const subtitle = item.subtitle?.trim();
+  return subtitle && subtitle !== item.title ? subtitle : null;
 }

--- a/apps/packages/product-ui/src/sidebar/ProductSidebar.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebar.tsx
@@ -36,6 +36,7 @@ export interface SidebarWorkspaceRowView {
   active: boolean;
   archived?: boolean;
   status?: ReactNode;
+  attentionStatus?: ReactNode;
   detail?: ReactNode;
   trailingLabel?: string | null;
   shortcutLabel?: string | null;
@@ -668,6 +669,7 @@ function WorkspaceRow({
       active={row.active}
       archived={row.archived}
       status={row.status}
+      attentionStatus={row.attentionStatus}
       label={row.label}
       subtitle={row.subtitle}
       detail={row.detail}
@@ -684,6 +686,7 @@ export interface ProductSidebarWorkspaceRowProps extends Omit<HTMLAttributes<HTM
   active?: boolean;
   archived?: boolean;
   status?: ReactNode;
+  attentionStatus?: ReactNode;
   label: string;
   subtitle?: string | null;
   detail?: ReactNode;
@@ -698,6 +701,7 @@ export function ProductSidebarWorkspaceRow({
   active = false,
   archived = false,
   status = null,
+  attentionStatus = null,
   label,
   subtitle = null,
   detail = null,
@@ -728,7 +732,13 @@ export function ProductSidebarWorkspaceRow({
           {status}
         </div>
 
-        <div className="ml-1.5 flex min-w-0 flex-1 items-center gap-2 pl-0.5">
+        {attentionStatus ? (
+          <div className="ml-1 flex w-3 shrink-0 items-center justify-center">
+            {attentionStatus}
+          </div>
+        ) : null}
+
+        <div className={`${attentionStatus ? "ml-1" : "ml-1.5"} flex min-w-0 flex-1 items-center gap-2 pl-0.5`}>
           <div className={`flex min-w-0 flex-1 self-stretch ${hasSubtitle ? "flex-col items-start justify-center gap-0.5" : "items-center gap-2"} text-base leading-5 ${archived ? "text-sidebar-muted-foreground/60" : "text-sidebar-foreground"
             }`}>
             <span

--- a/apps/packages/product-ui/src/workspaces/RecentWorkStatusDot.tsx
+++ b/apps/packages/product-ui/src/workspaces/RecentWorkStatusDot.tsx
@@ -1,0 +1,53 @@
+import type { RecentWorkStatusIndicatorView } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
+
+export interface RecentWorkStatusDotProps {
+  indicator: RecentWorkStatusIndicatorView;
+  showLabel?: boolean;
+  surface?: "default" | "sidebar";
+  className?: string;
+}
+
+export function RecentWorkStatusDot({
+  indicator,
+  showLabel = false,
+  surface = "default",
+  className = "",
+}: RecentWorkStatusDotProps) {
+  return (
+    <span
+      className={`inline-flex min-w-0 items-center gap-1.5 ${statusToneClass(indicator, surface)} ${className}`}
+      title={indicator.label}
+      aria-label={indicator.label}
+    >
+      <span
+        aria-hidden="true"
+        className={`size-1.5 shrink-0 rounded-full ${
+          indicator.hollow ? "border border-current bg-transparent" : "bg-current"
+        } ${indicator.live ? "animate-pulse" : ""}`}
+      />
+      {showLabel ? (
+        <span className="min-w-0 truncate text-xs leading-4">
+          {indicator.label}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function statusToneClass(
+  indicator: RecentWorkStatusIndicatorView,
+  surface: RecentWorkStatusDotProps["surface"],
+): string {
+  switch (indicator.tone) {
+    case "attention":
+      return "text-warning";
+    case "progress":
+      return "text-info";
+    case "success":
+      return "text-success";
+    case "danger":
+      return "text-destructive";
+    case "muted":
+      return surface === "sidebar" ? "text-sidebar-muted-foreground" : "text-muted-foreground";
+  }
+}

--- a/apps/web/src/components/app/navigation/WebSidebarController.tsx
+++ b/apps/web/src/components/app/navigation/WebSidebarController.tsx
@@ -38,6 +38,7 @@ import {
   ProductSidebar,
   SidebarActionButton,
 } from "@proliferate/product-ui/sidebar/ProductSidebar";
+import { RecentWorkStatusDot } from "@proliferate/product-ui/workspaces/RecentWorkStatusDot";
 
 import { routes } from "../../../config/routes";
 import {
@@ -381,6 +382,12 @@ function buildRecentWorkspaceGroups(input: {
       active: recentRowIsActive(item, input.routeState),
       archived: item.state === "done",
       status: <RecentSourceIndicator item={item} />,
+      attentionStatus: (
+        <RecentWorkStatusDot
+          indicator={item.statusIndicator}
+          surface="sidebar"
+        />
+      ),
       detail: null,
       trailingLabel: item.lastActivityLabel,
       actions: item.rowKind === "session"

--- a/apps/web/src/components/home/screen/HomeScreen.tsx
+++ b/apps/web/src/components/home/screen/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   type CloudTargetSummary,
+  type CloudWorkspaceSummary,
   listCloudWorkspaces,
   type CloudWorkspaceDetail,
   type CreateCloudWorkspaceRequest,
@@ -16,6 +17,7 @@ import {
   useCloudRepoConfigs,
   useCreateCloudWorkspace,
   useCloudTargets,
+  useVisibleCloudWorkspaces,
   useLaunchCloudWorkspaceOnTarget,
   useTargetLive,
   useAgentAuthCredentials,
@@ -28,6 +30,10 @@ import {
   resolveCloudLaunchSelection,
   type CloudLaunchComposerSelection,
 } from "@proliferate/product-domain/chats/cloud/composer-controls";
+import {
+  buildRecentWorkItems,
+  type RecentWorkItemView,
+} from "@proliferate/product-domain/workspaces/cloud-work-inventory";
 import {
   readySyncedCloudAgentKinds,
   resolveCloudHarnessAvailability,
@@ -56,6 +62,7 @@ import { savePendingHomePrompt } from "../../../lib/access/cloud/pending-home-pr
 import { saveWebCloudPromptIntents } from "../../../stores/cloud/web-cloud-chat-state-store";
 
 const HOME_PLACEHOLDER = "Describe a quick remote task...";
+const HOME_RECENT_LIMIT = 6;
 
 interface RepoOption {
   id: string;
@@ -115,6 +122,7 @@ export function HomeScreen() {
   const agentAuthCredentials = useAgentAuthCredentials();
   const createWorkspace = useCreateCloudWorkspace();
   const launchOnTarget = useLaunchCloudWorkspaceOnTarget();
+  const visibleWorkspaces = useVisibleCloudWorkspaces();
   const targets = useCloudTargets();
   const liveTargetId = runtimeId === "cloud" ? null : runtimeId;
   const targetLive = useTargetLive(liveTargetId, { enabled: Boolean(liveTargetId) });
@@ -463,6 +471,24 @@ export function HomeScreen() {
   if (runtimeNotice) notices.push(runtimeNotice);
   if (harnessNotice) notices.push(harnessNotice);
   if (errorNotice) notices.push(errorNotice);
+  const recentItems = useMemo(
+    () => homeRecentItems(visibleWorkspaces.data ?? []),
+    [visibleWorkspaces.data],
+  );
+
+  function handleRecentSelect(item: RecentWorkItemView) {
+    switch (item.openTarget.kind) {
+      case "session":
+        navigate(routes.chat(item.openTarget.workspaceId, item.openTarget.sessionId));
+        return;
+      case "workspace":
+        navigate(routes.workspace(item.openTarget.workspaceId));
+        return;
+      case "pending-session":
+        navigate(routes.workspace(item.openTarget.workspaceId));
+        return;
+    }
+  }
 
   return (
     <div className="h-full" data-telemetry-block>
@@ -485,6 +511,8 @@ export function HomeScreen() {
         extraComposerControls={composerControls}
         notices={notices}
         transcriptRows={transcriptRows}
+        recentItems={recentItems}
+        recentLoading={visibleWorkspaces.isLoading}
         commandMessage={
           pendingPrompt?.status === "creating"
             ? selectedRuntime?.kind === "target"
@@ -503,6 +531,7 @@ export function HomeScreen() {
         onSubmit={() => void handleSubmit()}
         onPickerSelect={handlePickerSelect}
         onAction={handleAction}
+        onRecentSelect={handleRecentSelect}
       />
       <AddCloudEnvironmentDialogController
         open={addRepoOpen}
@@ -511,6 +540,13 @@ export function HomeScreen() {
       />
     </div>
   );
+}
+
+function homeRecentItems(workspaces: readonly CloudWorkspaceSummary[]): RecentWorkItemView[] {
+  const items = buildRecentWorkItems(workspaces, { nowMs: Date.now() });
+  const nonErrorItems = items.filter((item) => item.statusIndicator.kind !== "error");
+  const activeItems = nonErrorItems.filter((item) => item.statusIndicator.kind !== "idle");
+  return (activeItems.length >= 3 ? activeItems : nonErrorItems).slice(0, HOME_RECENT_LIMIT);
 }
 
 function buildPendingPromptRows(


### PR DESCRIPTION
## Summary

- add shared workspace activity/status view models for cloud workspaces and sessions
- show status dots in the web sidebar and recent work below the web home composer
- migrate mobile work status presentation onto the shared status model
- align edge cases for failed sessions, non-routable cloud workspaces, billing holds, and concurrent session projections

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label
- Required: at least one `area:*` label

Release labels:
`release:minor-feature`

Area labels:
`area:product`, `area:cloud`

## Verification

- `pnpm --filter @proliferate/product-domain test -- src/workspaces/cloud-work-inventory.test.ts`
- `pnpm --filter @proliferate/product-domain build`
- `pnpm --filter @proliferate/product-ui build`
- `pnpm --filter @proliferate/web typecheck`
- `pnpm --filter @proliferate/mobile typecheck`
- `cd apps/desktop && pnpm exec tsc`
- `git diff --check`

## Review

- Ran three high/xhigh subagent review passes across product-domain, web/product-ui, and mobile/sidebar integration. Addressed the blocking model findings before merge.