### PR TITLE
fix(server): make analytics MCP test product-ready

### DIFF
--- a/server/tests/integration/test_analytics_api.py
+++ b/server/tests/integration/test_analytics_api.py
@@ -21,6 +21,7 @@ async def _register_and_login(client: AsyncClient, email: str) -> dict[str, str]
     from proliferate.auth.models import UserCreate
     from proliferate.auth.users import UserManager, get_user_db
     from proliferate.db.engine import get_async_session
+    from proliferate.db.models.auth import OAuthAccount
 
     user_id: str | None = None
     async for session in get_async_session():
@@ -32,6 +33,15 @@ async def _register_and_login(client: AsyncClient, email: str) -> dict[str, str]
                     password="unused-oauth-only",
                     display_name="Analytics Tester",
                 ),
+            )
+            session.add(
+                OAuthAccount(
+                    user_id=user.id,
+                    oauth_name="github",
+                    access_token="github-access-token",
+                    account_id=f"github-{user.id}",
+                    account_email=email,
+                )
             )
             await session.commit()
             user_id = str(user.id)


### PR DESCRIPTION
## Summary
- give the analytics MCP integration test a GitHub OAuth row so cloud MCP routes pass the product-readiness gate
- unblocks Server CI for production promotion

## Verification
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run pytest tests/integration/test_analytics_api.py::test_mcp_connection_create_and_delete_write_lifecycle_events -q
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run ruff format --check tests/integration/test_analytics_api.py
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run ruff check tests/integration/test_analytics_api.py