### PR TITLE
refactor(product): split chat transcript view

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptRows.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptRows.tsx
@@ -1,0 +1,20 @@
+import type { TranscriptRowListBaseProps } from "./TranscriptRowListShared";
+import { VirtualTranscriptRowList } from "./VirtualTranscriptRowList";
+
+interface ChatTranscriptRowsProps extends TranscriptRowListBaseProps {
+  rowListKey: string;
+}
+
+export function ChatTranscriptRows({
+  rowListKey,
+  ...props
+}: ChatTranscriptRowsProps) {
+  return (
+    <div className="flex-1 min-h-0" data-telemetry-block>
+      <VirtualTranscriptRowList
+        key={rowListKey}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
@@ -1,106 +1,27 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useRef } from "react";
 import type {
-  ChatTranscriptState,
-  PendingPromptEntry,
-  TranscriptState,
-  TurnRecord,
-} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
-import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
-import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
-import {
-  buildOutboxStartedAtByPromptId,
-  collectToolCallIdsWithProposedPlan,
-  findTrailingLiveExplorationBlock,
-  findTrailingLiveWorkBlock,
-  resolveTurnPromptTiming,
-} from "@proliferate/product-domain/chats/transcript/transcript-rendering";
-import {
-  latestTransientStatusText,
-  shouldAllowTurnTrailingStatus,
-} from "@proliferate/product-domain/chats/transcript/transcript-trailing-status";
-import {
-  turnHasAssistantRenderableTranscriptContent,
-  resolveVisibleOptimisticPrompt,
-  shouldShowPendingPromptActivity,
-} from "@proliferate/product-domain/chats/pending-prompts/pending-prompts";
-import {
-  outboxEntryToPendingPromptEntry,
-  renderableOutboxEntriesForTranscript,
-} from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
-import {
-  buildTranscriptRowModel,
-  createTranscriptRowModelCache,
-} from "@proliferate/product-domain/chats/transcript/transcript-row-model";
-import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
-import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
-import { buildTranscriptCopyText } from "@proliferate/product-domain/chats/transcript/transcript-copy";
-import { VirtualTranscriptRowList } from "./VirtualTranscriptRowList";
-import { useChatTranscriptSelection } from "./ChatTranscriptSelection";
+  ChatTranscriptOutboxActions,
+  ChatTranscriptViewProps,
+} from "./ChatTranscriptViewTypes";
+import { ChatTranscriptRows } from "./ChatTranscriptRows";
+import { useChatTranscriptCopySelection } from "./useChatTranscriptCopySelection";
+import { useChatTranscriptRowRenderer } from "./useChatTranscriptRowRenderer";
+import { useChatTranscriptViewModel } from "./useChatTranscriptViewModel";
+
+export type {
+  ChatTranscriptOutboxActions,
+  ChatTranscriptPendingPromptRenderInput,
+  ChatTranscriptPendingStatusInput,
+  ChatTranscriptTurnRowRenderInput,
+  ChatTranscriptTurnStatusInput,
+  ChatTranscriptViewProps,
+} from "./ChatTranscriptViewTypes";
 
 const noop = () => {};
-const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
 const NOOP_OUTBOX_ACTIONS: ChatTranscriptOutboxActions = {
   retryPrompt: noop,
   dismissPrompt: noop,
 };
-const LIVE_STATUS_GRACE_MS = 750;
-
-export interface ChatTranscriptOutboxActions {
-  retryPrompt: (clientPromptId: string) => void;
-  dismissPrompt: (clientPromptId: string) => void;
-}
-
-export interface ChatTranscriptPendingPromptRenderInput {
-  activeSessionId: string;
-  row: Extract<TranscriptVirtualRow, { kind: "pending_prompt" | "outbox_prompt" }>;
-  rowIndex: number;
-  prompt: PendingPromptEntry;
-  outboxEntry: PromptOutboxEntry | null;
-  optimisticTrailingStatus: ReactNode;
-  outboxActions: ChatTranscriptOutboxActions;
-}
-
-export interface ChatTranscriptTurnRowRenderInput {
-  row: Extract<TranscriptVirtualRow, { kind: "turn" }>;
-  rowIndex: number;
-  turn: TurnRecord;
-  transcript: TranscriptState;
-  latestTurnId: string | null;
-  latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
-  latestLiveStatus: ReactNode;
-  outboxStartedAtByPromptId: ReadonlyMap<string, string>;
-  selectedWorkspaceId: string | null;
-  sessionViewState: SessionViewState;
-}
-
-export interface ChatTranscriptPendingStatusInput {
-  queuedAt: string;
-  sessionViewState: SessionViewState;
-  forceWorking: boolean;
-}
-
-export interface ChatTranscriptTurnStatusInput {
-  startedAt: string;
-  sessionViewState: SessionViewState;
-  transientStatusText: string | null;
-}
-
-export interface ChatTranscriptViewProps {
-  state: ChatTranscriptState;
-  outboxActions?: ChatTranscriptOutboxActions;
-  onScrollSample?: () => void;
-  renderPendingPromptRow: (input: ChatTranscriptPendingPromptRenderInput) => ReactNode;
-  renderTurnRow: (input: ChatTranscriptTurnRowRenderInput) => ReactNode;
-  renderPendingPromptTrailingStatus?: (input: ChatTranscriptPendingStatusInput) => ReactNode;
-  renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
-}
 
 export function ChatTranscriptView({
   state,
@@ -111,292 +32,57 @@ export function ChatTranscriptView({
   renderPendingPromptTrailingStatus,
   renderTurnTrailingStatus,
 }: ChatTranscriptViewProps) {
-  const {
-    activeSessionId,
-    selectedWorkspaceId,
-    optimisticPrompt = null,
-    outboxEntries = EMPTY_OUTBOX_ENTRIES,
-    transcript,
-    sessionViewState,
-    history,
-    layout,
-  } = state;
-  const hasOlderHistory = history?.hasOlderHistory ?? false;
-  const isLoadingOlderHistory = history?.isLoadingOlderHistory ?? false;
-  const olderHistoryCursor = history?.olderHistoryCursor ?? null;
-  const onLoadOlderHistory = history?.onLoadOlderHistory ?? noop;
-  const bottomInsetPx = layout?.bottomInsetPx ?? 40;
-  const columnClassName = layout?.columnClassName;
-  const gutterClassName = layout?.gutterClassName;
-  const latestTurnId = transcript.turnOrder[transcript.turnOrder.length - 1] ?? null;
-  const latestTurn = latestTurnId ? transcript.turnsById[latestTurnId] ?? null : null;
-  const latestTurnHasAssistantRenderableContent = turnHasAssistantRenderableTranscriptContent(
-    latestTurn,
-    transcript,
-  );
-  const visibleOptimisticPrompt = resolveVisibleOptimisticPrompt({
-    optimisticPrompt,
-    latestTurnStartedAt: latestTurn?.startedAt ?? null,
-    latestTurnHasAssistantRenderableContent,
-  });
-  const optimisticPromptTrailingStatus = visibleOptimisticPrompt
-    && shouldShowPendingPromptActivity({
-      optimisticPrompt: visibleOptimisticPrompt,
-      sessionViewState,
-    })
-    ? renderPendingPromptTrailingStatus?.({
-        queuedAt: visibleOptimisticPrompt.queuedAt,
-        sessionViewState,
-        forceWorking: true,
-      }) ?? null
-    : null;
-  const visibleOutboxEntries = useMemo(
-    () => renderableOutboxEntriesForTranscript(outboxEntries, transcript),
-    [outboxEntries, transcript],
-  );
-  const outboxStartedAtByPromptId = useMemo(
-    () => buildOutboxStartedAtByPromptId(outboxEntries),
-    [outboxEntries],
-  );
-  const virtualRows = useSharedTranscriptRowModel({
-    activeSessionId,
-    transcript,
-    visibleOptimisticPrompt,
-    visibleOutboxEntries,
-    latestTurnId,
-    latestTurnHasAssistantRenderableContent,
-  });
-  const visibleTurnIds = useMemo(
-    () => {
-      const ids: string[] = [];
-      const seen = new Set<string>();
-      for (const row of virtualRows) {
-        if (row.kind !== "turn" || seen.has(row.turnId)) {
-          continue;
-        }
-        seen.add(row.turnId);
-        ids.push(row.turnId);
-      }
-      return ids;
-    },
-    [virtualRows],
-  );
-  const latestTurnInProgress = !!latestTurn && !latestTurn.completedAt;
-  const latestTurnPresentation = useMemo(
-    () => {
-      if (!latestTurnId) {
-        return null;
-      }
-      const latestRow = virtualRows.find((row) =>
-        row.kind === "turn" && row.turnId === latestTurnId
-      );
-      return latestRow?.kind === "turn" ? latestRow.presentation : null;
-    },
-    [latestTurnId, virtualRows],
-  );
-  const latestLiveExplorationBlock = useMemo(
-    () => latestTurnPresentation
-      ? findTrailingLiveExplorationBlock(
-          latestTurnPresentation.displayBlocks,
-          transcript,
-          latestTurnInProgress,
-        )
-      : null,
-    [latestTurnInProgress, latestTurnPresentation, transcript],
-  );
-  const latestLiveWorkBlock = useMemo(
-    () => latestTurnPresentation
-      ? findTrailingLiveWorkBlock(
-          latestTurnPresentation.displayBlocks,
-          transcript,
-          latestTurnInProgress,
-        )
-      : null,
-    [latestTurnInProgress, latestTurnPresentation, transcript],
-  );
-  const latestTurnHasActiveToolWork = latestTurn
-    ? turnHasActiveToolWork(latestTurn, transcript)
-    : false;
-  const latestTransientText = latestTurn
-    ? latestTransientStatusText(latestTurn, transcript)
-    : null;
-  const latestTurnTiming = latestTurn
-    ? resolveTurnPromptTiming(latestTurn, transcript, outboxStartedAtByPromptId)
-    : null;
-  const shouldShowDelayedLatestLiveStatus = !!latestTurn
-    && latestTurnInProgress
-    && !latestLiveExplorationBlock
-    && !latestLiveWorkBlock
-    && !latestTurnHasActiveToolWork
-    && transcript.isStreaming
-    && sessionViewState === "working"
-    && shouldAllowTurnTrailingStatus({
-      turn: latestTurn,
-      transcript,
-      isLatestTurnInProgress: true,
-    });
-  const shouldShowImmediateOutboxLiveStatus =
-    shouldShowDelayedLatestLiveStatus
-    && latestTurnTiming?.isOutboxStartedAt === true;
-  const [showDelayedLatestLiveStatus, setShowDelayedLatestLiveStatus] = useState(false);
-
-  useEffect(() => {
-    if (!shouldShowDelayedLatestLiveStatus) {
-      setShowDelayedLatestLiveStatus(false);
-      return;
-    }
-
-    setShowDelayedLatestLiveStatus(false);
-    const timeout = window.setTimeout(() => {
-      setShowDelayedLatestLiveStatus(true);
-    }, LIVE_STATUS_GRACE_MS);
-    return () => window.clearTimeout(timeout);
-  }, [
-    latestTransientText,
-    latestTurn?.itemOrder.length,
-    latestTurnTiming?.startedAt,
-    latestTurnId,
-    shouldShowDelayedLatestLiveStatus,
-  ]);
-
-  const latestLiveStatus = latestTurn
-    && (showDelayedLatestLiveStatus || shouldShowImmediateOutboxLiveStatus)
-      ? renderTurnTrailingStatus?.({
-          startedAt: latestTurnTiming?.startedAt ?? latestTurn.startedAt,
-          sessionViewState,
-          transientStatusText: latestTransientText,
-        }) ?? null
-      : null;
   const selectionRootRef = useRef<HTMLDivElement>(null);
-  const getTranscriptCopyText = useCallback(() => buildTranscriptCopyText({
-    transcript,
-    visibleTurnIds,
-    visibleOptimisticPrompt,
-    proposedPlanToolCallIds: collectToolCallIdsWithProposedPlan(transcript),
-  }), [
-    transcript,
-    visibleTurnIds,
-    visibleOptimisticPrompt,
-  ]);
-
-  useChatTranscriptSelection({
-    rootRef: selectionRootRef,
-    getCopyText: getTranscriptCopyText,
+  const model = useChatTranscriptViewModel({
+    state,
+    renderPendingPromptTrailingStatus,
+    renderTurnTrailingStatus,
   });
 
-  const renderVirtualRow = useCallback((row: TranscriptVirtualRow, rowIndex: number) => {
-    if (row.kind === "pending_prompt" || row.kind === "outbox_prompt") {
-      const outboxEntry = row.kind === "outbox_prompt"
-        ? visibleOutboxEntries.find((entry) => entry.clientPromptId === row.clientPromptId) ?? null
-        : null;
-      const prompt = row.kind === "pending_prompt"
-        ? visibleOptimisticPrompt
-        : outboxEntry
-          ? outboxEntryToPendingPromptEntry(outboxEntry)
-          : null;
-      if (!prompt) {
-        return null;
-      }
-      return renderPendingPromptRow({
-        activeSessionId,
-        row,
-        rowIndex,
-        prompt,
-        outboxEntry,
-        optimisticTrailingStatus: optimisticPromptTrailingStatus,
-        outboxActions,
-      });
-    }
+  useChatTranscriptCopySelection({
+    selectionRootRef,
+    transcript: model.transcript,
+    visibleTurnIds: model.visibleTurnIds,
+    visibleOptimisticPrompt: model.visibleOptimisticPrompt,
+  });
 
-    const turn = transcript.turnsById[row.turnId];
-    if (!turn) {
-      return null;
-    }
-
-    return renderTurnRow({
-      row,
-      rowIndex,
-      turn,
-      transcript,
-      latestTurnId,
-      latestLiveExplorationBlock,
-      latestLiveStatus,
-      outboxStartedAtByPromptId,
-      selectedWorkspaceId,
-      sessionViewState,
-    });
-  }, [
-    activeSessionId,
-    latestLiveExplorationBlock,
-    latestLiveStatus,
-    latestTurnId,
-    optimisticPromptTrailingStatus,
+  const renderVirtualRow = useChatTranscriptRowRenderer({
+    activeSessionId: model.activeSessionId,
+    latestLiveExplorationBlock: model.latestLiveExplorationBlock,
+    latestLiveStatus: model.latestLiveStatus,
+    latestTurnId: model.latestTurnId,
+    optimisticPromptTrailingStatus: model.optimisticPromptTrailingStatus,
     outboxActions,
-    outboxStartedAtByPromptId,
+    outboxStartedAtByPromptId: model.outboxStartedAtByPromptId,
     renderPendingPromptRow,
     renderTurnRow,
-    selectedWorkspaceId,
-    sessionViewState,
-    transcript,
-    visibleOutboxEntries,
-    visibleOptimisticPrompt,
-  ]);
+    selectedWorkspaceId: model.selectedWorkspaceId,
+    sessionViewState: model.sessionViewState,
+    transcript: model.transcript,
+    visibleOutboxEntries: model.visibleOutboxEntries,
+    visibleOptimisticPrompt: model.visibleOptimisticPrompt,
+  });
 
   return (
-    <div className="flex-1 min-h-0" data-telemetry-block>
-      <VirtualTranscriptRowList
-        key={`${selectedWorkspaceId ?? "workspace"}:${activeSessionId}`}
-        rows={virtualRows}
-        selectionRootRef={selectionRootRef}
-        hasOlderHistory={hasOlderHistory}
-        isLoadingOlderHistory={isLoadingOlderHistory}
-        olderHistoryCursor={olderHistoryCursor}
-        bottomInsetPx={bottomInsetPx}
-        selectedWorkspaceId={selectedWorkspaceId}
-        activeSessionId={activeSessionId}
-        isSessionBusy={sessionViewState === "working" || sessionViewState === "needs_input"}
-        pendingPromptText={visibleOptimisticPrompt?.text ?? null}
-        onLoadOlderHistory={onLoadOlderHistory}
-        onScrollSample={onScrollSample}
-        renderRow={renderVirtualRow}
-        columnClassName={columnClassName}
-        gutterClassName={gutterClassName}
-      />
-    </div>
+    <ChatTranscriptRows
+      rowListKey={`${model.selectedWorkspaceId ?? "workspace"}:${model.activeSessionId}`}
+      rows={model.virtualRows}
+      selectionRootRef={selectionRootRef}
+      hasOlderHistory={model.hasOlderHistory}
+      isLoadingOlderHistory={model.isLoadingOlderHistory}
+      olderHistoryCursor={model.olderHistoryCursor}
+      bottomInsetPx={model.bottomInsetPx}
+      selectedWorkspaceId={model.selectedWorkspaceId}
+      activeSessionId={model.activeSessionId}
+      isSessionBusy={
+        model.sessionViewState === "working" || model.sessionViewState === "needs_input"
+      }
+      pendingPromptText={model.visibleOptimisticPrompt?.text ?? null}
+      onLoadOlderHistory={model.onLoadOlderHistory}
+      onScrollSample={onScrollSample}
+      renderRow={renderVirtualRow}
+      columnClassName={model.columnClassName}
+      gutterClassName={model.gutterClassName}
+    />
   );
-}
-
-function useSharedTranscriptRowModel(input: {
-  activeSessionId: string;
-  transcript: TranscriptState;
-  visibleOptimisticPrompt: PendingPromptEntry | null;
-  visibleOutboxEntries: readonly PromptOutboxEntry[];
-  latestTurnId: string | null;
-  latestTurnHasAssistantRenderableContent: boolean;
-}): readonly TranscriptVirtualRow[] {
-  const cacheRef = useRef(createTranscriptRowModelCache());
-
-  return useMemo(
-    () => buildTranscriptRowModel(input, cacheRef.current),
-    [
-      input.activeSessionId,
-      input.latestTurnHasAssistantRenderableContent,
-      input.latestTurnId,
-      input.transcript,
-      input.visibleOptimisticPrompt,
-      input.visibleOutboxEntries,
-    ],
-  );
-}
-
-function turnHasActiveToolWork(
-  turn: Pick<TurnRecord, "itemOrder">,
-  transcript: TranscriptState,
-): boolean {
-  return turn.itemOrder.some((itemId) => {
-    const item = transcript.itemsById[itemId];
-    return item?.kind === "tool_call"
-      && item.status !== "completed"
-      && item.status !== "failed";
-  });
 }

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewRules.ts
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewRules.ts
@@ -1,0 +1,88 @@
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+  TurnRecord,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import { outboxEntryToPendingPromptEntry } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+
+type PendingPromptVirtualRow =
+  Extract<TranscriptVirtualRow, { kind: "pending_prompt" | "outbox_prompt" }>;
+type TurnVirtualRow = Extract<TranscriptVirtualRow, { kind: "turn" }>;
+
+export type LatestTurnPresentation = TurnVirtualRow["presentation"];
+
+export interface PendingPromptRenderTarget {
+  prompt: PendingPromptEntry;
+  outboxEntry: PromptOutboxEntry | null;
+}
+
+export function collectVisibleTurnIds(
+  virtualRows: readonly TranscriptVirtualRow[],
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const row of virtualRows) {
+    if (row.kind !== "turn" || seen.has(row.turnId)) {
+      continue;
+    }
+    seen.add(row.turnId);
+    ids.push(row.turnId);
+  }
+  return ids;
+}
+
+export function findLatestTurnPresentation(
+  virtualRows: readonly TranscriptVirtualRow[],
+  latestTurnId: string | null,
+): LatestTurnPresentation | null {
+  if (!latestTurnId) {
+    return null;
+  }
+
+  const latestRow = virtualRows.find((row): row is TurnVirtualRow =>
+    row.kind === "turn" && row.turnId === latestTurnId
+  );
+  return latestRow?.presentation ?? null;
+}
+
+export function resolvePendingPromptRenderTarget({
+  row,
+  visibleOptimisticPrompt,
+  visibleOutboxEntries,
+}: {
+  row: PendingPromptVirtualRow;
+  visibleOptimisticPrompt: PendingPromptEntry | null;
+  visibleOutboxEntries: readonly PromptOutboxEntry[];
+}): PendingPromptRenderTarget | null {
+  if (row.kind === "pending_prompt") {
+    return visibleOptimisticPrompt
+      ? { prompt: visibleOptimisticPrompt, outboxEntry: null }
+      : null;
+  }
+
+  const outboxEntry = visibleOutboxEntries.find((entry) =>
+    entry.clientPromptId === row.clientPromptId
+  ) ?? null;
+  if (!outboxEntry) {
+    return null;
+  }
+
+  return {
+    prompt: outboxEntryToPendingPromptEntry(outboxEntry),
+    outboxEntry,
+  };
+}
+
+export function turnHasActiveToolWork(
+  turn: Pick<TurnRecord, "itemOrder">,
+  transcript: TranscriptState,
+): boolean {
+  return turn.itemOrder.some((itemId) => {
+    const item = transcript.itemsById[itemId];
+    return item?.kind === "tool_call"
+      && item.status !== "completed"
+      && item.status !== "failed";
+  });
+}

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewTypes.ts
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewTypes.ts
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import type {
+  ChatTranscriptState,
+  PendingPromptEntry,
+  TranscriptState,
+  TurnRecord,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
+
+export interface ChatTranscriptOutboxActions {
+  retryPrompt: (clientPromptId: string) => void;
+  dismissPrompt: (clientPromptId: string) => void;
+}
+
+export interface ChatTranscriptPendingPromptRenderInput {
+  activeSessionId: string;
+  row: Extract<TranscriptVirtualRow, { kind: "pending_prompt" | "outbox_prompt" }>;
+  rowIndex: number;
+  prompt: PendingPromptEntry;
+  outboxEntry: PromptOutboxEntry | null;
+  optimisticTrailingStatus: ReactNode;
+  outboxActions: ChatTranscriptOutboxActions;
+}
+
+export interface ChatTranscriptTurnRowRenderInput {
+  row: Extract<TranscriptVirtualRow, { kind: "turn" }>;
+  rowIndex: number;
+  turn: TurnRecord;
+  transcript: TranscriptState;
+  latestTurnId: string | null;
+  latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
+  latestLiveStatus: ReactNode;
+  outboxStartedAtByPromptId: ReadonlyMap<string, string>;
+  selectedWorkspaceId: string | null;
+  sessionViewState: SessionViewState;
+}
+
+export interface ChatTranscriptPendingStatusInput {
+  queuedAt: string;
+  sessionViewState: SessionViewState;
+  forceWorking: boolean;
+}
+
+export interface ChatTranscriptTurnStatusInput {
+  startedAt: string;
+  sessionViewState: SessionViewState;
+  transientStatusText: string | null;
+}
+
+export interface ChatTranscriptViewProps {
+  state: ChatTranscriptState;
+  outboxActions?: ChatTranscriptOutboxActions;
+  onScrollSample?: () => void;
+  renderPendingPromptRow: (input: ChatTranscriptPendingPromptRenderInput) => ReactNode;
+  renderTurnRow: (input: ChatTranscriptTurnRowRenderInput) => ReactNode;
+  renderPendingPromptTrailingStatus?: (input: ChatTranscriptPendingStatusInput) => ReactNode;
+  renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
+}

--- a/apps/packages/product-ui/src/chat/transcript/useChatTranscriptCopySelection.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useChatTranscriptCopySelection.ts
@@ -1,0 +1,36 @@
+import { useCallback, type RefObject } from "react";
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import { collectToolCallIdsWithProposedPlan } from "@proliferate/product-domain/chats/transcript/transcript-rendering";
+import { buildTranscriptCopyText } from "@proliferate/product-domain/chats/transcript/transcript-copy";
+import { useChatTranscriptSelection } from "./ChatTranscriptSelection";
+
+export function useChatTranscriptCopySelection({
+  selectionRootRef,
+  transcript,
+  visibleTurnIds,
+  visibleOptimisticPrompt,
+}: {
+  selectionRootRef: RefObject<HTMLDivElement | null>;
+  transcript: TranscriptState;
+  visibleTurnIds: readonly string[];
+  visibleOptimisticPrompt: PendingPromptEntry | null;
+}): void {
+  const getTranscriptCopyText = useCallback(() => buildTranscriptCopyText({
+    transcript,
+    visibleTurnIds,
+    visibleOptimisticPrompt,
+    proposedPlanToolCallIds: collectToolCallIdsWithProposedPlan(transcript),
+  }), [
+    transcript,
+    visibleTurnIds,
+    visibleOptimisticPrompt,
+  ]);
+
+  useChatTranscriptSelection({
+    rootRef: selectionRootRef,
+    getCopyText: getTranscriptCopyText,
+  });
+}

--- a/apps/packages/product-ui/src/chat/transcript/useChatTranscriptRowRenderer.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useChatTranscriptRowRenderer.ts
@@ -1,0 +1,102 @@
+import { useCallback, type ReactNode } from "react";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
+import type {
+  ChatTranscriptOutboxActions,
+  ChatTranscriptPendingPromptRenderInput,
+  ChatTranscriptTurnRowRenderInput,
+} from "./ChatTranscriptViewTypes";
+import { resolvePendingPromptRenderTarget } from "./ChatTranscriptViewRules";
+
+export function useChatTranscriptRowRenderer({
+  activeSessionId,
+  latestLiveExplorationBlock,
+  latestLiveStatus,
+  latestTurnId,
+  optimisticPromptTrailingStatus,
+  outboxActions,
+  outboxStartedAtByPromptId,
+  renderPendingPromptRow,
+  renderTurnRow,
+  selectedWorkspaceId,
+  sessionViewState,
+  transcript,
+  visibleOutboxEntries,
+  visibleOptimisticPrompt,
+}: {
+  activeSessionId: string;
+  latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
+  latestLiveStatus: ReactNode;
+  latestTurnId: string | null;
+  optimisticPromptTrailingStatus: ReactNode;
+  outboxActions: ChatTranscriptOutboxActions;
+  outboxStartedAtByPromptId: ReadonlyMap<string, string>;
+  renderPendingPromptRow: (input: ChatTranscriptPendingPromptRenderInput) => ReactNode;
+  renderTurnRow: (input: ChatTranscriptTurnRowRenderInput) => ReactNode;
+  selectedWorkspaceId: string | null;
+  sessionViewState: SessionViewState;
+  transcript: TranscriptState;
+  visibleOutboxEntries: readonly PromptOutboxEntry[];
+  visibleOptimisticPrompt: PendingPromptEntry | null;
+}): (row: TranscriptVirtualRow, rowIndex: number) => ReactNode {
+  return useCallback((row: TranscriptVirtualRow, rowIndex: number) => {
+    if (row.kind === "pending_prompt" || row.kind === "outbox_prompt") {
+      const target = resolvePendingPromptRenderTarget({
+        row,
+        visibleOptimisticPrompt,
+        visibleOutboxEntries,
+      });
+      if (!target) {
+        return null;
+      }
+      return renderPendingPromptRow({
+        activeSessionId,
+        row,
+        rowIndex,
+        prompt: target.prompt,
+        outboxEntry: target.outboxEntry,
+        optimisticTrailingStatus: optimisticPromptTrailingStatus,
+        outboxActions,
+      });
+    }
+
+    const turn = transcript.turnsById[row.turnId];
+    if (!turn) {
+      return null;
+    }
+
+    return renderTurnRow({
+      row,
+      rowIndex,
+      turn,
+      transcript,
+      latestTurnId,
+      latestLiveExplorationBlock,
+      latestLiveStatus,
+      outboxStartedAtByPromptId,
+      selectedWorkspaceId,
+      sessionViewState,
+    });
+  }, [
+    activeSessionId,
+    latestLiveExplorationBlock,
+    latestLiveStatus,
+    latestTurnId,
+    optimisticPromptTrailingStatus,
+    outboxActions,
+    outboxStartedAtByPromptId,
+    renderPendingPromptRow,
+    renderTurnRow,
+    selectedWorkspaceId,
+    sessionViewState,
+    transcript,
+    visibleOutboxEntries,
+    visibleOptimisticPrompt,
+  ]);
+}

--- a/apps/packages/product-ui/src/chat/transcript/useChatTranscriptViewModel.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useChatTranscriptViewModel.ts
@@ -1,0 +1,155 @@
+import { useMemo, type ReactNode } from "react";
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
+import { buildOutboxStartedAtByPromptId } from "@proliferate/product-domain/chats/transcript/transcript-rendering";
+import {
+  turnHasAssistantRenderableTranscriptContent,
+  resolveVisibleOptimisticPrompt,
+  shouldShowPendingPromptActivity,
+} from "@proliferate/product-domain/chats/pending-prompts/pending-prompts";
+import { renderableOutboxEntriesForTranscript } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
+import type {
+  ChatTranscriptPendingStatusInput,
+  ChatTranscriptTurnStatusInput,
+  ChatTranscriptViewProps,
+} from "./ChatTranscriptViewTypes";
+import { collectVisibleTurnIds } from "./ChatTranscriptViewRules";
+import { useLatestTranscriptLiveStatus } from "./useLatestTranscriptLiveStatus";
+import { useSharedTranscriptRowModel } from "./useSharedTranscriptRowModel";
+
+const noop = () => {};
+const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
+
+export interface ChatTranscriptViewModel {
+  activeSessionId: string;
+  selectedWorkspaceId: string | null;
+  transcript: TranscriptState;
+  sessionViewState: SessionViewState;
+  hasOlderHistory: boolean;
+  isLoadingOlderHistory: boolean;
+  olderHistoryCursor: number | null;
+  onLoadOlderHistory: () => void;
+  bottomInsetPx: number;
+  columnClassName: string | undefined;
+  gutterClassName: string | undefined;
+  visibleOptimisticPrompt: PendingPromptEntry | null;
+  optimisticPromptTrailingStatus: ReactNode;
+  visibleOutboxEntries: readonly PromptOutboxEntry[];
+  outboxStartedAtByPromptId: ReadonlyMap<string, string>;
+  virtualRows: readonly TranscriptVirtualRow[];
+  visibleTurnIds: readonly string[];
+  latestTurnId: string | null;
+  latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
+  latestLiveStatus: ReactNode;
+}
+
+export function useChatTranscriptViewModel({
+  state,
+  renderPendingPromptTrailingStatus,
+  renderTurnTrailingStatus,
+}: {
+  state: ChatTranscriptViewProps["state"];
+  renderPendingPromptTrailingStatus?: (input: ChatTranscriptPendingStatusInput) => ReactNode;
+  renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
+}): ChatTranscriptViewModel {
+  const {
+    activeSessionId,
+    selectedWorkspaceId,
+    optimisticPrompt = null,
+    outboxEntries = EMPTY_OUTBOX_ENTRIES,
+    transcript,
+    sessionViewState,
+    history,
+    layout,
+  } = state;
+  const hasOlderHistory = history?.hasOlderHistory ?? false;
+  const isLoadingOlderHistory = history?.isLoadingOlderHistory ?? false;
+  const olderHistoryCursor = history?.olderHistoryCursor ?? null;
+  const onLoadOlderHistory = history?.onLoadOlderHistory ?? noop;
+  const bottomInsetPx = layout?.bottomInsetPx ?? 40;
+  const columnClassName = layout?.columnClassName;
+  const gutterClassName = layout?.gutterClassName;
+  const latestTurnId = transcript.turnOrder[transcript.turnOrder.length - 1] ?? null;
+  const latestTurn = latestTurnId ? transcript.turnsById[latestTurnId] ?? null : null;
+  const latestTurnHasAssistantRenderableContent = turnHasAssistantRenderableTranscriptContent(
+    latestTurn,
+    transcript,
+  );
+  const visibleOptimisticPrompt = resolveVisibleOptimisticPrompt({
+    optimisticPrompt,
+    latestTurnStartedAt: latestTurn?.startedAt ?? null,
+    latestTurnHasAssistantRenderableContent,
+  });
+  const optimisticPromptTrailingStatus = visibleOptimisticPrompt
+    && shouldShowPendingPromptActivity({
+      optimisticPrompt: visibleOptimisticPrompt,
+      sessionViewState,
+    })
+    ? renderPendingPromptTrailingStatus?.({
+        queuedAt: visibleOptimisticPrompt.queuedAt,
+        sessionViewState,
+        forceWorking: true,
+      }) ?? null
+    : null;
+  const visibleOutboxEntries = useMemo(
+    () => renderableOutboxEntriesForTranscript(outboxEntries, transcript),
+    [outboxEntries, transcript],
+  );
+  const outboxStartedAtByPromptId = useMemo(
+    () => buildOutboxStartedAtByPromptId(outboxEntries),
+    [outboxEntries],
+  );
+  const virtualRows = useSharedTranscriptRowModel({
+    activeSessionId,
+    transcript,
+    visibleOptimisticPrompt,
+    visibleOutboxEntries,
+    latestTurnId,
+    latestTurnHasAssistantRenderableContent,
+  });
+  const visibleTurnIds = useMemo(
+    () => collectVisibleTurnIds(virtualRows),
+    [virtualRows],
+  );
+  const {
+    latestLiveExplorationBlock,
+    latestLiveStatus,
+  } = useLatestTranscriptLiveStatus({
+    latestTurnId,
+    latestTurn,
+    transcript,
+    virtualRows,
+    outboxStartedAtByPromptId,
+    sessionViewState,
+    renderTurnTrailingStatus,
+  });
+
+  return {
+    activeSessionId,
+    selectedWorkspaceId,
+    transcript,
+    sessionViewState,
+    hasOlderHistory,
+    isLoadingOlderHistory,
+    olderHistoryCursor,
+    onLoadOlderHistory,
+    bottomInsetPx,
+    columnClassName,
+    gutterClassName,
+    visibleOptimisticPrompt,
+    optimisticPromptTrailingStatus,
+    visibleOutboxEntries,
+    outboxStartedAtByPromptId,
+    virtualRows,
+    visibleTurnIds,
+    latestTurnId,
+    latestLiveExplorationBlock,
+    latestLiveStatus,
+  };
+}

--- a/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
@@ -1,0 +1,136 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type {
+  TranscriptState,
+  TurnRecord,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
+import {
+  findTrailingLiveExplorationBlock,
+  findTrailingLiveWorkBlock,
+  resolveTurnPromptTiming,
+} from "@proliferate/product-domain/chats/transcript/transcript-rendering";
+import {
+  latestTransientStatusText,
+  shouldAllowTurnTrailingStatus,
+} from "@proliferate/product-domain/chats/transcript/transcript-trailing-status";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
+import type { ChatTranscriptTurnStatusInput } from "./ChatTranscriptViewTypes";
+import {
+  findLatestTurnPresentation,
+  turnHasActiveToolWork,
+} from "./ChatTranscriptViewRules";
+
+const LIVE_STATUS_GRACE_MS = 750;
+
+export interface LatestTranscriptLiveStatus {
+  latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
+  latestLiveStatus: ReactNode;
+}
+
+export function useLatestTranscriptLiveStatus({
+  latestTurnId,
+  latestTurn,
+  transcript,
+  virtualRows,
+  outboxStartedAtByPromptId,
+  sessionViewState,
+  renderTurnTrailingStatus,
+}: {
+  latestTurnId: string | null;
+  latestTurn: TurnRecord | null;
+  transcript: TranscriptState;
+  virtualRows: readonly TranscriptVirtualRow[];
+  outboxStartedAtByPromptId: ReadonlyMap<string, string>;
+  sessionViewState: SessionViewState;
+  renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
+}): LatestTranscriptLiveStatus {
+  const latestTurnInProgress = !!latestTurn && !latestTurn.completedAt;
+  const latestTurnPresentation = useMemo(
+    () => findLatestTurnPresentation(virtualRows, latestTurnId),
+    [latestTurnId, virtualRows],
+  );
+  const latestLiveExplorationBlock = useMemo(
+    () => latestTurnPresentation
+      ? findTrailingLiveExplorationBlock(
+          latestTurnPresentation.displayBlocks,
+          transcript,
+          latestTurnInProgress,
+        )
+      : null,
+    [latestTurnInProgress, latestTurnPresentation, transcript],
+  );
+  const latestLiveWorkBlock = useMemo(
+    () => latestTurnPresentation
+      ? findTrailingLiveWorkBlock(
+          latestTurnPresentation.displayBlocks,
+          transcript,
+          latestTurnInProgress,
+        )
+      : null,
+    [latestTurnInProgress, latestTurnPresentation, transcript],
+  );
+  const latestTurnHasActiveToolWork = latestTurn
+    ? turnHasActiveToolWork(latestTurn, transcript)
+    : false;
+  const latestTransientText = latestTurn
+    ? latestTransientStatusText(latestTurn, transcript)
+    : null;
+  const latestTurnTiming = latestTurn
+    ? resolveTurnPromptTiming(latestTurn, transcript, outboxStartedAtByPromptId)
+    : null;
+  const shouldShowDelayedLatestLiveStatus = !!latestTurn
+    && latestTurnInProgress
+    && !latestLiveExplorationBlock
+    && !latestLiveWorkBlock
+    && !latestTurnHasActiveToolWork
+    && transcript.isStreaming
+    && sessionViewState === "working"
+    && shouldAllowTurnTrailingStatus({
+      turn: latestTurn,
+      transcript,
+      isLatestTurnInProgress: true,
+    });
+  const shouldShowImmediateOutboxLiveStatus =
+    shouldShowDelayedLatestLiveStatus
+    && latestTurnTiming?.isOutboxStartedAt === true;
+  const [showDelayedLatestLiveStatus, setShowDelayedLatestLiveStatus] = useState(false);
+
+  useEffect(() => {
+    if (!shouldShowDelayedLatestLiveStatus) {
+      setShowDelayedLatestLiveStatus(false);
+      return;
+    }
+
+    setShowDelayedLatestLiveStatus(false);
+    const timeout = window.setTimeout(() => {
+      setShowDelayedLatestLiveStatus(true);
+    }, LIVE_STATUS_GRACE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [
+    latestTransientText,
+    latestTurn?.itemOrder.length,
+    latestTurnTiming?.startedAt,
+    latestTurnId,
+    shouldShowDelayedLatestLiveStatus,
+  ]);
+
+  const latestLiveStatus = latestTurn
+    && (showDelayedLatestLiveStatus || shouldShowImmediateOutboxLiveStatus)
+      ? renderTurnTrailingStatus?.({
+          startedAt: latestTurnTiming?.startedAt ?? latestTurn.startedAt,
+          sessionViewState,
+          transientStatusText: latestTransientText,
+        }) ?? null
+      : null;
+
+  return {
+    latestLiveExplorationBlock,
+    latestLiveStatus,
+  };
+}

--- a/apps/packages/product-ui/src/chat/transcript/useSharedTranscriptRowModel.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useSharedTranscriptRowModel.ts
@@ -1,0 +1,34 @@
+import { useMemo, useRef } from "react";
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+} from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import {
+  buildTranscriptRowModel,
+  createTranscriptRowModelCache,
+} from "@proliferate/product-domain/chats/transcript/transcript-row-model";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+
+export function useSharedTranscriptRowModel(input: {
+  activeSessionId: string;
+  transcript: TranscriptState;
+  visibleOptimisticPrompt: PendingPromptEntry | null;
+  visibleOutboxEntries: readonly PromptOutboxEntry[];
+  latestTurnId: string | null;
+  latestTurnHasAssistantRenderableContent: boolean;
+}): readonly TranscriptVirtualRow[] {
+  const cacheRef = useRef(createTranscriptRowModelCache());
+
+  return useMemo(
+    () => buildTranscriptRowModel(input, cacheRef.current),
+    [
+      input.activeSessionId,
+      input.latestTurnHasAssistantRenderableContent,
+      input.latestTurnId,
+      input.transcript,
+      input.visibleOptimisticPrompt,
+      input.visibleOutboxEntries,
+    ],
+  );
+}


### PR DESCRIPTION
## Summary
- split `ChatTranscriptView` into a small component entrypoint plus colocated transcript view types, row-list component, React hooks, and pure row/status rules
- preserved the existing `ChatTranscriptView` package subpath and type exports for current desktop/product-ui consumers
- kept the slice limited to `apps/packages/product-ui/src/chat/transcript/**`

## Verification
- `pnpm --filter @proliferate/product-ui typecheck`
- `pnpm --filter @proliferate/product-ui test`
- `python3 scripts/report_frontend_structure.py --summary-only`
- `python3 scripts/report_frontend_structure.py`
- `git diff --check`
- `pnpm --filter @proliferate/product-ui build && pnpm --dir apps/desktop exec tsc --noEmit`

## Notes
- The frontend structure report still lists two unrelated existing large files: `apps/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx` and `apps/desktop/src/lib/infra/debug/session-runtime-dev-sse.ts`. This PR does not touch either one.
