### PR TITLE
feat(web): refine workspace chat header

### DIFF
--- a/apps/packages/product-ui/src/chat/CloudChatSurface.tsx
+++ b/apps/packages/product-ui/src/chat/CloudChatSurface.tsx
@@ -1,12 +1,18 @@
 import {
-  ArrowLeft,
+  Check,
+  ChevronDown,
+  Copy,
   ExternalLink,
-  MessagesSquare,
   Plus,
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { IconButton } from "@proliferate/ui/primitives/IconButton";
+import {
+  POPOVER_SURFACE_CLASS,
+  PopoverButton,
+} from "@proliferate/ui/primitives/PopoverButton";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import {
   CloudChatComposer,
   type CloudChatComposerView,
@@ -16,31 +22,38 @@ import {
   type CloudChatTranscriptRowView,
 } from "./CloudChatTranscript";
 
-export interface CloudChatChipView {
-  id: string;
-  label: string;
-  icon?: "branch";
-}
-
-export interface CloudChatPrimaryActionView {
-  label: string;
-  kind?: "claim" | "continue" | "default";
-  loading?: boolean;
-  onClick?: () => void;
-}
-
 export interface CloudChatHeaderActionView {
-  id: string;
   label: string;
-  kind?: "new-session" | "default";
+  kind?: "claim" | "desktop" | "default";
   loading?: boolean;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
-export interface CloudChatTopNoticeView {
+export type CloudChatHeaderTone =
+  | "neutral"
+  | "info"
+  | "success"
+  | "warning"
+  | "destructive";
+
+export interface CloudChatStatusView {
+  label: string;
+  tone: CloudChatHeaderTone;
+  live?: boolean;
+}
+
+export interface CloudChatHeaderDiagnosticsView {
+  text: string;
+  onCopy?: () => void;
+}
+
+export interface CloudChatHeaderNoticeView {
   title: string;
   description?: string | null;
-  action?: CloudChatPrimaryActionView | null;
+  tone: Exclude<CloudChatHeaderTone, "neutral" | "success">;
+  action?: CloudChatHeaderActionView | null;
+  diagnostics?: CloudChatHeaderDiagnosticsView | null;
 }
 
 export interface CloudChatSessionOptionView {
@@ -60,112 +73,72 @@ export interface CloudChatSessionSwitcherView {
   onNewSession: () => void;
 }
 
+export interface CloudChatHeaderView {
+  workspaceLabel: string;
+  status: CloudChatStatusView;
+  sessionSwitcher: CloudChatSessionSwitcherView;
+  notice?: CloudChatHeaderNoticeView | null;
+  desktopAction?: CloudChatHeaderActionView | null;
+}
+
 export interface CloudChatSurfaceProps {
-  title: string;
-  eyebrowItems: readonly string[];
-  chips: readonly CloudChatChipView[];
+  header: CloudChatHeaderView;
   transcriptRows: readonly CloudChatTranscriptRowView[];
   emptyTitle: string;
   emptyDescription?: string;
   composer: CloudChatComposerView;
   commandMessage?: string | null;
-  primaryAction?: CloudChatPrimaryActionView | null;
-  headerActions?: readonly CloudChatHeaderActionView[];
-  sessionSwitcher?: CloudChatSessionSwitcherView | null;
-  topNotice?: CloudChatTopNoticeView | null;
-  desktopHref?: string | null;
   telemetryBlocked?: boolean;
-  onBack: () => void;
 }
 
 export function CloudChatSurface({
-  title,
-  eyebrowItems,
-  chips: _chips,
+  header,
   transcriptRows,
   emptyTitle,
   emptyDescription,
   composer,
   commandMessage = null,
-  primaryAction = null,
-  headerActions = [],
-  sessionSwitcher = null,
-  topNotice = null,
-  desktopHref = null,
   telemetryBlocked = false,
-  onBack,
 }: CloudChatSurfaceProps) {
   return (
     <div className="flex h-full flex-col" data-telemetry-block={telemetryBlocked || undefined}>
-      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-border px-4">
-        <IconButton title="Back" size="sm" onClick={onBack}>
-          <ArrowLeft size={15} />
-        </IconButton>
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          <h1 className="min-w-[7rem] max-w-[18rem] truncate text-sm font-medium text-foreground">
-            {title}
+      <header className={`flex h-14 shrink-0 items-center gap-2 px-4 ${
+        header.notice ? "border-b border-transparent" : "border-b border-border"
+      }`}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <h1 className="min-w-0 max-w-[16rem] truncate text-sm font-medium text-foreground">
+            {header.workspaceLabel}
           </h1>
-          {sessionSwitcher ? (
-            <CloudChatSessionSwitcher view={sessionSwitcher} />
-          ) : eyebrowItems[0] ? (
-            <span className="truncate rounded-lg border border-border/60 bg-foreground/[0.03] px-2.5 py-1 text-sm text-muted-foreground">
-              {eyebrowItems[0]}
-            </span>
-          ) : null}
+          <span className="shrink-0 text-xs text-muted-foreground/50" aria-hidden>
+            /
+          </span>
+          <CloudChatSessionSwitcher view={header.sessionSwitcher} />
+          <IconButton
+            title={header.sessionSwitcher.newSessionLabel}
+            size="sm"
+            onClick={header.sessionSwitcher.onNewSession}
+            className="shrink-0"
+          >
+            <Plus size={15} />
+          </IconButton>
         </div>
-        {primaryAction ? (
+        <CloudChatStatusChip status={header.status} />
+        {header.desktopAction ? (
           <Button
-            variant={primaryAction.kind === "claim" ? "secondary" : "outline"}
+            variant="ghost"
             size="sm"
-            loading={primaryAction.loading}
-            onClick={primaryAction.onClick}
+            loading={header.desktopAction.loading}
+            disabled={header.desktopAction.disabled}
+            onClick={header.desktopAction.onClick}
+            className="hidden h-7 shrink-0 gap-1.5 px-2 md:inline-flex"
           >
-            {primaryAction.kind === "continue" ? <ExternalLink size={14} /> : null}
-            {primaryAction.label}
+            <ExternalLink size={13} />
+            {header.desktopAction.label}
           </Button>
-        ) : null}
-        {headerActions.map((action) => (
-          <Button
-            key={action.id}
-            variant="outline"
-            size="sm"
-            loading={action.loading}
-            onClick={action.onClick}
-          >
-            {action.kind === "new-session" ? <Plus size={14} /> : null}
-            {action.label}
-          </Button>
-        ))}
-        {desktopHref ? (
-          <a
-            href={desktopHref}
-            className="inline-flex h-8 items-center gap-2 rounded-md border border-input px-3 text-xs text-muted-foreground hover:bg-accent"
-          >
-            <ExternalLink size={14} />
-            Open in Desktop
-          </a>
         ) : null}
       </header>
-      {topNotice ? (
-        <div className="flex shrink-0 items-center gap-3 border-b border-warning/20 bg-warning-subtle px-4 py-2 text-sm text-warning">
-          <div className="min-w-0 flex-1 leading-5">
-            <div className="font-medium">{topNotice.title}</div>
-            {topNotice.description ? (
-              <div className="text-warning/80">{topNotice.description}</div>
-            ) : null}
-          </div>
-          {topNotice.action ? (
-            <Button
-              variant="secondary"
-              size="sm"
-              loading={topNotice.action.loading}
-              onClick={topNotice.action.onClick}
-            >
-              {topNotice.action.label}
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+      {header.notice ? <CloudChatHeaderNotice notice={header.notice} /> : null}
 
       <div className="web-scrollbar min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto flex w-full max-w-3xl flex-col px-6 py-6">
@@ -192,72 +165,216 @@ export function CloudChatSurface({
 function CloudChatSessionSwitcher({ view }: { view: CloudChatSessionSwitcherView }) {
   const [open, setOpen] = useState(false);
   const activeSession = view.sessions.find((session) => session.id === view.activeSessionId);
+  const activeLabel = activeSession?.label ?? view.activeSessionLabel;
 
   return (
-    <div className="relative flex min-w-0 shrink items-center gap-1.5">
-      <button
-        type="button"
-        aria-label={`Switch sessions in ${view.workspaceLabel}`}
-        disabled={view.sessions.length === 0}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((current) => !current)}
-        className="flex h-8 min-w-0 max-w-[20rem] items-center gap-2 rounded-lg border border-border/70 bg-foreground/[0.035] px-2.5 text-left text-sm text-foreground outline-none hover:bg-foreground/[0.055] disabled:text-muted-foreground"
-      >
-        <MessagesSquare size={14} className="shrink-0 text-muted-foreground" />
-        <span className="shrink-0 text-xs text-muted-foreground">Session</span>
-        <span className="min-w-0 truncate font-medium">{activeSession?.label ?? view.activeSessionLabel}</span>
-      </button>
-      <IconButton
-        title={view.newSessionLabel}
-        size="sm"
-        onClick={view.onNewSession}
-      >
-        <Plus size={15} />
-      </IconButton>
-      {open ? (
-        <div
-          role="menu"
-          className="absolute left-0 top-[calc(100%+0.35rem)] z-50 w-72 rounded-lg border border-border bg-popover p-1.5 shadow-lg"
-        >
-          <div className="px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
-            {view.sessions.length} {view.sessions.length === 1 ? "session" : "sessions"}
-          </div>
-          {view.sessions.map((session) => (
-            <button
-              key={session.id}
-              type="button"
-              role="menuitemradio"
-              aria-checked={session.id === view.activeSessionId}
-              onClick={() => {
-                setOpen(false);
-                view.onSelectSession(session.id);
-              }}
-              className="flex w-full min-w-0 flex-col rounded-md px-2.5 py-2 text-left text-xs leading-4 text-popover-foreground outline-none hover:bg-popover-accent focus:bg-popover-accent"
-            >
-              <span className="max-w-full truncate font-medium">{session.label}</span>
-              <span className="max-w-full truncate text-muted-foreground">
-                {[session.statusLabel, session.detail].filter(Boolean).join(" - ")}
-              </span>
-            </button>
-          ))}
-          {view.sessions.length ? (
-            <div className="my-1 border-t border-border/60" aria-hidden />
-          ) : null}
-          <button
+    <div className="flex min-w-0 shrink items-center">
+      <PopoverButton
+        align="start"
+        side="bottom"
+        externalOpen={open}
+        onOpenChange={setOpen}
+        className={`w-80 max-w-[calc(100vw-2rem)] ${POPOVER_SURFACE_CLASS}`}
+        trigger={(
+          <Button
             type="button"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false);
-              view.onNewSession();
-            }}
-            className="flex w-full min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs font-medium leading-4 text-popover-foreground outline-none hover:bg-popover-accent focus:bg-popover-accent"
+            variant="unstyled"
+            size="unstyled"
+            aria-label={`Switch sessions in ${view.workspaceLabel}. Active session: ${activeLabel}`}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className="flex h-7 min-w-0 max-w-[20rem] items-center gap-1.5 rounded-md bg-foreground/[0.045] px-2 text-left text-sm text-foreground hover:bg-foreground/[0.07]"
           >
-            <Plus size={14} className="shrink-0" />
-            <span className="min-w-0 truncate">{view.newSessionLabel}</span>
-          </button>
+            <span className="min-w-0 truncate">{activeLabel}</span>
+            <ChevronDown
+              size={13}
+              className={`shrink-0 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
+            />
+          </Button>
+        )}
+      >
+        {(close) => (
+          <div role="menu" aria-label={`Sessions in ${view.workspaceLabel}`}>
+            <div className="px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
+              {view.sessions.length
+                ? `${view.sessions.length} ${view.sessions.length === 1 ? "session" : "sessions"}`
+                : "No saved sessions yet"}
+            </div>
+            {view.sessions.map((session) => (
+              <PopoverMenuItem
+                key={session.id}
+                role="menuitemradio"
+                aria-checked={session.id === view.activeSessionId}
+                label={session.label}
+                trailing={session.statusLabel}
+                onClick={() => {
+                  close();
+                  view.onSelectSession(session.id);
+                }}
+              >
+                {session.detail || null}
+              </PopoverMenuItem>
+            ))}
+            {view.sessions.length ? (
+              <div className="my-1 border-t border-border/60" aria-hidden />
+            ) : null}
+            <PopoverMenuItem
+              role="menuitem"
+              icon={<Plus size={14} />}
+              label={view.newSessionLabel}
+              onClick={() => {
+                close();
+                view.onNewSession();
+              }}
+            />
+          </div>
+        )}
+      </PopoverButton>
+    </div>
+  );
+}
+
+function CloudChatStatusChip({ status }: { status: CloudChatStatusView }) {
+  return (
+    <span
+      className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.045] px-2.5 text-xs text-foreground"
+      aria-label={`Status: ${status.label}`}
+    >
+      <StatusDot tone={status.tone} live={status.live} />
+      <span className={`max-w-[8rem] truncate ${statusTextClass(status.tone)}`}>
+        {status.label}
+      </span>
+    </span>
+  );
+}
+
+function CloudChatHeaderNotice({ notice }: { notice: CloudChatHeaderNoticeView }) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  function copyDetails() {
+    notice.diagnostics?.onCopy?.();
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  }
+
+  return (
+    <div className={`shrink-0 border-y px-4 py-2 text-sm ${noticeToneClass(notice.tone)}`}>
+      <div className="flex min-w-0 items-center gap-3">
+        <StatusDot tone={notice.tone} live={notice.tone === "info"} />
+        <div className="min-w-0 flex-1 leading-5">
+          <span className="font-medium">{notice.title}</span>
+          {notice.description ? (
+            <span className="ml-2 text-muted-foreground">{notice.description}</span>
+          ) : null}
+        </div>
+        {notice.action ? (
+          <Button
+            variant={notice.action.kind === "claim" ? "secondary" : "outline"}
+            size="sm"
+            loading={notice.action.loading}
+            disabled={notice.action.disabled}
+            onClick={notice.action.onClick}
+          >
+            {notice.action.label}
+          </Button>
+        ) : null}
+        {notice.diagnostics ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-expanded={detailsOpen}
+            onClick={() => setDetailsOpen((current) => !current)}
+            className="gap-1 px-2 text-muted-foreground"
+          >
+            Details
+            <ChevronDown
+              size={12}
+              className={`transition-transform ${detailsOpen ? "rotate-180" : ""}`}
+            />
+          </Button>
+        ) : null}
+      </div>
+      {detailsOpen && notice.diagnostics ? (
+        <div className="mt-2 flex items-start gap-2 pl-6">
+          <code
+            className="min-w-0 flex-1 break-words rounded-md bg-background/35 px-2 py-1.5 font-mono text-[11px] leading-5 text-muted-foreground"
+            data-telemetry-mask
+          >
+            {notice.diagnostics.text}
+          </code>
+          <IconButton
+            title={copied ? "Copied" : "Copy details"}
+            size="sm"
+            onClick={copyDetails}
+            className="shrink-0 border-border/60"
+          >
+            {copied ? <Check size={13} /> : <Copy size={13} />}
+          </IconButton>
         </div>
       ) : null}
     </div>
   );
+}
+
+function StatusDot({
+  tone,
+  live = false,
+}: {
+  tone: CloudChatHeaderTone;
+  live?: boolean;
+}) {
+  return (
+    <span
+      className={`size-1.5 shrink-0 rounded-full ${statusDotClass(tone)} ${
+        live ? "animate-pulse motion-reduce:animate-none" : ""
+      }`}
+      aria-hidden
+    />
+  );
+}
+
+function statusDotClass(tone: CloudChatHeaderTone): string {
+  switch (tone) {
+    case "info":
+      return "bg-info";
+    case "success":
+      return "bg-success";
+    case "warning":
+      return "bg-warning";
+    case "destructive":
+      return "bg-destructive";
+    case "neutral":
+    default:
+      return "bg-muted-foreground/55";
+  }
+}
+
+function statusTextClass(tone: CloudChatHeaderTone): string {
+  switch (tone) {
+    case "info":
+      return "text-info";
+    case "success":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "destructive":
+      return "text-destructive";
+    case "neutral":
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function noticeToneClass(tone: CloudChatHeaderNoticeView["tone"]): string {
+  switch (tone) {
+    case "info":
+      return "border-info/20 bg-info/10 text-foreground";
+    case "destructive":
+      return "border-destructive/25 bg-destructive-subtle text-foreground";
+    case "warning":
+    default:
+      return "border-warning/25 bg-warning-subtle text-foreground";
+  }
 }

--- a/apps/packages/product-ui/test/CloudChatSurface.test.tsx
+++ b/apps/packages/product-ui/test/CloudChatSurface.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CloudChatSurface,
+  type CloudChatHeaderView,
+} from "../src/chat/CloudChatSurface";
+
+describe("CloudChatSurface", () => {
+  afterEach(cleanup);
+
+  it("renders workspace/session breadcrumb without a redundant session label", () => {
+    renderSurface();
+
+    expect(screen.getByText("Bramble")).toBeTruthy();
+    expect(screen.getByText("/")).toBeTruthy();
+    expect(screen.getByText("Starting")).toBeTruthy();
+    expect(screen.queryByText("Session")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+
+    const switcher = screen.getByRole("button", {
+      name: /Switch sessions in Bramble/u,
+    });
+    expect(switcher.textContent).toContain("Fix auth flow");
+  });
+
+  it("selects sessions and starts a new session from the header", () => {
+    const onSelectSession = vi.fn();
+    const onNewSession = vi.fn();
+
+    renderSurface({
+      sessionSwitcher: {
+        ...baseHeader.sessionSwitcher,
+        onSelectSession,
+        onNewSession,
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Switch sessions in Bramble/u }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Second pass/u }));
+    expect(onSelectSession).toHaveBeenCalledWith("session-2");
+
+    fireEvent.click(screen.getByRole("button", { name: "New session" }));
+    expect(onNewSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows notice diagnostics behind details and emits copy", () => {
+    const onCopy = vi.fn();
+
+    renderSurface({
+      notice: {
+        title: "Workspace accepted.",
+        description: "Preparing the selected runtime so this session can start.",
+        tone: "info",
+        diagnostics: {
+          text: "workspace=workspace-1 · target=target-1",
+          onCopy,
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Details/u }));
+
+    expect(screen.getByText("workspace=workspace-1 · target=target-1")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy details" }));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+});
+
+const baseHeader: CloudChatHeaderView = {
+  workspaceLabel: "Bramble",
+  status: {
+    label: "Starting",
+    tone: "info",
+    live: true,
+  },
+  sessionSwitcher: {
+    workspaceLabel: "Bramble",
+    activeSessionId: "session-1",
+    activeSessionLabel: "Fix auth flow",
+    sessions: [
+      {
+        id: "session-1",
+        label: "Fix auth flow",
+        detail: "2m",
+        statusLabel: "In progress",
+      },
+      {
+        id: "session-2",
+        label: "Second pass",
+        detail: "1h",
+        statusLabel: "Ready",
+      },
+    ],
+    newSessionLabel: "New session",
+    onSelectSession: vi.fn(),
+    onNewSession: vi.fn(),
+  },
+  desktopAction: {
+    label: "Open in Desktop",
+    kind: "desktop",
+    onClick: vi.fn(),
+  },
+};
+
+function renderSurface(header: Partial<CloudChatHeaderView> = {}) {
+  return render(
+    <CloudChatSurface
+      header={{ ...baseHeader, ...header }}
+      transcriptRows={[]}
+      emptyTitle="No transcript yet"
+      composer={{
+        value: "",
+        placeholder: "Describe a task",
+        canSubmit: false,
+        onChange: vi.fn(),
+        onSubmit: vi.fn(),
+        controls: [],
+      }}
+    />,
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
     "build": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -35,6 +36,7 @@
     "@vitejs/plugin-react": "^4",
     "tailwindcss": "^4",
     "typescript": "^5.7",
-    "vite": "^6"
+    "vite": "^6",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/web/src/components/chat/screen/ChatScreen.tsx
+++ b/apps/web/src/components/chat/screen/ChatScreen.tsx
@@ -27,6 +27,8 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import {
   CloudChatSurface,
+  type CloudChatHeaderNoticeView,
+  type CloudChatHeaderView,
 } from "@proliferate/product-ui/chat/CloudChatSurface";
 import type {
   CloudChatComposerFooterControlView,
@@ -57,12 +59,15 @@ import {
 } from "@proliferate/product-domain/chats/cloud/harness-availability";
 import {
   cloudCommandReadiness,
-  recentWorkCloudAccessState,
   recentWorkCommandability,
-  recentWorkRuntimeLocationForWorkspace,
 } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
 
 import { routes } from "../../../config/routes";
+import {
+  buildCloudChatHeaderDiagnosticsText,
+  buildCloudChatHeaderStatus,
+  cloudChatSessionStatusLabel,
+} from "../../../lib/domain/chat/cloud-chat-header-presentation";
 import {
   dispatchPendingHomePrompt,
   enqueuePromptCommandWithRetry,
@@ -1422,7 +1427,6 @@ export function ChatScreen() {
   const branchName = workspace.repo.branch ?? defaultBranchName;
   const workspaceDisplayName = workspace.displayName?.trim() ?? "";
   const workspaceTitle = workspaceDisplayName || branchName || repoLabel;
-  const showBranchChip = !workspaceDisplayName || branchName !== defaultBranchName;
   const activeSessionLabel = session
     ? sessionOptionLabel(session)
     : "New session";
@@ -1444,13 +1448,88 @@ export function ChatScreen() {
   const workspaceStatusNotice = commandMessage && !isUnclaimed
     ? workspaceNoticeForCommandMessage(commandMessage)
     : null;
-  const transcriptSourceLabel = transcriptView.source === "events"
-    ? "Event transcript"
-    : transcriptView.source === "projection"
-      ? "Projection fallback"
-      : "No transcript";
-  const runtimeLabel = workspaceRuntimeLabel(recentWorkRuntimeLocationForWorkspace(workspace));
-  const cloudAccessLabel = workspaceCloudAccessLabel(recentWorkCloudAccessState(workspace));
+  const headerDiagnosticsText = buildCloudChatHeaderDiagnosticsText({
+    workspace,
+    session,
+    commandReadiness,
+    commandabilityLabel,
+    commandStatus: commandStatus.data,
+    sessionLiveConnected: sessionLive.isConnected,
+    transcriptSource: transcriptView.source,
+  });
+  const headerNotice: CloudChatHeaderNoticeView | null = isUnclaimed
+    ? {
+      title: "Unclaimed shared workspace.",
+      description: "Claim this workspace before sending prompts or changing session settings.",
+      tone: "warning",
+      action: {
+        label: "Claim",
+        kind: "claim",
+        loading: claimWorkspace.isPending,
+        onClick: () => void claimCurrentWorkspace(),
+      },
+    }
+    : workspaceStatusNotice
+      ? {
+        ...workspaceStatusNotice,
+        diagnostics: {
+          text: headerDiagnosticsText,
+          onCopy: () => void copyComposerFooterValue(headerDiagnosticsText, "Workspace diagnostics"),
+        },
+      }
+      : null;
+  const header: CloudChatHeaderView = {
+    workspaceLabel: workspaceTitle,
+    status: buildCloudChatHeaderStatus({
+      workspace,
+      session,
+      pendingInteractions,
+      workspaceCommandReady,
+      commandReadiness,
+      workspacePreparationMessage: isWorkspacePreparationStatus(commandMessage),
+      promptSubmitting,
+    }),
+    sessionSwitcher: {
+      workspaceLabel: workspaceTitle,
+      activeSessionId: session?.sessionId
+        ?? (pendingSessionDraft ? webCloudSessionDraftOptionId(pendingSessionDraft.id) : null),
+      activeSessionLabel,
+      sessions: [
+        ...(pendingSessionDraft
+          ? [{
+            id: webCloudSessionDraftOptionId(pendingSessionDraft.id),
+            label: "New session",
+            detail: pendingSessionDraft.selection.agentKind,
+            statusLabel: "Draft",
+          }]
+          : []),
+        ...sessions.map((candidate) => ({
+          id: candidate.sessionId,
+          label: sessionOptionLabel(candidate),
+          detail: relativeSessionTime(candidate.lastEventAt ?? candidate.startedAt ?? null),
+          statusLabel: cloudChatSessionStatusLabel(candidate),
+        })),
+      ],
+      newSessionLabel: "New session",
+      onSelectSession: (sessionId: string) => {
+        const draftId = webCloudSessionDraftIdFromOptionId(sessionId);
+        if (draftId) {
+          navigate(`${routes.workspace(workspace.id)}${webCloudSessionDraftSearch(draftId)}`);
+          return;
+        }
+        navigate(routes.chat(workspace.id, sessionId));
+      },
+      onNewSession: () => openNewSessionDraft(),
+    },
+    notice: headerNotice,
+    desktopAction: {
+      label: "Open in Desktop",
+      kind: "desktop",
+      onClick: () => {
+        window.location.href = desktopWorkspaceDeepLink(workspace.id);
+      },
+    },
+  };
   const claimFooterControl: CloudChatComposerFooterControlView | null = isUnclaimed
     ? {
       id: "claim",
@@ -1490,101 +1569,13 @@ export function ChatScreen() {
 
   return (
     <CloudChatSurface
-      title={workspaceTitle}
-      eyebrowItems={[
-        runtimeLabel,
-        cloudAccessLabel,
-        commandabilityLabel,
-      ]}
-      chips={[
-        ...(showBranchChip
-          ? [{
-            id: "branch",
-            label: branchName,
-            icon: "branch" as const,
-          }]
-          : []),
-        {
-          id: "repo",
-          label: repoLabel,
-        },
-        ...(workspace.visibility !== "private"
-          ? [{ id: "visibility", label: workspace.visibility }]
-          : []),
-        {
-          id: "live",
-          label: sessionLive.isConnected ? "Live stream" : "Snapshot",
-        },
-        {
-          id: "source",
-          label: transcriptSourceLabel,
-        },
-        ...(session
-          ? [{
-            id: "session",
-            label: `Session: ${activeSessionLabel}`,
-          }]
-          : []),
-      ]}
+      header={header}
       transcriptRows={visibleTranscriptRows}
       emptyTitle={emptyTitle}
       emptyDescription={
         !session ? `Send a message below to start the first session in ${workspaceTitle}.` : undefined
       }
       commandMessage={null}
-      primaryAction={isUnclaimed
-        ? {
-          label: "Claim",
-          kind: "claim",
-          loading: claimWorkspace.isPending,
-          onClick: () => void claimCurrentWorkspace(),
-        }
-        : null}
-      sessionSwitcher={{
-        workspaceLabel: workspaceTitle,
-        activeSessionId: session?.sessionId
-          ?? (pendingSessionDraft ? webCloudSessionDraftOptionId(pendingSessionDraft.id) : null),
-        activeSessionLabel,
-        sessions: [
-          ...(pendingSessionDraft
-            ? [{
-              id: webCloudSessionDraftOptionId(pendingSessionDraft.id),
-              label: "New session",
-              detail: pendingSessionDraft.selection.agentKind,
-              statusLabel: "Draft",
-            }]
-            : []),
-          ...sessions.map((candidate) => ({
-            id: candidate.sessionId,
-            label: sessionOptionLabel(candidate),
-            detail: relativeSessionTime(candidate.lastEventAt ?? candidate.startedAt ?? null),
-            statusLabel: sessionStatusLabel(candidate.status),
-          })),
-        ],
-        newSessionLabel: "New session",
-        onSelectSession: (sessionId: string) => {
-          const draftId = webCloudSessionDraftIdFromOptionId(sessionId);
-          if (draftId) {
-            navigate(`${routes.workspace(workspace.id)}${webCloudSessionDraftSearch(draftId)}`);
-            return;
-          }
-          navigate(routes.chat(workspace.id, sessionId));
-        },
-        onNewSession: () => openNewSessionDraft(),
-      }}
-      topNotice={isUnclaimed
-        ? {
-          title: "Unclaimed shared workspace.",
-          description: "Claim this workspace before sending prompts or changing session settings.",
-          action: {
-            label: "Claim",
-            kind: "claim",
-            loading: claimWorkspace.isPending,
-            onClick: () => void claimCurrentWorkspace(),
-          },
-        }
-        : workspaceStatusNotice}
-      desktopHref={desktopWorkspaceDeepLink(workspace.id)}
       composer={{
         value: draft,
         onChange: setDraft,
@@ -1606,7 +1597,6 @@ export function ChatScreen() {
                 ? "Desktop or remote runtime is offline"
                 : "Waiting for workspace",
       }}
-      onBack={() => navigate(routes.workspaces)}
     />
   );
 }
@@ -1702,14 +1692,6 @@ function cleanSessionTitle(title: string | null | undefined): string | null {
   return value;
 }
 
-function sessionStatusLabel(status: string): string {
-  return status
-    .split(/[_\s-]+/u)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ") || "Session";
-}
-
 function friendlyCommandStatusMessage(message: string | null | undefined): string | null {
   if (!message) {
     return null;
@@ -1730,22 +1712,27 @@ function isWorkspacePreparationStatus(message: string | null | undefined): boole
   return friendlyCommandStatusMessage(message)?.startsWith("Workspace accepted.") ?? false;
 }
 
-function workspaceNoticeForCommandMessage(message: string) {
+function workspaceNoticeForCommandMessage(
+  message: string,
+): Omit<CloudChatHeaderNoticeView, "action" | "diagnostics"> {
   if (message.startsWith("Workspace accepted.")) {
     return {
       title: "Workspace accepted.",
       description: "Preparing the selected runtime so this session can start.",
+      tone: "info",
     };
   }
   if (message.startsWith("Cloud sandbox setup cannot reach")) {
     return {
       title: "Workspace setup failed.",
       description: message,
+      tone: "destructive",
     };
   }
   return {
     title: "Workspace is not ready yet",
     description: message,
+    tone: "warning",
   };
 }
 
@@ -1896,34 +1883,6 @@ function relativeSessionTime(value: string | null): string | null {
     return `${hours}h`;
   }
   return `${Math.floor(hours / 24)}d`;
-}
-
-function workspaceRuntimeLabel(runtime: ReturnType<typeof recentWorkRuntimeLocationForWorkspace>): string {
-  switch (runtime) {
-    case "local_desktop":
-      return "Local Desktop runtime";
-    case "cloud_sandbox":
-      return "Cloud runtime";
-    case "ssh_remote":
-      return "SSH runtime";
-    case "offline":
-      return "Runtime offline";
-    case "unknown":
-      return "Runtime unknown";
-  }
-}
-
-function workspaceCloudAccessLabel(
-  state: ReturnType<typeof recentWorkCloudAccessState>,
-): string {
-  switch (state) {
-    case "enabled":
-      return "Cloud access enabled";
-    case "not_enabled":
-      return "Cloud access off";
-    case "unknown":
-      return "Cloud access unknown";
-  }
 }
 
 function workspaceCommandabilityLabel(

--- a/apps/web/src/lib/domain/chat/cloud-chat-header-presentation.test.ts
+++ b/apps/web/src/lib/domain/chat/cloud-chat-header-presentation.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CloudPendingInteraction,
+  CloudSessionProjection,
+  CloudWorkspaceSnapshot,
+} from "@proliferate/cloud-sdk";
+import type { cloudCommandReadiness } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
+import {
+  buildCloudChatHeaderDiagnosticsText,
+  buildCloudChatHeaderStatus,
+  cloudChatSessionStatusLabel,
+} from "./cloud-chat-header-presentation";
+
+type HeaderWorkspace = NonNullable<CloudWorkspaceSnapshot["workspace"]>;
+type HeaderSession = Pick<
+  CloudSessionProjection,
+  "phase" | "pendingInteractionCount" | "status"
+>;
+
+const READY_COMMAND: ReturnType<typeof cloudCommandReadiness> = {
+  state: "ready",
+  commandable: true,
+  message: null,
+};
+
+function workspace(overrides: Partial<HeaderWorkspace> = {}): HeaderWorkspace {
+  return {
+    id: "workspace-1",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "main",
+      baseBranch: "main",
+    },
+    workspaceStatus: "ready",
+    status: "ready",
+    runtime: {
+      environmentId: "runtime-1",
+      status: "running",
+      generation: 1,
+      actionBlockKind: null,
+      actionBlockReason: null,
+    },
+    targetId: "target-1",
+    anyharnessWorkspaceId: "anyharness-workspace-1",
+    exposureState: "live",
+    lastError: null,
+    statusDetail: null,
+    ...overrides,
+  } as HeaderWorkspace;
+}
+
+function session(overrides: Partial<HeaderSession> = {}): HeaderSession {
+  return {
+    phase: "idle",
+    pendingInteractionCount: 0,
+    status: "idle",
+    ...overrides,
+  };
+}
+
+function status(
+  overrides: Partial<Parameters<typeof buildCloudChatHeaderStatus>[0]> = {},
+) {
+  return buildCloudChatHeaderStatus({
+    workspace: workspace(),
+    session: null,
+    pendingInteractions: [],
+    workspaceCommandReady: true,
+    commandReadiness: READY_COMMAND,
+    workspacePreparationMessage: false,
+    promptSubmitting: false,
+    ...overrides,
+  });
+}
+
+describe("buildCloudChatHeaderStatus", () => {
+  it("prioritizes workspace errors", () => {
+    expect(status({
+      workspace: workspace({ workspaceStatus: "error", lastError: "Launch failed" }),
+    })).toEqual({ label: "Error", tone: "destructive" });
+  });
+
+  it("surfaces failed sessions as errors", () => {
+    expect(status({
+      session: session({ status: "failed", pendingInteractionCount: 1 }),
+    })).toEqual({ label: "Error", tone: "destructive" });
+  });
+
+  it("shows setup as live starting", () => {
+    expect(status({
+      workspace: workspace({ workspaceStatus: "materializing" }),
+      workspaceCommandReady: false,
+      commandReadiness: {
+        state: "workspace_not_ready",
+        commandable: false,
+        message: "Workspace is not ready yet.",
+      },
+    })).toEqual({ label: "Starting", tone: "info", live: true });
+  });
+
+  it("shows unresolved non-prompt interactions as needs input", () => {
+    expect(status({
+      pendingInteractions: [{
+        kind: "ask_user",
+        status: "pending",
+      } as CloudPendingInteraction],
+    })).toEqual({ label: "Needs input", tone: "warning" });
+  });
+
+  it("shows prompt submission and running sessions as in progress", () => {
+    expect(status({ promptSubmitting: true })).toEqual({
+      label: "In progress",
+      tone: "info",
+      live: true,
+    });
+    expect(status({
+      session: session({ phase: "running", status: "running" }),
+    })).toEqual({ label: "In progress", tone: "info", live: true });
+  });
+
+  it("shows review-ready sessions before generic ready", () => {
+    expect(status({
+      session: session({ phase: "review", status: "completed" }),
+    })).toEqual({ label: "Ready for review", tone: "success" });
+  });
+
+  it("keeps a ready workspace ready when no command is running", () => {
+    expect(status()).toEqual({ label: "Ready", tone: "success" });
+  });
+
+  it("falls back to idle when commands are unavailable and nothing is active", () => {
+    expect(status({
+      workspaceCommandReady: false,
+      commandReadiness: {
+        state: "runtime_unavailable",
+        commandable: false,
+        message: "Runtime unavailable.",
+      },
+    })).toEqual({ label: "Idle", tone: "neutral" });
+  });
+});
+
+describe("cloudChatSessionStatusLabel", () => {
+  it("prioritizes error over stale pending input", () => {
+    expect(cloudChatSessionStatusLabel(
+      session({ status: "failed", pendingInteractionCount: 1 }),
+    )).toBe("Error");
+  });
+
+  it("labels pending interactions as needs input", () => {
+    expect(cloudChatSessionStatusLabel(
+      session({ phase: "awaiting_interaction", status: "running" }),
+    )).toBe("Needs input");
+  });
+});
+
+describe("buildCloudChatHeaderDiagnosticsText", () => {
+  it("includes present diagnostics and skips null values", () => {
+    expect(buildCloudChatHeaderDiagnosticsText({
+      workspace: workspace({ statusDetail: null }),
+      session: null,
+      commandReadiness: READY_COMMAND,
+      commandabilityLabel: "Commands ready",
+      sessionLiveConnected: true,
+      transcriptSource: "events",
+    })).toContain("workspace=workspace-1");
+  });
+});

--- a/apps/web/src/lib/domain/chat/cloud-chat-header-presentation.ts
+++ b/apps/web/src/lib/domain/chat/cloud-chat-header-presentation.ts
@@ -1,0 +1,241 @@
+import type {
+  CloudCommandResponse,
+  CloudPendingInteraction,
+  CloudSessionProjection,
+  CloudWorkspaceSnapshot,
+} from "@proliferate/cloud-sdk";
+import type { cloudCommandReadiness } from "@proliferate/product-domain/workspaces/cloud-work-inventory";
+
+type HeaderWorkspace = NonNullable<CloudWorkspaceSnapshot["workspace"]>;
+type CloudChatHeaderTone =
+  | "neutral"
+  | "info"
+  | "success"
+  | "warning"
+  | "destructive";
+
+export interface CloudChatHeaderStatusPresentation {
+  label: string;
+  tone: CloudChatHeaderTone;
+  live?: boolean;
+}
+
+type HeaderSessionStatus = Pick<
+  CloudSessionProjection,
+  "phase" | "pendingInteractionCount" | "status"
+>;
+
+export function buildCloudChatHeaderStatus(input: {
+  workspace: HeaderWorkspace;
+  session: HeaderSessionStatus | null;
+  pendingInteractions: readonly CloudPendingInteraction[];
+  workspaceCommandReady: boolean;
+  commandReadiness: ReturnType<typeof cloudCommandReadiness>;
+  workspacePreparationMessage: boolean;
+  promptSubmitting: boolean;
+}): CloudChatHeaderStatusPresentation {
+  if (workspaceHasError(input.workspace)) {
+    return { label: "Error", tone: "destructive" };
+  }
+  if (workspaceIsPreparing(input.workspace) || input.workspacePreparationMessage) {
+    return { label: "Starting", tone: "info", live: true };
+  }
+  if (sessionHasError(input.session)) {
+    return { label: "Error", tone: "destructive" };
+  }
+  if (sessionPhaseNeedsInput(input.session) || pendingInteractionsNeedInput(input.pendingInteractions)) {
+    return { label: "Needs input", tone: "warning" };
+  }
+  if (
+    input.promptSubmitting
+    || sessionIsRunning(input.session)
+  ) {
+    return { label: "In progress", tone: "info", live: true };
+  }
+  if (sessionIsReviewReady(input.session)) {
+    return { label: "Ready for review", tone: "success" };
+  }
+  if (input.workspaceCommandReady || input.commandReadiness.state === "ready") {
+    return { label: "Ready", tone: "success" };
+  }
+  return { label: "Idle", tone: "neutral" };
+}
+
+export function cloudChatSessionStatusLabel(
+  session: HeaderSessionStatus,
+): string {
+  if (sessionHasError(session)) {
+    return "Error";
+  }
+  if (sessionHasPendingInput(session)) {
+    return "Needs input";
+  }
+  const normalized = normalizeStatusToken(session.phase) || normalizeStatusToken(session.status);
+  switch (normalized) {
+    case "starting":
+      return "Starting";
+    case "running":
+    case "queued":
+      return "In progress";
+    case "review":
+    case "ready_for_review":
+      return "Ready for review";
+    case "ended":
+    case "done":
+    case "completed":
+      return "Ready";
+    case "error":
+    case "errored":
+    case "failed":
+      return "Error";
+    case "idle":
+      return "Idle";
+    default:
+      return titleizeStatus(session.status);
+  }
+}
+
+export function buildCloudChatHeaderDiagnosticsText(input: {
+  workspace: HeaderWorkspace;
+  session: CloudSessionProjection | null;
+  commandReadiness: ReturnType<typeof cloudCommandReadiness>;
+  commandabilityLabel: string;
+  commandStatus?: CloudCommandResponse;
+  sessionLiveConnected: boolean;
+  transcriptSource: string;
+}): string {
+  return [
+    diagnosticPart("workspace", input.workspace.id),
+    diagnosticPart("workspace_status", input.workspace.workspaceStatus ?? input.workspace.status),
+    diagnosticPart("runtime_status", input.workspace.runtime?.status),
+    diagnosticPart("target", input.workspace.targetId),
+    diagnosticPart("anyharness_workspace", input.workspace.anyharnessWorkspaceId),
+    diagnosticPart("exposure", input.workspace.exposureState),
+    diagnosticPart("command_readiness", input.commandReadiness.state),
+    diagnosticPart("commandability", input.commandabilityLabel),
+    diagnosticPart("last_error", input.workspace.lastError),
+    diagnosticPart("status_detail", input.workspace.statusDetail),
+    diagnosticPart("session", input.session?.sessionId),
+    diagnosticPart("session_status", input.session?.status),
+    diagnosticPart("session_phase", input.session?.phase),
+    diagnosticPart("pending_interactions", input.session?.pendingInteractionCount),
+    diagnosticPart("live_stream", input.sessionLiveConnected ? "connected" : "snapshot"),
+    diagnosticPart("transcript_source", input.transcriptSource),
+    diagnosticPart("command", input.commandStatus?.commandId),
+    diagnosticPart("command_status", input.commandStatus?.status),
+    diagnosticPart("command_error_code", input.commandStatus?.errorCode),
+    diagnosticPart("command_error", input.commandStatus?.errorMessage),
+  ].filter(Boolean).join(" · ");
+}
+
+function titleizeStatus(status: string | null | undefined): string {
+  return (status ?? "")
+    .split(/[_\s-]+/u)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ") || "Session";
+}
+
+function diagnosticPart(label: string, value: string | number | null | undefined): string | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  return `${label}=${String(value)}`;
+}
+
+function workspaceHasError(workspace: HeaderWorkspace): boolean {
+  return Boolean(
+    workspace.lastError
+      || workspace.workspaceStatus === "error"
+      || workspace.status === "error"
+      || workspace.runtime?.status === "error",
+  );
+}
+
+function workspaceIsPreparing(workspace: HeaderWorkspace): boolean {
+  return workspace.workspaceStatus === "pending"
+    || workspace.workspaceStatus === "materializing"
+    || workspace.workspaceStatus === "needs_rematerialization"
+    || workspace.runtime?.status === "pending"
+    || workspace.runtime?.status === "provisioning";
+}
+
+function sessionHasPendingInput(
+  session: Pick<CloudSessionProjection, "phase" | "pendingInteractionCount"> | null,
+): boolean {
+  return Boolean(
+    session
+      && ((session.pendingInteractionCount ?? 0) > 0
+        || normalizeStatusToken(session.phase) === "awaiting_interaction"),
+  );
+}
+
+function sessionHasError(
+  session: Pick<CloudSessionProjection, "phase" | "status"> | null,
+): boolean {
+  if (!session) {
+    return false;
+  }
+  const values = [
+    normalizeStatusToken(session.phase),
+    normalizeStatusToken(session.status),
+  ];
+  return values.some((value) =>
+    value === "error"
+      || value === "errored"
+      || value === "failed"
+      || value === "failure"
+  );
+}
+
+function sessionPhaseNeedsInput(
+  session: Pick<CloudSessionProjection, "phase"> | null,
+): boolean {
+  return normalizeStatusToken(session?.phase) === "awaiting_interaction";
+}
+
+function pendingInteractionsNeedInput(
+  pendingInteractions: readonly CloudPendingInteraction[],
+): boolean {
+  return pendingInteractions.some((interaction) =>
+    interaction.status !== "resolved"
+      && interaction.status !== "completed"
+      && interaction.kind !== "send_prompt"
+  );
+}
+
+function sessionIsRunning(
+  session: Pick<CloudSessionProjection, "phase" | "status"> | null,
+): boolean {
+  if (!session) {
+    return false;
+  }
+  const values = [
+    normalizeStatusToken(session.phase),
+    normalizeStatusToken(session.status),
+  ];
+  return values.some((value) =>
+    value === "starting"
+      || value === "running"
+      || value === "queued"
+      || value === "leased"
+      || value === "delivered"
+  );
+}
+
+function sessionIsReviewReady(
+  session: Pick<CloudSessionProjection, "phase" | "status"> | null,
+): boolean {
+  if (!session) {
+    return false;
+  }
+  const values = [
+    normalizeStatusToken(session.phase),
+    normalizeStatusToken(session.status),
+  ];
+  return values.some((value) => value === "review" || value === "ready_for_review");
+}
+
+function normalizeStatusToken(value: string | null | undefined): string {
+  return value?.toLowerCase().replace(/[\s-]+/gu, "_").trim() ?? "";
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,6 +598,9 @@ importers:
       vite:
         specifier: ^6
         version: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@29.1.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   cloud/sdk:
     dependencies:


### PR DESCRIPTION
## Summary

- Reworks the web active workspace chat header around an explicit header view model.
- Adds status chip, session switcher, calm notice/details handling, and quieter Desktop action.
- Removes duplicate/noisy header metadata now covered by composer controls.
- Adds focused web-domain coverage for header status projection edge cases.

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label
- Required: at least one `area:*` label

## Verification

- `pnpm --filter @proliferate/web test -- src/lib/domain/chat/cloud-chat-header-presentation.test.ts`
- `pnpm --filter @proliferate/product-ui test -- CloudChatSurface.test.tsx`
- `pnpm --filter @proliferate/web build`