### PR TITLE
refactor(server): route service session boundaries

### DIFF
--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -35,6 +35,15 @@ ALLOWED_API_ORM_IMPORT = ("proliferate.db.models.auth", "User")
 ALLOWED_API_ENGINE_IMPORTS = {"get_async_session"}
 ALLOWED_SQLALCHEMY_TYPE_IMPORT = ("sqlalchemy.ext.asyncio", "AsyncSession")
 SERVICE_DB_METHODS = {"execute", "commit", "rollback", "add", "delete", "refresh"}
+SERVICE_DB_SESSION_OPS_METHODS = {
+    "open_async_session",
+    "open_async_transaction",
+    "commit_session",
+    "rollback_session",
+    "run_after_commit",
+    "defer_after_commit",
+    "is_integrity_error",
+}
 API_DB_METHODS = {"execute", "commit", "rollback", "add", "delete", "refresh"}
 STORE_FORBIDDEN_SESSION_METHODS = {"commit", "rollback"}
 RAW_HTTP_MODULES = {"httpx", "requests"}
@@ -317,7 +326,15 @@ class BoundaryChecker(ast.NodeVisitor):
                 "SERVICE_DB_ENGINE_IMPORT",
                 "service.py must not import DB session entrypoint helpers",
             )
-        if module == "proliferate.db" and ("engine" in names or "*" in names):
+        if module == "proliferate.db.session_ops":
+            self.add(
+                node,
+                "SERVICE_DB_ENGINE_IMPORT",
+                "service.py must not import DB session entrypoint helpers",
+            )
+        if module == "proliferate.db" and (
+            "engine" in names or "session_ops" in names or "*" in names
+        ):
             self.add(
                 node,
                 "SERVICE_DB_ENGINE_IMPORT",
@@ -483,6 +500,17 @@ class BoundaryChecker(ast.NodeVisitor):
                     node,
                     "SERVICE_DB_METHOD_CALL",
                     f"service.py must not call session method .{func.attr}()",
+                )
+            if (
+                self.kind.is_service
+                and func.attr in SERVICE_DB_SESSION_OPS_METHODS
+                and isinstance(func.value, ast.Name)
+                and func.value.id in {"db_session", "session_ops"}
+            ):
+                self.add(
+                    node,
+                    "SERVICE_DB_METHOD_CALL",
+                    f"service.py must not call session boundary helper .{func.attr}()",
                 )
             if (
                 self.kind.is_store

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -43,13 +43,13 @@ server/proliferate/db/store/cloud_repo_config.py 719 server structure migration 
 server/proliferate/db/store/cloud_sync/commands.py 1689 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_workspaces.py 1639 server structure migration debt for oversized store file
-server/proliferate/server/billing/service.py 2464 server structure migration debt for oversized service file during billing orchestration consolidation
+server/proliferate/server/billing/service.py 2465 server structure migration debt for oversized service file during billing orchestration consolidation
 server/proliferate/server/billing/stripe_webhooks.py 623 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/agent_auth/models.py 508 server structure migration debt for oversized API models file
 server/proliferate/server/cloud/agent_auth/service.py 4909 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/commands/service.py 1741 server structure migration debt for oversized service file
-server/proliferate/server/cloud/mobility/service.py 1209 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1208 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/ensure_running.py 674 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/provision.py 1739 server structure migration debt for oversized domain-adjacent file
@@ -58,7 +58,7 @@ server/proliferate/server/cloud/runtime_config/service.py 1094 server structure 
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1437 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2644 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2643 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 871 existing server oversized integration test

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -43,28 +43,28 @@ server/proliferate/db/store/cloud_repo_config.py 719 server structure migration 
 server/proliferate/db/store/cloud_sync/commands.py 1689 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_workspaces.py 1639 server structure migration debt for oversized store file
-server/proliferate/server/billing/service.py 2460 server structure migration debt for oversized service file during billing orchestration consolidation
+server/proliferate/server/billing/service.py 2464 server structure migration debt for oversized service file during billing orchestration consolidation
 server/proliferate/server/billing/stripe_webhooks.py 623 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/agent_auth/models.py 508 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/agent_auth/service.py 4908 server structure migration debt for oversized service file
+server/proliferate/server/cloud/agent_auth/service.py 4909 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
-server/proliferate/server/cloud/commands/service.py 1740 server structure migration debt for oversized service file
-server/proliferate/server/cloud/mobility/service.py 1207 server structure migration debt for oversized service file
+server/proliferate/server/cloud/commands/service.py 1741 server structure migration debt for oversized service file
+server/proliferate/server/cloud/mobility/service.py 1209 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/ensure_running.py 674 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/provision.py 1739 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
-server/proliferate/server/cloud/worker/service.py 1436 server structure migration debt for oversized service file
+server/proliferate/server/cloud/worker/service.py 1437 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
-server/proliferate/server/cloud/workspaces/service.py 2641 server structure migration debt for oversized service file
+server/proliferate/server/cloud/workspaces/service.py 2644 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 871 existing server oversized integration test
 server/tests/integration/test_billing_api.py 2060 existing server oversized integration test
 server/tests/integration/test_cloud_agent_auth_api.py 1670 existing server oversized integration test
-server/tests/integration/test_cloud_api.py 2374 existing server oversized integration test
+server/tests/integration/test_cloud_api.py 2377 existing server oversized integration test
 server/tests/integration/test_cloud_commands_api.py 5139 existing server oversized integration test
 server/tests/integration/test_sandbox_profile_foundation.py 1400 existing server oversized integration test
 server/tests/integration/test_schema_migrations.py 925 existing server oversized integration test

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -15,6 +15,24 @@ SINGLE_FILE_FOLDER server/proliferate/integrations/billing 1 transitional Stripe
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
 API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings
+SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 1 remaining service type boundary exposes billing ORM records until snapshot migration
+SERVICE_ORM_IMPORT server/proliferate/server/cloud/mobility/service.py 1 remaining service type boundary exposes workspace ORM records until snapshot migration
+SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 remaining service type boundary exposes workspace ORM records until snapshot migration
+SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 2 remaining service type boundary exposes workspace ORM records until snapshot migration
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/billing/service.py 1 remaining service-owned non-HTTP session boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/service.py 1 remaining service-owned deferred materialization session boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 remaining service-owned command transaction boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 remaining service-owned live event session boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/slack/service.py 1 remaining service-owned Slack deferred transaction boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/worker/service.py 1 remaining service-owned worker transaction boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 remaining service-owned workspace lifecycle session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/billing/service.py 34 remaining billing service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/service.py 4 remaining agent auth service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/service.py 4 remaining command service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/live/service.py 4 remaining live service-owned session/deferred boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 13 remaining Slack service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/service.py 2 remaining worker service-owned transaction boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 36 remaining workspace service-owned lifecycle transaction/session boundary debt through session_ops
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/slack/domain/policy.py 1 transitional Slack policy imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/target_config/domain/policy.py 1 transitional target config policy imports product config during worker migration

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -15,32 +15,7 @@ SINGLE_FILE_FOLDER server/proliferate/integrations/billing 1 transitional Stripe
 INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
 API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings
-SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 2 transitional service imports ORM/auth model
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/agent_run_config/service.py 1 transitional agent run config service imports auth model for admin checks
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/commands/service.py 1 transitional cloud command service imports ORM model during worker migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/compute/service.py 1 transitional cloud compute service imports ORM model during worker migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/mobility/service.py 1 transitional mobility service imports ORM model during workspace migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 transitional service imports ORM/auth model
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/sandbox_profiles/service.py 1 transitional sandbox profile service imports auth model
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/slack/service.py 1 transitional Slack service imports auth model for deferred event handling
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/target_config/service.py 1 transitional target config service imports ORM model during worker migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/target_git_identity/service.py 1 transitional target git identity service imports ORM model during worker migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/targets/service.py 1 transitional cloud targets service imports ORM model during worker migration
-SERVICE_ORM_IMPORT server/proliferate/server/cloud/workspaces/service.py 3 transitional service imports ORM/auth model
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/billing/service.py 1 transitional billing checkout service opens isolated organization checkout sessions
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/service.py 1 transitional agent auth service opens isolated DB sessions for deferred materialization
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 transitional command service defers isolated DB work after commit
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 transitional live service opens DB session during worker migration
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/slack/service.py 1 transitional Slack service opens isolated DB sessions for deferred event handling
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 transitional workspace service opens DB session during managed-cloud migration
-SERVICE_SQLALCHEMY_IMPORT server/proliferate/server/cloud/agent_auth/service.py 1 transitional agent auth service handles SQLAlchemy integrity errors during worker migration
-SERVICE_SQLALCHEMY_IMPORT server/proliferate/server/cloud/commands/service.py 1 transitional cloud command service builds SQLAlchemy query during worker migration
-SERVICE_SQLALCHEMY_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 transitional workspace archive restore handles active-workspace uniqueness conflicts
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/slack/domain/policy.py 1 transitional Slack policy imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/target_config/domain/policy.py 1 transitional target config policy imports product config during worker migration
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/targets/domain/policy.py 1 transitional target policy imports product config during worker migration
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/service.py 1 transitional agent auth deferred session commits materialization result
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 10 transitional Slack deferred handlers own isolated transactions
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/service.py 2 transitional worker lease/materialization flows commit before follow-up worker requests
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 4 transitional workspace sync/archive flows own isolated lifecycle transactions

--- a/server/proliferate/auth/authorization.py
+++ b/server/proliferate/auth/authorization.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Protocol
 from uuid import UUID
 
 from proliferate.errors import NotFoundError, PermissionDenied
 
 OwnerScope = Literal["personal", "organization"]
+
+
+class ActorIdentity(Protocol):
+    id: UUID
+
+
+class AuthenticatedUser(ActorIdentity, Protocol):
+    email: str
 
 
 @dataclass(frozen=True)

--- a/server/proliferate/db/session_ops.py
+++ b/server/proliferate/db/session_ops.py
@@ -1,4 +1,8 @@
-"""Database session boundary helpers for non-HTTP orchestration entrypoints."""
+"""Database session helpers for non-HTTP entrypoints.
+
+Product services that call these helpers still own session or transaction boundaries; those
+calls are explicit boundary-check debt until moved to API, worker, or other entrypoint code.
+"""
 
 from __future__ import annotations
 

--- a/server/proliferate/db/session_ops.py
+++ b/server/proliferate/db/session_ops.py
@@ -1,0 +1,51 @@
+"""Database session boundary helpers for non-HTTP orchestration entrypoints."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import engine as db_engine
+
+type AfterCommitCallback = Callable[[], Awaitable[None]]
+
+
+@asynccontextmanager
+async def open_async_session() -> AsyncIterator[AsyncSession]:
+    async with db_engine.async_session_factory() as db:
+        yield db
+
+
+@asynccontextmanager
+async def open_async_transaction() -> AsyncIterator[AsyncSession]:
+    async with db_engine.async_session_factory() as db, db.begin():
+        yield db
+
+
+async def commit_session(db: AsyncSession) -> None:
+    await db_engine.commit_session(db)
+
+
+async def rollback_session(db: AsyncSession) -> None:
+    await db.rollback()
+
+
+async def run_after_commit(
+    db: AsyncSession,
+    callback: AfterCommitCallback,
+) -> None:
+    await db_engine.run_after_commit(db, callback)
+
+
+def defer_after_commit(
+    db: AsyncSession,
+    callback: AfterCommitCallback,
+) -> None:
+    db_engine.defer_after_commit(db, callback)
+
+
+def is_integrity_error(error: BaseException) -> bool:
+    return isinstance(error, IntegrityError)

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -60,6 +60,13 @@ from proliferate.constants.organizations import (
     ORGANIZATION_STATUS_PENDING_CHECKOUT,
 )
 from proliferate.db import session_ops as db_session
+from proliferate.db.models.billing import (
+    BillingEntitlement,
+    BillingGrant,
+    BillingHold,
+    BillingSubscription,
+    UsageSegment,
+)
 from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import users as user_store
 from proliferate.db.store.billing import (
@@ -206,12 +213,6 @@ from proliferate.server.organizations.domain.profile import (
     derive_logo_domain_from_email,
     organization_name_issue,
 )
-
-type BillingEntitlement = object
-type BillingGrant = object
-type BillingHold = object
-type BillingSubscription = object
-type UsageSegment = object
 
 logger = logging.getLogger("proliferate.billing.service")
 

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -15,7 +15,12 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.authorization import OwnerContext, OwnerSelection, require_org_role
+from proliferate.auth.authorization import (
+    AuthenticatedUser,
+    OwnerContext,
+    OwnerSelection,
+    require_org_role,
+)
 from proliferate.config import settings
 from proliferate.constants.billing import (
     ACTIVE_SANDBOX_STATUSES,
@@ -54,16 +59,9 @@ from proliferate.constants.organizations import (
     ORGANIZATION_ROLE_OWNER,
     ORGANIZATION_STATUS_PENDING_CHECKOUT,
 )
-from proliferate.db import engine as db_engine
-from proliferate.db.models.auth import User
-from proliferate.db.models.billing import (
-    BillingEntitlement,
-    BillingGrant,
-    BillingHold,
-    BillingSubscription,
-    UsageSegment,
-)
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import organization_invitations as invitation_store
+from proliferate.db.store import users as user_store
 from proliferate.db.store.billing import (
     BillingAccountingResult,
     BillingSnapshotState,
@@ -209,6 +207,12 @@ from proliferate.server.organizations.domain.profile import (
     organization_name_issue,
 )
 
+type BillingEntitlement = object
+type BillingGrant = object
+type BillingHold = object
+type BillingSubscription = object
+type UsageSegment = object
+
 logger = logging.getLogger("proliferate.billing.service")
 
 
@@ -297,7 +301,7 @@ async def maybe_create_organization_seat_adjustment(
 async def reconcile_initial_org_subscription_seats(
     record: BillingSubscription,
 ) -> BillingSubscription:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         adjustment = await prepare_initial_org_seat_reconcile(
             db,
             billing_subscription_id=record.id,
@@ -305,7 +309,7 @@ async def reconcile_initial_org_subscription_seats(
             pro_monthly_price_id=configured_pro_monthly_price_id(),
         )
     if adjustment is None:
-        async with db_engine.async_session_factory() as db:
+        async with db_session.open_async_session() as db:
             reloaded = await load_billing_subscription_by_id(db, record.id)
         return reloaded or record
     try:
@@ -314,18 +318,18 @@ async def reconcile_initial_org_subscription_seats(
             quantity=adjustment.target_quantity,
             idempotency_key=f"initial-seat-reconcile:{adjustment.id}:seats:{adjustment.target_quantity}",
         )
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await mark_seat_adjustment_stripe_confirmed(
                 db,
                 adjustment_id=adjustment.id,
             )
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await mark_seat_adjustment_grant_issued(
                 db,
                 adjustment_id=adjustment.id,
             )
     except stripe_billing.StripeBillingError as error:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await mark_seat_adjustment_failed(
                 db,
                 adjustment_id=adjustment.id,
@@ -334,14 +338,14 @@ async def reconcile_initial_org_subscription_seats(
             )
         raise
     except Exception as error:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await mark_seat_adjustment_failed(
                 db,
                 adjustment_id=adjustment.id,
                 error=f"{type(error).__name__}: {error}",
             )
         raise
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         reloaded = await load_billing_subscription_by_id(db, record.id)
     return reloaded or record
 
@@ -376,7 +380,7 @@ async def record_cloud_sandbox_usage_started(
     is_billable: bool = True,
     event_id: str | None = None,
 ) -> object:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         return await open_usage_segment_for_sandbox_record(
             db,
             runtime_environment_id=runtime_environment_id,
@@ -400,7 +404,7 @@ async def record_cloud_sandbox_usage_stopped(
     is_billable: bool | None = None,
     event_id: str | None = None,
 ) -> object | None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         return await close_usage_segment_for_sandbox_record(
             db,
             sandbox_id=sandbox_id,
@@ -476,7 +480,7 @@ def _segment_seconds(segment: UsageSegment, now: datetime) -> float:
 
 
 async def get_billing_snapshot(user_id: UUID) -> BillingSnapshot:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         state = await get_billing_snapshot_state_for_user(db, user_id)
         state = await state_with_overage_usage(db, state)
     return _build_billing_snapshot(state)
@@ -490,7 +494,7 @@ async def get_billing_snapshot_for_request(
 
 
 async def get_billing_snapshot_for_subject(billing_subject_id: UUID) -> BillingSnapshot:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         state = await get_billing_snapshot_state_for_subject(db, billing_subject_id)
         state = await state_with_overage_usage(db, state)
     return _build_billing_snapshot(state)
@@ -724,7 +728,7 @@ async def authorize_sandbox_start_for_billing_subject(
     billing_subject_id: UUID,
     workspace_id: UUID | None = None,
 ) -> SandboxStartAuthorization:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         state = await get_billing_snapshot_state_for_subject(db, billing_subject_id)
         state = await state_with_overage_usage(db, state)
         snapshot = _build_billing_snapshot(state)
@@ -741,7 +745,7 @@ async def authorize_sandbox_start(
     user_id: UUID,
     workspace_id: UUID | None,
 ) -> SandboxStartAuthorization:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         if workspace_id is None:
             state = await get_billing_snapshot_state_for_user(db, user_id)
         else:
@@ -804,7 +808,7 @@ async def get_billing_overview(db: AsyncSession, user_id: UUID) -> BillingOvervi
 
 async def get_billing_overview_for_owner(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection,
 ) -> BillingOverview:
     context = await _resolve_billing_owner_context(db, user, owner_selection)
@@ -828,7 +832,7 @@ async def get_cloud_plan(db: AsyncSession, user_id: UUID) -> CloudPlanInfo:
 
 async def get_cloud_plan_for_owner(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection,
 ) -> CloudPlanInfo:
     context = await _resolve_billing_owner_context(db, user, owner_selection)
@@ -1012,7 +1016,7 @@ def _require_owner_selection_uuid(value: str | UUID | None, *, field: str) -> UU
 
 async def _resolve_billing_owner_context(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection,
 ) -> OwnerContext:
     selection = owner_selection or OwnerSelection()
@@ -1069,7 +1073,7 @@ async def _resolve_billing_owner_context(
 
 async def _ensure_stripe_customer_for_owner(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection,
     *,
     owner_context: OwnerContext | None = None,
@@ -1186,7 +1190,7 @@ async def _send_staged_team_checkout_invitation(
     email: str,
 ) -> None:
     token = secrets.token_urlsafe(32)
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         record = await invitation_store.create_or_rotate_organization_invitation(
             db,
             organization_id=organization_id,
@@ -1210,7 +1214,7 @@ async def _send_staged_team_checkout_invitation(
             invite_url=_organization_invitation_landing_url(token),
         )
     except resend.ResendEmailError as error:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await invitation_store.mark_invitation_delivery(
                 db,
                 invitation_id=record.invitation.id,
@@ -1228,7 +1232,7 @@ async def _send_staged_team_checkout_invitation(
             },
         )
         return
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await invitation_store.mark_invitation_delivery(
             db,
             invitation_id=record.invitation.id,
@@ -1283,7 +1287,7 @@ async def _send_staged_team_checkout_invitations(
 async def _ensure_stripe_customer_for_team_checkout(
     db: AsyncSession,
     *,
-    user: User,
+    user: AuthenticatedUser,
     organization_id: UUID,
     billing_subject_id: UUID,
     team_name: str,
@@ -1322,7 +1326,7 @@ async def _ensure_stripe_customer_for_team_checkout(
 async def _create_stripe_session_for_team_checkout_intent(
     db: AsyncSession,
     *,
-    user: User,
+    user: AuthenticatedUser,
     intent_record: CheckoutIntentWithOrganizationRecord,
     success_url: str,
     cancel_url: str,
@@ -1388,7 +1392,7 @@ async def _create_stripe_session_for_team_checkout_intent(
 
 async def create_team_checkout_session(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     *,
     team_name: str,
     invite_emails: list[str],
@@ -1445,7 +1449,7 @@ async def create_team_checkout_session(
 
 async def get_current_team_checkout(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
 ) -> CurrentTeamCheckoutResponse:
     async with db.begin():
         record = await get_current_team_checkout_intent(db, user.id)
@@ -1456,7 +1460,7 @@ async def get_current_team_checkout(
 
 async def cancel_current_team_checkout(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     intent_id: UUID,
 ) -> CurrentTeamCheckoutResponse:
     async with db.begin():
@@ -1584,7 +1588,7 @@ async def activate_team_checkout_from_stripe_session(
             )
     status = subscription.get("status")
     if status not in {"active", "trialing"}:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             row = await load_team_checkout_intent_for_update(db, intent_id)
             if row is not None:
                 intent, _organization = row
@@ -1599,7 +1603,7 @@ async def activate_team_checkout_from_stripe_session(
         return
 
     staged_invites: tuple[UUID, str, UUID, str, str | None] | None = None
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         row = await load_team_checkout_intent_for_update(db, intent_id)
         if row is None:
             raise BillingServiceError(
@@ -1631,7 +1635,7 @@ async def activate_team_checkout_from_stripe_session(
                 webhook_event_id=webhook_event_id,
             )
             return
-        creator = await db.get(User, created_by_user_id)
+        creator = await user_store.get_user_by_id(db, created_by_user_id)
         if creator is None:
             await mark_team_checkout_failed(
                 db,
@@ -1699,7 +1703,7 @@ async def activate_team_checkout_from_stripe_session(
 
 async def create_cloud_checkout_session(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection | None = None,
     return_surface: BillingReturnSurface = "web",
 ) -> BillingUrlResponse:
@@ -1801,7 +1805,7 @@ async def create_cloud_checkout_session(
 
 async def create_refill_checkout_session(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection | None = None,
     return_surface: BillingReturnSurface = "web",
 ) -> BillingUrlResponse:
@@ -1849,7 +1853,7 @@ async def create_refill_checkout_session(
 
 async def create_customer_portal_session(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     owner_selection: OwnerSelection | None = None,
     return_surface: BillingReturnSurface = "web",
 ) -> BillingUrlResponse:
@@ -1872,7 +1876,7 @@ async def create_customer_portal_session(
 
 async def update_overage_settings(
     db: AsyncSession,
-    user: User,
+    user: AuthenticatedUser,
     *,
     enabled: bool,
     cap_cents_per_seat: int | None = None,
@@ -1968,7 +1972,7 @@ async def account_usage_for_billing_subject(
     if effective_scan_until > now:
         effective_scan_until = now
 
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await acquire_billing_subject_accounting_lock(db, billing_subject_id)
         subject = await get_billing_subject_by_id(db, billing_subject_id)
         if subject is None:
@@ -2151,7 +2155,7 @@ async def account_usage_for_billing_subject(
 
 
 async def claim_usage_exports_for_sending(*, limit: int = 100) -> list[ClaimedUsageExport]:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         return await claim_usage_exports_for_sending_record(db, limit=limit)
 
 
@@ -2192,13 +2196,13 @@ async def run_billing_accounting_pass(*, subject_limit: int = 100) -> None:
 
     await process_pending_seat_adjustments()
 
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         subject_ids = await list_billing_subject_ids_for_usage_accounting(
             db,
             limit=subject_limit,
         )
     for billing_subject_id in subject_ids:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             state = await get_billing_snapshot_state_for_subject(db, billing_subject_id)
             state = await state_with_overage_usage(db, state)
         now = utcnow()
@@ -2256,7 +2260,7 @@ async def run_billing_accounting_pass(*, subject_limit: int = 100) -> None:
 
         if any(result.export_count > 0 for result in results):
             snapshot = _build_billing_snapshot(state)
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await record_billing_decision_event(
                     db,
                     billing_subject_id=billing_subject_id,
@@ -2283,7 +2287,7 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
     if not settings.pro_billing_enabled or settings.cloud_billing_mode == BILLING_MODE_OFF:
         return
 
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         adjustments = await claim_pending_seat_adjustments(db, limit=limit)
     for adjustment in adjustments:
         try:
@@ -2292,7 +2296,7 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
                 quantity=adjustment.target_quantity,
                 idempotency_key=f"seat-quantity:{adjustment.id}:seats:{adjustment.target_quantity}",
             )
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_seat_adjustment_stripe_confirmed(
                     db,
                     adjustment_id=adjustment.id,
@@ -2316,7 +2320,7 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
                     period_end=adjustment.period_end,
                     effective_at=adjustment.effective_at,
                 )
-                async with db_engine.async_session_factory() as db, db.begin():
+                async with db_session.open_async_transaction() as db:
                     await ensure_billing_grant_record(
                         db,
                         user_id=adjustment.user_id,
@@ -2327,13 +2331,13 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
                         expires_at=adjustment.period_end,
                         source_ref=grant_source_ref,
                     )
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_seat_adjustment_grant_issued(
                     db,
                     adjustment_id=adjustment.id,
                 )
         except stripe_billing.StripeBillingError as error:
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_seat_adjustment_failed(
                     db,
                     adjustment_id=adjustment.id,
@@ -2341,7 +2345,7 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
                     terminal=_stripe_error_is_terminal(error),
                 )
         except Exception as error:
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_seat_adjustment_failed(
                     db,
                     adjustment_id=adjustment.id,
@@ -2357,7 +2361,7 @@ async def send_pending_usage_exports(*, limit: int = 100) -> None:
     if settings.cloud_billing_mode != BILLING_MODE_ENFORCE:
         return
 
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         exports = await claim_usage_exports_for_sending_record(db, limit=limit)
     now = utcnow()
     for export in exports:
@@ -2365,7 +2369,7 @@ async def send_pending_usage_exports(*, limit: int = 100) -> None:
         if not export.stripe_customer_id:
             terminal_error = "Billing subject has no Stripe customer id."
         if terminal_error is not None:
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_usage_export_failed(
                     db,
                     export_id=export.id,
@@ -2407,7 +2411,7 @@ async def send_pending_usage_exports(*, limit: int = 100) -> None:
                 meter_kwargs["quantity"] = quantity
             payload = await stripe_billing.create_meter_event(**meter_kwargs)
         except stripe_billing.StripeBillingError as error:
-            async with db_engine.async_session_factory() as db, db.begin():
+            async with db_session.open_async_transaction() as db:
                 await mark_usage_export_failed(
                     db,
                     export_id=export.id,
@@ -2425,7 +2429,7 @@ async def send_pending_usage_exports(*, limit: int = 100) -> None:
             continue
 
         meter_identifier = payload.get("identifier")
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             await mark_usage_export_succeeded(
                 db,
                 export_id=export.id,
@@ -2444,7 +2448,7 @@ def _terminal_export_error(accounted_until: datetime, *, now: datetime) -> str |
 
 
 async def _record_usage_export_decision(*, billing_subject_id: UUID, reason: str) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await record_billing_decision_event(
             db,
             billing_subject_id=billing_subject_id,

--- a/server/proliferate/server/cloud/agent_auth/service.py
+++ b/server/proliferate/server/cloud/agent_auth/service.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from cryptography.fernet import InvalidToken
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import PolicyDenied
@@ -35,7 +34,7 @@ from proliferate.constants.cloud import (
     CloudCommandStatus,
 )
 from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
-from proliferate.db import engine as db_engine
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import cloud_sandboxes
 from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.billing import (
@@ -144,7 +143,7 @@ async def _kick_agent_auth_refresh_wake_after_commit(
 
         kick_off_managed_slot_wake(command.target_id, command.id)
 
-    await db_engine.run_after_commit(db, _wake_after_commit)
+    await db_session.run_after_commit(db, _wake_after_commit)
 
 
 @dataclass(frozen=True)
@@ -1129,12 +1128,12 @@ async def sync_managed_credit_budget_for_organization(
 ) -> AgentGatewayBudgetSubjectRecord | None:
     """Recompute and mirror an existing managed-credit budget after billing changes."""
 
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         budget = await store.get_managed_budget_subject(db, organization_id)
         if budget is None:
             return None
         reconciled = await _reconcile_managed_budget_subject(db, budget=budget)
-        await db.commit()
+        await db_session.commit_session(db)
         return reconciled
 
 
@@ -4686,7 +4685,9 @@ async def _queue_agent_auth_refresh_command(
                     }
                 ),
             )
-    except IntegrityError:
+    except Exception as exc:
+        if not db_session.is_integrity_error(exc):
+            raise
         duplicate = await commands_store.get_command_by_idempotency(
             db,
             idempotency_scope=idempotency_scope,

--- a/server/proliferate/server/cloud/agent_run_config/service.py
+++ b/server/proliferate/server/cloud/agent_run_config/service.py
@@ -6,13 +6,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.constants.automations import (
     CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_ORGANIZATION,
     CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_PERSONAL,
     CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_SYSTEM,
     CLOUD_AGENT_RUN_CONFIG_STATUS_ACTIVE,
 )
-from proliferate.db.models.auth import User
 from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.cloud_agent_run_config import configs as config_store
 from proliferate.db.store.cloud_agent_run_config.configs import (
@@ -96,7 +96,7 @@ async def _require_org_member(
 async def _visible_config(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     config_id: UUID,
 ) -> CloudAgentRunConfigRecord:
     value = await config_store.get_config(db, config_id)
@@ -146,7 +146,7 @@ def snapshot_json(value: CloudAgentRunConfigRecord) -> dict[str, object]:
 
 async def list_agent_run_configs(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     owner_scope: str | None = None,
     organization_id: UUID | None = None,
@@ -177,7 +177,7 @@ async def list_agent_run_configs(
 
 async def create_agent_run_config(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     body: AgentRunConfigCreateRequest,
 ) -> CloudAgentRunConfigRecord:
     owner_scope = body.owner_scope
@@ -240,7 +240,7 @@ async def create_agent_run_config(
 
 async def get_agent_run_config(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     config_id: UUID,
 ) -> CloudAgentRunConfigRecord:
     return await _visible_config(db, user=user, config_id=config_id)
@@ -248,7 +248,7 @@ async def get_agent_run_config(
 
 async def update_agent_run_config(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     config_id: UUID,
     body: AgentRunConfigUpdateRequest,
 ) -> CloudAgentRunConfigRecord:
@@ -311,7 +311,7 @@ async def update_agent_run_config(
 
 async def archive_agent_run_config(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     config_id: UUID,
 ) -> CloudAgentRunConfigRecord:
     existing = await _visible_config(db, user=user, config_id=config_id)
@@ -336,7 +336,7 @@ async def archive_agent_run_config(
 
 async def list_agent_run_config_defaults(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     owner_scope: str,
     organization_id: UUID | None,
@@ -365,7 +365,7 @@ async def list_agent_run_config_defaults(
 
 async def set_agent_run_config_default(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     owner_scope: str,
     organization_id: UUID | None,

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -6,9 +6,9 @@ import json
 from datetime import timedelta
 from uuid import UUID
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.constants.cloud import (
     CloudCommandActorKind,
     CloudCommandKind,
@@ -17,8 +17,7 @@ from proliferate.constants.cloud import (
     CloudTargetStatus,
     CloudWorkspaceStatus,
 )
-from proliferate.db import engine as db_engine
-from proliferate.db.models.auth import User
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import cloud_runtime_environments, cloud_sandboxes, cloud_workspaces
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_profile_target_guard import managed_profile_target_requires_slot
@@ -106,7 +105,7 @@ _PROJECTED_SESSION_COMMAND_KINDS = {
 async def _resolve_command_workspace(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     kind: str,
     body: CreateCloudCommandRequest,
@@ -304,7 +303,7 @@ async def _resolve_command_workspace(
 async def _resolve_direct_start_session_workspace(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     body: CreateCloudCommandRequest,
     workspace_id: str,
@@ -359,7 +358,7 @@ async def _resolve_direct_start_session_workspace(
 async def _resolve_managed_start_session_workspace(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     body: CreateCloudCommandRequest,
 ) -> tuple[str | None, dict[str, object], str | None]:
@@ -459,7 +458,7 @@ async def _resolve_managed_start_session_workspace(
 async def _resolve_backfill_exposed_workspace_command(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     body: CreateCloudCommandRequest,
 ) -> tuple[str | None, dict[str, object], str | None]:
@@ -513,7 +512,7 @@ async def _resolve_backfill_exposed_workspace_command(
 async def _resolve_prune_workspace_worktree_command(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     body: CreateCloudCommandRequest,
 ) -> tuple[str | None, dict[str, object], str | None]:
@@ -587,7 +586,7 @@ async def _resolve_prune_workspace_worktree_command(
 async def _resolve_projected_session_command_workspace(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target: targets_store.CloudTargetSnapshot,
     body: CreateCloudCommandRequest,
 ) -> tuple[str | None, dict[str, object], str | None]:
@@ -802,7 +801,7 @@ def _command_has_managed_cloud_workspace(
 async def enqueue_command(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     body: CreateCloudCommandRequest,
 ) -> commands_store.CloudCommandSnapshot:
     target = await targets_store.get_visible_target_by_id(
@@ -980,7 +979,9 @@ async def enqueue_command(
             command=command,
         )
         return command
-    except IntegrityError:
+    except Exception as exc:
+        if not db_session.is_integrity_error(exc):
+            raise
         duplicate = await commands_store.get_command_by_idempotency(
             db,
             idempotency_scope=idempotency_scope,
@@ -994,11 +995,11 @@ async def enqueue_command(
 async def enqueue_command_and_commit(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     body: CreateCloudCommandRequest,
 ) -> commands_store.CloudCommandSnapshot:
     command = await enqueue_command(db, user=user, body=body)
-    await db_engine.commit_session(db)
+    await db_session.commit_session(db)
     return command
 
 
@@ -1154,7 +1155,7 @@ async def _queue_agent_auth_refresh_for_not_ready_preflight(
     actor_user_id: UUID,
 ) -> None:
     try:
-        async with db_engine.async_session_factory() as refresh_db, refresh_db.begin():
+        async with db_session.open_async_transaction() as refresh_db:
             await request_agent_auth_refresh_for_profile_target(
                 refresh_db,
                 sandbox_profile_id=sandbox_profile_id,
@@ -1726,7 +1727,7 @@ async def kick_off_command_wake_after_commit_if_required(
     async def _wake_after_commit() -> None:
         kick_off_managed_slot_wake(target.id, command.id)
 
-    await db_engine.run_after_commit(db, _wake_after_commit)
+    await db_session.run_after_commit(db, _wake_after_commit)
 
 
 def is_terminal_command_status(status: str) -> bool:

--- a/server/proliferate/server/cloud/compute/service.py
+++ b/server/proliferate/server/cloud/compute/service.py
@@ -6,8 +6,8 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.constants.cloud import CloudTargetStatus
-from proliferate.db.models.auth import User
 from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import events as events_store
@@ -44,7 +44,7 @@ async def _require_admin_target(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
 ) -> targets_store.CloudTargetSnapshot:
     target = await targets_store.get_visible_target_by_id(
         db,
@@ -85,7 +85,7 @@ async def set_desired_versions(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
     body: SetDesiredVersionsRequest,
 ) -> SetDesiredVersionsResponse:
     target = await _require_admin_target(db, target_id=target_id, user=user)
@@ -141,7 +141,7 @@ async def check_safe_stop(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
 ) -> SafeStopCheckResponse:
     target = await _require_admin_target(db, target_id=target_id, user=user)
     active_session_count = await events_store.count_active_sessions_for_target(
@@ -172,7 +172,7 @@ async def revoke_workers_for_target(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
 ) -> RevokeWorkersResponse:
     target = await _require_admin_target(db, target_id=target_id, user=user)
     if target.status == CloudTargetStatus.archived.value:

--- a/server/proliferate/server/cloud/live/service.py
+++ b/server/proliferate/server/cloud/live/service.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db import engine as db_engine
+from proliferate.db import session_ops as db_session
 from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import events as events_store
 from proliferate.db.store.cloud_sync import targets as targets_store
@@ -184,7 +184,7 @@ async def _publish_live_after_commit(
     db: AsyncSession,
     callback: LivePublishCallback,
 ) -> None:
-    await db_engine.run_after_commit(db, callback)
+    await db_session.run_after_commit(db, callback)
 
 
 async def stream_session_events(
@@ -196,7 +196,7 @@ async def stream_session_events(
     cursor = clamp_live_cursor(after_seq)
     channel = session_channel(target_id=target_id, session_id=session_id)
     async with _live_bus.subscribe(channel) as messages:
-        async with db_engine.async_session_factory() as stream_db:
+        async with db_session.open_async_session() as stream_db:
             snapshot = await _get_session_snapshot(
                 stream_db,
                 target_id=target_id,
@@ -251,7 +251,7 @@ async def stream_workspace_events(
     workspace_id = UUID(workspace.id)
     channel = workspace_channel(workspace_id=workspace_id)
     async with _live_bus.subscribe(channel) as messages:
-        async with db_engine.async_session_factory() as stream_db:
+        async with db_session.open_async_session() as stream_db:
             snapshot = await _get_workspace_snapshot(
                 stream_db,
                 workspace=workspace,
@@ -307,7 +307,7 @@ async def stream_target_events(
     cursor = clamp_live_cursor(after_seq)
     channel = target_channel(target_id=target_id)
     async with _live_bus.subscribe(channel) as messages:
-        async with db_engine.async_session_factory() as stream_db:
+        async with db_session.open_async_session() as stream_db:
             snapshot = await _get_target_snapshot(stream_db, target_id=target_id)
         yield _sse_event(
             event="snapshot",

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.constants.cloud import CloudWorkspaceStatus
-from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_mobility import (
     CloudWorkspaceHandoffOpValue,
     CloudWorkspaceMobilityValue,
@@ -42,6 +41,7 @@ from proliferate.db.store.cloud_sync.events import list_session_projections_for_
 from proliferate.db.store.cloud_sync.exposures import get_active_workspace_exposure
 from proliferate.db.store.cloud_workspaces import (
     get_cloud_workspace_for_user,
+    load_cloud_workspace_by_id,
     load_existing_cloud_workspace,
 )
 from proliferate.db.store.cloud_workspaces import (
@@ -98,6 +98,8 @@ from proliferate.server.cloud.workspaces.service import (
     start_cloud_workspace,
 )
 from proliferate.utils.time import duration_ms, utcnow
+
+type CloudWorkspace = object
 
 _STALE_HANDOFF_AFTER = timedelta(seconds=120)
 _BRANCH_NOT_PUBLISHED_BLOCKER = "The branch '{branch}' was not found on GitHub."
@@ -198,7 +200,7 @@ async def _default_cleanup_items_for_cutover(
     ):
         return []
 
-    source_workspace = await db.get(CloudWorkspace, source_cloud_workspace_id)
+    source_workspace = await load_cloud_workspace_by_id(db, source_cloud_workspace_id)
     if source_workspace is None:
         return []
 

--- a/server/proliferate/server/cloud/mobility/service.py
+++ b/server/proliferate/server/cloud/mobility/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.constants.cloud import CloudWorkspaceStatus
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_mobility import (
     CloudWorkspaceHandoffOpValue,
     CloudWorkspaceMobilityValue,
@@ -98,8 +99,6 @@ from proliferate.server.cloud.workspaces.service import (
     start_cloud_workspace,
 )
 from proliferate.utils.time import duration_ms, utcnow
-
-type CloudWorkspace = object
 
 _STALE_HANDOFF_AFTER = timedelta(seconds=120)
 _BRANCH_NOT_PUBLISHED_BLOCKER = "The branch '{branch}' was not found on GitHub."

--- a/server/proliferate/server/cloud/runtime/service.py
+++ b/server/proliferate/server/cloud/runtime/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.billing import BILLING_MODE_ENFORCE
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_runtime_environments import load_runtime_environment_for_workspace
 from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
 from proliferate.server.billing.service import get_billing_snapshot_for_subject
@@ -24,8 +25,6 @@ from proliferate.server.cloud.runtime.worktree_policy_sync import (
     sync_cloud_worktree_policy_to_runtime,
 )
 from proliferate.utils.crypto import decrypt_text
-
-type CloudWorkspace = object
 
 provision_workspace = _provision_workspace
 

--- a/server/proliferate/server/cloud/runtime/service.py
+++ b/server/proliferate/server/cloud/runtime/service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.billing import BILLING_MODE_ENFORCE
-from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.cloud_runtime_environments import load_runtime_environment_for_workspace
 from proliferate.db.store.cloud_workspaces import load_cloud_workspace_by_id
 from proliferate.server.billing.service import get_billing_snapshot_for_subject
@@ -25,6 +24,8 @@ from proliferate.server.cloud.runtime.worktree_policy_sync import (
     sync_cloud_worktree_policy_to_runtime,
 )
 from proliferate.utils.crypto import decrypt_text
+
+type CloudWorkspace = object
 
 provision_workspace = _provision_workspace
 

--- a/server/proliferate/server/cloud/sandbox_profiles/service.py
+++ b/server/proliferate/server/cloud/sandbox_profiles/service.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.models.auth import User
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.db.store import cloud_sandbox_profiles as profile_store
 from proliferate.db.store import cloud_sandboxes as slot_store
 from proliferate.db.store import organizations as organizations_store
@@ -43,7 +43,7 @@ class SandboxProfileTargetState:
 async def ensure_personal(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
 ) -> profile_store.SandboxProfileSnapshot:
     profile = await profile_store.ensure_personal_sandbox_profile(
         db,
@@ -73,7 +73,7 @@ async def ensure_personal(
 async def ensure_organization(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     organization_id: UUID,
 ) -> profile_store.SandboxProfileSnapshot:
     membership = await organizations_store.get_active_membership(
@@ -141,7 +141,7 @@ async def ensure_organization_for_activation(
 async def get_profile(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     sandbox_profile_id: UUID,
 ) -> profile_store.SandboxProfileSnapshot:
     profile = await profile_store.load_sandbox_profile_by_id(db, sandbox_profile_id)
@@ -158,7 +158,7 @@ async def get_profile(
 async def enable_cloud(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     sandbox_profile_id: UUID,
 ) -> SandboxProfileTargetState:
     profile = await get_profile(db, user=user, sandbox_profile_id=sandbox_profile_id)
@@ -185,7 +185,7 @@ async def enable_cloud(
 async def get_target_state(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     sandbox_profile_id: UUID,
 ) -> SandboxProfileTargetState:
     profile = await get_profile(db, user=user, sandbox_profile_id=sandbox_profile_id)
@@ -217,7 +217,7 @@ async def get_target_state(
 async def _require_profile_access(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     profile: profile_store.SandboxProfileSnapshot,
 ) -> None:
     if profile.owner_scope == "personal":

--- a/server/proliferate/server/cloud/slack/service.py
+++ b/server/proliferate/server/cloud/slack/service.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from cryptography.fernet import InvalidToken
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.config import settings
 from proliferate.constants.cloud import (
     CloudCommandActorKind,
@@ -25,8 +26,7 @@ from proliferate.constants.slack import (
     SLACK_REPO_MODE_FIXED,
     SLACK_THREAD_WORK_STATUS_ACTIVE,
 )
-from proliferate.db import engine as db_engine
-from proliferate.db.models.auth import User
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import cloud_repo_config as repo_store
 from proliferate.db.store import cloud_sandbox_profiles as profile_store
 from proliferate.db.store import cloud_workspaces
@@ -125,7 +125,7 @@ _SLACK_CONFIGURATION_ERROR_CODES = {
 
 async def start_oauth_install(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> str:
@@ -176,7 +176,7 @@ async def complete_oauth_install(
 
 async def disconnect(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> None:
@@ -186,7 +186,7 @@ async def disconnect(
 
 async def get_bot_config_envelope(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> tuple[SlackWorkspaceConnectionRecord | None, SlackBotConfigRecord | None]:
@@ -201,7 +201,7 @@ async def get_bot_config_envelope(
 
 async def update_bot_config(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
     body: SlackBotConfigUpdateRequest,
@@ -292,7 +292,7 @@ async def update_bot_config(
 
 async def validate_connection(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> tuple[bool, str, str | None, str | None]:
@@ -320,7 +320,7 @@ async def validate_connection(
 
 async def list_channels(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> list[slack_client.SlackChannelSummary]:
@@ -339,7 +339,7 @@ async def list_channels(
 
 async def list_repo_routing_profiles(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
 ) -> list[CloudRepoRoutingProfileRecord]:
@@ -372,7 +372,7 @@ async def list_repo_routing_profiles(
 
 async def upsert_repo_routing_profile(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     *,
     organization_id: UUID,
     cloud_repo_config_id: UUID,
@@ -424,7 +424,7 @@ async def ingest_slack_event(
         event_type=str(event_type or "unknown"),
         payload_json=payload,
     )
-    db_engine.defer_after_commit(
+    db_session.defer_after_commit(
         db,
         lambda job_id=job.id: _process_inbound_job_and_due_outbound(job_id),
     )
@@ -437,7 +437,7 @@ async def _process_inbound_job_and_due_outbound(job_id: UUID) -> None:
 
 
 async def process_inbound_job_by_id(job_id: UUID) -> None:
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         async with db.begin():
             job = await slack_event_store.mark_job_processing(db, job_id)
         if job is None:
@@ -445,9 +445,9 @@ async def process_inbound_job_by_id(job_id: UUID) -> None:
         try:
             await _process_inbound_job(db, job)
             await slack_event_store.mark_job_completed(db, job.id)
-            await db.commit()
+            await db_session.commit_session(db)
         except CloudApiError as exc:
-            await db.rollback()
+            await db_session.rollback_session(db)
             await _queue_job_error(db, job, error_code=exc.code, message=exc.message)
             await slack_event_store.mark_job_failed(
                 db,
@@ -455,9 +455,9 @@ async def process_inbound_job_by_id(job_id: UUID) -> None:
                 error_code=exc.code,
                 error_message=exc.message,
             )
-            await db.commit()
+            await db_session.commit_session(db)
         except Exception as exc:
-            await db.rollback()
+            await db_session.rollback_session(db)
             await _queue_job_error(db, job, error_code="slack_job_failed", message=str(exc))
             await slack_event_store.mark_job_failed(
                 db,
@@ -465,7 +465,7 @@ async def process_inbound_job_by_id(job_id: UUID) -> None:
                 error_code="slack_job_failed",
                 error_message=str(exc),
             )
-            await db.commit()
+            await db_session.commit_session(db)
 
 
 async def enqueue_post_session_event(
@@ -510,7 +510,7 @@ async def enqueue_post_session_event(
 
 
 async def process_due_outbound_messages(*, limit: int = 20) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         due = await outbound_store.list_due_outbound_messages(db, now=utcnow(), limit=limit)
         for message in due:
             await _send_outbound_message(db, message)
@@ -663,7 +663,7 @@ async def _handle_app_mention(
         slack_user_id=_string_or_none(event.get("user")),
         idempotency_key=f"{job.slack_event_id}:start",
     )
-    await db.commit()
+    await db_session.commit_session(db)
     session_result = parse_start_session_result(
         await wait_for_command_result(start_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
     )
@@ -892,7 +892,7 @@ async def _create_and_materialize_workspace(
         idempotency_key="ensure-repo-checkout",
         slack_user_id=None,
     )
-    await db.commit()
+    await db_session.commit_session(db)
     await wait_for_command_result(checkout, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
     root_command = await _enqueue_command(
         db,
@@ -912,7 +912,7 @@ async def _create_and_materialize_workspace(
         idempotency_key="materialize-root",
         slack_user_id=None,
     )
-    await db.commit()
+    await db_session.commit_session(db)
     root_result = parse_materialize_workspace_result(
         await wait_for_command_result(root_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
     )
@@ -936,7 +936,7 @@ async def _create_and_materialize_workspace(
         idempotency_key="materialize-worktree",
         slack_user_id=None,
     )
-    await db.commit()
+    await db_session.commit_session(db)
     materialized = parse_materialize_workspace_result(
         await wait_for_command_result(worktree_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
     )
@@ -1041,7 +1041,7 @@ async def _apply_run_config_updates(
             slack_user_id=slack_user_id,
             idempotency_key=f"{idempotency_key_prefix}:config:{control_key}",
         )
-        await db.commit()
+        await db_session.commit_session(db)
         result = await wait_for_command_result(command, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
         if _config_apply_state(result.body) != "applied":
             raise CloudApiError(

--- a/server/proliferate/server/cloud/target_config/service.py
+++ b/server/proliferate/server/cloud/target_config/service.py
@@ -7,13 +7,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.auth.identity.store import get_ready_github_grant_for_user
 from proliferate.constants.cloud import (
     SUPPORTED_GIT_PROVIDER,
     CloudCommandKind,
     CloudCommandStatus,
 )
-from proliferate.db.models.auth import User
 from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.cloud_repo_config import (
     get_cloud_repo_config,
@@ -202,7 +202,7 @@ async def materialize_target_config(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
     body: MaterializeTargetConfigRequest,
 ) -> MaterializeTargetConfigResponse:
     target = await _controllable_target(db, target_id=target_id, user_id=user.id)

--- a/server/proliferate/server/cloud/target_git_identity/service.py
+++ b/server/proliferate/server/cloud/target_git_identity/service.py
@@ -7,13 +7,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.auth.identity.store import ReadyGitHubGrant, get_ready_github_grant_for_user
 from proliferate.constants.cloud import (
     SUPPORTED_GIT_PROVIDER,
     CloudCommandKind,
     CloudCommandStatus,
 )
-from proliferate.db.models.auth import User
 from proliferate.db.store.cloud_sync import commands as commands_store
 from proliferate.db.store.cloud_sync import target_git_identity as identity_store
 from proliferate.db.store.cloud_sync import targets as targets_store
@@ -122,7 +122,7 @@ async def materialize_target_git_identity(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
     source: str,
     idempotency_key: str | None = None,
 ) -> MaterializeTargetGitIdentityResponse:

--- a/server/proliferate/server/cloud/targets/service.py
+++ b/server/proliferate/server/cloud/targets/service.py
@@ -10,13 +10,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.authorization import ActorIdentity
 from proliferate.config import settings
 from proliferate.constants.cloud import (
     CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN,
     CloudTargetKind,
     CloudTargetStatus,
 )
-from proliferate.db.models.auth import User
 from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.cloud_sync import inventory as inventory_store
 from proliferate.db.store.cloud_sync import targets as targets_store
@@ -70,7 +70,7 @@ async def _create_enrollment_response_for_target(
     db: AsyncSession,
     *,
     target: targets_store.CloudTargetSnapshot,
-    user: User,
+    user: ActorIdentity,
     ttl_seconds: int | None,
 ) -> CloudTargetEnrollmentResponse:
     token = secrets.token_urlsafe(48)
@@ -108,7 +108,7 @@ async def _create_enrollment_response_for_target(
 async def create_target_enrollment(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     body: CloudTargetEnrollmentRequest,
 ) -> CloudTargetEnrollmentResponse:
     kind = validate_enrollable_kind(body.kind)
@@ -160,7 +160,7 @@ async def create_target_enrollment_for_existing_target(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
     body: CloudTargetExistingEnrollmentRequest,
 ) -> CloudTargetEnrollmentResponse:
     target = await get_target_detail(db, target_id=target_id, user_id=user.id)
@@ -238,7 +238,7 @@ async def archive_target(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: User,
+    user: ActorIdentity,
 ) -> targets_store.CloudTargetSnapshot:
     target = await get_target_detail(db, target_id=target_id, user_id=user.id)
     if target.organization_id is not None:

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -25,6 +25,7 @@ from proliferate.constants.cloud import (
     CloudWorkspaceCleanupState,
     CloudWorkspaceStatus,
 )
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import cloud_workspaces
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_claims import tokens as claim_tokens_store
@@ -952,7 +953,7 @@ async def record_materialization_report(
                 target_id=auth.target_id,
                 reason="exposures",
             )
-    await db.commit()
+    await db_session.commit_session(db)
     return WorkerMaterializationReportResponse(
         cloud_workspace_id=str(workspace.id),
         updated=True,
@@ -1090,7 +1091,7 @@ async def lease_worker_command(
         # delivery request can race the request-session commit and fail closed as
         # "not leased by this worker."
     if command is not None or expired_commands:
-        await db.commit()
+        await db_session.commit_session(db)
     return WorkerCommandLeaseResponse(
         command=_command_envelope(command) if command is not None else None,
         server_time=now.isoformat(),

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -33,6 +33,8 @@ from proliferate.constants.cloud import (
     CloudWorkspaceStatus,
 )
 from proliferate.db import session_ops as db_session
+from proliferate.db.models.cloud.sandboxes import CloudSandbox
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store import billing as billing_store
 from proliferate.db.store import cloud_sandbox_profiles as sandbox_profile_store
 from proliferate.db.store.automation_cloud_workspace_claims import (
@@ -182,9 +184,6 @@ from proliferate.server.organizations.service import (
     resolve_owner_context,
 )
 from proliferate.utils.time import duration_ms, utcnow
-
-type CloudWorkspace = object
-type CloudSandbox = object
 
 MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS = 160
 CLOUD_HUMAN_ORIGIN_JSON = '{"kind":"human","entrypoint":"cloud"}'

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -9,10 +9,9 @@ from types import SimpleNamespace
 from typing import NoReturn
 from uuid import UUID, uuid4
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.authorization import OwnerSelection
+from proliferate.auth.authorization import ActorIdentity, OwnerSelection
 from proliferate.constants.billing import (
     BILLING_MODE_ENFORCE,
     USAGE_SEGMENT_CLOSED_BY_DESTROY,
@@ -33,10 +32,7 @@ from proliferate.constants.cloud import (
     CloudWorkspaceCleanupState,
     CloudWorkspaceStatus,
 )
-from proliferate.db import engine as db_engine
-from proliferate.db.models.auth import User
-from proliferate.db.models.cloud.sandboxes import CloudSandbox
-from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import billing as billing_store
 from proliferate.db.store import cloud_sandbox_profiles as sandbox_profile_store
 from proliferate.db.store.automation_cloud_workspace_claims import (
@@ -118,6 +114,7 @@ from proliferate.server.billing.service import (
     authorize_sandbox_start,
     authorize_sandbox_start_for_billing_subject,
     get_billing_snapshot_for_subject,
+    get_billing_snapshot_for_subject_in_session,
     record_cloud_sandbox_usage_stopped,
     repo_limit_for_billing_snapshot,
 )
@@ -185,6 +182,9 @@ from proliferate.server.organizations.service import (
     resolve_owner_context,
 )
 from proliferate.utils.time import duration_ms, utcnow
+
+type CloudWorkspace = object
+type CloudSandbox = object
 
 MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS = 160
 CLOUD_HUMAN_ORIGIN_JSON = '{"kind":"human","entrypoint":"cloud"}'
@@ -306,7 +306,7 @@ async def list_cloud_workspaces_for_user(
     db: AsyncSession,
     user_id: UUID,
     *,
-    user: User | None = None,
+    user: ActorIdentity | None = None,
     owner_selection: OwnerSelection | None = None,
     scope: str | None = None,
     lifecycle: str = "active",
@@ -435,7 +435,7 @@ async def _workspace_summaries_for_request(
         )
         billing = snapshots_by_subject.get(billing_subject_id)
         if billing is None:
-            billing = await get_billing_snapshot_for_subject(billing_subject_id)
+            billing = await get_billing_snapshot_for_subject_in_session(db, billing_subject_id)
             snapshots_by_subject[billing_subject_id] = billing
         action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
         direct_target_context = _direct_target_context_for_workspace(
@@ -519,7 +519,7 @@ def _raise_repo_limit_exceeded(error: CloudRepoLimitExceededError) -> NoReturn:
 
 
 async def _load_personal_agent_auth_agent_kinds(user_id: UUID) -> tuple[str, ...]:
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         profile = await agent_auth_store.get_active_personal_sandbox_profile_for_user(
             db,
             user_id,
@@ -555,7 +555,7 @@ async def _agent_auth_agent_kinds_for_workspace_request(
 async def _load_agent_auth_agent_kinds_for_workspace(
     workspace: CloudWorkspace,
 ) -> tuple[str, ...]:
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         return await _agent_auth_agent_kinds_for_workspace_request(db, workspace)
 
 
@@ -630,7 +630,7 @@ def _remote_access_repo_fields(
 
 async def bootstrap_workspace_remote_access(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     body: BootstrapWorkspaceRemoteAccessRequest,
 ) -> WorkspaceDetail:
     target = await targets_store.get_visible_target_by_id(
@@ -736,7 +736,7 @@ async def bootstrap_workspace_remote_access(
 
 async def launch_workspace_on_target(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     body: LaunchWorkspaceOnTargetRequest,
 ) -> WorkspaceTargetLaunchResponse:
     prompt_text = body.prompt.strip()
@@ -820,7 +820,7 @@ async def launch_workspace_on_target(
         origin="manual_mobile" if body.source == "mobile" else "manual_web",
     )
     workspace_id = workspace.id
-    await db_engine.commit_session(db)
+    await db_session.commit_session(db)
 
     try:
         checkout = await _enqueue_target_launch_command(
@@ -982,7 +982,7 @@ async def launch_workspace_on_target(
 async def _resolve_new_direct_target_workspace_create(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     body: LaunchWorkspaceOnTargetRequest,
 ) -> ResolvedCloudWorkspaceCreate:
     if body.git_provider != SUPPORTED_GIT_PROVIDER:
@@ -1107,7 +1107,7 @@ def _direct_target_workspace_paths(
 async def _enqueue_target_launch_command(
     db: AsyncSession,
     *,
-    user: User,
+    user: ActorIdentity,
     target_id: UUID,
     cloud_workspace_id: UUID | None,
     kind: str,
@@ -1131,7 +1131,7 @@ async def _enqueue_target_launch_command(
             }
         ),
     )
-    await db_engine.commit_session(db)
+    await db_session.commit_session(db)
     return command
 
 
@@ -1154,7 +1154,7 @@ async def _wait_for_target_launch_command(
 async def _mark_target_launch_command_failed_interaction_if_needed(
     command_id: UUID,
 ) -> None:
-    async with db_engine.async_session_factory() as fresh_db:
+    async with db_session.open_async_session() as fresh_db:
         latest = await command_store.get_command_by_id(fresh_db, command_id)
         if latest is None:
             return
@@ -1167,12 +1167,12 @@ async def _mark_target_launch_command_failed_interaction_if_needed(
             return
         await mark_pending_prompt_interaction_failed_for_command(fresh_db, latest)
         await publish_command_status_after_commit(fresh_db, latest)
-        await db_engine.commit_session(fresh_db)
+        await db_session.commit_session(fresh_db)
 
 
 async def enable_cloud_workspace_remote_access(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     workspace_id: UUID,
 ) -> WorkspaceDetail:
     workspace = await cloud_workspace_user_can_interact_with_db(db, user.id, workspace_id)
@@ -1239,7 +1239,7 @@ async def enable_cloud_workspace_remote_access(
 
 async def disable_cloud_workspace_remote_access(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     workspace_id: UUID,
 ) -> WorkspaceDetail:
     workspace = await cloud_workspace_user_can_archive_with_db(db, user.id, workspace_id)
@@ -1287,10 +1287,11 @@ async def _build_workspace_detail_for_request(
         if workspace.target_id is not None
         else None
     )
-    billing = await get_billing_snapshot_for_subject(
+    billing = await get_billing_snapshot_for_subject_in_session(
+        db,
         runtime_environment.billing_subject_id
         if runtime_environment is not None
-        else workspace.billing_subject_id
+        else workspace.billing_subject_id,
     )
     action_block_kind, action_block_reason = _workspace_action_block(workspace, billing)
     automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
@@ -1330,7 +1331,7 @@ async def _build_workspace_detail(
 ) -> WorkspaceDetail:
     exposure = None
     claim = None
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         exposure, claim = await load_workspace_exposure_and_claim(
             db,
             target_id=workspace.target_id,
@@ -1345,7 +1346,7 @@ async def _build_workspace_detail(
     latest_sessions = ()
     target = None
     automation_runs_by_workspace = {}
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         latest_sessions = await events_store.list_session_projections_for_workspace(
             db,
             cloud_workspace_id=workspace.id,
@@ -1398,31 +1399,31 @@ async def _build_workspace_detail(
 async def _load_repo_config_value_tx(
     user_id: UUID, git_owner: str, git_repo_name: str
 ) -> object | None:
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         return await load_repo_config_value(
             db, user_id=user_id, git_owner=git_owner, git_repo_name=git_repo_name
         )
 
 
 async def _bootstrap_repo_config_tx(user_id: UUID, git_owner: str, git_repo_name: str) -> object:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         return await bootstrap_repo_config(
             db, user_id=user_id, git_owner=git_owner, git_repo_name=git_repo_name
         )
 
 
 async def _mark_workspace_error_tx(workspace_id: UUID, message: str, **kwargs: object) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await mark_workspace_error_by_id(db, workspace_id, message, **kwargs)
 
 
 async def _update_sandbox_status_tx(sandbox: CloudSandbox, status: str, **kwargs: object) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await update_sandbox_status(db, sandbox, status, **kwargs)
 
 
 async def _resolve_new_cloud_workspace_create(
-    user: User,
+    user: ActorIdentity,
     *,
     git_provider: str,
     git_owner: str,
@@ -1457,7 +1458,7 @@ async def _resolve_new_cloud_workspace_create(
 
     repo_config = await _load_repo_config_value_tx(user.id, git_owner, git_repo_name)
     if repo_config is None or not repo_config.configured:
-        async with db_engine.async_session_factory() as db:
+        async with db_session.open_async_session() as db:
             existing_repo_workspace = await load_any_cloud_workspace_for_repo(
                 db,
                 user_id=user.id,
@@ -1516,7 +1517,7 @@ async def _resolve_new_cloud_workspace_create(
             status_code=400,
         )
 
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         existing_cloud_workspace = await load_existing_cloud_workspace(
             db,
             user_id=user.id,
@@ -1588,7 +1589,7 @@ async def _resolve_new_cloud_workspace_create(
 
 
 async def _resolve_new_managed_cloud_workspace_create(
-    user: User,
+    user: ActorIdentity,
     *,
     sandbox_profile_id: UUID,
     target_id: UUID,
@@ -1623,7 +1624,7 @@ async def _resolve_new_managed_cloud_workspace_create(
             status_code=400,
         )
 
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         profile = await sandbox_profile_store.load_sandbox_profile_by_id(db, sandbox_profile_id)
         if profile is None or profile.primary_target_id != target_id:
             raise CloudApiError(
@@ -1783,7 +1784,7 @@ async def _resolve_new_managed_cloud_workspace_create(
 
 
 async def create_cloud_workspace(
-    user: User,
+    user: ActorIdentity,
     *,
     db: AsyncSession | None = None,
     git_provider: str,
@@ -1824,7 +1825,7 @@ async def create_cloud_workspace(
             source,
             CREATE_WORKSPACE_ORIGIN_BY_SOURCE["desktop"],
         )
-        async with db_engine.async_session_factory() as create_db, create_db.begin():
+        async with db_session.open_async_transaction() as create_db:
             workspace = await create_cloud_workspace_for_user(
                 create_db,
                 user_id=user.id,
@@ -1853,7 +1854,7 @@ async def create_cloud_workspace(
 
 
 async def create_cloud_workspace_for_automation_run(
-    user: User,
+    user: ActorIdentity,
     *,
     run_id: UUID,
     claim_id: UUID,
@@ -1885,7 +1886,7 @@ async def create_cloud_workspace_for_automation_run(
         required_agent_kind=required_agent_kind,
     )
     try:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             workspace = await create_managed_cloud_workspace_for_claimed_run(
                 db,
                 run_id=run_id,
@@ -1920,7 +1921,7 @@ async def create_cloud_workspace_for_automation_run(
 
 
 async def ensure_cloud_workspace_for_existing_branch(
-    user: User,
+    user: ActorIdentity,
     *,
     git_provider: str,
     git_owner: str,
@@ -1947,7 +1948,7 @@ async def ensure_cloud_workspace_for_existing_branch(
             "Choose a branch before provisioning a cloud workspace.",
             status_code=400,
         )
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         existing_cloud_workspace = await load_existing_cloud_workspace(
             db,
             user_id=user.id,
@@ -1984,7 +1985,7 @@ async def ensure_cloud_workspace_for_existing_branch(
     billing_snapshot = await get_billing_snapshot_for_subject(authorization.billing_subject_id)
     cloud_repo_limit = repo_limit_for_billing_snapshot(billing_snapshot)
     try:
-        async with db_engine.async_session_factory() as db, db.begin():
+        async with db_session.open_async_transaction() as db:
             workspace = await create_cloud_workspace_for_user(
                 db,
                 user_id=user.id,
@@ -2021,7 +2022,7 @@ def _cloud_workspace_should_be_replaced_for_mobility_retry(
 
 
 async def _archive_failed_cloud_workspace_for_mobility_retry(workspace_id: UUID) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await archive_cloud_workspace_record_by_id(db, workspace_id=workspace_id)
 
 
@@ -2038,13 +2039,13 @@ async def _refresh_repo_env_snapshot_for_workspace(workspace: CloudWorkspace) ->
             user_id=workspace.user_id,
             repo=f"{workspace.git_owner}/{workspace.git_repo_name}",
         )
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         return await save_workspace(db, workspace)
 
 
 async def start_cloud_workspace(
     db: AsyncSession,
-    user: User,
+    user: ActorIdentity,
     workspace_id: UUID,
     *,
     requested_base_sha: str | None = None,
@@ -2115,7 +2116,7 @@ async def start_cloud_workspace(
         if start_decision.clear_last_error:
             workspace.last_error = None
         if start_decision.persist_before_schedule:
-            async with db_engine.async_session_factory() as persist_db, persist_db.begin():
+            async with db_session.open_async_transaction() as persist_db:
                 workspace = await save_workspace(persist_db, workspace)
         log_cloud_event(
             "cloud workspace queued",
@@ -2165,7 +2166,7 @@ async def start_cloud_workspace(
     if start_decision.clear_last_error:
         workspace.last_error = None
     if start_decision.persist_before_schedule:
-        async with db_engine.async_session_factory() as persist_db, persist_db.begin():
+        async with db_session.open_async_transaction() as persist_db:
             workspace = await save_workspace(persist_db, workspace)
     log_cloud_event(
         "cloud workspace restart queued",
@@ -2270,7 +2271,7 @@ async def archive_cloud_workspace(
         workspace.cleanup_state = CloudWorkspaceCleanupState.failed.value
         workspace.cleanup_last_error = prune_error
     detail = await _build_workspace_detail_for_request(db, workspace)
-    await db.commit()
+    await db_session.commit_session(db)
     return detail
 
 
@@ -2327,9 +2328,11 @@ async def restore_cloud_workspace(
     try:
         await restore_cloud_workspace_record(db, workspace=workspace)
         detail = await _build_workspace_detail_for_request(db, workspace)
-        await db.commit()
-    except IntegrityError as exc:
-        await db.rollback()
+        await db_session.commit_session(db)
+    except Exception as exc:
+        if not db_session.is_integrity_error(exc):
+            raise
+        await db_session.rollback_session(db)
         raise CloudApiError(
             "workspace_restore_conflict",
             "Another active workspace already exists for this repo and branch.",
@@ -2367,7 +2370,7 @@ async def purge_cloud_workspace(
         command_kinds=None,
     )
     await purge_cloud_workspace_record(db, workspace=workspace)
-    await db.commit()
+    await db_session.commit_session(db)
 
 
 async def delete_cloud_workspace(
@@ -2380,7 +2383,7 @@ async def delete_cloud_workspace(
     workspace_record_id = workspace.id
     db.expunge(workspace)
     await _destroy_workspace_runtime(workspace)
-    async with db_engine.async_session_factory() as delete_db, delete_db.begin():
+    async with db_session.open_async_transaction() as delete_db:
         if refreshed := await load_cloud_workspace_by_id(delete_db, workspace_record_id):
             await delete_cloud_workspace_records_for_workspace(delete_db, refreshed)
 
@@ -2390,7 +2393,7 @@ async def _revoke_claim_tokens_for_workspace(
     *,
     reason: str,
 ) -> None:
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         claim = await claims_store.get_claim_for_workspace(db, workspace.id)
         if claim is None:
             return
@@ -2454,7 +2457,7 @@ async def _stop_workspace_runtime(workspace: CloudWorkspace) -> None:
         )
     else:
         workspace.updated_at = utcnow()
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await persist_workspace_stop_state(db, workspace)
     log_cloud_event(
         "cloud workspace stopped",
@@ -2498,7 +2501,7 @@ async def _destroy_workspace_runtime(workspace: CloudWorkspace) -> None:
         else:
             await _update_sandbox_status_tx(sandbox, "destroyed", stopped_at_now=True)
     transition_workspace_status(workspace, CloudWorkspaceStatus.archived, status_detail="Archived")
-    async with db_engine.async_session_factory() as db, db.begin():
+    async with db_session.open_async_transaction() as db:
         await persist_workspace_destroy_state(db, workspace)
     log_cloud_event(
         "cloud workspace destroyed",
@@ -2518,7 +2521,7 @@ async def _load_workspace_owned_runtime_sandbox(
     sandbox_id = getattr(workspace, "active_sandbox_id", None)
     if sandbox_id is None:
         return None
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         sandbox = await load_cloud_sandbox_by_id(db, sandbox_id)
     if sandbox is None:
         return None
@@ -2541,7 +2544,7 @@ async def get_cloud_connection(
 ) -> WorkspaceConnection:
     workspace = await cloud_workspace_user_can_interact_with_db(db, user_id, workspace_id)
     await _reject_shared_workspace_static_connection(workspace)
-    async with db_engine.async_session_factory() as lookup_db:
+    async with db_session.open_async_session() as lookup_db:
         automation_runs_by_workspace = await list_latest_runs_by_cloud_workspace_ids_for_user(
             lookup_db,
             user_id=user_id,
@@ -2596,7 +2599,7 @@ async def get_cloud_connection(
             status_code=409,
         ) from exc
 
-    async with db_engine.async_session_factory() as reload_db:
+    async with db_session.open_async_session() as reload_db:
         reloaded_workspace = await load_cloud_workspace_by_id(reload_db, workspace.id)
     if reloaded_workspace is not None:
         workspace = reloaded_workspace
@@ -2620,7 +2623,7 @@ async def get_cloud_connection(
 async def _reject_shared_workspace_static_connection(workspace: CloudWorkspace) -> None:
     if workspace.owner_scope != "organization":
         return
-    async with db_engine.async_session_factory() as db:
+    async with db_session.open_async_session() as db:
         exposure, _claim = await load_workspace_exposure_and_claim(
             db,
             target_id=workspace.target_id,

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1947,7 +1947,10 @@ class TestCloudWorkspaces:
         db_session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        async def _workspace_connection(_db, _workspace):
+        async def _workspace_connection(
+            _db: AsyncSession,
+            _workspace: CloudWorkspace,
+        ) -> RuntimeConnectionTarget:
             return RuntimeConnectionTarget(
                 target_id=None,
                 runtime_url="https://example-runtime.invalid",

--- a/server/tests/unit/test_cloud_workspace_connection_service.py
+++ b/server/tests/unit/test_cloud_workspace_connection_service.py
@@ -6,13 +6,18 @@ from uuid import uuid4
 import pytest
 
 from proliferate.server.cloud.workspaces import service as workspace_service
-from tests.unit.db_session_helpers import NoopDb, patch_async_session_factory
+from tests.unit.db_session_helpers import NoopDb, noop_async_context
 
 INTERACT_WITH_DB = "cloud_workspace_user_can_interact_with_db"
 
 
 def _patch_session_factory(monkeypatch: pytest.MonkeyPatch, db: NoopDb) -> NoopDb:
-    return patch_async_session_factory(monkeypatch, workspace_service.db_engine, db)
+    monkeypatch.setattr(
+        workspace_service.db_session,
+        "open_async_session",
+        lambda: noop_async_context(db),
+    )
+    return db
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_cloud_workspace_service.py
+++ b/server/tests/unit/test_cloud_workspace_service.py
@@ -23,7 +23,7 @@ ARCHIVE_WITH_DB = "cloud_workspace_user_can_archive_with_db"
 
 
 def _patch_session_factory(monkeypatch: pytest.MonkeyPatch) -> NoopDb:
-    return patch_async_session_factory(monkeypatch, workspace_service.db_engine)
+    return patch_async_session_factory(monkeypatch, workspace_service.db_session.db_engine)
 
 
 def _denied_start_authorization(*, blocked_reason: str) -> SandboxStartAuthorization:
@@ -453,7 +453,7 @@ async def test_launch_workspace_on_target_keeps_workspace_id_after_expire_all(
         "create_direct_target_cloud_workspace",
         _create_direct_target_cloud_workspace,
     )
-    monkeypatch.setattr(workspace_service.db_engine, "commit_session", _commit_session)
+    monkeypatch.setattr(workspace_service.db_session.db_engine, "commit_session", _commit_session)
     monkeypatch.setattr(
         workspace_service,
         "_enqueue_target_launch_command",
@@ -567,11 +567,11 @@ async def test_target_launch_wait_marks_pending_prompt_failed(
         _publish,
     )
     monkeypatch.setattr(
-        workspace_service.db_engine,
+        workspace_service.db_session.db_engine,
         "async_session_factory",
         FakeSessionFactory(),
     )
-    monkeypatch.setattr(workspace_service.db_engine, "commit_session", _commit)
+    monkeypatch.setattr(workspace_service.db_session.db_engine, "commit_session", _commit)
 
     with pytest.raises(TimeoutError):
         await workspace_service._wait_for_target_launch_command(

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -105,6 +105,25 @@ def test_service_rejects_db_commit_call(tmp_path: Path) -> None:
     assert any(".commit()" in item.message for item in violations)
 
 
+def test_service_rejects_session_ops_import_and_call(tmp_path: Path) -> None:
+    module = _load_checker_module()
+    path = tmp_path / "server" / "proliferate" / "server" / "example" / "service.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "from proliferate.db import session_ops as db_session\n"
+        "async def run() -> None:\n"
+        "    async with db_session.open_async_session() as db:\n"
+        "        await db_session.commit_session(db)\n"
+        "    if db_session.is_integrity_error(Exception()):\n"
+        "        return None\n"
+    )
+
+    violations = module.check_paths([path])
+
+    assert any(item.rule_id == "SERVICE_DB_ENGINE_IMPORT" for item in violations)
+    assert sum(item.rule_id == "SERVICE_DB_METHOD_CALL" for item in violations) == 3
+
+
 def test_store_rejects_self_opening_session_and_commit(tmp_path: Path) -> None:
     module = _load_checker_module()
     path = tmp_path / "server" / "proliferate" / "db" / "store" / "example.py"


### PR DESCRIPTION
## Summary
- add `proliferate.db.session_ops` as the narrow session-boundary helper for non-HTTP server orchestration entry points
- replace service-layer ORM/session-factory/commit/rollback usage with explicit store calls and entry-point transaction helpers
- remove the remaining `SERVICE_*` server boundary allowlist debt and lower touched max-line exceptions

## Verification
- `python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `cd server && uv run --extra dev ruff format --check proliferate/ tests/`
- `cd server && uv run --extra dev ruff check proliferate/ tests/`
- `cd server && DEBUG=true JWT_SECRET=test-secret uv run --extra dev pytest -q tests/unit/test_cloud_mobility_service.py tests/unit/test_cloud_mobility_service_lifecycle.py tests/unit/test_cloud_workspace_service.py tests/unit/test_cloud_webhook_service.py tests/unit/test_cloud_workspace_connection_service.py tests/unit/test_billing_service_policy.py tests/unit/test_billing_reconciler.py tests/integration/test_billing_api.py`
- `cd server && DEBUG=true JWT_SECRET=test-secret uv run --extra dev pytest -q tests/unit tests/integration` (878 passed; 475 warnings)