### PR TITLE
fix(desktop): avoid web-to-desktop handoff reload loops

### DIFF
--- a/apps/desktop/src/hooks/auth/workflows/use-auth-orchestration-effects.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-auth-orchestration-effects.ts
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { closeAllSessionStreamHandles } from "@/lib/access/anyharness/session-stream-handles";
 import type { AuthClientStatePatch } from "@/lib/domain/auth/auth-state-mapping";
 import type { AuthOrchestrationDeps } from "@/lib/integrations/auth/orchestration-effects";
@@ -11,6 +12,13 @@ import { useRepoSetupModalStore } from "@/stores/ui/repo-setup-modal-store";
 
 // Owns auth orchestration's store/runtime effect wiring. Does not own the auth network flow.
 export function useAuthOrchestrationEffects(): AuthOrchestrationDeps {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
+
   return useMemo(() => ({
     getAuthState: () => useAuthStore.getState(),
     setAuthState: (state: AuthClientStatePatch) => {
@@ -27,6 +35,9 @@ export function useAuthOrchestrationEffects(): AuthOrchestrationDeps {
     },
     showToast: (message: string) => {
       useToastStore.getState().show(message);
+    },
+    navigateDesktopRoute: (target: string) => {
+      navigateRef.current(target);
     },
   }), []);
 }

--- a/apps/desktop/src/lib/integrations/auth/orchestration-callback.ts
+++ b/apps/desktop/src/lib/integrations/auth/orchestration-callback.ts
@@ -32,7 +32,7 @@ export async function handleDesktopCallbackUrl(
   url: string,
   deps: AuthOrchestrationDeps,
 ): Promise<boolean> {
-  if (handleDesktopNavigationUrl(url)) {
+  if (handleDesktopNavigationUrl(url, deps)) {
     return true;
   }
 

--- a/apps/desktop/src/lib/integrations/auth/orchestration-effects.test.ts
+++ b/apps/desktop/src/lib/integrations/auth/orchestration-effects.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  captureTelemetryException: vi.fn(),
+}));
+
+import {
+  handleDesktopNavigationUrl,
+  type AuthOrchestrationDeps,
+} from "@/lib/integrations/auth/orchestration-effects";
+
+function createDeps(): AuthOrchestrationDeps {
+  return {
+    getAuthState: vi.fn(),
+    setAuthState: vi.fn(),
+    clearSessionRuntimeState: vi.fn(),
+    closeRepoSetupModal: vi.fn(),
+    showToast: vi.fn(),
+    navigateDesktopRoute: vi.fn(),
+  };
+}
+
+describe("handleDesktopNavigationUrl", () => {
+  it("routes desktop navigation deep links through app navigation", () => {
+    const deps = createDeps();
+
+    const handled = handleDesktopNavigationUrl(
+      "proliferate://plugins?source=mcp_oauth_callback&status=completed",
+      deps,
+    );
+
+    expect(handled).toBe(true);
+    expect(deps.navigateDesktopRoute).toHaveBeenCalledWith(
+      "/plugins?source=mcp_oauth_callback&status=completed",
+    );
+  });
+
+  it("ignores unsupported deep links", () => {
+    const deps = createDeps();
+
+    const handled = handleDesktopNavigationUrl("proliferate://plugins/extra", deps);
+
+    expect(handled).toBe(false);
+    expect(deps.navigateDesktopRoute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/integrations/auth/orchestration-effects.ts
+++ b/apps/desktop/src/lib/integrations/auth/orchestration-effects.ts
@@ -43,6 +43,7 @@ export interface AuthOrchestrationDeps {
   clearSessionRuntimeState(): void;
   closeRepoSetupModal(): void;
   showToast(message: string): void;
+  navigateDesktopRoute(target: string): void;
 }
 
 export function applyDevBypassState(deps: AuthOrchestrationDeps): void {
@@ -176,13 +177,16 @@ export function reportBackgroundAuthError(
   });
 }
 
-export function handleDesktopNavigationUrl(url: string): boolean {
+export function handleDesktopNavigationUrl(
+  url: string,
+  deps: AuthOrchestrationDeps,
+): boolean {
   const target = desktopNavigationTarget(url);
   if (!target) {
     return false;
   }
 
-  window.location.assign(target);
+  deps.navigateDesktopRoute(target);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- route Desktop deep-link navigation through React Router instead of full document navigation
- add a regression test for plugin handoff deep links

## Verification
- pnpm --dir apps/desktop exec vitest run src/lib/integrations/auth/orchestration-effects.test.ts src/lib/domain/auth/desktop-navigation.test.ts
- pnpm --filter @anyharness/sdk --filter @anyharness/sdk-react --filter @proliferate/cloud-sdk --filter @proliferate/cloud-sdk-react --filter @proliferate/design --filter @proliferate/product-domain --filter @proliferate/ui --filter @proliferate/product-ui --filter @proliferate/product-surfaces run build
- pnpm --dir apps/desktop exec tsc --noEmit --pretty false