### PR TITLE
ci(release): add release train hotfix automation

### DIFF
--- a/.github/workflows/_deploy-desktop.yml
+++ b/.github/workflows/_deploy-desktop.yml
@@ -74,7 +74,7 @@ jobs:
 
           tag_name="desktop-v$package_version"
           tag_target="$(git ls-remote --tags origin "refs/tags/$tag_name" | awk '{ print $1 }' | head -n 1)"
-          if [[ -n "$tag_target" && "$tag_target" == "$GIT_SHA" && "$DRY_RUN" != "true" ]]; then
+          if [[ -n "$tag_target" && "$tag_target" == "$GIT_SHA" && "$DRY_RUN" != "true" && "$PUBLISH_UPDATER" != "true" ]]; then
             echo "Desktop tag $tag_name already points at $GIT_SHA; skipping duplicate release."
             {
               echo "enabled=false"
@@ -82,6 +82,9 @@ jobs:
               echo "tag_name=$tag_name"
             } >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+          if [[ -n "$tag_target" && "$tag_target" == "$GIT_SHA" && "$PUBLISH_UPDATER" == "true" ]]; then
+            echo "Desktop tag $tag_name already points at $GIT_SHA; continuing so updater assets can be published."
           fi
           if [[ -n "$tag_target" && "$tag_target" != "$GIT_SHA" && "$DRY_RUN" != "true" ]]; then
             echo "::error::Desktop tag $tag_name already exists at $tag_target, not $GIT_SHA. Bump the desktop version before publishing desktop from this SHA."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,13 @@ jobs:
 
       - name: Check CI/CD scripts parse
         run: |
+          node --check scripts/ci-cd/create-release-tags.mjs
           node --check scripts/ci-cd/detect-deploy-surfaces.mjs
+          node --check scripts/ci-cd/prepare-artifact-release.mjs
           node --check scripts/ci-cd/resolve-deploy-base.mjs
+
+      - name: Test CI/CD scripts
+        run: node --test scripts/ci-cd/*.test.mjs
 
       - name: Check workflow YAML parses
         run: ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/*.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,6 +14,10 @@ on:
         description: Comma-separated surfaces to force, or all.
         required: false
         type: string
+      only_surfaces:
+        description: Exact comma-separated surfaces to deploy, or all. Overrides detection and force_surfaces.
+        required: false
+        type: string
       dry_run:
         description: Plan only; do not deploy.
         default: false
@@ -48,6 +52,8 @@ jobs:
       desktop: ${{ steps.detect.outputs.desktop }}
       runtime: ${{ steps.detect.outputs.runtime }}
       changed_files_count: ${{ steps.detect.outputs.changed_files_count }}
+      selection_mode: ${{ steps.detect.outputs.selection_mode }}
+      selected_surfaces: ${{ steps.detect.outputs.selected_surfaces }}
       summary_json: ${{ steps.detect.outputs.summary_json }}
     steps:
       - uses: actions/checkout@v4
@@ -136,8 +142,10 @@ jobs:
           --base "${{ steps.base.outputs.base_sha }}"
           --head "${{ steps.meta.outputs.head_sha }}"
           --force "$FORCE_SURFACES"
+          --only "$ONLY_SURFACES"
         env:
           FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || '' }}
+          ONLY_SURFACES: ${{ github.event.inputs.only_surfaces || '' }}
 
       - name: Summarize plan
         run: |
@@ -147,6 +155,10 @@ jobs:
             echo "- Head: \`${{ steps.detect.outputs.head_sha }}\`"
             echo "- Changed files: \`${{ steps.detect.outputs.changed_files_count }}\`"
             echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"
+            echo "- Selection: \`${{ steps.detect.outputs.selection_mode }}\`"
+            echo "- Forced surfaces: \`${{ steps.detect.outputs.forced_surfaces }}\`"
+            echo "- Only surfaces: \`${{ steps.detect.outputs.only_surfaces }}\`"
+            echo "- Selected surfaces: \`${{ steps.detect.outputs.selected_surfaces }}\`"
             echo ""
             echo "| Surface | Deploy |"
             echo "| --- | --- |"

--- a/.github/workflows/hotfix-production.yml
+++ b/.github/workflows/hotfix-production.yml
@@ -1,0 +1,279 @@
+name: Hotfix Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Main commit SHA or ref to hotfix from.
+        required: true
+        type: string
+      only_surfaces:
+        description: Exact comma-separated surfaces to hotfix, or all.
+        required: true
+        type: string
+      reason:
+        description: Short operator-facing reason for the hotfix.
+        required: true
+        type: string
+      bump_patch:
+        description: Bump patch versions for artifact lanes before publishing.
+        default: true
+        required: false
+        type: boolean
+      dry_run:
+        description: Plan only; do not push commits, tags, releases, or deploys.
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  packages: write
+
+concurrency:
+  group: hotfix-production
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.meta.outputs.release_id }}
+      head_sha: ${{ steps.commit.outputs.head_sha }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+      selected_surfaces: ${{ steps.detect.outputs.selected_surfaces }}
+      server: ${{ steps.detect.outputs.server }}
+      workers: ${{ steps.detect.outputs.workers }}
+      e2b: ${{ steps.detect.outputs.e2b }}
+      web: ${{ steps.detect.outputs.web }}
+      mobile: ${{ steps.detect.outputs.mobile }}
+      desktop: ${{ steps.detect.outputs.desktop }}
+      runtime: ${{ steps.detect.outputs.runtime }}
+      desktop_version: ${{ steps.artifacts.outputs.desktop_version }}
+      runtime_version: ${{ steps.artifacts.outputs.runtime_version }}
+      server_version: ${{ steps.artifacts.outputs.server_version }}
+      desktop_tag: ${{ steps.artifacts.outputs.desktop_tag }}
+      runtime_tag: ${{ steps.artifacts.outputs.runtime_tag }}
+      server_tag: ${{ steps.artifacts.outputs.server_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve hotfix metadata
+        id: meta
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags --prune
+          head_sha="$(git rev-parse HEAD)"
+          git merge-base --is-ancestor "$head_sha" refs/remotes/origin/main
+          release_id="hotfix-$(date -u +%F)-${GITHUB_RUN_NUMBER}"
+          {
+            echo "release_id=$release_id"
+            echo "head_sha=$head_sha"
+            echo "dry_run=$DRY_RUN"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select exact hotfix surfaces
+        id: detect
+        run: |
+          set -euo pipefail
+          if [[ -z "${ONLY_SURFACES// }" ]]; then
+            echo "::error::only_surfaces is required for production hotfixes."
+            exit 1
+          fi
+          node scripts/ci-cd/detect-deploy-surfaces.mjs \
+            --base "${{ steps.meta.outputs.head_sha }}" \
+            --head "${{ steps.meta.outputs.head_sha }}" \
+            --only "$ONLY_SURFACES"
+        env:
+          ONLY_SURFACES: ${{ github.event.inputs.only_surfaces }}
+
+      - name: Prepare artifact versions
+        id: artifacts
+        run: >
+          node scripts/ci-cd/prepare-artifact-release.mjs
+          --surfaces "${{ steps.detect.outputs.selected_surfaces }}"
+          --release-id "${{ steps.meta.outputs.release_id }}"
+          --bump-patch "${{ github.event.inputs.bump_patch || 'true' }}"
+          --dry-run "${{ steps.meta.outputs.dry_run }}"
+
+      - name: Commit version bumps
+        id: commit
+        env:
+          RELEASE_ID: ${{ steps.meta.outputs.release_id }}
+          DRY_RUN: ${{ steps.meta.outputs.dry_run }}
+          REASON: ${{ github.event.inputs.reason }}
+        run: |
+          set -euo pipefail
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --quiet; then
+            echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add apps/desktop/package.json apps/desktop/src-tauri/tauri.conf.json apps/desktop/src-tauri/Cargo.toml anyharness/sdk/package.json
+          git commit -m "release: prepare $RELEASE_ID" -m "$REASON"
+          git push origin HEAD:main
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create hotfix tag
+        if: steps.meta.outputs.dry_run != 'true'
+        run: >
+          node scripts/ci-cd/create-release-tags.mjs
+          --target "${{ steps.commit.outputs.head_sha }}"
+          --tags "${{ steps.meta.outputs.release_id }}"
+          --dry-run false
+
+      - name: Summarize hotfix
+        run: |
+          {
+            echo "### Production hotfix"
+            echo "- Hotfix: \`${{ steps.meta.outputs.release_id }}\`"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Head: \`${{ steps.commit.outputs.head_sha }}\`"
+            echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"
+            echo "- Selected surfaces: \`${{ steps.detect.outputs.selected_surfaces }}\`"
+            echo "- Desktop: \`${{ steps.artifacts.outputs.desktop_tag }}\`"
+            echo "- Runtime: \`${{ steps.artifacts.outputs.runtime_tag }}\`"
+            echo "- Server: \`${{ steps.artifacts.outputs.server_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-runtime:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.runtime == 'true' }}
+    uses: ./.github/workflows/release-runtime.yml
+    with:
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      version: ${{ needs.prepare.outputs.runtime_version }}
+      dry_run: false
+      publish: true
+    secrets: inherit
+
+  release-server:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.server == 'true' }}
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/server-ci.yml
+    with:
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      version: ${{ needs.prepare.outputs.server_version }}
+      dry_run: false
+      publish: true
+    secrets: inherit
+
+  promote-e2b:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-e2b.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.e2b == 'true' }}
+      rolling_tag: production
+      mode: build_and_promote
+    secrets: inherit
+
+  deploy-server:
+    needs: [prepare, promote-e2b]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-server.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.server == 'true' }}
+    secrets: inherit
+
+  deploy-workers:
+    needs: [prepare, deploy-server]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-workers.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.workers == 'true' }}
+    secrets: inherit
+
+  deploy-web:
+    needs: [prepare, deploy-server]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-web.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.web == 'true' }}
+    secrets: inherit
+
+  deploy-mobile:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-mobile.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.mobile == 'true' }}
+    secrets: inherit
+
+  deploy-desktop:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/_deploy-desktop.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.desktop == 'true' }}
+      dry_run: false
+      publish_updater: true
+    secrets: inherit
+
+  summary:
+    needs:
+      - prepare
+      - release-runtime
+      - release-server
+      - promote-e2b
+      - deploy-server
+      - deploy-workers
+      - deploy-web
+      - deploy-mobile
+      - deploy-desktop
+    if: ${{ always() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize results
+        run: |
+          {
+            echo "### Production hotfix result"
+            echo "- Hotfix: \`${{ needs.prepare.outputs.release_id }}\`"
+            echo "- Head: \`${{ needs.prepare.outputs.head_sha }}\`"
+            echo "- Surfaces: \`${{ needs.prepare.outputs.selected_surfaces }}\`"
+            echo "- Runtime release: \`${{ needs.release-runtime.result }}\`"
+            echo "- Server release: \`${{ needs.release-server.result }}\`"
+            echo "- E2B production: \`${{ needs.promote-e2b.result }}\`"
+            echo "- Server production: \`${{ needs.deploy-server.result }}\`"
+            echo "- Workers production: \`${{ needs.deploy-workers.result }}\`"
+            echo "- Web production: \`${{ needs.deploy-web.result }}\`"
+            echo "- Mobile production: \`${{ needs.deploy-mobile.result }}\`"
+            echo "- Desktop production: \`${{ needs.deploy-desktop.result }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -1,0 +1,277 @@
+name: Nightly Release Train
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to release. Defaults to main.
+        required: false
+        type: string
+      only_surfaces:
+        description: Exact comma-separated surfaces to release, or all. Defaults to detected changes since the previous train.
+        required: false
+        type: string
+      dry_run:
+        description: Plan only; do not push commits, tags, releases, or deploys.
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  packages: write
+
+concurrency:
+  group: nightly-release-train
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.meta.outputs.release_id }}
+      base_sha: ${{ steps.meta.outputs.base_sha }}
+      head_sha: ${{ steps.commit.outputs.head_sha }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+      selected_surfaces: ${{ steps.detect.outputs.selected_surfaces }}
+      server: ${{ steps.detect.outputs.server }}
+      workers: ${{ steps.detect.outputs.workers }}
+      e2b: ${{ steps.detect.outputs.e2b }}
+      web: ${{ steps.detect.outputs.web }}
+      mobile: ${{ steps.detect.outputs.mobile }}
+      desktop: ${{ steps.detect.outputs.desktop }}
+      runtime: ${{ steps.detect.outputs.runtime }}
+      desktop_version: ${{ steps.artifacts.outputs.desktop_version }}
+      runtime_version: ${{ steps.artifacts.outputs.runtime_version }}
+      server_version: ${{ steps.artifacts.outputs.server_version }}
+      desktop_tag: ${{ steps.artifacts.outputs.desktop_tag }}
+      runtime_tag: ${{ steps.artifacts.outputs.runtime_tag }}
+      server_tag: ${{ steps.artifacts.outputs.server_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || 'main' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve train metadata
+        id: meta
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref || '' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags --prune
+          head_sha="$(git rev-parse HEAD)"
+          release_id="release-$(date -u +%F)"
+          previous_train="$(git tag --list 'release-*' --sort=-creatordate | grep -v "^$release_id$" | head -n 1 || true)"
+          if [[ -n "$previous_train" ]]; then
+            base_sha="$(git rev-parse "$previous_train")"
+          else
+            base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-list --max-parents=0 "$head_sha" | tail -n1)"
+          fi
+          if [[ -n "$INPUT_REF" && "$INPUT_REF" != "main" && "$DRY_RUN" != "true" ]]; then
+            git merge-base --is-ancestor "$head_sha" refs/remotes/origin/main
+          fi
+          {
+            echo "release_id=$release_id"
+            echo "base_sha=$base_sha"
+            echo "head_sha=$head_sha"
+            echo "dry_run=$DRY_RUN"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect release surfaces
+        id: detect
+        run: >
+          node scripts/ci-cd/detect-deploy-surfaces.mjs
+          --base "${{ steps.meta.outputs.base_sha }}"
+          --head "${{ steps.meta.outputs.head_sha }}"
+          --only "$ONLY_SURFACES"
+        env:
+          ONLY_SURFACES: ${{ github.event.inputs.only_surfaces || '' }}
+
+      - name: Prepare artifact versions
+        id: artifacts
+        run: >
+          node scripts/ci-cd/prepare-artifact-release.mjs
+          --surfaces "${{ steps.detect.outputs.selected_surfaces }}"
+          --release-id "${{ steps.meta.outputs.release_id }}"
+          --bump-patch true
+          --dry-run "${{ steps.meta.outputs.dry_run }}"
+
+      - name: Commit version bumps
+        id: commit
+        env:
+          RELEASE_ID: ${{ steps.meta.outputs.release_id }}
+          DRY_RUN: ${{ steps.meta.outputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --quiet; then
+            echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add apps/desktop/package.json apps/desktop/src-tauri/tauri.conf.json apps/desktop/src-tauri/Cargo.toml anyharness/sdk/package.json
+          git commit -m "release: prepare $RELEASE_ID"
+          git push origin HEAD:main
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create release train tag
+        if: steps.meta.outputs.dry_run != 'true'
+        run: >
+          node scripts/ci-cd/create-release-tags.mjs
+          --target "${{ steps.commit.outputs.head_sha }}"
+          --tags "${{ steps.meta.outputs.release_id }}"
+          --dry-run false
+
+      - name: Summarize train
+        run: |
+          {
+            echo "### Nightly release train"
+            echo "- Release: \`${{ steps.meta.outputs.release_id }}\`"
+            echo "- Base: \`${{ steps.meta.outputs.base_sha }}\`"
+            echo "- Head: \`${{ steps.commit.outputs.head_sha }}\`"
+            echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"
+            echo "- Selected surfaces: \`${{ steps.detect.outputs.selected_surfaces }}\`"
+            echo "- Desktop: \`${{ steps.artifacts.outputs.desktop_tag }}\`"
+            echo "- Runtime: \`${{ steps.artifacts.outputs.runtime_tag }}\`"
+            echo "- Server: \`${{ steps.artifacts.outputs.server_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-runtime:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.runtime == 'true' }}
+    uses: ./.github/workflows/release-runtime.yml
+    with:
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      version: ${{ needs.prepare.outputs.runtime_version }}
+      dry_run: false
+      publish: true
+    secrets: inherit
+
+  release-server:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.server == 'true' }}
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/server-ci.yml
+    with:
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      version: ${{ needs.prepare.outputs.server_version }}
+      dry_run: false
+      publish: true
+    secrets: inherit
+
+  release-desktop:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.desktop == 'true' }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      version: ${{ needs.prepare.outputs.desktop_version }}
+      dry_run: false
+      publish_updater: false
+      target_os: all
+    secrets: inherit
+
+  deploy-e2b:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-e2b.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.e2b == 'true' }}
+      rolling_tag: staging
+      mode: build_and_promote
+    secrets: inherit
+
+  deploy-server:
+    needs: [prepare, deploy-e2b]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-server.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.server == 'true' }}
+    secrets: inherit
+
+  deploy-workers:
+    needs: [prepare, deploy-server]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-workers.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.workers == 'true' }}
+    secrets: inherit
+
+  deploy-web:
+    needs: [prepare, deploy-server]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-web.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.web == 'true' }}
+    secrets: inherit
+
+  deploy-mobile:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-mobile.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.mobile == 'true' }}
+    secrets: inherit
+
+  summary:
+    needs:
+      - prepare
+      - release-runtime
+      - release-server
+      - release-desktop
+      - deploy-e2b
+      - deploy-server
+      - deploy-workers
+      - deploy-web
+      - deploy-mobile
+    if: ${{ always() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize results
+        run: |
+          {
+            echo "### Nightly release train result"
+            echo "- Release: \`${{ needs.prepare.outputs.release_id }}\`"
+            echo "- Head: \`${{ needs.prepare.outputs.head_sha }}\`"
+            echo "- Surfaces: \`${{ needs.prepare.outputs.selected_surfaces }}\`"
+            echo "- Runtime release: \`${{ needs.release-runtime.result }}\`"
+            echo "- Server release: \`${{ needs.release-server.result }}\`"
+            echo "- Desktop release: \`${{ needs.release-desktop.result }}\`"
+            echo "- E2B staging: \`${{ needs.deploy-e2b.result }}\`"
+            echo "- Server staging: \`${{ needs.deploy-server.result }}\`"
+            echo "- Workers staging: \`${{ needs.deploy-workers.result }}\`"
+            echo "- Web staging: \`${{ needs.deploy-web.result }}\`"
+            echo "- Mobile staging: \`${{ needs.deploy-mobile.result }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -11,6 +11,10 @@ on:
         description: Comma-separated surfaces to force, or all.
         required: false
         type: string
+      only_surfaces:
+        description: Exact comma-separated surfaces to promote, or all. Overrides detection and force_surfaces.
+        required: false
+        type: string
       require_staging_success:
         description: Require a successful Deploy Staging run for this exact SHA.
         default: true
@@ -49,6 +53,8 @@ jobs:
       desktop: ${{ steps.detect.outputs.desktop }}
       runtime: ${{ steps.detect.outputs.runtime }}
       changed_files_count: ${{ steps.detect.outputs.changed_files_count }}
+      selection_mode: ${{ steps.detect.outputs.selection_mode }}
+      selected_surfaces: ${{ steps.detect.outputs.selected_surfaces }}
       summary_json: ${{ steps.detect.outputs.summary_json }}
     steps:
       - uses: actions/checkout@v4
@@ -106,8 +112,10 @@ jobs:
           --base "${{ steps.base.outputs.base_sha }}"
           --head "${{ steps.meta.outputs.head_sha }}"
           --force "$FORCE_SURFACES"
+          --only "$ONLY_SURFACES"
         env:
           FORCE_SURFACES: ${{ github.event.inputs.force_surfaces || '' }}
+          ONLY_SURFACES: ${{ github.event.inputs.only_surfaces || '' }}
 
       - name: Summarize plan
         run: |
@@ -117,6 +125,10 @@ jobs:
             echo "- Head: \`${{ steps.detect.outputs.head_sha }}\`"
             echo "- Changed files: \`${{ steps.detect.outputs.changed_files_count }}\`"
             echo "- Dry run: \`${{ steps.meta.outputs.dry_run }}\`"
+            echo "- Selection: \`${{ steps.detect.outputs.selection_mode }}\`"
+            echo "- Forced surfaces: \`${{ steps.detect.outputs.forced_surfaces }}\`"
+            echo "- Only surfaces: \`${{ steps.detect.outputs.only_surfaces }}\`"
+            echo "- Selected surfaces: \`${{ steps.detect.outputs.selected_surfaces }}\`"
             echo ""
             echo "| Surface | Deploy |"
             echo "| --- | --- |"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -513,6 +513,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name != 'push' && !inputs.dry_run)
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+
       - name: Validate release ref
         if: github.event_name == 'workflow_dispatch' && !inputs.git_sha
         shell: bash
@@ -521,6 +526,31 @@ jobs:
             echo "::error::Manual non-dry-run desktop releases must run from a desktop-v* tag ref, not ${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}."
             exit 1
           fi
+
+      - name: Ensure desktop release tag exists
+        if: ${{ !startsWith(github.ref_name, 'desktop-v') }}
+        env:
+          RELEASE_TAG: ${{ format('desktop-v{0}', inputs.version) }}
+        run: |
+          set -euo pipefail
+          release_target="$(git rev-parse HEAD)"
+          remote_tags="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}" || true)"
+          existing_target="$(
+            printf '%s\n' "$remote_tags" \
+              | awk '$2 ~ /\^\{\}$/ { peeled=$1 } $2 !~ /\^\{\}$/ && $2 != "" { direct=$1 } END { print peeled ? peeled : direct }'
+          )"
+
+          if [[ -n "$existing_target" ]]; then
+            if [[ "$existing_target" != "$release_target" ]]; then
+              echo "::error::Desktop tag $RELEASE_TAG already exists at $existing_target, not $release_target."
+              exit 1
+            fi
+            echo "Desktop tag $RELEASE_TAG already exists at $release_target."
+            exit 0
+          fi
+
+          git tag "$RELEASE_TAG" "$release_target"
+          git push origin "refs/tags/$RELEASE_TAG"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -10,6 +10,24 @@ on:
         description: "Run the full pipeline without publishing or creating a release"
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      git_sha:
+        description: "Commit SHA to package. Defaults to the caller ref."
+        required: false
+        type: string
+      version:
+        description: "Runtime version to release. Required for reusable releases."
+        required: false
+        type: string
+      dry_run:
+        description: "Run the full pipeline without publishing or creating a release"
+        type: boolean
+        default: false
+      publish:
+        description: "Publish npm package and GitHub Release"
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -46,6 +64,8 @@ jobs:
             archive: zip
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -100,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -124,7 +146,7 @@ jobs:
           pnpm run build
 
       - name: Publish to npm
-        if: github.event_name == 'push' && !inputs.dry_run
+        if: (github.event_name == 'push' || inputs.publish) && !inputs.dry_run
         working-directory: anyharness/sdk
         run: |
           if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
@@ -136,7 +158,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry-run publish
-        if: github.event_name != 'push' || inputs.dry_run
+        if: (github.event_name != 'push' && !inputs.publish) || inputs.dry_run
         working-directory: anyharness/sdk
         run: npm publish --access public --dry-run
 
@@ -145,6 +167,10 @@ jobs:
     needs: [build-binaries, publish-sdk]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -156,11 +182,32 @@ jobs:
           sha256sum anyharness-* > SHA256SUMS
           cat SHA256SUMS
 
+      - name: Ensure runtime release tag exists
+        if: github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run
+        env:
+          RELEASE_TAG: ${{ format('runtime-v{0}', inputs.version) }}
+          RELEASE_TARGET: ${{ inputs.git_sha }}
+        run: |
+          set -euo pipefail
+          : "${RELEASE_TAG:?Missing runtime release tag.}"
+          : "${RELEASE_TARGET:?Missing runtime release target.}"
+          existing_target="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" | awk '{ print $1 }' | head -n 1)"
+          if [[ -n "$existing_target" && "$existing_target" != "$RELEASE_TARGET" ]]; then
+            echo "::error::Runtime tag $RELEASE_TAG already exists at $existing_target, not $RELEASE_TARGET."
+            exit 1
+          fi
+          if [[ -z "$existing_target" ]]; then
+            git tag "$RELEASE_TAG" "$RELEASE_TARGET"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
       - name: Create GitHub Release
-        if: github.event_name == 'push' && !inputs.dry_run
+        if: (github.event_name == 'push' || inputs.publish) && !inputs.dry_run
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          target_commitish: ${{ inputs.git_sha || github.sha }}
+          tag_name: ${{ github.event_name == 'push' && github.ref_name || format('runtime-v{0}', inputs.version) }}
           files: |
             artifacts/anyharness-*
             artifacts/SHA256SUMS

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -22,6 +22,24 @@ on:
       - "scripts/validate-agent-catalog.mjs"
       - "server/**"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      git_sha:
+        description: "Commit SHA to validate and package. Defaults to the caller ref."
+        required: false
+        type: string
+      version:
+        description: "Server/self-hosted version to release. Required for reusable release calls."
+        required: false
+        type: string
+      dry_run:
+        description: "Run validation and packaging without publishing release artifacts."
+        type: boolean
+        default: false
+      publish:
+        description: "Publish GHCR image and GitHub Release assets."
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -35,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -91,6 +111,8 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -119,12 +141,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')) || (github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run)
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -135,12 +159,18 @@ jobs:
 
       - name: Compute image tags
         id: tags
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
           set -euo pipefail
           GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-server"
           TAGS=()
 
-          VERSION="${GITHUB_REF#refs/tags/server-v}"
+          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/server-v}"
+          else
+            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
+          fi
           TAGS+=("${GHCR_IMAGE}:${VERSION}")
 
           {
@@ -160,11 +190,13 @@ jobs:
   self-hosted-release-assets:
     runs-on: ubuntu-latest
     needs: [lint, test, docker]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')) || (github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run)
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -211,9 +243,31 @@ jobs:
             > artifacts/self-hosted-assets.SHA256SUMS
         working-directory: .
 
+      - name: Ensure server release tag exists
+        if: github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run
+        env:
+          RELEASE_TAG: ${{ format('server-v{0}', inputs.version) }}
+          RELEASE_TARGET: ${{ inputs.git_sha }}
+        run: |
+          set -euo pipefail
+          : "${RELEASE_TAG:?Missing server release tag.}"
+          : "${RELEASE_TARGET:?Missing server release target.}"
+          existing_target="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" | awk '{ print $1 }' | head -n 1)"
+          if [[ -n "$existing_target" && "$existing_target" != "$RELEASE_TARGET" ]]; then
+            echo "::error::Server tag $RELEASE_TAG already exists at $existing_target, not $RELEASE_TARGET."
+            exit 1
+          fi
+          if [[ -z "$existing_target" ]]; then
+            git tag "$RELEASE_TAG" "$RELEASE_TARGET"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+        working-directory: .
+
       - name: Publish self-hosted release assets
         uses: softprops/action-gh-release@v2
         with:
+          target_commitish: ${{ inputs.git_sha || github.sha }}
+          tag_name: ${{ github.event_name == 'push' && github.ref_name || format('server-v{0}', inputs.version) }}
           files: |
             artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz
             artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz

--- a/scripts/ci-cd/create-release-tags.mjs
+++ b/scripts/ci-cd/create-release-tags.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const parsed = {
+    target: "",
+    tags: "",
+    dryRun: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--target":
+        parsed.target = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--tags":
+        parsed.tags = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--dry-run":
+        parsed.dryRun = ["1", "true", "yes"].includes(String(argv[index + 1] || "false").toLowerCase());
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printUsage() {
+  console.log(`Create release tags at a target commit.
+
+Usage:
+  node scripts/ci-cd/create-release-tags.mjs --target <sha> --tags <csv> --dry-run <true|false>
+`);
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+export function parseTags(value) {
+  return value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function normalizeRemoteTagOutput(output) {
+  const rows = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, ref] = line.split(/\s+/);
+      return { sha, ref };
+    });
+  return rows.find((row) => row.ref.endsWith("^{}"))?.sha || rows[0]?.sha || "";
+}
+
+function remoteTagTarget(tag) {
+  try {
+    return normalizeRemoteTagOutput(
+      git(["ls-remote", "--tags", "origin", `refs/tags/${tag}`, `refs/tags/${tag}^{}`]),
+    );
+  } catch {
+    return "";
+  }
+}
+
+function localTagTarget(tag) {
+  try {
+    return git(["rev-parse", "--verify", `${tag}^{}`]);
+  } catch {
+    return "";
+  }
+}
+
+export function validateTagTargets({ tags, target, existingTargets }) {
+  const conflicts = [];
+  for (const tag of tags) {
+    const existingTarget = existingTargets[tag] || "";
+    if (existingTarget && existingTarget !== target) {
+      conflicts.push({ tag, existingTarget, target });
+    }
+  }
+  if (conflicts.length > 0) {
+    const details = conflicts
+      .map((conflict) => `${conflict.tag} exists at ${conflict.existingTarget}, not ${conflict.target}`)
+      .join("; ");
+    throw new Error(details);
+  }
+}
+
+function writeGithubOutput(result) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(outputPath, `created_tags=${result.createdTags.join(",")}\n`);
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+  if (!parsed.target) {
+    throw new Error("--target is required.");
+  }
+
+  const tags = parseTags(parsed.tags);
+  const existingTargets = {};
+  for (const tag of tags) {
+    existingTargets[tag] = remoteTagTarget(tag) || localTagTarget(tag);
+  }
+  validateTagTargets({ tags, target: parsed.target, existingTargets });
+
+  const createdTags = [];
+  for (const tag of tags) {
+    if (existingTargets[tag]) {
+      console.log(`${tag} already points at ${parsed.target}.`);
+      continue;
+    }
+    if (parsed.dryRun) {
+      console.log(`[dry-run] would create ${tag} at ${parsed.target}`);
+      createdTags.push(tag);
+      continue;
+    }
+    git(["tag", tag, parsed.target]);
+    git(["push", "origin", `refs/tags/${tag}`]);
+    createdTags.push(tag);
+  }
+
+  const result = { target: parsed.target, createdTags };
+  writeGithubOutput(result);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/ci-cd/detect-deploy-surfaces.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.mjs
@@ -2,8 +2,9 @@
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const SURFACES = [
+export const SURFACES = [
   "server",
   "workers",
   "e2b",
@@ -17,18 +18,19 @@ function printUsage() {
   console.log(`Detect deployable surfaces touched by a git diff.
 
 Usage:
-  node scripts/ci-cd/detect-deploy-surfaces.mjs --base <sha> --head <sha> [--force <surface[,surface]|all>]
+  node scripts/ci-cd/detect-deploy-surfaces.mjs --base <sha> --head <sha> [--force <surface[,surface]|all>] [--only <surface[,surface]|all>]
 
 Outputs JSON to stdout. When GITHUB_OUTPUT is set, also writes boolean outputs
 for each deploy surface plus base_sha, head_sha, and changed_files_count.
 `);
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const parsed = {
     base: "",
     head: "HEAD",
     force: "",
+    only: "",
     help: false,
   };
 
@@ -45,6 +47,10 @@ function parseArgs(argv) {
         break;
       case "--force":
         parsed.force = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--only":
+        parsed.only = argv[index + 1] || "";
         index += 1;
         break;
       case "--help":
@@ -93,7 +99,7 @@ function matches(path, prefixes) {
   return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 }
 
-function classifyFile(path) {
+export function classifyFile(path) {
   const touched = new Set();
 
   const workflowDeployPath =
@@ -197,22 +203,59 @@ function classifyFile(path) {
   return touched;
 }
 
-function forcedSurfaces(force) {
-  const normalized = force
+export function parseSurfaceList(value, optionName) {
+  const normalized = value
     .split(",")
-    .map((value) => value.trim())
+    .map((item) => item.trim())
     .filter(Boolean);
   if (normalized.length === 0) {
     return new Set();
   }
   if (normalized.includes("all")) {
+    if (normalized.length > 1) {
+      throw new Error(`${optionName}=all cannot be combined with other surfaces.`);
+    }
     return new Set(SURFACES);
   }
   const unknown = normalized.filter((surface) => !SURFACES.includes(surface));
   if (unknown.length > 0) {
-    throw new Error(`Unknown forced deploy surface(s): ${unknown.join(", ")}`);
+    throw new Error(`Unknown ${optionName} deploy surface(s): ${unknown.join(", ")}`);
   }
   return new Set(normalized);
+}
+
+function surfacesFromFiles(files) {
+  const touched = new Set();
+  for (const file of files) {
+    for (const surface of classifyFile(file)) {
+      touched.add(surface);
+    }
+  }
+  return touched;
+}
+
+export function selectSurfaces({ files, force = "", only = "" }) {
+  const detected = surfacesFromFiles(files);
+  const forced = parseSurfaceList(force, "forced");
+  const onlySurfaces = parseSurfaceList(only, "only");
+  const selectionMode = onlySurfaces.size > 0 ? "only" : "detected";
+
+  const selected =
+    selectionMode === "only"
+      ? new Set(onlySurfaces)
+      : new Set([...detected, ...forced]);
+
+  return {
+    selected,
+    detected,
+    forced,
+    only: onlySurfaces,
+    selectionMode,
+  };
+}
+
+function surfaceList(set) {
+  return [...set].sort((left, right) => SURFACES.indexOf(left) - SURFACES.indexOf(right));
 }
 
 function writeGithubOutput(result) {
@@ -225,12 +268,33 @@ function writeGithubOutput(result) {
     `base_sha=${result.baseSha}`,
     `head_sha=${result.headSha}`,
     `changed_files_count=${result.changedFiles.length}`,
+    `selection_mode=${result.selectionMode}`,
+    `detected_surfaces=${result.detectedSurfaces.join(",")}`,
+    `forced_surfaces=${result.forcedSurfaces.join(",")}`,
+    `only_surfaces=${result.onlySurfaces.join(",")}`,
+    `selected_surfaces=${result.selectedSurfaces.join(",")}`,
   ];
   for (const surface of SURFACES) {
     lines.push(`${surface}=${result.surfaces[surface] ? "true" : "false"}`);
   }
   lines.push(`summary_json=${JSON.stringify(result)}`);
   fs.appendFileSync(outputPath, `${lines.join("\n")}\n`);
+}
+
+export function buildResult({ baseSha, headSha, files, force, only }) {
+  const selection = selectSurfaces({ files, force, only });
+  const selectedSurfaces = surfaceList(selection.selected);
+  return {
+    baseSha,
+    headSha,
+    changedFiles: files,
+    selectionMode: selection.selectionMode,
+    detectedSurfaces: surfaceList(selection.detected),
+    forcedSurfaces: surfaceList(selection.forced),
+    onlySurfaces: surfaceList(selection.only),
+    selectedSurfaces,
+    surfaces: Object.fromEntries(SURFACES.map((surface) => [surface, selection.selected.has(surface)])),
+  };
 }
 
 function main() {
@@ -254,26 +318,18 @@ function main() {
   }
   const baseSha = resolveCommit(parsed.base) || firstCommit();
   const files = changedFiles(baseSha, headSha);
-  const forced = forcedSurfaces(parsed.force);
-  const touched = new Set(forced);
-
-  for (const file of files) {
-    for (const surface of classifyFile(file)) {
-      touched.add(surface);
-    }
-  }
-
-  const surfaces = Object.fromEntries(SURFACES.map((surface) => [surface, touched.has(surface)]));
-  const result = {
+  const result = buildResult({
     baseSha,
     headSha,
-    changedFiles: files,
-    forcedSurfaces: [...forced],
-    surfaces,
-  };
+    files,
+    force: parsed.force,
+    only: parsed.only,
+  });
 
   writeGithubOutput(result);
   console.log(JSON.stringify(result, null, 2));
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/ci-cd/detect-deploy-surfaces.test.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildResult,
+  parseSurfaceList,
+  selectSurfaces,
+} from "./detect-deploy-surfaces.mjs";
+
+test("selects detected surfaces when no override is provided", () => {
+  const selection = selectSurfaces({
+    files: ["server/proliferate/app.py", "apps/web/src/main.tsx"],
+  });
+
+  assert.equal(selection.selectionMode, "detected");
+  assert.deepEqual([...selection.selected].sort(), ["server", "web"]);
+});
+
+test("force surfaces are additive", () => {
+  const result = buildResult({
+    baseSha: "base",
+    headSha: "head",
+    files: ["server/proliferate/app.py"],
+    force: "desktop",
+    only: "",
+  });
+
+  assert.equal(result.selectionMode, "detected");
+  assert.equal(result.surfaces.server, true);
+  assert.equal(result.surfaces.desktop, true);
+  assert.equal(result.surfaces.web, false);
+  assert.deepEqual(result.forcedSurfaces, ["desktop"]);
+});
+
+test("only surfaces replace detected surfaces", () => {
+  const result = buildResult({
+    baseSha: "base",
+    headSha: "head",
+    files: ["server/proliferate/app.py", "apps/web/src/main.tsx"],
+    force: "desktop",
+    only: "web",
+  });
+
+  assert.equal(result.selectionMode, "only");
+  assert.equal(result.surfaces.web, true);
+  assert.equal(result.surfaces.server, false);
+  assert.equal(result.surfaces.desktop, false);
+  assert.deepEqual(result.onlySurfaces, ["web"]);
+});
+
+test("all expands to every known surface", () => {
+  assert.deepEqual([...parseSurfaceList("all", "only")].sort(), [
+    "desktop",
+    "e2b",
+    "mobile",
+    "runtime",
+    "server",
+    "web",
+    "workers",
+  ]);
+});
+
+test("invalid surfaces fail fast", () => {
+  assert.throws(
+    () => parseSurfaceList("web,billing", "only"),
+    /Unknown only deploy surface\(s\): billing/,
+  );
+});

--- a/scripts/ci-cd/prepare-artifact-release.mjs
+++ b/scripts/ci-cd/prepare-artifact-release.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseSurfaceList } from "./detect-deploy-surfaces.mjs";
+
+const ARTIFACT_SURFACES = new Set(["desktop", "runtime", "server"]);
+
+function parseArgs(argv) {
+  const parsed = {
+    surfaces: "",
+    releaseId: "",
+    bumpPatch: false,
+    dryRun: false,
+    root: process.cwd(),
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--surfaces":
+        parsed.surfaces = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--release-id":
+        parsed.releaseId = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--bump-patch":
+        parsed.bumpPatch = parseBoolean(argv[index + 1] || "false");
+        index += 1;
+        break;
+      case "--dry-run":
+        parsed.dryRun = parseBoolean(argv[index + 1] || "false");
+        index += 1;
+        break;
+      case "--root":
+        parsed.root = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printUsage() {
+  console.log(`Prepare artifact lane versions for a release train or hotfix.
+
+Usage:
+  node scripts/ci-cd/prepare-artifact-release.mjs --surfaces <csv|all> --release-id <id> --bump-patch <true|false> --dry-run <true|false>
+
+Writes GitHub outputs for desktop/runtime/server versions and tags. When
+--bump-patch=true and --dry-run=false, updates tracked version files for lanes
+that require committed version metadata.
+`);
+}
+
+function parseBoolean(value) {
+  return ["1", "true", "yes"].includes(String(value).toLowerCase());
+}
+
+export function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  if (!match) {
+    throw new Error(`Unsupported semver version: ${value}`);
+  }
+  return match.slice(1).map((part) => Number(part));
+}
+
+export function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] > b[index]) return 1;
+    if (a[index] < b[index]) return -1;
+  }
+  return 0;
+}
+
+export function incrementPatch(value) {
+  const [major, minor, patch] = parseVersion(value);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+export function nextPatchVersion(currentVersion, latestTagVersion = "") {
+  if (!latestTagVersion) {
+    return incrementPatch(currentVersion);
+  }
+  const base = compareVersions(currentVersion, latestTagVersion) >= 0 ? currentVersion : latestTagVersion;
+  return incrementPatch(base);
+}
+
+export function tagVersion(tag, prefix) {
+  if (!tag.startsWith(prefix)) {
+    return "";
+  }
+  const version = tag.slice(prefix.length);
+  return /^\d+\.\d+\.\d+$/.test(version) ? version : "";
+}
+
+export function latestVersionFromTags(tags, prefix) {
+  return tags
+    .map((tag) => tagVersion(tag, prefix))
+    .filter(Boolean)
+    .sort((left, right) => compareVersions(right, left))[0] || "";
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function remoteTags(prefix) {
+  try {
+    const output = git(["ls-remote", "--tags", "origin", `refs/tags/${prefix}*`]);
+    return output
+      .split("\n")
+      .map((line) => line.trim().split(/\s+/)[1] || "")
+      .filter(Boolean)
+      .map((ref) => ref.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, ""));
+  } catch {
+    return [];
+  }
+}
+
+function localTags(prefix) {
+  try {
+    return git(["tag", "--list", `${prefix}*`]).split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function latestVersionForPrefix(prefix) {
+  return latestVersionFromTags([...new Set([...remoteTags(prefix), ...localTags(prefix)])], prefix);
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value, dryRun) {
+  if (!dryRun) {
+    fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+  }
+  return true;
+}
+
+function replaceCargoVersion(file, version, dryRun) {
+  const source = fs.readFileSync(file, "utf8");
+  const updated = source.replace(/^version = "([^"]+)"/m, `version = "${version}"`);
+  if (source === updated) {
+    throw new Error(`Could not update Cargo version in ${file}`);
+  }
+  if (!dryRun) {
+    fs.writeFileSync(file, updated);
+  }
+  return true;
+}
+
+function readDesktopVersion(root) {
+  const packageJson = readJson(path.join(root, "apps/desktop/package.json"));
+  const tauriConfig = readJson(path.join(root, "apps/desktop/src-tauri/tauri.conf.json"));
+  const cargoToml = fs.readFileSync(path.join(root, "apps/desktop/src-tauri/Cargo.toml"), "utf8");
+  const cargoVersion = /^version = "([^"]+)"/m.exec(cargoToml)?.[1] || "";
+  if (packageJson.version !== tauriConfig.version || packageJson.version !== cargoVersion) {
+    throw new Error(
+      `Desktop version mismatch: package=${packageJson.version} tauri=${tauriConfig.version} cargo=${cargoVersion}`,
+    );
+  }
+  return packageJson.version;
+}
+
+function updateDesktopVersion(root, version, dryRun) {
+  const packagePath = path.join(root, "apps/desktop/package.json");
+  const tauriPath = path.join(root, "apps/desktop/src-tauri/tauri.conf.json");
+  const cargoPath = path.join(root, "apps/desktop/src-tauri/Cargo.toml");
+  const packageJson = readJson(packagePath);
+  const tauriConfig = readJson(tauriPath);
+  packageJson.version = version;
+  tauriConfig.version = version;
+  const changed = [];
+  if (writeJson(packagePath, packageJson, dryRun)) changed.push("apps/desktop/package.json");
+  if (writeJson(tauriPath, tauriConfig, dryRun)) changed.push("apps/desktop/src-tauri/tauri.conf.json");
+  if (replaceCargoVersion(cargoPath, version, dryRun)) changed.push("apps/desktop/src-tauri/Cargo.toml");
+  return changed;
+}
+
+function readRuntimeVersion(root) {
+  return readJson(path.join(root, "anyharness/sdk/package.json")).version;
+}
+
+function updateRuntimeVersion(root, version, dryRun) {
+  const packagePath = path.join(root, "anyharness/sdk/package.json");
+  const packageJson = readJson(packagePath);
+  packageJson.version = version;
+  return writeJson(packagePath, packageJson, dryRun) ? ["anyharness/sdk/package.json"] : [];
+}
+
+function artifactTagMap({ root, surfaces, bumpPatch, dryRun }) {
+  const tags = {};
+  const versions = {};
+  const changedFiles = [];
+
+  if (surfaces.has("desktop")) {
+    const current = readDesktopVersion(root);
+    const version = bumpPatch ? nextPatchVersion(current, latestVersionForPrefix("desktop-v")) : current;
+    versions.desktop = version;
+    tags.desktop = `desktop-v${version}`;
+    if (bumpPatch && version !== current) {
+      changedFiles.push(...updateDesktopVersion(root, version, dryRun));
+    }
+  }
+
+  if (surfaces.has("runtime")) {
+    const current = readRuntimeVersion(root);
+    const version = bumpPatch ? nextPatchVersion(current, latestVersionForPrefix("runtime-v")) : current;
+    versions.runtime = version;
+    tags.runtime = `runtime-v${version}`;
+    if (bumpPatch && version !== current) {
+      changedFiles.push(...updateRuntimeVersion(root, version, dryRun));
+    }
+  }
+
+  if (surfaces.has("server")) {
+    const latest = latestVersionForPrefix("server-v") || "0.1.0";
+    const version = bumpPatch ? incrementPatch(latest) : latest;
+    versions.server = version;
+    tags.server = `server-v${version}`;
+  }
+
+  return { tags, versions, changedFiles };
+}
+
+function writeGithubOutput(plan) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+  const lines = [
+    `release_id=${plan.releaseId}`,
+    `selected_surfaces=${plan.selectedSurfaces.join(",")}`,
+    `artifact_tags=${Object.values(plan.tags).filter(Boolean).join(",")}`,
+    `artifact_tags_json=${JSON.stringify(plan.tags)}`,
+    `changed_files_json=${JSON.stringify(plan.changedFiles)}`,
+  ];
+  for (const surface of ["desktop", "runtime", "server"]) {
+    lines.push(`${surface}_version=${plan.versions[surface] || ""}`);
+    lines.push(`${surface}_tag=${plan.tags[surface] || ""}`);
+  }
+  fs.appendFileSync(outputPath, `${lines.join("\n")}\n`);
+}
+
+export function buildArtifactPlan({ root, surfaces, releaseId, bumpPatch, dryRun }) {
+  const selectedSurfaces = [...surfaces].filter((surface) => ARTIFACT_SURFACES.has(surface));
+  const artifact = artifactTagMap({
+    root,
+    surfaces: new Set(selectedSurfaces),
+    bumpPatch,
+    dryRun,
+  });
+  return {
+    releaseId,
+    bumpPatch,
+    dryRun,
+    selectedSurfaces,
+    tags: artifact.tags,
+    versions: artifact.versions,
+    changedFiles: [...new Set(artifact.changedFiles)],
+  };
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+  if (!parsed.releaseId) {
+    throw new Error("--release-id is required.");
+  }
+
+  const surfaces = parseSurfaceList(parsed.surfaces, "artifact");
+  const plan = buildArtifactPlan({
+    root: path.resolve(parsed.root),
+    surfaces,
+    releaseId: parsed.releaseId,
+    bumpPatch: parsed.bumpPatch,
+    dryRun: parsed.dryRun,
+  });
+  writeGithubOutput(plan);
+  console.log(JSON.stringify(plan, null, 2));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/ci-cd/prepare-artifact-release.test.mjs
+++ b/scripts/ci-cd/prepare-artifact-release.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  compareVersions,
+  incrementPatch,
+  latestVersionFromTags,
+  nextPatchVersion,
+  tagVersion,
+} from "./prepare-artifact-release.mjs";
+
+import {
+  parseTags,
+  validateTagTargets,
+} from "./create-release-tags.mjs";
+
+test("calculates the next patch version from current and latest tag", () => {
+  assert.equal(nextPatchVersion("0.1.49", "0.1.52"), "0.1.53");
+  assert.equal(nextPatchVersion("0.1.49", "0.1.42"), "0.1.50");
+  assert.equal(nextPatchVersion("0.1.49", ""), "0.1.50");
+});
+
+test("orders semver versions", () => {
+  assert.equal(compareVersions("0.1.10", "0.1.9"), 1);
+  assert.equal(compareVersions("0.1.9", "0.1.10"), -1);
+  assert.equal(compareVersions("0.1.9", "0.1.9"), 0);
+  assert.equal(incrementPatch("1.2.3"), "1.2.4");
+});
+
+test("extracts latest versions from lane tags", () => {
+  assert.equal(tagVersion("desktop-v0.1.4", "desktop-v"), "0.1.4");
+  assert.equal(tagVersion("runtime-v0.1.4", "desktop-v"), "");
+  assert.equal(latestVersionFromTags(["runtime-v0.1.2", "runtime-v0.1.10"], "runtime-v"), "0.1.10");
+});
+
+test("parses release tag CSV", () => {
+  assert.deepEqual(parseTags("release-2026-06-06, runtime-v0.1.3"), [
+    "release-2026-06-06",
+    "runtime-v0.1.3",
+  ]);
+});
+
+test("tag validation fails on collisions", () => {
+  assert.throws(
+    () =>
+      validateTagTargets({
+        tags: ["runtime-v0.1.3"],
+        target: "next",
+        existingTargets: { "runtime-v0.1.3": "old" },
+      }),
+    /runtime-v0\.1\.3 exists at old, not next/,
+  );
+});
+
+test("tag validation allows existing tags at the same target", () => {
+  assert.doesNotThrow(() =>
+    validateTagTargets({
+      tags: ["runtime-v0.1.3"],
+      target: "same",
+      existingTargets: { "runtime-v0.1.3": "same" },
+    }),
+  );
+});

--- a/specs/developing/deploying/README.md
+++ b/specs/developing/deploying/README.md
@@ -44,6 +44,8 @@ Use this folder to answer four deployment questions:
 4. New release process:
    - desktop, runtime/SDK, cloud template, server image, mobile/TestFlight, and
      hosted web/API release paths live in [ci-cd.md](ci-cd.md)
+   - nightly trains and production hotfixes are coordinated by the release
+     train workflows in [ci-cd.md](ci-cd.md)
    - user-facing releases must also update the landing page, public docs,
      changelog/release notes, or in-app copy when the shipped behavior changes
      those surfaces

--- a/specs/developing/deploying/ci-cd.md
+++ b/specs/developing/deploying/ci-cd.md
@@ -83,6 +83,8 @@ Operating invariants:
 - A selected lane that fails means the deploy run failed, even if another lane
   produced the artifact the operator cared about.
 - `force_surfaces` is additive. It cannot suppress other detected lanes.
+- `only_surfaces` is exact. Use it for targeted staging plans, production
+  hotfixes, and any release where unrelated detected lanes must not move.
 - Staging desktop validates the plan but does not publish the stable updater.
   Production desktop publish is the point where `latest.json` becomes live.
 - Publishing the same desktop version twice does not update installed apps.
@@ -106,7 +108,7 @@ Before deploying:
 1. Confirm the target commit is on `main`.
 2. Confirm CI passed for that commit.
 3. Decide whether this is a normal detected-surface deploy, a forced full
-   deploy, or a deliberately gated partial deploy.
+   deploy, or an exact `only_surfaces` deploy.
 4. Inspect the target environment gates before dispatching:
    - `MOBILE_DEPLOY_ENABLED`
    - `EAS_SUBMIT_ENABLED`
@@ -136,6 +138,7 @@ when explicitly requested:
 Workflow: Deploy Staging
 ref: <main SHA or ref>
 force_surfaces: <blank, comma-separated surfaces, or all>
+only_surfaces: <blank, comma-separated surfaces, or all>
 dry_run: false
 ```
 
@@ -155,6 +158,7 @@ Production is promoted manually from a staging-tested commit:
 Workflow: Promote Production
 ref: <main SHA>
 force_surfaces: <blank, comma-separated surfaces, or all>
+only_surfaces: <blank, comma-separated surfaces, or all>
 require_staging_success: true
 dry_run: false
 ```
@@ -192,11 +196,71 @@ Dry-run production promotes upload `deploy-plan-production`, not
 `deploy-summary-production`, and are excluded from future production
 deploy-base resolution.
 
+### Nightly Release Train
+
+The nightly train coordinates artifact versions, artifact releases, and staging
+deploys from `main`.
+
+```text
+Workflow: Nightly Release Train
+ref: <blank or main SHA/ref>
+only_surfaces: <blank, comma-separated surfaces, or all>
+dry_run: false
+```
+
+Train behavior:
+
+1. Resolve a shared release id, `release-YYYY-MM-DD`.
+2. Diff the selected SHA against the previous `release-*` train tag.
+3. If `only_surfaces` is blank, release the detected surfaces. If
+   `only_surfaces` is set, release exactly those surfaces.
+4. Bump patch versions for selected artifact lanes:
+   - desktop updates `apps/desktop/package.json`,
+     `apps/desktop/src-tauri/tauri.conf.json`, and
+     `apps/desktop/src-tauri/Cargo.toml`
+   - runtime updates `anyharness/sdk/package.json`
+   - server derives the next `server-v*` tag without a tracked version file
+5. Commit version bumps back to `main` when needed.
+6. Create the `release-YYYY-MM-DD` train tag.
+7. Run selected artifact release lanes and selected staging deploy lanes.
+
+The train does not publish public changelog pages or raw release-note pages.
+Those surfaces are owned by separate product/website automation.
+
+### Production Hotfix
+
+Use `Hotfix Production` when an urgent fix must move exact surfaces to
+production without waiting for the next train.
+
+```text
+Workflow: Hotfix Production
+ref: <main SHA or ref>
+only_surfaces: <comma-separated surfaces or all>
+reason: <short reason>
+bump_patch: true
+dry_run: false
+```
+
+Hotfix behavior:
+
+1. Require `only_surfaces`; no detected-surface spillover is allowed.
+2. Verify the input ref is reachable from `main`.
+3. Bump selected artifact-lane patch versions when `bump_patch=true`.
+4. Commit version bumps back to `main` when needed.
+5. Create a `hotfix-YYYY-MM-DD-<run-number>` tag.
+6. Publish selected runtime/server artifacts and deploy selected production
+   lanes. Desktop hotfixes publish the stable updater feed.
+
+For production hotfixes, prefer `dry_run=true` first. Then dispatch the real
+run from the exact SHA after confirming the plan selected only the intended
+surfaces.
+
 ### Surface Selection
 
 The workflow detects deploy surfaces from the diff against the previous
-successful deploy. `force_surfaces` is additive: it adds surfaces to whatever
-the diff already detected. It is not an "only these surfaces" filter.
+successful deploy. `force_surfaces` and `only_surfaces` are different tools:
+`force_surfaces` adds lanes to detection, while `only_surfaces` replaces
+detection with the exact listed lanes.
 
 Use these values:
 
@@ -204,15 +268,16 @@ Use these values:
 force_surfaces=<blank>  # deploy only detected surfaces
 force_surfaces=all      # deploy every lane that is enabled by env gates
 force_surfaces=web      # deploy detected surfaces plus web
+only_surfaces=web       # deploy only web
+only_surfaces=all       # deploy every lane that is enabled by env gates
 ```
 
 If the intent is "only web" but the diff also detects mobile, server, E2B, or
-desktop, do not assume `force_surfaces=web` will suppress the other lanes.
+desktop, use `only_surfaces=web`.
 Only mobile, desktop, and workers currently have environment gates. Setting
 `EAS_SUBMIT_ENABLED=false` skips TestFlight submission only; the mobile build
 can still run when `MOBILE_DEPLOY_ENABLED=true`. Server, web, and E2B do not
-have skip gates, so do not dispatch a mixed deploy when those detected lanes
-must not run.
+have skip gates, so use `only_surfaces` when those detected lanes must not run.
 
 ### Verification
 
@@ -303,6 +368,8 @@ and any remaining owner.
   cloud-live-webhook.yml     # manual/nightly live E2B webhook delivery smoke
   release-cloud-template.yml # public E2B cloud template build + publish + staging promote
   promote-cloud-template.yml # manual production promote for public E2B templates
+  nightly-release-train.yml  # scheduled release train, staging deploy, artifact release coordinator
+  hotfix-production.yml      # exact-surface production hotfix coordinator
   pr-metadata.yml            # PR title and release/area label validation
   release-desktop.yml        # desktop packaging, draft release, updater publish
   release-runtime.yml        # AnyHarness binary release + npm publish for @anyharness/sdk
@@ -323,7 +390,9 @@ server/
   deploy/                    # self-hosted production compose + update scripts
 scripts/
   ci-cd/
+    create-release-tags.mjs
     detect-deploy-surfaces.mjs
+    prepare-artifact-release.mjs
     resolve-deploy-base.mjs
   build-agent-seed.mjs
   generate-desktop-installer-manifest.mjs
@@ -338,6 +407,10 @@ vercel.json                  # web app deploy config (Vercel project proliferate
   surface. Do not update one without checking the others.
 - Desktop releases create/use the `desktop-v*` tag line. Runtime releases ship
   off the `runtime-v*` tag line.
+- Release trains use shared `release-YYYY-MM-DD` tags. Artifact versions remain
+  lane-specific: `desktop-v*`, `runtime-v*`, and `server-v*`.
+- Changelog generation and feature launch pages are separate product surfaces.
+  These workflows own deploy and artifact mechanics only.
 - Cloud template releases are manually dispatched. They publish immutable
   `sha-*` tags, then move rolling `staging` and `production` tags separately.
 - Desktop versioning must stay consistent across
@@ -436,6 +509,10 @@ CI, release infra, dependency bumps, codegen, logging, dev tooling, and cleanup.
 Use `release:skip` only when the PR should not appear in generated release
 notes.
 
+Artifact GitHub Releases may still use GitHub-generated notes for downloads,
+checksums, and PR-level history. Public feature changelog pages and raw release
+note generation are separate from this release/deploy automation.
+
 Before making `.github/workflows/pr-metadata.yml` required in branch
 protection, create the full `release:*` and `area:*` label set in GitHub.
 Example:
@@ -525,6 +602,8 @@ Flow:
    When the desktop surface is enabled and `DESKTOP_DEPLOY_ENABLED=true` for
    the target environment, the promote workflow derives `desktop-v<VERSION>`
    from the promoted SHA and calls `release-desktop.yml` directly.
+   Promote-sourced releases create the missing lightweight `desktop-v<VERSION>`
+   git tag before creating the draft GitHub Release.
 4. Low-level/manual path: from updated `main`, create and push a tag like
    `desktop-v0.1.0`. The tag-push workflow still triggers automatically and
    publishes updater/download assets after the build succeeds.
@@ -631,7 +710,7 @@ Useful local wrappers:
 make release-desktop-dry-run DESKTOP_RELEASE_REF=feat/my-branch
 
 # Draft GitHub release preview from an already-pushed desktop tag.
-# Creates a draft release with generated notes, but does not publish updater assets.
+# Creates a draft release, but does not publish updater assets.
 make release-desktop-draft DESKTOP_RELEASE_TAG=desktop-v0.1.28
 ```
 
@@ -801,6 +880,9 @@ Trigger model:
    trigger. Desktop still produces `desktop-v*` release tags, but production
    promote owns deriving and invoking that desktop release from the promoted
    SHA.
+6. `Nightly Release Train` and `Hotfix Production` sit above this hosted spine:
+   they prepare shared train/hotfix ids, bump artifact versions, and then call
+   the same reusable deploy lanes.
 
 Deploy graph:
 
@@ -823,8 +905,8 @@ Deploy graph:
    - `web`
    - `mobile`
    - `desktop`
-   - `runtime` as a detector-only advisory output for runtime-shaped changes;
-     hosted staging/production do not have a runtime deploy lane
+   - `runtime` for runtime-shaped artifact releases; hosted
+     staging/production do not have a runtime deploy lane
 3. Deploy changed surfaces:
    - E2B builds immutable `sha-*` tags for staging, then moves the rolling
      `staging` tag after smoke
@@ -842,12 +924,10 @@ Deploy graph:
 4. Upload a deploy summary artifact.
 
 Important: `force_surfaces` is additive. It forces listed surfaces to deploy in
-addition to any surfaces detected from the diff; it is not an "only these
-surfaces" filter. Do not use `force_surfaces=web` when the diff also detects
-mobile/E2B/server and the intent is web-only. Only mobile, desktop, and workers
-currently have environment gates. Server, web, and E2B have no skip gate; until
-an explicit `only_surfaces`/`skip_surfaces` input exists, do not dispatch a
-deploy whose detected server/web/E2B lanes must not run.
+addition to any surfaces detected from the diff. Use `only_surfaces` when the
+intent is exact, such as `only_surfaces=web` for a web-only hotfix. Only mobile,
+desktop, and workers currently have environment gates. Setting `only_surfaces`
+is the supported way to keep detected server/web/E2B lanes from running.
 
 Required GitHub environment vars/secrets:
 


### PR DESCRIPTION
## Summary
- add exact `only_surfaces` selection to staging and production promote workflows
- add nightly release train and production hotfix coordinators
- add artifact version/tag prep helpers for desktop/runtime/server
- update CI/CD docs for release trains, hotfixes, and changelog separation

## Verification
- `node --check scripts/ci-cd/create-release-tags.mjs scripts/ci-cd/detect-deploy-surfaces.mjs scripts/ci-cd/prepare-artifact-release.mjs scripts/ci-cd/resolve-deploy-base.mjs`
- `node --test scripts/ci-cd/*.test.mjs`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- production dry-run: https://github.com/proliferate-ai/proliferate/actions/runs/27051422562