### PR TITLE
docs(specs): track migrated reference specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ e2b-connection.json
 
 reference/
 references/
+!specs/developing/reference/
+!specs/developing/reference/**
 # Generated cloud client OpenAPI spec (intermediate artifact, regenerated from Python)
 server/openapi.json
 

--- a/specs/developing/reference/env-secrets-matrix.md
+++ b/specs/developing/reference/env-secrets-matrix.md
@@ -1,0 +1,228 @@
+# Env and Secrets Matrix
+
+This document is the operator-facing source of truth for the Proliferate
+control plane env surface.
+
+## Principles
+
+- `server/proliferate/config.py` contains env-derived runtime settings only.
+- Hardcoded protocol values, template names, ports, workdirs, and auth lifetime
+  defaults live in `server/proliferate/constants/**`.
+- Secrets must be provided explicitly through:
+  - `server/.env`
+  - `server/.env.local`
+  - container/task/service environment injection
+  - a deployment secret manager
+- There is intentionally no home-directory fallback such as
+  `~/proliferate/.env.local`.
+- Any variable not listed below should be treated as unsupported on this branch.
+  `Settings` ignores unknown env vars, so removed overrides fail closed by being
+  ignored rather than raising an error.
+
+## Environment Boundaries
+
+- `server/.env` and `server/.env.local` expose the full control-plane env
+  surface for local development, direct server runs, and operator debugging.
+- `server/deploy/.env.static` is the curated self-hosted production surface.
+  It includes the common operator settings; advanced overrides from this matrix
+  may still be added there manually when needed.
+- `server/infra/self-hosted-aws/template.yaml` promotes an even smaller subset
+  of those settings into CloudFormation parameters. Advanced defaults that are
+  not parameterized there intentionally stay on their code defaults unless you
+  customize the template or edit the generated `.env.static` on the host.
+
+## Core Runtime Settings
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `API_BASE_URL` | No | Recommended for public/proxied deployments | Canonical public API base URL used for absolute auth callback generation |
+| `DEBUG` | No | No | Debug mode flag |
+| `PROLIFERATE_TELEMETRY_MODE` | No | Yes for explicit telemetry routing | Telemetry runtime mode: `local_dev`, `self_managed`, or `hosted_product` |
+| `DATABASE_URL` | Yes | Yes | PostgreSQL connection |
+| `DATABASE_ECHO` | No | No | SQLAlchemy query echo/logging |
+| `CORS_ALLOW_ORIGINS` | No | Yes for browser/desktop API access | Allowed browser/webview origins |
+| `JWT_SECRET` | Yes | Yes | JWT signing and OAuth state signing |
+
+## Desktop Auth
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `GITHUB_OAUTH_CLIENT_ID` | Yes | Only when desktop GitHub sign-in is enabled | GitHub OAuth client ID |
+| `GITHUB_OAUTH_CLIENT_SECRET` | Yes | Only when desktop GitHub sign-in is enabled | GitHub OAuth client secret |
+
+The desktop redirect scheme, callback path, deep-link launch behavior, and auth
+token lifetimes now live in `server/proliferate/constants/auth.py`. They are
+code defaults on this branch, not env overrides.
+
+Desktop runtime overrides live in `~/.proliferate/config.json` (or the
+profile-specific `PROLIFERATE_DEV_HOME/config.json` in profile dev). The
+supported fields are:
+
+```json
+{
+  "apiBaseUrl": "https://api.company.com",
+  "telemetryDisabled": false
+}
+```
+
+## Auth and Token Lifetimes
+
+No env overrides are currently supported for token lifetimes or desktop PKCE
+timers on this branch. These values are defined in
+`server/proliferate/constants/auth.py`.
+
+## Observability and Messaging
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `CUSTOMERIO_SITE_ID` | Yes | No | Customer.io workspace/account messaging |
+| `CUSTOMERIO_API_KEY` | Yes | No | Customer.io API auth |
+| `CUSTOMERIO_APP_API_KEY` | Yes | No | Customer.io app API auth |
+| `CUSTOMERIO_FROM_EMAIL` | No | No | Customer.io sender email address |
+| `CUSTOMERIO_WELCOME_TRANSACTIONAL_MESSAGE_ID` | No | No | Customer.io transactional message ID for the desktop welcome email; blank disables the welcome email |
+| `FRONTEND_BASE_URL` | No | No | Frontend base URL for email links etc. |
+| `PROLIFERATE_ANONYMOUS_TELEMETRY_ENDPOINT` | No | No | First-party anonymous telemetry collector endpoint |
+| `PROLIFERATE_ANONYMOUS_TELEMETRY_DISABLED` | No | No | Disable server-side anonymous telemetry emission |
+| `RESEND_API_KEY` | Yes | No | Resend transactional email API key for organization invitations |
+| `RESEND_FROM_EMAIL` | No | No | Resend sender email address for organization invitations |
+| `SENTRY_DSN` | Yes | No | Server Sentry |
+| `SENTRY_ENVIRONMENT` | No | No | Server Sentry environment |
+| `SENTRY_RELEASE` | No | No | Server Sentry release |
+| `SENTRY_TRACES_SAMPLE_RATE` | No | No | Server Sentry tracing |
+| `SUPPORT_SLACK_WEBHOOK_URL` | Yes | No | Slack destination for support messages |
+| `SIGNUPS_SLACK_WEBHOOK_URL` | Yes | No | Internal Slack destination for desktop GitHub hosted-user signup notifications; sends user email, GitHub handle/id, name, and creation date |
+| `BILLING_POSITIVE_SLACK_WEBHOOK_URL` | Yes | No | Internal Slack destination for positive billing notifications; sends billing owner email, GitHub handle/id, name, creation date, workspace count, and org user count |
+| `BILLING_NEGATIVE_SLACK_WEBHOOK_URL` | Yes | No | Internal Slack destination for negative billing notifications; sends billing owner email, GitHub handle/id, name, creation date, workspace count, and org user count |
+
+## AI Magic
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `ANTHROPIC_API_KEY` | Yes | No | Session title generation |
+| `AI_MAGIC_SESSION_TITLE_MODEL` | No | No | Anthropic model name for session titles |
+
+Rate-limit thresholds (`SESSION_TITLE_RATE_LIMIT_REQUESTS`,
+`SESSION_TITLE_RATE_LIMIT_WINDOW_SECONDS`) and title length caps now live in
+`server/proliferate/constants/ai_magic.py`. They are not env-overridable.
+
+## Cloud Workspaces and Billing
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `CLOUD_SECRET_KEY` | Yes | Yes for cloud-enabled deployments | Control-plane signing for cloud flows |
+| `CLOUD_FREE_SANDBOX_HOURS` | No | No | Free-tier usage limit |
+| `CLOUD_FREE_REPO_LIMIT` | No | No | Free-tier active cloud repo limit |
+| `CLOUD_PAID_REPO_LIMIT` | No | No | Paid Cloud active repo limit |
+| `CLOUD_CONCURRENT_SANDBOX_LIMIT` | No | No | Concurrent sandbox limit |
+| `CLOUD_BILLING_MODE` | No | No | Billing mode (`off`, `observe`, `enforce`) |
+| `STRIPE_SECRET_KEY` | Yes | Future hosted billing only | Stripe API key for checkout, portal, price validation, and legacy usage export |
+| `STRIPE_WEBHOOK_SECRET` | Yes | When receiving Stripe billing webhooks | Stripe webhook signature verification |
+| `STRIPE_CLOUD_MONTHLY_PRICE_ID` | No | Future hosted billing only | Stripe $200 Cloud monthly price ID |
+| `STRIPE_SANDBOX_METER_ID` | No | Future hosted billing only | Stripe billing meter ID for sandbox usage |
+| `STRIPE_SANDBOX_METER_EVENT_NAME` | No | Future hosted billing only | Stripe billing meter event name for sandbox usage |
+| `STRIPE_SANDBOX_OVERAGE_PRICE_ID` | No | Future hosted billing only | Legacy Stripe metered 10-hour overage block price ID |
+| `STRIPE_REFILL_10H_PRICE_ID` | No | Future hosted billing only | Stripe one-time 10-hour refill price ID |
+| `STRIPE_CHECKOUT_SUCCESS_URL` | No | Future hosted billing only | Checkout success redirect URL |
+| `STRIPE_CHECKOUT_CANCEL_URL` | No | Future hosted billing only | Checkout cancellation redirect URL |
+| `STRIPE_CUSTOMER_PORTAL_RETURN_URL` | No | Future hosted billing only | Customer portal return URL |
+
+The billing reconciler interval (`BILLING_RECONCILE_INTERVAL_SECONDS`) now
+lives in `server/proliferate/constants/billing.py`. It is not env-overridable.
+
+## Agent LLM Gateway
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `AGENT_GATEWAY_ENABLED` | No | No | Enables Bifrost-backed managed LLM auth and BYOK policy provisioning |
+| `AGENT_GATEWAY_BIFROST_BASE_URL` | No | When gateway is enabled | Private Bifrost management API base URL for provider keys, virtual keys, and logs |
+| `AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL` | No | When gateway is enabled | Public Bifrost inference base URL written into managed sandbox auth config |
+| `AGENT_GATEWAY_BIFROST_ADMIN_TOKEN` | Yes | When Bifrost admin API is protected | Optional Bifrost management API bearer token; never sent to sandboxes |
+| `AGENT_GATEWAY_BIFROST_REQUEST_TIMEOUT_SECONDS` | No | No | Bifrost management API timeout |
+| `AGENT_GATEWAY_BIFROST_ISOLATION_VERIFIED` | No | BYOK with Bifrost | Operator proof flag that Bifrost virtual keys isolate BYOK credentials safely |
+| `AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY` | Yes | Managed credits via Anthropic-backed Bifrost | Proliferate-owned Anthropic provider key materialized into Bifrost |
+| `AGENT_GATEWAY_MANAGED_OPENAI_API_KEY` | Yes | Managed credits via OpenAI-backed Bifrost | Proliferate-owned OpenAI provider key materialized into Bifrost |
+| `AGENT_GATEWAY_MANAGED_GEMINI_API_KEY` | Yes | Managed credits via Gemini-backed Bifrost | Proliferate-owned Gemini provider key materialized into Bifrost |
+| `AGENT_GATEWAY_MANAGED_BEDROCK_REGION` | No | Managed credits via Bedrock-backed Bifrost | AWS Bedrock region for Proliferate-owned managed credits |
+| `AGENT_GATEWAY_MANAGED_BEDROCK_ROLE_ARN` | No | Managed credits via Bedrock-backed Bifrost | AWS Bedrock role ARN for Proliferate-owned managed credits |
+| `AGENT_GATEWAY_MANAGED_BEDROCK_EXTERNAL_ID` | Yes | No | Optional ExternalId for the managed-credit Bedrock role |
+| `AGENT_GATEWAY_MANAGED_BUDGET_FREE_USD` | No | Only for organization managed credits | Included organization managed-credit budget for free-plan organizations |
+| `AGENT_GATEWAY_MANAGED_BUDGET_PRO_USD` | No | Only for organization managed credits | Included organization managed-credit budget for Pro organizations |
+| `AGENT_GATEWAY_MANAGED_BUDGET_UNLIMITED_USD` | No | Only for organization managed credits | Included organization managed-credit budget for unlimited-plan organizations |
+| `AGENT_GATEWAY_USER_FREE_CREDIT_ENABLED` | No | No | Enables personal onboarding managed-credit grants for GitHub-linked users |
+| `AGENT_GATEWAY_USER_FREE_CREDIT_USD` | No | Only for personal managed credits | Personal free managed-credit amount |
+| `AGENT_GATEWAY_USER_FREE_CREDIT_PERIOD` | No | Only for personal managed credits | Free-credit period key mode: registration or monthly |
+| `AGENT_GATEWAY_MANAGED_CREDIT_AGENT_KINDS` | No | Only for managed credits | Comma-separated agent kinds eligible for Proliferate managed credits |
+| `AGENT_GATEWAY_MAX_REQUEST_BYTES` | No | No | Maximum gateway request body size |
+| `AGENT_GATEWAY_REQUEST_TIMEOUT_SECONDS` | No | No | Gateway request timeout for any remaining compatibility callers |
+| `AGENT_GATEWAY_BYOK_ENABLED` | No | No | Enables user/org provider credentials through Bifrost; hosted-cloud V1 leaves this disabled |
+| `AGENT_GATEWAY_ANTHROPIC_BYOK_ENABLED` | No | Only with `AGENT_GATEWAY_BYOK_ENABLED` | Enables Anthropic API key credentials through the gateway |
+| `AGENT_GATEWAY_OPENAI_BYOK_ENABLED` | No | Only with `AGENT_GATEWAY_BYOK_ENABLED` | Enables OpenAI API key credentials through the gateway |
+| `AGENT_GATEWAY_BEDROCK_BYOK_ENABLED` | No | Only with `AGENT_GATEWAY_BYOK_ENABLED` | Enables AWS Bedrock AssumeRole credentials through the gateway |
+| `AGENT_GATEWAY_GEMINI_BYOK_ENABLED` | No | Only with `AGENT_GATEWAY_BYOK_ENABLED` and Bifrost | Enables Gemini API key credentials through Bifrost |
+| `AGENT_GATEWAY_OPENAI_COMPATIBLE_BYOK_ENABLED` | No | Only with `AGENT_GATEWAY_BYOK_ENABLED` | Enables OpenAI-compatible provider credentials through the gateway |
+| `AGENT_GATEWAY_OPENCODE_ENABLED` | No | No | Enables the experimental OpenCode gateway route |
+| `AGENT_GATEWAY_RECONCILER_ENABLED` | No | No | Starts the background router reconciler and Bifrost usage importer |
+| `AGENT_GATEWAY_RECONCILER_INTERVAL_SECONDS` | No | No | Delay between reconciliation passes |
+| `AGENT_GATEWAY_RECONCILER_BATCH_SIZE` | No | No | Maximum unsynced, drifted, failed policy, budget, or usage rows checked by one reconciliation pass |
+
+## Cloud MCP
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `CLOUD_MCP_ENABLED` | No | No | Enables cloud-owned MCP catalog, connection, OAuth, and materialization APIs |
+| `CLOUD_MCP_OAUTH_CALLBACK_BASE_URL` | No | Required for public OAuth deployments unless `API_BASE_URL` is set | Public base URL used to build MCP OAuth callback URLs |
+| `CLOUD_MCP_SLACK_ENABLED` | No | No | Shows the Slack MCP connector when static Slack OAuth config is also present |
+| `CLOUD_MCP_SLACK_CLIENT_ID` | Yes | Only when Slack MCP is enabled for this deployment | Static Slack OAuth client ID |
+| `CLOUD_MCP_SLACK_CLIENT_SECRET` | Yes | Only when Slack MCP is enabled for this deployment | Static Slack OAuth client secret |
+| `CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD` | No | No | Slack token endpoint auth method (`client_secret_post` or `client_secret_basic`) |
+| `CLOUD_MCP_GOOGLE_WORKSPACE_ENABLED` | No | No | Shows the local-only Gmail MCP connector |
+| `CLOUD_MCP_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID` | No | Only when Gmail MCP is enabled for this deployment | Google Desktop OAuth client ID for local Gmail OAuth |
+| `CLOUD_MCP_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET` | No | Only when Gmail MCP is enabled for this deployment | Google Desktop OAuth installed-app client secret passed to local Gmail OAuth setup; serialized to desktop catalog responses |
+
+Static OAuth MCP connectors are hidden from the catalog when their required
+deployment config is missing or their explicit connector enable flag is false.
+Gmail uses a Google restricted scope and must stay in test-user/dev mode until
+Google verification for the Proliferate OAuth app is accepted.
+The Google Desktop OAuth "client secret" is not a confidential server secret in
+this connector shape because the local MCP process must receive it to complete
+installed-app OAuth.
+
+## Sandbox Provider Settings
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `SANDBOX_PROVIDER` | No | Yes for cloud-enabled deployments | Selects `e2b` or `daytona` |
+| `E2B_API_KEY` | Yes | When `SANDBOX_PROVIDER=e2b` | E2B provisioning auth |
+| `E2B_TEMPLATE_NAME` | No | Required for non-debug E2B deployments | Explicit E2B template ref, typically `TEAM_SLUG/proliferate-runtime-cloud:production` |
+| `E2B_WEBHOOK_SIGNATURE_SECRET` | Yes | No | E2B webhook verification |
+| `DAYTONA_API_KEY` | Yes | When `SANDBOX_PROVIDER=daytona` | Daytona provisioning auth |
+| `DAYTONA_SERVER_URL` | No | No | Daytona API base URL |
+| `DAYTONA_TARGET` | No | No | Daytona target/region |
+
+Sandbox timeout defaults, runtime ports, workdirs, and target paths now live in
+`server/proliferate/constants/sandbox/e2b.py` and
+`server/proliferate/constants/sandbox/daytona.py`. They are code defaults, not
+env overrides.
+
+## Remote AnyHarness Injection
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `CLOUD_RUNTIME_SOURCE_BINARY_PATH` | No | No | Override path for the Linux AnyHarness binary uploaded into cloud sandboxes |
+| `CLOUD_WORKER_SOURCE_BINARY_PATH` | No | No | Override path for the Linux Proliferate Worker binary uploaded into cloud sandboxes |
+| `CLOUD_SUPERVISOR_SOURCE_BINARY_PATH` | No | No | Override path for the Linux Proliferate Supervisor binary uploaded into cloud sandboxes |
+| `CLOUD_RUNTIME_SENTRY_DSN` | Yes | No | Remote AnyHarness Sentry DSN |
+| `CLOUD_RUNTIME_SENTRY_ENVIRONMENT` | No | No | Remote AnyHarness Sentry environment |
+| `CLOUD_RUNTIME_SENTRY_RELEASE` | No | No | Remote AnyHarness Sentry release |
+| `CLOUD_RUNTIME_SENTRY_TRACES_SAMPLE_RATE` | No | No | Remote AnyHarness tracing |
+| `CLOUD_TARGET_SENTRY_DSN` | Yes | No | Remote target worker/supervisor Sentry DSN |
+| `CLOUD_TARGET_SENTRY_ENVIRONMENT` | No | No | Remote target worker/supervisor Sentry environment |
+| `CLOUD_TARGET_SENTRY_RELEASE` | No | No | Remote target worker/supervisor Sentry release |
+| `CLOUD_TARGET_SENTRY_TRACES_SAMPLE_RATE` | No | No | Remote target worker/supervisor tracing |
+
+## Legacy Compatibility
+
+There is no `E2B_RUNTIME_SENTRY_*` compatibility fallback on this branch.
+Operators should migrate any legacy runtime Sentry configuration to the
+`CLOUD_RUNTIME_*` variables above. The old `E2B_RUNTIME_SENTRY_*` names are not
+part of the supported env surface here.

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -1,0 +1,1422 @@
+# Canonical environment variable reference for the Proliferate stack.
+#
+# Every env var across every deployment surface lives here. Use the tags
+# to filter by deployment mode:
+#
+#   local-dev     — Mode B (local desktop + local control plane)
+#   self-hosted   — Mode C/D (Docker Compose or CloudFormation)
+#   production    — Mode E (Proliferate Cloud)
+#   ci            — GitHub Actions workflows
+#   desktop       — Desktop renderer (VITE_*) or native Tauri
+#   web           — Hosted web app build (VITE_*)
+#   mobile        — Expo mobile app build (EXPO_PUBLIC_*)
+#
+# Mode A (local desktop only) requires no env vars.
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Core
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: DEBUG
+  secret: false
+  default: "false"
+  description: Debug mode flag
+  tags: [local-dev]
+
+- name: PROLIFERATE_TELEMETRY_MODE
+  secret: false
+  default: "local_dev"
+  description: "Telemetry runtime mode: local_dev, self_managed, or hosted_product"
+  tags: [local-dev, self-hosted, production]
+
+- name: API_BASE_URL
+  secret: false
+  default: ""
+  description: Canonical public API base URL for absolute auth callback generation
+  tags: [local-dev, self-hosted, production]
+
+- name: API_PATH_PREFIX
+  secret: false
+  default: ""
+  description: Optional path prefix where the API is externally mounted, such as /api
+  tags: [local-dev, self-hosted, production]
+
+- name: DATABASE_URL
+  secret: true
+  default: "postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate"
+  description: PostgreSQL connection string
+  tags: [local-dev, self-hosted, production]
+
+- name: DATABASE_ECHO
+  secret: false
+  default: "false"
+  description: SQLAlchemy query echo/logging
+  tags: [local-dev]
+
+- name: CORS_ALLOW_ORIGINS
+  secret: false
+  default: "desktop, web, mobile-web, Metro, and tauri local origins"
+  description: Comma-separated browser/webview origins allowed to call the API
+  tags: [local-dev, self-hosted, production]
+
+- name: PROLIFERATE_DEV
+  secret: false
+  default: ""
+  description: Enables local desktop/runtime dev profile behavior
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_DEV_PROFILE
+  secret: false
+  default: ""
+  description: Local dev profile name used by make dev PROFILE=<name>
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_DEV_HOME
+  secret: false
+  default: ""
+  description: Profile-specific desktop file-backed state directory
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_API_PORT
+  secret: false
+  default: "8000"
+  description: Profile-specific local API port
+  tags: [local-dev]
+
+- name: PROLIFERATE_WEB_PORT
+  secret: false
+  default: "1420"
+  description: Profile-specific local Vite dev server port
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_WEB_HMR_PORT
+  secret: false
+  default: "1421"
+  description: Profile-specific local Vite hot-module-reload websocket port
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE
+  secret: false
+  default: "49321"
+  description: Base port for the profile-scoped 64-port Google Workspace MCP loopback OAuth pool
+  tags: [local-dev, desktop]
+
+- name: PROLIFERATE_DEV_DB_NAME
+  secret: false
+  default: ""
+  description: Profile-specific local Postgres database name
+  tags: [local-dev]
+
+- name: JWT_SECRET
+  secret: true
+  default: "CHANGE-ME-IN-PRODUCTION"
+  description: JWT signing and OAuth state signing
+  tags: [local-dev, self-hosted, production]
+
+- name: PASSWORD_AUTH_ENABLED
+  secret: false
+  default: "true"
+  description: Enables product-owned email/password login for password-provisioned accounts
+  tags: [local-dev, self-hosted, production]
+
+- name: PASSWORD_AUTH_TRUSTED_PROXY_HOSTS
+  secret: false
+  default: ""
+  description: Comma-separated proxy IPs or CIDRs allowed to supply x-forwarded-for for password login throttling
+  tags: [self-hosted, production]
+
+- name: MOBILE_REDIRECT_URI
+  secret: false
+  default: "proliferate://auth/callback"
+  description: Exact mobile OAuth callback URI accepted by the server
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: GitHub OAuth
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: GITHUB_OAUTH_CLIENT_ID
+  secret: true
+  default: ""
+  description: GitHub OAuth client ID for the shared /auth/github/callback sign-in flow
+  tags: [local-dev, self-hosted, production]
+
+- name: GITHUB_OAUTH_CLIENT_SECRET
+  secret: true
+  default: ""
+  description: GitHub OAuth client secret for the shared /auth/github/callback sign-in flow
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Sandbox Providers
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: SANDBOX_PROVIDER
+  secret: false
+  default: "e2b"
+  description: "Cloud sandbox provider: e2b or daytona"
+  tags: [local-dev, self-hosted, production]
+
+- name: E2B_API_KEY
+  secret: true
+  default: ""
+  description: E2B provisioning auth
+  tags: [local-dev, self-hosted, production]
+
+- name: E2B_TEMPLATE_NAME
+  secret: false
+  default: ""
+  description: Explicit E2B template ref for cloud provisioning, typically TEAM_SLUG/proliferate-runtime-cloud:production
+  tags: [local-dev, self-hosted, production]
+
+- name: E2B_WEBHOOK_SIGNATURE_SECRET
+  secret: true
+  default: ""
+  description: E2B webhook verification
+  tags: [production]
+
+- name: STRIPE_WEBHOOK_SECRET
+  secret: true
+  default: ""
+  description: Stripe webhook signing secret for billing event intake
+  tags: [local-dev, production]
+
+- name: DAYTONA_API_KEY
+  secret: true
+  default: ""
+  description: Daytona provisioning auth
+  tags: [local-dev, self-hosted, production]
+
+- name: DAYTONA_SERVER_URL
+  secret: false
+  default: "https://app.daytona.io/api"
+  description: Daytona API base URL
+  tags: [local-dev, self-hosted, production]
+
+- name: DAYTONA_TARGET
+  secret: false
+  default: "us"
+  description: Daytona target/region
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Cloud Workspaces
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: CLOUD_SECRET_KEY
+  secret: true
+  default: "CHANGE-ME-IN-PRODUCTION-CLOUD-SECRET"
+  description: Control-plane signing for cloud flows
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_FREE_SANDBOX_HOURS
+  secret: false
+  default: "2000.0"
+  description: Free-tier usage limit (hours)
+  tags: [self-hosted, production]
+
+- name: CLOUD_FREE_REPO_LIMIT
+  secret: false
+  default: "1"
+  description: Free-tier active cloud repo limit
+  tags: [self-hosted, production]
+
+- name: CLOUD_PAID_REPO_LIMIT
+  secret: false
+  default: "4"
+  description: Paid Cloud active repo limit
+  tags: [self-hosted, production]
+
+- name: CLOUD_CONCURRENT_SANDBOX_LIMIT
+  secret: false
+  default: "200"
+  description: Concurrent sandbox limit
+  tags: [self-hosted, production]
+
+- name: CLOUD_BILLING_MODE
+  secret: false
+  default: "off"
+  description: "Billing mode: off, observe, or enforce"
+  tags: [production]
+
+- name: PRO_BILLING_ENABLED
+  secret: false
+  default: "false"
+  description: Enables Pro billing policy, free-v2 trial behavior, and Pro response fields
+  tags: [production]
+
+- name: STRIPE_SECRET_KEY
+  secret: true
+  default: ""
+  description: Stripe API key for checkout, portal, price validation, and legacy usage export
+  tags: [local-dev, production]
+
+- name: STRIPE_WEBHOOK_SECRET
+  secret: true
+  default: ""
+  description: Stripe webhook signature verification
+  tags: [local-dev, production]
+
+- name: STRIPE_CLOUD_MONTHLY_PRICE_ID
+  secret: false
+  default: ""
+  description: Transitional alias for STRIPE_PRO_MONTHLY_PRICE_ID when no legacy Cloud price is configured
+  tags: [local-dev, production]
+
+- name: STRIPE_PRO_MONTHLY_PRICE_ID
+  secret: false
+  default: ""
+  description: Stripe Pro monthly seat price ID at $20/user/month
+  tags: [local-dev, production]
+
+- name: STRIPE_LEGACY_CLOUD_MONTHLY_PRICE_ID
+  secret: false
+  default: ""
+  description: Optional legacy $200 Cloud monthly price ID for grandfathered subscriptions
+  tags: [production]
+
+- name: STRIPE_MANAGED_CLOUD_OVERAGE_PRICE_ID
+  secret: false
+  default: ""
+  description: Stripe metered price ID for managed cloud overage cents
+  tags: [local-dev, production]
+
+- name: STRIPE_SANDBOX_METER_ID
+  secret: false
+  default: ""
+  description: Legacy alias for the managed cloud overage meter ID
+  tags: [local-dev, production]
+
+- name: STRIPE_SANDBOX_METER_EVENT_NAME
+  secret: false
+  default: "proliferate_sandbox_seconds"
+  description: Legacy sandbox usage meter event name
+  tags: [local-dev, production]
+
+- name: STRIPE_MANAGED_CLOUD_OVERAGE_METER_ID
+  secret: false
+  default: ""
+  description: Stripe billing meter ID for managed cloud overage cents
+  tags: [local-dev, production]
+
+- name: STRIPE_MANAGED_CLOUD_OVERAGE_METER_EVENT_NAME
+  secret: false
+  default: "proliferate_managed_cloud_overage_cents"
+  description: Stripe billing meter event name for managed cloud overage cents
+  tags: [local-dev, production]
+
+- name: STRIPE_SANDBOX_OVERAGE_PRICE_ID
+  secret: false
+  default: ""
+  description: Legacy Stripe metered 10-hour overage block price ID
+  tags: [local-dev, production]
+
+- name: STRIPE_REFILL_10H_PRICE_ID
+  secret: false
+  default: ""
+  description: Stripe one-time 10-hour refill price ID
+  tags: [local-dev, production]
+
+- name: STRIPE_CHECKOUT_SUCCESS_URL
+  secret: false
+  default: ""
+  description: Checkout success redirect URL
+  tags: [local-dev, production]
+
+- name: STRIPE_CHECKOUT_CANCEL_URL
+  secret: false
+  default: ""
+  description: Checkout cancellation redirect URL
+  tags: [local-dev, production]
+
+- name: STRIPE_CUSTOMER_PORTAL_RETURN_URL
+  secret: false
+  default: ""
+  description: Customer portal return URL
+  tags: [local-dev, production]
+
+- name: STRIPE_FORWARD_TO
+  secret: false
+  default: "http://127.0.0.1:8000/v1/billing/webhooks/stripe"
+  description: Local Stripe CLI webhook forwarding destination used by Makefile dev targets
+  tags: [local-dev]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Agent LLM Gateway
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: AGENT_GATEWAY_ENABLED
+  secret: false
+  default: "false"
+  description: Enables Bifrost-backed managed LLM auth and BYOK policy provisioning
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BIFROST_BASE_URL
+  secret: false
+  default: "http://127.0.0.1:8080"
+  description: Private Bifrost management API base URL used by the control plane for provider keys, virtual keys, and log import
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL
+  secret: false
+  default: ""
+  description: Public Bifrost inference base URL written into managed sandbox auth config
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BIFROST_ADMIN_TOKEN
+  secret: true
+  default: ""
+  description: Optional Bifrost management API bearer token; never sent to sandboxes
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BIFROST_REQUEST_TIMEOUT_SECONDS
+  secret: false
+  default: "30.0"
+  description: Timeout for Bifrost management API requests
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BIFROST_ISOLATION_VERIFIED
+  secret: false
+  default: "false"
+  description: Operator proof flag that Bifrost virtual keys restrict BYOK secrets and routes safely enough for BYOK launch
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY
+  secret: true
+  default: ""
+  description: Proliferate-owned Anthropic key materialized into Bifrost for managed credits
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_OPENAI_API_KEY
+  secret: true
+  default: ""
+  description: Proliferate-owned OpenAI key materialized into Bifrost for managed credits
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_GEMINI_API_KEY
+  secret: true
+  default: ""
+  description: Proliferate-owned Gemini key materialized into Bifrost for managed credits
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BEDROCK_REGION
+  secret: false
+  default: ""
+  description: AWS Bedrock region used by Proliferate-owned managed-credit Bedrock routing through Bifrost
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BEDROCK_ROLE_ARN
+  secret: false
+  default: ""
+  description: AWS Bedrock role ARN used by Proliferate-owned managed-credit Bedrock routing through Bifrost
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BEDROCK_EXTERNAL_ID
+  secret: true
+  default: ""
+  description: Optional ExternalId used when Bifrost assumes the managed-credit Bedrock role
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BUDGET_FREE_USD
+  secret: false
+  default: "0"
+  description: Included organization managed-credit budget for free-plan organizations; zero disables org managed credits for this plan
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BUDGET_PRO_USD
+  secret: false
+  default: "0"
+  description: Included organization managed-credit budget for Pro organizations; zero disables org managed credits for this plan
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_BUDGET_UNLIMITED_USD
+  secret: false
+  default: "0"
+  description: Included organization managed-credit budget for unlimited-plan organizations; zero disables org managed credits for this plan
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_USER_FREE_CREDIT_ENABLED
+  secret: false
+  default: "false"
+  description: Enables personal Proliferate-provided LLM credits for GitHub-linked users
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_USER_FREE_CREDIT_USD
+  secret: false
+  default: "0"
+  description: Personal free managed-credit amount materialized into the selected router; zero disables the allocation
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_USER_FREE_CREDIT_PERIOD
+  secret: false
+  default: "registration"
+  description: Free-credit period key mode; registration is one-time, monthly uses YYYY-MM period keys and router budgets
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MANAGED_CREDIT_AGENT_KINDS
+  secret: false
+  default: "claude"
+  description: Comma-separated agent kinds eligible for Proliferate managed credits; unsupported kinds are ignored
+  tags: [local-dev, production]
+
+- name: AGENT_GATEWAY_MAX_REQUEST_BYTES
+  secret: false
+  default: "4194304"
+  description: Maximum protocol request body size accepted by the agent gateway
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_REQUEST_TIMEOUT_SECONDS
+  secret: false
+  default: "120.0"
+  description: Timeout for forwarding gateway requests in the legacy Proliferate gateway data plane
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables user/org provider credentials through the selected router; also requires verified route isolation before any BYOK policy can launch
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_PERSONAL_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables personal BYOK provider credentials after AGENT_GATEWAY_BYOK_ENABLED and route-isolation verification are also enabled
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_ANTHROPIC_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables Anthropic API key credentials through the gateway when AGENT_GATEWAY_BYOK_ENABLED is also true
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_OPENAI_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables OpenAI API key credentials through the gateway when AGENT_GATEWAY_BYOK_ENABLED is also true
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BEDROCK_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables AWS Bedrock AssumeRole credentials through the gateway when AGENT_GATEWAY_BYOK_ENABLED is also true
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_GEMINI_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables Gemini API key credentials through Bifrost when AGENT_GATEWAY_BYOK_ENABLED is also true
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_OPENAI_COMPATIBLE_BYOK_ENABLED
+  secret: false
+  default: "false"
+  description: Enables OpenAI-compatible provider credentials through the gateway when AGENT_GATEWAY_BYOK_ENABLED is also true
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_OPENCODE_ENABLED
+  secret: false
+  default: "false"
+  description: Enables the experimental OpenCode gateway route and model surface
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_RECONCILER_ENABLED
+  secret: false
+  default: "false"
+  description: Starts the background router reconciler and Bifrost usage-log importer when the agent gateway is enabled
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_RECONCILER_INTERVAL_SECONDS
+  secret: false
+  default: "300.0"
+  description: Delay between background router reconciliation passes
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_RECONCILER_BATCH_SIZE
+  secret: false
+  default: "50"
+  description: Maximum unsynced, drifted, failed policy, budget, or usage rows checked by one router reconciliation pass
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Cloud MCP
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: CLOUD_MCP_ENABLED
+  secret: false
+  default: "true"
+  description: Enables cloud-owned MCP catalog, connection, OAuth, and materialization APIs
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_OAUTH_CALLBACK_BASE_URL
+  secret: false
+  default: ""
+  description: Public base URL used to build MCP OAuth callback URLs; falls back to API_BASE_URL
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_SLACK_ENABLED
+  secret: false
+  default: "false"
+  description: Shows the Slack MCP connector when static Slack OAuth config is also present
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_SLACK_CLIENT_ID
+  secret: true
+  default: ""
+  description: Static OAuth client ID for Slack MCP
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_SLACK_CLIENT_SECRET
+  secret: true
+  default: ""
+  description: Static OAuth client secret for Slack MCP
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD
+  secret: false
+  default: "client_secret_post"
+  description: "Slack MCP token endpoint auth method: client_secret_post or client_secret_basic"
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_GOOGLE_WORKSPACE_ENABLED
+  secret: false
+  default: "false"
+  description: Shows the local-only Gmail MCP connector when Google Desktop OAuth client credentials are configured
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID
+  secret: false
+  default: ""
+  description: Google Desktop OAuth client ID used by the local-only Gmail MCP connector
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET
+  secret: false
+  default: ""
+  description: Google Desktop OAuth installed-app client secret passed to local workspace-mcp; this is serialized to desktop catalog responses and is not treated as a confidential server secret
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Cloud Runtime Injection (both E2B and Daytona)
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: CLOUD_RUNTIME_SOURCE_BINARY_PATH
+  secret: false
+  default: ""
+  description: Path to the Linux AnyHarness binary uploaded into cloud sandboxes
+  tags: [self-hosted, production]
+
+- name: CLOUD_WORKER_SOURCE_BINARY_PATH
+  secret: false
+  default: ""
+  description: Path to the Linux Proliferate Worker binary uploaded into cloud sandboxes
+  tags: [self-hosted, production]
+
+- name: CLOUD_SUPERVISOR_SOURCE_BINARY_PATH
+  secret: false
+  default: ""
+  description: Path to the Linux Proliferate Supervisor binary uploaded into cloud sandboxes
+  tags: [self-hosted, production]
+
+- name: CLOUD_RUNTIME_SENTRY_DSN
+  secret: true
+  default: ""
+  description: Sentry DSN for remote AnyHarness in cloud sandboxes
+  tags: [self-hosted, production]
+
+- name: CLOUD_RUNTIME_SENTRY_ENVIRONMENT
+  secret: false
+  default: ""
+  description: Sentry environment for remote AnyHarness
+  tags: [self-hosted, production]
+
+- name: CLOUD_RUNTIME_SENTRY_RELEASE
+  secret: false
+  default: ""
+  description: Sentry release for remote AnyHarness
+  tags: [self-hosted, production]
+
+- name: CLOUD_RUNTIME_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Sentry traces sample rate for remote AnyHarness
+  tags: [self-hosted, production]
+
+- name: CLOUD_TARGET_SENTRY_DSN
+  secret: true
+  default: ""
+  description: Sentry DSN for cloud target worker and supervisor processes
+  tags: [self-hosted, production]
+
+- name: CLOUD_TARGET_SENTRY_ENVIRONMENT
+  secret: false
+  default: ""
+  description: Sentry environment for cloud target worker and supervisor processes
+  tags: [self-hosted, production]
+
+- name: CLOUD_TARGET_SENTRY_RELEASE
+  secret: false
+  default: ""
+  description: Sentry release for cloud target worker and supervisor processes
+  tags: [self-hosted, production]
+
+- name: CLOUD_TARGET_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Sentry traces sample rate for cloud target worker and supervisor processes
+  tags: [self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: AI Magic
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: ANTHROPIC_API_KEY
+  secret: true
+  default: ""
+  description: Anthropic API key for AI session title generation
+  tags: [local-dev, self-hosted, production]
+
+- name: AI_MAGIC_SESSION_TITLE_MODEL
+  secret: false
+  default: "claude-haiku-4-5-20251001"
+  description: Claude model used for session titles
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Observability
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: SENTRY_DSN
+  secret: true
+  default: ""
+  description: Server Sentry DSN
+  tags: [self-hosted, production]
+
+- name: SENTRY_ENVIRONMENT
+  secret: false
+  default: "trusted-beta"
+  description: Server Sentry environment
+  tags: [self-hosted, production]
+
+- name: SENTRY_RELEASE
+  secret: false
+  default: "proliferate-server@0.1.0"
+  description: Server Sentry release tag
+  tags: [self-hosted, production]
+
+- name: SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Server Sentry traces sample rate
+  tags: [self-hosted, production]
+
+- name: PROLIFERATE_ANONYMOUS_TELEMETRY_ENDPOINT
+  secret: false
+  default: "https://app.proliferate.com/api/v1/telemetry/anonymous"
+  description: Anonymous telemetry collector endpoint
+  tags: [self-hosted, production]
+
+- name: PROLIFERATE_ANONYMOUS_TELEMETRY_DISABLED
+  secret: false
+  default: "false"
+  description: Disable anonymous telemetry emission from the server
+  tags: [self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Server: Messaging
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: CUSTOMERIO_SITE_ID
+  secret: true
+  default: ""
+  description: Customer.io workspace ID
+  tags: [production]
+
+- name: CUSTOMERIO_API_KEY
+  secret: true
+  default: ""
+  description: Customer.io API auth
+  tags: [production]
+
+- name: CUSTOMERIO_APP_API_KEY
+  secret: true
+  default: ""
+  description: Customer.io app API auth
+  tags: [production]
+
+- name: CUSTOMERIO_FROM_EMAIL
+  secret: false
+  default: "hello@proliferate.com"
+  description: Customer.io sender email address
+  tags: [production]
+
+- name: CUSTOMERIO_WELCOME_TRANSACTIONAL_MESSAGE_ID
+  secret: false
+  default: ""
+  description: Customer.io transactional message ID used to send the desktop welcome email; leave blank to disable welcome emails
+  tags: [production]
+
+- name: RESEND_API_KEY
+  secret: true
+  default: ""
+  description: Resend transactional email API key for organization invitations
+  tags: [production]
+
+- name: RESEND_FROM_EMAIL
+  secret: false
+  default: "hello@proliferate.dev"
+  description: Resend sender email address for organization invitations
+  tags: [production]
+
+- name: FRONTEND_BASE_URL
+  secret: false
+  default: ""
+  description: Frontend base URL for email links
+  tags: [production]
+
+- name: SUPPORT_SLACK_WEBHOOK_URL
+  secret: true
+  default: ""
+  description: Slack incoming webhook for support messages and completed support report notifications (Proliferate Cloud only)
+  tags: [production]
+
+- name: SUPPORT_REPORT_S3_BUCKET
+  secret: false
+  default: ""
+  description: Private S3 bucket used for support report diagnostics and attachments; leave blank to disable support report uploads
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_S3_PREFIX
+  secret: false
+  default: "support/reports"
+  description: S3 key prefix for support report request, diagnostics, attachment, and completion objects
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_S3_REGION
+  secret: false
+  default: ""
+  description: Optional AWS region override for support report S3 clients and presigned URLs
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_UPLOAD_URL_EXPIRES_SECONDS
+  secret: false
+  default: "900"
+  description: Lifetime in seconds for support report presigned PUT URLs
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_DIAGNOSTICS_MAX_BYTES
+  secret: false
+  default: "26214400"
+  description: Maximum uncompressed diagnostics package size accepted for a support report
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_ATTACHMENT_MAX_BYTES
+  secret: false
+  default: "26214400"
+  description: Maximum size of a single support report attachment
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_TOTAL_ATTACHMENT_MAX_BYTES
+  secret: false
+  default: "104857600"
+  description: Maximum combined size of all support report attachments
+  tags: [local-dev, self-hosted, production]
+
+- name: SUPPORT_REPORT_INTERNAL_BASE_URL
+  secret: false
+  default: ""
+  description: Internal support-report viewer URL prefix; Slack, GitHub, and Linear receive only this report URL or report ID, never S3 keys
+  tags: [production]
+
+- name: SUPPORT_TRACKER_ENABLED
+  secret: false
+  default: "false"
+  description: Enables server-owned creation/reconciliation of GitHub and Linear issues for completed support reports
+  tags: [local-dev, production]
+
+- name: SUPPORT_TRACKER_RECONCILER_INTERVAL_SECONDS
+  secret: false
+  default: "30.0"
+  description: Background support tracker reconciliation interval in seconds
+  tags: [production]
+
+- name: SUPPORT_TRACKER_RECONCILER_BATCH_SIZE
+  secret: false
+  default: "10"
+  description: Maximum support reports processed per tracker reconciliation pass
+  tags: [production]
+
+- name: SUPPORT_TRACKER_MAX_ATTEMPTS
+  secret: false
+  default: "8"
+  description: Maximum retry attempts before a support tracker job is marked permanently failed
+  tags: [production]
+
+- name: SUPPORT_TRACKER_RETRY_BASE_SECONDS
+  secret: false
+  default: "60.0"
+  description: Base exponential-backoff delay for retryable support tracker failures
+  tags: [production]
+
+- name: SUPPORT_GITHUB_APP_ID
+  secret: false
+  default: ""
+  description: GitHub App ID for the support issue bot
+  tags: [production]
+
+- name: SUPPORT_GITHUB_APP_PRIVATE_KEY
+  secret: true
+  default: ""
+  description: GitHub App private key for the support issue bot
+  tags: [production]
+
+- name: SUPPORT_GITHUB_APP_PRIVATE_KEY_PARAMETER_NAME
+  secret: false
+  default: ""
+  description: SSM SecureString parameter name used as the ECS secret source for SUPPORT_GITHUB_APP_PRIVATE_KEY
+  tags: [production]
+
+- name: SUPPORT_GITHUB_APP_INSTALLATION_ID
+  secret: false
+  default: ""
+  description: Installation ID for the GitHub App on the support issue repository
+  tags: [production]
+
+- name: SUPPORT_GITHUB_OWNER
+  secret: false
+  default: ""
+  description: GitHub owner or organization that receives public support issues
+  tags: [production]
+
+- name: SUPPORT_GITHUB_REPO
+  secret: false
+  default: ""
+  description: GitHub repository that receives public support issues
+  tags: [production]
+
+- name: SUPPORT_GITHUB_LABEL_SUPPORT
+  secret: false
+  default: "support issue"
+  description: Label applied to every GitHub issue created from a support report
+  tags: [production]
+
+- name: SUPPORT_GITHUB_LABEL_PRIVATE
+  secret: false
+  default: "private"
+  description: Label applied when the submitter does not consent to publishing their message in GitHub
+  tags: [production]
+
+- name: SUPPORT_LINEAR_API_KEY
+  secret: true
+  default: ""
+  description: Optional Linear API key used to create private internal support triage issues
+  tags: [production]
+
+- name: SUPPORT_LINEAR_API_KEY_PARAMETER_NAME
+  secret: false
+  default: ""
+  description: SSM SecureString parameter name used as the ECS secret source for SUPPORT_LINEAR_API_KEY
+  tags: [production]
+
+- name: SUPPORT_LINEAR_TEAM_ID
+  secret: false
+  default: ""
+  description: Optional Linear team ID for support report tracker issues
+  tags: [production]
+
+- name: SUPPORT_LINEAR_PROJECT_ID
+  secret: false
+  default: ""
+  description: Optional Linear project ID for support report tracker issues
+  tags: [production]
+
+- name: SUPPORT_LINEAR_LABEL_IDS
+  secret: false
+  default: ""
+  description: Optional comma-separated Linear label IDs applied to support report tracker issues
+  tags: [production]
+
+- name: SIGNUPS_SLACK_WEBHOOK_URL
+  secret: true
+  default: ""
+  description: Slack incoming webhook for internal desktop GitHub hosted-user signup notifications; messages include user email, GitHub handle/id, name, and creation date
+  tags: [production]
+
+- name: BILLING_POSITIVE_SLACK_WEBHOOK_URL
+  secret: true
+  default: ""
+  description: Slack incoming webhook for internal positive billing notifications; messages include billing owner email, GitHub handle/id, name, creation date, workspace count, and org user count
+  tags: [production]
+
+- name: BILLING_NEGATIVE_SLACK_WEBHOOK_URL
+  secret: true
+  default: ""
+  description: Slack incoming webhook for internal negative billing notifications; messages include billing owner email, GitHub handle/id, name, creation date, workspace count, and org user count
+  tags: [production]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Desktop/Web: Renderer Build Vars (VITE_*)
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: VITE_PROLIFERATE_API_BASE_URL
+  secret: false
+  default: "http://127.0.0.1:8000"
+  description: Desktop/web control-plane base URL; desktop may override it at runtime through ~/.proliferate/config.json
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_ENVIRONMENT
+  secret: false
+  default: "development"
+  description: Desktop/web telemetry environment
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_RELEASE
+  secret: false
+  default: "proliferate-desktop@dev"
+  description: Desktop/web telemetry release tag
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_TELEMETRY_DISABLED
+  secret: false
+  default: "false"
+  description: Disable both vendor and anonymous desktop/web telemetry
+  tags: [local-dev, desktop, web]
+
+- name: VITE_PROLIFERATE_ANONYMOUS_TELEMETRY_ENDPOINT
+  secret: false
+  default: "https://app.proliferate.com/api/v1/telemetry/anonymous"
+  description: Renderer anonymous telemetry collector endpoint
+  tags: [local-dev, ci]
+
+- name: VITE_DEV_DISABLE_AUTH
+  secret: false
+  default: ""
+  description: Dev-only auth bypass
+  tags: [local-dev]
+
+- name: VITE_REQUIRE_AUTH
+  secret: false
+  default: ""
+  description: Force or disable desktop auth requirement; production desktop releases default to requiring auth
+  tags: [local-dev, production, desktop]
+
+- name: VITE_PROLIFERATE_DEBUG_LATENCY
+  secret: false
+  default: ""
+  description: Extra latency logging in dev
+  tags: [local-dev]
+
+- name: VITE_PROLIFERATE_DEBUG_MAIN_THREAD
+  secret: false
+  default: ""
+  description: Dev-only renderer main-thread measurement for React commits, render counts, long tasks, and frame gaps
+  tags: [local-dev, desktop]
+
+- name: VITE_PROLIFERATE_DEBUG_ANYHARNESS_TIMING
+  secret: false
+  default: ""
+  description: Dev-only privacy-safe AnyHarness/cloud request and stream timing measurement
+  tags: [local-dev, desktop]
+
+- name: VITE_PROLIFERATE_SENTRY_DSN
+  secret: false
+  default: ""
+  description: Desktop/web Sentry DSN
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Desktop/web Sentry traces sample rate
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_SENTRY_ENABLE_LOGS
+  secret: false
+  default: "true"
+  description: Desktop/web Sentry log capture
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_POSTHOG_KEY
+  secret: false
+  default: ""
+  description: Desktop/web PostHog project key
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_POSTHOG_HOST
+  secret: false
+  default: "https://us.i.posthog.com"
+  description: Desktop/web PostHog ingest host
+  tags: [local-dev, ci, desktop, web]
+
+- name: VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED
+  secret: false
+  default: "false"
+  description: Desktop PostHog session recording toggle; reserved for web because web replay is currently disabled in code
+  tags: [local-dev, ci, desktop, web]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Mobile: Expo Public Build Vars
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: EXPO_PUBLIC_PROLIFERATE_API_BASE_URL
+  secret: false
+  default: ""
+  description: Mobile control-plane base URL
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_ENVIRONMENT
+  secret: false
+  default: "development"
+  description: Mobile telemetry environment
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_RELEASE
+  secret: false
+  default: "proliferate-mobile@0.1.0"
+  description: Mobile telemetry release tag
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_TELEMETRY_DISABLED
+  secret: false
+  default: "false"
+  description: Disable mobile vendor telemetry
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_SENTRY_DSN
+  secret: false
+  default: ""
+  description: Mobile Sentry DSN
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Mobile Sentry traces sample rate
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_POSTHOG_KEY
+  secret: false
+  default: ""
+  description: Mobile PostHog project key
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_POSTHOG_HOST
+  secret: false
+  default: "https://us.i.posthog.com"
+  description: Mobile PostHog ingest host
+  tags: [local-dev, production, mobile]
+
+- name: EXPO_PUBLIC_PROLIFERATE_POSTHOG_SESSION_REPLAY_ENABLED
+  secret: false
+  default: "false"
+  description: Mobile PostHog session replay startup toggle
+  tags: [local-dev, production, mobile]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Desktop: Native Tauri (compile-time)
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: PROLIFERATE_DESKTOP_SENTRY_DSN
+  secret: false
+  default: ""
+  description: Native desktop Sentry DSN (baked into release builds)
+  tags: [ci]
+
+- name: PROLIFERATE_DESKTOP_SENTRY_ENVIRONMENT
+  secret: false
+  default: "development"
+  description: Native desktop Sentry environment
+  tags: [ci]
+
+- name: PROLIFERATE_DESKTOP_SENTRY_RELEASE
+  secret: false
+  default: "proliferate-desktop-native@dev"
+  description: Native desktop Sentry release tag
+  tags: [ci]
+
+- name: PROLIFERATE_DESKTOP_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Native desktop Sentry traces sample rate
+  tags: [ci]
+
+- name: ANYHARNESS_SENTRY_DSN
+  secret: false
+  default: ""
+  description: Bundled sidecar Sentry DSN (baked into release builds)
+  tags: [ci]
+
+- name: ANYHARNESS_SENTRY_ENVIRONMENT
+  secret: false
+  default: "development"
+  description: Bundled sidecar Sentry environment
+  tags: [ci]
+
+- name: ANYHARNESS_SENTRY_RELEASE
+  secret: false
+  default: "anyharness-sidecar@dev"
+  description: Bundled sidecar Sentry release tag
+  tags: [ci]
+
+- name: ANYHARNESS_SENTRY_TRACES_SAMPLE_RATE
+  secret: false
+  default: "1.0"
+  description: Bundled sidecar Sentry traces sample rate
+  tags: [ci]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Desktop: Native Tauri (runtime)
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: ANYHARNESS_BIN
+  secret: false
+  default: ""
+  description: Explicit sidecar binary path override
+  tags: [local-dev]
+
+- name: ANYHARNESS_DEV_URL
+  secret: false
+  default: ""
+  description: Skip bundled sidecar, connect to an external AnyHarness
+  tags: [local-dev]
+
+- name: ANYHARNESS_DEV_CORS
+  secret: false
+  default: ""
+  description: Enables permissive AnyHarness CORS for local desktop dev
+  tags: [local-dev]
+
+- name: ANYHARNESS_PORT
+  secret: false
+  default: ""
+  description: Override the local sidecar port
+  tags: [local-dev]
+
+- name: ANYHARNESS_RUNTIME_HOME
+  secret: false
+  default: ""
+  description: Profile-specific AnyHarness runtime state directory used by the local dev launcher
+  tags: [local-dev]
+
+- name: ANYHARNESS_WORKTREES_ROOT
+  secret: false
+  default: ""
+  description: Absolute path override for the AnyHarness-managed worktree root used by inventory, orphan pruning, and automatic checkout retention
+  tags: [local-dev, self-hosted]
+
+# ═══════════════════════════════════════════════════════════════════════
+# Deploy: Docker Compose / Bootstrap
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: SITE_ADDRESS
+  secret: false
+  default: ""
+  description: Public hostname for Caddy TLS (DNS must resolve before first boot)
+  tags: [self-hosted]
+
+- name: PROLIFERATE_SERVER_IMAGE
+  secret: false
+  default: "ghcr.io/proliferate-ai/proliferate-server"
+  description: Server container image repository
+  tags: [self-hosted]
+
+- name: PROLIFERATE_SERVER_IMAGE_TAG
+  secret: false
+  default: "stable"
+  description: Server container image tag
+  tags: [self-hosted]
+
+- name: PROLIFERATE_HOST_BIN_DIR
+  secret: false
+  default: "/opt/proliferate/bin"
+  description: Host directory for runtime binaries (mounted into API container)
+  tags: [self-hosted]
+
+- name: PROLIFERATE_PUBLIC_HEALTHCHECK_URL
+  secret: false
+  default: ""
+  description: Public HTTPS endpoint to verify after local health passes
+  tags: [self-hosted]
+
+- name: RUNTIME_BINARY_URL
+  secret: false
+  default: ""
+  description: Tarball URL for runtime bundle download; archives should contain anyharness, proliferate-worker, and proliferate-supervisor
+  tags: [self-hosted]
+
+- name: RUNTIME_BINARY_SHA256_URL
+  secret: false
+  default: ""
+  description: SHA256SUMS file URL for tarball verification
+  tags: [self-hosted]
+
+- name: POSTGRES_DB
+  secret: false
+  default: "proliferate"
+  description: PostgreSQL database name (Docker Compose)
+  tags: [self-hosted]
+
+- name: POSTGRES_USER
+  secret: false
+  default: "proliferate"
+  description: PostgreSQL user (Docker Compose)
+  tags: [self-hosted]
+
+- name: POSTGRES_PASSWORD
+  secret: true
+  default: ""
+  description: PostgreSQL password (auto-generated on first bootstrap if blank)
+  tags: [self-hosted]
+
+- name: AWS_REGION
+  secret: false
+  default: ""
+  description: AWS region (only needed for private ECR pulls)
+  tags: [self-hosted]
+
+# ═══════════════════════════════════════════════════════════════════════
+# CI: Server
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: AWS_ROLE_ARN
+  secret: false
+  description: GitHub OIDC role ARN for ECR push
+  tags: [ci]
+  ci_type: var
+  workflow: server-ci
+
+# ═══════════════════════════════════════════════════════════════════════
+# CI: Desktop Release
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: TAURI_SIGNING_PRIVATE_KEY
+  secret: true
+  description: Desktop updater signing key
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+  secret: true
+  description: Desktop updater signing key password
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_CERTIFICATE
+  secret: true
+  description: Apple Developer cert (.p12, base64-encoded)
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_CERTIFICATE_PASSWORD
+  secret: true
+  description: Apple cert password
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_SIGNING_IDENTITY
+  secret: true
+  description: Apple team ID for code signing
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_API_KEY
+  secret: true
+  description: App Store Connect API key ID
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_API_KEY_PATH
+  secret: true
+  description: App Store Connect .p8 key content
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: APPLE_API_ISSUER
+  secret: true
+  description: Apple notarization issuer ID
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: KEYCHAIN_PASSWORD
+  secret: true
+  description: macOS keychain password for CI
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: SENTRY_AUTH_TOKEN
+  secret: true
+  description: Sentry source map upload token
+  tags: [ci]
+  ci_type: secret
+  workflow: release-desktop
+
+- name: SENTRY_ORG
+  secret: false
+  description: Sentry organization slug
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: SENTRY_PROJECT
+  secret: false
+  description: Default Sentry project slug for upload jobs
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: SENTRY_WEB_PROJECT
+  secret: false
+  description: Sentry web project slug; falls back to SENTRY_PROJECT
+  tags: [ci, web]
+  ci_type: var
+  workflow: web/manual builds
+
+- name: SENTRY_MOBILE_PROJECT
+  secret: false
+  description: Sentry mobile project slug; falls back to SENTRY_PROJECT
+  tags: [ci, mobile]
+  ci_type: var
+  workflow: mobile/manual builds
+
+- name: SENTRY_DESKTOP_NATIVE_PROJECT
+  secret: false
+  description: Sentry desktop native project slug; falls back to SENTRY_PROJECT
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: SENTRY_ANYHARNESS_PROJECT
+  secret: false
+  description: Sentry AnyHarness/sidecar project slug; falls back to SENTRY_PROJECT
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: AWS_DESKTOP_RELEASE_ROLE_ARN
+  secret: false
+  description: GitHub OIDC role ARN for S3 + CloudFront
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: DESKTOP_DOWNLOADS_S3_BUCKET
+  secret: false
+  description: S3 bucket for desktop updater assets
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop
+
+- name: DESKTOP_CLOUDFRONT_DISTRIBUTION_ID
+  secret: false
+  description: CloudFront distribution for desktop updater
+  tags: [ci]
+  ci_type: var
+  workflow: release-desktop

--- a/specs/developing/reference/workspace-command-environment.md
+++ b/specs/developing/reference/workspace-command-environment.md
@@ -1,0 +1,22 @@
+# Workspace Command Environment
+
+Workspace run commands execute inside the selected workspace. The desktop app
+sets these environment variables before launching the command:
+
+- `PROLIFERATE_WORKSPACE_DIR`: absolute path to the selected workspace.
+- `PROLIFERATE_REPO_DIR`: absolute path to the source repo.
+- `PROLIFERATE_WORKSPACE_KIND`: workspace type, such as `worktree` or `cloud`.
+- `PROLIFERATE_BRANCH`: workspace branch when known.
+- `PROLIFERATE_WORKTREE_DIR`: set for local worktree workspaces.
+
+Use normal shell expansion in commands:
+
+```sh
+cd "$PROLIFERATE_WORKSPACE_DIR" && make dev
+```
+
+For commands that should prefer a worktree path when available:
+
+```sh
+cd "${PROLIFERATE_WORKTREE_DIR:-$PROLIFERATE_WORKSPACE_DIR}" && make dev
+```


### PR DESCRIPTION
## Summary

- Track the migrated `specs/developing/reference/**` files that were hidden by the root `reference/` ignore rule.
- Add a `.gitignore` exception so future specs reference docs are visible to Git.

## Verification

- `git diff --cached --check`
- `rg -n '<<<<<<<|>>>>>>>' specs .gitignore`
- `rg -n 'docs/(dev|features|primitives|structures|tbd)|\.\/docs|`docs/' AGENTS.md CONTRIBUTING.md README.md anyharness apps server specs -g '!docs/**'`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_anyharness_old_paths.py`
- `python3 scripts/check_server_boundaries.py`
