### PR TITLE
refactor(server): split command and worker transactions

### DIFF
--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -57,6 +57,12 @@ AGENT_AUTH_SERVICE_CONCERN_EXCLUDED_FILES = {
     "models.py",
     "reconciler.py",
 }
+SERVICE_BOUNDARY_DEBT_MODULES = {
+    "server/proliferate/server/cloud/commands/agent_auth_refresh.py",
+    "server/proliferate/server/cloud/commands/transactions.py",
+    "server/proliferate/server/cloud/commands/wake.py",
+    "server/proliferate/server/cloud/worker/transactions.py",
+}
 
 
 @dataclass(frozen=True)
@@ -88,6 +94,7 @@ class AllowlistEntry:
 class SourceKind:
     is_api: bool = False
     is_service: bool = False
+    is_service_boundary_debt: bool = False
     is_domain: bool = False
     is_product_models: bool = False
     is_store: bool = False
@@ -155,6 +162,7 @@ def classify_path(path: Path) -> SourceKind:
     is_orm_model = _starts_with(parts, ("server", "proliferate", "db", "models"))
     is_integration = _starts_with(parts, ("server", "proliferate", "integrations"))
     name = path.name
+    relative = relative_path(path)
     is_agent_auth_service_concern = (
         _starts_with(
             parts,
@@ -170,6 +178,7 @@ def classify_path(path: Path) -> SourceKind:
         is_service=(
             is_product and (name == "service.py" or is_agent_auth_service_concern)
         ),
+        is_service_boundary_debt=relative in SERVICE_BOUNDARY_DEBT_MODULES,
         is_domain=is_product and "domain" in path.parts,
         is_product_models=is_product and name == "models.py",
         is_store=is_store,
@@ -283,7 +292,7 @@ class BoundaryChecker(ast.NodeVisitor):
     ) -> None:
         if self.kind.is_api:
             self._check_api_import(node, module, names)
-        if self.kind.is_service:
+        if self.kind.is_service or self.kind.is_service_boundary_debt:
             self._check_service_import(node, module, names)
         if self.kind.is_domain:
             self._check_domain_import(node, module, names)
@@ -513,7 +522,7 @@ class BoundaryChecker(ast.NodeVisitor):
                     f"api.py must not call session method .{func.attr}()",
                 )
             if (
-                self.kind.is_service
+                (self.kind.is_service or self.kind.is_service_boundary_debt)
                 and func.attr in SERVICE_DB_METHODS
                 and looks_like_db_handle(func.value)
             ):
@@ -523,7 +532,7 @@ class BoundaryChecker(ast.NodeVisitor):
                     f"service.py must not call session method .{func.attr}()",
                 )
             if (
-                self.kind.is_service
+                (self.kind.is_service or self.kind.is_service_boundary_debt)
                 and func.attr in SERVICE_DB_SESSION_OPS_METHODS
                 and isinstance(func.value, ast.Name)
                 and func.value.id in {"db_session", "session_ops"}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -43,14 +43,14 @@ server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration
 server/proliferate/db/store/cloud_workspaces.py 1639 server structure migration debt for oversized store file
 server/proliferate/server/billing/service.py 2459 server structure migration debt for oversized service file during billing orchestration consolidation
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
-server/proliferate/server/cloud/commands/service.py 1741 server structure migration debt for oversized service file
+server/proliferate/server/cloud/commands/service.py 1708 server structure migration debt for oversized service file
 server/proliferate/server/cloud/mobility/service.py 1208 server structure migration debt for oversized service file
 server/proliferate/server/cloud/runtime/bootstrap.py 922 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime/provision.py 1715 server structure migration debt for oversized domain-adjacent file
 server/proliferate/server/cloud/runtime_config/domain/resolver.py 611 server structure migration debt for oversized pure-domain file
 server/proliferate/server/cloud/runtime_config/service.py 1094 server structure migration debt for oversized service file
 server/proliferate/server/cloud/slack/service.py 1591 server structure migration debt for oversized service file
-server/proliferate/server/cloud/worker/service.py 1437 server structure migration debt for oversized service file
+server/proliferate/server/cloud/worker/service.py 1434 server structure migration debt for oversized service file
 server/proliferate/server/cloud/workspaces/models.py 934 server structure migration debt for oversized API models file
 server/proliferate/server/cloud/workspaces/service.py 2643 server structure migration debt for oversized service file
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -21,10 +21,9 @@ SERVICE_DB_ENGINE_IMPORT server/proliferate/server/billing/service.py 1 remainin
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/managed_credits.py 1 remaining agent-auth service concern managed-credit sync session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/refresh.py 1 remaining agent-auth service concern refresh wake/error session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/session_loader.py 1 remaining agent-auth service concern read-loader session boundary debt through db engine
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 remaining service-owned command transaction boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 remaining command idempotency integrity check still imports session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 remaining service-owned live event session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/slack/service.py 1 remaining service-owned Slack deferred transaction boundary debt through session_ops
-SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/worker/service.py 1 remaining service-owned worker transaction boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 remaining service-owned workspace lifecycle session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/billing/service.py 34 remaining billing service-owned transaction/session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/managed_credits.py 2 remaining agent-auth service concern managed-credit sync session boundary debt through session_ops
@@ -32,7 +31,6 @@ SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/refresh.py 2 r
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/service.py 4 remaining command service-owned transaction/session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/live/service.py 4 remaining live service-owned session/deferred boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 13 remaining Slack service-owned transaction/session boundary debt through session_ops
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/service.py 2 remaining worker service-owned transaction boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 36 remaining workspace service-owned lifecycle transaction/session boundary debt through session_ops
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/slack/domain/policy.py 1 transitional Slack policy imports product constants

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -21,16 +21,23 @@ SERVICE_DB_ENGINE_IMPORT server/proliferate/server/billing/service.py 1 remainin
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/managed_credits.py 1 remaining agent-auth service concern managed-credit sync session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/refresh.py 1 remaining agent-auth service concern refresh wake/error session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/agent_auth/session_loader.py 1 remaining agent-auth service concern read-loader session boundary debt through db engine
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/agent_auth_refresh.py 1 Lane 7 explicit transaction-boundary debt for best-effort preflight refresh
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/service.py 1 remaining command idempotency integrity check still imports session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/transactions.py 1 Lane 7 explicit API-facing command commit boundary debt
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/commands/wake.py 1 Lane 7 explicit after-commit command wake boundary debt
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/live/service.py 1 remaining service-owned live event session boundary debt through session_ops
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/slack/service.py 1 remaining service-owned Slack deferred transaction boundary debt through session_ops
+SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/worker/transactions.py 1 Lane 7 explicit worker API pre-response commit boundary debt
 SERVICE_DB_ENGINE_IMPORT server/proliferate/server/cloud/workspaces/service.py 1 remaining service-owned workspace lifecycle session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/billing/service.py 34 remaining billing service-owned transaction/session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/managed_credits.py 2 remaining agent-auth service concern managed-credit sync session boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/agent_auth/refresh.py 2 remaining agent-auth service concern refresh wake/error session boundary debt through session_ops
-SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/service.py 4 remaining command service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/agent_auth_refresh.py 1 Lane 7 explicit transaction-boundary debt for best-effort preflight refresh
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/transactions.py 1 Lane 7 explicit API-facing command commit boundary debt
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/commands/wake.py 1 Lane 7 explicit after-commit command wake boundary debt
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/live/service.py 4 remaining live service-owned session/deferred boundary debt through session_ops
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/slack/service.py 13 remaining Slack service-owned transaction/session boundary debt through session_ops
+SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/worker/transactions.py 2 Lane 7 explicit worker API pre-response commit boundary debt
 SERVICE_DB_METHOD_CALL server/proliferate/server/cloud/workspaces/service.py 36 remaining workspace service-owned lifecycle transaction/session boundary debt through session_ops
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/slack/domain/policy.py 1 transitional Slack policy imports product constants

--- a/server/proliferate/server/cloud/commands/agent_auth_refresh.py
+++ b/server/proliferate/server/cloud/commands/agent_auth_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from proliferate.db import session_ops as db_session
@@ -34,5 +35,5 @@ async def queue_agent_auth_refresh_for_not_ready_preflight(
             sandbox_profile_id=sandbox_profile_id,
             actor_user_id=actor_user_id,
             error_type=exc.__class__.__name__,
-            level="warning",
+            level=logging.WARNING,
         )

--- a/server/proliferate/server/cloud/commands/agent_auth_refresh.py
+++ b/server/proliferate/server/cloud/commands/agent_auth_refresh.py
@@ -1,0 +1,38 @@
+"""Command-triggered agent-auth refresh transaction helpers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from proliferate.db import session_ops as db_session
+from proliferate.server.cloud._logging import log_cloud_event
+from proliferate.server.cloud.agent_auth.service import (
+    request_agent_auth_refresh_for_profile_target,
+)
+
+
+async def queue_agent_auth_refresh_for_not_ready_preflight(
+    *,
+    sandbox_profile_id: UUID,
+    target_id: UUID,
+    actor_user_id: UUID,
+) -> None:
+    try:
+        async with db_session.open_async_transaction() as refresh_db:
+            await request_agent_auth_refresh_for_profile_target(
+                refresh_db,
+                sandbox_profile_id=sandbox_profile_id,
+                target_id=target_id,
+                actor_user_id=actor_user_id,
+                reason="command_preflight",
+                force_restart=False,
+            )
+    except Exception as exc:
+        log_cloud_event(
+            "cloud command preflight agent auth refresh request failed",
+            target_id=target_id,
+            sandbox_profile_id=sandbox_profile_id,
+            actor_user_id=actor_user_id,
+            error_type=exc.__class__.__name__,
+            level="warning",
+        )

--- a/server/proliferate/server/cloud/commands/api.py
+++ b/server/proliferate/server/cloud/commands/api.py
@@ -16,10 +16,8 @@ from proliferate.server.cloud.commands.models import (
     CreateCloudCommandRequest,
     command_response_payload,
 )
-from proliferate.server.cloud.commands.service import (
-    enqueue_command_and_commit,
-    get_command_status,
-)
+from proliferate.server.cloud.commands.service import get_command_status
+from proliferate.server.cloud.commands.transactions import enqueue_command_and_commit
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 
 router = APIRouter(prefix="/commands", tags=["cloud-commands"])

--- a/server/proliferate/server/cloud/commands/service.py
+++ b/server/proliferate/server/cloud/commands/service.py
@@ -17,7 +17,7 @@ from proliferate.constants.cloud import (
     CloudTargetStatus,
     CloudWorkspaceStatus,
 )
-from proliferate.db import session_ops as db_session
+from proliferate.db.session_ops import is_integrity_error
 from proliferate.db.store import cloud_runtime_environments, cloud_sandboxes, cloud_workspaces
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_profile_target_guard import managed_profile_target_requires_slot
@@ -28,10 +28,10 @@ from proliferate.db.store.cloud_sync import exposures as exposures_store
 from proliferate.db.store.cloud_sync import target_config as target_config_store
 from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.server.cloud._logging import log_cloud_event
-from proliferate.server.cloud.agent_auth.service import (
-    request_agent_auth_refresh_for_profile_target,
-)
 from proliferate.server.cloud.claims.access import require_workspace_interact
+from proliferate.server.cloud.commands.agent_auth_refresh import (
+    queue_agent_auth_refresh_for_not_ready_preflight,
+)
 from proliferate.server.cloud.commands.domain.rules import (
     compact_command_json,
     validate_active_command_kind,
@@ -40,6 +40,7 @@ from proliferate.server.cloud.commands.domain.rules import (
     validate_command_source,
 )
 from proliferate.server.cloud.commands.models import CreateCloudCommandRequest
+from proliferate.server.cloud.commands.wake import schedule_managed_slot_wake_after_commit
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.live.service import (
     publish_command_status_after_commit,
@@ -980,7 +981,7 @@ async def enqueue_command(
         )
         return command
     except Exception as exc:
-        if not db_session.is_integrity_error(exc):
+        if not is_integrity_error(exc):
             raise
         duplicate = await commands_store.get_command_by_idempotency(
             db,
@@ -990,17 +991,6 @@ async def enqueue_command(
         if duplicate is not None:
             return duplicate
         raise
-
-
-async def enqueue_command_and_commit(
-    db: AsyncSession,
-    *,
-    user: ActorIdentity,
-    body: CreateCloudCommandRequest,
-) -> commands_store.CloudCommandSnapshot:
-    command = await enqueue_command(db, user=user, body=body)
-    await db_session.commit_session(db)
-    return command
 
 
 async def _record_pending_prompt_interaction_for_command(
@@ -1130,7 +1120,7 @@ async def _validate_agent_auth_preflight(
         )
         or (requires_slot and active_slot is None)
     ):
-        await _queue_agent_auth_refresh_for_not_ready_preflight(
+        await queue_agent_auth_refresh_for_not_ready_preflight(
             sandbox_profile_id=profile.id,
             target_id=target.id,
             actor_user_id=actor_user_id,
@@ -1145,31 +1135,6 @@ async def _validate_agent_auth_preflight(
             "cloud_command_agent_auth_restart_required",
             "Agent auth changes require the session to restart before this command can run.",
             status_code=409,
-        )
-
-
-async def _queue_agent_auth_refresh_for_not_ready_preflight(
-    *,
-    sandbox_profile_id: UUID,
-    target_id: UUID,
-    actor_user_id: UUID,
-) -> None:
-    try:
-        async with db_session.open_async_transaction() as refresh_db:
-            await request_agent_auth_refresh_for_profile_target(
-                refresh_db,
-                sandbox_profile_id=sandbox_profile_id,
-                target_id=target_id,
-                actor_user_id=actor_user_id,
-                reason="command_preflight",
-                force_restart=False,
-            )
-    except Exception as exc:
-        log_cloud_event(
-            "cloud command preflight agent auth refresh request failed",
-            target_id=target_id,
-            sandbox_profile_id=sandbox_profile_id,
-            error=str(exc),
         )
 
 
@@ -1724,10 +1689,12 @@ async def kick_off_command_wake_after_commit_if_required(
     if not _command_requires_managed_slot_wake(target, command):
         return
 
-    async def _wake_after_commit() -> None:
-        kick_off_managed_slot_wake(target.id, command.id)
-
-    await db_session.run_after_commit(db, _wake_after_commit)
+    await schedule_managed_slot_wake_after_commit(
+        db,
+        target_id=target.id,
+        command_id=command.id,
+        wake=kick_off_managed_slot_wake,
+    )
 
 
 def is_terminal_command_status(status: str) -> bool:

--- a/server/proliferate/server/cloud/commands/transactions.py
+++ b/server/proliferate/server/cloud/commands/transactions.py
@@ -1,0 +1,22 @@
+"""API-facing command transaction helpers."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.authorization import ActorIdentity
+from proliferate.db import session_ops as db_session
+from proliferate.db.store.cloud_sync import commands as commands_store
+from proliferate.server.cloud.commands.models import CreateCloudCommandRequest
+from proliferate.server.cloud.commands.service import enqueue_command
+
+
+async def enqueue_command_and_commit(
+    db: AsyncSession,
+    *,
+    user: ActorIdentity,
+    body: CreateCloudCommandRequest,
+) -> commands_store.CloudCommandSnapshot:
+    command = await enqueue_command(db, user=user, body=body)
+    await db_session.commit_session(db)
+    return command

--- a/server/proliferate/server/cloud/commands/wake.py
+++ b/server/proliferate/server/cloud/commands/wake.py
@@ -1,0 +1,25 @@
+"""Command wake scheduling helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import session_ops as db_session
+
+type ManagedSlotWake = Callable[[UUID, UUID | None], None]
+
+
+async def schedule_managed_slot_wake_after_commit(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    command_id: UUID,
+    wake: ManagedSlotWake,
+) -> None:
+    async def _wake_after_commit() -> None:
+        wake(target_id, command_id)
+
+    await db_session.run_after_commit(db, _wake_after_commit)

--- a/server/proliferate/server/cloud/worker/api.py
+++ b/server/proliferate/server/cloud/worker/api.py
@@ -41,7 +41,6 @@ from proliferate.server.cloud.worker.models import (
 from proliferate.server.cloud.worker.service import (
     authenticate_worker,
     enroll_worker,
-    lease_worker_command,
     list_revoked_jtis,
     list_worker_exposures,
     record_command_delivery,
@@ -49,9 +48,12 @@ from proliferate.server.cloud.worker.service import (
     record_event_batch,
     record_heartbeat,
     record_inventory,
-    record_materialization_report,
     record_projection_gap,
     record_update_status,
+)
+from proliferate.server.cloud.worker.transactions import (
+    lease_worker_command_and_commit_if_needed,
+    record_materialization_report_and_commit,
 )
 
 router = APIRouter(prefix="/worker", tags=["cloud-worker"])
@@ -102,7 +104,7 @@ async def worker_materialization_report_endpoint(
 ) -> WorkerMaterializationReportResponse:
     try:
         auth = await authenticate_worker(db, authorization=authorization)
-        return await record_materialization_report(db, auth=auth, body=body)
+        return await record_materialization_report_and_commit(db, auth=auth, body=body)
     except CloudApiError as error:
         raise_cloud_error(error)
 
@@ -128,7 +130,7 @@ async def worker_command_lease_endpoint(
 ) -> WorkerCommandLeaseResponse:
     try:
         auth = await authenticate_worker(db, authorization=authorization)
-        return await lease_worker_command(db, auth=auth, body=body)
+        return await lease_worker_command_and_commit_if_needed(db, auth=auth, body=body)
     except CloudApiError as error:
         raise_cloud_error(error)
 

--- a/server/proliferate/server/cloud/worker/service.py
+++ b/server/proliferate/server/cloud/worker/service.py
@@ -25,7 +25,6 @@ from proliferate.constants.cloud import (
     CloudWorkspaceCleanupState,
     CloudWorkspaceStatus,
 )
-from proliferate.db import session_ops as db_session
 from proliferate.db.store import cloud_workspaces
 from proliferate.db.store.cloud_agent_auth import store as agent_auth_store
 from proliferate.db.store.cloud_claims import tokens as claim_tokens_store
@@ -953,7 +952,6 @@ async def record_materialization_report(
                 target_id=auth.target_id,
                 reason="exposures",
             )
-    await db_session.commit_session(db)
     return WorkerMaterializationReportResponse(
         cloud_workspace_id=str(workspace.id),
         updated=True,
@@ -1042,12 +1040,12 @@ async def record_update_status(
     )
 
 
-async def lease_worker_command(
+async def prepare_worker_command_lease(
     db: AsyncSession,
     *,
     auth: WorkerAuthContext,
     body: WorkerCommandLeaseRequest,
-) -> WorkerCommandLeaseResponse:
+) -> tuple[WorkerCommandLeaseResponse, bool]:
     supported_kinds = normalize_supported_command_kinds(body.supported_kinds)
     lease_seconds = clamp_command_lease_seconds(body.lease_timeout_seconds)
     now = utcnow()
@@ -1090,12 +1088,11 @@ async def lease_worker_command(
         # must be committed before the HTTP response is returned, otherwise the
         # delivery request can race the request-session commit and fail closed as
         # "not leased by this worker."
-    if command is not None or expired_commands:
-        await db_session.commit_session(db)
-    return WorkerCommandLeaseResponse(
+    response = WorkerCommandLeaseResponse(
         command=_command_envelope(command) if command is not None else None,
         server_time=now.isoformat(),
     )
+    return response, bool(command is not None or expired_commands)
 
 
 async def record_command_delivery(

--- a/server/proliferate/server/cloud/worker/transactions.py
+++ b/server/proliferate/server/cloud/worker/transactions.py
@@ -1,0 +1,42 @@
+"""API-facing worker transaction helpers."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import session_ops as db_session
+from proliferate.server.cloud.worker import service
+from proliferate.server.cloud.worker.domain.types import WorkerAuthContext
+from proliferate.server.cloud.worker.models import (
+    WorkerCommandLeaseRequest,
+    WorkerCommandLeaseResponse,
+    WorkerMaterializationReportRequest,
+    WorkerMaterializationReportResponse,
+)
+
+
+async def record_materialization_report_and_commit(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerMaterializationReportRequest,
+) -> WorkerMaterializationReportResponse:
+    response = await service.record_materialization_report(db, auth=auth, body=body)
+    await db_session.commit_session(db)
+    return response
+
+
+async def lease_worker_command_and_commit_if_needed(
+    db: AsyncSession,
+    *,
+    auth: WorkerAuthContext,
+    body: WorkerCommandLeaseRequest,
+) -> WorkerCommandLeaseResponse:
+    response, should_commit = await service.prepare_worker_command_lease(
+        db,
+        auth=auth,
+        body=body,
+    )
+    if should_commit:
+        await db_session.commit_session(db)
+    return response

--- a/server/tests/unit/test_cloud_command_agent_auth_refresh.py
+++ b/server/tests/unit/test_cloud_command_agent_auth_refresh.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from proliferate.server.cloud.commands import agent_auth_refresh
+
+
+class _FailingRefreshTransaction:
+    async def __aenter__(self) -> object:
+        return object()
+
+    async def __aexit__(
+        self,
+        _exc_type: object,
+        _exc: object,
+        _traceback: object,
+    ) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_agent_auth_refresh_failure_logs_warning_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_calls: list[tuple[str, int]] = []
+
+    async def _request_refresh(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("refresh failed")
+
+    def _log_cloud_event(message: str, *, level: int = logging.INFO, **_fields: object) -> None:
+        log_calls.append((message, level))
+
+    monkeypatch.setattr(
+        agent_auth_refresh.db_session,
+        "open_async_transaction",
+        _FailingRefreshTransaction,
+    )
+    monkeypatch.setattr(
+        agent_auth_refresh,
+        "request_agent_auth_refresh_for_profile_target",
+        _request_refresh,
+    )
+    monkeypatch.setattr(agent_auth_refresh, "log_cloud_event", _log_cloud_event)
+
+    await agent_auth_refresh.queue_agent_auth_refresh_for_not_ready_preflight(
+        sandbox_profile_id=uuid4(),
+        target_id=uuid4(),
+        actor_user_id=uuid4(),
+    )
+
+    assert log_calls == [
+        (
+            "cloud command preflight agent auth refresh request failed",
+            logging.WARNING,
+        )
+    ]


### PR DESCRIPTION
## Summary
- move command wake, agent-auth refresh, and transaction helpers out of the command service
- move worker transaction entry points behind a worker transaction module
- reduce command/worker service boundary and max-lines debt without changing lease or status contracts

## Verification
- python3 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check origin/main...HEAD
- DEBUG=1 uv run pytest -q requested Lane 7 focused suite