### PR TITLE
ci(deploy): key promotion checks off deploy artifacts

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -70,34 +70,22 @@ jobs:
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
 
-      - name: Verify staging success
-        if: ${{ github.event.inputs.require_staging_success == 'true' }}
+      - name: Verify promoted commit is on main
         run: |
           set -euo pipefail
-          mapfile -t runs < <(
-            gh run list \
-              --workflow deploy-staging.yml \
-              --commit "${{ steps.meta.outputs.head_sha }}" \
-              --status success \
-              --limit 20 \
-              --json databaseId,url \
-              --jq '.[] | [.databaseId, .url] | @tsv'
-          )
-          for run in "${runs[@]}"; do
-            IFS=$'\t' read -r run_id url <<< "$run"
-            artifact_count="$(
-              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
-                --jq '[.artifacts[] | select(.name == "deploy-summary-staging" and .expired == false)] | length'
-            )"
-            if [[ "$artifact_count" != "0" ]]; then
-              echo "Found successful non-dry-run Deploy Staging run for ${{ steps.meta.outputs.head_sha }}: $url"
-              exit 0
-            fi
-          done
-          echo "No successful non-dry-run Deploy Staging run found for ${{ steps.meta.outputs.head_sha }}." >&2
-          exit 1
+          git fetch origin main --prune
+          git merge-base --is-ancestor "${{ steps.meta.outputs.head_sha }}" refs/remotes/origin/main
+
+      - name: Verify staging success
+        if: ${{ github.event.inputs.require_staging_success == 'true' }}
+        run: >
+          node scripts/ci-cd/find-deploy-run.mjs
+          --workflow deploy-staging.yml
+          --branch main
+          --head "${{ steps.meta.outputs.head_sha }}"
+          --artifact deploy-summary-staging
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Resolve previous successful production deploy
         id: base

--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -138,7 +138,10 @@ dry_run: false
 For a staging plan only, use `dry_run=true` and do not treat it as a deploy.
 Dry-run staging runs upload `deploy-plan-staging`, not
 `deploy-summary-staging`; deploy-base resolution and production's staging
-success check require the real deploy summary artifact.
+success check require the real deploy summary artifact. When a staging run is
+triggered by `workflow_run`, the GitHub run-level SHA can point at the branch
+tip even if the deploy job checked out the CI commit that triggered it. Use the
+deploy summary artifact's `headSha` as the deployed commit of record.
 
 ### Production
 
@@ -156,11 +159,13 @@ Normal production flow:
 
 1. Confirm a successful `Deploy Staging` run exists for the exact `main` SHA.
    The run must be a non-dry-run deploy with a `deploy-summary-staging`
-   artifact; a dry-run plan is not enough.
+   artifact whose JSON `headSha` matches the promoted SHA; a dry-run plan is
+   not enough.
 2. Dispatch `Promote Production` with `require_staging_success=true`.
-3. Approve the GitHub `Production` environment gates as they appear.
-4. Watch every selected lane until completion.
-5. Verify the production surfaces that ran.
+3. The promote plan verifies the promoted commit is reachable from `main`.
+4. Approve the GitHub `Production` environment gates as they appear.
+5. Watch every selected lane until completion.
+6. Verify the production surfaces that ran.
 
 The production GitHub environment currently exists as `Production`; workflow
 inputs and reusable workflow calls use `production`, and GitHub resolves that
@@ -775,9 +780,16 @@ Deploy graph:
 
 1. Resolve base/head:
    - staging diffs against the last successful non-dry-run
-     `deploy-staging.yml` run with a `deploy-summary-staging` artifact
+     `deploy-staging.yml` run with a `deploy-summary-staging` artifact; the
+     artifact `headSha` is the base when it differs from the GitHub run-level
+     SHA
    - production diffs against the last successful non-dry-run
-     `promote-production.yml` run with a `deploy-summary-production` artifact
+     `promote-production.yml` run with a `deploy-summary-production` artifact;
+     the artifact `headSha` is the base when it differs from the GitHub
+     run-level SHA
+   - deploy-base lookup fails closed on GitHub API, artifact download, or scan
+     limit errors when `GITHUB_TOKEN` is available; local/no-token runs fall
+     back to the parent SHA for developer ergonomics
 2. Detect changed surfaces:
    - `server`
    - `workers`

--- a/scripts/ci-cd/find-deploy-run.mjs
+++ b/scripts/ci-cd/find-deploy-run.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+import {
+  listSuccessfulWorkflowRuns,
+  readPositiveIntegerEnv,
+  readRunArtifactSummary,
+} from "./github-deploy-artifacts.mjs";
+
+function printUsage() {
+  console.log(`Find a successful deploy run by summary artifact head SHA.
+
+Usage:
+  node scripts/ci-cd/find-deploy-run.mjs --workflow <workflow-file> --branch <branch> --head <sha> --artifact <name>
+
+The script scans recent successful workflow runs, downloads the named deploy
+summary artifact, and succeeds only when the artifact JSON headSha matches the
+requested SHA. This avoids relying on workflow_run metadata, which can point at
+the branch tip rather than the commit that the deploy job checked out.
+`);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    workflow: "",
+    branch: "main",
+    head: "",
+    artifact: "",
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--workflow":
+        parsed.workflow = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--branch":
+        parsed.branch = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--head":
+        parsed.head = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--artifact":
+        parsed.artifact = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function writeGithubOutputs(run, summary) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(
+    outputPath,
+    [`run_id=${run.id}`, `run_url=${run.html_url}`, `artifact_head_sha=${summary.headSha}`].join("\n") +
+      "\n"
+  );
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    printUsage();
+    process.exit(1);
+  }
+
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+  if (!parsed.workflow) {
+    throw new Error("--workflow is required.");
+  }
+  if (!parsed.head) {
+    throw new Error("--head is required.");
+  }
+  if (!parsed.artifact) {
+    throw new Error("--artifact is required.");
+  }
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required.");
+  }
+
+  const maxPages = readPositiveIntegerEnv("DEPLOY_RUN_SCAN_MAX_PAGES", 20);
+  let exhausted = false;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const data = await listSuccessfulWorkflowRuns({
+      workflow: parsed.workflow,
+      branch: parsed.branch,
+      page,
+      token,
+    });
+    const candidates = data.workflow_runs || [];
+    if (candidates.length === 0) {
+      exhausted = true;
+      break;
+    }
+    for (const candidate of candidates) {
+      const summary = await readRunArtifactSummary(candidate.id, parsed.artifact, token);
+      if (summary?.headSha !== parsed.head) {
+        continue;
+      }
+      writeGithubOutputs(candidate, summary);
+      console.log(candidate.html_url);
+      return;
+    }
+  }
+
+  const scope = exhausted
+    ? "in the complete successful-run history"
+    : `within DEPLOY_RUN_SCAN_MAX_PAGES=${maxPages}`;
+  console.error(`No successful deploy run with ${parsed.artifact} for ${parsed.head} was found ${scope}.`);
+  process.exit(1);
+}
+
+main();

--- a/scripts/ci-cd/github-deploy-artifacts.mjs
+++ b/scripts/ci-cd/github-deploy-artifacts.mjs
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function readPositiveIntegerEnv(name, fallback) {
+  const value = process.env[name];
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export async function githubJson(apiPath, token) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY is required.");
+  }
+  const response = await fetch(`https://api.github.com/repos/${repository}${apiPath}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed (${response.status}): ${await response.text()}`);
+  }
+  return response.json();
+}
+
+export async function listSuccessfulWorkflowRuns({ workflow, branch, page, token }) {
+  const params = new URLSearchParams({
+    branch,
+    status: "success",
+    per_page: "50",
+    page: String(page),
+  });
+  return githubJson(`/actions/workflows/${encodeURIComponent(workflow)}/runs?${params}`, token);
+}
+
+export async function runHasArtifact(runId, artifactName, token) {
+  const maxPages = readPositiveIntegerEnv("DEPLOY_ARTIFACT_SCAN_MAX_PAGES", 10);
+  for (let page = 1; page <= maxPages; page += 1) {
+    const data = await githubJson(
+      `/actions/runs/${encodeURIComponent(runId)}/artifacts?per_page=100&page=${page}`,
+      token
+    );
+    const artifacts = data.artifacts || [];
+    if (
+      artifacts.some((artifact) => {
+        return artifact.name === artifactName && artifact.expired !== true;
+      })
+    ) {
+      return true;
+    }
+    if (artifacts.length === 0) {
+      return false;
+    }
+  }
+  throw new Error(
+    `Artifact scan reached DEPLOY_ARTIFACT_SCAN_MAX_PAGES without finding ${artifactName}.`
+  );
+}
+
+function collectJsonFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsonFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export function downloadArtifactSummary(runId, artifactName, token) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY is required.");
+  }
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "deploy-artifact-"));
+  try {
+    execFileSync(
+      "gh",
+      ["run", "download", String(runId), "--repo", repository, "--name", artifactName, "--dir", directory],
+      {
+        env: {
+          ...process.env,
+          GH_TOKEN: token,
+          GITHUB_TOKEN: token,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+
+    for (const file of collectJsonFiles(directory)) {
+      const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (parsed && typeof parsed === "object" && typeof parsed.headSha === "string") {
+        return parsed;
+      }
+    }
+    return null;
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+export async function readRunArtifactSummary(runId, artifactName, token) {
+  if (!(await runHasArtifact(runId, artifactName, token))) {
+    return null;
+  }
+  return downloadArtifactSummary(runId, artifactName, token);
+}

--- a/scripts/ci-cd/resolve-deploy-base.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.mjs
@@ -2,6 +2,12 @@
 
 import fs from "node:fs";
 
+import {
+  listSuccessfulWorkflowRuns,
+  readPositiveIntegerEnv,
+  readRunArtifactSummary,
+} from "./github-deploy-artifacts.mjs";
+
 function printUsage() {
   console.log(`Resolve the previous successful deploy SHA for an environment.
 
@@ -61,37 +67,6 @@ function parseArgs(argv) {
   return parsed;
 }
 
-async function githubJson(path, token) {
-  const repository = process.env.GITHUB_REPOSITORY;
-  if (!repository) {
-    throw new Error("GITHUB_REPOSITORY is required.");
-  }
-  const response = await fetch(`https://api.github.com/repos/${repository}${path}`, {
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      "x-github-api-version": "2022-11-28",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub API request failed (${response.status}): ${await response.text()}`);
-  }
-  return response.json();
-}
-
-async function runHasRequiredArtifact(runId, artifactName, token) {
-  if (!artifactName) {
-    return true;
-  }
-  const data = await githubJson(
-    `/actions/runs/${encodeURIComponent(runId)}/artifacts?per_page=100`,
-    token
-  );
-  return (data.artifacts || []).some((artifact) => {
-    return artifact.name === artifactName && artifact.expired !== true;
-  });
-}
-
 function fallbackSha(parsed) {
   return parsed.fallback || parsed.head;
 }
@@ -102,6 +77,15 @@ function writeGithubOutput(baseSha) {
     return;
   }
   fs.appendFileSync(outputPath, `base_sha=${baseSha}\n`);
+}
+
+async function resolveCandidateDeployHeadSha(candidate, artifactName, token) {
+  if (!artifactName) {
+    return candidate.head_sha || "";
+  }
+
+  const summary = await readRunArtifactSummary(candidate.id, artifactName, token);
+  return summary?.headSha || "";
 }
 
 async function main() {
@@ -125,7 +109,7 @@ async function main() {
     throw new Error("--head is required.");
   }
 
-  const token = process.env.GITHUB_TOKEN;
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     const baseSha = fallbackSha(parsed);
     writeGithubOutput(baseSha);
@@ -134,48 +118,51 @@ async function main() {
   }
 
   const currentRunId = process.env.GITHUB_RUN_ID || "";
-  try {
-    let run;
-    for (let page = 1; page <= 5 && !run; page += 1) {
-      const params = new URLSearchParams({
-        branch: parsed.branch,
-        status: "success",
-        per_page: "50",
-        page: String(page),
-      });
-      const data = await githubJson(
-        `/actions/workflows/${encodeURIComponent(parsed.workflow)}/runs?${params.toString()}`,
+  const maxPages = readPositiveIntegerEnv("DEPLOY_RUN_SCAN_MAX_PAGES", 20);
+  let run;
+  let exhausted = false;
+  for (let page = 1; page <= maxPages && !run; page += 1) {
+    const data = await listSuccessfulWorkflowRuns({
+      workflow: parsed.workflow,
+      branch: parsed.branch,
+      page,
+      token,
+    });
+    const candidates = data.workflow_runs || [];
+    if (candidates.length === 0) {
+      exhausted = true;
+      break;
+    }
+    for (const candidate of candidates) {
+      if (
+        String(candidate.id) === currentRunId ||
+        candidate.conclusion !== "success" ||
+        !candidate.head_sha
+      ) {
+        continue;
+      }
+      const deployHeadSha = await resolveCandidateDeployHeadSha(
+        candidate,
+        parsed.requiredArtifact,
         token
       );
-      const candidates = data.workflow_runs || [];
-      if (candidates.length === 0) {
-        break;
+      if (!deployHeadSha || deployHeadSha === parsed.head) {
+        continue;
       }
-      for (const candidate of candidates) {
-        if (
-          String(candidate.id) === currentRunId ||
-          candidate.conclusion !== "success" ||
-          !candidate.head_sha ||
-          candidate.head_sha === parsed.head
-        ) {
-          continue;
-        }
-        if (!(await runHasRequiredArtifact(candidate.id, parsed.requiredArtifact, token))) {
-          continue;
-        }
-        run = candidate;
-        break;
-      }
+      run = { ...candidate, deployHeadSha };
+      break;
     }
-    const baseSha = run?.head_sha || fallbackSha(parsed);
-    writeGithubOutput(baseSha);
-    console.log(baseSha);
-  } catch (error) {
-    console.warn(error instanceof Error ? error.message : String(error));
-    const baseSha = fallbackSha(parsed);
-    writeGithubOutput(baseSha);
-    console.log(baseSha);
   }
+
+  if (!run && !exhausted) {
+    throw new Error(
+      `Deploy base scan reached DEPLOY_RUN_SCAN_MAX_PAGES=${maxPages} without finding a base.`
+    );
+  }
+
+  const baseSha = run?.deployHeadSha || fallbackSha(parsed);
+  writeGithubOutput(baseSha);
+  console.log(baseSha);
 }
 
 main();


### PR DESCRIPTION
## Summary
- key deploy base resolution off deploy summary artifact `headSha` instead of run-level SHA
- make production staging gate find real deploy summaries by artifact head and require promoted commits to be on `main`
- document artifact-head source of truth and fail-closed deploy-base lookup

## Verification
- `node --check scripts/ci-cd/github-deploy-artifacts.mjs && node --check scripts/ci-cd/find-deploy-run.mjs && node --check scripts/ci-cd/resolve-deploy-base.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/promote-production.yml .github/workflows/deploy-staging.yml`\n- `python3 scripts/check_max_lines.py`\n- `git diff --check`\n- live smoke: `find-deploy-run` found Deploy Staging 26746526841 by artifact `headSha=cb794de4`\n- live smoke: `resolve-deploy-base` with only `GH_TOKEN` returned `cb794de4` for head `fd31fdaa`\n- live smoke: `git merge-base --is-ancestor cb794de4 origin/main`\n\nRelease notes: None - CI/CD hardening only.