### PR TITLE
docs(frontend): tighten frontend structure guidance

### DIFF
--- a/specs/codebase/structures/frontend/guides/hooks.md
+++ b/specs/codebase/structures/frontend/guides/hooks.md
@@ -1,217 +1,150 @@
 # Frontend Hooks
 
-Hooks own React behavior: effects, refs, context, query/mutation wiring,
-subscriptions, local UI mechanics, and UI-facing orchestration.
+Hooks own **React behavior**: effects, refs, context, query/mutation wiring, subscriptions, local UI mechanics, and UI-facing orchestration. Pure logic that doesn't touch React belongs in `lib/`, not a hook.
 
-## Hook Types
+## Axes — how to place any hook
 
-### UI Hooks
+Four questions decide the type:
+- **returns** — a value / callbacks / nothing / query-state *(the primary discriminator)*
+- **modifies** — nothing / any / UI-only / an external system
+- **accesses** — UI-only / one external resource / many sources / stores+providers+queries
+- **product-aware or generic**
 
-Generic UI mechanics with no product concepts.
+The one-line test: **what does it return?** → value = `derived`, callbacks = `workflow`, nothing (runs on mount) = `lifecycle`, query-state = `access`, grouped values = `facade`.
 
+## Shape
+
+```text
+hooks/
+  ui/<mechanic>/                            # generic UI mechanics
+  access/<system>/                          # external-system query/mutation wrappers
+  <domain>/[<optional subdomain>/]<type>/   # type ∈ {derived, workflows, lifecycle, ui, cache, facade}
+```
+
+The **type folder is the required leaf**; a **subdomain is optional**, only when a domain grows large. Product hook files live in a responsibility (type) folder, never directly under `hooks/<domain>/`. Don't create empty folders; add one when real files need it.
+
+## Imports / use (layer-wide)
+
+- **Hooks may call hooks. Plain functions in `lib/**` must not call hooks.**
+- Access hooks may call `lib/access/**`, SDK clients, and shared Cloud SDK React hooks; anything wrapping a raw external request goes under `hooks/access/<system>/**`.
+- **Platform-bound hooks stay in the owning app** — Tauri hooks are desktop-only; DOM-subscription hooks don't exist on mobile. A shared/cross-platform hook must not import a platform-specific access hook.
+
+## The hook types (index)
+
+| Type | Returns / consumed as | Accesses | Modifies | Must NOT |
+|---|---|---|---|---|
+| **ui** (generic) | a value or function | UI / DOM / native only | UI mechanics only | know product (sessions, cloud, billing…) |
+| **access** | query/mutation state + callbacks | one external resource | that resource; **owns cache keys + invalidation** | contain product workflow branching |
+| **cache** | one product-owned data model | **multiple** external/local sources | the composed read-model it owns (no external writes) | wrap a single endpoint (→ `access`) |
+| **derived** | UI-ready state (a value or model) | stores, providers, queries | **nothing** | write, fetch, invalidate, navigate, emit telemetry, return callbacks |
+| **workflow** | **callbacks** (functions that do work) | stores, providers, access hooks | any (via callbacks) | build raw clients, define query keys, hand-edit cache shape |
+| **lifecycle** | **nothing** (mounted; runs in background) | any | any | fetch (use React Query), or derive state-from-state |
+| **product ui** | a value or function | UI mechanics + product vocab | UI mechanics | be generic (→ `hooks/ui`) or run workflows |
+| **facade** | grouped / renamed values | other hooks | nothing new | add behavior, raw access, or query keys |
+
+## Per type
+
+### UI hooks — generic UI mechanics
 ```text
 hooks/ui/keyboard/use-keyboard-shortcut.ts
 hooks/ui/pointer/use-click-outside.ts
 hooks/ui/layout/use-element-size.ts
 ```
+Refs, local state, effects, DOM/native subscriptions, timers, platform UI APIs. **Best practice:** keep them dumb and reusable, return a stable value/callback, clean up every listener/timer. Never reference sessions, workspaces, agents, billing, repos, or cloud.
 
-UI hooks may use refs, local state, effects, DOM/native subscriptions, timers,
-and platform UI APIs. They must not know about sessions, workspaces, agents,
-billing, repositories, or cloud.
-
-### Access Hooks
-
-React Query and mutation wrappers around external systems.
-
+### Access hooks — external-system wrappers
 ```text
 hooks/access/cloud/billing/use-cloud-billing.ts
-hooks/access/cloud/mobility/use-cloud-mobility-workspaces.ts
 hooks/access/anyharness/runtime/use-runtime-workspaces.ts
-hooks/access/tauri/updater/use-updater-actions.ts
-```
-
-Access hooks own query keys, `useQuery`, `useMutation`, retry policy,
-invalidation, cache shape, and request telemetry. If a hook directly wraps an
-external request, it belongs under `hooks/access/<system>/**`.
-
-Query keys live beside the access hook that owns the resource:
-
-```text
-hooks/access/cloud/automations/query-keys.ts
+hooks/access/cloud/automations/query-keys.ts        # keys live beside the owner
 hooks/access/cloud/automations/use-automations.ts
 ```
+Own query keys, `useQuery`/`useMutation`, retry policy, invalidation, cache shape, request telemetry. **Best practices:** one external resource per hook; **gate queries with `enabled`** instead of firing with null params; keep **mutation invalidation + optimistic update/rollback co-located here** (`onSuccess`/`onError`) so callers never touch the cache. No product workflow branching.
 
-Access hooks may call `lib/access/**`, SDK clients, SDK React hooks, or shared
-Cloud SDK React hooks. They must not contain product workflow branching.
-
-### Product Cache Hooks
-
-Rare React Query caches that combine multiple external/local sources into one
-product-owned data model.
-
+### Product cache hooks — compose multiple sources
 ```text
 hooks/<domain>/cache/<cache-name>-query.ts
 hooks/<domain>/cache/<cache-name>-cache.ts
 ```
+**Best practice:** use only when composing **≥2** external/local sources into one product model. A single endpoint is an `access` hook, not a cache hook.
 
-Use this for product-composed state, not simple endpoint queries. One external
-resource still belongs in `hooks/access/**`.
-
-### Derived Hooks
-
-Read stores, providers, and queries; return UI-ready state.
-
+### Derived hooks — read-only UI state
 ```text
 hooks/<domain>/derived/use-<thing>-state.ts
 hooks/<domain>/derived/use-<thing>-model.ts
 ```
+Read stores, providers, and queries; return UI-ready state. **Best practices:** pure read — the moment you reach for a setter, fetch, or callback it's the wrong type; **select narrow store slices** (not the whole store) to avoid over-render; memoize expensive computations. Need actions too? compose `derived` + `workflow` behind a `facade`.
 
-Derived hooks must not write, fetch, invalidate, navigate, emit telemetry, or
-return mutating callbacks. If the component needs actions too, compose a
-derived hook and workflow hook behind a facade.
-
-### Workflow Hooks
-
-User-action callbacks and React-facing orchestration.
-
+### Workflow hooks — user-action orchestration
 ```text
 hooks/<domain>/workflows/use-<workflow>-actions.ts
 hooks/<domain>/workflows/use-<workflow>-workflow.ts
 ```
+Read stores/providers/access hooks, expose callbacks, call `lib/domain/**` for pure decisions and `lib/workflows/**` for sequences. **Best practices:** return **stable** callbacks (`useCallback`); keep one short intent inline, extract to `lib/workflows` once it has ordering/branching/rollback/retries; the lib fn takes `(input, deps)` and **never imports hooks**. Must not build raw clients, define query keys, or hand-edit cache shape.
 
-Workflow hooks may read stores/providers/access hooks, expose callbacks, call
-`lib/domain/**` for pure decisions, call `lib/workflows/**` for sequences, and
-use access-owned cache/invalidation callbacks.
-
-Workflow hooks must not construct raw clients, call raw endpoint paths, define
-query keys, hand-edit cache object shapes, or bury large reusable algorithms.
-
-Default split:
-
-```text
-workflow hook = gathers React/store/query/provider deps + returns callbacks
-lib/workflows function = receives input + deps and runs the product sequence
-```
-
-### Actions vs. Workflows
-
-Keep a callback inline in the workflow hook when it is one short user intent:
-validate a snapshot, call one access function/mutation, update owned local
-state/cache, and return.
-
-Move a sequence to `lib/workflows/<domain>/**` when it has ordering
-invariants, branching on fetched data, rollback, retries, multi-step error
-recovery, or a useful unit-test boundary. Dependency objects should be narrow;
-large `EverythingDeps` types usually mean the boundary is too broad.
-
-State values that change per call belong in `input`. Stable capabilities such
-as access calls, store setters, cache invalidation, navigation, toasts,
-telemetry, clocks, or id generation belong in `deps`.
-
-### Lifecycle Hooks
-
-Mounted background behavior.
-
+### Lifecycle hooks — mounted background behavior
 ```text
 hooks/<domain>/lifecycle/use-<thing>-lifecycle.ts
 hooks/<domain>/lifecycle/use-<thing>-dispatcher.ts
 hooks/<domain>/lifecycle/use-<thing>-reconciler.ts
 ```
+Streams, dispatchers, subscriptions, polling, bootstrap/teardown, cross-store reconciliation, external-event-driven behavior. **Best practices:** mount once at the owning boundary; **clean up every timer/listener/observer/handle/subscription it creates**; never use it to derive state-from-state or to fetch (that's React Query).
 
-Use lifecycle hooks for streams, dispatchers, subscriptions, polling,
-bootstrap, teardown, cross-store reconciliation, imperative controllers, and
-external-event-driven behavior. They should be mounted at the owning boundary
-and clean up every timer, listener, observer, handle, or subscription they
-create.
-
-### Product UI Hooks
-
-Product-specific UI mechanics.
-
+### Product UI hooks — UI mechanics with product vocabulary
 ```text
 hooks/<domain>/ui/use-<mechanic>.ts
 ```
+**Best practice:** use only when the mechanic needs product vocabulary; generic mechanics stay in `hooks/ui/**`, workflows in `workflows/**`.
 
-Use this when the hook is UI behavior but needs product vocabulary. Generic
-mechanics stay in `hooks/ui/**`; workflows stay in `workflows/**`.
-
-### Facade Hooks
-
-Thin composition wrappers around several hooks.
-
+### Facade hooks — thin composition
 ```text
 hooks/<domain>/facade/use-<surface>.ts
 ```
+Group and rename values for a component. **Best practice:** the moment it branches, fetches, or adds behavior, it's no longer a facade — and keep its outputs stable.
 
-Facades may group and rename values for a component. They must not introduce
-new product behavior, raw access, query keys, or business branching.
+## Actions vs. workflows
 
-## Folder Shape
+Keep a callback inline in the workflow hook when it's one short user intent: validate a snapshot, call one access function/mutation, update owned local state/cache, return.
 
-```text
-hooks/
-  access/
-    anyharness/
-    cloud/
-    tauri/
-  ui/
-    keyboard/
-    layout/
-    pointer/
-  <domain>/
-    derived/
-    workflows/
-    lifecycle/
-    ui/
-    cache/
-    facade/
-```
+Move a sequence to `lib/workflows/<domain>/**` when it has ordering invariants, branching on fetched data, rollback, retries, multi-step error recovery, or a useful unit-test boundary. Keep dependency objects narrow — a large `EverythingDeps` type means the boundary is too broad.
 
-Product hook files belong in a responsibility folder, not directly under
-`hooks/<domain>/`. Do not create empty folders; add folders when real files need
-them.
-
-## Placement Rules
-
-- Raw external calls live in `lib/access/**` or `hooks/access/**`.
-- Pure product decisions live in `lib/domain/**` or `product-domain`.
-- Real multi-step sequences live in `lib/workflows/**`.
-- Another hook is only warranted when the extracted code owns React behavior.
-- Focused tests belong next to risky or meaningful domain/workflow logic.
-
-## Rules
-
-- Product hooks should not construct raw Cloud, AnyHarness, MCP, or Tauri
-  clients directly.
-- Components should not call `queryClient.invalidateQueries` directly.
-- Product hooks should not define query keys or own cache object shape.
-- Components should not call multiple store setters in sequence; put that in a
-  workflow hook.
-- Hooks may call hooks. Plain functions in `lib/**` must not call hooks.
-- Query/mutation wrappers for external systems live in `hooks/access/**`, not
-  product-domain hook folders.
-- Reducers are pure functions, not hooks. Do not use a `use-` prefix for pure
-  reducers.
-- Non-trivial hooks should start with a short ownership comment when the name
-  alone is not enough.
+- **`input`** = state that changes per call.
+- **`deps`** = stable capabilities: access calls, store setters, cache invalidation, navigation, toasts, telemetry, clocks, id generation.
 
 ## Effects
 
-Valid `useEffect` ownership:
+Valid `useEffect` ownership: SSE/WebSocket connections · Tauri IPC listeners · DOM/native event subscriptions · resize/intersection observers · timers/debouncing/polling · one-time app init · lifecycle reconciliation driven by external events.
 
-- SSE/WebSocket connections
-- Tauri IPC listeners
-- DOM/native event subscriptions
-- resize/intersection observers
-- timers, debouncing, and polling
-- one-time app initialization
-- lifecycle reconciliation driven by external events
+Invalid `useEffect` ownership: fetching data that should use React Query · deriving state from other state · watching one state value only to set another.
 
-Invalid `useEffect` ownership:
+Avoid `useEffect(fn)` with no dependency array unless every-render execution is intentional and documented.
 
-- fetching data that should use React Query
-- deriving state from other state
-- watching one state value only to set another state value
+## Cross-platform binding
 
-Avoid `useEffect(fn)` with no dependency array unless every-render execution is
-intentional and documented.
+- Tauri/DOM/RN-native behavior is **platform-specific**: the hook lives in the owning app (or behind a platform boundary), never in a shared package.
+- A **shared/cross-platform hook must be platform-neutral** — it must not import a platform-bound access hook.
+- **Mobile (React Native) has no DOM** — generic `hooks/ui` DOM mechanics don't apply there; mobile uses native equivalents.
+
+## Naming
+
+- `use-` prefix for hooks; **the suffix signals the type** — `-state`/`-model` (derived), `-actions`/`-workflow` (workflow), `-lifecycle`/`-dispatcher`/`-reconciler` (lifecycle).
+- One primary hook per file (the named export).
+- Reducers are pure functions, not hooks — **no `use-` prefix on a reducer**.
+- Non-trivial hooks open with a one-line ownership comment when the name isn't enough.
+
+## Rules (hard)
+
+- Product hooks must not construct raw Cloud/AnyHarness/MCP/Tauri clients, define query keys, or own cache object shape — that's `access`.
+- **Hooks return data or callbacks, never JSX** (that's a component).
+- **Return stable references** — memoize returned callbacks/objects so consumers and effects don't thrash.
+- Components must not call `queryClient.invalidateQueries` or sequence multiple store setters — put that in a workflow hook.
+- **Errors flow by layer:** access surfaces a typed error → workflow decides the UX (toast/retry) → component renders. Hooks don't swallow errors; components don't parse raw error payloads.
+- Query/mutation wrappers for external systems live in `hooks/access/**`, not product-domain hook folders.
+- Another hook is only warranted when the extracted code owns React behavior.
+
+## Placement & testing
+
+- Raw external calls → `lib/access/**` or `hooks/access/**`.
+- Pure product decisions → `lib/domain/**` or `product-domain`.
+- Real multi-step sequences → `lib/workflows/**`.
+- **Test the pure `lib/workflows` function, not the rendered hook** — push testable logic into `lib` with `(input, deps)` so tests don't render; only render-test what genuinely owns React behavior. Focused tests live next to risky domain/workflow logic.

--- a/specs/codebase/structures/frontend/guides/lib.md
+++ b/specs/codebase/structures/frontend/guides/lib.md
@@ -1,119 +1,122 @@
 # Frontend Lib
 
-`lib/**` is non-component logic. Hooks own React behavior. Access layers own
-external systems.
+`lib/**` is **non-component, non-React** logic. Hooks own React behavior; `lib` owns the logic underneath. **Nothing in `lib/**` imports React, hooks, stores, providers, or query clients** — hooks call `lib`, never the reverse.
 
-## `lib/domain/**`
+## Axes — how to place anything in `lib`
 
-Pure product logic for one app.
+Ask *what the code touches*:
+- a **pure product decision or model** (no I/O) → `domain`
+- a **multi-step product sequence** (touches the world only via injected deps) → `workflows`
+- **raw access to your product's own backends/runtimes** → `access`
+- a **third-party cross-cutting provider** (auth, analytics, error reporting) → `integrations`
+- **generic technical machinery** with no product and no vendor → `infra`
 
-Use app-local `lib/domain/**` when the rule is platform/app-specific. Move the
-rule to `apps/packages/product-domain/**` when Desktop, Web, or Mobile need the
-same decision or view model.
+Two discriminators: **purity** (`domain`/`workflows` are logic; `access`/`integrations`/`infra` are access layers) and **what external thing it touches** (*your backend* → access · *third-party provider* → integrations · *nothing external* → infra).
 
-Owns:
-
-- product validation and normalization
-- status labels, tones, icons, and display metadata
-- workspace/session/chat projection models
-- pure reducers
-- pure side-effect planners
-
-Must not import:
-
-- React, JSX, hooks, stores, providers, query clients
-- DOM, React Native components, Tauri, or platform APIs
-- SDK clients, raw access helpers, or app code from another boundary
-
-Shape:
+## Shape
 
 ```text
-lib/domain/<domain>/<subdomain>/<rule>.ts
+lib/
+  domain/<domain>/<subdomain>/<rule>.ts
+  workflows/<domain>/<workflow>.ts
+  access/<system>/<helper>.ts
+  integrations/<provider>/<file>.ts
+  infra/<technical-concern>/<helper>.ts
 ```
 
-Name files for the product rule: `<specific-rule>.ts`,
-`<thing>-model.ts`, `<thing>-reducer.ts`, `<thing>-effect-plan.ts`, or
-`<thing>-presentation.ts`. Avoid `utils.ts`, `helpers.ts`, and broad
-`types.ts` files unless the scope is tiny and local.
+## Imports / use (layer-wide)
 
-### Side-Effect Planners
+- **No `lib/**` file imports React, hooks, stores, providers, or query clients.**
+- `domain` is pure — imports only other `domain`/`infra` pure helpers.
+- `workflows` reach the world **only through injected `deps`**.
+- `access` / `integrations` may import SDK / platform / vendor clients.
+- `infra` imports only low-level/generic libraries.
 
-A planner decides what effects should happen and returns an explicit plan. It
-does not execute effects. The executor belongs in a workflow hook, lifecycle
-hook, or `lib/workflows/**`.
+## The lib folders (index)
 
-Use planners when product decisions are pure but the resulting effects are not,
-such as stream refresh decisions, toast decisions, or reconciliation commands.
+| Folder | Purpose | Touches | May import | Must NOT |
+|---|---|---|---|---|
+| **domain** | pure product logic for one app | nothing (data in → decision/model out) | other `domain` + `infra` pure helpers | React/hooks/stores/query, DOM/RN/Tauri, SDK clients, raw access |
+| **workflows** | non-React product sequences | the world via injected `deps` | `domain` directly, `infra` | React hooks/stores/query, hidden singletons, raw endpoints/client construction |
+| **access** | raw access to *your* backends/runtimes | Cloud SDK, AnyHarness, Tauri, browser | SDK clients, platform bridges | product workflow branching, UI state, stores, shared-package logic |
+| **integrations** | third-party cross-cutting providers | auth provider, Sentry, PostHog, analytics | vendor SDKs | product workflow branching, core-backend access (→ `access`), React behavior |
+| **infra** | generic technical machinery | nothing external or product | low-level/generic libs | any product vocabulary (chats/sessions/agents/…) |
 
-## `lib/workflows/**`
+## Per folder
 
-Plain non-React product sequences.
+### `lib/domain/**`
+Pure product decisions and models for **one app**. App-local; **promote a rule to `product-domain` when ≥2 apps need the same decision or view model** (app-local first).
 
-Use this when a user or lifecycle action coordinates multiple dependencies and
-the sequence should be readable/testable outside React. The owning hook gathers
-dependencies and calls the workflow.
+**Owns:** validation/normalization · status labels, tones, icons, display metadata · workspace/session/chat projection (view) models · pure reducers · **pure side-effect planners**.
 
-Owns:
+**Must not import:** React/JSX/hooks/stores/providers/query clients · DOM/RN/Tauri/platform APIs · SDK clients, raw access, or other-boundary app code.
 
-- ordered product sequences
-- branching across fetched/local data
-- retries, rollback, and multi-step error recovery
-- app-local orchestration that should not call hooks directly
+**Shape:** `lib/domain/<domain>/<subdomain>/<rule>.ts` — named for the rule (`<rule>.ts`, `<thing>-model.ts`, `<thing>-reducer.ts`, `<thing>-effect-plan.ts`, `<thing>-presentation.ts`). No `utils.ts`/`helpers.ts`/broad `types.ts`.
 
-Must not import:
+**Side-effect planners.** A planner **decides what effects should happen and returns an explicit plan — it does not execute.** The executor lives in a workflow hook, lifecycle hook, or `lib/workflows`. Use when the *decision* is pure but the *effects* aren't (stream-refresh, toast, reconciliation decisions). This is the "decide here, execute there" split.
 
-- React hooks, providers, stores, or query clients
-- hidden singletons for app state
-- raw endpoint paths or client construction for product workflows
+**Best practice:** if it needs I/O, a client, or a store, it isn't `domain` — it takes data in and returns data out.
 
-Shape:
+### `lib/workflows/**`
+Plain non-React product sequences a hook orchestrates; use when an action coordinates multiple deps and should be readable/testable **outside React**.
 
+**Owns:** ordered sequences · branching across fetched/local data · retries, rollback, multi-step error recovery · app-local orchestration that must not call hooks.
+
+**Must not import:** React hooks/providers/stores/query clients · hidden singletons · raw endpoint paths or client construction.
+
+**Shape:** `lib/workflows/<domain>/<workflow>.ts`.
+
+**`(input, deps)` contract:** per-call values → `input`; **live capabilities → `deps`** (access calls, store setters, cache invalidation, navigation, toasts, telemetry, runtime resolution, clocks, id generation). **Do not pass pure helpers/constants/formatting as deps — import those directly.**
+
+**Best practice:** keep a short single action inline in the workflow hook; extract here only when ordering/branching/rollback/retry/testability is the reason. Keep deps narrow — a large `EverythingDeps` means the boundary is too broad. The lib fn never imports hooks.
+
+### `lib/access/**`
+Raw app-local access to the systems your product **is**: client setup, platform bridges, native wrappers, low-level auth/storage bridges, thin SDK adapters. The **React-facing query/mutation wrappers live in `hooks/access/**`**; this is the raw layer beneath.
+
+**Must not own:** product workflow branching, UI state, stores, or reusable shared-package logic.
+
+**Shape:** `lib/access/<system>/<helper>.ts`. See `access.md` for the system map.
+
+**Best practice:** raw and thin — if it branches on product data it's a `workflow`; if it's React-facing it's a hook.
+
+### `lib/integrations/**`
+Integration with third-party **services** the app plugs into — **auth** (provider flow) and **telemetry** (analytics/error reporting). Distinct from `access` (your own backends) and `infra` (no vendor).
+
+**Owns:** the vendor SDK wiring + flow. Examples:
 ```text
-lib/workflows/<domain>/<workflow>.ts
+integrations/auth/        proliferate-auth · orchestration-{bootstrap,callback,redirect,transport,effects,provider-flow}
+integrations/telemetry/   sentry · posthog · anonymous · scrub · client · native-diagnostics · config
 ```
 
-Use an `(input, deps)` shape. Per-call values belong in `input`. Live
-capabilities belong in `deps`: access calls, store setters, cache invalidation,
-navigation, toasts, telemetry, runtime resolution, clocks, and id generation.
+**Must not own:** product workflow branching · core-backend access (→ `access`) · React behavior (the provider/hook that consumes it lives above).
 
-Do not pass pure helpers, constants, or formatting functions as deps. Import
-pure domain helpers and static config directly.
+**Shape:** `lib/integrations/<provider>/<file>.ts`.
 
-Keep a sequence in the workflow hook when it is a short single action. Move it
-to `lib/workflows/**` when ordering, branching, rollback, retry, or testability
-is the reason for the extraction.
+**Best practices:** one provider family per folder; keep product decisions *out* (pass them in); **scrub/redact at this boundary** (telemetry); generic local logging without a vendor belongs in `infra`.
 
-## `lib/access/**`
+### `lib/infra/**`
+Generic technical machinery with **no product vocabulary and no vendor**.
 
-Raw app-local access helpers.
+**Owns:** persistence helpers · scheduling/batching/timers · ids/stable keys · measurement plumbing · safe JSON parsing · generic logging utilities.
 
-Use this for client setup, platform bridges, native wrappers, auth/storage
-integration, and thin app-specific adapters around SDK clients. Query/mutation
-hooks that expose this access to React live in `hooks/access/**`.
+**Must not:** know about chats/sessions/workspaces/agents/billing/repos/prompts (→ `domain`) · be a vendor integration like Sentry/PostHog (→ `integrations/telemetry`).
 
-Must not own product workflow branching, UI state, stores, or reusable shared
-package logic.
+**Shape:** `lib/infra/<technical-concern>/<helper>.ts`.
 
-See [access.md](access.md) for the concrete system map.
+## Rules (hard)
 
-## `lib/infra/**`
+- **No `lib/**` file imports React, hooks, stores, providers, or query clients.** Hooks call lib; lib never calls hooks.
+- `domain` is pure (data in/out); the moment it needs I/O, a client, or a store, it isn't domain.
+- `workflows` reach the world only through `deps`, and `deps` are **capabilities, not pure helpers**.
+- Keep the three access-ish layers distinct: **`access` = your backends · `integrations` = third-party providers · `infra` = no external system.**
+- **App-local first:** promote a pure rule to `product-domain` only when ≥2 apps need it.
+- No `utils.ts`/`helpers.ts`/`misc.ts` — name the concept.
 
-Generic technical machinery with no product-domain vocabulary.
+## Placement & testing
 
-Owns:
-
-- persistence helpers
-- scheduling, batching, and timers
-- ids and stable keys
-- measurement plumbing
-- safe JSON parsing
-- logging utilities
-
-If a function knows about chats, sessions, workspaces, agents, billing,
-repositories, or prompts, it is not infra.
-
-Shape:
-
-```text
-lib/infra/<technical-concern>/<helper>.ts
-```
+- Pure decision/model/reducer/**planner** → `domain` (or `product-domain` if shared).
+- Multi-step sequence → `workflows`.
+- Raw backend/platform access → `access`.
+- Third-party provider wiring → `integrations`.
+- Generic machinery → `infra`.
+- **Everything in `lib` is non-React → unit-test functions directly** (`domain` purely, `workflows` via `(input, deps)`); no rendering. Tests live beside risky domain/workflow logic.

--- a/specs/codebase/structures/frontend/packages/README.md
+++ b/specs/codebase/structures/frontend/packages/README.md
@@ -2,242 +2,122 @@
 
 Status: authoritative for shared frontend package ownership.
 
-## Scope
+Scope: `apps/packages/{design,ui,product-domain,product-ui,product-surfaces}/**`
 
-- `apps/packages/design/**`
-- `apps/packages/ui/**`
-- `apps/packages/product-domain/**`
-- `apps/packages/product-ui/**`
-- `apps/packages/product-surfaces/**`
+**Packages are the *shared tier* of the app-local layers — not a separate taxonomy.** Most are 1-1 with a layer you already know; derive them rather than re-learning them:
 
-Use app-local code first. Put code in a package only when shared ownership
-makes Desktop/Web/Mobile easier to keep in sync.
+| Package | = the shared tier of |
+|---|---|
+| `design` | app `styles/` + tokens |
+| `product-domain` | `lib/domain` |
+| `product-ui` | `components` |
+| `product-surfaces` | `components` + `hooks/access` (a *connected* page) |
+| `ui` | — *(no app-local analog: the **only** home for DOM primitives)* |
 
-## Package Map
+## The two governing rules
 
-| Package | Owns | May Import | Must Not Import |
-| --- | --- | --- | --- |
-| `design` | Shared tokens, DOM CSS, React Native-safe token values. | Token/build tooling. | Product concepts, app code, SDK clients, hooks, stores. |
-| `ui` | Canonical Desktop/Web DOM primitives and layout components. | `design`, React, DOM-safe libraries. | Product concepts, app code, SDK clients, hooks, stores, Tauri, React Native. |
-| `product-domain` | Pure shared product rules, vocabulary, validation, projections, and view models. | Generated/SDK contract types, pure utilities. | React, DOM, React Native components, SDK clients, query clients, stores, app code, raw access. |
-| `product-ui` | Shared Desktop/Web product presentation by domain and surface. Props in, callbacks out. | `design`, `ui`, `product-domain`, React, DOM-safe rendering libraries. | SDK clients, access helpers, query hooks, stores, routes, Tauri, AnyHarness runtime wiring, React Native, custom primitive redefinitions. |
-| `product-surfaces` | Shared connected Desktop/Web Cloud surfaces with SDK/query wiring and product UI composition. | Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, `design`. | Desktop/Web app internals, Tauri, AnyHarness runtime wiring, app stores, app routes, React Native, custom primitive redefinitions. |
+Everything else derives from these:
 
-## Package Shape
+1. **Promotion — app-local first.** Code starts in the app. Move it to a package **only when ≥2 apps need the same thing.** A package is never the default home.
+2. **Platform — Mobile is DOM-free.** Mobile may import **only `product-domain` + `design/react-native`** (+ SDK packages). It must **never** import the DOM packages: `ui`, `product-ui`, `product-surfaces`.
+
+What promotion *adds* is predictable: a package loses all app internals (stores, routes, Tauri, AnyHarness wiring) — and **`components → product-ui` additionally loses hooks** (it becomes pure presentational: props in, callbacks out, because hooks stay app-local).
+
+## Package map
+
+| Package | Shared tier of | Owns | May import | Must NOT import |
+|---|---|---|---|---|
+| `design` | styles/tokens | shared tokens, DOM CSS, RN-safe token values | token/build tooling | product concepts, app code, SDK clients, hooks, stores |
+| `ui` | — (primitives only) | canonical Desktop/Web DOM primitives + layout | `design`, React, DOM-safe libs | product concepts, app code, SDK clients, hooks, stores, Tauri, React Native |
+| `product-domain` | `lib/domain` | pure shared product rules, vocab, validation, projections, view models, planners | generated/SDK **contract types**, pure utils | React, DOM, RN components, SDK clients, query clients, stores, app code, raw access |
+| `product-ui` | `components` | shared Desktop/Web product presentation — **props in, callbacks out** | `design`, `ui`, `product-domain`, React, DOM-safe render libs | SDK clients, access helpers, query hooks, stores, routes, Tauri, AnyHarness wiring, RN, custom primitives |
+| `product-surfaces` | `components` + `hooks/access` | shared **connected** Desktop/Web Cloud surfaces (SDK/query wiring + `product-ui` composition) | Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, `design` | Desktop/Web app internals, Tauri, AnyHarness wiring, app stores, app routes, RN, custom primitives |
+
+## Shape
 
 ```text
 apps/packages/
-  design/
-    src/
-      tokens.ts
-      css/
-        dom.css
-        desktop.css
-      react-native.ts
-
-  ui/
-    src/
-      layout/
-      primitives/
-
-  product-domain/
-    src/
-      <domain>/
-
-  product-ui/
-    src/
-      <domain>/
-        <surface>/
-
-  product-surfaces/
-    src/
-      <domain>/
-        <surface>/
+  design/src/        tokens.ts · css/{dom.css,desktop.css} · react-native.ts
+  ui/src/            primitives/ · layout/
+  product-domain/src/<domain>/
+  product-ui/src/<domain>/<surface>/
+  product-surfaces/src/<domain>/<surface>/
 ```
 
-## Dependency Direction
+## Dependency direction
 
 ```text
-apps
-  -> product-surfaces
-  -> product-ui
-  -> ui
-  -> design
-
-apps
-  -> product-domain
+apps -> product-surfaces -> product-ui -> ui -> design
+apps -> product-domain
 product-surfaces -> product-domain
-product-ui -> product-domain
+product-ui       -> product-domain
 ```
 
-Mobile may import `design/react-native`, `product-domain`, and SDK packages.
-Mobile must not import DOM packages: `ui`, `product-ui`, or
-`product-surfaces`.
+Mobile: `design/react-native` + `product-domain` + SDK only. **Never** `ui`/`product-ui`/`product-surfaces`.
 
-## DOM UI Contract
-
-`apps/packages/ui/**` is the single DOM primitive system for Desktop, Web,
-`product-ui`, and `product-surfaces`.
-
-Hard invariant: no DOM primitive component may be defined outside
-`apps/packages/ui/**`.
-
-A primitive component is any generic reusable control, shell, or low-level UI
-building block, including a wrapper around a raw DOM control. This applies even
-when the component has a different name but still behaves like a local button,
-input, dialog, menu, tab, tooltip, badge, or layout primitive.
-
-Primitives that belong in `ui`:
-
-- `Button`, `IconButton`, button groups
-- `Input`, `Textarea`, `Label`, `Select`
-- `Checkbox`, `Switch`, radio controls
-- `Tabs`, segmented controls
-- `Menu`, `Popover`, `Tooltip`
-- `Dialog`, modal shells, confirmation dialogs
-- badges, pills, separators, scroll areas, layout shells
-
-Rules:
-
-- Do not define primitive components in `apps/desktop/src/**`,
-  `apps/web/src/**`, `apps/packages/product-ui/**`, or
-  `apps/packages/product-surfaces/**`.
-- Do not define a second button/input/dialog/menu/select/tabs primitive with a
-  different name.
-- Do not restyle raw DOM controls at callsites to mimic a primitive.
-- Do not render raw `<button>`, `<input>`, `<label>`, `<select>`, or
-  `<textarea>` outside `apps/packages/ui/**`.
-- If the primitive needs a new size, tone, density, icon position, loading
-  state, destructive state, or layout mode, add that API to `ui` first.
-- Callsite classes may handle layout and spacing. The primitive owns color,
-  border, radius, typography, focus, hover, disabled, and loading behavior.
-- `product-ui` composes `ui` primitives with product view models.
-- `product-surfaces` composes Cloud SDK React hooks, `product-ui`, and `ui`
-  primitives. It does not create its own primitive layer.
-- Mobile has a separate native component layer and does not import DOM
-  primitives.
-- Primitive definitions outside `apps/packages/ui/**` violate this standard.
-  Do not add them or copy them; put them in `ui`.
-
-## When To Share
-
-- Put a rule in `product-domain` when the same product decision or view
-  model is needed by more than one app.
-- Put a component in `product-ui` when Desktop and Web should render the
-  same product presentation and data/callback props are enough.
-- Put a surface in `product-surfaces` when Desktop and Web should share the
-  same connected Cloud CRUD surface, including SDK React hooks and mutation
-  wiring.
-- Keep code app-local when it depends on Tauri, local AnyHarness runtime
-  selection, native mobile navigation/storage, browser route state, app-local
-  stores, or one-off UI.
-
-## Package Rules
-
-- Use concrete export-map subpaths such as
-  `@proliferate/ui/primitives/Button`; do not add barrels.
-- Package code must not import app code through `@/` or relative paths into an
-  app.
-- Package code must not import app stores, app providers, app routes, Tauri
-  wrappers, or local AnyHarness runtime wiring unless the package table above
-  explicitly allows it.
-- Do not add `shared`, `common`, `types`, or `utils` buckets.
-- Name package files for the rule, primitive, component, or surface they own.
-- Tests live with shared logic when the logic is meaningful or risky.
-- If sharing requires many app-specific branches, keep the code app-local and
-  extract only the pure `product-domain` rule.
-
-## Responsibilities
+## Per package
 
 ### `design`
-
-Owns serializable design values and generated CSS.
+The shared tier of app `styles/` + tokens. Owns serializable design values and generated CSS — tokens, DOM CSS, React Native-safe token values.
 
 ```text
-apps/packages/design/src/tokens.ts
-apps/packages/design/src/css/dom.css
-apps/packages/design/src/css/desktop.css
-apps/packages/design/src/react-native.ts
-apps/packages/design/dist/theme.css
+design/src/tokens.ts · css/{dom.css,desktop.css} · react-native.ts · dist/theme.css
 ```
 
-Do not put product copy, product status colors, route concepts, or component
-behavior here.
-
-May import token source files and build tooling. Must not import React, app
-code, SDK clients, stores, providers, query clients, or product concepts.
+Must not hold product copy, product status colors, route concepts, or component behavior. Imports token source + build tooling only — never React, app code, SDK clients, stores, providers, query clients, or product concepts.
 
 ### `ui`
-
-Owns canonical DOM primitives.
+The **single DOM primitive system** for Desktop, Web, `product-ui`, and `product-surfaces`. It has no app-local analog — this is the *only* place primitives exist.
 
 ```text
-apps/packages/ui/src/primitives/**
-apps/packages/ui/src/layout/**
+ui/src/primitives/** · ui/src/layout/**
 ```
 
-Use this for reusable controls and layout helpers with no Proliferate product
-concepts. This is where primitive variants are added; apps and product
-packages consume those variants instead of redefining primitives locally.
+**Hard invariant: no DOM primitive component may be defined outside `apps/packages/ui/**`.** A primitive is any generic reusable control/shell/low-level building block — *including a differently-named wrapper* around a raw DOM control.
 
-May import `design`, React, and DOM-safe libraries. Must not import product
-concepts, app code, SDK clients, hooks, stores, Tauri, or React Native.
+Primitives that belong here: `Button`/`IconButton`, `Input`/`Textarea`/`Label`/`Select`, `Checkbox`/`Switch`/radio, `Tabs`/segmented controls, `Menu`/`Popover`/`Tooltip`, `Dialog`/modal shells, badges/pills/separators/scroll-areas/layout shells.
+
+Rules:
+- Do **not** define primitives in `apps/desktop/src`, `apps/web/src`, `product-ui`, or `product-surfaces`.
+- Do **not** define a second button/input/dialog/menu/select/tabs primitive under another name, or restyle raw DOM controls at callsites to mimic one.
+- Do **not** render raw `<button>`/`<input>`/`<label>`/`<select>`/`<textarea>` outside `ui`.
+- Need a new size/tone/density/icon-position/loading/destructive/layout mode? **Add the API to `ui` first.**
+- Callsite classes may handle layout/spacing; the primitive owns color, border, radius, typography, focus, hover, disabled, and loading behavior.
+- Mobile has a separate **native** component layer and does not import DOM primitives.
+
+May import `design`, React, DOM-safe libraries. Must not import product concepts, app code, SDK clients, hooks, stores, Tauri, or React Native.
 
 ### `product-domain`
-
-Owns pure product rules and view models.
+The shared tier of `lib/domain` — same purity and shape (validation, vocabulary, projections, view models, **pure planners**), promoted for cross-app reuse.
 
 ```text
-apps/packages/product-domain/src/<domain>/**
+product-domain/src/<domain>/**
 ```
 
-This is the primary sharing point for Mobile. If Mobile and Web need the same
-behavior, share the rule here and render it separately in native and DOM UI.
-
-May import generated or SDK types only when they are contract shapes. Must not
-import SDK clients, SDK React hooks, React, DOM components, React Native
-components, app code, stores, query clients, or access helpers.
+This is **Mobile's primary sharing point**: if Mobile and Web need the same behavior, share the rule here and render it separately in native and DOM UI. May import generated/SDK **contract types** only — never SDK clients, React, DOM/RN components, app code, stores, query clients, or access helpers. *Promote when:* ≥2 apps need the same decision or view model.
 
 ### `product-ui`
-
-Owns Desktop/Web DOM product components.
+The shared tier of app `components` — same product presentation, but **strictly presentational**: props in, callbacks out, **no hooks, SDK, stores, or routes** (those stay app-local). Desktop/Web only.
 
 ```text
-apps/packages/product-ui/src/<domain>/<surface>/<Component>.tsx
+product-ui/src/<domain>/<surface>/<Component>.tsx
 ```
 
-Use this for product-specific rows, cards, panes, chat pieces, settings
-sections, account/billing views, and other shared Desktop/Web presentation.
-It must compose `ui` primitives for controls and must not create local
-primitive lookalikes.
-
-May import `design`, `ui`, `product-domain`, React, and DOM-safe rendering
-libraries. Must not import SDK clients, SDK React hooks, access helpers, app
-stores, app providers, app routes, Tauri, local AnyHarness runtime wiring, or
-React Native.
-
-Components here are UI-only: data in, callbacks out. If the component needs
-query/mutation state, client construction, route state, or app store state, it
-does not belong in `product-ui`.
+Use for product-specific rows, cards, panes, chat pieces, settings sections, account/billing views, and other shared Desktop/Web presentation. **Composes `ui` primitives** and must not create local primitive lookalikes. May import `design`, `ui`, `product-domain`, React, DOM-safe render libs. If a component needs query/mutation state, client construction, route state, or app store state, it does not belong here. *Promote when:* Desktop and Web should render the same presentation and data/callback props are enough.
 
 ### `product-surfaces`
-
-Owns fully connected Desktop/Web Cloud surfaces.
+A **connected page**: the shared tier of `components` + `hooks/access`. It calls shared **Cloud SDK React hooks** and renders `product-ui`, with base controls from `ui`.
 
 ```text
-apps/packages/product-surfaces/src/<domain>/<surface>/**
+product-surfaces/src/<domain>/<surface>/**
 ```
 
-A surface may call shared Cloud SDK React hooks and render `product-ui`.
-App-specific routing, shell placement, Tauri/AnyHarness access, app stores,
-telemetry wiring, and native mobile UI stay outside. Base controls still come
-from `ui`.
+May import Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, `design`. Must not import Desktop/Web app internals, app routing/shell placement, Tauri/AnyHarness access, app stores, telemetry wiring, or React Native — app-specific behavior stays in the app and is passed in as callbacks/adapters. *Promote when:* Desktop and Web should share the same connected Cloud CRUD surface, including SDK React hooks and mutation wiring, and duplicating that wiring would make the product harder to keep consistent.
 
-May import Cloud SDK React hooks, `product-domain`, `product-ui`, `ui`, and
-`design`. Must not import Desktop/Web app internals, app stores, app providers,
-app routes, Tauri, local AnyHarness runtime wiring, or React Native.
+## Package rules
 
-Use this for shared connected Cloud surfaces where duplicating SDK/query wiring
-in Desktop and Web would make the product harder to keep consistent. Do not
-put Desktop-only runtime access, local workspace logic, or app shell behavior
-in `product-surfaces`; pass app-specific callbacks or adapters from the app.
+- Use concrete export-map subpaths (`@proliferate/ui/primitives/Button`); **no barrels.**
+- Package code must not import app code via `@/` or relative paths into an app, nor app stores/providers/routes/Tauri/AnyHarness wiring unless the map above allows it.
+- No `shared`/`common`/`types`/`utils` buckets. Name files for the rule/primitive/component/surface they own.
+- If sharing needs many app-specific branches, keep it app-local and extract only the pure `product-domain` rule.
+- Tests live with shared logic when it's meaningful or risky.


### PR DESCRIPTION
## Summary

- Tightens frontend hooks guidance around type placement, responsibilities, and effect ownership.
- Clarifies frontend lib boundaries for domain/workflow/access/integration/infra code.
- Reframes shared frontend package ownership and promotion rules.

## PR Metadata

- Release label: `release:docs`
- Area label: `area:docs`

## Verification

- `git diff --check`