### PR TITLE
ci(deploy): fail closed on artifact lookup errors

### DIFF
--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -242,6 +242,10 @@ ran, skipped lanes, verification results, and any follow-up needed.
 
 - Do not call a deploy successful while a selected lane is still running,
   waiting for approval, failed, or canceled.
+- If deploy-base resolution cannot verify a required deploy summary artifact
+  because the GitHub artifact API or artifact download fails, rerun the
+  workflow after GitHub recovers. The resolver fails closed in that case rather
+  than falling back to an ancestor SHA that could under-detect deploy surfaces.
 - If web fails on `vercel pull` or `vercel deploy` with an invalid token,
   refresh the `VERCEL_TOKEN` environment secret from a valid local or
   organization token; never paste the token in chat or docs.

--- a/scripts/ci-cd/resolve-deploy-base.mjs
+++ b/scripts/ci-cd/resolve-deploy-base.mjs
@@ -79,6 +79,10 @@ function writeGithubOutput(baseSha) {
   fs.appendFileSync(outputPath, `base_sha=${baseSha}\n`);
 }
 
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function resolveCandidateDeployHeadSha(candidate, artifactName, token) {
   if (!artifactName) {
     return candidate.head_sha || "";
@@ -121,6 +125,7 @@ async function main() {
   const maxPages = readPositiveIntegerEnv("DEPLOY_RUN_SCAN_MAX_PAGES", 20);
   let run;
   let exhausted = false;
+  const artifactLookupFailures = [];
   for (let page = 1; page <= maxPages && !run; page += 1) {
     const data = await listSuccessfulWorkflowRuns({
       workflow: parsed.workflow,
@@ -141,11 +146,24 @@ async function main() {
       ) {
         continue;
       }
-      const deployHeadSha = await resolveCandidateDeployHeadSha(
-        candidate,
-        parsed.requiredArtifact,
-        token
-      );
+      let deployHeadSha;
+      try {
+        deployHeadSha = await resolveCandidateDeployHeadSha(
+          candidate,
+          parsed.requiredArtifact,
+          token
+        );
+      } catch (error) {
+        const details = [
+          `run ${candidate.id}${candidate.html_url ? ` (${candidate.html_url})` : ""}`,
+          errorMessage(error),
+        ].join(": ");
+        artifactLookupFailures.push(details);
+        console.warn(
+          `Skipping candidate because its deploy artifact could not be verified: ${details}`
+        );
+        continue;
+      }
       if (!deployHeadSha || deployHeadSha === parsed.head) {
         continue;
       }
@@ -157,6 +175,21 @@ async function main() {
   if (!run && !exhausted) {
     throw new Error(
       `Deploy base scan reached DEPLOY_RUN_SCAN_MAX_PAGES=${maxPages} without finding a base.`
+    );
+  }
+
+  if (!run && artifactLookupFailures.length > 0) {
+    const examples = artifactLookupFailures
+      .slice(0, 5)
+      .map((failure) => `- ${failure}`)
+      .join("\n");
+    throw new Error(
+      [
+        `Unable to verify ${parsed.requiredArtifact} on ${artifactLookupFailures.length} candidate deploy run(s).`,
+        "Failing instead of falling back to an ancestor SHA, because that could under-detect deploy surfaces.",
+        "Retry the workflow or inspect GitHub Actions artifact API health.",
+        examples,
+      ].join("\n")
     );
   }
 


### PR DESCRIPTION
## Summary
- keep scanning candidate deploy runs when one required deploy-summary artifact lookup fails
- fail the resolver instead of falling back to an ancestor SHA if artifact verification was unreliable and no valid base was found
- document the fail-closed deploy-base behavior in the CI/CD runbook

## Notes
- The Greptile `per_page=100` workflow comment is already covered on current `main`: `promote-production.yml` uses `find-deploy-run.mjs`, which goes through `github-deploy-artifacts.mjs` and requests artifacts with `per_page=100`.

## Tests
- `git diff --check`
- `node --check scripts/ci-cd/resolve-deploy-base.mjs && node --check scripts/ci-cd/find-deploy-run.mjs && node --check scripts/ci-cd/github-deploy-artifacts.mjs`
- `GITHUB_TOKEN= GH_TOKEN= node scripts/ci-cd/resolve-deploy-base.mjs --workflow promote-production.yml --branch main --head HEADSHA --fallback FALLBACKSHA --required-artifact deploy-summary-production`
