### PR TITLE
fix(mobile): use remote production build numbers

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 18.13.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -20,6 +20,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_PROLIFERATE_API_BASE_URL": "https://app.proliferate.com/api",
         "SENTRY_DISABLE_AUTO_UPLOAD": "true"


### PR DESCRIPTION
## Summary\n- switch EAS mobile version source to remote for CI-safe build numbers\n- enable production auto-increment so the next iOS build advances past the used 0.1.1 (29) build number\n\n## Verification\n- jq apps/mobile/eas.json\n- pnpm dlx eas-cli@18.13.0 config --platform ios --profile production --json --non-interactive