### PR TITLE
fix(desktop): make new workspace shortcuts reliable

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
@@ -158,7 +158,7 @@ vi.mock("@/components/workspace/chat/transcript/UserMessage", () => ({
   ),
 }));
 
-function installLocalStorageMock() {
+function installLocalStorageMock(options?: { throwOnSet?: boolean }) {
   const values = new Map<string, string>();
   Object.defineProperty(window, "localStorage", {
     configurable: true,
@@ -170,7 +170,12 @@ function installLocalStorageMock() {
       getItem: (key: string) => values.get(key) ?? null,
       key: (index: number) => Array.from(values.keys())[index] ?? null,
       removeItem: (key: string) => values.delete(key),
-      setItem: (key: string, value: string) => values.set(key, String(value)),
+      setItem: (key: string, value: string) => {
+        if (options?.throwOnSet) {
+          throw new Error("localStorage write failed");
+        }
+        values.set(key, String(value));
+      },
     },
   });
 }
@@ -381,5 +386,19 @@ describe("HomeNextScreen target selection persistence", () => {
         repoLaunchKind: "local",
         baseBranchOverride: "feature/sticky",
       });
+  });
+
+  it("keeps target selection in memory when localStorage writes fail", () => {
+    installLocalStorageMock({ throwOnSet: true });
+    resetHomeNext();
+    render(<HomeNextScreen />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mock repo" }));
+
+    expect(screenMocks.homeNextStateArgs).toMatchObject({
+      destination: "repository",
+      repositorySelection: { kind: "repository", sourceRoot: "/repo-b" },
+    });
+    expect(window.localStorage.getItem(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY)).toBeNull();
   });
 });

--- a/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RepoGroup } from "@/components/workspace/shell/sidebar/RepoGroup";
+import type { NewWorkspaceCommandScope } from "@/lib/domain/workspaces/creation/new-workspace-command";
+import { useNewWorkspaceCommandScopeStore } from "@/stores/workspaces/new-workspace-command-scope-store";
+
+vi.mock("@proliferate/ui/icons", () => ({
+  ChevronRight: () => <span data-icon="chevron" />,
+  CloudIcon: () => <span data-icon="cloud" />,
+  FolderClosedFilled: () => <span data-icon="folder-closed" />,
+  FolderFilled: () => <span data-icon="folder-filled" />,
+  Plus: () => <span data-icon="plus" />,
+  Settings: () => <span data-icon="settings" />,
+  Trash: () => <span data-icon="trash" />,
+}));
+
+vi.mock("@proliferate/ui/primitives/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@proliferate/ui/primitives/PopoverButton", () => ({
+  POPOVER_SURFACE_CLASS: "popover-surface",
+  PopoverButton: ({
+    children,
+    className,
+    onOpenChange,
+    trigger,
+  }: {
+    children: (close: () => void) => ReactNode;
+    className?: string;
+    onOpenChange?: (open: boolean) => void;
+    trigger: ReactNode;
+  }) => {
+    const testId = className?.includes("w-64") ? "create-popover" : "context-popover";
+    return (
+      <div data-testid={testId}>
+        {trigger}
+        <button type="button" onClick={() => onOpenChange?.(true)}>
+          Open {testId}
+        </button>
+        <button type="button" onClick={() => onOpenChange?.(false)}>
+          Close {testId}
+        </button>
+        <div>{children(() => onOpenChange?.(false))}</div>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@proliferate/ui/primitives/PopoverMenuItem", () => ({
+  PopoverMenuItem: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{label}</button>
+  ),
+}));
+
+vi.mock("@proliferate/ui/primitives/ConfirmationDialog", () => ({
+  ConfirmationDialog: () => null,
+}));
+
+vi.mock("@proliferate/ui/layout/ShortcutBadge", () => ({
+  ShortcutBadge: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+vi.mock("@/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon", () => ({
+  SidebarWorkspaceVariantIcon: () => <span data-icon="variant" />,
+}));
+
+vi.mock("@/hooks/workspaces/ui/use-repo-group-native-context-menu", () => ({
+  useRepoGroupNativeContextMenu: () => ({ onContextMenuCapture: vi.fn() }),
+}));
+
+vi.mock("./SidebarActionButton", () => ({
+  SidebarActionButton: ({
+    children,
+    title,
+  }: {
+    children: ReactNode;
+    title: string;
+  }) => (
+    <button type="button" aria-label={title}>{children}</button>
+  ),
+}));
+
+vi.mock("@proliferate/product-ui/sidebar/ProductSidebar", () => ({
+  ProductSidebarRepoGroupHeader: ({ action, label }: {
+    action: ReactNode;
+    label: string;
+  }) => (
+    <div>
+      <span>{label}</span>
+      {action}
+    </div>
+  ),
+}));
+
+const scope: NewWorkspaceCommandScope = {
+  id: "sidebar:/repo-a",
+  source: "sidebar",
+  repoGroupKeyToExpand: "/repo-a",
+  localSourceRoot: "/repo-a",
+  repoRootId: "repo-root-a",
+  sourceWorkspaceId: null,
+  cloudRepoTarget: null,
+  baseBranch: null,
+};
+
+describe("RepoGroup new workspace command scope", () => {
+  beforeEach(() => {
+    useNewWorkspaceCommandScopeStore.setState({ activeScope: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useNewWorkspaceCommandScopeStore.setState({ activeScope: null });
+  });
+
+  it("clears an active create-menu scope when the repo group unmounts", () => {
+    const { unmount } = render(
+      <RepoGroup
+        name="Repo A"
+        count={1}
+        collapsed={false}
+        onToggleCollapsed={vi.fn()}
+        newWorkspaceCommandScope={scope}
+      >
+        <div>Workspace A</div>
+      </RepoGroup>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open create-popover" }));
+    expect(useNewWorkspaceCommandScopeStore.getState().activeScope?.id).toBe(scope.id);
+
+    unmount();
+
+    expect(useNewWorkspaceCommandScopeStore.getState().activeScope).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { ChevronRight, CloudIcon, FolderClosedFilled, FolderFilled, Plus, Settings, Trash } from "@proliferate/ui/icons";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
@@ -8,12 +8,14 @@ import { ShortcutBadge } from "@proliferate/ui/layout/ShortcutBadge";
 import { SidebarWorkspaceVariantIcon } from "@/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon";
 import { SHORTCUTS } from "@/config/shortcuts";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
+import type { NewWorkspaceCommandScope } from "@/lib/domain/workspaces/creation/new-workspace-command";
 import {
   confirmRepoRemoval,
   repoRemovalConfirmationCopy,
   requestRepoRemovalConfirmation,
 } from "@/lib/domain/workspaces/sidebar/repo-context-menu";
 import { useRepoGroupNativeContextMenu } from "@/hooks/workspaces/ui/use-repo-group-native-context-menu";
+import { useNewWorkspaceCommandScopeStore } from "@/stores/workspaces/new-workspace-command-scope-store";
 import { SidebarActionButton } from "./SidebarActionButton";
 import { ProductSidebarRepoGroupHeader } from "@proliferate/product-ui/sidebar/ProductSidebar";
 
@@ -26,6 +28,7 @@ interface RepoGroupProps {
   onNewWorkspace?: () => void;
   onNewLocalWorkspace?: () => void;
   onCloudWorkspaceAction?: () => void;
+  newWorkspaceCommandScope?: NewWorkspaceCommandScope | null;
   cloudWorkspaceLabel?: string;
   cloudWorkspaceEnabled?: boolean;
   cloudWorkspaceTooltip?: string;
@@ -44,6 +47,7 @@ export function RepoGroup({
   onNewWorkspace,
   onNewLocalWorkspace,
   onCloudWorkspaceAction,
+  newWorkspaceCommandScope,
   cloudWorkspaceLabel = "New cloud workspace",
   cloudWorkspaceEnabled = true,
   cloudWorkspaceTooltip,
@@ -51,6 +55,8 @@ export function RepoGroup({
   onOpenSettings,
 }: RepoGroupProps) {
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
+  const setActiveNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.setActiveScope);
+  const clearActiveNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.clearActiveScope);
   const handleRequestRemove = () => requestRepoRemovalConfirmation(
     () => setRemoveConfirmOpen(true),
   );
@@ -67,6 +73,24 @@ export function RepoGroup({
     onOpenSettings: () => onOpenSettings?.(),
     onRequestRemove: handleRequestRemove,
   });
+  const handleCreatePopoverOpenChange = (open: boolean) => {
+    if (!newWorkspaceCommandScope) {
+      return;
+    }
+    if (open) {
+      setActiveNewWorkspaceScope(newWorkspaceCommandScope);
+    } else {
+      clearActiveNewWorkspaceScope(newWorkspaceCommandScope.id);
+    }
+  };
+  useEffect(() => {
+    const scopeId = newWorkspaceCommandScope?.id;
+    return () => {
+      if (scopeId) {
+        clearActiveNewWorkspaceScope(scopeId);
+      }
+    };
+  }, [clearActiveNewWorkspaceScope, newWorkspaceCommandScope?.id]);
 
   const headerRow = (
     <ProductSidebarRepoGroupHeader
@@ -96,6 +120,7 @@ export function RepoGroup({
           side="right"
           stopPropagation
           className={`w-64 ${POPOVER_SURFACE_CLASS}`}
+          onOpenChange={handleCreatePopoverOpenChange}
         >
           {(close) => (
             <>

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -7,6 +7,7 @@ import {
   type SidebarEmptyState,
   type SidebarGroupState,
 } from "@/lib/domain/workspaces/sidebar/sidebar-model";
+import { buildSidebarNewWorkspaceCommandScope } from "@/lib/domain/workspaces/creation/new-workspace-command";
 import { visibleSidebarGroupItems } from "@/lib/domain/workspaces/sidebar/sidebar-visible-items";
 import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { SkeletonBlock } from "@/components/feedback/Skeleton";
@@ -142,6 +143,12 @@ export function SidebarWorkspaceContent({
     const cloudRepoTarget = group.cloudRepoTarget;
     const hasArchivedHiddenItems =
       group.items.length === 0 && group.allLogicalWorkspaceIds.length > 0;
+    const newWorkspaceCommandScope = buildSidebarNewWorkspaceCommandScope({
+      sourceRoot: group.sourceRoot,
+      localSourceRoot: group.localSourceRoot,
+      repoRootId: group.repoRootId,
+      cloudRepoTarget: group.cloudRepoTarget,
+    });
 
     return (
       <RepoGroup
@@ -152,6 +159,7 @@ export function SidebarWorkspaceContent({
         onToggleCollapsed={() => onToggleRepoCollapsed(group.sourceRoot)}
         onNewWorkspace={() => onCreateWorktreeWorkspace(group.repoRootId, group.sourceRoot)}
         onNewLocalWorkspace={() => onCreateLocalWorkspace(group.localSourceRoot, group.sourceRoot)}
+        newWorkspaceCommandScope={newWorkspaceCommandScope}
         cloudWorkspaceEnabled={cloudWorkspaceEnabled && cloudRepoAction.kind !== "loading"}
         cloudWorkspaceTooltip={
           cloudRepoAction.kind === "loading"

--- a/apps/desktop/src/config/shortcuts.ts
+++ b/apps/desktop/src/config/shortcuts.ts
@@ -156,8 +156,8 @@ export const SHORTCUTS = {
     nonMacLabel: "Ctrl+Alt+Shift+N",
     description: "New worktree workspace",
     owner: "js",
-    match: { kind: "fixed", key: "n", meta: true, shift: false, alt: true },
-    nonMacMatch: { kind: "fixed", key: "n", meta: true, shift: true, alt: true },
+    match: { kind: "fixed-code", code: "KeyN", meta: true, shift: false, alt: true },
+    nonMacMatch: { kind: "fixed-code", code: "KeyN", meta: true, shift: true, alt: true },
     allowInInputs: true,
   },
   newLocal: {
@@ -166,7 +166,7 @@ export const SHORTCUTS = {
     nonMacLabel: "Ctrl+Shift+N",
     description: "New local workspace",
     owner: "js",
-    match: { kind: "fixed", key: "n", meta: true, shift: true, alt: false },
+    match: { kind: "fixed-code", code: "KeyN", meta: true, shift: true, alt: false },
     allowInInputs: true,
   },
   newCloud: {
@@ -175,8 +175,8 @@ export const SHORTCUTS = {
     nonMacLabel: "Ctrl+Alt+N",
     description: "New cloud workspace",
     owner: "js",
-    match: { kind: "fixed", key: "n", meta: true, ctrl: true, shift: false, alt: false },
-    nonMacMatch: { kind: "fixed", key: "n", meta: true, shift: false, alt: true },
+    match: { kind: "fixed-code", code: "KeyN", meta: true, ctrl: true, shift: false, alt: false },
+    nonMacMatch: { kind: "fixed-code", code: "KeyN", meta: true, shift: false, alt: true },
     allowInInputs: true,
   },
   addRepository: {

--- a/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
+++ b/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppCommandActions } from "@/hooks/app/workflows/use-app-command-actions";
+
+const hookMocks = vi.hoisted(() => ({
+  addRepoFromPicker: vi.fn(),
+  copyBranchName: vi.fn(),
+  copyWorkspaceLocation: vi.fn(),
+  createCloudWorkspaceAndEnter: vi.fn(() => Promise.resolve()),
+  createLocalWorkspaceAndEnter: vi.fn(() => Promise.resolve()),
+  createWorktreeAndEnter: vi.fn(() => Promise.resolve()),
+  goToTopLevelRoute: vi.fn(),
+  navigateToWorkspaceShell: vi.fn(),
+  showToast: vi.fn(),
+  selectedWorkspaceId: null as string | null,
+  selectedLogicalWorkspace: null as unknown,
+  activeNewWorkspaceScope: null as unknown,
+  homeTargetSelection: {
+    destination: "repository",
+    repositorySelection: { kind: "repository", sourceRoot: "/repo-b" },
+    repoLaunchKind: "worktree",
+    selectedSshTargetId: null,
+    baseBranchOverride: "stale/from-other-repo",
+  },
+  homeRepositorySelection: {
+    selectedRepository: {
+      sourceRoot: "/repo-b",
+      name: "Repo B",
+      secondaryLabel: null,
+      workspaceCount: 1,
+      repoRootId: "repo-root-b",
+      localWorkspaceId: "workspace-local-b",
+      gitProvider: "github",
+      gitOwner: "proliferate-ai",
+      gitRepoName: "repo-b",
+    },
+    selectedBranchName: "main",
+  },
+}));
+
+vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: true }),
+}));
+
+vi.mock("@/hooks/cloud/facade/use-cloud-billing", () => ({
+  useCloudBilling: () => ({ data: null }),
+}));
+
+vi.mock("@/hooks/access/cloud/use-cloud-repo-configs", () => ({
+  useCloudRepoConfigs: () => ({
+    data: { configs: [{ gitOwner: "proliferate-ai", gitRepoName: "repo-b", configured: true }] },
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
+  useCreateCloudWorkspace: () => ({
+    createCloudWorkspaceAndEnter: hookMocks.createCloudWorkspaceAndEnter,
+    isCreatingCloudWorkspace: false,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-selected-logical-workspace", () => ({
+  useSelectedLogicalWorkspace: () => ({
+    selectedLogicalWorkspace: hookMocks.selectedLogicalWorkspace,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-standard-repo-projection", () => ({
+  useStandardRepoProjection: () => ({
+    repoRoots: [],
+    localWorkspaces: [],
+    cloudWorkspaces: [],
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/use-workspace-entry-actions", () => ({
+  useWorkspaceEntryActions: () => ({
+    createLocalWorkspaceAndEnter: hookMocks.createLocalWorkspaceAndEnter,
+    isCreatingLocalWorkspace: false,
+    createWorktreeAndEnter: hookMocks.createWorktreeAndEnter,
+    isCreatingWorktreeWorkspace: false,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-add-repo", () => ({
+  useAddRepo: () => ({
+    addRepoFromPicker: hookMocks.addRepoFromPicker,
+    canAddRepo: true,
+    addRepoDisabledReason: null,
+    isAddingRepo: false,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-copy-actions", () => ({
+  useWorkspaceCopyActions: () => ({
+    copyWorkspaceLocation: hookMocks.copyWorkspaceLocation,
+    copyBranchName: hookMocks.copyBranchName,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    goToTopLevelRoute: hookMocks.goToTopLevelRoute,
+    navigateToWorkspaceShell: hookMocks.navigateToWorkspaceShell,
+  }),
+}));
+
+vi.mock("@/hooks/home/ui/use-home-next-target-selection-state", () => ({
+  useHomeNextTargetSelectionSnapshot: () => hookMocks.homeTargetSelection,
+}));
+
+vi.mock("@/hooks/home/derived/use-home-next-repository-selection", () => ({
+  useHomeNextRepositorySelection: () => hookMocks.homeRepositorySelection,
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: { selectedWorkspaceId: string | null }) => unknown) =>
+    selector({ selectedWorkspaceId: hookMocks.selectedWorkspaceId }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: (message: string) => void }) => unknown) =>
+    selector({ show: hookMocks.showToast }),
+}));
+
+vi.mock("@/stores/workspaces/new-workspace-command-scope-store", () => ({
+  useNewWorkspaceCommandScopeStore: (
+    selector: (state: { activeScope: unknown }) => unknown,
+  ) => selector({ activeScope: hookMocks.activeNewWorkspaceScope }),
+}));
+
+vi.mock("@/lib/infra/measurement/latency-flow", () => ({
+  failLatencyFlow: vi.fn(),
+  startLatencyFlow: vi.fn(() => "latency-flow-1"),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={["/"]}>{children}</MemoryRouter>;
+}
+
+describe("useAppCommandActions", () => {
+  beforeEach(() => {
+    hookMocks.addRepoFromPicker.mockClear();
+    hookMocks.copyBranchName.mockClear();
+    hookMocks.copyWorkspaceLocation.mockClear();
+    hookMocks.createCloudWorkspaceAndEnter.mockClear();
+    hookMocks.createLocalWorkspaceAndEnter.mockClear();
+    hookMocks.createWorktreeAndEnter.mockClear();
+    hookMocks.goToTopLevelRoute.mockClear();
+    hookMocks.navigateToWorkspaceShell.mockClear();
+    hookMocks.showToast.mockClear();
+    hookMocks.selectedWorkspaceId = null;
+    hookMocks.activeNewWorkspaceScope = null;
+    hookMocks.homeTargetSelection.baseBranchOverride = "stale/from-other-repo";
+    hookMocks.homeRepositorySelection.selectedBranchName = "main";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses Home's resolved visible branch for new worktree shortcuts", () => {
+    const { result } = renderHook(() => useAppCommandActions(), { wrapper });
+
+    act(() => {
+      result.current.newWorktreeWorkspace.execute("shortcut");
+    });
+
+    expect(hookMocks.navigateToWorkspaceShell).toHaveBeenCalledTimes(1);
+    expect(hookMocks.createWorktreeAndEnter).toHaveBeenCalledWith({
+      repoRootId: "repo-root-b",
+      sourceWorkspaceId: "workspace-local-b",
+      baseBranch: "main",
+    }, expect.objectContaining({
+      latencyFlowId: "latency-flow-1",
+      repoGroupKeyToExpand: "/repo-b",
+    }));
+  });
+});

--- a/apps/desktop/src/hooks/app/workflows/use-app-command-actions.ts
+++ b/apps/desktop/src/hooks/app/workflows/use-app-command-actions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import type { Workspace } from "@anyharness/sdk";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { useCloudBilling } from "@/hooks/cloud/facade/use-cloud-billing";
@@ -11,6 +11,8 @@ import { useWorkspaceEntryActions } from "@/hooks/workspaces/use-workspace-entry
 import { useAddRepo } from "@/hooks/workspaces/workflows/use-add-repo";
 import { useWorkspaceCopyActions } from "@/hooks/workspaces/workflows/use-workspace-copy-actions";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { useHomeNextTargetSelectionSnapshot } from "@/hooks/home/ui/use-home-next-target-selection-state";
+import { useHomeNextRepositorySelection } from "@/hooks/home/derived/use-home-next-repository-selection";
 import { APP_ROUTES } from "@/config/app-routes";
 import { requestSupportDialog } from "@/lib/infra/support/support-dialog-request";
 import { buildCloudRepoSettingsHref, buildSettingsHref } from "@/lib/domain/settings/navigation";
@@ -18,14 +20,15 @@ import {
   buildConfiguredCloudRepoKeys,
   resolveCloudRepoActionState,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
-import { getCloudRepoTargetForSelectedWorkspace, getRepoForSelectedWorkspace } from "@/lib/domain/workspaces/cloud/selected-repo-target";
 import {
-  sidebarRepoGroupKeyForCloudTarget,
-  sidebarRepoGroupKeyForWorkspace,
-} from "@/lib/domain/workspaces/sidebar/sidebar-group-key";
+  buildRepositoryNewWorkspaceCommandScope,
+  buildSelectedWorkspaceNewWorkspaceCommandScope,
+  resolveNewWorkspaceCommandTarget,
+} from "@/lib/domain/workspaces/creation/new-workspace-command";
 import { workspaceCopyMetadataForLogicalWorkspace } from "@/lib/domain/workspaces/workspace-copy-metadata";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
+import { useNewWorkspaceCommandScopeStore } from "@/stores/workspaces/new-workspace-command-scope-store";
 import {
   failLatencyFlow,
   startLatencyFlow,
@@ -59,11 +62,20 @@ export interface AppCommandActions {
 // The hook wires existing workspace/cloud workflows into one command surface.
 export function useAppCommandActions(): AppCommandActions {
   const navigate = useNavigate();
+  const location = useLocation();
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const showToast = useToastStore((state) => state.show);
-  const { goToTopLevelRoute } = useWorkspaceNavigationWorkflow();
+  const { goToTopLevelRoute, navigateToWorkspaceShell } = useWorkspaceNavigationWorkflow();
   const { selectedLogicalWorkspace } = useSelectedLogicalWorkspace();
   const { copyWorkspaceLocation, copyBranchName } = useWorkspaceCopyActions();
+  const homeTargetSelection = useHomeNextTargetSelectionSnapshot();
+  const homeRepositorySelection = useHomeNextRepositorySelection({
+    destination: homeTargetSelection.destination,
+    repositorySelection: homeTargetSelection.repositorySelection,
+    repoLaunchKind: homeTargetSelection.repoLaunchKind,
+    baseBranchOverride: homeTargetSelection.baseBranchOverride,
+  });
+  const activeNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.activeScope);
   const { cloudActive } = useCloudAvailabilityState();
   const { data: billingPlan } = useCloudBilling();
   const {
@@ -101,25 +113,49 @@ export function useAppCommandActions(): AppCommandActions {
     && isCloudRepoConfigsPending
     && !cloudRepoConfigs;
   const cloudWorkspaceBlocked = billingPlan?.billingMode === "enforce" && billingPlan.startBlocked;
-  const selectedRepoContext = useMemo(
-    () => getRepoForSelectedWorkspace(selectedWorkspaceId, workspaces),
-    [selectedWorkspaceId, workspaces],
-  );
-  const selectedCloudTarget = useMemo(
-    () => getCloudRepoTargetForSelectedWorkspace(
+  const homeNewWorkspaceScope = useMemo(() => {
+    if (
+      location.pathname !== APP_ROUTES.home
+      || homeTargetSelection.destination !== "repository"
+    ) {
+      return null;
+    }
+
+    return buildRepositoryNewWorkspaceCommandScope(
+      homeRepositorySelection.selectedRepository,
+      homeRepositorySelection.selectedBranchName,
+      "home",
+    );
+  }, [
+    homeTargetSelection.destination,
+    homeRepositorySelection.selectedBranchName,
+    homeRepositorySelection.selectedRepository,
+    location.pathname,
+  ]);
+  const selectedNewWorkspaceScope = useMemo(
+    () => buildSelectedWorkspaceNewWorkspaceCommandScope({
       selectedWorkspaceId,
       workspaces,
       cloudWorkspaces,
-    ),
-    [cloudWorkspaces, selectedWorkspaceId, workspaces],
+      repoRoots,
+    }),
+    [cloudWorkspaces, repoRoots, selectedWorkspaceId, workspaces],
   );
-  const cloudRepoAction = useMemo(
+  const newWorkspaceCommandScope =
+    activeNewWorkspaceScope
+    ?? homeNewWorkspaceScope
+    ?? selectedNewWorkspaceScope;
+  const commandCloudRepoAction = useMemo(
     () => resolveCloudRepoActionState({
-      repoTarget: selectedCloudTarget,
+      repoTarget: newWorkspaceCommandScope?.cloudRepoTarget ?? null,
       configuredRepoKeys: configuredCloudRepoKeys,
       isInitialConfigLoad: cloudRepoConfigsInitialLoading,
     }),
-    [cloudRepoConfigsInitialLoading, configuredCloudRepoKeys, selectedCloudTarget],
+    [
+      cloudRepoConfigsInitialLoading,
+      configuredCloudRepoKeys,
+      newWorkspaceCommandScope?.cloudRepoTarget,
+    ],
   );
   const selectedWorkspaceCopyMetadata = useMemo(
     () => workspaceCopyMetadataForLogicalWorkspace(selectedLogicalWorkspace),
@@ -157,111 +193,123 @@ export function useAppCommandActions(): AppCommandActions {
     void addRepoFromPicker();
   }, [addRepoFromPicker, addRepositoryDisabledReason]);
 
-  const sourceRoot = selectedRepoContext?.repoWs.sourceRepoRootPath?.trim() ?? "";
-  const newLocalDisabledReason = isCreatingLocalWorkspace
-    ? "Action already in progress."
-    : selectedRepoContext?.repoWs && sourceRoot
-      ? null
-      : "Select a repository workspace first.";
-  const newLocalWorkspace = useCallback(() => {
-    if (newLocalDisabledReason || !selectedRepoContext?.repoWs || !sourceRoot) {
+  const showDisabledShortcutToast = useCallback((
+    invocation: AppCommandInvocation,
+    reason: string,
+  ) => {
+    if (invocation === "shortcut") {
+      showToast(reason);
+    }
+  }, [showToast]);
+  const newLocalCommandTarget = useMemo(() => resolveNewWorkspaceCommandTarget({
+    commandKind: "local",
+    scope: newWorkspaceCommandScope,
+    busyReason: isCreatingLocalWorkspace ? "Action already in progress." : null,
+  }), [isCreatingLocalWorkspace, newWorkspaceCommandScope]);
+  const newLocalDisabledReason = newLocalCommandTarget.disabledReason;
+  const newLocalWorkspace = useCallback((invocation: AppCommandInvocation) => {
+    if (newLocalCommandTarget.disabledReason !== null) {
+      showDisabledShortcutToast(invocation, newLocalCommandTarget.disabledReason);
       return;
     }
 
-    void createLocalWorkspaceAndEnter(sourceRoot, {
-      repoGroupKeyToExpand: sidebarRepoGroupKeyForWorkspace(selectedRepoContext.repoWs, repoRoots),
+    navigateToWorkspaceShell();
+    void createLocalWorkspaceAndEnter(newLocalCommandTarget.sourceRoot, {
+      repoGroupKeyToExpand: newLocalCommandTarget.repoGroupKeyToExpand,
     }).catch((error) => {
       showToast(error instanceof Error ? error.message : "Failed to create workspace.");
     });
   }, [
     createLocalWorkspaceAndEnter,
-    newLocalDisabledReason,
-    repoRoots,
-    selectedRepoContext?.repoWs,
+    navigateToWorkspaceShell,
+    newLocalCommandTarget,
+    showDisabledShortcutToast,
     showToast,
-    sourceRoot,
   ]);
 
-  const repoRootId = selectedRepoContext?.repoWs.repoRootId?.trim() ?? "";
-  const newWorktreeDisabledReason = isCreatingWorktreeWorkspace
-    ? "Action already in progress."
-    : selectedRepoContext?.repoWs && repoRootId
-      ? null
-      : "Select a repository workspace first.";
+  const newWorktreeCommandTarget = useMemo(() => resolveNewWorkspaceCommandTarget({
+    commandKind: "worktree",
+    scope: newWorkspaceCommandScope,
+    busyReason: isCreatingWorktreeWorkspace ? "Action already in progress." : null,
+  }), [isCreatingWorktreeWorkspace, newWorkspaceCommandScope]);
+  const newWorktreeDisabledReason = newWorktreeCommandTarget.disabledReason;
   const newWorktreeWorkspace = useCallback((invocation: AppCommandInvocation) => {
-    if (newWorktreeDisabledReason || !selectedRepoContext?.repoWs || !repoRootId) {
+    if (newWorktreeCommandTarget.disabledReason !== null) {
+      showDisabledShortcutToast(invocation, newWorktreeCommandTarget.disabledReason);
       return;
     }
 
+    navigateToWorkspaceShell();
     const latencyFlowId = startLatencyFlow({
       flowKind: "worktree_enter",
       source: invocation,
-      targetWorkspaceId: repoRootId,
+      targetWorkspaceId: newWorktreeCommandTarget.repoRootId,
     });
     void createWorktreeAndEnter({
-      repoRootId,
-      sourceWorkspaceId: selectedRepoContext.repoWs.id,
+      repoRootId: newWorktreeCommandTarget.repoRootId,
+      sourceWorkspaceId: newWorktreeCommandTarget.sourceWorkspaceId,
+      baseBranch: newWorktreeCommandTarget.baseBranch ?? undefined,
     }, {
       latencyFlowId,
-      repoGroupKeyToExpand: sidebarRepoGroupKeyForWorkspace(selectedRepoContext.repoWs, repoRoots),
+      repoGroupKeyToExpand: newWorktreeCommandTarget.repoGroupKeyToExpand,
     }).catch((error) => {
       failLatencyFlow(latencyFlowId, "worktree_enter_failed");
       showToast(error instanceof Error ? error.message : "Failed to create worktree.");
     });
   }, [
     createWorktreeAndEnter,
-    newWorktreeDisabledReason,
-    repoRootId,
-    repoRoots,
-    selectedRepoContext?.repoWs,
+    navigateToWorkspaceShell,
+    newWorktreeCommandTarget,
+    showDisabledShortcutToast,
     showToast,
   ]);
 
-  const newCloudDisabledReason = (() => {
-    if (isCreatingCloudWorkspace) {
-      return "Action already in progress.";
-    }
-    if (!cloudActive) {
-      return "Cloud workspaces are unavailable.";
-    }
-    if (cloudWorkspaceBlocked) {
-      return "Cloud workspaces are blocked by billing.";
-    }
-    if (!selectedCloudTarget || cloudRepoAction.kind === "hidden") {
-      return "Select a repository workspace first.";
-    }
-    if (cloudRepoAction.kind === "loading") {
-      return "Cloud repository settings are loading.";
-    }
-    return null;
-  })();
+  const cloudUnavailableReason = !cloudActive
+    ? "Cloud workspaces are unavailable."
+    : cloudWorkspaceBlocked
+      ? "Cloud workspaces are blocked by billing."
+      : null;
+  const newCloudCommandTarget = useMemo(() => resolveNewWorkspaceCommandTarget({
+    commandKind: "cloud",
+    scope: newWorkspaceCommandScope,
+    busyReason: isCreatingCloudWorkspace ? "Action already in progress." : null,
+    cloudUnavailableReason,
+    cloudRepoAction: commandCloudRepoAction,
+  }), [
+    cloudUnavailableReason,
+    commandCloudRepoAction,
+    isCreatingCloudWorkspace,
+    newWorkspaceCommandScope,
+  ]);
+  const newCloudDisabledReason = newCloudCommandTarget.disabledReason;
   const newCloudWorkspace = useCallback((invocation: AppCommandInvocation) => {
-    if (newCloudDisabledReason || !selectedCloudTarget) {
+    if (newCloudCommandTarget.disabledReason !== null) {
+      showDisabledShortcutToast(invocation, newCloudCommandTarget.disabledReason);
       return;
     }
-    if (cloudRepoAction.kind === "configure") {
-      navigate(buildCloudRepoSettingsHref(selectedCloudTarget.gitOwner, selectedCloudTarget.gitRepoName));
-      return;
-    }
-    if (cloudRepoAction.kind !== "create") {
+    if (newCloudCommandTarget.cloudActionKind === "configure") {
+      navigate(buildCloudRepoSettingsHref(
+        newCloudCommandTarget.target.gitOwner,
+        newCloudCommandTarget.target.gitRepoName,
+      ));
       return;
     }
 
+    navigateToWorkspaceShell();
     const latencyFlowId = startLatencyFlow({
       flowKind: "cloud_workspace_create",
       source: invocation,
     });
-    void createCloudWorkspaceAndEnter(selectedCloudTarget, {
+    void createCloudWorkspaceAndEnter(newCloudCommandTarget.target, {
       latencyFlowId,
-      repoGroupKeyToExpand: sidebarRepoGroupKeyForCloudTarget(selectedCloudTarget, repoRoots),
+      repoGroupKeyToExpand: newCloudCommandTarget.repoGroupKeyToExpand,
     });
   }, [
-    cloudRepoAction.kind,
     createCloudWorkspaceAndEnter,
     navigate,
-    newCloudDisabledReason,
-    repoRoots,
-    selectedCloudTarget,
+    navigateToWorkspaceShell,
+    newCloudCommandTarget,
+    showDisabledShortcutToast,
   ]);
   const copyWorkspacePathAction = useCallback(() => {
     void copyWorkspaceLocation(selectedWorkspaceCopyMetadata.workspaceLocation);

--- a/apps/desktop/src/hooks/home/ui/use-home-next-target-selection-state.ts
+++ b/apps/desktop/src/hooks/home/ui/use-home-next-target-selection-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type {
   HomeNextDestination,
   HomeNextRepoLaunchKind,
@@ -24,6 +24,10 @@ const DEFAULT_HOME_NEXT_TARGET_SELECTION: HomeNextTargetSelectionState = {
   selectedSshTargetId: null,
   baseBranchOverride: null,
 };
+const homeNextTargetSelectionListeners = new Set<() => void>();
+let cachedHomeNextTargetSelectionRaw: string | null | undefined;
+let cachedHomeNextTargetSelection = DEFAULT_HOME_NEXT_TARGET_SELECTION;
+let hasHomeNextTargetSelectionMemoryOverride = false;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -89,45 +93,85 @@ function getLocalStorage(): Storage | null {
 }
 
 function readPersistedTargetSelection(): HomeNextTargetSelectionState {
-  const storage = getLocalStorage();
-  if (!storage) {
-    return DEFAULT_HOME_NEXT_TARGET_SELECTION;
+  if (hasHomeNextTargetSelectionMemoryOverride) {
+    return cachedHomeNextTargetSelection;
   }
 
+  const storage = getLocalStorage();
+  if (!storage) {
+    return cachedHomeNextTargetSelection;
+  }
+
+  let raw: string | null = null;
   try {
-    const raw = storage.getItem(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY);
-    if (!raw) {
-      return DEFAULT_HOME_NEXT_TARGET_SELECTION;
+    raw = storage.getItem(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY);
+    if (raw === cachedHomeNextTargetSelectionRaw) {
+      return cachedHomeNextTargetSelection;
     }
-    return normalizeHomeNextTargetSelectionState(JSON.parse(raw));
+    cachedHomeNextTargetSelectionRaw = raw;
+    if (!raw) {
+      cachedHomeNextTargetSelection = DEFAULT_HOME_NEXT_TARGET_SELECTION;
+      return cachedHomeNextTargetSelection;
+    }
+    cachedHomeNextTargetSelection = normalizeHomeNextTargetSelectionState(JSON.parse(raw));
+    return cachedHomeNextTargetSelection;
   } catch {
-    return DEFAULT_HOME_NEXT_TARGET_SELECTION;
+    cachedHomeNextTargetSelectionRaw = raw;
+    cachedHomeNextTargetSelection = DEFAULT_HOME_NEXT_TARGET_SELECTION;
+    return cachedHomeNextTargetSelection;
   }
 }
 
 function persistTargetSelection(selection: HomeNextTargetSelectionState): void {
-  const storage = getLocalStorage();
-  if (!storage) return;
+  const raw = JSON.stringify(selection);
+  cachedHomeNextTargetSelectionRaw = raw;
+  cachedHomeNextTargetSelection = selection;
 
-  try {
-    storage.setItem(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY, JSON.stringify(selection));
-  } catch {
-    // Local storage can be unavailable in restricted browser contexts.
+  const storage = getLocalStorage();
+  if (storage) {
+    try {
+      storage.setItem(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY, raw);
+      hasHomeNextTargetSelectionMemoryOverride = false;
+    } catch {
+      hasHomeNextTargetSelectionMemoryOverride = true;
+    }
+  } else {
+    hasHomeNextTargetSelectionMemoryOverride = true;
+  }
+
+  for (const listener of homeNextTargetSelectionListeners) {
+    listener();
   }
 }
 
+export function readHomeNextTargetSelectionState(): HomeNextTargetSelectionState {
+  return readPersistedTargetSelection();
+}
+
+export function subscribeHomeNextTargetSelectionState(listener: () => void): () => void {
+  homeNextTargetSelectionListeners.add(listener);
+  return () => {
+    homeNextTargetSelectionListeners.delete(listener);
+  };
+}
+
+export function useHomeNextTargetSelectionSnapshot(): HomeNextTargetSelectionState {
+  return useSyncExternalStore(
+    subscribeHomeNextTargetSelectionState,
+    readHomeNextTargetSelectionState,
+    () => DEFAULT_HOME_NEXT_TARGET_SELECTION,
+  );
+}
+
 export function useHomeNextTargetSelectionState() {
-  const [targetSelection, setTargetSelection] = useState(readPersistedTargetSelection);
+  const targetSelection = useHomeNextTargetSelectionSnapshot();
 
   const patchTargetSelection = useCallback((patch: HomeNextTargetSelectionPatch) => {
-    setTargetSelection((current) => {
-      const next = normalizeHomeNextTargetSelectionState({
-        ...current,
-        ...patch,
-      });
-      persistTargetSelection(next);
-      return next;
+    const next = normalizeHomeNextTargetSelectionState({
+      ...readHomeNextTargetSelectionState(),
+      ...patch,
     });
+    persistTargetSelection(next);
   }, []);
 
   return {

--- a/apps/desktop/src/lib/domain/shortcuts/keyboard-resolution.test.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/keyboard-resolution.test.ts
@@ -211,6 +211,52 @@ describe("resolveKeyboardShortcut", () => {
     } as KeyboardEvent)).toBeNull();
   });
 
+  it("resolves new workspace shortcuts by physical KeyN on mac", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "Dead",
+      code: "KeyN",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.new-worktree",
+      shortcut: expect.objectContaining({ id: "workspace.new-worktree" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "N",
+      code: "KeyN",
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.new-local",
+      shortcut: expect.objectContaining({ id: "workspace.new-local" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "Unexpected",
+      code: "KeyN",
+      metaKey: true,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.new-cloud",
+      shortcut: expect.objectContaining({ id: "workspace.new-cloud" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+  });
+
   it("resolves command-option workspace and tab shortcuts on mac", () => {
     vi.stubGlobal("navigator", {
       platform: "MacIntel",

--- a/apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.test.ts
@@ -1,0 +1,192 @@
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import type { SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
+import {
+  buildRepositoryNewWorkspaceCommandScope,
+  buildSelectedWorkspaceNewWorkspaceCommandScope,
+  buildSidebarNewWorkspaceCommandScope,
+  resolveNewWorkspaceCommandTarget,
+} from "@/lib/domain/workspaces/creation/new-workspace-command";
+
+const repoRoot = {
+  id: "repo-root-1",
+  path: "/repos/proliferate",
+  displayName: "Proliferate",
+  remoteProvider: "github",
+  remoteOwner: "proliferate-ai",
+  remoteRepoName: "proliferate",
+  defaultBranch: "main",
+} as RepoRoot;
+
+const localWorkspace = {
+  id: "workspace-local",
+  kind: "local",
+  surface: "workspace",
+  path: "/repos/proliferate",
+  repoRootId: "repo-root-1",
+  sourceRepoRootPath: "/repos/proliferate",
+  gitProvider: "github",
+  gitOwner: "proliferate-ai",
+  gitRepoName: "proliferate",
+  currentBranch: "main",
+  originalBranch: "main",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+} as unknown as Workspace;
+
+const repository = {
+  sourceRoot: "/repos/proliferate",
+  name: "proliferate",
+  secondaryLabel: null,
+  workspaceCount: 1,
+  repoRootId: "repo-root-1",
+  localWorkspaceId: "workspace-local",
+  gitProvider: "github",
+  gitOwner: "proliferate-ai",
+  gitRepoName: "proliferate",
+} satisfies SettingsRepositoryEntry;
+
+describe("new workspace command targets", () => {
+  it("resolves sidebar menu scope for all workspace creation variants", () => {
+    const scope = buildSidebarNewWorkspaceCommandScope({
+      sourceRoot: "/repos/proliferate",
+      localSourceRoot: "/repos/proliferate",
+      repoRootId: "repo-root-1",
+      cloudRepoTarget: {
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+      },
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "local",
+      scope,
+    })).toMatchObject({
+      commandKind: "local",
+      sourceRoot: "/repos/proliferate",
+      repoGroupKeyToExpand: "/repos/proliferate",
+      disabledReason: null,
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "worktree",
+      scope,
+    })).toMatchObject({
+      commandKind: "worktree",
+      repoRootId: "repo-root-1",
+      sourceWorkspaceId: null,
+      repoGroupKeyToExpand: "/repos/proliferate",
+      disabledReason: null,
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "cloud",
+      scope,
+      cloudRepoAction: { kind: "create", label: "New cloud workspace" },
+    })).toMatchObject({
+      commandKind: "cloud",
+      cloudActionKind: "create",
+      target: {
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+      },
+      repoGroupKeyToExpand: "/repos/proliferate",
+      disabledReason: null,
+    });
+  });
+
+  it("uses Home repository selection and branch override as command scope", () => {
+    const scope = buildRepositoryNewWorkspaceCommandScope(
+      repository,
+      "feature/base",
+      "home",
+    );
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "worktree",
+      scope,
+    })).toMatchObject({
+      commandKind: "worktree",
+      repoRootId: "repo-root-1",
+      sourceWorkspaceId: "workspace-local",
+      baseBranch: "feature/base",
+      repoGroupKeyToExpand: "/repos/proliferate",
+      disabledReason: null,
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "cloud",
+      scope,
+      cloudRepoAction: { kind: "create", label: "New cloud workspace" },
+    })).toMatchObject({
+      commandKind: "cloud",
+      cloudActionKind: "create",
+      target: {
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+        baseBranch: "feature/base",
+      },
+      disabledReason: null,
+    });
+  });
+
+  it("falls back to the selected workspace repository when no explicit scope exists", () => {
+    const scope = buildSelectedWorkspaceNewWorkspaceCommandScope({
+      selectedWorkspaceId: "workspace-local",
+      workspaces: [localWorkspace],
+      cloudWorkspaces: [],
+      repoRoots: [repoRoot],
+    });
+
+    expect(scope).toMatchObject({
+      source: "selected-workspace",
+      repoGroupKeyToExpand: "/repos/proliferate",
+      localSourceRoot: "/repos/proliferate",
+      repoRootId: "repo-root-1",
+      sourceWorkspaceId: "workspace-local",
+      cloudRepoTarget: {
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+      },
+    });
+  });
+
+  it("keeps cloud configuration states distinct from missing targets", () => {
+    const scope = buildSidebarNewWorkspaceCommandScope({
+      sourceRoot: "/repos/proliferate",
+      localSourceRoot: "/repos/proliferate",
+      repoRootId: "repo-root-1",
+      cloudRepoTarget: {
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+      },
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "cloud",
+      scope,
+      cloudRepoAction: { kind: "loading", label: "Loading cloud..." },
+    })).toEqual({
+      commandKind: "cloud",
+      disabledReason: "Cloud repository settings are loading.",
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "cloud",
+      scope,
+      cloudRepoAction: { kind: "configure", label: "Configure cloud" },
+    })).toMatchObject({
+      commandKind: "cloud",
+      cloudActionKind: "configure",
+      disabledReason: null,
+    });
+
+    expect(resolveNewWorkspaceCommandTarget({
+      commandKind: "cloud",
+      scope: null,
+      cloudRepoAction: { kind: "hidden", label: null },
+    })).toEqual({
+      commandKind: "cloud",
+      disabledReason: "Select a repository workspace first.",
+    });
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.ts
+++ b/apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.ts
@@ -1,0 +1,265 @@
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import type { SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
+import {
+  type CloudRepoActionState,
+  type CloudWorkspaceRepoTarget,
+} from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+import {
+  getCloudRepoTargetForSelectedWorkspace,
+  getRepoForSelectedWorkspace,
+} from "@/lib/domain/workspaces/cloud/selected-repo-target";
+import {
+  sidebarRepoGroupKeyForCloudTarget,
+  sidebarRepoGroupKeyForWorkspace,
+} from "@/lib/domain/workspaces/sidebar/sidebar-group-key";
+
+export type NewWorkspaceCommandKind = "local" | "worktree" | "cloud";
+
+export type NewWorkspaceCommandScopeSource =
+  | "sidebar"
+  | "home"
+  | "selected-workspace";
+
+export interface NewWorkspaceCommandScope {
+  id: string;
+  source: NewWorkspaceCommandScopeSource;
+  repoGroupKeyToExpand: string | null;
+  localSourceRoot: string | null;
+  repoRootId: string | null;
+  sourceWorkspaceId: string | null;
+  cloudRepoTarget: CloudWorkspaceRepoTarget | null;
+  baseBranch: string | null;
+}
+
+export type NewWorkspaceDisabledCommandTarget<
+  Kind extends NewWorkspaceCommandKind = NewWorkspaceCommandKind,
+> = {
+  commandKind: Kind;
+  disabledReason: string;
+};
+
+export type NewLocalWorkspaceCommandTarget =
+  | {
+    commandKind: "local";
+    sourceRoot: string;
+    repoGroupKeyToExpand: string | null;
+    disabledReason: null;
+  }
+  | NewWorkspaceDisabledCommandTarget<"local">;
+
+export type NewWorktreeWorkspaceCommandTarget =
+  | {
+    commandKind: "worktree";
+    repoRootId: string;
+    sourceWorkspaceId: string | null;
+    baseBranch: string | null;
+    repoGroupKeyToExpand: string | null;
+    disabledReason: null;
+  }
+  | NewWorkspaceDisabledCommandTarget<"worktree">;
+
+export type NewCloudWorkspaceCommandTarget =
+  | {
+    commandKind: "cloud";
+    cloudActionKind: "create" | "configure";
+    target: CloudWorkspaceRepoTarget;
+    repoGroupKeyToExpand: string | null;
+    disabledReason: null;
+  }
+  | NewWorkspaceDisabledCommandTarget<"cloud">;
+
+export type NewWorkspaceCommandTarget =
+  | NewLocalWorkspaceCommandTarget
+  | NewWorktreeWorkspaceCommandTarget
+  | NewCloudWorkspaceCommandTarget;
+
+interface ResolveNewWorkspaceCommandTargetInput<
+  Kind extends NewWorkspaceCommandKind = NewWorkspaceCommandKind,
+> {
+  commandKind: Kind;
+  scope: NewWorkspaceCommandScope | null;
+  busyReason?: string | null;
+  cloudUnavailableReason?: string | null;
+  cloudRepoAction?: CloudRepoActionState | null;
+}
+
+export interface BuildSelectedWorkspaceCommandScopeInput {
+  selectedWorkspaceId: string | null;
+  workspaces: Workspace[];
+  cloudWorkspaces: CloudWorkspaceSummary[];
+  repoRoots: RepoRoot[];
+}
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function withBaseBranch(
+  target: CloudWorkspaceRepoTarget,
+  baseBranch: string | null,
+): CloudWorkspaceRepoTarget {
+  const normalizedBaseBranch = trimToNull(target.baseBranch) ?? trimToNull(baseBranch);
+  return normalizedBaseBranch
+    ? { ...target, baseBranch: normalizedBaseBranch }
+    : { gitOwner: target.gitOwner, gitRepoName: target.gitRepoName };
+}
+
+function disabledTarget<Kind extends NewWorkspaceCommandKind>(
+  commandKind: Kind,
+  disabledReason: string,
+): NewWorkspaceDisabledCommandTarget<Kind> {
+  return { commandKind, disabledReason };
+}
+
+export function buildSidebarNewWorkspaceCommandScope(input: {
+  sourceRoot: string;
+  localSourceRoot: string | null;
+  repoRootId: string | null;
+  cloudRepoTarget: CloudWorkspaceRepoTarget | null;
+}): NewWorkspaceCommandScope {
+  const sourceRoot = trimToNull(input.sourceRoot) ?? "unknown";
+
+  return {
+    id: `sidebar:${sourceRoot}`,
+    source: "sidebar",
+    repoGroupKeyToExpand: sourceRoot,
+    localSourceRoot: trimToNull(input.localSourceRoot),
+    repoRootId: trimToNull(input.repoRootId),
+    sourceWorkspaceId: null,
+    cloudRepoTarget: input.cloudRepoTarget,
+    baseBranch: null,
+  };
+}
+
+export function buildRepositoryNewWorkspaceCommandScope(
+  repository: SettingsRepositoryEntry | null,
+  baseBranch: string | null,
+  source: "home",
+): NewWorkspaceCommandScope | null {
+  const sourceRoot = trimToNull(repository?.sourceRoot);
+  if (!repository || !sourceRoot) {
+    return null;
+  }
+
+  const normalizedBaseBranch = trimToNull(baseBranch);
+  const gitOwner = trimToNull(repository.gitOwner);
+  const gitRepoName = trimToNull(repository.gitRepoName);
+  const cloudRepoTarget = gitOwner && gitRepoName
+    ? withBaseBranch({ gitOwner, gitRepoName }, normalizedBaseBranch)
+    : null;
+
+  return {
+    id: `${source}:${sourceRoot}`,
+    source,
+    repoGroupKeyToExpand: sourceRoot,
+    localSourceRoot: sourceRoot,
+    repoRootId: trimToNull(repository.repoRootId),
+    sourceWorkspaceId: trimToNull(repository.localWorkspaceId),
+    cloudRepoTarget,
+    baseBranch: normalizedBaseBranch,
+  };
+}
+
+export function buildSelectedWorkspaceNewWorkspaceCommandScope(
+  input: BuildSelectedWorkspaceCommandScopeInput,
+): NewWorkspaceCommandScope | null {
+  const repoContext = getRepoForSelectedWorkspace(
+    input.selectedWorkspaceId,
+    input.workspaces,
+  );
+  const cloudRepoTarget = getCloudRepoTargetForSelectedWorkspace(
+    input.selectedWorkspaceId,
+    input.workspaces,
+    input.cloudWorkspaces,
+  );
+
+  if (!repoContext?.repoWs && !cloudRepoTarget) {
+    return null;
+  }
+
+  const repoWs = repoContext?.repoWs ?? null;
+  const repoGroupKeyToExpand = repoWs
+    ? sidebarRepoGroupKeyForWorkspace(repoWs, input.repoRoots)
+    : cloudRepoTarget
+      ? sidebarRepoGroupKeyForCloudTarget(cloudRepoTarget, input.repoRoots)
+      : null;
+
+  return {
+    id: `selected:${input.selectedWorkspaceId ?? "none"}`,
+    source: "selected-workspace",
+    repoGroupKeyToExpand,
+    localSourceRoot: trimToNull(repoWs?.sourceRepoRootPath),
+    repoRootId: trimToNull(repoWs?.repoRootId),
+    sourceWorkspaceId: trimToNull(repoWs?.id),
+    cloudRepoTarget,
+    baseBranch: null,
+  };
+}
+
+export function resolveNewWorkspaceCommandTarget(
+  input: ResolveNewWorkspaceCommandTargetInput<"local">,
+): NewLocalWorkspaceCommandTarget;
+export function resolveNewWorkspaceCommandTarget(
+  input: ResolveNewWorkspaceCommandTargetInput<"worktree">,
+): NewWorktreeWorkspaceCommandTarget;
+export function resolveNewWorkspaceCommandTarget(
+  input: ResolveNewWorkspaceCommandTargetInput<"cloud">,
+): NewCloudWorkspaceCommandTarget;
+export function resolveNewWorkspaceCommandTarget(
+  input: ResolveNewWorkspaceCommandTargetInput,
+): NewWorkspaceCommandTarget {
+  if (input.busyReason) {
+    return disabledTarget(input.commandKind, input.busyReason);
+  }
+
+  if (input.commandKind === "local") {
+    const sourceRoot = trimToNull(input.scope?.localSourceRoot);
+    return sourceRoot
+      ? {
+        commandKind: "local",
+        sourceRoot,
+        repoGroupKeyToExpand: trimToNull(input.scope?.repoGroupKeyToExpand),
+        disabledReason: null,
+      }
+      : disabledTarget("local", "Select a repository workspace first.");
+  }
+
+  if (input.commandKind === "worktree") {
+    const repoRootId = trimToNull(input.scope?.repoRootId);
+    return repoRootId
+      ? {
+        commandKind: "worktree",
+        repoRootId,
+        sourceWorkspaceId: trimToNull(input.scope?.sourceWorkspaceId),
+        baseBranch: trimToNull(input.scope?.baseBranch),
+        repoGroupKeyToExpand: trimToNull(input.scope?.repoGroupKeyToExpand),
+        disabledReason: null,
+      }
+      : disabledTarget("worktree", "Select a repository workspace first.");
+  }
+
+  if (input.cloudUnavailableReason) {
+    return disabledTarget("cloud", input.cloudUnavailableReason);
+  }
+
+  const target = input.scope?.cloudRepoTarget
+    ? withBaseBranch(input.scope.cloudRepoTarget, trimToNull(input.scope.baseBranch))
+    : null;
+  const cloudRepoAction = input.cloudRepoAction ?? { kind: "hidden", label: null };
+  if (!target || cloudRepoAction.kind === "hidden") {
+    return disabledTarget("cloud", "Select a repository workspace first.");
+  }
+  if (cloudRepoAction.kind === "loading") {
+    return disabledTarget("cloud", "Cloud repository settings are loading.");
+  }
+
+  return {
+    commandKind: "cloud",
+    cloudActionKind: cloudRepoAction.kind,
+    target,
+    repoGroupKeyToExpand: trimToNull(input.scope?.repoGroupKeyToExpand),
+    disabledReason: null,
+  };
+}

--- a/apps/desktop/src/stores/workspaces/new-workspace-command-scope-store.ts
+++ b/apps/desktop/src/stores/workspaces/new-workspace-command-scope-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import type { NewWorkspaceCommandScope } from "@/lib/domain/workspaces/creation/new-workspace-command";
+
+interface NewWorkspaceCommandScopeState {
+  activeScope: NewWorkspaceCommandScope | null;
+  setActiveScope: (scope: NewWorkspaceCommandScope) => void;
+  clearActiveScope: (scopeId?: string | null) => void;
+}
+
+export const useNewWorkspaceCommandScopeStore = create<NewWorkspaceCommandScopeState>((set) => ({
+  activeScope: null,
+  setActiveScope: (scope) => set({ activeScope: scope }),
+  clearActiveScope: (scopeId) => set((state) => {
+    if (scopeId && state.activeScope?.id !== scopeId) {
+      return state;
+    }
+    return { activeScope: null };
+  }),
+}));

--- a/docs/features/pending-workspace-shell.md
+++ b/docs/features/pending-workspace-shell.md
@@ -20,6 +20,7 @@ Use this map to decide whether this spec applies and where to look first.
 | Path | Owns |
 | --- | --- |
 | `apps/desktop/src/lib/domain/workspaces/creation/pending-entry.ts` | Pending workspace model and path helpers. |
+| `apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.ts` | Shared target resolution for new workspace commands and shortcuts. |
 | `apps/desktop/src/lib/domain/workspaces/selection/optimistic-session-shell.ts` | Fast-open session candidate and placeholder rules. |
 | `apps/desktop/src/hooks/workspaces/selection/run-workspace-selection.ts` | Existing workspace selection and first active-session projection. |
 | `apps/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts` | Session-list bootstrap and optimistic session validation. |
@@ -284,6 +285,12 @@ summary and stream replace it as soon as AnyHarness session data is available.
 ## 7. Begin Flow
 
 All workspace creation entrypoints should converge on this shape:
+
+Keyboard shortcuts and command-palette entries must resolve the same repository
+target as the visible UI. If a sidebar repo create menu is open, use that repo.
+If Home is showing a repository target, use Home's selected repository and
+branch. Otherwise fall back to the selected workspace. Create commands should
+enter the workspace shell before dispatching the async create work.
 
 1. Resolve deterministic display and request data before shell entry.
    For worktrees this includes `workspaceName`, `branchName`, `baseBranch`,


### PR DESCRIPTION
## Summary

- Match new workspace shortcuts by physical `KeyN` so Option/Alt keyboard layouts do not break them.
- Resolve new workspace command targets consistently across sidebar popovers, Home repository selection, and selected workspaces.
- Fix review-found edge cases for stale sidebar scopes, stale Home branch overrides, and localStorage write failures.
- Add shared target-resolution tests and document command target precedence.

## Verification

- `pnpm --filter @proliferate/product-surfaces build`
- `pnpm --dir apps/desktop exec tsc --noEmit`
- `pnpm --dir apps/desktop exec vitest run src/components/workspace/shell/sidebar/RepoGroup.test.tsx src/hooks/app/workflows/use-app-command-actions.test.tsx src/components/home/screen/HomeNextScreen.test.tsx src/lib/domain/shortcuts/keyboard-resolution.test.ts src/lib/domain/workspaces/creation/new-workspace-command.test.ts src/hooks/app/lifecycle/use-app-shortcuts.test.tsx`