### PR TITLE
fix(desktop): preserve billing return handoff

### DIFF
--- a/apps/desktop/src/components/settings/panes/BillingPane.tsx
+++ b/apps/desktop/src/components/settings/panes/BillingPane.tsx
@@ -27,6 +27,7 @@ export function BillingPane() {
   return (
     <BillingSettingsSurface
       enabled={billingEnabled && cloudActive}
+      billingReturnSurface="desktop"
       organization={activeOrganization
         ? {
             id: activeOrganization.id,

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
@@ -125,6 +125,31 @@ describe("BillingSettingsSurface", () => {
     expect(cloudHooks.createBillingPortal).toHaveBeenCalledTimes(1);
   });
 
+  it("passes the selected return surface to billing actions", () => {
+    render(
+      <BillingSettingsSurface
+        billingReturnSurface="desktop"
+        organization={{
+          id: "org_1",
+          name: "Team One",
+          canManageBilling: true,
+          loading: false,
+        }}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(cloudHooks.useCloudBillingActions).toHaveBeenCalledWith(
+      { ownerScope: "organization", organizationId: "org_1" },
+      { returnSurface: "desktop" },
+    );
+    expect(cloudHooks.useCloudBillingActions).toHaveBeenCalledWith(
+      undefined,
+      { returnSurface: "desktop" },
+    );
+  });
+
   it("shows billing action errors from failed checkout starts", async () => {
     cloudHooks.useCloudBilling.mockImplementation(() => ({
       data: billingPlan(),

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { CloudOwnerSelection } from "@proliferate/cloud-sdk";
+import type { BillingReturnSurface, CloudOwnerSelection } from "@proliferate/cloud-sdk";
 import {
   useCloudBilling,
   useCloudBillingActions,
@@ -29,6 +29,7 @@ export interface BillingSettingsSurfaceProps {
   organization: BillingSettingsOrganization | null;
   organizationLoading?: boolean;
   enabled?: boolean;
+  billingReturnSurface?: BillingReturnSurface;
   checkoutReturnState?: BillingCheckoutReturnState;
   onOpenUrl: (url: string) => void | Promise<void>;
   onOpenOrganizationSettings: () => void;
@@ -38,15 +39,17 @@ export function BillingSettingsSurface({
   organization,
   organizationLoading = organization?.loading ?? false,
   enabled = true,
+  billingReturnSurface = "web",
   checkoutReturnState = null,
   onOpenUrl,
   onOpenOrganizationSettings,
 }: BillingSettingsSurfaceProps) {
+  const billingReturnOptions = { returnSurface: billingReturnSurface };
   const comparisonOwner = organization?.canManageBilling
     ? { ownerScope: "organization" as const, organizationId: organization.id }
     : undefined;
   const comparisonBilling = useCloudBilling(comparisonOwner, enabled);
-  const comparisonActions = useCloudBillingActions(comparisonOwner);
+  const comparisonActions = useCloudBillingActions(comparisonOwner, billingReturnOptions);
   const [comparisonActionError, setComparisonActionError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -118,6 +121,7 @@ export function BillingSettingsSurface({
           actionsEnabled={false}
           accountCreditsOnly
           enabled={enabled}
+          billingReturnSurface={billingReturnSurface}
           onOpenUrl={onOpenUrl}
         />
 
@@ -155,6 +159,7 @@ export function BillingSettingsSurface({
             checkoutReturnState={checkoutReturnState}
             actionsEnabled
             enabled={enabled}
+            billingReturnSurface={billingReturnSurface}
             onOpenUrl={onOpenUrl}
           />
         ) : organization ? (
@@ -179,6 +184,7 @@ function BillingOwnerController({
   actionsEnabled,
   accountCreditsOnly = false,
   enabled,
+  billingReturnSurface,
   onOpenUrl,
 }: {
   title: string;
@@ -189,10 +195,11 @@ function BillingOwnerController({
   actionsEnabled: boolean;
   accountCreditsOnly?: boolean;
   enabled: boolean;
+  billingReturnSurface: BillingReturnSurface;
   onOpenUrl: (url: string) => void | Promise<void>;
 }) {
   const billing = useCloudBilling(owner, enabled);
-  const billingActions = useCloudBillingActions(owner);
+  const billingActions = useCloudBillingActions(owner, { returnSurface: billingReturnSurface });
   const billingPlan = billing.data;
   const [actionError, setActionError] = useState<string | null>(null);
   const invoiceUrl = billingPlan?.hostedInvoiceUrl ?? null;

--- a/apps/web/src/pages/BillingReturnHandoffPage.tsx
+++ b/apps/web/src/pages/BillingReturnHandoffPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 
 import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
@@ -32,8 +32,13 @@ export function BillingReturnHandoffPage() {
   const location = useLocation();
   const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const shouldReturnToDesktop = params.get("returnSurface") === "desktop";
+  const [handoffTimedOut, setHandoffTimedOut] = useState(false);
   const deepLinkUrl = useMemo(
     () => desktopBillingDeepLink(location.search),
+    [location.search],
+  );
+  const webBillingPath = useMemo(
+    () => webBillingSettingsPath(location.search),
     [location.search],
   );
 
@@ -43,8 +48,35 @@ export function BillingReturnHandoffPage() {
     }
   }, [deepLinkUrl, shouldReturnToDesktop]);
 
+  useEffect(() => {
+    if (!shouldReturnToDesktop) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => setHandoffTimedOut(true), 8000);
+    return () => window.clearTimeout(timer);
+  }, [shouldReturnToDesktop]);
+
   if (!shouldReturnToDesktop) {
-    return <Navigate to={webBillingSettingsPath(location.search)} replace />;
+    return <Navigate to={webBillingPath} replace />;
+  }
+
+  if (handoffTimedOut) {
+    return (
+      <RedirectCallbackScreen
+        title="Desktop did not open"
+        description="The billing return link is ready, but the operating system has not handed it to Proliferate Desktop."
+        statusLabel="Billing redirect waiting"
+        primaryAction={{
+          label: "Try opening Desktop again",
+          onClick: () => window.location.assign(deepLinkUrl),
+        }}
+        secondaryAction={{
+          label: "Open billing in browser",
+          onClick: () => window.location.assign(webBillingPath),
+        }}
+      />
+    );
   }
 
   return (

--- a/cloud/sdk-react/src/hooks/billing.ts
+++ b/cloud/sdk-react/src/hooks/billing.ts
@@ -8,6 +8,7 @@ import {
   getCurrentTeamCheckout,
   getCloudBillingPlan,
   updateOverageSettings,
+  type BillingCheckoutReturnOptions,
   type BillingPlanInfo,
   type BillingUrlResponse,
   type CloudOwnerSelection,
@@ -44,7 +45,10 @@ export function useCloudBilling(owner?: CloudOwnerSelection, enabled = true) {
   });
 }
 
-export function useCloudBillingActions(owner?: CloudOwnerSelection) {
+export function useCloudBillingActions(
+  owner?: CloudOwnerSelection,
+  returnOptions?: BillingCheckoutReturnOptions,
+) {
   const client = useCloudClient();
   const queryClient = useQueryClient();
   const keyOwner = normalizedOwner(owner);
@@ -53,15 +57,15 @@ export function useCloudBillingActions(owner?: CloudOwnerSelection) {
   };
 
   const cloudCheckout = useMutation<BillingUrlResponse>({
-    mutationFn: () => createCloudCheckoutSession(keyOwner, client),
+    mutationFn: () => createCloudCheckoutSession(keyOwner, client, returnOptions),
     onSuccess: invalidateBilling,
   });
   const billingPortal = useMutation<BillingUrlResponse>({
-    mutationFn: () => createBillingPortalSession(keyOwner, client),
+    mutationFn: () => createBillingPortalSession(keyOwner, client, returnOptions),
     onSuccess: invalidateBilling,
   });
   const refillCheckout = useMutation<BillingUrlResponse>({
-    mutationFn: () => createRefillCheckoutSession(keyOwner, client),
+    mutationFn: () => createRefillCheckoutSession(keyOwner, client, returnOptions),
     onSuccess: invalidateBilling,
   });
   const overage = useMutation<


### PR DESCRIPTION
## Summary
- pass billing return surface through shared billing actions
- make Desktop billing settings request desktop Stripe returns
- show a browser fallback if the Desktop deep link does not open

## Verification
- pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react typecheck
- pnpm --filter @proliferate/product-surfaces test -- BillingSettingsSurface.test.tsx
- pnpm --filter @proliferate/web typecheck
- pnpm --dir apps/desktop exec tsc --noEmit
- pnpm --dir apps/desktop exec vitest run src/lib/domain/auth/desktop-navigation.test.ts
- git diff --check