### PR TITLE
fix(server): keep worker control service boundary clean

### DIFF
--- a/server/proliferate/server/cloud/worker/control/checks.py
+++ b/server/proliferate/server/cloud/worker/control/checks.py
@@ -1,0 +1,221 @@
+"""Database-backed worker control checks."""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta
+from uuid import UUID
+
+from proliferate.db import engine as db_engine
+from proliferate.db.store.cloud_sync import commands as commands_store
+from proliferate.db.store.cloud_sync import targets as targets_store
+from proliferate.db.store.cloud_sync import worker_control as worker_control_store
+from proliferate.db.store.cloud_sync import worker_exposures as worker_exposures_store
+from proliferate.server.cloud._logging import log_cloud_event
+from proliferate.server.cloud.commands import service as command_service
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.live.service import publish_command_status_after_commit
+from proliferate.server.cloud.worker.domain.rules import (
+    clamp_command_lease_seconds,
+    normalize_supported_command_kinds,
+)
+from proliferate.server.cloud.worker.models import (
+    WorkerControlWaitRequest,
+    WorkerControlWaitResponse,
+    WorkerExposureSnapshotResponse,
+)
+from proliferate.server.cloud.worker.service import _command_envelope, authenticate_worker
+from proliferate.server.cloud.worker.slot_guard import require_current_managed_worker_slot
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class ControlCheck:
+    target_id: UUID
+    response: WorkerControlWaitResponse | None
+
+
+async def check_worker_control(
+    *,
+    body: WorkerControlWaitRequest,
+    authorization: str | None,
+    timeout_response: bool,
+) -> ControlCheck:
+    supported_kinds = normalize_supported_command_kinds(body.supported_kinds)
+    lease_seconds = clamp_command_lease_seconds(body.lease_timeout_seconds)
+    cursor = worker_control_store.parse_control_cursor(body.control_cursor)
+    async with db_engine.async_session_factory() as db:
+        auth = await authenticate_worker(db, authorization=authorization)
+        target = await targets_store.get_target_by_id(db, auth.target_id)
+        if target is None:
+            raise CloudApiError(
+                "cloud_worker_target_missing",
+                "Worker target no longer exists.",
+                status_code=401,
+            )
+        await require_current_managed_worker_slot(db, auth=auth, target=target)
+
+        now = utcnow()
+        expired_commands = await command_service.expire_stale_client_commands_for_target(
+            db,
+            target_id=auth.target_id,
+        )
+        blocked_commands: list[commands_store.CloudCommandSnapshot] = []
+        command = await commands_store.lease_next_command(
+            db,
+            target_id=auth.target_id,
+            worker_id=auth.worker_id,
+            supported_kinds=supported_kinds,
+            lease_id=secrets.token_urlsafe(24),
+            lease_expires_at=now + timedelta(seconds=lease_seconds),
+            now=now,
+            blocked_commands=blocked_commands,
+        )
+        command_scan_changed_state = bool(blocked_commands)
+        if command is not None:
+            log_cloud_event(
+                "cloud worker command leased",
+                command_id=command.id,
+                target_id=auth.target_id,
+                worker_id=auth.worker_id,
+                kind=command.kind,
+                workspace_id=command.workspace_id,
+                session_id=command.session_id,
+                cloud_workspace_id=command.cloud_workspace_id,
+                attempt_count=command.attempt_count,
+                lease_expires_at=command.lease_expires_at,
+            )
+            await publish_command_status_after_commit(db, command)
+        for blocked_command in blocked_commands:
+            await publish_command_status_after_commit(db, blocked_command)
+        if command_scan_changed_state:
+            await worker_control_store.bump_control_revision(
+                db,
+                target_id=auth.target_id,
+                now=now,
+            )
+
+        state = await worker_control_store.get_or_create_control_state(
+            db,
+            target_id=auth.target_id,
+        )
+        needs_full_snapshot = worker_control_store.cursor_needs_full_snapshot(cursor, state)
+        exposures_current = (
+            False
+            if needs_full_snapshot
+            else worker_control_store.cursor_exposures_are_current(cursor, state)
+        )
+        include_exposures = not exposures_current
+        exposure_snapshots: tuple[worker_exposures_store.WorkerExposureSnapshot, ...] = ()
+        if include_exposures:
+            exposure_snapshots = (
+                await worker_exposures_store.list_worker_exposure_snapshots_for_target(
+                    db,
+                    target_id=auth.target_id,
+                )
+            )
+            state = await worker_control_store.ensure_exposure_state_current(
+                db,
+                target_id=auth.target_id,
+                snapshots=exposure_snapshots,
+            )
+            needs_full_snapshot = worker_control_store.cursor_needs_full_snapshot(cursor, state)
+            exposures_current = (
+                False
+                if needs_full_snapshot
+                else worker_control_store.cursor_exposures_are_current(cursor, state)
+            )
+            include_exposures = not exposures_current
+        control_cursor = worker_control_store.control_cursor_for_state(state)
+        state_current = (
+            False if needs_full_snapshot else worker_control_store.cursor_is_current(cursor, state)
+        )
+
+        response: WorkerControlWaitResponse | None = None
+        if command is not None:
+            reason = "command_and_exposures" if include_exposures else "command"
+            response = WorkerControlWaitResponse(
+                command=_command_envelope(command),
+                exposures=(_exposure_responses(exposure_snapshots) if include_exposures else None),
+                control_cursor=control_cursor,
+                reason=reason,
+                server_time=now.isoformat(),
+            )
+        elif include_exposures:
+            response = WorkerControlWaitResponse(
+                command=None,
+                exposures=_exposure_responses(exposure_snapshots),
+                control_cursor=control_cursor,
+                reason="exposures",
+                server_time=now.isoformat(),
+            )
+        elif not state_current or expired_commands or command_scan_changed_state:
+            response = WorkerControlWaitResponse(
+                command=None,
+                exposures=None,
+                control_cursor=control_cursor,
+                reason="state_changed",
+                server_time=now.isoformat(),
+            )
+        elif timeout_response:
+            response = WorkerControlWaitResponse(
+                command=None,
+                exposures=None,
+                control_cursor=control_cursor,
+                reason="timeout",
+                server_time=now.isoformat(),
+            )
+
+        if response is not None and (
+            command is not None
+            or expired_commands
+            or command_scan_changed_state
+            or response.reason in {"exposures", "command_and_exposures", "state_changed"}
+        ):
+            await db.commit()
+        return ControlCheck(target_id=auth.target_id, response=response)
+
+
+async def timeout_response(
+    *,
+    body: WorkerControlWaitRequest,
+    authorization: str | None,
+) -> WorkerControlWaitResponse:
+    check = await check_worker_control(
+        body=body,
+        authorization=authorization,
+        timeout_response=True,
+    )
+    if check.response is None:
+        raise CloudApiError(
+            "cloud_worker_control_timeout_missing",
+            "Worker control timeout response could not be built.",
+            status_code=500,
+        )
+    return check.response
+
+
+def _exposure_responses(
+    snapshots: tuple[worker_exposures_store.WorkerExposureSnapshot, ...],
+) -> list[WorkerExposureSnapshotResponse]:
+    return [
+        WorkerExposureSnapshotResponse(
+            exposure_id=str(snapshot.exposure_id),
+            target_id=str(snapshot.target_id),
+            cloud_workspace_id=str(snapshot.cloud_workspace_id),
+            session_projection_id=(
+                str(snapshot.session_projection_id)
+                if snapshot.session_projection_id is not None
+                else None
+            ),
+            anyharness_workspace_id=snapshot.anyharness_workspace_id,
+            anyharness_session_id=snapshot.anyharness_session_id,
+            projection_level=snapshot.projection_level,
+            commandable=snapshot.commandable,
+            status=snapshot.status,
+            revision=snapshot.revision,
+            last_uploaded_seq=snapshot.last_uploaded_seq,
+        )
+        for snapshot in snapshots
+    ]

--- a/server/proliferate/server/cloud/worker/control/service.py
+++ b/server/proliferate/server/cloud/worker/control/service.py
@@ -3,46 +3,24 @@
 from __future__ import annotations
 
 import asyncio
-import secrets
-from dataclasses import dataclass
-from datetime import timedelta
 from time import perf_counter
-from uuid import UUID
 
-from proliferate.db import engine as db_engine
-from proliferate.db.store.cloud_sync import commands as commands_store
-from proliferate.db.store.cloud_sync import targets as targets_store
-from proliferate.db.store.cloud_sync import worker_control as worker_control_store
-from proliferate.db.store.cloud_sync import worker_exposures as worker_exposures_store
 from proliferate.integrations.pubsub.redis import get_pubsub_bus
 from proliferate.server.cloud._logging import log_cloud_event
-from proliferate.server.cloud.commands import service as command_service
-from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.live.domain.channels import worker_control_channel
-from proliferate.server.cloud.live.service import publish_command_status_after_commit
-from proliferate.server.cloud.worker.domain.rules import (
-    clamp_command_lease_seconds,
-    normalize_supported_command_kinds,
+from proliferate.server.cloud.worker.control.checks import (
+    check_worker_control,
+    timeout_response,
 )
 from proliferate.server.cloud.worker.models import (
     WorkerControlWaitRequest,
     WorkerControlWaitResponse,
-    WorkerExposureSnapshotResponse,
 )
-from proliferate.server.cloud.worker.service import _command_envelope, authenticate_worker
-from proliferate.server.cloud.worker.slot_guard import require_current_managed_worker_slot
-from proliferate.utils.time import utcnow
 
 _CONTROL_WAIT_DEFAULT_SECONDS = 20
 _CONTROL_WAIT_MAX_SECONDS = 20
 _CONTROL_WAIT_MIN_SECONDS = 1
 _worker_control_bus = get_pubsub_bus()
-
-
-@dataclass(frozen=True)
-class _ControlCheck:
-    target_id: UUID
-    response: WorkerControlWaitResponse | None
 
 
 async def wait_for_worker_control(
@@ -52,13 +30,13 @@ async def wait_for_worker_control(
 ) -> WorkerControlWaitResponse:
     started = perf_counter()
     wait_seconds = _clamp_wait_seconds(body.wait_seconds)
-    first = await _check_worker_control(
+    first = await check_worker_control(
         body=body,
         authorization=authorization,
         timeout_response=False,
     )
     if first.response is not None or wait_seconds <= 0:
-        response = first.response or await _timeout_response(
+        response = first.response or await timeout_response(
             body=body,
             authorization=authorization,
         )
@@ -67,7 +45,7 @@ async def wait_for_worker_control(
 
     channel = worker_control_channel(target_id=first.target_id)
     async with _worker_control_bus.subscribe(channel) as messages:
-        recheck = await _check_worker_control(
+        recheck = await check_worker_control(
             body=body,
             authorization=authorization,
             timeout_response=False,
@@ -91,7 +69,7 @@ async def wait_for_worker_control(
                 break
             except TimeoutError:
                 break
-            update = await _check_worker_control(
+            update = await check_worker_control(
                 body=body,
                 authorization=authorization,
                 timeout_response=False,
@@ -104,194 +82,9 @@ async def wait_for_worker_control(
                 )
                 return update.response
 
-    response = await _timeout_response(body=body, authorization=authorization)
+    response = await timeout_response(body=body, authorization=authorization)
     _log_control_wait_response(response, wait_seconds=wait_seconds, started=started)
     return response
-
-
-async def _check_worker_control(
-    *,
-    body: WorkerControlWaitRequest,
-    authorization: str | None,
-    timeout_response: bool,
-) -> _ControlCheck:
-    supported_kinds = normalize_supported_command_kinds(body.supported_kinds)
-    lease_seconds = clamp_command_lease_seconds(body.lease_timeout_seconds)
-    cursor = worker_control_store.parse_control_cursor(body.control_cursor)
-    async with db_engine.async_session_factory() as db:
-        auth = await authenticate_worker(db, authorization=authorization)
-        target = await targets_store.get_target_by_id(db, auth.target_id)
-        if target is None:
-            raise CloudApiError(
-                "cloud_worker_target_missing",
-                "Worker target no longer exists.",
-                status_code=401,
-            )
-        await require_current_managed_worker_slot(db, auth=auth, target=target)
-
-        now = utcnow()
-        expired_commands = await command_service.expire_stale_client_commands_for_target(
-            db,
-            target_id=auth.target_id,
-        )
-        blocked_commands: list[commands_store.CloudCommandSnapshot] = []
-        command = await commands_store.lease_next_command(
-            db,
-            target_id=auth.target_id,
-            worker_id=auth.worker_id,
-            supported_kinds=supported_kinds,
-            lease_id=secrets.token_urlsafe(24),
-            lease_expires_at=now + timedelta(seconds=lease_seconds),
-            now=now,
-            blocked_commands=blocked_commands,
-        )
-        command_scan_changed_state = bool(blocked_commands)
-        if command is not None:
-            log_cloud_event(
-                "cloud worker command leased",
-                command_id=command.id,
-                target_id=auth.target_id,
-                worker_id=auth.worker_id,
-                kind=command.kind,
-                workspace_id=command.workspace_id,
-                session_id=command.session_id,
-                cloud_workspace_id=command.cloud_workspace_id,
-                attempt_count=command.attempt_count,
-                lease_expires_at=command.lease_expires_at,
-            )
-            await publish_command_status_after_commit(db, command)
-        for blocked_command in blocked_commands:
-            await publish_command_status_after_commit(db, blocked_command)
-        if command_scan_changed_state:
-            await worker_control_store.bump_control_revision(
-                db,
-                target_id=auth.target_id,
-                now=now,
-            )
-
-        state = await worker_control_store.get_or_create_control_state(
-            db,
-            target_id=auth.target_id,
-        )
-        needs_full_snapshot = worker_control_store.cursor_needs_full_snapshot(cursor, state)
-        exposures_current = (
-            False
-            if needs_full_snapshot
-            else worker_control_store.cursor_exposures_are_current(cursor, state)
-        )
-        include_exposures = not exposures_current
-        exposure_snapshots: tuple[worker_exposures_store.WorkerExposureSnapshot, ...] = ()
-        if include_exposures:
-            exposure_snapshots = (
-                await worker_exposures_store.list_worker_exposure_snapshots_for_target(
-                    db,
-                    target_id=auth.target_id,
-                )
-            )
-            state = await worker_control_store.ensure_exposure_state_current(
-                db,
-                target_id=auth.target_id,
-                snapshots=exposure_snapshots,
-            )
-            needs_full_snapshot = worker_control_store.cursor_needs_full_snapshot(cursor, state)
-            exposures_current = (
-                False
-                if needs_full_snapshot
-                else worker_control_store.cursor_exposures_are_current(cursor, state)
-            )
-            include_exposures = not exposures_current
-        control_cursor = worker_control_store.control_cursor_for_state(state)
-        state_current = (
-            False if needs_full_snapshot else worker_control_store.cursor_is_current(cursor, state)
-        )
-
-        response: WorkerControlWaitResponse | None = None
-        if command is not None:
-            reason = "command_and_exposures" if include_exposures else "command"
-            response = WorkerControlWaitResponse(
-                command=_command_envelope(command),
-                exposures=(_exposure_responses(exposure_snapshots) if include_exposures else None),
-                control_cursor=control_cursor,
-                reason=reason,
-                server_time=now.isoformat(),
-            )
-        elif include_exposures:
-            response = WorkerControlWaitResponse(
-                command=None,
-                exposures=_exposure_responses(exposure_snapshots),
-                control_cursor=control_cursor,
-                reason="exposures",
-                server_time=now.isoformat(),
-            )
-        elif not state_current or expired_commands or command_scan_changed_state:
-            response = WorkerControlWaitResponse(
-                command=None,
-                exposures=None,
-                control_cursor=control_cursor,
-                reason="state_changed",
-                server_time=now.isoformat(),
-            )
-        elif timeout_response:
-            response = WorkerControlWaitResponse(
-                command=None,
-                exposures=None,
-                control_cursor=control_cursor,
-                reason="timeout",
-                server_time=now.isoformat(),
-            )
-
-        if response is not None and (
-            command is not None
-            or expired_commands
-            or command_scan_changed_state
-            or response.reason in {"exposures", "command_and_exposures", "state_changed"}
-        ):
-            await db.commit()
-        return _ControlCheck(target_id=auth.target_id, response=response)
-
-
-async def _timeout_response(
-    *,
-    body: WorkerControlWaitRequest,
-    authorization: str | None,
-) -> WorkerControlWaitResponse:
-    check = await _check_worker_control(
-        body=body,
-        authorization=authorization,
-        timeout_response=True,
-    )
-    if check.response is None:
-        raise CloudApiError(
-            "cloud_worker_control_timeout_missing",
-            "Worker control timeout response could not be built.",
-            status_code=500,
-        )
-    return check.response
-
-
-def _exposure_responses(
-    snapshots: tuple[worker_exposures_store.WorkerExposureSnapshot, ...],
-) -> list[WorkerExposureSnapshotResponse]:
-    return [
-        WorkerExposureSnapshotResponse(
-            exposure_id=str(snapshot.exposure_id),
-            target_id=str(snapshot.target_id),
-            cloud_workspace_id=str(snapshot.cloud_workspace_id),
-            session_projection_id=(
-                str(snapshot.session_projection_id)
-                if snapshot.session_projection_id is not None
-                else None
-            ),
-            anyharness_workspace_id=snapshot.anyharness_workspace_id,
-            anyharness_session_id=snapshot.anyharness_session_id,
-            projection_level=snapshot.projection_level,
-            commandable=snapshot.commandable,
-            status=snapshot.status,
-            revision=snapshot.revision,
-            last_uploaded_seq=snapshot.last_uploaded_seq,
-        )
-        for snapshot in snapshots
-    ]
 
 
 def _clamp_wait_seconds(value: int | None) -> int:


### PR DESCRIPTION
## Summary
- move DB-backed worker control checks out of service.py so the orchestration service does not import the DB session factory or commit sessions directly

## Verification
- python3.12 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check
- uv run --with ruff ruff check proliferate/server/cloud/worker/control/service.py proliferate/server/cloud/worker/control/checks.py
- DEBUG=true uv run --with pytest --with pytest-asyncio --with httpx pytest -q tests/integration/test_cloud_worker_exposures_api.py