### PR TITLE
refactor(desktop): split session runtime dev SSE logging

### DIFF
--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
@@ -10,7 +10,7 @@ import {
   recordMeasurementWorkflowStep,
   startMeasurementOperation,
 } from "@/lib/infra/measurement/debug-measurement";
-import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/session-runtime-dev-sse";
+import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/dev-session-runtime-log";
 import { markLatencyFlowLiveAttached } from "@/lib/infra/measurement/latency-flow";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts
@@ -9,8 +9,8 @@ import type {
 import { applyStreamEnvelopeBatch } from "@/lib/domain/sessions/stream/stream-state";
 import {
   logDevSSEEvent,
-  logDevSessionRuntimeEvent,
-} from "@/lib/infra/debug/session-runtime-dev-sse";
+} from "@/lib/infra/debug/dev-sse-event-log";
+import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/dev-session-runtime-log";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   finishOrCancelMeasurementOperation,

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-controller.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-controller.ts
@@ -2,7 +2,7 @@ import type { SessionEventEnvelope } from "@anyharness/sdk";
 import {
   createFrameStreamBatchScheduler,
 } from "@proliferate/product-domain/chats/transcript/stream-batcher";
-import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/session-runtime-dev-sse";
+import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/dev-session-runtime-log";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import { getSessionRecord } from "@/stores/sessions/session-records";
 import { applySessionStreamFlushBatch } from "@/hooks/sessions/lifecycle/session-stream-flush-apply";

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-runtime-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-runtime-actions.ts
@@ -8,7 +8,7 @@ import {
   getSessionClientAndWorkspace,
   resumeSession,
 } from "@/lib/access/anyharness/session-runtime";
-import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/session-runtime-dev-sse";
+import { logDevSessionRuntimeEvent } from "@/lib/infra/debug/dev-session-runtime-log";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import {
   resolveSessionStatus,

--- a/apps/desktop/src/lib/infra/debug/dev-session-runtime-log.ts
+++ b/apps/desktop/src/lib/infra/debug/dev-session-runtime-log.ts
@@ -1,0 +1,34 @@
+type DevSessionRuntimeRecord = {
+  sessionId: string;
+  recordedAt: string;
+  kind: string;
+  details: Record<string, unknown>;
+};
+
+export function logDevSessionRuntimeEvent(
+  sessionId: string,
+  kind: string,
+  details: Record<string, unknown>,
+): void {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  const debugGlobal = globalThis as typeof globalThis & {
+    __APOLLO_SESSION_RUNTIME__?: DevSessionRuntimeRecord[];
+    __APOLLO_SESSION_RUNTIME_CONSOLE__?: boolean;
+  };
+
+  const record: DevSessionRuntimeRecord = {
+    sessionId,
+    recordedAt: new Date().toISOString(),
+    kind,
+    details,
+  };
+
+  const existing = debugGlobal.__APOLLO_SESSION_RUNTIME__ ?? [];
+  debugGlobal.__APOLLO_SESSION_RUNTIME__ = [...existing.slice(-499), record];
+  if (debugGlobal.__APOLLO_SESSION_RUNTIME_CONSOLE__ === true) {
+    console.debug("[session-runtime]", kind, record);
+  }
+}

--- a/apps/desktop/src/lib/infra/debug/dev-sse-envelope-sanitizer.ts
+++ b/apps/desktop/src/lib/infra/debug/dev-sse-envelope-sanitizer.ts
@@ -1,0 +1,70 @@
+import type { ContentPart, SessionEventEnvelope } from "@anyharness/sdk";
+
+export function sanitizeDevSSEEnvelope(envelope: SessionEventEnvelope): SessionEventEnvelope {
+  const event = envelope.event;
+  if (event.type === "item_started" || event.type === "item_completed") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        item: {
+          ...event.item,
+          contentParts: sanitizeContentParts(event.item.contentParts ?? []),
+          rawInput: undefined,
+          rawOutput: undefined,
+        },
+      },
+    };
+  }
+  if (event.type === "item_delta") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        delta: {
+          ...event.delta,
+          replaceContentParts: event.delta.replaceContentParts
+            ? sanitizeContentParts(event.delta.replaceContentParts)
+            : undefined,
+          appendContentParts: event.delta.appendContentParts
+            ? sanitizeContentParts(event.delta.appendContentParts)
+            : undefined,
+          rawInput: undefined,
+          rawOutput: undefined,
+        },
+      },
+    };
+  }
+  if (event.type === "pending_prompt_added" || event.type === "pending_prompt_updated") {
+    return {
+      ...envelope,
+      event: {
+        ...event,
+        text: summarizeSanitizedContent(event.contentParts ?? [], event.text),
+        contentParts: sanitizeContentParts(event.contentParts ?? []),
+      },
+    };
+  }
+  return envelope;
+}
+
+function sanitizeContentParts(parts: ContentPart[]): ContentPart[] {
+  return parts.map((part) => {
+    switch (part.type) {
+      case "text":
+        return { type: "text", text: `[text:${part.text.length}]` };
+      case "resource":
+        return { ...part, preview: part.preview ? `[preview:${part.preview.length}]` : undefined };
+      case "tool_input_text":
+        return { type: "tool_input_text", text: `[text:${part.text.length}]` };
+      case "tool_result_text":
+        return { type: "tool_result_text", text: `[text:${part.text.length}]` };
+      default:
+        return part;
+    }
+  });
+}
+
+function summarizeSanitizedContent(parts: ContentPart[], fallback: string): string {
+  return parts.length > 0 ? `[content_parts:${parts.length}]` : `[text:${fallback.length}]`;
+}

--- a/apps/desktop/src/lib/infra/debug/dev-sse-event-log.ts
+++ b/apps/desktop/src/lib/infra/debug/dev-sse-event-log.ts
@@ -1,0 +1,32 @@
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+import type {
+  DevSSEEventRecord,
+  DevSSEEventStatus,
+} from "@/lib/infra/debug/dev-sse-event-record";
+import { sanitizeDevSSEEnvelope } from "@/lib/infra/debug/dev-sse-envelope-sanitizer";
+import { logDevTranscriptPhaseEvent } from "@/lib/infra/debug/dev-transcript-phase-log";
+
+export function logDevSSEEvent(
+  sessionId: string,
+  envelope: SessionEventEnvelope,
+  status: DevSSEEventStatus,
+): void {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  const debugGlobal = globalThis as typeof globalThis & {
+    __APOLLO_SSE_EVENTS__?: DevSSEEventRecord[];
+  };
+
+  const record: DevSSEEventRecord = {
+    sessionId,
+    receivedAt: new Date().toISOString(),
+    status,
+    envelope: sanitizeDevSSEEnvelope(envelope),
+  };
+
+  const existing = debugGlobal.__APOLLO_SSE_EVENTS__ ?? [];
+  debugGlobal.__APOLLO_SSE_EVENTS__ = [...existing.slice(-499), record];
+  logDevTranscriptPhaseEvent(sessionId, envelope, status);
+}

--- a/apps/desktop/src/lib/infra/debug/dev-sse-event-record.ts
+++ b/apps/desktop/src/lib/infra/debug/dev-sse-event-record.ts
@@ -1,0 +1,10 @@
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+
+export type DevSSEEventStatus = "applied" | "duplicate" | "gap";
+
+export type DevSSEEventRecord = {
+  sessionId: string;
+  receivedAt: string;
+  status: DevSSEEventStatus;
+  envelope: SessionEventEnvelope;
+};

--- a/apps/desktop/src/lib/infra/debug/dev-transcript-phase-log.ts
+++ b/apps/desktop/src/lib/infra/debug/dev-transcript-phase-log.ts
@@ -1,11 +1,5 @@
-import type { ContentPart, SessionEventEnvelope } from "@anyharness/sdk";
-
-type DevSSEEventRecord = {
-  sessionId: string;
-  receivedAt: string;
-  status: "applied" | "duplicate" | "gap";
-  envelope: SessionEventEnvelope;
-};
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+import type { DevSSEEventStatus } from "@/lib/infra/debug/dev-sse-event-record";
 
 type DevTranscriptPhaseKind =
   | "turn"
@@ -19,7 +13,7 @@ type DevTranscriptPhaseKind =
 type DevTranscriptPhaseRecord = {
   sessionId: string;
   recordedAt: string;
-  status: DevSSEEventRecord["status"];
+  status: DevSSEEventStatus;
   seq: number;
   eventTimestamp: string;
   eventType: string;
@@ -56,139 +50,10 @@ type DevTranscriptPhaseSessionState = {
   itemsById: Record<string, DevTranscriptPhaseItemState>;
 };
 
-type DevSessionRuntimeRecord = {
-  sessionId: string;
-  recordedAt: string;
-  kind: string;
-  details: Record<string, unknown>;
-};
-
-export function logDevSSEEvent(
+export function logDevTranscriptPhaseEvent(
   sessionId: string,
   envelope: SessionEventEnvelope,
-  status: DevSSEEventRecord["status"],
-): void {
-  if (!import.meta.env.DEV) {
-    return;
-  }
-
-  const debugGlobal = globalThis as typeof globalThis & {
-    __APOLLO_SSE_EVENTS__?: DevSSEEventRecord[];
-  };
-
-  const record: DevSSEEventRecord = {
-    sessionId,
-    receivedAt: new Date().toISOString(),
-    status,
-    envelope: sanitizeDevSSEEnvelope(envelope),
-  };
-
-  const existing = debugGlobal.__APOLLO_SSE_EVENTS__ ?? [];
-  debugGlobal.__APOLLO_SSE_EVENTS__ = [...existing.slice(-499), record];
-  logDevTranscriptPhaseEvent(sessionId, envelope, status);
-}
-
-export function logDevSessionRuntimeEvent(
-  sessionId: string,
-  kind: string,
-  details: Record<string, unknown>,
-): void {
-  if (!import.meta.env.DEV) {
-    return;
-  }
-
-  const debugGlobal = globalThis as typeof globalThis & {
-    __APOLLO_SESSION_RUNTIME__?: DevSessionRuntimeRecord[];
-    __APOLLO_SESSION_RUNTIME_CONSOLE__?: boolean;
-  };
-
-  const record: DevSessionRuntimeRecord = {
-    sessionId,
-    recordedAt: new Date().toISOString(),
-    kind,
-    details,
-  };
-
-  const existing = debugGlobal.__APOLLO_SESSION_RUNTIME__ ?? [];
-  debugGlobal.__APOLLO_SESSION_RUNTIME__ = [...existing.slice(-499), record];
-  if (debugGlobal.__APOLLO_SESSION_RUNTIME_CONSOLE__ === true) {
-    console.debug("[session-runtime]", kind, record);
-  }
-}
-
-function sanitizeDevSSEEnvelope(envelope: SessionEventEnvelope): SessionEventEnvelope {
-  const event = envelope.event;
-  if (event.type === "item_started" || event.type === "item_completed") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        item: {
-          ...event.item,
-          contentParts: sanitizeContentParts(event.item.contentParts ?? []),
-          rawInput: undefined,
-          rawOutput: undefined,
-        },
-      },
-    };
-  }
-  if (event.type === "item_delta") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        delta: {
-          ...event.delta,
-          replaceContentParts: event.delta.replaceContentParts
-            ? sanitizeContentParts(event.delta.replaceContentParts)
-            : undefined,
-          appendContentParts: event.delta.appendContentParts
-            ? sanitizeContentParts(event.delta.appendContentParts)
-            : undefined,
-          rawInput: undefined,
-          rawOutput: undefined,
-        },
-      },
-    };
-  }
-  if (event.type === "pending_prompt_added" || event.type === "pending_prompt_updated") {
-    return {
-      ...envelope,
-      event: {
-        ...event,
-        text: summarizeSanitizedContent(event.contentParts ?? [], event.text),
-        contentParts: sanitizeContentParts(event.contentParts ?? []),
-      },
-    };
-  }
-  return envelope;
-}
-
-function sanitizeContentParts(parts: ContentPart[]): ContentPart[] {
-  return parts.map((part) => {
-    switch (part.type) {
-      case "text":
-        return { type: "text", text: `[text:${part.text.length}]` };
-      case "resource":
-        return { ...part, preview: part.preview ? `[preview:${part.preview.length}]` : undefined };
-      case "tool_input_text":
-        return { type: "tool_input_text", text: `[text:${part.text.length}]` };
-      case "tool_result_text":
-        return { type: "tool_result_text", text: `[text:${part.text.length}]` };
-      default:
-        return part;
-    }
-  });
-}
-
-function summarizeSanitizedContent(parts: ContentPart[], fallback: string): string {
-  return parts.length > 0 ? `[content_parts:${parts.length}]` : `[text:${fallback.length}]`;
-}
-
-function logDevTranscriptPhaseEvent(
-  sessionId: string,
-  envelope: SessionEventEnvelope,
-  status: DevSSEEventRecord["status"],
+  status: DevSSEEventStatus,
 ): void {
   if (!import.meta.env.DEV) {
     return;


### PR DESCRIPTION
## Summary
- Split desktop dev SSE/session runtime debug logging into smaller direct-import modules under `apps/desktop/src/lib/infra/debug`.
- Updated session runtime callers to import the exact logger modules they use.
- Removed the old combined `session-runtime-dev-sse.ts` module path.

## Verification
- `python3 scripts/check_frontend_boundaries.py`
- `pnpm --dir apps/desktop exec tsc --noEmit`