### PR TITLE
chore(server): add structure guardrails

### DIFF
--- a/docs/structures/server/README.md
+++ b/docs/structures/server/README.md
@@ -311,6 +311,9 @@ matching count in the same PR.
 ### Folder hygiene
 
 - Single-file folders are forbidden. If a folder has only one file, inline it.
+- Exception: `server/**/domain/` may contain exactly one meaningful pure-domain
+  module such as `policy.py`, `pricing.py`, or `validation.py`. Do not add
+  placeholder files just to satisfy folder shape.
 - Domain folders answer "what product area?" — not transport (`cloud/`,
   `api/`, `tauri/` are forbidden as `server/` children; transport stays in
   `integrations/` or `db/`) and not UI shape.

--- a/docs/structures/server/README.md
+++ b/docs/structures/server/README.md
@@ -286,19 +286,26 @@ See [guides/errors.md](guides/errors.md) for the detailed error model.
 
 Soft is a PR-review prompt. Hard requires a justification in the PR
 description (typically a tracking issue + reason it can't split now).
+`scripts/check_max_lines.py` enforces the hard column for server layers and
+falls back to the repo-wide 600-line ceiling for server files without a
+server-specific hard threshold. Existing oversized files are count-allowlisted
+in `scripts/max_lines_allowlist.txt`; if one shrinks, lower or remove the
+matching count in the same PR.
 
 ### Naming
 
 - Canonical files (`api.py`, `service.py`, `models.py`, `worker.py`,
   `reconciler.py`, `scheduler.py`) are never prefixed or suffixed.
 - Domain subdirectory files use descriptive nouns (`pricing.py`, `policy.py`,
-  `validation.py`). No `_service`, `_helper`, or `_utils` suffixes.
+  `validation.py`). No `_service.py`, `_helper.py`, `_helpers.py`, or
+  `_utils.py` suffixes.
 - Subdomain folders use singular product concepts (`subscriptions/`,
   `seats/`). No "manager"/"handler" suffixes.
 - Store files match the ORM resource name. Flat: prefixed
   (`cloud_workspaces.py`). Folder: un-prefixed inside (`cloud_mcp/connections.py`).
-- No underscore-prefixed module names at module scope (`_logging.py` is
-  forbidden).
+- No single-underscore-prefixed module names at module scope (`_logging.py` is
+  forbidden). Python package mechanics such as `__init__.py` and
+  `__main__.py` are allowed.
 - Constants use `UPPER_SNAKE_CASE` and live in `constants/<area>.py`.
 
 ### Folder hygiene
@@ -311,9 +318,9 @@ description (typically a tracking issue + reason it can't split now).
   consistently or is flat. Mixed shapes are forbidden.
 - New top-level `server/proliferate/` folders require a doc-touching PR with
   a one-paragraph rationale.
-- No junk-drawer modules: `helpers.py`, `misc.py`, `utils.py` at any
-  domain level. `utils/` at the project root is for truly generic helpers
-  only.
+- No junk-drawer modules: `helper.py`, `helpers.py`, `misc.py`, `common.py`,
+  or `utils.py` at any checked server boundary. `utils/` at the project root
+  is for truly generic helpers only.
 
 ### Cross-domain coordination
 

--- a/docs/structures/server/audits/server-structure-hygiene.md
+++ b/docs/structures/server/audits/server-structure-hygiene.md
@@ -179,9 +179,20 @@ STORE_SESSION_FACTORY_IMPORT 16 findings across 16 files
 ```
 
 The max-lines checker also passes through an allowlist. Server-specific hard
-thresholds in `docs/structures/server/README.md` are stricter than the repo-wide
-600-line guardrail, so oversized server files should be treated as real
-decomposition work even when CI is green.
+thresholds in `docs/structures/server/README.md` are enforced for the server
+layers they cover, with the repo-wide 600-line guardrail as the fallback for
+other files. The allowlist records observed line counts, so oversized files
+cannot grow without updating the explicit exception and files that shrink must
+lower or remove their exception.
+
+The structure checker also tracks folder and naming migration debt through the
+same count-based allowlist:
+
+```text
+SERVICE_SUFFIX_MODULE         1 finding  across 1 file
+SINGLE_FILE_FOLDER           11 findings across 11 folders
+UNDERSCORE_PREFIXED_MODULE    1 finding  across 1 file
+```
 
 ## Lane 1: Docs Truth And Guardrails
 
@@ -210,10 +221,11 @@ Target result:
 
 - Canonical docs describe the current target shape without stale claims.
 - Shape checks cover the server-specific rules that can be enforced safely:
-  single-file folders, underscore-prefixed modules, `_service.py` names,
-  server-specific line thresholds, and existing boundary allowlist shrinkage.
-- Allowlist format remains count-based so cleanup PRs can shrink debt
-  incrementally.
+  single-file folders, single-underscore-prefixed modules, `_service.py`
+  names, helper/misc/common junk-drawer names, server-specific line
+  thresholds, and existing boundary allowlist shrinkage.
+- Boundary and max-lines allowlists remain count-based so cleanup PRs can
+  shrink debt incrementally.
 
 Do not change:
 
@@ -676,8 +688,8 @@ Target result:
 - Single-file folders are inlined or promoted into meaningful multi-file
   folders.
 - No underscore-prefixed modules at module scope.
-- No `_service.py`, `_helper.py`, `_utils.py`, `helpers.py`, `misc.py`, or
-  `common.py` domain files.
+- No `_service.py`, `_helper.py`, `_helpers.py`, `_utils.py`, `helper.py`,
+  `helpers.py`, `misc.py`, `common.py`, or `utils.py` domain files.
 - Parent-level sibling files either become `domain/<concern>.py`, legal
   `worker/` files, legal integrations, or promoted subdomains.
 

--- a/docs/structures/server/audits/server-structure-hygiene.md
+++ b/docs/structures/server/audits/server-structure-hygiene.md
@@ -190,7 +190,7 @@ same count-based allowlist:
 
 ```text
 SERVICE_SUFFIX_MODULE         1 finding  across 1 file
-SINGLE_FILE_FOLDER           11 findings across 11 folders
+SINGLE_FILE_FOLDER            4 findings across 4 folders
 UNDERSCORE_PREFIXED_MODULE    1 finding  across 1 file
 ```
 
@@ -221,9 +221,10 @@ Target result:
 
 - Canonical docs describe the current target shape without stale claims.
 - Shape checks cover the server-specific rules that can be enforced safely:
-  single-file folders, single-underscore-prefixed modules, `_service.py`
-  names, helper/misc/common junk-drawer names, server-specific line
-  thresholds, and existing boundary allowlist shrinkage.
+  single-file folders except allowed one-file `domain/` pure-rule folders,
+  single-underscore-prefixed modules, `_service.py` names,
+  helper/misc/common junk-drawer names, server-specific line thresholds, and
+  existing boundary allowlist shrinkage.
 - Boundary and max-lines allowlists remain count-based so cleanup PRs can
   shrink debt incrementally.
 
@@ -686,7 +687,7 @@ Current debt:
 Target result:
 
 - Single-file folders are inlined or promoted into meaningful multi-file
-  folders.
+  folders, except allowed one-file `domain/` pure-rule folders.
 - No underscore-prefixed modules at module scope.
 - No `_service.py`, `_helper.py`, `_helpers.py`, `_utils.py`, `helper.py`,
   `helpers.py`, `misc.py`, `common.py`, or `utils.py` domain files.

--- a/docs/structures/server/guides/domains.md
+++ b/docs/structures/server/guides/domains.md
@@ -302,7 +302,9 @@ A top-level sibling file in `server/<domain>/` that:
   store + service.
 - Has REST handlers. Those go in `api.py`.
 - Mixes business orchestration with vendor specifics. Split.
-- Is named `helpers.py`, `misc.py`, `utils.py`, or `common.py`. Junk-drawer.
+- Is named `helper.py`, `helpers.py`, `misc.py`, `common.py`, or `utils.py`,
+  or uses `_helper.py`, `_helpers.py`, or `_utils.py` as a suffix.
+  Junk-drawer.
 
 ## Subdomain Promotion
 

--- a/docs/structures/server/guides/domains.md
+++ b/docs/structures/server/guides/domains.md
@@ -466,7 +466,9 @@ rules belong in `provisioning/domain/`; vendor calls belong in
 
 - A domain folder either has subfolder children consistently or is flat.
   Mixed shapes (some subfolders, some flat sibling files belonging to a
-  subdomain) are forbidden.
+  subdomain) are forbidden. `domain/` is the narrow exception to the
+  single-file-folder rule: one meaningful pure-domain file is allowed when
+  the domain only has one extracted rule module.
 - Service composes; domain decides; store persists. If you find a service
   computing a complex rule inline, the rule belongs in `domain/`. If you find
   a domain function calling a store, it's not domain.

--- a/scripts/check_max_lines.py
+++ b/scripts/check_max_lines.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-import sys
+from typing import Optional
 
 MAX_LINES = 600
 COMPONENT_MAX_LINES = 500
+SERVER_API_MAX_LINES = 400
+SERVER_SERVICE_MAX_LINES = 800
+SERVER_MODELS_MAX_LINES = 500
+SERVER_DOMAIN_MAX_LINES = 500
+SERVER_STORE_MAX_LINES = 700
+SERVER_DB_MODELS_MAX_LINES = 500
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWLIST_PATH = REPO_ROOT / "scripts" / "max_lines_allowlist.txt"
 CHECK_ROOTS = [
@@ -28,13 +35,48 @@ EXCLUDED_PATH_PREFIXES = {
 }
 
 
-def load_allowlist() -> set[str]:
-    entries: set[str] = set()
-    for raw_line in ALLOWLIST_PATH.read_text().splitlines():
+@dataclass(frozen=True)
+class AllowlistEntry:
+    path: str
+    max_lines: int
+    reason: str
+
+
+def load_allowlist() -> dict[str, AllowlistEntry]:
+    entries: dict[str, AllowlistEntry] = {}
+    for line_number, raw_line in enumerate(ALLOWLIST_PATH.read_text().splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
-        entries.add(line)
+        parts = line.split(maxsplit=2)
+        if len(parts) != 3:
+            raise ValueError(
+                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{line_number}: "
+                "expected path max_lines reason"
+            )
+        entry_path, raw_max_lines, reason = parts
+        try:
+            max_lines = int(raw_max_lines)
+        except ValueError as exc:
+            raise ValueError(
+                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{line_number}: "
+                "max_lines must be an integer"
+            ) from exc
+        if max_lines < 1:
+            raise ValueError(
+                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{line_number}: "
+                "max_lines must be positive"
+            )
+        if entry_path in entries:
+            raise ValueError(
+                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{line_number}: "
+                "duplicate allowlist entry"
+            )
+        entries[entry_path] = AllowlistEntry(
+            path=entry_path,
+            max_lines=max_lines,
+            reason=reason,
+        )
     return entries
 
 
@@ -49,7 +91,35 @@ def count_lines(path: Path) -> int:
     return data.count(b"\n") + (0 if data.endswith(b"\n") else 1)
 
 
+def server_max_lines_for(relative_path: str) -> Optional[int]:
+    path = Path(relative_path)
+    parts = path.parts
+    name = path.name
+
+    if relative_path.startswith("server/proliferate/server/"):
+        if name == "api.py":
+            return SERVER_API_MAX_LINES
+        if name == "service.py":
+            return SERVER_SERVICE_MAX_LINES
+        if name == "models.py":
+            return SERVER_MODELS_MAX_LINES
+        if "domain" in parts:
+            return SERVER_DOMAIN_MAX_LINES
+        return None
+
+    if relative_path.startswith("server/proliferate/db/store/"):
+        return SERVER_STORE_MAX_LINES
+
+    if relative_path.startswith("server/proliferate/db/models/"):
+        return SERVER_DB_MODELS_MAX_LINES
+
+    return None
+
+
 def max_lines_for(relative_path: str) -> int:
+    server_max_lines = server_max_lines_for(relative_path)
+    if server_max_lines is not None:
+        return server_max_lines
     if (
         relative_path.startswith("apps/desktop/src/components/")
         and relative_path.endswith(".tsx")
@@ -81,39 +151,68 @@ def iter_source_files() -> list[tuple[str, int]]:
 
 def main() -> int:
     allowlist = load_allowlist()
-    violations: list[tuple[str, int, int]] = []
+    violations: list[str] = []
     stale_allowlist: list[str] = []
+    seen_paths: set[str] = set()
 
     for relative_path, line_count in iter_source_files():
+        seen_paths.add(relative_path)
         max_lines = max_lines_for(relative_path)
-        if line_count <= max_lines:
-            if relative_path in allowlist:
-                stale_allowlist.append(relative_path)
-            continue
-        if relative_path in allowlist:
-            continue
-        violations.append((relative_path, line_count, max_lines))
+        entry = allowlist.get(relative_path)
 
-    stale_allowlist.extend(sorted(path for path in allowlist if not (REPO_ROOT / path).exists()))
+        if line_count <= max_lines:
+            if entry is not None:
+                stale_allowlist.append(
+                    f"{relative_path} allowlisted={entry.max_lines} "
+                    f"observed={line_count} max={max_lines}"
+                )
+            continue
+
+        if entry is not None:
+            if line_count > entry.max_lines:
+                violations.append(
+                    f"{relative_path}: {line_count} "
+                    f"(max {max_lines}, allowlisted {entry.max_lines})"
+                )
+            elif line_count < entry.max_lines:
+                stale_allowlist.append(
+                    f"{relative_path} allowlisted={entry.max_lines} "
+                    f"observed={line_count} max={max_lines}"
+                )
+            continue
+
+        violations.append(f"{relative_path}: {line_count} (max {max_lines})")
+
+    stale_allowlist.extend(
+        sorted(
+            f"{path} allowlisted={entry.max_lines} observed=missing-file"
+            for path, entry in allowlist.items()
+            if path not in seen_paths and not (REPO_ROOT / path).exists()
+        )
+    )
 
     if not violations and not stale_allowlist:
         print(
             "Max-lines check passed "
-            f"(repo max {MAX_LINES}, component max {COMPONENT_MAX_LINES} lines)."
+            f"(repo max {MAX_LINES}, component max {COMPONENT_MAX_LINES}, "
+            "server layer maxes enabled)."
         )
         return 0
 
     if violations:
-        print("Files above their max line threshold that are not allowlisted:")
-        for relative_path, line_count, max_lines in violations:
-            print(f"  {relative_path}: {line_count} (max {max_lines})")
+        print(
+            "Files above their max line threshold that are not allowlisted "
+            "or exceed their allowlisted count:"
+        )
+        for violation in violations:
+            print(f"  {violation}")
 
     if stale_allowlist:
         if violations:
             print()
-        print("Stale allowlist entries (remove these from scripts/max_lines_allowlist.txt):")
-        for relative_path in sorted(stale_allowlist):
-            print(f"  {relative_path}")
+        print("Stale max-lines allowlist entries:")
+        for entry in sorted(stale_allowlist):
+            print(f"  {entry}")
 
     return 1
 

--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import ast
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+import os
 from pathlib import Path
+import shutil
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -18,6 +20,16 @@ CHECK_ROOTS = [
     REPO_ROOT / "server" / "proliferate" / "integrations",
 ]
 EXCLUDED_PARTS = {"__pycache__", "alembic", "migrations"}
+STRUCTURE_ROOTS = CHECK_ROOTS
+DUNDER_MODULES = {"__init__.py", "__main__.py"}
+BANNED_JUNK_DRAWER_MODULES = {
+    "common.py",
+    "helper.py",
+    "helpers.py",
+    "misc.py",
+    "utils.py",
+}
+BANNED_JUNK_DRAWER_SUFFIXES = ("_helper.py", "_helpers.py", "_utils.py")
 
 ALLOWED_API_ORM_IMPORT = ("proliferate.db.models.auth", "User")
 ALLOWED_API_ENGINE_IMPORTS = {"get_async_session"}
@@ -79,6 +91,18 @@ def iter_target_files(repo_root: Path) -> list[Path]:
                 continue
             files.append(path)
     return files
+
+
+def iter_structure_folders(repo_root: Path) -> list[Path]:
+    folders: set[Path] = set()
+    for root in STRUCTURE_ROOTS:
+        if not root.is_dir():
+            continue
+        folders.add(root)
+        for path in sorted(root.rglob("*")):
+            if path.is_dir() and not should_skip(path):
+                folders.add(path)
+    return sorted(folders)
 
 
 def relative_path(path: Path, repo_root: Path = REPO_ROOT) -> str:
@@ -147,6 +171,18 @@ def looks_like_db_handle(node: ast.AST) -> bool:
 
 def is_public_async_export(node: ast.AsyncFunctionDef) -> bool:
     return not node.name.startswith("_")
+
+
+def is_dunder_module(path: Path) -> bool:
+    return path.name in DUNDER_MODULES
+
+
+def has_single_underscore_prefix(path: Path) -> bool:
+    return (
+        path.suffix == ".py"
+        and path.name.startswith("_")
+        and not path.name.startswith("__")
+    )
 
 
 class BoundaryChecker(ast.NodeVisitor):
@@ -274,7 +310,8 @@ class BoundaryChecker(ast.NodeVisitor):
             self.add(
                 node,
                 "DOMAIN_FORBIDDEN_IMPORT",
-                "domain modules must be pure and must not import framework, DB, config, or integration modules",
+                "domain modules must be pure and must not import framework, "
+                "DB, config, or integration modules",
             )
         if is_module(module, "proliferate.server") and module.endswith(".service"):
             self.add(
@@ -394,7 +431,11 @@ class BoundaryChecker(ast.NodeVisitor):
     def _check_call(self, node: ast.Call) -> None:
         func = node.func
         if isinstance(func, ast.Attribute):
-            if self.kind.is_api and func.attr in API_DB_METHODS and looks_like_db_handle(func.value):
+            if (
+                self.kind.is_api
+                and func.attr in API_DB_METHODS
+                and looks_like_db_handle(func.value)
+            ):
                 self.add(
                     node,
                     "API_DB_METHOD_CALL",
@@ -443,7 +484,8 @@ class BoundaryChecker(ast.NodeVisitor):
                         self.add(
                             node,
                             "MODELS_FROM_ATTRIBUTES",
-                            "Pydantic response models must not map ORM objects with from_attributes",
+                            "Pydantic response models must not map ORM objects "
+                            "with from_attributes",
                         )
         if isinstance(func, ast.Name) and func.id == "HTTPException":
             if self.kind.is_domain or self.kind.is_store or self.kind.is_integration:
@@ -465,6 +507,70 @@ def check_paths(paths: list[Path]) -> list[Violation]:
         tree = parse_source(path)
         checker.visit(tree)
         violations.extend(checker.violations)
+    return violations
+
+
+def check_structure(repo_root: Path = REPO_ROOT) -> list[Violation]:
+    violations: list[Violation] = []
+
+    for path in iter_target_files(repo_root):
+        if has_single_underscore_prefix(path):
+            violations.append(
+                Violation(
+                    rule_id="UNDERSCORE_PREFIXED_MODULE",
+                    path=path,
+                    lineno=1,
+                    message="server module names must not start with a single underscore",
+                )
+            )
+        if path.name.endswith("_service.py"):
+            violations.append(
+                Violation(
+                    rule_id="SERVICE_SUFFIX_MODULE",
+                    path=path,
+                    lineno=1,
+                    message="server modules must use service.py, not *_service.py",
+                )
+            )
+        if path.name in BANNED_JUNK_DRAWER_MODULES or path.name.endswith(
+            BANNED_JUNK_DRAWER_SUFFIXES
+        ):
+            violations.append(
+                Violation(
+                    rule_id="JUNK_DRAWER_MODULE",
+                    path=path,
+                    lineno=1,
+                    message=(
+                        "server modules must use owned concern names, "
+                        "not helper/misc/common/utils names"
+                    ),
+                )
+            )
+
+    for folder in iter_structure_folders(repo_root):
+        if should_skip(folder):
+            continue
+        source_files = [
+            path
+            for path in folder.iterdir()
+            if path.is_file() and path.suffix == ".py" and not is_dunder_module(path)
+        ]
+        child_folders = [
+            path
+            for path in folder.iterdir()
+            if path.is_dir() and not should_skip(path) and path.name != "__pycache__"
+        ]
+        if len(source_files) == 1 and not child_folders:
+            only_file = source_files[0].name
+            violations.append(
+                Violation(
+                    rule_id="SINGLE_FILE_FOLDER",
+                    path=folder,
+                    lineno=1,
+                    message=f"single-file folders are forbidden; inline or promote {only_file}",
+                )
+            )
+
     return violations
 
 
@@ -539,8 +645,13 @@ def apply_allowlist(
     return failing, stale
 
 
-def print_summary(violations: list[Violation], allowlist: dict[tuple[str, str], AllowlistEntry]) -> None:
-    observed = Counter((violation.rule_id, violation.relative_path()) for violation in violations)
+def print_summary(
+    violations: list[Violation],
+    allowlist: dict[tuple[str, str], AllowlistEntry],
+) -> None:
+    observed = Counter(
+        (violation.rule_id, violation.relative_path()) for violation in violations
+    )
     if not observed:
         return
     print("Observed server boundary debt:")
@@ -551,14 +662,26 @@ def print_summary(violations: list[Violation], allowlist: dict[tuple[str, str], 
     print()
 
 
+def reexec_with_python_312() -> None:
+    if sys.version_info >= (3, 12):
+        return
+    python_312 = shutil.which("python3.12")
+    if python_312 is None:
+        return
+    if Path(python_312).resolve() == Path(sys.executable).resolve():
+        return
+    os.execv(python_312, [python_312, *sys.argv])
+
+
 def main() -> int:
+    reexec_with_python_312()
     if sys.version_info < (3, 12):
         print("Server boundary check requires Python 3.12+ to parse server source.")
         return 2
 
     paths = iter_target_files(REPO_ROOT)
     allowlist = load_allowlist()
-    violations = check_paths(paths)
+    violations = [*check_paths(paths), *check_structure(REPO_ROOT)]
     failing, stale = apply_allowlist(violations, allowlist)
 
     if not failing and not stale:

--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -185,6 +185,39 @@ def has_single_underscore_prefix(path: Path) -> bool:
     )
 
 
+def is_banned_junk_drawer_module(path: Path) -> bool:
+    return path.name in BANNED_JUNK_DRAWER_MODULES or path.name.endswith(
+        BANNED_JUNK_DRAWER_SUFFIXES
+    )
+
+
+def is_product_domain_folder(folder: Path) -> bool:
+    parts = logical_parts(folder)
+    return _starts_with(parts, ("server", "proliferate", "server")) and folder.name == "domain"
+
+
+def is_meaningful_domain_module(path: Path) -> bool:
+    return (
+        path.suffix == ".py"
+        and not has_single_underscore_prefix(path)
+        and not path.name.endswith("_service.py")
+        and not is_banned_junk_drawer_module(path)
+    )
+
+
+def is_allowed_single_file_domain_folder(
+    folder: Path,
+    source_files: list[Path],
+    child_folders: list[Path],
+) -> bool:
+    return (
+        is_product_domain_folder(folder)
+        and len(source_files) == 1
+        and not child_folders
+        and is_meaningful_domain_module(source_files[0])
+    )
+
+
 class BoundaryChecker(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -532,9 +565,7 @@ def check_structure(repo_root: Path = REPO_ROOT) -> list[Violation]:
                     message="server modules must use service.py, not *_service.py",
                 )
             )
-        if path.name in BANNED_JUNK_DRAWER_MODULES or path.name.endswith(
-            BANNED_JUNK_DRAWER_SUFFIXES
-        ):
+        if is_banned_junk_drawer_module(path):
             violations.append(
                 Violation(
                     rule_id="JUNK_DRAWER_MODULE",
@@ -560,6 +591,9 @@ def check_structure(repo_root: Path = REPO_ROOT) -> list[Violation]:
             for path in folder.iterdir()
             if path.is_dir() and not should_skip(path) and path.name != "__pycache__"
         ]
+        if is_allowed_single_file_domain_folder(folder, source_files, child_folders):
+            continue
+
         if len(source_files) == 1 and not child_folders:
             only_file = source_files[0].name
             violations.append(

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -1,106 +1,101 @@
 # Existing oversized source files. Keep this list shrinking over time.
-anyharness/crates/anyharness-lib/src/live/sessions/manager.rs
-anyharness/crates/anyharness-lib/src/live/sessions/connection/runtime_client.rs
-anyharness/crates/anyharness-lib/src/adapters/git/diff.rs
-anyharness/crates/anyharness-lib/src/domains/agents/installer.rs
-anyharness/crates/anyharness-lib/src/domains/agents/readiness/resolver.rs
-anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs
-anyharness/crates/anyharness-lib/src/domains/plans/service.rs
-anyharness/crates/anyharness-lib/src/api/openapi.rs
-anyharness/crates/anyharness-lib/src/api/router_tests.rs
-anyharness/crates/anyharness-lib/src/api/http/git.rs
-anyharness/crates/anyharness-lib/src/api/http/sessions.rs
-anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
-anyharness/crates/anyharness-lib/src/api/http/mobility.rs
-anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude.rs
-anyharness/crates/anyharness-contract/src/v1/events.rs
-anyharness/crates/anyharness-contract/src/v1/sessions.rs
-anyharness/crates/anyharness-lib/src/adapters/files/service.rs
-anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs
-anyharness/crates/anyharness-lib/src/sessions/live_config.rs
-anyharness/crates/anyharness-lib/src/sessions/prompt.rs
-anyharness/crates/anyharness-lib/src/sessions/service.rs
-anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
-anyharness/crates/anyharness-lib/src/domains/mobility/service.rs
-anyharness/crates/anyharness-lib/src/live/sessions/actor/interactions/handle.rs
-anyharness/crates/anyharness-lib/src/workspaces/service.rs
-anyharness/crates/anyharness-lib/src/workspaces/runtime.rs
-anyharness/crates/anyharness-lib/src/workspaces/store.rs
-anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
-anyharness/crates/proliferate-worker/src/commands/mapping.rs
-apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
-apps/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx
-apps/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx
-apps/desktop/src/components/automations/editor/AutomationEditorModal.tsx
-apps/desktop/src/components/home/screen/HomeTargetPicker.tsx
-apps/desktop/src/components/settings/panes/SlackBotPane.tsx
-apps/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
-apps/desktop/src/lib/workflows/mcp/connector-persistence.test.ts
-apps/desktop/src/lib/workflows/mcp/connector-persistence.ts
-anyharness/sdk/src/reducer/transcript.ts
-anyharness/sdk/src/reducer/__tests__/transcript.test.ts
-anyharness/sdk-react/src/hooks/sessions.ts
-apps/desktop/src/hooks/sessions/use-session-creation-actions.ts
-apps/desktop/src/hooks/sessions/use-session-runtime-actions.ts
-apps/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.ts
-apps/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
-apps/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts
-apps/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts
-apps/desktop/src/hooks/home/workflows/use-home-next-launch.ts
-apps/desktop/src/lib/integrations/auth/orchestration.ts
-apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
-apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
-apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
-apps/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts
-apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts
-apps/desktop/src/lib/integrations/auth/orchestration.ts
-server/tests/integration/test_cloud_api.py
-server/tests/integration/test_auth_flow.py
-server/tests/integration/test_cloud_agent_auth_api.py
-server/tests/integration/test_billing_accounting.py
-server/tests/integration/test_billing_api.py
-server/tests/integration/test_stripe_webhooks.py
-server/proliferate/db/models/cloud/agent_auth.py
-server/proliferate/db/store/billing.py
-server/proliferate/db/store/cloud_agent_auth/store.py
-server/proliferate/db/store/cloud_repo_config.py
-server/proliferate/db/store/cloud_mobility.py
-server/proliferate/db/store/cloud_sync/commands.py
-server/proliferate/db/store/cloud_sync/events.py
-server/proliferate/db/store/cloud_sync/targets.py
-server/tests/unit/test_cloud_mobility_service.py
-server/tests/unit/test_cloud_runtime_provision.py
-server/tests/unit/test_cloud_workspace_service.py
-server/tests/integration/test_cloud_commands_api.py
-server/proliferate/server/billing/service.py
-server/proliferate/server/billing/stripe_webhooks.py
-server/proliferate/db/store/cloud_workspaces.py
-server/proliferate/server/cloud/commands/service.py
-server/proliferate/server/cloud/commands/domain/rules.py
-server/proliferate/server/cloud/worker/service.py
-server/proliferate/server/cloud/runtime/bootstrap.py
-server/proliferate/server/cloud/runtime_config/domain/resolver.py
-server/proliferate/server/cloud/runtime_config/service.py
-server/proliferate/server/cloud/worker/service.py
-server/proliferate/server/cloud/agent_auth/service.py
-server/proliferate/server/cloud/runtime/ensure_running.py
-server/proliferate/server/cloud/runtime/provision.py
-server/proliferate/server/cloud/workspaces/service.py
-server/proliferate/db/store/automations.py
-server/proliferate/server/cloud/events/service.py
-server/proliferate/server/cloud/mobility/service.py
-server/proliferate/server/cloud/mcp_oauth/service.py
-server/proliferate/server/cloud/slack/service.py
-server/proliferate/server/cloud/workspaces/models.py
-server/proliferate/auth/identity/service.py
-server/tests/integration/schema_migration_assertions.py
-server/tests/integration/test_schema_migrations.py
-server/tests/integration/test_cloud_commands_api.py
-anyharness/crates/anyharness-lib/src/sessions/service.rs
-server/proliferate/db/models/cloud/agent_auth.py
-server/proliferate/db/store/cloud_agent_auth/store.py
-server/proliferate/server/cloud/agent_auth/service.py
-server/tests/integration/test_cloud_agent_auth_api.py
-server/tests/unit/test_cloud_runtime_ensure_running.py
-server/tests/integration/test_sandbox_profile_foundation.py
-server/proliferate/server/organizations/service.py
+#
+# Format:
+# path max_lines reason
+#
+# max_lines is the observed line count allowed for this file. If the file
+# grows, the check fails. If it shrinks, update the count or remove the entry
+# when the file is under its threshold.
+
+anyharness/crates/anyharness-contract/src/v1/events.rs 949 existing AnyHarness contract oversized file
+anyharness/crates/anyharness-contract/src/v1/sessions.rs 802 existing AnyHarness contract oversized file
+anyharness/crates/anyharness-lib/src/adapters/files/service.rs 1050 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/adapters/git/diff.rs 831 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/http/git.rs 882 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/http/mobility.rs 1035 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/http/sessions.rs 1611 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/http/workspaces.rs 1482 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/openapi.rs 854 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/api/router_tests.rs 1216 existing AnyHarness oversized test file
+anyharness/crates/anyharness-lib/src/domains/agents/installer.rs 1632 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/agents/readiness/resolver.rs 1125 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1882 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1534 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/plans/service.rs 653 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 1519 existing AnyHarness oversized test file
+anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs 1057 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/live/sessions/actor/interactions/handle.rs 615 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude.rs 663 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/live/sessions/connection/runtime_client.rs 695 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/live/sessions/manager.rs 933 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/sessions/live_config.rs 675 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/sessions/prompt.rs 1423 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/sessions/service.rs 645 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/workspaces/runtime.rs 1844 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/workspaces/service.rs 952 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/workspaces/store.rs 734 existing AnyHarness oversized file
+anyharness/crates/proliferate-worker/src/commands/dispatcher.rs 1718 existing Proliferate worker oversized file
+anyharness/crates/proliferate-worker/src/commands/mapping.rs 954 existing Proliferate worker oversized file
+anyharness/sdk-react/src/hooks/sessions.ts 653 existing SDK React oversized file
+anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1880 existing SDK oversized test file
+anyharness/sdk/src/reducer/transcript.ts 1575 existing SDK oversized file
+apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
+apps/desktop/src/components/automations/editor/AutomationEditorModal.tsx 610 existing desktop component oversized file
+apps/desktop/src/components/home/screen/HomeTargetPicker.tsx 509 existing desktop component oversized file
+apps/desktop/src/components/settings/panes/SlackBotPane.tsx 545 existing desktop component oversized file
+apps/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx 528 existing desktop component oversized file
+apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx 735 existing desktop component oversized file
+apps/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx 732 existing desktop component oversized test file
+apps/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx 637 existing desktop component oversized file
+apps/desktop/src/hooks/home/workflows/use-home-next-launch.ts 611 existing desktop hook oversized file
+apps/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.ts 666 existing desktop hook oversized file
+apps/desktop/src/hooks/sessions/use-session-creation-actions.ts 765 existing desktop hook oversized file
+apps/desktop/src/hooks/sessions/use-session-runtime-actions.ts 860 existing desktop hook oversized file
+apps/desktop/src/hooks/workspaces/tabs/use-workspace-header-subagent-hierarchy.ts 643 existing desktop hook oversized file
+apps/desktop/src/hooks/workspaces/tabs/use-workspace-shell-activation.ts 671 existing desktop hook oversized file
+apps/desktop/src/hooks/workspaces/use-workspace-bootstrap-actions.ts 899 existing desktop hook oversized file
+apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 759 existing desktop oversized test file
+apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts 1284 existing desktop oversized file
+apps/desktop/src/lib/integrations/auth/orchestration.ts 628 existing desktop oversized file
+apps/desktop/src/lib/workflows/mcp/connector-persistence.test.ts 704 existing desktop oversized test file
+apps/desktop/src/lib/workflows/mcp/connector-persistence.ts 638 existing desktop oversized file
+server/proliferate/auth/identity/service.py 809 existing auth service exceeds repo max-lines threshold
+server/proliferate/db/models/cloud/agent_auth.py 1030 server structure migration debt for oversized ORM model file
+server/proliferate/db/store/automations.py 802 server structure migration debt for oversized store file
+server/proliferate/db/store/billing.py 2851 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_agent_auth/store.py 2607 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_mobility.py 1411 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_repo_config.py 720 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_sync/commands.py 1689 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_workspaces.py 1642 server structure migration debt for oversized store file
+server/proliferate/server/billing/service.py 2021 server structure migration debt for oversized service file
+server/proliferate/server/billing/stripe_webhooks.py 624 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/agent_auth/models.py 508 server structure migration debt for oversized API models file
+server/proliferate/server/cloud/agent_auth/service.py 4908 server structure migration debt for oversized service file
+server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
+server/proliferate/server/cloud/commands/service.py 1740 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1208 server structure migration debt for oversized service file
+server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/ensure_running.py 667 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/provision.py 1727 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
+server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
+server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
+server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
+server/proliferate/server/cloud/workspaces/service.py 2626 server structure migration debt for oversized service file
+server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
+server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
+server/tests/integration/test_billing_accounting.py 873 existing server oversized integration test
+server/tests/integration/test_billing_api.py 2060 existing server oversized integration test
+server/tests/integration/test_cloud_agent_auth_api.py 1670 existing server oversized integration test
+server/tests/integration/test_cloud_api.py 2374 existing server oversized integration test
+server/tests/integration/test_cloud_commands_api.py 5140 existing server oversized integration test
+server/tests/integration/test_sandbox_profile_foundation.py 1400 existing server oversized integration test
+server/tests/integration/test_schema_migrations.py 925 existing server oversized integration test
+server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
+server/tests/unit/test_cloud_mobility_service.py 808 existing server oversized unit test
+server/tests/unit/test_cloud_runtime_ensure_running.py 869 existing server oversized unit test
+server/tests/unit/test_cloud_runtime_provision.py 1803 existing server oversized unit test
+server/tests/unit/test_cloud_workspace_service.py 1322 existing server oversized unit test

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -6,6 +6,19 @@
 # This is migration debt, not permission for new code. If a cleanup reduces a
 # count, update this file in the same PR.
 
+SERVICE_SUFFIX_MODULE server/proliferate/server/automations/local_executor_service.py 1 transitional automation executor service naming cleanup belongs to folder hygiene lane
+UNDERSCORE_PREFIXED_MODULE server/proliferate/server/cloud/_logging.py 1 transitional cloud logging helper naming cleanup belongs to folder hygiene lane
+SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_agent_run_config 1 transitional store folder has not yet been flattened or promoted
+SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_plugins 1 transitional store folder has not yet been flattened or promoted
+SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_skills 1 transitional store folder has not yet been flattened or promoted
+SINGLE_FILE_FOLDER server/proliferate/integrations/billing 1 transitional Stripe integration folder will move to canonical stripe package
+SINGLE_FILE_FOLDER server/proliferate/server/catalogs/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/agent_run_config/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/commands/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/mcp_connections/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/mobility/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/plugins/catalog/domain 1 transitional pure-domain folder has not yet been flattened or expanded
+SINGLE_FILE_FOLDER server/proliferate/server/cloud/repo_config/domain 1 transitional pure-domain folder has not yet been flattened or expanded
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
 API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -12,13 +12,6 @@ SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_agent_run_config 1 transiti
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_plugins 1 transitional store folder has not yet been flattened or promoted
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_skills 1 transitional store folder has not yet been flattened or promoted
 SINGLE_FILE_FOLDER server/proliferate/integrations/billing 1 transitional Stripe integration folder will move to canonical stripe package
-SINGLE_FILE_FOLDER server/proliferate/server/catalogs/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/agent_run_config/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/commands/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/mcp_connections/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/mobility/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/plugins/catalog/domain 1 transitional pure-domain folder has not yet been flattened or expanded
-SINGLE_FILE_FOLDER server/proliferate/server/cloud/repo_config/domain 1 transitional pure-domain folder has not yet been flattened or expanded
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
 API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings


### PR DESCRIPTION
## Summary
- add server-specific max-line thresholds and count-based max-lines allowlist entries
- add server structure guardrails for single-file folders, underscore-prefixed modules, service suffix modules, and junk-drawer module names
- align server docs and the hygiene handoff with the executable guardrails

## Verification
- `python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 -m py_compile scripts/check_server_boundaries.py scripts/check_max_lines.py`
- `git diff --check`

## Notes
- Existing structure debt remains count-allowlisted for downstream hygiene lanes to shrink.
