### PR TITLE
fix(desktop): scale composer input text with chat size

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
@@ -5,6 +5,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "./HomeNextScreen";
 import { HOME_NEXT_TARGET_SELECTION_STORAGE_KEY } from "@/hooks/home/ui/use-home-next-target-selection-state";
+import {
+  CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS,
+  HOME_CHAT_COMPOSER_INPUT,
+} from "@/config/chat";
 
 const screenMocks = vi.hoisted(() => {
   const handleHomeAction = vi.fn();
@@ -249,6 +253,17 @@ describe("HomeNextScreen model availability notices", () => {
     expect(screen.queryByText("No ready models")).toBeNull();
     expect(screen.queryByText("Loading models")).toBeNull();
     expect(screen.queryByText("Couldn't load models")).toBeNull();
+  });
+
+  it("caps the home composer using the scaled textarea line-height", () => {
+    render(<HomeNextScreen />);
+
+    const textarea = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    const expectedMaxHeight =
+      `calc(${CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS} * ${HOME_CHAT_COMPOSER_INPUT.maxRows})`;
+
+    expect(textarea.style.maxHeight).toBe(expectedMaxHeight);
+    expect(textarea.parentElement?.style.maxHeight).toBe(expectedMaxHeight);
   });
 
   it("still renders target-specific disabled reasons after typing", () => {

--- a/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import {
-  CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
+  CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS,
   HOME_CHAT_COMPOSER_INPUT,
 } from "@/config/chat";
 import { HomeModePicker } from "@/components/home/screen/HomeModePicker";
@@ -70,6 +70,8 @@ export function HomeNextScreen() {
     launchControlValues: homeLaunchControls.launchControlValues,
     launchTarget: homeNext.launchTarget,
   });
+  const homeComposerInputMaxHeight =
+    `calc(${CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS} * ${HOME_CHAT_COMPOSER_INPUT.maxRows})`;
 
   const promptTarget = destination === "repository"
     ? homeNext.selectedRepository?.name?.trim()
@@ -112,7 +114,7 @@ export function HomeNextScreen() {
                 className="mt-3 mb-2 flex-grow select-text overflow-y-auto px-4"
                 style={{
                   minHeight: `${HOME_CHAT_COMPOSER_INPUT.minHeightRem}rem`,
-                  maxHeight: `${HOME_CHAT_COMPOSER_INPUT.maxRows * CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM}rem`,
+                  maxHeight: homeComposerInputMaxHeight,
                 }}
               >
                 <ComposerTextarea
@@ -130,7 +132,7 @@ export function HomeNextScreen() {
                   autoCapitalize="off"
                   style={{
                     minHeight: `${HOME_CHAT_COMPOSER_INPUT.minHeightRem}rem`,
-                    maxHeight: `${HOME_CHAT_COMPOSER_INPUT.maxRows * CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM}rem`,
+                    maxHeight: homeComposerInputMaxHeight,
                   }}
                 />
               </div>

--- a/apps/desktop/src/config/chat.ts
+++ b/apps/desktop/src/config/chat.ts
@@ -1,5 +1,7 @@
-/** Rem value; keep aligned with the chat composer textarea line-height. */
+/** Default rem fallback used when computed textarea line-height is unavailable. */
 export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM = 1;
+/** CSS length; keep aligned with the shared ComposerTextarea line-height. */
+export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS = "calc(var(--text-chat, 12px) + 4px)";
 
 export const WORKSPACE_CHAT_COMPOSER_INPUT = {
   minRows: 2,

--- a/apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.test.tsx
+++ b/apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { useRef } from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
+  WORKSPACE_CHAT_COMPOSER_INPUT,
+} from "@/config/chat";
+import { useComposerTextareaAutosize } from "./use-composer-textarea-autosize";
+
+let textareaLineHeightPx = 16;
+let textareaScrollHeightPx = 400;
+const originalScrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLTextAreaElement.prototype,
+  "scrollHeight",
+);
+
+function AutosizeHarness() {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  useComposerTextareaAutosize({
+    textareaRef,
+    value: "long draft",
+    lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
+    minRows: WORKSPACE_CHAT_COMPOSER_INPUT.minRows,
+    maxRows: WORKSPACE_CHAT_COMPOSER_INPUT.maxRows,
+    minHeightRem: WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem,
+  });
+
+  return <textarea aria-label="Composer" ref={textareaRef} />;
+}
+
+describe("useComposerTextareaAutosize", () => {
+  beforeEach(() => {
+    textareaLineHeightPx = 16;
+    textareaScrollHeightPx = 400;
+    vi.stubGlobal("getComputedStyle", (element: Element) => ({
+      fontSize: element === document.documentElement ? "16px" : "12px",
+      lineHeight: element.tagName === "TEXTAREA" ? `${textareaLineHeightPx}px` : "16px",
+    } as CSSStyleDeclaration));
+    Object.defineProperty(HTMLTextAreaElement.prototype, "scrollHeight", {
+      configurable: true,
+      get: () => textareaScrollHeightPx,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    document.documentElement.removeAttribute("style");
+    if (originalScrollHeightDescriptor) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        "scrollHeight",
+        originalScrollHeightDescriptor,
+      );
+    } else {
+      delete (HTMLTextAreaElement.prototype as { scrollHeight?: number }).scrollHeight;
+    }
+  });
+
+  it("recomputes cached sizing when appearance text scale changes", async () => {
+    render(<AutosizeHarness />);
+
+    const textarea = screen.getByLabelText("Composer") as HTMLTextAreaElement;
+    expect(textarea.style.height).toBe("256px");
+
+    textareaLineHeightPx = 17;
+    document.documentElement.style.setProperty("--text-chat", "13px");
+
+    await waitFor(() => {
+      expect(textarea.style.height).toBe("272px");
+    });
+  });
+});

--- a/apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts
@@ -74,5 +74,25 @@ export function useComposerTextareaAutosize({
     resizeTextarea();
   }, [resizeTextarea, value]);
 
+  useLayoutEffect(() => {
+    if (typeof MutationObserver === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => {
+      cachedSizingRef.current = null;
+      resizeTextarea();
+    });
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["style", "data-ui-font-size"],
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [resizeTextarea]);
+
   return { resizeTextarea };
 }

--- a/apps/packages/ui/src/primitives/ComposerTextarea.tsx
+++ b/apps/packages/ui/src/primitives/ComposerTextarea.tsx
@@ -4,7 +4,7 @@ import { Textarea } from "./Textarea";
 type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const COMPOSER_TEXTAREA_CLASSNAME =
-  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:0.75rem] leading-[1rem] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-faint)_50%,transparent)] focus:ring-0";
+  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:var(--text-chat,12px)] leading-[calc(var(--text-chat,12px)+4px)] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-faint)_50%,transparent)] focus:ring-0";
 
 export const ComposerTextarea = forwardRef<HTMLTextAreaElement, ComposerTextareaProps>(
   function ComposerTextarea({ className = "", ...props }, ref) {


### PR DESCRIPTION
## Summary

- scale the shared composer textarea font size from the chat text-size token
- keep the composer line-height tighter than transcript text so the caret stays proportional
- invalidate composer autosize measurements when the root appearance text scale changes

## Verification

- pnpm --filter proliferate exec vitest run src/lib/domain/chat/composer/composer-textarea-sizing.test.ts src/hooks/chat/ui/use-composer-textarea-autosize.test.tsx src/components/home/screen/HomeNextScreen.test.tsx
- pnpm --filter proliferate exec tsc -p tsconfig.json --noEmit
- pnpm --filter @proliferate/ui build
- git diff --check
- Browser: default composer metrics 12px / 16px / 256px, Cmd+= metrics 13px / 17px / 272px
