### PR TITLE
refactor(anyharness): align product mcp structure

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
@@ -1,25 +1,21 @@
 use axum::{
+    Json,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    Json,
 };
 use serde_json::Value;
 
 use super::access::assert_workspace_mutable;
 use super::error::ApiError;
 use crate::app::AppState;
-use crate::domains::cowork::mcp::definition as cowork_mcp_definition;
-use crate::domains::reviews::mcp::definition as reviews_mcp_definition;
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDispatchError,
-    ProductMcpRequestContext, PRODUCT_MCP_TOKEN_HEADER_NAME,
+    PRODUCT_MCP_TOKEN_HEADER_NAME, ProductMcpAuthHeader, ProductMcpContextError,
+    ProductMcpDispatchError, ProductMcpEndpointOperation, ProductMcpRequestContext,
 };
 use crate::sessions::mcp_bindings::product_registry::{
-    ProductMcpEndpointHandler, ProductMcpEndpointOperation,
+    ProductMcpEndpointHandler, legacy_route_aliases,
 };
-use crate::sessions::subagents::mcp::definition as subagents_mcp_definition;
-use crate::sessions::workspace_naming::mcp::definition as workspace_naming_mcp_definition;
 
 pub async fn get_product_mcp_endpoint(
     State(_state): State<AppState>,
@@ -62,7 +58,7 @@ pub async fn post_subagents_legacy_mcp_endpoint(
         &state,
         &workspace_id,
         &session_id,
-        subagents_mcp_definition::ROUTE_SLUG,
+        legacy_route_aliases::SUBAGENTS,
         headers,
         body,
     )
@@ -86,7 +82,7 @@ pub async fn post_reviews_legacy_mcp_endpoint(
         &state,
         &workspace_id,
         &session_id,
-        reviews_mcp_definition::ROUTE_SLUG,
+        legacy_route_aliases::REVIEWS,
         headers,
         body,
     )
@@ -110,7 +106,7 @@ pub async fn post_workspace_naming_legacy_mcp_endpoint(
         &state,
         &workspace_id,
         &session_id,
-        workspace_naming_mcp_definition::ROUTE_SLUG,
+        legacy_route_aliases::WORKSPACE_NAMING,
         headers,
         body,
     )
@@ -134,7 +130,7 @@ pub async fn post_cowork_legacy_mcp_endpoint(
         &state,
         &workspace_id,
         &session_id,
-        cowork_mcp_definition::ROUTE_SLUG,
+        legacy_route_aliases::COWORK,
         headers,
         body,
     )

--- a/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
@@ -1,8 +1,8 @@
 use axum::{
-    Json,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
+    Json,
 };
 use serde_json::Value;
 
@@ -10,11 +10,11 @@ use super::access::assert_workspace_mutable;
 use super::error::ApiError;
 use crate::app::AppState;
 use crate::integrations::mcp::product_server::{
-    PRODUCT_MCP_TOKEN_HEADER_NAME, ProductMcpAuthHeader, ProductMcpContextError,
-    ProductMcpDispatchError, ProductMcpEndpointOperation, ProductMcpRequestContext,
+    ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDispatchError,
+    ProductMcpEndpointOperation, ProductMcpRequestContext, PRODUCT_MCP_TOKEN_HEADER_NAME,
 };
 use crate::sessions::mcp_bindings::product_registry::{
-    ProductMcpEndpointHandler, legacy_route_aliases,
+    legacy_route_aliases, ProductMcpEndpointHandler,
 };
 
 pub async fn get_product_mcp_endpoint(

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::mcp::{
-    self as cowork_mcp, CoworkProductMcpServer, auth::CoworkMcpAuth, tools as cowork_mcp_tools,
+    self as cowork_mcp, auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
 };
 use crate::domains::cowork::runtime::CoworkRuntime;
-use crate::domains::plugins::mcp::{SkillsProductMcpServer, auth::SkillsMcpAuth};
+use crate::domains::plugins::mcp::{auth::SkillsMcpAuth, SkillsProductMcpServer};
 use crate::domains::reviews::mcp::{
-    self as review_mcp, ReviewProductMcpServer, auth::ReviewMcpAuth, tools as review_mcp_tools,
+    self as review_mcp, auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
 };
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::domains::runtime_config::service::RuntimeConfigService;
@@ -17,17 +17,17 @@ use crate::sessions::mcp_bindings::product_launch::{
     ProductMcpLaunchRegistration, ProductMcpSelectionContext,
 };
 use crate::sessions::mcp_bindings::product_registry::{
-    ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
-    legacy_route_aliases,
+    legacy_route_aliases, ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration,
+    ProductMcpEndpointRegistry,
 };
 use crate::sessions::runtime::SessionRuntime;
 use crate::sessions::store::SessionStore;
 use crate::sessions::subagents::mcp::{
-    SubagentProductMcpServer, auth::SubagentMcpAuth, tools as subagent_mcp_tools,
+    auth::SubagentMcpAuth, tools as subagent_mcp_tools, SubagentProductMcpServer,
 };
 use crate::sessions::subagents::service::SubagentService;
 use crate::sessions::workspace_naming::mcp::{
-    WorkspaceNamingProductMcpServer, auth::WorkspaceNamingMcpAuth,
+    auth::WorkspaceNamingMcpAuth, WorkspaceNamingProductMcpServer,
 };
 use crate::workspaces::access_gate::WorkspaceAccessGate;
 use crate::workspaces::operation_gate::WorkspaceOperationKind;

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::mcp::{
-    self as cowork_mcp, auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
+    self as cowork_mcp, CoworkProductMcpServer, auth::CoworkMcpAuth, tools as cowork_mcp_tools,
 };
 use crate::domains::cowork::runtime::CoworkRuntime;
-use crate::domains::plugins::mcp::{auth::SkillsMcpAuth, SkillsProductMcpServer};
+use crate::domains::plugins::mcp::{SkillsProductMcpServer, auth::SkillsMcpAuth};
 use crate::domains::reviews::mcp::{
-    self as review_mcp, auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
+    self as review_mcp, ReviewProductMcpServer, auth::ReviewMcpAuth, tools as review_mcp_tools,
 };
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::domains::runtime_config::service::RuntimeConfigService;
@@ -18,15 +18,16 @@ use crate::sessions::mcp_bindings::product_launch::{
 };
 use crate::sessions::mcp_bindings::product_registry::{
     ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
+    legacy_route_aliases,
 };
 use crate::sessions::runtime::SessionRuntime;
 use crate::sessions::store::SessionStore;
 use crate::sessions::subagents::mcp::{
-    auth::SubagentMcpAuth, tools as subagent_mcp_tools, SubagentProductMcpServer,
+    SubagentProductMcpServer, auth::SubagentMcpAuth, tools as subagent_mcp_tools,
 };
 use crate::sessions::subagents::service::SubagentService;
 use crate::sessions::workspace_naming::mcp::{
-    auth::WorkspaceNamingMcpAuth, WorkspaceNamingProductMcpServer,
+    WorkspaceNamingProductMcpServer, auth::WorkspaceNamingMcpAuth,
 };
 use crate::workspaces::access_gate::WorkspaceAccessGate;
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
@@ -168,40 +169,52 @@ pub(super) fn build_product_mcp_endpoint_registry(
     } = deps;
 
     let product_mcp_endpoint_registrations = vec![
-        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-            Arc::new(ReviewProductMcpServer::new(review_runtime, review_mcp_auth)),
-            Some(WorkspaceOperationKind::ReviewWrite),
-            review_mcp_tools::MUTATING_TOOL_NAMES,
-        ))),
-        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-            Arc::new(SubagentProductMcpServer::new(
-                subagent_service.clone(),
-                session_runtime,
-                workspace_runtime.clone(),
-                subagent_mcp_auth,
+        ProductMcpEndpointRegistration::with_route_aliases(
+            Arc::new(ProductMcpEndpointHandlerAdapter::new(
+                Arc::new(ReviewProductMcpServer::new(review_runtime, review_mcp_auth)),
+                Some(WorkspaceOperationKind::ReviewWrite),
+                review_mcp_tools::MUTATING_TOOL_NAMES,
             )),
-            Some(WorkspaceOperationKind::SubagentWrite),
-            subagent_mcp_tools::MUTATING_TOOL_NAMES,
-        ))),
-        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-            Arc::new(WorkspaceNamingProductMcpServer::new(
-                workspace_runtime,
-                workspace_access_gate,
-                SessionStore::new(db),
-                workspace_naming_mcp_auth,
+            &[legacy_route_aliases::REVIEWS],
+        ),
+        ProductMcpEndpointRegistration::with_route_aliases(
+            Arc::new(ProductMcpEndpointHandlerAdapter::new(
+                Arc::new(SubagentProductMcpServer::new(
+                    subagent_service.clone(),
+                    session_runtime,
+                    workspace_runtime.clone(),
+                    subagent_mcp_auth,
+                )),
+                Some(WorkspaceOperationKind::SubagentWrite),
+                subagent_mcp_tools::MUTATING_TOOL_NAMES,
             )),
-            None,
-            &[],
-        ))),
-        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
-            Arc::new(CoworkProductMcpServer::new(
-                cowork_artifact_runtime,
-                cowork_runtime,
-                cowork_mcp_auth,
+            &[legacy_route_aliases::SUBAGENTS],
+        ),
+        ProductMcpEndpointRegistration::with_route_aliases(
+            Arc::new(ProductMcpEndpointHandlerAdapter::new(
+                Arc::new(WorkspaceNamingProductMcpServer::new(
+                    workspace_runtime,
+                    workspace_access_gate,
+                    SessionStore::new(db),
+                    workspace_naming_mcp_auth,
+                )),
+                None,
+                &[],
             )),
-            Some(WorkspaceOperationKind::CoworkWrite),
-            cowork_mcp_tools::MUTATING_TOOL_NAMES,
-        ))),
+            &[legacy_route_aliases::WORKSPACE_NAMING],
+        ),
+        ProductMcpEndpointRegistration::with_route_aliases(
+            Arc::new(ProductMcpEndpointHandlerAdapter::new(
+                Arc::new(CoworkProductMcpServer::new(
+                    cowork_artifact_runtime,
+                    cowork_runtime,
+                    cowork_mcp_auth,
+                )),
+                Some(WorkspaceOperationKind::CoworkWrite),
+                cowork_mcp_tools::MUTATING_TOOL_NAMES,
+            )),
+            &[legacy_route_aliases::COWORK],
+        ),
         ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
             Arc::new(SkillsProductMcpServer::new(
                 runtime_config_service,

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
-use super::tools::{MUTATING_TOOL_NAMES, READ_ONLY_TOOL_NAMES, build_tool_list};
+use super::tools::{build_tool_list, MUTATING_TOOL_NAMES, READ_ONLY_TOOL_NAMES};
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition,
     ProductMcpEndpointOperation, ProductMcpRequestContext, ProductMcpServer,

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
@@ -1,15 +1,16 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::tools::{build_tool_list, MUTATING_TOOL_NAMES, READ_ONLY_TOOL_NAMES};
+use super::tools::{MUTATING_TOOL_NAMES, READ_ONLY_TOOL_NAMES, build_tool_list};
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
-    ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition,
+    ProductMcpEndpointOperation, ProductMcpRequestContext, ProductMcpServer,
+    ProductMcpTokenValidation,
 };
 use crate::sessions::mcp_bindings::product_registry::{
-    ProductMcpEndpointHandler, ProductMcpEndpointHandlerAdapter, ProductMcpEndpointOperation,
+    ProductMcpEndpointHandler, ProductMcpEndpointHandlerAdapter,
 };
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
 

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/endpoint.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/endpoint.rs
@@ -1,0 +1,72 @@
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductMcpEndpointOperation {
+    Initialize,
+    InitializedNotification,
+    ToolsList,
+    ToolsCall { tool_name: Option<String> },
+    Other,
+}
+
+impl ProductMcpEndpointOperation {
+    pub fn from_request_body(body: &Value) -> Self {
+        match body.get("method").and_then(Value::as_str) {
+            Some("initialize") => Self::Initialize,
+            Some("notifications/initialized") => Self::InitializedNotification,
+            Some("tools/list") => Self::ToolsList,
+            Some("tools/call") => Self::ToolsCall {
+                tool_name: body
+                    .get("params")
+                    .and_then(|params| params.get("name"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+            },
+            _ => Self::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn endpoint_operation_parses_tools_call_name() {
+        let operation = ProductMcpEndpointOperation::from_request_body(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "create_subagent" }
+        }));
+
+        assert_eq!(
+            operation,
+            ProductMcpEndpointOperation::ToolsCall {
+                tool_name: Some("create_subagent".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn endpoint_operation_treats_protocol_methods_as_non_tool_operations() {
+        assert_eq!(
+            ProductMcpEndpointOperation::from_request_body(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize"
+            })),
+            ProductMcpEndpointOperation::Initialize
+        );
+        assert_eq!(
+            ProductMcpEndpointOperation::from_request_body(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list"
+            })),
+            ProductMcpEndpointOperation::ToolsList
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
@@ -8,10 +8,10 @@ pub mod response;
 
 pub use auth::ProductMcpAuth;
 pub use definition::{ProductMcpDefinition, ProductMcpPromptPolicy, ProductMcpVisibility};
-pub use dispatcher::{ProductMcpServer, dispatch_product_mcp_request};
+pub use dispatcher::{dispatch_product_mcp_request, ProductMcpServer};
 pub use endpoint::ProductMcpEndpointOperation;
 pub use errors::{ProductMcpContextError, ProductMcpDispatchError};
 pub use request::{
-    PRODUCT_MCP_TOKEN_HEADER_NAME, ProductMcpAuthHeader, ProductMcpRequestContext,
-    ProductMcpTokenValidation,
+    ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
+    PRODUCT_MCP_TOKEN_HEADER_NAME,
 };

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
@@ -1,15 +1,17 @@
 pub mod auth;
 pub mod definition;
 pub mod dispatcher;
+pub mod endpoint;
 pub mod errors;
 pub mod request;
 pub mod response;
 
 pub use auth::ProductMcpAuth;
 pub use definition::{ProductMcpDefinition, ProductMcpPromptPolicy, ProductMcpVisibility};
-pub use dispatcher::{dispatch_product_mcp_request, ProductMcpServer};
+pub use dispatcher::{ProductMcpServer, dispatch_product_mcp_request};
+pub use endpoint::ProductMcpEndpointOperation;
 pub use errors::{ProductMcpContextError, ProductMcpDispatchError};
 pub use request::{
-    ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
-    PRODUCT_MCP_TOKEN_HEADER_NAME,
+    PRODUCT_MCP_TOKEN_HEADER_NAME, ProductMcpAuthHeader, ProductMcpRequestContext,
+    ProductMcpTokenValidation,
 };

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_registry.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_registry.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuthHeader, ProductMcpDefinition, ProductMcpDispatchError,
-    ProductMcpEndpointOperation, ProductMcpRequestContext, ProductMcpServer,
-    ProductMcpTokenValidation, dispatch_product_mcp_request,
+    dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpDefinition,
+    ProductMcpDispatchError, ProductMcpEndpointOperation, ProductMcpRequestContext,
+    ProductMcpServer, ProductMcpTokenValidation,
 };
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
 
@@ -428,11 +428,9 @@ mod tests {
         .err()
         .expect("duplicate route slug should fail");
 
-        assert!(
-            error
-                .to_string()
-                .contains("duplicate product MCP route slug")
-        );
+        assert!(error
+            .to_string()
+            .contains("duplicate product MCP route slug"));
     }
 
     #[test]
@@ -450,10 +448,8 @@ mod tests {
         .err()
         .expect("duplicate route alias should fail");
 
-        assert!(
-            error
-                .to_string()
-                .contains("duplicate product MCP route alias")
-        );
+        assert!(error
+            .to_string()
+            .contains("duplicate product MCP route alias"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_registry.rs
+++ b/anyharness/crates/anyharness-lib/src/sessions/mcp_bindings/product_registry.rs
@@ -5,36 +5,17 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::integrations::mcp::product_server::{
-    dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpDefinition,
-    ProductMcpDispatchError, ProductMcpRequestContext, ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpAuthHeader, ProductMcpDefinition, ProductMcpDispatchError,
+    ProductMcpEndpointOperation, ProductMcpRequestContext, ProductMcpServer,
+    ProductMcpTokenValidation, dispatch_product_mcp_request,
 };
 use crate::workspaces::operation_gate::WorkspaceOperationKind;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ProductMcpEndpointOperation {
-    Initialize,
-    InitializedNotification,
-    ToolsList,
-    ToolsCall { tool_name: Option<String> },
-    Other,
-}
-
-impl ProductMcpEndpointOperation {
-    pub fn from_request_body(body: &Value) -> Self {
-        match body.get("method").and_then(Value::as_str) {
-            Some("initialize") => Self::Initialize,
-            Some("notifications/initialized") => Self::InitializedNotification,
-            Some("tools/list") => Self::ToolsList,
-            Some("tools/call") => Self::ToolsCall {
-                tool_name: body
-                    .get("params")
-                    .and_then(|params| params.get("name"))
-                    .and_then(Value::as_str)
-                    .map(str::to_owned),
-            },
-            _ => Self::Other,
-        }
-    }
+pub mod legacy_route_aliases {
+    pub const COWORK: &str = "legacy:cowork";
+    pub const REVIEWS: &str = "legacy:reviews";
+    pub const SUBAGENTS: &str = "legacy:subagents";
+    pub const WORKSPACE_NAMING: &str = "legacy:workspace_naming";
 }
 
 #[async_trait]
@@ -367,43 +348,6 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_operation_parses_tools_call_name() {
-        let operation = ProductMcpEndpointOperation::from_request_body(&json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": { "name": "create_subagent" }
-        }));
-
-        assert_eq!(
-            operation,
-            ProductMcpEndpointOperation::ToolsCall {
-                tool_name: Some("create_subagent".to_string())
-            }
-        );
-    }
-
-    #[test]
-    fn endpoint_operation_treats_protocol_methods_as_non_tool_operations() {
-        assert_eq!(
-            ProductMcpEndpointOperation::from_request_body(&json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize"
-            })),
-            ProductMcpEndpointOperation::Initialize
-        );
-        assert_eq!(
-            ProductMcpEndpointOperation::from_request_body(&json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/list"
-            })),
-            ProductMcpEndpointOperation::ToolsList
-        );
-    }
-
-    #[test]
     fn endpoint_handler_adapter_gates_only_mutating_tool_calls() {
         let adapter = ProductMcpEndpointHandlerAdapter::new(
             Arc::new(TestProductMcpServer),
@@ -442,6 +386,24 @@ mod tests {
     }
 
     #[test]
+    fn registry_indexes_route_aliases_to_the_registered_handler() {
+        let handler = Arc::new(TestEndpointHandler(&TEST_DEFINITION_A));
+        let registry = ProductMcpEndpointRegistry::new(vec![
+            ProductMcpEndpointRegistration::with_route_aliases(handler, &["legacy:test-a"]),
+        ])
+        .expect("registry");
+
+        assert_eq!(
+            registry
+                .get_by_route_slug("legacy:test-a")
+                .expect("alias")
+                .definition()
+                .id,
+            "test_a"
+        );
+    }
+
+    #[test]
     fn registry_rejects_duplicate_product_ids() {
         let error = ProductMcpEndpointRegistry::new(vec![
             ProductMcpEndpointRegistration::new(Arc::new(TestEndpointHandler(&TEST_DEFINITION_A))),
@@ -466,9 +428,11 @@ mod tests {
         .err()
         .expect("duplicate route slug should fail");
 
-        assert!(error
-            .to_string()
-            .contains("duplicate product MCP route slug"));
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate product MCP route slug")
+        );
     }
 
     #[test]
@@ -486,8 +450,10 @@ mod tests {
         .err()
         .expect("duplicate route alias should fail");
 
-        assert!(error
-            .to_string()
-            .contains("duplicate product MCP route alias"));
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate product MCP route alias")
+        );
     }
 }


### PR DESCRIPTION
## Docs read
- docs/README.md
- docs/tbd/structure-alignment-coordinator-model.md
- docs/tbd/anyharness-structure-alignment-swarms.md
- docs/structures/anyharness/README.md
- docs/structures/anyharness/guides/repo-shape.md
- docs/structures/anyharness/guides/domains.md
- docs/structures/anyharness/guides/integrations.md
- docs/structures/anyharness/guides/app.md
- docs/structures/anyharness/guides/api.md
- docs/primitives/mcp-runtime.md
- docs/primitives/mcp-skills.md
- docs/features/product-mcps/servers.md
- docs/features/product-mcps/definitions/README.md
- docs/features/product-mcps/definitions/subagents.md
- docs/features/product-mcps/definitions/cowork.md
- docs/features/product-mcps/definitions/reviews.md
- docs/features/product-mcps/definitions/workspace-naming.md
- docs/features/product-mcps/definitions/artifacts.md
- docs/features/product-mcps/definitions/prompt-and-skill-policy.md
- docs/dev/ci-cd.md

## High-level changes
- Moved generic Product MCP endpoint operation parsing into `integrations/mcp/product_server/endpoint.rs`, keeping JSON-RPC method inspection with the MCP integration layer.
- Registered legacy Product MCP compatibility routes as session-owned endpoint-registry aliases, so `api/http/product_mcp.rs` no longer imports product-domain MCP definitions for dispatch.
- Kept product tool behavior, launch selection, capability-token semantics, public contracts, and SDK/generated code unchanged.

## Behavior preservation
- Fresh `/sessions/{session_id}/mcp/{product_mcp_slug}` routes still dispatch by registered route slug.
- Legacy subagents, reviews, workspace naming, and cowork routes still dispatch to the same registered product MCP handlers through alias keys.
- Mutating-tool workspace operation gates remain attached through the existing endpoint handler adapter.

## Checks run
- `python3 scripts/check_anyharness_old_paths.py`
- `python3 scripts/check_anyharness_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check origin/main...HEAD`
- `cargo test -p anyharness-lib product_mcp --lib`
- `cargo test -p anyharness-lib mcp_bindings --lib`
- `cargo test -p anyharness-lib mcp::product_server --lib`
- `cargo test -p anyharness-lib mcp --lib`
- `cargo check -p anyharness-lib`

## Remaining exceptions
- Final `sessions/** -> domains/sessions/**` topology remains deferred to the late topology swarm.
- Artifact MCP promotion remains deferred to Swarm 9; cowork artifact behavior is not moved here.
- Legacy Product MCP HTTP routes remain as compatibility aliases while fresh routes use the generic product MCP path.
