### PR TITLE
fix(server): isolate automation snapshot failures

### DIFF
--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -29,6 +29,7 @@ from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.agent_run_config import CloudAgentRunConfig
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
 from proliferate.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
@@ -202,7 +203,7 @@ ScheduleAdvanceResolver = Callable[
     [AutomationScheduleFields, datetime],
     AutomationScheduleAdvance,
 ]
-AgentRunConfigSnapshotBuilder = Callable[[CloudAgentRunConfig], dict[str, object]]
+AgentRunConfigSnapshotBuilder = Callable[[CloudAgentRunConfigRecord], dict[str, object] | None]
 
 
 def _automation_value(record: Automation, repo_config: CloudRepoConfig) -> AutomationValue:
@@ -272,6 +273,28 @@ def _run_value(record: AutomationRun) -> AutomationRunValue:
         last_error_message=record.last_error_message,
         created_at=record.created_at,
         updated_at=record.updated_at,
+    )
+
+
+def _run_config_value(record: CloudAgentRunConfig) -> CloudAgentRunConfigRecord:
+    return CloudAgentRunConfigRecord(
+        id=record.id,
+        owner_scope=record.owner_scope,
+        owner_user_id=record.owner_user_id,
+        organization_id=record.organization_id,
+        created_by_user_id=record.created_by_user_id,
+        name=record.name,
+        agent_kind=record.agent_kind,
+        model_id=record.model_id,
+        control_values_json=dict(record.control_values_json or {}),
+        usable_in_personal_sandboxes=record.usable_in_personal_sandboxes,
+        usable_in_shared_sandboxes=record.usable_in_shared_sandboxes,
+        seed_key=record.seed_key,
+        system_default_rank=record.system_default_rank,
+        status=record.status,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        archived_at=record.archived_at,
     )
 
 
@@ -701,69 +724,79 @@ async def create_due_scheduled_runs_batch(
             record.updated_at = now
             continue
         if advance.scheduled_for is not None:
-            snapshot = agent_run_config_snapshot_builder(run_config)
-            result = await db.execute(
-                pg_insert(AutomationRun)
-                .values(
-                    automation_id=record.id,
-                    owner_scope=record.owner_scope,
-                    owner_user_id=record.owner_user_id,
-                    organization_id=record.organization_id,
-                    created_by_user_id=record.created_by_user_id,
-                    trigger_kind=AUTOMATION_RUN_TRIGGER_SCHEDULED,
-                    scheduled_for=advance.scheduled_for,
-                    target_mode=record.target_mode,
-                    status=AUTOMATION_RUN_STATUS_QUEUED,
-                    title_snapshot=record.title,
-                    prompt_snapshot=record.prompt,
-                    git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
-                    git_owner_snapshot=repo_config.git_owner,
-                    git_repo_name_snapshot=repo_config.git_repo_name,
-                    cloud_repo_config_id_snapshot=record.cloud_repo_config_id,
-                    cloud_target_id_snapshot=None,
-                    cloud_target_kind_snapshot=None,
-                    sandbox_profile_id=None,
-                    cloud_workspace_exposure_id=None,
-                    agent_run_config_snapshot_json=snapshot,
-                    cascade_attempt=0,
-                    last_cascade_command_id=None,
-                    last_cascade_reason=None,
-                    executor_kind=None,
-                    executor_id=None,
-                    claim_id=None,
-                    claimed_at=None,
-                    claim_expires_at=None,
-                    last_heartbeat_at=None,
-                    dispatch_started_at=None,
-                    dispatched_at=None,
-                    failed_at=None,
-                    cloud_workspace_id=None,
-                    anyharness_workspace_id=None,
-                    anyharness_session_id=None,
-                    cancelled_at=None,
-                    last_error_code=None,
-                    last_error_message=None,
-                    created_at=now,
-                    updated_at=now,
-                )
-                .on_conflict_do_nothing(
-                    index_elements=[
-                        AutomationRun.automation_id,
-                        AutomationRun.scheduled_for,
-                    ],
-                    index_where=AutomationRun.trigger_kind == AUTOMATION_RUN_TRIGGER_SCHEDULED,
-                )
-                .returning(AutomationRun.id)
-            )
-            if result.scalar_one_or_none() is not None:
-                inserted_count += 1
-                record.last_scheduled_at = advance.scheduled_for
-            else:
-                logger.debug(
-                    "automation scheduled slot already existed automation_id=%s scheduled_for=%s",
+            snapshot = agent_run_config_snapshot_builder(_run_config_value(run_config))
+            if snapshot is None:
+                logger.warning(
+                    "automation agent run config snapshot unavailable; "
+                    "skipping scheduled run automation_id=%s run_config_id=%s scheduled_for=%s",
                     record.id,
+                    run_config.id,
                     advance.scheduled_for,
                 )
+            else:
+                result = await db.execute(
+                    pg_insert(AutomationRun)
+                    .values(
+                        automation_id=record.id,
+                        owner_scope=record.owner_scope,
+                        owner_user_id=record.owner_user_id,
+                        organization_id=record.organization_id,
+                        created_by_user_id=record.created_by_user_id,
+                        trigger_kind=AUTOMATION_RUN_TRIGGER_SCHEDULED,
+                        scheduled_for=advance.scheduled_for,
+                        target_mode=record.target_mode,
+                        status=AUTOMATION_RUN_STATUS_QUEUED,
+                        title_snapshot=record.title,
+                        prompt_snapshot=record.prompt,
+                        git_provider_snapshot=SUPPORTED_GIT_PROVIDER,
+                        git_owner_snapshot=repo_config.git_owner,
+                        git_repo_name_snapshot=repo_config.git_repo_name,
+                        cloud_repo_config_id_snapshot=record.cloud_repo_config_id,
+                        cloud_target_id_snapshot=None,
+                        cloud_target_kind_snapshot=None,
+                        sandbox_profile_id=None,
+                        cloud_workspace_exposure_id=None,
+                        agent_run_config_snapshot_json=snapshot,
+                        cascade_attempt=0,
+                        last_cascade_command_id=None,
+                        last_cascade_reason=None,
+                        executor_kind=None,
+                        executor_id=None,
+                        claim_id=None,
+                        claimed_at=None,
+                        claim_expires_at=None,
+                        last_heartbeat_at=None,
+                        dispatch_started_at=None,
+                        dispatched_at=None,
+                        failed_at=None,
+                        cloud_workspace_id=None,
+                        anyharness_workspace_id=None,
+                        anyharness_session_id=None,
+                        cancelled_at=None,
+                        last_error_code=None,
+                        last_error_message=None,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    .on_conflict_do_nothing(
+                        index_elements=[
+                            AutomationRun.automation_id,
+                            AutomationRun.scheduled_for,
+                        ],
+                        index_where=AutomationRun.trigger_kind == AUTOMATION_RUN_TRIGGER_SCHEDULED,
+                    )
+                    .returning(AutomationRun.id)
+                )
+                if result.scalar_one_or_none() is not None:
+                    inserted_count += 1
+                    record.last_scheduled_at = advance.scheduled_for
+                else:
+                    logger.debug(
+                        "automation scheduled slot already existed automation_id=%s "
+                        "scheduled_for=%s",
+                        record.id,
+                        advance.scheduled_for,
+                    )
         record.next_run_at = advance.next_run_at
         record.updated_at = now
     return inserted_count

--- a/server/proliferate/server/automations/worker/service.py
+++ b/server/proliferate/server/automations/worker/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from proliferate.db.store.automations import (
     AutomationScheduleFields,
     create_due_scheduled_runs_batch,
 )
+from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
 from proliferate.server.automations.domain.claim_lifecycle import (
     AUTOMATION_RUN_STATUS_DISPATCHING,
     dispatch_uncertain_failure,
@@ -25,7 +27,10 @@ from proliferate.server.automations.domain.schedule import due_and_next_occurren
 from proliferate.server.cloud.agent_run_config.service import (
     snapshot_json as agent_run_config_snapshot_json,
 )
+from proliferate.server.cloud.errors import CloudApiError
 from proliferate.utils.time import utcnow
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -48,6 +53,22 @@ def _resolve_due_schedule(
         now=now,
     )
     return AutomationScheduleAdvance(scheduled_for=scheduled_for, next_run_at=next_run_at)
+
+
+def _scheduled_agent_run_config_snapshot_json(
+    value: CloudAgentRunConfigRecord,
+) -> dict[str, object] | None:
+    try:
+        return agent_run_config_snapshot_json(value)
+    except CloudApiError as error:
+        logger.warning(
+            "automation scheduled run config snapshot failed; "
+            "skipping run_config_id=%s code=%s message=%s",
+            value.id,
+            error.code,
+            error.message,
+        )
+        return None
 
 
 async def _sweep_expired_dispatching_runs(
@@ -73,7 +94,7 @@ async def _create_due_scheduled_runs_batch(
             now=utcnow(),
             limit=max(1, batch_size),
             schedule_advance_resolver=_resolve_due_schedule,
-            agent_run_config_snapshot_builder=agent_run_config_snapshot_json,
+            agent_run_config_snapshot_builder=_scheduled_agent_run_config_snapshot_json,
         )
 
 

--- a/server/tests/unit/test_automation_store.py
+++ b/server/tests/unit/test_automation_store.py
@@ -16,6 +16,7 @@ from proliferate.db.models.auth import User
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.agent_run_config import CloudAgentRunConfig
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
 from proliferate.db.store.automations import (
     AutomationScheduleAdvance,
     create_due_scheduled_runs_batch,
@@ -120,7 +121,9 @@ def _repo_row(
     )
 
 
-def _agent_snapshot(config: CloudAgentRunConfig) -> dict[str, object]:
+def _agent_snapshot(
+    config: CloudAgentRunConfig | CloudAgentRunConfigRecord,
+) -> dict[str, object]:
     return {
         "config_id": str(config.id),
         "config_name": config.name,
@@ -221,6 +224,104 @@ async def test_due_scheduler_disables_bad_schedule_and_continues_batch(
 
 
 @pytest.mark.asyncio
+async def test_due_scheduler_skips_failed_snapshot_and_continues_batch(
+    test_engine,  # type: ignore[no-untyped-def]
+) -> None:
+    original_factory = engine_module.async_session_factory
+    engine_module.async_session_factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    user_id = uuid.uuid4()
+
+    try:
+        async with engine_module.async_session_factory() as session:
+            await _create_user(session, user_id=user_id)
+            good_run_config = await _create_run_config(
+                session,
+                user_id=user_id,
+                model_id="gpt-5.4",
+            )
+            bad_run_config = await _create_run_config(
+                session,
+                user_id=user_id,
+                model_id="retired-model",
+            )
+            good_repo = _repo_row(user_id=user_id, git_repo_name="snapshot-good", now=now)
+            bad_repo = _repo_row(user_id=user_id, git_repo_name="snapshot-bad", now=now)
+            session.add_all([good_repo, bad_repo])
+            await session.flush()
+            good_automation = _automation_row(
+                user_id=user_id,
+                repo_id=good_repo.id,
+                run_config_id=good_run_config.id,
+                title="Good snapshot",
+                prompt="Run good snapshot",
+                schedule_rrule="RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=0",
+                next_run_at=now,
+            )
+            bad_automation = _automation_row(
+                user_id=user_id,
+                repo_id=bad_repo.id,
+                run_config_id=bad_run_config.id,
+                title="Bad snapshot",
+                prompt="Run bad snapshot",
+                schedule_rrule="RRULE:FREQ=HOURLY;INTERVAL=1;BYMINUTE=0",
+                next_run_at=now,
+            )
+            session.add_all([good_automation, bad_automation])
+            await session.commit()
+            good_id = good_automation.id
+            bad_id = bad_automation.id
+
+        def _advance(fields, _now):  # type: ignore[no-untyped-def]
+            return AutomationScheduleAdvance(
+                scheduled_for=fields.next_run_at,
+                next_run_at=now + timedelta(hours=1),
+            )
+
+        def _snapshot_or_skip(
+            config: CloudAgentRunConfigRecord,
+        ) -> dict[str, object] | None:
+            if config.model_id == "retired-model":
+                return None
+            return _agent_snapshot(config)
+
+        async with engine_module.async_session_factory() as session, session.begin():
+            created = await create_due_scheduled_runs_batch(
+                session,
+                now=now,
+                limit=10,
+                schedule_advance_resolver=_advance,
+                agent_run_config_snapshot_builder=_snapshot_or_skip,
+            )
+
+        async with engine_module.async_session_factory() as session:
+            good = await session.get(Automation, good_id)
+            bad = await session.get(Automation, bad_id)
+            runs = list(
+                (
+                    await session.execute(
+                        select(AutomationRun).order_by(AutomationRun.created_at.asc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert created == 1
+        assert good is not None
+        assert good.last_scheduled_at == now
+        assert good.next_run_at == now + timedelta(hours=1)
+        assert bad is not None
+        assert bad.last_scheduled_at is None
+        assert bad.next_run_at == now + timedelta(hours=1)
+        assert [run.automation_id for run in runs] == [good_id]
+        assert runs[0].agent_run_config_snapshot_json is not None
+        assert runs[0].agent_run_config_snapshot_json["model_id"] == "gpt-5.4"
+    finally:
+        engine_module.async_session_factory = original_factory
+
+
+@pytest.mark.asyncio
 async def test_due_scheduler_uses_precomputed_agent_run_config_snapshot(
     test_engine,  # type: ignore[no-untyped-def]
 ) -> None:
@@ -260,7 +361,7 @@ async def test_due_scheduler_uses_precomputed_agent_run_config_snapshot(
                 next_run_at=now + timedelta(hours=1),
             )
 
-        def _canonical_snapshot(config: CloudAgentRunConfig) -> dict[str, object]:
+        def _canonical_snapshot(config: CloudAgentRunConfigRecord) -> dict[str, object]:
             snapshot = _agent_snapshot(config)
             snapshot["model_id"] = "gpt-5.3-codex"
             return snapshot

--- a/server/tests/unit/test_automation_worker_scheduler.py
+++ b/server/tests/unit/test_automation_worker_scheduler.py
@@ -15,10 +15,61 @@ from proliferate.db.models.auth import User
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.agent_run_config import CloudAgentRunConfig
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
 from proliferate.server.automations.domain.claim_lifecycle import (
     AUTOMATION_ERROR_DISPATCH_UNCERTAIN,
 )
 from proliferate.server.automations.worker import service as worker_service
+from proliferate.server.cloud.errors import CloudApiError
+
+
+def _run_config_record(*, user_id: uuid.UUID) -> CloudAgentRunConfigRecord:
+    now = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+    return CloudAgentRunConfigRecord(
+        id=uuid.uuid4(),
+        owner_scope=AUTOMATION_OWNER_SCOPE_PERSONAL,
+        owner_user_id=user_id,
+        organization_id=None,
+        created_by_user_id=user_id,
+        name="Retired model config",
+        agent_kind="codex",
+        model_id="retired-model",
+        control_values_json={},
+        usable_in_personal_sandboxes=True,
+        usable_in_shared_sandboxes=False,
+        seed_key=None,
+        system_default_rank=None,
+        status="active",
+        created_at=now,
+        updated_at=now,
+        archived_at=None,
+    )
+
+
+def test_scheduled_snapshot_wrapper_skips_cloud_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+
+    def _raise_cloud_api_error(_config: CloudAgentRunConfigRecord) -> dict[str, object]:
+        raise CloudApiError(
+            "model_unavailable",
+            "Model is not available for this agent.",
+            status_code=400,
+        )
+
+    monkeypatch.setattr(
+        worker_service,
+        "agent_run_config_snapshot_json",
+        _raise_cloud_api_error,
+    )
+
+    assert (
+        worker_service._scheduled_agent_run_config_snapshot_json(
+            _run_config_record(user_id=user_id),
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- prevent one invalid scheduled automation run config snapshot from rolling back the entire due-run batch
- convert scheduler snapshot failures into a skip sentinel while advancing that automation cursor
- align the snapshot builder type with CloudAgentRunConfigRecord and cover the failure path

## Verification
- uv run --extra dev ruff check --fix proliferate/db/store/automations.py proliferate/server/automations/worker/service.py tests/unit/test_automation_store.py tests/unit/test_automation_worker_scheduler.py
- uv run --extra dev ruff format proliferate/db/store/automations.py proliferate/server/automations/worker/service.py tests/unit/test_automation_store.py tests/unit/test_automation_worker_scheduler.py
- uv run --extra dev ruff check proliferate/db/store/automations.py proliferate/server/automations/worker/service.py tests/unit/test_automation_store.py tests/unit/test_automation_worker_scheduler.py
- DEBUG=true uv run --extra dev pytest -q tests/unit/test_automation_store.py::test_due_scheduler_skips_failed_snapshot_and_continues_batch tests/unit/test_automation_worker_scheduler.py::test_scheduled_snapshot_wrapper_skips_cloud_api_errors tests/unit/test_automation_worker_scheduler.py::test_scheduler_tick_commits_sweep_before_due_batch_failure
- DEBUG=true uv run --extra dev pytest -q tests/unit/test_automation_store.py tests/unit/test_automation_worker_scheduler.py