### PR TITLE
docs(runbooks): add cloud ops recovery inventory

### DIFF
--- a/specs/developing/debugging/support-reports.md
+++ b/specs/developing/debugging/support-reports.md
@@ -643,6 +643,10 @@ curl -X POST \
   absent or invalid.
 - Fix config, deploy, then decide whether to reset/requeue the specific report
   through an admin/backfill path.
+- Use
+  [`../runbooks/operator-security-posture.md`](../runbooks/operator-security-posture.md)
+  for break-glass access and audit closeout if a manual reset/backfill is
+  approved before a first-class recovery endpoint exists.
 
 `tracker_status=partial`:
 

--- a/specs/developing/reference/env-secrets-matrix.md
+++ b/specs/developing/reference/env-secrets-matrix.md
@@ -226,3 +226,13 @@ There is no `E2B_RUNTIME_SENTRY_*` compatibility fallback on this branch.
 Operators should migrate any legacy runtime Sentry configuration to the
 `CLOUD_RUNTIME_*` variables above. The old `E2B_RUNTIME_SENTRY_*` names are not
 part of the supported env surface here.
+
+## Operator Recovery References
+
+Use [`../runbooks/operator-security-posture.md`](../runbooks/operator-security-posture.md)
+before rotating secrets, using break-glass access, or handling support bundles.
+Use [`../runbooks/cloud-provisioning-failure.md`](../runbooks/cloud-provisioning-failure.md)
+and [`../runbooks/worker-enrollment-failure.md`](../runbooks/worker-enrollment-failure.md)
+to triage cloud runtime failures before changing secret values. Use
+[`../runbooks/e2b-template-rollback.md`](../runbooks/e2b-template-rollback.md)
+when a bad E2B template promotion is the suspected cause.

--- a/specs/developing/runbooks/README.md
+++ b/specs/developing/runbooks/README.md
@@ -13,6 +13,10 @@ permissions, happy path, verification, and failure modes for one operation.
 | [billing-pro-promo-codes.md](billing-pro-promo-codes.md) | Grant a user free or discounted Pro access via a Stripe promotional code. |
 | [stripe-webhook-failure.md](stripe-webhook-failure.md) | Triage and recover Stripe webhook delivery or billing mirror failures. |
 | [e2b-template-rollback.md](e2b-template-rollback.md) | Roll an E2B cloud runtime template rolling tag back to a known-good immutable build. |
+| [cloud-provisioning-failure.md](cloud-provisioning-failure.md) | Triage managed cloud sandbox provisioning failures before worker enrollment. |
+| [worker-enrollment-failure.md](worker-enrollment-failure.md) | Triage worker enrollment, heartbeat, and control-loop delivery failures. |
+| [managed-target-replacement.md](managed-target-replacement.md) | Contain unrecoverable managed targets until the operator-safe replacement flow ships. |
+| [operator-security-posture.md](operator-security-posture.md) | Baseline for break-glass access, secret rotation, support bundle handling, and audit closeout. |
 
 ## Adding A Runbook
 

--- a/specs/developing/runbooks/cloud-provisioning-failure.md
+++ b/specs/developing/runbooks/cloud-provisioning-failure.md
@@ -1,0 +1,124 @@
+# Cloud provisioning failure
+
+Status: authoritative for first-response triage of managed cloud sandbox
+provisioning failures.
+
+Use this runbook when managed cloud target creation, sandbox creation, runtime
+bootstrap, or workspace materialization fails before a worker is enrolled. The
+data model is owned by
+[`../../codebase/primitives/sandbox-provisioning.md`](../../codebase/primitives/sandbox-provisioning.md).
+Template rollback is covered by
+[`e2b-template-rollback.md`](e2b-template-rollback.md).
+
+## Required access
+
+- Read access to the affected Proliferate database.
+- CloudWatch, Sentry, or server log access for the affected environment.
+- Provider dashboard access for the configured `SANDBOX_PROVIDER`.
+- GitHub Actions access when the failure follows a template or deploy change.
+- Secret-store access only when an incident owner asks you to verify provider
+  credentials or runtime injection config.
+
+Secrets policy:
+
+- Do not paste provider API keys, worker enrollment tokens, runtime access
+  tokens, signed URLs, target environment values, or user repo secrets into
+  chat, issues, PRs, or docs.
+- Share target ids, sandbox ids, workspace ids, command ids, request ids,
+  template refs, workflow run URLs, and sanitized log snippets.
+
+## First response
+
+1. Identify the failing environment and provider:
+
+   ```sql
+   select id, slug, provider, status, created_at, updated_at
+   from cloud_target
+   where id = '<target-id>';
+   ```
+
+2. Inspect the active sandbox row:
+
+   ```sql
+   select
+     id,
+     target_id,
+     provider,
+     provider_sandbox_id,
+     status,
+     template_ref,
+     last_error_code,
+     last_error_message,
+     created_at,
+     updated_at
+   from cloud_sandbox
+   where target_id = '<target-id>'
+   order by created_at desc
+   limit 5;
+   ```
+
+3. Check provisioning commands and runtime events around the same time:
+
+   ```sql
+   select id, kind, status, error_code, error_message, created_at, updated_at
+   from cloud_command
+   where target_id = '<target-id>'
+   order by created_at desc
+   limit 20;
+   ```
+
+4. Search logs and Sentry for the target id, sandbox id, provider sandbox id,
+   request id, and template ref.
+5. If the failure started immediately after a template promotion, follow
+   [`e2b-template-rollback.md`](e2b-template-rollback.md) before retrying more
+   user work.
+
+## Recovery path
+
+Prefer fixing the upstream provisioning blocker and retrying the normal product
+path. Avoid manual database edits unless an incident owner records the exact
+reason and a follow-up issue.
+
+1. Provider auth or quota failure: verify provider status, account quota, and
+   hosted secret configuration. Refresh secrets in the owning secret store
+   without printing values.
+2. Template boot or missing binary failure: roll back the template or deploy a
+   repaired immutable template. Do not keep creating sandboxes from a known bad
+   rolling tag.
+3. Runtime bootstrap failure: inspect injected binary paths and Sentry DSNs in
+   [`../reference/env-secrets-matrix.md`](../reference/env-secrets-matrix.md).
+4. Workspace materialization failure: inspect the command payload, workspace
+   row, and repo config. Retry only after the root cause is fixed.
+5. If an already-created target is stuck on a bad sandbox image, use
+   [`managed-target-replacement.md`](managed-target-replacement.md) for
+   containment and escalation.
+
+## Verification
+
+The incident is recovered when all of these are true:
+
+- New sandbox creation reaches the expected running/enrolled state.
+- The active `cloud_sandbox` row has the expected provider id and no current
+  provisioning error.
+- A new or retried workspace command completes successfully.
+- CloudWatch and Sentry no longer show repeated provisioning failures for the
+  same template, provider account, or target cohort.
+- Any affected support report or incident issue is updated with target ids,
+  sandbox ids, and sanitized verification evidence.
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Provider create returns auth failure | Verify provider secret presence and environment binding; rotate only through the secret store. |
+| Provider create returns quota or capacity failure | Check provider status/quota and pause retries if capacity is exhausted. |
+| Sandbox starts but worker never enrolls | Switch to [`worker-enrollment-failure.md`](worker-enrollment-failure.md). |
+| New sandboxes boot with the old bad image | Confirm `E2B_TEMPLATE_NAME` or provider config is not pinned to a bad immutable ref. |
+| Existing targets still fail after rollback | Existing sandboxes keep their image; coordinate target replacement or user rematerialization. |
+
+## Final report
+
+Report the environment, provider, target ids, sandbox ids, template ref,
+first-failing deploy or workflow run, recovery action, verification query
+results, and any targets that still need replacement. State explicitly that no
+secrets, signed URLs, enrollment tokens, or raw user repo values were shared.

--- a/specs/developing/runbooks/managed-target-replacement.md
+++ b/specs/developing/runbooks/managed-target-replacement.md
@@ -1,0 +1,92 @@
+# Managed target replacement
+
+Status: operational placeholder until the operator-safe replacement flow ships.
+
+Use this runbook when an already-created managed target is stuck on a bad
+sandbox image, corrupted runtime state, revoked credentials, or an unrecoverable
+provider-side sandbox. The current product has target archive and sandbox
+state helpers, but it does not yet expose a single safe operator flow that
+archives the old target, creates a replacement, rematerializes workspaces, and
+makes stale callbacks inert.
+
+## Required access
+
+- Incident owner approval before replacing or archiving user runtime state.
+- Read/write access to the affected Proliferate database only through approved
+  internal tooling or migration scripts.
+- Provider dashboard access for the affected sandbox.
+- Server logs, CloudWatch, and Sentry access.
+- Product/support context for affected user, organization, workspace, and repo.
+
+Secrets policy:
+
+- Do not paste provider API keys, runtime tokens, worker enrollment tokens,
+  direct-attach credentials, signed URLs, repo secrets, or user files into
+  chat, issues, PRs, or docs.
+- Share target ids, sandbox ids, worker ids, workspace ids, command ids,
+  support report ids, and sanitized error messages.
+
+## Current safe posture
+
+Because the full replacement flow is not implemented yet, do not improvise a
+manual row-by-row replacement during a live incident. Use this containment path
+instead:
+
+1. Stop the bleeding:
+   - Roll back a bad template if new targets are also affected.
+   - Disable or pause provider retries if they are creating more bad sandboxes.
+   - Keep the affected target isolated from new work where product controls
+     allow it.
+2. Preserve evidence:
+   - Record target id, sandbox id, worker id, workspace ids, template ref,
+     provider state, command ids, and support report id.
+   - Save sanitized logs and Sentry links.
+3. Determine user impact:
+   - Is work already committed or exportable?
+   - Are pending commands idempotent to replay?
+   - Does the user need a support-led migration to a fresh workspace?
+4. Escalate to an incident owner for one of:
+   - product-supported archive and recreate,
+   - a reviewed one-off data repair,
+   - waiting for the operator-safe replacement implementation.
+
+## Target end state for the future flow
+
+The replacement implementation should be treated as complete only when it can
+do all of the following atomically or with a resumable operation record:
+
+- archive the old target and revoke old workers/grants;
+- mark the old sandbox terminal and reject stale provider callbacks;
+- create or select the replacement target and provision a fresh sandbox;
+- rematerialize affected workspaces or clearly mark them for user action;
+- publish control/patch events so workers and clients converge;
+- emit operator audit events for each privileged action;
+- provide verification queries and a rollback/abort story.
+
+## Verification for any approved one-off
+
+The incident owner must verify:
+
+- The old target no longer accepts new work.
+- Old workers, runtime grants, and direct-attach credentials are revoked or
+  expired.
+- The old sandbox is terminal or provider-killed.
+- A new target or workspace can run a lightweight command successfully.
+- Stale callbacks from the old sandbox no longer mutate active product state.
+- The support issue names the remaining user-visible work, if any.
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Existing target still uses bad image after template rollback | Existing sandboxes keep their image; contain the target and escalate replacement. |
+| Old worker keeps polling after archive | Re-check worker revocation and direct-attach token expiry; rotate if necessary. |
+| Provider callback updates archived state | Open a blocking bug; stale callback rejection is required before broad replacement. |
+| Workspace state is unclear | Stop and involve support/product; do not guess whether user work is disposable. |
+
+## Final report
+
+Report the incident owner, affected ids, containment action, user-impact
+decision, approved repair path, verification evidence, and any follow-up code
+or product work. State explicitly that no secrets, signed URLs, tokens, repo
+secrets, or user files were shared.

--- a/specs/developing/runbooks/operator-security-posture.md
+++ b/specs/developing/runbooks/operator-security-posture.md
@@ -1,0 +1,103 @@
+# Operator security posture
+
+Status: authoritative baseline for privileged support and recovery actions.
+
+Use this runbook before actions that can expose customer data, rotate secrets,
+revoke worker access, attach directly to runtime infrastructure, or modify
+billing/support/runtime state outside normal product flows.
+
+## Required posture
+
+- Name one incident owner before starting privileged work.
+- Use the least-privileged access path that can answer the question or perform
+  the recovery.
+- Prefer read-only evidence collection before write actions.
+- Keep secrets in the owning secret store. Never paste them into chat, issues,
+  PRs, docs, terminal transcripts, screenshots, or support tickets.
+- Record operator actions in the incident issue with sanitized ids and links.
+- Create a follow-up issue when a manual action reveals missing product or
+  operator tooling.
+
+## Break-glass access
+
+Break-glass access is for active incidents only.
+
+1. Confirm the incident owner and affected environment.
+2. State the exact action and why ordinary product/admin flows are insufficient.
+3. Time-box the access and scope it to the smallest environment/resource set.
+4. Capture sanitized evidence before and after the action.
+5. Revoke or let temporary credentials expire after the action.
+6. Add an audit closeout to the incident issue.
+
+## Secret rotation
+
+Rotate secrets through the owning hosted secret manager or provider dashboard.
+Do not rotate by editing local env files and copying values around.
+
+Common secret groups:
+
+- Cloud control-plane signing: `CLOUD_SECRET_KEY`.
+- Provider access: `E2B_API_KEY`, `DAYTONA_API_KEY`.
+- Provider webhooks: `E2B_WEBHOOK_SIGNATURE_SECRET`.
+- Remote runtime observability: `CLOUD_RUNTIME_SENTRY_DSN`,
+  `CLOUD_TARGET_SENTRY_DSN`.
+- Billing: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`.
+- Support tracker/storage: support S3, GitHub, Linear, and Slack credentials.
+
+After rotation:
+
+- restart or redeploy the processes that read the secret;
+- verify new requests succeed;
+- verify old credentials no longer work when the provider supports it;
+- update the incident issue with secret name, environment, operator, and
+  verification, not the secret value.
+
+## Support bundles and customer data
+
+- Start from the `support_report` row and uploaded bundle index.
+- Download only the files required for the investigation.
+- Store temporary copies under a local private incident directory.
+- Do not attach raw support bundle files to public issues or PRs.
+- Delete temporary local copies after the investigation closes unless legal or
+  security asks for retention.
+
+## Direct attach and runtime credentials
+
+Direct attach, runtime access tokens, and worker enrollment credentials are
+privileged runtime access.
+
+- Use direct attach only when logs, Sentry, database state, and support bundles
+  are insufficient.
+- Prefer provider console/session tooling that records operator identity.
+- Rotate or revoke direct-attach credentials after use when compromise or
+  broad exposure is suspected.
+- Verify worker/control convergence after revocation.
+
+## Audit closeout
+
+Every privileged action should leave an incident note with:
+
+- operator;
+- timestamp;
+- environment;
+- action category;
+- affected ids;
+- verification result;
+- secrets rotated by name only;
+- remaining risk or follow-up issue.
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Secret value appears in chat or an issue | Treat as exposure; rotate the secret and ask security/incident owner for retention cleanup. |
+| Operator cannot prove what was changed | Stop additional manual work and reconstruct evidence from logs, provider audit trails, and database updated timestamps. |
+| Temporary access remains active | Revoke it before closing the incident and record the revocation evidence. |
+| Manual data repair was required | Open a product/operator-tooling follow-up so the action becomes audited and repeatable. |
+
+## Final report
+
+Report the incident owner, privileged action categories, affected ids, secret
+names rotated, verification evidence, temporary access revocation, support
+bundle handling, and follow-up issues. State explicitly that no secret values,
+runtime tokens, signed URLs, or raw customer files were shared.

--- a/specs/developing/runbooks/worker-enrollment-failure.md
+++ b/specs/developing/runbooks/worker-enrollment-failure.md
@@ -1,0 +1,111 @@
+# Worker enrollment failure
+
+Status: authoritative for first-response triage of managed worker enrollment
+failures.
+
+Use this runbook when the sandbox provider created a sandbox, but the
+Proliferate Worker or Supervisor does not enroll, does not heartbeat, or cannot
+receive control-loop work. Worker structure is owned by
+[`../../codebase/structures/proliferate-worker/README.md`](../../codebase/structures/proliferate-worker/README.md).
+Provisioning failures before worker startup are covered by
+[`cloud-provisioning-failure.md`](cloud-provisioning-failure.md).
+
+## Required access
+
+- Read access to target, worker, sandbox, command, and runtime-access rows.
+- CloudWatch, Sentry, or provider log access for server and target processes.
+- Provider dashboard access for the affected sandbox.
+- GitHub Actions access when the failure follows a worker, supervisor, or
+  template release.
+- Secret-store access only when rotating signing keys or provider/runtime
+  credentials.
+
+Secrets policy:
+
+- Do not paste worker enrollment tokens, direct-attach tokens, runtime access
+  token ciphertext, JWT signing keys, provider API keys, or sandbox environment
+  values into chat, issues, PRs, or docs.
+- Share worker ids, target ids, sandbox ids, command ids, request ids, template
+  refs, and sanitized log excerpts.
+
+## First response
+
+1. Find the target, sandbox, and latest worker records:
+
+   ```sql
+   select id, status, last_seen_at, desired_version, created_at, updated_at
+   from cloud_worker
+   where target_id = '<target-id>'
+   order by created_at desc
+   limit 10;
+   ```
+
+2. Inspect target runtime access:
+
+   ```sql
+   select target_id, runtime_url, created_at, updated_at
+   from cloud_target_runtime_access
+   where target_id = '<target-id>';
+   ```
+
+3. Check control and command delivery state:
+
+   ```sql
+   select id, kind, status, lease_id, error_code, updated_at
+   from cloud_command
+   where target_id = '<target-id>'
+   order by created_at desc
+   limit 20;
+   ```
+
+4. Search logs and Sentry for the target id, worker id, sandbox id, enrollment
+   token fingerprint if one exists, and request id.
+5. If a recent template or worker binary promotion preceded the failure, check
+   the corresponding GitHub Actions run before rotating credentials.
+
+## Recovery path
+
+1. Worker binary missing or crashes before enrollment: treat it as a template
+   or runtime injection issue and use
+   [`e2b-template-rollback.md`](e2b-template-rollback.md) if the bad image is
+   newly promoted.
+2. Enrollment token rejected: verify target identity, token domain, token
+   expiry, and server signing key configuration. Rotate signing keys only via
+   the operator security posture runbook.
+3. Worker enrolls but does not heartbeat: inspect Supervisor and Worker logs in
+   the sandbox. Check network egress and server URL configuration.
+4. Worker heartbeats but does not receive work: inspect control-loop cursor,
+   command leases, and revoked-token delivery. Confirm the worker supports the
+   command kind being queued.
+5. Existing target remains unhealthy after provider/template recovery: use
+   [`managed-target-replacement.md`](managed-target-replacement.md) for
+   containment and escalation.
+
+## Verification
+
+The incident is recovered when all of these are true:
+
+- A worker row for the target is active and heartbeating.
+- The active sandbox has runtime access materialized.
+- A control-loop poll advances and command leases are not stuck.
+- A lightweight command or workspace materialization completes successfully.
+- Logs and Sentry no longer show repeated enrollment or heartbeat failures for
+  the same target cohort.
+
+## Common failure modes
+
+| Symptom | First response |
+| --- | --- |
+| Worker never appears | Check template contents, binary paths, Supervisor startup, and provider logs. |
+| Worker enrollment is unauthorized | Verify token domain/expiry and server signing config; do not print tokens. |
+| Worker enrolls repeatedly | Check sandbox restarts, Supervisor crash loops, and duplicate startup scripts. |
+| Worker heartbeats but commands remain queued | Inspect supported command kinds, control-loop state, and command leases. |
+| Revoked worker continues polling | Confirm revoked-token delivery and rotate direct-attach credentials if needed. |
+
+## Final report
+
+Report the environment, target ids, worker ids, sandbox ids, template ref,
+first-failing deploy or workflow run, recovery action, verification query
+results, and any targets that still need replacement. State explicitly that no
+worker tokens, signing keys, provider secrets, or sandbox environment values
+were shared.

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -333,8 +333,13 @@ Current runbooks:
 - `billing-pro-promo-codes.md`
 - `stripe-webhook-failure.md`
 - `e2b-template-rollback.md`
+- `cloud-provisioning-failure.md`
+- `worker-enrollment-failure.md`
+- `managed-target-replacement.md`
+- `operator-security-posture.md`
 
-**⚠️ Gap:** Missing runbooks for cloud provisioning failure, worker enrollment failure, and managed target replacement.
+**⚠️ Gap:** `managed-target-replacement.md` is an operational placeholder
+until the operator-safe replacement flow and audit trail are implemented.
 
 ---
 


### PR DESCRIPTION
## Summary
- add cloud provisioning and worker enrollment failure runbooks
- add a managed-target replacement placeholder that states the current safe containment posture
- add operator security posture guidance for break-glass access, rotation, bundles, and audit closeout
- update the runbook index, spec catalog, env/secrets reference, and support-report debugging links

## Verification
- git diff --check