### PR TITLE
fix(anyharness): honor requested Claude model ids

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
@@ -22,9 +22,10 @@ pub(super) fn build_session_launch_env(
     resolved_agent: &ResolvedAgent,
     runtime_home: &Path,
     protected_agent_auth_env: &BTreeMap<String, String>,
+    requested_model_id: Option<&str>,
 ) -> anyhow::Result<BTreeMap<String, String>> {
     match resolved_agent.descriptor.kind {
-        AgentKind::Claude => build_claude_session_launch_env(resolved_agent),
+        AgentKind::Claude => build_claude_session_launch_env(resolved_agent, requested_model_id),
         AgentKind::Codex => {
             if protected_agent_auth_env.contains_key("CODEX_HOME") {
                 return Ok(BTreeMap::new());
@@ -41,19 +42,29 @@ pub(super) fn build_session_launch_env(
 
 fn build_claude_session_launch_env(
     resolved_agent: &ResolvedAgent,
+    requested_model_id: Option<&str>,
 ) -> anyhow::Result<BTreeMap<String, String>> {
-    let Some(path) = resolved_agent
+    let mut env = BTreeMap::new();
+
+    if let Some(path) = resolved_agent
         .native
         .as_ref()
         .and_then(|artifact| artifact.path.as_ref())
-    else {
-        return Ok(BTreeMap::new());
-    };
+    {
+        env.insert(
+            "CLAUDE_CODE_EXECUTABLE".to_string(),
+            path.to_string_lossy().into_owned(),
+        );
+    }
 
-    Ok(BTreeMap::from([(
-        "CLAUDE_CODE_EXECUTABLE".to_string(),
-        path.to_string_lossy().into_owned(),
-    )]))
+    if let Some(model_id) = requested_model_id
+        .map(str::trim)
+        .filter(|model_id| !model_id.is_empty())
+    {
+        env.insert("ANTHROPIC_MODEL".to_string(), model_id.to_string());
+    }
+
+    Ok(env)
 }
 
 fn prepare_local_codex_home(runtime_home: &Path) -> anyhow::Result<PathBuf> {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -387,6 +387,7 @@ impl SessionRuntime {
             &resolved_agent,
             &self.runtime_home,
             &agent_auth_overlay.protected_env,
+            record.requested_model_id.as_deref(),
         )
         .map_err(StartSessionError::Internal)?;
         let session_store = self.session_service.store().clone();

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
@@ -194,9 +194,31 @@ fn build_session_launch_env_sets_claude_code_executable_for_claude() {
         &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
         runtime_home.path(),
         &BTreeMap::new(),
+        None,
     )
     .expect("build env");
 
+    assert_eq!(
+        env.get("CLAUDE_CODE_EXECUTABLE").map(String::as_str),
+        Some("/tmp/managed/claude")
+    );
+}
+
+#[test]
+fn build_session_launch_env_sets_requested_model_for_claude() {
+    let runtime_home = TempDirGuard::new("claude-model-home");
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        runtime_home.path(),
+        &BTreeMap::new(),
+        Some("opus[1m]"),
+    )
+    .expect("build env");
+
+    assert_eq!(
+        env.get("ANTHROPIC_MODEL").map(String::as_str),
+        Some("opus[1m]")
+    );
     assert_eq!(
         env.get("CLAUDE_CODE_EXECUTABLE").map(String::as_str),
         Some("/tmp/managed/claude")
@@ -210,10 +232,29 @@ fn build_session_launch_env_ignores_claude_without_native_path() {
         &resolved_agent(AgentKind::Claude, None),
         runtime_home.path(),
         &BTreeMap::new(),
+        None,
     )
     .expect("build env");
 
     assert!(env.is_empty());
+}
+
+#[test]
+fn build_session_launch_env_sets_requested_model_without_claude_native_path() {
+    let runtime_home = TempDirGuard::new("claude-model-only-home");
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, None),
+        runtime_home.path(),
+        &BTreeMap::new(),
+        Some("sonnet"),
+    )
+    .expect("build env");
+
+    assert_eq!(
+        env.get("ANTHROPIC_MODEL").map(String::as_str),
+        Some("sonnet")
+    );
+    assert!(!env.contains_key("CLAUDE_CODE_EXECUTABLE"));
 }
 
 #[test]
@@ -231,6 +272,7 @@ fn build_session_launch_env_sets_clean_codex_home_for_local_codex() {
         &resolved_agent(AgentKind::Codex, Some("/tmp/managed/codex")),
         runtime_home.path(),
         &BTreeMap::new(),
+        None,
     )
     .expect("build env");
 
@@ -262,6 +304,7 @@ fn build_session_launch_env_does_not_override_protected_codex_home() {
         &resolved_agent(AgentKind::Codex, Some("/tmp/managed/codex")),
         runtime_home.path(),
         &protected_env,
+        Some("ignored"),
     )
     .expect("build env");
 
@@ -276,6 +319,7 @@ fn build_session_launch_env_ignores_other_agents() {
         &resolved_agent(AgentKind::Gemini, Some("/tmp/managed/gemini")),
         runtime_home.path(),
         &BTreeMap::new(),
+        Some("ignored"),
     )
     .expect("build env");
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -30,14 +30,25 @@ pub(in crate::live::sessions::actor) async fn try_apply_model_preference(
         find_select_option_by_purpose(&startup_state.config_options, ConfigPurpose::Model)
     {
         let config_id = option.id.to_string();
-        return apply_select_config_option(
+        let option_contains_desired = select_option_contains_value(option, desired_model_id);
+        let outcome = apply_select_config_option(
             conn,
             native_session_id,
             startup_state,
             &config_id,
             desired_model_id,
         )
-        .await;
+        .await?;
+        if outcome == ConfigApplyOutcome::NotApplied && !option_contains_desired {
+            return apply_model_via_direct_setter(
+                conn,
+                native_session_id,
+                startup_state,
+                desired_model_id,
+            )
+            .await;
+        }
+        return Ok(outcome);
     }
 
     apply_model_via_direct_setter(conn, native_session_id, startup_state, desired_model_id).await
@@ -390,6 +401,13 @@ pub(in crate::live::sessions::actor) async fn apply_model_via_direct_setter(
         desired_model_id.to_string(),
     ))
     .await?;
+
+    startup_state.current_model_id = Some(desired_model_id.to_string());
+    set_select_option_current_value_for_purpose(
+        &mut startup_state.config_options,
+        ConfigPurpose::Model,
+        desired_model_id,
+    );
 
     Ok(ConfigApplyOutcome::AppliedRequested)
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -12,7 +12,9 @@ use crate::live::sessions::actor::config::apply::{
 };
 use crate::live::sessions::actor::config::persist::persist_requested_config_value_if_changed;
 use crate::live::sessions::actor::config::queue::queue_pending_config_change;
-use crate::live::sessions::actor::config::selection::find_select_option_for_request;
+use crate::live::sessions::actor::config::selection::{
+    find_select_option_by_purpose, find_select_option_for_request, select_option_values,
+};
 use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose, PersistedSessionConfigState,
 };
@@ -26,7 +28,23 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
 ) -> anyhow::Result<()> {
     if let Some(model_id) = session.requested_model_id.as_deref() {
         match try_apply_model_preference(conn, native_session_id, model_id, startup_state).await {
-            Ok(_) => {}
+            Ok(ConfigApplyOutcome::NotApplied) => {
+                tracing::warn!(
+                    native_session_id,
+                    requested_model_id = model_id,
+                    current_model_id = ?startup_state.current_model_id,
+                    available_model_ids = ?live_model_ids(startup_state),
+                    "requested model is not available in active session; keeping agent-selected model"
+                );
+            }
+            Ok(outcome) => {
+                tracing::debug!(
+                    native_session_id,
+                    requested_model_id = model_id,
+                    outcome = ?outcome,
+                    "applied requested model preference"
+                );
+            }
             Err(error) => {
                 // Model prefs are best-effort at startup because live ACP/provider IDs can
                 // drift while the session remains usable. Mode prefs stay strict below.
@@ -60,6 +78,23 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
     }
 
     Ok(())
+}
+
+fn live_model_ids(startup_state: &SessionStartupState) -> Vec<String> {
+    if let Some(option) =
+        find_select_option_by_purpose(&startup_state.config_options, ConfigPurpose::Model)
+    {
+        let values = select_option_values(option);
+        if !values.is_empty() {
+            return values;
+        }
+    }
+
+    startup_state
+        .available_models
+        .iter()
+        .map(|model| model.id.clone())
+        .collect()
 }
 
 pub(in crate::live::sessions::actor) async fn handle_idle_config_command(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
@@ -214,3 +214,23 @@ pub(in crate::live::sessions::actor) fn select_option_contains_value(
         _ => false,
     }
 }
+
+pub(in crate::live::sessions::actor) fn select_option_values(
+    option: &acp::SessionConfigOption,
+) -> Vec<String> {
+    match &option.kind {
+        acp::SessionConfigKind::Select(select) => match &select.options {
+            acp::SessionConfigSelectOptions::Ungrouped(options) => options
+                .iter()
+                .map(|candidate| candidate.value.to_string())
+                .collect(),
+            acp::SessionConfigSelectOptions::Grouped(groups) => groups
+                .iter()
+                .flat_map(|group| group.options.iter())
+                .map(|candidate| candidate.value.to_string())
+                .collect(),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
@@ -358,6 +358,25 @@ fn generic_model_request_can_resolve_model_option_by_purpose() {
 }
 
 #[test]
+fn select_option_values_flattens_grouped_options() {
+    let option = acp::SessionConfigOption::select(
+        "model",
+        "Model",
+        "sonnet",
+        vec![acp::SessionConfigSelectGroup::new(
+            "claude",
+            "Claude",
+            vec![
+                acp::SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                acp::SessionConfigSelectOption::new("opus[1m]", "Opus"),
+            ],
+        )],
+    );
+
+    assert_eq!(select_option_values(&option), vec!["sonnet", "opus[1m]"]);
+}
+
+#[test]
 fn model_config_request_rejects_values_outside_live_select_options() {
     let db = Db::open_in_memory().expect("open db");
     let store = SessionStore::new(db);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -11,7 +11,7 @@ use super::config::persist::{load_startup_restore_snapshot, persisted_control_va
 use super::config::queue::queue_pending_config_change;
 use super::config::selection::{
     find_select_option_for_request, is_mode_config_request, is_model_config_request,
-    pending_config_rank,
+    pending_config_rank, select_option_values,
 };
 use super::config::types::{tracked_config_purpose, PersistedSessionConfigState};
 use super::interactions::cleanup::resolve_pending_interactions;


### PR DESCRIPTION
## Summary
- pass requested Claude model IDs into the session launch environment as ANTHROPIC_MODEL
- fall back to Claude's direct model setter when the active model select option does not expose the requested value
- keep live startup model state and diagnostics aligned with grouped/ungrouped model options

## Verification
- cargo fmt --package anyharness-lib
- cargo test -p anyharness-lib build_session_launch_env -- --test-threads=1 --nocapture
- cargo test -p anyharness-lib config -- --test-threads=1 --nocapture
- cargo test -p anyharness-lib --lib -- --test-threads=1
- git diff --check
- python3 scripts/check_max_lines.py