### PR TITLE
refactor(server): thread automation store db sessions

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -61,7 +61,7 @@ apps/desktop/src/lib/workflows/mcp/connector-persistence.test.ts 704 existing de
 apps/desktop/src/lib/workflows/mcp/connector-persistence.ts 638 existing desktop oversized file
 server/proliferate/auth/identity/service.py 809 existing auth service exceeds repo max-lines threshold
 server/proliferate/db/models/cloud/agent_auth.py 1030 server structure migration debt for oversized ORM model file
-server/proliferate/db/store/automations.py 802 server structure migration debt for oversized store file
+server/proliferate/db/store/automations.py 801 server structure migration debt for oversized store file
 server/proliferate/db/store/billing.py 2851 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_agent_auth/store.py 2607 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_mobility.py 1411 server structure migration debt for oversized store file
@@ -84,7 +84,7 @@ server/proliferate/server/cloud/runtime_config/service.py 1094 server structure 
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2626 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2624 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 873 existing server oversized integration test

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -84,7 +84,7 @@ server/proliferate/server/cloud/runtime_config/service.py 1094 server structure 
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2624 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2623 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 873 existing server oversized integration test

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -44,22 +44,13 @@ SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/service.py 1 t
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 10 transitional Slack deferred handlers own isolated transactions
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/service.py 2 transitional worker lease/materialization flows commit before follow-up worker requests
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 5 transitional workspace sync/archive flows own isolated lifecycle transactions
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions own transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/automation_run_claims.py 1 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/billing.py 29 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
 STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 14 transitional store owns transaction commit
 STORE_FORBIDDEN_IMPORT server/proliferate/db/store/billing.py 4 transitional store imports product/integration code
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions open DB sessions
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automation_run_claims.py 2 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/automations.py 1 cloud workspace helper still opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/billing.py 29 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/auth.py 3 materialization refresh wrappers open isolated DB sessions
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper opens isolated DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 9 transitional store opens DB session
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environments.py 7 phase 8 runtime lifecycle wrappers open isolated DB sessions
@@ -69,13 +60,7 @@ STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organization_invitations.py 2 intentional create/rotate transaction commits before external email delivery
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 1 transitional wrapper used by deferred organization/cloud callers
 STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_cloud_workspace_claims.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claim_transitions.py 1 transitional automation claim transitions import DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automation_run_claims.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/automations.py 1 cloud workspace helper still imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/billing.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/auth.py 1 materialization refresh wrappers import DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mcp/oauth_clients.py 1 materialization refresh wrapper imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mobility.py 1 transitional store imports DB session factory
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_repo_config.py 1 deferred runtime/workspace flows still use isolated repo-config reads
 STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_runtime_environments.py 1 phase 8 runtime lifecycle wrappers import DB session factory

--- a/server/proliferate/db/store/automation_cloud_workspace_claims.py
+++ b/server/proliferate/db/store/automation_cloud_workspace_claims.py
@@ -6,12 +6,12 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.automations import (
     AUTOMATION_EXECUTION_TARGET_CLOUD,
     AUTOMATION_EXECUTOR_KIND_CLOUD,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.exposures import CloudWorkspaceExposure
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.automation_run_claims import (
@@ -26,6 +26,7 @@ from proliferate.db.store.cloud_workspaces import (
 
 
 async def create_cloud_workspace_for_claimed_run(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -44,6 +45,7 @@ async def create_cloud_workspace_for_claimed_run(
     cloud_repo_limit: int | None = None,
 ) -> CloudWorkspace | None:
     return await _create_workspace_for_claimed_run(
+        db,
         run_id=run_id,
         claim_id=claim_id,
         user_id=user_id,
@@ -64,6 +66,7 @@ async def create_cloud_workspace_for_claimed_run(
 
 
 async def create_managed_cloud_workspace_for_claimed_run(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -85,6 +88,7 @@ async def create_managed_cloud_workspace_for_claimed_run(
     origin: str = "automation",
 ) -> CloudWorkspace | None:
     return await _create_workspace_for_claimed_run(
+        db,
         run_id=run_id,
         claim_id=claim_id,
         sandbox_profile_id=sandbox_profile_id,
@@ -107,6 +111,7 @@ async def create_managed_cloud_workspace_for_claimed_run(
 
 
 async def _create_workspace_for_claimed_run(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -128,67 +133,66 @@ async def _create_workspace_for_claimed_run(
     sandbox_profile_id: UUID | None = None,
     target_id: UUID | None = None,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
+    run = await load_claimed_run_for_update(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        allowed_statuses=transition.allowed_statuses,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return None
+    if run.cloud_workspace_id is not None:
+        return None
+    if sandbox_profile_id is not None and target_id is not None:
+        workspace = await create_managed_cloud_workspace_for_profile(
             db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=transition.allowed_statuses,
-            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
+            sandbox_profile_id=sandbox_profile_id,
+            target_id=target_id,
+            created_by_user_id=user_id,
+            display_name=display_name,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            git_branch=git_branch,
+            git_base_branch=git_base_branch,
+            worktree_path=worktree_path,
+            origin_json=origin_json,
+            origin=origin,
+            template_version=template_version,
         )
-        if run is None:
-            return None
-        if run.cloud_workspace_id is not None:
-            return None
-        if sandbox_profile_id is not None and target_id is not None:
-            workspace = await create_managed_cloud_workspace_for_profile(
-                db,
-                sandbox_profile_id=sandbox_profile_id,
-                target_id=target_id,
-                created_by_user_id=user_id,
-                display_name=display_name,
-                git_provider=git_provider,
-                git_owner=git_owner,
-                git_repo_name=git_repo_name,
-                git_branch=git_branch,
-                git_base_branch=git_base_branch,
-                worktree_path=worktree_path,
-                origin_json=origin_json,
-                origin=origin,
-                template_version=template_version,
-            )
-        else:
-            workspace = await create_cloud_workspace_record(
-                db,
-                user_id=user_id,
-                display_name=display_name,
-                git_provider=git_provider,
-                git_owner=git_owner,
-                git_repo_name=git_repo_name,
-                git_branch=git_branch,
-                git_base_branch=git_base_branch,
-                origin_json=origin_json,
-                template_version=template_version,
-                cloud_repo_limit=cloud_repo_limit,
-                commit=False,
-            )
-        run.cloud_workspace_id = workspace.id
-        if target_id is not None:
-            exposure_id = (
-                await db.execute(
-                    select(CloudWorkspaceExposure.id).where(
-                        CloudWorkspaceExposure.target_id == target_id,
-                        CloudWorkspaceExposure.cloud_workspace_id == workspace.id,
-                        CloudWorkspaceExposure.archived_at.is_(None),
-                    )
+    else:
+        workspace = await create_cloud_workspace_record(
+            db,
+            user_id=user_id,
+            display_name=display_name,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            git_branch=git_branch,
+            git_base_branch=git_base_branch,
+            origin_json=origin_json,
+            template_version=template_version,
+            cloud_repo_limit=cloud_repo_limit,
+            commit=False,
+        )
+    run.cloud_workspace_id = workspace.id
+    if target_id is not None:
+        exposure_id = (
+            await db.execute(
+                select(CloudWorkspaceExposure.id).where(
+                    CloudWorkspaceExposure.target_id == target_id,
+                    CloudWorkspaceExposure.cloud_workspace_id == workspace.id,
+                    CloudWorkspaceExposure.archived_at.is_(None),
                 )
-            ).scalar_one_or_none()
-            run.cloud_workspace_exposure_id = exposure_id
-        run.updated_at = now
-        await db.commit()
-        await db.refresh(workspace)
-        return workspace
+            )
+        ).scalar_one_or_none()
+        run.cloud_workspace_exposure_id = exposure_id
+    run.updated_at = now
+    await db.flush()
+    await db.refresh(workspace)
+    return workspace

--- a/server/proliferate/db/store/automation_run_claim_transitions.py
+++ b/server/proliferate/db/store/automation_run_claim_transitions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from datetime import datetime
 from uuid import UUID
 
@@ -20,7 +19,6 @@ from proliferate.constants.automations import (
     AUTOMATION_RUN_STATUS_FAILED,
     AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import AutomationRun
 from proliferate.db.store.automation_run_claim_values import (
     AutomationRunClaimValue,
@@ -32,13 +30,6 @@ from proliferate.db.store.automation_run_claims import (
     clear_claim_metadata,
     load_claimed_run_for_update,
 )
-
-
-async def _run_self_committing[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
-    async with db_engine.async_session_factory() as db:
-        result = await operation(db)
-        await db.commit()
-        return result
 
 
 def _transition_requirements_satisfied(
@@ -118,7 +109,7 @@ async def _mark_claim_status(
 
 
 async def mark_run_creating_workspace(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -129,24 +120,22 @@ async def mark_run_creating_workspace(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
-        return await _mark_claim_status(
-            session,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            status=AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
-            transition=transition,
-            claim_is_active=claim_is_active,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    return await _mark_claim_status(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_CREATING_WORKSPACE,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+    )
 
 
 async def attach_cloud_workspace_to_run(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -155,27 +144,25 @@ async def attach_cloud_workspace_to_run(
     transition: ClaimTransitionRule,
     claim_is_active: ClaimActivePredicate,
 ) -> bool:
-    async def operation(db: AsyncSession) -> bool:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-            claim_is_active=claim_is_active,
-        )
-        if run is None:
-            return False
-        run.cloud_workspace_id = cloud_workspace_id
-        run.updated_at = now
-        return True
-
-    return await _run_self_committing(operation)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+        claim_is_active=claim_is_active,
+    )
+    if run is None:
+        return False
+    run.cloud_workspace_id = cloud_workspace_id
+    run.updated_at = now
+    return True
 
 
 async def attach_cloud_target_snapshot_to_run(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -186,31 +173,28 @@ async def attach_cloud_target_snapshot_to_run(
     transition: ClaimTransitionRule,
     claim_is_active: ClaimActivePredicate,
 ) -> AutomationRunClaimValue | None:
-    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-            claim_is_active=claim_is_active,
-        )
-        if run is None:
-            return None
-        run.cloud_target_id_snapshot = cloud_target_id
-        run.cloud_target_kind_snapshot = cloud_target_kind
-        if sandbox_profile_id is not None:
-            run.sandbox_profile_id = sandbox_profile_id
-        run.updated_at = now
-        return claim_value(run)
-
-    return await _run_self_committing(operation)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+        claim_is_active=claim_is_active,
+    )
+    if run is None:
+        return None
+    run.cloud_target_id_snapshot = cloud_target_id
+    run.cloud_target_kind_snapshot = cloud_target_kind
+    if sandbox_profile_id is not None:
+        run.sandbox_profile_id = sandbox_profile_id
+    run.updated_at = now
+    return claim_value(run)
 
 
 async def attach_anyharness_workspace_to_run(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -222,29 +206,26 @@ async def attach_anyharness_workspace_to_run(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_DESKTOP,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.updated_at = now
-        return claim_value(run)
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return None
+    run.anyharness_workspace_id = anyharness_workspace_id
+    run.updated_at = now
+    return claim_value(run)
 
 
 async def mark_run_provisioning_workspace(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -255,25 +236,22 @@ async def mark_run_provisioning_workspace(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
-        return await _mark_claim_status(
-            session,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            status=AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
-            transition=transition,
-            claim_is_active=claim_is_active,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    return await _mark_claim_status(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_PROVISIONING_WORKSPACE,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+    )
 
 
 async def mark_run_creating_session(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -285,26 +263,23 @@ async def mark_run_creating_session(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
-        return await _mark_claim_status(
-            session,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            status=AUTOMATION_RUN_STATUS_CREATING_SESSION,
-            transition=transition,
-            claim_is_active=claim_is_active,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-            anyharness_workspace_id=anyharness_workspace_id,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    return await _mark_claim_status(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_CREATING_SESSION,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+    )
 
 
 async def attach_anyharness_session_to_run(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -317,30 +292,27 @@ async def attach_anyharness_session_to_run(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async def operation(db: AsyncSession) -> bool:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.anyharness_session_id = anyharness_session_id
-        run.updated_at = now
-        return True
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return False
+    run.anyharness_workspace_id = anyharness_workspace_id
+    run.anyharness_session_id = anyharness_session_id
+    run.updated_at = now
+    return True
 
 
 async def mark_run_dispatching(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -351,26 +323,23 @@ async def mark_run_dispatching(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
-        return await _mark_claim_status(
-            session,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            status=AUTOMATION_RUN_STATUS_DISPATCHING,
-            transition=transition,
-            claim_is_active=claim_is_active,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-            dispatch_started_at=now,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    return await _mark_claim_status(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        status=AUTOMATION_RUN_STATUS_DISPATCHING,
+        transition=transition,
+        claim_is_active=claim_is_active,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        user_id=user_id,
+        dispatch_started_at=now,
+    )
 
 
 async def mark_run_dispatched(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -383,33 +352,30 @@ async def mark_run_dispatched(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async def operation(db: AsyncSession) -> bool:
-        run = await _load_run_for_transition(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            transition=transition,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.status = AUTOMATION_RUN_STATUS_DISPATCHED
-        run.dispatched_at = now
-        run.anyharness_workspace_id = anyharness_workspace_id
-        run.anyharness_session_id = anyharness_session_id
-        clear_claim_metadata(run)
-        run.updated_at = now
-        return True
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    run = await _load_run_for_transition(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        transition=transition,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return False
+    run.status = AUTOMATION_RUN_STATUS_DISPATCHED
+    run.dispatched_at = now
+    run.anyharness_workspace_id = anyharness_workspace_id
+    run.anyharness_session_id = anyharness_session_id
+    clear_claim_metadata(run)
+    run.updated_at = now
+    return True
 
 
 async def mark_run_failed(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -422,26 +388,23 @@ async def mark_run_failed(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> bool:
-    async def operation(db: AsyncSession) -> bool:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=active_statuses,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return False
-        run.status = AUTOMATION_RUN_STATUS_FAILED
-        run.failed_at = now
-        run.last_error_code = error_code
-        run.last_error_message = message
-        clear_claim_metadata(run)
-        run.updated_at = now
-        return True
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    run = await load_claimed_run_for_update(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        allowed_statuses=active_statuses,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return False
+    run.status = AUTOMATION_RUN_STATUS_FAILED
+    run.failed_at = now
+    run.last_error_code = error_code
+    run.last_error_message = message
+    clear_claim_metadata(run)
+    run.updated_at = now
+    return True

--- a/server/proliferate/db/store/automation_run_claims.py
+++ b/server/proliferate/db/store/automation_run_claims.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Protocol
 from uuid import UUID, uuid4
@@ -23,7 +22,6 @@ from proliferate.constants.automations import (
     AUTOMATION_TARGET_MODE_PERSONAL_CLOUD,
     AUTOMATION_TARGET_MODE_SHARED_CLOUD,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import AutomationRun
 from proliferate.db.store.automation_run_claim_values import (
     AutomationRunClaimValue,
@@ -51,13 +49,6 @@ class LocalAutomationRepoIdentity(Protocol):
 
 class ClaimActivePredicate(Protocol):
     def __call__(self, claim_expires_at: datetime | None, now: datetime) -> bool: ...
-
-
-async def _run_self_committing[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
-    async with db_engine.async_session_factory() as db:
-        result = await operation(db)
-        await db.commit()
-        return result
 
 
 async def load_claimed_run_for_update(
@@ -126,6 +117,7 @@ def _fail_unconfigured_agent(
 
 
 async def claim_cloud_automation_runs(
+    db: AsyncSession,
     *,
     executor_id: str,
     claim_ttl: timedelta,
@@ -134,26 +126,23 @@ async def claim_cloud_automation_runs(
     reclaimable_statuses: frozenset[str],
     unconfigured_agent_failure: ClaimFailure,
 ) -> list[AutomationRunClaimValue]:
-    async def operation(db: AsyncSession) -> list[AutomationRunClaimValue]:
-        return await _claim_automation_runs(
-            db,
-            executor_id=executor_id,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
-            execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
-            claim_ttl=claim_ttl,
-            limit=limit,
-            now=now,
-            reclaimable_statuses=reclaimable_statuses,
-            unconfigured_agent_failure=unconfigured_agent_failure,
-            user_id=None,
-            repo_identities=None,
-        )
-
-    return await _run_self_committing(operation)
+    return await _claim_automation_runs(
+        db,
+        executor_id=executor_id,
+        executor_kind=AUTOMATION_EXECUTOR_KIND_CLOUD,
+        execution_target=AUTOMATION_EXECUTION_TARGET_CLOUD,
+        claim_ttl=claim_ttl,
+        limit=limit,
+        now=now,
+        reclaimable_statuses=reclaimable_statuses,
+        unconfigured_agent_failure=unconfigured_agent_failure,
+        user_id=None,
+        repo_identities=None,
+    )
 
 
 async def claim_local_automation_runs(
-    db: AsyncSession | None = None,
+    db: AsyncSession,
     *,
     user_id: UUID,
     executor_id: str,
@@ -173,22 +162,19 @@ async def claim_local_automation_runs(
         return []
     repo_identities = sorted(identities)
 
-    async def operation(session: AsyncSession) -> list[AutomationRunClaimValue]:
-        return await _claim_automation_runs(
-            session,
-            executor_id=executor_id,
-            executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
-            execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
-            claim_ttl=claim_ttl,
-            limit=limit,
-            now=now,
-            reclaimable_statuses=reclaimable_statuses,
-            unconfigured_agent_failure=unconfigured_agent_failure,
-            user_id=user_id,
-            repo_identities=repo_identities,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
+    return await _claim_automation_runs(
+        db,
+        executor_id=executor_id,
+        executor_kind=AUTOMATION_EXECUTOR_KIND_DESKTOP,
+        execution_target=AUTOMATION_EXECUTION_TARGET_LOCAL,
+        claim_ttl=claim_ttl,
+        limit=limit,
+        now=now,
+        reclaimable_statuses=reclaimable_statuses,
+        unconfigured_agent_failure=unconfigured_agent_failure,
+        user_id=user_id,
+        repo_identities=repo_identities,
+    )
 
 
 async def _claim_automation_runs(
@@ -273,6 +259,7 @@ async def _claim_automation_runs(
 
 
 async def load_current_run_claim(
+    db: AsyncSession,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -283,54 +270,23 @@ async def load_current_run_claim(
     executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
     user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
-    async with db_engine.async_session_factory() as db:
-        run = await load_claimed_run_for_update(
-            db,
-            run_id=run_id,
-            claim_id=claim_id,
-            now=now,
-            allowed_statuses=active_statuses,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            claim_is_active=claim_is_active,
-            user_id=user_id,
-        )
-        if run is None:
-            return None
-        return claim_value(run)
+    run = await load_claimed_run_for_update(
+        db,
+        run_id=run_id,
+        claim_id=claim_id,
+        now=now,
+        allowed_statuses=active_statuses,
+        execution_target=execution_target,
+        executor_kind=executor_kind,
+        claim_is_active=claim_is_active,
+        user_id=user_id,
+    )
+    if run is None:
+        return None
+    return claim_value(run)
 
 
 async def heartbeat_run_claim(
-    db: AsyncSession | None = None,
-    *,
-    run_id: UUID,
-    claim_id: UUID,
-    claim_ttl: timedelta,
-    now: datetime,
-    active_statuses: frozenset[str],
-    claim_is_active: ClaimActivePredicate,
-    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
-    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
-    user_id: UUID | None = None,
-) -> AutomationRunClaimValue | None:
-    async def operation(session: AsyncSession) -> AutomationRunClaimValue | None:
-        return await _heartbeat_run_claim(
-            session,
-            run_id=run_id,
-            claim_id=claim_id,
-            claim_ttl=claim_ttl,
-            now=now,
-            active_statuses=active_statuses,
-            claim_is_active=claim_is_active,
-            execution_target=execution_target,
-            executor_kind=executor_kind,
-            user_id=user_id,
-        )
-
-    return await operation(db) if db is not None else await _run_self_committing(operation)
-
-
-async def _heartbeat_run_claim(
     db: AsyncSession,
     *,
     run_id: UUID,
@@ -339,9 +295,9 @@ async def _heartbeat_run_claim(
     now: datetime,
     active_statuses: frozenset[str],
     claim_is_active: ClaimActivePredicate,
-    execution_target: str,
-    executor_kind: str,
-    user_id: UUID | None,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
 ) -> AutomationRunClaimValue | None:
     run = await load_claimed_run_for_update(
         db,

--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -25,7 +25,6 @@ from proliferate.constants.automations import (
     AUTOMATION_TARGET_MODE_PERSONAL_CLOUD,
 )
 from proliferate.constants.cloud import SUPPORTED_GIT_PROVIDER
-from proliferate.db import engine as db_engine
 from proliferate.db.models.automations import Automation, AutomationRun
 from proliferate.db.models.cloud.agent_run_config import CloudAgentRunConfig
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
@@ -635,6 +634,7 @@ async def list_runs_for_automation_for_user(
 
 
 async def list_latest_runs_by_cloud_workspace_ids_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     cloud_workspace_ids: list[UUID],
@@ -642,22 +642,21 @@ async def list_latest_runs_by_cloud_workspace_ids_for_user(
     if not cloud_workspace_ids:
         return {}
     unique_ids = list(dict.fromkeys(cloud_workspace_ids))
-    async with db_engine.async_session_factory() as db:
-        records = list(
-            (
-                await db.execute(
-                    select(AutomationRun)
-                    .where(
-                        AutomationRun.owner_scope == AUTOMATION_OWNER_SCOPE_PERSONAL,
-                        AutomationRun.owner_user_id == user_id,
-                        AutomationRun.cloud_workspace_id.in_(unique_ids),
-                    )
-                    .order_by(AutomationRun.created_at.desc(), AutomationRun.id.desc())
+    records = list(
+        (
+            await db.execute(
+                select(AutomationRun)
+                .where(
+                    AutomationRun.owner_scope == AUTOMATION_OWNER_SCOPE_PERSONAL,
+                    AutomationRun.owner_user_id == user_id,
+                    AutomationRun.cloud_workspace_id.in_(unique_ids),
                 )
+                .order_by(AutomationRun.created_at.desc(), AutomationRun.id.desc())
             )
-            .scalars()
-            .all()
         )
+        .scalars()
+        .all()
+    )
     values_by_workspace: dict[UUID, AutomationRunValue] = {}
     for record in records:
         if record.cloud_workspace_id is None or record.cloud_workspace_id in values_by_workspace:

--- a/server/proliferate/db/store/cloud_mcp/auth.py
+++ b/server/proliferate/db/store/cloud_mcp/auth.py
@@ -77,6 +77,7 @@ async def upsert_connection_auth(
     await db.refresh(auth)
     return _record(auth)
 
+
 async def load_connection_auth(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_mcp/auth.py
+++ b/server/proliferate/db/store/cloud_mcp/auth.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.mcp import CloudMcpConnection, CloudMcpConnectionAuth
 from proliferate.db.store.cloud_mcp.types import CloudMcpAuthRecord
 from proliferate.utils.time import utcnow
@@ -77,7 +76,6 @@ async def upsert_connection_auth(
     await db.flush()
     await db.refresh(auth)
     return _record(auth)
-
 
 async def load_connection_auth(
     db: AsyncSession,
@@ -162,57 +160,3 @@ async def mark_connection_auth_status_if_version(
     await db.flush()
     await db.refresh(auth)
     return _record(auth)
-
-
-async def load_connection_auth_standalone(
-    *,
-    connection_db_id: UUID,
-) -> CloudMcpAuthRecord | None:
-    # Materialization refresh work runs concurrently; each refresh read/write
-    # gets its own session instead of sharing the request session across tasks.
-    async with db_engine.async_session_factory() as db:
-        return await load_connection_auth(db, connection_db_id=connection_db_id)
-
-
-async def update_connection_auth_if_version_standalone(
-    *,
-    connection_db_id: UUID,
-    expected_auth_version: int,
-    auth_kind: str,
-    auth_status: str,
-    payload_ciphertext: str | None,
-    payload_format: str,
-    token_expires_at: datetime | None = None,
-    last_error_code: str | None = None,
-) -> CloudMcpAuthRecord | None:
-    async with db_engine.async_session_factory() as db, db.begin():
-        return await update_connection_auth_if_version(
-            db,
-            connection_db_id=connection_db_id,
-            expected_auth_version=expected_auth_version,
-            auth_kind=auth_kind,
-            auth_status=auth_status,
-            payload_ciphertext=payload_ciphertext,
-            payload_format=payload_format,
-            token_expires_at=token_expires_at,
-            last_error_code=last_error_code,
-        )
-
-
-async def mark_connection_auth_status_if_version_standalone(
-    *,
-    connection_db_id: UUID,
-    expected_auth_version: int,
-    auth_kind: str,
-    auth_status: str,
-    last_error_code: str | None,
-) -> CloudMcpAuthRecord | None:
-    async with db_engine.async_session_factory() as db, db.begin():
-        return await mark_connection_auth_status_if_version(
-            db,
-            connection_db_id=connection_db_id,
-            expected_auth_version=expected_auth_version,
-            auth_kind=auth_kind,
-            auth_status=auth_status,
-            last_error_code=last_error_code,
-        )

--- a/server/proliferate/db/store/cloud_mcp/oauth_clients.py
+++ b/server/proliferate/db/store/cloud_mcp/oauth_clients.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.mcp import CloudMcpOAuthClient
 from proliferate.db.store.cloud_mcp.types import CloudMcpOAuthClientRecord
 from proliferate.utils.time import utcnow
@@ -46,23 +45,6 @@ async def get_oauth_client(
         )
     ).scalar_one_or_none()
     return _record(client) if client is not None else None
-
-
-async def get_oauth_client_standalone(
-    *,
-    issuer: str,
-    redirect_uri: str,
-    catalog_entry_id: str,
-) -> CloudMcpOAuthClientRecord | None:
-    # Materialization token refreshes run concurrently; keep OAuth client reads
-    # isolated from the request session used to list candidate connections.
-    async with db_engine.async_session_factory() as db:
-        return await get_oauth_client(
-            db,
-            issuer=issuer,
-            redirect_uri=redirect_uri,
-            catalog_entry_id=catalog_entry_id,
-        )
 
 
 async def upsert_oauth_client(

--- a/server/proliferate/server/automations/worker/claim_transactions.py
+++ b/server/proliferate/server/automations/worker/claim_transactions.py
@@ -1,0 +1,327 @@
+"""Transaction wrappers for cloud automation claim mutations."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.automations import (
+    AUTOMATION_EXECUTION_TARGET_CLOUD,
+    AUTOMATION_EXECUTOR_KIND_CLOUD,
+)
+from proliferate.db import engine as db_engine
+from proliferate.db.store import automation_run_claim_transitions as transition_store
+from proliferate.db.store import automation_run_claims as claim_store
+from proliferate.db.store.automation_run_claim_values import AutomationRunClaimValue
+from proliferate.db.store.automation_run_claims import (
+    ClaimActivePredicate,
+    ClaimFailure,
+    ClaimTransitionRule,
+)
+
+
+async def _run_in_session[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    async with db_engine.async_session_factory() as db:
+        return await operation(db)
+
+
+async def _run_in_transaction[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await operation(db)
+
+
+async def claim_cloud_automation_runs(
+    *,
+    executor_id: str,
+    claim_ttl: timedelta,
+    limit: int,
+    now: datetime,
+    reclaimable_statuses: frozenset[str],
+    unconfigured_agent_failure: ClaimFailure,
+) -> list[AutomationRunClaimValue]:
+    async def operation(db: AsyncSession) -> list[AutomationRunClaimValue]:
+        return await claim_store.claim_cloud_automation_runs(
+            db,
+            executor_id=executor_id,
+            claim_ttl=claim_ttl,
+            limit=limit,
+            now=now,
+            reclaimable_statuses=reclaimable_statuses,
+            unconfigured_agent_failure=unconfigured_agent_failure,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def load_current_run_claim(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await claim_store.load_current_run_claim(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            active_statuses=active_statuses,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+        )
+
+    return await _run_in_session(operation)
+
+
+async def heartbeat_run_claim(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    claim_ttl: timedelta,
+    now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+    user_id: UUID | None = None,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await claim_store.heartbeat_run_claim(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            claim_ttl=claim_ttl,
+            now=now,
+            active_statuses=active_statuses,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+            user_id=user_id,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_creating_workspace(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.mark_run_creating_workspace(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def attach_cloud_target_snapshot_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    cloud_target_id: UUID,
+    cloud_target_kind: str,
+    sandbox_profile_id: UUID | None = None,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.attach_cloud_target_snapshot_to_run(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            cloud_target_id=cloud_target_id,
+            cloud_target_kind=cloud_target_kind,
+            sandbox_profile_id=sandbox_profile_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def attach_anyharness_workspace_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+    execution_target: str = AUTOMATION_EXECUTION_TARGET_CLOUD,
+    executor_kind: str = AUTOMATION_EXECUTOR_KIND_CLOUD,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.attach_anyharness_workspace_to_run(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+            execution_target=execution_target,
+            executor_kind=executor_kind,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_provisioning_workspace(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.mark_run_provisioning_workspace(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_creating_session(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.mark_run_creating_session(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def attach_anyharness_session_to_run(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    anyharness_session_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> bool:
+    async def operation(db: AsyncSession) -> bool:
+        return await transition_store.attach_anyharness_session_to_run(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+            anyharness_session_id=anyharness_session_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_dispatching(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> AutomationRunClaimValue | None:
+    async def operation(db: AsyncSession) -> AutomationRunClaimValue | None:
+        return await transition_store.mark_run_dispatching(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_dispatched(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    anyharness_workspace_id: str,
+    anyharness_session_id: str,
+    now: datetime,
+    transition: ClaimTransitionRule,
+    claim_is_active: ClaimActivePredicate,
+) -> bool:
+    async def operation(db: AsyncSession) -> bool:
+        return await transition_store.mark_run_dispatched(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            anyharness_workspace_id=anyharness_workspace_id,
+            anyharness_session_id=anyharness_session_id,
+            now=now,
+            transition=transition,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)
+
+
+async def mark_run_failed(
+    *,
+    run_id: UUID,
+    claim_id: UUID,
+    error_code: str,
+    message: str,
+    now: datetime,
+    active_statuses: frozenset[str],
+    claim_is_active: ClaimActivePredicate,
+) -> bool:
+    async def operation(db: AsyncSession) -> bool:
+        return await transition_store.mark_run_failed(
+            db,
+            run_id=run_id,
+            claim_id=claim_id,
+            error_code=error_code,
+            message=message,
+            now=now,
+            active_statuses=active_statuses,
+            claim_is_active=claim_is_active,
+        )
+
+    return await _run_in_transaction(operation)

--- a/server/proliferate/server/automations/worker/cloud_execution/stages/prompt.py
+++ b/server/proliferate/server/automations/worker/cloud_execution/stages/prompt.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from proliferate.db.store.automation_run_claim_transitions import (
-    mark_run_dispatched,
-    mark_run_dispatching,
-)
 from proliferate.db.store.automation_run_claims import (
     ClaimTransitionRule as StoreClaimTransitionRule,
 )
@@ -16,6 +12,10 @@ from proliferate.server.automations.domain.claim_lifecycle import (
     DISPATCHED_TRANSITION,
     DISPATCHING_TRANSITION,
     claim_is_active,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    mark_run_dispatched,
+    mark_run_dispatching,
 )
 from proliferate.server.automations.worker.cloud_execution.command_models import (
     SendPromptPayload,

--- a/server/proliferate/server/automations/worker/cloud_execution/stages/session.py
+++ b/server/proliferate/server/automations/worker/cloud_execution/stages/session.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from proliferate.db.store.automation_run_claim_transitions import (
-    attach_anyharness_session_to_run,
-    mark_run_creating_session,
-)
 from proliferate.db.store.automation_run_claims import (
     ClaimTransitionRule as StoreClaimTransitionRule,
 )
@@ -15,6 +11,10 @@ from proliferate.server.automations.domain.claim_lifecycle import (
     ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
     CREATING_SESSION_TRANSITION,
     claim_is_active,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    attach_anyharness_session_to_run,
+    mark_run_creating_session,
 )
 from proliferate.server.automations.worker.cloud_execution.command_models import (
     StartSessionPayload,

--- a/server/proliferate/server/automations/worker/cloud_execution/stages/target.py
+++ b/server/proliferate/server/automations/worker/cloud_execution/stages/target.py
@@ -10,13 +10,13 @@ from proliferate.constants.automations import (
 )
 from proliferate.constants.cloud import CloudTargetKind, CloudTargetStatus
 from proliferate.db import engine as db_engine
-from proliferate.db.store.automation_run_claim_transitions import (
-    attach_cloud_target_snapshot_to_run,
-)
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.automations.domain.claim_lifecycle import (
     CLOUD_WORKSPACE_ATTACHMENT_TRANSITION,
     claim_is_active,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    attach_cloud_target_snapshot_to_run,
 )
 from proliferate.server.automations.worker.cloud_execution.context import (
     AutomationExecutionContext,

--- a/server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
+++ b/server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
@@ -11,11 +11,6 @@ from proliferate.constants.automations import (
 )
 from proliferate.constants.cloud import CloudWorkspaceStatus
 from proliferate.db import engine as db_engine
-from proliferate.db.store.automation_run_claim_transitions import (
-    attach_anyharness_workspace_to_run,
-    mark_run_creating_workspace,
-    mark_run_provisioning_workspace,
-)
 from proliferate.db.store.automation_run_claims import (
     ClaimTransitionRule as StoreClaimTransitionRule,
 )
@@ -29,6 +24,11 @@ from proliferate.server.automations.domain.claim_lifecycle import (
     CREATING_WORKSPACE_TRANSITION,
     claim_is_active,
     provisioning_workspace_transition,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    attach_anyharness_workspace_to_run,
+    mark_run_creating_workspace,
+    mark_run_provisioning_workspace,
 )
 from proliferate.server.automations.worker.cloud_execution.command_models import (
     EnsureRepoCheckoutPayload,

--- a/server/proliferate/server/automations/worker/cloud_executor.py
+++ b/server/proliferate/server/automations/worker/cloud_executor.py
@@ -11,11 +11,13 @@ from proliferate.constants.automations import (
 from proliferate.constants.cloud import SUPPORTED_CLOUD_AGENTS
 from proliferate.db import engine as db_engine
 from proliferate.db.store.automation_run_claim_values import AutomationRunClaimValue
-from proliferate.db.store.automation_run_claims import claim_cloud_automation_runs
 from proliferate.db.store.cloud_agent_run_config import configs as run_config_store
 from proliferate.server.automations.domain.claim_lifecycle import (
     RECLAIMABLE_STATUSES,
     unconfigured_agent_failure,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    claim_cloud_automation_runs,
 )
 from proliferate.server.automations.worker.cloud_execution.context import (
     AutomationExecutionContext,

--- a/server/proliferate/server/automations/worker/cloud_executor_claims.py
+++ b/server/proliferate/server/automations/worker/cloud_executor_claims.py
@@ -5,20 +5,18 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from proliferate.db.store.automation_run_claim_transitions import (
-    mark_run_failed,
-)
 from proliferate.db.store.automation_run_claim_values import (
     AutomationRunClaimValue,
-)
-from proliferate.db.store.automation_run_claims import (
-    heartbeat_run_claim,
-    load_current_run_claim,
 )
 from proliferate.server.automations.domain.claim_lifecycle import (
     ACTIVE_CLAIM_STATUSES,
     automation_error_message,
     claim_is_active,
+)
+from proliferate.server.automations.worker.claim_transactions import (
+    heartbeat_run_claim,
+    load_current_run_claim,
+    mark_run_failed,
 )
 from proliferate.server.automations.worker.cloud_executor_config import CloudExecutorConfig
 from proliferate.utils.time import utcnow

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -403,7 +403,8 @@ async def _workspace_summaries_for_request(
     workspaces: list[CloudWorkspace],
 ) -> list[WorkspaceSummary]:
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        db, user_id=user_id,
+        db,
+        user_id=user_id,
         cloud_workspace_ids=[workspace.id for workspace in workspaces],
     )
     snapshots_by_subject: dict[UUID, BillingSnapshot] = {}
@@ -1301,7 +1302,8 @@ async def _build_workspace_detail_for_request(
     )
     action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        db, user_id=workspace.user_id,
+        db,
+        user_id=workspace.user_id,
         cloud_workspace_ids=[workspace.id],
     )
     direct_target_context = _direct_target_context_for_workspace(
@@ -1364,7 +1366,8 @@ async def _build_workspace_detail(
             else None
         )
         automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-            db, user_id=workspace.user_id,
+            db,
+            user_id=workspace.user_id,
             cloud_workspace_ids=[workspace.id],
         )
     billing = await get_billing_snapshot_for_subject(
@@ -1868,11 +1871,17 @@ async def create_cloud_workspace_for_automation_run(
     try:
         async with db_engine.async_session_factory() as db, db.begin():
             workspace = await create_managed_cloud_workspace_for_claimed_run(
-                db, run_id=run_id, claim_id=claim_id,
-                sandbox_profile_id=sandbox_profile_id, target_id=target_id,
-                user_id=user.id, display_name=resolved.display_name,
-                git_provider=resolved.git_provider, git_owner=resolved.git_owner,
-                git_repo_name=resolved.git_repo_name, git_branch=resolved.git_branch,
+                db,
+                run_id=run_id,
+                claim_id=claim_id,
+                sandbox_profile_id=sandbox_profile_id,
+                target_id=target_id,
+                user_id=user.id,
+                display_name=resolved.display_name,
+                git_provider=resolved.git_provider,
+                git_owner=resolved.git_owner,
+                git_repo_name=resolved.git_repo_name,
+                git_branch=resolved.git_branch,
                 git_base_branch=resolved.git_base_branch,
                 worktree_path=worktree_path,
                 origin_json=CLOUD_SYSTEM_ORIGIN_JSON,
@@ -1909,14 +1918,12 @@ async def ensure_cloud_workspace_for_existing_branch(
             "Only GitHub repositories are supported for cloud workspaces.",
             status_code=400,
         )
-
     if get_linked_github_account(user) is None:
         raise CloudApiError(
             "github_link_required",
             "Connect a GitHub account before provisioning a cloud workspace.",
             status_code=400,
         )
-
     cleaned_branch_name = branch_name.strip()
     if not cleaned_branch_name:
         raise CloudApiError(
@@ -1924,7 +1931,6 @@ async def ensure_cloud_workspace_for_existing_branch(
             "Choose a branch before provisioning a cloud workspace.",
             status_code=400,
         )
-
     existing_cloud_workspace = await load_existing_cloud_workspace(
         user_id=user.id,
         git_provider=git_provider,
@@ -1944,7 +1950,6 @@ async def ensure_cloud_workspace_for_existing_branch(
             )
         else:
             return existing_cloud_workspace
-
     repo_config = await load_repo_config_value(
         user_id=user.id,
         git_owner=git_owner,
@@ -1961,7 +1966,6 @@ async def ensure_cloud_workspace_for_existing_branch(
             user_id=user.id,
             repo=f"{git_owner}/{git_repo_name}",
         )
-
     authorization = await authorize_sandbox_start(
         user_id=user.id,
         workspace_id=None,
@@ -1969,7 +1973,6 @@ async def ensure_cloud_workspace_for_existing_branch(
     _raise_if_cloud_workspace_start_denied(authorization)
     billing_snapshot = await get_billing_snapshot_for_subject(authorization.billing_subject_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
-
     try:
         workspace = await create_cloud_workspace_for_user(
             user_id=user.id,
@@ -2183,7 +2186,6 @@ async def sync_cloud_workspace_branch(
             "Branch name is required.",
             status_code=400,
         )
-
     workspace = await cloud_workspace_user_can_interact_with_db(db, user_id, workspace_id)
     workspace = await update_workspace_branch(db, workspace, cleaned_branch_name)
     return await _build_workspace_detail_for_request(db, workspace)
@@ -2201,7 +2203,6 @@ async def sync_cloud_workspace_display_name(
     `display_name=None` (or an empty/whitespace string) clears the override
     and restores the default branch- or repo-derived label in the sidebar.
     """
-
     cleaned: str | None
     if display_name is None or not display_name.strip():
         cleaned = None
@@ -2216,7 +2217,6 @@ async def sync_cloud_workspace_display_name(
                 ),
                 status_code=400,
             )
-
     workspace = await cloud_workspace_user_can_interact_with_db(db, user_id, workspace_id)
     workspace = await update_workspace_display_name(db, workspace, cleaned)
     return await _build_workspace_detail_for_request(db, workspace)
@@ -2483,7 +2483,6 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
                 )
         else:
             await update_sandbox_status(sandbox, "destroyed", stopped_at_now=True)
-
     transition_workspace_status(workspace, CloudWorkspaceStatus.archived, status_detail="Archived")
     await persist_workspace_destroy_state(workspace)
     log_cloud_event(
@@ -2501,7 +2500,6 @@ async def _load_workspace_owned_runtime_sandbox(
     Managed cloud slots are shared by all workspaces on a sandbox profile and
     target. Workspace stop/delete must not pause or destroy that shared slot.
     """
-
     sandbox_id = getattr(workspace, "active_sandbox_id", None)
     if sandbox_id is None:
         return None
@@ -2528,7 +2526,8 @@ async def get_cloud_connection(
     await _reject_shared_workspace_static_connection(workspace)
     async with db_engine.async_session_factory() as db:
         automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-            db, user_id=user_id,
+            db,
+            user_id=user_id,
             cloud_workspace_ids=[workspace.id],
         )
     latest_run = automation_runs_by_workspace.get(workspace.id)

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -403,7 +403,7 @@ async def _workspace_summaries_for_request(
     workspaces: list[CloudWorkspace],
 ) -> list[WorkspaceSummary]:
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        user_id=user_id,
+        db, user_id=user_id,
         cloud_workspace_ids=[workspace.id for workspace in workspaces],
     )
     snapshots_by_subject: dict[UUID, BillingSnapshot] = {}
@@ -1301,7 +1301,7 @@ async def _build_workspace_detail_for_request(
     )
     action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        user_id=workspace.user_id,
+        db, user_id=workspace.user_id,
         cloud_workspace_ids=[workspace.id],
     )
     direct_target_context = _direct_target_context_for_workspace(
@@ -1350,6 +1350,7 @@ async def _build_workspace_detail(
     ready_agent_kind_values = await _load_agent_auth_agent_kinds_for_workspace(workspace)
     latest_sessions = ()
     target = None
+    automation_runs_by_workspace = {}
     async with db_engine.async_session_factory() as db:
         latest_sessions = await events_store.list_session_projections_for_workspace(
             db,
@@ -1362,16 +1363,16 @@ async def _build_workspace_detail(
             if workspace.target_id is not None
             else None
         )
+        automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
+            db, user_id=workspace.user_id,
+            cloud_workspace_ids=[workspace.id],
+        )
     billing = await get_billing_snapshot_for_subject(
         runtime_environment.billing_subject_id
         if runtime_environment is not None
         else workspace.billing_subject_id
     )
     action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
-    automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        user_id=workspace.user_id,
-        cloud_workspace_ids=[workspace.id],
-    )
     direct_target_context = _direct_target_context_for_workspace(
         workspace,
         target.kind if target is not None else None,
@@ -1865,25 +1866,21 @@ async def create_cloud_workspace_for_automation_run(
         required_agent_kind=required_agent_kind,
     )
     try:
-        workspace = await create_managed_cloud_workspace_for_claimed_run(
-            run_id=run_id,
-            claim_id=claim_id,
-            sandbox_profile_id=sandbox_profile_id,
-            target_id=target_id,
-            user_id=user.id,
-            display_name=resolved.display_name,
-            git_provider=resolved.git_provider,
-            git_owner=resolved.git_owner,
-            git_repo_name=resolved.git_repo_name,
-            git_branch=resolved.git_branch,
-            git_base_branch=resolved.git_base_branch,
-            worktree_path=worktree_path,
-            origin_json=CLOUD_SYSTEM_ORIGIN_JSON,
-            template_version=get_configured_sandbox_provider().template_version,
-            now=utcnow(),
-            transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
-            claim_is_active=claim_is_active,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            workspace = await create_managed_cloud_workspace_for_claimed_run(
+                db, run_id=run_id, claim_id=claim_id,
+                sandbox_profile_id=sandbox_profile_id, target_id=target_id,
+                user_id=user.id, display_name=resolved.display_name,
+                git_provider=resolved.git_provider, git_owner=resolved.git_owner,
+                git_repo_name=resolved.git_repo_name, git_branch=resolved.git_branch,
+                git_base_branch=resolved.git_base_branch,
+                worktree_path=worktree_path,
+                origin_json=CLOUD_SYSTEM_ORIGIN_JSON,
+                template_version=get_configured_sandbox_provider().template_version,
+                now=utcnow(),
+                transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
+                claim_is_active=claim_is_active,
+            )
     except CloudRepoLimitExceededError as error:
         _raise_repo_limit_exceeded(error)
     if workspace is not None:
@@ -2529,10 +2526,11 @@ async def get_cloud_connection(
 ) -> WorkspaceConnection:
     workspace = await cloud_workspace_user_can_interact(user_id, workspace_id)
     await _reject_shared_workspace_static_connection(workspace)
-    automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-        user_id=user_id,
-        cloud_workspace_ids=[workspace.id],
-    )
+    async with db_engine.async_session_factory() as db:
+        automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
+            db, user_id=user_id,
+            cloud_workspace_ids=[workspace.id],
+        )
     latest_run = automation_runs_by_workspace.get(workspace.id)
     if (
         latest_run is not None

--- a/server/tests/unit/automation_claim_store_helpers.py
+++ b/server/tests/unit/automation_claim_store_helpers.py
@@ -1,7 +1,12 @@
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.constants.automations import (
     AUTOMATION_EXECUTION_TARGET_CLOUD,
     AUTOMATION_RUN_STATUS_DISPATCHING,
 )
+from proliferate.db import engine as engine_module
 from proliferate.db.store.automation_cloud_workspace_claims import (
     create_cloud_workspace_for_claimed_run as create_cloud_workspace_for_claimed_run_store,
 )
@@ -37,94 +42,164 @@ from proliferate.server.automations.domain.claim_lifecycle import (
     unconfigured_agent_failure,
 )
 
+async def _run_in_transaction[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
+    async with engine_module.async_session_factory() as db, db.begin():
+        return await operation(db)
+
 
 async def claim_cloud_automation_runs(**kwargs):  # type: ignore[no-untyped-def]
-    return await claim_cloud_automation_runs_store(
-        **kwargs,
-        reclaimable_statuses=RECLAIMABLE_STATUSES,
-        unconfigured_agent_failure=unconfigured_agent_failure(),
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await claim_cloud_automation_runs_store(
+            session,
+            **kwargs,
+            reclaimable_statuses=RECLAIMABLE_STATUSES,
+            unconfigured_agent_failure=unconfigured_agent_failure(),
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def claim_local_automation_runs(**kwargs):  # type: ignore[no-untyped-def]
-    return await claim_local_automation_runs_store(
-        **kwargs,
-        reclaimable_statuses=RECLAIMABLE_STATUSES,
-        unconfigured_agent_failure=unconfigured_agent_failure(),
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await claim_local_automation_runs_store(
+            session,
+            **kwargs,
+            reclaimable_statuses=RECLAIMABLE_STATUSES,
+            unconfigured_agent_failure=unconfigured_agent_failure(),
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def heartbeat_run_claim(**kwargs):  # type: ignore[no-untyped-def]
-    return await heartbeat_run_claim_store(
-        **kwargs,
-        active_statuses=ACTIVE_CLAIM_STATUSES,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await heartbeat_run_claim_store(
+            session,
+            **kwargs,
+            active_statuses=ACTIVE_CLAIM_STATUSES,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_creating_workspace(**kwargs):  # type: ignore[no-untyped-def]
-    return await mark_run_creating_workspace_store(
-        **kwargs,
-        transition=CREATING_WORKSPACE_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_creating_workspace_store(
+            session,
+            **kwargs,
+            transition=CREATING_WORKSPACE_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def attach_anyharness_workspace_to_run(**kwargs):  # type: ignore[no-untyped-def]
-    return await attach_anyharness_workspace_to_run_store(
-        **kwargs,
-        transition=ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await attach_anyharness_workspace_to_run_store(
+            session,
+            **kwargs,
+            transition=ANYHARNESS_WORKSPACE_ATTACHMENT_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_provisioning_workspace(**kwargs):  # type: ignore[no-untyped-def]
     execution_target = kwargs.get("execution_target", AUTOMATION_EXECUTION_TARGET_CLOUD)
-    return await mark_run_provisioning_workspace_store(
-        **kwargs,
-        transition=provisioning_workspace_transition(execution_target),
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_provisioning_workspace_store(
+            session,
+            **kwargs,
+            transition=provisioning_workspace_transition(execution_target),
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_creating_session(**kwargs):  # type: ignore[no-untyped-def]
-    return await mark_run_creating_session_store(
-        **kwargs,
-        transition=CREATING_SESSION_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_creating_session_store(
+            session,
+            **kwargs,
+            transition=CREATING_SESSION_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def attach_anyharness_session_to_run(**kwargs):  # type: ignore[no-untyped-def]
-    return await attach_anyharness_session_to_run_store(
-        **kwargs,
-        transition=ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await attach_anyharness_session_to_run_store(
+            session,
+            **kwargs,
+            transition=ANYHARNESS_SESSION_ATTACHMENT_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_dispatching(**kwargs):  # type: ignore[no-untyped-def]
-    return await mark_run_dispatching_store(
-        **kwargs,
-        transition=DISPATCHING_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_dispatching_store(
+            session,
+            **kwargs,
+            transition=DISPATCHING_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_dispatched(**kwargs):  # type: ignore[no-untyped-def]
-    return await mark_run_dispatched_store(
-        **kwargs,
-        transition=DISPATCHED_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_dispatched_store(
+            session,
+            **kwargs,
+            transition=DISPATCHED_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def mark_run_failed(**kwargs):  # type: ignore[no-untyped-def]
-    return await mark_run_failed_store(
-        **kwargs,
-        active_statuses=ACTIVE_CLAIM_STATUSES,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await mark_run_failed_store(
+            session,
+            **kwargs,
+            active_statuses=ACTIVE_CLAIM_STATUSES,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)
 
 
 async def sweep_expired_dispatching_runs(**kwargs):  # type: ignore[no-untyped-def]
@@ -136,8 +211,14 @@ async def sweep_expired_dispatching_runs(**kwargs):  # type: ignore[no-untyped-d
 
 
 async def create_cloud_workspace_for_claimed_run(**kwargs):  # type: ignore[no-untyped-def]
-    return await create_cloud_workspace_for_claimed_run_store(
-        **kwargs,
-        transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
-        claim_is_active=claim_is_active,
-    )
+    db = kwargs.pop("db", None)
+
+    async def operation(session: AsyncSession):  # type: ignore[no-untyped-def]
+        return await create_cloud_workspace_for_claimed_run_store(
+            session,
+            **kwargs,
+            transition=CLOUD_WORKSPACE_CREATION_TRANSITION,
+            claim_is_active=claim_is_active,
+        )
+
+    return await operation(db) if db is not None else await _run_in_transaction(operation)

--- a/server/tests/unit/automation_claim_store_helpers.py
+++ b/server/tests/unit/automation_claim_store_helpers.py
@@ -42,6 +42,7 @@ from proliferate.server.automations.domain.claim_lifecycle import (
     unconfigured_agent_failure,
 )
 
+
 async def _run_in_transaction[T](operation: Callable[[AsyncSession], Awaitable[T]]) -> T:
     async with engine_module.async_session_factory() as db, db.begin():
         return await operation(db)


### PR DESCRIPTION
## Summary
- thread explicit `AsyncSession` parameters through scoped automation and MCP store helpers
- move automation claim transaction timing to worker-owned orchestration helpers
- remove scoped store session-factory/commit allowlist debt

## Verification
- `DEBUG=true uv run pytest -q tests/unit/test_automation_store.py tests/unit/test_automation_claim_contracts.py tests/unit/test_automation_local_executor_db_threading.py tests/unit/test_mcp_oauth.py`
- `python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- `uv run ruff check <touched files>`

## Notes
- Existing unrelated server structure allowlist debt remains for later lanes.
