### PR TITLE
chore(desktop): bump release to 0.1.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "anyharness-credential-discovery",
  "base64 0.22.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proliferate",
   "private": true,
-  "version": "0.1.42",
+  "version": "0.1.43",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proliferate"
-version = "0.1.42"
+version = "0.1.43"
 edition.workspace = true
 
 [build-dependencies]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Proliferate",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "identifier": "com.proliferate.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump desktop package/Tauri/Cargo versions to 0.1.43
- update Cargo.lock so production promote can publish desktop-v0.1.43 from the promoted SHA

## Verification

- `node -e "const fs=require('fs'); const pkg=require('./apps/desktop/package.json').version; const tauri=JSON.parse(fs.readFileSync('./apps/desktop/src-tauri/tauri.conf.json', 'utf8')).version; const cargo=fs.readFileSync('./apps/desktop/src-tauri/Cargo.toml', 'utf8').match(/^version = \\\"([^\\\"]+)\\\"/m)[1]; const lock=fs.readFileSync('./Cargo.lock', 'utf8').match(/name = \\\"proliferate\\\"\\nversion = \\\"([^\\\"]+)\\\"/)[1]; if(new Set([pkg,tauri,cargo,lock]).size!==1 || pkg!== '0.1.43') process.exit(1);"`\n- `git diff --check -- Cargo.lock apps/desktop/package.json apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/tauri.conf.json`