### PR TITLE
fix(product): complete desktop handoff redirects

### DIFF
--- a/apps/desktop/src/pages/DesktopWorkspaceDeepLinkPage.test.tsx
+++ b/apps/desktop/src/pages/DesktopWorkspaceDeepLinkPage.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { DesktopWorkspaceDeepLinkPage } from "@/pages/DesktopWorkspaceDeepLinkPage";
+
+const pageMocks = vi.hoisted(() => ({
+  captureTelemetryException: vi.fn(),
+  refreshCloudWorkspace: vi.fn(),
+  selectWorkspaceFromSurface: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/hooks/cloud/workflows/use-cloud-workspace-actions", () => ({
+  useCloudWorkspaceActions: () => ({
+    refreshCloudWorkspace: pageMocks.refreshCloudWorkspace,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    selectWorkspaceFromSurface: pageMocks.selectWorkspaceFromSurface,
+  }),
+}));
+
+vi.mock("@proliferate/product-ui/auth/RedirectCallbackScreen", () => ({
+  RedirectCallbackScreen: ({
+    title,
+    description,
+    statusLabel,
+    primaryAction,
+    secondaryAction,
+  }: any) => (
+    <main>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <p>{statusLabel}</p>
+      {primaryAction ? (
+        <button type="button" onClick={primaryAction.onClick}>
+          {primaryAction.label}
+        </button>
+      ) : null}
+      {secondaryAction ? (
+        <button type="button" onClick={secondaryAction.onClick}>
+          {secondaryAction.label}
+        </button>
+      ) : null}
+    </main>
+  ),
+}));
+
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  captureTelemetryException: pageMocks.captureTelemetryException,
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: (message: string) => void }) => unknown) =>
+    selector({ show: pageMocks.showToast }),
+}));
+
+function renderDeepLinkPage(workspaceId = "workspace-1") {
+  render(
+    <MemoryRouter initialEntries={[`/cloud/workspaces/${workspaceId}/open`]}>
+      <Routes>
+        <Route
+          path="/cloud/workspaces/:workspaceId/open"
+          element={<DesktopWorkspaceDeepLinkPage />}
+        />
+        <Route path="/workspaces" element={<div>Workspaces</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("DesktopWorkspaceDeepLinkPage", () => {
+  beforeEach(() => {
+    pageMocks.refreshCloudWorkspace.mockResolvedValue({ id: "workspace-1" });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("selects the resolved cloud workspace", async () => {
+    renderDeepLinkPage();
+
+    await waitFor(() => {
+      expect(pageMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
+        "cloud:workspace-1",
+        "desktop_deep_link",
+      );
+    });
+
+    expect(pageMocks.captureTelemetryException).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a retry when the workspace handoff stalls", async () => {
+    vi.useFakeTimers();
+    pageMocks.refreshCloudWorkspace.mockReturnValue(new Promise(() => undefined));
+
+    renderDeepLinkPage();
+
+    expect(screen.getByText("Opening workspace")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(12000);
+    });
+
+    expect(screen.getByText("Workspace did not open")).toBeTruthy();
+    expect(screen.getByText("Try opening workspace again")).toBeTruthy();
+    expect(pageMocks.captureTelemetryException).toHaveBeenCalledTimes(1);
+
+    const [error, context] = pageMocks.captureTelemetryException.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "Desktop workspace deep link did not finish before timeout",
+    );
+    expect(context).toEqual({
+      level: "warning",
+      tags: {
+        action: "open_workspace_deep_link",
+        domain: "cloud_workspace",
+      },
+    });
+  });
+
+  it("retries the workspace handoff after a timeout", async () => {
+    vi.useFakeTimers();
+    pageMocks.refreshCloudWorkspace
+      .mockReturnValueOnce(new Promise(() => undefined))
+      .mockResolvedValueOnce({ id: "workspace-2" });
+
+    renderDeepLinkPage("workspace-2");
+
+    await act(async () => {
+      vi.advanceTimersByTime(12000);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Try opening workspace again"));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(pageMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
+      "cloud:workspace-2",
+      "desktop_deep_link",
+    );
+  });
+});

--- a/apps/desktop/src/pages/DesktopWorkspaceDeepLinkPage.tsx
+++ b/apps/desktop/src/pages/DesktopWorkspaceDeepLinkPage.tsx
@@ -1,11 +1,14 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
 import { APP_ROUTES } from "@/config/app-routes";
 import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-workspace-actions";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
 import { useToastStore } from "@/stores/toast/toast-store";
+
+const DEEP_LINK_TIMEOUT_MS = 12000;
 
 export function DesktopWorkspaceDeepLinkPage() {
   const { workspaceId } = useParams();
@@ -13,6 +16,13 @@ export function DesktopWorkspaceDeepLinkPage() {
   const { refreshCloudWorkspace } = useCloudWorkspaceActions();
   const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
   const showToast = useToastStore((state) => state.show);
+  const [handoffTimedOut, setHandoffTimedOut] = useState(false);
+  const [openAttempt, setOpenAttempt] = useState(0);
+
+  const retryOpenWorkspace = useCallback(() => {
+    setHandoffTimedOut(false);
+    setOpenAttempt((value) => value + 1);
+  }, []);
 
   useEffect(() => {
     if (!workspaceId) {
@@ -20,12 +30,32 @@ export function DesktopWorkspaceDeepLinkPage() {
       return;
     }
 
+    setHandoffTimedOut(false);
+
     let active = true;
+    const timeoutId = window.setTimeout(() => {
+      if (!active) {
+        return;
+      }
+      setHandoffTimedOut(true);
+      captureTelemetryException(
+        new Error("Desktop workspace deep link did not finish before timeout"),
+        {
+          level: "warning",
+          tags: {
+            action: "open_workspace_deep_link",
+            domain: "cloud_workspace",
+          },
+        },
+      );
+    }, DEEP_LINK_TIMEOUT_MS);
+
     void refreshCloudWorkspace(workspaceId)
       .then((workspace) => {
         if (!active) {
           return;
         }
+        window.clearTimeout(timeoutId);
         selectWorkspaceFromSurface(
           cloudWorkspaceSyntheticId(workspace.id),
           "desktop_deep_link",
@@ -35,6 +65,13 @@ export function DesktopWorkspaceDeepLinkPage() {
         if (!active) {
           return;
         }
+        window.clearTimeout(timeoutId);
+        captureTelemetryException(error, {
+          tags: {
+            action: "open_workspace_deep_link",
+            domain: "cloud_workspace",
+          },
+        });
         const message = error instanceof Error ? error.message : "Failed to open workspace.";
         showToast(message);
         navigate(APP_ROUTES.workspaces, { replace: true });
@@ -42,14 +79,34 @@ export function DesktopWorkspaceDeepLinkPage() {
 
     return () => {
       active = false;
+      window.clearTimeout(timeoutId);
     };
   }, [
+    openAttempt,
     navigate,
     refreshCloudWorkspace,
     selectWorkspaceFromSurface,
     showToast,
     workspaceId,
   ]);
+
+  if (handoffTimedOut) {
+    return (
+      <RedirectCallbackScreen
+        title="Workspace did not open"
+        description="Desktop is still trying to open this cloud workspace, but the handoff has taken longer than expected."
+        statusLabel="Workspace deep link waiting"
+        primaryAction={{
+          label: "Try opening workspace again",
+          onClick: retryOpenWorkspace,
+        }}
+        secondaryAction={{
+          label: "View workspaces",
+          onClick: () => navigate(APP_ROUTES.workspaces, { replace: true }),
+        }}
+      />
+    );
+  }
 
   return (
     <RedirectCallbackScreen

--- a/apps/web/src/pages/DesktopHandoffPage.tsx
+++ b/apps/web/src/pages/DesktopHandoffPage.tsx
@@ -1,7 +1,47 @@
+import { useEffect, useState } from "react";
 import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
 
+import { routes } from "../config/routes";
+
+const HANDOFF_TIMEOUT_MS = 8000;
+const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function desktopDeepLinkScheme(): "proliferate" | "proliferate-local" {
+  return LOCALHOST_NAMES.has(window.location.hostname)
+    ? "proliferate-local"
+    : "proliferate";
+}
+
 export function DesktopHandoffPage() {
-  const desktopHref = "proliferate://";
+  const desktopHref = `${desktopDeepLinkScheme()}://`;
+  const [handoffTimedOut, setHandoffTimedOut] = useState(false);
+
+  useEffect(() => {
+    window.location.replace(desktopHref);
+  }, [desktopHref]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setHandoffTimedOut(true), HANDOFF_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  if (handoffTimedOut) {
+    return (
+      <RedirectCallbackScreen
+        title="Desktop did not open"
+        description="The desktop link is ready, but the browser has not handed it to Proliferate Desktop."
+        statusLabel="Desktop redirect waiting"
+        primaryAction={{
+          label: "Try opening Desktop again",
+          onClick: () => window.location.assign(desktopHref),
+        }}
+        secondaryAction={{
+          label: "Open web app",
+          onClick: () => window.location.assign(routes.home),
+        }}
+      />
+    );
+  }
 
   return (
     <RedirectCallbackScreen


### PR DESCRIPTION
## Summary
- trigger `/auth/desktop/handoff` custom-protocol redirects immediately instead of only rendering the loading screen
- add web and desktop timeout fallbacks with retry actions so handoffs cannot spin forever
- capture desktop telemetry for stalled or failed workspace deep-link resolution

## Verification
- `pnpm --filter proliferate exec vitest run src/pages/DesktopWorkspaceDeepLinkPage.test.tsx`
- `pnpm --filter @proliferate/web typecheck`
- `pnpm --filter proliferate exec tsc --noEmit`
- `git diff --check`