### PR TITLE
fix(server): avoid wake transaction leak

### DIFF
--- a/server/proliferate/server/cloud/runtime/wake.py
+++ b/server/proliferate/server/cloud/runtime/wake.py
@@ -33,6 +33,20 @@ _WAKE_BLOCKED_ERROR_CODE = "sandbox_wake_blocked"
 _WAKE_BLOCKED_FALLBACK_MESSAGE = "Sandbox wake is blocked by billing."
 
 
+async def cancel_managed_slot_wake_tasks() -> None:
+    """Cancel outstanding in-process wake attempts during shutdown or test cleanup."""
+
+    tasks = tuple(_wake_tasks.values())
+    if not tasks:
+        return
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    for key, task in tuple(_wake_tasks.items()):
+        if task in tasks:
+            _wake_tasks.pop(key, None)
+
+
 def kick_off_managed_slot_wake(target_id: UUID, command_id: UUID | None = None) -> None:
     """Schedule a managed slot wake attempt without waiting for provider work."""
 
@@ -69,11 +83,15 @@ async def run_managed_slot_wake_job(target_id: UUID, command_id: UUID | None = N
         profile = await load_sandbox_profile_by_id(db, target.sandbox_profile_id)
         if profile is None:
             return
-        authorization = await authorize_sandbox_start_for_billing_subject(
-            actor_user_id=target.created_by_user_id,
-            billing_subject_id=profile.billing_subject_id,
-        )
-        if not authorization.allowed:
+        actor_user_id = target.created_by_user_id
+        billing_subject_id = profile.billing_subject_id
+
+    authorization = await authorize_sandbox_start_for_billing_subject(
+        actor_user_id=actor_user_id,
+        billing_subject_id=billing_subject_id,
+    )
+    if not authorization.allowed:
+        async with db_engine.async_session_factory() as db:
             message = (
                 authorization.message
                 or authorization.start_block_reason
@@ -81,7 +99,7 @@ async def run_managed_slot_wake_job(target_id: UUID, command_id: UUID | None = N
             )
             commands = await commands_store.mark_queued_commands_failed_delivery_for_target(
                 db,
-                target_id=target.id,
+                target_id=target_id,
                 command_kinds=WAKE_REQUIRED_CLOUD_COMMAND_KINDS,
                 error_code=_WAKE_BLOCKED_ERROR_CODE,
                 error_message=message,
@@ -95,13 +113,12 @@ async def run_managed_slot_wake_job(target_id: UUID, command_id: UUID | None = N
                 "Blocked managed slot wake because billing denied sandbox start",
                 extra={
                     "target_id": str(target_id),
-                    "billing_subject_id": str(profile.billing_subject_id),
+                    "billing_subject_id": str(billing_subject_id),
                     "reason": authorization.start_block_reason,
                     "failed_command_count": len(commands),
                 },
             )
             return
-        await db.commit()
 
     resumed = await _resume_target_runtime_environment(target_id, command_id=command_id)
     if resumed:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -18,6 +18,12 @@ from tests.postgres import (
 )
 
 
+async def _cancel_test_background_tasks() -> None:
+    from proliferate.server.cloud.runtime.wake import cancel_managed_slot_wake_tasks
+
+    await cancel_managed_slot_wake_tasks()
+
+
 @pytest.fixture(scope="session")
 def event_loop():  # type: ignore[no-untyped-def]
     loop = asyncio.new_event_loop()
@@ -42,8 +48,10 @@ async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
 
 @pytest_asyncio.fixture(autouse=True)
 async def reset_test_database(test_engine) -> AsyncGenerator[None, None]:  # type: ignore[no-untyped-def]
+    await _cancel_test_background_tasks()
     await truncate_all_tables(test_engine)
     yield
+    await _cancel_test_background_tasks()
     await truncate_all_tables(test_engine)
 
 

--- a/server/tests/e2e/cloud/helpers/github.py
+++ b/server/tests/e2e/cloud/helpers/github.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import uuid
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.auth import OAuthAccount
+from proliferate.auth.identity.store import upsert_identity_for_user, upsert_provider_grant
+from proliferate.auth.identity.types import REQUIRED_GITHUB_SCOPES, VerifiedProviderIdentity
 
 
 async def seed_linked_github_account(
@@ -15,14 +18,43 @@ async def seed_linked_github_account(
     account_id: str | None = None,
     account_email: str | None = None,
 ) -> None:
-    account = OAuthAccount(
-        user_id=uuid.UUID(user_id),
-        oauth_name="github",
+    user_uuid = uuid.UUID(user_id)
+    resolved_account_id = account_id or f"github-{user_id}"
+    resolved_account_email = account_email or f"cloud-e2e-{uuid.uuid4().hex[:8]}@example.com"
+    account = (
+        await db_session.execute(
+            select(OAuthAccount)
+            .where(
+                OAuthAccount.user_id == user_uuid,
+                OAuthAccount.oauth_name == "github",
+            )
+            .order_by(OAuthAccount.id.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if account is None:
+        account = OAuthAccount(user_id=user_uuid, oauth_name="github")
+        db_session.add(account)
+    account.access_token = access_token
+    account.account_id = resolved_account_id
+    account.account_email = resolved_account_email
+
+    verified = VerifiedProviderIdentity(
+        provider="github",
+        provider_subject=resolved_account_id,
+        email=resolved_account_email,
+        email_verified=True,
+        display_name=None,
+        provider_login=None,
+        avatar_url=None,
         access_token=access_token,
-        account_id=account_id or f"gh-{uuid.uuid4().hex[:10]}",
-        account_email=account_email or f"cloud-e2e-{uuid.uuid4().hex[:8]}@example.com",
+        refresh_token=None,
+        expires_at=None,
+        expires_at_timestamp=None,
+        scopes=frozenset(REQUIRED_GITHUB_SCOPES),
     )
-    db_session.add(account)
+    identity = await upsert_identity_for_user(db_session, user_id=user_uuid, verified=verified)
+    await upsert_provider_grant(db_session, identity=identity, verified=verified)
     await db_session.commit()
 
 


### PR DESCRIPTION
## Summary
- close the cloud wake read session before billing authorization opens its own DB work
- reopen a short session only when a blocked wake must fail queued commands

## Verification
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run pytest tests/integration/test_cloud_agent_auth_api.py::test_bifrost_usage_import_paginates_and_flags_missing_managed_cost tests/integration/test_cloud_agent_auth_api.py::test_bifrost_revoke_byok_disables_provider_key_and_runtime_virtual_key tests/integration/test_cloud_agent_auth_api.py::test_bifrost_selection_change_disables_old_runtime_virtual_key -vv --durations=20
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run pytest tests/integration/test_cloud_agent_auth_api.py -q --durations=20
- DEBUG=1 JWT_SECRET=local CLOUD_SECRET_KEY=local uv --directory server run pytest tests/integration/test_cloud_commands_api.py::TestCloudCommandsApi::test_managed_slot_wake_resumes_command_runtime_environment tests/integration/test_cloud_commands_api.py::TestCloudCommandsApi::test_managed_slot_wake_billing_failure_fails_pending_prompt_interaction tests/integration/test_cloud_commands_api.py::TestCloudCommandsApi::test_managed_slot_wake_hydrates_environment_from_runtime_access -q --durations=20
- uv --directory server run ruff check proliferate/ tests/
- uv --directory server run ruff format --check proliferate/ tests/
