### PR TITLE
refactor(server): thread cloud store db sessions

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -49,7 +49,7 @@ server/proliferate/server/cloud/agent_auth/models.py 508 server structure migrat
 server/proliferate/server/cloud/agent_auth/service.py 4908 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/commands/service.py 1740 server structure migration debt for oversized service file
-server/proliferate/server/cloud/mobility/service.py 1211 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1207 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/ensure_running.py 674 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/provision.py 1739 server structure migration debt for oversized domain-adjacent file
@@ -58,7 +58,7 @@ server/proliferate/server/cloud/runtime_config/service.py 1094 server structure 
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2642 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2641 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 871 existing server oversized integration test

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -69,7 +69,7 @@ server/tests/integration/test_cloud_commands_api.py 5139 existing server oversiz
 server/tests/integration/test_sandbox_profile_foundation.py 1400 existing server oversized integration test
 server/tests/integration/test_schema_migrations.py 925 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
-server/tests/unit/test_cloud_mobility_service.py 814 existing server oversized unit test
+server/tests/unit/test_cloud_mobility_service.py 806 existing server oversized unit test
 server/tests/unit/test_cloud_runtime_ensure_running.py 876 existing server oversized unit test
 server/tests/unit/test_cloud_runtime_provision.py 1803 existing server oversized unit test
 server/tests/unit/test_cloud_workspace_service.py 1319 existing server oversized unit test

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -38,21 +38,21 @@ server/proliferate/db/models/cloud/agent_auth.py 1030 server structure migration
 server/proliferate/db/store/automations.py 801 server structure migration debt for oversized store file
 server/proliferate/db/store/billing.py 2602 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_agent_auth/store.py 2607 server structure migration debt for oversized store file
-server/proliferate/db/store/cloud_mobility.py 1411 server structure migration debt for oversized store file
-server/proliferate/db/store/cloud_repo_config.py 720 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_mobility.py 1410 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_repo_config.py 719 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_sync/commands.py 1689 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration debt for oversized store file
-server/proliferate/db/store/cloud_workspaces.py 1642 server structure migration debt for oversized store file
+server/proliferate/db/store/cloud_workspaces.py 1639 server structure migration debt for oversized store file
 server/proliferate/server/billing/service.py 2460 server structure migration debt for oversized service file during billing orchestration consolidation
 server/proliferate/server/billing/stripe_webhooks.py 623 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/agent_auth/models.py 508 server structure migration debt for oversized API models file
 server/proliferate/server/cloud/agent_auth/service.py 4908 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/commands/service.py 1740 server structure migration debt for oversized service file
-server/proliferate/server/cloud/mobility/service.py 1208 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1207 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
-server/proliferate/server/cloud/runtime/ensure_running.py 667 server structure migration debt for oversized domain-adjacent file
-server/proliferate/server/cloud/runtime/provision.py 1727 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/ensure_running.py 664 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/provision.py 1730 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
@@ -65,11 +65,11 @@ server/tests/integration/test_billing_accounting.py 871 existing server oversize
 server/tests/integration/test_billing_api.py 2060 existing server oversized integration test
 server/tests/integration/test_cloud_agent_auth_api.py 1670 existing server oversized integration test
 server/tests/integration/test_cloud_api.py 2374 existing server oversized integration test
-server/tests/integration/test_cloud_commands_api.py 5140 existing server oversized integration test
+server/tests/integration/test_cloud_commands_api.py 5139 existing server oversized integration test
 server/tests/integration/test_sandbox_profile_foundation.py 1400 existing server oversized integration test
 server/tests/integration/test_schema_migrations.py 925 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
 server/tests/unit/test_cloud_mobility_service.py 808 existing server oversized unit test
 server/tests/unit/test_cloud_runtime_ensure_running.py 869 existing server oversized unit test
 server/tests/unit/test_cloud_runtime_provision.py 1803 existing server oversized unit test
-server/tests/unit/test_cloud_workspace_service.py 1322 existing server oversized unit test
+server/tests/unit/test_cloud_workspace_service.py 1315 existing server oversized unit test

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -49,16 +49,16 @@ server/proliferate/server/cloud/agent_auth/models.py 508 server structure migrat
 server/proliferate/server/cloud/agent_auth/service.py 4908 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/commands/service.py 1740 server structure migration debt for oversized service file
-server/proliferate/server/cloud/mobility/service.py 1207 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1211 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
-server/proliferate/server/cloud/runtime/ensure_running.py 664 server structure migration debt for oversized domain-adjacent file
-server/proliferate/server/cloud/runtime/provision.py 1730 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/ensure_running.py 674 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/cloud/runtime/provision.py 1739 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2621 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2642 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 871 existing server oversized integration test
@@ -69,7 +69,7 @@ server/tests/integration/test_cloud_commands_api.py 5139 existing server oversiz
 server/tests/integration/test_sandbox_profile_foundation.py 1400 existing server oversized integration test
 server/tests/integration/test_schema_migrations.py 925 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
-server/tests/unit/test_cloud_mobility_service.py 808 existing server oversized unit test
-server/tests/unit/test_cloud_runtime_ensure_running.py 869 existing server oversized unit test
+server/tests/unit/test_cloud_mobility_service.py 814 existing server oversized unit test
+server/tests/unit/test_cloud_runtime_ensure_running.py 876 existing server oversized unit test
 server/tests/unit/test_cloud_runtime_provision.py 1803 existing server oversized unit test
-server/tests/unit/test_cloud_workspace_service.py 1315 existing server oversized unit test
+server/tests/unit/test_cloud_workspace_service.py 1319 existing server oversized unit test

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -43,24 +43,4 @@ DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/targets/domain/policy.py
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/service.py 1 transitional agent auth deferred session commits materialization result
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 10 transitional Slack deferred handlers own isolated transactions
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/service.py 2 transitional worker lease/materialization flows commit before follow-up worker requests
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 5 transitional workspace sync/archive flows own isolated lifecycle transactions
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_mobility.py 6 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_runtime_environments.py 3 phase 8 runtime lifecycle wrappers own deliberate checkpoint transactions
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspace_setup_runs.py 4 transitional store owns transaction commit
-STORE_COMMIT_ROLLBACK server/proliferate/db/store/cloud_workspaces.py 14 transitional store owns transaction commit
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_mobility.py 9 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_repo_config.py 2 deferred runtime/workspace flows still use isolated repo-config reads
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_runtime_environments.py 7 phase 8 runtime lifecycle wrappers open isolated DB sessions
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspace_setup_runs.py 5 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_workspaces.py 24 transitional store opens DB session
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/organizations.py 1 transitional wrapper used by deferred organization/cloud callers
-STORE_SESSION_FACTORY_CALL server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_mobility.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_repo_config.py 1 deferred runtime/workspace flows still use isolated repo-config reads
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_runtime_environments.py 1 phase 8 runtime lifecycle wrappers import DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspace_setup_runs.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_workspaces.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/cloud_worktree_policy.py 1 deferred runtime policy sync still uses isolated policy read
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/organizations.py 1 transitional store imports DB session factory
-STORE_SESSION_FACTORY_IMPORT server/proliferate/db/store/users.py 1 deferred runtime/mobility/worker callers still use isolated OAuth-account user load
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 4 transitional workspace sync/archive flows own isolated lifecycle transactions

--- a/server/proliferate/db/store/automation_cloud_workspace_claims.py
+++ b/server/proliferate/db/store/automation_cloud_workspace_claims.py
@@ -178,7 +178,6 @@ async def _create_workspace_for_claimed_run(
             origin_json=origin_json,
             template_version=template_version,
             cloud_repo_limit=cloud_repo_limit,
-            commit=False,
         )
     run.cloud_workspace_id = workspace.id
     if target_id is not None:

--- a/server/proliferate/db/store/cloud_mobility.py
+++ b/server/proliferate/db/store/cloud_mobility.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.analytics import CloudWorkspaceMobilityEvent
 from proliferate.db.models.cloud.mobility import (
     CloudWorkspaceHandoffOp,
@@ -498,7 +497,7 @@ async def ensure_cloud_workspace_mobility(
             updated_at=now,
         )
         db.add(record)
-        await db.commit()
+        await db.flush()
         await db.refresh(record)
         return _mobility_value(record)
 
@@ -537,7 +536,7 @@ async def ensure_cloud_workspace_mobility(
         changed = True
     if changed:
         record.updated_at = now
-        await db.commit()
+        await db.flush()
         await db.refresh(record)
 
     active_handoff = None
@@ -634,7 +633,7 @@ async def create_cloud_workspace_handoff_op(
         occurred_at=now,
     )
 
-    await db.commit()
+    await db.flush()
     await db.refresh(record)
     await db.refresh(mobility_workspace)
     return _handoff_value(record)
@@ -1039,38 +1038,39 @@ async def fail_cloud_workspace_handoff_op(
 
 
 async def list_cloud_workspace_mobility_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
 ) -> list[CloudWorkspaceMobilityValue]:
-    async with db_engine.async_session_factory() as db:
-        records = await list_cloud_workspace_mobility(db, user_id=user_id)
-        values: list[CloudWorkspaceMobilityValue] = []
-        for record in records:
-            active_handoff = None
-            if record.active_handoff_op_id is not None:
-                active_handoff = await get_cloud_workspace_handoff_op(
-                    db,
-                    user_id=user_id,
-                    handoff_op_id=record.active_handoff_op_id,
-                )
-            values.append(_mobility_value(record, active_handoff=active_handoff))
-        return values
+    records = await list_cloud_workspace_mobility(db, user_id=user_id)
+    values: list[CloudWorkspaceMobilityValue] = []
+    for record in records:
+        active_handoff = None
+        if record.active_handoff_op_id is not None:
+            active_handoff = await get_cloud_workspace_handoff_op(
+                db,
+                user_id=user_id,
+                handoff_op_id=record.active_handoff_op_id,
+            )
+        values.append(_mobility_value(record, active_handoff=active_handoff))
+    return values
 
 
 async def load_cloud_workspace_mobility_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
 ) -> CloudWorkspaceMobilityValue | None:
-    async with db_engine.async_session_factory() as db:
-        return await load_cloud_workspace_mobility_value(
-            db,
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-        )
+    return await load_cloud_workspace_mobility_value(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
+    )
 
 
 async def ensure_cloud_workspace_mobility_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_provider: str,
@@ -1083,52 +1083,52 @@ async def ensure_cloud_workspace_mobility_for_user(
     display_name: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceMobilityValue:
-    async with db_engine.async_session_factory() as db:
-        return await ensure_cloud_workspace_mobility(
-            db,
-            user_id=user_id,
-            git_provider=git_provider,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            git_branch=git_branch,
-            owner_hint=owner_hint,
-            active_lifecycle_state=active_lifecycle_state,
-            is_retryable_failure=is_retryable_failure,
-            display_name=display_name,
-            cloud_workspace_id=cloud_workspace_id,
-        )
+    return await ensure_cloud_workspace_mobility(
+        db,
+        user_id=user_id,
+        git_provider=git_provider,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        git_branch=git_branch,
+        owner_hint=owner_hint,
+        active_lifecycle_state=active_lifecycle_state,
+        is_retryable_failure=is_retryable_failure,
+        display_name=display_name,
+        cloud_workspace_id=cloud_workspace_id,
+    )
 
 
 async def backfill_cloud_workspace_mobility_for_workspace(
+    db: AsyncSession,
     *,
     workspace: CloudWorkspace,
     active_lifecycle_state: str,
     is_retryable_failure: RetryableMobilityFailurePredicate,
 ) -> CloudWorkspaceMobilityValue:
-    async with db_engine.async_session_factory() as db:
-        return await backfill_cloud_workspace_mobility_from_workspace(
-            db,
-            workspace=workspace,
-            active_lifecycle_state=active_lifecycle_state,
-            is_retryable_failure=is_retryable_failure,
-        )
+    return await backfill_cloud_workspace_mobility_from_workspace(
+        db,
+        workspace=workspace,
+        active_lifecycle_state=active_lifecycle_state,
+        is_retryable_failure=is_retryable_failure,
+    )
 
 
 async def load_active_user_handoff_op_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     final_handoff_phases: tuple[str, ...],
 ) -> CloudWorkspaceHandoffOpValue | None:
-    async with db_engine.async_session_factory() as db:
-        record = await get_active_user_handoff_op(
-            db,
-            user_id=user_id,
-            final_handoff_phases=final_handoff_phases,
-        )
-        return _handoff_value(record) if record is not None else None
+    record = await get_active_user_handoff_op(
+        db,
+        user_id=user_id,
+        final_handoff_phases=final_handoff_phases,
+    )
+    return _handoff_value(record) if record is not None else None
 
 
 async def record_cloud_workspace_mobility_event_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     cloud_workspace_id: UUID | None,
@@ -1141,25 +1141,25 @@ async def record_cloud_workspace_mobility_event_for_user(
     to_phase: str | None = None,
     failure_code: str | None = None,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        _record_mobility_event(
-            db,
-            user_id=user_id,
-            cloud_workspace_id=cloud_workspace_id,
-            handoff_op_id=handoff_op_id,
-            event_type=event_type,
-            direction=direction,
-            source_owner=source_owner,
-            target_owner=target_owner,
-            from_phase=from_phase,
-            to_phase=to_phase,
-            failure_code=failure_code,
-            occurred_at=utcnow(),
-        )
-        await db.commit()
+    _record_mobility_event(
+        db,
+        user_id=user_id,
+        cloud_workspace_id=cloud_workspace_id,
+        handoff_op_id=handoff_op_id,
+        event_type=event_type,
+        direction=direction,
+        source_owner=source_owner,
+        target_owner=target_owner,
+        from_phase=from_phase,
+        to_phase=to_phase,
+        failure_code=failure_code,
+        occurred_at=utcnow(),
+    )
+    await db.flush()
 
 
 async def create_cloud_workspace_handoff_op_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -1172,32 +1172,31 @@ async def create_cloud_workspace_handoff_op_for_user(
     requested_base_sha: str | None,
     exclude_paths: list[str],
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        mobility_workspace = await get_cloud_workspace_mobility_for_update(
-            db,
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-        )
-        if mobility_workspace is None:
-            raise ValueError("mobility workspace not found")
-        existing_handoff = await get_active_handoff_for_mobility(
-            db,
-            mobility_workspace_id=mobility_workspace_id,
-            final_handoff_phases=final_handoff_phases,
-        )
-        if existing_handoff is not None:
-            raise ValueError("handoff already in progress for workspace")
-        return await create_cloud_workspace_handoff_op(
-            db,
-            mobility_workspace=mobility_workspace,
-            direction=direction,
-            source_owner=source_owner,
-            target_owner=target_owner,
-            moving_lifecycle_state=moving_lifecycle_state,
-            requested_branch=requested_branch,
-            requested_base_sha=requested_base_sha,
-            exclude_paths=exclude_paths,
-        )
+    mobility_workspace = await get_cloud_workspace_mobility_for_update(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
+    )
+    if mobility_workspace is None:
+        raise ValueError("mobility workspace not found")
+    existing_handoff = await get_active_handoff_for_mobility(
+        db,
+        mobility_workspace_id=mobility_workspace_id,
+        final_handoff_phases=final_handoff_phases,
+    )
+    if existing_handoff is not None:
+        raise ValueError("handoff already in progress for workspace")
+    return await create_cloud_workspace_handoff_op(
+        db,
+        mobility_workspace=mobility_workspace,
+        direction=direction,
+        source_owner=source_owner,
+        target_owner=target_owner,
+        moving_lifecycle_state=moving_lifecycle_state,
+        requested_branch=requested_branch,
+        requested_base_sha=requested_base_sha,
+        exclude_paths=exclude_paths,
+    )
 
 
 async def update_cloud_workspace_handoff_phase_for_user(
@@ -1234,6 +1233,7 @@ async def update_cloud_workspace_handoff_phase_for_user(
 
 
 async def update_cloud_workspace_handoff_phase_checkpoint_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -1242,18 +1242,17 @@ async def update_cloud_workspace_handoff_phase_checkpoint_for_user(
     status_detail: str | None,
     cloud_workspace_id: UUID | None = None,
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        value = await update_cloud_workspace_handoff_phase_for_user(
-            db,
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-            handoff_op_id=handoff_op_id,
-            phase=phase,
-            status_detail=status_detail,
-            cloud_workspace_id=cloud_workspace_id,
-        )
-        await db.commit()
-        return value
+    value = await update_cloud_workspace_handoff_phase_for_user(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
+        handoff_op_id=handoff_op_id,
+        phase=phase,
+        status_detail=status_detail,
+        cloud_workspace_id=cloud_workspace_id,
+    )
+    await db.flush()
+    return value
 
 
 async def heartbeat_cloud_workspace_handoff_op_for_user(
@@ -1379,6 +1378,7 @@ async def fail_cloud_workspace_handoff_op_for_user(
 
 
 async def fail_cloud_workspace_handoff_op_checkpoint_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     mobility_workspace_id: UUID,
@@ -1392,20 +1392,19 @@ async def fail_cloud_workspace_handoff_op_checkpoint_for_user(
     keep_active_handoff: bool = False,
     event_type: str = "handoff_failed",
 ) -> CloudWorkspaceHandoffOpValue:
-    async with db_engine.async_session_factory() as db:
-        value = await fail_cloud_workspace_handoff_op_for_user(
-            db,
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-            handoff_op_id=handoff_op_id,
-            phase=phase,
-            lifecycle_state=lifecycle_state,
-            failure_code=failure_code,
-            failure_detail=failure_detail,
-            status_detail=status_detail,
-            last_error=last_error,
-            keep_active_handoff=keep_active_handoff,
-            event_type=event_type,
-        )
-        await db.commit()
-        return value
+    value = await fail_cloud_workspace_handoff_op_for_user(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
+        handoff_op_id=handoff_op_id,
+        phase=phase,
+        lifecycle_state=lifecycle_state,
+        failure_code=failure_code,
+        failure_detail=failure_detail,
+        status_detail=status_detail,
+        last_error=last_error,
+        keep_active_handoff=keep_active_handoff,
+        event_type=event_type,
+    )
+    await db.flush()
+    return value

--- a/server/proliferate/db/store/cloud_repo_config.py
+++ b/server/proliferate/db/store/cloud_repo_config.py
@@ -11,7 +11,6 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig, CloudRepoFile
 from proliferate.db.store.billing import (
     acquire_billing_subject_repo_limit_lock,
@@ -689,32 +688,32 @@ async def bootstrap_cloud_repo_config(
 
 
 async def load_cloud_repo_config_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
 ) -> CloudRepoConfigValue | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_repo_config(
-            db,
-            user_id=user_id,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-        )
+    return await get_cloud_repo_config(
+        db,
+        user_id=user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+    )
 
 
 async def bootstrap_cloud_repo_config_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
     cloud_repo_limit: int | None,
 ) -> CloudRepoConfigValue:
-    async with db_engine.async_session_factory() as db, db.begin():
-        return await bootstrap_cloud_repo_config(
-            db,
-            user_id=user_id,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            cloud_repo_limit=cloud_repo_limit,
-        )
+    return await bootstrap_cloud_repo_config(
+        db,
+        user_id=user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        cloud_repo_limit=cloud_repo_limit,
+    )

--- a/server/proliferate/db/store/cloud_runtime_environments.py
+++ b/server/proliferate/db/store/cloud_runtime_environments.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
@@ -16,7 +14,6 @@ from proliferate.constants.cloud import (
     CloudRuntimeEnvironmentStatus,
     CloudRuntimeIsolationPolicy,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.runtime_environments import CloudRuntimeEnvironment
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
@@ -282,70 +279,47 @@ async def persist_runtime_environment_state(
 
 
 async def ensure_runtime_environment_for_workspace_id(
+    db: AsyncSession,
     workspace_id: UUID,
 ) -> CloudRuntimeEnvironment | None:
-    async with db_engine.async_session_factory() as db:
-        workspace = await db.get(CloudWorkspace, workspace_id)
-        if workspace is None:
-            return None
-        environment = await ensure_runtime_environment_for_workspace(db, workspace)
-        await db.commit()
-        await db.refresh(environment)
-        return environment
+    workspace = await db.get(CloudWorkspace, workspace_id)
+    if workspace is None:
+        return None
+    environment = await ensure_runtime_environment_for_workspace(db, workspace)
+    await db.flush()
+    await db.refresh(environment)
+    return environment
 
 
 async def load_runtime_environment_by_id(
+    db: AsyncSession,
     runtime_environment_id: UUID,
 ) -> CloudRuntimeEnvironment | None:
-    async with db_engine.async_session_factory() as db:
-        return await db.get(CloudRuntimeEnvironment, runtime_environment_id)
-
-
-@asynccontextmanager
-async def runtime_environment_credential_apply_lock(
-    runtime_environment_id: UUID,
-) -> AsyncIterator[None]:
-    """Serialize credential apply operations for a runtime environment."""
-
-    async with db_engine.async_session_factory() as db:
-        dialect_name = db.get_bind().dialect.name
-        lock_key = f"runtime-credentials:{runtime_environment_id}"
-        if dialect_name == "postgresql":
-            await db.execute(
-                text("SELECT pg_advisory_lock(hashtextextended(:lock_key, 0))"),
-                {"lock_key": lock_key},
-            )
-        try:
-            yield
-        finally:
-            if dialect_name == "postgresql":
-                await db.execute(
-                    text("SELECT pg_advisory_unlock(hashtextextended(:lock_key, 0))"),
-                    {"lock_key": lock_key},
-                )
+    return await db.get(CloudRuntimeEnvironment, runtime_environment_id)
 
 
 async def load_runtime_environment_for_workspace(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> CloudRuntimeEnvironment | None:
     if workspace.runtime_environment_id is None:
         return None
-    async with db_engine.async_session_factory() as db:
-        return await db.get(CloudRuntimeEnvironment, workspace.runtime_environment_id)
+    return await db.get(CloudRuntimeEnvironment, workspace.runtime_environment_id)
 
 
 async def load_runtime_environment_with_sandbox(
+    db: AsyncSession,
     runtime_environment_id: UUID,
 ) -> RuntimeEnvironmentWithSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        environment = await db.get(CloudRuntimeEnvironment, runtime_environment_id)
-        if environment is None:
-            return None
-        sandbox = await get_active_sandbox_for_environment(db, environment)
-        return RuntimeEnvironmentWithSandbox(environment=environment, sandbox=sandbox)
+    environment = await db.get(CloudRuntimeEnvironment, runtime_environment_id)
+    if environment is None:
+        return None
+    sandbox = await get_active_sandbox_for_environment(db, environment)
+    return RuntimeEnvironmentWithSandbox(environment=environment, sandbox=sandbox)
 
 
 async def reserve_and_attach_sandbox_for_environment(
+    db: AsyncSession,
     runtime_environment_id: UUID,
     *,
     external_sandbox_id: str | None,
@@ -357,34 +331,33 @@ async def reserve_and_attach_sandbox_for_environment(
     sandbox_profile_id: UUID | None = None,
     target_id: UUID | None = None,
 ) -> CloudSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        sandbox = await reserve_sandbox_slot_for_environment(
-            db,
-            runtime_environment_id=runtime_environment_id,
-            external_sandbox_id=external_sandbox_id,
-            provider=provider,
-            template_version=template_version,
-            status=status,
-            started_at=started_at,
-            concurrent_sandbox_limit=concurrent_sandbox_limit,
-            sandbox_profile_id=sandbox_profile_id,
-            target_id=target_id,
-        )
-        await db.commit()
-        if sandbox is not None:
-            await db.refresh(sandbox)
-        return sandbox
+    sandbox = await reserve_sandbox_slot_for_environment(
+        db,
+        runtime_environment_id=runtime_environment_id,
+        external_sandbox_id=external_sandbox_id,
+        provider=provider,
+        template_version=template_version,
+        status=status,
+        started_at=started_at,
+        concurrent_sandbox_limit=concurrent_sandbox_limit,
+        sandbox_profile_id=sandbox_profile_id,
+        target_id=target_id,
+    )
+    await db.flush()
+    if sandbox is not None:
+        await db.refresh(sandbox)
+    return sandbox
 
 
 async def save_runtime_environment_state(
+    db: AsyncSession,
     runtime_environment_id: UUID,
     **kwargs: object,
 ) -> CloudRuntimeEnvironment:
-    async with db_engine.async_session_factory() as db:
-        environment = await db.get(CloudRuntimeEnvironment, runtime_environment_id)
-        if environment is None:
-            raise RuntimeError("Runtime environment not found.")
-        updated = await persist_runtime_environment_state(db, environment, **kwargs)
-        await db.commit()
-        await db.refresh(updated)
-        return updated
+    environment = await db.get(CloudRuntimeEnvironment, runtime_environment_id)
+    if environment is None:
+        raise RuntimeError("Runtime environment not found.")
+    updated = await persist_runtime_environment_state(db, environment, **kwargs)
+    await db.flush()
+    await db.refresh(updated)
+    return updated

--- a/server/proliferate/db/store/cloud_workspace_setup_runs.py
+++ b/server/proliferate/db/store/cloud_workspace_setup_runs.py
@@ -14,7 +14,6 @@ from proliferate.constants.cloud import (
     SETUP_RUN_ACTIVE_STATUSES,
     SETUP_RUN_STATUS_RUNNING,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.workspaces import CloudWorkspace, CloudWorkspaceSetupRun
 from proliferate.utils.time import utcnow
 
@@ -60,6 +59,7 @@ class SetupRunFinalizationClassifier(Protocol):
 
 
 async def create_cloud_workspace_setup_run(
+    db: AsyncSession,
     *,
     workspace_id: UUID,
     anyharness_workspace_id: str,
@@ -70,39 +70,39 @@ async def create_cloud_workspace_setup_run(
     deadline_at: datetime,
     status: str = SETUP_RUN_STATUS_RUNNING,
 ) -> CloudWorkspaceSetupRun:
-    async with db_engine.async_session_factory() as db:
-        now = utcnow()
-        run = CloudWorkspaceSetupRun(
-            workspace_id=workspace_id,
-            anyharness_workspace_id=anyharness_workspace_id,
-            terminal_id=terminal_id,
-            command_run_id=command_run_id,
-            setup_script_version=setup_script_version,
-            apply_token=apply_token,
-            status=status,
-            deadline_at=deadline_at,
-            claim_owner=None,
-            claim_until=None,
-            last_polled_at=None,
-            next_poll_at=now,
-            last_error=None,
-            created_at=now,
-            updated_at=now,
-        )
-        db.add(run)
-        await db.commit()
-        await db.refresh(run)
-        return run
+    now = utcnow()
+    run = CloudWorkspaceSetupRun(
+        workspace_id=workspace_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        terminal_id=terminal_id,
+        command_run_id=command_run_id,
+        setup_script_version=setup_script_version,
+        apply_token=apply_token,
+        status=status,
+        deadline_at=deadline_at,
+        claim_owner=None,
+        claim_until=None,
+        last_polled_at=None,
+        next_poll_at=now,
+        last_error=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(run)
+    await db.flush()
+    await db.refresh(run)
+    return run
 
 
 async def load_cloud_workspace_setup_run(
+    db: AsyncSession,
     setup_run_id: UUID,
 ) -> CloudWorkspaceSetupRun | None:
-    async with db_engine.async_session_factory() as db:
-        return await db.get(CloudWorkspaceSetupRun, setup_run_id)
+    return await db.get(CloudWorkspaceSetupRun, setup_run_id)
 
 
 async def claim_due_setup_runs(
+    db: AsyncSession,
     *,
     owner: str,
     limit: int = 10,
@@ -110,40 +110,40 @@ async def claim_due_setup_runs(
 ) -> list[CloudWorkspaceSetupRun]:
     now = now or utcnow()
     claim_until = now + SETUP_MONITOR_CLAIM_TTL
-    async with db_engine.async_session_factory() as db:
-        runs = list(
-            (
-                await db.execute(
-                    select(CloudWorkspaceSetupRun)
-                    .where(
-                        CloudWorkspaceSetupRun.status.in_(SETUP_RUN_ACTIVE_STATUSES),
-                        or_(
-                            CloudWorkspaceSetupRun.next_poll_at.is_(None),
-                            CloudWorkspaceSetupRun.next_poll_at <= now,
-                            CloudWorkspaceSetupRun.deadline_at <= now,
-                        ),
-                        or_(
-                            CloudWorkspaceSetupRun.claim_until.is_(None),
-                            CloudWorkspaceSetupRun.claim_until <= now,
-                        ),
-                    )
-                    .order_by(CloudWorkspaceSetupRun.next_poll_at.asc().nullsfirst())
-                    .limit(limit)
-                    .with_for_update(skip_locked=True)
+    runs = list(
+        (
+            await db.execute(
+                select(CloudWorkspaceSetupRun)
+                .where(
+                    CloudWorkspaceSetupRun.status.in_(SETUP_RUN_ACTIVE_STATUSES),
+                    or_(
+                        CloudWorkspaceSetupRun.next_poll_at.is_(None),
+                        CloudWorkspaceSetupRun.next_poll_at <= now,
+                        CloudWorkspaceSetupRun.deadline_at <= now,
+                    ),
+                    or_(
+                        CloudWorkspaceSetupRun.claim_until.is_(None),
+                        CloudWorkspaceSetupRun.claim_until <= now,
+                    ),
                 )
+                .order_by(CloudWorkspaceSetupRun.next_poll_at.asc().nullsfirst())
+                .limit(limit)
+                .with_for_update(skip_locked=True)
             )
-            .scalars()
-            .all()
         )
-        for run in runs:
-            run.claim_owner = owner
-            run.claim_until = claim_until
-            run.updated_at = now
-        await db.commit()
-        return runs
+        .scalars()
+        .all()
+    )
+    for run in runs:
+        run.claim_owner = owner
+        run.claim_until = claim_until
+        run.updated_at = now
+    await db.flush()
+    return runs
 
 
 async def release_setup_run_claim(
+    db: AsyncSession,
     setup_run_id: UUID,
     *,
     bound_error: SetupMonitorErrorBounder,
@@ -151,22 +151,22 @@ async def release_setup_run_claim(
     next_poll_at: datetime | None = None,
     last_error: str | None = None,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        run = await db.get(CloudWorkspaceSetupRun, setup_run_id)
-        if run is None:
-            return
-        now = utcnow()
-        run.status = status
-        run.claim_owner = None
-        run.claim_until = None
-        run.last_polled_at = now
-        run.next_poll_at = next_poll_at or (now + SETUP_MONITOR_POLL_INTERVAL)
-        run.last_error = bound_error(last_error)
-        run.updated_at = now
-        await db.commit()
+    run = await db.get(CloudWorkspaceSetupRun, setup_run_id)
+    if run is None:
+        return
+    now = utcnow()
+    run.status = status
+    run.claim_owner = None
+    run.claim_until = None
+    run.last_polled_at = now
+    run.next_poll_at = next_poll_at or (now + SETUP_MONITOR_POLL_INTERVAL)
+    run.last_error = bound_error(last_error)
+    run.updated_at = now
+    await db.flush()
 
 
 async def finalize_setup_run(
+    db: AsyncSession,
     setup_run_id: UUID,
     *,
     classify_finalization: SetupRunFinalizationClassifier,
@@ -174,16 +174,15 @@ async def finalize_setup_run(
     success: bool,
     last_error: str | None = None,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        await _finalize_setup_run(
-            db,
-            setup_run_id,
-            classify_finalization,
-            final_status,
-            success,
-            last_error,
-        )
-        await db.commit()
+    await _finalize_setup_run(
+        db,
+        setup_run_id,
+        classify_finalization,
+        final_status,
+        success,
+        last_error,
+    )
+    await db.flush()
 
 
 async def _finalize_setup_run(
@@ -240,11 +239,13 @@ async def _finalize_setup_run(
 
 
 async def mark_setup_run_timed_out(
+    db: AsyncSession,
     setup_run_id: UUID,
     *,
     classify_finalization: SetupRunFinalizationClassifier,
 ) -> None:
     await finalize_setup_run(
+        db,
         setup_run_id,
         classify_finalization=classify_finalization,
         final_status="timed_out",

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -24,7 +24,6 @@ from proliferate.constants.organizations import (
     ORGANIZATION_ROLE_ADMIN,
     ORGANIZATION_ROLE_OWNER,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.exposures import CloudWorkspaceExposure
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
@@ -387,7 +386,6 @@ async def create_cloud_workspace_record(
     origin: str = "manual_desktop",
     repo_env_vars_ciphertext: str | None = None,
     cloud_repo_limit: int | None = None,
-    commit: bool = True,
 ) -> CloudWorkspace:
     now = utcnow()
     billing_subject = await ensure_personal_billing_subject(db, user_id)
@@ -442,11 +440,8 @@ async def create_cloud_workspace_record(
         updated_at=now,
     )
     db.add(workspace)
-    if commit:
-        await db.commit()
-        await db.refresh(workspace)
-    else:
-        await db.flush()
+    await db.flush()
+    await db.refresh(workspace)
     return workspace
 
 
@@ -654,7 +649,7 @@ async def delete_cloud_workspace_records(
     workspace: CloudWorkspace,
 ) -> None:
     await archive_cloud_workspace_record(db, workspace=workspace)
-    await db.commit()
+    await db.flush()
 
 
 async def archive_cloud_workspace_record(
@@ -878,7 +873,7 @@ async def reserve_sandbox_slot_for_workspace(
     await db.flush()
     workspace.active_sandbox_id = sandbox.id
     workspace.updated_at = now
-    await db.commit()
+    await db.flush()
     await db.refresh(sandbox)
     return sandbox
 
@@ -891,14 +886,14 @@ async def persist_sandbox_status(
     stopped_at_now: bool = False,
     started_at: datetime | None = None,
 ) -> None:
-    """Update sandbox status and commit."""
+    """Update sandbox status."""
     sandbox.status = status
     sandbox.updated_at = utcnow()
     if started_at is not None:
         sandbox.started_at = started_at
     if stopped_at_now:
         sandbox.stopped_at = utcnow()
-    await db.commit()
+    await db.flush()
 
 
 async def persist_workspace_record(
@@ -906,7 +901,7 @@ async def persist_workspace_record(
     workspace: CloudWorkspace,
 ) -> CloudWorkspace:
     workspace.updated_at = utcnow()
-    await db.commit()
+    await db.flush()
     await db.refresh(workspace)
     return workspace
 
@@ -915,21 +910,20 @@ async def persist_workspace_stop(
     db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> None:
-    """Commit the workspace after the service has applied the ready transition."""
-    await db.commit()
+    await db.flush()
 
 
 async def persist_workspace_destroy(
     db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> None:
-    """Clear runtime metadata and commit after the service has applied the stopped transition."""
+    """Clear runtime metadata after the service has applied the stopped transition."""
     workspace.active_sandbox_id = None
     workspace.runtime_url = None
     workspace.runtime_token_ciphertext = None
     workspace.anyharness_workspace_id = None
     workspace.stopped_at = utcnow()
-    await db.commit()
+    await db.flush()
 
 
 async def persist_bound_sandbox(
@@ -945,7 +939,7 @@ async def persist_bound_sandbox(
     sandbox.started_at = started_at
     sandbox.stopped_at = None
     sandbox.updated_at = utcnow()
-    await db.commit()
+    await db.flush()
     await db.refresh(sandbox)
     return sandbox
 
@@ -986,7 +980,7 @@ async def persist_sandbox_provider_state(
             replaced_sandbox_id=sandbox.id,
             replaced_slot_generation=sandbox.slot_generation,
         )
-    await db.commit()
+    await db.flush()
     await db.refresh(sandbox)
     return sandbox
 
@@ -1020,7 +1014,7 @@ async def finalize_workspace_provision(
         workspace=workspace,
         anyharness_workspace_id=anyharness_workspace_id,
     )
-    await db.commit()
+    await db.flush()
     await db.refresh(workspace)
     await db.refresh(sandbox)
     return workspace
@@ -1125,7 +1119,7 @@ async def persist_runtime_reconnect_state(
     workspace.updated_at = utcnow()
     if restarted_runtime:
         workspace.runtime_generation = workspace.runtime_generation + 1
-    await db.commit()
+    await db.flush()
     await db.refresh(workspace)
     await db.refresh(sandbox)
     return sandbox
@@ -1153,7 +1147,7 @@ async def update_workspace_status(
     workspace.status = status.value if hasattr(status, "value") else str(status)
     workspace.status_detail = status_detail
     workspace.updated_at = utcnow()
-    await db.commit()
+    await db.flush()
 
 
 async def attach_anyharness_workspace_id(
@@ -1245,29 +1239,31 @@ async def update_workspace_repo_apply_status(
     if status_detail is not _UNSET:
         workspace.status_detail = status_detail
     workspace.updated_at = utcnow()
-    await db.commit()
+    await db.flush()
     await db.refresh(workspace)
     return workspace
 
 
 async def update_workspace_status_by_id(
+    db: AsyncSession,
     workspace_id: UUID,
     status: CloudWorkspaceStatus | WorkspaceStatus | str,
     status_detail: str,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        await update_workspace_status(db, workspace_id, status, status_detail)
+    await update_workspace_status(db, workspace_id, status, status_detail)
 
 
 @asynccontextmanager
-async def workspace_repo_apply_lock(workspace_id: UUID) -> AsyncIterator[bool]:
-    async with db_engine.async_session_factory() as db:
-        acquired = await try_acquire_workspace_repo_apply_lock(db, workspace_id)
-        try:
-            yield acquired
-        finally:
-            if acquired:
-                await release_workspace_repo_apply_lock(db, workspace_id)
+async def workspace_repo_apply_lock(
+    db: AsyncSession,
+    workspace_id: UUID,
+) -> AsyncIterator[bool]:
+    acquired = await try_acquire_workspace_repo_apply_lock(db, workspace_id)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            await release_workspace_repo_apply_lock(db, workspace_id)
 
 
 async def mark_workspace_error(
@@ -1305,30 +1301,33 @@ async def mark_workspace_error(
         if sandbox is not None:
             sandbox.status = "error"
             sandbox.updated_at = utcnow()
-    await db.commit()
+    await db.flush()
 
 
-async def list_cloud_workspaces_for_user(user_id: UUID) -> list[CloudWorkspace]:
-    async with db_engine.async_session_factory() as db:
-        return await list_cloud_workspaces(db, user_id)
+async def list_cloud_workspaces_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> list[CloudWorkspace]:
+    return await list_cloud_workspaces(db, user_id)
 
 
 async def load_cloud_workspace_for_user(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_workspace_for_user(db, user_id, workspace_id)
+    return await get_cloud_workspace_for_user(db, user_id, workspace_id)
 
 
 async def load_cloud_workspace_by_id(
+    db: AsyncSession,
     workspace_id: UUID,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_workspace_by_id(db, workspace_id)
+    return await get_cloud_workspace_by_id(db, workspace_id)
 
 
 async def load_existing_cloud_workspace(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_provider: str,
@@ -1336,39 +1335,39 @@ async def load_existing_cloud_workspace(
     git_repo_name: str,
     git_branch: str,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_existing_cloud_workspace(
-            db,
-            user_id=user_id,
-            git_provider=git_provider,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            git_branch=git_branch,
-        )
+    return await get_existing_cloud_workspace(
+        db,
+        user_id=user_id,
+        git_provider=git_provider,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        git_branch=git_branch,
+    )
 
 
 async def load_any_cloud_workspace_for_repo(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        return (
-            await db.execute(
-                select(CloudWorkspace)
-                .where(
-                    CloudWorkspace.owner_scope == "personal",
-                    CloudWorkspace.owner_user_id == user_id,
-                    CloudWorkspace.git_owner == git_owner,
-                    CloudWorkspace.git_repo_name == git_repo_name,
-                )
-                .order_by(CloudWorkspace.updated_at.desc())
+    return (
+        await db.execute(
+            select(CloudWorkspace)
+            .where(
+                CloudWorkspace.owner_scope == "personal",
+                CloudWorkspace.owner_user_id == user_id,
+                CloudWorkspace.git_owner == git_owner,
+                CloudWorkspace.git_repo_name == git_repo_name,
             )
-        ).scalar_one_or_none()
+            .order_by(CloudWorkspace.updated_at.desc())
+        )
+    ).scalar_one_or_none()
 
 
 async def create_cloud_workspace_for_user(
+    db: AsyncSession,
     *,
     user_id: UUID,
     display_name: str | None,
@@ -1383,59 +1382,58 @@ async def create_cloud_workspace_for_user(
     repo_env_vars_ciphertext: str | None = None,
     cloud_repo_limit: int | None = None,
 ) -> CloudWorkspace:
-    async with db_engine.async_session_factory() as db:
-        return await create_cloud_workspace_record(
-            db,
-            user_id=user_id,
-            display_name=display_name,
-            git_provider=git_provider,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            git_branch=git_branch,
-            git_base_branch=git_base_branch,
-            origin=origin,
-            origin_json=origin_json,
-            template_version=template_version,
-            repo_env_vars_ciphertext=repo_env_vars_ciphertext,
-            cloud_repo_limit=cloud_repo_limit,
-        )
+    return await create_cloud_workspace_record(
+        db,
+        user_id=user_id,
+        display_name=display_name,
+        git_provider=git_provider,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        git_branch=git_branch,
+        git_base_branch=git_base_branch,
+        origin=origin,
+        origin_json=origin_json,
+        template_version=template_version,
+        repo_env_vars_ciphertext=repo_env_vars_ciphertext,
+        cloud_repo_limit=cloud_repo_limit,
+    )
 
 
 async def load_active_sandbox_for_workspace(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> CloudSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_active_sandbox(db, workspace)
+    return await get_active_sandbox(db, workspace)
 
 
 async def load_cloud_sandbox_by_id(
+    db: AsyncSession,
     sandbox_id: UUID,
 ) -> CloudSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_sandbox_by_id(db, sandbox_id)
+    return await get_cloud_sandbox_by_id(db, sandbox_id)
 
 
 async def load_cloud_sandbox_by_external_id(
+    db: AsyncSession,
     external_sandbox_id: str,
 ) -> CloudSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_sandbox_by_external_id(db, external_sandbox_id)
+    return await get_cloud_sandbox_by_external_id(db, external_sandbox_id)
 
 
-async def load_cloud_sandbox_placeholders() -> list[CloudSandbox]:
-    async with db_engine.async_session_factory() as db:
-        return await list_cloud_sandbox_placeholders(db)
+async def load_cloud_sandbox_placeholders(db: AsyncSession) -> list[CloudSandbox]:
+    return await list_cloud_sandbox_placeholders(db)
 
 
 async def save_workspace(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> CloudWorkspace:
-    async with db_engine.async_session_factory() as db:
-        merged = await db.merge(workspace)
-        return await persist_workspace_record(db, merged)
+    merged = await db.merge(workspace)
+    return await persist_workspace_record(db, merged)
 
 
 async def reserve_and_attach_sandbox_for_workspace(
+    db: AsyncSession,
     workspace_id: UUID,
     *,
     external_sandbox_id: str | None,
@@ -1445,40 +1443,40 @@ async def reserve_and_attach_sandbox_for_workspace(
     started_at: datetime | None = None,
     concurrent_sandbox_limit: int | None,
 ) -> CloudSandbox | None:
-    async with db_engine.async_session_factory() as db:
-        return await reserve_sandbox_slot_for_workspace(
-            db,
-            workspace_id=workspace_id,
-            external_sandbox_id=external_sandbox_id,
-            provider=provider,
-            template_version=template_version,
-            status=status,
-            started_at=started_at,
-            concurrent_sandbox_limit=concurrent_sandbox_limit,
-        )
+    return await reserve_sandbox_slot_for_workspace(
+        db,
+        workspace_id=workspace_id,
+        external_sandbox_id=external_sandbox_id,
+        provider=provider,
+        template_version=template_version,
+        status=status,
+        started_at=started_at,
+        concurrent_sandbox_limit=concurrent_sandbox_limit,
+    )
 
 
 async def bind_allocated_sandbox(
+    db: AsyncSession,
     sandbox_id: UUID,
     *,
     external_sandbox_id: str,
     status: str = "provisioning",
     started_at: datetime | None,
 ) -> CloudSandbox:
-    async with db_engine.async_session_factory() as db:
-        sandbox = await get_cloud_sandbox_by_id(db, sandbox_id)
-        if sandbox is None:
-            raise RuntimeError("Sandbox placeholder disappeared before provider allocation.")
-        return await persist_bound_sandbox(
-            db,
-            sandbox,
-            external_sandbox_id=external_sandbox_id,
-            status=status,
-            started_at=started_at,
-        )
+    sandbox = await get_cloud_sandbox_by_id(db, sandbox_id)
+    if sandbox is None:
+        raise RuntimeError("Sandbox placeholder disappeared before provider allocation.")
+    return await persist_bound_sandbox(
+        db,
+        sandbox,
+        external_sandbox_id=external_sandbox_id,
+        status=status,
+        started_at=started_at,
+    )
 
 
 async def finalize_workspace_provision_for_ids(
+    db: AsyncSession,
     workspace_id: UUID,
     sandbox_record_id: UUID,
     *,
@@ -1487,23 +1485,23 @@ async def finalize_workspace_provision_for_ids(
     anyharness_workspace_id: str,
     template_version: str,
 ) -> CloudWorkspace:
-    async with db_engine.async_session_factory() as db:
-        workspace = await get_cloud_workspace_by_id(db, workspace_id)
-        sandbox = await db.get(CloudSandbox, sandbox_record_id)
-        if workspace is None or sandbox is None:
-            raise RuntimeError("Workspace or sandbox record disappeared before finalization.")
-        return await finalize_workspace_provision(
-            db,
-            workspace,
-            sandbox,
-            runtime_url=runtime_url,
-            runtime_token_ciphertext=runtime_token_ciphertext,
-            anyharness_workspace_id=anyharness_workspace_id,
-            template_version=template_version,
-        )
+    workspace = await get_cloud_workspace_by_id(db, workspace_id)
+    sandbox = await db.get(CloudSandbox, sandbox_record_id)
+    if workspace is None or sandbox is None:
+        raise RuntimeError("Workspace or sandbox record disappeared before finalization.")
+    return await finalize_workspace_provision(
+        db,
+        workspace,
+        sandbox,
+        runtime_url=runtime_url,
+        runtime_token_ciphertext=runtime_token_ciphertext,
+        anyharness_workspace_id=anyharness_workspace_id,
+        template_version=template_version,
+    )
 
 
 async def update_workspace_repo_apply_status_by_id(
+    db: AsyncSession,
     workspace_id: UUID,
     *,
     repo_files_applied_version: int | object = _UNSET,
@@ -1518,86 +1516,86 @@ async def update_workspace_repo_apply_status_by_id(
     repo_files_last_error: str | None | object = _UNSET,
     status_detail: str | None | object = _UNSET,
 ) -> CloudWorkspace | None:
-    async with db_engine.async_session_factory() as db:
-        return await update_workspace_repo_apply_status(
-            db,
-            workspace_id,
-            repo_files_applied_version=repo_files_applied_version,
-            repo_files_applied_at=repo_files_applied_at,
-            repo_post_ready_phase=repo_post_ready_phase,
-            repo_post_ready_files_total=repo_post_ready_files_total,
-            repo_post_ready_files_applied=repo_post_ready_files_applied,
-            repo_post_ready_apply_token=repo_post_ready_apply_token,
-            repo_post_ready_started_at=repo_post_ready_started_at,
-            repo_post_ready_completed_at=repo_post_ready_completed_at,
-            repo_files_last_failed_path=repo_files_last_failed_path,
-            repo_files_last_error=repo_files_last_error,
-            status_detail=status_detail,
-        )
+    return await update_workspace_repo_apply_status(
+        db,
+        workspace_id,
+        repo_files_applied_version=repo_files_applied_version,
+        repo_files_applied_at=repo_files_applied_at,
+        repo_post_ready_phase=repo_post_ready_phase,
+        repo_post_ready_files_total=repo_post_ready_files_total,
+        repo_post_ready_files_applied=repo_post_ready_files_applied,
+        repo_post_ready_apply_token=repo_post_ready_apply_token,
+        repo_post_ready_started_at=repo_post_ready_started_at,
+        repo_post_ready_completed_at=repo_post_ready_completed_at,
+        repo_files_last_failed_path=repo_files_last_failed_path,
+        repo_files_last_error=repo_files_last_error,
+        status_detail=status_detail,
+    )
 
 
 async def persist_workspace_stop_state(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        merged = await db.merge(workspace)
-        await persist_workspace_stop(db, merged)
+    merged = await db.merge(workspace)
+    await persist_workspace_stop(db, merged)
 
 
 async def persist_workspace_destroy_state(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        merged = await db.merge(workspace)
-        await persist_workspace_destroy(db, merged)
+    merged = await db.merge(workspace)
+    await persist_workspace_destroy(db, merged)
 
 
 async def update_sandbox_status(
+    db: AsyncSession,
     sandbox: CloudSandbox,
     status: str,
     *,
     stopped_at_now: bool = False,
     started_at: datetime | None = None,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        merged = await db.merge(sandbox)
-        await persist_sandbox_status(
-            db,
-            merged,
-            status,
-            stopped_at_now=stopped_at_now,
-            started_at=started_at,
-        )
+    merged = await db.merge(sandbox)
+    await persist_sandbox_status(
+        db,
+        merged,
+        status,
+        stopped_at_now=stopped_at_now,
+        started_at=started_at,
+    )
 
 
 async def persist_runtime_reconnect_state_for_workspace(
+    db: AsyncSession,
     workspace: CloudWorkspace,
     sandbox: CloudSandbox,
     *,
     restarted_runtime: bool,
     runtime_url: str | None = None,
 ) -> CloudSandbox:
-    async with db_engine.async_session_factory() as db:
-        merged_workspace = await db.merge(workspace)
-        merged_sandbox = await db.merge(sandbox)
-        return await persist_runtime_reconnect_state(
-            db,
-            merged_workspace,
-            merged_sandbox,
-            restarted_runtime=restarted_runtime,
-            runtime_url=runtime_url,
-        )
+    merged_workspace = await db.merge(workspace)
+    merged_sandbox = await db.merge(sandbox)
+    return await persist_runtime_reconnect_state(
+        db,
+        merged_workspace,
+        merged_sandbox,
+        restarted_runtime=restarted_runtime,
+        runtime_url=runtime_url,
+    )
 
 
 async def delete_cloud_workspace_records_for_workspace(
+    db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        merged = await db.merge(workspace)
-        await delete_cloud_workspace_records(db, merged)
+    merged = await db.merge(workspace)
+    await delete_cloud_workspace_records(db, merged)
 
 
 async def mark_workspace_error_by_id(
+    db: AsyncSession,
     workspace_id: UUID,
     message: str,
     *,
@@ -1605,18 +1603,18 @@ async def mark_workspace_error_by_id(
     clear_runtime_metadata: bool = True,
     clear_active_sandbox: bool = False,
 ) -> None:
-    async with db_engine.async_session_factory() as db:
-        await mark_workspace_error(
-            db,
-            workspace_id,
-            message,
-            status_detail=status_detail,
-            clear_runtime_metadata=clear_runtime_metadata,
-            clear_active_sandbox=clear_active_sandbox,
-        )
+    await mark_workspace_error(
+        db,
+        workspace_id,
+        message,
+        status_detail=status_detail,
+        clear_runtime_metadata=clear_runtime_metadata,
+        clear_active_sandbox=clear_active_sandbox,
+    )
 
 
 async def save_sandbox_provider_state(
+    db: AsyncSession,
     sandbox_id: UUID,
     *,
     external_sandbox_id: str | None | object = _UNSET,
@@ -1626,17 +1624,16 @@ async def save_sandbox_provider_state(
     last_provider_event_at: datetime | None | object = _UNSET,
     last_provider_event_kind: str | None | object = _UNSET,
 ) -> CloudSandbox:
-    async with db_engine.async_session_factory() as db:
-        sandbox = await get_cloud_sandbox_by_id(db, sandbox_id)
-        if sandbox is None:
-            raise RuntimeError("Sandbox record not found.")
-        return await persist_sandbox_provider_state(
-            db,
-            sandbox,
-            external_sandbox_id=external_sandbox_id,
-            status=status,
-            started_at=started_at,
-            stopped_at=stopped_at,
-            last_provider_event_at=last_provider_event_at,
-            last_provider_event_kind=last_provider_event_kind,
-        )
+    sandbox = await get_cloud_sandbox_by_id(db, sandbox_id)
+    if sandbox is None:
+        raise RuntimeError("Sandbox record not found.")
+    return await persist_sandbox_provider_state(
+        db,
+        sandbox,
+        external_sandbox_id=external_sandbox_id,
+        status=status,
+        started_at=started_at,
+        stopped_at=stopped_at,
+        last_provider_event_at=last_provider_event_at,
+        last_provider_event_kind=last_provider_event_kind,
+    )

--- a/server/proliferate/db/store/cloud_worktree_policy.py
+++ b/server/proliferate/db/store/cloud_worktree_policy.py
@@ -76,10 +76,7 @@ async def save_cloud_worktree_policy(
 
 
 async def load_cloud_worktree_policy_for_user(
+    db: AsyncSession,
     user_id: UUID,
 ) -> CloudWorktreePolicyValue | None:
-    # Transitional runtime-sync read; Phase 8 should thread this session boundary.
-    from proliferate.db import engine as db_engine
-
-    async with db_engine.async_session_factory() as db:
-        return await get_cloud_worktree_policy(db, user_id)
+    return await get_cloud_worktree_policy(db, user_id)

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -29,7 +29,6 @@ from proliferate.constants.organizations import (
     ORGANIZATION_STATUS_ARCHIVED,
     ORGANIZATION_STATUS_PENDING_CHECKOUT,
 )
-from proliferate.db import engine as db_engine
 from proliferate.db.models.auth import User
 from proliferate.db.models.billing import BillingSubject
 from proliferate.db.models.organizations import (
@@ -204,16 +203,16 @@ async def get_organization_with_membership(
 
 
 async def load_active_membership(
+    db: AsyncSession,
     *,
     organization_id: UUID,
     user_id: UUID,
 ) -> MembershipRecord | None:
-    async with db_engine.async_session_factory() as db:
-        return await get_active_membership(
-            db,
-            organization_id=organization_id,
-            user_id=user_id,
-        )
+    return await get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 async def get_active_membership(

--- a/server/proliferate/db/store/users.py
+++ b/server/proliferate/db/store/users.py
@@ -7,7 +7,6 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from proliferate.db import engine as db_engine
 from proliferate.db.models.auth import OAuthAccount, User
 
 
@@ -115,8 +114,8 @@ async def clear_customerio_welcome_send(
     )
 
 
-async def load_user_with_oauth_accounts_by_id(user_id: UUID) -> User | None:
-    # Transitional isolated read for deferred runtime/mobility/worker flows.
-    # Request-scoped callers should use get_user_with_oauth_accounts_by_id(db, ...).
-    async with db_engine.async_session_factory() as db:
-        return await get_user_with_oauth_accounts_by_id(db, user_id)
+async def load_user_with_oauth_accounts_by_id(
+    db: AsyncSession,
+    user_id: UUID,
+) -> User | None:
+    return await get_user_with_oauth_accounts_by_id(db, user_id)

--- a/server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
+++ b/server/proliferate/server/automations/worker/cloud_execution/stages/workspace.py
@@ -94,7 +94,8 @@ async def _create_workspace_record(
     if current.cloud_workspace_id is not None:
         return ctx.with_claim(current)
 
-    user = await load_user_with_oauth_accounts_by_id(current.user_id)
+    async with db_engine.async_session_factory() as db:
+        user = await load_user_with_oauth_accounts_by_id(db, current.user_id)
     if user is None:
         await fail_claim(current, code="user_not_found")
         return None
@@ -135,7 +136,8 @@ async def materialize_workspace_stage(
         return None
 
     if ctx.claim.anyharness_workspace_id is not None:
-        workspace = await load_cloud_workspace_by_id(ctx.claim.cloud_workspace_id)
+        async with db_engine.async_session_factory() as db:
+            workspace = await load_cloud_workspace_by_id(db, ctx.claim.cloud_workspace_id)
         branch_name = (
             workspace.git_branch
             if workspace is not None and workspace.git_branch
@@ -165,7 +167,8 @@ async def materialize_workspace_stage(
         return None
     ctx = ctx.with_claim(current)
 
-    workspace = await load_cloud_workspace_by_id(current.cloud_workspace_id)
+    async with db_engine.async_session_factory() as db:
+        workspace = await load_cloud_workspace_by_id(db, current.cloud_workspace_id)
     if workspace is None:
         await fail_claim(current, code="workspace_missing")
         return None

--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -178,53 +178,60 @@ async def _mark_environment_unavailable(
 ) -> None:
     if runtime_environment_id is None:
         return
-    environment = await load_runtime_environment_by_id(runtime_environment_id)
-    if environment is None:
-        return
-    if destroyed:
-        await save_runtime_environment_state(
-            environment.id,
-            status=CloudRuntimeEnvironmentStatus.error.value,
-            runtime_url=None,
-            runtime_token_ciphertext=None,
-            active_sandbox_id=None,
-            increment_runtime_generation=True,
-            last_error="Provider sandbox was destroyed.",
-        )
-    else:
-        await save_runtime_environment_state(
-            environment.id,
-            status=CloudRuntimeEnvironmentStatus.paused.value,
-        )
+    async with db_engine.async_session_factory() as db, db.begin():
+        environment = await load_runtime_environment_by_id(db, runtime_environment_id)
+        if environment is None:
+            return
+        if destroyed:
+            await save_runtime_environment_state(
+                db,
+                environment.id,
+                status=CloudRuntimeEnvironmentStatus.error.value,
+                runtime_url=None,
+                runtime_token_ciphertext=None,
+                active_sandbox_id=None,
+                increment_runtime_generation=True,
+                last_error="Provider sandbox was destroyed.",
+            )
+        else:
+            await save_runtime_environment_state(
+                db,
+                environment.id,
+                status=CloudRuntimeEnvironmentStatus.paused.value,
+            )
 
 
 async def _repair_placeholders(
     *,
     states_by_placeholder_id: dict[str, ProviderSandboxState],
 ) -> None:
-    placeholders = await load_cloud_sandbox_placeholders()
+    async with db_engine.async_session_factory() as db:
+        placeholders = await load_cloud_sandbox_placeholders(db)
     for placeholder in placeholders:
         state = states_by_placeholder_id.get(str(placeholder.id))
         if state is None:
             continue
-        environment = (
-            await load_runtime_environment_by_id(placeholder.runtime_environment_id)
-            if placeholder.runtime_environment_id is not None
-            else None
-        )
-        workspace = (
-            await load_cloud_workspace_by_id(placeholder.cloud_workspace_id)
-            if placeholder.cloud_workspace_id is not None
-            else None
-        )
+        async with db_engine.async_session_factory() as db:
+            environment = (
+                await load_runtime_environment_by_id(db, placeholder.runtime_environment_id)
+                if placeholder.runtime_environment_id is not None
+                else None
+            )
+            workspace = (
+                await load_cloud_workspace_by_id(db, placeholder.cloud_workspace_id)
+                if placeholder.cloud_workspace_id is not None
+                else None
+            )
         if environment is None and workspace is None:
             continue
-        await save_sandbox_provider_state(
-            placeholder.id,
-            external_sandbox_id=state.external_sandbox_id,
-            status="running" if _is_running_state(state.state) else state.state,
-            started_at=state.started_at,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await save_sandbox_provider_state(
+                db,
+                placeholder.id,
+                external_sandbox_id=state.external_sandbox_id,
+                status="running" if _is_running_state(state.state) else state.state,
+                started_at=state.started_at,
+            )
         if _is_running_state(state.state):
             await open_usage_segment_for_sandbox(
                 user_id=environment.user_id if environment is not None else workspace.user_id,
@@ -245,7 +252,8 @@ async def _enforce_or_reconcile_segment(
     state: ProviderSandboxState | None,
     billing_snapshot: BillingSnapshot,
 ) -> None:
-    sandbox = await load_cloud_sandbox_by_id(segment.sandbox_id)
+    async with db_engine.async_session_factory() as db:
+        sandbox = await load_cloud_sandbox_by_id(db, segment.sandbox_id)
     if sandbox is None:
         return
 
@@ -278,11 +286,13 @@ async def _enforce_or_reconcile_segment(
             ended_at=state.end_at or state.observed_at,
             closed_by=USAGE_SEGMENT_CLOSED_BY_RECONCILER,
         )
-        await save_sandbox_provider_state(
-            sandbox.id,
-            status="paused",
-            stopped_at=state.end_at or state.observed_at,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await save_sandbox_provider_state(
+                db,
+                sandbox.id,
+                status="paused",
+                stopped_at=state.end_at or state.observed_at,
+            )
         await _mark_environment_unavailable(sandbox.runtime_environment_id, destroyed=False)
         return
 
@@ -292,11 +302,13 @@ async def _enforce_or_reconcile_segment(
             ended_at=state.end_at or state.observed_at,
             closed_by=USAGE_SEGMENT_CLOSED_BY_RECONCILER,
         )
-        await save_sandbox_provider_state(
-            sandbox.id,
-            status="destroyed",
-            stopped_at=state.end_at or state.observed_at,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await save_sandbox_provider_state(
+                db,
+                sandbox.id,
+                status="destroyed",
+                stopped_at=state.end_at or state.observed_at,
+            )
         await _mark_environment_unavailable(sandbox.runtime_environment_id, destroyed=True)
         return
 
@@ -320,11 +332,13 @@ async def _enforce_or_reconcile_segment(
             ended_at=ended_at,
             closed_by=USAGE_SEGMENT_CLOSED_BY_QUOTA_ENFORCEMENT,
         )
-        await save_sandbox_provider_state(
-            sandbox.id,
-            status="paused",
-            stopped_at=ended_at,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await save_sandbox_provider_state(
+                db,
+                sandbox.id,
+                status="paused",
+                stopped_at=ended_at,
+            )
         await _mark_environment_unavailable(sandbox.runtime_environment_id, destroyed=False)
 
 

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -347,20 +347,20 @@ async def reconcile_initial_org_subscription_seats(
 
 
 async def remember_cloud_sandbox_event_receipt(
+    db: AsyncSession,
     *,
     event_id: str,
     provider: str,
     event_type: str,
     external_sandbox_id: str | None,
 ) -> bool:
-    async with db_engine.async_session_factory() as db, db.begin():
-        return await remember_sandbox_event_receipt_record(
-            db,
-            event_id=event_id,
-            provider=provider,
-            event_type=event_type,
-            external_sandbox_id=external_sandbox_id,
-        )
+    return await remember_sandbox_event_receipt_record(
+        db,
+        event_id=event_id,
+        provider=provider,
+        event_type=event_type,
+        external_sandbox_id=external_sandbox_id,
+    )
 
 
 async def record_cloud_sandbox_usage_started(

--- a/server/proliferate/server/cloud/mobility/api.py
+++ b/server/proliferate/server/cloud/mobility/api.py
@@ -52,8 +52,9 @@ router = APIRouter(prefix="/mobility", tags=["cloud-mobility"])
 @router.get("/workspaces", response_model=list[MobilityWorkspaceSummary])
 async def list_mobility_workspaces_endpoint(
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> list[MobilityWorkspaceSummary]:
-    values = await list_cloud_workspace_mobility_for_user(user.id)
+    values = await list_cloud_workspace_mobility_for_user(db, user.id)
     return [mobility_workspace_summary_payload(value) for value in values]
 
 
@@ -61,9 +62,11 @@ async def list_mobility_workspaces_endpoint(
 async def ensure_mobility_workspace_endpoint(
     body: EnsureMobilityWorkspaceRequest,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityWorkspaceDetail:
     try:
         value = await ensure_cloud_workspace_mobility(
+            db,
             user_id=user.id,
             git_provider=body.git_provider,
             git_owner=body.git_owner,
@@ -102,9 +105,11 @@ async def preflight_mobility_handoff_endpoint(
     mobility_workspace_id: UUID,
     body: WorkspaceMobilityPreflightRequest,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceMobilityPreflightResponse:
     try:
         return await preflight_cloud_workspace_handoff(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             direction=body.direction,
@@ -123,9 +128,11 @@ async def start_mobility_handoff_endpoint(
     mobility_workspace_id: UUID,
     body: StartWorkspaceMobilityHandoffRequest,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> MobilityHandoffSummary:
     try:
         value = await start_cloud_workspace_handoff(
+            db,
             user_id=user.id,
             mobility_workspace_id=mobility_workspace_id,
             direction=body.direction,

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -586,7 +586,7 @@ async def start_cloud_workspace_handoff(
     requested_base_sha: str | None,
     exclude_paths: list[str],
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
+    await mobility_tx.expire_stale_handoffs_tx(user_id=user_id, stale_after=_STALE_HANDOFF_AFTER)
     workspace = await get_cloud_workspace_mobility_detail(
         db,
         user_id=user_id,

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -258,9 +258,9 @@ async def _default_cleanup_items_for_cutover(
     return items
 
 
-async def expire_stale_cloud_workspace_handoffs_for_user(*, user_id: UUID) -> None:
+async def expire_stale_cloud_workspace_handoffs_for_user(db: AsyncSession, *, user_id: UUID) -> None:
     stale_before = utcnow() - _STALE_HANDOFF_AFTER
-    workspaces = await list_cloud_workspace_mobility_store(user_id=user_id)
+    workspaces = await list_cloud_workspace_mobility_store(db, user_id=user_id)
     for workspace in workspaces:
         active_handoff = workspace.active_handoff
         if active_handoff is None or active_handoff.heartbeat_at >= stale_before:
@@ -271,6 +271,7 @@ async def expire_stale_cloud_workspace_handoffs_for_user(*, user_id: UUID) -> No
             canonical_side=active_handoff.canonical_side,
         )
         await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             handoff_op_id=active_handoff.id,
@@ -286,22 +287,24 @@ async def expire_stale_cloud_workspace_handoffs_for_user(*, user_id: UUID) -> No
 
 
 async def list_cloud_workspace_mobility_for_user(
-    user_id: UUID,
+    db: AsyncSession, user_id: UUID
 ) -> list[CloudWorkspaceMobilityValue]:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
-    workspaces = await list_cloud_workspaces_store(user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
+    workspaces = await list_cloud_workspaces_store(db, user_id)
     for workspace in workspaces:
         if not _should_backfill_mobility_from_cloud_workspace(workspace):
             continue
         await backfill_cloud_workspace_mobility_for_workspace(
+            db,
             workspace=workspace,
             active_lifecycle_state=active_lifecycle_state(OWNER_CLOUD),
             is_retryable_failure=_preserve_failed_handoff_during_passive_backfill,
         )
-    return await list_cloud_workspace_mobility_store(user_id=user_id)
+    return await list_cloud_workspace_mobility_store(db, user_id=user_id)
 
 
 async def ensure_cloud_workspace_mobility(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_provider: str,
@@ -311,7 +314,7 @@ async def ensure_cloud_workspace_mobility(
     display_name: str | None,
     owner_hint: str,
 ) -> CloudWorkspaceMobilityValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     owner_hint = normalize_owner(owner_hint)
     if not is_valid_owner(owner_hint):
         raise CloudApiError(
@@ -322,6 +325,7 @@ async def ensure_cloud_workspace_mobility(
         )
 
     existing_cloud_workspace = await load_existing_cloud_workspace(
+        db,
         user_id=user_id,
         git_provider=git_provider,
         git_owner=git_owner,
@@ -333,6 +337,7 @@ async def ensure_cloud_workspace_mobility(
         existing_cloud_workspace.display_name if existing_cloud_workspace else None
     )
     return await ensure_cloud_workspace_mobility_for_user(
+        db,
         user_id=user_id,
         git_provider=git_provider,
         git_owner=git_owner,
@@ -347,23 +352,15 @@ async def ensure_cloud_workspace_mobility(
 
 
 async def get_cloud_workspace_mobility_detail(
-    db: AsyncSession | None = None,
-    *,
+    db: AsyncSession, *,
     user_id: UUID,
     mobility_workspace_id: UUID,
 ) -> CloudWorkspaceMobilityValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
-    record = (
-        await load_cloud_workspace_mobility_value(
-            db,
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-        )
-        if db is not None
-        else await load_cloud_workspace_mobility_for_user(
-            user_id=user_id,
-            mobility_workspace_id=mobility_workspace_id,
-        )
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
+    record = await load_cloud_workspace_mobility_value(
+        db,
+        user_id=user_id,
+        mobility_workspace_id=mobility_workspace_id,
     )
     if record is None:
         raise CloudApiError(
@@ -375,7 +372,7 @@ async def get_cloud_workspace_mobility_detail(
 
 
 async def preflight_cloud_workspace_handoff(
-    *,
+    db: AsyncSession, *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     direction: str,
@@ -394,9 +391,10 @@ async def preflight_cloud_workspace_handoff(
         normalized_requested_base_sha
         and _FULL_SHA_RE.fullmatch(normalized_requested_base_sha) is not None
     )
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     detail_started = time.perf_counter()
     workspace = await get_cloud_workspace_mobility_detail(
+        db,
         user_id=user_id,
         mobility_workspace_id=mobility_workspace_id,
     )
@@ -424,8 +422,7 @@ async def preflight_cloud_workspace_handoff(
             )
         )
     active_handoff = await load_active_user_handoff_op_for_user(
-        user_id=user_id,
-        final_handoff_phases=FINAL_HANDOFF_PHASES,
+        db, user_id=user_id, final_handoff_phases=FINAL_HANDOFF_PHASES
     )
     if active_handoff is not None and active_handoff.mobility_workspace_id != workspace.id:
         blockers.append(
@@ -457,7 +454,7 @@ async def preflight_cloud_workspace_handoff(
             )
         )
     if is_valid_handoff_direction(direction):
-        user = await load_user_with_oauth_accounts_by_id(user_id)
+        user = await load_user_with_oauth_accounts_by_id(db, user_id)
         if user is None:
             raise CloudApiError("user_not_found", "User not found.", status_code=404)
         branch_lookup_started = time.perf_counter()
@@ -524,9 +521,7 @@ async def preflight_cloud_workspace_handoff(
 
     repo_config_started = time.perf_counter()
     repo_config = await load_cloud_repo_config_for_user(
-        user_id=user_id,
-        git_owner=workspace.git_owner,
-        git_repo_name=workspace.git_repo_name,
+        db, user_id=user_id, git_owner=workspace.git_owner, git_repo_name=workspace.git_repo_name
     )
     repo_config_elapsed_ms = duration_ms(repo_config_started)
     excluded_paths = (
@@ -565,6 +560,7 @@ async def preflight_cloud_workspace_handoff(
     )
     with suppress(Exception):
         await record_cloud_workspace_mobility_event_for_user(
+            db,
             user_id=user_id,
             cloud_workspace_id=workspace.cloud_workspace_id,
             handoff_op_id=workspace.active_handoff.id if workspace.active_handoff else None,
@@ -579,7 +575,7 @@ async def preflight_cloud_workspace_handoff(
 
 
 async def start_cloud_workspace_handoff(
-    *,
+    db: AsyncSession, *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     direction: str,
@@ -587,12 +583,14 @@ async def start_cloud_workspace_handoff(
     requested_base_sha: str | None,
     exclude_paths: list[str],
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     workspace = await get_cloud_workspace_mobility_detail(
+        db,
         user_id=user_id,
         mobility_workspace_id=mobility_workspace_id,
     )
     preflight = await preflight_cloud_workspace_handoff(
+        db,
         user_id=user_id,
         mobility_workspace_id=mobility_workspace_id,
         direction=direction,
@@ -612,6 +610,7 @@ async def start_cloud_workspace_handoff(
     target_owner = target_owner_for_direction(direction)
     try:
         handoff = await create_cloud_workspace_handoff_op_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             direction=direction,
@@ -639,7 +638,7 @@ async def start_cloud_workspace_handoff(
         raise
     if direction == "local_to_cloud":
         try:
-            user = await load_user_with_oauth_accounts_by_id(user_id)
+            user = await load_user_with_oauth_accounts_by_id(db, user_id)
             if user is None:
                 raise CloudApiError("user_not_found", "User not found.", status_code=404)
             cloud_workspace = await ensure_cloud_workspace_for_existing_branch(
@@ -651,9 +650,7 @@ async def start_cloud_workspace_handoff(
                 display_name=workspace.display_name,
             )
             await start_cloud_workspace(
-                user,
-                cloud_workspace.id,
-                requested_base_sha=requested_base_sha,
+                db, user, cloud_workspace.id, requested_base_sha=requested_base_sha
             )
         except Exception as error:
             failure_code = (
@@ -666,6 +663,7 @@ async def start_cloud_workspace_handoff(
             )
             with suppress(ValueError):
                 await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+                    db,
                     user_id=user_id,
                     mobility_workspace_id=mobility_workspace_id,
                     handoff_op_id=handoff.id,
@@ -678,6 +676,7 @@ async def start_cloud_workspace_handoff(
                 )
             raise
         return await update_cloud_workspace_handoff_phase_checkpoint_for_user(
+            db,
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff.id,
@@ -695,7 +694,7 @@ async def heartbeat_cloud_workspace_handoff(
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     try:
         return await heartbeat_cloud_workspace_handoff_op_for_user(
             db,
@@ -717,7 +716,7 @@ async def update_cloud_workspace_handoff_phase(
     status_detail: str | None,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     if not is_valid_handoff_phase(phase):
         raise CloudApiError(
             "invalid_handoff_phase",
@@ -774,7 +773,7 @@ async def finalize_cloud_workspace_handoff(
     handoff_op_id: UUID,
     cloud_workspace_id: UUID | None,
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     source_workspace = await get_cloud_workspace_mobility_detail(
         db,
         user_id=user_id,
@@ -877,7 +876,7 @@ async def complete_cloud_workspace_handoff_cleanup(
     mobility_workspace_id: UUID,
     handoff_op_id: UUID,
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     cleanup_items = await list_cleanup_items_for_handoff(db, handoff_op_id=handoff_op_id)
     if cleanup_items:
         for item in cleanup_items:
@@ -1167,7 +1166,7 @@ async def fail_cloud_workspace_handoff(
     failure_code: str,
     failure_detail: str,
 ) -> CloudWorkspaceHandoffOpValue:
-    await expire_stale_cloud_workspace_handoffs_for_user(user_id=user_id)
+    await expire_stale_cloud_workspace_handoffs_for_user(db, user_id=user_id)
     try:
         await _require_handoff_belongs_to_workspace(
             db,

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -19,7 +19,6 @@ from proliferate.db.store.cloud_mobility import (
     all_cleanup_items_completed,
     backfill_cloud_workspace_mobility_for_workspace,
     complete_cloud_workspace_handoff_cleanup_for_user,
-    create_cloud_workspace_handoff_op_for_user,
     ensure_cloud_workspace_mobility_for_user,
     fail_cloud_workspace_handoff_op_checkpoint_for_user,
     fail_cloud_workspace_handoff_op_for_user,
@@ -33,7 +32,6 @@ from proliferate.db.store.cloud_mobility import (
     load_cloud_workspace_mobility_value,
     record_cloud_workspace_mobility_event_for_user,
     update_cleanup_item_status,
-    update_cloud_workspace_handoff_phase_checkpoint_for_user,
     update_cloud_workspace_handoff_phase_for_user,
 )
 from proliferate.db.store.cloud_mobility import (
@@ -52,6 +50,7 @@ from proliferate.db.store.cloud_workspaces import (
 from proliferate.db.store.users import load_user_with_oauth_accounts_by_id
 from proliferate.server.cloud._logging import log_cloud_event
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.mobility import transactions as mobility_tx
 from proliferate.server.cloud.mobility.cleanup_executor import (
     SERVER_CLEANUP_ITEM_KINDS,
     cleanup_item_execution_rank,
@@ -613,8 +612,7 @@ async def start_cloud_workspace_handoff(
     source_owner = normalize_owner(workspace.owner)
     target_owner = target_owner_for_direction(direction)
     try:
-        handoff = await create_cloud_workspace_handoff_op_for_user(
-            db,
+        handoff = await mobility_tx.create_cloud_workspace_handoff_op_checkpoint_tx(
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             direction=direction,
@@ -666,8 +664,7 @@ async def start_cloud_workspace_handoff(
                 else str(error) or "Workspace handoff start failed."
             )
             with suppress(ValueError):
-                await fail_cloud_workspace_handoff_op_checkpoint_for_user(
-                    db,
+                await mobility_tx.fail_cloud_workspace_handoff_op_checkpoint_tx(
                     user_id=user_id,
                     mobility_workspace_id=mobility_workspace_id,
                     handoff_op_id=handoff.id,
@@ -679,8 +676,7 @@ async def start_cloud_workspace_handoff(
                     last_error=visible_failure_last_error(failure_detail),
                 )
             raise
-        return await update_cloud_workspace_handoff_phase_checkpoint_for_user(
-            db,
+        return await mobility_tx.update_cloud_workspace_handoff_phase_checkpoint_tx(
             user_id=user_id,
             mobility_workspace_id=mobility_workspace_id,
             handoff_op_id=handoff.id,

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -30,7 +30,6 @@ from proliferate.db.store.cloud_mobility import (
     insert_cleanup_items_for_handoff,
     list_cleanup_items_for_handoff,
     load_active_user_handoff_op_for_user,
-    load_cloud_workspace_mobility_for_user,
     load_cloud_workspace_mobility_value,
     record_cloud_workspace_mobility_event_for_user,
     update_cleanup_item_status,
@@ -258,7 +257,9 @@ async def _default_cleanup_items_for_cutover(
     return items
 
 
-async def expire_stale_cloud_workspace_handoffs_for_user(db: AsyncSession, *, user_id: UUID) -> None:
+async def expire_stale_cloud_workspace_handoffs_for_user(
+    db: AsyncSession, *, user_id: UUID
+) -> None:
     stale_before = utcnow() - _STALE_HANDOFF_AFTER
     workspaces = await list_cloud_workspace_mobility_store(db, user_id=user_id)
     for workspace in workspaces:
@@ -352,7 +353,8 @@ async def ensure_cloud_workspace_mobility(
 
 
 async def get_cloud_workspace_mobility_detail(
-    db: AsyncSession, *,
+    db: AsyncSession,
+    *,
     user_id: UUID,
     mobility_workspace_id: UUID,
 ) -> CloudWorkspaceMobilityValue:
@@ -372,7 +374,8 @@ async def get_cloud_workspace_mobility_detail(
 
 
 async def preflight_cloud_workspace_handoff(
-    db: AsyncSession, *,
+    db: AsyncSession,
+    *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     direction: str,
@@ -575,7 +578,8 @@ async def preflight_cloud_workspace_handoff(
 
 
 async def start_cloud_workspace_handoff(
-    db: AsyncSession, *,
+    db: AsyncSession,
+    *,
     user_id: UUID,
     mobility_workspace_id: UUID,
     direction: str,

--- a/server/proliferate/server/cloud/mobility/transactions.py
+++ b/server/proliferate/server/cloud/mobility/transactions.py
@@ -1,0 +1,94 @@
+"""Durable mobility transaction boundaries owned outside db/store."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from proliferate.db import engine as db_engine
+from proliferate.db.store.cloud_mobility import (
+    CloudWorkspaceHandoffOpValue,
+    create_cloud_workspace_handoff_op_for_user,
+    fail_cloud_workspace_handoff_op_checkpoint_for_user,
+    update_cloud_workspace_handoff_phase_checkpoint_for_user,
+)
+
+
+async def create_cloud_workspace_handoff_op_checkpoint_tx(
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+    direction: str,
+    source_owner: str,
+    target_owner: str,
+    moving_lifecycle_state: str,
+    final_handoff_phases: tuple[str, ...],
+    requested_branch: str,
+    requested_base_sha: str | None,
+    exclude_paths: list[str],
+) -> CloudWorkspaceHandoffOpValue:
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await create_cloud_workspace_handoff_op_for_user(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+            direction=direction,
+            source_owner=source_owner,
+            target_owner=target_owner,
+            moving_lifecycle_state=moving_lifecycle_state,
+            final_handoff_phases=final_handoff_phases,
+            requested_branch=requested_branch,
+            requested_base_sha=requested_base_sha,
+            exclude_paths=exclude_paths,
+        )
+
+
+async def update_cloud_workspace_handoff_phase_checkpoint_tx(
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+    handoff_op_id: UUID,
+    phase: str,
+    status_detail: str | None,
+    cloud_workspace_id: UUID | None = None,
+) -> CloudWorkspaceHandoffOpValue:
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await update_cloud_workspace_handoff_phase_checkpoint_for_user(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+            handoff_op_id=handoff_op_id,
+            phase=phase,
+            status_detail=status_detail,
+            cloud_workspace_id=cloud_workspace_id,
+        )
+
+
+async def fail_cloud_workspace_handoff_op_checkpoint_tx(
+    *,
+    user_id: UUID,
+    mobility_workspace_id: UUID,
+    handoff_op_id: UUID,
+    phase: str,
+    lifecycle_state: str,
+    failure_code: str,
+    failure_detail: str,
+    status_detail: str | None,
+    last_error: str,
+    keep_active_handoff: bool = False,
+    event_type: str = "handoff_failed",
+) -> CloudWorkspaceHandoffOpValue:
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+            db,
+            user_id=user_id,
+            mobility_workspace_id=mobility_workspace_id,
+            handoff_op_id=handoff_op_id,
+            phase=phase,
+            lifecycle_state=lifecycle_state,
+            failure_code=failure_code,
+            failure_detail=failure_detail,
+            status_detail=status_detail,
+            last_error=last_error,
+            keep_active_handoff=keep_active_handoff,
+            event_type=event_type,
+        )

--- a/server/proliferate/server/cloud/mobility/transactions.py
+++ b/server/proliferate/server/cloud/mobility/transactions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from uuid import UUID
 
 from proliferate.db import engine as db_engine
@@ -9,8 +10,48 @@ from proliferate.db.store.cloud_mobility import (
     CloudWorkspaceHandoffOpValue,
     create_cloud_workspace_handoff_op_for_user,
     fail_cloud_workspace_handoff_op_checkpoint_for_user,
+    list_cloud_workspace_mobility_for_user,
     update_cloud_workspace_handoff_phase_checkpoint_for_user,
 )
+from proliferate.server.cloud.mobility.domain.lifecycle import (
+    stale_handoff_outcome,
+    visible_failure_last_error,
+    visible_failure_status_detail,
+)
+from proliferate.utils.time import utcnow
+
+
+async def expire_stale_handoffs_tx(
+    *,
+    user_id: UUID,
+    stale_after: timedelta,
+) -> None:
+    stale_before = utcnow() - stale_after
+    async with db_engine.async_session_factory() as db, db.begin():
+        workspaces = await list_cloud_workspace_mobility_for_user(db, user_id=user_id)
+        for workspace in workspaces:
+            active_handoff = workspace.active_handoff
+            if active_handoff is None or active_handoff.heartbeat_at >= stale_before:
+                continue
+            outcome = stale_handoff_outcome(
+                finalized_at=active_handoff.finalized_at,
+                cleanup_completed_at=active_handoff.cleanup_completed_at,
+                canonical_side=active_handoff.canonical_side,
+            )
+            await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+                db,
+                user_id=user_id,
+                mobility_workspace_id=workspace.id,
+                handoff_op_id=active_handoff.id,
+                phase=outcome.phase,
+                lifecycle_state=outcome.lifecycle_state,
+                failure_code=outcome.failure_code,
+                failure_detail=outcome.failure_detail,
+                status_detail=visible_failure_status_detail(outcome.failure_detail),
+                last_error=visible_failure_last_error(outcome.failure_detail),
+                keep_active_handoff=outcome.keep_active_handoff,
+                event_type="handoff_stale",
+            )
 
 
 async def create_cloud_workspace_handoff_op_checkpoint_tx(

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -415,12 +415,14 @@ async def save_repo_file(
 
 
 async def load_repo_config_value(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
 ) -> CloudRepoConfigValue | None:
     return await load_cloud_repo_config_for_user(
+        db,
         user_id=user_id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
@@ -428,6 +430,7 @@ async def load_repo_config_value(
 
 
 async def bootstrap_repo_config(
+    db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
@@ -437,6 +440,7 @@ async def bootstrap_repo_config(
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
     try:
         return await bootstrap_cloud_repo_config_for_user(
+            db,
             user_id=user_id,
             git_owner=git_owner,
             git_repo_name=git_repo_name,
@@ -508,7 +512,7 @@ async def resync_workspace_files(
     workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
-    target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
+    target = await get_workspace_connection(db, workspace)  # type: ignore[arg-type]
     try:
         await apply_workspace_repo_config(
             workspace,  # type: ignore[arg-type]
@@ -546,7 +550,7 @@ async def run_workspace_setup(
     workspace = await _load_authorized_workspace_for_repo_config(db, user_id, workspace_id)
 
     # Workspace stores still return ORM rows; this lane only removes ORM-aware response builders.
-    target = await get_workspace_connection(workspace)  # type: ignore[arg-type]
+    target = await get_workspace_connection(db, workspace)  # type: ignore[arg-type]
     try:
         started = await run_workspace_saved_setup(
             workspace,  # type: ignore[arg-type]

--- a/server/proliferate/server/cloud/runtime/ensure_running.py
+++ b/server/proliferate/server/cloud/runtime/ensure_running.py
@@ -436,7 +436,11 @@ async def _persist_reconnect(
 ) -> None:
     async with db_engine.async_session_factory() as db, db.begin():
         await persist_runtime_reconnect_state_for_workspace(
-            db, workspace, sandbox_record, restarted_runtime=restarted_runtime, runtime_url=runtime_url
+            db,
+            workspace,
+            sandbox_record,
+            restarted_runtime=restarted_runtime,
+            runtime_url=runtime_url,
         )
 
 
@@ -600,12 +604,16 @@ async def ensure_environment_runtime_ready(
     ):
         if not force_launcher_restart:
             if should_persist_rotated_runtime_url(environment.runtime_url, endpoint.runtime_url):
-                await _save_env_updates(environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url))
+                await _save_env_updates(
+                    environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url)
+                )
             return endpoint.runtime_url
         if not allow_launcher_restart:
             raise CloudRuntimeReconnectError("Cloud runtime restart was requested but disallowed.")
         if should_persist_rotated_runtime_url(environment.runtime_url, endpoint.runtime_url):
-            await _save_env_updates(environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url))
+            await _save_env_updates(
+                environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url)
+            )
 
     if not allow_launcher_restart:
         raise CloudRuntimeReconnectError("Cloud runtime is unavailable in the existing sandbox.")
@@ -660,5 +668,7 @@ async def ensure_environment_runtime_ready(
             not_before=worker_restart_started_at,
             previous_worker_id=previous_worker_id,
         )
-    await _save_env_updates(environment.id, runtime_process_relaunched_update(endpoint.runtime_url))
+    await _save_env_updates(
+        environment.id, runtime_process_relaunched_update(endpoint.runtime_url)
+    )
     return endpoint.runtime_url

--- a/server/proliferate/server/cloud/runtime/ensure_running.py
+++ b/server/proliferate/server/cloud/runtime/ensure_running.py
@@ -431,6 +431,20 @@ async def _connect_or_resume_sandbox(
     raise CloudRuntimeReconnectError("Cloud workspace sandbox is unavailable.")
 
 
+async def _persist_reconnect(
+    workspace: CloudWorkspace, sandbox_record: object, restarted_runtime: bool, runtime_url: str
+) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await persist_runtime_reconnect_state_for_workspace(
+            db, workspace, sandbox_record, restarted_runtime=restarted_runtime, runtime_url=runtime_url
+        )
+
+
+async def _save_env_updates(environment_id: UUID, updates: dict[str, object]) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await save_runtime_environment_state(db, environment_id, **updates)
+
+
 async def ensure_workspace_runtime_ready(
     workspace: CloudWorkspace,
     *,
@@ -450,7 +464,8 @@ async def ensure_workspace_runtime_ready(
     ):
         return workspace.runtime_url
 
-    sandbox_record = await load_active_sandbox_for_workspace(workspace)
+    async with db_engine.async_session_factory() as db:
+        sandbox_record = await load_active_sandbox_for_workspace(db, workspace)
     if sandbox_record is None:
         raise CloudRuntimeReconnectError("Cloud workspace sandbox record was not found.")
 
@@ -483,12 +498,7 @@ async def ensure_workspace_runtime_ready(
         delay_seconds=endpoint_probe.delay_seconds,
     ):
         if should_persist_rotated_runtime_url(workspace.runtime_url, endpoint.runtime_url):
-            await persist_runtime_reconnect_state_for_workspace(
-                workspace,
-                sandbox_record,
-                restarted_runtime=False,
-                runtime_url=endpoint.runtime_url,
-            )
+            await _persist_reconnect(workspace, sandbox_record, False, endpoint.runtime_url)
         return endpoint.runtime_url
 
     if not allow_launcher_restart:
@@ -528,12 +538,7 @@ async def ensure_workspace_runtime_ready(
         access_token,
         workspace_id=workspace.id,
     )
-    await persist_runtime_reconnect_state_for_workspace(
-        workspace,
-        sandbox_record,
-        restarted_runtime=True,
-        runtime_url=endpoint.runtime_url,
-    )
+    await _persist_reconnect(workspace, sandbox_record, True, endpoint.runtime_url)
     return endpoint.runtime_url
 
 
@@ -561,7 +566,8 @@ async def ensure_environment_runtime_ready(
     ):
         return environment.runtime_url
 
-    sandbox_record = await load_cloud_sandbox_by_id(environment.active_sandbox_id)
+    async with db_engine.async_session_factory() as db:
+        sandbox_record = await load_cloud_sandbox_by_id(db, environment.active_sandbox_id)
     if sandbox_record is None:
         raise CloudRuntimeReconnectError("Cloud runtime environment sandbox record was not found.")
 
@@ -594,18 +600,12 @@ async def ensure_environment_runtime_ready(
     ):
         if not force_launcher_restart:
             if should_persist_rotated_runtime_url(environment.runtime_url, endpoint.runtime_url):
-                await save_runtime_environment_state(
-                    environment.id,
-                    **runtime_endpoint_rotated_update(endpoint.runtime_url),
-                )
+                await _save_env_updates(environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url))
             return endpoint.runtime_url
         if not allow_launcher_restart:
             raise CloudRuntimeReconnectError("Cloud runtime restart was requested but disallowed.")
         if should_persist_rotated_runtime_url(environment.runtime_url, endpoint.runtime_url):
-            await save_runtime_environment_state(
-                environment.id,
-                **runtime_endpoint_rotated_update(endpoint.runtime_url),
-            )
+            await _save_env_updates(environment.id, runtime_endpoint_rotated_update(endpoint.runtime_url))
 
     if not allow_launcher_restart:
         raise CloudRuntimeReconnectError("Cloud runtime is unavailable in the existing sandbox.")
@@ -660,8 +660,5 @@ async def ensure_environment_runtime_ready(
             not_before=worker_restart_started_at,
             previous_worker_id=previous_worker_id,
         )
-    await save_runtime_environment_state(
-        environment.id,
-        **runtime_process_relaunched_update(endpoint.runtime_url),
-    )
+    await _save_env_updates(environment.id, runtime_process_relaunched_update(endpoint.runtime_url))
     return endpoint.runtime_url

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -205,7 +205,8 @@ async def _load_provision_input(
         runtime_environment = await ensure_runtime_environment_for_workspace_id(db, workspace_id)
         if runtime_environment and not runtime_environment.anyharness_data_key_ciphertext:
             runtime_environment = await save_runtime_environment_state(
-                db, runtime_environment.id,
+                db,
+                runtime_environment.id,
                 anyharness_data_key_ciphertext=encrypt_text(generate_anyharness_data_key()),
             )
     if runtime_environment is None:
@@ -569,7 +570,9 @@ async def _mark_sandbox_running(sandbox_id: UUID, started_at: object) -> None:
         )
 
 
-async def _save_runtime_environment_updates(runtime_environment_id: UUID, updates: dict[str, object]) -> None:
+async def _save_runtime_environment_updates(
+    runtime_environment_id: UUID, updates: dict[str, object]
+) -> None:
     async with db_engine.async_session_factory() as db, db.begin():
         await save_runtime_environment_state(db, runtime_environment_id, **updates)
 
@@ -647,7 +650,9 @@ async def _connect_existing_profile_slot(
         runtime_token_ciphertext=runtime_access.runtime_token_ciphertext,
         anyharness_data_key_ciphertext=runtime_access.anyharness_data_key_ciphertext,
     )
-    update = runtime_connected_sandbox_update(runtime_url=endpoint.runtime_url, active_sandbox_id=slot.id)
+    update = runtime_connected_sandbox_update(
+        runtime_url=endpoint.runtime_url, active_sandbox_id=slot.id
+    )
     await _save_runtime_environment_updates(ctx.runtime_environment_id, update)
     tracker.complete(runtime_url=endpoint.runtime_url, reused_sandbox=True)
 
@@ -1703,7 +1708,11 @@ async def provision_workspace(
                 await update_sandbox_status(db, sandbox_record, "destroyed", stopped_at_now=True)
         async with db_engine.async_session_factory() as db, db.begin():
             await mark_workspace_error_by_id(
-                db, workspace_id, error_message, clear_runtime_metadata=True, clear_active_sandbox=True
+                db,
+                workspace_id,
+                error_message,
+                clear_runtime_metadata=True,
+                clear_active_sandbox=True,
             )
         total_elapsed_ms = duration_ms(provision_started)
         log_cloud_event(

--- a/server/proliferate/server/cloud/runtime/provision.py
+++ b/server/proliferate/server/cloud/runtime/provision.py
@@ -196,18 +196,20 @@ async def _load_provision_input(
     *,
     requested_base_sha: str | None = None,
 ) -> CloudProvisionInput | None:
-    workspace = await load_cloud_workspace_by_id(workspace_id)
+    async with db_engine.async_session_factory() as db:
+        workspace = await load_cloud_workspace_by_id(db, workspace_id)
     if workspace is None:
         return None
 
-    runtime_environment = await ensure_runtime_environment_for_workspace_id(workspace_id)
+    async with db_engine.async_session_factory() as db, db.begin():
+        runtime_environment = await ensure_runtime_environment_for_workspace_id(db, workspace_id)
+        if runtime_environment and not runtime_environment.anyharness_data_key_ciphertext:
+            runtime_environment = await save_runtime_environment_state(
+                db, runtime_environment.id,
+                anyharness_data_key_ciphertext=encrypt_text(generate_anyharness_data_key()),
+            )
     if runtime_environment is None:
         return None
-    if not runtime_environment.anyharness_data_key_ciphertext:
-        runtime_environment = await save_runtime_environment_state(
-            runtime_environment.id,
-            anyharness_data_key_ciphertext=encrypt_text(generate_anyharness_data_key()),
-        )
     anyharness_data_key_ciphertext = runtime_environment.anyharness_data_key_ciphertext
     if anyharness_data_key_ciphertext is None:
         raise CloudApiError(
@@ -216,12 +218,11 @@ async def _load_provision_input(
             status_code=500,
         )
 
-    user = await load_user_with_oauth_accounts_by_id(workspace.user_id)
+    async with db_engine.async_session_factory() as db:
+        user = await load_user_with_oauth_accounts_by_id(db, workspace.user_id)
+        github_grant = await get_ready_github_grant_for_user(db, user_id=workspace.user_id)
     if user is None:
         return None
-
-    async with db_engine.async_session_factory() as db:
-        github_grant = await get_ready_github_grant_for_user(db, user_id=workspace.user_id)
     if github_grant is None:
         raise CloudApiError(
             "github_link_required",
@@ -320,11 +321,13 @@ async def _load_provision_input(
                 git_repo_name=workspace.git_repo_name,
             )
     else:
-        repo_config = await load_cloud_repo_config_for_user(
-            user_id=workspace.user_id,
-            git_owner=workspace.git_owner,
-            git_repo_name=workspace.git_repo_name,
-        )
+        async with db_engine.async_session_factory() as db:
+            repo_config = await load_cloud_repo_config_for_user(
+                db,
+                user_id=workspace.user_id,
+                git_owner=workspace.git_owner,
+                git_repo_name=workspace.git_repo_name,
+            )
 
     if repo_config is not None and repo_config.configured:
         repo_env_vars = repo_config.env_vars
@@ -437,11 +440,13 @@ async def _set_workspace_status(
     detail: str | None = None,
 ) -> None:
     resolved_detail = detail or str(status).replace("_", " ").title()
-    await update_workspace_status_by_id(
-        workspace_id,
-        status,
-        resolved_detail,
-    )
+    async with db_engine.async_session_factory() as db, db.begin():
+        await update_workspace_status_by_id(
+            db,
+            workspace_id,
+            status,
+            resolved_detail,
+        )
     log_cloud_event(
         "cloud workspace status updated",
         workspace_id=workspace_id,
@@ -493,12 +498,14 @@ async def _create_and_connect_sandbox(
     )
     tracker.complete(sandbox_id=handle.sandbox_id)
     started_at = utcnow()
-    await bind_allocated_sandbox(
-        sandbox_record_id,
-        external_sandbox_id=handle.sandbox_id,
-        status="provisioning",
-        started_at=started_at,
-    )
+    async with db_engine.async_session_factory() as db, db.begin():
+        await bind_allocated_sandbox(
+            db,
+            sandbox_record_id,
+            external_sandbox_id=handle.sandbox_id,
+            status="provisioning",
+            started_at=started_at,
+        )
     await record_cloud_sandbox_usage_started(
         user_id=ctx.user_id,
         runtime_environment_id=ctx.runtime_environment_id,
@@ -553,6 +560,18 @@ async def _persist_target_runtime_access(
         )
         if runtime_access is None:
             raise RuntimeError("Managed target runtime access rejected stale sandbox slot state.")
+
+
+async def _mark_sandbox_running(sandbox_id: UUID, started_at: object) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await save_sandbox_provider_state(
+            db, sandbox_id, status="running", started_at=started_at or utcnow(), stopped_at=None
+        )
+
+
+async def _save_runtime_environment_updates(runtime_environment_id: UUID, updates: dict[str, object]) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await save_runtime_environment_state(db, runtime_environment_id, **updates)
 
 
 async def _connect_existing_profile_slot(
@@ -619,12 +638,7 @@ async def _connect_existing_profile_slot(
         tracker.complete(reused_sandbox=False, reason="connect_failed")
         return None
 
-    await save_sandbox_provider_state(
-        slot.id,
-        status="running",
-        started_at=provider_state.started_at or utcnow(),
-        stopped_at=None,
-    )
+    await _mark_sandbox_running(slot.id, provider_state.started_at)
     await _persist_target_runtime_access(
         ctx,
         sandbox_record_id=slot.id,
@@ -633,13 +647,8 @@ async def _connect_existing_profile_slot(
         runtime_token_ciphertext=runtime_access.runtime_token_ciphertext,
         anyharness_data_key_ciphertext=runtime_access.anyharness_data_key_ciphertext,
     )
-    await save_runtime_environment_state(
-        ctx.runtime_environment_id,
-        **runtime_connected_sandbox_update(
-            runtime_url=endpoint.runtime_url,
-            active_sandbox_id=slot.id,
-        ),
-    )
+    update = runtime_connected_sandbox_update(runtime_url=endpoint.runtime_url, active_sandbox_id=slot.id)
+    await _save_runtime_environment_updates(ctx.runtime_environment_id, update)
     tracker.complete(runtime_url=endpoint.runtime_url, reused_sandbox=True)
 
     return (
@@ -664,7 +673,8 @@ async def _connect_existing_environment_sandbox(
     ctx: CloudProvisionInput,
     provider: SandboxProvider,
 ) -> tuple[ConnectedSandbox, UUID, int, str] | None:
-    runtime = await load_runtime_environment_with_sandbox(ctx.runtime_environment_id)
+    async with db_engine.async_session_factory() as db:
+        runtime = await load_runtime_environment_with_sandbox(db, ctx.runtime_environment_id)
     sandbox_record = runtime.sandbox if runtime is not None else None
     if sandbox_record is None or not sandbox_record.external_sandbox_id:
         return None
@@ -714,12 +724,7 @@ async def _connect_existing_environment_sandbox(
         tracker.complete(reused_sandbox=False, reason="connect_failed")
         return None
 
-    await save_sandbox_provider_state(
-        sandbox_record.id,
-        status="running",
-        started_at=provider_state.started_at or utcnow(),
-        stopped_at=None,
-    )
+    await _mark_sandbox_running(sandbox_record.id, provider_state.started_at)
     await _persist_target_runtime_access(
         ctx,
         sandbox_record_id=sandbox_record.id,
@@ -728,13 +733,10 @@ async def _connect_existing_environment_sandbox(
         runtime_token_ciphertext=runtime.environment.runtime_token_ciphertext,
         anyharness_data_key_ciphertext=runtime.environment.anyharness_data_key_ciphertext,
     )
-    await save_runtime_environment_state(
-        ctx.runtime_environment_id,
-        **runtime_connected_sandbox_update(
-            runtime_url=endpoint.runtime_url,
-            active_sandbox_id=sandbox_record.id,
-        ),
+    update = runtime_connected_sandbox_update(
+        runtime_url=endpoint.runtime_url, active_sandbox_id=sandbox_record.id
     )
+    await _save_runtime_environment_updates(ctx.runtime_environment_id, update)
     tracker.complete(runtime_url=endpoint.runtime_url, reused_sandbox=True)
 
     return (
@@ -1609,14 +1611,16 @@ async def provision_workspace(
 
         runtime_token_ciphertext = encrypt_text(handshake.runtime_token)
         anyharness_data_key_ciphertext = encrypt_text(ctx.anyharness_data_key)
-        await finalize_workspace_provision_for_ids(
-            workspace_id,
-            sandbox_record_id,
-            runtime_url=connected.endpoint.runtime_url,
-            runtime_token_ciphertext=runtime_token_ciphertext,
-            anyharness_workspace_id=handshake.anyharness_workspace_id,
-            template_version=connected.handle.template_version,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await finalize_workspace_provision_for_ids(
+                db,
+                workspace_id,
+                sandbox_record_id,
+                runtime_url=connected.endpoint.runtime_url,
+                runtime_token_ciphertext=runtime_token_ciphertext,
+                anyharness_workspace_id=handshake.anyharness_workspace_id,
+                template_version=connected.handle.template_version,
+            )
         await _persist_target_runtime_access(
             ctx,
             sandbox_record_id=sandbox_record_id,
@@ -1634,11 +1638,9 @@ async def provision_workspace(
             launched_runtime=launched_runtime_this_attempt,
             repo_env_applied_version=ctx.repo_env_version,
         )
-        await save_runtime_environment_state(
-            ctx.runtime_environment_id,
-            **runtime_state_updates,
-        )
-        provisioned_workspace = await load_cloud_workspace_by_id(workspace_id)
+        await _save_runtime_environment_updates(ctx.runtime_environment_id, runtime_state_updates)
+        async with db_engine.async_session_factory() as db:
+            provisioned_workspace = await load_cloud_workspace_by_id(db, workspace_id)
         if provisioned_workspace is not None:
             await apply_workspace_repo_config_after_provision(
                 provisioned_workspace,
@@ -1668,9 +1670,11 @@ async def provision_workspace(
         )
     except Exception as exc:
         error_message = format_exception_message(exc)
-        sandbox_record = (
-            await load_cloud_sandbox_by_id(sandbox_record_id) if sandbox_record_id else None
-        )
+        if sandbox_record_id:
+            async with db_engine.async_session_factory() as db:
+                sandbox_record = await load_cloud_sandbox_by_id(db, sandbox_record_id)
+        else:
+            sandbox_record = None
         external_sandbox_id = (
             connected.handle.sandbox_id
             if connected is not None
@@ -1695,13 +1699,12 @@ async def provision_workspace(
                 closed_by=USAGE_SEGMENT_CLOSED_BY_PROVISION_FAILURE,
                 is_billable=False,
             )
-            await update_sandbox_status(sandbox_record, "destroyed", stopped_at_now=True)
-        await mark_workspace_error_by_id(
-            workspace_id,
-            error_message,
-            clear_runtime_metadata=True,
-            clear_active_sandbox=True,
-        )
+            async with db_engine.async_session_factory() as db, db.begin():
+                await update_sandbox_status(db, sandbox_record, "destroyed", stopped_at_now=True)
+        async with db_engine.async_session_factory() as db, db.begin():
+            await mark_workspace_error_by_id(
+                db, workspace_id, error_message, clear_runtime_metadata=True, clear_active_sandbox=True
+            )
         total_elapsed_ms = duration_ms(provision_started)
         log_cloud_event(
             "cloud workspace provisioning failed",

--- a/server/proliferate/server/cloud/runtime/repo_config_apply.py
+++ b/server/proliferate/server/cloud/runtime/repo_config_apply.py
@@ -64,13 +64,15 @@ class WorkspaceSetupStartResult:
 
 @asynccontextmanager
 async def _workspace_apply_lock(workspace_id: UUID) -> AsyncIterator[None]:
-    async with db_engine.async_session_factory() as db:
-        async with workspace_repo_apply_lock(db, workspace_id) as acquired:
-            if not acquired:
-                raise WorkspaceRepoApplyBusyError(
-                    "A repo config apply operation is already running for this workspace."
-                )
-            yield
+    async with (
+        db_engine.async_session_factory() as db,
+        workspace_repo_apply_lock(db, workspace_id) as acquired,
+    ):
+        if not acquired:
+            raise WorkspaceRepoApplyBusyError(
+                "A repo config apply operation is already running for this workspace."
+            )
+        yield
 
 
 async def _load_workspace_repo_config(workspace: CloudWorkspace) -> CloudRepoConfigValue | None:

--- a/server/proliferate/server/cloud/runtime/repo_config_apply.py
+++ b/server/proliferate/server/cloud/runtime/repo_config_apply.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from uuid import UUID, uuid4
 
+from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_repo_config import (
     CloudRepoConfigValue,
@@ -63,20 +64,23 @@ class WorkspaceSetupStartResult:
 
 @asynccontextmanager
 async def _workspace_apply_lock(workspace_id: UUID) -> AsyncIterator[None]:
-    async with workspace_repo_apply_lock(workspace_id) as acquired:
-        if not acquired:
-            raise WorkspaceRepoApplyBusyError(
-                "A repo config apply operation is already running for this workspace."
-            )
-        yield
+    async with db_engine.async_session_factory() as db:
+        async with workspace_repo_apply_lock(db, workspace_id) as acquired:
+            if not acquired:
+                raise WorkspaceRepoApplyBusyError(
+                    "A repo config apply operation is already running for this workspace."
+                )
+            yield
 
 
 async def _load_workspace_repo_config(workspace: CloudWorkspace) -> CloudRepoConfigValue | None:
-    return await load_cloud_repo_config_for_user(
-        user_id=workspace.user_id,
-        git_owner=workspace.git_owner,
-        git_repo_name=workspace.git_repo_name,
-    )
+    async with db_engine.async_session_factory() as db:
+        return await load_cloud_repo_config_for_user(
+            db,
+            user_id=workspace.user_id,
+            git_owner=workspace.git_owner,
+            git_repo_name=workspace.git_repo_name,
+        )
 
 
 async def _apply_post_ready_patch(
@@ -110,7 +114,8 @@ async def _apply_post_ready_patch(
         kwargs["repo_post_ready_apply_token"] = None
     elif patch.apply_token is not None:
         kwargs["repo_post_ready_apply_token"] = patch.apply_token
-    await update_workspace_repo_apply_status_by_id(workspace_id, **kwargs)
+    async with db_engine.async_session_factory() as db, db.begin():
+        await update_workspace_repo_apply_status_by_id(db, workspace_id, **kwargs)
 
 
 async def _start_workspace_setup_monitor(
@@ -140,16 +145,18 @@ async def _start_workspace_setup_monitor(
         )
         if not started.command_run_id:
             raise CloudRuntimeOperationError("Remote setup start did not return a commandRunId.")
-        await create_cloud_workspace_setup_run(
-            workspace_id=workspace.id,
-            anyharness_workspace_id=runtime.anyharness_workspace_id,
-            terminal_id=started.terminal_id,
-            command_run_id=started.command_run_id,
-            setup_script_version=repo_config.files_version,
-            apply_token=apply_token,
-            deadline_at=utcnow() + timedelta(minutes=35),
-            status="running",
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            await create_cloud_workspace_setup_run(
+                db,
+                workspace_id=workspace.id,
+                anyharness_workspace_id=runtime.anyharness_workspace_id,
+                terminal_id=started.terminal_id,
+                command_run_id=started.command_run_id,
+                setup_script_version=repo_config.files_version,
+                apply_token=apply_token,
+                deadline_at=utcnow() + timedelta(minutes=35),
+                status="running",
+            )
     except Exception as exc:
         error_message = format_exception_message(exc)
         await _apply_post_ready_patch(

--- a/server/proliferate/server/cloud/runtime/service.py
+++ b/server/proliferate/server/cloud/runtime/service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.constants.billing import BILLING_MODE_ENFORCE
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_runtime_environments import load_runtime_environment_for_workspace
@@ -27,8 +29,11 @@ from proliferate.utils.crypto import decrypt_text
 provision_workspace = _provision_workspace
 
 
-async def get_workspace_connection(workspace: CloudWorkspace) -> RuntimeConnectionTarget:
-    runtime_environment = await load_runtime_environment_for_workspace(workspace)
+async def get_workspace_connection(
+    db: AsyncSession,
+    workspace: CloudWorkspace,
+) -> RuntimeConnectionTarget:
+    runtime_environment = await load_runtime_environment_for_workspace(db, workspace)
     billing_subject_id = (
         runtime_environment.billing_subject_id
         if runtime_environment is not None
@@ -71,8 +76,9 @@ async def get_workspace_connection(workspace: CloudWorkspace) -> RuntimeConnecti
         allow_launcher_restart=True,
         access_token=access_token,
     )
-    reloaded_workspace = await load_cloud_workspace_by_id(workspace.id)
+    reloaded_workspace = await load_cloud_workspace_by_id(db, workspace.id)
     reloaded_environment = await load_runtime_environment_for_workspace(
+        db,
         reloaded_workspace or workspace,
     )
     if (

--- a/server/proliferate/server/cloud/runtime/service.py
+++ b/server/proliferate/server/cloud/runtime/service.py
@@ -33,6 +33,7 @@ async def get_workspace_connection(
     db: AsyncSession,
     workspace: CloudWorkspace,
 ) -> RuntimeConnectionTarget:
+    workspace_id = workspace.id
     runtime_environment = await load_runtime_environment_for_workspace(db, workspace)
     billing_subject_id = (
         runtime_environment.billing_subject_id
@@ -72,11 +73,12 @@ async def get_workspace_connection(
     access_token = decrypt_text(runtime_environment.runtime_token_ciphertext)
     runtime_url = await ensure_environment_runtime_ready(
         runtime_environment,
-        workspace_id=workspace.id,
+        workspace_id=workspace_id,
         allow_launcher_restart=True,
         access_token=access_token,
     )
-    reloaded_workspace = await load_cloud_workspace_by_id(db, workspace.id)
+    db.expire_all()
+    reloaded_workspace = await load_cloud_workspace_by_id(db, workspace_id)
     reloaded_environment = await load_runtime_environment_for_workspace(
         db,
         reloaded_workspace or workspace,
@@ -106,14 +108,14 @@ async def get_workspace_connection(
         user_id=reloaded_workspace.user_id,
         runtime_url=runtime_url,
         access_token=access_token,
-        workspace_id=workspace.id,
+        workspace_id=workspace_id,
         run_deferred_startup_cleanup=True,
         await_deferred_startup_cleanup=False,
     )
     ready_agent_kinds = await get_runtime_ready_agent_kinds(
         runtime_url,
         access_token,
-        workspace_id=workspace.id,
+        workspace_id=workspace_id,
     )
     return RuntimeConnectionTarget(
         target_id=reloaded_environment.target_id,

--- a/server/proliferate/server/cloud/runtime/setup_monitor.py
+++ b/server/proliferate/server/cloud/runtime/setup_monitor.py
@@ -8,6 +8,7 @@ import socket
 import time
 from uuid import UUID, uuid4
 
+from proliferate.db import engine as db_engine
 from proliferate.db.store.cloud_workspace_setup_runs import (
     claim_due_setup_runs,
     finalize_setup_run,
@@ -67,7 +68,9 @@ async def _cloud_setup_monitor_loop() -> None:
 
 
 async def reconcile_cloud_setup_runs() -> None:
-    for run in await claim_due_setup_runs(owner=_SETUP_MONITOR_OWNER):
+    async with db_engine.async_session_factory() as db, db.begin():
+        claimed_runs = await claim_due_setup_runs(db, owner=_SETUP_MONITOR_OWNER)
+    for run in claimed_runs:
         try:
             await _poll_setup_run(run.id)
         except Exception as exc:
@@ -84,14 +87,16 @@ async def reconcile_cloud_setup_runs() -> None:
 
 
 async def _poll_setup_run(setup_run_id: UUID) -> None:
-    setup_run = await load_cloud_workspace_setup_run(setup_run_id)
+    async with db_engine.async_session_factory() as db:
+        setup_run = await load_cloud_workspace_setup_run(db, setup_run_id)
     if setup_run is None:
         return
     if utcnow() >= setup_run.deadline_at:
         await _mark_setup_run_timed_out(setup_run.id)
         return
 
-    workspace = await load_cloud_workspace_by_id(setup_run.workspace_id)
+    async with db_engine.async_session_factory() as db:
+        workspace = await load_cloud_workspace_by_id(db, setup_run.workspace_id)
     if workspace is None:
         await _finalize_setup_run(
             setup_run.id,
@@ -101,7 +106,8 @@ async def _poll_setup_run(setup_run_id: UUID) -> None:
         )
         return
 
-    target = await get_workspace_connection(workspace)
+    async with db_engine.async_session_factory() as db:
+        target = await get_workspace_connection(db, workspace)
     if not target.anyharness_workspace_id:
         await _release_setup_run_claim(
             setup_run.id,
@@ -158,12 +164,14 @@ async def _release_setup_run_claim(
     status: str = "running",
     last_error: str | None = None,
 ) -> None:
-    await release_setup_run_claim(
-        setup_run_id,
-        bound_error=bounded_setup_monitor_error,
-        status=status,
-        last_error=last_error,
-    )
+    async with db_engine.async_session_factory() as db, db.begin():
+        await release_setup_run_claim(
+            db,
+            setup_run_id,
+            bound_error=bounded_setup_monitor_error,
+            status=status,
+            last_error=last_error,
+        )
 
 
 async def _finalize_setup_run(
@@ -173,17 +181,21 @@ async def _finalize_setup_run(
     success: bool,
     last_error: str | None = None,
 ) -> None:
-    await finalize_setup_run(
-        setup_run_id,
-        classify_finalization=classify_setup_run_finalization,
-        final_status=final_status,
-        success=success,
-        last_error=last_error,
-    )
+    async with db_engine.async_session_factory() as db, db.begin():
+        await finalize_setup_run(
+            db,
+            setup_run_id,
+            classify_finalization=classify_setup_run_finalization,
+            final_status=final_status,
+            success=success,
+            last_error=last_error,
+        )
 
 
 async def _mark_setup_run_timed_out(setup_run_id: UUID) -> None:
-    await mark_setup_run_timed_out(
-        setup_run_id,
-        classify_finalization=classify_setup_run_finalization,
-    )
+    async with db_engine.async_session_factory() as db, db.begin():
+        await mark_setup_run_timed_out(
+            db,
+            setup_run_id,
+            classify_finalization=classify_setup_run_finalization,
+        )

--- a/server/proliferate/server/cloud/runtime/worktree_policy_sync.py
+++ b/server/proliferate/server/cloud/runtime/worktree_policy_sync.py
@@ -7,6 +7,7 @@ import logging
 import time
 from uuid import UUID
 
+from proliferate.db import engine as db_engine
 from proliferate.integrations import anyharness
 from proliferate.server.cloud._logging import format_exception_message, log_cloud_event
 from proliferate.server.cloud.worktree_policy.service import (
@@ -96,7 +97,8 @@ async def sync_cloud_worktree_policy_to_runtime(
     run_deferred_startup_cleanup: bool,
     await_deferred_startup_cleanup: bool = True,
 ) -> int:
-    policy = await get_worktree_retention_policy(user_id)
+    async with db_engine.async_session_factory() as db:
+        policy = await get_worktree_retention_policy(db, user_id)
     limit = policy.max_materialized_worktrees_per_repo
     await update_runtime_worktree_retention_policy(
         runtime_url,

--- a/server/proliferate/server/cloud/webhooks/service.py
+++ b/server/proliferate/server/cloud/webhooks/service.py
@@ -143,7 +143,7 @@ async def close_usage_segment_for_sandbox(
 
 
 async def handle_e2b_webhook(
-    _db: AsyncSession,
+    db: AsyncSession,
     *,
     payload: bytes,
     signature: str | None,
@@ -165,11 +165,11 @@ async def handle_e2b_webhook(
     metadata = event.event_data.sandbox_metadata
     sandbox = None
     if event.sandbox_id:
-        sandbox = await load_cloud_sandbox_by_external_id(event.sandbox_id)
+        sandbox = await load_cloud_sandbox_by_external_id(db, event.sandbox_id)
     if sandbox is None:
         metadata_sandbox_id = _metadata_sandbox_id(metadata)
         if metadata_sandbox_id is not None:
-            sandbox = await load_cloud_sandbox_by_id(metadata_sandbox_id)
+            sandbox = await load_cloud_sandbox_by_id(db, metadata_sandbox_id)
     if sandbox is None:
         return E2BWebhookReceipt()
 
@@ -182,12 +182,12 @@ async def handle_e2b_webhook(
         return E2BWebhookReceipt()
 
     runtime_environment = (
-        await load_runtime_environment_by_id(sandbox.runtime_environment_id)
+        await load_runtime_environment_by_id(db, sandbox.runtime_environment_id)
         if sandbox.runtime_environment_id is not None
         else None
     )
     workspace = (
-        await load_cloud_workspace_by_id(sandbox.cloud_workspace_id)
+        await load_cloud_workspace_by_id(db, sandbox.cloud_workspace_id)
         if sandbox.cloud_workspace_id is not None
         else None
     )
@@ -195,6 +195,7 @@ async def handle_e2b_webhook(
         return E2BWebhookReceipt()
 
     await save_sandbox_provider_state(
+        db,
         sandbox.id,
         external_sandbox_id=event.sandbox_id if event.sandbox_id else sandbox.external_sandbox_id,
         last_provider_event_at=event.timestamp,
@@ -219,6 +220,7 @@ async def handle_e2b_webhook(
                 event_id=event.id,
             )
             await save_sandbox_provider_state(
+                db,
                 sandbox.id,
                 status="paused",
                 stopped_at=event.timestamp,
@@ -227,6 +229,7 @@ async def handle_e2b_webhook(
             )
             if runtime_environment is not None:
                 await save_runtime_environment_state(
+                    db,
                     runtime_environment.id,
                     **runtime_provider_paused_update(),
                 )
@@ -254,6 +257,7 @@ async def handle_e2b_webhook(
             event_id=event.id,
         )
         await save_sandbox_provider_state(
+            db,
             sandbox.id,
             status="running",
             started_at=event.timestamp,
@@ -263,6 +267,7 @@ async def handle_e2b_webhook(
         )
         if runtime_environment is not None:
             await save_runtime_environment_state(
+                db,
                 runtime_environment.id,
                 **runtime_provider_running_update(),
             )
@@ -280,6 +285,7 @@ async def handle_e2b_webhook(
             event_id=event.id,
         )
         await save_sandbox_provider_state(
+            db,
             sandbox.id,
             status="paused",
             stopped_at=event.timestamp,
@@ -288,6 +294,7 @@ async def handle_e2b_webhook(
         )
         if runtime_environment is not None:
             await save_runtime_environment_state(
+                db,
                 runtime_environment.id,
                 **runtime_provider_paused_update(),
             )
@@ -301,6 +308,7 @@ async def handle_e2b_webhook(
             event_id=event.id,
         )
         await save_sandbox_provider_state(
+            db,
             sandbox.id,
             status="destroyed",
             stopped_at=event.timestamp,
@@ -309,6 +317,7 @@ async def handle_e2b_webhook(
         )
         if runtime_environment is not None:
             await save_runtime_environment_state(
+                db,
                 runtime_environment.id,
                 **runtime_provider_destroyed_update(),
             )

--- a/server/proliferate/server/cloud/webhooks/service.py
+++ b/server/proliferate/server/cloud/webhooks/service.py
@@ -84,6 +84,7 @@ def _metadata_sandbox_id(metadata: dict[str, str]) -> UUID | None:
 
 
 async def remember_sandbox_event_receipt(
+    db: AsyncSession,
     *,
     event_id: str,
     provider: str,
@@ -91,6 +92,7 @@ async def remember_sandbox_event_receipt(
     external_sandbox_id: str | None,
 ) -> bool:
     return await remember_cloud_sandbox_event_receipt(
+        db,
         event_id=event_id,
         provider=provider,
         event_type=event_type,
@@ -155,6 +157,7 @@ async def handle_e2b_webhook(
         return E2BWebhookReceipt()
 
     if not await remember_sandbox_event_receipt(
+        db,
         event_id=event.id,
         provider="e2b",
         event_type=event.type,

--- a/server/proliferate/server/cloud/workspaces/access.py
+++ b/server/proliferate/server/cloud/workspaces/access.py
@@ -43,11 +43,10 @@ async def cloud_workspace_user_can_read(
 ) -> CloudWorkspace:
     # Transitional: the cloud workspace service still consumes ORM objects.
     # Keep lookup/policy ownership here until the store returns snapshots.
-    workspace = await load_cloud_workspace_by_id(workspace_id)
-    if workspace is None:
-        _raise_workspace_not_found()
-
     async with db_engine.async_session_factory() as db:
+        workspace = await load_cloud_workspace_by_id(db, workspace_id)
+        if workspace is None:
+            _raise_workspace_not_found()
         exposure, _claim = await load_workspace_exposure_and_claim(
             db,
             target_id=workspace.target_id,

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -153,9 +153,10 @@ async def get_cloud_workspace_endpoint(
 async def get_cloud_workspace_connection_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceConnection:
     try:
-        return await get_cloud_connection(user.id, workspace_id)
+        return await get_cloud_connection(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
 
@@ -188,9 +189,10 @@ async def disable_cloud_workspace_remote_access_endpoint(
 async def start_cloud_workspace_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
-        payload = await start_cloud_workspace(user, workspace_id)
+        payload = await start_cloud_workspace(db, user, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
     return payload
@@ -200,9 +202,10 @@ async def start_cloud_workspace_endpoint(
 async def stop_cloud_workspace_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceDetail:
     try:
-        payload = await stop_cloud_workspace(user.id, workspace_id)
+        payload = await stop_cloud_workspace(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
     return payload
@@ -288,9 +291,10 @@ async def update_cloud_workspace_display_name_endpoint(
 async def delete_cloud_workspace_endpoint(
     workspace_id: UUID,
     user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
 ) -> dict[str, bool]:
     try:
-        await delete_cloud_workspace(user.id, workspace_id)
+        await delete_cloud_workspace(db, user.id, workspace_id)
     except CloudApiError as error:
         raise_cloud_error(error)
     return {"ok": True}

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -2377,9 +2377,12 @@ async def delete_cloud_workspace(
 ) -> None:
     workspace = await cloud_workspace_user_can_archive_with_db(db, user_id, workspace_id)
     await _revoke_claim_tokens_for_workspace(workspace, reason="workspace_deleted")
+    workspace_record_id = workspace.id
+    db.expunge(workspace)
     await _destroy_workspace_runtime(workspace)
     async with db_engine.async_session_factory() as delete_db, delete_db.begin():
-        await delete_cloud_workspace_records_for_workspace(delete_db, workspace)
+        if refreshed := await load_cloud_workspace_by_id(delete_db, workspace_record_id):
+            await delete_cloud_workspace_records_for_workspace(delete_db, refreshed)
 
 
 async def _revoke_claim_tokens_for_workspace(
@@ -2398,12 +2401,8 @@ async def _revoke_claim_tokens_for_workspace(
         )
 
 
-# ---------------------------------------------------------------------------
-# Runtime lifecycle orchestration
-# ---------------------------------------------------------------------------
 # These helpers own the interaction with the persisted sandbox provider
 # (pause / destroy) and delegate the persistence update to store.py primitives.
-# ---------------------------------------------------------------------------
 
 
 async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -943,18 +943,14 @@ async def launch_workspace_on_target(
         await _wait_for_target_launch_command(send_command, workspace_id=workspace_id)
     except CloudApiError as exc:
         message = format_exception_message(exc) or exc.message
-        await mark_workspace_error_by_id(
-            workspace_id,
-            message,
-            status_detail="Desktop dispatch failed",
+        await _mark_workspace_error_tx(
+            workspace_id, message, status_detail="Desktop dispatch failed"
         )
         raise
     except (RuntimeError, TimeoutError, ValueError) as exc:
         message = format_exception_message(exc) or str(exc)
-        await mark_workspace_error_by_id(
-            workspace_id,
-            message,
-            status_detail="Desktop dispatch failed",
+        await _mark_workspace_error_tx(
+            workspace_id, message, status_detail="Desktop dispatch failed"
         )
         raise CloudApiError(
             "target_launch_failed",
@@ -1342,7 +1338,7 @@ async def _build_workspace_detail(
             target_id=workspace.target_id,
             cloud_workspace_id=workspace.id,
         )
-    runtime_environment = await load_runtime_environment_for_workspace(workspace)
+        runtime_environment = await load_runtime_environment_for_workspace(db, workspace)
     runtime_auth = await load_workspace_runtime_auth_snapshot(
         workspace=workspace,
         runtime_environment=runtime_environment,
@@ -1401,6 +1397,30 @@ async def _build_workspace_detail(
     )
 
 
+async def _load_repo_config_value_tx(user_id: UUID, git_owner: str, git_repo_name: str) -> object | None:
+    async with db_engine.async_session_factory() as db:
+        return await load_repo_config_value(
+            db, user_id=user_id, git_owner=git_owner, git_repo_name=git_repo_name
+        )
+
+
+async def _bootstrap_repo_config_tx(user_id: UUID, git_owner: str, git_repo_name: str) -> object:
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await bootstrap_repo_config(
+            db, user_id=user_id, git_owner=git_owner, git_repo_name=git_repo_name
+        )
+
+
+async def _mark_workspace_error_tx(workspace_id: UUID, message: str, **kwargs: object) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await mark_workspace_error_by_id(db, workspace_id, message, **kwargs)
+
+
+async def _update_sandbox_status_tx(sandbox: CloudSandbox, status: str, **kwargs: object) -> None:
+    async with db_engine.async_session_factory() as db, db.begin():
+        await update_sandbox_status(db, sandbox, status, **kwargs)
+
+
 async def _resolve_new_cloud_workspace_create(
     user: User,
     *,
@@ -1435,28 +1455,22 @@ async def _resolve_new_cloud_workspace_create(
             status_code=400,
         )
 
-    repo_config = await load_repo_config_value(
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
+    repo_config = await _load_repo_config_value_tx(user.id, git_owner, git_repo_name)
     if repo_config is None or not repo_config.configured:
-        existing_repo_workspace = await load_any_cloud_workspace_for_repo(
-            user_id=user.id,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-        )
+        async with db_engine.async_session_factory() as db:
+            existing_repo_workspace = await load_any_cloud_workspace_for_repo(
+                db,
+                user_id=user.id,
+                git_owner=git_owner,
+                git_repo_name=git_repo_name,
+            )
         if existing_repo_workspace is None:
             raise CloudApiError(
                 "cloud_repo_not_configured",
                 "Configure cloud settings for this repo before creating a cloud workspace.",
                 status_code=409,
             )
-        repo_config = await bootstrap_repo_config(
-            user_id=user.id,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-        )
+        repo_config = await _bootstrap_repo_config_tx(user.id, git_owner, git_repo_name)
         log_cloud_event(
             "cloud repo config auto-bootstrapped",
             user_id=user.id,
@@ -1502,13 +1516,15 @@ async def _resolve_new_cloud_workspace_create(
             status_code=400,
         )
 
-    existing_cloud_workspace = await load_existing_cloud_workspace(
-        user_id=user.id,
-        git_provider=git_provider,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-        git_branch=cleaned_branch_name,
-    )
+    async with db_engine.async_session_factory() as db:
+        existing_cloud_workspace = await load_existing_cloud_workspace(
+            db,
+            user_id=user.id,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            git_branch=cleaned_branch_name,
+        )
     if existing_cloud_workspace is not None:
         raise CloudApiError(
             "cloud_branch_already_exists",
@@ -1808,19 +1824,15 @@ async def create_cloud_workspace(
             source,
             CREATE_WORKSPACE_ORIGIN_BY_SOURCE["desktop"],
         )
-        workspace = await create_cloud_workspace_for_user(
-            user_id=user.id,
-            display_name=resolved.display_name,
-            git_provider=resolved.git_provider,
-            git_owner=resolved.git_owner,
-            git_repo_name=resolved.git_repo_name,
-            git_branch=resolved.git_branch,
-            git_base_branch=resolved.git_base_branch,
-            origin=origin,
-            origin_json=origin_json,
-            template_version=get_configured_sandbox_provider().template_version,
-            cloud_repo_limit=resolved.cloud_repo_limit,
-        )
+        async with db_engine.async_session_factory() as create_db, create_db.begin():
+            workspace = await create_cloud_workspace_for_user(
+                create_db, user_id=user.id, display_name=resolved.display_name,
+                git_provider=resolved.git_provider, git_owner=resolved.git_owner,
+                git_repo_name=resolved.git_repo_name, git_branch=resolved.git_branch,
+                git_base_branch=resolved.git_base_branch, origin=origin, origin_json=origin_json,
+                template_version=get_configured_sandbox_provider().template_version,
+                cloud_repo_limit=resolved.cloud_repo_limit,
+            )
     except CloudRepoLimitExceededError as error:
         _raise_repo_limit_exceeded(error)
     log_cloud_event(
@@ -1929,13 +1941,15 @@ async def ensure_cloud_workspace_for_existing_branch(
             "Choose a branch before provisioning a cloud workspace.",
             status_code=400,
         )
-    existing_cloud_workspace = await load_existing_cloud_workspace(
-        user_id=user.id,
-        git_provider=git_provider,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-        git_branch=cleaned_branch_name,
-    )
+    async with db_engine.async_session_factory() as db:
+        existing_cloud_workspace = await load_existing_cloud_workspace(
+            db,
+            user_id=user.id,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            git_branch=cleaned_branch_name,
+        )
     if existing_cloud_workspace is not None:
         if _cloud_workspace_should_be_replaced_for_mobility_retry(existing_cloud_workspace):
             await _archive_failed_cloud_workspace_for_mobility_retry(existing_cloud_workspace.id)
@@ -1948,17 +1962,9 @@ async def ensure_cloud_workspace_for_existing_branch(
             )
         else:
             return existing_cloud_workspace
-    repo_config = await load_repo_config_value(
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
+    repo_config = await _load_repo_config_value_tx(user.id, git_owner, git_repo_name)
     if repo_config is None or not repo_config.configured:
-        repo_config = await bootstrap_repo_config(
-            user_id=user.id,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-        )
+        repo_config = await _bootstrap_repo_config_tx(user.id, git_owner, git_repo_name)
         log_cloud_event(
             "cloud repo config auto-bootstrapped",
             user_id=user.id,
@@ -1972,18 +1978,16 @@ async def ensure_cloud_workspace_for_existing_branch(
     billing_snapshot = await get_billing_snapshot_for_subject(authorization.billing_subject_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
     try:
-        workspace = await create_cloud_workspace_for_user(
-            user_id=user.id,
-            display_name=(display_name.strip() if display_name and display_name.strip() else None),
-            git_provider=git_provider,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            git_branch=cleaned_branch_name,
-            git_base_branch=cleaned_branch_name,
-            origin_json=CLOUD_HUMAN_ORIGIN_JSON,
-            template_version=get_configured_sandbox_provider().template_version,
-            cloud_repo_limit=cloud_repo_limit,
-        )
+        async with db_engine.async_session_factory() as db, db.begin():
+            workspace = await create_cloud_workspace_for_user(
+                db, user_id=user.id,
+                display_name=display_name.strip() if display_name and display_name.strip() else None,
+                git_provider=git_provider, git_owner=git_owner, git_repo_name=git_repo_name,
+                git_branch=cleaned_branch_name, git_base_branch=cleaned_branch_name,
+                origin_json=CLOUD_HUMAN_ORIGIN_JSON,
+                template_version=get_configured_sandbox_provider().template_version,
+                cloud_repo_limit=cloud_repo_limit,
+            )
     except CloudRepoLimitExceededError as error:
         _raise_repo_limit_exceeded(error)
     log_cloud_event(
@@ -2005,40 +2009,33 @@ def _cloud_workspace_should_be_replaced_for_mobility_retry(
 
 
 async def _archive_failed_cloud_workspace_for_mobility_retry(workspace_id: UUID) -> None:
-    async with db_engine.async_session_factory() as db:
-        await archive_cloud_workspace_record_by_id(db, workspace_id=workspace_id)
-        await db.commit()
+    async with db_engine.async_session_factory() as db, db.begin(): await archive_cloud_workspace_record_by_id(db, workspace_id=workspace_id)
 
 
-async def _refresh_repo_env_snapshot_for_workspace(
-    workspace: CloudWorkspace,
-) -> CloudWorkspace:
-    repo_config = await load_repo_config_value(
-        user_id=workspace.user_id,
-        git_owner=workspace.git_owner,
-        git_repo_name=workspace.git_repo_name,
+async def _refresh_repo_env_snapshot_for_workspace(workspace: CloudWorkspace) -> CloudWorkspace:
+    repo_config = await _load_repo_config_value_tx(
+        workspace.user_id, workspace.git_owner, workspace.git_repo_name
     )
     if repo_config is None or not repo_config.configured:
-        repo_config = await bootstrap_repo_config(
-            user_id=workspace.user_id,
-            git_owner=workspace.git_owner,
-            git_repo_name=workspace.git_repo_name,
+        repo_config = await _bootstrap_repo_config_tx(
+            workspace.user_id, workspace.git_owner, workspace.git_repo_name
         )
         log_cloud_event(
             "cloud repo config auto-bootstrapped",
             user_id=workspace.user_id,
             repo=f"{workspace.git_owner}/{workspace.git_repo_name}",
         )
-    return await save_workspace(workspace)
+    async with db_engine.async_session_factory() as db, db.begin(): return await save_workspace(db, workspace)
 
 
 async def start_cloud_workspace(
+    db: AsyncSession,
     user: User,
     workspace_id: UUID,
     *,
     requested_base_sha: str | None = None,
 ) -> WorkspaceDetail:
-    workspace = await cloud_workspace_user_can_interact(user.id, workspace_id)
+    workspace = await cloud_workspace_user_can_interact_with_db(db, user.id, workspace_id)
     has_requested_revision = bool((requested_base_sha or "").strip())
     if start_request_should_return_existing(workspace.status) and not has_requested_revision:
         return await _build_workspace_detail(workspace)
@@ -2104,7 +2101,7 @@ async def start_cloud_workspace(
         if start_decision.clear_last_error:
             workspace.last_error = None
         if start_decision.persist_before_schedule:
-            await save_workspace(workspace)
+            async with db_engine.async_session_factory() as persist_db, persist_db.begin(): workspace = await save_workspace(persist_db, workspace)
         log_cloud_event(
             "cloud workspace queued",
             workspace_id=workspace.id,
@@ -2153,7 +2150,7 @@ async def start_cloud_workspace(
     if start_decision.clear_last_error:
         workspace.last_error = None
     if start_decision.persist_before_schedule:
-        await save_workspace(workspace)
+        async with db_engine.async_session_factory() as persist_db, persist_db.begin(): workspace = await save_workspace(persist_db, workspace)
     log_cloud_event(
         "cloud workspace restart queued",
         workspace_id=workspace.id,
@@ -2221,10 +2218,11 @@ async def sync_cloud_workspace_display_name(
 
 
 async def stop_cloud_workspace(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> WorkspaceDetail:
-    workspace = await cloud_workspace_user_can_archive(user_id, workspace_id)
+    workspace = await cloud_workspace_user_can_archive_with_db(db, user_id, workspace_id)
     await _stop_workspace_runtime(workspace)
     await _revoke_claim_tokens_for_workspace(workspace, reason="workspace_archived")
     workspace = await cloud_workspace_user_can_read(user_id, workspace_id)
@@ -2357,13 +2355,14 @@ async def purge_cloud_workspace(
 
 
 async def delete_cloud_workspace(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> None:
-    workspace = await cloud_workspace_user_can_archive(user_id, workspace_id)
+    workspace = await cloud_workspace_user_can_archive_with_db(db, user_id, workspace_id)
     await _revoke_claim_tokens_for_workspace(workspace, reason="workspace_deleted")
     await _destroy_workspace_runtime(workspace)
-    await delete_cloud_workspace_records_for_workspace(workspace)
+    async with db_engine.async_session_factory() as delete_db, delete_db.begin(): await delete_cloud_workspace_records_for_workspace(delete_db, workspace)
 
 
 async def _revoke_claim_tokens_for_workspace(
@@ -2407,7 +2406,7 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
                 await provider.pause_sandbox(sandbox.external_sandbox_id)
             except Exception:
                 failure_state = provider_failure_debug_state("stop")
-                await update_sandbox_status(sandbox, failure_state.sandbox_status)
+                await _update_sandbox_status_tx(sandbox, failure_state.sandbox_status)
                 log_cloud_event(
                     "cloud sandbox pause failed",
                     level=logging.WARNING,
@@ -2421,7 +2420,7 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
                     ended_at=utcnow(),
                     closed_by=USAGE_SEGMENT_CLOSED_BY_MANUAL_STOP,
                 )
-                await update_sandbox_status(sandbox, "paused", stopped_at_now=True)
+                await _update_sandbox_status_tx(sandbox, "paused", stopped_at_now=True)
                 log_cloud_event(
                     "cloud sandbox paused",
                     workspace_id=workspace.id,
@@ -2429,7 +2428,7 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
                     external_sandbox_id=sandbox.external_sandbox_id,
                 )
         else:
-            await update_sandbox_status(sandbox, "paused", stopped_at_now=True)
+            await _update_sandbox_status_tx(sandbox, "paused", stopped_at_now=True)
 
     if workspace.status != CloudWorkspaceStatus.archived.value:
         transition_workspace_status(
@@ -2439,7 +2438,7 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
         )
     else:
         workspace.updated_at = utcnow()
-    await persist_workspace_stop_state(workspace)
+    async with db_engine.async_session_factory() as db, db.begin(): await persist_workspace_stop_state(db, workspace)
     log_cloud_event(
         "cloud workspace stopped",
         workspace_id=workspace.id,
@@ -2458,7 +2457,7 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
                 await provider.destroy_sandbox(sandbox.external_sandbox_id)
             except Exception:
                 failure_state = provider_failure_debug_state("destroy")
-                await update_sandbox_status(sandbox, failure_state.sandbox_status)
+                await _update_sandbox_status_tx(sandbox, failure_state.sandbox_status)
                 log_cloud_event(
                     "cloud sandbox destroy failed",
                     level=logging.WARNING,
@@ -2472,7 +2471,7 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
                     ended_at=utcnow(),
                     closed_by=USAGE_SEGMENT_CLOSED_BY_DESTROY,
                 )
-                await update_sandbox_status(sandbox, "destroyed", stopped_at_now=True)
+                await _update_sandbox_status_tx(sandbox, "destroyed", stopped_at_now=True)
                 log_cloud_event(
                     "cloud sandbox destroyed",
                     workspace_id=workspace.id,
@@ -2480,9 +2479,9 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
                     external_sandbox_id=sandbox.external_sandbox_id,
                 )
         else:
-            await update_sandbox_status(sandbox, "destroyed", stopped_at_now=True)
+            await _update_sandbox_status_tx(sandbox, "destroyed", stopped_at_now=True)
     transition_workspace_status(workspace, CloudWorkspaceStatus.archived, status_detail="Archived")
-    await persist_workspace_destroy_state(workspace)
+    async with db_engine.async_session_factory() as db, db.begin(): await persist_workspace_destroy_state(db, workspace)
     log_cloud_event(
         "cloud workspace destroyed",
         workspace_id=workspace.id,
@@ -2501,7 +2500,7 @@ async def _load_workspace_owned_runtime_sandbox(
     sandbox_id = getattr(workspace, "active_sandbox_id", None)
     if sandbox_id is None:
         return None
-    sandbox = await load_cloud_sandbox_by_id(sandbox_id)
+    async with db_engine.async_session_factory() as db: sandbox = await load_cloud_sandbox_by_id(db, sandbox_id)
     if sandbox is None:
         return None
     if sandbox.cloud_workspace_id != workspace.id:
@@ -2517,10 +2516,11 @@ async def _load_workspace_owned_runtime_sandbox(
 
 
 async def get_cloud_connection(
+    db: AsyncSession,
     user_id: UUID,
     workspace_id: UUID,
 ) -> WorkspaceConnection:
-    workspace = await cloud_workspace_user_can_interact(user_id, workspace_id)
+    workspace = await cloud_workspace_user_can_interact_with_db(db, user_id, workspace_id)
     await _reject_shared_workspace_static_connection(workspace)
     async with db_engine.async_session_factory() as db:
         automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
@@ -2541,7 +2541,7 @@ async def get_cloud_connection(
             status_code=409,
         )
     try:
-        target = await get_workspace_connection(workspace)
+        target = await get_workspace_connection(db, workspace)
     except CloudRuntimeReconnectError as exc:
         log_cloud_event(
             "cloud workspace connection still resuming",
@@ -2558,7 +2558,7 @@ async def get_cloud_connection(
     except CloudApiError:
         raise
     except Exception as exc:
-        await mark_workspace_error_by_id(
+        await _mark_workspace_error_tx(
             workspace.id,
             format_exception_message(exc),
             status_detail="Reconnect failed",
@@ -2577,7 +2577,7 @@ async def get_cloud_connection(
             status_code=409,
         ) from exc
 
-    reloaded_workspace = await load_cloud_workspace_by_id(workspace.id)
+    async with db_engine.async_session_factory() as reload_db: reloaded_workspace = await load_cloud_workspace_by_id(reload_db, workspace.id)
     if reloaded_workspace is not None:
         workspace = reloaded_workspace
     log_cloud_event(

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -2541,9 +2541,9 @@ async def get_cloud_connection(
 ) -> WorkspaceConnection:
     workspace = await cloud_workspace_user_can_interact_with_db(db, user_id, workspace_id)
     await _reject_shared_workspace_static_connection(workspace)
-    async with db_engine.async_session_factory() as db:
+    async with db_engine.async_session_factory() as lookup_db:
         automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
-            db,
+            lookup_db,
             user_id=user_id,
             cloud_workspace_ids=[workspace.id],
         )

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -155,9 +155,7 @@ from proliferate.server.cloud.runtime.service import (
     get_workspace_connection,
 )
 from proliferate.server.cloud.workspaces.access import (
-    cloud_workspace_user_can_archive,
     cloud_workspace_user_can_archive_with_db,
-    cloud_workspace_user_can_interact,
     cloud_workspace_user_can_interact_with_db,
     cloud_workspace_user_can_read,
     cloud_workspace_user_can_read_with_db,
@@ -1397,7 +1395,9 @@ async def _build_workspace_detail(
     )
 
 
-async def _load_repo_config_value_tx(user_id: UUID, git_owner: str, git_repo_name: str) -> object | None:
+async def _load_repo_config_value_tx(
+    user_id: UUID, git_owner: str, git_repo_name: str
+) -> object | None:
     async with db_engine.async_session_factory() as db:
         return await load_repo_config_value(
             db, user_id=user_id, git_owner=git_owner, git_repo_name=git_repo_name
@@ -1826,10 +1826,16 @@ async def create_cloud_workspace(
         )
         async with db_engine.async_session_factory() as create_db, create_db.begin():
             workspace = await create_cloud_workspace_for_user(
-                create_db, user_id=user.id, display_name=resolved.display_name,
-                git_provider=resolved.git_provider, git_owner=resolved.git_owner,
-                git_repo_name=resolved.git_repo_name, git_branch=resolved.git_branch,
-                git_base_branch=resolved.git_base_branch, origin=origin, origin_json=origin_json,
+                create_db,
+                user_id=user.id,
+                display_name=resolved.display_name,
+                git_provider=resolved.git_provider,
+                git_owner=resolved.git_owner,
+                git_repo_name=resolved.git_repo_name,
+                git_branch=resolved.git_branch,
+                git_base_branch=resolved.git_base_branch,
+                origin=origin,
+                origin_json=origin_json,
                 template_version=get_configured_sandbox_provider().template_version,
                 cloud_repo_limit=resolved.cloud_repo_limit,
             )
@@ -1980,10 +1986,16 @@ async def ensure_cloud_workspace_for_existing_branch(
     try:
         async with db_engine.async_session_factory() as db, db.begin():
             workspace = await create_cloud_workspace_for_user(
-                db, user_id=user.id,
-                display_name=display_name.strip() if display_name and display_name.strip() else None,
-                git_provider=git_provider, git_owner=git_owner, git_repo_name=git_repo_name,
-                git_branch=cleaned_branch_name, git_base_branch=cleaned_branch_name,
+                db,
+                user_id=user.id,
+                display_name=display_name.strip()
+                if display_name and display_name.strip()
+                else None,
+                git_provider=git_provider,
+                git_owner=git_owner,
+                git_repo_name=git_repo_name,
+                git_branch=cleaned_branch_name,
+                git_base_branch=cleaned_branch_name,
                 origin_json=CLOUD_HUMAN_ORIGIN_JSON,
                 template_version=get_configured_sandbox_provider().template_version,
                 cloud_repo_limit=cloud_repo_limit,
@@ -2009,7 +2021,8 @@ def _cloud_workspace_should_be_replaced_for_mobility_retry(
 
 
 async def _archive_failed_cloud_workspace_for_mobility_retry(workspace_id: UUID) -> None:
-    async with db_engine.async_session_factory() as db, db.begin(): await archive_cloud_workspace_record_by_id(db, workspace_id=workspace_id)
+    async with db_engine.async_session_factory() as db, db.begin():
+        await archive_cloud_workspace_record_by_id(db, workspace_id=workspace_id)
 
 
 async def _refresh_repo_env_snapshot_for_workspace(workspace: CloudWorkspace) -> CloudWorkspace:
@@ -2025,7 +2038,8 @@ async def _refresh_repo_env_snapshot_for_workspace(workspace: CloudWorkspace) ->
             user_id=workspace.user_id,
             repo=f"{workspace.git_owner}/{workspace.git_repo_name}",
         )
-    async with db_engine.async_session_factory() as db, db.begin(): return await save_workspace(db, workspace)
+    async with db_engine.async_session_factory() as db, db.begin():
+        return await save_workspace(db, workspace)
 
 
 async def start_cloud_workspace(
@@ -2101,7 +2115,8 @@ async def start_cloud_workspace(
         if start_decision.clear_last_error:
             workspace.last_error = None
         if start_decision.persist_before_schedule:
-            async with db_engine.async_session_factory() as persist_db, persist_db.begin(): workspace = await save_workspace(persist_db, workspace)
+            async with db_engine.async_session_factory() as persist_db, persist_db.begin():
+                workspace = await save_workspace(persist_db, workspace)
         log_cloud_event(
             "cloud workspace queued",
             workspace_id=workspace.id,
@@ -2150,7 +2165,8 @@ async def start_cloud_workspace(
     if start_decision.clear_last_error:
         workspace.last_error = None
     if start_decision.persist_before_schedule:
-        async with db_engine.async_session_factory() as persist_db, persist_db.begin(): workspace = await save_workspace(persist_db, workspace)
+        async with db_engine.async_session_factory() as persist_db, persist_db.begin():
+            workspace = await save_workspace(persist_db, workspace)
     log_cloud_event(
         "cloud workspace restart queued",
         workspace_id=workspace.id,
@@ -2362,7 +2378,8 @@ async def delete_cloud_workspace(
     workspace = await cloud_workspace_user_can_archive_with_db(db, user_id, workspace_id)
     await _revoke_claim_tokens_for_workspace(workspace, reason="workspace_deleted")
     await _destroy_workspace_runtime(workspace)
-    async with db_engine.async_session_factory() as delete_db, delete_db.begin(): await delete_cloud_workspace_records_for_workspace(delete_db, workspace)
+    async with db_engine.async_session_factory() as delete_db, delete_db.begin():
+        await delete_cloud_workspace_records_for_workspace(delete_db, workspace)
 
 
 async def _revoke_claim_tokens_for_workspace(
@@ -2438,7 +2455,8 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
         )
     else:
         workspace.updated_at = utcnow()
-    async with db_engine.async_session_factory() as db, db.begin(): await persist_workspace_stop_state(db, workspace)
+    async with db_engine.async_session_factory() as db, db.begin():
+        await persist_workspace_stop_state(db, workspace)
     log_cloud_event(
         "cloud workspace stopped",
         workspace_id=workspace.id,
@@ -2481,7 +2499,8 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
         else:
             await _update_sandbox_status_tx(sandbox, "destroyed", stopped_at_now=True)
     transition_workspace_status(workspace, CloudWorkspaceStatus.archived, status_detail="Archived")
-    async with db_engine.async_session_factory() as db, db.begin(): await persist_workspace_destroy_state(db, workspace)
+    async with db_engine.async_session_factory() as db, db.begin():
+        await persist_workspace_destroy_state(db, workspace)
     log_cloud_event(
         "cloud workspace destroyed",
         workspace_id=workspace.id,
@@ -2500,7 +2519,8 @@ async def _load_workspace_owned_runtime_sandbox(
     sandbox_id = getattr(workspace, "active_sandbox_id", None)
     if sandbox_id is None:
         return None
-    async with db_engine.async_session_factory() as db: sandbox = await load_cloud_sandbox_by_id(db, sandbox_id)
+    async with db_engine.async_session_factory() as db:
+        sandbox = await load_cloud_sandbox_by_id(db, sandbox_id)
     if sandbox is None:
         return None
     if sandbox.cloud_workspace_id != workspace.id:
@@ -2577,7 +2597,8 @@ async def get_cloud_connection(
             status_code=409,
         ) from exc
 
-    async with db_engine.async_session_factory() as reload_db: reloaded_workspace = await load_cloud_workspace_by_id(reload_db, workspace.id)
+    async with db_engine.async_session_factory() as reload_db:
+        reloaded_workspace = await load_cloud_workspace_by_id(reload_db, workspace.id)
     if reloaded_workspace is not None:
         workspace = reloaded_workspace
     log_cloud_event(

--- a/server/proliferate/server/cloud/worktree_policy/service.py
+++ b/server/proliferate/server/cloud/worktree_policy/service.py
@@ -91,9 +91,10 @@ async def set_worktree_retention_policy(
 
 
 async def load_worktree_retention_policy_for_runtime(
+    db: AsyncSession,
     user_id: UUID,
 ) -> CloudWorktreeRetentionPolicy:
-    value = await load_cloud_worktree_policy_for_user(user_id)
+    value = await load_cloud_worktree_policy_for_user(db, user_id)
     if value is None:
         return _default_worktree_policy()
     return _worktree_policy_result(value)

--- a/server/tests/e2e/cloud/helpers/workspaces.py
+++ b/server/tests/e2e/cloud/helpers/workspaces.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import httpx
 import pytest
@@ -11,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
+from proliferate.db import engine as db_engine
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_workspaces import (
@@ -308,9 +310,8 @@ async def force_delete_cloud_workspace_records(
     db_session: AsyncSession,
     workspace_id: str,
 ) -> None:
-    import uuid
-
-    workspace = await db_session.get(CloudWorkspace, uuid.UUID(workspace_id))
+    workspace_record_id = UUID(workspace_id)
+    workspace = await db_session.get(CloudWorkspace, workspace_record_id)
     if workspace is None:
         return
     await db_session.refresh(workspace)
@@ -321,7 +322,14 @@ async def force_delete_cloud_workspace_records(
             provider = get_sandbox_provider(sandbox.provider)
             with suppress(Exception):
                 await provider.destroy_sandbox(sandbox.external_sandbox_id)
-    await delete_cloud_workspace_records_for_workspace(workspace)
+    await _delete_cloud_workspace_records_in_transaction(workspace_record_id)
+
+
+async def _delete_cloud_workspace_records_in_transaction(workspace_id: UUID) -> None:
+    async with db_engine.async_session_factory() as delete_db, delete_db.begin():
+        workspace = await delete_db.get(CloudWorkspace, workspace_id)
+        if workspace is not None:
+            await delete_cloud_workspace_records_for_workspace(delete_db, workspace)
 
 
 async def cleanup_stale_provider_test_workspaces(
@@ -349,7 +357,7 @@ async def cleanup_stale_provider_test_workspaces(
             ):
                 with suppress(Exception):
                     await provider.destroy_sandbox(sandbox.external_sandbox_id)
-        await delete_cloud_workspace_records_for_workspace(workspace)
+        await _delete_cloud_workspace_records_in_transaction(workspace.id)
 
 
 async def provision_workspace_with_credentials(

--- a/server/tests/e2e/cloud/test_e2b_webhooks.py
+++ b/server/tests/e2e/cloud/test_e2b_webhooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 import uuid
 
 import httpx
@@ -9,8 +10,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
+from proliferate.constants.billing import BILLING_MODE_ENFORCE
 from proliferate.db.models.billing import UsageSegment
 from proliferate.db.store.billing import open_usage_segment_for_sandbox
+from proliferate.server.cloud.webhooks import service as webhook_service
 from proliferate.server.billing.models import utcnow
 from tests.e2e.cloud.helpers import (
     CloudE2ETestError,
@@ -129,6 +132,67 @@ async def test_e2b_webhook_duplicate_ignored(
     assert refreshed_workspace.status == "ready"
     assert refreshed_environment.status == "paused"
     assert refreshed_sandbox.status == "paused"
+
+
+@pytest.mark.asyncio
+async def test_e2b_webhook_failed_quota_pause_keeps_receipt_retryable(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "e2b_webhook_signature_secret", "test-secret")
+    auth = await create_user_and_login(client, db_session, email_prefix="webhook-retry")
+    workspace, sandbox = await create_seeded_workspace_and_sandbox(
+        db_session,
+        user_id=auth.user_id,
+        provider="e2b",
+        workspace_status="ready",
+        sandbox_status="running",
+    )
+    workspace_id = str(workspace.id)
+    event_id = f"evt-{uuid.uuid4()}"
+    body, signature = build_signed_e2b_webhook(
+        event_id=event_id,
+        event_type="sandbox.lifecycle.resumed",
+        sandbox_id=sandbox.external_sandbox_id or "",
+        metadata={"cloud_sandbox_id": str(sandbox.id)},
+    )
+    pause_calls = 0
+
+    class _Provider:
+        async def pause_sandbox(self, sandbox_id: str) -> None:
+            nonlocal pause_calls
+            assert sandbox_id == sandbox.external_sandbox_id
+            pause_calls += 1
+            if pause_calls == 1:
+                raise RuntimeError("pause failed")
+
+    async def _billing_snapshot(_billing_subject_id):
+        return SimpleNamespace(billing_mode=BILLING_MODE_ENFORCE, active_spend_hold=True)
+
+    monkeypatch.setattr(webhook_service, "get_sandbox_provider", lambda _provider: _Provider())
+    monkeypatch.setattr(webhook_service, "get_billing_snapshot_for_subject", _billing_snapshot)
+
+    with pytest.raises(RuntimeError, match="pause failed"):
+        await client.post(
+            "/v1/cloud/webhooks/e2b",
+            content=body,
+            headers={"e2b-signature": signature},
+        )
+    assert await event_receipt_count(db_session, event_id=event_id) == 0
+    assert (await load_active_sandbox_record(db_session, workspace_id)).status == "running"
+
+    retry = await client.post(
+        "/v1/cloud/webhooks/e2b",
+        content=body,
+        headers={"e2b-signature": signature},
+    )
+    assert retry.status_code == 200
+    assert pause_calls == 2
+    assert await event_receipt_count(db_session, event_id=event_id) == 1
+    assert (await load_active_sandbox_record(db_session, workspace_id)).status == "paused"
+    environment = await load_runtime_environment_record(db_session, workspace_id)
+    assert environment.status == "paused"
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1947,7 +1947,7 @@ class TestCloudWorkspaces:
         db_session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        async def _workspace_connection(_workspace: CloudWorkspace) -> RuntimeConnectionTarget:
+        async def _workspace_connection(_db, _workspace):
             return RuntimeConnectionTarget(
                 target_id=None,
                 runtime_url="https://example-runtime.invalid",

--- a/server/tests/integration/test_cloud_commands_api.py
+++ b/server/tests/integration/test_cloud_commands_api.py
@@ -261,7 +261,6 @@ async def _create_ready_cloud_workspace(
         git_base_branch="main",
         origin_json=None,
         template_version="test",
-        commit=False,
     )
     workspace.status = CloudWorkspaceStatus.ready.value
     workspace.anyharness_workspace_id = anyharness_workspace_id

--- a/server/tests/integration/test_cloud_repo_limits.py
+++ b/server/tests/integration/test_cloud_repo_limits.py
@@ -157,6 +157,7 @@ async def test_archived_workspace_releases_cloud_repo_slot(
     assert workspace_for_archive is not None
     await delete_cloud_workspace_records(db_session, workspace_for_archive)
     assert workspace_for_archive.archived_at is not None
+    await db_session.commit()
 
     replacement = await _create_workspace(
         user_id=user_id,

--- a/server/tests/integration/test_cloud_repo_limits.py
+++ b/server/tests/integration/test_cloud_repo_limits.py
@@ -39,18 +39,20 @@ async def _create_workspace(
     branch_name: str = "main",
     cloud_repo_limit: int,
 ):
-    return await create_cloud_workspace_for_user(
-        user_id=user_id,
-        display_name=f"acme/{repo_name}",
-        git_provider="github",
-        git_owner="acme",
-        git_repo_name=repo_name,
-        git_branch=branch_name,
-        git_base_branch="main",
-        origin_json=None,
-        template_version="v1",
-        cloud_repo_limit=cloud_repo_limit,
-    )
+    async with engine_module.async_session_factory() as db, db.begin():
+        return await create_cloud_workspace_for_user(
+            db,
+            user_id=user_id,
+            display_name=f"acme/{repo_name}",
+            git_provider="github",
+            git_owner="acme",
+            git_repo_name=repo_name,
+            git_branch=branch_name,
+            git_base_branch="main",
+            origin_json=None,
+            template_version="v1",
+            cloud_repo_limit=cloud_repo_limit,
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_workspace_lifecycle_store.py
+++ b/server/tests/integration/test_cloud_workspace_lifecycle_store.py
@@ -45,11 +45,13 @@ def _patch_global_session_factory(
 
 
 async def _create_workspace(
+    db: AsyncSession,
     *,
     user_id: uuid.UUID,
     repo_name: str = "rocket",
 ) -> CloudWorkspace:
     return await create_cloud_workspace_for_user(
+        db,
         user_id=user_id,
         display_name=f"acme/{repo_name}",
         git_provider="github",
@@ -73,9 +75,10 @@ async def test_setup_run_claim_release_and_expired_claim_reclaim(
     user_id = uuid.uuid4()
     await ensure_personal_billing_subject(db_session, user_id)
     await db_session.commit()
-    workspace = await _create_workspace(user_id=user_id)
+    workspace = await _create_workspace(db_session, user_id=user_id)
     now = datetime.now(UTC)
     first = await create_cloud_workspace_setup_run(
+        db_session,
         workspace_id=workspace.id,
         anyharness_workspace_id="workspace-1",
         terminal_id="terminal-1",
@@ -85,6 +88,7 @@ async def test_setup_run_claim_release_and_expired_claim_reclaim(
         deadline_at=now + timedelta(minutes=10),
     )
     second = await create_cloud_workspace_setup_run(
+        db_session,
         workspace_id=workspace.id,
         anyharness_workspace_id="workspace-1",
         terminal_id="terminal-2",
@@ -95,16 +99,22 @@ async def test_setup_run_claim_release_and_expired_claim_reclaim(
     )
 
     claim_now = datetime.now(UTC) + timedelta(seconds=1)
-    claimed = await claim_due_setup_runs(owner="worker-a", limit=1, now=claim_now)
+    claimed = await claim_due_setup_runs(db_session, owner="worker-a", limit=1, now=claim_now)
     assert [run.id for run in claimed] == [first.id]
     assert claimed[0].claim_owner == "worker-a"
     assert claimed[0].claim_until is not None
 
-    next_claim = await claim_due_setup_runs(owner="worker-b", limit=10, now=claim_now)
+    next_claim = await claim_due_setup_runs(
+        db_session,
+        owner="worker-b",
+        limit=10,
+        now=claim_now,
+    )
     assert [run.id for run in next_claim] == [second.id]
 
     next_poll_at = now + timedelta(seconds=30)
     await release_setup_run_claim(
+        db_session,
         first.id,
         bound_error=bounded_setup_monitor_error,
         next_poll_at=next_poll_at,
@@ -119,8 +129,9 @@ async def test_setup_run_claim_release_and_expired_claim_reclaim(
     assert released.next_poll_at == next_poll_at
     assert released.last_error == "retry"
 
-    assert await claim_due_setup_runs(owner="worker-c", limit=10, now=claim_now) == []
+    assert await claim_due_setup_runs(db_session, owner="worker-c", limit=10, now=claim_now) == []
     reclaimed = await claim_due_setup_runs(
+        db_session,
         owner="worker-c",
         limit=10,
         now=claim_now + timedelta(minutes=2),
@@ -139,7 +150,7 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
     user_id = uuid.uuid4()
     await ensure_personal_billing_subject(db_session, user_id)
     await db_session.commit()
-    workspace = await _create_workspace(user_id=user_id)
+    workspace = await _create_workspace(db_session, user_id=user_id)
     stored_workspace = await db_session.get(CloudWorkspace, workspace.id)
     assert stored_workspace is not None
     stored_workspace.repo_post_ready_phase = WorkspacePostReadyPhase.starting_setup.value
@@ -147,6 +158,7 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
     await db_session.commit()
 
     stale_run = await create_cloud_workspace_setup_run(
+        db_session,
         workspace_id=workspace.id,
         anyharness_workspace_id="workspace-1",
         terminal_id=None,
@@ -156,6 +168,7 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
         deadline_at=datetime.now(UTC) + timedelta(minutes=10),
     )
     await finalize_setup_run(
+        db_session,
         stale_run.id,
         classify_finalization=classify_setup_run_finalization,
         final_status="succeeded",
@@ -172,6 +185,7 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
     assert stored_workspace.repo_setup_applied_version == 0
 
     active_run = await create_cloud_workspace_setup_run(
+        db_session,
         workspace_id=workspace.id,
         anyharness_workspace_id="workspace-1",
         terminal_id=None,
@@ -181,6 +195,7 @@ async def test_setup_run_finalize_updates_workspace_only_for_active_token(
         deadline_at=datetime.now(UTC) + timedelta(minutes=10),
     )
     await finalize_setup_run(
+        db_session,
         active_run.id,
         classify_finalization=classify_setup_run_finalization,
         final_status="succeeded",
@@ -211,8 +226,8 @@ async def test_sandbox_reservation_limit_and_provision_finalization_are_atomic(
     user_id = uuid.uuid4()
     await ensure_personal_billing_subject(db_session, user_id)
     await db_session.commit()
-    first_workspace = await _create_workspace(user_id=user_id, repo_name="first")
-    second_workspace = await _create_workspace(user_id=user_id, repo_name="second")
+    first_workspace = await _create_workspace(db_session, user_id=user_id, repo_name="first")
+    second_workspace = await _create_workspace(db_session, user_id=user_id, repo_name="second")
 
     sandbox = await reserve_sandbox_slot_for_workspace(
         db_session,
@@ -276,7 +291,7 @@ async def test_provision_failure_cleanup_is_idempotent_and_preserves_failed_sand
     user_id = uuid.uuid4()
     await ensure_personal_billing_subject(db_session, user_id)
     await db_session.commit()
-    workspace = await _create_workspace(user_id=user_id)
+    workspace = await _create_workspace(db_session, user_id=user_id)
     stored_workspace = await db_session.get(CloudWorkspace, workspace.id)
     assert stored_workspace is not None
     sandbox = CloudSandbox(

--- a/server/tests/integration/test_cloud_workspace_lifecycle_store.py
+++ b/server/tests/integration/test_cloud_workspace_lifecycle_store.py
@@ -376,15 +376,17 @@ async def test_stop_and_destroy_preserve_retry_state_after_provider_failure(
     async def _load_workspace_owned_runtime_sandbox(_workspace: CloudWorkspace):
         return sandbox
 
-    async def _update_sandbox_status(_sandbox: CloudSandbox, status: str, **_kwargs) -> None:
+    async def _update_sandbox_status(
+        _db: _NoopDb, _sandbox: CloudSandbox, status: str, **_kwargs
+    ) -> None:
         sandbox_statuses.append(status)
         _sandbox.status = status
 
-    async def _persist_workspace_stop_state(_workspace: CloudWorkspace) -> None:
+    async def _persist_workspace_stop_state(_db: _NoopDb, _workspace: CloudWorkspace) -> None:
         stopped.append(_workspace)
         await persist_workspace_stop(_NoopDb(), _workspace)
 
-    async def _persist_workspace_destroy_state(_workspace: CloudWorkspace) -> None:
+    async def _persist_workspace_destroy_state(_db: _NoopDb, _workspace: CloudWorkspace) -> None:
         destroyed.append(_workspace)
         await persist_workspace_destroy(_NoopDb(), _workspace)
 
@@ -435,5 +437,8 @@ async def test_stop_and_destroy_preserve_retry_state_after_provider_failure(
 
 
 class _NoopDb:
+    async def flush(self) -> None:
+        return None
+
     async def commit(self) -> None:
         return None

--- a/server/tests/unit/db_session_helpers.py
+++ b/server/tests/unit/db_session_helpers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+
+@asynccontextmanager
+async def noop_async_context(value: object) -> AsyncIterator[object]:
+    yield value
+
+
+class NoopDb(SimpleNamespace):
+    def begin(self) -> object:
+        return noop_async_context(self)
+
+
+def patch_async_session_factory(monkeypatch, engine_module, db: NoopDb | None = None):  # type: ignore[no-untyped-def]
+    db = db or NoopDb()
+    monkeypatch.setattr(engine_module, "async_session_factory", lambda: noop_async_context(db))
+    return db

--- a/server/tests/unit/db_session_helpers.py
+++ b/server/tests/unit/db_session_helpers.py
@@ -14,6 +14,9 @@ class NoopDb(SimpleNamespace):
     def begin(self) -> object:
         return noop_async_context(self)
 
+    def expunge(self, _instance: object) -> None:
+        return None
+
 
 def patch_async_session_factory(monkeypatch, engine_module, db: NoopDb | None = None):  # type: ignore[no-untyped-def]
     db = db or NoopDb()

--- a/server/tests/unit/test_billing_reconciler.py
+++ b/server/tests/unit/test_billing_reconciler.py
@@ -104,7 +104,7 @@ async def test_reconcile_segment_confirms_missing_list_state_before_marking_paus
     async def _mark_environment_unavailable(*args, **kwargs) -> None:
         marked.append((args, kwargs))
 
-    async def _load_cloud_sandbox_by_id(_sandbox_id):
+    async def _load_cloud_sandbox_by_id(_db, _sandbox_id):
         return sandbox
 
     monkeypatch.setattr(reconciler, "load_cloud_sandbox_by_id", _load_cloud_sandbox_by_id)

--- a/server/tests/unit/test_cloud_mobility_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_lifecycle.py
@@ -135,6 +135,7 @@ async def test_create_handoff_sets_active_pointer_and_moving_state(
     )
 
     refreshed = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -164,6 +165,7 @@ async def test_create_handoff_for_user_rejects_existing_active_workspace_handoff
 
     with pytest.raises(ValueError, match="handoff already in progress for workspace"):
         await create_cloud_workspace_handoff_op_for_user(
+            db_session,
             user_id=user_id,
             mobility_workspace_id=mobility.id,
             direction="local_to_cloud",
@@ -273,6 +275,7 @@ async def test_finalize_flips_owner_before_cleanup_clears_active_handoff(
     await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -319,6 +322,7 @@ async def test_cleanup_completion_clears_active_handoff_and_marks_completed(
     await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -404,6 +408,7 @@ async def test_cleanup_completion_restores_active_lifecycle_after_cleanup_failur
     await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -455,6 +460,7 @@ async def test_failure_clears_active_handoff_and_truncates_visible_error(
     await db_session.commit()
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -490,6 +496,7 @@ async def test_stale_expiry_before_finalize_marks_failed_and_clears_active_hando
     )
 
     expired = await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
         handoff_op_id=handoff.id,
@@ -504,6 +511,7 @@ async def test_stale_expiry_before_finalize_marks_failed_and_clears_active_hando
     )
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )
@@ -539,6 +547,7 @@ async def test_stale_expiry_after_finalize_marks_cleanup_failed_and_keeps_active
     )
 
     expired = await fail_cloud_workspace_handoff_op_checkpoint_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
         handoff_op_id=handoff.id,
@@ -553,6 +562,7 @@ async def test_stale_expiry_after_finalize_marks_cleanup_failed_and_keeps_active
     )
 
     visible = await load_cloud_workspace_mobility_for_user(
+        db_session,
         user_id=user_id,
         mobility_workspace_id=mobility.id,
     )

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -462,8 +462,8 @@ async def test_start_handoff_maps_existing_workspace_conflict_to_409(
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(
-        mobility_service,
-        "create_cloud_workspace_handoff_op_for_user",
+        mobility_service.mobility_tx,
+        "create_cloud_workspace_handoff_op_checkpoint_tx",
         _create,
     )
 
@@ -525,8 +525,8 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(
-        mobility_service,
-        "create_cloud_workspace_handoff_op_for_user",
+        mobility_service.mobility_tx,
+        "create_cloud_workspace_handoff_op_checkpoint_tx",
         _create,
     )
     monkeypatch.setattr(
@@ -540,8 +540,8 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
         _ensure_cloud_workspace,
     )
     monkeypatch.setattr(
-        mobility_service,
-        "fail_cloud_workspace_handoff_op_checkpoint_for_user",
+        mobility_service.mobility_tx,
+        "fail_cloud_workspace_handoff_op_checkpoint_tx",
         _fail_handoff,
     )
     monkeypatch.setattr(

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -106,7 +106,7 @@ def _cleanup_item(
     )
 
 
-async def _noop_expire(*_args, user_id):
+async def _noop_expire(*_args, **_kwargs):
     return None
 
 
@@ -454,11 +454,7 @@ async def test_start_handoff_maps_existing_workspace_conflict_to_409(
     async def _create(*_args, **_kwargs):
         raise ValueError("handoff already in progress for workspace")
 
-    monkeypatch.setattr(
-        mobility_service,
-        "expire_stale_cloud_workspace_handoffs_for_user",
-        _noop_expire,
-    )
+    monkeypatch.setattr(mobility_service.mobility_tx, "expire_stale_handoffs_tx", _noop_expire)
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(
@@ -517,11 +513,7 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     async def _unexpected_start_cloud_workspace(*_args, **_kwargs):
         raise AssertionError("cloud workspace start should not run after ensure failure")
 
-    monkeypatch.setattr(
-        mobility_service,
-        "expire_stale_cloud_workspace_handoffs_for_user",
-        _noop_expire,
-    )
+    monkeypatch.setattr(mobility_service.mobility_tx, "expire_stale_handoffs_tx", _noop_expire)
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -240,7 +240,8 @@ async def test_preflight_blocks_when_workspace_handoff_is_already_active(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -297,7 +298,8 @@ async def test_preflight_blocks_when_github_repo_access_is_missing(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -356,7 +358,8 @@ async def test_preflight_blocks_when_branch_is_not_published(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -413,7 +416,8 @@ async def test_preflight_blocks_when_github_branch_head_is_behind_requested_comm
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
+    response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -464,7 +468,8 @@ async def test_start_handoff_maps_existing_workspace_conflict_to_409(
     )
 
     with pytest.raises(CloudApiError) as exc_info:
-        await mobility_service.start_cloud_workspace_handoff(object(),
+        await mobility_service.start_cloud_workspace_handoff(
+            object(),
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             direction="local_to_cloud",
@@ -546,7 +551,8 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     )
 
     with pytest.raises(CloudApiError) as exc_info:
-        await mobility_service.start_cloud_workspace_handoff(object(),
+        await mobility_service.start_cloud_workspace_handoff(
+            object(),
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             direction="local_to_cloud",

--- a/server/tests/unit/test_cloud_mobility_service.py
+++ b/server/tests/unit/test_cloud_mobility_service.py
@@ -106,7 +106,7 @@ def _cleanup_item(
     )
 
 
-async def _noop_expire(*, user_id):
+async def _noop_expire(*_args, user_id):
     return None
 
 
@@ -117,14 +117,14 @@ async def test_list_mobility_skips_error_cloud_workspace_backfill(
     user_id = uuid4()
     backfilled: list[object] = []
 
-    async def _list_workspaces(_user_id):
+    async def _list_workspaces(_db, _user_id):
         assert _user_id == user_id
         return [SimpleNamespace(status=CloudWorkspaceStatus.error.value)]
 
-    async def _backfill(**kwargs):
+    async def _backfill(*_args, **kwargs):
         backfilled.append(kwargs["workspace"])
 
-    async def _list_mobility(**kwargs):
+    async def _list_mobility(*_args, **kwargs):
         assert kwargs["user_id"] == user_id
         return []
 
@@ -145,7 +145,7 @@ async def test_list_mobility_skips_error_cloud_workspace_backfill(
         _list_mobility,
     )
 
-    assert await mobility_service.list_cloud_workspace_mobility_for_user(user_id) == []
+    assert await mobility_service.list_cloud_workspace_mobility_for_user(object(), user_id) == []
     assert backfilled == []
 
 
@@ -156,11 +156,11 @@ async def test_list_mobility_backfill_does_not_clear_failed_handoff_state(
     user_id = uuid4()
     predicate_results: list[bool] = []
 
-    async def _list_workspaces(_user_id):
+    async def _list_workspaces(_db, _user_id):
         assert _user_id == user_id
         return [SimpleNamespace(status=CloudWorkspaceStatus.ready.value)]
 
-    async def _backfill(**kwargs):
+    async def _backfill(*_args, **kwargs):
         predicate_results.append(
             kwargs["is_retryable_failure"](
                 lifecycle_state=LIFECYCLE_HANDOFF_FAILED,
@@ -168,7 +168,7 @@ async def test_list_mobility_backfill_does_not_clear_failed_handoff_state(
             )
         )
 
-    async def _list_mobility(**kwargs):
+    async def _list_mobility(*_args, **kwargs):
         assert kwargs["user_id"] == user_id
         return []
 
@@ -189,7 +189,7 @@ async def test_list_mobility_backfill_does_not_clear_failed_handoff_state(
         _list_mobility,
     )
 
-    assert await mobility_service.list_cloud_workspace_mobility_for_user(user_id) == []
+    assert await mobility_service.list_cloud_workspace_mobility_for_user(object(), user_id) == []
     assert predicate_results == [False]
 
 
@@ -203,13 +203,13 @@ async def test_preflight_blocks_when_workspace_handoff_is_already_active(
         active_handoff=_handoff(mobility_workspace_id=workspace_id),
     )
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id, **_kwargs):
+    async def _load_active_user_handoff(*_args, user_id, **_kwargs):
         return None
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _repo_branches(*_args, **_kwargs):
@@ -218,7 +218,7 @@ async def test_preflight_blocks_when_workspace_handoff_is_already_active(
             branch_heads_by_name={"feature/cloud": REQUESTED_SHA},
         )
 
-    async def _load_repo_config(**_kwargs):
+    async def _load_repo_config(*_args, **_kwargs):
         return None
 
     monkeypatch.setattr(
@@ -240,7 +240,7 @@ async def test_preflight_blocks_when_workspace_handoff_is_already_active(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(
+    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -259,13 +259,13 @@ async def test_preflight_blocks_when_github_repo_access_is_missing(
 ) -> None:
     workspace = _workspace()
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id, **_kwargs):
+    async def _load_active_user_handoff(*_args, user_id, **_kwargs):
         return None
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _repo_branches(*_args, **_kwargs):
@@ -275,7 +275,7 @@ async def test_preflight_blocks_when_github_repo_access_is_missing(
             status_code=400,
         )
 
-    async def _load_repo_config(**_kwargs):
+    async def _load_repo_config(*_args, **_kwargs):
         return None
 
     monkeypatch.setattr(
@@ -297,7 +297,7 @@ async def test_preflight_blocks_when_github_repo_access_is_missing(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(
+    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -319,13 +319,13 @@ async def test_preflight_blocks_when_branch_is_not_published(
 ) -> None:
     workspace = _workspace()
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id, **_kwargs):
+    async def _load_active_user_handoff(*_args, user_id, **_kwargs):
         return None
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _repo_branches(*_args, **_kwargs):
@@ -334,7 +334,7 @@ async def test_preflight_blocks_when_branch_is_not_published(
             branch_heads_by_name={"main": GITHUB_SHA},
         )
 
-    async def _load_repo_config(**_kwargs):
+    async def _load_repo_config(*_args, **_kwargs):
         return None
 
     monkeypatch.setattr(
@@ -356,7 +356,7 @@ async def test_preflight_blocks_when_branch_is_not_published(
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(
+    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -376,13 +376,13 @@ async def test_preflight_blocks_when_github_branch_head_is_behind_requested_comm
 ) -> None:
     workspace = _workspace()
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id, **_kwargs):
+    async def _load_active_user_handoff(*_args, user_id, **_kwargs):
         return None
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _repo_branches(*_args, **_kwargs):
@@ -391,7 +391,7 @@ async def test_preflight_blocks_when_github_branch_head_is_behind_requested_comm
             branch_heads_by_name={"feature/cloud": GITHUB_SHA},
         )
 
-    async def _load_repo_config(**_kwargs):
+    async def _load_repo_config(*_args, **_kwargs):
         return None
 
     monkeypatch.setattr(
@@ -413,7 +413,7 @@ async def test_preflight_blocks_when_github_branch_head_is_behind_requested_comm
     monkeypatch.setattr(mobility_service, "get_repo_branches_for_user", _repo_branches)
     monkeypatch.setattr(mobility_service, "load_cloud_repo_config_for_user", _load_repo_config)
 
-    response = await mobility_service.preflight_cloud_workspace_handoff(
+    response = await mobility_service.preflight_cloud_workspace_handoff(object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -441,13 +441,13 @@ async def test_start_handoff_maps_existing_workspace_conflict_to_409(
     user_id = uuid4()
     workspace = _workspace()
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _preflight(**_kwargs):
+    async def _preflight(*_args, **_kwargs):
         return SimpleNamespace(can_start=True, blockers=[])
 
-    async def _create(**_kwargs):
+    async def _create(*_args, **_kwargs):
         raise ValueError("handoff already in progress for workspace")
 
     monkeypatch.setattr(
@@ -464,7 +464,7 @@ async def test_start_handoff_maps_existing_workspace_conflict_to_409(
     )
 
     with pytest.raises(CloudApiError) as exc_info:
-        await mobility_service.start_cloud_workspace_handoff(
+        await mobility_service.start_cloud_workspace_handoff(object(),
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             direction="local_to_cloud",
@@ -486,16 +486,16 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     handoff = _handoff(mobility_workspace_id=workspace.id)
     failed_calls: list[dict[str, object]] = []
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _preflight(**_kwargs):
+    async def _preflight(*_args, **_kwargs):
         return SimpleNamespace(can_start=True, blockers=[])
 
-    async def _create(**_kwargs):
+    async def _create(*_args, **_kwargs):
         return handoff
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _ensure_cloud_workspace(*_args, **_kwargs):
@@ -505,7 +505,7 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
             status_code=400,
         )
 
-    async def _fail_handoff(**kwargs):
+    async def _fail_handoff(*_args, **kwargs):
         failed_calls.append(kwargs)
         return handoff
 
@@ -546,7 +546,7 @@ async def test_start_local_to_cloud_marks_handoff_failed_when_cloud_setup_fails(
     )
 
     with pytest.raises(CloudApiError) as exc_info:
-        await mobility_service.start_cloud_workspace_handoff(
+        await mobility_service.start_cloud_workspace_handoff(object(),
             user_id=user_id,
             mobility_workspace_id=workspace.id,
             direction="local_to_cloud",
@@ -613,7 +613,7 @@ async def test_fail_handoff_does_not_overwrite_completed_cleanup(
     async def _get_handoff(*_args, **_kwargs):
         return handoff
 
-    async def _unexpected_fail(**_kwargs):
+    async def _unexpected_fail(*_args, **_kwargs):
         raise AssertionError("completed cleanup must not be failed")
 
     monkeypatch.setattr(

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -245,8 +245,8 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(
-        mobility_service,
-        "create_cloud_workspace_handoff_op_for_user",
+        mobility_service.mobility_tx,
+        "create_cloud_workspace_handoff_op_checkpoint_tx",
         _create,
     )
     monkeypatch.setattr(
@@ -261,8 +261,8 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     )
     monkeypatch.setattr(mobility_service, "start_cloud_workspace", _start_cloud_workspace)
     monkeypatch.setattr(
-        mobility_service,
-        "update_cloud_workspace_handoff_phase_checkpoint_for_user",
+        mobility_service.mobility_tx,
+        "update_cloud_workspace_handoff_phase_checkpoint_tx",
         _update_phase,
     )
 
@@ -314,8 +314,8 @@ async def test_start_cloud_to_local_creates_handoff_without_cloud_provisioning(
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
     monkeypatch.setattr(
-        mobility_service,
-        "create_cloud_workspace_handoff_op_for_user",
+        mobility_service.mobility_tx,
+        "create_cloud_workspace_handoff_op_checkpoint_tx",
         _create,
     )
     monkeypatch.setattr(

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -71,7 +71,7 @@ def _handoff(*, mobility_workspace_id=None) -> CloudWorkspaceHandoffOpValue:
     )
 
 
-async def _noop_expire(*, user_id):
+async def _noop_expire(*_args, user_id):
     return None
 
 
@@ -81,13 +81,13 @@ def _stub_common_preflight_dependencies(
     workspace: CloudWorkspaceMobilityValue,
     active_handoff: CloudWorkspaceHandoffOpValue | None = None,
 ) -> None:
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _load_active_user_handoff(*, user_id, **_kwargs):
+    async def _load_active_user_handoff(*_args, user_id, **_kwargs):
         return active_handoff
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _repo_branches(*_args, **_kwargs):
@@ -96,7 +96,7 @@ def _stub_common_preflight_dependencies(
             branch_heads_by_name={"feature/cloud": REQUESTED_SHA},
         )
 
-    async def _load_repo_config(**_kwargs):
+    async def _load_repo_config(*_args, **_kwargs):
         return None
 
     monkeypatch.setattr(
@@ -133,6 +133,7 @@ async def test_preflight_blocks_another_active_handoff_for_same_user(
     )
 
     response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=user_id,
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -163,6 +164,7 @@ async def test_preflight_blocks_owner_direction_mismatch(
     _stub_common_preflight_dependencies(monkeypatch, workspace=workspace)
 
     response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction=direction,
@@ -183,6 +185,7 @@ async def test_preflight_blocks_cloud_lost_workspace(
     _stub_common_preflight_dependencies(monkeypatch, workspace=workspace)
 
     response = await mobility_service.preflight_cloud_workspace_handoff(
+        object(),
         user_id=uuid4(),
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -205,17 +208,17 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     cloud_workspace_id = uuid4()
     events: list[str] = []
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _preflight(**_kwargs):
+    async def _preflight(*_args, **_kwargs):
         return SimpleNamespace(can_start=True, blockers=[])
 
-    async def _create(**_kwargs):
+    async def _create(*_args, **_kwargs):
         events.append("handoff_created")
         return handoff
 
-    async def _load_user(_user_id):
+    async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _ensure_cloud_workspace(*_args, **_kwargs):
@@ -227,7 +230,7 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
         assert events == ["handoff_created", "workspace_ensured"]
         events.append("workspace_started")
 
-    async def _update_phase(**kwargs):
+    async def _update_phase(*_args, **kwargs):
         events.append("phase_updated")
         assert kwargs["handoff_op_id"] == handoff.id
         assert kwargs["phase"] == "start_requested"
@@ -264,6 +267,7 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     )
 
     await mobility_service.start_cloud_workspace_handoff(
+        object(),
         user_id=user_id,
         mobility_workspace_id=workspace.id,
         direction="local_to_cloud",
@@ -289,13 +293,13 @@ async def test_start_cloud_to_local_creates_handoff_without_cloud_provisioning(
     handoff = _handoff(mobility_workspace_id=workspace.id)
     events: list[str] = []
 
-    async def _get_detail(**_kwargs):
+    async def _get_detail(*_args, **_kwargs):
         return workspace
 
-    async def _preflight(**_kwargs):
+    async def _preflight(*_args, **_kwargs):
         return SimpleNamespace(can_start=True, blockers=[])
 
-    async def _create(**_kwargs):
+    async def _create(*_args, **_kwargs):
         events.append("handoff_created")
         return handoff
 
@@ -322,6 +326,7 @@ async def test_start_cloud_to_local_creates_handoff_without_cloud_provisioning(
     monkeypatch.setattr(mobility_service, "start_cloud_workspace", _unexpected)
 
     result = await mobility_service.start_cloud_workspace_handoff(
+        object(),
         user_id=user_id,
         mobility_workspace_id=workspace.id,
         direction="cloud_to_local",

--- a/server/tests/unit/test_cloud_mobility_service_lifecycle.py
+++ b/server/tests/unit/test_cloud_mobility_service_lifecycle.py
@@ -71,7 +71,7 @@ def _handoff(*, mobility_workspace_id=None) -> CloudWorkspaceHandoffOpValue:
     )
 
 
-async def _noop_expire(*_args, user_id):
+async def _noop_expire(*_args, **_kwargs):
     return None
 
 
@@ -218,16 +218,19 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
         events.append("handoff_created")
         return handoff
 
+    async def _checkpoint_expire(*_args, **_kwargs):
+        events.append("stale_expired_checkpoint")
+
     async def _load_user(_db, _user_id):
         return SimpleNamespace(id=_user_id)
 
     async def _ensure_cloud_workspace(*_args, **_kwargs):
-        assert events == ["handoff_created"]
+        assert events == ["stale_expired_checkpoint", "handoff_created"]
         events.append("workspace_ensured")
         return SimpleNamespace(id=cloud_workspace_id)
 
     async def _start_cloud_workspace(*_args, **_kwargs):
-        assert events == ["handoff_created", "workspace_ensured"]
+        assert events == ["stale_expired_checkpoint", "handoff_created", "workspace_ensured"]
         events.append("workspace_started")
 
     async def _update_phase(*_args, **kwargs):
@@ -238,9 +241,9 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
         return handoff
 
     monkeypatch.setattr(
-        mobility_service,
-        "expire_stale_cloud_workspace_handoffs_for_user",
-        _noop_expire,
+        mobility_service.mobility_tx,
+        "expire_stale_handoffs_tx",
+        _checkpoint_expire,
     )
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)
     monkeypatch.setattr(mobility_service, "preflight_cloud_workspace_handoff", _preflight)
@@ -277,6 +280,7 @@ async def test_start_local_to_cloud_creates_handoff_before_provisioning(
     )
 
     assert events == [
+        "stale_expired_checkpoint",
         "handoff_created",
         "workspace_ensured",
         "workspace_started",
@@ -307,8 +311,8 @@ async def test_start_cloud_to_local_creates_handoff_without_cloud_provisioning(
         raise AssertionError("cloud provisioning should not run for cloud_to_local")
 
     monkeypatch.setattr(
-        mobility_service,
-        "expire_stale_cloud_workspace_handoffs_for_user",
+        mobility_service.mobility_tx,
+        "expire_stale_handoffs_tx",
         _noop_expire,
     )
     monkeypatch.setattr(mobility_service, "get_cloud_workspace_mobility_detail", _get_detail)

--- a/server/tests/unit/test_cloud_runtime_ensure_running.py
+++ b/server/tests/unit/test_cloud_runtime_ensure_running.py
@@ -35,7 +35,7 @@ async def test_ensure_workspace_runtime_ready_reuses_healthy_existing_runtime_ur
         assert runtime_url == workspace.runtime_url
         assert access_token == "runtime-token"
 
-    async def _load_active_sandbox(_workspace: object) -> object:
+    async def _load_active_sandbox(_db: object, _workspace: object) -> object:
         raise AssertionError(
             "active sandbox should not be loaded when the cached runtime is healthy"
         )
@@ -105,11 +105,11 @@ async def test_ensure_workspace_runtime_ready_rotates_to_fresh_endpoint_without_
         assert access_token == "runtime-token"
         provider_calls.append("verify")
 
-    async def _load_active_sandbox(_workspace: object) -> object:
+    async def _load_active_sandbox(_db: object, _workspace: object) -> object:
         return sandbox_record
 
     async def _persist(
-        _workspace: object,
+        _db: object, _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,
@@ -188,10 +188,10 @@ async def test_ensure_environment_runtime_ready_rotates_url_without_generation_i
         assert runtime_url == "https://fresh.invalid"
         assert access_token == "runtime-token"
 
-    async def _load_cloud_sandbox_by_id(_sandbox_id: object) -> object:
+    async def _load_cloud_sandbox_by_id(_db: object, _sandbox_id: object) -> object:
         return sandbox_record
 
-    async def _save_runtime_environment_state(_environment_id: object, **kwargs: object) -> None:
+    async def _save_runtime_environment_state(_db: object, _environment_id: object, **kwargs: object) -> None:
         saved.append(kwargs)
 
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
@@ -283,7 +283,7 @@ async def test_ensure_environment_runtime_ready_refreshes_worker_before_forced_r
         assert access_token == "runtime-token"
         events.append("verify")
 
-    async def _load_cloud_sandbox_by_id(_sandbox_id: object) -> object:
+    async def _load_cloud_sandbox_by_id(_db: object, _sandbox_id: object) -> object:
         return sandbox_record
 
     async def _refresh(
@@ -325,7 +325,7 @@ async def test_ensure_environment_runtime_ready_refreshes_worker_before_forced_r
         events.append("wait-worker")
         return object()
 
-    async def _save_runtime_environment_state(_environment_id: object, **_kwargs: object) -> None:
+    async def _save_runtime_environment_state(_db: object, _environment_id: object, **_kwargs: object) -> None:
         events.append("save")
 
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
@@ -678,11 +678,11 @@ async def test_ensure_workspace_runtime_ready_resumes_paused_sandbox(
         assert access_token == "runtime-token"
         provider_calls.append("verify")
 
-    async def _load_active_sandbox(_workspace: object) -> object:
+    async def _load_active_sandbox(_db: object, _workspace: object) -> object:
         return sandbox_record
 
     async def _persist(
-        _workspace: object,
+        _db: object, _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,
@@ -773,11 +773,11 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
         assert access_token == "runtime-token"
         events.append("verify")
 
-    async def _load_active_sandbox(_workspace: object) -> object:
+    async def _load_active_sandbox(_db: object, _workspace: object) -> object:
         return sandbox_record
 
     async def _persist(
-        _workspace: object,
+        _db: object, _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,
@@ -853,7 +853,7 @@ async def test_ensure_workspace_runtime_ready_raises_when_restart_is_disallowed(
     async def _verify(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("auth verification should not run when health never succeeds")
 
-    async def _load_active_sandbox(_workspace: object) -> object:
+    async def _load_active_sandbox(_db: object, _workspace: object) -> object:
         return sandbox_record
 
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)

--- a/server/tests/unit/test_cloud_runtime_ensure_running.py
+++ b/server/tests/unit/test_cloud_runtime_ensure_running.py
@@ -109,7 +109,8 @@ async def test_ensure_workspace_runtime_ready_rotates_to_fresh_endpoint_without_
         return sandbox_record
 
     async def _persist(
-        _db: object, _workspace: object,
+        _db: object,
+        _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,
@@ -191,7 +192,9 @@ async def test_ensure_environment_runtime_ready_rotates_url_without_generation_i
     async def _load_cloud_sandbox_by_id(_db: object, _sandbox_id: object) -> object:
         return sandbox_record
 
-    async def _save_runtime_environment_state(_db: object, _environment_id: object, **kwargs: object) -> None:
+    async def _save_runtime_environment_state(
+        _db: object, _environment_id: object, **kwargs: object
+    ) -> None:
         saved.append(kwargs)
 
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
@@ -325,7 +328,9 @@ async def test_ensure_environment_runtime_ready_refreshes_worker_before_forced_r
         events.append("wait-worker")
         return object()
 
-    async def _save_runtime_environment_state(_db: object, _environment_id: object, **_kwargs: object) -> None:
+    async def _save_runtime_environment_state(
+        _db: object, _environment_id: object, **_kwargs: object
+    ) -> None:
         events.append("save")
 
     monkeypatch.setattr(ensure_running, "wait_for_runtime_health", _wait)
@@ -682,7 +687,8 @@ async def test_ensure_workspace_runtime_ready_resumes_paused_sandbox(
         return sandbox_record
 
     async def _persist(
-        _db: object, _workspace: object,
+        _db: object,
+        _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,
@@ -777,7 +783,8 @@ async def test_ensure_workspace_runtime_ready_relaunches_only_after_fresh_endpoi
         return sandbox_record
 
     async def _persist(
-        _db: object, _workspace: object,
+        _db: object,
+        _workspace: object,
         _sandbox: object,
         *,
         restarted_runtime: bool,

--- a/server/tests/unit/test_cloud_runtime_provision.py
+++ b/server/tests/unit/test_cloud_runtime_provision.py
@@ -14,7 +14,6 @@ from proliferate.constants.cloud import AGENT_GATEWAY_CIPHERTEXT_KEY_ID
 from proliferate.db.models.auth import OAuthAccount, User
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
-from proliferate.db.store import cloud_workspaces, users
 from proliferate.integrations.anyharness import ResolvedRemoteWorkspace
 from proliferate.integrations.sandbox import SandboxProviderKind
 from proliferate.server.cloud.agent_auth import session_loader as agent_auth_session_loader
@@ -100,9 +99,7 @@ def _patched_session_factory(monkeypatch: pytest.MonkeyPatch, test_engine) -> No
         "async_session_factory",
         factory,
     )
-    monkeypatch.setattr(cloud_workspaces.db_engine, "async_session_factory", factory)
     monkeypatch.setattr(runtime_provision.db_engine, "async_session_factory", factory)
-    monkeypatch.setattr(users.db_engine, "async_session_factory", factory)
 
 
 class TestLoadProvisionInput:
@@ -299,6 +296,7 @@ class TestWorkspaceStatusLogging:
         workspace_id = uuid.uuid4()
 
         async def _update_workspace_status_by_id(
+            _db: object,
             _workspace_id: uuid.UUID,
             status: object,
             detail: str,
@@ -1018,6 +1016,7 @@ class TestProvisionWorkspaceGitSetup:
             )
 
         async def _mark_workspace_error_by_id(
+            _db: object,
             _workspace_id,
             message: str,
             **_kwargs: object,
@@ -1072,7 +1071,7 @@ class TestProvisionWorkspaceGitSetup:
             allocation_attempts.append("ensure_profile_slot")
             return SimpleNamespace(id=uuid.uuid4(), slot_generation=1, external_sandbox_id=None)
 
-        async def _mark_workspace_error_by_id(_workspace_id, message: str, **_kwargs):
+        async def _mark_workspace_error_by_id(_db: object, _workspace_id, message: str, **_kwargs):
             errors.append(message)
 
         async def _set_workspace_status(*args, **kwargs) -> None:
@@ -1503,6 +1502,7 @@ class TestProvisionWorkspaceGitSetup:
             return None
 
         async def _mark_workspace_error_by_id(
+            _db: object,
             _workspace_id,
             message: str,
             **_kwargs: object,
@@ -1594,16 +1594,16 @@ class TestProvisionWorkspaceGitSetup:
         async def _set_workspace_status(*args, **kwargs) -> None:
             return None
 
-        async def _load_cloud_sandbox_by_id(_sandbox_id):
+        async def _load_cloud_sandbox_by_id(_db: object, _sandbox_id):
             return sandbox_record
 
         async def _close_usage_segment_for_sandbox(**kwargs):
             closed_usage.append(kwargs)
 
-        async def _update_sandbox_status(sandbox, status: str, **_kwargs):
+        async def _update_sandbox_status(_db: object, sandbox, status: str, **_kwargs):
             sandbox_statuses.append((sandbox, status))
 
-        async def _mark_workspace_error_by_id(_workspace_id, message: str, **kwargs):
+        async def _mark_workspace_error_by_id(_db: object, _workspace_id, message: str, **kwargs):
             workspace_errors.append({"message": message, **kwargs})
 
         monkeypatch.setattr(runtime_provision, "_load_provision_input", _load_provision_input)
@@ -1733,13 +1733,13 @@ class TestProvisionWorkspaceGitSetup:
         async def _set_workspace_status(*args, **kwargs) -> None:
             return None
 
-        async def _load_cloud_sandbox_by_id(_sandbox_id):
+        async def _load_cloud_sandbox_by_id(_db: object, _sandbox_id):
             return sandbox_record
 
-        async def _update_sandbox_status(sandbox, status: str, **_kwargs):
+        async def _update_sandbox_status(_db: object, sandbox, status: str, **_kwargs):
             sandbox_statuses.append((sandbox, status))
 
-        async def _mark_workspace_error_by_id(_workspace_id, message: str, **kwargs):
+        async def _mark_workspace_error_by_id(_db: object, _workspace_id, message: str, **kwargs):
             workspace_errors.append({"message": message, **kwargs})
 
         monkeypatch.setattr(runtime_provision, "_load_provision_input", _load_provision_input)

--- a/server/tests/unit/test_cloud_webhook_service.py
+++ b/server/tests/unit/test_cloud_webhook_service.py
@@ -117,7 +117,9 @@ async def test_killed_e2b_webhook_clears_runtime_metadata_and_increments_generat
     async def _load_cloud_sandbox_by_external_id(_db: object, _external_sandbox_id: str) -> object:
         return sandbox
 
-    async def _load_runtime_environment_by_id(_db: object, _runtime_environment_id: object) -> object:
+    async def _load_runtime_environment_by_id(
+        _db: object, _runtime_environment_id: object
+    ) -> object:
         return runtime_environment
 
     async def _save_sandbox_provider_state(
@@ -226,7 +228,9 @@ async def test_timeout_e2b_webhook_closes_usage_as_paused(
     async def _load_cloud_sandbox_by_external_id(_db: object, _external_sandbox_id: str) -> object:
         return sandbox
 
-    async def _load_runtime_environment_by_id(_db: object, _runtime_environment_id: object) -> object:
+    async def _load_runtime_environment_by_id(
+        _db: object, _runtime_environment_id: object
+    ) -> object:
         return runtime_environment
 
     async def _save_sandbox_provider_state(

--- a/server/tests/unit/test_cloud_webhook_service.py
+++ b/server/tests/unit/test_cloud_webhook_service.py
@@ -114,19 +114,24 @@ async def test_killed_e2b_webhook_clears_runtime_metadata_and_increments_generat
     async def _remember_sandbox_event_receipt(*_args: object, **_kwargs: object) -> bool:
         return True
 
-    async def _load_cloud_sandbox_by_external_id(_external_sandbox_id: str) -> object:
+    async def _load_cloud_sandbox_by_external_id(_db: object, _external_sandbox_id: str) -> object:
         return sandbox
 
-    async def _load_runtime_environment_by_id(_runtime_environment_id: object) -> object:
+    async def _load_runtime_environment_by_id(_db: object, _runtime_environment_id: object) -> object:
         return runtime_environment
 
-    async def _save_sandbox_provider_state(_sandbox_id: object, **kwargs: object) -> None:
+    async def _save_sandbox_provider_state(
+        _db: object,
+        _sandbox_id: object,
+        **kwargs: object,
+    ) -> None:
         sandbox_state_updates.append(kwargs)
 
     async def _close_usage_segment_for_sandbox(*_args: object, **_kwargs: object) -> None:
         return None
 
     async def _save_runtime_environment_state(
+        _db: object,
         _runtime_environment_id: object,
         **kwargs: object,
     ) -> None:
@@ -218,19 +223,24 @@ async def test_timeout_e2b_webhook_closes_usage_as_paused(
     async def _remember_sandbox_event_receipt(*_args: object, **_kwargs: object) -> bool:
         return True
 
-    async def _load_cloud_sandbox_by_external_id(_external_sandbox_id: str) -> object:
+    async def _load_cloud_sandbox_by_external_id(_db: object, _external_sandbox_id: str) -> object:
         return sandbox
 
-    async def _load_runtime_environment_by_id(_runtime_environment_id: object) -> object:
+    async def _load_runtime_environment_by_id(_db: object, _runtime_environment_id: object) -> object:
         return runtime_environment
 
-    async def _save_sandbox_provider_state(_sandbox_id: object, **kwargs: object) -> None:
+    async def _save_sandbox_provider_state(
+        _db: object,
+        _sandbox_id: object,
+        **kwargs: object,
+    ) -> None:
         sandbox_state_updates.append(kwargs)
 
     async def _close_usage_segment_for_sandbox(*_args: object, **kwargs: object) -> None:
         closed_segments.append(kwargs)
 
     async def _save_runtime_environment_state(
+        _db: object,
         _runtime_environment_id: object,
         **kwargs: object,
     ) -> None:

--- a/server/tests/unit/test_cloud_workspace_connection_service.py
+++ b/server/tests/unit/test_cloud_workspace_connection_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from proliferate.server.cloud.workspaces import service as workspace_service
+from tests.unit.db_session_helpers import NoopDb, patch_async_session_factory
+
+INTERACT_WITH_DB = "cloud_workspace_user_can_interact_with_db"
+
+
+def _patch_session_factory(monkeypatch: pytest.MonkeyPatch, db: NoopDb) -> NoopDb:
+    return patch_async_session_factory(monkeypatch, workspace_service.db_engine, db)
+
+
+@pytest.mark.asyncio
+async def test_get_cloud_connection_uses_request_session_for_runtime_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_db = NoopDb(name="request")
+    lookup_db = _patch_session_factory(monkeypatch, NoopDb(name="lookup"))
+    user_id = uuid4()
+    workspace = SimpleNamespace(id=uuid4(), owner_scope="personal", target_id=None)
+
+    async def _interact(db, _user_id, _workspace_id):
+        assert db is request_db
+        return workspace
+
+    async def _reject_shared(_workspace):
+        return None
+
+    async def _latest_runs(db, *, user_id, cloud_workspace_ids):
+        assert db is lookup_db
+        assert cloud_workspace_ids == [workspace.id]
+        return {}
+
+    async def _workspace_connection(db, _workspace):
+        assert db is request_db
+        return SimpleNamespace(
+            runtime_url="https://example-runtime.invalid",
+            access_token="runtime-token",
+            anyharness_workspace_id="workspace-123",
+            runtime_generation=1,
+            ready_agent_kinds=["codex"],
+            runtime_auth=SimpleNamespace(
+                status="current",
+                config_current=True,
+                target_current=True,
+                requires_restart=False,
+                desired_revision=None,
+                applied_revision=None,
+                last_error=None,
+                last_error_at=None,
+                last_attempted_at=None,
+                last_applied_at=None,
+            ),
+        )
+
+    async def _reload_workspace(db, workspace_id):
+        assert db is lookup_db
+        assert workspace_id == workspace.id
+        return workspace
+
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _interact)
+    monkeypatch.setattr(
+        workspace_service, "_reject_shared_workspace_static_connection", _reject_shared
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "list_latest_runs_by_cloud_workspace_ids_for_user",
+        _latest_runs,
+    )
+    monkeypatch.setattr(workspace_service, "get_workspace_connection", _workspace_connection)
+    monkeypatch.setattr(workspace_service, "load_cloud_workspace_by_id", _reload_workspace)
+
+    connection = await workspace_service.get_cloud_connection(
+        request_db,
+        user_id,
+        workspace.id,
+    )
+
+    assert connection.runtime_url == "https://example-runtime.invalid"
+    assert connection.access_token == "runtime-token"

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -15,6 +15,14 @@ from proliferate.server.billing.models import SandboxStartAuthorization
 from proliferate.server.automations.worker.cloud_executor_commands import AutomationCommandResult
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.workspaces import service as workspace_service
+from tests.unit.db_session_helpers import NoopDb, patch_async_session_factory
+
+INTERACT_WITH_DB = "cloud_workspace_user_can_interact_with_db"
+ARCHIVE_WITH_DB = "cloud_workspace_user_can_archive_with_db"
+
+
+def _patch_session_factory(monkeypatch: pytest.MonkeyPatch) -> NoopDb:
+    return patch_async_session_factory(monkeypatch, workspace_service.db_engine)
 
 
 def _denied_start_authorization(*, blocked_reason: str) -> SandboxStartAuthorization:
@@ -116,7 +124,7 @@ async def test_create_cloud_workspace_blocks_when_billing_snapshot_is_blocked(
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
         return SimpleNamespace(branches=["main"])
 
-    async def _existing_workspace(**_kwargs):
+    async def _existing_workspace(*_args, **_kwargs):
         return None
 
     async def _authorization(**_kwargs) -> SandboxStartAuthorization:
@@ -127,7 +135,7 @@ async def test_create_cloud_workspace_blocks_when_billing_snapshot_is_blocked(
     async def _unexpected(*_args, **_kwargs) -> None:
         raise AssertionError("downstream workspace creation should not run when billing blocks")
 
-    async def _repo_config_value(**_kwargs):
+    async def _repo_config_value(*_args, **_kwargs):
         return SimpleNamespace(configured=True, env_vars={}, default_branch=None)
 
     monkeypatch.setattr(workspace_service, "get_linked_github_account", lambda _user: object())
@@ -137,6 +145,7 @@ async def test_create_cloud_workspace_blocks_when_billing_snapshot_is_blocked(
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(workspace_service, "_load_personal_agent_auth_agent_kinds", _unexpected)
     monkeypatch.setattr(workspace_service, "create_cloud_workspace_for_user", _unexpected)
+    _patch_session_factory(monkeypatch)
 
     with pytest.raises(CloudApiError) as exc_info:
         await workspace_service.create_cloud_workspace(
@@ -163,7 +172,7 @@ async def test_automation_workspace_requires_selected_agent_credentials(
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
         return SimpleNamespace(branches=["main"], default_branch="main")
 
-    async def _existing_workspace(**_kwargs):
+    async def _existing_workspace(*_args, **_kwargs):
         return None
 
     async def _authorization(**_kwargs) -> SandboxStartAuthorization:
@@ -172,7 +181,7 @@ async def test_automation_workspace_requires_selected_agent_credentials(
     async def _billing_snapshot(_billing_subject_id):
         return SimpleNamespace()
 
-    async def _repo_config_value(**_kwargs):
+    async def _repo_config_value(*_args, **_kwargs):
         return SimpleNamespace(configured=True, default_branch="main")
 
     async def _agent_auth_agent_kinds(_user_id):
@@ -190,6 +199,7 @@ async def test_automation_workspace_requires_selected_agent_credentials(
         "_load_personal_agent_auth_agent_kinds",
         _agent_auth_agent_kinds,
     )
+    _patch_session_factory(monkeypatch)
 
     with pytest.raises(CloudApiError) as exc_info:
         await workspace_service._resolve_new_cloud_workspace_create(
@@ -267,7 +277,7 @@ async def test_create_cloud_workspace_returns_pending_after_queueing_provision(
             cloud_repo_limit=4,
         )
 
-    async def _create_cloud_workspace_for_user(**_kwargs):
+    async def _create_cloud_workspace_for_user(*_args, **_kwargs):
         create_kwargs.update(_kwargs)
         return workspace
 
@@ -284,6 +294,7 @@ async def test_create_cloud_workspace_returns_pending_after_queueing_provision(
         "create_cloud_workspace_for_user",
         _create_cloud_workspace_for_user,
     )
+    _patch_session_factory(monkeypatch)
     monkeypatch.setattr(
         workspace_service,
         "get_configured_sandbox_provider",
@@ -295,6 +306,7 @@ async def test_create_cloud_workspace_returns_pending_after_queueing_provision(
         lambda workspace_id: scheduled.append(workspace_id),
     )
     monkeypatch.setattr(workspace_service, "_build_workspace_detail", _build_workspace_detail)
+    _patch_session_factory(monkeypatch)
 
     payload = await workspace_service.create_cloud_workspace(
         user,
@@ -586,7 +598,7 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
     workspace = SimpleNamespace(id=workspace_id)
     calls: list[tuple[str, object]] = []
 
-    async def _cloud_workspace_user_can_archive(_user_id, _workspace_id):
+    async def _cloud_workspace_user_can_archive(_db, _user_id, _workspace_id):
         assert _user_id == user_id
         assert _workspace_id == workspace_id
         calls.append(("load", _workspace_id))
@@ -600,15 +612,11 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
         assert _workspace is workspace
         calls.append(("destroy", _workspace.id))
 
-    async def _delete_cloud_workspace_records_for_workspace(_workspace) -> None:
+    async def _delete_cloud_workspace_records_for_workspace(_db, _workspace) -> None:
         assert _workspace is workspace
         calls.append(("archive", _workspace.id))
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_archive",
-        _cloud_workspace_user_can_archive,
-    )
+    monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive)
     monkeypatch.setattr(
         workspace_service,
         "_revoke_claim_tokens_for_workspace",
@@ -624,8 +632,9 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
         "delete_cloud_workspace_records_for_workspace",
         _delete_cloud_workspace_records_for_workspace,
     )
+    db = _patch_session_factory(monkeypatch)
 
-    await workspace_service.delete_cloud_workspace(user_id, workspace_id)
+    await workspace_service.delete_cloud_workspace(db, user_id, workspace_id)
 
     assert calls == [
         ("load", workspace_id),
@@ -700,11 +709,7 @@ async def test_restore_cloud_workspace_uses_lifecycle_permission(
 
     db.commit = _commit
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_archive_with_db",
-        _cloud_workspace_user_can_archive_with_db,
-    )
+    monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db)
     monkeypatch.setattr(
         workspace_service,
         "restore_cloud_workspace_record",
@@ -744,7 +749,7 @@ async def test_purge_cloud_workspace_is_idempotent_when_record_is_missing(
     )
     monkeypatch.setattr(
         workspace_service,
-        "cloud_workspace_user_can_archive_with_db",
+        ARCHIVE_WITH_DB,
         _unexpected,
     )
 
@@ -781,11 +786,7 @@ async def test_purge_cloud_workspace_requires_archived_workspace(
         "get_cloud_workspace_by_id",
         _get_cloud_workspace_by_id,
     )
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_archive_with_db",
-        _cloud_workspace_user_can_archive_with_db,
-    )
+    monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db)
     monkeypatch.setattr(
         workspace_service,
         "_revoke_claim_tokens_for_workspace",
@@ -825,7 +826,7 @@ async def test_destroy_workspace_runtime_skips_shared_profile_slot(
     async def _load_cloud_sandbox_by_id(_sandbox_id):
         raise AssertionError("shared profile slot should not be loaded from workspace destroy")
 
-    async def _persist_workspace_destroy_state(_workspace) -> None:
+    async def _persist_workspace_destroy_state(_db, _workspace) -> None:
         assert _workspace is workspace
         calls.append("persist")
 
@@ -839,6 +840,7 @@ async def test_destroy_workspace_runtime_skips_shared_profile_slot(
         "persist_workspace_destroy_state",
         _persist_workspace_destroy_state,
     )
+    _patch_session_factory(monkeypatch)
 
     await workspace_service._destroy_workspace_runtime(workspace)
 
@@ -861,13 +863,13 @@ async def test_ensure_cloud_workspace_replaces_failed_unmaterialized_retry_targe
     archived: list[object] = []
     created: list[dict[str, object]] = []
 
-    async def _load_existing_cloud_workspace(**_kwargs):
+    async def _load_existing_cloud_workspace(*_args, **_kwargs):
         return failed_workspace
 
     async def _archive_failed(workspace_id):
         archived.append(workspace_id)
 
-    async def _load_repo_config_value(**_kwargs):
+    async def _load_repo_config_value(*_args, **_kwargs):
         return SimpleNamespace(configured=True)
 
     async def _authorization(**_kwargs) -> SandboxStartAuthorization:
@@ -879,7 +881,7 @@ async def test_ensure_cloud_workspace_replaces_failed_unmaterialized_retry_targe
     def _repo_limit_for_billing_snapshot(_snapshot):
         return 10
 
-    async def _create_cloud_workspace_for_user(**kwargs):
+    async def _create_cloud_workspace_for_user(*_args, **kwargs):
         created.append(kwargs)
         return created_workspace
 
@@ -944,7 +946,7 @@ async def test_ensure_cloud_workspace_reuses_materialized_error_workspace(
         last_error="agent runtime failed",
     )
 
-    async def _load_existing_cloud_workspace(**_kwargs):
+    async def _load_existing_cloud_workspace(*_args, **_kwargs):
         return existing_workspace
 
     async def _unexpected(*_args, **_kwargs) -> None:
@@ -970,6 +972,7 @@ async def test_ensure_cloud_workspace_reuses_materialized_error_workspace(
         "create_cloud_workspace_for_user",
         _unexpected,
     )
+    _patch_session_factory(monkeypatch)
 
     result = await workspace_service.ensure_cloud_workspace_for_existing_branch(
         user,
@@ -997,7 +1000,7 @@ async def test_start_cloud_workspace_blocks_when_billing_snapshot_is_blocked(
         git_base_branch="main",
     )
 
-    async def _require_workspace(_user_id, _workspace_id):
+    async def _require_workspace(_db, _user_id, _workspace_id):
         return workspace
 
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
@@ -1011,14 +1014,14 @@ async def test_start_cloud_workspace_blocks_when_billing_snapshot_is_blocked(
     async def _unexpected(*_args, **_kwargs) -> None:
         raise AssertionError("workspace start should stop before credential/runtime work")
 
-    monkeypatch.setattr(workspace_service, "cloud_workspace_user_can_interact", _require_workspace)
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _require_workspace)
     monkeypatch.setattr(workspace_service, "get_github_repo_branches", _repo_branches)
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(workspace_service, "_load_personal_agent_auth_agent_kinds", _unexpected)
     monkeypatch.setattr(workspace_service, "save_workspace", _unexpected)
 
     with pytest.raises(CloudApiError) as exc_info:
-        await workspace_service.start_cloud_workspace(user, uuid4())
+        await workspace_service.start_cloud_workspace(NoopDb(), user, uuid4())
 
     assert exc_info.value.code == "quota_exceeded"
     assert exc_info.value.status_code == 403
@@ -1049,7 +1052,7 @@ async def test_start_cloud_workspace_requeues_error_workspace(
     saved_statuses: list[tuple[object, object]] = []
     scheduled: list[object] = []
 
-    async def _require_workspace(_user_id, _workspace_id):
+    async def _require_workspace(_db, _user_id, _workspace_id):
         return workspace
 
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
@@ -1061,17 +1064,14 @@ async def test_start_cloud_workspace_requeues_error_workspace(
     async def _agent_auth_agent_kinds(_user_id):
         return ("claude",)
 
-    async def _save_workspace(_workspace):
+    async def _save_workspace(_db, _workspace):
         saved_statuses.append((_workspace.status, _workspace.last_error))
+        return _workspace
 
     async def _build_workspace_detail(_workspace):
         return SimpleNamespace(status=_workspace.status)
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_interact",
-        _require_workspace,
-    )
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _require_workspace)
     monkeypatch.setattr(workspace_service, "get_github_repo_branches", _repo_branches)
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(
@@ -1081,13 +1081,14 @@ async def test_start_cloud_workspace_requeues_error_workspace(
     )
     monkeypatch.setattr(workspace_service, "save_workspace", _save_workspace)
     monkeypatch.setattr(workspace_service, "_build_workspace_detail", _build_workspace_detail)
+    _patch_session_factory(monkeypatch)
     monkeypatch.setattr(
         workspace_service,
         "schedule_workspace_provision",
         lambda workspace_id, **_kwargs: scheduled.append(workspace_id),
     )
 
-    payload = await workspace_service.start_cloud_workspace(user, workspace.id)
+    payload = await workspace_service.start_cloud_workspace(NoopDb(), user, workspace.id)
 
     assert payload.status == workspace_service.CloudWorkspaceStatus.materializing.value
     assert workspace.status == workspace_service.CloudWorkspaceStatus.materializing.value
@@ -1116,7 +1117,7 @@ async def test_start_cloud_workspace_requeues_queued_workspace_for_mobility(
     saved_statuses: list[tuple[object, object]] = []
     refreshed_env_snapshots: list[object] = []
 
-    async def _require_workspace(_user_id, _workspace_id):
+    async def _require_workspace(_db, _user_id, _workspace_id):
         return workspace
 
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
@@ -1132,18 +1133,14 @@ async def test_start_cloud_workspace_requeues_queued_workspace_for_mobility(
         refreshed_env_snapshots.append(_workspace.id)
         return _workspace
 
-    async def _save_workspace(_workspace):
+    async def _save_workspace(_db, _workspace):
         saved_statuses.append((_workspace.status, _workspace.last_error))
         return _workspace
 
     async def _build_workspace_detail(_workspace):
         return SimpleNamespace(status=_workspace.status)
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_interact",
-        _require_workspace,
-    )
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _require_workspace)
     monkeypatch.setattr(workspace_service, "get_github_repo_branches", _repo_branches)
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(
@@ -1158,6 +1155,7 @@ async def test_start_cloud_workspace_requeues_queued_workspace_for_mobility(
     )
     monkeypatch.setattr(workspace_service, "save_workspace", _save_workspace)
     monkeypatch.setattr(workspace_service, "_build_workspace_detail", _build_workspace_detail)
+    _patch_session_factory(monkeypatch)
     monkeypatch.setattr(
         workspace_service,
         "schedule_workspace_provision",
@@ -1167,6 +1165,7 @@ async def test_start_cloud_workspace_requeues_queued_workspace_for_mobility(
     )
 
     payload = await workspace_service.start_cloud_workspace(
+        NoopDb(),
         user,
         workspace.id,
         requested_base_sha="abc123",
@@ -1200,7 +1199,7 @@ async def test_start_cloud_workspace_returns_ready_workspace_without_requeue(
         ready_at=datetime.now(UTC),
     )
 
-    async def _require_workspace(_user_id, _workspace_id):
+    async def _require_workspace(_db, _user_id, _workspace_id):
         return workspace
 
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
@@ -1218,11 +1217,7 @@ async def test_start_cloud_workspace_returns_ready_workspace_without_requeue(
     async def _build_workspace_detail(_workspace):
         return SimpleNamespace(status=_workspace.status)
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_interact",
-        _require_workspace,
-    )
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _require_workspace)
     monkeypatch.setattr(workspace_service, "get_github_repo_branches", _repo_branches)
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(
@@ -1234,7 +1229,7 @@ async def test_start_cloud_workspace_returns_ready_workspace_without_requeue(
     monkeypatch.setattr(workspace_service, "schedule_workspace_provision", _unexpected)
     monkeypatch.setattr(workspace_service, "_build_workspace_detail", _build_workspace_detail)
 
-    payload = await workspace_service.start_cloud_workspace(user, workspace.id)
+    payload = await workspace_service.start_cloud_workspace(NoopDb(), user, workspace.id)
 
     assert payload.status == workspace_service.CloudWorkspaceStatus.ready.value
     assert workspace.status == workspace_service.CloudWorkspaceStatus.ready.value
@@ -1264,7 +1259,7 @@ async def test_start_cloud_workspace_requeues_ready_workspace_for_requested_revi
     scheduled: list[tuple[object, object]] = []
     saved_statuses: list[tuple[object, object, object]] = []
 
-    async def _require_workspace(_user_id, _workspace_id):
+    async def _require_workspace(_db, _user_id, _workspace_id):
         return workspace
 
     async def _repo_branches(*_args, **_kwargs) -> SimpleNamespace:
@@ -1276,18 +1271,14 @@ async def test_start_cloud_workspace_requeues_ready_workspace_for_requested_revi
     async def _agent_auth_agent_kinds(_user_id):
         return ("claude",)
 
-    async def _save_workspace(_workspace):
+    async def _save_workspace(_db, _workspace):
         saved_statuses.append((_workspace.status, _workspace.status_detail, _workspace.last_error))
         return _workspace
 
     async def _build_workspace_detail(_workspace):
         return SimpleNamespace(status=_workspace.status)
 
-    monkeypatch.setattr(
-        workspace_service,
-        "cloud_workspace_user_can_interact",
-        _require_workspace,
-    )
+    monkeypatch.setattr(workspace_service, INTERACT_WITH_DB, _require_workspace)
     monkeypatch.setattr(workspace_service, "get_github_repo_branches", _repo_branches)
     monkeypatch.setattr(workspace_service, "authorize_sandbox_start", _authorization)
     monkeypatch.setattr(
@@ -1297,6 +1288,7 @@ async def test_start_cloud_workspace_requeues_ready_workspace_for_requested_revi
     )
     monkeypatch.setattr(workspace_service, "save_workspace", _save_workspace)
     monkeypatch.setattr(workspace_service, "_build_workspace_detail", _build_workspace_detail)
+    _patch_session_factory(monkeypatch)
     monkeypatch.setattr(
         workspace_service,
         "schedule_workspace_provision",
@@ -1306,6 +1298,7 @@ async def test_start_cloud_workspace_requeues_ready_workspace_for_requested_revi
     )
 
     payload = await workspace_service.start_cloud_workspace(
+        NoopDb(),
         user,
         workspace.id,
         requested_base_sha="a" * 40,

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -596,6 +597,7 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
     user_id = uuid4()
     workspace_id = uuid4()
     workspace = SimpleNamespace(id=workspace_id)
+    load_workspace = AsyncMock(return_value=workspace)
     calls: list[tuple[str, object]] = []
 
     async def _cloud_workspace_user_can_archive(_db, _user_id, _workspace_id):
@@ -605,15 +607,12 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
         return workspace
 
     async def _revoke_claim_tokens_for_workspace(_workspace, *, reason: str) -> None:
-        assert _workspace is workspace
         calls.append(("revoke", reason))
 
     async def _destroy_workspace_runtime(_workspace) -> None:
-        assert _workspace is workspace
         calls.append(("destroy", _workspace.id))
 
     async def _delete_cloud_workspace_records_for_workspace(_db, _workspace) -> None:
-        assert _workspace is workspace
         calls.append(("archive", _workspace.id))
 
     monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive)
@@ -627,6 +626,7 @@ async def test_delete_cloud_workspace_destroys_runtime_before_archiving(
         "_destroy_workspace_runtime",
         _destroy_workspace_runtime,
     )
+    monkeypatch.setattr(workspace_service, "load_cloud_workspace_by_id", load_workspace)
     monkeypatch.setattr(
         workspace_service,
         "delete_cloud_workspace_records_for_workspace",

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -709,7 +709,9 @@ async def test_restore_cloud_workspace_uses_lifecycle_permission(
 
     db.commit = _commit
 
-    monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db)
+    monkeypatch.setattr(
+        workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db
+    )
     monkeypatch.setattr(
         workspace_service,
         "restore_cloud_workspace_record",
@@ -786,7 +788,9 @@ async def test_purge_cloud_workspace_requires_archived_workspace(
         "get_cloud_workspace_by_id",
         _get_cloud_workspace_by_id,
     )
-    monkeypatch.setattr(workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db)
+    monkeypatch.setattr(
+        workspace_service, ARCHIVE_WITH_DB, _cloud_workspace_user_can_archive_with_db
+    )
     monkeypatch.setattr(
         workspace_service,
         "_revoke_claim_tokens_for_workspace",

--- a/server/tests/unit/test_cloud_worktree_policy_sync.py
+++ b/server/tests/unit/test_cloud_worktree_policy_sync.py
@@ -19,7 +19,7 @@ async def test_sync_policy_can_trigger_deferred_cleanup_without_awaiting(
     cleanup_release = asyncio.Event()
     cleanup_finished = asyncio.Event()
 
-    async def _get_policy(_user_id):
+    async def _get_policy(_db, _user_id):
         return SimpleNamespace(max_materialized_worktrees_per_repo=42)
 
     async def _update_policy(*_args, **_kwargs) -> None:


### PR DESCRIPTION
## Summary
- threads cloud workspace, mobility, runtime, repo config, setup, worktree policy, organization, and user store calls through caller-owned async sessions
- updates cloud service/runtime/webhook/reconciler callers to own transaction boundaries explicitly
- preserves mobility checkpoint, workspace deletion, runtime reload, and cleanup transaction boundaries after review fix-up
- reduces server boundary and max-lines allowlist debt for cloud store session factories

## Checks
- python3 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- cd server && uv run --extra dev ruff format --check proliferate/ tests/
- cd server && uv run --extra dev ruff check proliferate/ tests/
- cd server && DEBUG=true uv run --extra dev pytest -q tests/integration/test_cloud_repo_limits.py tests/integration/test_cloud_workspace_lifecycle_store.py tests/unit/test_cloud_runtime_ensure_running.py tests/unit/test_cloud_runtime_provision.py tests/unit/test_cloud_workspace_service.py tests/unit/test_cloud_mobility_service.py tests/integration/test_cloud_commands_api.py tests/integration/test_cloud_workspace_claims_api.py tests/unit/test_cloud_webhook_service.py (138 passed)