### PR TITLE
fix(release): align desktop sentry preflight guard

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -262,11 +262,15 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_DESKTOP_RENDERER_PROJECT || vars.SENTRY_PROJECT }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         run: |
+          export VITE_PROLIFERATE_RELEASE="proliferate-desktop@${PROLIFERATE_RELEASE_VERSION}"
+
           if [[ -n "$VITE_PROLIFERATE_SENTRY_DSN" ]]; then
             : "${SENTRY_AUTH_TOKEN:?Set SENTRY_AUTH_TOKEN secret for desktop renderer Sentry sourcemaps.}"
             : "${SENTRY_ORG:?Set SENTRY_ORG GitHub variable for desktop renderer Sentry sourcemaps.}"
             : "${SENTRY_PROJECT:?Set SENTRY_DESKTOP_RENDERER_PROJECT or SENTRY_PROJECT GitHub variable for desktop renderer Sentry sourcemaps.}"
+          fi
 
+          if [[ -n "$SENTRY_AUTH_TOKEN" && -n "$SENTRY_ORG" && -n "$SENTRY_PROJECT" && -n "$VITE_PROLIFERATE_RELEASE" ]]; then
             sentry_url="${SENTRY_URL:-https://sentry.io/}"
             sentry_status="$(
               curl -sS -o /tmp/sentry-desktop-renderer-project.json -w "%{http_code}" \
@@ -281,7 +285,6 @@ jobs:
             fi
           fi
 
-          export VITE_PROLIFERATE_RELEASE="proliferate-desktop@${PROLIFERATE_RELEASE_VERSION}"
           pnpm run build
 
       - name: Import Apple Developer Certificate


### PR DESCRIPTION
## Summary
- export the desktop renderer Sentry release before preflight validation
- keep the strict DSN-enabled requirement for upload env vars
- validate the Sentry project whenever the Vite upload inputs are complete

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-desktop.yml"); puts "workflow yaml ok"'
- git diff --check