### PR TITLE
refactor(desktop): centralize settings admin role checks

### DIFF
--- a/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthCredentialForm.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthCredentialForm.tsx
@@ -10,7 +10,6 @@ import { Select } from "@proliferate/ui/primitives/Select";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
-import { isAgentAuthAdminRole } from "@/lib/domain/agent-auth/agent-auth-agent-presentation";
 import { agentAuthByokCapabilityLabel } from "@/lib/domain/agent-auth/agent-auth-gateway-capabilities";
 import {
   agentAuthGatewayCreatePayloadReady,
@@ -19,6 +18,7 @@ import {
   type AgentAuthGatewaySelectableAgentKind,
   type AgentAuthGatewayProviderChoice,
 } from "@/lib/domain/agent-auth/agent-auth-gateway-form";
+import { isSettingsAdminRole } from "@/lib/domain/settings/admin-roles";
 
 export interface OrganizationOption {
   id: string;
@@ -368,7 +368,7 @@ export function CloudAgentAuthCredentialForm({
 }
 
 function isAdminOrganization(organization: OrganizationOption): boolean {
-  return isAgentAuthAdminRole(organization.membership?.role);
+  return isSettingsAdminRole(organization.membership?.role);
 }
 
 function selectedOrganizationName(

--- a/apps/desktop/src/hooks/access/cloud/organizations/use-is-admin.ts
+++ b/apps/desktop/src/hooks/access/cloud/organizations/use-is-admin.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useOrganizationMembers } from "@/hooks/access/cloud/organizations/use-organization-members";
+import { isSettingsAdminRole, isSettingsOwnerRole } from "@/lib/domain/settings/admin-roles";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
 export function useIsAdmin(organizationId: string | null) {
@@ -10,8 +11,8 @@ export function useIsAdmin(organizationId: string | null) {
     [currentUserId, membersQuery.data?.members],
   );
   const role = currentMember?.role ?? null;
-  const isOwner = role === "owner";
-  const isAdmin = role === "owner" || role === "admin";
+  const isOwner = isSettingsOwnerRole(role);
+  const isAdmin = isSettingsAdminRole(role);
 
   return {
     isAdmin,

--- a/apps/desktop/src/hooks/settings/workflows/agent-auth-library/use-agent-auth-library-organization-selection.ts
+++ b/apps/desktop/src/hooks/settings/workflows/agent-auth-library/use-agent-auth-library-organization-selection.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useOrganizations } from "@/hooks/access/cloud/organizations/use-organizations";
-import { isAgentAuthAdminRole } from "@/lib/domain/agent-auth/agent-auth-agent-presentation";
+import { isSettingsAdminRole } from "@/lib/domain/settings/admin-roles";
 
 export type AgentAuthLibraryOrganizationOption =
   NonNullable<ReturnType<typeof useOrganizations>["data"]>["organizations"][number];
@@ -56,5 +56,5 @@ export function useAgentAuthLibraryOrganizationSelection(initialOrganizationId: 
 }
 
 function isAdminOrganization(organization: AgentAuthLibraryOrganizationOption): boolean {
-  return isAgentAuthAdminRole(organization.membership?.role);
+  return isSettingsAdminRole(organization.membership?.role);
 }

--- a/apps/desktop/src/lib/domain/agent-auth/agent-auth-agent-presentation.ts
+++ b/apps/desktop/src/lib/domain/agent-auth/agent-auth-agent-presentation.ts
@@ -1,4 +1,5 @@
 import type { AgentAuthAgentKind } from "@proliferate/cloud-sdk";
+import { isSettingsAdminRole } from "@/lib/domain/settings/admin-roles";
 
 export const AGENT_AUTH_AGENT_ORDER: AgentAuthAgentKind[] = [
   "claude",
@@ -8,7 +9,7 @@ export const AGENT_AUTH_AGENT_ORDER: AgentAuthAgentKind[] = [
 ];
 
 export function isAgentAuthAdminRole(role: string | null | undefined): boolean {
-  return role === "owner" || role === "admin";
+  return isSettingsAdminRole(role);
 }
 
 export function agentAuthAgentLabel(agentKind: string): string {

--- a/apps/desktop/src/lib/domain/settings/admin-roles.ts
+++ b/apps/desktop/src/lib/domain/settings/admin-roles.ts
@@ -1,0 +1,7 @@
+export function isSettingsOwnerRole(role: string | null | undefined): boolean {
+  return role === "owner";
+}
+
+export function isSettingsAdminRole(role: string | null | undefined): boolean {
+  return isSettingsOwnerRole(role) || role === "admin";
+}


### PR DESCRIPTION
## Summary
- add a settings-domain admin/owner role helper
- route useIsAdmin and agent-auth settings organization filters through the shared helper
- keep the existing agent-auth role helper delegating to the settings-owned rule

## Verification
- pnpm --dir apps/desktop exec vitest run src/lib/domain/agent-auth/agent-auth-presentation.test.ts
- python3 scripts/report_frontend_structure.py --strict --summary-only
- python3 scripts/check_frontend_boundaries.py
- pnpm --dir apps/desktop run build