### PR TITLE
fix(server): format runtime config service

### DIFF
--- a/server/proliferate/server/cloud/runtime_config/service.py
+++ b/server/proliferate/server/cloud/runtime_config/service.py
@@ -185,11 +185,7 @@ async def desktop_runtime_config_apply_request(
             status_code=409,
         )
     target = await targets_store.get_target_by_id(db, resolved_target_id)
-    if (
-        target is None
-        or target.sandbox_profile_id != profile.id
-        or target.archived_at is not None
-    ):
+    if target is None or target.sandbox_profile_id != profile.id or target.archived_at is not None:
         raise CloudApiError(
             "runtime_config_target_not_found",
             "Runtime config target was not found for this sandbox profile.",


### PR DESCRIPTION
## Summary
- format `runtime_config/service.py` so Server CI ruff format passes on latest main

## Verification
- uv --directory server run ruff check proliferate/ tests/
- uv --directory server run ruff format --check proliferate/ tests/
