### PR TITLE
fix(desktop): apply appearance theme in support window

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,7 +8,6 @@ import { ToastContainer } from "@/components/feedback/Toast"
 import { TurnEndCelebration } from "@/components/feedback/TurnEndCelebration"
 import { UpdateRestartDialog } from "@/components/feedback/UpdateRestartDialog"
 import { MacWindowControlsSafeArea } from "@/components/app/chrome/MacWindowControlsSafeArea"
-import { applyAppearancePreference, initializeTheme } from "@/config/theme"
 import { useExportRunningAgentCount } from "@/hooks/app/lifecycle/use-export-running-agent-count"
 import { useWorkspaceActivityIndicator } from "@/hooks/app/lifecycle/use-workspace-activity-indicator"
 import { useAppShortcuts } from "@/hooks/app/lifecycle/use-app-shortcuts"
@@ -18,6 +17,7 @@ import { useAgentAutoReconcile } from "@/hooks/agents/lifecycle/use-agent-auto-r
 import { useLocalAutomationExecutor } from "@/hooks/automations/lifecycle/use-local-automation-executor"
 import { useHomeDeferredLaunchRunner } from "@/hooks/home/lifecycle/use-home-deferred-launch-runner"
 import { useRuntimeInputSyncRuntime } from "@/hooks/cloud/lifecycle/use-runtime-input-sync-runtime"
+import { useAppearancePreferenceLifecycle } from "@/hooks/preferences/lifecycle/use-appearance-preference-lifecycle"
 import { useRepoPreferencesLifecycle } from "@/hooks/preferences/lifecycle/use-repo-preferences-lifecycle"
 import { useUserPreferencesLifecycle } from "@/hooks/preferences/lifecycle/use-user-preferences-lifecycle"
 import { useWorkspaceUiLifecycle } from "@/hooks/preferences/lifecycle/use-workspace-ui-lifecycle"
@@ -186,6 +186,9 @@ function AppRuntime() {
   recordBootDiagnosticOnce("app_runtime.render.before.use_user_preferences_lifecycle")
   useUserPreferencesLifecycle()
   recordBootDiagnosticOnce("app_runtime.render.after.use_user_preferences_lifecycle")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_appearance_preference_lifecycle")
+  useAppearancePreferenceLifecycle()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_appearance_preference_lifecycle")
   recordBootDiagnosticOnce("app_runtime.render.before.use_repo_preferences_lifecycle")
   useRepoPreferencesLifecycle()
   recordBootDiagnosticOnce("app_runtime.render.after.use_repo_preferences_lifecycle")
@@ -205,41 +208,6 @@ function AppRuntime() {
   useEffect(() => {
     recordAppRendererEvent("app.bootstrap.start")
     logStartupDebug("app.bootstrap.start")
-    initializeTheme()
-    const applyStoredAppearance = () => {
-      const {
-        themePreset,
-        colorMode,
-        uiFontSizeId,
-        readableCodeFontSizeId,
-      } = useUserPreferencesStore.getState()
-      applyAppearancePreference({
-        themePreset,
-        colorMode,
-        uiFontSizeId,
-        readableCodeFontSizeId,
-      })
-    }
-    applyStoredAppearance()
-
-    const unsubscribeAppearance = useUserPreferencesStore.subscribe((state, prev) => {
-      if (
-        state.themePreset !== prev.themePreset
-        || state.colorMode !== prev.colorMode
-        || state.uiFontSizeId !== prev.uiFontSizeId
-        || state.readableCodeFontSizeId !== prev.readableCodeFontSizeId
-      ) {
-        applyStoredAppearance()
-      }
-    })
-    const systemModeQuery = window.matchMedia("(prefers-color-scheme: dark)")
-    const handleSystemModeChange = () => {
-      if (useUserPreferencesStore.getState().colorMode === "system") {
-        applyStoredAppearance()
-      }
-    }
-    systemModeQuery.addEventListener("change", handleSystemModeChange)
-
     const authBootstrapStartedAt = startStartupTimer()
     recordAppRendererEvent("app.auth_bootstrap.start")
     logStartupDebug("app.auth_bootstrap.start")
@@ -253,10 +221,6 @@ function AppRuntime() {
         authStatus: useAuthStore.getState().status,
       })
     })
-    return () => {
-      unsubscribeAppearance()
-      systemModeQuery.removeEventListener("change", handleSystemModeChange)
-    }
   }, [bootstrapAuth])
 
   useEffect(() => {

--- a/apps/desktop/src/components/support/SupportReportWindow.tsx
+++ b/apps/desktop/src/components/support/SupportReportWindow.tsx
@@ -42,7 +42,7 @@ export function SupportReportWindow() {
 
   return (
     <main
-      className="flex h-screen min-h-0 flex-col overflow-hidden bg-popover/95 font-mono text-popover-foreground shadow-floating backdrop-blur-lg"
+      className="flex h-screen min-h-0 flex-col overflow-hidden bg-popover/95 text-popover-foreground shadow-floating backdrop-blur-lg"
       onPaste={handleAttachmentPaste}
       onDragOver={handleAttachmentDragOver}
       onDrop={handleAttachmentDrop}

--- a/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx
+++ b/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppearancePreferenceLifecycle } from "@/hooks/preferences/lifecycle/use-appearance-preference-lifecycle";
+import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+interface MatchMediaStub {
+  setMatches: (matches: boolean) => void;
+}
+
+function resetAppearanceState() {
+  useUserPreferencesStore.setState({
+    ...USER_PREFERENCE_DEFAULTS,
+    _hydrated: false,
+    _persistedMetadata: {},
+  });
+  const root = document.documentElement;
+  delete root.dataset.theme;
+  delete root.dataset.mode;
+  delete root.dataset.uiFontSize;
+  delete root.dataset.readableCodeFontSize;
+  root.style.cssText = "";
+}
+
+function installMatchMediaStub(initialMatches: boolean): MatchMediaStub {
+  let matches = initialMatches;
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const query = {
+    get matches() {
+      return matches;
+    },
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: vi.fn((_type: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((_type: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MediaQueryList;
+
+  vi.stubGlobal("matchMedia", vi.fn(() => query));
+
+  return {
+    setMatches: (nextMatches: boolean) => {
+      matches = nextMatches;
+      const event = { matches, media: query.media } as MediaQueryListEvent;
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+}
+
+describe("useAppearancePreferenceLifecycle", () => {
+  beforeEach(() => {
+    resetAppearanceState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    resetAppearanceState();
+  });
+
+  it("applies default mono appearance tokens on mount", async () => {
+    installMatchMediaStub(true);
+
+    renderHook(() => useAppearancePreferenceLifecycle());
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("mono");
+      expect(document.documentElement.dataset.mode).toBe("dark");
+      expect(document.documentElement.dataset.uiFontSize).toBe("default");
+      expect(document.documentElement.dataset.readableCodeFontSize).toBe("default");
+      expect(document.documentElement.style.getPropertyValue("--text-chat")).toBe("12px");
+    });
+  });
+
+  it("tracks store changes for theme and size tokens", async () => {
+    installMatchMediaStub(true);
+
+    renderHook(() => useAppearancePreferenceLifecycle());
+
+    act(() => {
+      useUserPreferencesStore.getState().setMultiple({
+        themePreset: "tbpn",
+        uiFontSizeId: "large",
+        readableCodeFontSizeId: "xlarge",
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("tbpn");
+      expect(document.documentElement.dataset.mode).toBe("dark");
+      expect(document.documentElement.dataset.uiFontSize).toBe("large");
+      expect(document.documentElement.dataset.readableCodeFontSize).toBe("xlarge");
+      expect(document.documentElement.style.getPropertyValue("--text-chat")).toBe("13px");
+      expect(document.documentElement.style.getPropertyValue("--readable-code-font-size")).toBe("0.8125rem");
+    });
+  });
+
+  it("reapplies system color mode when the system preference changes", async () => {
+    const matchMedia = installMatchMediaStub(false);
+
+    renderHook(() => useAppearancePreferenceLifecycle());
+
+    act(() => {
+      useUserPreferencesStore.getState().set("colorMode", "system");
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.mode).toBe("light");
+    });
+
+    act(() => {
+      matchMedia.setMatches(true);
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.mode).toBe("dark");
+    });
+  });
+});

--- a/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts
+++ b/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import {
+  applyAppearancePreference,
+  initializeTheme,
+} from "@/config/theme";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+function applyStoredAppearancePreference(): void {
+  const {
+    themePreset,
+    colorMode,
+    uiFontSizeId,
+    readableCodeFontSizeId,
+  } = useUserPreferencesStore.getState();
+  applyAppearancePreference({
+    themePreset,
+    colorMode,
+    uiFontSizeId,
+    readableCodeFontSizeId,
+  });
+}
+
+// Owns applying user appearance preferences to document-level theme tokens.
+export function useAppearancePreferenceLifecycle(): void {
+  useEffect(() => {
+    initializeTheme();
+    applyStoredAppearancePreference();
+
+    const unsubscribeAppearance = useUserPreferencesStore.subscribe((state, prev) => {
+      if (
+        state.themePreset !== prev.themePreset
+        || state.colorMode !== prev.colorMode
+        || state.uiFontSizeId !== prev.uiFontSizeId
+        || state.readableCodeFontSizeId !== prev.readableCodeFontSizeId
+      ) {
+        applyStoredAppearancePreference();
+      }
+    });
+
+    const systemModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleSystemModeChange = () => {
+      if (useUserPreferencesStore.getState().colorMode === "system") {
+        applyStoredAppearancePreference();
+      }
+    };
+    systemModeQuery.addEventListener("change", handleSystemModeChange);
+
+    return () => {
+      unsubscribeAppearance();
+      systemModeQuery.removeEventListener("change", handleSystemModeChange);
+    };
+  }, []);
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { SupportReportWindow } from "./components/support/SupportReportWindow";
+import { initializeTheme } from "./config/theme";
 import "./lib/access/cloud/client";
 import { bootstrapProliferateApiConfig } from "./lib/infra/proliferate-api";
 import { initializeAnonymousTelemetry } from "./lib/integrations/telemetry/anonymous";
@@ -23,6 +24,8 @@ import {
 } from "./lib/infra/measurement/boot-stall-diagnostics";
 import { installDebugMeasurement } from "./lib/infra/measurement/debug-measurement-install";
 import { logRendererEvent } from "./lib/access/tauri/diagnostics";
+import { useAppearancePreferenceLifecycle } from "./hooks/preferences/lifecycle/use-appearance-preference-lifecycle";
+import { useUserPreferencesLifecycle } from "./hooks/preferences/lifecycle/use-user-preferences-lifecycle";
 import { AppProviders } from "./providers/AppProviders";
 import "./index.css";
 
@@ -35,6 +38,7 @@ const IS_SUPPORT_WINDOW =
   && new URLSearchParams(window.location.search).get("support") === "1";
 
 document.documentElement.dataset.proliferateClient = "desktop";
+initializeTheme();
 
 const rendererStartupStartedAt = startStartupTimer();
 installWebKitPerformanceMeasureDetailGuard();
@@ -104,7 +108,7 @@ if (!import.meta.env.DEV) {
 function renderApp() {
   recordRendererStartupEvent("render.start");
   const content = IS_SUPPORT_WINDOW ? (
-    <SupportReportWindow />
+    <SupportReportWindowHost />
   ) : (
     <BrowserRouter>
       <AppProviders>
@@ -121,6 +125,12 @@ function renderApp() {
     </React.StrictMode>,
   );
   recordRendererStartupEvent("render.scheduled");
+}
+
+function SupportReportWindowHost() {
+  useUserPreferencesLifecycle();
+  useAppearancePreferenceLifecycle();
+  return <SupportReportWindow />;
 }
 
 let appRendered = false;


### PR DESCRIPTION
## Summary
- extract the desktop appearance preference application into a shared lifecycle hook
- mount that lifecycle in the dedicated support report window host so the popup receives persisted Mono theme tokens
- remove the accidental global monospace font from the support window shell

## Verification
- pnpm --filter proliferate exec tsc --noEmit
- pnpm --filter proliferate exec vitest run src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.test.tsx src/hooks/support/facade/use-support-report-window-state.test.tsx
- python3 scripts/check_frontend_boundaries.py && python3 scripts/check_max_lines.py && git diff --check
- local browser smoke check of http://127.0.0.1:5176/?support=1 confirmed data-theme=mono and data-mode=dark
