### PR TITLE
ci(server): let server test job finish

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 75
     env:
       DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
       JWT_SECRET: test-jwt-secret
@@ -114,7 +114,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -xvs --durations=20
+        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- raise the Server CI test job timeout from 40 to 75 minutes
- switch the server pytest invocation from verbose `-xvs` to quiet `-q` while keeping `--durations=20`

## Why
- server hygiene PRs are completing local focused and full server suites, but GitHub cancels the full Server CI test job at the 40-minute cap after many passing tests
- this lets server PRs finish checks normally instead of relying on admin merge of timeout-cancelled jobs

## Verification
- `git diff --check`
- `node --check scripts/ci-cd/detect-deploy-surfaces.mjs`
- `node --check scripts/ci-cd/resolve-deploy-base.mjs`