### PR TITLE
refactor(mcp): purge legacy routes, headers, and deprecated tool params

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
@@ -9,9 +9,6 @@ use serde_json::Value;
 use super::access::assert_workspace_mutable;
 use super::error::ApiError;
 use crate::app::AppState;
-use crate::domains::sessions::mcp_bindings::product_registry::{
-    legacy_route_aliases, ProductMcpEndpointHandler,
-};
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDispatchError,
     ProductMcpEndpointOperation, ProductMcpRequestContext, PRODUCT_MCP_TOKEN_HEADER_NAME,
@@ -41,102 +38,6 @@ pub async fn post_product_mcp_endpoint(
     .await
 }
 
-pub async fn get_subagents_legacy_mcp_endpoint(
-    State(_state): State<AppState>,
-    Path((_workspace_id, _session_id)): Path<(String, String)>,
-) -> impl IntoResponse {
-    StatusCode::NO_CONTENT
-}
-
-pub async fn post_subagents_legacy_mcp_endpoint(
-    State(state): State<AppState>,
-    Path((workspace_id, session_id)): Path<(String, String)>,
-    headers: HeaderMap,
-    Json(body): Json<Value>,
-) -> Result<Response, ApiError> {
-    dispatch_product_mcp(
-        &state,
-        &workspace_id,
-        &session_id,
-        legacy_route_aliases::SUBAGENTS,
-        headers,
-        body,
-    )
-    .await
-}
-
-pub async fn get_reviews_legacy_mcp_endpoint(
-    State(_state): State<AppState>,
-    Path((_workspace_id, _session_id)): Path<(String, String)>,
-) -> impl IntoResponse {
-    StatusCode::NO_CONTENT
-}
-
-pub async fn post_reviews_legacy_mcp_endpoint(
-    State(state): State<AppState>,
-    Path((workspace_id, session_id)): Path<(String, String)>,
-    headers: HeaderMap,
-    Json(body): Json<Value>,
-) -> Result<Response, ApiError> {
-    dispatch_product_mcp(
-        &state,
-        &workspace_id,
-        &session_id,
-        legacy_route_aliases::REVIEWS,
-        headers,
-        body,
-    )
-    .await
-}
-
-pub async fn get_workspace_naming_legacy_mcp_endpoint(
-    State(_state): State<AppState>,
-    Path((_workspace_id, _session_id)): Path<(String, String)>,
-) -> impl IntoResponse {
-    StatusCode::NO_CONTENT
-}
-
-pub async fn post_workspace_naming_legacy_mcp_endpoint(
-    State(state): State<AppState>,
-    Path((workspace_id, session_id)): Path<(String, String)>,
-    headers: HeaderMap,
-    Json(body): Json<Value>,
-) -> Result<Response, ApiError> {
-    dispatch_product_mcp(
-        &state,
-        &workspace_id,
-        &session_id,
-        legacy_route_aliases::WORKSPACE_NAMING,
-        headers,
-        body,
-    )
-    .await
-}
-
-pub async fn get_cowork_legacy_mcp_endpoint(
-    State(_state): State<AppState>,
-    Path((_workspace_id, _session_id)): Path<(String, String)>,
-) -> impl IntoResponse {
-    StatusCode::NO_CONTENT
-}
-
-pub async fn post_cowork_legacy_mcp_endpoint(
-    State(state): State<AppState>,
-    Path((workspace_id, session_id)): Path<(String, String)>,
-    headers: HeaderMap,
-    Json(body): Json<Value>,
-) -> Result<Response, ApiError> {
-    dispatch_product_mcp(
-        &state,
-        &workspace_id,
-        &session_id,
-        legacy_route_aliases::COWORK,
-        headers,
-        body,
-    )
-    .await
-}
-
 pub async fn dispatch_product_mcp(
     state: &AppState,
     workspace_id: &str,
@@ -152,7 +53,7 @@ pub async fn dispatch_product_mcp(
     let definition = server.definition();
     let request = ProductMcpRequestContext::new(workspace_id, session_id, definition.id);
     let endpoint_operation = ProductMcpEndpointOperation::from_request_body(&body);
-    let auth_header = read_auth_header(server, &headers).ok_or_else(|| {
+    let auth_header = read_auth_header(&headers).ok_or_else(|| {
         ApiError::unauthorized(
             "Missing product MCP capability token.",
             definition.unauthorized_code,
@@ -208,23 +109,11 @@ fn map_dispatch_error(error: ProductMcpDispatchError, request_invalid_code: &str
     }
 }
 
-fn read_auth_header<'a>(
-    server: &dyn ProductMcpEndpointHandler,
-    headers: &'a HeaderMap,
-) -> Option<ProductMcpAuthHeader<'a>> {
-    if let Some(value) = headers
+fn read_auth_header(headers: &HeaderMap) -> Option<ProductMcpAuthHeader<'_>> {
+    headers
         .get(PRODUCT_MCP_TOKEN_HEADER_NAME)
         .and_then(|value| value.to_str().ok())
-    {
-        return Some(ProductMcpAuthHeader::Product { value });
-    }
-
-    server.legacy_header_names().iter().find_map(|name| {
-        headers
-            .get(*name)
-            .and_then(|value| value.to_str().ok())
-            .map(|value| ProductMcpAuthHeader::Legacy { name, value })
-    })
+        .map(|value| ProductMcpAuthHeader::Product { value })
 }
 
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/api/router.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router.rs
@@ -168,26 +168,6 @@ pub fn build_router(state: AppState) -> Router {
             get(cowork::get_cowork_artifact),
         )
         .route(
-            "/workspaces/{workspace_id}/cowork/sessions/{session_id}/mcp",
-            get(product_mcp::get_cowork_legacy_mcp_endpoint)
-                .post(product_mcp::post_cowork_legacy_mcp_endpoint),
-        )
-        .route(
-            "/workspaces/{workspace_id}/sessions/{session_id}/subagents/mcp",
-            get(product_mcp::get_subagents_legacy_mcp_endpoint)
-                .post(product_mcp::post_subagents_legacy_mcp_endpoint),
-        )
-        .route(
-            "/workspaces/{workspace_id}/sessions/{session_id}/reviews/mcp",
-            get(product_mcp::get_reviews_legacy_mcp_endpoint)
-                .post(product_mcp::post_reviews_legacy_mcp_endpoint),
-        )
-        .route(
-            "/workspaces/{workspace_id}/sessions/{session_id}/workspace-naming/mcp",
-            get(product_mcp::get_workspace_naming_legacy_mcp_endpoint)
-                .post(product_mcp::post_workspace_naming_legacy_mcp_endpoint),
-        )
-        .route(
             "/workspaces/{workspace_id}/sessions/{session_id}/mcp/{product_mcp_slug}",
             get(product_mcp::get_product_mcp_endpoint).post(product_mcp::post_product_mcp_endpoint),
         )

--- a/anyharness/crates/anyharness-lib/src/api/router_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router_tests.rs
@@ -27,7 +27,6 @@ use crate::{
     domains::terminals::model::{CreateTerminalOptions, TerminalPurpose},
     domains::{
         agents::seed::AgentSeedStore,
-        cowork::mcp::auth::{LEGACY_CAPABILITY_HEADER_NAME, SECRET_FILE_NAME},
         sessions::{model::SessionRecord, store::SessionStore},
         workspaces::{
             access_model::{WorkspaceAccessMode, WorkspaceAccessRecord},
@@ -35,7 +34,6 @@ use crate::{
         },
     },
     integrations::agent_cli::executable::make_executable,
-    integrations::mcp::capability_token::{McpCapabilityTokenIssuer, McpCapabilityTokenSignature},
     persistence::Db,
 };
 
@@ -392,81 +390,6 @@ async fn scoped_direct_attach_jwt_filters_workspaces_and_honors_revocation() {
         .await
         .expect("expected response");
     assert_eq!(revoked_response.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn legacy_cowork_mcp_route_uses_product_mcp_auth_errors() {
-    let _lock = test_support::ENV_MUTEX
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("expected env mutex");
-    let _guard = test_support::set_bearer_token_env(None);
-    let app = build_router(test_state(false));
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/workspaces/workspace-1/cowork/sessions/session-1/mcp")
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" }).to_string(),
-                ))
-                .expect("expected request"),
-        )
-        .await
-        .expect("expected response");
-
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    let body = to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("read response body");
-    let payload: Value = serde_json::from_slice(&body).expect("parse response json");
-    assert_eq!(payload["code"], "COWORK_MCP_UNAUTHORIZED");
-}
-
-#[tokio::test]
-async fn legacy_cowork_mcp_route_accepts_legacy_capability_token() {
-    let _lock = test_support::ENV_MUTEX
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("expected env mutex");
-    let _guard = test_support::set_bearer_token_env(None);
-    let state = test_state(false);
-    let legacy_token = McpCapabilityTokenIssuer::new(
-        state.runtime_home.clone(),
-        SECRET_FILE_NAME,
-        McpCapabilityTokenSignature::LegacySha256Dot,
-        60,
-    )
-    .mint_workspace_session_token("workspace-1", "session-1")
-    .expect("expected legacy token");
-    let app = build_router(state);
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/workspaces/workspace-1/cowork/sessions/session-1/mcp")
-                .header(header::CONTENT_TYPE, "application/json")
-                .header(LEGACY_CAPABILITY_HEADER_NAME, legacy_token)
-                .body(Body::from(
-                    json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" }).to_string(),
-                ))
-                .expect("expected request"),
-        )
-        .await
-        .expect("expected response");
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("read response body");
-    let payload: Value = serde_json::from_slice(&body).expect("parse response json");
-    assert_eq!(
-        payload["result"]["serverInfo"]["name"],
-        "proliferate-cowork"
-    );
 }
 
 #[tokio::test]

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -16,8 +16,7 @@ use crate::domains::sessions::mcp_bindings::product_launch::{
     ProductMcpLaunchRegistration, ProductMcpSelectionContext,
 };
 use crate::domains::sessions::mcp_bindings::product_registry::{
-    legacy_route_aliases, ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration,
-    ProductMcpEndpointRegistry,
+    ProductMcpEndpointHandlerAdapter, ProductMcpEndpointRegistration, ProductMcpEndpointRegistry,
 };
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::store::SessionStore;
@@ -174,52 +173,40 @@ pub(super) fn build_product_mcp_endpoint_registry(
     } = deps;
 
     let product_mcp_endpoint_registrations = vec![
-        ProductMcpEndpointRegistration::with_route_aliases(
-            Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(ReviewProductMcpServer::new(review_runtime, review_mcp_auth)),
-                Some(WorkspaceOperationKind::ReviewWrite),
-                review_mcp_tools::MUTATING_TOOL_NAMES,
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(ReviewProductMcpServer::new(review_runtime, review_mcp_auth)),
+            Some(WorkspaceOperationKind::ReviewWrite),
+            review_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(SubagentProductMcpServer::new(
+                subagent_service.clone(),
+                session_runtime,
+                workspace_runtime.clone(),
+                subagent_mcp_auth,
             )),
-            &[legacy_route_aliases::REVIEWS],
-        ),
-        ProductMcpEndpointRegistration::with_route_aliases(
-            Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(SubagentProductMcpServer::new(
-                    subagent_service.clone(),
-                    session_runtime,
-                    workspace_runtime.clone(),
-                    subagent_mcp_auth,
-                )),
-                Some(WorkspaceOperationKind::SubagentWrite),
-                subagent_mcp_tools::MUTATING_TOOL_NAMES,
+            Some(WorkspaceOperationKind::SubagentWrite),
+            subagent_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(WorkspaceNamingProductMcpServer::new(
+                workspace_runtime,
+                workspace_access_gate,
+                SessionStore::new(db),
+                workspace_naming_mcp_auth,
             )),
-            &[legacy_route_aliases::SUBAGENTS],
-        ),
-        ProductMcpEndpointRegistration::with_route_aliases(
-            Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(WorkspaceNamingProductMcpServer::new(
-                    workspace_runtime,
-                    workspace_access_gate,
-                    SessionStore::new(db),
-                    workspace_naming_mcp_auth,
-                )),
-                None,
-                &[],
+            None,
+            &[],
+        ))),
+        ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
+            Arc::new(CoworkProductMcpServer::new(
+                cowork_artifact_runtime,
+                cowork_runtime,
+                cowork_mcp_auth,
             )),
-            &[legacy_route_aliases::WORKSPACE_NAMING],
-        ),
-        ProductMcpEndpointRegistration::with_route_aliases(
-            Arc::new(ProductMcpEndpointHandlerAdapter::new(
-                Arc::new(CoworkProductMcpServer::new(
-                    cowork_artifact_runtime,
-                    cowork_runtime,
-                    cowork_mcp_auth,
-                )),
-                Some(WorkspaceOperationKind::CoworkWrite),
-                cowork_mcp_tools::MUTATING_TOOL_NAMES,
-            )),
-            &[legacy_route_aliases::COWORK],
-        ),
+            Some(WorkspaceOperationKind::CoworkWrite),
+            cowork_mcp_tools::MUTATING_TOOL_NAMES,
+        ))),
         ProductMcpEndpointRegistration::new(Arc::new(ProductMcpEndpointHandlerAdapter::new(
             Arc::new(SkillsProductMcpServer::new(
                 runtime_config_service,

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/auth.rs
@@ -6,7 +6,6 @@ use crate::integrations::mcp::product_server::{
 };
 
 pub(crate) const SECRET_FILE_NAME: &str = "cowork-mcp-token.key";
-pub const LEGACY_CAPABILITY_HEADER_NAME: &str = "x-cowork-session-token";
 
 #[derive(Clone)]
 pub struct CoworkMcpAuth {
@@ -16,16 +15,11 @@ pub struct CoworkMcpAuth {
 impl CoworkMcpAuth {
     pub fn new(runtime_home: PathBuf) -> Self {
         Self {
-            // Fresh generic-header tokens use the shared product HMAC envelope.
-            // The legacy cowork route still validates old SHA256-dot
-            // workspace/session tokens for already-running sessions.
             inner: ProductMcpAuth::new(
                 runtime_home,
                 SECRET_FILE_NAME,
                 McpCapabilityTokenSignature::HmacSha256,
-                McpCapabilityTokenSignature::LegacySha256Dot,
                 super::definition::DEFINITION.id,
-                LEGACY_CAPABILITY_HEADER_NAME,
             ),
         }
     }
@@ -50,7 +44,6 @@ impl CoworkMcpAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::integrations::mcp::capability_token::McpCapabilityTokenIssuer;
 
     fn runtime_home(test_name: &str) -> PathBuf {
         let path = std::env::temp_dir().join(format!(
@@ -62,7 +55,7 @@ mod tests {
     }
 
     #[test]
-    fn validates_product_and_legacy_tokens_without_cross_accepting_scopes() {
+    fn validates_product_token_and_rejects_wrong_scope() {
         let home = runtime_home("scope");
         let auth = CoworkMcpAuth::new(home.clone());
         let request = ProductMcpRequestContext::new("workspace-1", "session-1", "cowork");
@@ -80,46 +73,16 @@ mod tests {
             .expect("validate product token"),
             ProductMcpTokenValidation::Valid,
         );
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Legacy {
-                    name: LEGACY_CAPABILITY_HEADER_NAME,
-                    value: &product_token,
-                },
-                &request,
-            )
-            .expect("reject product token in legacy header"),
-            ProductMcpTokenValidation::Invalid,
-        );
 
-        let legacy_issuer = McpCapabilityTokenIssuer::new(
-            home.clone(),
-            SECRET_FILE_NAME,
-            McpCapabilityTokenSignature::LegacySha256Dot,
-            60,
-        );
-        let legacy_token = legacy_issuer
-            .mint_workspace_session_token("workspace-1", "session-1")
-            .expect("mint legacy token");
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Legacy {
-                    name: LEGACY_CAPABILITY_HEADER_NAME,
-                    value: &legacy_token,
-                },
-                &request,
-            )
-            .expect("validate legacy token"),
-            ProductMcpTokenValidation::Valid,
-        );
+        let wrong_scope = ProductMcpRequestContext::new("workspace-1", "session-1", "subagents");
         assert_eq!(
             auth.validate_capability_header(
                 ProductMcpAuthHeader::Product {
-                    value: &legacy_token,
+                    value: &product_token,
                 },
-                &request,
+                &wrong_scope,
             )
-            .expect("reject legacy token in product header"),
+            .expect("reject wrong scope"),
             ProductMcpTokenValidation::Invalid,
         );
 

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/calls.rs
@@ -3,8 +3,7 @@ use serde_json::{json, Value};
 use super::calls_helpers::{
     coding_session_workspace_id, cowork_agent_search_response_json,
     cowork_agent_turns_response_json, initial_config_string, launch_agents_to_json,
-    mode_options_to_json, non_empty, prompt_outcome_label, recommended_modes_by_agent_kind_json,
-    resolve_preferred_string,
+    mode_options_to_json, prompt_outcome_label, recommended_modes_by_agent_kind_json,
 };
 use super::context::CoworkMcpContext;
 use super::tools::{
@@ -284,11 +283,10 @@ fn get_coding_session_launch_options(
     let parent = cowork_runtime
         .session_record(parent_session_id)?
         .ok_or_else(|| anyhow::anyhow!("parent session not found"))?;
-    let workspace_id_arg = non_empty(args.workspace_id);
     let managed = cowork_runtime.resolve_managed_coding_workspace(
         parent_session_id,
         args.cowork_workspace_id.as_deref(),
-        workspace_id_arg.as_deref(),
+        None,
     )?;
     let live_config = cowork_runtime.live_config_snapshot(parent_session_id)?;
     let live_mode_control = live_config
@@ -344,31 +342,13 @@ async fn create_coding_session(
     let managed = cowork_runtime.resolve_managed_coding_workspace(
         parent_session_id,
         args.cowork_workspace_id.as_deref(),
-        args.workspace_id.as_deref(),
+        None,
     )?;
     let workspace_id = managed.workspace_id.clone();
     let cowork_workspace_id = managed.public_id.clone();
-    let harness_id = resolve_preferred_string(
-        args.harness_id.as_deref(),
-        args.agent_kind.as_deref(),
-        "harnessId",
-        "agentKind",
-    )?;
-    let config_model_id =
-        initial_config_string(args.initial_config.as_ref(), &["modelId", "model"]);
-    let config_mode_id = initial_config_string(args.initial_config.as_ref(), &["modeId", "mode"]);
-    let model_id = resolve_preferred_string(
-        config_model_id.as_deref(),
-        args.model_id.as_deref(),
-        "initialConfig.modelId",
-        "modelId",
-    )?;
-    let mode_id = resolve_preferred_string(
-        config_mode_id.as_deref(),
-        args.mode_id.as_deref(),
-        "initialConfig.modeId",
-        "modeId",
-    )?;
+    let harness_id = args.harness_id;
+    let model_id = initial_config_string(args.initial_config.as_ref(), &["modelId", "model"]);
+    let mode_id = initial_config_string(args.initial_config.as_ref(), &["modeId", "mode"]);
     let result = cowork_runtime
         .create_coding_session(
             parent_session_id,
@@ -428,7 +408,7 @@ async fn send_coding_message(
     let link = cowork_runtime.resolve_coding_session_target(
         parent_session_id,
         args.cowork_agent_id.as_deref(),
-        args.coding_session_id.as_deref(),
+        None,
     )?;
     let workspace_id = coding_session_workspace_id(cowork_runtime, &link.child_session_id)?;
     let outcome = cowork_runtime
@@ -466,7 +446,7 @@ fn schedule_coding_wake(
     let (link, created) = cowork_runtime.schedule_coding_wake_for_target(
         parent_session_id,
         args.cowork_agent_id.as_deref(),
-        args.coding_session_id.as_deref(),
+        None,
     )?;
     let workspace_id = coding_session_workspace_id(cowork_runtime, &link.child_session_id)?;
     Ok(json!({
@@ -490,7 +470,7 @@ async fn get_coding_status(
         .coding_status_for_target(
             parent_session_id,
             args.cowork_agent_id.as_deref(),
-            args.coding_session_id.as_deref(),
+            None,
         )
         .await?;
     Ok(json!({
@@ -525,7 +505,7 @@ fn read_coding_events(
     let slice = cowork_runtime.read_coding_events_for_target(
         parent_session_id,
         args.cowork_agent_id.as_deref(),
-        args.coding_session_id.as_deref(),
+        None,
         args.since_seq,
         args.limit,
     )?;
@@ -545,7 +525,7 @@ fn read_cowork_agent_latest_turns(
     let (link, turns) = cowork_runtime.read_coding_latest_turns_for_target(
         parent_session_id,
         args.cowork_agent_id.as_deref(),
-        args.coding_session_id.as_deref(),
+        None,
         args.limit,
     )?;
     Ok(cowork_agent_turns_response_json(&link, turns))
@@ -559,7 +539,7 @@ fn search_cowork_agent_transcript(
     let (link, matches) = cowork_runtime.search_coding_transcript_for_target(
         parent_session_id,
         args.cowork_agent_id.as_deref(),
-        args.coding_session_id.as_deref(),
+        None,
         &args.query,
         args.limit,
     )?;
@@ -577,7 +557,7 @@ async fn close_cowork_agent(
         .close_coding_session_for_target(
             parent_session_id,
             args.cowork_agent_id.as_deref(),
-            args.coding_session_id.as_deref(),
+            None,
         )
         .await?;
     Ok(json!({

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/calls_helpers.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/calls_helpers.rs
@@ -75,31 +75,6 @@ pub(super) fn initial_config_string(config: Option<&Value>, keys: &[&str]) -> Op
     })
 }
 
-pub(super) fn resolve_preferred_string(
-    preferred: Option<&str>,
-    legacy: Option<&str>,
-    preferred_name: &str,
-    legacy_name: &str,
-) -> anyhow::Result<Option<String>> {
-    let preferred = preferred.map(str::trim).filter(|value| !value.is_empty());
-    let legacy = legacy.map(str::trim).filter(|value| !value.is_empty());
-    if let (Some(left), Some(right)) = (preferred, legacy) {
-        if left != right {
-            anyhow::bail!("{preferred_name} conflicts with deprecated {legacy_name}");
-        }
-    }
-    Ok(preferred.or(legacy).map(ToString::to_string))
-}
-
-pub(super) fn non_empty(value: String) -> Option<String> {
-    let value = value.trim().to_string();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
-}
-
 pub(super) fn coding_session_workspace_id(
     cowork_runtime: &CoworkRuntime,
     coding_session_id: &str,

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use self::auth::{CoworkMcpAuth, LEGACY_CAPABILITY_HEADER_NAME};
+use self::auth::CoworkMcpAuth;
 use self::context::CoworkMcpContext;
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::runtime::CoworkRuntime;
@@ -50,10 +50,6 @@ impl ProductMcpServer for CoworkProductMcpServer {
 
     fn definition(&self) -> &'static ProductMcpDefinition {
         &definition::DEFINITION
-    }
-
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        &[LEGACY_CAPABILITY_HEADER_NAME]
     }
 
     fn validate_capability_token(

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools.rs
@@ -278,7 +278,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkWorkspaceId": { "type": "string" }
+                    "coworkWorkspaceId": { "type": "string", "description": "Stable cowork workspace target id." }
                 }
             }),
         ),
@@ -288,7 +288,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkWorkspaceId": { "type": "string" },
+                    "coworkWorkspaceId": { "type": "string", "description": "Stable cowork workspace target id." },
                     "prompt": { "type": "string" },
                     "label": { "type": "string" },
                     "harnessId": { "type": "string" },
@@ -311,7 +311,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" },
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." },
                     "prompt": { "type": "string" },
                     "wakeOnCompletion": { "type": "boolean" }
                 },
@@ -324,7 +324,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" }
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." }
                 }
             }),
         ),
@@ -334,7 +334,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" }
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." }
                 }
             }),
         ),
@@ -344,7 +344,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" },
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." },
                     "sinceSeq": { "type": "integer" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 100 }
                 }
@@ -356,7 +356,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" },
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 10 }
                 }
             }),
@@ -367,7 +367,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" },
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." },
                     "query": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 25 }
                 },
@@ -380,7 +380,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string" }
+                    "coworkAgentId": { "type": "string", "description": "Stable cowork agent target id." }
                 }
             }),
         ),

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools.rs
@@ -83,8 +83,6 @@ pub(super) struct CreateCodingWorkspaceArgs {
 pub(super) struct CodingWorkspaceArgs {
     #[serde(default)]
     pub cowork_workspace_id: Option<String>,
-    #[serde(default)]
-    pub workspace_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -92,8 +90,6 @@ pub(super) struct CodingWorkspaceArgs {
 pub(super) struct CreateCodingSessionArgs {
     #[serde(default)]
     pub cowork_workspace_id: Option<String>,
-    #[serde(default)]
-    pub workspace_id: Option<String>,
     pub prompt: String,
     #[serde(default)]
     pub label: Option<String>,
@@ -101,12 +97,6 @@ pub(super) struct CreateCodingSessionArgs {
     pub harness_id: Option<String>,
     #[serde(default)]
     pub initial_config: Option<Value>,
-    #[serde(default)]
-    pub agent_kind: Option<String>,
-    #[serde(default)]
-    pub model_id: Option<String>,
-    #[serde(default)]
-    pub mode_id: Option<String>,
     #[serde(default)]
     pub wake_on_completion: bool,
 }
@@ -116,8 +106,6 @@ pub(super) struct CreateCodingSessionArgs {
 pub(super) struct CodingSessionArgs {
     #[serde(default)]
     pub cowork_agent_id: Option<String>,
-    #[serde(default)]
-    pub coding_session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -125,8 +113,6 @@ pub(super) struct CodingSessionArgs {
 pub(super) struct SendCodingMessageArgs {
     #[serde(default)]
     pub cowork_agent_id: Option<String>,
-    #[serde(default)]
-    pub coding_session_id: Option<String>,
     pub prompt: String,
     #[serde(default)]
     pub wake_on_completion: bool,
@@ -137,8 +123,6 @@ pub(super) struct SendCodingMessageArgs {
 pub(super) struct ReadCodingEventsArgs {
     #[serde(default)]
     pub cowork_agent_id: Option<String>,
-    #[serde(default)]
-    pub coding_session_id: Option<String>,
     #[serde(default)]
     pub since_seq: Option<i64>,
     #[serde(default)]
@@ -151,8 +135,6 @@ pub(super) struct ReadCodingLatestTurnsArgs {
     #[serde(default)]
     pub cowork_agent_id: Option<String>,
     #[serde(default)]
-    pub coding_session_id: Option<String>,
-    #[serde(default)]
     pub limit: Option<usize>,
 }
 
@@ -161,8 +143,6 @@ pub(super) struct ReadCodingLatestTurnsArgs {
 pub(super) struct SearchCodingTranscriptArgs {
     #[serde(default)]
     pub cowork_agent_id: Option<String>,
-    #[serde(default)]
-    pub coding_session_id: Option<String>,
     pub query: String,
     #[serde(default)]
     pub limit: Option<usize>,
@@ -298,8 +278,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkWorkspaceId": { "type": "string", "description": "Preferred stable cowork workspace target. Provide either coworkWorkspaceId or deprecated workspaceId." },
-                    "workspaceId": { "type": "string", "description": "Deprecated legacy target." }
+                    "coworkWorkspaceId": { "type": "string" }
                 }
             }),
         ),
@@ -309,8 +288,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkWorkspaceId": { "type": "string", "description": "Preferred stable cowork workspace target. Provide either coworkWorkspaceId or deprecated workspaceId." },
-                    "workspaceId": { "type": "string", "description": "Deprecated legacy target." },
+                    "coworkWorkspaceId": { "type": "string" },
                     "prompt": { "type": "string" },
                     "label": { "type": "string" },
                     "harnessId": { "type": "string" },
@@ -322,9 +300,6 @@ fn delegation_tool_definitions() -> Vec<Value> {
                             "modeId": { "type": "string" }
                         }
                     },
-                    "agentKind": { "type": "string", "description": "Deprecated alias for harnessId." },
-                    "modelId": { "type": "string", "description": "Deprecated alias for initialConfig.modelId." },
-                    "modeId": { "type": "string", "description": "Deprecated alias for initialConfig.modeId." },
                     "wakeOnCompletion": { "type": "boolean" }
                 },
                 "required": ["prompt"]
@@ -336,8 +311,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "coworkAgentId": { "type": "string" },
                     "prompt": { "type": "string" },
                     "wakeOnCompletion": { "type": "boolean" }
                 },
@@ -350,8 +324,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "coworkAgentId": { "type": "string" }
                 }
             }),
         ),
@@ -361,8 +334,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "coworkAgentId": { "type": "string" }
                 }
             }),
         ),
@@ -372,8 +344,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "coworkAgentId": { "type": "string" },
                     "sinceSeq": { "type": "integer" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 100 }
                 }
@@ -385,8 +356,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "coworkAgentId": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 10 }
                 }
             }),
@@ -397,8 +367,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "coworkAgentId": { "type": "string" },
                     "query": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 25 }
                 },
@@ -411,8 +380,7 @@ fn delegation_tool_definitions() -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "coworkAgentId": { "type": "string", "description": "Preferred stable cowork agent target. Provide either coworkAgentId or deprecated codingSessionId." },
-                    "codingSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "coworkAgentId": { "type": "string" }
                 }
             }),
         ),

--- a/anyharness/crates/anyharness-lib/src/domains/plugins/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plugins/mcp/auth.rs
@@ -19,9 +19,7 @@ impl SkillsMcpAuth {
                 runtime_home,
                 SECRET_FILE_NAME,
                 McpCapabilityTokenSignature::HmacSha256,
-                McpCapabilityTokenSignature::HmacSha256,
                 super::definition::DEFINITION.id,
-                "x-proliferate-skills-session-token",
             ),
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/auth.rs
@@ -6,7 +6,6 @@ use crate::integrations::mcp::product_server::{
 };
 
 const SECRET_FILE_NAME: &str = "review-mcp-token.key";
-pub const LEGACY_CAPABILITY_HEADER_NAME: &str = "x-review-session-token";
 
 #[derive(Clone)]
 pub struct ReviewMcpAuth {
@@ -20,9 +19,7 @@ impl ReviewMcpAuth {
                 runtime_home,
                 SECRET_FILE_NAME,
                 McpCapabilityTokenSignature::HmacSha256,
-                McpCapabilityTokenSignature::HmacSha256,
                 super::definition::DEFINITION.id,
-                LEGACY_CAPABILITY_HEADER_NAME,
             ),
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/calls.rs
@@ -51,7 +51,11 @@ pub async fn call_tool(
             "mark_review_revision_ready",
         ) => {
             let args: MarkReviewRevisionReadyArgs = deserialize_args(arguments)?;
-            let review_id = resolve_review_id(args.review_id, args.review_run_id)?;
+            let review_id = args
+                .review_id
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("reviewId is required"))?;
             runtime
                 .mark_revision_ready_from_parent_tool(
                     &ctx.session_id,
@@ -66,7 +70,10 @@ pub async fn call_tool(
         }
         (ReviewMcpRole::Parent { .. }, "get_review_status") => {
             let args: GetReviewStatusArgs = deserialize_args(arguments)?;
-            let review_id = optional_review_id(args.review_id, args.review_run_id)?;
+            let review_id = args
+                .review_id
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
             runtime
                 .service()
                 .list_session_reviews(&ctx.session_id)
@@ -86,32 +93,6 @@ pub async fn call_tool(
         }
         (_, tool_name) => Err(anyhow::anyhow!("unknown tool for review role: {tool_name}")),
     }
-}
-
-fn optional_review_id(
-    review_id: Option<String>,
-    review_run_id: Option<String>,
-) -> anyhow::Result<Option<String>> {
-    let review_id = review_id
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-    let review_run_id = review_run_id
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-    if let (Some(current), Some(legacy)) = (review_id.as_deref(), review_run_id.as_deref()) {
-        if current != legacy {
-            anyhow::bail!("reviewId conflicts with deprecated reviewRunId");
-        }
-    }
-    Ok(review_id.or(review_run_id))
-}
-
-fn resolve_review_id(
-    review_id: Option<String>,
-    review_run_id: Option<String>,
-) -> anyhow::Result<String> {
-    optional_review_id(review_id, review_run_id)?
-        .ok_or_else(|| anyhow::anyhow!("reviewId is required"))
 }
 
 fn review_status_json(review: anyharness_contract::v1::ReviewRunDetail) -> Value {

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use self::auth::{ReviewMcpAuth, LEGACY_CAPABILITY_HEADER_NAME};
+use self::auth::ReviewMcpAuth;
 use self::context::ReviewMcpContext;
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::integrations::mcp::product_server::{
@@ -35,10 +35,6 @@ impl ProductMcpServer for ReviewProductMcpServer {
 
     fn definition(&self) -> &'static ProductMcpDefinition {
         &definition::DEFINITION
-    }
-
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        &[LEGACY_CAPABILITY_HEADER_NAME]
     }
 
     fn validate_capability_token(

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/tools.rs
@@ -57,7 +57,7 @@ pub fn parent_tool_list(can_signal_revision: bool) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "reviewId": { "type": "string" },
+                    "reviewId": { "type": "string", "description": "Stable review target id." },
                     "revisedPlanId": { "type": "string" }
                 }
             }),
@@ -69,7 +69,7 @@ pub fn parent_tool_list(can_signal_revision: bool) -> Vec<Value> {
         json!({
             "type": "object",
             "properties": {
-                "reviewId": { "type": "string" }
+                "reviewId": { "type": "string", "description": "Stable review target id." }
             }
         }),
     ));

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/tools.rs
@@ -19,8 +19,6 @@ pub struct MarkReviewRevisionReadyArgs {
     #[serde(default)]
     pub review_id: Option<String>,
     #[serde(default)]
-    pub review_run_id: Option<String>,
-    #[serde(default)]
     pub revised_plan_id: Option<String>,
 }
 
@@ -29,8 +27,6 @@ pub struct MarkReviewRevisionReadyArgs {
 pub struct GetReviewStatusArgs {
     #[serde(default)]
     pub review_id: Option<String>,
-    #[serde(default)]
-    pub review_run_id: Option<String>,
 }
 
 pub fn reviewer_tool_list() -> Vec<Value> {
@@ -57,12 +53,11 @@ pub fn parent_tool_list(can_signal_revision: bool) -> Vec<Value> {
     if can_signal_revision {
         tools.push(tool_definition(
             "mark_review_revision_ready",
-            "Signal that the reviewed plan or implementation has been revised and is ready for the next review round. reviewId is required unless using the deprecated reviewRunId alias.",
+            "Signal that the reviewed plan or implementation has been revised and is ready for the next review round.",
             json!({
                 "type": "object",
                 "properties": {
-                    "reviewId": { "type": "string", "description": "Preferred stable review target. Provide either reviewId or deprecated reviewRunId." },
-                    "reviewRunId": { "type": "string", "description": "Deprecated alias for reviewId." },
+                    "reviewId": { "type": "string" },
                     "revisedPlanId": { "type": "string" }
                 }
             }),
@@ -70,12 +65,11 @@ pub fn parent_tool_list(can_signal_revision: bool) -> Vec<Value> {
     }
     tools.push(tool_definition(
         "get_review_status",
-        "Get active review status for this parent session. Optionally filter by reviewId; reviewRunId is a deprecated alias.",
+        "Get active review status for this parent session. Optionally filter by reviewId.",
         json!({
             "type": "object",
             "properties": {
-                "reviewId": { "type": "string" },
-                "reviewRunId": { "type": "string", "description": "Deprecated alias for reviewId." }
+                "reviewId": { "type": "string" }
             }
         }),
     ));

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_catalog.rs
@@ -168,7 +168,6 @@ mod tests {
     use std::sync::Arc;
 
     use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
-    use crate::domains::sessions::workspace_naming::mcp::auth::LEGACY_CAPABILITY_HEADER_NAME;
     use crate::domains::workspaces::model::{
         WorkspaceCleanupState, WorkspaceKind, WorkspaceLifecycleState, WorkspaceRecord,
         WorkspaceSurface,
@@ -381,9 +380,5 @@ mod tests {
             .headers
             .iter()
             .any(|header| header.name == PRODUCT_MCP_TOKEN_HEADER_NAME));
-        assert!(!server
-            .headers
-            .iter()
-            .any(|header| header.name == LEGACY_CAPABILITY_HEADER_NAME));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_registry.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_registry.rs
@@ -11,13 +11,6 @@ use crate::integrations::mcp::product_server::{
     ProductMcpServer, ProductMcpTokenValidation,
 };
 
-pub mod legacy_route_aliases {
-    pub const COWORK: &str = "legacy:cowork";
-    pub const REVIEWS: &str = "legacy:reviews";
-    pub const SUBAGENTS: &str = "legacy:subagents";
-    pub const WORKSPACE_NAMING: &str = "legacy:workspace_naming";
-}
-
 #[async_trait]
 pub trait ProductMcpEndpointHandler: Send + Sync {
     fn definition(&self) -> &'static ProductMcpDefinition;
@@ -26,8 +19,6 @@ pub trait ProductMcpEndpointHandler: Send + Sync {
         &self,
         operation: ProductMcpEndpointOperation,
     ) -> Option<WorkspaceOperationKind>;
-
-    fn legacy_header_names(&self) -> &'static [&'static str];
 
     fn validate_capability_token(
         &self,
@@ -45,25 +36,11 @@ pub trait ProductMcpEndpointHandler: Send + Sync {
 #[derive(Clone)]
 pub struct ProductMcpEndpointRegistration {
     handler: Arc<dyn ProductMcpEndpointHandler>,
-    route_aliases: &'static [&'static str],
 }
 
 impl ProductMcpEndpointRegistration {
     pub fn new(handler: Arc<dyn ProductMcpEndpointHandler>) -> Self {
-        Self {
-            handler,
-            route_aliases: &[],
-        }
-    }
-
-    pub fn with_route_aliases(
-        handler: Arc<dyn ProductMcpEndpointHandler>,
-        route_aliases: &'static [&'static str],
-    ) -> Self {
-        Self {
-            handler,
-            route_aliases,
-        }
+        Self { handler }
     }
 }
 
@@ -113,10 +90,6 @@ where
         }
     }
 
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        self.server.legacy_header_names()
-    }
-
     fn validate_capability_token(
         &self,
         header: ProductMcpAuthHeader<'_>,
@@ -159,14 +132,6 @@ impl ProductMcpEndpointRegistry {
                 registration.handler.clone(),
                 "product MCP route slug",
             )?;
-            for alias in registration.route_aliases {
-                insert_unique(
-                    &mut by_slug,
-                    alias,
-                    registration.handler.clone(),
-                    "product MCP route alias",
-                )?;
-            }
         }
 
         Ok(Self {
@@ -231,20 +196,6 @@ mod tests {
 
     static TEST_DEFINITION_DUPLICATE_ID: ProductMcpDefinition = ProductMcpDefinition {
         id: "test_a",
-        route_slug: "test-b",
-        acp_server_name: "test_b",
-        server_info_name: "proliferate-test-b",
-        display_name: "Test B",
-        description: "Test B",
-        visibility: ProductMcpVisibility::Internal,
-        instructions: "Test B",
-        unauthorized_code: "TEST_B_UNAUTHORIZED",
-        request_invalid_code: "TEST_B_INVALID",
-        prompt_policy: ProductMcpPromptPolicy::System,
-    };
-
-    static TEST_DEFINITION_B: ProductMcpDefinition = ProductMcpDefinition {
-        id: "test_b",
         route_slug: "test-b",
         acp_server_name: "test_b",
         server_info_name: "proliferate-test-b",
@@ -326,10 +277,6 @@ mod tests {
             None
         }
 
-        fn legacy_header_names(&self) -> &'static [&'static str] {
-            &[]
-        }
-
         fn validate_capability_token(
             &self,
             _header: ProductMcpAuthHeader<'_>,
@@ -386,24 +333,6 @@ mod tests {
     }
 
     #[test]
-    fn registry_indexes_route_aliases_to_the_registered_handler() {
-        let handler = Arc::new(TestEndpointHandler(&TEST_DEFINITION_A));
-        let registry = ProductMcpEndpointRegistry::new(vec![
-            ProductMcpEndpointRegistration::with_route_aliases(handler, &["legacy:test-a"]),
-        ])
-        .expect("registry");
-
-        assert_eq!(
-            registry
-                .get_by_route_slug("legacy:test-a")
-                .expect("alias")
-                .definition()
-                .id,
-            "test_a"
-        );
-    }
-
-    #[test]
     fn registry_rejects_duplicate_product_ids() {
         let error = ProductMcpEndpointRegistry::new(vec![
             ProductMcpEndpointRegistration::new(Arc::new(TestEndpointHandler(&TEST_DEFINITION_A))),
@@ -431,25 +360,5 @@ mod tests {
         assert!(error
             .to_string()
             .contains("duplicate product MCP route slug"));
-    }
-
-    #[test]
-    fn registry_rejects_route_alias_collisions() {
-        let error = ProductMcpEndpointRegistry::new(vec![
-            ProductMcpEndpointRegistration::with_route_aliases(
-                Arc::new(TestEndpointHandler(&TEST_DEFINITION_A)),
-                &["alias"],
-            ),
-            ProductMcpEndpointRegistration::with_route_aliases(
-                Arc::new(TestEndpointHandler(&TEST_DEFINITION_B)),
-                &["alias"],
-            ),
-        ])
-        .err()
-        .expect("duplicate route alias should fail");
-
-        assert!(error
-            .to_string()
-            .contains("duplicate product MCP route alias"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/auth.rs
@@ -6,7 +6,6 @@ use crate::integrations::mcp::product_server::{
 };
 
 const SECRET_FILE_NAME: &str = "subagent-mcp-token.key";
-pub const LEGACY_CAPABILITY_HEADER_NAME: &str = "x-subagent-session-token";
 
 #[derive(Clone)]
 pub struct SubagentMcpAuth {
@@ -16,16 +15,11 @@ pub struct SubagentMcpAuth {
 impl SubagentMcpAuth {
     pub fn new(runtime_home: PathBuf) -> Self {
         Self {
-            // Fresh generic-header tokens use the shared product HMAC envelope.
-            // The legacy header still validates old SHA256-dot workspace/session
-            // tokens for already-running sessions.
             inner: ProductMcpAuth::new(
                 runtime_home,
                 SECRET_FILE_NAME,
                 McpCapabilityTokenSignature::HmacSha256,
-                McpCapabilityTokenSignature::LegacySha256Dot,
                 super::definition::DEFINITION.id,
-                LEGACY_CAPABILITY_HEADER_NAME,
             ),
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use super::super::service::SubagentService;
 use super::calls_helpers::{
     default_model_for_agent, initial_config_string, launch_agents_to_json, mode_options_to_json,
-    prompt_outcome_label, resolve_preferred_string, summaries_to_json,
+    prompt_outcome_label, summaries_to_json,
 };
 use super::context::SubagentMcpContext;
 use super::tools::{
@@ -52,7 +52,7 @@ pub async fn call_tool(
                 .read_subagent_events(
                     &ctx.parent_session_id,
                     args.subagent_id.as_deref(),
-                    args.child_session_id.as_deref(),
+                    None,
                     args.since_seq,
                     args.limit,
                 )
@@ -71,7 +71,7 @@ pub async fn call_tool(
             let link = service.resolve_target_including_closed(
                 &ctx.parent_session_id,
                 args.subagent_id.as_deref(),
-                args.child_session_id.as_deref(),
+                None,
             )?;
             service
                 .read_latest_turns(
@@ -104,7 +104,7 @@ pub async fn call_tool(
             let link = service.resolve_target_including_closed(
                 &ctx.parent_session_id,
                 args.subagent_id.as_deref(),
-                args.child_session_id.as_deref(),
+                None,
             )?;
             service
                 .search_transcript(
@@ -236,32 +236,15 @@ async fn create_subagent(
     if prompt.trim().is_empty() {
         anyhow::bail!("prompt is required");
     }
-    let harness_id = resolve_preferred_string(
-        args.harness_id.as_deref(),
-        args.agent_kind.as_deref(),
-        "harnessId",
-        "agentKind",
-    )?;
-    let agent_kind = harness_id.unwrap_or_else(|| parent.agent_kind.clone());
-    let config_model_id =
-        initial_config_string(args.initial_config.as_ref(), &["modelId", "model"]);
-    let config_mode_id = initial_config_string(args.initial_config.as_ref(), &["modeId", "mode"]);
-    let model_id = resolve_preferred_string(
-        config_model_id.as_deref(),
-        args.model_id.as_deref(),
-        "initialConfig.modelId",
-        "modelId",
-    )?
-    .or(parent.current_model_id.clone())
-    .or(parent.requested_model_id.clone());
-    let mode_id = resolve_preferred_string(
-        config_mode_id.as_deref(),
-        args.mode_id.as_deref(),
-        "initialConfig.modeId",
-        "modeId",
-    )?
-    .or(parent.current_mode_id.clone())
-    .or(parent.requested_mode_id.clone());
+    let agent_kind = args
+        .harness_id
+        .unwrap_or_else(|| parent.agent_kind.clone());
+    let model_id = initial_config_string(args.initial_config.as_ref(), &["modelId", "model"])
+        .or(parent.current_model_id.clone())
+        .or(parent.requested_model_id.clone());
+    let mode_id = initial_config_string(args.initial_config.as_ref(), &["modeId", "mode"])
+        .or(parent.current_mode_id.clone())
+        .or(parent.requested_mode_id.clone());
     let label = args
         .label
         .map(|value| value.trim().to_string())
@@ -399,14 +382,14 @@ async fn send_subagent_message(
     let link = service.authorize_target(
         parent_session_id,
         args.subagent_id.as_deref(),
-        args.child_session_id.as_deref(),
+        None,
     )?;
     let wake_scheduled = if args.wake_on_completion {
         service
             .schedule_wake_for_target(
                 parent_session_id,
                 args.subagent_id.as_deref(),
-                args.child_session_id.as_deref(),
+                None,
             )?
             .1
     } else {
@@ -456,7 +439,7 @@ fn schedule_subagent_wake(
     let (link, inserted) = service.schedule_wake_for_target(
         parent_session_id,
         args.subagent_id.as_deref(),
-        args.child_session_id.as_deref(),
+        None,
     )?;
     Ok(json!({
         "subagentId": link.public_id,
@@ -478,7 +461,7 @@ async fn get_subagent_status(
     let link = service.resolve_target_including_closed(
         parent_session_id,
         args.subagent_id.as_deref(),
-        args.child_session_id.as_deref(),
+        None,
     )?;
     let session = service
         .session_store()
@@ -507,7 +490,7 @@ async fn close_subagent(
     let link = service.resolve_target_including_closed(
         parent_session_id,
         args.subagent_id.as_deref(),
-        args.child_session_id.as_deref(),
+        None,
     )?;
     let already_closed = link.closed_at.is_some();
     let now = chrono::Utc::now().to_rfc3339();
@@ -525,7 +508,7 @@ async fn close_subagent(
     let refreshed = service.resolve_target_including_closed(
         parent_session_id,
         args.subagent_id.as_deref(),
-        args.child_session_id.as_deref(),
+        None,
     )?;
     Ok(json!({
         "subagentId": refreshed.public_id,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls_helpers.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls_helpers.rs
@@ -94,22 +94,6 @@ pub(super) fn initial_config_string(config: Option<&Value>, keys: &[&str]) -> Op
     })
 }
 
-pub(super) fn resolve_preferred_string(
-    preferred: Option<&str>,
-    legacy: Option<&str>,
-    preferred_name: &str,
-    legacy_name: &str,
-) -> anyhow::Result<Option<String>> {
-    let preferred = preferred.map(str::trim).filter(|value| !value.is_empty());
-    let legacy = legacy.map(str::trim).filter(|value| !value.is_empty());
-    if let (Some(left), Some(right)) = (preferred, legacy) {
-        if left != right {
-            anyhow::bail!("{preferred_name} conflicts with deprecated {legacy_name}");
-        }
-    }
-    Ok(preferred.or(legacy).map(ToString::to_string))
-}
-
 pub(super) fn prompt_outcome_label(outcome: &SendPromptOutcome) -> &'static str {
     match outcome {
         SendPromptOutcome::Running { .. } => "running",

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use self::auth::{SubagentMcpAuth, LEGACY_CAPABILITY_HEADER_NAME};
+use self::auth::SubagentMcpAuth;
 use self::context::SubagentMcpContext;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::subagents::service::SubagentService;
@@ -50,10 +50,6 @@ impl ProductMcpServer for SubagentProductMcpServer {
 
     fn definition(&self) -> &'static ProductMcpDefinition {
         &definition::DEFINITION
-    }
-
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        &[LEGACY_CAPABILITY_HEADER_NAME]
     }
 
     fn validate_capability_token(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/tools.rs
@@ -122,7 +122,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" },
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." },
                     "prompt": { "type": "string" },
                     "wakeOnCompletion": { "type": "boolean" }
                 },
@@ -135,7 +135,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" }
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." }
                 }
             }),
         ),
@@ -145,7 +145,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" }
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." }
                 }
             }),
         ),
@@ -155,7 +155,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" },
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 10 }
                 }
             }),
@@ -166,7 +166,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" },
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." },
                     "query": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 25 }
                 },
@@ -179,7 +179,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" },
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." },
                     "sinceSeq": { "type": "integer" },
                     "limit": {
                         "type": "integer",
@@ -195,7 +195,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string" }
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." }
                 }
             }),
         ),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/tools.rs
@@ -23,12 +23,6 @@ pub struct CreateSubagentArgs {
     #[serde(default)]
     pub initial_config: Option<Value>,
     #[serde(default)]
-    pub agent_kind: Option<String>,
-    #[serde(default)]
-    pub model_id: Option<String>,
-    #[serde(default)]
-    pub mode_id: Option<String>,
-    #[serde(default)]
     pub wake_on_completion: bool,
 }
 
@@ -37,8 +31,6 @@ pub struct CreateSubagentArgs {
 pub struct ChildSessionArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
-    #[serde(default)]
-    pub child_session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -46,8 +38,6 @@ pub struct ChildSessionArgs {
 pub struct SendSubagentMessageArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
-    #[serde(default)]
-    pub child_session_id: Option<String>,
     pub prompt: String,
     #[serde(default)]
     pub wake_on_completion: bool,
@@ -58,8 +48,6 @@ pub struct SendSubagentMessageArgs {
 pub struct ReadSubagentEventsArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
-    #[serde(default)]
-    pub child_session_id: Option<String>,
     #[serde(default)]
     pub since_seq: Option<i64>,
     #[serde(default)]
@@ -72,8 +60,6 @@ pub struct ReadSubagentLatestTurnsArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
     #[serde(default)]
-    pub child_session_id: Option<String>,
-    #[serde(default)]
     pub limit: Option<usize>,
 }
 
@@ -82,8 +68,6 @@ pub struct ReadSubagentLatestTurnsArgs {
 pub struct SearchSubagentTranscriptArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
-    #[serde(default)]
-    pub child_session_id: Option<String>,
     pub query: String,
     #[serde(default)]
     pub limit: Option<usize>,
@@ -122,10 +106,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
                                 "modeId": { "type": "string" }
                             }
                         },
-                        "wakeOnCompletion": { "type": "boolean" },
-                        "agentKind": { "type": "string", "description": "Deprecated alias for harnessId." },
-                        "modelId": { "type": "string", "description": "Deprecated alias for initialConfig.modelId." },
-                        "modeId": { "type": "string", "description": "Deprecated alias for initialConfig.modeId." }
+                        "wakeOnCompletion": { "type": "boolean" }
                     },
                     "required": ["prompt"]
                 }),
@@ -141,8 +122,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "subagentId": { "type": "string" },
                     "prompt": { "type": "string" },
                     "wakeOnCompletion": { "type": "boolean" }
                 },
@@ -155,8 +135,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "subagentId": { "type": "string" }
                 }
             }),
         ),
@@ -166,8 +145,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "subagentId": { "type": "string" }
                 }
             }),
         ),
@@ -177,8 +155,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "subagentId": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 10 }
                 }
             }),
@@ -189,8 +166,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "subagentId": { "type": "string" },
                     "query": { "type": "string" },
                     "limit": { "type": "integer", "minimum": 1, "maximum": 25 }
                 },
@@ -203,8 +179,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." },
+                    "subagentId": { "type": "string" },
                     "sinceSeq": { "type": "integer" },
                     "limit": {
                         "type": "integer",
@@ -220,8 +195,7 @@ pub fn build_tool_list(ctx: &SubagentMcpContext) -> Vec<Value> {
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Preferred stable subagent target. Provide either subagentId or deprecated childSessionId." },
-                    "childSessionId": { "type": "string", "description": "Deprecated legacy target." }
+                    "subagentId": { "type": "string" }
                 }
             }),
         ),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/workspace_naming/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/workspace_naming/mcp/auth.rs
@@ -6,7 +6,6 @@ use crate::integrations::mcp::product_server::{
 };
 
 const SECRET_FILE_NAME: &str = "workspace-naming-mcp-token.key";
-pub const LEGACY_CAPABILITY_HEADER_NAME: &str = "x-workspace-naming-session-token";
 
 #[derive(Clone)]
 pub struct WorkspaceNamingMcpAuth {
@@ -20,9 +19,7 @@ impl WorkspaceNamingMcpAuth {
                 runtime_home,
                 SECRET_FILE_NAME,
                 McpCapabilityTokenSignature::HmacSha256,
-                McpCapabilityTokenSignature::HmacSha256,
                 super::definition::DEFINITION.id,
-                LEGACY_CAPABILITY_HEADER_NAME,
             ),
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/workspace_naming/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/workspace_naming/mcp/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use self::auth::{WorkspaceNamingMcpAuth, LEGACY_CAPABILITY_HEADER_NAME};
+use self::auth::WorkspaceNamingMcpAuth;
 use self::context::WorkspaceNamingMcpContext;
 use crate::domains::sessions::store::SessionStore;
 use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
@@ -49,10 +49,6 @@ impl ProductMcpServer for WorkspaceNamingProductMcpServer {
 
     fn definition(&self) -> &'static ProductMcpDefinition {
         &definition::DEFINITION
-    }
-
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        &[LEGACY_CAPABILITY_HEADER_NAME]
     }
 
     fn validate_capability_token(

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/auth.rs
@@ -12,9 +12,7 @@ const TOKEN_TTL_SECONDS: i64 = 60 * 60 * 12;
 #[derive(Clone)]
 pub struct ProductMcpAuth {
     product_issuer: McpCapabilityTokenIssuer,
-    legacy_issuer: McpCapabilityTokenIssuer,
     product_mcp_id: &'static str,
-    legacy_header_name: &'static str,
 }
 
 impl ProductMcpAuth {
@@ -22,25 +20,16 @@ impl ProductMcpAuth {
         runtime_home: PathBuf,
         secret_file_name: &'static str,
         product_signature: McpCapabilityTokenSignature,
-        legacy_signature: McpCapabilityTokenSignature,
         product_mcp_id: &'static str,
-        legacy_header_name: &'static str,
     ) -> Self {
         Self {
             product_issuer: McpCapabilityTokenIssuer::new(
-                runtime_home.clone(),
+                runtime_home,
                 secret_file_name,
                 product_signature,
                 TOKEN_TTL_SECONDS,
             ),
-            legacy_issuer: McpCapabilityTokenIssuer::new(
-                runtime_home,
-                secret_file_name,
-                legacy_signature,
-                TOKEN_TTL_SECONDS,
-            ),
             product_mcp_id,
-            legacy_header_name,
         }
     }
 
@@ -73,16 +62,6 @@ impl ProductMcpAuth {
                     },
                 )?
             }
-            ProductMcpAuthHeader::Legacy { name, value }
-                if name.eq_ignore_ascii_case(self.legacy_header_name) =>
-            {
-                self.legacy_issuer.validate_workspace_session_token(
-                    value,
-                    &request.workspace_id,
-                    &request.session_id,
-                )?
-            }
-            ProductMcpAuthHeader::Legacy { .. } => false,
         };
         Ok(if valid {
             ProductMcpTokenValidation::Valid
@@ -95,7 +74,6 @@ impl ProductMcpAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::integrations::mcp::capability_token::McpCapabilityTokenIssuer;
 
     fn runtime_home(test_name: &str) -> PathBuf {
         let path = std::env::temp_dir().join(format!(
@@ -107,15 +85,13 @@ mod tests {
     }
 
     #[test]
-    fn validates_product_and_legacy_headers_without_cross_accepting_scopes() {
+    fn validates_product_token_and_rejects_wrong_scope() {
         let home = runtime_home("scope");
         let auth = ProductMcpAuth::new(
             home.clone(),
             "test-product.key",
             McpCapabilityTokenSignature::HmacSha256,
-            McpCapabilityTokenSignature::HmacSha256,
             "reviews",
-            "x-review-session-token",
         );
         let request = ProductMcpRequestContext::new("workspace-1", "session-1", "reviews");
         let product_token = auth
@@ -132,107 +108,17 @@ mod tests {
             .expect("validate product header"),
             ProductMcpTokenValidation::Valid,
         );
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Legacy {
-                    name: "x-review-session-token",
-                    value: &product_token,
-                },
-                &request,
-            )
-            .expect("reject product token in legacy header"),
-            ProductMcpTokenValidation::Invalid,
-        );
 
-        let legacy_issuer = McpCapabilityTokenIssuer::new(
-            home.clone(),
-            "test-product.key",
-            McpCapabilityTokenSignature::HmacSha256,
-            60,
-        );
-        let legacy_token = legacy_issuer
-            .mint_workspace_session_token("workspace-1", "session-1")
-            .expect("mint legacy token");
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Legacy {
-                    name: "x-review-session-token",
-                    value: &legacy_token,
-                },
-                &request,
-            )
-            .expect("validate legacy header"),
-            ProductMcpTokenValidation::Valid,
-        );
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Product {
-                    value: &legacy_token,
-                },
-                &request,
-            )
-            .expect("reject legacy token in product header"),
-            ProductMcpTokenValidation::Invalid,
-        );
-
-        let _ = std::fs::remove_dir_all(home);
-    }
-
-    #[test]
-    fn fresh_product_tokens_can_use_hmac_while_legacy_headers_use_legacy_sha256_dot() {
-        let home = runtime_home("split-signatures");
-        let auth = ProductMcpAuth::new(
-            home.clone(),
-            "test-product.key",
-            McpCapabilityTokenSignature::HmacSha256,
-            McpCapabilityTokenSignature::LegacySha256Dot,
-            "subagents",
-            "x-subagent-session-token",
-        );
-        let request = ProductMcpRequestContext::new("workspace-1", "session-1", "subagents");
-        let product_token = auth
-            .mint_capability_token("workspace-1", "session-1")
-            .expect("mint product token");
-
+        let wrong_scope_request =
+            ProductMcpRequestContext::new("workspace-1", "session-1", "subagents");
         assert_eq!(
             auth.validate_capability_header(
                 ProductMcpAuthHeader::Product {
                     value: &product_token,
                 },
-                &request,
+                &wrong_scope_request,
             )
-            .expect("validate product header"),
-            ProductMcpTokenValidation::Valid,
-        );
-
-        let legacy_issuer = McpCapabilityTokenIssuer::new(
-            home.clone(),
-            "test-product.key",
-            McpCapabilityTokenSignature::LegacySha256Dot,
-            60,
-        );
-        let legacy_token = legacy_issuer
-            .mint_workspace_session_token("workspace-1", "session-1")
-            .expect("mint legacy token");
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Legacy {
-                    name: "x-subagent-session-token",
-                    value: &legacy_token,
-                },
-                &request,
-            )
-            .expect("validate legacy header"),
-            ProductMcpTokenValidation::Valid,
-        );
-        assert_eq!(
-            auth.validate_capability_header(
-                ProductMcpAuthHeader::Product {
-                    value: &legacy_token,
-                },
-                &request,
-            )
-            .expect("reject legacy token in product header"),
+            .expect("reject wrong scope"),
             ProductMcpTokenValidation::Invalid,
         );
 

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
@@ -70,7 +70,6 @@ impl ProductMcpRequestContext {
 #[derive(Debug, Clone, Copy)]
 pub enum ProductMcpAuthHeader<'a> {
     Product { value: &'a str },
-    Legacy { name: &'static str, value: &'a str },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,10 +112,6 @@ pub trait ProductMcpServer: Send + Sync {
     type Context: Send + Sync;
 
     fn definition(&self) -> &'static ProductMcpDefinition;
-
-    fn legacy_header_names(&self) -> &'static [&'static str] {
-        &[]
-    }
 
     fn validate_capability_token(
         &self,

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -10,7 +10,7 @@
 anyharness/crates/anyharness-contract/src/v1/events.rs 949 existing AnyHarness contract oversized file
 anyharness/crates/anyharness-contract/src/v1/sessions.rs 802 existing AnyHarness contract oversized file
 anyharness/crates/anyharness-lib/src/api/openapi.rs 859 existing AnyHarness oversized file
-anyharness/crates/anyharness-lib/src/api/router_tests.rs 1179 existing AnyHarness oversized test file
+anyharness/crates/anyharness-lib/src/api/router_tests.rs 1102 existing AnyHarness oversized test file
 anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1897 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1524 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file


### PR DESCRIPTION
## Summary

- Delete 4 legacy product MCP URL routes (`/sessions/{id}/subagents/mcp`, `/sessions/{id}/reviews/mcp`, `/sessions/{id}/workspace-naming/mcp`, `/cowork/sessions/{id}/mcp`) and their 8 handler functions
- Delete `legacy_route_aliases` module and `with_route_aliases` constructor from `ProductMcpEndpointRegistration`
- Remove legacy capability header validation (`x-cowork-session-token`, `x-review-session-token`, `x-subagent-session-token`, `x-workspace-naming-session-token`) from `ProductMcpAuth` and all domain auth implementations — only `x-anyharness-product-mcp-token` is accepted now
- Remove deprecated tool params (`workspaceId`, `codingSessionId`, `childSessionId`, `reviewRunId`) from cowork, subagent, and review tool schemas and call handlers
- Drop `legacy_header_names()` from `ProductMcpServer` trait and all implementations

Stacked on #610.

## In-flight session safety

The route-404 and silently-dropped-param concerns raised in review are moot under the deploy story: product MCP servers are in-process HTTP endpoints on AnyHarness itself (`127.0.0.1`), and agent processes are spawned and owned by the AnyHarness live session manager. A binary update restarts AnyHarness, which terminates every live agent process with it — no agent carrying old injected MCP URLs or old tool schemas can survive the deploy. Resumed sessions re-inject MCP server configs and re-fetch `tools/list` from current code on relaunch, so the first post-deploy tool call always sees the new routes and schemas.

The legacy headers and routes are also purely agent-facing: they are only ever constructed by `product_catalog.rs` injection. A repo-wide grep of desktop, mobile, web, and server code confirms no consumer hand-constructs these headers or URLs, so no out-of-repo caller can break.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p anyharness-lib` — 609 passed, 0 failed
- [x] `check_max_lines.py` — pass (router_tests.rs allowlist updated: 1179→1102)
- [x] `check_anyharness_boundaries.py` — pass
- [x] `check_anyharness_old_paths.py` — pass
- [x] No remaining `legacy_route_aliases`, `LEGACY_CAPABILITY_HEADER_NAME`, or `legacy_header_names` refs in non-test source
- [x] No legacy header/route references in desktop/mobile/web/server code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Known accepted residual risk:** resumed sessions replay conversation history, and a model can imitate a deprecated param it sees in its own old tool calls even after re-fetching fresh schemas — those args now drop silently. The magnitude is small (the primary params were always preferred, and the tail decays with session age); accepted as-is per review.
