### PR TITLE
fix(desktop): clarify support report upload failures

### DIFF
--- a/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
+++ b/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
@@ -14,7 +14,10 @@ import type {
   SupportReportUploadRequest,
   SupportReportUploadResponse,
 } from "@proliferate/cloud-sdk/types";
-import { collectSupportDiagnostics } from "@/lib/access/tauri/diagnostics";
+import {
+  collectSupportDiagnostics,
+  logRendererEvent,
+} from "@/lib/access/tauri/diagnostics";
 import {
   deleteStagedSupportReportAttachment,
   listenSupportReportJobs,
@@ -22,6 +25,12 @@ import {
 } from "@/lib/access/tauri/support";
 import { createSessionDebugClient } from "@/lib/access/anyharness/debug-client";
 import type { SupportReportJob } from "@/lib/domain/support/report-types";
+import {
+  describeSupportReportUploadFailure,
+  shouldShowSupportReportUploadFailureToast,
+  type SupportReportUploadFailure,
+  type SupportReportUploadFailureKind,
+} from "@/lib/domain/support/report-upload-failure";
 import {
   buildSupportReportPackage,
   type SupportReportUploadDependencies,
@@ -39,6 +48,9 @@ interface PersistedSupportReportJob {
   attemptCount: number;
   nextAttemptAt?: string | null;
   lastError?: string | null;
+  lastFailureKind?: SupportReportUploadFailureKind | null;
+  lastFailureToastAt?: string | null;
+  lastFailureToastKind?: SupportReportUploadFailureKind | null;
 }
 
 export function useSupportReportUploadQueue(): void {
@@ -120,9 +132,30 @@ async function drainSupportReportQueue(
       removePersistedJob(entry.job.jobId);
       showToast("Thanks. Report sent.", "info");
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Report upload failed.";
-      markPersistedJobFailed(entry.job.jobId, message);
-      showToast("Report could not be sent. We'll retry in the background.");
+      const attemptCount = entry.attemptCount + 1;
+      const failure = describeSupportReportUploadFailure(error, attemptCount);
+      void logRendererEvent({
+        source: "support_report_upload",
+        message: `failed.${failure.kind}`,
+      });
+      if (!failure.retryable) {
+        removePersistedJob(entry.job.jobId);
+        await deleteSupportReportJobAttachments(entry.job);
+        showToast(failure.toastMessage);
+        continue;
+      }
+
+      const nowMs = Date.now();
+      const shouldToast = shouldShowSupportReportUploadFailureToast({
+        failure,
+        lastToastAt: entry.lastFailureToastAt,
+        lastToastKind: entry.lastFailureToastKind,
+        nowMs,
+      });
+      markPersistedJobFailed(entry.job.jobId, failure, new Date(nowMs), shouldToast);
+      if (shouldToast) {
+        showToast(failure.toastMessage);
+      }
     }
   }
 }
@@ -202,11 +235,7 @@ async function uploadSupportReport(
     },
   };
   await completeSupportReportUpload(upload.reportId, completeRequest);
-  await Promise.all(job.attachments.map(async (attachment) => {
-    if (attachment.stagedPath) {
-      await deleteStagedSupportReportAttachment(attachment.stagedPath).catch(() => {});
-    }
-  }));
+  await deleteSupportReportJobAttachments(job);
 }
 
 async function putPresignedObject(
@@ -297,17 +326,31 @@ function removePersistedJob(jobId: string): void {
   writePersistedJobs(readPersistedJobs().filter((entry) => entry.job.jobId !== jobId));
 }
 
-function markPersistedJobFailed(jobId: string, message: string): void {
+function markPersistedJobFailed(
+  jobId: string,
+  failure: SupportReportUploadFailure,
+  failedAt: Date,
+  markedToastShown: boolean,
+): void {
   writePersistedJobs(readPersistedJobs().map((entry) => {
     if (entry.job.jobId !== jobId) {
       return entry;
     }
-    const attemptCount = entry.attemptCount + 1;
+    const attemptCount = Math.max(entry.attemptCount + 1, 1);
     return {
       ...entry,
       attemptCount,
-      lastError: message,
-      nextAttemptAt: new Date(Date.now() + retryDelayMs(attemptCount)).toISOString(),
+      lastError: failure.message,
+      lastFailureKind: failure.kind,
+      lastFailureToastAt: markedToastShown
+        ? failedAt.toISOString()
+        : entry.lastFailureToastAt ?? null,
+      lastFailureToastKind: markedToastShown
+        ? failure.kind
+        : entry.lastFailureToastKind ?? null,
+      nextAttemptAt: failure.retryDelayMs == null
+        ? null
+        : new Date(failedAt.getTime() + failure.retryDelayMs).toISOString(),
     };
   }));
 }
@@ -330,16 +373,6 @@ function scheduleNextRetry(
   retryTimerRef.current = window.setTimeout(processQueue, Math.max(1000, next - Date.now()));
 }
 
-function retryDelayMs(attemptCount: number): number {
-  if (attemptCount <= 1) {
-    return 30_000;
-  }
-  if (attemptCount === 2) {
-    return 5 * 60_000;
-  }
-  return 30 * 60_000;
-}
-
 function readPersistedJobs(): PersistedSupportReportJob[] {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -355,4 +388,12 @@ function readPersistedJobs(): PersistedSupportReportJob[] {
 
 function writePersistedJobs(jobs: PersistedSupportReportJob[]): void {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs.slice(-10)));
+}
+
+async function deleteSupportReportJobAttachments(job: SupportReportJob): Promise<void> {
+  await Promise.all(job.attachments.map(async (attachment) => {
+    if (attachment.stagedPath) {
+      await deleteStagedSupportReportAttachment(attachment.stagedPath).catch(() => {});
+    }
+  }));
 }

--- a/apps/desktop/src/lib/domain/support/report-upload-failure.test.ts
+++ b/apps/desktop/src/lib/domain/support/report-upload-failure.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeSupportReportUploadFailure,
+  shouldShowSupportReportUploadFailureToast,
+} from "./report-upload-failure";
+
+describe("describeSupportReportUploadFailure", () => {
+  it("surfaces missing Cloud sign-in as an actionable queued failure", () => {
+    const failure = describeSupportReportUploadFailure(
+      {
+        message: "You must sign in to use cloud workspaces.",
+        status: 401,
+        code: "unauthorized",
+      },
+      1,
+    );
+
+    expect(failure).toMatchObject({
+      kind: "auth_required",
+      retryable: true,
+      retryDelayMs: 5 * 60_000,
+      toastMessage: "Sign in to Proliferate Cloud to send support reports. Report is queued.",
+    });
+  });
+
+  it("surfaces dev auth bypass distinctly from expired sign-in", () => {
+    const failure = describeSupportReportUploadFailure(
+      {
+        message: "Cloud workspaces require real sign-in.",
+        status: 401,
+        code: "dev_auth_bypass",
+      },
+      1,
+    );
+
+    expect(failure).toMatchObject({
+      kind: "dev_auth_bypass",
+      retryable: true,
+      retryDelayMs: 30 * 60_000,
+      toastMessage: "Support reports need real Cloud sign-in. Disable dev auth bypass first.",
+    });
+  });
+
+  it("surfaces missing support storage config without generic retry copy", () => {
+    const failure = describeSupportReportUploadFailure(
+      {
+        message: "Support report upload storage is not configured.",
+        status: 503,
+        code: "support_report_storage_unavailable",
+      },
+      3,
+    );
+
+    expect(failure).toMatchObject({
+      kind: "storage_unconfigured",
+      retryable: true,
+      retryDelayMs: 30 * 60_000,
+      toastMessage: "Support uploads are not configured for this server. Report is queued.",
+    });
+  });
+
+  it("does not retry local payload failures that the queue cannot repair", () => {
+    const failure = describeSupportReportUploadFailure(
+      new Error("Attachment is too large: screenshot.png"),
+      1,
+    );
+
+    expect(failure).toMatchObject({
+      kind: "local_payload_invalid",
+      retryable: false,
+      retryDelayMs: null,
+      toastMessage: "Report is too large or missing attachment data. Try again with fewer files.",
+    });
+  });
+
+  it("keeps generic transient upload failures retryable", () => {
+    const failure = describeSupportReportUploadFailure(new Error("Upload failed with 503."), 2);
+
+    expect(failure).toMatchObject({
+      kind: "transient",
+      retryable: true,
+      retryDelayMs: 5 * 60_000,
+      toastMessage: "Report could not be sent. We'll retry in the background.",
+    });
+  });
+});
+
+describe("shouldShowSupportReportUploadFailureToast", () => {
+  it("shows the first toast for a failure kind", () => {
+    const failure = describeSupportReportUploadFailure(
+      { message: "You must sign in.", status: 401, code: "unauthorized" },
+      1,
+    );
+
+    expect(shouldShowSupportReportUploadFailureToast({
+      failure,
+      nowMs: Date.parse("2026-05-31T10:00:00.000Z"),
+    })).toBe(true);
+  });
+
+  it("suppresses repeated queued-auth toasts inside the cooldown", () => {
+    const failure = describeSupportReportUploadFailure(
+      { message: "You must sign in.", status: 401, code: "unauthorized" },
+      2,
+    );
+
+    expect(shouldShowSupportReportUploadFailureToast({
+      failure,
+      lastToastAt: "2026-05-31T10:00:00.000Z",
+      lastToastKind: "auth_required",
+      nowMs: Date.parse("2026-05-31T10:10:00.000Z"),
+    })).toBe(false);
+  });
+
+  it("shows a toast again after the failure kind changes", () => {
+    const failure = describeSupportReportUploadFailure(
+      {
+        message: "Support report upload storage is not configured.",
+        code: "support_report_storage_unavailable",
+      },
+      2,
+    );
+
+    expect(shouldShowSupportReportUploadFailureToast({
+      failure,
+      lastToastAt: "2026-05-31T10:00:00.000Z",
+      lastToastKind: "auth_required",
+      nowMs: Date.parse("2026-05-31T10:10:00.000Z"),
+    })).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/domain/support/report-upload-failure.ts
+++ b/apps/desktop/src/lib/domain/support/report-upload-failure.ts
@@ -1,0 +1,164 @@
+export type SupportReportUploadFailureKind =
+  | "auth_required"
+  | "cloud_unconfigured"
+  | "dev_auth_bypass"
+  | "local_payload_invalid"
+  | "storage_unconfigured"
+  | "transient";
+
+export interface SupportReportUploadFailure {
+  kind: SupportReportUploadFailureKind;
+  message: string;
+  retryable: boolean;
+  retryDelayMs: number | null;
+  toastMessage: string;
+  toastCooldownMs: number;
+}
+
+interface ErrorShape {
+  message?: unknown;
+  status?: unknown;
+  code?: unknown;
+}
+
+const SHORT_RETRY_DELAY_MS = 30_000;
+const RETRY_AFTER_SIGN_IN_DELAY_MS = 5 * 60_000;
+const CONFIG_RETRY_DELAY_MS = 30 * 60_000;
+const TRANSIENT_TOAST_COOLDOWN_MS = 5 * 60_000;
+const BLOCKED_TOAST_COOLDOWN_MS = 60 * 60_000;
+
+export function describeSupportReportUploadFailure(
+  error: unknown,
+  attemptCount: number,
+): SupportReportUploadFailure {
+  const message = supportReportUploadErrorMessage(error);
+  const code = supportReportUploadErrorCode(error);
+  const status = supportReportUploadErrorStatus(error);
+
+  if (code === "dev_auth_bypass") {
+    return {
+      kind: "dev_auth_bypass",
+      message,
+      retryable: true,
+      retryDelayMs: CONFIG_RETRY_DELAY_MS,
+      toastMessage: "Support reports need real Cloud sign-in. Disable dev auth bypass first.",
+      toastCooldownMs: BLOCKED_TOAST_COOLDOWN_MS,
+    };
+  }
+
+  if (code === "unauthorized" || status === 401) {
+    return {
+      kind: "auth_required",
+      message,
+      retryable: true,
+      retryDelayMs: RETRY_AFTER_SIGN_IN_DELAY_MS,
+      toastMessage: "Sign in to Proliferate Cloud to send support reports. Report is queued.",
+      toastCooldownMs: BLOCKED_TOAST_COOLDOWN_MS,
+    };
+  }
+
+  if (code === "cloud_client_unconfigured") {
+    return {
+      kind: "cloud_unconfigured",
+      message,
+      retryable: true,
+      retryDelayMs: CONFIG_RETRY_DELAY_MS,
+      toastMessage: "Support uploads need Proliferate Cloud configuration. Report is queued.",
+      toastCooldownMs: BLOCKED_TOAST_COOLDOWN_MS,
+    };
+  }
+
+  if (
+    code === "support_report_storage_unavailable"
+    || message.toLowerCase().includes("support report upload storage is not configured")
+  ) {
+    return {
+      kind: "storage_unconfigured",
+      message,
+      retryable: true,
+      retryDelayMs: CONFIG_RETRY_DELAY_MS,
+      toastMessage: "Support uploads are not configured for this server. Report is queued.",
+      toastCooldownMs: BLOCKED_TOAST_COOLDOWN_MS,
+    };
+  }
+
+  if (isLocalPayloadError(message)) {
+    return {
+      kind: "local_payload_invalid",
+      message,
+      retryable: false,
+      retryDelayMs: null,
+      toastMessage: "Report is too large or missing attachment data. Try again with fewer files.",
+      toastCooldownMs: 0,
+    };
+  }
+
+  return {
+    kind: "transient",
+    message,
+    retryable: true,
+    retryDelayMs: retryDelayMs(attemptCount),
+    toastMessage: "Report could not be sent. We'll retry in the background.",
+    toastCooldownMs: TRANSIENT_TOAST_COOLDOWN_MS,
+  };
+}
+
+export function shouldShowSupportReportUploadFailureToast(input: {
+  failure: SupportReportUploadFailure;
+  lastToastKind?: SupportReportUploadFailureKind | null;
+  lastToastAt?: string | null;
+  nowMs: number;
+}): boolean {
+  if (!input.failure.retryable) {
+    return true;
+  }
+  if (input.lastToastKind !== input.failure.kind) {
+    return true;
+  }
+  const lastToastMs = input.lastToastAt ? Date.parse(input.lastToastAt) : Number.NaN;
+  if (!Number.isFinite(lastToastMs)) {
+    return true;
+  }
+  return input.nowMs - lastToastMs >= input.failure.toastCooldownMs;
+}
+
+function supportReportUploadErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  const shaped = error as ErrorShape | null;
+  if (shaped && typeof shaped.message === "string" && shaped.message.trim()) {
+    return shaped.message;
+  }
+  return "Report upload failed.";
+}
+
+function supportReportUploadErrorCode(error: unknown): string | null {
+  const shaped = error as ErrorShape | null;
+  return shaped && typeof shaped.code === "string" ? shaped.code : null;
+}
+
+function supportReportUploadErrorStatus(error: unknown): number | null {
+  const shaped = error as ErrorShape | null;
+  return shaped && typeof shaped.status === "number" ? shaped.status : null;
+}
+
+function isLocalPayloadError(message: string): boolean {
+  return message.startsWith("Diagnostics are too large")
+    || message.startsWith("Attachments are too large")
+    || message.startsWith("Attachment is too large:")
+    || message.startsWith("Attachment data is missing:");
+}
+
+function retryDelayMs(attemptCount: number): number {
+  if (attemptCount <= 1) {
+    return SHORT_RETRY_DELAY_MS;
+  }
+  if (attemptCount === 2) {
+    return 5 * 60_000;
+  }
+  return CONFIG_RETRY_DELAY_MS;
+}

--- a/docs/features/support-reporting.md
+++ b/docs/features/support-reporting.md
@@ -31,6 +31,13 @@ attachment. Clicking `Send` emits a support report job to the main app and
 closes the support window immediately. Progress and failure notifications are
 shown from the main app toast system.
 
+Upload failures distinguish retryable transfer errors from blocked setup
+states. Missing Cloud sign-in, dev auth bypass, and missing server storage
+configuration keep the report queued but show actionable copy instead of the
+generic background-retry message. Local payload problems such as oversized or
+missing attachment data are terminal and ask the user to submit again with a
+smaller payload.
+
 Development builds may keep the old manual debug exports available behind the
 legacy support dialog. Production UI must not expose raw export names such as
 active session JSON, workspace JSON, debug bundle, or investigation JSON.


### PR DESCRIPTION
## Summary
- classify support report upload failures so auth/config issues show actionable toasts instead of generic retry copy
- keep queued blocked reports on a slower retry path and discard terminal local payload failures
- document the support-report failure behavior

## Verification
- pnpm --filter proliferate exec vitest run src/lib/domain/support/report-upload-failure.test.ts
- pnpm --filter proliferate build