### PR TITLE
fix(desktop): fail release on broken sentry upload

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -58,6 +58,7 @@ env:
   VITE_PROLIFERATE_SENTRY_ENABLE_LOGS: ${{ vars.VITE_PROLIFERATE_SENTRY_ENABLE_LOGS }}
   VITE_PROLIFERATE_POSTHOG_KEY: ${{ vars.VITE_PROLIFERATE_POSTHOG_KEY }}
   VITE_PROLIFERATE_POSTHOG_HOST: ${{ vars.VITE_PROLIFERATE_POSTHOG_HOST }}
+  SENTRY_DESKTOP_RENDERER_PROJECT: ${{ vars.SENTRY_DESKTOP_RENDERER_PROJECT || vars.SENTRY_PROJECT }}
   PROLIFERATE_DESKTOP_SENTRY_DSN: ${{ vars.PROLIFERATE_DESKTOP_SENTRY_DSN || vars.VITE_PROLIFERATE_SENTRY_DSN }}
   PROLIFERATE_DESKTOP_SENTRY_ENVIRONMENT: ${{ vars.PROLIFERATE_DESKTOP_SENTRY_ENVIRONMENT || vars.VITE_PROLIFERATE_ENVIRONMENT || 'production' }}
   PROLIFERATE_DESKTOP_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.PROLIFERATE_DESKTOP_SENTRY_TRACES_SAMPLE_RATE || vars.VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE }}
@@ -258,9 +259,28 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_DESKTOP_RENDERER_PROJECT || vars.SENTRY_PROJECT }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         run: |
+          if [[ -n "$VITE_PROLIFERATE_SENTRY_DSN" ]]; then
+            : "${SENTRY_AUTH_TOKEN:?Set SENTRY_AUTH_TOKEN secret for desktop renderer Sentry sourcemaps.}"
+            : "${SENTRY_ORG:?Set SENTRY_ORG GitHub variable for desktop renderer Sentry sourcemaps.}"
+            : "${SENTRY_PROJECT:?Set SENTRY_DESKTOP_RENDERER_PROJECT or SENTRY_PROJECT GitHub variable for desktop renderer Sentry sourcemaps.}"
+
+            sentry_url="${SENTRY_URL:-https://sentry.io/}"
+            sentry_status="$(
+              curl -sS -o /tmp/sentry-desktop-renderer-project.json -w "%{http_code}" \
+                -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+                "${sentry_url%/}/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/" \
+                || true
+            )"
+
+            if [[ "$sentry_status" != "200" ]]; then
+              echo "::error::Sentry desktop renderer project '$SENTRY_PROJECT' is not accessible in org '$SENTRY_ORG' (HTTP $sentry_status). Update SENTRY_DESKTOP_RENDERER_PROJECT before releasing."
+              exit 1
+            fi
+          fi
+
           export VITE_PROLIFERATE_RELEASE="proliferate-desktop@${PROLIFERATE_RELEASE_VERSION}"
           pnpm run build
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
           org: sentryOrg!,
           project: sentryProject!,
           telemetry: false,
+          errorHandler(error) {
+            throw error;
+          },
           release: {
             name: sentryRelease!,
           },

--- a/docs/dev/analytics/sentry-setup-runbook.md
+++ b/docs/dev/analytics/sentry-setup-runbook.md
@@ -104,6 +104,7 @@ Also set these non-secret GitHub variables once projects exist (used by
 `release-desktop.yml` and the mobile sourcemap script):
 
 - `SENTRY_URL=https://sentry.io/`
+- `SENTRY_DESKTOP_RENDERER_PROJECT=proliferate-desktop`
 - `SENTRY_WEB_PROJECT=proliferate-web`
 - `SENTRY_DESKTOP_NATIVE_PROJECT=proliferate-desktop-native`
 - `SENTRY_ANYHARNESS_PROJECT=anyharness`

--- a/docs/dev/analytics/sentry.md
+++ b/docs/dev/analytics/sentry.md
@@ -46,7 +46,8 @@ Upload targets:
 - `SENTRY_ORG`
 - `SENTRY_PROJECT`
 - `SENTRY_URL` when using a non-Sentry.io host
-- optional overrides: `SENTRY_WEB_PROJECT`, `SENTRY_MOBILE_PROJECT`,
+- optional overrides: `SENTRY_DESKTOP_RENDERER_PROJECT`,
+  `SENTRY_WEB_PROJECT`, `SENTRY_MOBILE_PROJECT`,
   `SENTRY_DESKTOP_NATIVE_PROJECT`, `SENTRY_ANYHARNESS_PROJECT`
 
 ## Privacy


### PR DESCRIPTION
## Summary
- route desktop renderer release uploads through the explicit SENTRY_DESKTOP_RENDERER_PROJECT override
- validate the configured Sentry project before desktop frontend release builds
- make the Sentry Vite plugin throw on release/sourcemap upload failures and document the renderer project var

## Verification
- pnpm --filter @proliferate/cloud-sdk build
- pnpm --dir apps/desktop exec tsc --noEmit
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-desktop.yml"); puts "workflow yaml ok"'
- git diff --check
- pnpm --dir apps/desktop run build

Also set GitHub repo variable SENTRY_DESKTOP_RENDERER_PROJECT=proliferate-desktop.