### PR TITLE
docs(server): align server guide structure

### DIFF
--- a/docs/structures/server/guides/auth.md
+++ b/docs/structures/server/guides/auth.md
@@ -1,10 +1,10 @@
 # Auth
 
-Status: authoritative for authentication, authorization helpers,
-resource-access route deps, and product policy rules.
-
-Read after `docs/structures/server/README.md`. This guide details the three-layer auth
-model and how each layer's responsibility is enforced.
+Server auth has three distinct boundaries: authentication identifies the user,
+resource access checks whether that user can touch a resource, and product
+policy decides whether the current resource state allows an action. Keep those
+boundaries separate so route handlers stay thin and services do not become
+hidden permission layers.
 
 ## Ownership
 
@@ -22,7 +22,7 @@ Plus one shared module:
 |---|---|
 | `auth/authorization.py` | Reusable helpers (`require_org_role`, `OwnerContext`, `PolicyVerdict`) used by both resource-access deps and policy functions |
 
-## Folder Shape
+## Shape
 
 ```text
 auth/
@@ -311,9 +311,10 @@ the handler body.
 - Mixing authentication and authorization in one dep. Each dep does one
   job; compose them via `Depends(... = Depends(...))`.
 
-## Migration Notes
+## Migration Exceptions
 
-When moving authorization helpers to `auth/authorization.py`:
+Existing code may still keep shared authorization helpers inside product
+domains. When touching that code:
 
 1. Move `require_org_role` and related helpers from
    `organizations/service.py`.
@@ -322,7 +323,8 @@ When moving authorization helpers to `auth/authorization.py`:
 3. Verify no domain-specific assumptions baked into the helpers; helpers
    are domain-agnostic.
 
-When introducing `<domain>/access.py`:
+Existing code may still do resource lookup and access checks inline in
+services. When introducing `<domain>/access.py`:
 
 1. Identify endpoints currently doing authorization inline in service.py.
 2. Move the lookup + access check to a route dep returning the resource.
@@ -330,6 +332,7 @@ When introducing `<domain>/access.py`:
 4. Remove the inline authorization from the service.
 5. Service now operates on a snapshot known to be authorized.
 
+Existing code may still keep state-based product rules inline in services.
 When introducing `<domain>/domain/policy.py`:
 
 1. Find inline `if not allowed: raise HTTPException(...)` blocks in

--- a/docs/structures/server/guides/config.md
+++ b/docs/structures/server/guides/config.md
@@ -1,11 +1,8 @@
 # Config And Constants
 
-Status: authoritative for `config.py`, `constants/<area>.py`, and server
-module-level constants.
-
-Read after `docs/structures/server/README.md` when a change introduces or moves settings,
-limits, defaults, timeouts, headers, protocol labels, feature flags, URLs, or
-other shared values.
+Server values have three homes: deployment-derived settings, shared product or
+protocol constants, and private file-local implementation details. Put each
+value in the narrowest home that makes its ownership obvious.
 
 ## Ownership
 
@@ -135,9 +132,10 @@ Ask these in order:
 
 If unsure, prefer `constants/<area>.py` over scattering the value inline.
 
-## Migration Notes
+## Migration Exceptions
 
-When cleaning an existing domain:
+Existing code may still keep product constants inline in services, handlers,
+workers, integrations, or stores. When touching that code:
 
 1. Search for module-level literals in `api.py`, `service.py`, worker files,
    and `db/store/**`.

--- a/docs/structures/server/guides/database.md
+++ b/docs/structures/server/guides/database.md
@@ -1,11 +1,8 @@
 # Database
 
-Status: authoritative for `db/store/`, `db/models/`, transactions, and the
-type pipeline between persistence, internal logic, and wire format.
-
-Read after `docs/structures/server/README.md`. This guide details how database access is
-organized, how data flows from ORM to dataclass to Pydantic, how transactions
-are owned, and the column conventions that apply across the schema.
+The database layer owns persistence schema, query execution, transaction
+boundaries, and the type boundary between persistence, internal logic, and wire
+format. Service code sees frozen dataclasses, not ORM rows.
 
 ## Ownership
 
@@ -25,7 +22,7 @@ this guide because they're all aspects of the database layer.
 
 ORM tables. Nothing else.
 
-### Folder shape
+### Shape
 
 ```text
 db/models/
@@ -60,7 +57,7 @@ classes (a primary entity plus its junction tables).
 
 All DB access lives here.
 
-### Folder shape
+### Shape
 
 Default: flat file per resource.
 

--- a/docs/structures/server/guides/domains.md
+++ b/docs/structures/server/guides/domains.md
@@ -1,11 +1,8 @@
 # Server Domains
 
-Status: authoritative for `server/<domain>/` layout.
-
-Read after `docs/structures/server/README.md`. This guide details the shape of a backend
-product domain: api/service/models layout, where pure logic goes, when to
-promote a subdomain, how worker-side logic fits in, and how domains coordinate
-with each other.
+Backend product domains keep transport, orchestration, wire models, pure rules,
+authorization deps, errors, and non-HTTP entry points in predictable homes. A
+domain folder answers "what product area owns this?"
 
 ## Ownership
 
@@ -23,7 +20,7 @@ A `server/<domain>/` folder is one product area's home. It owns:
 A domain folder must answer "what product area?" — not transport, not UI shape,
 not deployment target.
 
-## Folder Shape
+## Shape
 
 Default shape for a small or moderate domain:
 
@@ -407,61 +404,61 @@ Two `service.py` files coexist when surfaces are genuinely distinct. They
 share `domain/` and the store. See [workers.md](workers.md) for the full
 worker organization.
 
-## Worked Example: Cloud Runtime Carving
+## Migration Example: Cloud Runtime Carving
 
-Today `cloud/runtime/` is a 17-file flat folder mixing five distinct
-concerns. Post-carving:
+`cloud/runtime/` is a migration exception when it mixes vendor access,
+provisioning, credentials, config sync, and liveness concerns in one flat
+folder. The carved shape is:
 
 ```text
-integrations/anyharness/                  ← MOVED OUT
+integrations/anyharness/                  <- moved out
   __init__.py
-  client.py                               ← was anyharness_api.py
-  sessions.py                             ← was session_api.py
-  workspace_operations.py                 ← was workspace_operations.py
+  client.py                               <- was anyharness_api.py
+  sessions.py                             <- was session_api.py
+  workspace_operations.py                 <- was workspace_operations.py
   errors.py
   models.py
 
 cloud/runtime/
   api.py
-  service.py                              ← cross-cutting only
-  models.py                               ← shared types
+  service.py                              <- cross-cutting only
+  models.py                               <- shared types
 
-  provisioning/                           ← subdomain
-    service.py                            ← was provision.py (further decomposed)
-    models.py                             ← provision input/result types
-    bootstrap.py                          ← runtime startup setup
+  provisioning/                           <- subdomain
+    service.py                            <- was provision.py
+    models.py                             <- provision input/result types
+    bootstrap.py                          <- runtime startup setup
     git_operations.py
-    sandbox_helpers.py                    ← was sandbox_exec.py
-    scheduler.py                          ← provision task scheduling
+    sandbox_helpers.py                    <- was sandbox_exec.py
+    scheduler.py                          <- provision task scheduling
     domain/
-      step_tracker.py                     ← _StepTracker extracted
-      identity_resolver.py                ← _resolve_git_identity extracted
-      data_key.py                         ← was top-level
+      step_tracker.py                     <- _StepTracker extracted
+      identity_resolver.py                <- _resolve_git_identity extracted
+      data_key.py                         <- was top-level
 
-  credentials/                            ← subdomain
-    service.py                            ← sync_workspace_credentials
-    models.py                             ← provision credential dataclasses
+  credentials/                            <- subdomain
+    service.py                            <- sync_workspace_credentials
+    models.py                             <- provision credential dataclasses
     domain/
-      freshness.py                        ← was credential_freshness.py
+      freshness.py                        <- was credential_freshness.py
 
-  config_sync/                            ← subdomain
-    service.py                            ← combines repo + worktree policy
-    repo_config.py                        ← was repo_config_apply.py
-    worktree_policy.py                    ← was worktree_policy_sync.py
+  config_sync/                            <- subdomain
+    service.py                            <- combines repo + worktree policy
+    repo_config.py                        <- was repo_config_apply.py
+    worktree_policy.py                    <- was worktree_policy_sync.py
 
-  liveness/                               ← subdomain
-    service.py                            ← ensure_running orchestration
-    reconciler.py                         ← was setup_monitor.py
+  liveness/                               <- subdomain
+    service.py                            <- ensure_running orchestration
+    reconciler.py                         <- was setup_monitor.py
     domain/
-      restart_policy.py                   ← pure restart logic
-      health_checks.py                    ← provider-specific health waits
+      restart_policy.py                   <- pure restart logic
+      health_checks.py                    <- provider-specific health waits
 ```
 
 Each subdomain is coherent and reasonably sized. The AnyHarness vendor client
-leaves product code entirely. `provisioning/service.py` is still large after
-the carving and needs internal decomposition as a follow-up — that work
-extracts the pure helpers (step tracker, identity resolver) into
-`provisioning/domain/`.
+leaves product code entirely. Large provisioning helpers that are pure product
+rules belong in `provisioning/domain/`; vendor calls belong in
+`integrations/anyharness/`.
 
 ## Patterns
 

--- a/docs/structures/server/guides/errors.md
+++ b/docs/structures/server/guides/errors.md
@@ -1,10 +1,8 @@
 # Errors
 
-Status: authoritative for server error classes, integration-error
-translation, and HTTP error mapping.
-
-Read after `docs/structures/server/README.md` when a change adds, moves, catches, or
-translates errors.
+Server errors have three homes: shared product error bases, domain-specific
+product errors, and integration-local vendor errors. Product services raise
+product/domain errors; one HTTP translation boundary turns them into responses.
 
 ## Ownership
 
@@ -145,8 +143,8 @@ Direct `HTTPException` is allowed only at actual HTTP boundaries:
   with FastAPI
 - routes returning non-product assets or callback pages where the response is
   not the normal JSON error contract
-- temporary transitional route translation while a domain has not yet moved to
-  product errors
+- route-level translation in a migration exception that does not yet have a
+  domain error type
 
 It is banned in:
 
@@ -173,9 +171,10 @@ Banned:
 - Integration code catching its own error type to produce an HTTP response.
 - Domain errors wrapping unrelated exceptions without adding product meaning.
 
-## Migration Notes
+## Migration Exceptions
 
-When migrating a domain:
+Existing code may still translate domain errors inside route handlers or keep
+service error classes outside the domain error model. When touching that code:
 
 1. Add or update `server/<domain>/errors.py`.
 2. Convert service-layer `*ServiceError` classes to domain errors.

--- a/docs/structures/server/guides/integrations.md
+++ b/docs/structures/server/guides/integrations.md
@@ -1,15 +1,8 @@
 # Integrations
 
-Status: provisional. Authoritative for `integrations/<vendor>/` shapes and
-adapter conventions until the integration patterns are revisited.
-
-Read after `docs/structures/server/README.md`. This guide details how third-party SDK
-and API access is organized: when to use a single file, when to promote to a
-folder, and how multi-vendor protocols are abstracted.
-
-This guide is marked provisional because the current rules are based on a
-small number of existing integrations. Patterns may shift as new
-integrations expose gaps.
+Integrations are the server's raw external access boundary. Product domains
+call integration public APIs; integrations own vendor clients, vendor wire
+types, authentication, retries, and protocol translation.
 
 ## Ownership
 
@@ -32,7 +25,7 @@ Integration code does not own:
 - Database access (no `db/store/**` imports).
 - Service-layer orchestration.
 
-## Folder Shape
+## Shape
 
 Three legal shapes, picked by what the integration is.
 
@@ -51,7 +44,7 @@ Inside the file:
 - Payload dataclasses (when the integration parses structured responses).
 - Public functions exported to product code.
 
-Examples (today): `anthropic.py`, `customerio.py`, `github.py`, `resend.py`,
+Examples: `anthropic.py`, `customerio.py`, `github.py`, `resend.py`,
 `sentry.py`, `anonymous_telemetry.py`.
 
 ### Shape 2: Folder, single provider
@@ -78,7 +71,7 @@ or any set of features that don't fit cleanly in one file.
   This is the explicit Python-package exception to the repo-wide no-barrel
   rule; use it only for integration package public APIs.
 
-Example (today): `slack/` with `webhooks.py` + `errors.py`.
+Example: `slack/` with `webhooks.py` + `errors.py`.
 
 Concern files should be coarse and meaningful. Do not mechanically mirror
 every endpoint, REST resource, or SDK method into its own file. Start with the
@@ -110,7 +103,7 @@ selects an implementation at runtime.
 - `errors.py` — shared error types raised by any provider.
 - `__init__.py` — exports the factory and shared types.
 
-Example (today): `sandbox/` with `base.py`, `daytona.py`, `e2b.py`,
+Example: `sandbox/` with `base.py`, `daytona.py`, `e2b.py`,
 `factory.py`.
 
 ## Picking a Shape
@@ -121,7 +114,7 @@ Example (today): `sandbox/` with `base.py`, `daytona.py`, `e2b.py`,
 | One vendor, multiple distinct concerns | Shape 2 (single-provider folder) |
 | Multiple vendors implementing the same protocol | Shape 3 (polymorphic folder) |
 
-Shape can change over time:
+Shape changes when ownership changes:
 
 - Single file → single-provider folder when concerns split (extract
   webhooks, OAuth, etc.).
@@ -276,16 +269,16 @@ service owns "what to do when the event arrives."
 6. **Add unit tests** for the integration that mock the HTTP layer.
 7. **For folder integrations:** export the public API from `__init__.py`.
 
-## Forward Pass
+## Migration Exceptions
 
-When the existing integrations are revisited:
+Existing code has these integration-boundary exceptions:
 
-- The `billing/stripe.py` (single-file folder) anti-pattern needs flattening
-  to `integrations/stripe.py` until a second billing provider arrives.
-- `integrations/mcp_oauth.py` (450 lines) likely needs promotion to
-  `mcp_oauth/` with `client.py`, `flows.py`, `models.py`, `errors.py`.
-- `cloud/runtime/anyharness_api.py` (593 lines) + `session_api.py` (251) +
-  `workspace_operations.py` (222) need consolidation under
+- `billing/stripe.py` is a single-file folder anti-pattern. Flatten it to
+  `integrations/stripe.py` unless it earns a multi-file vendor folder.
+- `integrations/mcp_oauth.py` is large enough to earn `mcp_oauth/` with
+  `client.py`, `flows.py`, `models.py`, and `errors.py`.
+- `cloud/runtime/anyharness_api.py`, `session_api.py`, and
+  `workspace_operations.py` are AnyHarness vendor access and belong under
   `integrations/anyharness/` as a single-provider folder.
 
 These are concrete cleanups, not rule changes.

--- a/docs/structures/server/guides/workers.md
+++ b/docs/structures/server/guides/workers.md
@@ -1,16 +1,9 @@
 # Workers
 
-Status: provisional but authoritative for current background-job cleanup.
-
-Read after `docs/structures/server/README.md`. This guide details how non-HTTP entry
-points are organized, how worker-side logic relates to HTTP-side logic, and
-when a worker subfolder is earned.
-
-This guide is intentionally modest. Proliferate does not yet have a robust
-worker framework, queue abstraction, or broad scheduler system. Do not use this
-guide as permission to invent one. It exists to keep the background jobs we
-already have from mixing entrypoint code, service orchestration, store access,
-and pure logic in the same files.
+Workers are non-HTTP entry points for domain work that runs outside the request
+lifecycle. Keep entry points, worker orchestration, stores, integrations, and
+pure logic separate in the same way HTTP code separates handlers, services,
+stores, integrations, and domain rules.
 
 Default to the simplest shape that keeps ownership clear:
 
@@ -42,7 +35,7 @@ Worker code follows the same layer law as HTTP code:
 - Worker entry points don't construct vendor clients. Worker services or
   executors call integrations through their public API.
 
-## Folder Shape
+## Shape
 
 ### Default: sibling files at the domain root
 
@@ -255,7 +248,7 @@ process entry, scheduler loop, worker-facing orchestration, and one or more
 server-side executors. The promoted shape should separate API-facing
 operations from worker-process operations.
 
-### Today (transitional)
+### Migration exception
 
 ```text
 server/<domain>/
@@ -268,7 +261,7 @@ server/<domain>/
   <external_executor_surface>.py # API-facing surface for an external executor
 ```
 
-Issues:
+This flat shape is an exception because:
 
 - Pure parsing logic belongs in `domain/`, not at the worker-shaped layer.
 - Worker-process executors and scheduler logic sit alongside API-facing
@@ -276,7 +269,7 @@ Issues:
 - API-facing services for external executors must not be mistaken for
   server-side worker executors.
 
-### Target
+### Canonical shape
 
 ```text
 server/<domain>/
@@ -329,9 +322,10 @@ The parent `service.py` remains API-facing. Worker-process concerns move into
 - A worker subfolder with only `main.py`. Promote when there's substantial
   content; otherwise keep `worker.py` at the parent.
 
-## Migration Notes
+## Migration Exceptions
 
-When promoting an existing flat layout to `worker/`:
+Existing domains may still keep worker-only files at the parent domain level.
+When promoting that layout to `worker/`:
 
 1. Identify worker-only files (executors, scheduler loop bodies, queue
    handlers).


### PR DESCRIPTION
## Summary
- align server guide openings with the frontend guide style
- normalize folder-shape headings to Shape where applicable
- convert loose migration/forward-pass sections into Migration Exceptions

## Verification
- git diff --check -- docs/structures/server/guides