### PR TITLE
refactor(server): align billing Stripe integration

### DIFF
--- a/docs/dev/billing-pro-promo-codes.md
+++ b/docs/dev/billing-pro-promo-codes.md
@@ -17,7 +17,7 @@ there is no app-side "make this account Pro" toggle.
 - **Script** [`server/scripts/mint_pro_promo_codes.py`](../../server/scripts/mint_pro_promo_codes.py):
   mints one unique, single-use code per person off the coupon.
 - Checkout already passes `allow_promotion_codes=true`
-  (`server/proliferate/integrations/billing/stripe.py`), so codes are
+  (`server/proliferate/integrations/stripe/client.py`), so codes are
   redeemable in the "Add promotion code" box at upgrade.
 
 ## Mint codes

--- a/docs/primitives/billing.md
+++ b/docs/primitives/billing.md
@@ -264,11 +264,11 @@ BillingPlanPolicy dataclass:
   (and others)
 ```
 
-**Stripe integration** (`server/proliferate/server/billing/`):
+**Billing domain + Stripe integration**:
 
 ```text
 api.py             route registration
-stripe_webhooks.py handle_stripe_webhook + signature verify
+stripe_webhooks.py handle_stripe_webhook + Stripe event dispatch
 service.py         authorize_sandbox_start, snapshot building,
                    create_cloud_checkout_session,
                    update_overage_settings,
@@ -282,8 +282,9 @@ pricing.py         price ids from settings
 seats.py           proration grant helpers
 domain/            pure functions: accounting, plan rules,
                    pricing, seat calcs, webhook parsing
-integrations/billing/stripe.py
-                   raw Stripe API calls
+integrations/stripe/
+                   raw Stripe HTTP, webhook signature/event construction,
+                   typed Stripe payloads, and Stripe errors
 ```
 
 **Stripe webhook events handled today**:

--- a/docs/structures/server/audits/server-structure-hygiene.md
+++ b/docs/structures/server/audits/server-structure-hygiene.md
@@ -353,7 +353,7 @@ Scope:
 
 - `server/proliferate/server/billing/**`
 - `server/proliferate/db/store/billing.py`
-- `server/proliferate/integrations/billing/**`
+- `server/proliferate/integrations/stripe/**`
 - billing tests
 
 Canonical docs:
@@ -370,9 +370,13 @@ Current debt:
 - Billing store self-opens sessions and commits heavily.
 - Billing store imports product code.
 - Billing service imports ORM/session internals.
-- `integrations/billing/stripe.py` is a single-file folder and imports product
-  billing pricing helpers.
 - Billing service and store are oversized.
+
+Resolved debt:
+
+- The old billing-scoped Stripe integration single-file folder and product
+  import debt has been removed. Stripe now lives under
+  `server/proliferate/integrations/stripe/**`.
 
 Target result:
 
@@ -408,8 +412,8 @@ Done when:
 
 - Billing-related boundary allowlist entries are gone or materially reduced per
   PR.
-- `integrations/billing/stripe.py` is replaced by a legal multi-file
-  `integrations/stripe/` package.
+- Stripe uses the legal multi-file `server/proliferate/integrations/stripe/**`
+  package and does not import billing product domains.
 - Billing files above server hard thresholds are split along documented
   ownership boundaries.
 

--- a/docs/structures/server/guides/integrations.md
+++ b/docs/structures/server/guides/integrations.md
@@ -273,8 +273,6 @@ service owns "what to do when the event arrives."
 
 Existing code has these integration-boundary exceptions:
 
-- `billing/stripe.py` is a single-file folder anti-pattern. Flatten it to
-  `integrations/stripe.py` unless it earns a multi-file vendor folder.
 - `integrations/mcp_oauth.py` is large enough to earn `mcp_oauth/` with
   `client.py`, `flows.py`, `models.py`, and `errors.py`.
 - `cloud/runtime/anyharness_api.py`, `session_api.py`, and

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -43,8 +43,7 @@ server/proliferate/db/store/cloud_repo_config.py 719 server structure migration 
 server/proliferate/db/store/cloud_sync/commands.py 1689 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_sync/events.py 1109 server structure migration debt for oversized store file
 server/proliferate/db/store/cloud_workspaces.py 1639 server structure migration debt for oversized store file
-server/proliferate/server/billing/service.py 2465 server structure migration debt for oversized service file during billing orchestration consolidation
-server/proliferate/server/billing/stripe_webhooks.py 623 server structure migration debt for oversized domain-adjacent file
+server/proliferate/server/billing/service.py 2459 server structure migration debt for oversized service file during billing orchestration consolidation
 server/proliferate/server/cloud/agent_auth/models.py 508 server structure migration debt for oversized API models file
 server/proliferate/server/cloud/agent_auth/service.py 4909 server structure migration debt for oversized service file
 server/proliferate/server/cloud/commands/domain/rules.py 607 server structure migration debt for oversized pure-domain file
@@ -62,7 +61,7 @@ server/proliferate/server/cloud/workspaces/service.py 2643 server structure migr
 server/tests/integration/schema_migration_assertions.py 869 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 871 existing server oversized integration test
-server/tests/integration/test_billing_api.py 2060 existing server oversized integration test
+server/tests/integration/test_billing_api.py 2056 existing server oversized integration test
 server/tests/integration/test_cloud_agent_auth_api.py 1670 existing server oversized integration test
 server/tests/integration/test_cloud_api.py 2377 existing server oversized integration test
 server/tests/integration/test_cloud_commands_api.py 5139 existing server oversized integration test

--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -11,8 +11,6 @@ UNDERSCORE_PREFIXED_MODULE server/proliferate/server/cloud/_logging.py 1 transit
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_agent_run_config 1 transitional store folder has not yet been flattened or promoted
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_plugins 1 transitional store folder has not yet been flattened or promoted
 SINGLE_FILE_FOLDER server/proliferate/db/store/cloud_skills 1 transitional store folder has not yet been flattened or promoted
-SINGLE_FILE_FOLDER server/proliferate/integrations/billing 1 transitional Stripe integration folder will move to canonical stripe package
-INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/billing/stripe.py 1 transitional integration depends on product domain types/logic
 API_STORE_IMPORT server/proliferate/server/cloud/live/api.py 1 transitional live API reads store types during cloud worker migration
 API_STORE_IMPORT server/proliferate/server/cloud/slack/api.py 2 transitional Slack API composes repo routing store records for admin settings
 SERVICE_ORM_IMPORT server/proliferate/server/billing/service.py 1 remaining service type boundary exposes billing ORM records until snapshot migration

--- a/server/proliferate/integrations/billing/__init__.py
+++ b/server/proliferate/integrations/billing/__init__.py
@@ -1,1 +1,0 @@
-"""External billing provider integrations."""

--- a/server/proliferate/integrations/stripe/__init__.py
+++ b/server/proliferate/integrations/stripe/__init__.py
@@ -1,0 +1,56 @@
+"""Public API for the Stripe integration."""
+
+from __future__ import annotations
+
+from proliferate.integrations.stripe.client import (
+    create_customer,
+    create_customer_portal_session,
+    create_meter_event,
+    create_refill_checkout_session,
+    create_subscription_checkout_session,
+    line_items_include_price,
+    list_checkout_session_line_items,
+    list_invoice_lines,
+    retrieve_invoice,
+    retrieve_price,
+    retrieve_price_details,
+    retrieve_subscription,
+    update_subscription_item_quantity,
+)
+from proliferate.integrations.stripe.errors import StripeBillingError, StripeIntegrationError
+from proliferate.integrations.stripe.models import (
+    StripePriceDetails,
+    StripeSignature,
+    StripeUrlResponse,
+    StripeWebhookEvent,
+)
+from proliferate.integrations.stripe.webhooks import (
+    construct_webhook_event,
+    parse_signature_header,
+    verify_webhook_signature,
+)
+
+__all__ = [
+    "StripeBillingError",
+    "StripeIntegrationError",
+    "StripePriceDetails",
+    "StripeSignature",
+    "StripeUrlResponse",
+    "StripeWebhookEvent",
+    "construct_webhook_event",
+    "create_customer",
+    "create_customer_portal_session",
+    "create_meter_event",
+    "create_refill_checkout_session",
+    "create_subscription_checkout_session",
+    "line_items_include_price",
+    "list_checkout_session_line_items",
+    "list_invoice_lines",
+    "parse_signature_header",
+    "retrieve_invoice",
+    "retrieve_price",
+    "retrieve_price_details",
+    "retrieve_subscription",
+    "update_subscription_item_quantity",
+    "verify_webhook_signature",
+]

--- a/server/proliferate/integrations/stripe/client.py
+++ b/server/proliferate/integrations/stripe/client.py
@@ -1,48 +1,23 @@
-"""Stripe billing integration.
-
-This adapter owns raw Stripe HTTP calls. Billing policy and local accounting
-stay in ``server.billing`` and ``db.store.billing``.
-"""
+"""Stripe HTTP client helpers."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
 
 import httpx
 
 from proliferate.config import settings
-from proliferate.constants.billing import PRO_SEAT_MONTHLY_AMOUNT_CENTS
-from proliferate.server.billing.pricing import (
-    configured_managed_cloud_meter_id,
-    configured_managed_cloud_overage_price_id,
-    configured_pro_monthly_price_id,
-)
+from proliferate.integrations.stripe.errors import StripeIntegrationError
+from proliferate.integrations.stripe.models import StripePriceDetails, StripeUrlResponse
 
 STRIPE_API_BASE = "https://api.stripe.com/v1"
 STRIPE_TIMEOUT_SECONDS = 10.0
-CLOUD_MONTHLY_AMOUNT_CENTS = 20000
-REFILL_10H_AMOUNT_CENTS = 2000
-
-
-class StripeBillingError(RuntimeError):
-    def __init__(self, code: str, message: str, *, status_code: int = 502) -> None:
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.status_code = status_code
-
-
-@dataclass(frozen=True)
-class StripeUrlResponse:
-    url: str
-    id: str | None = None
 
 
 def _require_secret_key() -> str:
     if not settings.stripe_secret_key:
-        raise StripeBillingError(
+        raise StripeIntegrationError(
             "stripe_unconfigured",
             "Stripe secret key is not configured.",
             status_code=503,
@@ -81,7 +56,7 @@ async def _request(
                 content=content,
             )
     except httpx.HTTPError as exc:
-        raise StripeBillingError(
+        raise StripeIntegrationError(
             "stripe_request_failed",
             "Could not reach Stripe. Check the local Stripe configuration and network.",
         ) from exc
@@ -95,13 +70,15 @@ async def _request(
             error = payload.get("error")
             if isinstance(error, dict) and isinstance(error.get("message"), str):
                 message = error["message"]
-        raise StripeBillingError(
+        raise StripeIntegrationError(
             "stripe_request_failed",
             message,
             status_code=response.status_code,
         )
     if not isinstance(payload, dict):
-        raise StripeBillingError("stripe_invalid_response", "Stripe returned an invalid response.")
+        raise StripeIntegrationError(
+            "stripe_invalid_response", "Stripe returned an invalid response."
+        )
     return payload
 
 
@@ -188,11 +165,7 @@ async def create_subscription_checkout_session(
             ]
         )
     if overage_price_id:
-        data.extend(
-            [
-                ("line_items[1][price]", overage_price_id),
-            ]
-        )
+        data.append(("line_items[1][price]", overage_price_id))
     payload = await _request(
         "POST",
         "/checkout/sessions",
@@ -201,7 +174,7 @@ async def create_subscription_checkout_session(
     )
     url = payload.get("url")
     if not isinstance(url, str):
-        raise StripeBillingError(
+        raise StripeIntegrationError(
             "stripe_invalid_response",
             "Stripe did not return a checkout URL.",
         )
@@ -237,7 +210,9 @@ async def create_refill_checkout_session(
     )
     url = payload.get("url")
     if not isinstance(url, str):
-        raise StripeBillingError("stripe_invalid_response", "Stripe did not return a refill URL.")
+        raise StripeIntegrationError(
+            "stripe_invalid_response", "Stripe did not return a refill URL."
+        )
     return StripeUrlResponse(url=url)
 
 
@@ -255,7 +230,9 @@ async def create_customer_portal_session(
     )
     url = payload.get("url")
     if not isinstance(url, str):
-        raise StripeBillingError("stripe_invalid_response", "Stripe did not return a portal URL.")
+        raise StripeIntegrationError(
+            "stripe_invalid_response", "Stripe did not return a portal URL."
+        )
     return StripeUrlResponse(url=url)
 
 
@@ -291,6 +268,24 @@ async def retrieve_price(price_id: str) -> dict[str, Any]:
     return await _request("GET", f"/prices/{price_id}")
 
 
+async def retrieve_price_details(price_id: str) -> StripePriceDetails:
+    payload = await retrieve_price(price_id)
+    recurring = payload.get("recurring")
+    recurring_payload = recurring if isinstance(recurring, dict) else {}
+    currency = payload.get("currency")
+    unit_amount = payload.get("unit_amount")
+    interval = recurring_payload.get("interval")
+    usage_type = recurring_payload.get("usage_type")
+    meter = recurring_payload.get("meter")
+    return StripePriceDetails(
+        currency=currency if isinstance(currency, str) else None,
+        unit_amount=unit_amount if isinstance(unit_amount, int) else None,
+        recurring_interval=interval if isinstance(interval, str) else None,
+        recurring_usage_type=usage_type if isinstance(usage_type, str) else None,
+        recurring_meter=meter if isinstance(meter, str) else None,
+    )
+
+
 async def create_meter_event(
     *,
     event_name: str,
@@ -303,7 +298,9 @@ async def create_meter_event(
 ) -> dict[str, Any]:
     meter_quantity = quantity if quantity is not None else quantity_seconds
     if meter_quantity is None:
-        raise StripeBillingError("stripe_invalid_meter_quantity", "Meter quantity is required.")
+        raise StripeIntegrationError(
+            "stripe_invalid_meter_quantity", "Meter quantity is required."
+        )
     data = [
         ("event_name", event_name),
         ("identifier", identifier),
@@ -337,79 +334,6 @@ def line_items_include_price(lines: list[dict[str, Any]], price_id: str) -> bool
     return any(_price_id(line) == price_id for line in lines)
 
 
-def _assert_price(condition: bool, message: str) -> None:
-    if not condition:
-        raise StripeBillingError("stripe_price_misconfigured", message, status_code=503)
-
-
-def _recurring(price: dict[str, Any]) -> dict[str, Any]:
-    recurring = price.get("recurring")
-    return recurring if isinstance(recurring, dict) else {}
-
-
-async def validate_cloud_subscription_price_configuration() -> None:
-    if not settings.stripe_cloud_monthly_price_id:
-        raise StripeBillingError(
-            "stripe_price_unconfigured",
-            "Stripe Cloud monthly price ID is not configured.",
-            status_code=503,
-        )
-    cloud = await retrieve_price(settings.stripe_cloud_monthly_price_id)
-
-    _assert_price(
-        cloud.get("unit_amount") == CLOUD_MONTHLY_AMOUNT_CENTS,
-        "Cloud monthly price must be $200/month.",
-    )
-    _assert_price(
-        _recurring(cloud).get("interval") == "month",
-        "Cloud monthly price must recur monthly.",
-    )
-
-
-async def validate_pro_subscription_price_configuration() -> None:
-    pro_price_id = configured_pro_monthly_price_id()
-    overage_price_id = configured_managed_cloud_overage_price_id()
-    if not pro_price_id:
-        raise StripeBillingError(
-            "stripe_price_unconfigured",
-            "Stripe Pro monthly price ID is not configured.",
-            status_code=503,
-        )
-    if not overage_price_id:
-        raise StripeBillingError(
-            "stripe_price_unconfigured",
-            "Stripe managed cloud overage price ID is not configured.",
-            status_code=503,
-        )
-
-    pro_price = await retrieve_price(pro_price_id)
-    _assert_price(pro_price.get("currency") == "usd", "Pro monthly price must be USD.")
-    _assert_price(
-        pro_price.get("unit_amount") == PRO_SEAT_MONTHLY_AMOUNT_CENTS,
-        "Pro monthly price must be $20/month.",
-    )
-    _assert_price(
-        _recurring(pro_price).get("interval") == "month",
-        "Pro price must recur monthly.",
-    )
-
-    overage = await retrieve_price(overage_price_id)
-    recurring = _recurring(overage)
-    _assert_price(overage.get("currency") == "usd", "Overage price must be USD.")
-    _assert_price(overage.get("unit_amount") == 1, "Overage price must be 1 cent per unit.")
-    _assert_price(recurring.get("interval") == "month", "Overage price must recur monthly.")
-    _assert_price(
-        recurring.get("usage_type") == "metered",
-        "Overage price must be a metered recurring price.",
-    )
-    meter_id = configured_managed_cloud_meter_id()
-    if meter_id:
-        _assert_price(
-            recurring.get("meter") == meter_id,
-            "Overage price must use the configured managed cloud meter.",
-        )
-
-
 async def update_subscription_item_quantity(
     *,
     subscription_item_id: str,
@@ -424,18 +348,4 @@ async def update_subscription_item_quantity(
             ("proration_behavior", "always_invoice"),
         ],
         idempotency_key=idempotency_key,
-    )
-
-
-async def validate_refill_price_configuration() -> None:
-    if not settings.stripe_refill_10h_price_id:
-        raise StripeBillingError(
-            "stripe_refill_price_unconfigured",
-            "Stripe refill price is not configured.",
-            status_code=503,
-        )
-    refill = await retrieve_price(settings.stripe_refill_10h_price_id)
-    _assert_price(
-        refill.get("unit_amount") == REFILL_10H_AMOUNT_CENTS,
-        "Refill price must be $20.",
     )

--- a/server/proliferate/integrations/stripe/errors.py
+++ b/server/proliferate/integrations/stripe/errors.py
@@ -1,0 +1,16 @@
+"""Error types for the Stripe integration."""
+
+from __future__ import annotations
+
+
+class StripeIntegrationError(RuntimeError):
+    """Raised on failures talking to or verifying Stripe."""
+
+    def __init__(self, code: str, message: str, *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+StripeBillingError = StripeIntegrationError

--- a/server/proliferate/integrations/stripe/models.py
+++ b/server/proliferate/integrations/stripe/models.py
@@ -1,0 +1,36 @@
+"""Typed Stripe payload models exposed by the integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class StripeUrlResponse:
+    url: str
+    id: str | None = None
+
+
+@dataclass(frozen=True)
+class StripePriceDetails:
+    currency: str | None
+    unit_amount: int | None
+    recurring_interval: str | None
+    recurring_usage_type: str | None
+    recurring_meter: str | None
+
+
+@dataclass(frozen=True)
+class StripeSignature:
+    timestamp: int
+    signatures: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StripeWebhookEvent:
+    event_id: str
+    event_type: str
+    livemode: bool | None
+    payload: dict[str, Any]
+    data_object: dict[str, Any]

--- a/server/proliferate/integrations/stripe/webhooks.py
+++ b/server/proliferate/integrations/stripe/webhooks.py
@@ -1,0 +1,127 @@
+"""Stripe webhook signature verification and event construction."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+from proliferate.config import settings
+from proliferate.integrations.stripe.errors import StripeIntegrationError
+from proliferate.integrations.stripe.models import StripeSignature, StripeWebhookEvent
+
+STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300
+
+
+def construct_webhook_event(
+    *,
+    payload: bytes,
+    signature_header: str | None,
+    secret: str | None = None,
+    now: int | None = None,
+) -> StripeWebhookEvent:
+    webhook_secret = settings.stripe_webhook_secret if secret is None else secret
+    if not webhook_secret:
+        raise StripeIntegrationError(
+            "stripe_webhook_unconfigured",
+            "Stripe webhook secret is not configured.",
+            status_code=503,
+        )
+    verify_webhook_signature(
+        payload=payload,
+        signature_header=signature_header,
+        secret=webhook_secret,
+        now=now,
+    )
+    try:
+        event = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_json",
+            "Stripe webhook payload is not valid JSON.",
+            status_code=400,
+        ) from exc
+    if not isinstance(event, dict):
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_event",
+            "Stripe webhook payload must be an event object.",
+            status_code=400,
+        )
+
+    event_id = event.get("id")
+    event_type = event.get("type")
+    if not isinstance(event_id, str) or not isinstance(event_type, str):
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_event",
+            "Stripe webhook payload is missing an event id or type.",
+            status_code=400,
+        )
+    livemode = event.get("livemode")
+    data = event.get("data")
+    data_object: Any = data.get("object") if isinstance(data, dict) else None
+    return StripeWebhookEvent(
+        event_id=event_id,
+        event_type=event_type,
+        livemode=livemode if isinstance(livemode, bool) else None,
+        payload=event,
+        data_object=data_object if isinstance(data_object, dict) else {},
+    )
+
+
+def verify_webhook_signature(
+    *,
+    payload: bytes,
+    signature_header: str | None,
+    secret: str,
+    now: int | None = None,
+) -> None:
+    signature = parse_signature_header(signature_header)
+    current_time = int(time.time()) if now is None else now
+    if abs(current_time - signature.timestamp) > STRIPE_SIGNATURE_TOLERANCE_SECONDS:
+        raise StripeIntegrationError(
+            "stripe_webhook_stale_signature",
+            "Stripe webhook signature timestamp is outside the allowed tolerance.",
+            status_code=401,
+        )
+    signed_payload = str(signature.timestamp).encode("ascii") + b"." + payload
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    if not any(hmac.compare_digest(expected, candidate) for candidate in signature.signatures):
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_signature",
+            "Stripe webhook signature is invalid.",
+            status_code=401,
+        )
+
+
+def parse_signature_header(signature_header: str | None) -> StripeSignature:
+    if not signature_header:
+        raise StripeIntegrationError(
+            "stripe_webhook_missing_signature",
+            "Stripe webhook signature header is missing.",
+            status_code=401,
+        )
+    fields: dict[str, list[str]] = {}
+    for item in signature_header.split(","):
+        key, separator, value = item.partition("=")
+        if not separator:
+            continue
+        fields.setdefault(key, []).append(value)
+    timestamps = fields.get("t") or []
+    signatures = tuple(value for value in fields.get("v1", []) if value)
+    try:
+        timestamp = int(timestamps[0])
+    except (IndexError, ValueError) as exc:
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_signature",
+            "Stripe webhook signature timestamp is invalid.",
+            status_code=401,
+        ) from exc
+    if not signatures:
+        raise StripeIntegrationError(
+            "stripe_webhook_invalid_signature",
+            "Stripe webhook signature does not include a v1 signature.",
+            status_code=401,
+        )
+    return StripeSignature(timestamp=timestamp, signatures=signatures)

--- a/server/proliferate/server/billing/domain/pricing.py
+++ b/server/proliferate/server/billing/domain/pricing.py
@@ -8,9 +8,12 @@ from proliferate.constants.billing import (
     BILLING_PRICE_CLASS_LEGACY_CLOUD,
     BILLING_PRICE_CLASS_PRO,
     BILLING_PRICE_CLASS_UNKNOWN,
+    PRO_SEAT_MONTHLY_AMOUNT_CENTS,
 )
 
 BillingPriceClass = str
+LEGACY_CLOUD_MONTHLY_AMOUNT_CENTS = 20_000
+REFILL_10H_AMOUNT_CENTS = 2_000
 
 
 @dataclass(frozen=True)
@@ -23,6 +26,15 @@ class BillingPriceIds:
     managed_cloud_overage_meter_id: str = ""
     sandbox_meter_id: str = ""
     managed_cloud_overage_meter_event_name: str = ""
+
+
+@dataclass(frozen=True)
+class BillingPriceShape:
+    currency: str | None = None
+    unit_amount: int | None = None
+    recurring_interval: str | None = None
+    recurring_usage_type: str | None = None
+    recurring_meter: str | None = None
 
 
 def clean_price_id(price_id: str | None) -> str:
@@ -106,3 +118,45 @@ def monthly_price_is_pro(price_id: str | None, *, price_ids: BillingPriceIds) ->
 
 def monthly_price_is_paid(price_id: str | None, *, price_ids: BillingPriceIds) -> bool:
     return price_class_is_paid(classify_monthly_price_id(price_id, price_ids=price_ids))
+
+
+def validate_legacy_cloud_monthly_price_shape(price: BillingPriceShape) -> str | None:
+    if price.unit_amount != LEGACY_CLOUD_MONTHLY_AMOUNT_CENTS:
+        return "Cloud monthly price must be $200/month."
+    if price.recurring_interval != "month":
+        return "Cloud monthly price must recur monthly."
+    return None
+
+
+def validate_pro_monthly_price_shape(price: BillingPriceShape) -> str | None:
+    if price.currency != "usd":
+        return "Pro monthly price must be USD."
+    if price.unit_amount != PRO_SEAT_MONTHLY_AMOUNT_CENTS:
+        return "Pro monthly price must be $20/month."
+    if price.recurring_interval != "month":
+        return "Pro price must recur monthly."
+    return None
+
+
+def validate_managed_cloud_overage_price_shape(
+    price: BillingPriceShape,
+    *,
+    meter_id: str,
+) -> str | None:
+    if price.currency != "usd":
+        return "Overage price must be USD."
+    if price.unit_amount != 1:
+        return "Overage price must be 1 cent per unit."
+    if price.recurring_interval != "month":
+        return "Overage price must recur monthly."
+    if price.recurring_usage_type != "metered":
+        return "Overage price must be a metered recurring price."
+    if meter_id and price.recurring_meter != meter_id:
+        return "Overage price must use the configured managed cloud meter."
+    return None
+
+
+def validate_refill_price_shape(price: BillingPriceShape) -> str | None:
+    if price.unit_amount != REFILL_10H_AMOUNT_CENTS:
+        return "Refill price must be $20."
+    return None

--- a/server/proliferate/server/billing/pricing.py
+++ b/server/proliferate/server/billing/pricing.py
@@ -1,21 +1,22 @@
-"""Billing price classification helpers.
-
-These helpers are intentionally env-only. Stripe HTTP validation stays in the
-Stripe integration adapter; billing policy only needs a stable local
-classification for already-synced price ids.
-"""
+"""Billing price configuration helpers."""
 
 from __future__ import annotations
 
 from proliferate.config import settings
+from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.domain.pricing import (
     BillingPriceClass,
     BillingPriceIds,
+    BillingPriceShape,
     effective_legacy_cloud_monthly_price_id,
     effective_managed_cloud_meter_event_name,
     effective_managed_cloud_meter_id,
     effective_managed_cloud_overage_price_id,
     effective_pro_monthly_price_id,
+    validate_legacy_cloud_monthly_price_shape,
+    validate_managed_cloud_overage_price_shape,
+    validate_pro_monthly_price_shape,
+    validate_refill_price_shape,
 )
 from proliferate.server.billing.domain.pricing import (
     classify_monthly_price_id as classify_monthly_price_id_for_config,
@@ -23,6 +24,7 @@ from proliferate.server.billing.domain.pricing import (
 from proliferate.server.billing.domain.pricing import (
     price_class_is_paid as price_class_is_paid_for_config,
 )
+from proliferate.server.billing.models import BillingServiceError
 
 
 def billing_price_ids_from_settings() -> BillingPriceIds:
@@ -75,3 +77,73 @@ def classify_monthly_price_id(price_id: str | None) -> BillingPriceClass:
 
 def price_class_is_paid(price_class: BillingPriceClass) -> bool:
     return price_class_is_paid_for_config(price_class)
+
+
+def _map_stripe_error(error: stripe_billing.StripeBillingError) -> BillingServiceError:
+    return BillingServiceError(error.code, error.message, status_code=error.status_code)
+
+
+def _stripe_price_configuration_error(code: str, message: str) -> BillingServiceError:
+    return BillingServiceError(code, message, status_code=503)
+
+
+async def _retrieve_billing_price_shape(price_id: str) -> BillingPriceShape:
+    try:
+        price = await stripe_billing.retrieve_price_details(price_id)
+    except stripe_billing.StripeBillingError as error:
+        raise _map_stripe_error(error) from error
+    return BillingPriceShape(
+        currency=price.currency,
+        unit_amount=price.unit_amount,
+        recurring_interval=price.recurring_interval,
+        recurring_usage_type=price.recurring_usage_type,
+        recurring_meter=price.recurring_meter,
+    )
+
+
+async def validate_cloud_subscription_price_configuration() -> None:
+    if not settings.stripe_cloud_monthly_price_id:
+        raise _stripe_price_configuration_error(
+            "stripe_price_unconfigured",
+            "Stripe Cloud monthly price ID is not configured.",
+        )
+    cloud_price = await _retrieve_billing_price_shape(settings.stripe_cloud_monthly_price_id)
+    if message := validate_legacy_cloud_monthly_price_shape(cloud_price):
+        raise _stripe_price_configuration_error("stripe_price_misconfigured", message)
+
+
+async def validate_pro_subscription_price_configuration() -> None:
+    pro_price_id = configured_pro_monthly_price_id()
+    overage_price_id = configured_managed_cloud_overage_price_id()
+    if not pro_price_id:
+        raise _stripe_price_configuration_error(
+            "stripe_price_unconfigured",
+            "Stripe Pro monthly price ID is not configured.",
+        )
+    if not overage_price_id:
+        raise _stripe_price_configuration_error(
+            "stripe_price_unconfigured",
+            "Stripe managed cloud overage price ID is not configured.",
+        )
+
+    pro_price = await _retrieve_billing_price_shape(pro_price_id)
+    if message := validate_pro_monthly_price_shape(pro_price):
+        raise _stripe_price_configuration_error("stripe_price_misconfigured", message)
+
+    overage_price = await _retrieve_billing_price_shape(overage_price_id)
+    if message := validate_managed_cloud_overage_price_shape(
+        overage_price,
+        meter_id=configured_managed_cloud_meter_id(),
+    ):
+        raise _stripe_price_configuration_error("stripe_price_misconfigured", message)
+
+
+async def validate_refill_price_configuration() -> None:
+    if not settings.stripe_refill_10h_price_id:
+        raise _stripe_price_configuration_error(
+            "stripe_refill_price_unconfigured",
+            "Stripe refill price is not configured.",
+        )
+    refill_price = await _retrieve_billing_price_shape(settings.stripe_refill_10h_price_id)
+    if message := validate_refill_price_shape(refill_price):
+        raise _stripe_price_configuration_error("stripe_price_misconfigured", message)

--- a/server/proliferate/server/billing/service.py
+++ b/server/proliferate/server/billing/service.py
@@ -138,7 +138,7 @@ from proliferate.db.store.organizations import (
 )
 from proliferate.errors import ProliferateError
 from proliferate.integrations import resend
-from proliferate.integrations.billing import stripe as stripe_billing
+from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.domain.accounting import (
     active_pro_period_start,
     next_accounting_boundary,
@@ -202,6 +202,9 @@ from proliferate.server.billing.pricing import (
     configured_managed_cloud_meter_event_name,
     configured_managed_cloud_overage_price_id,
     configured_pro_monthly_price_id,
+    validate_cloud_subscription_price_configuration,
+    validate_pro_subscription_price_configuration,
+    validate_refill_price_configuration,
 )
 from proliferate.server.billing.seats import (
     prorated_seat_grant_hours,
@@ -1408,10 +1411,7 @@ async def create_team_checkout_session(
     clean_name = _raise_team_name_issue(team_name)
     normalized_invites = sorted({email.strip().lower() for email in invite_emails if email})
     success_url, cancel_url, _portal_return_url = _require_redirect_urls(return_surface)
-    try:
-        await stripe_billing.validate_pro_subscription_price_configuration()
-    except stripe_billing.StripeBillingError as error:
-        raise _map_stripe_error(error) from error
+    await validate_pro_subscription_price_configuration()
 
     async with db.begin():
         await acquire_membership_activation_lock(db, user.id)
@@ -1728,13 +1728,10 @@ async def create_cloud_checkout_session(
                 status_code=409,
             )
     success_url, cancel_url, portal_return_url = _require_redirect_urls(return_surface)
-    try:
-        if settings.pro_billing_enabled:
-            await stripe_billing.validate_pro_subscription_price_configuration()
-        else:
-            await stripe_billing.validate_cloud_subscription_price_configuration()
-    except stripe_billing.StripeBillingError as error:
-        raise _map_stripe_error(error) from error
+    if settings.pro_billing_enabled:
+        await validate_pro_subscription_price_configuration()
+    else:
+        await validate_cloud_subscription_price_configuration()
 
     subject_id, stripe_customer_id = await _ensure_stripe_customer_for_owner(
         db,
@@ -1824,10 +1821,7 @@ async def create_refill_checkout_session(
             status_code=409,
         )
     success_url, cancel_url, _portal_return_url = _require_redirect_urls(return_surface)
-    try:
-        await stripe_billing.validate_refill_price_configuration()
-    except stripe_billing.StripeBillingError as error:
-        raise _map_stripe_error(error) from error
+    await validate_refill_price_configuration()
     subject_id, stripe_customer_id = await _ensure_stripe_customer_for_owner(
         db,
         user,

--- a/server/proliferate/server/billing/stripe_webhooks.py
+++ b/server/proliferate/server/billing/stripe_webhooks.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
-import json
 import logging
-import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -34,7 +30,7 @@ from proliferate.db.store.billing import (
     mark_webhook_event_processed_by_id,
     upsert_stripe_subscription_record,
 )
-from proliferate.integrations.billing import stripe as stripe_billing
+from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.domain.pricing import (
     monthly_subscription_price_ids,
     overage_subscription_price_ids,
@@ -87,7 +83,6 @@ from proliferate.server.notifications import (
     load_billing_slack_notification_context,
 )
 
-STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300
 STRIPE_PROVIDER = "stripe"
 PAYMENT_HOLD_SOURCE = "stripe_webhook"
 BILLING_SLACK_ACTIVE_STATUSES = {"active", "trialing"}
@@ -95,6 +90,10 @@ BILLING_SLACK_CANCELLED_STATUSES = {"canceled"}
 BILLING_SLACK_PRE_START_STATUSES = {"incomplete"}
 
 logger = logging.getLogger(__name__)
+
+
+def _map_stripe_error(error: stripe_billing.StripeBillingError) -> BillingServiceError:
+    return BillingServiceError(error.code, error.message, status_code=error.status_code)
 
 
 async def _run_billing_store_read[T, **P](
@@ -118,12 +117,6 @@ async def _run_billing_store_write[T, **P](
 
 
 @dataclass(frozen=True)
-class StripeSignature:
-    timestamp: int
-    signatures: tuple[str, ...]
-
-
-@dataclass(frozen=True)
 class SubscriptionSyncResult:
     record: BillingSubscription | None
     notifications: tuple[BillingSlackNotification, ...] = ()
@@ -134,40 +127,19 @@ async def handle_stripe_webhook(
     payload: bytes,
     signature_header: str | None,
 ) -> StripeWebhookAck:
-    if not settings.stripe_webhook_secret:
-        raise BillingServiceError(
-            "stripe_webhook_unconfigured",
-            "Stripe webhook secret is not configured.",
-            status_code=503,
-        )
-    _verify_stripe_signature(
-        payload=payload,
-        signature_header=signature_header,
-        secret=settings.stripe_webhook_secret,
-    )
     try:
-        event = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise BillingServiceError(
-            "stripe_webhook_invalid_json",
-            "Stripe webhook payload is not valid JSON.",
-            status_code=400,
-        ) from exc
-
-    event_id = event.get("id")
-    event_type = event.get("type")
-    if not isinstance(event_id, str) or not isinstance(event_type, str):
-        raise BillingServiceError(
-            "stripe_webhook_invalid_event",
-            "Stripe webhook payload is missing an event id or type.",
-            status_code=400,
+        stripe_event = stripe_billing.construct_webhook_event(
+            payload=payload,
+            signature_header=signature_header,
         )
+    except stripe_billing.StripeBillingError as error:
+        raise _map_stripe_error(error) from error
 
     claim = await _run_billing_store_write(
         claim_webhook_event,
         provider=STRIPE_PROVIDER,
-        event_id=event_id,
-        event_type=event_type,
+        event_id=stripe_event.event_id,
+        event_type=stripe_event.event_type,
     )
     if claim.status == "in_progress":
         raise BillingServiceError(
@@ -179,7 +151,7 @@ async def handle_stripe_webhook(
     notifications: tuple[BillingSlackNotification, ...] = ()
     if claim.status == "claimed" and claim.receipt is not None:
         try:
-            dispatch_notifications = await _dispatch_stripe_event(event)
+            dispatch_notifications = await _dispatch_stripe_event(stripe_event.payload)
         except Exception as exc:
             await _run_billing_store_write(
                 mark_webhook_event_failed_by_id,
@@ -194,11 +166,10 @@ async def handle_stripe_webhook(
         )
         await deliver_billing_slack_notifications(notifications)
 
-    livemode = event.get("livemode")
     return StripeWebhookAck(
-        event_id=event_id,
-        event_type=event_type,
-        livemode=livemode if isinstance(livemode, bool) else None,
+        event_id=stripe_event.event_id,
+        event_type=stripe_event.event_type,
+        livemode=stripe_event.livemode,
     )
 
 
@@ -564,60 +535,3 @@ async def _apply_payment_hold_for_subscription(subscription: dict[str, Any]) -> 
         source=PAYMENT_HOLD_SOURCE,
         source_ref=_id_from_expandable(subscription.get("id")),
     )
-
-
-def _verify_stripe_signature(
-    *,
-    payload: bytes,
-    signature_header: str | None,
-    secret: str,
-    now: int | None = None,
-) -> None:
-    signature = _parse_signature_header(signature_header)
-    current_time = int(time.time()) if now is None else now
-    if abs(current_time - signature.timestamp) > STRIPE_SIGNATURE_TOLERANCE_SECONDS:
-        raise BillingServiceError(
-            "stripe_webhook_stale_signature",
-            "Stripe webhook signature timestamp is outside the allowed tolerance.",
-            status_code=401,
-        )
-    signed_payload = str(signature.timestamp).encode("ascii") + b"." + payload
-    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
-    if not any(hmac.compare_digest(expected, candidate) for candidate in signature.signatures):
-        raise BillingServiceError(
-            "stripe_webhook_invalid_signature",
-            "Stripe webhook signature is invalid.",
-            status_code=401,
-        )
-
-
-def _parse_signature_header(signature_header: str | None) -> StripeSignature:
-    if not signature_header:
-        raise BillingServiceError(
-            "stripe_webhook_missing_signature",
-            "Stripe webhook signature header is missing.",
-            status_code=401,
-        )
-    fields: dict[str, list[str]] = {}
-    for item in signature_header.split(","):
-        key, separator, value = item.partition("=")
-        if not separator:
-            continue
-        fields.setdefault(key, []).append(value)
-    timestamps = fields.get("t") or []
-    signatures = tuple(value for value in fields.get("v1", []) if value)
-    try:
-        timestamp = int(timestamps[0])
-    except (IndexError, ValueError) as exc:
-        raise BillingServiceError(
-            "stripe_webhook_invalid_signature",
-            "Stripe webhook signature timestamp is invalid.",
-            status_code=401,
-        ) from exc
-    if not signatures:
-        raise BillingServiceError(
-            "stripe_webhook_invalid_signature",
-            "Stripe webhook signature does not include a v1 signature.",
-            status_code=401,
-        )
-    return StripeSignature(timestamp=timestamp, signatures=signatures)

--- a/server/tests/integration/test_billing_accounting.py
+++ b/server/tests/integration/test_billing_accounting.py
@@ -38,7 +38,7 @@ from proliferate.db.store.billing import (
     ensure_billing_grant,
     ensure_personal_billing_subject,
 )
-from proliferate.integrations.billing import stripe as stripe_billing
+from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing import service as billing_service
 from tests.integration.billing_accounting_helpers import (
     patch_global_session_factory,

--- a/server/tests/integration/test_billing_api.py
+++ b/server/tests/integration/test_billing_api.py
@@ -57,7 +57,7 @@ from proliferate.db.store.cloud_runtime_environments import (
     ensure_runtime_environment_for_workspace,
 )
 from proliferate.integrations import resend
-from proliferate.integrations.billing import stripe as stripe_billing
+from proliferate.integrations import stripe as stripe_billing
 from proliferate.integrations.github import GitHubRepoBranches
 from proliferate.server.billing.service import (
     activate_team_checkout_from_stripe_session,
@@ -368,8 +368,7 @@ class TestBillingApi:
             return stripe_billing.StripeUrlResponse(url="https://portal.test/active")
 
         monkeypatch.setattr(
-            stripe_billing,
-            "validate_cloud_subscription_price_configuration",
+            "proliferate.server.billing.service.validate_cloud_subscription_price_configuration",
             fake_validate_cloud_subscription_price_configuration,
         )
         monkeypatch.setattr(
@@ -464,8 +463,7 @@ class TestBillingApi:
             )
 
         monkeypatch.setattr(
-            stripe_billing,
-            "validate_pro_subscription_price_configuration",
+            "proliferate.server.billing.service.validate_pro_subscription_price_configuration",
             fake_validate_pro_subscription_price_configuration,
         )
         monkeypatch.setattr(stripe_billing, "create_customer", fake_create_customer)
@@ -573,8 +571,7 @@ class TestBillingApi:
             )
 
         monkeypatch.setattr(
-            stripe_billing,
-            "validate_pro_subscription_price_configuration",
+            "proliferate.server.billing.service.validate_pro_subscription_price_configuration",
             fake_validate_pro_subscription_price_configuration,
         )
         monkeypatch.setattr(stripe_billing, "create_customer", fake_create_customer)
@@ -839,8 +836,7 @@ class TestBillingApi:
             return stripe_billing.StripeUrlResponse(url="https://checkout.test/org")
 
         monkeypatch.setattr(
-            stripe_billing,
-            "validate_pro_subscription_price_configuration",
+            "proliferate.server.billing.service.validate_pro_subscription_price_configuration",
             fake_validate_pro_subscription_price_configuration,
         )
         monkeypatch.setattr(stripe_billing, "create_customer", fake_create_customer)

--- a/server/tests/unit/test_stripe_billing.py
+++ b/server/tests/unit/test_stripe_billing.py
@@ -5,7 +5,36 @@ from typing import Any
 import pytest
 
 from proliferate.config import settings
-from proliferate.integrations.billing import stripe
+from proliferate.integrations import stripe
+from proliferate.integrations.stripe import client as stripe_client
+from proliferate.server.billing import service as billing_service
+from proliferate.server.billing.models import BillingServiceError
+
+
+def _price_details(payload: dict[str, Any]) -> stripe.StripePriceDetails:
+    recurring = payload.get("recurring")
+    recurring_payload = recurring if isinstance(recurring, dict) else {}
+    return stripe.StripePriceDetails(
+        currency=payload.get("currency") if isinstance(payload.get("currency"), str) else None,
+        unit_amount=payload.get("unit_amount")
+        if isinstance(payload.get("unit_amount"), int)
+        else None,
+        recurring_interval=(
+            recurring_payload.get("interval")
+            if isinstance(recurring_payload.get("interval"), str)
+            else None
+        ),
+        recurring_usage_type=(
+            recurring_payload.get("usage_type")
+            if isinstance(recurring_payload.get("usage_type"), str)
+            else None
+        ),
+        recurring_meter=(
+            recurring_payload.get("meter")
+            if isinstance(recurring_payload.get("meter"), str)
+            else None
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -33,7 +62,7 @@ async def test_subscription_checkout_session_is_flat_monthly_with_promotion_code
         )
         return {"url": "https://checkout.stripe.test/session"}
 
-    monkeypatch.setattr(stripe, "_request", _request)
+    monkeypatch.setattr(stripe_client, "_request", _request)
 
     response = await stripe.create_subscription_checkout_session(
         stripe_customer_id="cus_test",
@@ -84,7 +113,7 @@ async def test_pro_subscription_checkout_session_includes_overage_item_and_seat_
         )
         return {"url": "https://checkout.stripe.test/pro-session"}
 
-    monkeypatch.setattr(stripe, "_request", _request)
+    monkeypatch.setattr(stripe_client, "_request", _request)
 
     response = await stripe.create_subscription_checkout_session(
         stripe_customer_id="cus_test",
@@ -122,15 +151,15 @@ async def test_cloud_subscription_price_validation_only_requires_monthly_price(
 ) -> None:
     requested_price_ids: list[str] = []
 
-    async def _retrieve_price(price_id: str) -> dict[str, Any]:
+    async def _retrieve_price_details(price_id: str) -> stripe.StripePriceDetails:
         requested_price_ids.append(price_id)
-        return {"unit_amount": 20000, "recurring": {"interval": "month"}}
+        return _price_details({"unit_amount": 20000, "recurring": {"interval": "month"}})
 
     monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_cloud_monthly")
     monkeypatch.setattr(settings, "stripe_sandbox_overage_price_id", "")
-    monkeypatch.setattr(stripe, "retrieve_price", _retrieve_price)
+    monkeypatch.setattr(stripe, "retrieve_price_details", _retrieve_price_details)
 
-    await stripe.validate_cloud_subscription_price_configuration()
+    await billing_service.validate_cloud_subscription_price_configuration()
 
     assert requested_price_ids == ["price_cloud_monthly"]
 
@@ -139,17 +168,17 @@ async def test_cloud_subscription_price_validation_only_requires_monthly_price(
 async def test_pro_price_validation_requires_overage_price_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _retrieve_price(_price_id: str) -> dict[str, Any]:
+    async def _retrieve_price_details(_price_id: str) -> stripe.StripePriceDetails:
         raise AssertionError("validation should fail before retrieving prices")
 
     monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro_monthly")
     monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "")
     monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
     monkeypatch.setattr(settings, "stripe_managed_cloud_overage_price_id", "")
-    monkeypatch.setattr(stripe, "retrieve_price", _retrieve_price)
+    monkeypatch.setattr(stripe, "retrieve_price_details", _retrieve_price_details)
 
-    with pytest.raises(stripe.StripeBillingError) as exc_info:
-        await stripe.validate_pro_subscription_price_configuration()
+    with pytest.raises(BillingServiceError) as exc_info:
+        await billing_service.validate_pro_subscription_price_configuration()
 
     assert exc_info.value.code == "stripe_price_unconfigured"
 
@@ -209,11 +238,11 @@ async def test_pro_price_validation_rejects_misconfigured_prices(
     meter_id: str,
     message: str,
 ) -> None:
-    async def _retrieve_price(price_id: str) -> dict[str, Any]:
+    async def _retrieve_price_details(price_id: str) -> stripe.StripePriceDetails:
         if price_id == "price_pro_monthly":
-            return pro_price
+            return _price_details(pro_price)
         if price_id == "price_overage":
-            return overage_price
+            return _price_details(overage_price)
         raise AssertionError(f"unexpected price id {price_id}")
 
     monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro_monthly")
@@ -221,10 +250,10 @@ async def test_pro_price_validation_rejects_misconfigured_prices(
     monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
     monkeypatch.setattr(settings, "stripe_managed_cloud_overage_price_id", "price_overage")
     monkeypatch.setattr(settings, "stripe_managed_cloud_overage_meter_id", meter_id)
-    monkeypatch.setattr(stripe, "retrieve_price", _retrieve_price)
+    monkeypatch.setattr(stripe, "retrieve_price_details", _retrieve_price_details)
 
-    with pytest.raises(stripe.StripeBillingError) as exc_info:
-        await stripe.validate_pro_subscription_price_configuration()
+    with pytest.raises(BillingServiceError) as exc_info:
+        await billing_service.validate_pro_subscription_price_configuration()
 
     assert exc_info.value.code == "stripe_price_misconfigured"
     assert exc_info.value.message == message
@@ -234,13 +263,13 @@ async def test_pro_price_validation_rejects_misconfigured_prices(
 async def test_refill_price_validation_is_separate_from_subscription_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _retrieve_price(_price_id: str) -> dict[str, Any]:
+    async def _retrieve_price_details(_price_id: str) -> stripe.StripePriceDetails:
         raise AssertionError("refill validation should fail before calling Stripe")
 
     monkeypatch.setattr(settings, "stripe_refill_10h_price_id", "")
-    monkeypatch.setattr(stripe, "retrieve_price", _retrieve_price)
+    monkeypatch.setattr(stripe, "retrieve_price_details", _retrieve_price_details)
 
-    with pytest.raises(stripe.StripeBillingError) as exc_info:
-        await stripe.validate_refill_price_configuration()
+    with pytest.raises(BillingServiceError) as exc_info:
+        await billing_service.validate_refill_price_configuration()
 
     assert exc_info.value.code == "stripe_refill_price_unconfigured"


### PR DESCRIPTION
## Summary
- promote the raw Stripe adapter into server/proliferate/integrations/stripe
- keep billing pricing/product policy in billing domain code
- update billing docs/tests and shrink the billing structure allowlists

## Verification
- python3 scripts/check_server_boundaries.py
- python3 scripts/check_max_lines.py
- git diff --check origin/main...HEAD
- DEBUG=true JWT_SECRET=test-secret uv run --extra dev pytest -q tests/unit/test_billing_domain.py tests/unit/test_billing_service_policy.py tests/unit/test_billing_reconciler.py tests/unit/test_stripe_billing.py tests/integration/test_billing_accounting.py tests/integration/test_billing_api.py tests/integration/test_stripe_webhooks.py