### PR TITLE
fix(desktop): normalize composer caret sizing

### DIFF
--- a/apps/desktop/src/config/chat.ts
+++ b/apps/desktop/src/config/chat.ts
@@ -1,5 +1,5 @@
 /** Rem value; keep aligned with the chat composer textarea line-height. */
-export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM = 1.125;
+export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM = 1;
 
 export const WORKSPACE_CHAT_COMPOSER_INPUT = {
   minRows: 2,

--- a/apps/desktop/src/lib/domain/chat/composer/composer-textarea-sizing.test.ts
+++ b/apps/desktop/src/lib/domain/chat/composer/composer-textarea-sizing.test.ts
@@ -10,7 +10,7 @@ describe("computeComposerTextareaAutosize", () => {
   it("clamps short content to the configured minimum height", () => {
     expect(computeComposerTextareaAutosize({
       scrollHeightPx: 12,
-      lineHeightPx: 18,
+      lineHeightPx: 16,
       rootFontSizePx: 16,
       lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
       minRows: WORKSPACE_CHAT_COMPOSER_INPUT.minRows,
@@ -25,14 +25,14 @@ describe("computeComposerTextareaAutosize", () => {
   it("caps workspace composer content at 16 rows", () => {
     expect(computeComposerTextareaAutosize({
       scrollHeightPx: 400,
-      lineHeightPx: 18,
+      lineHeightPx: 16,
       rootFontSizePx: 16,
       lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
       minRows: WORKSPACE_CHAT_COMPOSER_INPUT.minRows,
       maxRows: WORKSPACE_CHAT_COMPOSER_INPUT.maxRows,
       minHeightRem: WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem,
     })).toEqual({
-      heightPx: 288,
+      heightPx: 256,
       overflowY: "auto",
     });
   });
@@ -40,29 +40,29 @@ describe("computeComposerTextareaAutosize", () => {
   it("keeps the home composer cap at 8 rows", () => {
     expect(computeComposerTextareaAutosize({
       scrollHeightPx: 400,
-      lineHeightPx: 18,
+      lineHeightPx: 16,
       rootFontSizePx: 16,
       lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
       minRows: HOME_CHAT_COMPOSER_INPUT.minRows,
       maxRows: HOME_CHAT_COMPOSER_INPUT.maxRows,
       minHeightRem: HOME_CHAT_COMPOSER_INPUT.minHeightRem,
     })).toEqual({
-      heightPx: 144,
+      heightPx: 128,
       overflowY: "auto",
     });
   });
 
   it("does not scroll at the max-height threshold", () => {
     expect(computeComposerTextareaAutosize({
-      scrollHeightPx: 288,
-      lineHeightPx: 18,
+      scrollHeightPx: 256,
+      lineHeightPx: 16,
       rootFontSizePx: 16,
       lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
       minRows: WORKSPACE_CHAT_COMPOSER_INPUT.minRows,
       maxRows: WORKSPACE_CHAT_COMPOSER_INPUT.maxRows,
       minHeightRem: WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem,
     })).toEqual({
-      heightPx: 288,
+      heightPx: 256,
       overflowY: "hidden",
     });
   });

--- a/apps/packages/ui/src/primitives/ComposerTextarea.tsx
+++ b/apps/packages/ui/src/primitives/ComposerTextarea.tsx
@@ -4,7 +4,7 @@ import { Textarea } from "./Textarea";
 type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const COMPOSER_TEXTAREA_CLASSNAME =
-  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:0.6875rem] leading-[1.125rem] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-faint)_50%,transparent)] focus:ring-0";
+  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:0.75rem] leading-[1rem] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-faint)_50%,transparent)] focus:ring-0";
 
 export const ComposerTextarea = forwardRef<HTMLTextAreaElement, ComposerTextareaProps>(
   function ComposerTextarea({ className = "", ...props }, ref) {


### PR DESCRIPTION
## Summary

- normalize the shared composer textarea font and line-height so the native caret no longer renders oversized relative to prompt text
- keep desktop composer autosize constants and row-cap tests aligned with the new line-height

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label: `release:fix`
- Required: at least one `area:*` label: `area:desktop`

## Verification

- `pnpm --filter proliferate exec vitest run src/lib/domain/chat/composer/composer-textarea-sizing.test.ts`
- `pnpm --filter @proliferate/ui build`
- `git diff --check`
- opened the desktop dev playground at `/playground?s=composer-long-input` and confirmed the rendered textarea computes to `fontSize: 12px`, `lineHeight: 16px`, `height: 256px`, with no browser warnings/errors
