### PR TITLE
refactor(frontend): route support access through sdk react

### DIFF
--- a/apps/packages/product-surfaces/src/support/CloudSupportSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/support/CloudSupportSurface.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import type { ProliferateCloudClient } from "@proliferate/cloud-sdk";
+import { CloudClientProvider } from "@proliferate/cloud-sdk-react";
 import {
   cleanup,
   fireEvent,
@@ -11,17 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CloudSupportSurface } from "./CloudSupportSurface";
 
 const support = vi.hoisted(() => ({
-  completeSupportReportUpload: vi.fn(),
-  createSupportReport: vi.fn(),
-  ensureSupportReportTracker: vi.fn(),
-}));
-
-vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudSupportReportActions: () => ({
-    completeSupportReportUpload: support.completeSupportReportUpload,
-    createSupportReport: support.createSupportReport,
-    ensureSupportReportTracker: support.ensureSupportReportTracker,
-  }),
+  client: { POST: vi.fn() },
 }));
 
 afterEach(() => {
@@ -31,39 +23,36 @@ afterEach(() => {
 
 describe("CloudSupportSurface", () => {
   it("creates a zero-upload support report with app-provided context", async () => {
-    support.createSupportReport.mockResolvedValue({
-      reportId: "report-1",
-      status: "created",
-      cloudDiagnosticsStatus: "not_applicable",
-      serverCorrelation: {
-        reportId: "report-1",
-        ownerUserId: "user-1",
-        primaryTenantId: "user:user-1",
-        tenantIds: ["user:user-1"],
-        cloudWorkspaceIds: [],
-        cloudTargetIds: [],
-        anyharnessWorkspaceIds: [],
-        sessionIds: [],
-      },
-    });
-    support.completeSupportReportUpload.mockResolvedValue({ ok: true, reportId: "report-1" });
-    support.ensureSupportReportTracker.mockResolvedValue({
-      ok: true,
-      reportId: "report-1",
-      trackerStatus: "pending",
-      githubIssueUrl: null,
-      linearIssueUrl: null,
+    support.client.POST.mockImplementation(async (path: string, options?: CloudPostOptions) => {
+      if (path === "/v1/support/reports") {
+        return {
+          data: {
+            reportId: "report-1",
+            clientJobId: supportRequestBody(options).clientJobId,
+            status: "created",
+            cloudDiagnosticsStatus: "not_applicable",
+            serverCorrelation: serverCorrelation("report-1"),
+          },
+        };
+      }
+      if (path === "/v1/support/reports/{report_id}/complete") {
+        return { data: { ok: true, reportId: "report-1" } };
+      }
+      if (path === "/v1/support/reports/{report_id}/tracker") {
+        return {
+          data: {
+            ok: true,
+            reportId: "report-1",
+            trackerStatus: "pending",
+            githubIssueUrl: null,
+            linearIssueUrl: null,
+          },
+        };
+      }
+      throw new Error(`Unexpected support endpoint: ${path}`);
     });
 
-    render(
-      <CloudSupportSurface
-        context={{
-          source: "settings",
-          intent: "general",
-          pathname: "/settings/support",
-        }}
-      />,
-    );
+    renderCloudSupportSurface();
 
     fireEvent.change(screen.getByPlaceholderText("What happened?"), {
       target: { value: "The workspace stopped syncing." },
@@ -71,75 +60,89 @@ describe("CloudSupportSurface", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send support message" }));
 
     await waitFor(() => {
-      expect(support.createSupportReport).toHaveBeenCalledWith(
-        {
-          clientJobId: expect.any(String),
-          message: "The workspace stopped syncing.",
-          sourceSurface: "web",
-          context: {
-            source: "settings",
-            intent: "general",
-            pathname: "/settings/support",
-          },
-          scope: {
-            kind: "app_only",
-            workspaceIds: [],
-          },
-          workspaceRefs: [],
-          expectedClientUploads: {
-            diagnostics: false,
-            attachmentCount: 0,
-          },
-          publicContentConsent: true,
-        },
-      );
+      expect(findPostCall("/v1/support/reports/{report_id}/tracker")).toBeTruthy();
     });
-    expect(support.completeSupportReportUpload).toHaveBeenCalledWith(
-      "report-1",
-      expect.objectContaining({
+    const createBody = supportRequestBody(findPostCall("/v1/support/reports")?.[1]);
+    expect(createBody).toEqual({
+      clientJobId: expect.any(String),
+      message: "The workspace stopped syncing.",
+      sourceSurface: "web",
+      context: {
+        source: "settings",
+        intent: "general",
+        pathname: "/settings/support",
+      },
+      scope: {
+        kind: "app_only",
+        workspaceIds: [],
+      },
+      workspaceRefs: [],
+      expectedClientUploads: {
+        diagnostics: false,
+        attachmentCount: 0,
+      },
+      publicContentConsent: true,
+    });
+    expect(findPostCall("/v1/support/reports/{report_id}/complete")?.[1]).toEqual({
+      params: {
+        path: {
+          report_id: "report-1",
+        },
+      },
+      body: {
         diagnostics: null,
         attachments: [],
-      }),
-    );
-    expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-1");
+        packageManifest: {
+          schemaVersion: 1,
+          clientJobId: createBody.clientJobId,
+          reportId: "report-1",
+          sourceSurface: "web",
+        },
+      },
+    });
+    expect(findPostCall("/v1/support/reports/{report_id}/tracker")?.[1]).toEqual({
+      params: {
+        path: {
+          report_id: "report-1",
+        },
+      },
+    });
     expect(screen.queryByText("Support issue sent.")).not.toBeNull();
   });
 
   it("reuses a pending client job id and skips completion once report is completed", async () => {
-    support.createSupportReport
-      .mockRejectedValueOnce(new Error("network down"))
-      .mockResolvedValueOnce({
-        reportId: "report-2",
-        status: "completed",
-        cloudDiagnosticsStatus: "not_applicable",
-        serverCorrelation: {
-          reportId: "report-2",
-          ownerUserId: "user-1",
-          primaryTenantId: "user:user-1",
-          tenantIds: ["user:user-1"],
-          cloudWorkspaceIds: [],
-          cloudTargetIds: [],
-          anyharnessWorkspaceIds: [],
-          sessionIds: [],
-        },
-      });
-    support.ensureSupportReportTracker.mockResolvedValue({
-      ok: true,
-      reportId: "report-2",
-      trackerStatus: "completed",
-      githubIssueUrl: "https://github.com/proliferate-ai/proliferate/issues/2",
-      linearIssueUrl: null,
+    let createAttempts = 0;
+    support.client.POST.mockImplementation(async (path: string, options?: CloudPostOptions) => {
+      if (path === "/v1/support/reports") {
+        createAttempts += 1;
+        if (createAttempts === 1) {
+          throw new Error("network down");
+        }
+        return {
+          data: {
+            reportId: "report-2",
+            clientJobId: supportRequestBody(options).clientJobId,
+            status: "completed",
+            cloudDiagnosticsStatus: "not_applicable",
+            serverCorrelation: serverCorrelation("report-2"),
+          },
+        };
+      }
+      if (path === "/v1/support/reports/{report_id}/tracker") {
+        return {
+          data: {
+            ok: true,
+            reportId: "report-2",
+            trackerStatus: "completed",
+            githubIssueUrl: "https://github.com/proliferate-ai/proliferate/issues/2",
+            linearIssueUrl: null,
+          },
+        };
+      }
+      throw new Error(`Unexpected support endpoint: ${path}`);
     });
 
-    render(
-      <CloudSupportSurface
-        context={{
-          source: "settings",
-          intent: "general",
-          pathname: "/settings/support",
-        }}
-      />,
-    );
+    renderCloudSupportSurface();
 
     fireEvent.change(screen.getByPlaceholderText("What happened?"), {
       target: { value: "The workspace stopped syncing." },
@@ -153,11 +156,77 @@ describe("CloudSupportSurface", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send support message" }));
 
     await waitFor(() => {
-      const firstJobId = support.createSupportReport.mock.calls[0]?.[0]?.clientJobId;
-      const secondJobId = support.createSupportReport.mock.calls[1]?.[0]?.clientJobId;
-      expect(secondJobId).toBe(firstJobId);
-      expect(support.completeSupportReportUpload).not.toHaveBeenCalled();
-      expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-2");
+      expect(findPostCall("/v1/support/reports/{report_id}/tracker")).toBeTruthy();
+    });
+    const createBodies = postCalls("/v1/support/reports").map((call) =>
+      supportRequestBody(call[1])
+    );
+    expect(createBodies).toHaveLength(2);
+    expect(createBodies[1]?.clientJobId).toBe(createBodies[0]?.clientJobId);
+    expect(findPostCall("/v1/support/reports/{report_id}/complete")).toBeUndefined();
+    expect(findPostCall("/v1/support/reports/{report_id}/tracker")?.[1]).toEqual({
+      params: {
+        path: {
+          report_id: "report-2",
+        },
+      },
     });
   });
 });
+
+interface CloudPostOptions {
+  body?: unknown;
+  params?: unknown;
+}
+
+interface SupportReportCreateBody {
+  clientJobId: string;
+  message: string;
+  sourceSurface: string;
+  context: unknown;
+  scope: unknown;
+  workspaceRefs: unknown[];
+  expectedClientUploads: unknown;
+  publicContentConsent: boolean;
+}
+
+function renderCloudSupportSurface() {
+  render(
+    <CloudClientProvider client={support.client as unknown as ProliferateCloudClient}>
+      <CloudSupportSurface
+        context={{
+          source: "settings",
+          intent: "general",
+          pathname: "/settings/support",
+        }}
+      />
+    </CloudClientProvider>,
+  );
+}
+
+function postCalls(path: string): Array<[string, CloudPostOptions | undefined]> {
+  return support.client.POST.mock.calls.filter((call): call is [string, CloudPostOptions | undefined] =>
+    call[0] === path
+  );
+}
+
+function findPostCall(path: string): [string, CloudPostOptions | undefined] | undefined {
+  return postCalls(path)[0];
+}
+
+function supportRequestBody(options: CloudPostOptions | undefined): SupportReportCreateBody {
+  return options?.body as SupportReportCreateBody;
+}
+
+function serverCorrelation(reportId: string) {
+  return {
+    reportId,
+    ownerUserId: "user-1",
+    primaryTenantId: "user:user-1",
+    tenantIds: ["user:user-1"],
+    cloudWorkspaceIds: [],
+    cloudTargetIds: [],
+    anyharnessWorkspaceIds: [],
+    sessionIds: [],
+  };
+}

--- a/apps/packages/product-surfaces/src/support/CloudSupportSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/support/CloudSupportSurface.test.tsx
@@ -11,20 +11,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CloudSupportSurface } from "./CloudSupportSurface";
 
 const support = vi.hoisted(() => ({
-  client: { requestJson: vi.fn() },
   completeSupportReportUpload: vi.fn(),
   createSupportReport: vi.fn(),
   ensureSupportReportTracker: vi.fn(),
 }));
 
-vi.mock("@proliferate/cloud-sdk", () => ({
-  completeSupportReportUpload: support.completeSupportReportUpload,
-  createSupportReport: support.createSupportReport,
-  ensureSupportReportTracker: support.ensureSupportReportTracker,
-}));
-
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudClient: () => support.client,
+  useCloudSupportReportActions: () => ({
+    completeSupportReportUpload: support.completeSupportReportUpload,
+    createSupportReport: support.createSupportReport,
+    ensureSupportReportTracker: support.ensureSupportReportTracker,
+  }),
 }));
 
 afterEach(() => {
@@ -95,7 +92,6 @@ describe("CloudSupportSurface", () => {
           },
           publicContentConsent: true,
         },
-        support.client,
       );
     });
     expect(support.completeSupportReportUpload).toHaveBeenCalledWith(
@@ -104,9 +100,8 @@ describe("CloudSupportSurface", () => {
         diagnostics: null,
         attachments: [],
       }),
-      support.client,
     );
-    expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-1", support.client);
+    expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-1");
     expect(screen.queryByText("Support issue sent.")).not.toBeNull();
   });
 
@@ -162,7 +157,7 @@ describe("CloudSupportSurface", () => {
       const secondJobId = support.createSupportReport.mock.calls[1]?.[0]?.clientJobId;
       expect(secondJobId).toBe(firstJobId);
       expect(support.completeSupportReportUpload).not.toHaveBeenCalled();
-      expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-2", support.client);
+      expect(support.ensureSupportReportTracker).toHaveBeenCalledWith("report-2");
     });
   });
 });

--- a/apps/packages/product-surfaces/src/support/CloudSupportSurface.tsx
+++ b/apps/packages/product-surfaces/src/support/CloudSupportSurface.tsx
@@ -2,59 +2,21 @@ import type { SupportMessageContext } from "@proliferate/cloud-sdk";
 import { useCloudSupportReportActions } from "@proliferate/cloud-sdk-react";
 import type { SupportSurfaceSubmitInput } from "@proliferate/product-ui/support/SupportSurface";
 import { SupportSurface } from "@proliferate/product-ui/support/SupportSurface";
-import { useRef } from "react";
 
 export interface CloudSupportSurfaceProps {
   context: SupportMessageContext;
 }
 
 export function CloudSupportSurface({ context }: CloudSupportSurfaceProps) {
-  const {
-    completeSupportReportUpload,
-    createSupportReport,
-    ensureSupportReportTracker,
-  } = useCloudSupportReportActions();
-  const clientJobIdRef = useRef<string | null>(null);
+  const { submitSupportReport: submitCloudSupportReport } = useCloudSupportReportActions();
 
   async function submitSupportReport(input: SupportSurfaceSubmitInput) {
-    const clientJobId = clientJobIdRef.current ?? crypto.randomUUID();
-    clientJobIdRef.current = clientJobId;
-    const report = await createSupportReport(
-      {
-        clientJobId,
-        message: input.message,
-        sourceSurface: "web",
-        context,
-        scope: {
-          kind: "app_only",
-          workspaceIds: [],
-        },
-        workspaceRefs: [],
-        expectedClientUploads: {
-          diagnostics: false,
-          attachmentCount: 0,
-        },
-        publicContentConsent: input.publicContentConsent,
-      },
-    );
-    if (report.status !== "completed") {
-      await completeSupportReportUpload(
-        report.reportId,
-        {
-          diagnostics: null,
-          attachments: [],
-          packageManifest: {
-            schemaVersion: 1,
-            clientJobId,
-            reportId: report.reportId,
-            sourceSurface: "web",
-          },
-        },
-      );
-    }
-    clientJobIdRef.current = null;
-    void ensureSupportReportTracker(report.reportId).catch(() => undefined);
-    return undefined;
+    await submitCloudSupportReport({
+      message: input.message,
+      publicContentConsent: input.publicContentConsent,
+      context,
+      sourceSurface: "web",
+    });
   }
 
   return (

--- a/apps/packages/product-surfaces/src/support/CloudSupportSurface.tsx
+++ b/apps/packages/product-surfaces/src/support/CloudSupportSurface.tsx
@@ -1,10 +1,5 @@
-import {
-  completeSupportReportUpload,
-  createSupportReport,
-  ensureSupportReportTracker,
-  type SupportMessageContext,
-} from "@proliferate/cloud-sdk";
-import { useCloudClient } from "@proliferate/cloud-sdk-react";
+import type { SupportMessageContext } from "@proliferate/cloud-sdk";
+import { useCloudSupportReportActions } from "@proliferate/cloud-sdk-react";
 import type { SupportSurfaceSubmitInput } from "@proliferate/product-ui/support/SupportSurface";
 import { SupportSurface } from "@proliferate/product-ui/support/SupportSurface";
 import { useRef } from "react";
@@ -14,7 +9,11 @@ export interface CloudSupportSurfaceProps {
 }
 
 export function CloudSupportSurface({ context }: CloudSupportSurfaceProps) {
-  const client = useCloudClient();
+  const {
+    completeSupportReportUpload,
+    createSupportReport,
+    ensureSupportReportTracker,
+  } = useCloudSupportReportActions();
   const clientJobIdRef = useRef<string | null>(null);
 
   async function submitSupportReport(input: SupportSurfaceSubmitInput) {
@@ -37,7 +36,6 @@ export function CloudSupportSurface({ context }: CloudSupportSurfaceProps) {
         },
         publicContentConsent: input.publicContentConsent,
       },
-      client,
     );
     if (report.status !== "completed") {
       await completeSupportReportUpload(
@@ -52,11 +50,10 @@ export function CloudSupportSurface({ context }: CloudSupportSurfaceProps) {
             sourceSurface: "web",
           },
         },
-        client,
       );
     }
     clientJobIdRef.current = null;
-    void ensureSupportReportTracker(report.reportId, client).catch(() => undefined);
+    void ensureSupportReportTracker(report.reportId).catch(() => undefined);
     return undefined;
   }
 

--- a/cloud/sdk-react/src/hooks/support.ts
+++ b/cloud/sdk-react/src/hooks/support.ts
@@ -2,56 +2,76 @@ import {
   completeSupportReportUpload as completeSupportReportUploadWithClient,
   createSupportReport as createSupportReportWithClient,
   ensureSupportReportTracker as ensureSupportReportTrackerWithClient,
-  type SupportReportCompleteRequest,
-  type SupportReportCompleteResponse,
+  type SupportMessageContext,
   type SupportReportCreateRequest,
-  type SupportReportCreateResponse,
-  type SupportReportTrackerResponse,
 } from "@proliferate/cloud-sdk";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 
+export interface CloudSupportReportSubmitInput {
+  message: string;
+  publicContentConsent: boolean;
+  context: SupportMessageContext;
+  sourceSurface: SupportReportCreateRequest["sourceSurface"];
+}
+
 export interface CloudSupportReportActions {
-  createSupportReport: (
-    input: SupportReportCreateRequest,
-  ) => Promise<SupportReportCreateResponse>;
-  completeSupportReportUpload: (
-    reportId: string,
-    input: SupportReportCompleteRequest,
-  ) => Promise<SupportReportCompleteResponse>;
-  ensureSupportReportTracker: (
-    reportId: string,
-  ) => Promise<SupportReportTrackerResponse>;
+  submitSupportReport: (input: CloudSupportReportSubmitInput) => Promise<void>;
 }
 
 export function useCloudSupportReportActions(): CloudSupportReportActions {
   const client = useCloudClient();
+  const clientJobIdRef = useRef<string | null>(null);
 
-  const createSupportReport = useCallback(
-    (input: SupportReportCreateRequest) =>
-      createSupportReportWithClient(input, client),
-    [client],
-  );
-  const completeSupportReportUpload = useCallback(
-    (reportId: string, input: SupportReportCompleteRequest) =>
-      completeSupportReportUploadWithClient(reportId, input, client),
-    [client],
-  );
-  const ensureSupportReportTracker = useCallback(
-    (reportId: string) => ensureSupportReportTrackerWithClient(reportId, client),
+  const submitSupportReport = useCallback(
+    async (input: CloudSupportReportSubmitInput) => {
+      const clientJobId = clientJobIdRef.current ?? crypto.randomUUID();
+      clientJobIdRef.current = clientJobId;
+      const report = await createSupportReportWithClient(
+        {
+          clientJobId,
+          message: input.message,
+          sourceSurface: input.sourceSurface,
+          context: input.context,
+          scope: {
+            kind: "app_only",
+            workspaceIds: [],
+          },
+          workspaceRefs: [],
+          expectedClientUploads: {
+            diagnostics: false,
+            attachmentCount: 0,
+          },
+          publicContentConsent: input.publicContentConsent,
+        },
+        client,
+      );
+      if (report.status !== "completed") {
+        await completeSupportReportUploadWithClient(
+          report.reportId,
+          {
+            diagnostics: null,
+            attachments: [],
+            packageManifest: {
+              schemaVersion: 1,
+              clientJobId,
+              reportId: report.reportId,
+              sourceSurface: input.sourceSurface,
+            },
+          },
+          client,
+        );
+      }
+      clientJobIdRef.current = null;
+      void ensureSupportReportTrackerWithClient(report.reportId, client).catch(() => undefined);
+    },
     [client],
   );
 
   return useMemo(
     () => ({
-      createSupportReport,
-      completeSupportReportUpload,
-      ensureSupportReportTracker,
+      submitSupportReport,
     }),
-    [
-      completeSupportReportUpload,
-      createSupportReport,
-      ensureSupportReportTracker,
-    ],
+    [submitSupportReport],
   );
 }

--- a/cloud/sdk-react/src/hooks/support.ts
+++ b/cloud/sdk-react/src/hooks/support.ts
@@ -1,0 +1,57 @@
+import {
+  completeSupportReportUpload as completeSupportReportUploadWithClient,
+  createSupportReport as createSupportReportWithClient,
+  ensureSupportReportTracker as ensureSupportReportTrackerWithClient,
+  type SupportReportCompleteRequest,
+  type SupportReportCompleteResponse,
+  type SupportReportCreateRequest,
+  type SupportReportCreateResponse,
+  type SupportReportTrackerResponse,
+} from "@proliferate/cloud-sdk";
+import { useCallback, useMemo } from "react";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+
+export interface CloudSupportReportActions {
+  createSupportReport: (
+    input: SupportReportCreateRequest,
+  ) => Promise<SupportReportCreateResponse>;
+  completeSupportReportUpload: (
+    reportId: string,
+    input: SupportReportCompleteRequest,
+  ) => Promise<SupportReportCompleteResponse>;
+  ensureSupportReportTracker: (
+    reportId: string,
+  ) => Promise<SupportReportTrackerResponse>;
+}
+
+export function useCloudSupportReportActions(): CloudSupportReportActions {
+  const client = useCloudClient();
+
+  const createSupportReport = useCallback(
+    (input: SupportReportCreateRequest) =>
+      createSupportReportWithClient(input, client),
+    [client],
+  );
+  const completeSupportReportUpload = useCallback(
+    (reportId: string, input: SupportReportCompleteRequest) =>
+      completeSupportReportUploadWithClient(reportId, input, client),
+    [client],
+  );
+  const ensureSupportReportTracker = useCallback(
+    (reportId: string) => ensureSupportReportTrackerWithClient(reportId, client),
+    [client],
+  );
+
+  return useMemo(
+    () => ({
+      createSupportReport,
+      completeSupportReportUpload,
+      ensureSupportReportTracker,
+    }),
+    [
+      completeSupportReportUpload,
+      createSupportReport,
+      ensureSupportReportTracker,
+    ],
+  );
+}

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -16,6 +16,7 @@ export * from "./hooks/runtime-config.js";
 export * from "./hooks/repo-configs.js";
 export * from "./hooks/repos.js";
 export * from "./hooks/sessions.js";
+export * from "./hooks/support.js";
 export * from "./hooks/targets.js";
 export * from "./hooks/workspaces.js";
 export * from "./lib/client-cache.js";


### PR DESCRIPTION
## Summary
- Added `useCloudSupportReportActions` in `@proliferate/cloud-sdk-react` with a single `submitSupportReport` action that owns the app-only support-report lifecycle.
- Moved client job id generation/reuse, create, conditional zero-upload completion, package manifest creation, tracker nudge, and cleanup into SDK React.
- Kept `CloudSupportSurface` thin: it maps UI input plus support context into one SDK React submit action and passes that callback to `SupportSurface`.
- Updated the support surface test to use the real SDK React provider with a fake Cloud client, preserving assertions for create payload, completion manifest, tracker call, and retry job id reuse.

## Docs read
- `docs/README.md`
- `docs/tbd/structure-alignment-coordinator-model.md`
- `docs/tbd/frontend-structure-alignment-migration.md`
- `docs/structures/frontend/README.md`
- `docs/structures/frontend/packages/README.md`
- `docs/structures/frontend/guides/components.md`
- `docs/structures/frontend/guides/hooks.md`
- `docs/structures/frontend/guides/access.md`
- `docs/structures/frontend/guides/lib.md`
- `docs/features/support-reporting.md`

## Behavior
Behavior is preserved: the web support surface still creates a zero-upload app-only report, completes reports that are not already completed, reuses the pending `clientJobId` across failed submission retries, and nudges tracker creation after success.

## Checks
- `python3 scripts/report_frontend_structure.py --summary-only` passed (`FORBIDDEN_SHARED_PACKAGE_IMPORT: 0`)
- `python3 scripts/check_frontend_boundaries.py` passed
- `python3 scripts/check_max_lines.py` passed
- `git diff --check origin/main...HEAD` passed
- `pnpm --filter @proliferate/cloud-sdk-react typecheck` passed
- `pnpm --filter @proliferate/product-surfaces test` passed (3 files, 9 tests)
- Extra: `pnpm --filter @proliferate/product-surfaces typecheck` passed

## Remaining exceptions
None for this stream. The structure report still lists pre-existing report-only inventory outside this stream: `COMPONENT_TS_FILE: 2` and `LARGE_FRONTEND_FILE: 98`.
