### PR TITLE
docs(structures): add worker and supervisor structure guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,24 @@ at the start of the task, not halfway through implementation.
 
 1. `docs/structures/server/README.md`
 
-### AnyHarness Runtime (`anyharness/crates/**`)
+### Proliferate Worker (`anyharness/crates/proliferate-worker/**`)
+
+1. `docs/structures/proliferate-worker/README.md`
+
+### Proliferate Supervisor (`anyharness/crates/proliferate-supervisor/**`)
+
+1. `docs/structures/proliferate-supervisor/README.md`
+2. `install/README.md` when changing SSH installer config, service generation,
+   target install layout, or target smoke-test behavior.
+3. `docs/structures/server/README.md` when changing managed-cloud bootstrap
+   code that writes supervisor config or launches supervisor.
+
+### AnyHarness Runtime
+
+Applies to `anyharness/crates/anyharness/**`,
+`anyharness/crates/anyharness-lib/**`,
+`anyharness/crates/anyharness-contract/**`, and
+`anyharness/crates/anyharness-credential-discovery/**`.
 
 1. `docs/structures/anyharness/README.md`
 2. The focused guide under `docs/structures/anyharness/guides/**` for the layer being

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ migration exception and state the canonical owner/rule directly.
 
 | Folder | Owns | Start here |
 | --- | --- | --- |
-| `docs/structures/` | Folder decomposition, dependency direction, ownership rules, and code maps for each major system. | `docs/structures/frontend/README.md`, `docs/structures/anyharness/README.md`, `docs/structures/proliferate-worker/README.md`, `docs/structures/server/README.md`, `docs/structures/desktop-native/README.md`, `docs/structures/sdk/README.md` |
+| `docs/structures/` | Folder decomposition, dependency direction, ownership rules, and code maps for each major system. | `docs/structures/frontend/README.md`, `docs/structures/anyharness/README.md`, `docs/structures/proliferate-worker/README.md`, `docs/structures/proliferate-supervisor/README.md`, `docs/structures/server/README.md`, `docs/structures/desktop-native/README.md`, `docs/structures/sdk/README.md` |
 | `docs/primitives/` | Reusable product/runtime concepts: sandbox provisioning, workspace lifecycle, MCP/skills, agent auth, cloud commands, claiming, billing, model catalog, and related low-level contracts. | Read the primitive that owns the tables, command contracts, or runtime behavior you are changing. |
 | `docs/features/` | Product workflows and surfaces built from primitives: onboarding, automations, Slack, dispatch, chat surfaces, workspace files, product MCPs, and settings/admin IA. | Read the feature spec for the user-facing workflow being changed, plus any primitive it depends on. |
 | `docs/dev/` | How to run, verify, release, deploy, observe, and operate the repo. | `docs/dev/README.md`, `docs/dev/running-locally.md`, `docs/dev/ci-cd.md`, `docs/dev/reference/env-vars.yaml` |
@@ -41,7 +41,8 @@ migration exception and state the canonical owner/rule directly.
 | Frontend apps and shared packages | `docs/structures/frontend/README.md`; focused guides under `docs/structures/frontend/guides/`; shared package rules in `docs/structures/frontend/packages/README.md`; feature specs under `docs/features/` |
 | Desktop native / Tauri | `docs/structures/desktop-native/README.md`; sidecar and agent seed specs under `docs/structures/desktop-native/specs/` |
 | AnyHarness runtime | `docs/structures/anyharness/README.md`; guides under `docs/structures/anyharness/guides/`; contract in `docs/structures/anyharness/contract.md`; active runtime specs under `docs/structures/anyharness/specs/` |
-| Proliferate Worker | `docs/structures/proliferate-worker/README.md` |
+| Proliferate Worker | `docs/structures/proliferate-worker/README.md`; focused guides under `docs/structures/proliferate-worker/guides/` |
+| Proliferate Supervisor | `docs/structures/proliferate-supervisor/README.md` |
 | Server | `docs/structures/server/README.md`; focused guides under `docs/structures/server/guides/` |
 | AnyHarness SDKs | `docs/structures/sdk/README.md` |
 | Cloud provisioning, commands, auth, MCPs, billing, claiming | `docs/primitives/` |

--- a/docs/structures/proliferate-supervisor/README.md
+++ b/docs/structures/proliferate-supervisor/README.md
@@ -1,0 +1,233 @@
+# Proliferate Supervisor Structure
+
+Status: target standard for `proliferate-supervisor` code.
+
+## Scope
+
+These standards apply to the target-side Supervisor binary:
+
+- `anyharness/crates/proliferate-supervisor/**`
+
+This document defines Supervisor source structure and ownership rules. It does
+not own server-side managed-cloud bootstrap, SSH installer behavior, Worker
+command delivery, or AnyHarness runtime internals. Read the owning docs for
+those areas when changing those boundaries:
+
+- `docs/structures/server/README.md` for managed-cloud bootstrap code under
+  `server/**`
+- `install/README.md` for SSH target installer behavior
+- `docs/structures/proliferate-worker/README.md` for target Worker behavior
+- `docs/structures/anyharness/README.md` for AnyHarness runtime behavior
+
+## Goal
+
+Supervisor exists to make a Proliferate target boring to operate. Once a target
+has the runtime bundle, one local process should own the lifecycle of the two
+long-lived child processes:
+
+```text
+proliferate-supervisor
+  starts and restarts:
+    anyharness
+    proliferate-worker
+```
+
+The explicit goals are:
+
+- make target process lifecycle predictable
+- keep Worker focused on Cloud transport and command delivery
+- keep AnyHarness focused on runtime execution
+- keep Cloud and installers responsible for provisioning/configuration, not
+  child-process supervision
+- keep update staging local, narrow, verifiable, and separate from rollout
+  policy
+
+Supervisor is not Cloud, not Worker, and not AnyHarness.
+
+## Target Shape
+
+```text
+src/
+  main.rs
+  config.rs
+  error.rs
+  logging.rs
+  observability.rs
+
+  process/
+    mod.rs
+    child.rs
+    health.rs
+    restart.rs
+
+  install/
+    mod.rs
+    layout.rs
+    service.rs
+
+  update/
+    mod.rs
+    manifest.rs
+    staging.rs
+    rollback.rs
+```
+
+Do not create empty folders. Introduce a file or folder only when it has real
+responsibility to own.
+
+## What Goes Where
+
+Use the lowest layer that can own the logic cleanly.
+
+| Area | Path | Owns | Must Not Own |
+| --- | --- | --- | --- |
+| CLI entry | `src/main.rs` | CLI parsing, command dispatch, top-level error capture, and invoking the owning module. | Process lifecycle logic, update artifact mechanics, config schema policy, Cloud or AnyHarness semantics. |
+| Config | `src/config.rs` | `SupervisorConfig`, TOML load/parse, default config path, and default restart/argument values. | Server bootstrap config generation, installer env validation, runtime execution policy. |
+| Process lifecycle | `src/process/**` | Starting AnyHarness, starting Worker, restart timing, child process kill/wait behavior, and upgrade-window hooks. | Cloud command semantics, AnyHarness session/workspace behavior, binary download/swap, target enrollment. |
+| Child spawning | `src/process/child.rs` | Focused child process spawn wrapper and env injection. | Restart loops or command-specific process behavior. |
+| Restart policy | `src/process/restart.rs` | Boring restart delay/backoff helpers. | Product policy or target availability decisions. |
+| Process health hooks | `src/process/health.rs` | Narrow process-lifecycle health gates such as upgrade-window checks. | AnyHarness `/health` interpretation, Worker heartbeat status, Cloud target state. |
+| Install helpers | `src/install/**` | Supervisor-owned install layout helpers and systemd unit rendering. | Full SSH installer flow, binary download, enrollment token handling, Cloud API calls. |
+| Update manifest | `src/update/manifest.rs` | Manifest parsing, supported component validation, artifact lookup, size checks, and checksum verification. | Rollout policy, desired-version reconciliation, binary replacement. |
+| Update staging | `src/update/staging.rs` | Verified artifact staging, private permissions, atomic write/rename, and parent directory sync. | Downloading artifacts, applying swaps, restarting children after swaps. |
+| Rollback data | `src/update/rollback.rs` | Rollback plan data shapes when needed by update mechanics. | Production rollout orchestration or Worker/Cloud status policy. |
+| Logging | `src/logging.rs` | Tracing/Sentry initialization and target-safe event scrubbing. | Product analytics, Cloud status, command correlation policy outside Supervisor logs. |
+| Observability | `src/observability.rs` | Small semantic log helpers for Supervisor-owned events. | Broad telemetry pipelines or target inventory reporting. |
+| Errors | `src/error.rs` | `SupervisorError` variants for Supervisor-owned failures. | Worker, Cloud, AnyHarness, or installer error domains. |
+
+## Core Workflow
+
+The main `run` workflow lives in `src/process/mod.rs`.
+
+```text
+load SupervisorConfig
+
+loop:
+  spawn AnyHarness with configured args/env
+
+  loop:
+    spawn Worker with:
+      --config <worker_config>
+      PROLIFERATE_SUPERVISOR_VERSION=<supervisor version>
+
+    if AnyHarness exits:
+      kill Worker
+      wait for Worker
+      restart both
+
+    if Worker exits:
+      wait restart delay
+      restart Worker
+
+  wait restart delay
+```
+
+This is the core Supervisor primitive. Keep it legible.
+
+## Boundary Model
+
+```text
+Server / SSH installer
+  writes worker config
+  writes supervisor config
+  launches supervisor
+
+Supervisor
+  starts/restarts AnyHarness and Worker
+  injects configured env into children
+  verifies/stages update artifacts
+
+Worker
+  enrolls target with Cloud
+  heartbeats component versions/status
+  leases Cloud commands
+  writes narrow desired-update mailbox requests
+
+AnyHarness
+  owns target-local runtime execution:
+  workspaces, sessions, transcripts, agents, MCP, files, git, terminals
+```
+
+Supervisor should know paths, binaries, env, child exits, restart delay, and
+update artifacts. It should not know product workflows.
+
+## Hard Rules
+
+- `main.rs` stays a thin CLI and command dispatcher.
+- `process/**` owns child lifecycle only. It must not call Cloud APIs,
+  AnyHarness HTTP APIs, or Worker internals.
+- Supervisor starts Worker; Worker talks to Cloud. Do not add a Cloud client
+  to Supervisor.
+- Supervisor starts AnyHarness; AnyHarness owns runtime semantics. Do not add
+  session, workspace, agent, MCP, file, git, or terminal behavior to
+  Supervisor.
+- Supervisor may stage and verify update artifacts. It must not own desired
+  version policy, update admission, billing, target selection, or Cloud status
+  policy.
+- Update artifact identifiers must remain path-safe. Components stay limited
+  to `anyharness`, `worker`, and `supervisor`.
+- Staged update files and update directories must use private permissions.
+- Child processes must be killed/waited in the same lifecycle boundary that
+  spawned them.
+- Environment passed to children must be explicit and config-driven. Do not
+  silently inherit new credential or product env.
+- Keep module names concrete. Do not add `utils.rs`, `helpers.rs`, or
+  `misc.rs`.
+
+## Dependency Direction
+
+Preferred direction:
+
+```text
+main -> config / process / install / update / logging / observability
+
+process -> config / error
+process -> process/child
+process -> process/restart
+process -> process/health
+
+install -> config / install/layout
+update -> error
+observability -> update/staging
+logging -> no product modules
+```
+
+Forbidden direction:
+
+```text
+Supervisor -> server/**
+Supervisor -> proliferate-worker internals
+Supervisor -> anyharness-lib runtime internals
+Supervisor -> cloud SDK/client code
+```
+
+If a dependency feels awkward, keep the boundary narrow by passing paths,
+args, env, or manifest data in through config or CLI arguments.
+
+## Change Discipline
+
+- Preserve the simple process model unless the task explicitly changes target
+  lifecycle behavior.
+- When changing runtime bundle layout, check server bootstrap, SSH installer,
+  release/template scripts, and smoke tests together.
+- When changing config schema, update both managed-cloud config generation and
+  SSH installer config generation.
+- When changing update staging or manifest validation, add focused Rust tests
+  for path safety, checksum/size rejection, and permission behavior.
+- When splitting files, split by responsibility first and preserve behavior.
+- Keep Supervisor docs focused on Supervisor. Link to Worker, Server,
+  Installer, and AnyHarness docs instead of copying their rules here.
+
+## Review Checklist
+
+- Can I tell from the path whether this is CLI, config, child lifecycle,
+  install rendering, update verification/staging, logging, or errors?
+- Did process lifecycle stay independent from Cloud command semantics?
+- Did Supervisor avoid AnyHarness runtime behavior?
+- Did Supervisor avoid Worker command/event/status logic?
+- Are child env vars explicit and intentional?
+- Are update artifact identifiers and staged paths path-safe?
+- Are staged update permissions private?
+- Did config schema changes update every config writer?
+- Did runtime bundle changes check SSH, managed cloud, release, and smoke
+  paths together?

--- a/docs/structures/proliferate-worker/README.md
+++ b/docs/structures/proliferate-worker/README.md
@@ -1,24 +1,17 @@
-# Proliferate Worker Structure
+# Proliferate Worker Standards
 
-Status: target standard for `proliferate-worker` code.
+Status: authoritative for `anyharness/crates/proliferate-worker/**`.
 
-Scope:
+## Scope
+
+These standards apply to the target-side Proliferate Worker binary:
 
 - `anyharness/crates/proliferate-worker/**`
 
-This document defines the intended source structure and ownership rules for the
-target-side Proliferate Worker binary. Existing code may still be migrating
-toward this shape, but new code should follow this structure.
-
-## Purpose
-
 Proliferate Worker is the target-side bridge between Proliferate Cloud and the
-local AnyHarness runtime.
-
-The worker exists because Cloud-mediated clients often cannot call a target
-directly. The worker runs on the target, connects outbound to Cloud, leases
-commands, calls local AnyHarness or performs target-local preparation, and
-uploads results, status, inventory, and runtime events back to Cloud.
+local AnyHarness runtime. It runs on the target, connects outbound to Cloud,
+leases commands, calls local AnyHarness or performs target-local preparation,
+and uploads results, status, inventory, and runtime events back to Cloud.
 
 The worker is not Cloud, not AnyHarness, and not supervisor.
 
@@ -32,6 +25,154 @@ AnyHarness -> Worker -> Cloud
 target -> Worker -> Cloud
   target status
 ```
+
+## Goal
+
+The worker is organized into distinct folders for process composition, Cloud
+command delivery, AnyHarness event uplink, target health reporting, target-local
+effects, raw clients, local durability, identity, and root support files.
+
+The explicit goals are:
+
+- make the two bridge directions obvious from the path
+- keep loops boring and keep workflow semantics in the owning folder
+- separate raw HTTP access from Worker-owned command, event, and target logic
+- keep target-local filesystem/Git/auth effects out of Cloud and AnyHarness
+  clients
+- make restart recovery, idempotency, stale-slot checks, and cursor durability
+  visible instead of incidental
+
+A file path should tell a developer whether the code is downlink, uplink,
+target status, target-local effect, client access, store persistence, identity,
+or runtime composition before they open the file.
+
+## Target Shape
+
+Existing code that violates this shape is a migration exception, not precedent.
+Do not create empty folders; add a file or folder when it has real
+responsibility to own.
+
+```text
+src/
+  main.rs
+
+  runtime/
+    mod.rs
+    context.rs
+    tasks.rs
+    shutdown.rs
+
+  command_downlink/
+    mod.rs
+    loop.rs
+    lease_state.rs
+    catalog.rs
+    processor.rs
+    mapping.rs
+    anyharness_dispatch.rs
+    reporting.rs
+    idempotency.rs
+    stale_slot.rs
+    handlers/
+
+  event_uplink/
+    mod.rs
+    loop.rs
+    exposures.rs
+    cursors.rs
+    discovery.rs
+    tailer.rs
+    event_mapping.rs
+    gaps.rs
+    backfill.rs
+
+  target_status/
+    mod.rs
+    loop.rs
+    health.rs
+    heartbeat.rs
+    inventory_report.rs
+    update_observation.rs
+
+  target/
+    mod.rs
+    materialization/
+      mod.rs
+    inventory/
+      mod.rs
+    updates/
+      mod.rs
+
+  clients/
+    mod.rs
+    cloud/
+    anyharness/
+
+  store/
+    mod.rs
+    connection.rs
+    migrations.rs
+    identity.rs
+    pending_command_results.rs
+    projection_cursors.rs
+    workspace_mappings.rs
+    workspace_discovery.rs
+
+  identity/
+    mod.rs
+    enrollment.rs
+    credentials.rs
+    fingerprint.rs
+
+  config.rs
+  error.rs
+  logging.rs
+  observability.rs
+  versions.rs
+```
+
+## What Goes Where
+
+Use the lowest layer that can own the logic cleanly.
+
+| Area | Path | Owns | Must Not Own | Canon |
+| --- | --- | --- | --- | --- |
+| Process entry | `src/main.rs` | CLI/config entry, logging bootstrap, and call into `runtime::run`. | Worker workflows or subsystem policy. | This doc, [guides/runtime.md](guides/runtime.md) |
+| Runtime | `src/runtime/**` | Process composition, shared context construction, task spawning, task joins, and shutdown. | Command kinds, event cursors, heartbeat payload semantics, target materialization, raw workflow logic. | [guides/runtime.md](guides/runtime.md) |
+| Command downlink | `src/command_downlink/**` | Cloud command lease polling, supported-kind policy, one-command lifecycle, AnyHarness dispatch mapping, custom handlers, delivery/result reporting, idempotency, stale-slot checks. | Cloud authorization, exposure policy, event tailing, target inventory, raw HTTP implementation, supervisor update application. | [guides/command-downlink.md](guides/command-downlink.md) |
+| Event uplink | `src/event_uplink/**` | Cloud exposure interpretation, local event cursors, AnyHarness event tailing, gap detection, event mapping, backfill, Cloud batch upload, ack application. | Exposure policy, Cloud projection persistence, transcript reconstruction, AnyHarness mutation, command delivery. | [guides/event-uplink.md](guides/event-uplink.md) |
+| Target status | `src/target_status/**` | Target health/status loop, AnyHarness health probe summaries, heartbeat payloads, inventory upload orchestration, desired-version observation. | Applying updates, target materialization, command processing, Cloud policy. | [guides/target-status.md](guides/target-status.md) |
+| Target-local effects | `src/target/**` | Filesystem/Git/env/auth/runtime-config materialization, local inventory inspection, capability inspection, supervisor update mailbox writing. | Raw Cloud HTTP, Cloud policy, AnyHarness execution semantics, supervisor process management. | [guides/target.md](guides/target.md) |
+| Clients | `src/clients/**` | Raw Worker-facing Cloud HTTP endpoints, local AnyHarness HTTP endpoints, request/response wire types, auth headers, status parsing. | Product workflows, retry loops beyond request mechanics, store writes, filesystem effects. | [guides/clients.md](guides/clients.md) |
+| Store | `src/store/**` | Worker-local SQLite, migrations, identity row access, pending command results, event cursors, workspace/session mapping caches, discovery throttles. | Cloud/AnyHarness HTTP, command processing, event uplink workflows, product authorization, service-layer reconciliation. | [guides/store.md](guides/store.md) |
+| Identity | `src/identity/**` | Enrollment, durable Worker identity, credential load/save coordination, fingerprint and hostname hints. | Heartbeat scheduling, command leasing, supported-kind policy, AnyHarness auth behavior, target inventory. | [guides/identity.md](guides/identity.md) |
+| Root support files | `src/config.rs`, `src/error.rs`, `src/logging.rs`, `src/observability.rs`, `src/versions.rs` | Cross-cutting support that is small, boring, and not a subsystem. | Workflows, generic utilities, hidden service layers. | [guides/root-support.md](guides/root-support.md) |
+
+## Read Order
+
+Always start here. Then read the focused guide for the folder being changed:
+
+- [guides/runtime.md](guides/runtime.md)
+- [guides/command-downlink.md](guides/command-downlink.md)
+- [guides/event-uplink.md](guides/event-uplink.md)
+- [guides/target-status.md](guides/target-status.md)
+- [guides/target.md](guides/target.md)
+- [guides/clients.md](guides/clients.md)
+- [guides/store.md](guides/store.md)
+- [guides/identity.md](guides/identity.md)
+- [guides/root-support.md](guides/root-support.md)
+
+When behavior crosses Worker boundaries, also read the primitive or system doc
+that owns the external contract:
+
+- Cloud commands: `docs/primitives/cloud-commands.md`
+- Sandbox provisioning: `docs/primitives/sandbox-provisioning.md`
+- Workspace lifecycle: `docs/primitives/workspace-lifecycle.md`
+- Agent auth: `docs/primitives/agent-auth.md`
+- MCPs and skills: `docs/primitives/mcp-runtime.md` and
+  `docs/primitives/mcp-skills.md`
+- Server control plane: `docs/structures/server/README.md`
+- AnyHarness runtime: `docs/structures/anyharness/README.md`
 
 ## Ownership Boundaries
 
@@ -60,6 +201,9 @@ Supervisor owns:
 - restart behavior
 - applying update requests
 
+Supervisor structure rules live in
+`docs/structures/proliferate-supervisor/README.md`.
+
 Worker owns:
 
 - outbound Cloud communication from the target
@@ -71,600 +215,6 @@ Worker owns:
   mappings
 - writing a narrow supervisor update-request mailbox when Cloud desired
   versions differ from installed versions
-
-Worker must not own:
-
-- Cloud authorization or exposure policy
-- AnyHarness execution truth or transcript reconstruction
-- direct mutation of AnyHarness SQLite
-- supervisor install, restart, rollback, or binary replacement
-- broad bidirectional state sync
-
-## Target Source Shape
-
-```text
-src/
-  main.rs
-
-  runtime/
-    mod.rs
-    context.rs
-    tasks.rs
-    shutdown.rs
-
-  command_downlink/
-    loop.rs
-    lease_state.rs
-    catalog.rs
-    processor.rs
-    mapping.rs
-    anyharness_dispatch.rs
-    reporting.rs
-    idempotency.rs
-    stale_slot.rs
-    handlers/
-      git_identity.rs
-      repo_checkout.rs
-      environment.rs
-      agent_auth.rs
-      runtime_config.rs
-      pruning.rs
-      backfill.rs
-
-  event_uplink/
-    loop.rs
-    exposures.rs
-    projection_cursors.rs
-    discovery.rs
-    tailer.rs
-    event_mapping.rs
-    gaps.rs
-    backfill.rs
-
-  target_status/
-    loop.rs
-    health.rs
-    heartbeat.rs
-    inventory_report.rs
-    update_observation.rs
-
-  target/
-    materialization/
-      mod.rs
-      paths.rs
-      files.rs
-      env.rs
-      git.rs
-      git_identity.rs
-      repo_checkout.rs
-      runtime_config.rs
-      agent_auth.rs
-      manifest.rs
-
-    inventory/
-      mod.rs
-      platform.rs
-      versions.rs
-      capabilities.rs
-      providers.rs
-      mcp.rs
-
-    updates/
-      desired_versions.rs
-      supervisor_mailbox.rs
-      status.rs
-
-  clients/
-    cloud/
-    anyharness/
-
-  store/
-    mod.rs
-    connection.rs
-    migrations.rs
-    identity.rs
-    pending_command_results.rs
-    projection_cursors.rs
-    workspace_mappings.rs
-    workspace_discovery.rs
-
-  identity/
-    enrollment.rs
-    credentials.rs
-    fingerprint.rs
-
-  config.rs
-  error.rs
-  logging.rs
-  observability.rs
-  versions.rs
-```
-
-Do not create empty folders. Introduce a file or folder when it has real
-responsibility to own.
-
-## Runtime
-
-`runtime/` owns process composition and lifecycle.
-
-High-level goal:
-
-```text
-initialize -> build shared context -> start named flows -> coordinate shutdown
-```
-
-Files:
-
-- `runtime/mod.rs`: top-level `run(config, once)` orchestration.
-- `runtime/context.rs`: shared `WorkerContext` containing config, store,
-  clients, identity, and static process metadata.
-- `runtime/tasks.rs`: named task spawning and task join behavior.
-- `runtime/shutdown.rs`: cancellation, signal handling, graceful drain, and
-  clean exit coordination.
-
-Allowed:
-
-- opening the store
-- building clients
-- ensuring worker identity
-- creating shared context
-- starting `command_downlink`, `event_uplink`, `target_status`, and other named
-  loops
-- coordinating shutdown and final drains
-
-Banned:
-
-- command kind logic
-- event cursor mechanics
-- target materialization details
-- Cloud command result shaping
-- AnyHarness payload mapping
-- heartbeat payload semantics beyond delegating to `target_status`
-
-`runtime/` may know every subsystem exists. It should not implement those
-subsystems.
-
-## Command Downlink
-
-`command_downlink/` owns the Cloud command delivery path.
-
-```text
-Cloud command queue
-  -> worker lease
-  -> command processor
-  -> target-local handler or AnyHarness dispatch
-  -> Cloud delivery/result report
-```
-
-### Files
-
-- `command_downlink/loop.rs`: long-running lease loop. Flushes pending results,
-  builds lease state, leases one command from Cloud, passes it to the processor,
-  and sleeps/backoffs.
-- `command_downlink/lease_state.rs`: builds a snapshot of what this worker can
-  currently handle, such as AnyHarness configured, AnyHarness healthy,
-  materialization root available, slot current, and worker version.
-- `command_downlink/catalog.rs`: canonical command names, command categories,
-  and requirements. Pure policy over command specs.
-- `command_downlink/processor.rs`: one-command lifecycle. Validates context,
-  classifies the command, calls the right handler or generic AnyHarness path,
-  coordinates delivery and final result reporting.
-- `command_downlink/mapping.rs`: pure Cloud command envelope to internal
-  `AnyHarnessCommand` mapping for commands that use the generic AnyHarness
-  path.
-- `command_downlink/anyharness_dispatch.rs`: internal `AnyHarnessCommand` to
-  local AnyHarness HTTP call.
-- `command_downlink/reporting.rs`: Cloud delivery reports, terminal result
-  reports, failure classification, safe result payload shaping, and
-  pending-result retry.
-- `command_downlink/idempotency.rs`: duplicate lease, crash recovery, and safe
-  retry rules once they become non-trivial.
-- `command_downlink/stale_slot.rs`: worker-side stale sandbox/profile/slot
-  checks once they become non-trivial.
-- `command_downlink/handlers/**`: command kinds that need Worker-owned behavior
-  beyond simple AnyHarness mapping and dispatch.
-
-### Lease State And Supported Kinds
-
-The command lease loop asks Cloud for a command the worker can currently
-handle. It sends Cloud a list of supported command kinds in the lease request.
-
-That list is not Cloud policy. It is worker capability policy.
-
-Examples:
-
-```text
-AnyHarness healthy
-  Worker can lease AnyHarness-backed commands such as send_prompt,
-  start_session, cancel_turn, close_session, materialize_workspace, and
-  backfill_exposed_workspace.
-
-AnyHarness missing or unhealthy
-  Worker should lease only target-local materialization commands that do not
-  need AnyHarness, such as configure_git_identity, ensure_repo_checkout, and
-  materialize_environment.
-```
-
-`lease_state.rs` builds the current state snapshot. `catalog.rs` decides which
-command specs are satisfied by that state.
-
-### Processor
-
-`processor.rs` is the canonical place to understand one-command deliverability.
-
-It owns this lifecycle:
-
-```text
-leased Cloud command
-  -> validate lease and slot context
-  -> classify command kind
-  -> enforce requirements from catalog
-  -> call custom handler if needed
-  -> otherwise map to AnyHarnessCommand
-  -> report delivery when appropriate
-  -> dispatch to AnyHarness when appropriate
-  -> classify handler or AnyHarness response
-  -> save pending result before Cloud upload
-  -> report terminal result to Cloud
-  -> clear pending result after successful upload
-```
-
-Do not bury this pipeline in the lease loop or in a command-family handler.
-
-### Generic AnyHarness Path
-
-Many commands should not have a custom handler. If a command is simply:
-
-```text
-Cloud payload -> AnyHarness request -> Cloud result
-```
-
-it should use:
-
-```text
-mapping.rs -> anyharness_dispatch.rs -> reporting.rs
-```
-
-Examples:
-
-- `send_prompt`
-- `resolve_interaction`
-- `update_session_config`
-- `cancel_turn`
-- `close_session`
-
-Add a custom handler only when the command has Worker-owned target effects,
-special Cloud status reporting, cross-boundary orchestration, or command-family
-logic that does not belong in the generic path.
-
-### Handlers
-
-Handlers own command-family-specific behavior.
-
-- `handlers/git_identity.rs`: `configure_git_identity`. Fetch Cloud material
-  and write target-local Git credential/config.
-- `handlers/repo_checkout.rs`: `ensure_repo_checkout`. Clone/fetch/verify repo
-  checkout on the target.
-- `handlers/environment.rs`: `materialize_environment`. Fetch target config
-  plan, write env/files/config, and coordinate runtime config apply if needed.
-- `handlers/agent_auth.rs`: `refresh_agent_auth_config`. Fetch agent auth plan,
-  materialize gateway/synced-file auth, call AnyHarness apply endpoint, and
-  report agent auth status.
-- `handlers/runtime_config.rs`: runtime config apply orchestration when it grows
-  large enough to split from environment handling.
-- `handlers/pruning.rs`: `prune_workspace_worktree`. Call AnyHarness
-  retire/cleanup APIs and report Cloud workspace materialization state.
-- `handlers/backfill.rs`: command entry for `backfill_exposed_workspace`.
-  Delegates actual backfill mechanics to `event_uplink/backfill.rs`.
-
-Avoid `handlers/materialization.rs`; it collides with `target/materialization/`
-and hides which command family is being handled.
-
-## Event Uplink
-
-`event_uplink/` owns the AnyHarness-to-Cloud runtime event path.
-
-```text
-AnyHarness events / snapshots
-  -> Worker event uplink
-  -> Cloud ingest / projection read models
-```
-
-Use `event_uplink`, not `sync`. Worker does not own broad bidirectional sync.
-Cloud owns projection read models; Worker owns the uplink mechanics that feed
-them.
-
-Files:
-
-- `event_uplink/loop.rs`: long-running event uplink loop. Probes AnyHarness,
-  runs one uplink pass, sleeps/backoffs, and observes shutdown.
-- `event_uplink/exposures.rs`: fetches and interprets Cloud exposure snapshots
-  for this worker.
-- `event_uplink/projection_cursors.rs`: reconciles Cloud exposure snapshots
-  into local projection cursors.
-- `event_uplink/discovery.rs`: discovers sessions inside exposed workspaces
-  and triggers backfill when Cloud is missing session mappings.
-- `event_uplink/tailer.rs`: tails AnyHarness session events after local cursor
-  sequence.
-- `event_uplink/event_mapping.rs`: maps AnyHarness event envelopes into worker
-  event batch payloads for Cloud.
-- `event_uplink/gaps.rs`: detects sequence gaps, reports them to Cloud, and
-  marks local cursors paused when needed.
-- `event_uplink/backfill.rs`: builds and uploads bounded workspace/session
-  snapshots for exposed work.
-
-Allowed:
-
-- reading Cloud exposure/projection inputs
-- maintaining local projection cursors
-- reading AnyHarness events and snapshots
-- uploading event batches and backfill batches to Cloud
-- applying Cloud event acknowledgements to local cursors
-
-Banned:
-
-- deciding exposure policy
-- owning Cloud projection read model persistence
-- reconstructing transcript truth
-- mutating AnyHarness state
-- command delivery
-
-## Target Status
-
-`target_status/` owns the target health and status reporting flow.
-
-```text
-target / AnyHarness / versions
-  -> Worker status loop
-  -> Cloud heartbeat, inventory, desired-version status
-```
-
-Files:
-
-- `target_status/loop.rs`: recurring status loop. Sleeps on the heartbeat
-  interval, probes health, sends heartbeat/status, observes desired versions,
-  and handles shutdown.
-- `target_status/health.rs`: health probes and health summaries, especially
-  AnyHarness availability.
-- `target_status/heartbeat.rs`: Cloud heartbeat request construction and
-  response interpretation.
-- `target_status/inventory_report.rs`: target inventory upload orchestration.
-- `target_status/update_observation.rs`: desired-version observation and
-  delegation to `target/updates`.
-
-`target_status/` may report update status, but it must not apply updates.
-Applying updates belongs to supervisor.
-
-## Target
-
-`target/` owns target-local facts and effects.
-
-It can inspect the target and write target-local files. It should not call raw
-Cloud endpoints or decide Cloud product policy.
-
-### Target Materialization
-
-`target/materialization/` owns target-local preparation work.
-
-Files:
-
-- `paths.rs`: allowed-root checks, home expansion, symlink traversal defense,
-  path normalization, and path safety.
-- `files.rs`: atomic/private file writes, directory creation, permissions, and
-  common file helpers.
-- `env.rs`: environment file materialization.
-- `git.rs`: focused Git helpers.
-- `git_identity.rs`: target-scoped Git credential/config materialization.
-- `repo_checkout.rs`: clone/fetch/checkout and repo identity validation.
-- `runtime_config.rs`: runtime config projection files, artifact integrity
-  checks, and credential reference helpers.
-- `agent_auth.rs`: target-local agent auth synced-file and gateway config
-  materialization helpers.
-- `manifest.rs`: `.proliferate/**` manifest writing.
-
-Allowed:
-
-- filesystem writes under allowed roots
-- Git operations required for checkout/bootstrap
-- local credential file writes approved by Cloud-provided plans
-- artifact/hash validation
-- target-local manifest generation
-
-Banned:
-
-- Cloud materialization plan creation
-- Cloud authorization decisions
-- raw Cloud HTTP calls
-- AnyHarness execution semantics
-- supervisor process management
-
-### Target Inventory
-
-`target/inventory/` owns local facts about the machine.
-
-Files:
-
-- `platform.rs`: OS, arch, distro, shell.
-- `versions.rs`: local tool version probes.
-- `capabilities.rs`: local capability facts.
-- `providers.rs`: agent/provider readiness facts.
-- `mcp.rs`: local MCP capability facts.
-
-Inventory code should be read-only. It should not mutate target state.
-
-### Target Updates
-
-`target/updates/` owns the worker side of desired-version observation.
-
-Files:
-
-- `desired_versions.rs`: compare Cloud desired versions with observed installed
-  versions.
-- `supervisor_mailbox.rs`: write and clear supervisor update request files.
-- `status.rs`: construct worker update status reports.
-
-Allowed:
-
-- compare desired and installed versions
-- write a narrow supervisor mailbox request
-- report staged/failed status through callers
-
-Banned:
-
-- downloading binaries
-- replacing binaries
-- restarting processes
-- rollback
-- supervisor lifecycle decisions
-
-## Clients
-
-`clients/` owns raw HTTP access boundaries.
-
-Clients are not services. They do not own product workflows.
-
-### Cloud Client
-
-`clients/cloud/` owns worker-facing Cloud HTTP endpoints and wire types.
-
-Examples:
-
-- enrollment
-- heartbeat
-- inventory upload
-- command lease/delivery/result
-- exposure listing
-- event batch upload
-- backfill upload
-- target config materialization fetch
-- target Git identity materialization fetch
-- agent auth materialization fetch/status
-- revoked-token listing
-- update status
-
-### AnyHarness Client
-
-`clients/anyharness/` owns local AnyHarness HTTP endpoints and wire types.
-
-Examples:
-
-- health/version probe
-- workspace resolve/worktree/retire APIs
-- session start/prompt/config/cancel/close APIs
-- interaction resolution APIs
-- event listing
-- backfill snapshot
-- runtime config apply
-- agent auth config apply
-
-Allowed in clients:
-
-- URL construction
-- auth headers
-- request/response structs
-- HTTP status parsing
-- small wire compatibility shims
-
-Banned in clients:
-
-- command lifecycle
-- retry loops beyond focused request mechanics
-- filesystem effects
-- store writes
-- Cloud policy
-- AnyHarness execution semantics
-
-## Store
-
-`store/` owns worker-local SQLite and bridge durability.
-
-The worker store is not product truth. It exists so the bridge can recover from
-restarts and transient Cloud failures.
-
-Files:
-
-- `connection.rs`: SQLite connection setup, pragmas, busy timeout.
-- `migrations.rs`: worker DB schema creation and migration helpers.
-- `identity.rs`: persisted worker identity row.
-- `pending_command_results.rs`: command result retry records.
-- `projection_cursors.rs`: event uplink cursor state, ack state, and gap state.
-- `workspace_mappings.rs`: local AnyHarness workspace/session to Cloud mapping
-  cache.
-- `workspace_discovery.rs`: exposed-workspace discovery throttling.
-
-Allowed:
-
-- table-shaped CRUD
-- row mapping
-- local transactions
-- migration helpers
-
-Banned:
-
-- Cloud HTTP calls
-- AnyHarness HTTP calls
-- command processing workflows
-- event uplink workflows
-- product authorization
-- broad "reconcile everything" service methods
-
-Good store APIs are boring:
-
-```rust
-save_pending_command_result(...)
-list_pending_command_results(...)
-delete_pending_command_result(...)
-reconcile_projection_cursors(...)
-list_active_projection_cursors(...)
-update_projection_cursor_ack(...)
-upsert_workspace_mapping(...)
-```
-
-Bad store APIs hide workflows:
-
-```rust
-process_command_result(...)
-apply_projection_state(...)
-reconcile_everything_for_workspace(...)
-```
-
-## Identity
-
-`identity/` owns the worker's Cloud identity lifecycle.
-
-Files:
-
-- `enrollment.rs`: one-time enrollment token exchange and enroll request
-  construction.
-- `credentials.rs`: in-memory worker identity/credential shape and save/load
-  coordination.
-- `fingerprint.rs`: target machine fingerprint and hostname helpers.
-
-Persistence for the identity row belongs in `store/identity.rs`.
-
-Conceptual split:
-
-```text
-identity/
-  Cloud identity lifecycle
-
-store/identity.rs
-  SQLite persistence for the identity row
-```
-
-## Root Support Files
-
-Keep these boring support files at `src/` root unless they grow enough to earn
-a folder:
-
-- `config.rs`: worker config load, parse, sanitize, and private config writes.
-- `error.rs`: worker error enum and conversions.
-- `logging.rs`: tracing/Sentry/log initialization.
-- `observability.rs`: shared diagnostic helpers and correlation conventions.
-- `versions.rs`: worker, AnyHarness, and supervisor version helpers.
-
-Do not create an `infra/` folder unless root support files become a real source
-of clutter. `infra/` must not become a `utils/` bucket.
 
 ## Dependency Direction
 
@@ -699,20 +249,24 @@ identity -> store only through narrow save/load helpers
 When a dependency feels awkward, prefer moving a small DTO or pure helper to the
 owning boundary over importing across layers casually.
 
-## Naming Rules
+## Hard Rules
 
-- Use `command_downlink`, not generic `commands`, when naming the whole flow.
-- Use `event_uplink`, not `sync`, for AnyHarness-to-Cloud event/projection
-  feeding.
+- Worker must not own Cloud authorization or exposure policy.
+- Worker must not own AnyHarness execution truth or transcript reconstruction.
+- Worker must not mutate AnyHarness SQLite directly.
+- Worker must not own supervisor install, restart, rollback, or binary
+  replacement.
+- Worker must not implement broad bidirectional sync. Use `event_uplink`, not
+  `sync`, for AnyHarness-to-Cloud event/projection feeding.
+- Use `command_downlink`, not generic `commands`, for the Cloud-to-target
+  command flow.
 - Use `target/materialization` for filesystem/Git/env/auth local effects.
 - Do not use `handlers/materialization.rs`; name handlers by command family.
-- Do not add `utils.rs`, `helpers.rs`, or `misc.rs`.
-- Do not use broad "service" names unless the file owns a clearly named
-  workflow boundary.
+- Do not add `utils.rs`, `helpers.rs`, `misc.rs`, or broad service buckets.
+- Preserve current behavior unless an explicit behavior change is requested.
+- Delete dead code when replacing an implementation.
 
 ## Review Checklist
-
-Ask these before adding or moving Worker code:
 
 - Can I tell from the path whether this is command downlink, event uplink,
   target status, target-local effect, client access, store state, identity, or
@@ -727,9 +281,9 @@ Ask these before adding or moving Worker code:
 - Did Worker start owning Cloud auth/exposure policy?
 - Did Worker start owning AnyHarness execution or transcript truth?
 - Did Worker start owning supervisor update application?
-- Are stale-slot, idempotency, and pending-result recovery still visible?
+- Are stale-slot, idempotency, pending-result recovery, and event cursor
+  recovery still visible?
 - Do logs include the relevant correlation fields for the flow:
   `command_id`, `lease_id`, `target_id`, `worker_id`, `sandbox_profile_id`,
   `slot_generation`, `cloud_workspace_id`, `anyharness_workspace_id`,
   `session_id`, `session_projection_id`, and `exposure_id` when available?
-

--- a/docs/structures/proliferate-worker/guides/clients.md
+++ b/docs/structures/proliferate-worker/guides/clients.md
@@ -1,0 +1,87 @@
+# Worker Clients
+
+Status: authoritative for `anyharness/crates/proliferate-worker/src/clients/**`.
+
+`clients/` owns raw HTTP access boundaries. Clients are not services. They do
+not own product workflows.
+
+## Target Shape
+
+```text
+clients/
+  mod.rs
+  cloud/
+  anyharness/
+```
+
+## Cloud Client
+
+`clients/cloud/` owns Worker-facing Cloud HTTP endpoints and wire types.
+
+Examples:
+
+- enrollment
+- heartbeat
+- inventory upload
+- command lease/delivery/result
+- exposure listing
+- event batch upload
+- backfill upload
+- target config materialization fetch
+- target Git identity materialization fetch
+- agent auth materialization fetch/status
+- revoked-token listing
+- update status
+
+## AnyHarness Client
+
+`clients/anyharness/` owns local AnyHarness HTTP endpoints and wire types.
+
+Examples:
+
+- health/version probe
+- workspace resolve/worktree/retire APIs
+- session start/prompt/config/cancel/close APIs
+- interaction resolution APIs
+- event listing
+- backfill snapshot
+- runtime config apply
+- agent auth config apply
+
+## Allowed
+
+Clients may own:
+
+- base URL handling
+- auth headers
+- request/response structs
+- endpoint paths
+- HTTP method calls
+- HTTP status parsing
+- small wire compatibility shims
+
+## Banned
+
+Clients must not own:
+
+- command lifecycle
+- event cursor reconciliation
+- retry loops beyond focused request mechanics
+- filesystem effects
+- store writes
+- Cloud product policy
+- AnyHarness execution semantics
+- target materialization workflows
+
+## Hard Rules
+
+- If code decides what a command means, it belongs in `command_downlink`, not a
+  client.
+- If code decides what an event cursor means, it belongs in `event_uplink`, not
+  a client.
+- If code writes target-local files or runs Git, it belongs in `target`, not a
+  client.
+- If code persists Worker-local recovery state, it belongs in `store`, not a
+  client.
+- Generated wire types may be used when available, but the Worker client
+  remains a narrow explicit access layer.

--- a/docs/structures/proliferate-worker/guides/command-downlink.md
+++ b/docs/structures/proliferate-worker/guides/command-downlink.md
@@ -1,0 +1,201 @@
+# Worker Command Downlink
+
+Status: authoritative for
+`anyharness/crates/proliferate-worker/src/command_downlink/**`.
+
+`command_downlink/` owns the Cloud command delivery path.
+
+```text
+Cloud command queue
+  -> Worker lease
+  -> command processor
+  -> target-local handler or AnyHarness dispatch
+  -> Cloud delivery/result report
+```
+
+## Target Shape
+
+```text
+command_downlink/
+  mod.rs
+  loop.rs
+  lease_state.rs
+  catalog.rs
+  processor.rs
+  mapping.rs
+  anyharness_dispatch.rs
+  reporting.rs
+  idempotency.rs
+  stale_slot.rs
+  handlers/
+    git_identity.rs
+    repo_checkout.rs
+    environment.rs
+    agent_auth.rs
+    runtime_config.rs
+    pruning.rs
+    backfill.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Facade exposing `run_loop` and types needed by runtime/tests. | Command processing logic. |
+| `loop.rs` | Boring lease loop: flush pending results, build lease state, lease from Cloud, pass command to processor, sleep/backoff, honor shutdown. | Command-specific behavior. |
+| `lease_state.rs` | Per-pass local capability snapshot. | Command catalog policy or Cloud HTTP mechanics. |
+| `catalog.rs` | Canonical command names, categories, and requirements. | Cloud client code. |
+| `processor.rs` | One-command lifecycle and deliverability pipeline. | Family-specific target effects. |
+| `mapping.rs` | Pure Cloud command envelope to internal `AnyHarnessCommand` conversion. | HTTP, SQLite, Cloud reporting, target effects. |
+| `anyharness_dispatch.rs` | Internal `AnyHarnessCommand` to local AnyHarness HTTP call. | Command lifecycle policy. |
+| `reporting.rs` | Delivery/result reports, result shaping, pending-result save-before-send, retry, and cleanup. | Handler-specific target effects. |
+| `idempotency.rs` | Duplicate lease, crash recovery, and safe retry rules. | Generic result upload mechanics. |
+| `stale_slot.rs` | Worker-side stale sandbox/profile/slot checks and logging. | Cloud-side source-of-truth enforcement. |
+| `handlers/**` | Command-family behavior that needs Worker-owned target effects or cross-boundary orchestration. | Generic AnyHarness command mapping. |
+
+## Command Lifecycle
+
+```text
+lease request
+  -> Cloud marks command leased
+  -> Worker receives command envelope
+  -> processor validates/classifies command
+  -> Worker reports delivery when local delivery begins
+  -> custom handler or generic AnyHarness dispatch runs
+  -> Worker shapes accepted/rejected/failed result
+  -> Worker reports result to Cloud
+```
+
+Terms:
+
+- `lease`: Cloud reserves a command row for this worker.
+- `delivery`: Worker says it received the lease and started local delivery.
+- `result`: immediate local delivery outcome: accepted,
+  accepted-but-queued, rejected, or failed delivery.
+- `events`: runtime truth after acceptance. Agent progress and completion flow
+  through `event_uplink`, not command results.
+
+## Supported Kinds
+
+The lease loop tells Cloud which command kinds this worker can safely lease
+right now. This is Worker capability policy, not Cloud authorization policy.
+
+`lease_state.rs` builds the current state:
+
+- AnyHarness configured
+- AnyHarness healthy
+- materialization root configured
+- supervisor update mailbox available
+- slot identity present/current
+- worker version known
+- AnyHarness version known
+- provider/tooling readiness when supported by inventory
+
+`catalog.rs` maps that state to command support.
+
+Canonical command kinds:
+
+- `start_session`
+- `configure_git_identity`
+- `ensure_repo_checkout`
+- `materialize_workspace`
+- `prune_workspace_worktree`
+- `materialize_environment`
+- `refresh_agent_auth_config`
+- `send_prompt`
+- `resolve_interaction`
+- `update_session_config`
+- `cancel_turn`
+- `close_session`
+- `backfill_exposed_workspace`
+
+Requirement categories:
+
+- materialization-only
+- requires AnyHarness
+- requires healthy AnyHarness
+- requires materialization root
+- requires supervisor mailbox
+- requires current slot
+
+## Processor
+
+`processor.rs` is the canonical place to understand one-command
+deliverability.
+
+It owns this pipeline:
+
+```text
+leased Cloud command
+  -> validate lease and slot context
+  -> classify command kind
+  -> enforce requirements from catalog
+  -> call custom handler if needed
+  -> otherwise map to AnyHarnessCommand
+  -> report delivery when appropriate
+  -> dispatch to AnyHarness when appropriate
+  -> classify handler or AnyHarness response
+  -> save pending result before Cloud upload
+  -> report terminal result to Cloud
+  -> clear pending result after successful upload
+```
+
+Do not bury this pipeline in `loop.rs` or in a command-family handler.
+
+## Generic AnyHarness Path
+
+Commands that are only:
+
+```text
+Cloud payload -> AnyHarness request -> Cloud result
+```
+
+use:
+
+```text
+mapping.rs -> anyharness_dispatch.rs -> reporting.rs
+```
+
+Examples:
+
+- `send_prompt`
+- `resolve_interaction`
+- `update_session_config`
+- `cancel_turn`
+- `close_session`
+
+Add a custom handler only when the command has Worker-owned target effects,
+special Cloud status reporting, cross-boundary orchestration, or
+command-family logic that does not belong in the generic path.
+
+## Handlers
+
+- `handlers/git_identity.rs`: `configure_git_identity`. Fetch Cloud material
+  and write target-local Git credential/config.
+- `handlers/repo_checkout.rs`: `ensure_repo_checkout`. Clone, fetch, and
+  verify repo checkout on the target.
+- `handlers/environment.rs`: `materialize_environment`. Fetch target config
+  plan, write env/files/config, and coordinate runtime config apply.
+- `handlers/agent_auth.rs`: `refresh_agent_auth_config`. Fetch agent auth
+  materialization plan, materialize synced auth files/gateway config, call
+  AnyHarness apply endpoint, and report agent auth status.
+- `handlers/runtime_config.rs`: runtime config apply orchestration when
+  environment/agent-auth flows need a dedicated split.
+- `handlers/pruning.rs`: `prune_workspace_worktree`. Call AnyHarness
+  retire/cleanup APIs and report Cloud materialization state.
+- `handlers/backfill.rs`: `backfill_exposed_workspace`. Command entrypoint
+  that delegates actual backfill mechanics to `event_uplink/backfill.rs`.
+
+Avoid `handlers/materialization.rs`; it collides with `target/materialization`
+and hides which command family is being handled.
+
+## Hard Rules
+
+- The loop stays boring.
+- Supported-kind policy lives in `catalog.rs`, not in the Cloud client.
+- Mapping stays pure.
+- AnyHarness HTTP dispatch lives in `anyharness_dispatch.rs`.
+- Result retry lives in `reporting.rs`.
+- Idempotency and stale-slot behavior stay explicit.
+- Command downlink does not own event tailing, Cloud exposure policy, or
+  supervisor update application.

--- a/docs/structures/proliferate-worker/guides/event-uplink.md
+++ b/docs/structures/proliferate-worker/guides/event-uplink.md
@@ -1,0 +1,111 @@
+# Worker Event Uplink
+
+Status: authoritative for
+`anyharness/crates/proliferate-worker/src/event_uplink/**`.
+
+`event_uplink/` owns the AnyHarness-to-Cloud runtime event path.
+
+```text
+AnyHarness events / snapshots
+  -> Worker event uplink
+  -> Cloud ingest / projection read models
+```
+
+Use `event_uplink`, not `sync`. Worker does not own broad bidirectional sync.
+Cloud owns projection read models; Worker owns the uplink mechanics that feed
+them.
+
+## Target Shape
+
+```text
+event_uplink/
+  mod.rs
+  loop.rs
+  exposures.rs
+  cursors.rs
+  discovery.rs
+  tailer.rs
+  event_mapping.rs
+  gaps.rs
+  backfill.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Facade exposing the uplink loop and test-facing types. | Event cursor or backfill implementation. |
+| `loop.rs` | Boring recurring loop: fetch exposure inputs, run one pass, sleep/backoff, honor shutdown. | Event mapping, gap policy, Cloud projection rules. |
+| `exposures.rs` | Fetch and interpret Cloud exposure snapshots for this worker. | Deciding exposure policy. |
+| `cursors.rs` | Reconcile Cloud exposure snapshots into local event cursors and ack state. | Tailing AnyHarness or uploading batches. |
+| `discovery.rs` | Discover sessions inside exposed workspaces and request backfill when Cloud lacks mappings. | Durable Cloud projection persistence. |
+| `tailer.rs` | Read AnyHarness session events after the local cursor sequence. | Mapping events to Cloud payloads or deciding exposure. |
+| `event_mapping.rs` | Map AnyHarness event envelopes into Worker event batch payloads for Cloud. | HTTP upload, cursor persistence, transcript reconstruction. |
+| `gaps.rs` | Detect sequence gaps, report gaps to Cloud, and pause local cursors when needed. | Repairing AnyHarness history. |
+| `backfill.rs` | Build and upload bounded workspace/session snapshots for exposed work. | Command lifecycle; command entry belongs in `command_downlink/handlers/backfill.rs`. |
+
+## Flow
+
+One uplink pass is:
+
+```text
+fetch Cloud exposure snapshot
+  -> reconcile local cursors for exposed work
+  -> discover missing sessions/workspace mappings
+  -> backfill bounded snapshots when required
+  -> tail AnyHarness events after cursor
+  -> detect gaps
+  -> map events to Cloud batch payload
+  -> upload batch
+  -> apply Cloud ack to local cursor
+```
+
+The worker store keeps cursors and mapping caches so the bridge can recover
+after restart or transient Cloud failures. It is not product truth.
+
+## Exposure And Cursor Rules
+
+Cloud decides what should be exposed. Worker reads that decision and turns it
+into local cursor work.
+
+Worker may:
+
+- fetch exposure snapshots from Cloud
+- create/update local event cursors for exposed sessions
+- pause a cursor when a sequence gap makes safe tailing impossible
+- upload gap reports and event batches
+- apply Cloud acknowledgements to local cursors
+
+Worker must not:
+
+- decide that a workspace/session should be exposed
+- persist Cloud projection read models
+- reconstruct transcript truth from partial events
+- mutate AnyHarness state or SQLite directly
+
+## Backfill
+
+Backfill spans command downlink and event uplink:
+
+```text
+command_downlink/handlers/backfill.rs
+  Cloud command entrypoint and result reporting
+
+event_uplink/backfill.rs
+  Snapshot discovery, bounded payload construction, and Cloud upload mechanics
+```
+
+This split keeps Cloud command lifecycle out of event mechanics while still
+letting Cloud request a bounded repair.
+
+## Hard Rules
+
+- `loop.rs` stays boring.
+- Event uplink reads AnyHarness through the AnyHarness client; it does not read
+  or mutate AnyHarness SQLite directly.
+- Cloud exposure policy belongs to Cloud.
+- Cloud projection persistence belongs to Cloud.
+- Cursor persistence belongs to `store`.
+- Gap detection is visible in `gaps.rs`; do not hide it in the tailer or mapper.
+- Backfill mechanics live in `event_uplink/backfill.rs`; command entry lives in
+  `command_downlink/handlers/backfill.rs`.

--- a/docs/structures/proliferate-worker/guides/identity.md
+++ b/docs/structures/proliferate-worker/guides/identity.md
@@ -1,0 +1,105 @@
+# Worker Identity
+
+Status: authoritative for `anyharness/crates/proliferate-worker/src/identity/**`.
+
+`identity/` owns the worker's Cloud identity lifecycle. It turns a one-time
+enrollment token into durable Worker credentials, persists those credentials
+locally through store APIs, and exposes the enrolled identity to the rest of the
+worker process.
+
+## Target Shape
+
+```text
+identity/
+  mod.rs
+  enrollment.rs
+  credentials.rs
+  fingerprint.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Identity facade and `ensure_enrolled` workflow. | Command, event, heartbeat, or target materialization logic. |
+| `enrollment.rs` | One-time bootstrap exchange and enroll request construction. | Durable row CRUD. |
+| `credentials.rs` | Already-enrolled identity shape, load/save coordination, and auth helpers. | Enrollment HTTP request mechanics. |
+| `fingerprint.rs` | Machine fingerprint and hostname hints used during enrollment. | Authentication decisions. |
+
+Persistence for the identity row belongs in `store/identity.rs`.
+
+## Enrollment Workflow
+
+`identity::ensure_enrolled` is the only high-level identity workflow:
+
+```text
+if identity exists in store:
+  clear enrollment_token from config if present
+  return identity
+
+otherwise:
+  require enrollment_token from config
+  build enrollment request
+  call Cloud enroll endpoint
+  convert response into WorkerIdentity
+  save identity
+  clear enrollment_token from config
+  return identity
+```
+
+Other modules should not hand-roll enrollment checks.
+
+## Credential Shape
+
+Target type:
+
+```rust
+pub struct WorkerIdentity {
+    pub target_id: String,
+    pub sandbox_profile_id: Option<String>,
+    pub cloud_sandbox_id: Option<String>,
+    pub slot_generation: Option<i64>,
+    pub worker_id: String,
+    pub worker_token: String,
+}
+```
+
+Interpretation:
+
+- `target_id`: Cloud target this worker belongs to.
+- `worker_id`: Cloud worker row created during enrollment.
+- `worker_token`: durable Worker -> Cloud bearer credential.
+- `sandbox_profile_id`: managed sandbox profile, when applicable.
+- `cloud_sandbox_id`: managed sandbox slot, when applicable.
+- `slot_generation`: generation fence used to reject stale workers.
+
+## Auth Lanes
+
+Keep these distinct:
+
+- `enrollment_token`: one-time bootstrap credential.
+- `worker_token`: durable Worker -> Cloud bearer credential.
+- `anyharness_bearer_token`: local Worker -> AnyHarness credential.
+
+Never treat AnyHarness auth as Cloud auth. Never treat fingerprint as auth.
+
+## Fingerprint
+
+Current model:
+
+```text
+machine_fingerprint = sha256(os + ":" + arch + ":" + hostname)
+hostname            = HOSTNAME or COMPUTERNAME, if present
+```
+
+The fingerprint is a stable display/debug hint for Cloud enrollment records. It
+is not an auth credential, not a secure hardware identity, and not a
+replacement for `worker_token`.
+
+## Hard Rules
+
+- All enrollment flows through `identity::ensure_enrolled`.
+- Bootstrap token use is limited to enrollment.
+- Durable Worker auth is represented by `WorkerIdentity`.
+- Credential storage remains local and private.
+- Identity code avoids command, event, heartbeat, and materialization logic.

--- a/docs/structures/proliferate-worker/guides/root-support.md
+++ b/docs/structures/proliferate-worker/guides/root-support.md
@@ -1,0 +1,58 @@
+# Worker Root Support Files
+
+Status: authoritative for support files at
+`anyharness/crates/proliferate-worker/src/*.rs`.
+
+Root support files are small, boring cross-cutting modules that do not yet need
+their own folder. They are not a place for generic utilities or hidden service
+layers.
+
+## Target Shape
+
+```text
+src/
+  config.rs
+  error.rs
+  logging.rs
+  observability.rs
+  versions.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `config.rs` | Worker config load, parse, sanitize, and private config writes. | Command, event, target, or identity workflows. |
+| `error.rs` | Worker error enum and conversions. | Domain-specific control flow. |
+| `logging.rs` | Tracing/Sentry/log initialization. | Per-flow observability policy. |
+| `observability.rs` | Shared diagnostic helpers and correlation conventions. | Workflow implementation or hidden global state. |
+| `versions.rs` | Worker, AnyHarness, and supervisor version helpers. | Target inventory upload orchestration or update application. |
+
+## Observability
+
+Shared observability helpers may define correlation-field conventions and small
+formatting utilities. Flow code still owns when and why it logs.
+
+Important correlation fields:
+
+- `command_id`
+- `lease_id`
+- `target_id`
+- `worker_id`
+- `sandbox_profile_id`
+- `slot_generation`
+- `cloud_workspace_id`
+- `anyharness_workspace_id`
+- `session_id`
+- `session_projection_id`
+- `exposure_id`
+
+## Hard Rules
+
+- Keep root support files small and boring.
+- Do not add `utils.rs`, `helpers.rs`, or `misc.rs`.
+- Do not create an `infra/` folder unless root support files become a real
+  source of clutter.
+- `infra/` must not become a softer name for `utils`.
+- Move code into an owning subsystem when it starts making product, command,
+  event, target, store, client, or identity decisions.

--- a/docs/structures/proliferate-worker/guides/runtime.md
+++ b/docs/structures/proliferate-worker/guides/runtime.md
@@ -1,0 +1,73 @@
+# Worker Runtime
+
+Status: authoritative for `anyharness/crates/proliferate-worker/src/runtime/**`.
+
+`runtime/` owns process composition and lifecycle. It starts the worker, builds
+shared dependencies, starts named loops, and coordinates shutdown.
+
+## Goal
+
+```text
+initialize -> build shared context -> start named flows -> coordinate shutdown
+```
+
+`runtime/` may know every subsystem exists. It must not implement those
+subsystems.
+
+## Target Shape
+
+```text
+runtime/
+  mod.rs
+  context.rs
+  tasks.rs
+  shutdown.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Public `run(config, once)` entrypoint and startup choreography. | Command, event, status, or target workflow implementation. |
+| `context.rs` | `WorkerContext` construction: config, store, clients, identity, and static process metadata. | Per-loop computed state such as supported command kinds, active cursors, heartbeat payloads, or event batches. |
+| `tasks.rs` | Named task spawning, task handles, unexpected-exit logging, and task joins. | Loop internals or workflow decisions. |
+| `shutdown.rs` | OS signal handling, cancellation notification, join timeout, and final drain hooks. | Command processing, event tailing, or target materialization logic. |
+
+## Worker Context
+
+Long-lived dependencies used by multiple loops belong in `WorkerContext`.
+
+Target shape:
+
+```rust
+pub struct WorkerContext {
+    pub config: WorkerConfig,
+    pub store: WorkerStore,
+    pub cloud: CloudClient,
+    pub identity: WorkerIdentity,
+    pub anyharness: Option<AnyHarnessClient>,
+    pub versions: InstalledVersions,
+}
+```
+
+State that changes per loop pass does not belong in `WorkerContext`.
+
+Examples:
+
+- command lease state
+- supported command kinds
+- active event cursors
+- current heartbeat request
+- materialization command payload
+- event batch payload
+
+## Hard Rules
+
+- `runtime/mod.rs` reads like process choreography.
+- `context.rs` builds dependencies; it does not derive per-loop policy.
+- `tasks.rs` knows which loops exist; it does not know how they work.
+- Shutdown may trigger final drains, but it does not contain command or event
+  workflow logic.
+- Runtime delegates heartbeat semantics to `target_status`, command semantics
+  to `command_downlink`, event cursor mechanics to `event_uplink`, target-local
+  effects to `target`, and identity lifecycle to `identity`.

--- a/docs/structures/proliferate-worker/guides/store.md
+++ b/docs/structures/proliferate-worker/guides/store.md
@@ -1,0 +1,88 @@
+# Worker Store
+
+Status: authoritative for `anyharness/crates/proliferate-worker/src/store/**`.
+
+`store/` owns worker-local SQLite and bridge durability.
+
+The worker store is not product truth. It exists so the bridge can recover from
+restarts and transient Cloud failures.
+
+## Target Shape
+
+```text
+store/
+  mod.rs
+  connection.rs
+  migrations.rs
+  identity.rs
+  pending_command_results.rs
+  projection_cursors.rs
+  workspace_mappings.rs
+  workspace_discovery.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Store facade and narrow construction surface. | Workflow methods. |
+| `connection.rs` | SQLite connection setup, pragmas, busy timeout. | Table-specific queries. |
+| `migrations.rs` | Worker DB schema creation and migration helpers. | Runtime workflow decisions. |
+| `identity.rs` | Persisted worker identity row access. | Enrollment workflow. |
+| `pending_command_results.rs` | Command result retry records. | Command processing lifecycle. |
+| `projection_cursors.rs` | Event uplink cursor state, ack state, and gap state. | Event tailing or Cloud upload. |
+| `workspace_mappings.rs` | Local AnyHarness workspace/session to Cloud mapping cache. | Cloud projection persistence. |
+| `workspace_discovery.rs` | Exposed-workspace discovery throttling. | Discovery workflow orchestration. |
+
+## Allowed
+
+Store code may own:
+
+- table-shaped CRUD
+- row mapping
+- local transactions
+- migration helpers
+- narrow recovery queries used by loops
+
+## Banned
+
+Store code must not own:
+
+- Cloud HTTP calls
+- AnyHarness HTTP calls
+- command processing workflows
+- event uplink workflows
+- product authorization
+- broad "reconcile everything" service methods
+
+## API Shape
+
+Good store APIs are boring:
+
+```rust
+save_pending_command_result(...)
+list_pending_command_results(...)
+delete_pending_command_result(...)
+reconcile_projection_cursors(...)
+list_active_projection_cursors(...)
+update_projection_cursor_ack(...)
+upsert_workspace_mapping(...)
+```
+
+Bad store APIs hide workflows:
+
+```rust
+process_command_result(...)
+apply_projection_state(...)
+reconcile_everything_for_workspace(...)
+```
+
+## Hard Rules
+
+- Store APIs stay table-shaped and recovery-oriented.
+- Store does not call Cloud or AnyHarness.
+- Store does not own command lifecycle or event uplink workflow.
+- SQLite rows are Worker bridge durability, not Cloud or AnyHarness product
+  truth.
+- Rename misleading store files only with a migration plan for code references;
+  do not preserve `sync` vocabulary in new code.

--- a/docs/structures/proliferate-worker/guides/target-status.md
+++ b/docs/structures/proliferate-worker/guides/target-status.md
@@ -1,0 +1,75 @@
+# Worker Target Status
+
+Status: authoritative for
+`anyharness/crates/proliferate-worker/src/target_status/**`.
+
+`target_status/` owns target health and status reporting.
+
+```text
+target / AnyHarness / versions
+  -> Worker status loop
+  -> Cloud heartbeat, inventory, desired-version status
+```
+
+## Target Shape
+
+```text
+target_status/
+  mod.rs
+  loop.rs
+  health.rs
+  heartbeat.rs
+  inventory_report.rs
+  update_observation.rs
+```
+
+## What Goes Where
+
+| File | Owns | Must Not Own |
+| --- | --- | --- |
+| `mod.rs` | Facade exposing the target status loop and test-facing types. | Status-loop internals. |
+| `loop.rs` | Recurring loop: sleep on interval, probe health, send heartbeat/status, observe desired versions, honor shutdown. | Health probe details, update application, target materialization. |
+| `health.rs` | Health probes and health summaries, especially AnyHarness availability. | Command lease support policy. |
+| `heartbeat.rs` | Cloud heartbeat request construction and response interpretation. | Inventory collection internals or update mailbox writes. |
+| `inventory_report.rs` | Target inventory upload orchestration. | Inventory fact collection; that belongs under `target/inventory`. |
+| `update_observation.rs` | Desired-version observation and delegation to `target/updates`. | Binary download, replacement, restart, or rollback. |
+
+## Responsibilities
+
+Target status reports what is true about the target and what Cloud currently
+wants. It does not change runtime state except by delegating narrow update
+mailbox writes to `target/updates`.
+
+It may report:
+
+- Worker identity and slot metadata
+- Worker, AnyHarness, and supervisor versions
+- AnyHarness health
+- target inventory summaries
+- desired-version observation
+- update request/status summaries
+
+## Update Boundary
+
+Worker may:
+
+- observe Cloud desired versions from heartbeat/status responses
+- compare desired versions with installed versions
+- write a narrow supervisor update-request mailbox through `target/updates`
+- report update request/status state back to Cloud
+
+Worker must not:
+
+- download binaries
+- replace binaries
+- restart processes
+- rollback versions
+- decide supervisor lifecycle
+
+## Hard Rules
+
+- `target_status/loop.rs` stays boring.
+- Health summaries are status inputs, not command lease policy.
+- Inventory collection lives under `target/inventory`.
+- Update application belongs to supervisor.
+- Desired-version mailbox writes go through `target/updates`.

--- a/docs/structures/proliferate-worker/guides/target.md
+++ b/docs/structures/proliferate-worker/guides/target.md
@@ -1,0 +1,109 @@
+# Worker Target
+
+Status: authoritative for `anyharness/crates/proliferate-worker/src/target/**`.
+
+`target/` owns target-local facts and effects. It can inspect the target and
+write target-local files. It must not call raw Cloud endpoints or decide Cloud
+product policy.
+
+## Target Shape
+
+```text
+target/
+  mod.rs
+  materialization/
+    mod.rs
+    paths.rs
+    files.rs
+    env.rs
+    git.rs
+    git_identity.rs
+    repo_checkout.rs
+    runtime_config.rs
+    agent_auth.rs
+    manifest.rs
+
+  inventory/
+    mod.rs
+    platform.rs
+    versions.rs
+    capabilities.rs
+    providers.rs
+    mcp.rs
+
+  updates/
+    mod.rs
+    desired_versions.rs
+    supervisor_mailbox.rs
+    status.rs
+```
+
+## What Goes Where
+
+| Area | Owns | Must Not Own |
+| --- | --- | --- |
+| `materialization/` | Target-local filesystem, Git, env, auth, runtime config, and manifest effects. | Cloud materialization plan creation, Cloud authorization, AnyHarness execution semantics, supervisor process management. |
+| `inventory/` | Read-only local machine facts: platform, versions, capabilities, providers, MCP availability. | Mutating target state. |
+| `updates/` | Worker side of desired-version observation: compare desired/installed versions, write supervisor mailbox, construct status reports. | Downloading/replacing binaries, restarting processes, rollback. |
+
+## Materialization
+
+`target/materialization/` owns target-local preparation work.
+
+Files:
+
+- `paths.rs`: allowed-root checks, home expansion, symlink traversal defense,
+  path normalization, and path safety.
+- `files.rs`: atomic/private file writes, directory creation, permissions, and
+  common file helpers.
+- `env.rs`: environment file materialization.
+- `git.rs`: focused Git helpers.
+- `git_identity.rs`: target-scoped Git credential/config materialization.
+- `repo_checkout.rs`: clone/fetch/checkout and repo identity validation.
+- `runtime_config.rs`: runtime config projection files, artifact integrity
+  checks, and credential reference helpers.
+- `agent_auth.rs`: target-local agent auth synced-file and gateway config
+  materialization helpers.
+- `manifest.rs`: `.proliferate/**` manifest writing.
+
+Allowed:
+
+- filesystem writes under allowed roots
+- Git operations required for checkout/bootstrap
+- local credential file writes approved by Cloud-provided plans
+- artifact/hash validation
+- target-local manifest generation
+
+## Inventory
+
+`target/inventory/` owns local facts about the machine.
+
+Files:
+
+- `platform.rs`: OS, arch, distro, shell.
+- `versions.rs`: local tool version probes.
+- `capabilities.rs`: local capability facts.
+- `providers.rs`: agent/provider readiness facts.
+- `mcp.rs`: local MCP capability facts.
+
+Inventory code is read-only. It does not mutate target state.
+
+## Updates
+
+`target/updates/` owns the worker side of desired-version observation.
+
+Files:
+
+- `desired_versions.rs`: compare Cloud desired versions with observed installed
+  versions.
+- `supervisor_mailbox.rs`: write and clear supervisor update request files.
+- `status.rs`: construct worker update status reports.
+
+## Hard Rules
+
+- Target code does not call raw Cloud HTTP.
+- Target code does not decide Cloud authorization or exposure policy.
+- Target materialization centralizes path safety and private file writes.
+- Inventory code is read-only.
+- Worker update code only writes the supervisor mailbox and reports status.
+- Supervisor owns binary download, replacement, restart, and rollback.


### PR DESCRIPTION
## Summary
- split Proliferate Worker structure docs into focused guide files
- add a Proliferate Supervisor structure guide
- wire the new structure docs into AGENTS.md and the docs read map

## Verification
- git diff --cached --check
- checked referenced doc paths exist