### PR TITLE
fix(server): guard worker control migration replay

### DIFF
--- a/server/alembic/versions/7a8192b3c4d5_worker_control_state.py
+++ b/server/alembic/versions/7a8192b3c4d5_worker_control_state.py
@@ -12,7 +12,14 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _has_table(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
 def upgrade() -> None:
+    if _has_table("cloud_worker_target_control_state"):
+        return
+
     op.create_table(
         "cloud_worker_target_control_state",
         sa.Column("target_id", sa.UUID(), nullable=False),
@@ -36,4 +43,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("cloud_worker_target_control_state")
+    if _has_table("cloud_worker_target_control_state"):
+        op.drop_table("cloud_worker_target_control_state")


### PR DESCRIPTION
## Summary
- guard the worker control Alembic migration when replayed from removed legacy revisions
- keep downgrade tolerant of absent replay state

## Verification
- DEBUG=true uv run --with pytest --with pytest-asyncio --with httpx pytest -q tests/integration/test_schema_migrations.py::test_alembic_upgrade_from_removed_c9_revision
- DEBUG=true uv run --with pytest --with pytest-asyncio --with httpx pytest -q tests/integration/test_schema_migrations.py
- uv run --with ruff ruff check alembic/versions/7a8192b3c4d5_worker_control_state.py
- python3 scripts/check_max_lines.py
- python3.12 scripts/check_server_boundaries.py