### PR TITLE
fix(desktop): allow support window event listen

### DIFF
--- a/apps/desktop/src-tauri/capabilities/support.json
+++ b/apps/desktop/src-tauri/capabilities/support.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "support",
+  "description": "Capability for the support report window",
+  "windows": ["support"],
+  "webviews": ["support"],
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "core:window:allow-start-dragging"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated Tauri capability for the support report window
- allow only event listen/unlisten plus drag-region window support for the `support` webview
- avoid broadening the existing main-window capability

## Verification
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- python3 scripts/check_max_lines.py && git diff --check
- python3 scripts/check_frontend_boundaries.py
