### PR TITLE
refactor(server): split Slack cloud bot workers

### DIFF
--- a/docs/features/slack-bot.md
+++ b/docs/features/slack-bot.md
@@ -603,12 +603,12 @@ END_OF_TURN_KINDS = {
 }
 ```
 
-`enqueue_post_session_processors` schedules a small handler:
+`enqueue_post_session_processors` schedules the Slack worker post-session hook:
 
 ```text
-server/proliferate/server/cloud/slack/post_session_hook.py
+server/proliferate/server/cloud/slack/worker/post_session.py
 
-handle_post_session_event(cloud_session_id, event):
+enqueue_post_session_event(cloud_session_id, event):
   load slack_thread_work via cloud_session.cloud_workspace_id
   if no slack_thread_work: return
   format Slack reply (block kit) using messages.py helpers:
@@ -661,11 +661,14 @@ slack_outbound_message_queue
   CHECK ck_slack_outbound_source
 ```
 
-Worker:
+Worker transaction entry and sender:
 
 ```text
-server/proliferate/server/cloud/slack/outbound_worker.py
-  every N seconds:
+server/proliferate/server/cloud/slack/worker/main.py
+  process_due_outbound_messages() opens the worker transaction
+
+server/proliferate/server/cloud/slack/worker/outbound.py
+  within each worker pass:
     select up to batch_size queued rows where next_attempt_at <= now
     for each row:
       attempt post via Slack chat.postMessage (decrypt bot token)
@@ -795,11 +798,15 @@ server/proliferate/server/cloud/slack/                               (new)
                           PATCH /v1/cloud/slack/bot-config
                           POST /v1/cloud/slack/bot-config/validate-connection
   service.py              install/reconnect; bot_config CRUD;
-                          mention handler; thread follow-up handler
+                          event ingest fast path
   signature.py            HMAC-SHA256 verification (Slack-flavored)
   oauth.py                exchange code; refresh as needed
-  outbound_worker.py      retry + rate-limit aware sender
-  post_session_hook.py    end-of-turn -> outbound queue insert
+  worker/
+    main.py               deferred job and outbound transaction entry points
+    events.py             mention handler; thread follow-up handler
+    commands.py           command launch + workspace materialization helpers
+    outbound.py           retry + rate-limit aware sender
+    post_session.py       end-of-turn -> outbound queue insert
   domain/
     repo_router.py        pure router (heuristic match)
     mention_parse.py      strip @mention, extract --repo hints
@@ -885,28 +892,28 @@ Chunk C  Inbound event handler
   - POST /v1/cloud/slack/events
   - signature.py HMAC verify
   - parse + dedupe via slack_event_envelope_seen
-  - enqueue slack_inbound_event_job (lightweight background loop)
+  - enqueue slack_inbound_event_job and defer worker/main.py entry point
   - 200 OK fast path
 
 Chunk D  Mention handler + thread follow-up handler
-  - background processor for inbound jobs
+  - worker/events.py background processor for inbound jobs
   - ensure_organization_sandbox_profile
   - repo router (fixed + auto)
   - managed_profile_launch with origin='slack'
   - slack_thread_work insert
   - ack message via outbound queue
-  - start_session + send_prompt enqueue
+  - worker/commands.py start_session + send_prompt enqueue
   - follow-up: send_prompt on existing session
 
 Chunk E  End-of-turn hook + post-session processor
   - END_OF_TURN_KINDS in events/service.py
-  - enqueue_post_session_processors after _apply_projection
-  - PostSessionProcessor registry
-  - Slack processor: looks up slack_thread_work; formats reply;
+  - enqueue_post_session_event after _apply_projection
+  - worker/post_session.py looks up slack_thread_work; formats reply;
     inserts into outbound queue
 
 Chunk F  Outbound queue + sender
-  - outbound_worker.py periodic loop
+  - worker/main.py periodic entry point
+  - worker/outbound.py sender
   - Slack chat.postMessage call (httpx)
   - rate-limit/Retry-After handling
   - exponential backoff
@@ -1014,7 +1021,7 @@ server/tests/cloud/slack/test_repo_config_owner_scope.py
 server/tests/cloud/slack/test_outbound_retry_after.py
 server/tests/cloud/slack/test_outbound_exponential_backoff.py
 server/tests/cloud/slack/test_outbound_idempotency_key.py
-server/tests/cloud/slack/test_post_session_hook_registers.py
+server/tests/cloud/slack/test_post_session_worker_registers.py
 server/tests/cloud/slack/test_end_of_turn_enqueues_outbound.py
 server/tests/cloud/slack/test_admin_gate_on_settings.py
 server/tests/cloud/slack/test_agent_run_config_inheritance.py

--- a/docs/structures/server/audits/server-structure-hygiene.md
+++ b/docs/structures/server/audits/server-structure-hygiene.md
@@ -633,11 +633,13 @@ Canonical docs:
 
 Current debt:
 
-- Slack API imports store records directly.
-- Slack service opens sessions and commits/rolls back in deferred handlers.
-- Slack domain policy imports product constants.
-- Slack service is oversized and coordinates repo routing, events, outbound,
-  command launch, OAuth, and settings.
+- Slack bot remains parked/disabled, so revive-path comments and feature docs
+  must point at the current worker owners before the flow is re-enabled.
+- Deferred Slack event, post-session, outbound, and command-launch work now
+  lives under `server/proliferate/server/cloud/slack/worker/**`; future revive
+  work must keep transaction ownership at those worker entry points.
+- Slack API/store, Slack service session-helper, Slack domain purity, and Slack
+  service max-lines allowlist debt has been removed by Lane 8.
 
 Target result:
 

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -49,7 +49,6 @@ server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migrat
 server/proliferate/server/cloud/runtime/provision.py 1715 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
-server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
 server/proliferate/server/cloud/worker/service.py 1434 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
 server/proliferate/server/cloud/workspaces/service.py 2643 server structure migration debt for oversized service file

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -12,7 +12,6 @@ SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_agent_run_config 1 transiti
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_plugins 1 transitional store folder has not yet been flattened or promoted
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_skills 1 transitional store folder has not yet been flattened or promoted
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
-API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 1 remaining service type boundary exposes billing ORM records until snapshot migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/mobility/service.py 1 remaining service type boundary exposes workspace ORM records until snapshot migration
 SERVICE_ORM_IMPORT server/proliferate/server/cloud/runtime/service.py 1 remaining service type boundary exposes workspace ORM records until snapshot migration
@@ -26,7 +25,6 @@ SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 r
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/transactions.py 1 Lane 7 explicit API-facing command commit boundary debt
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/wake.py 1 Lane 7 explicit after-commit command wake boundary debt
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 remaining service-owned live event session boundary debt through session_ops
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/slack/service.py 1 remaining service-owned Slack deferred transaction boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/worker/transactions.py 1 Lane 7 explicit worker API pre-response commit boundary debt
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 remaining service-owned workspace lifecycle session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/billing/service.py 34 remaining billing service-owned transaction/session boundary debt through session_ops
@@ -36,10 +34,8 @@ SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/agent_auth_refre
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/transactions.py 1 Lane 7 explicit API-facing command commit boundary debt
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/wake.py 1 Lane 7 explicit after-commit command wake boundary debt
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/live/service.py 4 remaining live service-owned session/deferred boundary debt through session_ops
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 13 remaining Slack service-owned transaction/session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/transactions.py 2 Lane 7 explicit worker API pre-response commit boundary debt
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 36 remaining workspace service-owned lifecycle transaction/session boundary debt through session_ops
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
-DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/slack/domain/policy.py 1 transitional Slack policy imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/target_config/domain/policy.py 1 transitional target config policy imports product config during worker migration
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/targets/domain/policy.py 1 transitional target policy imports product config during worker migration

--- a/server/proliferate/server/cloud/events/service.py
+++ b/server/proliferate/server/cloud/events/service.py
@@ -47,13 +47,11 @@ from proliferate.server.cloud.live.service import (
 )
 from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
 
-# SLACK BOT PARKED: outbound Slack callbacks are preserved in the Slack service
-# but intentionally detached from event ingest while the bot flow is disabled.
+# SLACK BOT PARKED: outbound Slack callbacks are preserved in Slack worker
+# owners but intentionally detached from event ingest while the bot flow is disabled.
 # from proliferate.db import engine as db_engine
-# from proliferate.server.cloud.slack.service import (
-#     enqueue_post_session_event,
-#     process_due_outbound_messages,
-# )
+# from proliferate.server.cloud.slack.worker.main import process_due_outbound_messages
+# from proliferate.server.cloud.slack.worker.post_session import enqueue_post_session_event
 
 SESSION_DURABLE_EVENT_HARD_CAP = 10_000
 SESSION_PAYLOAD_BYTES_HARD_CAP = 25 * 1024 * 1024

--- a/server/proliferate/server/cloud/slack/api.py
+++ b/server/proliferate/server/cloud/slack/api.py
@@ -14,8 +14,6 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.config import settings
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
-from proliferate.db.store import cloud_repo_config as repo_store
-from proliferate.db.store.cloud_slack.records import CloudRepoRoutingProfileRecord
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.slack.models import (
     SlackBotConfigEnvelopeResponse,
@@ -31,12 +29,13 @@ from proliferate.server.cloud.slack.models import (
     repo_routing_profile_payload,
 )
 from proliferate.server.cloud.slack.service import (
+    SlackRepoRoutingProfileDetails,
     complete_oauth_install,
     disconnect,
     get_bot_config_envelope,
     ingest_slack_event,
     list_channels,
-    list_repo_routing_profiles,
+    list_repo_routing_profile_details,
     start_oauth_install,
     update_bot_config,
     upsert_repo_routing_profile,
@@ -47,29 +46,19 @@ from proliferate.server.cloud.slack.signature import verify_slack_signature
 router = APIRouter(prefix="/slack", tags=["cloud-slack"])
 
 
-async def _repo_profile_response(
-    db: AsyncSession,
-    organization_id: UUID,
-    profiles: list[CloudRepoRoutingProfileRecord],
+def _repo_profile_response(
+    profiles: list[SlackRepoRoutingProfileDetails],
 ) -> SlackRepoRoutingProfilesResponse:
-    repo_by_id = {
-        repo.id: repo
-        for repo in await repo_store.list_organization_cloud_repo_configs(
-            db,
-            organization_id=organization_id,
-        )
-    }
-    payloads = []
-    for profile in profiles:
-        repo = repo_by_id.get(profile.cloud_repo_config_id)
-        payloads.append(
+    return SlackRepoRoutingProfilesResponse(
+        profiles=[
             repo_routing_profile_payload(
-                profile,
-                git_owner=repo.git_owner if repo else None,
-                git_repo_name=repo.git_repo_name if repo else None,
+                detail.profile,
+                git_owner=detail.git_owner,
+                git_repo_name=detail.git_repo_name,
             )
-        )
-    return SlackRepoRoutingProfilesResponse(profiles=payloads)
+            for detail in profiles
+        ],
+    )
 
 
 @router.get("/oauth/start", response_model=SlackOAuthStartResponse)
@@ -185,8 +174,8 @@ async def list_slack_repo_routing_profiles_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> SlackRepoRoutingProfilesResponse:
-    profiles = await list_repo_routing_profiles(db, user, organization_id=organization_id)
-    return await _repo_profile_response(db, organization_id, profiles)
+    profiles = await list_repo_routing_profile_details(db, user, organization_id=organization_id)
+    return _repo_profile_response(profiles)
 
 
 @router.put("/repo-routing-profiles", response_model=SlackRepoRoutingProfilesResponse)
@@ -204,8 +193,8 @@ async def upsert_slack_repo_routing_profile_endpoint(
         display_name=body.display_name,
         description=body.description,
     )
-    profiles = await list_repo_routing_profiles(db, user, organization_id=organization_id)
-    return await _repo_profile_response(db, organization_id, profiles)
+    profiles = await list_repo_routing_profile_details(db, user, organization_id=organization_id)
+    return _repo_profile_response(profiles)
 
 
 @router.post("/events")

--- a/server/proliferate/server/cloud/slack/domain/mention_parse.py
+++ b/server/proliferate/server/cloud/slack/domain/mention_parse.py
@@ -22,3 +22,18 @@ def parse_slack_mention_text(text: str, *, bot_user_id: str | None) -> ParsedSla
         repo_hint = match.group(1).strip()
         cleaned = (cleaned[: match.start()] + cleaned[match.end() :]).strip()
     return ParsedSlackMention(prompt=cleaned or "Help with this repository.", repo_hint=repo_hint)
+
+
+def is_human_slack_message(event: dict[str, object], *, bot_user_id: str | None) -> bool:
+    if _string_or_none(event.get("subtype")) is not None:
+        return False
+    if _string_or_none(event.get("bot_id")) is not None:
+        return False
+    if _string_or_none(event.get("app_id")) is not None:
+        return False
+    user_id = _string_or_none(event.get("user"))
+    return bool(user_id and user_id != bot_user_id)
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/server/proliferate/server/cloud/slack/domain/policy.py
+++ b/server/proliferate/server/cloud/slack/domain/policy.py
@@ -2,38 +2,58 @@
 
 from __future__ import annotations
 
-from proliferate.constants.slack import SLACK_CONNECTION_STATUS_ACTIVE
-from proliferate.db.store.cloud_slack.records import (
-    SlackBotConfigRecord,
-    SlackWorkspaceConnectionRecord,
-)
-from proliferate.server.cloud.errors import CloudApiError
+from dataclasses import dataclass
+from typing import Protocol
 
 
-def require_active_slack_bot(
+class SlackConnectionState(Protocol):
+    status: str
+
+
+class SlackBotConfigState(Protocol):
+    enabled: bool
+    allowed_slack_channel_ids: str | None
+
+
+@dataclass(frozen=True)
+class SlackBotAllowed:
+    pass
+
+
+@dataclass(frozen=True)
+class SlackBotDenied:
+    code: str
+    message: str
+    status_code: int
+
+
+SlackBotVerdict = SlackBotAllowed | SlackBotDenied
+
+
+def check_active_slack_bot(
     *,
-    connection: SlackWorkspaceConnectionRecord | None,
-    config: SlackBotConfigRecord | None,
+    connection: SlackConnectionState | None,
+    config: SlackBotConfigState | None,
     slack_channel_id: str | None = None,
-) -> tuple[SlackWorkspaceConnectionRecord, SlackBotConfigRecord]:
+) -> SlackBotVerdict:
     if connection is None:
-        raise CloudApiError("slack_not_connected", "Slack is not connected.", status_code=404)
-    if connection.status != SLACK_CONNECTION_STATUS_ACTIVE:
-        raise CloudApiError(
+        return SlackBotDenied("slack_not_connected", "Slack is not connected.", 404)
+    if connection.status != "active":
+        return SlackBotDenied(
             "slack_connection_requires_reauth",
             "Slack needs to be reconnected.",
-            status_code=409,
+            409,
         )
     if config is None or not config.enabled:
-        raise CloudApiError("slack_bot_disabled", "Slack bot is disabled.", status_code=409)
+        return SlackBotDenied("slack_bot_disabled", "Slack bot is disabled.", 409)
     if slack_channel_id and config.allowed_slack_channel_ids:
         allowed = {
             item.strip() for item in config.allowed_slack_channel_ids.split(",") if item.strip()
         }
         if slack_channel_id not in allowed:
-            raise CloudApiError(
+            return SlackBotDenied(
                 "slack_channel_not_allowed",
                 "Slack bot is not enabled for this channel.",
-                status_code=403,
+                403,
             )
-    return connection, config
+    return SlackBotAllowed()

--- a/server/proliferate/server/cloud/slack/domain/policy.py
+++ b/server/proliferate/server/cloud/slack/domain/policy.py
@@ -24,7 +24,6 @@ class SlackBotAllowed:
 class SlackBotDenied:
     code: str
     message: str
-    status_code: int
 
 
 SlackBotVerdict = SlackBotAllowed | SlackBotDenied
@@ -37,15 +36,14 @@ def check_active_slack_bot(
     slack_channel_id: str | None = None,
 ) -> SlackBotVerdict:
     if connection is None:
-        return SlackBotDenied("slack_not_connected", "Slack is not connected.", 404)
+        return SlackBotDenied("slack_not_connected", "Slack is not connected.")
     if connection.status != "active":
         return SlackBotDenied(
             "slack_connection_requires_reauth",
             "Slack needs to be reconnected.",
-            409,
         )
     if config is None or not config.enabled:
-        return SlackBotDenied("slack_bot_disabled", "Slack bot is disabled.", 409)
+        return SlackBotDenied("slack_bot_disabled", "Slack bot is disabled.")
     if slack_channel_id and config.allowed_slack_channel_ids:
         allowed = {
             item.strip() for item in config.allowed_slack_channel_ids.split(",") if item.strip()
@@ -54,6 +52,5 @@ def check_active_slack_bot(
             return SlackBotDenied(
                 "slack_channel_not_allowed",
                 "Slack bot is not enabled for this channel.",
-                403,
             )
     return SlackBotAllowed()

--- a/server/proliferate/server/cloud/slack/service.py
+++ b/server/proliferate/server/cloud/slack/service.py
@@ -43,6 +43,12 @@ from proliferate.utils.crypto import decrypt_text
 SLACK_BOT_SCOPES = (
     "app_mentions:read,chat:write,chat:write.public,channels:history,channels:read,groups:read"
 )
+_SLACK_BOT_POLICY_STATUS_CODES = {
+    "slack_channel_not_allowed": 403,
+    "slack_not_connected": 404,
+    "slack_bot_disabled": 409,
+    "slack_connection_requires_reauth": 409,
+}
 
 
 @dataclass(frozen=True)
@@ -64,7 +70,11 @@ def require_active_slack_bot(
         slack_channel_id=slack_channel_id,
     )
     if isinstance(verdict, SlackBotDenied):
-        raise CloudApiError(verdict.code, verdict.message, status_code=verdict.status_code)
+        raise CloudApiError(
+            verdict.code,
+            verdict.message,
+            status_code=_SLACK_BOT_POLICY_STATUS_CODES[verdict.code],
+        )
     assert connection is not None
     assert config is not None
     return connection, config

--- a/server/proliferate/server/cloud/slack/service.py
+++ b/server/proliferate/server/cloud/slack/service.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
-import re
-from datetime import timedelta
+from dataclasses import dataclass
 from uuid import UUID
 
 from cryptography.fernet import InvalidToken
@@ -12,115 +10,64 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import ActorIdentity
 from proliferate.config import settings
-from proliferate.constants.cloud import (
-    CloudCommandActorKind,
-    CloudCommandKind,
-    CloudCommandSource,
-)
 from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
-from proliferate.constants.slack import (
-    SLACK_OUTBOUND_SOURCE_ACK,
-    SLACK_OUTBOUND_SOURCE_FAILED,
-    SLACK_OUTBOUND_SOURCE_TURN,
-    SLACK_REPO_MODE_AUTO,
-    SLACK_REPO_MODE_FIXED,
-    SLACK_THREAD_WORK_STATUS_ACTIVE,
-)
-from proliferate.db import session_ops as db_session
+from proliferate.constants.slack import SLACK_REPO_MODE_AUTO, SLACK_REPO_MODE_FIXED
 from proliferate.db.store import cloud_repo_config as repo_store
-from proliferate.db.store import cloud_sandbox_profiles as profile_store
-from proliferate.db.store import cloud_workspaces
 from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.cloud_agent_run_config import configs as run_config_store
-from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
 from proliferate.db.store.cloud_slack import bot_configs as bot_config_store
 from proliferate.db.store.cloud_slack import connections as connection_store
 from proliferate.db.store.cloud_slack import events as slack_event_store
-from proliferate.db.store.cloud_slack import outbound as outbound_store
 from proliferate.db.store.cloud_slack import repo_routing_profiles as routing_profile_store
-from proliferate.db.store.cloud_slack import thread_work as thread_work_store
 from proliferate.db.store.cloud_slack.records import (
     CloudRepoRoutingProfileRecord,
     SlackBotConfigRecord,
-    SlackInboundEventJobRecord,
-    SlackOutboundMessageRecord,
-    SlackThreadWorkRecord,
     SlackWorkspaceConnectionRecord,
 )
-from proliferate.db.store.cloud_sync import commands as commands_store
-from proliferate.db.store.cloud_sync import exposures as exposures_store
-from proliferate.db.store.cloud_sync import targets as target_store
 from proliferate.integrations.slack import client as slack_client
 from proliferate.integrations.slack.errors import SlackApiError
-from proliferate.server.automations.worker.cloud_execution.command_models import (
-    EnsureRepoCheckoutPayload,
-    MaterializeWorkspacePayload,
-    SendPromptPayload,
-    StartSessionPayload,
-)
-from proliferate.server.automations.worker.cloud_execution.commands import (
-    parse_materialize_workspace_result,
-    parse_start_session_result,
-)
-from proliferate.server.automations.worker.cloud_executor_commands import (
-    wait_for_command_result,
-)
-from proliferate.server.automations.worker.cloud_executor_config import (
-    default_cloud_executor_config,
-)
-from proliferate.server.cloud.agent_run_config import service as run_config_service
 from proliferate.server.cloud.agent_run_config.domain.resolve import (
     validate_config_execution_scope,
 )
-from proliferate.server.cloud.commands.domain.rules import compact_command_json
-from proliferate.server.cloud.commands.service import (
-    kick_off_command_wake_after_commit_if_required,
-    stamp_and_validate_command_preflight,
-)
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.live.service import publish_worker_control_after_commit
-from proliferate.server.cloud.slack.domain.mention_parse import (
-    ParsedSlackMention,
-    parse_slack_mention_text,
-)
-from proliferate.server.cloud.slack.domain.message_format import (
-    ack_blocks,
-    clarification_blocks,
-    completion_blocks,
-    configuration_blocks,
-)
-from proliferate.server.cloud.slack.domain.policy import require_active_slack_bot
-from proliferate.server.cloud.slack.domain.repo_router import (
-    RepoRoutingCandidate,
-    choose_repo,
-)
+from proliferate.server.cloud.slack.domain.policy import SlackBotDenied, check_active_slack_bot
 from proliferate.server.cloud.slack.models import (
     SlackBotConfigUpdateRequest,
     csv_from_string_list,
     csv_from_uuid_list,
 )
 from proliferate.server.cloud.slack.oauth import create_oauth_state, parse_oauth_state
-from proliferate.server.cloud.workspaces.service import get_configured_sandbox_provider
-from proliferate.utils.crypto import decrypt_text, encrypt_json
-from proliferate.utils.time import utcnow
+from proliferate.server.cloud.slack.worker.main import defer_inbound_job_after_commit
+from proliferate.utils.crypto import decrypt_text
 
 SLACK_BOT_SCOPES = (
     "app_mentions:read,chat:write,chat:write.public,channels:history,channels:read,groups:read"
 )
-_SYSTEM_SLACK_USER_UUID = UUID("00000000-0000-0000-0000-000000000007")
-SLACK_COMMAND_WAIT_TIMEOUT = timedelta(seconds=240)
-_SLACK_CONFIGURATION_ERROR_CODES = {
-    "slack_agent_run_config_invalid",
-    "slack_agent_run_config_missing",
-    "slack_bot_config_not_found",
-    "slack_bot_disabled",
-    "slack_channel_not_allowed",
-    "slack_connection_reauth_required",
-    "slack_connection_requires_reauth",
-    "slack_fixed_repo_required",
-    "slack_not_connected",
-    "slack_repo_mode_invalid",
-}
+
+
+@dataclass(frozen=True)
+class SlackRepoRoutingProfileDetails:
+    profile: CloudRepoRoutingProfileRecord
+    git_owner: str | None
+    git_repo_name: str | None
+
+
+def require_active_slack_bot(
+    *,
+    connection: SlackWorkspaceConnectionRecord | None,
+    config: SlackBotConfigRecord | None,
+    slack_channel_id: str | None = None,
+) -> tuple[SlackWorkspaceConnectionRecord, SlackBotConfigRecord]:
+    verdict = check_active_slack_bot(
+        connection=connection,
+        config=config,
+        slack_channel_id=slack_channel_id,
+    )
+    if isinstance(verdict, SlackBotDenied):
+        raise CloudApiError(verdict.code, verdict.message, status_code=verdict.status_code)
+    assert connection is not None
+    assert config is not None
+    return connection, config
 
 
 async def start_oauth_install(
@@ -370,6 +317,34 @@ async def list_repo_routing_profiles(
     )
 
 
+async def list_repo_routing_profile_details(
+    db: AsyncSession,
+    user: ActorIdentity,
+    *,
+    organization_id: UUID,
+) -> list[SlackRepoRoutingProfileDetails]:
+    profiles = await list_repo_routing_profiles(db, user, organization_id=organization_id)
+    repo_by_id = {
+        repo.id: repo
+        for repo in await repo_store.list_organization_cloud_repo_configs(
+            db,
+            organization_id=organization_id,
+        )
+    }
+    return [
+        SlackRepoRoutingProfileDetails(
+            profile=profile,
+            git_owner=repo_by_id[profile.cloud_repo_config_id].git_owner
+            if profile.cloud_repo_config_id in repo_by_id
+            else None,
+            git_repo_name=repo_by_id[profile.cloud_repo_config_id].git_repo_name
+            if profile.cloud_repo_config_id in repo_by_id
+            else None,
+        )
+        for profile in profiles
+    ]
+
+
 async def upsert_repo_routing_profile(
     db: AsyncSession,
     user: ActorIdentity,
@@ -424,956 +399,8 @@ async def ingest_slack_event(
         event_type=str(event_type or "unknown"),
         payload_json=payload,
     )
-    db_session.defer_after_commit(
-        db,
-        lambda job_id=job.id: _process_inbound_job_and_due_outbound(job_id),
-    )
+    defer_inbound_job_after_commit(db, job.id)
     return {"ok": True}
-
-
-async def _process_inbound_job_and_due_outbound(job_id: UUID) -> None:
-    await process_inbound_job_by_id(job_id)
-    await process_due_outbound_messages()
-
-
-async def process_inbound_job_by_id(job_id: UUID) -> None:
-    async with db_session.open_async_session() as db:
-        async with db.begin():
-            job = await slack_event_store.mark_job_processing(db, job_id)
-        if job is None:
-            return
-        try:
-            await _process_inbound_job(db, job)
-            await slack_event_store.mark_job_completed(db, job.id)
-            await db_session.commit_session(db)
-        except CloudApiError as exc:
-            await db_session.rollback_session(db)
-            await _queue_job_error(db, job, error_code=exc.code, message=exc.message)
-            await slack_event_store.mark_job_failed(
-                db,
-                job.id,
-                error_code=exc.code,
-                error_message=exc.message,
-            )
-            await db_session.commit_session(db)
-        except Exception as exc:
-            await db_session.rollback_session(db)
-            await _queue_job_error(db, job, error_code="slack_job_failed", message=str(exc))
-            await slack_event_store.mark_job_failed(
-                db,
-                job.id,
-                error_code="slack_job_failed",
-                error_message=str(exc),
-            )
-            await db_session.commit_session(db)
-
-
-async def enqueue_post_session_event(
-    db: AsyncSession,
-    *,
-    cloud_workspace_id: UUID | None,
-    session_id: str,
-    event_type: str,
-    event_payload: dict[str, object],
-    seq: int,
-) -> None:
-    if cloud_workspace_id is None:
-        return
-    thread_work = await thread_work_store.get_thread_work_by_workspace(
-        db,
-        cloud_workspace_id=cloud_workspace_id,
-    )
-    if thread_work is None or thread_work.status != SLACK_THREAD_WORK_STATUS_ACTIVE:
-        return
-    connection = await connection_store.get_active_connection_for_org(
-        db,
-        organization_id=thread_work.organization_id,
-    )
-    if connection is None:
-        return
-    text = _post_session_text(event_type=event_type, event_payload=event_payload)
-    if not text:
-        return
-    fallback, blocks = completion_blocks(message=text, web_url=_workspace_url(cloud_workspace_id))
-    await outbound_store.enqueue_outbound_message(
-        db,
-        organization_id=thread_work.organization_id,
-        slack_workspace_connection_id=connection.id,
-        slack_team_id=thread_work.slack_team_id,
-        slack_channel_id=thread_work.slack_channel_id,
-        slack_thread_ts=thread_work.slack_thread_ts,
-        blocks_json=blocks,
-        fallback_text=fallback,
-        source=SLACK_OUTBOUND_SOURCE_TURN,
-        source_event_id=f"cloud-session:{session_id}:{seq}:{event_type}",
-    )
-
-
-async def process_due_outbound_messages(*, limit: int = 20) -> None:
-    async with db_session.open_async_transaction() as db:
-        due = await outbound_store.list_due_outbound_messages(db, now=utcnow(), limit=limit)
-        for message in due:
-            await _send_outbound_message(db, message)
-
-
-async def _process_inbound_job(
-    db: AsyncSession,
-    job: SlackInboundEventJobRecord,
-) -> None:
-    event = job.payload_json.get("event")
-    if not isinstance(event, dict):
-        return
-    event_type = _string_or_none(event.get("type"))
-    if event_type == "app_mention":
-        await _handle_app_mention(db, job=job, event=event)
-    elif event_type == "message" and event.get("thread_ts"):
-        await _handle_thread_followup(db, job=job, event=event)
-
-
-async def _handle_app_mention(
-    db: AsyncSession,
-    *,
-    job: SlackInboundEventJobRecord,
-    event: dict[str, object],
-) -> None:
-    connection = await _connection_for_job(db, job)
-    if not _is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
-        return
-    config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
-    require_active_slack_bot(
-        connection=connection,
-        config=config,
-        slack_channel_id=_required_str(event, "channel"),
-    )
-    assert config is not None
-    channel_id = _required_str(event, "channel")
-    message_ts = _required_str(event, "ts")
-    thread_ts = _string_or_none(event.get("thread_ts")) or message_ts
-    existing = await thread_work_store.get_thread_work(
-        db,
-        slack_team_id=connection.slack_team_id,
-        slack_channel_id=channel_id,
-        slack_thread_ts=thread_ts,
-    )
-    if existing is not None:
-        await _enqueue_prompt_for_existing_thread(
-            db,
-            connection=connection,
-            thread_work=existing,
-            prompt_text=parse_slack_mention_text(
-                _string_or_none(event.get("text")) or "",
-                bot_user_id=connection.slack_bot_user_id,
-            ).prompt,
-            slack_user_id=_string_or_none(event.get("user")),
-            source_event_id=job.slack_event_id,
-        )
-        return
-
-    parsed = parse_slack_mention_text(
-        _string_or_none(event.get("text")) or "",
-        bot_user_id=connection.slack_bot_user_id,
-    )
-    repo = await _resolve_repo(
-        db,
-        organization_id=connection.organization_id,
-        config=config,
-        parsed=parsed,
-    )
-    if repo is None:
-        fallback, blocks = configuration_blocks(
-            message=(
-                "I could not tell which repository to use. Set a fixed Slack repo "
-                "or add `--repo owner/name`."
-            ),
-            settings_url=_slack_settings_url(),
-        )
-        await _queue_message(
-            db,
-            connection=connection,
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-            fallback=fallback,
-            blocks=blocks,
-            source=SLACK_OUTBOUND_SOURCE_FAILED,
-            source_event_id=f"{job.slack_event_id}:repo-clarification",
-        )
-        return
-    run_config = await _resolve_run_config(
-        db,
-        organization_id=connection.organization_id,
-        config=config,
-    )
-    if run_config is None:
-        raise CloudApiError(
-            "slack_agent_run_config_missing",
-            "Slack does not have a shared agent run config.",
-            status_code=409,
-        )
-    run_snapshot = run_config_service.snapshot_json(run_config)
-    workspace, anyharness_workspace_id = await _create_and_materialize_workspace(
-        db,
-        organization_id=connection.organization_id,
-        created_by_user_id=connection.installed_by_user_id,
-        repo=repo,
-        prompt=parsed.prompt,
-        agent_kind=run_snapshot["agent_kind"],
-        job_id=job.id,
-    )
-    exposure = await exposures_store.get_active_workspace_exposure(
-        db,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-    )
-    thread_work = await thread_work_store.create_thread_work(
-        db,
-        organization_id=connection.organization_id,
-        slack_team_id=connection.slack_team_id,
-        slack_channel_id=channel_id,
-        slack_thread_ts=thread_ts,
-        cloud_workspace_id=workspace.id,
-        cloud_workspace_exposure_id=exposure.id if exposure else None,
-        root_message_ts=message_ts,
-        initial_repo_id=repo.id,
-        agent_run_config_snapshot_json=run_snapshot,
-    )
-    fallback, blocks = ack_blocks(
-        repo_label=f"{repo.git_owner}/{repo.git_repo_name}",
-        web_url=_workspace_url(workspace.id),
-    )
-    await _queue_message(
-        db,
-        connection=connection,
-        channel_id=channel_id,
-        thread_ts=thread_ts,
-        fallback=fallback,
-        blocks=blocks,
-        source=SLACK_OUTBOUND_SOURCE_ACK,
-        source_event_id=f"{job.slack_event_id}:ack",
-    )
-    start_command = await _enqueue_start_session(
-        db,
-        organization_id=connection.organization_id,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-        anyharness_workspace_id=anyharness_workspace_id,
-        session_id=f"slack-{job.id.hex[:16]}",
-        agent_kind=str(run_snapshot["agent_kind"]),
-        model_id=_string_or_none(run_snapshot.get("model_id")),
-        mode_id=_snapshot_control(run_snapshot, "mode"),
-        slack_user_id=_string_or_none(event.get("user")),
-        idempotency_key=f"{job.slack_event_id}:start",
-    )
-    await db_session.commit_session(db)
-    session_result = parse_start_session_result(
-        await wait_for_command_result(start_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
-    )
-    session_id = session_result.session_id
-    await thread_work_store.update_thread_work_session(
-        db,
-        thread_work_id=thread_work.id,
-        cloud_session_id=session_id,
-    )
-    await _apply_run_config_updates(
-        db,
-        organization_id=connection.organization_id,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-        anyharness_workspace_id=anyharness_workspace_id,
-        session_id=session_id,
-        run_snapshot=run_snapshot,
-        slack_user_id=_string_or_none(event.get("user")),
-        idempotency_key_prefix=job.slack_event_id,
-    )
-    await _enqueue_send_prompt(
-        db,
-        organization_id=connection.organization_id,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-        anyharness_workspace_id=anyharness_workspace_id,
-        session_id=session_id,
-        prompt_text=parsed.prompt,
-        prompt_id=f"slack-event:{job.slack_event_id}",
-        slack_user_id=_string_or_none(event.get("user")),
-        idempotency_key=f"{job.slack_event_id}:prompt",
-    )
-
-
-async def _handle_thread_followup(
-    db: AsyncSession,
-    *,
-    job: SlackInboundEventJobRecord,
-    event: dict[str, object],
-) -> None:
-    connection = await _connection_for_job(db, job)
-    if not _is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
-        return
-    config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
-    require_active_slack_bot(
-        connection=connection,
-        config=config,
-        slack_channel_id=_required_str(event, "channel"),
-    )
-    thread_ts = _required_str(event, "thread_ts")
-    thread_work = await thread_work_store.get_thread_work(
-        db,
-        slack_team_id=connection.slack_team_id,
-        slack_channel_id=_required_str(event, "channel"),
-        slack_thread_ts=thread_ts,
-    )
-    if thread_work is None:
-        return
-    await _enqueue_prompt_for_existing_thread(
-        db,
-        connection=connection,
-        thread_work=thread_work,
-        prompt_text=_string_or_none(event.get("text")) or "",
-        slack_user_id=_string_or_none(event.get("user")),
-        source_event_id=job.slack_event_id,
-    )
-
-
-async def _enqueue_prompt_for_existing_thread(
-    db: AsyncSession,
-    *,
-    connection: SlackWorkspaceConnectionRecord,
-    thread_work: SlackThreadWorkRecord,
-    prompt_text: str,
-    slack_user_id: str | None,
-    source_event_id: str,
-) -> None:
-    if not thread_work.cloud_session_id:
-        raise CloudApiError(
-            "slack_thread_session_pending",
-            "The Slack thread session is not ready yet.",
-            status_code=409,
-        )
-    workspace = await cloud_workspaces.get_cloud_workspace_by_id(
-        db,
-        thread_work.cloud_workspace_id,
-    )
-    if workspace is None or not workspace.target_id:
-        raise CloudApiError(
-            "slack_workspace_missing",
-            "Slack workspace is missing.",
-            status_code=404,
-        )
-    exposure = await exposures_store.get_active_workspace_exposure(
-        db,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-    )
-    if exposure is None or not exposure.anyharness_workspace_id:
-        raise CloudApiError(
-            "slack_workspace_not_ready",
-            "Slack workspace is not ready for prompts.",
-            status_code=409,
-        )
-    if exposure.visibility == "claimed" or exposure.claimed_by_user_id is not None:
-        fallback, blocks = clarification_blocks(
-            message=(
-                "This Slack workspace has been claimed in Proliferate. "
-                "Continue from the claimed Proliferate session."
-            ),
-        )
-        await _queue_message(
-            db,
-            connection=connection,
-            channel_id=thread_work.slack_channel_id,
-            thread_ts=thread_work.slack_thread_ts,
-            fallback=fallback,
-            blocks=blocks,
-            source=SLACK_OUTBOUND_SOURCE_FAILED,
-            source_event_id=f"{source_event_id}:claimed",
-        )
-        return
-    await _enqueue_send_prompt(
-        db,
-        organization_id=connection.organization_id,
-        target_id=workspace.target_id,
-        cloud_workspace_id=workspace.id,
-        anyharness_workspace_id=exposure.anyharness_workspace_id,
-        session_id=thread_work.cloud_session_id,
-        prompt_text=prompt_text,
-        prompt_id=f"slack-event:{source_event_id}",
-        slack_user_id=slack_user_id,
-        idempotency_key=f"{source_event_id}:prompt",
-    )
-
-
-async def _create_and_materialize_workspace(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    created_by_user_id: UUID,
-    repo: repo_store.CloudRepoConfigValue,
-    prompt: str,
-    agent_kind: object,
-    job_id: UUID,
-) -> tuple[cloud_workspaces.CloudWorkspace, str]:
-    profile = await profile_store.ensure_organization_sandbox_profile(
-        db,
-        organization_id=organization_id,
-        created_by_user_id=created_by_user_id,
-    )
-    target = await target_store.ensure_primary_profile_target(
-        db,
-        sandbox_profile_id=profile.id,
-        created_by_user_id=created_by_user_id,
-    )
-    branch_name = _slack_branch_name(prompt=prompt, job_id=job_id)
-    repo_root_path, worktree_path = _workspace_paths(
-        repo=repo,
-        branch_name=branch_name,
-        workspace_root=target.default_workspace_root,
-    )
-    workspace = await cloud_workspaces.create_managed_cloud_workspace_for_profile(
-        db,
-        sandbox_profile_id=profile.id,
-        target_id=target.id,
-        created_by_user_id=created_by_user_id,
-        display_name=f"Slack: {repo.git_owner}/{repo.git_repo_name}",
-        git_provider="github",
-        git_owner=repo.git_owner,
-        git_repo_name=repo.git_repo_name,
-        git_branch=branch_name,
-        git_base_branch=repo.default_branch,
-        worktree_path=worktree_path,
-        origin_json=json.dumps(
-            {
-                "kind": "system",
-                "entrypoint": "slack",
-                "repoId": str(repo.id),
-                "agentKind": str(agent_kind),
-            },
-            separators=(",", ":"),
-            sort_keys=True,
-        ),
-        template_version=get_configured_sandbox_provider().template_version,
-        repo_env_vars_ciphertext=encrypt_json(repo.env_vars) if repo.env_vars else None,
-    )
-    workspace.origin = "slack"
-    workspace.updated_at = utcnow()
-    await db.flush()
-    exposure = await exposures_store.upsert_workspace_exposure(
-        db,
-        target_id=target.id,
-        cloud_workspace_id=workspace.id,
-        anyharness_workspace_id=None,
-        owner_scope="organization",
-        owner_user_id=None,
-        organization_id=organization_id,
-        visibility="shared_unclaimed",
-        claimed_by_user_id=None,
-        default_projection_level="live",
-        commandable=True,
-        status="active",
-        origin="slack",
-    )
-    await publish_worker_control_after_commit(
-        db,
-        target_id=exposure.target_id,
-        reason="exposures",
-    )
-    checkout = await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target.id,
-        cloud_workspace_id=workspace.id,
-        session_id=None,
-        kind=CloudCommandKind.ensure_repo_checkout.value,
-        payload=EnsureRepoCheckoutPayload(
-            provider="github",
-            owner=repo.git_owner,
-            name=repo.git_repo_name,
-            path=repo_root_path,
-            base_branch=repo.default_branch,
-        ).to_json(),
-        idempotency_scope=f"slack-workspace:{workspace.id}",
-        idempotency_key="ensure-repo-checkout",
-        slack_user_id=None,
-    )
-    await db_session.commit_session(db)
-    await wait_for_command_result(checkout, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
-    root_command = await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target.id,
-        cloud_workspace_id=workspace.id,
-        session_id=None,
-        kind=CloudCommandKind.materialize_workspace.value,
-        payload=MaterializeWorkspacePayload(
-            mode="existing_path",
-            path=repo_root_path,
-            display_name=f"{repo.git_owner}/{repo.git_repo_name}",
-            origin={"kind": "system", "entrypoint": "cloud"},
-            creator_context={"kind": "human", "label": "Slack"},
-        ).to_json(),
-        idempotency_scope=f"slack-workspace:{workspace.id}",
-        idempotency_key="materialize-root",
-        slack_user_id=None,
-    )
-    await db_session.commit_session(db)
-    root_result = parse_materialize_workspace_result(
-        await wait_for_command_result(root_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
-    )
-    worktree_command = await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target.id,
-        cloud_workspace_id=workspace.id,
-        session_id=None,
-        kind=CloudCommandKind.materialize_workspace.value,
-        payload=MaterializeWorkspacePayload(
-            mode="worktree",
-            repo_root_id=root_result.repo_root_id,
-            target_path=worktree_path,
-            new_branch_name=branch_name,
-            base_branch=repo.default_branch,
-            origin={"kind": "system", "entrypoint": "cloud"},
-            creator_context={"kind": "human", "label": "Slack"},
-        ).to_json(),
-        idempotency_scope=f"slack-workspace:{workspace.id}",
-        idempotency_key="materialize-worktree",
-        slack_user_id=None,
-    )
-    await db_session.commit_session(db)
-    materialized = parse_materialize_workspace_result(
-        await wait_for_command_result(worktree_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
-    )
-    exposure = await exposures_store.get_active_workspace_exposure(
-        db,
-        target_id=target.id,
-        cloud_workspace_id=workspace.id,
-    )
-    anyharness_workspace_id = (
-        exposure.anyharness_workspace_id
-        if exposure and exposure.anyharness_workspace_id
-        else materialized.anyharness_workspace_id
-    )
-    return workspace, anyharness_workspace_id
-
-
-async def _enqueue_start_session(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    target_id: UUID,
-    cloud_workspace_id: UUID,
-    anyharness_workspace_id: str,
-    session_id: str,
-    agent_kind: str,
-    model_id: str | None,
-    mode_id: str | None,
-    slack_user_id: str | None,
-    idempotency_key: str,
-) -> commands_store.CloudCommandSnapshot:
-    return await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target_id,
-        cloud_workspace_id=cloud_workspace_id,
-        session_id=None,
-        kind=CloudCommandKind.start_session.value,
-        payload=StartSessionPayload(
-            workspace_id=anyharness_workspace_id,
-            agent_kind=agent_kind,
-            model_id=model_id,
-            mode_id=mode_id,
-            origin={"kind": "system", "entrypoint": "cloud"},
-        ).to_json(),
-        idempotency_scope=f"slack-session:{session_id}",
-        idempotency_key=idempotency_key,
-        workspace_id=anyharness_workspace_id,
-        slack_user_id=slack_user_id,
-    )
-
-
-async def _enqueue_send_prompt(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    target_id: UUID,
-    cloud_workspace_id: UUID,
-    anyharness_workspace_id: str,
-    session_id: str,
-    prompt_text: str,
-    prompt_id: str,
-    slack_user_id: str | None,
-    idempotency_key: str,
-) -> commands_store.CloudCommandSnapshot:
-    return await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target_id,
-        cloud_workspace_id=cloud_workspace_id,
-        session_id=session_id,
-        kind=CloudCommandKind.send_prompt.value,
-        payload=SendPromptPayload(text=prompt_text, prompt_id=prompt_id).to_json(),
-        idempotency_scope=f"slack-session:{session_id}",
-        idempotency_key=idempotency_key,
-        workspace_id=anyharness_workspace_id,
-        slack_user_id=slack_user_id,
-    )
-
-
-async def _apply_run_config_updates(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    target_id: UUID,
-    cloud_workspace_id: UUID,
-    anyharness_workspace_id: str,
-    session_id: str,
-    run_snapshot: dict[str, object],
-    slack_user_id: str | None,
-    idempotency_key_prefix: str,
-) -> None:
-    for control_key, value in _snapshot_session_config_updates(run_snapshot):
-        command = await _enqueue_update_session_config(
-            db,
-            organization_id=organization_id,
-            target_id=target_id,
-            cloud_workspace_id=cloud_workspace_id,
-            anyharness_workspace_id=anyharness_workspace_id,
-            session_id=session_id,
-            control_key=control_key,
-            value=value,
-            slack_user_id=slack_user_id,
-            idempotency_key=f"{idempotency_key_prefix}:config:{control_key}",
-        )
-        await db_session.commit_session(db)
-        result = await wait_for_command_result(command, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
-        if _config_apply_state(result.body) != "applied":
-            raise CloudApiError(
-                "slack_agent_config_apply_failed",
-                "Slack could not apply the selected agent configuration.",
-                status_code=502,
-            )
-
-
-async def _enqueue_update_session_config(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    target_id: UUID,
-    cloud_workspace_id: UUID,
-    anyharness_workspace_id: str,
-    session_id: str,
-    control_key: str,
-    value: str,
-    slack_user_id: str | None,
-    idempotency_key: str,
-) -> commands_store.CloudCommandSnapshot:
-    return await _enqueue_command(
-        db,
-        organization_id=organization_id,
-        target_id=target_id,
-        cloud_workspace_id=cloud_workspace_id,
-        session_id=session_id,
-        kind=CloudCommandKind.update_session_config.value,
-        payload={"normalizedControl": control_key, "value": value},
-        idempotency_scope=f"slack-session:{session_id}",
-        idempotency_key=idempotency_key,
-        workspace_id=anyharness_workspace_id,
-        slack_user_id=slack_user_id,
-    )
-
-
-async def _enqueue_command(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    target_id: UUID,
-    cloud_workspace_id: UUID | None,
-    session_id: str | None,
-    kind: str,
-    payload: dict[str, object],
-    idempotency_scope: str,
-    idempotency_key: str,
-    slack_user_id: str | None,
-    workspace_id: str | None = None,
-) -> commands_store.CloudCommandSnapshot:
-    target = await target_store.get_target_by_id(db, target_id)
-    if target is None:
-        raise CloudApiError("cloud_target_not_found", "Cloud target not found.", status_code=404)
-    payload = await stamp_and_validate_command_preflight(
-        db,
-        actor_user_id=_SYSTEM_SLACK_USER_UUID,
-        target_id=target_id,
-        kind=kind,
-        payload=payload,
-    )
-    existing = await commands_store.get_command_by_idempotency(
-        db,
-        idempotency_scope=idempotency_scope,
-        idempotency_key=idempotency_key,
-    )
-    if existing is not None:
-        await kick_off_command_wake_after_commit_if_required(db, target=target, command=existing)
-        return existing
-    command = await commands_store.create_command(
-        db,
-        idempotency_scope=idempotency_scope,
-        idempotency_key=idempotency_key,
-        target_id=target_id,
-        organization_id=organization_id,
-        actor_user_id=None,
-        actor_kind=CloudCommandActorKind.slack.value,
-        source=CloudCommandSource.slack.value,
-        workspace_id=workspace_id,
-        session_id=session_id,
-        cloud_workspace_id=cloud_workspace_id,
-        kind=kind,
-        payload_json=compact_command_json(payload) or "{}",
-        observed_event_seq=None,
-        preconditions_json=None,
-        authorization_context_json=compact_command_json(
-            {
-                "slackUserId": slack_user_id,
-                "organizationId": str(organization_id),
-                "cloudWorkspaceId": str(cloud_workspace_id) if cloud_workspace_id else None,
-            }
-        ),
-    )
-    await kick_off_command_wake_after_commit_if_required(db, target=target, command=command)
-    return command
-
-
-async def _resolve_repo(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    config: SlackBotConfigRecord,
-    parsed: ParsedSlackMention,
-) -> repo_store.CloudRepoConfigValue | None:
-    if config.repo_mode == SLACK_REPO_MODE_FIXED and config.fixed_cloud_repo_config_id:
-        return await _require_org_repo(
-            db,
-            organization_id=organization_id,
-            repo_id=config.fixed_cloud_repo_config_id,
-        )
-    allowed_ids = _uuid_csv(config.allowed_cloud_repo_config_ids)
-    repos = await repo_store.list_organization_cloud_repo_configs(
-        db,
-        organization_id=organization_id,
-    )
-    if allowed_ids:
-        repos = [repo for repo in repos if repo.id in allowed_ids]
-    profiles = {
-        profile.cloud_repo_config_id: profile
-        for profile in await routing_profile_store.list_profiles_for_org(
-            db,
-            organization_id=organization_id,
-        )
-    }
-    candidates = tuple(
-        RepoRoutingCandidate(
-            cloud_repo_config_id=repo.id,
-            git_owner=repo.git_owner,
-            git_repo_name=repo.git_repo_name,
-            display_name=(profiles.get(repo.id).display_name if profiles.get(repo.id) else None),
-            description=(profiles.get(repo.id).description if profiles.get(repo.id) else None),
-            readme_summary=(
-                profiles.get(repo.id).readme_summary if profiles.get(repo.id) else None
-            ),
-            languages=(
-                tuple(profiles.get(repo.id).languages_json or ()) if profiles.get(repo.id) else ()
-            ),
-            topics=(
-                tuple(profiles.get(repo.id).topics_json or ()) if profiles.get(repo.id) else ()
-            ),
-        )
-        for repo in repos
-    )
-    choice = choose_repo(
-        message_text=parsed.prompt,
-        repo_hint=parsed.repo_hint,
-        candidates=candidates,
-    )
-    if choice.cloud_repo_config_id is None:
-        return None
-    return await repo_store.get_cloud_repo_config_by_id(
-        db,
-        cloud_repo_config_id=choice.cloud_repo_config_id,
-    )
-
-
-async def _resolve_run_config(
-    db: AsyncSession,
-    *,
-    organization_id: UUID,
-    config: SlackBotConfigRecord,
-) -> CloudAgentRunConfigRecord | None:
-    if config.default_agent_run_config_id is not None:
-        explicit = await run_config_store.get_config(db, config.default_agent_run_config_id)
-        return _shared_slack_run_config_or_none(explicit, organization_id=organization_id)
-    agent_kind = config.default_agent_kind or "claude"
-    default = await run_config_store.get_default_config(
-        db,
-        owner_scope="organization",
-        owner_user_id=None,
-        organization_id=organization_id,
-        agent_kind=agent_kind,
-    )
-    return _shared_slack_run_config_or_none(default, organization_id=organization_id)
-
-
-def _shared_slack_run_config_or_none(
-    config: CloudAgentRunConfigRecord | None,
-    *,
-    organization_id: UUID,
-) -> CloudAgentRunConfigRecord | None:
-    if config is None:
-        return None
-    issue = validate_config_execution_scope(
-        config,
-        actor_user_id=None,
-        owner_scope="organization",
-        organization_id=organization_id,
-        usable_in="shared_sandboxes",
-    )
-    return None if issue is not None else config
-
-
-async def _connection_for_job(
-    db: AsyncSession,
-    job: SlackInboundEventJobRecord,
-) -> SlackWorkspaceConnectionRecord:
-    if not job.slack_team_id:
-        raise CloudApiError(
-            "slack_team_missing",
-            "Slack event is missing team id.",
-            status_code=400,
-        )
-    connection = await connection_store.get_active_connection_for_team(
-        db,
-        slack_team_id=job.slack_team_id,
-    )
-    if connection is None:
-        raise CloudApiError("slack_not_connected", "Slack is not connected.", status_code=404)
-    return connection
-
-
-async def _queue_job_error(
-    db: AsyncSession,
-    job: SlackInboundEventJobRecord,
-    *,
-    error_code: str,
-    message: str,
-) -> None:
-    if not job.slack_team_id:
-        return
-    connection = await connection_store.get_active_connection_for_team(
-        db,
-        slack_team_id=job.slack_team_id,
-    )
-    if connection is None:
-        return
-    event = job.payload_json.get("event")
-    if not isinstance(event, dict):
-        return
-    channel_id = _string_or_none(event.get("channel"))
-    thread_ts = _string_or_none(event.get("thread_ts")) or _string_or_none(event.get("ts"))
-    if not channel_id or not thread_ts:
-        return
-    if error_code in _SLACK_CONFIGURATION_ERROR_CODES:
-        fallback, blocks = configuration_blocks(
-            message=f"{message} ({error_code})",
-            settings_url=_slack_settings_url(),
-        )
-    else:
-        fallback, blocks = clarification_blocks(message=f"{message} ({error_code})")
-    await _queue_message(
-        db,
-        connection=connection,
-        channel_id=channel_id,
-        thread_ts=thread_ts,
-        fallback=fallback,
-        blocks=blocks,
-        source=SLACK_OUTBOUND_SOURCE_FAILED,
-        source_event_id=f"{job.slack_event_id}:error",
-    )
-
-
-async def _queue_message(
-    db: AsyncSession,
-    *,
-    connection: SlackWorkspaceConnectionRecord,
-    channel_id: str,
-    thread_ts: str | None,
-    fallback: str,
-    blocks: list[dict[str, object]],
-    source: str,
-    source_event_id: str | None,
-) -> None:
-    await outbound_store.enqueue_outbound_message(
-        db,
-        organization_id=connection.organization_id,
-        slack_workspace_connection_id=connection.id,
-        slack_team_id=connection.slack_team_id,
-        slack_channel_id=channel_id,
-        slack_thread_ts=thread_ts,
-        blocks_json=blocks,
-        fallback_text=fallback,
-        source=source,
-        source_event_id=source_event_id,
-    )
-
-
-async def _send_outbound_message(
-    db: AsyncSession,
-    message: SlackOutboundMessageRecord,
-) -> None:
-    sending = await outbound_store.mark_outbound_sending(db, message_id=message.id)
-    if sending is None or sending.status != "sending":
-        return
-    connection = await connection_store.get_connection(db, sending.slack_workspace_connection_id)
-    if connection is None:
-        await outbound_store.mark_outbound_failed(
-            db,
-            message_id=sending.id,
-            error_code="slack_connection_missing",
-            error_message="Slack connection is missing.",
-        )
-        return
-    try:
-        bot_token = await _decrypt_bot_token_or_reauth(db, connection=connection)
-    except CloudApiError as exc:
-        await outbound_store.mark_outbound_failed(
-            db,
-            message_id=sending.id,
-            error_code=exc.code,
-            error_message=exc.message,
-        )
-        return
-    try:
-        result = await slack_client.chat_post_message(
-            bot_token=bot_token,
-            channel_id=sending.slack_channel_id,
-            text=sending.fallback_text,
-            blocks=sending.blocks_json,
-            thread_ts=sending.slack_thread_ts,
-        )
-    except SlackApiError as exc:
-        retry_after = exc.retry_after_seconds
-        attempts = sending.attempts + (0 if retry_after else 1)
-        max_attempts = max(1, settings.slack_outbound_max_attempts)
-        await outbound_store.mark_outbound_retry(
-            db,
-            message_id=sending.id,
-            attempts=attempts,
-            next_attempt_at=utcnow()
-            + timedelta(seconds=retry_after or min(300, 2 ** min(attempts, 8))),
-            error_code=exc.code,
-            error_message=str(exc),
-            dropped=attempts >= max_attempts,
-        )
-        return
-    await outbound_store.mark_outbound_sent(
-        db,
-        message_id=sending.id,
-        sent_message_ts=result.message_ts,
-    )
 
 
 async def _decrypt_bot_token_or_reauth(
@@ -1448,108 +475,6 @@ async def _require_org_repo(
     return repo
 
 
-def _post_session_text(*, event_type: str, event_payload: dict[str, object]) -> str | None:
-    if event_type == "item_completed":
-        item = event_payload.get("item")
-        if isinstance(item, dict) and item.get("kind") == "assistant_message":
-            return _content_text(item)[:3000] or None
-    if event_type == "session_ended":
-        return "Session ended."
-    if event_type == "turn_ended":
-        return None
-    if event_type == "interaction_requested":
-        return "The agent needs input. Reply in this thread to continue."
-    return None
-
-
-def _content_text(item: dict[str, object]) -> str:
-    parts = item.get("contentParts")
-    if not isinstance(parts, list):
-        return ""
-    texts: list[str] = []
-    for part in parts:
-        if (
-            isinstance(part, dict)
-            and part.get("type") == "text"
-            and isinstance(part.get("text"), str)
-        ):
-            texts.append(part["text"])
-    return "".join(texts).strip()
-
-
-def _workspace_url(cloud_workspace_id: UUID | None) -> str | None:
-    if cloud_workspace_id is None or not settings.frontend_base_url:
-        return None
-    return f"{settings.frontend_base_url.rstrip('/')}/cloud/workspaces/{cloud_workspace_id}"
-
-
-def _slack_settings_url() -> str | None:
-    if not settings.frontend_base_url:
-        return None
-    return f"{settings.frontend_base_url.rstrip('/')}/settings?section=slack-bot"
-
-
-def _slack_branch_name(*, prompt: str, job_id: UUID) -> str:
-    config = default_cloud_executor_config()
-    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", prompt.lower()).strip("-._")[
-        : config.max_branch_slug_chars
-    ]
-    slug = slug or "slack"
-    return f"{config.branch_prefix}/{slug}-{job_id.hex[:12]}"
-
-
-def _workspace_paths(
-    *,
-    repo: repo_store.CloudRepoConfigValue,
-    branch_name: str,
-    workspace_root: str | None,
-) -> tuple[str, str]:
-    owner = repo.git_owner.strip().replace("/", "-")
-    name = repo.git_repo_name.strip().replace("/", "-")
-    root = (workspace_root or "/workspace").rstrip("/") or "/workspace"
-    repo_root_path = f"{root}/repos/{owner}/{name}"
-    worktree_path = f"{root}/worktrees/{owner}/{name}/{branch_name.replace('/', '-')}"
-    return repo_root_path, worktree_path
-
-
-def _snapshot_control(snapshot: dict[str, object], key: str) -> str | None:
-    controls = snapshot.get("control_values")
-    if not isinstance(controls, dict):
-        return None
-    return _string_or_none(controls.get(key))
-
-
-def _snapshot_session_config_updates(snapshot: dict[str, object]) -> list[tuple[str, str]]:
-    controls = snapshot.get("control_values")
-    if not isinstance(controls, dict):
-        return []
-    updates: list[tuple[str, str]] = []
-    for key in sorted(controls):
-        if key in {"mode", "model"}:
-            continue
-        value = controls.get(key)
-        if isinstance(value, str) and value.strip():
-            updates.append((key, value))
-    return updates
-
-
-def _config_apply_state(body: dict[str, object]) -> str | None:
-    value = body.get("applyState")
-    return value if isinstance(value, str) and value.strip() else None
-
-
-def _uuid_csv(value: str | None) -> set[UUID]:
-    if not value:
-        return set()
-    result: set[UUID] = set()
-    for item in value.split(","):
-        try:
-            result.add(UUID(item.strip()))
-        except ValueError:
-            continue
-    return result
-
-
 def _required_str(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if isinstance(value, str) and value:
@@ -1559,21 +484,6 @@ def _required_str(payload: dict[str, object], key: str) -> str:
 
 def _string_or_none(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
-
-
-def _is_human_slack_message(
-    event: dict[str, object],
-    *,
-    bot_user_id: str | None,
-) -> bool:
-    if _string_or_none(event.get("subtype")) is not None:
-        return False
-    if _string_or_none(event.get("bot_id")) is not None:
-        return False
-    if _string_or_none(event.get("app_id")) is not None:
-        return False
-    user_id = _string_or_none(event.get("user"))
-    return bool(user_id and user_id != bot_user_id)
 
 
 def _require_oauth_settings() -> None:

--- a/server/proliferate/server/cloud/slack/worker/__init__.py
+++ b/server/proliferate/server/cloud/slack/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Worker entry points for the Cloud Slack bot."""

--- a/server/proliferate/server/cloud/slack/worker/commands.py
+++ b/server/proliferate/server/cloud/slack/worker/commands.py
@@ -1,0 +1,422 @@
+"""Command-launch helpers for deferred Slack bot jobs."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import timedelta
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import (
+    CloudCommandActorKind,
+    CloudCommandKind,
+    CloudCommandSource,
+)
+from proliferate.db import session_ops as db_session
+from proliferate.db.store import cloud_repo_config as repo_store
+from proliferate.db.store import cloud_sandbox_profiles as profile_store
+from proliferate.db.store import cloud_workspaces
+from proliferate.db.store.cloud_sync import commands as commands_store
+from proliferate.db.store.cloud_sync import exposures as exposures_store
+from proliferate.db.store.cloud_sync import targets as target_store
+from proliferate.server.automations.worker.cloud_execution.command_models import (
+    EnsureRepoCheckoutPayload,
+    MaterializeWorkspacePayload,
+    SendPromptPayload,
+    StartSessionPayload,
+)
+from proliferate.server.automations.worker.cloud_execution.commands import (
+    parse_materialize_workspace_result,
+    parse_start_session_result,
+)
+from proliferate.server.automations.worker.cloud_executor_commands import (
+    wait_for_command_result,
+)
+from proliferate.server.automations.worker.cloud_executor_config import (
+    default_cloud_executor_config,
+)
+from proliferate.server.cloud.commands.domain.rules import compact_command_json
+from proliferate.server.cloud.commands.service import (
+    kick_off_command_wake_after_commit_if_required,
+    stamp_and_validate_command_preflight,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.live.service import publish_worker_control_after_commit
+from proliferate.server.cloud.workspaces.service import get_configured_sandbox_provider
+from proliferate.utils.crypto import encrypt_json
+from proliferate.utils.time import utcnow
+
+SYSTEM_SLACK_USER_UUID = UUID("00000000-0000-0000-0000-000000000007")
+SLACK_COMMAND_WAIT_TIMEOUT = timedelta(seconds=240)
+
+
+async def create_and_materialize_workspace(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    created_by_user_id: UUID,
+    repo: repo_store.CloudRepoConfigValue,
+    prompt: str,
+    agent_kind: object,
+    job_id: UUID,
+) -> tuple[cloud_workspaces.CloudWorkspace, str]:
+    profile = await profile_store.ensure_organization_sandbox_profile(
+        db,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+    )
+    target = await target_store.ensure_primary_profile_target(
+        db,
+        sandbox_profile_id=profile.id,
+        created_by_user_id=created_by_user_id,
+    )
+    branch_name = _slack_branch_name(prompt=prompt, job_id=job_id)
+    repo_root_path, worktree_path = _workspace_paths(
+        repo=repo,
+        branch_name=branch_name,
+        workspace_root=target.default_workspace_root,
+    )
+    workspace = await cloud_workspaces.create_managed_cloud_workspace_for_profile(
+        db,
+        sandbox_profile_id=profile.id,
+        target_id=target.id,
+        created_by_user_id=created_by_user_id,
+        display_name=f"Slack: {repo.git_owner}/{repo.git_repo_name}",
+        git_provider="github",
+        git_owner=repo.git_owner,
+        git_repo_name=repo.git_repo_name,
+        git_branch=branch_name,
+        git_base_branch=repo.default_branch,
+        worktree_path=worktree_path,
+        origin_json=json.dumps(
+            {
+                "kind": "system",
+                "entrypoint": "slack",
+                "repoId": str(repo.id),
+                "agentKind": str(agent_kind),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        template_version=get_configured_sandbox_provider().template_version,
+        repo_env_vars_ciphertext=encrypt_json(repo.env_vars) if repo.env_vars else None,
+    )
+    workspace.origin = "slack"
+    workspace.updated_at = utcnow()
+    await db.flush()
+    exposure = await exposures_store.upsert_workspace_exposure(
+        db,
+        target_id=target.id,
+        cloud_workspace_id=workspace.id,
+        anyharness_workspace_id=None,
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id,
+        visibility="shared_unclaimed",
+        claimed_by_user_id=None,
+        default_projection_level="live",
+        commandable=True,
+        status="active",
+        origin="slack",
+    )
+    await publish_worker_control_after_commit(
+        db,
+        target_id=exposure.target_id,
+        reason="exposures",
+    )
+    checkout = await enqueue_command(
+        db,
+        organization_id=organization_id,
+        target_id=target.id,
+        cloud_workspace_id=workspace.id,
+        session_id=None,
+        kind=CloudCommandKind.ensure_repo_checkout.value,
+        payload=EnsureRepoCheckoutPayload(
+            provider="github",
+            owner=repo.git_owner,
+            name=repo.git_repo_name,
+            path=repo_root_path,
+            base_branch=repo.default_branch,
+        ).to_json(),
+        idempotency_scope=f"slack-workspace:{workspace.id}",
+        idempotency_key="ensure-repo-checkout",
+        slack_user_id=None,
+    )
+    await db_session.commit_session(db)
+    await wait_for_command_result(checkout, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
+    root_command = await enqueue_command(
+        db,
+        organization_id=organization_id,
+        target_id=target.id,
+        cloud_workspace_id=workspace.id,
+        session_id=None,
+        kind=CloudCommandKind.materialize_workspace.value,
+        payload=MaterializeWorkspacePayload(
+            mode="existing_path",
+            path=repo_root_path,
+            display_name=f"{repo.git_owner}/{repo.git_repo_name}",
+            origin={"kind": "system", "entrypoint": "cloud"},
+            creator_context={"kind": "human", "label": "Slack"},
+        ).to_json(),
+        idempotency_scope=f"slack-workspace:{workspace.id}",
+        idempotency_key="materialize-root",
+        slack_user_id=None,
+    )
+    await db_session.commit_session(db)
+    root_result = parse_materialize_workspace_result(
+        await wait_for_command_result(root_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
+    )
+    worktree_command = await enqueue_command(
+        db,
+        organization_id=organization_id,
+        target_id=target.id,
+        cloud_workspace_id=workspace.id,
+        session_id=None,
+        kind=CloudCommandKind.materialize_workspace.value,
+        payload=MaterializeWorkspacePayload(
+            mode="worktree",
+            repo_root_id=root_result.repo_root_id,
+            target_path=worktree_path,
+            new_branch_name=branch_name,
+            base_branch=repo.default_branch,
+            origin={"kind": "system", "entrypoint": "cloud"},
+            creator_context={"kind": "human", "label": "Slack"},
+        ).to_json(),
+        idempotency_scope=f"slack-workspace:{workspace.id}",
+        idempotency_key="materialize-worktree",
+        slack_user_id=None,
+    )
+    await db_session.commit_session(db)
+    materialized = parse_materialize_workspace_result(
+        await wait_for_command_result(worktree_command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
+    )
+    exposure = await exposures_store.get_active_workspace_exposure(
+        db,
+        target_id=target.id,
+        cloud_workspace_id=workspace.id,
+    )
+    anyharness_workspace_id = (
+        exposure.anyharness_workspace_id
+        if exposure and exposure.anyharness_workspace_id
+        else materialized.anyharness_workspace_id
+    )
+    return workspace, anyharness_workspace_id
+
+
+async def start_session(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    target_id: UUID,
+    cloud_workspace_id: UUID,
+    anyharness_workspace_id: str,
+    session_id: str,
+    agent_kind: str,
+    model_id: str | None,
+    mode_id: str | None,
+    slack_user_id: str | None,
+    idempotency_key: str,
+) -> str:
+    command = await enqueue_command(
+        db,
+        organization_id=organization_id,
+        target_id=target_id,
+        cloud_workspace_id=cloud_workspace_id,
+        session_id=None,
+        kind=CloudCommandKind.start_session.value,
+        payload=StartSessionPayload(
+            workspace_id=anyharness_workspace_id,
+            agent_kind=agent_kind,
+            model_id=model_id,
+            mode_id=mode_id,
+            origin={"kind": "system", "entrypoint": "cloud"},
+        ).to_json(),
+        idempotency_scope=f"slack-session:{session_id}",
+        idempotency_key=idempotency_key,
+        workspace_id=anyharness_workspace_id,
+        slack_user_id=slack_user_id,
+    )
+    await db_session.commit_session(db)
+    result = parse_start_session_result(
+        await wait_for_command_result(command, timeout=SLACK_COMMAND_WAIT_TIMEOUT),
+    )
+    return result.session_id
+
+
+async def enqueue_send_prompt(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    target_id: UUID,
+    cloud_workspace_id: UUID,
+    anyharness_workspace_id: str,
+    session_id: str,
+    prompt_text: str,
+    prompt_id: str,
+    slack_user_id: str | None,
+    idempotency_key: str,
+) -> commands_store.CloudCommandSnapshot:
+    return await enqueue_command(
+        db,
+        organization_id=organization_id,
+        target_id=target_id,
+        cloud_workspace_id=cloud_workspace_id,
+        session_id=session_id,
+        kind=CloudCommandKind.send_prompt.value,
+        payload=SendPromptPayload(text=prompt_text, prompt_id=prompt_id).to_json(),
+        idempotency_scope=f"slack-session:{session_id}",
+        idempotency_key=idempotency_key,
+        workspace_id=anyharness_workspace_id,
+        slack_user_id=slack_user_id,
+    )
+
+
+async def apply_run_config_updates(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    target_id: UUID,
+    cloud_workspace_id: UUID,
+    anyharness_workspace_id: str,
+    session_id: str,
+    run_snapshot: dict[str, object],
+    slack_user_id: str | None,
+    idempotency_key_prefix: str,
+) -> None:
+    for control_key, value in snapshot_session_config_updates(run_snapshot):
+        command = await enqueue_command(
+            db,
+            organization_id=organization_id,
+            target_id=target_id,
+            cloud_workspace_id=cloud_workspace_id,
+            session_id=session_id,
+            kind=CloudCommandKind.update_session_config.value,
+            payload={"normalizedControl": control_key, "value": value},
+            idempotency_scope=f"slack-session:{session_id}",
+            idempotency_key=f"{idempotency_key_prefix}:config:{control_key}",
+            workspace_id=anyharness_workspace_id,
+            slack_user_id=slack_user_id,
+        )
+        await db_session.commit_session(db)
+        result = await wait_for_command_result(command, timeout=SLACK_COMMAND_WAIT_TIMEOUT)
+        if _config_apply_state(result.body) != "applied":
+            raise CloudApiError(
+                "slack_agent_config_apply_failed",
+                "Slack could not apply the selected agent configuration.",
+                status_code=502,
+            )
+
+
+async def enqueue_command(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    target_id: UUID,
+    cloud_workspace_id: UUID | None,
+    session_id: str | None,
+    kind: str,
+    payload: dict[str, object],
+    idempotency_scope: str,
+    idempotency_key: str,
+    slack_user_id: str | None,
+    workspace_id: str | None = None,
+) -> commands_store.CloudCommandSnapshot:
+    target = await target_store.get_target_by_id(db, target_id)
+    if target is None:
+        raise CloudApiError("cloud_target_not_found", "Cloud target not found.", status_code=404)
+    payload = await stamp_and_validate_command_preflight(
+        db,
+        actor_user_id=SYSTEM_SLACK_USER_UUID,
+        target_id=target_id,
+        kind=kind,
+        payload=payload,
+    )
+    existing = await commands_store.get_command_by_idempotency(
+        db,
+        idempotency_scope=idempotency_scope,
+        idempotency_key=idempotency_key,
+    )
+    if existing is not None:
+        await kick_off_command_wake_after_commit_if_required(db, target=target, command=existing)
+        return existing
+    command = await commands_store.create_command(
+        db,
+        idempotency_scope=idempotency_scope,
+        idempotency_key=idempotency_key,
+        target_id=target_id,
+        organization_id=organization_id,
+        actor_user_id=None,
+        actor_kind=CloudCommandActorKind.slack.value,
+        source=CloudCommandSource.slack.value,
+        workspace_id=workspace_id,
+        session_id=session_id,
+        cloud_workspace_id=cloud_workspace_id,
+        kind=kind,
+        payload_json=compact_command_json(payload) or "{}",
+        observed_event_seq=None,
+        preconditions_json=None,
+        authorization_context_json=compact_command_json(
+            {
+                "slackUserId": slack_user_id,
+                "organizationId": str(organization_id),
+                "cloudWorkspaceId": str(cloud_workspace_id) if cloud_workspace_id else None,
+            }
+        ),
+    )
+    await kick_off_command_wake_after_commit_if_required(db, target=target, command=command)
+    return command
+
+
+def snapshot_control(snapshot: dict[str, object], key: str) -> str | None:
+    controls = snapshot.get("control_values")
+    if not isinstance(controls, dict):
+        return None
+    return _string_or_none(controls.get(key))
+
+
+def snapshot_session_config_updates(snapshot: dict[str, object]) -> list[tuple[str, str]]:
+    controls = snapshot.get("control_values")
+    if not isinstance(controls, dict):
+        return []
+    updates: list[tuple[str, str]] = []
+    for key in sorted(controls):
+        if key in {"mode", "model"}:
+            continue
+        value = controls.get(key)
+        if isinstance(value, str) and value.strip():
+            updates.append((key, value))
+    return updates
+
+
+def _slack_branch_name(*, prompt: str, job_id: UUID) -> str:
+    config = default_cloud_executor_config()
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", prompt.lower()).strip("-._")[
+        : config.max_branch_slug_chars
+    ]
+    slug = slug or "slack"
+    return f"{config.branch_prefix}/{slug}-{job_id.hex[:12]}"
+
+
+def _workspace_paths(
+    *,
+    repo: repo_store.CloudRepoConfigValue,
+    branch_name: str,
+    workspace_root: str | None,
+) -> tuple[str, str]:
+    owner = repo.git_owner.strip().replace("/", "-")
+    name = repo.git_repo_name.strip().replace("/", "-")
+    root = (workspace_root or "/workspace").rstrip("/") or "/workspace"
+    repo_root_path = f"{root}/repos/{owner}/{name}"
+    worktree_path = f"{root}/worktrees/{owner}/{name}/{branch_name.replace('/', '-')}"
+    return repo_root_path, worktree_path
+
+
+def _config_apply_state(body: dict[str, object]) -> str | None:
+    value = body.get("applyState")
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/server/proliferate/server/cloud/slack/worker/events.py
+++ b/server/proliferate/server/cloud/slack/worker/events.py
@@ -43,12 +43,12 @@ from proliferate.server.cloud.slack.domain.message_format import (
     clarification_blocks,
     configuration_blocks,
 )
-from proliferate.server.cloud.slack.domain.policy import SlackBotDenied, check_active_slack_bot
 from proliferate.server.cloud.slack.domain.repo_router import (
     RepoRoutingCandidate,
     choose_repo,
 )
 from proliferate.server.cloud.slack.worker import commands as command_worker
+from proliferate.server.cloud.slack.worker.policy import require_active_slack_bot
 
 SLACK_CONFIGURATION_ERROR_CODES = {
     "slack_agent_run_config_invalid",
@@ -129,7 +129,7 @@ async def _handle_app_mention(
     if not is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
         return
     config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
-    _require_active_slack_bot(
+    require_active_slack_bot(
         connection=connection,
         config=config,
         slack_channel_id=_required_str(event, "channel"),
@@ -292,7 +292,7 @@ async def _handle_thread_followup(
     if not is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
         return
     config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
-    _require_active_slack_bot(
+    require_active_slack_bot(
         connection=connection,
         config=config,
         slack_channel_id=_required_str(event, "channel"),
@@ -544,28 +544,12 @@ async def _require_org_repo(
     return repo
 
 
-def _require_active_slack_bot(
-    *,
-    connection: SlackWorkspaceConnectionRecord | None,
-    config: SlackBotConfigRecord | None,
-    slack_channel_id: str | None = None,
-) -> tuple[SlackWorkspaceConnectionRecord, SlackBotConfigRecord]:
-    verdict = check_active_slack_bot(
-        connection=connection,
-        config=config,
-        slack_channel_id=slack_channel_id,
-    )
-    if isinstance(verdict, SlackBotDenied):
-        raise CloudApiError(verdict.code, verdict.message, status_code=verdict.status_code)
-    assert connection is not None
-    assert config is not None
-    return connection, config
-
-
 def _workspace_url(cloud_workspace_id: UUID | None) -> str | None:
-    if cloud_workspace_id is None or not settings.frontend_base_url:
-        return None
-    return f"{settings.frontend_base_url.rstrip('/')}/cloud/workspaces/{cloud_workspace_id}"
+    return (
+        None
+        if cloud_workspace_id is None or not settings.frontend_base_url
+        else f"{settings.frontend_base_url.rstrip('/')}/cloud/workspaces/{cloud_workspace_id}"
+    )
 
 
 def _slack_settings_url() -> str | None:

--- a/server/proliferate/server/cloud/slack/worker/events.py
+++ b/server/proliferate/server/cloud/slack/worker/events.py
@@ -1,0 +1,597 @@
+"""Inbound Slack event job handling."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.slack import (
+    SLACK_OUTBOUND_SOURCE_ACK,
+    SLACK_OUTBOUND_SOURCE_FAILED,
+    SLACK_REPO_MODE_FIXED,
+)
+from proliferate.db.store import cloud_repo_config as repo_store
+from proliferate.db.store import cloud_workspaces
+from proliferate.db.store.cloud_agent_run_config import configs as run_config_store
+from proliferate.db.store.cloud_agent_run_config.configs import CloudAgentRunConfigRecord
+from proliferate.db.store.cloud_slack import bot_configs as bot_config_store
+from proliferate.db.store.cloud_slack import connections as connection_store
+from proliferate.db.store.cloud_slack import outbound as outbound_store
+from proliferate.db.store.cloud_slack import repo_routing_profiles as routing_profile_store
+from proliferate.db.store.cloud_slack import thread_work as thread_work_store
+from proliferate.db.store.cloud_slack.records import (
+    SlackBotConfigRecord,
+    SlackInboundEventJobRecord,
+    SlackThreadWorkRecord,
+    SlackWorkspaceConnectionRecord,
+)
+from proliferate.db.store.cloud_sync import exposures as exposures_store
+from proliferate.server.cloud.agent_run_config import service as run_config_service
+from proliferate.server.cloud.agent_run_config.domain.resolve import (
+    validate_config_execution_scope,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.slack.domain.mention_parse import (
+    ParsedSlackMention,
+    is_human_slack_message,
+    parse_slack_mention_text,
+)
+from proliferate.server.cloud.slack.domain.message_format import (
+    ack_blocks,
+    clarification_blocks,
+    configuration_blocks,
+)
+from proliferate.server.cloud.slack.domain.policy import SlackBotDenied, check_active_slack_bot
+from proliferate.server.cloud.slack.domain.repo_router import (
+    RepoRoutingCandidate,
+    choose_repo,
+)
+from proliferate.server.cloud.slack.worker import commands as command_worker
+
+SLACK_CONFIGURATION_ERROR_CODES = {
+    "slack_agent_run_config_invalid",
+    "slack_agent_run_config_missing",
+    "slack_bot_config_not_found",
+    "slack_bot_disabled",
+    "slack_channel_not_allowed",
+    "slack_connection_reauth_required",
+    "slack_connection_requires_reauth",
+    "slack_fixed_repo_required",
+    "slack_not_connected",
+    "slack_repo_mode_invalid",
+}
+
+
+async def process_inbound_job(
+    db: AsyncSession,
+    job: SlackInboundEventJobRecord,
+) -> None:
+    event = job.payload_json.get("event")
+    if not isinstance(event, dict):
+        return
+    event_type = _string_or_none(event.get("type"))
+    if event_type == "app_mention":
+        await _handle_app_mention(db, job=job, event=event)
+    elif event_type == "message" and event.get("thread_ts"):
+        await _handle_thread_followup(db, job=job, event=event)
+
+
+async def queue_job_error(
+    db: AsyncSession,
+    job: SlackInboundEventJobRecord,
+    *,
+    error_code: str,
+    message: str,
+) -> None:
+    if not job.slack_team_id:
+        return
+    connection = await connection_store.get_active_connection_for_team(
+        db,
+        slack_team_id=job.slack_team_id,
+    )
+    if connection is None:
+        return
+    event = job.payload_json.get("event")
+    if not isinstance(event, dict):
+        return
+    channel_id = _string_or_none(event.get("channel"))
+    thread_ts = _string_or_none(event.get("thread_ts")) or _string_or_none(event.get("ts"))
+    if not channel_id or not thread_ts:
+        return
+    if error_code in SLACK_CONFIGURATION_ERROR_CODES:
+        fallback, blocks = configuration_blocks(
+            message=f"{message} ({error_code})",
+            settings_url=_slack_settings_url(),
+        )
+    else:
+        fallback, blocks = clarification_blocks(message=f"{message} ({error_code})")
+    await _queue_message(
+        db,
+        connection=connection,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        fallback=fallback,
+        blocks=blocks,
+        source=SLACK_OUTBOUND_SOURCE_FAILED,
+        source_event_id=f"{job.slack_event_id}:error",
+    )
+
+
+async def _handle_app_mention(
+    db: AsyncSession,
+    *,
+    job: SlackInboundEventJobRecord,
+    event: dict[str, object],
+) -> None:
+    connection = await _connection_for_job(db, job)
+    if not is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
+        return
+    config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
+    _require_active_slack_bot(
+        connection=connection,
+        config=config,
+        slack_channel_id=_required_str(event, "channel"),
+    )
+    assert config is not None
+    channel_id = _required_str(event, "channel")
+    message_ts = _required_str(event, "ts")
+    thread_ts = _string_or_none(event.get("thread_ts")) or message_ts
+    existing = await thread_work_store.get_thread_work(
+        db,
+        slack_team_id=connection.slack_team_id,
+        slack_channel_id=channel_id,
+        slack_thread_ts=thread_ts,
+    )
+    if existing is not None:
+        await _enqueue_prompt_for_existing_thread(
+            db,
+            connection=connection,
+            thread_work=existing,
+            prompt_text=parse_slack_mention_text(
+                _string_or_none(event.get("text")) or "",
+                bot_user_id=connection.slack_bot_user_id,
+            ).prompt,
+            slack_user_id=_string_or_none(event.get("user")),
+            source_event_id=job.slack_event_id,
+        )
+        return
+
+    parsed = parse_slack_mention_text(
+        _string_or_none(event.get("text")) or "",
+        bot_user_id=connection.slack_bot_user_id,
+    )
+    repo = await _resolve_repo(
+        db,
+        organization_id=connection.organization_id,
+        config=config,
+        parsed=parsed,
+    )
+    if repo is None:
+        fallback, blocks = configuration_blocks(
+            message=(
+                "I could not tell which repository to use. Set a fixed Slack repo "
+                "or add `--repo owner/name`."
+            ),
+            settings_url=_slack_settings_url(),
+        )
+        await _queue_message(
+            db,
+            connection=connection,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            fallback=fallback,
+            blocks=blocks,
+            source=SLACK_OUTBOUND_SOURCE_FAILED,
+            source_event_id=f"{job.slack_event_id}:repo-clarification",
+        )
+        return
+    run_config = await _resolve_run_config(
+        db,
+        organization_id=connection.organization_id,
+        config=config,
+    )
+    if run_config is None:
+        raise CloudApiError(
+            "slack_agent_run_config_missing",
+            "Slack does not have a shared agent run config.",
+            status_code=409,
+        )
+    run_snapshot = run_config_service.snapshot_json(run_config)
+    workspace, anyharness_workspace_id = await command_worker.create_and_materialize_workspace(
+        db,
+        organization_id=connection.organization_id,
+        created_by_user_id=connection.installed_by_user_id,
+        repo=repo,
+        prompt=parsed.prompt,
+        agent_kind=run_snapshot["agent_kind"],
+        job_id=job.id,
+    )
+    exposure = await exposures_store.get_active_workspace_exposure(
+        db,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+    )
+    thread_work = await thread_work_store.create_thread_work(
+        db,
+        organization_id=connection.organization_id,
+        slack_team_id=connection.slack_team_id,
+        slack_channel_id=channel_id,
+        slack_thread_ts=thread_ts,
+        cloud_workspace_id=workspace.id,
+        cloud_workspace_exposure_id=exposure.id if exposure else None,
+        root_message_ts=message_ts,
+        initial_repo_id=repo.id,
+        agent_run_config_snapshot_json=run_snapshot,
+    )
+    fallback, blocks = ack_blocks(
+        repo_label=f"{repo.git_owner}/{repo.git_repo_name}",
+        web_url=_workspace_url(workspace.id),
+    )
+    await _queue_message(
+        db,
+        connection=connection,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        fallback=fallback,
+        blocks=blocks,
+        source=SLACK_OUTBOUND_SOURCE_ACK,
+        source_event_id=f"{job.slack_event_id}:ack",
+    )
+    session_id = await command_worker.start_session(
+        db,
+        organization_id=connection.organization_id,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        session_id=f"slack-{job.id.hex[:16]}",
+        agent_kind=str(run_snapshot["agent_kind"]),
+        model_id=_string_or_none(run_snapshot.get("model_id")),
+        mode_id=command_worker.snapshot_control(run_snapshot, "mode"),
+        slack_user_id=_string_or_none(event.get("user")),
+        idempotency_key=f"{job.slack_event_id}:start",
+    )
+    await thread_work_store.update_thread_work_session(
+        db,
+        thread_work_id=thread_work.id,
+        cloud_session_id=session_id,
+    )
+    await command_worker.apply_run_config_updates(
+        db,
+        organization_id=connection.organization_id,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        session_id=session_id,
+        run_snapshot=run_snapshot,
+        slack_user_id=_string_or_none(event.get("user")),
+        idempotency_key_prefix=job.slack_event_id,
+    )
+    await command_worker.enqueue_send_prompt(
+        db,
+        organization_id=connection.organization_id,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        session_id=session_id,
+        prompt_text=parsed.prompt,
+        prompt_id=f"slack-event:{job.slack_event_id}",
+        slack_user_id=_string_or_none(event.get("user")),
+        idempotency_key=f"{job.slack_event_id}:prompt",
+    )
+
+
+async def _handle_thread_followup(
+    db: AsyncSession,
+    *,
+    job: SlackInboundEventJobRecord,
+    event: dict[str, object],
+) -> None:
+    connection = await _connection_for_job(db, job)
+    if not is_human_slack_message(event, bot_user_id=connection.slack_bot_user_id):
+        return
+    config = await bot_config_store.get_bot_config(db, organization_id=connection.organization_id)
+    _require_active_slack_bot(
+        connection=connection,
+        config=config,
+        slack_channel_id=_required_str(event, "channel"),
+    )
+    thread_ts = _required_str(event, "thread_ts")
+    thread_work = await thread_work_store.get_thread_work(
+        db,
+        slack_team_id=connection.slack_team_id,
+        slack_channel_id=_required_str(event, "channel"),
+        slack_thread_ts=thread_ts,
+    )
+    if thread_work is None:
+        return
+    await _enqueue_prompt_for_existing_thread(
+        db,
+        connection=connection,
+        thread_work=thread_work,
+        prompt_text=_string_or_none(event.get("text")) or "",
+        slack_user_id=_string_or_none(event.get("user")),
+        source_event_id=job.slack_event_id,
+    )
+
+
+async def _enqueue_prompt_for_existing_thread(
+    db: AsyncSession,
+    *,
+    connection: SlackWorkspaceConnectionRecord,
+    thread_work: SlackThreadWorkRecord,
+    prompt_text: str,
+    slack_user_id: str | None,
+    source_event_id: str,
+) -> None:
+    if not thread_work.cloud_session_id:
+        raise CloudApiError(
+            "slack_thread_session_pending",
+            "The Slack thread session is not ready yet.",
+            status_code=409,
+        )
+    workspace = await cloud_workspaces.get_cloud_workspace_by_id(
+        db,
+        thread_work.cloud_workspace_id,
+    )
+    if workspace is None or not workspace.target_id:
+        raise CloudApiError(
+            "slack_workspace_missing",
+            "Slack workspace is missing.",
+            status_code=404,
+        )
+    exposure = await exposures_store.get_active_workspace_exposure(
+        db,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+    )
+    if exposure is None or not exposure.anyharness_workspace_id:
+        raise CloudApiError(
+            "slack_workspace_not_ready",
+            "Slack workspace is not ready for prompts.",
+            status_code=409,
+        )
+    if exposure.visibility == "claimed" or exposure.claimed_by_user_id is not None:
+        fallback, blocks = clarification_blocks(
+            message=(
+                "This Slack workspace has been claimed in Proliferate. "
+                "Continue from the claimed Proliferate session."
+            ),
+        )
+        await _queue_message(
+            db,
+            connection=connection,
+            channel_id=thread_work.slack_channel_id,
+            thread_ts=thread_work.slack_thread_ts,
+            fallback=fallback,
+            blocks=blocks,
+            source=SLACK_OUTBOUND_SOURCE_FAILED,
+            source_event_id=f"{source_event_id}:claimed",
+        )
+        return
+    await command_worker.enqueue_send_prompt(
+        db,
+        organization_id=connection.organization_id,
+        target_id=workspace.target_id,
+        cloud_workspace_id=workspace.id,
+        anyharness_workspace_id=exposure.anyharness_workspace_id,
+        session_id=thread_work.cloud_session_id,
+        prompt_text=prompt_text,
+        prompt_id=f"slack-event:{source_event_id}",
+        slack_user_id=slack_user_id,
+        idempotency_key=f"{source_event_id}:prompt",
+    )
+
+
+async def _resolve_repo(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    config: SlackBotConfigRecord,
+    parsed: ParsedSlackMention,
+) -> repo_store.CloudRepoConfigValue | None:
+    if config.repo_mode == SLACK_REPO_MODE_FIXED and config.fixed_cloud_repo_config_id:
+        return await _require_org_repo(
+            db,
+            organization_id=organization_id,
+            repo_id=config.fixed_cloud_repo_config_id,
+        )
+    allowed_ids = _uuid_csv(config.allowed_cloud_repo_config_ids)
+    repos = await repo_store.list_organization_cloud_repo_configs(
+        db,
+        organization_id=organization_id,
+    )
+    if allowed_ids:
+        repos = [repo for repo in repos if repo.id in allowed_ids]
+    profiles = {
+        profile.cloud_repo_config_id: profile
+        for profile in await routing_profile_store.list_profiles_for_org(
+            db,
+            organization_id=organization_id,
+        )
+    }
+    candidates = tuple(
+        RepoRoutingCandidate(
+            cloud_repo_config_id=repo.id,
+            git_owner=repo.git_owner,
+            git_repo_name=repo.git_repo_name,
+            display_name=(profiles.get(repo.id).display_name if profiles.get(repo.id) else None),
+            description=(profiles.get(repo.id).description if profiles.get(repo.id) else None),
+            readme_summary=(
+                profiles.get(repo.id).readme_summary if profiles.get(repo.id) else None
+            ),
+            languages=(
+                tuple(profiles.get(repo.id).languages_json or ()) if profiles.get(repo.id) else ()
+            ),
+            topics=(
+                tuple(profiles.get(repo.id).topics_json or ()) if profiles.get(repo.id) else ()
+            ),
+        )
+        for repo in repos
+    )
+    choice = choose_repo(
+        message_text=parsed.prompt,
+        repo_hint=parsed.repo_hint,
+        candidates=candidates,
+    )
+    if choice.cloud_repo_config_id is None:
+        return None
+    return await repo_store.get_cloud_repo_config_by_id(
+        db,
+        cloud_repo_config_id=choice.cloud_repo_config_id,
+    )
+
+
+async def _resolve_run_config(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    config: SlackBotConfigRecord,
+) -> CloudAgentRunConfigRecord | None:
+    if config.default_agent_run_config_id is not None:
+        explicit = await run_config_store.get_config(db, config.default_agent_run_config_id)
+        return _shared_slack_run_config_or_none(explicit, organization_id=organization_id)
+    agent_kind = config.default_agent_kind or "claude"
+    default = await run_config_store.get_default_config(
+        db,
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id,
+        agent_kind=agent_kind,
+    )
+    return _shared_slack_run_config_or_none(default, organization_id=organization_id)
+
+
+def _shared_slack_run_config_or_none(
+    config: CloudAgentRunConfigRecord | None,
+    *,
+    organization_id: UUID,
+) -> CloudAgentRunConfigRecord | None:
+    if config is None:
+        return None
+    issue = validate_config_execution_scope(
+        config,
+        actor_user_id=None,
+        owner_scope="organization",
+        organization_id=organization_id,
+        usable_in="shared_sandboxes",
+    )
+    return None if issue is not None else config
+
+
+async def _connection_for_job(
+    db: AsyncSession,
+    job: SlackInboundEventJobRecord,
+) -> SlackWorkspaceConnectionRecord:
+    if not job.slack_team_id:
+        raise CloudApiError(
+            "slack_team_missing",
+            "Slack event is missing team id.",
+            status_code=400,
+        )
+    connection = await connection_store.get_active_connection_for_team(
+        db,
+        slack_team_id=job.slack_team_id,
+    )
+    if connection is None:
+        raise CloudApiError("slack_not_connected", "Slack is not connected.", status_code=404)
+    return connection
+
+
+async def _queue_message(
+    db: AsyncSession,
+    *,
+    connection: SlackWorkspaceConnectionRecord,
+    channel_id: str,
+    thread_ts: str | None,
+    fallback: str,
+    blocks: list[dict[str, object]],
+    source: str,
+    source_event_id: str | None,
+) -> None:
+    await outbound_store.enqueue_outbound_message(
+        db,
+        organization_id=connection.organization_id,
+        slack_workspace_connection_id=connection.id,
+        slack_team_id=connection.slack_team_id,
+        slack_channel_id=channel_id,
+        slack_thread_ts=thread_ts,
+        blocks_json=blocks,
+        fallback_text=fallback,
+        source=source,
+        source_event_id=source_event_id,
+    )
+
+
+async def _require_org_repo(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    repo_id: UUID,
+) -> repo_store.CloudRepoConfigValue:
+    repo = await repo_store.get_cloud_repo_config_by_id(db, cloud_repo_config_id=repo_id)
+    if (
+        repo is None
+        or repo.owner_scope != "organization"
+        or repo.organization_id != organization_id
+    ):
+        raise CloudApiError(
+            "cloud_repo_not_found",
+            "Cloud repo config not found.",
+            status_code=404,
+        )
+    return repo
+
+
+def _require_active_slack_bot(
+    *,
+    connection: SlackWorkspaceConnectionRecord | None,
+    config: SlackBotConfigRecord | None,
+    slack_channel_id: str | None = None,
+) -> tuple[SlackWorkspaceConnectionRecord, SlackBotConfigRecord]:
+    verdict = check_active_slack_bot(
+        connection=connection,
+        config=config,
+        slack_channel_id=slack_channel_id,
+    )
+    if isinstance(verdict, SlackBotDenied):
+        raise CloudApiError(verdict.code, verdict.message, status_code=verdict.status_code)
+    assert connection is not None
+    assert config is not None
+    return connection, config
+
+
+def _workspace_url(cloud_workspace_id: UUID | None) -> str | None:
+    if cloud_workspace_id is None or not settings.frontend_base_url:
+        return None
+    return f"{settings.frontend_base_url.rstrip('/')}/cloud/workspaces/{cloud_workspace_id}"
+
+
+def _slack_settings_url() -> str | None:
+    if not settings.frontend_base_url:
+        return None
+    return f"{settings.frontend_base_url.rstrip('/')}/settings?section=slack-bot"
+
+
+def _uuid_csv(value: str | None) -> set[UUID]:
+    if not value:
+        return set()
+    result: set[UUID] = set()
+    for item in value.split(","):
+        try:
+            result.add(UUID(item.strip()))
+        except ValueError:
+            continue
+    return result
+
+
+def _required_str(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if isinstance(value, str) and value:
+        return value
+    raise CloudApiError("slack_event_invalid", f"Slack event is missing {key}.", status_code=400)
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/server/proliferate/server/cloud/slack/worker/main.py
+++ b/server/proliferate/server/cloud/slack/worker/main.py
@@ -1,0 +1,61 @@
+"""Transaction entry points for deferred Cloud Slack bot work."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import session_ops as db_session
+from proliferate.db.store.cloud_slack import events as slack_event_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.slack.worker import events, outbound
+
+
+def defer_inbound_job_after_commit(db: AsyncSession, job_id: UUID) -> None:
+    db_session.defer_after_commit(
+        db,
+        lambda job_id=job_id: process_inbound_job_and_due_outbound(job_id),
+    )
+
+
+async def process_inbound_job_and_due_outbound(job_id: UUID) -> None:
+    await process_inbound_job_by_id(job_id)
+    await process_due_outbound_messages()
+
+
+async def process_inbound_job_by_id(job_id: UUID) -> None:
+    async with db_session.open_async_session() as db:
+        async with db.begin():
+            job = await slack_event_store.mark_job_processing(db, job_id)
+        if job is None:
+            return
+        try:
+            await events.process_inbound_job(db, job)
+            await slack_event_store.mark_job_completed(db, job.id)
+            await db_session.commit_session(db)
+        except CloudApiError as exc:
+            await db_session.rollback_session(db)
+            await events.queue_job_error(db, job, error_code=exc.code, message=exc.message)
+            await slack_event_store.mark_job_failed(
+                db,
+                job.id,
+                error_code=exc.code,
+                error_message=exc.message,
+            )
+            await db_session.commit_session(db)
+        except Exception as exc:
+            await db_session.rollback_session(db)
+            await events.queue_job_error(db, job, error_code="slack_job_failed", message=str(exc))
+            await slack_event_store.mark_job_failed(
+                db,
+                job.id,
+                error_code="slack_job_failed",
+                error_message=str(exc),
+            )
+            await db_session.commit_session(db)
+
+
+async def process_due_outbound_messages(*, limit: int = 20) -> None:
+    async with db_session.open_async_transaction() as db:
+        await outbound.process_due_outbound_messages(db, limit=limit)

--- a/server/proliferate/server/cloud/slack/worker/outbound.py
+++ b/server/proliferate/server/cloud/slack/worker/outbound.py
@@ -1,0 +1,99 @@
+"""Outbound Slack message processing."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from cryptography.fernet import InvalidToken
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.store.cloud_slack import connections as connection_store
+from proliferate.db.store.cloud_slack import outbound as outbound_store
+from proliferate.db.store.cloud_slack.records import (
+    SlackOutboundMessageRecord,
+    SlackWorkspaceConnectionRecord,
+)
+from proliferate.integrations.slack import client as slack_client
+from proliferate.integrations.slack.errors import SlackApiError
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.utils.crypto import decrypt_text
+from proliferate.utils.time import utcnow
+
+
+async def process_due_outbound_messages(db: AsyncSession, *, limit: int) -> None:
+    due = await outbound_store.list_due_outbound_messages(db, now=utcnow(), limit=limit)
+    for message in due:
+        await send_outbound_message(db, message)
+
+
+async def send_outbound_message(
+    db: AsyncSession,
+    message: SlackOutboundMessageRecord,
+) -> None:
+    sending = await outbound_store.mark_outbound_sending(db, message_id=message.id)
+    if sending is None or sending.status != "sending":
+        return
+    connection = await connection_store.get_connection(db, sending.slack_workspace_connection_id)
+    if connection is None:
+        await outbound_store.mark_outbound_failed(
+            db,
+            message_id=sending.id,
+            error_code="slack_connection_missing",
+            error_message="Slack connection is missing.",
+        )
+        return
+    try:
+        bot_token = await _decrypt_bot_token_or_reauth(db, connection=connection)
+    except CloudApiError as exc:
+        await outbound_store.mark_outbound_failed(
+            db,
+            message_id=sending.id,
+            error_code=exc.code,
+            error_message=exc.message,
+        )
+        return
+    try:
+        result = await slack_client.chat_post_message(
+            bot_token=bot_token,
+            channel_id=sending.slack_channel_id,
+            text=sending.fallback_text,
+            blocks=sending.blocks_json,
+            thread_ts=sending.slack_thread_ts,
+        )
+    except SlackApiError as exc:
+        retry_after = exc.retry_after_seconds
+        attempts = sending.attempts + (0 if retry_after else 1)
+        max_attempts = max(1, settings.slack_outbound_max_attempts)
+        await outbound_store.mark_outbound_retry(
+            db,
+            message_id=sending.id,
+            attempts=attempts,
+            next_attempt_at=utcnow()
+            + timedelta(seconds=retry_after or min(300, 2 ** min(attempts, 8))),
+            error_code=exc.code,
+            error_message=str(exc),
+            dropped=attempts >= max_attempts,
+        )
+        return
+    await outbound_store.mark_outbound_sent(
+        db,
+        message_id=sending.id,
+        sent_message_ts=result.message_ts,
+    )
+
+
+async def _decrypt_bot_token_or_reauth(
+    db: AsyncSession,
+    *,
+    connection: SlackWorkspaceConnectionRecord,
+) -> str:
+    try:
+        return decrypt_text(connection.bot_token_ciphertext)
+    except InvalidToken as exc:
+        await connection_store.mark_connection_reauth_required(db, connection_id=connection.id)
+        raise CloudApiError(
+            "slack_connection_reauth_required",
+            "Slack must be reconnected before the bot can be used.",
+            status_code=409,
+        ) from exc

--- a/server/proliferate/server/cloud/slack/worker/policy.py
+++ b/server/proliferate/server/cloud/slack/worker/policy.py
@@ -1,0 +1,40 @@
+"""Worker-side adapters for pure Slack bot policy verdicts."""
+
+from __future__ import annotations
+
+from proliferate.db.store.cloud_slack.records import (
+    SlackBotConfigRecord,
+    SlackWorkspaceConnectionRecord,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.slack.domain.policy import SlackBotDenied, check_active_slack_bot
+
+
+def require_active_slack_bot(
+    *,
+    connection: SlackWorkspaceConnectionRecord | None,
+    config: SlackBotConfigRecord | None,
+    slack_channel_id: str | None = None,
+) -> tuple[SlackWorkspaceConnectionRecord, SlackBotConfigRecord]:
+    verdict = check_active_slack_bot(
+        connection=connection,
+        config=config,
+        slack_channel_id=slack_channel_id,
+    )
+    if isinstance(verdict, SlackBotDenied):
+        raise CloudApiError(
+            verdict.code,
+            verdict.message,
+            status_code=_policy_status_code(verdict.code),
+        )
+    assert connection is not None
+    assert config is not None
+    return connection, config
+
+
+def _policy_status_code(code: str) -> int:
+    if code == "slack_channel_not_allowed":
+        return 403
+    if code == "slack_not_connected":
+        return 404
+    return 409

--- a/server/proliferate/server/cloud/slack/worker/post_session.py
+++ b/server/proliferate/server/cloud/slack/worker/post_session.py
@@ -1,0 +1,93 @@
+"""Post-session Slack notification hooks."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.slack import (
+    SLACK_OUTBOUND_SOURCE_TURN,
+    SLACK_THREAD_WORK_STATUS_ACTIVE,
+)
+from proliferate.db.store.cloud_slack import connections as connection_store
+from proliferate.db.store.cloud_slack import outbound as outbound_store
+from proliferate.db.store.cloud_slack import thread_work as thread_work_store
+from proliferate.server.cloud.slack.domain.message_format import completion_blocks
+
+
+async def enqueue_post_session_event(
+    db: AsyncSession,
+    *,
+    cloud_workspace_id: UUID | None,
+    session_id: str,
+    event_type: str,
+    event_payload: dict[str, object],
+    seq: int,
+) -> None:
+    if cloud_workspace_id is None:
+        return
+    thread_work = await thread_work_store.get_thread_work_by_workspace(
+        db,
+        cloud_workspace_id=cloud_workspace_id,
+    )
+    if thread_work is None or thread_work.status != SLACK_THREAD_WORK_STATUS_ACTIVE:
+        return
+    connection = await connection_store.get_active_connection_for_org(
+        db,
+        organization_id=thread_work.organization_id,
+    )
+    if connection is None:
+        return
+    text = _post_session_text(event_type=event_type, event_payload=event_payload)
+    if not text:
+        return
+    fallback, blocks = completion_blocks(message=text, web_url=_workspace_url(cloud_workspace_id))
+    await outbound_store.enqueue_outbound_message(
+        db,
+        organization_id=thread_work.organization_id,
+        slack_workspace_connection_id=connection.id,
+        slack_team_id=thread_work.slack_team_id,
+        slack_channel_id=thread_work.slack_channel_id,
+        slack_thread_ts=thread_work.slack_thread_ts,
+        blocks_json=blocks,
+        fallback_text=fallback,
+        source=SLACK_OUTBOUND_SOURCE_TURN,
+        source_event_id=f"cloud-session:{session_id}:{seq}:{event_type}",
+    )
+
+
+def _post_session_text(*, event_type: str, event_payload: dict[str, object]) -> str | None:
+    if event_type == "item_completed":
+        item = event_payload.get("item")
+        if isinstance(item, dict) and item.get("kind") == "assistant_message":
+            return _content_text(item)[:3000] or None
+    if event_type == "session_ended":
+        return "Session ended."
+    if event_type == "turn_ended":
+        return None
+    if event_type == "interaction_requested":
+        return "The agent needs input. Reply in this thread to continue."
+    return None
+
+
+def _content_text(item: dict[str, object]) -> str:
+    parts = item.get("contentParts")
+    if not isinstance(parts, list):
+        return ""
+    texts: list[str] = []
+    for part in parts:
+        if (
+            isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+        ):
+            texts.append(part["text"])
+    return "".join(texts).strip()
+
+
+def _workspace_url(cloud_workspace_id: UUID | None) -> str | None:
+    if cloud_workspace_id is None or not settings.frontend_base_url:
+        return None
+    return f"{settings.frontend_base_url.rstrip('/')}/cloud/workspaces/{cloud_workspace_id}"

--- a/server/tests/unit/test_slack_bot_service.py
+++ b/server/tests/unit/test_slack_bot_service.py
@@ -13,6 +13,7 @@ from proliferate.db.store.cloud_slack.records import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.slack import service
+from proliferate.server.cloud.slack.worker import outbound
 
 
 def _connection() -> SlackWorkspaceConnectionRecord:
@@ -166,13 +167,13 @@ async def test_outbound_send_marks_failed_when_connection_needs_reauth(
     async def fail_chat_post(*args: object, **kwargs: object) -> None:
         raise AssertionError("Slack post should not run with an undecryptable token")
 
-    monkeypatch.setattr(service.outbound_store, "mark_outbound_sending", mark_sending)
-    monkeypatch.setattr(service.connection_store, "get_connection", get_connection)
-    monkeypatch.setattr(service.connection_store, "mark_connection_reauth_required", mark_reauth)
-    monkeypatch.setattr(service.outbound_store, "mark_outbound_failed", mark_failed)
-    monkeypatch.setattr(service.slack_client, "chat_post_message", fail_chat_post)
+    monkeypatch.setattr(outbound.outbound_store, "mark_outbound_sending", mark_sending)
+    monkeypatch.setattr(outbound.connection_store, "get_connection", get_connection)
+    monkeypatch.setattr(outbound.connection_store, "mark_connection_reauth_required", mark_reauth)
+    monkeypatch.setattr(outbound.outbound_store, "mark_outbound_failed", mark_failed)
+    monkeypatch.setattr(outbound.slack_client, "chat_post_message", fail_chat_post)
 
-    await service._send_outbound_message(None, message)  # type: ignore[arg-type]
+    await outbound.send_outbound_message(None, message)  # type: ignore[arg-type]
 
     assert marked_reauth == [connection.id]
     assert failed["message_id"] == message.id


### PR DESCRIPTION
## Summary
- make Slack API/service layers thinner and move deferred Slack work into explicit worker owners
- keep Slack policy/mention parsing in domain code and reduce Slack boundary debt
- update Slack focused tests for the split

## Verification
- python3 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check origin/main...HEAD
- DEBUG=1 uv run pytest -q requested Lane 8 Slack/cloud API focused suite