### PR TITLE
fix(server): format password auth changes

### DIFF
--- a/server/proliferate/db/store/auth_passwords.py
+++ b/server/proliferate/db/store/auth_passwords.py
@@ -33,9 +33,7 @@ class PasswordLoginBlock:
 
 
 async def get_user_by_normalized_email(db: AsyncSession, email: str) -> User | None:
-    result = await db.execute(
-        select(User).where(func.lower(User.email) == email).limit(1)
-    )
+    result = await db.execute(select(User).where(func.lower(User.email) == email).limit(1))
     return result.scalar_one_or_none()
 
 

--- a/server/tests/integration/schema_migration_assertions.py
+++ b/server/tests/integration/schema_migration_assertions.py
@@ -337,8 +337,7 @@ async def assert_current_schema(
 
     password_login_attempt_columns = await conn.run_sync(
         lambda sync_conn: {
-            column["name"]
-            for column in inspect(sync_conn).get_columns("password_login_attempt")
+            column["name"] for column in inspect(sync_conn).get_columns("password_login_attempt")
         }
     )
     assert {


### PR DESCRIPTION
## Summary
- apply Ruff formatting to the password auth store and schema migration assertions after #382

## Verification
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run ruff format --check proliferate/ tests/
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run ruff check proliferate/ tests/