### PR TITLE
fix(support): harden debug report correlation

### DIFF
--- a/apps/desktop/src-tauri/src/diagnostics/bundle.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/bundle.rs
@@ -293,6 +293,8 @@ pub async fn collect_support_diagnostics_bundle(
         })
         .map(|value| scrub_diagnostic_text(&value));
 
+    let support_health = health.clone().map(scrub_health_response);
+
     Ok(SupportDiagnosticsBundle {
         schema_version: 1,
         manifest: SupportDiagnosticsManifest {
@@ -310,10 +312,18 @@ pub async fn collect_support_diagnostics_bundle(
             platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
             timestamp: Utc::now().to_rfc3339(),
         },
-        health,
+        health: support_health,
         logs,
         collection_errors,
     })
+}
+
+fn scrub_health_response(health: HealthResponse) -> HealthResponse {
+    HealthResponse {
+        runtime_home: scrub_diagnostic_text(&health.runtime_home),
+        status: health.status,
+        version: health.version,
+    }
 }
 
 fn collect_log_files(base_path: &Path) -> Vec<PathBuf> {
@@ -461,7 +471,10 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{collect_log_files, scrub_diagnostic_text, suggested_bundle_file_name};
+    use super::{
+        collect_log_files, scrub_diagnostic_text, scrub_health_response,
+        suggested_bundle_file_name, HealthResponse,
+    };
 
     fn temp_path(file_name: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -497,5 +510,18 @@ mod tests {
     fn scrubber_hides_secrets_in_exported_text() {
         let scrubbed = scrub_diagnostic_text("Authorization: Bearer token123");
         assert!(!scrubbed.contains("token123"));
+    }
+
+    #[test]
+    fn scrub_health_response_hides_runtime_home() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/example".to_string());
+        let health = scrub_health_response(HealthResponse {
+            runtime_home: format!("{home}/.proliferate/anyharness"),
+            status: "ok".to_string(),
+            version: "0.1.0".to_string(),
+        });
+
+        assert!(!health.runtime_home.contains(&home));
+        assert!(health.runtime_home.starts_with("~") || !home.starts_with('/'));
     }
 }

--- a/apps/desktop/src/hooks/support/derived/use-support-report-snapshot.ts
+++ b/apps/desktop/src/hooks/support/derived/use-support-report-snapshot.ts
@@ -8,12 +8,16 @@ import {
 import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { workspaceDisplayName } from "@/lib/domain/workspaces/display/workspace-display";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import type {
   SupportReportWindowSnapshot,
   SupportReportWorkspaceOption,
 } from "@/lib/domain/support/report-types";
 import type { SupportMessageContext } from "@/lib/domain/support/types";
+
+const MAX_LOCAL_SESSION_REFS_PER_WORKSPACE = 12;
 
 interface UseSupportReportSnapshotOptions {
   source: SupportMessageContext["source"];
@@ -25,6 +29,18 @@ export function useSupportReportSnapshot({
   const location = useLocation();
   const { data: workspaceCollections } = useWorkspaces();
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
+  const sessionIdsByWorkspaceId = useSessionDirectoryStore((state) =>
+    state.sessionIdsByWorkspaceId
+  );
+  const lastViewedSessionByWorkspace = useWorkspaceUiStore((state) =>
+    state.lastViewedSessionByWorkspace
+  );
+  const visibleChatSessionIdsByWorkspace = useWorkspaceUiStore((state) =>
+    state.visibleChatSessionIdsByWorkspace
+  );
+  const sessionLastInteracted = useWorkspaceUiStore((state) => state.sessionLastInteracted);
+  const sessionLastViewedAt = useWorkspaceUiStore((state) => state.sessionLastViewedAt);
 
   return useMemo(() => {
     const pathname = `${location.pathname}${location.search}`;
@@ -36,6 +52,14 @@ export function useSupportReportSnapshot({
       branch: workspaceCurrentBranchName(workspace),
       status: workspace.lifecycleState,
       updatedAt: workspace.updatedAt,
+      sessionIds: sessionIdsForWorkspace({
+        activeSessionId,
+        directorySessionIds: sessionIdsByWorkspaceId[workspace.id] ?? [],
+        lastViewedSessionId: lastViewedSessionByWorkspace[workspace.id],
+        visibleSessionIds: visibleChatSessionIdsByWorkspace[workspace.id] ?? [],
+        sessionLastInteracted,
+        sessionLastViewedAt,
+      }),
     }));
     const cloudOptions = (workspaceCollections?.cloudWorkspaces ?? []).map(cloudWorkspaceOption);
     const workspaceOptions = [...localOptions, ...cloudOptions]
@@ -60,9 +84,53 @@ export function useSupportReportSnapshot({
     location.pathname,
     location.search,
     selectedWorkspaceId,
+    activeSessionId,
+    lastViewedSessionByWorkspace,
     source,
+    sessionIdsByWorkspaceId,
+    sessionLastInteracted,
+    sessionLastViewedAt,
+    visibleChatSessionIdsByWorkspace,
     workspaceCollections,
   ]);
+}
+
+function sessionIdsForWorkspace({
+  activeSessionId,
+  directorySessionIds,
+  lastViewedSessionId,
+  visibleSessionIds,
+  sessionLastInteracted,
+  sessionLastViewedAt,
+}: {
+  activeSessionId: string | null;
+  directorySessionIds: readonly string[];
+  lastViewedSessionId: string | undefined;
+  visibleSessionIds: readonly string[];
+  sessionLastInteracted: Record<string, string>;
+  sessionLastViewedAt: Record<string, string>;
+}): string[] {
+  const directorySet = new Set(directorySessionIds);
+  const recentDirectorySessionIds = [...directorySessionIds].sort((a, b) =>
+    sessionRecencyMs(b, sessionLastInteracted, sessionLastViewedAt)
+      - sessionRecencyMs(a, sessionLastInteracted, sessionLastViewedAt)
+  );
+  const ordered = [
+    activeSessionId && directorySet.has(activeSessionId) ? activeSessionId : null,
+    lastViewedSessionId && directorySet.has(lastViewedSessionId) ? lastViewedSessionId : null,
+    ...visibleSessionIds.filter((sessionId) => directorySet.has(sessionId)),
+    ...recentDirectorySessionIds,
+  ].filter((sessionId): sessionId is string => !!sessionId);
+
+  return [...new Set(ordered)].slice(0, MAX_LOCAL_SESSION_REFS_PER_WORKSPACE);
+}
+
+function sessionRecencyMs(
+  sessionId: string,
+  sessionLastInteracted: Record<string, string>,
+  sessionLastViewedAt: Record<string, string>,
+): number {
+  return Math.max(dateMs(sessionLastInteracted[sessionId]), dateMs(sessionLastViewedAt[sessionId]));
 }
 
 function cloudWorkspaceOption(

--- a/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
+++ b/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
@@ -33,7 +33,10 @@ import type {
   SupportReportServerCorrelation,
   SupportReportWorkspaceOption,
 } from "@/lib/domain/support/report-types";
-import { trackProductEvent } from "@/lib/integrations/telemetry/client";
+import {
+  getSupportReportTelemetryRefs,
+  trackProductEvent,
+} from "@/lib/integrations/telemetry/client";
 import {
   describeSupportReportUploadFailure,
   shouldShowSupportReportUploadFailureToast,
@@ -255,6 +258,7 @@ function buildCreateReportRequest(
     context: job.snapshot.context,
     scope: job.scope,
     workspaceRefs: workspaceRefsForJob(job),
+    telemetryRefs: getSupportReportTelemetryRefs(),
     expectedClientUploads: {
       diagnostics: true,
       attachmentCount,

--- a/apps/desktop/src/lib/integrations/telemetry/client.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.ts
@@ -20,6 +20,7 @@ import {
 import {
   identifyDesktopPostHogUser,
   initializeDesktopPostHog,
+  getDesktopPostHogSupportRefs,
   resetDesktopPostHogUser,
   trackDesktopPostHogEvent,
 } from "./posthog";
@@ -28,6 +29,7 @@ import {
   captureDesktopSentryException,
   clearDesktopSentryUser,
   getDesktopRootErrorHandlers,
+  getRecentDesktopSentryEventIds,
   initializeDesktopSentry,
   setDesktopSentryTag,
   setDesktopSentryUser,
@@ -159,4 +161,21 @@ export function setTelemetryTag(key: string, value: string): void {
   }
 
   setDesktopSentryTag(key, value);
+}
+
+export function getSupportReportTelemetryRefs(): {
+  posthogDistinctId?: string;
+  posthogSessionId?: string;
+  sentryEventIds?: string[];
+} | undefined {
+  if (!getDesktopTelemetryRuntimeState().vendorEnabled) {
+    return undefined;
+  }
+  const posthogRefs = getDesktopPostHogSupportRefs();
+  const sentryEventIds = getRecentDesktopSentryEventIds();
+  const refs = {
+    ...posthogRefs,
+    ...(sentryEventIds.length > 0 ? { sentryEventIds } : {}),
+  };
+  return Object.keys(refs).length > 0 ? refs : undefined;
 }

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -79,3 +79,20 @@ export function resetDesktopPostHogUser(): void {
   if (!posthogInitialized) return;
   posthog.reset(true);
 }
+
+export function getDesktopPostHogSupportRefs(): {
+  posthogDistinctId?: string;
+  posthogSessionId?: string;
+} {
+  if (!posthogInitialized) {
+    return {};
+  }
+  const client = posthog as unknown as {
+    get_distinct_id?: () => string | undefined;
+    get_session_id?: () => string | undefined;
+  };
+  return {
+    posthogDistinctId: client.get_distinct_id?.(),
+    posthogSessionId: client.get_session_id?.(),
+  };
+}

--- a/apps/desktop/src/lib/integrations/telemetry/sentry.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/sentry.ts
@@ -26,6 +26,8 @@ const InstrumentedRoutes = (() => {
 })();
 
 let sentryInitialized = false;
+const RECENT_SENTRY_EVENT_ID_LIMIT = 20;
+const recentSentryEventIds: string[] = [];
 
 function buildTracePropagationTargets(apiBaseUrl: string): Array<string | RegExp> {
   const targets: Array<string | RegExp> = [
@@ -172,8 +174,22 @@ export function captureDesktopSentryException(
       }
     }
 
-    Sentry.captureException(normalized);
+    rememberSentryEventId(Sentry.captureException(normalized));
   });
+}
+
+export function getRecentDesktopSentryEventIds(): string[] {
+  return [...recentSentryEventIds];
+}
+
+function rememberSentryEventId(eventId: string | undefined): void {
+  if (!eventId) {
+    return;
+  }
+  recentSentryEventIds.push(eventId);
+  if (recentSentryEventIds.length > RECENT_SENTRY_EVENT_ID_LIMIT) {
+    recentSentryEventIds.splice(0, recentSentryEventIds.length - RECENT_SENTRY_EVENT_ID_LIMIT);
+  }
 }
 
 export { InstrumentedRoutes };

--- a/apps/desktop/src/lib/workflows/support/support-report-upload-workflows.test.ts
+++ b/apps/desktop/src/lib/workflows/support/support-report-upload-workflows.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  GetSessionLiveConfigResponse,
+  Session,
+  SessionEventEnvelope,
+  SessionRawNotificationEnvelope,
+} from "@anyharness/sdk";
+import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
+import type { SupportReportJob } from "@/lib/domain/support/report-types";
+import {
+  buildSupportReportPackage,
+  type SupportReportUploadDependencies,
+} from "@/lib/workflows/support/support-report-upload-workflows";
+
+const now = new Date("2026-05-31T12:00:00.000Z");
+
+describe("buildSupportReportPackage", () => {
+  it("redacts prompt, event, notification, and live-config bodies", async () => {
+    const sessionId = "session-redaction";
+    const connection: AnyHarnessResolvedConnection = {
+      runtimeUrl: "http://127.0.0.1:7007",
+      anyharnessWorkspaceId: "workspace-ah",
+    };
+    const dependencies: SupportReportUploadDependencies = {
+      now: () => now,
+      collectDiagnostics: vi.fn(async () => null),
+      resolveWorkspace: vi.fn(async () => ({ workspaceId: "workspace-ui", connection })),
+      getClient: vi.fn(() => ({
+        runtime: {
+          getHealth: vi.fn(),
+        },
+        sessions: {
+          list: vi.fn(async () => [makeSession(sessionId)]),
+          get: vi.fn(async () => makeSession(sessionId)),
+          listEvents: vi.fn(async () => [makeContentEvent(sessionId)]),
+          listRawNotifications: vi.fn(async () => [makeRawNotification(sessionId)]),
+          getLiveConfig: vi.fn(async () => makeLiveConfig()),
+        },
+      })),
+    };
+
+    const payload = await buildSupportReportPackage(makeJob(), dependencies, {
+      reportId: "report-1",
+      requestId: "request-1",
+      ownerUserId: "user-1",
+      primaryOrganizationId: null,
+      primaryTenantId: "user:user-1",
+      tenantIds: ["user:user-1"],
+      cloudWorkspaceIds: [],
+      cloudTargetIds: [],
+      anyharnessWorkspaceIds: ["workspace-ah"],
+      sessionIds: [sessionId],
+    });
+    const json = JSON.stringify(payload);
+
+    expect(json).not.toContain("prompt secret");
+    expect(json).not.toContain("tool output secret");
+    expect(json).not.toContain("raw input secret");
+    expect(json).not.toContain("raw notification secret");
+    expect(json).not.toContain("system prompt secret");
+    expect(payload.workspaces[0]?.sessions[0]?.summary).toMatchObject({
+      pendingPrompts: [{ text: "[content:13]" }],
+    });
+    expect(payload.workspaces[0]?.sessions[0]?.normalizedEvents[0]).toMatchObject({
+      event: {
+        item: {
+          contentParts: [{ type: "tool_result_text", text: "[text:18]" }],
+          rawInput: undefined,
+          rawOutput: undefined,
+        },
+      },
+    });
+    expect(payload.workspaces[0]?.sessions[0]?.rawNotifications[0]).toMatchObject({
+      notification: { redacted: true },
+    });
+    expect(payload.workspaces[0]?.sessions[0]?.liveConfig).toMatchObject({
+      liveConfig: {
+        systemPrompt: "[REDACTED]",
+        normalizedControls: {
+          model: { currentValue: "gpt-5.4" },
+        },
+      },
+    });
+  });
+});
+
+function makeJob(): SupportReportJob {
+  return {
+    jobId: "job-1",
+    createdAt: now.toISOString(),
+    message: "help",
+    scope: {
+      kind: "most_recent_workspace",
+      workspaceIds: ["workspace-ui"],
+    },
+    snapshot: {
+      openedAt: now.toISOString(),
+      source: "sidebar",
+      context: {
+        source: "sidebar",
+        intent: "general",
+        workspaceId: "workspace-ui",
+        workspaceLocation: "local",
+      },
+      defaultScope: "most_recent_workspace",
+      defaultWorkspaceId: "workspace-ui",
+      workspaceOptions: [
+        {
+          id: "workspace-ui",
+          label: "Workspace",
+          location: "local",
+          anyharnessWorkspaceId: "workspace-ah",
+        },
+      ],
+    },
+    attachments: [],
+  };
+}
+
+function makeSession(sessionId: string): Session {
+  return {
+    id: sessionId,
+    workspaceId: "workspace-ah",
+    agentKind: "codex",
+    status: "idle",
+    title: "Debug session",
+    modelId: "gpt-5.4",
+    modeId: "default",
+    actionCapabilities: { fork: false, targetedFork: false },
+    nativeSessionId: null,
+    createdAt: "2026-05-31T11:00:00.000Z",
+    updatedAt: "2026-05-31T11:30:00.000Z",
+    pendingPrompts: [{
+      contentParts: [{ type: "text", text: "prompt secret" }],
+      promptId: "prompt-1",
+      promptProvenance: null,
+      queuedAt: "2026-05-31T11:31:00.000Z",
+      seq: 2,
+      text: "prompt secret",
+    }],
+  };
+}
+
+function makeContentEvent(sessionId: string): SessionEventEnvelope {
+  return {
+    sessionId,
+    seq: 1,
+    timestamp: "2026-05-31T11:32:00.000Z",
+    turnId: "turn-1",
+    itemId: "item-1",
+    event: {
+      type: "item_completed",
+      item: {
+        contentParts: [{ type: "tool_result_text", text: "tool output secret" }],
+        kind: "tool_invocation",
+        rawInput: { text: "raw input secret" },
+        rawOutput: { text: "tool output secret" },
+        sourceAgentKind: "codex",
+        status: "completed",
+      },
+    } as SessionEventEnvelope["event"],
+  };
+}
+
+function makeRawNotification(sessionId: string): SessionRawNotificationEnvelope {
+  return {
+    sessionId,
+    seq: 1,
+    timestamp: "2026-05-31T11:33:00.000Z",
+    notificationKind: "session/update",
+    notification: { text: "raw notification secret" },
+  };
+}
+
+function makeLiveConfig(): GetSessionLiveConfigResponse {
+  return {
+    liveConfig: {
+      systemPrompt: "system prompt secret",
+      normalizedControls: {
+        model: { currentValue: "gpt-5.4" },
+      },
+    },
+  } as unknown as GetSessionLiveConfigResponse;
+}

--- a/apps/desktop/src/lib/workflows/support/support-report-upload-workflows.ts
+++ b/apps/desktop/src/lib/workflows/support/support-report-upload-workflows.ts
@@ -1,6 +1,11 @@
+import type {
+  GetSessionLiveConfigResponse,
+  SessionRawNotificationEnvelope,
+} from "@anyharness/sdk";
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import type { SupportDiagnosticsBundle } from "@/lib/access/tauri/diagnostics";
 import { sanitizeSupportUploadPayload } from "@/lib/domain/support/report-upload-sanitizer";
+import { sanitizeSessionDebugExportedSession } from "@/lib/domain/support/session-debug/sanitizer";
 import type {
   SupportReportJob,
   SupportReportServerCorrelation,
@@ -14,6 +19,8 @@ const MAX_WORKSPACES = 5;
 const MAX_SESSIONS_PER_WORKSPACE = 3;
 const MAX_EVENTS_PER_SESSION = 200;
 const MAX_RAW_NOTIFICATIONS_PER_SESSION = 100;
+const SENSITIVE_LIVE_CONFIG_KEY_PATTERN =
+  /(prompt|instruction|message|content|text|rawInput|rawOutput|rawConfig)/i;
 
 export interface SupportReportUploadDependencies<
   Connection extends AnyHarnessResolvedConnection = AnyHarnessResolvedConnection,
@@ -74,15 +81,13 @@ export async function buildSupportReportPackage<
 ): Promise<SupportReportPackage> {
   const collectionErrors: string[] = [];
   const runtimeDiagnostics = await dependencies.collectDiagnostics().catch((error) => {
-      collectionErrors.push(formatError("runtimeDiagnostics", error));
-      return null;
-    });
+    collectionErrors.push(formatError("runtimeDiagnostics", error));
+    return null;
+  });
   const workspaceIds = workspaceIdsForJob(job).slice(0, MAX_WORKSPACES);
-  const workspaces = job.scope.kind === "app_only"
-    ? []
-    : await Promise.all(workspaceIds.map((workspaceId) =>
-      collectWorkspaceDiagnostics(workspaceId, dependencies)
-    ));
+  const workspaces = job.scope.kind === "app_only" ? [] : await Promise.all(
+    workspaceIds.map((workspaceId) => collectWorkspaceDiagnostics(workspaceId, dependencies)),
+  );
 
   return sanitizeSupportUploadPayload({
     schemaVersion: 2,
@@ -126,9 +131,9 @@ async function collectWorkspaceDiagnostics<
     const recentSessions = [...sessions]
       .sort(compareUpdatedAtDesc)
       .slice(0, MAX_SESSIONS_PER_WORKSPACE);
-    const exportedSessions = await Promise.all(recentSessions.map((session) =>
-      collectSessionDiagnostics(client, session.id)
-    ));
+    const exportedSessions = await Promise.all(
+      recentSessions.map((session) => collectSessionDiagnostics(client, session.id)),
+    );
 
     return {
       requestedWorkspaceId: workspaceId,
@@ -175,12 +180,20 @@ async function collectSessionDiagnostics(
     },
   );
 
+  const sanitized = sanitizeSessionDebugExportedSession({
+    session: summary,
+    normalizedEvents: Array.isArray(normalizedEvents) ? normalizedEvents : [],
+    liveConfig: sanitizeLiveConfig(liveConfig),
+    rawNotifications: Array.isArray(rawNotifications) ? rawNotifications : [],
+    errors: [],
+  });
+
   return {
     sessionId,
-    summary,
-    normalizedEvents: Array.isArray(normalizedEvents) ? normalizedEvents : [],
-    liveConfig,
-    rawNotifications: Array.isArray(rawNotifications) ? rawNotifications : [],
+    summary: sanitized.session,
+    normalizedEvents: sanitized.normalizedEvents ?? [],
+    liveConfig: sanitized.liveConfig,
+    rawNotifications: sanitized.rawNotifications ?? [],
     errors,
   };
 }
@@ -220,16 +233,41 @@ function dateMs(value: string | null | undefined): number {
   return Number.isFinite(time) ? time : 0;
 }
 
-function redactNotificationBody(value: unknown): unknown {
-  if (!value || typeof value !== "object") {
+function redactNotificationBody(
+  value: SessionRawNotificationEnvelope,
+): SessionRawNotificationEnvelope {
+  return {
+    ...value,
+    notification: { redacted: true },
+  };
+}
+
+function sanitizeLiveConfig(
+  value: GetSessionLiveConfigResponse | null,
+): GetSessionLiveConfigResponse | null {
+  return sanitizeLiveConfigValue(value) as GetSessionLiveConfigResponse | null;
+}
+
+function sanitizeLiveConfigValue(value: unknown, keyHint = ""): unknown {
+  if (value == null) {
     return value;
   }
-  return {
-    ...(value as Record<string, unknown>),
-    body: "[REDACTED]",
-    payload: "[REDACTED]",
-    notification: "[REDACTED]",
-  };
+  if (typeof value === "string") {
+    return SENSITIVE_LIVE_CONFIG_KEY_PATTERN.test(keyHint) ? "[REDACTED]" : value;
+  }
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeLiveConfigValue(item, keyHint));
+  }
+  const output: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    output[key] = SENSITIVE_LIVE_CONFIG_KEY_PATTERN.test(key)
+      ? "[REDACTED]"
+      : sanitizeLiveConfigValue(item, key);
+  }
+  return output;
 }
 
 function formatError(scope: string, error: unknown): string {

--- a/docs/features/support-reporting.md
+++ b/docs/features/support-reporting.md
@@ -64,6 +64,10 @@ workspace IDs only. The package includes recent sessions, session summaries,
 recent normalized events, live config snapshots, and raw notification metadata
 with notification bodies redacted. Collection enforces global caps and does not
 include full workspace history by default.
+Desktop applies the same session-debug sanitizer used by manual exports before
+uploading support diagnostics, so prompt bodies, message text, raw tool input,
+raw tool output, and raw live-config prompt/config content are represented by
+shape/length placeholders rather than copied verbatim.
 
 Desktop uploads `diagnostics.json` with `schemaVersion: 2`. The package has a
 top-level `correlation` object supplied by Cloud and does not duplicate the
@@ -72,11 +76,15 @@ so investigators know whether the private `request.json` contains user-written
 context.
 
 Cloud workspace diagnostics are server-written. When a report references
-authorized cloud workspaces, Cloud writes `cloud-diagnostics.json` under the
-same support S3 prefix. The cloud diagnostics file is an allowlisted metadata
-snapshot: workspace, target, runtime access, sandbox, command, session,
-event-ingest, setup-run, and transcript item metadata. It does not copy prompt
-bodies, transcript bodies, raw command payloads, tool output, provider tokens,
+authorized cloud workspaces, Cloud writes `cloud-diagnostics.json` after the
+support report database row and `request.json` have been committed. Cloud
+workspace references in the case file are server-derived from the database; if
+the client sends an unknown or unauthorized cloud workspace ID, the persisted
+reference is marked `cloud:[unverified]` and is excluded from server
+correlation IDs. The cloud diagnostics file is an allowlisted metadata snapshot:
+workspace, target, runtime access, sandbox, command, session, event-ingest,
+setup-run, and transcript item metadata. It does not copy prompt bodies,
+transcript bodies, raw command payloads, tool output, provider tokens,
 ciphertexts, cookies, signed URLs, or attachment contents. It also does not
 wake stopped sandboxes or create runtime sessions just to collect diagnostics.
 
@@ -107,10 +115,14 @@ refs, and server-derived correlation IDs. It must not contain presigned URLs.
 `POST /v1/support/reports/{reportId}/upload-targets` validates diagnostics and
 attachment metadata for the report owner, persists the expected object manifest,
 and returns short-lived presigned `PUT` targets. Clients may call it again to
-refresh expired URLs while the report is still uploadable.
+refresh expired URLs while the report is still uploadable, but the object
+manifest is immutable once written. A retry with different diagnostics or
+attachment metadata is rejected so completion cannot be pointed at a different
+payload than the original upload intent.
 
 `POST /v1/support/reports/{reportId}/complete` verifies uploaded object keys are
-inside the stored report prefix, verifies object sizes with S3 metadata, writes
+inside the stored report prefix, requires every object in the stored manifest to
+be present exactly once, verifies object sizes with S3 metadata, writes
 `complete.json`, marks the report completed, and posts the internal Slack
 notification once. Slack failure is logged server-side and does not fail an
 otherwise completed report.
@@ -143,7 +155,10 @@ The server writes these IDs into the support report response, `request.json`,
 context/tags where safe. Desktop also emits the low-cardinality
 `support_report_submitted` product event through the typed telemetry path so
 PostHog can be used as a replay/session pivot when hosted-product telemetry is
-enabled.
+enabled. When hosted-product telemetry is enabled, `request.json` may also
+include the current PostHog distinct/session IDs and recent Desktop Sentry event
+IDs so an investigator can jump from the support report to replay and exception
+contexts without relying on user-entered text.
 
 Cloud logging records request, user, tenant, support report, cloud workspace,
 target, sandbox, session, interaction, command, worker, and slot-generation

--- a/docs/tbd/support-debug-correlation.md
+++ b/docs/tbd/support-debug-correlation.md
@@ -15,8 +15,16 @@ Desktop support reports now use a durable Cloud case file:
 - server-written `request.json`, `complete.json`, and cloud diagnostics when
   authorized cloud workspace references are present
 - top-level server correlation IDs in client diagnostics
+- server-trusted cloud workspace references, with unauthorized client-supplied
+  cloud IDs persisted only as `cloud:[unverified]`
+- immutable upload manifests and completion checks that require every expected
+  object to be uploaded
+- redacted Desktop session diagnostics that preserve event/config shape without
+  copying prompt, transcript, notification, or tool-output bodies
 - structured server log and Sentry correlation context
 - low-cardinality Desktop `support_report_submitted` PostHog event
+- optional PostHog and Desktop Sentry pivot IDs in the private support request
+  object when hosted-product telemetry is enabled
 
 ## Deferred Work
 
@@ -25,6 +33,8 @@ Desktop support reports now use a durable Cloud case file:
   Sentry, PostHog, CloudWatch, Cloud DB, and runtime target pivots.
 - Add CloudWatch Logs Insights saved queries or dashboards for tenant/report
   correlation.
+- Add relational indexes or a normalized companion table for common support
+  correlation fields once investigator query patterns settle.
 - Collect runtime tail logs for cloud targets only when an already-running
   managed target can be proven reachable without waking it.
 - Add a server-side sweeper for old `created` or `uploading` reports that never

--- a/server/proliferate/middleware/request_telemetry.py
+++ b/server/proliferate/middleware/request_telemetry.py
@@ -24,8 +24,10 @@ class RequestTelemetryMiddleware(BaseHTTPMiddleware):
             set_server_sentry_tag("request_id", request_id)
         set_server_sentry_tag("http_method", request.method)
         set_server_sentry_tag("http_route", _sanitized_route(request))
-        response = await call_next(request)
-        set_server_sentry_correlation_context(get_correlation_context())
+        try:
+            response = await call_next(request)
+        finally:
+            set_server_sentry_correlation_context(get_correlation_context())
         return response
 
 

--- a/server/proliferate/server/support/api.py
+++ b/server/proliferate/server/support/api.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
-from proliferate.server.support.diagnostics import collect_cloud_diagnostics_for_report
+from proliferate.server.support.jobs import schedule_cloud_diagnostics_after_commit
 from proliferate.server.support.models import (
     SupportMessageRequest,
     SupportMessageResponse,
@@ -62,7 +62,6 @@ async def create_support_report_upload_endpoint(
 @router.post("/reports", response_model=SupportReportCreateResponse)
 async def create_support_report_endpoint(
     body: SupportReportCreateRequest,
-    background_tasks: BackgroundTasks,
     user: User = Depends(current_active_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> SupportReportCreateResponse:
@@ -74,7 +73,7 @@ async def create_support_report_endpoint(
         body=body,
     )
     if response.cloud_diagnostics_status == "pending":
-        background_tasks.add_task(collect_cloud_diagnostics_for_report, response.report_id)
+        await schedule_cloud_diagnostics_after_commit(db, response.report_id)
     return response
 
 

--- a/server/proliferate/server/support/domain/report_records.py
+++ b/server/proliferate/server/support/domain/report_records.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from proliferate.server.support.models import (
     SupportReportCreateRequest,
     SupportReportUploadResponse,
+    SupportReportWorkspaceScope,
 )
 
 
@@ -30,8 +31,13 @@ class SupportReportLike(Protocol):
 
 
 class AuthorizedCloudRefLike(Protocol):
+    id: UUID
     organization_id: UUID | None
     owner_user_id: UUID | None
+    target_id: UUID | None
+    sandbox_profile_id: UUID | None
+    anyharness_workspace_id: str | None
+    status: str
 
 
 @dataclass(frozen=True)
@@ -53,6 +59,38 @@ def workspace_refs_for_create(
     return tuple(refs)
 
 
+def trusted_workspace_refs_for_report(
+    workspace_refs: tuple[dict[str, object], ...],
+    authorized_cloud_refs: tuple[AuthorizedCloudRefLike, ...],
+) -> tuple[dict[str, object], ...]:
+    authorized_by_id = {ref.id: ref for ref in authorized_cloud_refs}
+    trusted_refs: list[dict[str, object]] = []
+    for ref in workspace_refs:
+        cloud_workspace_id = _cloud_workspace_id_from_ref(ref)
+        if cloud_workspace_id is not None:
+            authorized = authorized_by_id.get(cloud_workspace_id)
+            trusted_refs.append(
+                _trusted_cloud_workspace_ref(authorized)
+                if authorized is not None
+                else _unverified_cloud_workspace_ref()
+            )
+            continue
+        trusted_refs.append(_trusted_local_workspace_ref(ref))
+    return tuple(trusted_refs)
+
+
+def support_scope_record(
+    scope: SupportReportWorkspaceScope,
+    workspace_refs: tuple[dict[str, object], ...],
+) -> dict[str, object]:
+    record = scope.model_dump(by_alias=True)
+    if record.get("kind") != "app_only":
+        record["workspaceIds"] = [
+            str(ref["id"]) for ref in workspace_refs if isinstance(ref.get("id"), str)
+        ]
+    return record
+
+
 def workspace_ref_from_id(workspace_id: str) -> dict[str, object]:
     if workspace_id.startswith("cloud:"):
         return {
@@ -71,16 +109,9 @@ def cloud_workspace_ids_from_refs(
 ) -> tuple[UUID, ...]:
     ids: list[UUID] = []
     for ref in workspace_refs:
-        raw = ref.get("cloudWorkspaceId")
-        if not raw and isinstance(ref.get("id"), str):
-            raw_id = str(ref["id"])
-            raw = raw_id.removeprefix("cloud:") if raw_id.startswith("cloud:") else None
-        if not raw:
-            continue
-        try:
-            ids.append(UUID(str(raw)))
-        except ValueError:
-            continue
+        cloud_workspace_id = _cloud_workspace_id_from_ref(ref)
+        if cloud_workspace_id is not None:
+            ids.append(cloud_workspace_id)
     return tuple(dict.fromkeys(ids))
 
 
@@ -121,6 +152,55 @@ def support_context_record(context: object | None) -> dict[str, object]:
     pathname = record.get("pathname")
     if isinstance(pathname, str):
         record["pathname"] = sanitize_pathname(pathname)
+    return record
+
+
+def _cloud_workspace_id_from_ref(ref: dict[str, object]) -> UUID | None:
+    raw = ref.get("cloudWorkspaceId")
+    if not raw and isinstance(ref.get("id"), str):
+        raw_id = str(ref["id"])
+        raw = raw_id.removeprefix("cloud:") if raw_id.startswith("cloud:") else None
+    if not raw:
+        return None
+    try:
+        return UUID(str(raw))
+    except ValueError:
+        return None
+
+
+def _trusted_cloud_workspace_ref(ref: AuthorizedCloudRefLike) -> dict[str, object]:
+    record: dict[str, object] = {
+        "id": f"cloud:{ref.id}",
+        "location": "cloud",
+        "cloudWorkspaceId": str(ref.id),
+        "status": ref.status,
+    }
+    if ref.target_id is not None:
+        record["cloudTargetId"] = str(ref.target_id)
+    if ref.sandbox_profile_id is not None:
+        record["sandboxProfileId"] = str(ref.sandbox_profile_id)
+    if ref.anyharness_workspace_id:
+        record["anyharnessWorkspaceId"] = ref.anyharness_workspace_id
+    return record
+
+
+def _unverified_cloud_workspace_ref() -> dict[str, object]:
+    return {
+        "id": "cloud:[unverified]",
+        "location": "cloud",
+        "status": "unverified",
+    }
+
+
+def _trusted_local_workspace_ref(ref: dict[str, object]) -> dict[str, object]:
+    record: dict[str, object] = {
+        "id": str(ref.get("id") or "local:[unknown]"),
+        "location": "local",
+    }
+    for key in ("anyharnessWorkspaceId", "sessionIds", "status"):
+        value = ref.get(key)
+        if value:
+            record[key] = value
     return record
 
 

--- a/server/proliferate/server/support/jobs.py
+++ b/server/proliferate/server/support/jobs.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import run_after_commit
+from proliferate.server.support.diagnostics import collect_cloud_diagnostics_for_report
+
+
+async def schedule_cloud_diagnostics_after_commit(db: AsyncSession, report_id: str) -> None:
+    async def _collect_after_commit() -> None:
+        await collect_cloud_diagnostics_for_report(report_id)
+
+    await run_after_commit(db, _collect_after_commit)

--- a/server/proliferate/server/support/redaction.py
+++ b/server/proliferate/server/support/redaction.py
@@ -6,16 +6,22 @@ import re
 from collections.abc import Mapping
 
 _SECRET_KEY_RE = re.compile(
-    r"(token|secret|password|credential|cookie|authorization|ciphertext|apply_token)",
+    r"(token|secret|password|credential|cookie|authorization|ciphertext|apply_token|"
+    r"apikey|api[_-]?key|accesskey|access[_-]?key|privatekey|private[_-]?key|^key$)",
     re.IGNORECASE,
 )
 _BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE)
+_ENV_SECRET_RE = re.compile(
+    r"\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*)[^\s,;]+",
+    re.IGNORECASE,
+)
 _SIGNED_URL_QUERY_RE = re.compile(r"([?&](?:X-Amz|AWSAccessKeyId|Signature)[^=]*=)[^&\s]+")
 _OPAQUE_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_-]{48,}\b")
 
 
 def redact_support_text(value: str, *, max_chars: int = 2000) -> str:
     scrubbed = _BEARER_RE.sub("Bearer [REDACTED]", value)
+    scrubbed = _ENV_SECRET_RE.sub(r"\1[REDACTED]", scrubbed)
     scrubbed = _SIGNED_URL_QUERY_RE.sub(r"\1[REDACTED]", scrubbed)
     scrubbed = _OPAQUE_TOKEN_RE.sub("[REDACTED]", scrubbed)
     if len(scrubbed) > max_chars:
@@ -28,14 +34,16 @@ def redact_mapping(value: Mapping[str, object]) -> dict[str, object]:
     for key, item in value.items():
         if _SECRET_KEY_RE.search(key):
             redacted[key] = "[REDACTED]"
-        elif isinstance(item, str):
-            redacted[key] = redact_support_text(item)
-        elif isinstance(item, Mapping):
-            redacted[key] = redact_mapping(item)
-        elif isinstance(item, list):
-            redacted[key] = [
-                redact_mapping(entry) if isinstance(entry, Mapping) else entry for entry in item
-            ]
         else:
-            redacted[key] = item
+            redacted[key] = _redact_value(item)
     return redacted
+
+
+def _redact_value(value: object) -> object:
+    if isinstance(value, str):
+        return redact_support_text(value)
+    if isinstance(value, Mapping):
+        return redact_mapping(value)
+    if isinstance(value, list):
+        return [_redact_value(entry) for entry in value]
+    return value

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
@@ -11,11 +12,11 @@ from proliferate.db.store import support_reports
 from proliferate.integrations.aws import (
     AwsIntegrationError,
     get_json_object,
-    head_object,
-    presign_put_object,
     put_json_object,
 )
+from proliferate.integrations.sentry import set_server_sentry_correlation_context
 from proliferate.middleware.request_context import (
+    get_correlation_context,
     get_request_id,
     set_resource_tenant_context,
     set_support_report_context,
@@ -29,7 +30,9 @@ from proliferate.server.support.domain.report_records import (
     safe_file_name,
     support_context_record,
     support_request_record,
+    support_scope_record,
     tenant_context_for_report,
+    trusted_workspace_refs_for_report,
     workspace_refs_for_create,
 )
 from proliferate.server.support.errors import (
@@ -44,7 +47,6 @@ from proliferate.server.support.models import (
     SupportReportCreateResponse,
     SupportReportUploadRequest,
     SupportReportUploadResponse,
-    SupportReportUploadTarget,
     SupportReportUploadTargetsRequest,
     support_report_correlation_record,
     support_report_create_response,
@@ -52,6 +54,12 @@ from proliferate.server.support.models import (
 from proliferate.server.support.notifications import (
     notify_support_report,
 )
+from proliferate.server.support.storage import (
+    presign_support_upload_target,
+    verify_completed_support_object,
+)
+
+logger = logging.getLogger(__name__)
 
 
 async def create_support_report(
@@ -69,6 +77,10 @@ async def create_support_report(
         db,
         sender_user_id=sender_user_id,
         workspace_refs=workspace_refs,
+    )
+    trusted_workspace_refs = trusted_workspace_refs_for_report(
+        workspace_refs,
+        authorized_cloud_refs,
     )
     tenant_context = tenant_context_for_report(
         sender_user_id=sender_user_id,
@@ -99,7 +111,7 @@ async def create_support_report(
             s3_prefix=_report_prefix(report_id),
             source_surface=body.source_surface,
             source_context=support_context_record(body.context),
-            workspace_refs=workspace_refs,
+            workspace_refs=trusted_workspace_refs,
             telemetry_refs=(
                 body.telemetry_refs.model_dump(by_alias=True, exclude_none=True)
                 if body.telemetry_refs
@@ -115,7 +127,7 @@ async def create_support_report(
         sender_email=sender_email,
         sender_display_name=sender_display_name,
         message=body.message,
-        scope=body.scope.model_dump(by_alias=True),
+        scope=support_scope_record(body.scope, report.workspace_refs),
         correlation=support_report_correlation_record(report),
     )
     try:
@@ -129,6 +141,15 @@ async def create_support_report(
         raise SupportReportStorageUnavailable() from exc
 
     report = await support_reports.mark_request_object_written(db, report_id=report.id)
+    logger.info(
+        "Support report created.",
+        extra={
+            "support_report_id": report.id,
+            "support_report_status": report.status,
+            "support_report_source_surface": report.source_surface,
+            "support_report_cloud_diagnostics_status": report.cloud_diagnostics_status,
+        },
+    )
     return support_report_create_response(report)
 
 
@@ -153,10 +174,23 @@ async def create_support_report_upload_targets(
         attachments=body.attachments,
         targets=targets,
     )
+    existing_manifest = report.object_manifest
+    if existing_manifest.get("schemaVersion") == 1 and existing_manifest != manifest:
+        raise SupportReportUploadInvalid(
+            "Support report upload targets already exist for different objects."
+        )
     await support_reports.update_report_upload_manifest(
         db,
         report_id=report.id,
         object_manifest=manifest,
+    )
+    logger.info(
+        "Support report upload targets issued.",
+        extra={
+            "support_report_id": report.id,
+            "support_report_attachment_count": len(body.attachments),
+            "support_report_diagnostics_expected": body.diagnostics is not None,
+        },
     )
     return targets
 
@@ -243,6 +277,8 @@ async def _complete_db_backed_report(
 
     _install_report_correlation(report)
     expected_keys = expected_manifest_keys(report.object_manifest)
+    if report.object_manifest.get("schemaVersion") != 1:
+        raise SupportReportUploadInvalid("Support report upload targets have not been created.")
     completed_keys = [
         *([body.diagnostics.object_key] if body.diagnostics else []),
         *[attachment.object_key for attachment in body.attachments],
@@ -250,9 +286,12 @@ async def _complete_db_backed_report(
     unexpected = sorted(set(completed_keys).difference(expected_keys))
     if unexpected:
         raise SupportReportUploadInvalid("Support report completion included unknown objects.")
+    missing = sorted(expected_keys.difference(completed_keys))
+    if missing:
+        raise SupportReportUploadInvalid("Support report completion is missing expected objects.")
 
     if body.diagnostics is not None:
-        await _verify_completed_object(
+        await verify_completed_support_object(
             bucket=report.s3_bucket,
             region_name=_support_report_region(),
             prefix=report.s3_prefix,
@@ -260,7 +299,7 @@ async def _complete_db_backed_report(
             expected_size=body.diagnostics.size_bytes,
         )
     for attachment in body.attachments:
-        await _verify_completed_object(
+        await verify_completed_support_object(
             bucket=report.s3_bucket,
             region_name=_support_report_region(),
             prefix=report.s3_prefix,
@@ -298,6 +337,15 @@ async def _complete_db_backed_report(
         report_id=report.id,
         complete_request_id=get_request_id(),
         object_manifest={**report.object_manifest, "completed": complete_record},
+    )
+    logger.info(
+        "Support report completed.",
+        extra={
+            "support_report_id": completed_report.id,
+            "support_report_attachment_count": len(body.attachments),
+            "support_report_diagnostics_included": body.diagnostics is not None,
+            "support_report_cloud_diagnostics_status": completed_report.cloud_diagnostics_status,
+        },
     )
     if should_notify:
         await notify_support_report(
@@ -349,7 +397,7 @@ async def _complete_legacy_report(
         raise SupportReportUploadInvalid("Support report completion included unknown objects.")
 
     if body.diagnostics is not None:
-        await _verify_completed_object(
+        await verify_completed_support_object(
             bucket=bucket,
             region_name=region,
             prefix=prefix,
@@ -357,7 +405,7 @@ async def _complete_legacy_report(
             expected_size=body.diagnostics.size_bytes,
         )
     for attachment in body.attachments:
-        await _verify_completed_object(
+        await verify_completed_support_object(
             bucket=bucket,
             region_name=region,
             prefix=prefix,
@@ -451,9 +499,9 @@ async def _create_upload_targets_for_report(
     expires_seconds = settings.support_report_upload_url_expires_seconds
     region = _support_report_region()
 
-    diagnostics_target: SupportReportUploadTarget | None = None
+    diagnostics_target = None
     if body.diagnostics is not None:
-        diagnostics_target = await _presign_target(
+        diagnostics_target = await presign_support_upload_target(
             bucket=report.s3_bucket,
             key=f"{report.s3_prefix}/diagnostics.json",
             content_type=body.diagnostics.content_type,
@@ -464,7 +512,7 @@ async def _create_upload_targets_for_report(
 
     attachment_targets: list[SupportReportAttachmentUploadTarget] = []
     for attachment in body.attachments:
-        target = await _presign_target(
+        target = await presign_support_upload_target(
             bucket=report.s3_bucket,
             key=(
                 f"{report.s3_prefix}/attachments/{attachment.client_file_id}/"
@@ -517,59 +565,7 @@ def _install_report_correlation(report: support_reports.SupportReportSnapshot) -
         else None,
         tenant_id=report.primary_tenant_id,
     )
-
-
-async def _presign_target(
-    *,
-    bucket: str,
-    key: str,
-    content_type: str,
-    max_size_bytes: int,
-    expires_seconds: int,
-    region_name: str | None,
-) -> SupportReportUploadTarget:
-    try:
-        url = await presign_put_object(
-            bucket=bucket,
-            key=key,
-            content_type=content_type,
-            expires_seconds=expires_seconds,
-            region_name=region_name,
-        )
-    except AwsIntegrationError as exc:
-        raise SupportReportStorageUnavailable() from exc
-    return SupportReportUploadTarget(
-        objectKey=key,
-        putUrl=url,
-        contentType=content_type,
-        maxSizeBytes=max_size_bytes,
-        expiresInSeconds=expires_seconds,
-        headers={"x-amz-server-side-encryption": "AES256"},
-    )
-
-
-async def _verify_completed_object(
-    *,
-    bucket: str,
-    region_name: str | None,
-    prefix: str,
-    object_key: str,
-    expected_size: int,
-) -> None:
-    if not object_key.startswith(f"{prefix}/"):
-        raise SupportReportUploadInvalid("Support report object key is outside report prefix.")
-    try:
-        metadata = await head_object(
-            bucket=bucket,
-            key=object_key,
-            region_name=region_name,
-        )
-    except AwsIntegrationError as exc:
-        raise SupportReportUploadInvalid("Support report object upload is missing.") from exc
-
-    content_length = metadata.get("ContentLength")
-    if isinstance(content_length, int) and content_length != expected_size:
-        raise SupportReportUploadInvalid("Support report object size did not match.")
+    set_server_sentry_correlation_context(get_correlation_context())
 
 
 def _support_report_bucket() -> str:

--- a/server/proliferate/server/support/storage.py
+++ b/server/proliferate/server/support/storage.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from proliferate.integrations.aws import AwsIntegrationError, head_object, presign_put_object
+from proliferate.server.support.errors import (
+    SupportReportStorageUnavailable,
+    SupportReportUploadInvalid,
+)
+from proliferate.server.support.models import SupportReportUploadTarget
+
+
+async def presign_support_upload_target(
+    *,
+    bucket: str,
+    key: str,
+    content_type: str,
+    max_size_bytes: int,
+    expires_seconds: int,
+    region_name: str | None,
+) -> SupportReportUploadTarget:
+    try:
+        url = await presign_put_object(
+            bucket=bucket,
+            key=key,
+            content_type=content_type,
+            expires_seconds=expires_seconds,
+            region_name=region_name,
+        )
+    except AwsIntegrationError as exc:
+        raise SupportReportStorageUnavailable() from exc
+    return SupportReportUploadTarget(
+        objectKey=key,
+        putUrl=url,
+        contentType=content_type,
+        maxSizeBytes=max_size_bytes,
+        expiresInSeconds=expires_seconds,
+        headers={"x-amz-server-side-encryption": "AES256"},
+    )
+
+
+async def verify_completed_support_object(
+    *,
+    bucket: str,
+    region_name: str | None,
+    prefix: str,
+    object_key: str,
+    expected_size: int,
+) -> None:
+    if not object_key.startswith(f"{prefix}/"):
+        raise SupportReportUploadInvalid("Support report object key is outside report prefix.")
+    try:
+        metadata = await head_object(
+            bucket=bucket,
+            key=object_key,
+            region_name=region_name,
+        )
+    except AwsIntegrationError as exc:
+        raise SupportReportUploadInvalid("Support report object upload is missing.") from exc
+
+    content_length = metadata.get("ContentLength")
+    if isinstance(content_length, int) and content_length != expected_size:
+        raise SupportReportUploadInvalid("Support report object size did not match.")

--- a/server/tests/integration/test_support_api.py
+++ b/server/tests/integration/test_support_api.py
@@ -263,7 +263,7 @@ class TestSupportApi:
             records.append(value)
 
         monkeypatch.setattr(
-            "proliferate.server.support.service.presign_put_object",
+            "proliferate.server.support.storage.presign_put_object",
             fake_presign_put_object,
         )
         monkeypatch.setattr(
@@ -347,7 +347,7 @@ class TestSupportApi:
             fake_put_json_object,
         )
         monkeypatch.setattr(
-            "proliferate.server.support.service.presign_put_object",
+            "proliferate.server.support.storage.presign_put_object",
             fake_presign_put_object,
         )
 
@@ -402,70 +402,21 @@ class TestSupportApi:
         assert payload["diagnostics"]["putUrl"].startswith("https://s3.test/")
         assert payload["attachments"][0]["clientFileId"] == "file-1"
 
-    @pytest.mark.asyncio
-    async def test_support_report_create_includes_authorized_cloud_workspace_correlation(
-        self,
-        client: AsyncClient,
-        db_session: AsyncSession,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        session = await _register_and_login(client, "support-report-cloud@example.com")
-        workspace = await _seed_personal_cloud_workspace(
-            db_session,
-            user_id=session["user_id"],
-            suffix="support",
-        )
-        headers = {"Authorization": f"Bearer {session['access_token']}"}
-        monkeypatch.setattr(settings, "support_report_s3_bucket", "support-bucket")
-
-        async def fake_put_json_object(
-            *,
-            bucket: str,
-            key: str,
-            value: dict[str, object],
-            region_name: str | None = None,
-        ) -> None:
-            assert bucket == "support-bucket"
-            assert key.endswith("/request.json")
-
-        async def fake_collect_cloud_diagnostics_for_report(report_id: str) -> None:
-            assert report_id
-
-        monkeypatch.setattr(
-            "proliferate.server.support.service.put_json_object",
-            fake_put_json_object,
-        )
-        monkeypatch.setattr(
-            "proliferate.server.support.api.collect_cloud_diagnostics_for_report",
-            fake_collect_cloud_diagnostics_for_report,
-        )
-
-        response = await client.post(
-            "/v1/support/reports",
+        changed_upload_targets = await client.post(
+            f"/v1/support/reports/{first.json()['reportId']}/upload-targets",
             headers=headers,
             json={
-                "clientJobId": "support-job-cloud",
-                "message": "Cloud workspace failed.",
-                "sourceSurface": "desktop",
-                "scope": {
-                    "kind": "choose_workspace",
-                    "workspaceIds": [f"cloud:{workspace.id}"],
+                "diagnostics": {
+                    "contentType": "application/json",
+                    "sizeBytes": 1024,
+                    "sha256": "changed",
                 },
-                "workspaceRefs": [
-                    {
-                        "id": f"cloud:{workspace.id}",
-                        "location": "cloud",
-                        "cloudWorkspaceId": str(workspace.id),
-                        "anyharnessWorkspaceId": workspace.anyharness_workspace_id,
-                    }
-                ],
+                "attachments": [],
             },
         )
 
-        assert response.status_code == 200
-        payload = response.json()
-        assert payload["cloudDiagnosticsStatus"] == "pending"
-        assert payload["serverCorrelation"]["cloudWorkspaceIds"] == [str(workspace.id)]
+        assert changed_upload_targets.status_code == 400
+        assert changed_upload_targets.json()["detail"]["code"] == "support_report_upload_invalid"
 
     @pytest.mark.asyncio
     async def test_support_report_upload_returns_503_when_storage_unconfigured(
@@ -564,7 +515,7 @@ class TestSupportApi:
         monkeypatch.setattr(
             "proliferate.server.support.service.get_json_object", fake_get_json_object
         )
-        monkeypatch.setattr("proliferate.server.support.service.head_object", fake_head_object)
+        monkeypatch.setattr("proliferate.server.support.storage.head_object", fake_head_object)
         monkeypatch.setattr(
             "proliferate.server.support.service.put_json_object", fake_put_json_object
         )

--- a/server/tests/integration/test_support_api_hardening.py
+++ b/server/tests/integration/test_support_api_hardening.py
@@ -1,0 +1,241 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db import engine as engine_module
+from proliferate.db.store import support_reports
+from tests.integration.test_support_api import (
+    _register_and_login,
+    _seed_personal_cloud_workspace,
+)
+
+
+@pytest.mark.asyncio
+async def test_support_report_create_includes_authorized_cloud_workspace_correlation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _register_and_login(client, "support-report-cloud@example.com")
+    workspace = await _seed_personal_cloud_workspace(
+        db_session,
+        user_id=session["user_id"],
+        suffix="support",
+    )
+    headers = {"Authorization": f"Bearer {session['access_token']}"}
+    monkeypatch.setattr(settings, "support_report_s3_bucket", "support-bucket")
+    cloud_diagnostics_started = asyncio.Event()
+
+    async def fake_put_json_object(
+        *,
+        bucket: str,
+        key: str,
+        value: dict[str, object],
+        region_name: str | None = None,
+    ) -> None:
+        assert bucket == "support-bucket"
+        assert key.endswith("/request.json")
+
+    async def fake_collect_cloud_diagnostics_for_report(report_id: str) -> None:
+        async with engine_module.async_session_factory() as session:
+            report = await support_reports.get_report_by_id(session, report_id)
+        assert report is not None
+        assert report.request_object_written_at is not None
+        cloud_diagnostics_started.set()
+
+    monkeypatch.setattr(
+        "proliferate.server.support.service.put_json_object",
+        fake_put_json_object,
+    )
+    monkeypatch.setattr(
+        "proliferate.server.support.jobs.collect_cloud_diagnostics_for_report",
+        fake_collect_cloud_diagnostics_for_report,
+    )
+
+    response = await client.post(
+        "/v1/support/reports",
+        headers=headers,
+        json={
+            "clientJobId": "support-job-cloud",
+            "message": "Cloud workspace failed.",
+            "sourceSurface": "desktop",
+            "scope": {
+                "kind": "choose_workspace",
+                "workspaceIds": [f"cloud:{workspace.id}"],
+            },
+            "workspaceRefs": [
+                {
+                    "id": f"cloud:{workspace.id}",
+                    "location": "cloud",
+                    "cloudWorkspaceId": str(workspace.id),
+                    "anyharnessWorkspaceId": workspace.anyharness_workspace_id,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["cloudDiagnosticsStatus"] == "pending"
+    assert payload["serverCorrelation"]["cloudWorkspaceIds"] == [str(workspace.id)]
+    await asyncio.wait_for(cloud_diagnostics_started.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_support_report_create_excludes_unverified_cloud_refs_from_correlation(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _register_and_login(client, "support-report-unverified@example.com")
+    headers = {"Authorization": f"Bearer {session['access_token']}"}
+    monkeypatch.setattr(settings, "support_report_s3_bucket", "support-bucket")
+    records: list[dict[str, object]] = []
+
+    async def fake_put_json_object(
+        *,
+        bucket: str,
+        key: str,
+        value: dict[str, object],
+        region_name: str | None = None,
+    ) -> None:
+        assert bucket == "support-bucket"
+        assert key.endswith("/request.json")
+        records.append(value)
+
+    monkeypatch.setattr(
+        "proliferate.server.support.service.put_json_object",
+        fake_put_json_object,
+    )
+
+    response = await client.post(
+        "/v1/support/reports",
+        headers=headers,
+        json={
+            "clientJobId": "support-job-unverified-cloud",
+            "message": "Cloud workspace failed.",
+            "sourceSurface": "desktop",
+            "scope": {
+                "kind": "choose_workspace",
+                "workspaceIds": ["cloud:11111111-1111-1111-1111-111111111111"],
+            },
+            "workspaceRefs": [
+                {
+                    "id": "cloud:11111111-1111-1111-1111-111111111111",
+                    "location": "cloud",
+                    "cloudWorkspaceId": "11111111-1111-1111-1111-111111111111",
+                    "cloudTargetId": "22222222-2222-2222-2222-222222222222",
+                    "anyharnessWorkspaceId": "forged-workspace",
+                    "sessionIds": ["forged-session"],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["cloudDiagnosticsStatus"] == "not_applicable"
+    assert payload["serverCorrelation"]["cloudWorkspaceIds"] == []
+    assert payload["serverCorrelation"]["cloudTargetIds"] == []
+    assert payload["serverCorrelation"]["anyharnessWorkspaceIds"] == []
+    assert payload["serverCorrelation"]["sessionIds"] == []
+    assert records[0]["workspaceRefs"] == [
+        {
+            "id": "cloud:[unverified]",
+            "location": "cloud",
+            "status": "unverified",
+        }
+    ]
+    assert records[0]["scope"]["workspaceIds"] == ["cloud:[unverified]"]
+
+
+@pytest.mark.asyncio
+async def test_support_report_complete_requires_all_expected_uploads(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await _register_and_login(client, "support-report-missing-upload@example.com")
+    headers = {"Authorization": f"Bearer {session['access_token']}"}
+    monkeypatch.setattr(settings, "support_report_s3_bucket", "support-bucket")
+
+    async def fake_put_json_object(
+        *,
+        bucket: str,
+        key: str,
+        value: dict[str, object],
+        region_name: str | None = None,
+    ) -> None:
+        assert bucket == "support-bucket"
+        assert key.endswith("/request.json")
+
+    async def fake_presign_put_object(
+        *,
+        bucket: str,
+        key: str,
+        content_type: str,
+        expires_seconds: int,
+        region_name: str | None = None,
+    ) -> str:
+        return f"https://s3.test/{key}"
+
+    monkeypatch.setattr(
+        "proliferate.server.support.service.put_json_object",
+        fake_put_json_object,
+    )
+    monkeypatch.setattr(
+        "proliferate.server.support.storage.presign_put_object",
+        fake_presign_put_object,
+    )
+
+    create = await client.post(
+        "/v1/support/reports",
+        headers=headers,
+        json={
+            "clientJobId": "support-job-missing-upload",
+            "message": "The app got stuck.",
+            "sourceSurface": "desktop",
+            "scope": {"kind": "app_only", "workspaceIds": []},
+        },
+    )
+    assert create.status_code == 200
+    report_id = create.json()["reportId"]
+    targets = await client.post(
+        f"/v1/support/reports/{report_id}/upload-targets",
+        headers=headers,
+        json={
+            "diagnostics": {
+                "contentType": "application/json",
+                "sizeBytes": 512,
+                "sha256": "abc123",
+            },
+            "attachments": [
+                {
+                    "clientFileId": "file-1",
+                    "fileName": "screen.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 100,
+                    "sha256": "def456",
+                }
+            ],
+        },
+    )
+    assert targets.status_code == 200
+
+    complete = await client.post(
+        f"/v1/support/reports/{report_id}/complete",
+        headers=headers,
+        json={
+            "diagnostics": {
+                "objectKey": targets.json()["diagnostics"]["objectKey"],
+                "sha256": "abc123",
+                "sizeBytes": 512,
+            },
+            "attachments": [],
+            "packageManifest": {"schemaVersion": 2},
+        },
+    )
+
+    assert complete.status_code == 400
+    assert complete.json()["detail"]["code"] == "support_report_upload_invalid"

--- a/server/tests/unit/test_request_telemetry_middleware.py
+++ b/server/tests/unit/test_request_telemetry_middleware.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+
+from proliferate.middleware import request_telemetry
+from proliferate.middleware.request_context import with_correlation_context
+from proliferate.middleware.request_telemetry import RequestTelemetryMiddleware
+
+
+def _request(path: str = "/v1/support/reports/report123/complete") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [],
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 123),
+            "query_string": b"",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_telemetry_sets_correlation_context_when_handler_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_set_server_sentry_correlation_context(context: dict[str, str]) -> None:
+        captured.update(context)
+
+    monkeypatch.setattr(
+        request_telemetry,
+        "set_server_sentry_correlation_context",
+        fake_set_server_sentry_correlation_context,
+    )
+    monkeypatch.setattr(request_telemetry, "set_server_sentry_tag", lambda *_args: None)
+
+    middleware = RequestTelemetryMiddleware(app=lambda _scope, _receive, _send: None)
+
+    async def raise_error(_request: Request):
+        raise RuntimeError("boom")
+
+    with (
+        with_correlation_context(request_id="req-1", support_report_id="report-1"),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await middleware.dispatch(_request(), raise_error)
+
+    assert captured["request_id"] == "req-1"
+    assert captured["support_report_id"] == "report-1"

--- a/server/tests/unit/test_support_redaction.py
+++ b/server/tests/unit/test_support_redaction.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from proliferate.server.support.redaction import redact_mapping
+
+
+def test_support_redaction_scrubs_strings_nested_inside_lists() -> None:
+    opaque = "a" * 56
+
+    redacted = redact_mapping(
+        {
+            "notes": [
+                f"Authorization: Bearer {opaque}",
+                "AWS_SECRET_ACCESS_KEY=abc123",
+                {
+                    "url": (
+                        "https://s3.example/object?"
+                        "X-Amz-Signature=super-secret&X-Amz-Date=20260531"
+                    )
+                },
+                [f"token={opaque}"],
+            ],
+            "metadata": {"apiKey": "already summary"},
+        }
+    )
+
+    assert redacted == {
+        "notes": [
+            "Authorization: Bearer [REDACTED]",
+            "AWS_SECRET_ACCESS_KEY=[REDACTED]",
+            {
+                "url": (
+                    "https://s3.example/object?X-Amz-Signature=[REDACTED]&X-Amz-Date=[REDACTED]"
+                )
+            },
+            ["token=[REDACTED]"],
+        ],
+        "metadata": {"apiKey": "[REDACTED]"},
+    }


### PR DESCRIPTION
## Summary
- trust server-derived cloud workspace refs and mark unauthorized client refs as unverified
- make upload manifests immutable and require all expected objects at completion
- redact Desktop session/live-config diagnostics before support upload and include telemetry pivots
- schedule cloud diagnostics after DB commit and add structured Sentry/log correlation coverage

## Verification
- uv run --extra dev ruff check proliferate/server/support proliferate/middleware/request_telemetry.py tests/integration/test_support_api.py tests/integration/test_support_api_hardening.py tests/unit/test_request_telemetry_middleware.py tests/unit/test_support_redaction.py
- DEBUG=1 JWT_SECRET=local-test-secret CLOUD_SECRET_KEY=local-cloud-secret uv run --extra dev pytest tests/integration/test_support_api.py tests/integration/test_support_api_hardening.py tests/unit/test_request_telemetry_middleware.py tests/unit/test_support_redaction.py -q
- pnpm --filter proliferate exec tsc --noEmit
- pnpm --filter proliferate exec vitest run src/lib/workflows/support/support-report-upload-workflows.test.ts
- python3 scripts/check_frontend_boundaries.py && python3 scripts/check_max_lines.py && git diff --check
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml diagnostics::bundle::tests::scrub_health_response_hides_runtime_home
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml