### PR TITLE
fix(product): canonicalize frontier model defaults

### DIFF
--- a/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
@@ -94,10 +94,12 @@ describe("user preference migration", () => {
       .toBe("gpt-5.3-codex-high");
     expect(normalizeDefaultChatModelId("cursor", "gpt-5.3-codex-spark-preview-xhigh"))
       .toBe("gpt-5.3-codex-xhigh");
+    expect(normalizeDefaultChatModelId("opencode", "opencode/minimax-m2.5-free"))
+      .toBe("opencode/mimo-v2.5-free");
     expect(normalizeDefaultChatModelId("opencode", "opencode/ring-2.6-1t-free"))
-      .toBe("opencode/ring-2.6-1t-free");
+      .toBe("opencode/nemotron-3-super-free");
     expect(normalizeDefaultChatModelId("gemini", "auto-gemini-2.5"))
-      .toBe("auto-gemini-2.5");
+      .toBe("auto-gemini-3");
   });
 
   it("moves misstored Codex plan defaults into live collaboration controls", () => {

--- a/apps/desktop/src/lib/domain/preferences/user/session-defaults.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/session-defaults.ts
@@ -68,6 +68,15 @@ const LEGACY_CURSOR_MODEL_IDS: Record<string, string> = {
   "kimi-k2.5[]": "kimi-k2.5",
 };
 
+const LEGACY_OPENCODE_MODEL_IDS: Record<string, string> = {
+  "opencode/minimax-m2.5-free": "opencode/mimo-v2.5-free",
+  "opencode/ring-2.6-1t-free": "opencode/nemotron-3-super-free",
+};
+
+const LEGACY_GEMINI_MODEL_IDS: Record<string, string> = {
+  "auto-gemini-2.5": "auto-gemini-3",
+};
+
 const DEFAULT_LIVE_SESSION_CONTROL_KEYS = new Set<DefaultLiveSessionControlKey>([
   "collaboration_mode",
   "reasoning",
@@ -202,6 +211,12 @@ export function normalizeDefaultChatModelId(agentKind: string, modelId: string):
   }
   if (agentKind === "cursor") {
     return LEGACY_CURSOR_MODEL_IDS[modelId] ?? modelId;
+  }
+  if (agentKind === "opencode") {
+    return LEGACY_OPENCODE_MODEL_IDS[modelId] ?? modelId;
+  }
+  if (agentKind === "gemini") {
+    return LEGACY_GEMINI_MODEL_IDS[modelId] ?? modelId;
   }
   return modelId;
 }

--- a/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -236,6 +236,59 @@ describe("user preference migration", () => {
     expect(persisted.futurePreference).toBe(true);
   });
 
+  it("resets existing frontier-agent visibility overrides once", async () => {
+    storeMocks.values.set("user_preferences", {
+      ...USER_PREFERENCE_DEFAULTS,
+      chatModelVisibilityOverridesByAgentKind: {
+        claude: {
+          "us.anthropic.claude-opus-4-8[1m]": false,
+        },
+        cursor: {
+          "composer-2-fast": true,
+          "gpt-5.5-extra-high": false,
+        },
+        gemini: {
+          "auto-gemini-2.5": true,
+        },
+        opencode: {
+          "opencode/ring-2.6-1t-free": true,
+        },
+      },
+    } as unknown as UserPreferences);
+
+    await bootstrapUserPreferencesForTest();
+
+    const preferences = useUserPreferencesStore.getState();
+    expect(preferences.chatModelVisibilityOverridesByAgentKind).toEqual({
+      claude: {
+        "us.anthropic.claude-opus-4-8[1m]": false,
+      },
+    });
+    const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
+    expect(hasAppliedModelVisibilityDefaultsReset(persisted)).toBe(true);
+  });
+
+  it("preserves frontier-agent visibility overrides after the reset marker exists", async () => {
+    storeMocks.values.set("user_preferences", {
+      ...USER_PREFERENCE_DEFAULTS,
+      modelVisibilityDefaults20260531Reset: true,
+      chatModelVisibilityOverridesByAgentKind: {
+        cursor: {
+          "gpt-5.5-extra-high": false,
+        },
+      },
+    } as unknown as UserPreferences);
+
+    await bootstrapUserPreferencesForTest();
+
+    const preferences = useUserPreferencesStore.getState();
+    expect(preferences.chatModelVisibilityOverridesByAgentKind).toEqual({
+      cursor: {
+        "gpt-5.5-extra-high": false,
+      },
+    });
+  });
+
   it("migrates old unified scalar model preferences into the primary harness map", async () => {
     storeMocks.values.set("user_preferences", {
       ...USER_PREFERENCE_DEFAULTS,

--- a/catalogs/agents/v1/catalog.json
+++ b/catalogs/agents/v1/catalog.json
@@ -2411,7 +2411,9 @@
             "id": "opencode/mimo-v2.5-free",
             "displayName": "MiMo V2.5 Free",
             "description": null,
-            "aliases": [],
+            "aliases": [
+              "opencode/minimax-m2.5-free"
+            ],
             "status": "active",
             "isDefault": false,
             "provider": "opencode",
@@ -2432,7 +2434,9 @@
             "id": "opencode/nemotron-3-super-free",
             "displayName": "Nemotron 3 Super Free",
             "description": null,
-            "aliases": [],
+            "aliases": [
+              "opencode/ring-2.6-1t-free"
+            ],
             "status": "active",
             "isDefault": false,
             "provider": "opencode",

--- a/server/alembic/versions/d6e7f8a9b0c1_automation_run_configs.py
+++ b/server/alembic/versions/d6e7f8a9b0c1_automation_run_configs.py
@@ -178,6 +178,29 @@ def _backfill_automation_agent_run_configs() -> None:
                 config_name,
                 normalized_agent_kind,
                 COALESCE(
+                  CASE normalized_agent_kind
+                    WHEN 'cursor' THEN
+                      CASE legacy_model_id
+                        WHEN 'composer-2[fast=true]' THEN 'composer-2.5-fast'
+                        WHEN 'composer-2-fast' THEN 'composer-2.5-fast'
+                        WHEN 'composer-1.5[]' THEN 'composer-2.5'
+                        WHEN 'composer-2' THEN 'composer-2.5'
+                        WHEN 'gpt-5.3-codex-spark-preview-low' THEN 'gpt-5.3-codex-low'
+                        WHEN 'gpt-5.3-codex-spark-preview' THEN 'gpt-5.3-codex'
+                        WHEN 'gpt-5.3-codex-spark[reasoning=medium]' THEN 'gpt-5.3-codex'
+                        WHEN 'gpt-5.3-codex-spark-preview-high' THEN 'gpt-5.3-codex-high'
+                        WHEN 'gpt-5.3-codex-spark-preview-xhigh' THEN 'gpt-5.3-codex-xhigh'
+                      END
+                    WHEN 'opencode' THEN
+                      CASE legacy_model_id
+                        WHEN 'opencode/minimax-m2.5-free' THEN 'opencode/mimo-v2.5-free'
+                        WHEN 'opencode/ring-2.6-1t-free' THEN 'opencode/nemotron-3-super-free'
+                      END
+                    WHEN 'gemini' THEN
+                      CASE legacy_model_id
+                        WHEN 'auto-gemini-2.5' THEN 'auto-gemini-3'
+                      END
+                  END,
                   legacy_model_id,
                   CASE normalized_agent_kind
                     WHEN 'claude' THEN 'us.anthropic.claude-sonnet-4-6'
@@ -277,7 +300,32 @@ def _backfill_automation_run_agent_snapshots() -> None:
                 'config_id', config.id::text,
                 'config_name', config.name,
                 'agent_kind', COALESCE(NULLIF(run.agent_kind_snapshot, ''), config.agent_kind),
-                'model_id', COALESCE(NULLIF(run.model_id_snapshot, ''), config.model_id),
+                'model_id', COALESCE(
+                  CASE COALESCE(NULLIF(run.agent_kind_snapshot, ''), config.agent_kind)
+                    WHEN 'cursor' THEN
+                      CASE COALESCE(NULLIF(run.model_id_snapshot, ''), config.model_id)
+                        WHEN 'composer-2[fast=true]' THEN 'composer-2.5-fast'
+                        WHEN 'composer-2-fast' THEN 'composer-2.5-fast'
+                        WHEN 'composer-1.5[]' THEN 'composer-2.5'
+                        WHEN 'composer-2' THEN 'composer-2.5'
+                        WHEN 'gpt-5.3-codex-spark-preview-low' THEN 'gpt-5.3-codex-low'
+                        WHEN 'gpt-5.3-codex-spark-preview' THEN 'gpt-5.3-codex'
+                        WHEN 'gpt-5.3-codex-spark[reasoning=medium]' THEN 'gpt-5.3-codex'
+                        WHEN 'gpt-5.3-codex-spark-preview-high' THEN 'gpt-5.3-codex-high'
+                        WHEN 'gpt-5.3-codex-spark-preview-xhigh' THEN 'gpt-5.3-codex-xhigh'
+                      END
+                    WHEN 'opencode' THEN
+                      CASE COALESCE(NULLIF(run.model_id_snapshot, ''), config.model_id)
+                        WHEN 'opencode/minimax-m2.5-free' THEN 'opencode/mimo-v2.5-free'
+                        WHEN 'opencode/ring-2.6-1t-free' THEN 'opencode/nemotron-3-super-free'
+                      END
+                    WHEN 'gemini' THEN
+                      CASE COALESCE(NULLIF(run.model_id_snapshot, ''), config.model_id)
+                        WHEN 'auto-gemini-2.5' THEN 'auto-gemini-3'
+                      END
+                  END,
+                  COALESCE(NULLIF(run.model_id_snapshot, ''), config.model_id)
+                ),
                 'control_values', jsonb_strip_nulls(
                   jsonb_build_object(
                     'mode', NULLIF(run.mode_id_snapshot, ''),

--- a/server/tests/unit/test_cloud_agent_run_config_service.py
+++ b/server/tests/unit/test_cloud_agent_run_config_service.py
@@ -83,6 +83,12 @@ def test_model_aliases_validate_and_resolve_to_canonical_catalog_ids() -> None:
         ("cursor", "gpt-5.3-codex-spark-preview", "gpt-5.3-codex"),
         ("cursor", "gpt-5.3-codex-spark-preview-high", "gpt-5.3-codex-high"),
         ("cursor", "gpt-5.3-codex-spark-preview-xhigh", "gpt-5.3-codex-xhigh"),
+        ("opencode", "opencode/minimax-m2.5-free", "opencode/mimo-v2.5-free"),
+        (
+            "opencode",
+            "opencode/ring-2.6-1t-free",
+            "opencode/nemotron-3-super-free",
+        ),
     ]
 
     for agent_kind, legacy_model_id, canonical_model_id in cases:


### PR DESCRIPTION
## Summary
- canonicalize renamed Cursor, OpenCode, and Gemini frontier model defaults in persisted desktop preferences and automation backfills
- add OpenCode legacy model aliases to the agent catalog
- cover legacy cloud agent run config aliases resolving to canonical catalog ids

## Tests
- `git diff --cached --check`
- `node scripts/validate-agent-catalog.mjs`
- `pnpm --dir apps/desktop exec vitest run src/lib/domain/preferences/user/migration.test.ts src/stores/preferences/user-preferences-store.test.ts`
- `debug=true uv run --python 3.12 --extra dev pytest -q tests/unit/test_cloud_agent_run_config_service.py`
