### PR TITLE
docs(release): capture production deploy learnings

### DIFF
--- a/specs/developing/deploying/ci-cd.md
+++ b/specs/developing/deploying/ci-cd.md
@@ -179,6 +179,11 @@ Bypass `require_staging_success` only when explicitly directed. If bypassing
 staging, the agent must state that staging was bypassed and should watch the
 E2B lane closely because production will build and smoke the immutable template
 before moving the rolling production tag.
+If a human operator explicitly asks to go to production while a staging run is
+still in progress, dispatch production from the exact `main` SHA with
+`require_staging_success=false`. Leave the staging run alone, but do not treat
+it as the production gate; production is successful only after the production
+run itself completes and the live production URLs/artifacts verify.
 
 If forcing `e2b` in production while `require_staging_success=true`, first
 force `e2b` in staging for the same SHA. Production uses `promote_only` in
@@ -223,6 +228,12 @@ Web staging: curl -I https://staging.proliferate.com/
 Desktop stable updater:
 curl -fsS https://downloads.proliferate.com/desktop/stable/latest.json
 curl -fsS https://downloads.proliferate.com/desktop/stable/installers.json
+curl -fsSI <each DMG URL from installers.json>
+
+Treat desktop as live only after the production `deploy-desktop / release`
+`publish-updater` job succeeds and the stable updater manifests advertise the
+new version. The macOS build jobs and draft GitHub Release are necessary
+intermediate steps, but they do not update installed apps by themselves.
 
 Desktop staging:
 Confirm the staging `deploy-desktop` lane completed its build/dry-run jobs and
@@ -264,6 +275,16 @@ and any remaining owner.
   once before changing code; repeated failures need the notary log.
 - E2B cache save/restore warnings are not failures when the E2B job completes
   and smoke passes.
+- E2B `cargo install cargo-zigbuild --locked` can fail on transient crates.io
+  or GitHub runner network errors such as `curl failed` with `[16] Error in the
+  HTTP2 framing layer`. Rerun the failed E2B job once before changing code.
+- Desktop production can be the long pole. The
+  `deploy-desktop / release / build-desktop` matrix builds the AnyHarness
+  runtime, bundled agent seed, debug helper, worker, SDK, frontend, and Tauri
+  app before uploading artifacts. Intel macOS often lags Apple Silicon by many
+  minutes. If the job is still `in_progress`, inspect active step names with
+  `gh run view <run> --json jobs`; GitHub may not expose live logs until the job
+  completes.
 
 ## 1. File Tree
 


### PR DESCRIPTION
## Summary
- Document explicit production staging-gate bypass handling
- Clarify when desktop is actually live in stable updater metadata
- Add retry guidance for transient E2B cargo-zigbuild network failures and slow desktop build expectations

## Verification
- git diff --check
- python3 scripts/check_max_lines.py

Labels: release:maintenance, area:release, area:docs