### PR TITLE
ci(frontend): enforce structure report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check frontend layer boundaries
         run: python3 scripts/check_frontend_boundaries.py
 
+      - name: Check frontend structure drift
+        run: python3 scripts/report_frontend_structure.py --strict --summary-only
+
       - name: Check server layer boundaries
         run: python3 scripts/check_server_boundaries.py
 


### PR DESCRIPTION
## Summary
- add the strict frontend structure drift report to repo-shape CI
- keep the existing boundary check in place and fail CI when the report regresses

## Verification
- python3 scripts/report_frontend_structure.py --strict --summary-only
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'