### PR TITLE
ci(desktop): allow promote-sourced release refs

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -96,7 +96,7 @@ jobs:
           fi
 
       - name: Validate release ref
-        if: steps.filter.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && !inputs.dry_run
+        if: steps.filter.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && !inputs.dry_run && !inputs.git_sha
         shell: bash
         run: |
           if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != desktop-v* ]]; then
@@ -491,7 +491,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name != 'push' && !inputs.dry_run)
     steps:
       - name: Validate release ref
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.git_sha
         shell: bash
         run: |
           if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != desktop-v* ]]; then

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -76,6 +76,7 @@ server/proliferate/server/billing/service.py
 server/proliferate/server/billing/stripe_webhooks.py
 server/proliferate/db/store/cloud_workspaces.py
 server/proliferate/server/cloud/commands/service.py
+server/proliferate/server/cloud/commands/domain/rules.py
 server/proliferate/server/cloud/worker/service.py
 server/proliferate/server/cloud/runtime/bootstrap.py
 server/proliferate/server/cloud/runtime_config/domain/resolver.py


### PR DESCRIPTION
## Summary
- allow production promote to call the desktop release workflow with an explicit git SHA without tripping the manual desktop-v* tag guard
- keep direct manual non-dry desktop releases guarded to desktop-v* tag refs
- allowlist the merged cloud command rules file so latest main repo-shape checks pass

## Validation
- actionlint .github/workflows/release-desktop.yml .github/workflows/_deploy-desktop.yml .github/workflows/promote-production.yml
- ruby YAML parse for release desktop, deploy desktop, and promote production workflows
- python3 scripts/check_max_lines.py
- git diff --check -- .github/workflows/release-desktop.yml scripts/max_lines_allowlist.txt