### PR TITLE
docs(runbooks): add Stripe and E2B recovery guides

### DIFF
--- a/specs/developing/README.md
+++ b/specs/developing/README.md
@@ -24,8 +24,9 @@ the area docs under `specs/codebase/structures/**`.
 - [qa/README.md](qa/README.md)
   - release QA process and per-surface verification checklist
 - [runbooks/README.md](runbooks/README.md)
-  - specific, repeatable operational runbooks (billing promo codes, and future
-    cloud/worker/sandbox operational procedures)
+  - specific, repeatable operational runbooks (billing promo codes, Stripe
+    webhook failures, E2B template rollback, and future cloud/worker/sandbox
+    operational procedures)
 - [reference/README.md](reference/README.md)
   - canonical environment variable inventory, secrets matrix, and workspace
     command environment reference

--- a/specs/developing/debugging/README.md
+++ b/specs/developing/debugging/README.md
@@ -80,6 +80,10 @@ Required permissions depend on the issue surface:
   Desktop retry behavior.
 - [performance-profiling.md](performance-profiling.md): privacy-safe renderer
   and AnyHarness timing baselines.
+- [../runbooks/stripe-webhook-failure.md](../runbooks/stripe-webhook-failure.md):
+  Stripe webhook delivery, replay, and billing mirror recovery.
+- [../runbooks/e2b-template-rollback.md](../runbooks/e2b-template-rollback.md):
+  E2B template rollback for managed cloud runtime release failures.
 - [../analytics/sentry.md](../analytics/sentry.md): Sentry projects, privacy,
   support correlation, alerts, and release/debug uploads.
 - [../local/README.md](../local/README.md): local reproduction with dev

--- a/specs/developing/runbooks/README.md
+++ b/specs/developing/runbooks/README.md
@@ -11,6 +11,8 @@ permissions, happy path, verification, and failure modes for one operation.
 | Runbook | Operation |
 | --- | --- |
 | [billing-pro-promo-codes.md](billing-pro-promo-codes.md) | Grant a user free or discounted Pro access via a Stripe promotional code. |
+| [stripe-webhook-failure.md](stripe-webhook-failure.md) | Triage and recover Stripe webhook delivery or billing mirror failures. |
+| [e2b-template-rollback.md](e2b-template-rollback.md) | Roll an E2B cloud runtime template rolling tag back to a known-good immutable build. |
 
 ## Adding A Runbook
 

--- a/specs/developing/runbooks/e2b-template-rollback.md
+++ b/specs/developing/runbooks/e2b-template-rollback.md
@@ -1,0 +1,187 @@
+# E2B template rollback
+
+Status: authoritative for rolling an E2B cloud runtime template tag back to a
+known-good immutable build.
+
+Use this runbook when a newly promoted E2B template causes managed cloud
+sandbox creation, runtime boot, worker enrollment, or template smoke failures.
+The release lane is documented in
+[`../deploying/ci-cd.md`](../deploying/ci-cd.md), and the managed sandbox model
+is documented in
+[`../../codebase/primitives/sandbox-provisioning.md`](../../codebase/primitives/sandbox-provisioning.md).
+
+## Mental model
+
+Cloud template releases publish immutable `sha-<shortsha>` tags, smoke-test the
+exact immutable ref, and then move a rolling tag:
+
+```text
+TEAM_SLUG/proliferate-runtime-cloud:sha-<shortsha>
+TEAM_SLUG/proliferate-runtime-cloud:staging
+TEAM_SLUG/proliferate-runtime-cloud:production
+```
+
+Rollback means smoke-testing a previously good immutable `sha-*` tag and moving
+the affected rolling tag back to that immutable build. Do not edit server
+runtime or provisioning code for a template rollback.
+
+Rolling tags affect newly created E2B sandboxes. Existing running or paused
+sandboxes keep the image they already started with. If an already-created
+target must be replaced, coordinate the managed-target replacement path
+separately.
+
+## Required access
+
+- GitHub Actions through the GitHub MCP, `gh`, or the GitHub web UI.
+- E2B access for the template family.
+- Local shell with Node dependencies installed when using the repo scripts.
+- `E2B_API_KEY` for smoke and tag promotion.
+- `E2B_ACCESS_TOKEN` and `E2B_TEAM_ID` only when building or publishing a new
+  template, which rollback should normally avoid.
+- GitHub environment access when checking `E2B_PUBLIC_TEMPLATE_FAMILY`,
+  `E2B_TEMPLATE_REF`, or hosted deploy summaries.
+
+Secrets policy:
+
+- Do not paste `E2B_API_KEY`, `E2B_ACCESS_TOKEN`, provider dashboard tokens,
+  sandbox environment values, or worker enrollment tokens into chat, issues,
+  PRs, or docs.
+- Share template family refs, rolling tags, immutable tags, workflow run URLs,
+  sandbox ids from smoke tests, and sanitized log snippets.
+
+## Find the rollback target
+
+1. Identify the affected environment and rolling tag:
+   - staging uses `:staging`
+   - production uses `:production`
+2. Find the current bad immutable tag from the failed `Deploy Staging`,
+   `Promote Production`, `Release Cloud Template`, or
+   `Promote Cloud Template` run summary. The E2B job summary prints the
+   immutable tag and template family.
+3. Find the previous known-good immutable `sha-*` tag from the last successful
+   run for the same rolling tag. Do not use a rolling tag as the rollback
+   source.
+4. Confirm the hosted environment points at the rolling ref. In hosted deploys,
+   `E2B_TEMPLATE_REF` should be the family plus `:staging` or `:production`.
+   Server runtime config uses `E2B_TEMPLATE_NAME`.
+
+Useful commands:
+
+```bash
+gh run list --workflow "Deploy Staging" --limit 20
+gh run list --workflow "Promote Production" --limit 20
+gh run list --workflow "Release Cloud Template" --limit 20
+gh run list --workflow "Promote Cloud Template" --limit 20
+```
+
+Inspect a candidate run and look for `Immutable tag`, `Rolling tag`, and
+`Family` in the summary or logs:
+
+```bash
+gh run view <run-id> --web
+gh run view <run-id> --log | rg 'sha-|E2B template|Promoted'
+```
+
+## Smoke the source tag
+
+Run the smoke test against the exact immutable rollback source before moving
+any rolling tag:
+
+```bash
+export E2B_PUBLIC_TEMPLATE_FAMILY='TEAM_SLUG/proliferate-runtime-cloud'
+export GOOD_SHA_TAG='sha-<known-good-shortsha>'
+
+E2B_API_KEY='<from-secret-store>' \
+  node scripts/smoke-cloud-template.mjs \
+  --template "$E2B_PUBLIC_TEMPLATE_FAMILY:$GOOD_SHA_TAG"
+```
+
+The smoke test creates a throwaway sandbox, verifies the AnyHarness, Worker,
+and Supervisor binaries, checks agent install availability, starts Supervisor,
+and kills the sandbox before exit.
+
+If the source tag fails smoke, do not promote it. Choose an earlier known-good
+immutable tag or treat the incident as an E2B/provider or repo-wide runtime
+issue.
+
+## Roll back staging
+
+There is no dedicated staging rollback workflow today. After the source tag
+passes smoke, move the `staging` rolling tag with the repo promotion script:
+
+```bash
+E2B_API_KEY='<from-secret-store>' \
+  node scripts/promote-cloud-template.mjs \
+  --name "$E2B_PUBLIC_TEMPLATE_FAMILY" \
+  --source-tag "$GOOD_SHA_TAG" \
+  --tag staging
+```
+
+Then smoke the rolling staging ref:
+
+```bash
+E2B_API_KEY='<from-secret-store>' \
+  node scripts/smoke-cloud-template.mjs \
+  --template "$E2B_PUBLIC_TEMPLATE_FAMILY:staging"
+```
+
+## Roll back production
+
+Prefer the manual GitHub workflow so the rollback is visible in Actions:
+
+```text
+Workflow: Promote Cloud Template
+source_tag: sha-<known-good-shortsha>
+```
+
+The workflow re-smoke-tests the immutable source tag and promotes it to the
+rolling `production` tag. Watch the run to completion before declaring
+production recovered.
+
+If GitHub Actions is unavailable and an incident owner approves local recovery,
+use the same script path as staging with `--tag production`, then create a
+follow-up issue with the command, operator, and verification evidence.
+
+## Verification
+
+The rollback is complete when all of these are true:
+
+- The promotion command or workflow reports that the known-good immutable tag
+  was assigned to the affected rolling tag.
+- A post-promotion smoke test passes against the rolling ref:
+
+  ```bash
+  E2B_API_KEY='<from-secret-store>' \
+    node scripts/smoke-cloud-template.mjs \
+    --template "$E2B_PUBLIC_TEMPLATE_FAMILY:<staging-or-production>"
+  ```
+
+- The next managed cloud sandbox creation in the affected environment uses the
+  rolled-back ref and reaches the normal running/enrolled state.
+- New cloud command failures are no longer dominated by template boot,
+  executable missing, Supervisor start, or Worker enrollment errors.
+
+For staging, run the cloud E2B suite when provider credentials and time allow:
+
+```bash
+make test-cloud-e2b
+```
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| `Source tag ... does not exist` | Confirm the template family and immutable tag from the Actions summary; build ids are not rollback tags. |
+| Smoke fails on the rollback source | Pick an earlier successful `sha-*` tag; do not move the rolling tag to an unverified source. |
+| Promotion succeeds but new sandboxes still use the bad image | Check whether the environment is pinned to an immutable `E2B_TEMPLATE_REF` or `E2B_TEMPLATE_NAME` instead of the rolling tag. |
+| Production rollback workflow fails before smoke | Inspect GitHub secrets and E2B access; refresh credentials in the owning secret store without printing them. |
+| Existing user workspace still fails after rollback | The workspace may already be on the bad sandbox image; coordinate target replacement rather than rebuilding the template again. |
+| E2B API or sandbox create is degraded | Pause further promotion attempts, preserve workflow and smoke evidence, and update the incident owner. |
+
+## Final report
+
+Report the affected environment, bad immutable tag, rollback immutable tag,
+template family, rolling tag moved, workflow run URL or exact local command,
+smoke results, whether any existing targets still need replacement, and any
+remaining owner. State explicitly that no E2B secrets, enrollment tokens, or
+sandbox environment values were shared.

--- a/specs/developing/runbooks/stripe-webhook-failure.md
+++ b/specs/developing/runbooks/stripe-webhook-failure.md
@@ -1,0 +1,204 @@
+# Stripe webhook failure
+
+Status: authoritative for triaging and recovering Stripe webhook delivery
+failures.
+
+Use this runbook when Checkout, subscription, invoice, refill, or payment-hold
+state changed in Stripe but Proliferate did not reflect it. Billing behavior is
+owned by [`../../codebase/primitives/billing.md`](../../codebase/primitives/billing.md).
+Local webhook setup is owned by
+[`../local/stripe-local-testing.md`](../local/stripe-local-testing.md).
+
+## What exists
+
+Stripe webhooks are the supported way to mirror commercial state into
+Proliferate. The server verifies the Stripe signature, records idempotency in
+`webhook_event_receipt`, and updates billing mirrors such as
+`billing_subscription`, `billing_grant`, `billing_hold`, and
+`billing_usage_export`.
+
+Handled production billing events are:
+
+```text
+checkout.session.completed
+customer.subscription.created
+customer.subscription.updated
+customer.subscription.deleted
+invoice.paid
+invoice.payment_failed
+```
+
+Synthetic `stripe trigger` events prove delivery and signature handling, but
+they often lack the configured price, subscription, or customer shape required
+to prove account-state side effects. Use real Checkout or real Stripe events
+when verifying subscription mirrors, Pro grants, payment holds, and refills.
+
+## Required access
+
+- Stripe Dashboard or Stripe CLI access for the affected account mode.
+- Read access to the affected Proliferate database.
+- CloudWatch, Sentry, or server log access for the affected environment.
+- GitHub Actions and environment-admin access only when deploy-time webhook
+  configuration must be repaired.
+- AWS ECS/SSM access when hosted runtime secrets or task definitions must be
+  inspected or refreshed.
+
+Secrets policy:
+
+- Do not paste `sk_*`, `rk_*`, `whsec_*`, customer PII, card details, signed
+  URLs, request bodies, or raw webhook payloads into chat, issues, PRs, or
+  docs.
+- Share Stripe event ids, customer ids, subscription ids, invoice ids, request
+  ids, receipt status, and sanitized log excerpts.
+
+## First response
+
+1. Identify the environment: local, staging, or production. Confirm whether the
+   event came from Stripe test mode or live mode.
+2. Collect stable ids: Stripe event id, customer id, subscription id, invoice
+   id, Checkout session id, Proliferate user id, organization id, and support
+   report id if one exists.
+3. In Stripe, inspect the event delivery for the Proliferate webhook endpoint.
+   Note the HTTP status, last delivery time, and whether Stripe still has
+   retries pending.
+4. Check Proliferate intake by event id:
+
+   ```sql
+   select
+     event_id,
+     provider,
+     event_type,
+     status,
+     attempt_count,
+     received_at,
+     processed_at,
+     last_error
+   from webhook_event_receipt
+   where provider = 'stripe'
+      and event_id = '<evt_...>'
+   order by received_at desc;
+   ```
+
+5. Check the affected billing mirror. Start with the Stripe customer or
+   subscription id:
+
+   ```sql
+   select id, kind, user_id, organization_id, stripe_customer_id
+   from billing_subject
+   where stripe_customer_id = '<cus_...>';
+
+   select
+     status,
+     stripe_subscription_id,
+     latest_invoice_id,
+     latest_invoice_status,
+     current_period_start,
+     current_period_end,
+     seat_quantity,
+     updated_at
+   from billing_subscription
+   where stripe_subscription_id = '<sub_...>'
+      or stripe_customer_id = '<cus_...>';
+
+   select grant_type, remaining_seconds, source_ref, created_at
+   from billing_grant
+   where source_ref in ('<evt_...>', '<invoice-or-session-id>')
+   order by created_at desc;
+
+   select kind, status, source, source_ref, created_at, resolved_at
+   from billing_hold
+   where source_ref in ('<evt_...>', '<invoice-or-subscription-id>')
+   order by created_at desc;
+   ```
+
+6. Search server logs and Sentry for the Stripe event id and request id. If the
+   endpoint returned 5xx, fix the server/deploy incident before replaying.
+
+## Recovery path
+
+Prefer replaying Stripe events over manual database edits. Manual edits need an
+incident owner and a follow-up issue because they bypass the idempotent webhook
+path.
+
+1. Fix the delivery blocker first:
+   - Endpoint down or 5xx: restore the server, confirm `/api/health`, and
+     check recent deploys.
+   - Signature failure: verify the endpoint belongs to the same Stripe mode and
+     environment, then refresh `STRIPE_WEBHOOK_SECRET` in the owning hosted
+     secret store. Do not print the secret.
+   - Wrong endpoint URL: correct the Stripe endpoint or hosted environment
+     config, then confirm new deliveries reach
+     `/v1/billing/webhooks/stripe`.
+   - Event accepted but ignored: verify the event type and price ids. If the
+     event type is unsupported, open a billing issue instead of replaying
+     indefinitely.
+2. Replay only the missing or failed event ids. Use the Stripe Dashboard resend
+   action, or the Stripe CLI equivalent when the endpoint id is known:
+
+   ```bash
+   stripe events resend <evt_...> --webhook-endpoint <we_...>
+   ```
+
+3. Preserve causal order when replaying multiple events for the same customer:
+   checkout or subscription creation before subscription updates, then invoice
+   events.
+4. Wait for Proliferate processing and re-run the receipt and billing mirror
+   queries.
+5. If a user is blocked from cloud launch by stale billing state, also inspect
+   active holds:
+
+   ```sql
+   select kind, status, source, source_ref, created_at
+   from billing_hold
+   where billing_subject_id = '<billing-subject-id>'
+     and status = 'active'
+   order by created_at desc;
+   ```
+
+## Local recovery
+
+For local profile testing, prefer restarting the Stripe listener rather than
+editing `server/.env.local`.
+
+```bash
+make dev PROFILE=billing STRIPE=1
+```
+
+The profile launcher exports the listener's `STRIPE_WEBHOOK_SECRET` into the
+backend process only. If you run the server manually, start the listener
+yourself, copy the printed `whsec_...` into local process config, restart the
+server, and trigger a test event:
+
+```bash
+stripe trigger invoice.payment_failed
+```
+
+## Verification
+
+The incident is recovered when all of these are true:
+
+- Stripe shows a successful delivery for the affected event ids.
+- `webhook_event_receipt` has one processed receipt per replayed event id.
+- `billing_subscription`, `billing_grant`, `billing_hold`, or
+  `billing_usage_export` reflects the expected side effect.
+- The user's Cloud settings or support-visible billing snapshot matches Stripe.
+- Server logs and Sentry no longer show repeated failures for the same event.
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Stripe delivery returns 404 | Confirm the endpoint URL includes `/v1/billing/webhooks/stripe` under the API prefix for that environment. |
+| Stripe delivery returns 400 signature errors | Verify the endpoint mode and `STRIPE_WEBHOOK_SECRET`; do not reuse a local listener secret in hosted environments. |
+| Event receipt exists but no Pro grant appears | Check that the event references configured Cloud Pro or refill price ids; synthetic events may not. |
+| Payment failure hold did not clear after payment | Replay or inspect the later `invoice.paid` event for the same customer and subscription. |
+| Replayed event is ignored as duplicate | The receipt already processed successfully; inspect mirror rows and open a bug if side effects are still missing. |
+| Local listener forwards to the wrong port | Restart with `make dev PROFILE=<name> STRIPE=1` so the profile-specific API port is exported. |
+
+## Final report
+
+Report the environment, Stripe event ids, customer/subscription/invoice ids,
+Proliferate user or organization id, receipt status before and after recovery,
+which events were replayed, verification query results, and any remaining
+owner. State explicitly that no secret values or raw webhook payloads were
+shared.

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -328,9 +328,13 @@ the root matrix.
 
 **`specs/developing/runbooks/`**
 
-Currently one runbook: `billing-pro-promo-codes.md`.
+Current runbooks:
 
-**⚠️ Gap:** Missing runbooks for cloud provisioning failure, worker enrollment failure, Stripe webhook failure, managed target replacement, E2B template release rollback.
+- `billing-pro-promo-codes.md`
+- `stripe-webhook-failure.md`
+- `e2b-template-rollback.md`
+
+**⚠️ Gap:** Missing runbooks for cloud provisioning failure, worker enrollment failure, and managed target replacement.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Stripe webhook failure runbook for delivery, replay, and billing mirror recovery
- add an E2B template rollback runbook for managed cloud runtime release failures
- update the developing/runbook indexes and spec catalog gap list

## Verification
- `git diff --check origin/main...HEAD`
- checked package scripts for Markdown/doc lint commands; none were present