### PR TITLE
fix(desktop): align live tool call labels

### DIFF
--- a/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -76,6 +76,10 @@ describe("CollapsedActions", () => {
     expect(activeButton.innerHTML).toContain("thinking-text");
     expect(activeButton.innerHTML).toContain("data-text=\"Exploring 1 file\"");
     expect(activeButton.innerHTML).not.toContain("motion-safe:animate-pulse");
+    const activeLabel = activeButton.querySelector("[data-thinking-text]");
+    const activeLabelClasses = activeLabel?.className.split(/\s+/) ?? [];
+    expect(activeLabelClasses).toContain("block");
+    expect(activeLabelClasses).toContain("leading-[inherit]");
 
     cleanup();
 

--- a/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
@@ -75,7 +75,7 @@ export function CollapsedActions({
             ? (
               <ThinkingText
                 text={summary}
-                className="max-w-full truncate font-normal"
+                className="block max-w-full truncate font-normal leading-[inherit]"
               />
             )
             : summary}


### PR DESCRIPTION
## Summary
- Align live collapsed tool-call labels by inheriting the row line-height.
- Add regression coverage for the active collapsed-actions label classes.

## Verification
- pnpm --dir apps/desktop exec vitest run src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
- pnpm --dir apps/desktop exec tsc --noEmit