### PR TITLE
feat(codex): migrate to standard ACP elicitation + repin to 0.16 fork

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -132,6 +132,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     let client_for_notif = client.clone();
     let client_for_perm = client.clone();
     let client_for_ext = client.clone();
+    let client_for_elicitation = client.clone();
 
     let connect_future = acp::Client
         .builder()
@@ -164,6 +165,13 @@ pub(in crate::live::sessions::actor) async fn start_actor(
                     }
                     _ => Err(acp::Error::method_not_found()),
                 }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |req: acp::schema::CreateElicitationRequest, responder: acp::Responder<acp::schema::CreateElicitationResponse>, _cx| {
+                let result = client_for_elicitation.standard_mcp_elicitation(req).await;
+                responder.respond_with_result(result)
             },
             acp::on_receive_request!(),
         )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -150,6 +150,13 @@ pub(in crate::live::sessions::actor) async fn start_actor(
             acp::on_receive_request!(),
         )
         .on_receive_request(
+            async move |req: acp::schema::CreateElicitationRequest, responder: acp::Responder<acp::schema::CreateElicitationResponse>, _cx| {
+                let result = client_for_elicitation.standard_mcp_elicitation(req).await;
+                responder.respond_with_result(result)
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
             async move |req: acp::AgentRequest, responder: acp::Responder<serde_json::Value>, _cx| {
                 match req {
                     acp::AgentRequest::ExtMethodRequest(ext_req) => {
@@ -165,13 +172,6 @@ pub(in crate::live::sessions::actor) async fn start_actor(
                     }
                     _ => Err(acp::Error::method_not_found()),
                 }
-            },
-            acp::on_receive_request!(),
-        )
-        .on_receive_request(
-            async move |req: acp::schema::CreateElicitationRequest, responder: acp::Responder<acp::schema::CreateElicitationResponse>, _cx| {
-                let result = client_for_elicitation.standard_mcp_elicitation(req).await;
-                responder.respond_with_result(result)
             },
             acp::on_receive_request!(),
         )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/runtime_client/mcp_elicitation.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/runtime_client/mcp_elicitation.rs
@@ -6,19 +6,17 @@ use anyharness_contract::v1::{
 
 use super::{raw_ext_response, RuntimeClient};
 use crate::live::sessions::interactions::mcp_elicitation::{
-    claude_ext_response_from_outcome, codex_ext_response_from_outcome,
-    normalize_claude_mcp_elicitation, normalize_codex_mcp_elicitation,
-    ClaudeMcpElicitationExtParams, CodexMcpElicitationExtParams,
+    claude_ext_response_from_outcome, normalize_claude_mcp_elicitation,
+    normalize_standard_mcp_elicitation, standard_elicitation_response_from_outcome,
+    ClaudeMcpElicitationExtParams,
 };
 
 impl RuntimeClient {
-    pub(super) async fn codex_mcp_elicitation(
+    pub(crate) async fn standard_mcp_elicitation(
         &self,
-        args: acp::schema::ExtRequest,
-    ) -> acp::Result<acp::schema::ExtResponse> {
-        let request = serde_json::from_str::<CodexMcpElicitationExtParams>(args.params.get())
-            .map_err(|error| acp::Error::invalid_params().data(error.to_string()))?;
-        let normalized = normalize_codex_mcp_elicitation(request)
+        request: acp::schema::CreateElicitationRequest,
+    ) -> acp::Result<acp::schema::CreateElicitationResponse> {
+        let normalized = normalize_standard_mcp_elicitation(request)
             .map_err(|error| acp::Error::invalid_params().data(format!("{error:?}")))?;
 
         let request_id = uuid::Uuid::new_v4().to_string();
@@ -71,7 +69,9 @@ impl RuntimeClient {
             pending_wait
         };
 
-        raw_ext_response(codex_ext_response_from_outcome(pending_wait.wait().await))
+        Ok(standard_elicitation_response_from_outcome(
+            pending_wait.wait().await,
+        ))
     }
 
     pub(super) async fn claude_mcp_elicitation(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/runtime_client/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/runtime_client/mod.rs
@@ -15,7 +15,6 @@ mod permission;
 mod user_input;
 
 const CODEX_REQUEST_USER_INPUT_METHOD: &str = "experimental/codex/requestUserInput";
-const CODEX_MCP_ELICITATION_METHOD: &str = "experimental/codex/mcpElicitation";
 const CLAUDE_REQUEST_USER_INPUT_METHOD: &str = "experimental/claude/requestUserInput";
 const CLAUDE_MCP_ELICITATION_METHOD: &str = "experimental/claude/mcpElicitation";
 
@@ -66,7 +65,6 @@ impl RuntimeClient {
     ) -> acp::Result<acp::schema::ExtResponse> {
         match args.method.as_ref() {
             CODEX_REQUEST_USER_INPUT_METHOD => self.codex_request_user_input(args).await,
-            CODEX_MCP_ELICITATION_METHOD => self.codex_mcp_elicitation(args).await,
             CLAUDE_REQUEST_USER_INPUT_METHOD => self.claude_request_user_input(args).await,
             CLAUDE_MCP_ELICITATION_METHOD => self.claude_mcp_elicitation(args).await,
             _ => Err(acp::Error::method_not_found()),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/start.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/start.rs
@@ -4,18 +4,15 @@ use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
 use std::time::Instant;
 pub(in crate::live::sessions) fn build_client_capabilities(
     source_agent_kind: &str,
-    resolved_agent: &ResolvedAgent,
+    _resolved_agent: &ResolvedAgent,
 ) -> acp::schema::ClientCapabilities {
     let mut meta = serde_json::Map::new();
 
     if source_agent_kind == AgentKind::Codex.as_str() {
-        let mut codex_capabilities = serde_json::Map::from_iter([(
+        let codex_capabilities = serde_json::Map::from_iter([(
             "requestUserInput".to_string(),
             serde_json::Value::Bool(true),
         )]);
-        if should_advertise_codex_mcp_elicitation(source_agent_kind, resolved_agent) {
-            codex_capabilities.insert("mcpElicitation".to_string(), serde_json::Value::Bool(true));
-        }
         meta.insert(
             "codex".to_string(),
             serde_json::Value::Object(codex_capabilities),
@@ -33,14 +30,6 @@ pub(in crate::live::sessions) fn build_client_capabilities(
     }
 
     acp::schema::ClientCapabilities::new().meta(acp::schema::Meta::from_iter(meta))
-}
-
-pub(in crate::live::sessions) fn should_advertise_codex_mcp_elicitation(
-    source_agent_kind: &str,
-    resolved_agent: &ResolvedAgent,
-) -> bool {
-    source_agent_kind == AgentKind::Codex.as_str()
-        && resolved_agent.agent_process.source.as_deref() == Some("override")
 }
 
 pub(in crate::live::sessions) fn should_attempt_advertised_auth(source_agent_kind: &str) -> bool {
@@ -248,45 +237,29 @@ mod tests {
     use crate::domains::agents::registry::built_in_registry;
 
     #[test]
-    fn client_capabilities_preserve_codex_managed_gate() {
-        let capabilities = build_client_capabilities(
-            AgentKind::Codex.as_str(),
-            &resolved_agent_with_source(AgentKind::Codex, "managed"),
-        );
+    fn client_capabilities_codex_only_advertises_request_user_input() {
+        for source in &["managed", "override"] {
+            let capabilities = build_client_capabilities(
+                AgentKind::Codex.as_str(),
+                &resolved_agent_with_source(AgentKind::Codex, source),
+            );
 
-        assert_eq!(
-            capability_bool(&capabilities, "codex", "requestUserInput"),
-            Some(true)
-        );
-        assert_eq!(
-            capability_bool(&capabilities, "codex", "mcpElicitation"),
-            None
-        );
-        assert_eq!(
-            capability_bool(&capabilities, "claude", "mcpElicitation"),
-            None
-        );
-    }
-
-    #[test]
-    fn client_capabilities_preserve_codex_override_gate() {
-        let capabilities = build_client_capabilities(
-            AgentKind::Codex.as_str(),
-            &resolved_agent_with_source(AgentKind::Codex, "override"),
-        );
-
-        assert_eq!(
-            capability_bool(&capabilities, "codex", "requestUserInput"),
-            Some(true)
-        );
-        assert_eq!(
-            capability_bool(&capabilities, "codex", "mcpElicitation"),
-            Some(true)
-        );
-        assert_eq!(
-            capability_bool(&capabilities, "claude", "mcpElicitation"),
-            None
-        );
+            assert_eq!(
+                capability_bool(&capabilities, "codex", "requestUserInput"),
+                Some(true),
+                "source={source}"
+            );
+            assert_eq!(
+                capability_bool(&capabilities, "codex", "mcpElicitation"),
+                None,
+                "source={source}: mcpElicitation must not be advertised (standard elicitation is used instead)"
+            );
+            assert_eq!(
+                capability_bool(&capabilities, "claude", "mcpElicitation"),
+                None,
+                "source={source}"
+            );
+        }
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/broker/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/broker/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::live::sessions::interactions::mcp_elicitation::{
-    normalize_codex_mcp_elicitation, CodexMcpElicitationExtParams, CodexMcpElicitationExtRequest,
+use crate::live::sessions::interactions::mcp_elicitation::normalize_standard_mcp_elicitation;
+use agent_client_protocol::schema::{
+    CreateElicitationRequest, ElicitationFormMode, ElicitationSchema, ElicitationSessionScope,
 };
 use anyharness_contract::v1::{UserInputQuestionOption, UserInputSubmittedAnswer};
 use serde_json::json;
@@ -39,28 +40,16 @@ fn answer(
 }
 
 fn mcp_elicitation() -> StoredMcpElicitation {
-    normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-        server_name: "google".to_string(),
-        request: CodexMcpElicitationExtRequest::Form {
-            meta: None,
-            message: "Pick account".to_string(),
-            requested_schema: json!({
-                "type": "object",
-                "properties": {
-                    "account": {
-                        "type": "string",
-                        "title": "Account",
-                        "enum": ["acct_123"],
-                        "enumNames": ["Work"]
-                    }
-                },
-                "required": ["account"],
-                "additionalProperties": false
-            }),
-        },
-    })
-    .expect("schema should normalize")
-    .pending
+    let request = CreateElicitationRequest::new(
+        ElicitationFormMode::new(
+            ElicitationSessionScope::new("sess_test"),
+            ElicitationSchema::new().string("account", true),
+        ),
+        "Pick account",
+    );
+    normalize_standard_mcp_elicitation(request)
+        .expect("schema should normalize")
+        .pending
 }
 
 #[tokio::test]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
@@ -258,7 +258,146 @@ fn first_non_empty(value: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::{
+        CreateElicitationRequest, ElicitationFormMode, ElicitationId, ElicitationSchema,
+        ElicitationSessionScope, ElicitationUrlMode, EnumOption, StringPropertySchema,
+    };
+    use anyharness_contract::v1::McpElicitationSubmittedValue;
     use serde_json::json;
+
+    fn standard_select_request() -> CreateElicitationRequest {
+        let schema = ElicitationSchema::new().property(
+            "account_id_secret",
+            StringPropertySchema::new().title("Account").one_of(vec![
+                EnumOption::new("acct_123", "Work"),
+                EnumOption::new("acct_456", "Personal"),
+            ]),
+            true,
+        );
+        CreateElicitationRequest::new(
+            ElicitationFormMode::new(ElicitationSessionScope::new("sess_test"), schema),
+            "Pick account",
+        )
+    }
+
+    #[test]
+    fn normalizes_schema_without_persisting_raw_names_or_values() {
+        let normalized =
+            normalize_standard_mcp_elicitation(standard_select_request()).expect("should normalize");
+
+        let public_json = serde_json::to_string(&normalized.payload).unwrap();
+        assert!(!public_json.contains("account_id_secret"));
+        assert!(!public_json.contains("acct_123"));
+        assert!(public_json.contains("Work"));
+    }
+
+    #[test]
+    fn accepted_select_maps_generated_option_to_raw_value() {
+        let normalized =
+            normalize_standard_mcp_elicitation(standard_select_request()).expect("should normalize");
+
+        let outcome = normalized
+            .pending
+            .accept(vec![McpElicitationSubmittedField {
+                field_id: "field_1".to_string(),
+                value: McpElicitationSubmittedValue::Option {
+                    option_id: "field_1_option_1".to_string(),
+                },
+            }])
+            .expect("submission should validate");
+
+        let McpElicitationOutcome::Accepted { content, .. } = outcome else {
+            panic!("expected accepted outcome");
+        };
+        assert_eq!(content, Some(json!({ "account_id_secret": "acct_123" })));
+    }
+
+    #[test]
+    fn duplicate_multi_select_option_ids_are_rejected() {
+        let normalized = normalize_form(
+            "google".to_string(),
+            "Pick accounts".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "accounts": {
+                        "type": "array",
+                        "title": "Accounts",
+                        "items": {
+                            "oneOf": [
+                                {"const": "acct_123", "title": "Work"},
+                                {"const": "acct_456", "title": "Personal"}
+                            ]
+                        },
+                        "minItems": 2
+                    }
+                },
+                "required": ["accounts"]
+            }),
+        )
+        .expect("schema should normalize");
+
+        let error = normalized
+            .pending
+            .accept(vec![McpElicitationSubmittedField {
+                field_id: "field_1".to_string(),
+                value: McpElicitationSubmittedValue::OptionArray {
+                    option_ids: vec![
+                        "field_1_option_1".to_string(),
+                        "field_1_option_1".to_string(),
+                    ],
+                },
+            }])
+            .expect_err("duplicate option ids should be rejected");
+        assert_eq!(error, McpElicitationValidationError::InvalidValue);
+    }
+
+    #[test]
+    fn url_payload_and_debug_do_not_expose_full_url() {
+        let request = CreateElicitationRequest::new(
+            ElicitationUrlMode::new(
+                ElicitationSessionScope::new("sess_test"),
+                ElicitationId::new("elic_test"),
+                "https://accounts.example.com/oauth?token=secret-token",
+            ),
+            "Authorize",
+        );
+        let normalized =
+            normalize_standard_mcp_elicitation(request).expect("url should normalize");
+
+        let public_json = serde_json::to_string(&normalized.payload).unwrap();
+        assert!(public_json.contains("https://accounts.example.com"));
+        assert!(!public_json.contains("secret-token"));
+
+        let debug = format!("{:?}", normalized.pending);
+        assert!(!debug.contains("secret-token"));
+    }
+
+    #[test]
+    fn accepted_outcome_debug_redacts_submitted_values() {
+        let schema = ElicitationSchema::new().string("account", true);
+        let request = CreateElicitationRequest::new(
+            ElicitationFormMode::new(ElicitationSessionScope::new("sess_test"), schema),
+            "Name account",
+        );
+        let normalized =
+            normalize_standard_mcp_elicitation(request).expect("schema should normalize");
+
+        let outcome = normalized
+            .pending
+            .accept(vec![McpElicitationSubmittedField {
+                field_id: "field_1".to_string(),
+                value: McpElicitationSubmittedValue::String {
+                    value: "submitted-secret".to_string(),
+                },
+            }])
+            .expect("submission should validate");
+
+        let debug = format!("{outcome:?}");
+        assert!(!debug.contains("submitted-secret"));
+        assert!(!debug.contains("account"));
+        assert!(debug.contains("field_1"));
+    }
 
     #[test]
     fn normalizes_claude_elicitation_to_shared_payload() {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
@@ -268,10 +268,13 @@ mod tests {
     fn standard_select_request() -> CreateElicitationRequest {
         let schema = ElicitationSchema::new().property(
             "account_id_secret",
-            StringPropertySchema::new().title("Account").one_of(vec![
-                EnumOption::new("acct_123", "Work"),
-                EnumOption::new("acct_456", "Personal"),
-            ]),
+            StringPropertySchema::new()
+                .title("Account")
+                .default_value("acct_123")
+                .one_of(vec![
+                    EnumOption::new("acct_123", "Work"),
+                    EnumOption::new("acct_456", "Personal"),
+                ]),
             true,
         );
         CreateElicitationRequest::new(
@@ -288,6 +291,7 @@ mod tests {
         let public_json = serde_json::to_string(&normalized.payload).unwrap();
         assert!(!public_json.contains("account_id_secret"));
         assert!(!public_json.contains("acct_123"));
+        assert!(!public_json.contains("default"));
         assert!(public_json.contains("Work"));
     }
 
@@ -371,6 +375,7 @@ mod tests {
 
         let debug = format!("{:?}", normalized.pending);
         assert!(!debug.contains("secret-token"));
+        assert!(!debug.contains("elic_test"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
@@ -372,6 +372,7 @@ mod tests {
         let public_json = serde_json::to_string(&normalized.payload).unwrap();
         assert!(public_json.contains("https://accounts.example.com"));
         assert!(!public_json.contains("secret-token"));
+        assert!(!public_json.contains("elic_test"));
 
         let debug = format!("{:?}", normalized.pending);
         assert!(!debug.contains("secret-token"));

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation.rs
@@ -1,10 +1,13 @@
 use std::fmt;
 
 use accept::accept_form;
+use agent_client_protocol as acp;
 #[cfg(test)]
 use anyharness_contract::v1::McpElicitationSubmittedValue;
 use anyharness_contract::v1::{McpElicitationInteractionPayload, McpElicitationSubmittedField};
-pub use ext_response::{claude_ext_response_from_outcome, codex_ext_response_from_outcome};
+pub use ext_response::{
+    claude_ext_response_from_outcome, standard_elicitation_response_from_outcome,
+};
 use normalize::{normalize_form, normalize_url};
 use serde::Deserialize;
 use serde_json::Value;
@@ -13,40 +16,6 @@ use url::Url;
 mod accept;
 mod ext_response;
 mod normalize;
-
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CodexMcpElicitationExtParams {
-    pub server_name: String,
-    pub request: CodexMcpElicitationExtRequest,
-}
-
-impl fmt::Debug for CodexMcpElicitationExtParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CodexMcpElicitationExtParams")
-            .field("server_name", &self.server_name)
-            .field("request", &self.request)
-            .finish()
-    }
-}
-
-#[derive(Clone, Deserialize)]
-#[serde(tag = "mode", rename_all = "snake_case")]
-pub enum CodexMcpElicitationExtRequest {
-    Form {
-        #[serde(rename = "_meta", default)]
-        meta: Option<Value>,
-        message: String,
-        requested_schema: Value,
-    },
-    Url {
-        #[serde(rename = "_meta", default)]
-        meta: Option<Value>,
-        message: String,
-        url: String,
-        elicitation_id: String,
-    },
-}
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -75,31 +44,6 @@ impl fmt::Debug for ClaudeMcpElicitationExtParams {
             .field("url_display", &self.url.as_deref().map(safe_url_display))
             .field("schema_present", &self.requested_schema.is_some())
             .finish()
-    }
-}
-
-impl fmt::Debug for CodexMcpElicitationExtRequest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Form {
-                message,
-                requested_schema,
-                meta,
-            } => f
-                .debug_struct("Form")
-                .field("message", message)
-                .field("schema_present", &requested_schema.is_object())
-                .field("meta_present", &meta.is_some())
-                .finish(),
-            Self::Url {
-                message, url, meta, ..
-            } => f
-                .debug_struct("Url")
-                .field("message", message)
-                .field("url_display", &safe_url_display(url))
-                .field("meta_present", &meta.is_some())
-                .finish(),
-        }
     }
 }
 
@@ -215,21 +159,22 @@ pub enum McpElicitationValidationError {
     NotUrlElicitation,
 }
 
-pub fn normalize_codex_mcp_elicitation(
-    params: CodexMcpElicitationExtParams,
+pub fn normalize_standard_mcp_elicitation(
+    request: acp::schema::CreateElicitationRequest,
 ) -> Result<NormalizedMcpElicitation, McpElicitationValidationError> {
-    match params.request {
-        CodexMcpElicitationExtRequest::Form {
-            message,
-            requested_schema,
-            meta: _,
-        } => normalize_form(params.server_name, message, requested_schema),
-        CodexMcpElicitationExtRequest::Url {
-            message,
-            url,
-            elicitation_id: _,
-            meta: _,
-        } => Ok(normalize_url(params.server_name, message, url)),
+    use acp::schema::ElicitationMode;
+
+    let message = request.message;
+    let server_name = "mcp".to_string();
+
+    match request.mode {
+        ElicitationMode::Form(form) => {
+            let schema = serde_json::to_value(&form.requested_schema)
+                .map_err(|_| McpElicitationValidationError::UnsupportedSchema)?;
+            normalize_form(server_name, message, schema)
+        }
+        ElicitationMode::Url(url) => Ok(normalize_url(server_name, message, url.url)),
+        _ => Err(McpElicitationValidationError::UnsupportedSchema),
     }
 }
 
@@ -316,146 +261,6 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn normalizes_schema_without_persisting_raw_names_or_values() {
-        let normalized = normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-            server_name: "google".to_string(),
-            request: CodexMcpElicitationExtRequest::Form {
-                meta: None,
-                message: "Pick account".to_string(),
-                requested_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "account_id_secret": {
-                            "type": "string",
-                            "title": "Account",
-                            "enum": ["acct_123", "acct_456"],
-                            "enumNames": ["Work", "Personal"],
-                            "default": "acct_123"
-                        }
-                    },
-                    "required": ["account_id_secret"],
-                    "additionalProperties": false
-                }),
-            },
-        })
-        .expect("schema should normalize");
-
-        let public_json = serde_json::to_string(&normalized.payload).unwrap();
-        assert!(!public_json.contains("account_id_secret"));
-        assert!(!public_json.contains("acct_123"));
-        assert!(!public_json.contains("default"));
-        assert!(public_json.contains("Work"));
-    }
-
-    #[test]
-    fn accepted_select_maps_generated_option_to_raw_value() {
-        let normalized = normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-            server_name: "google".to_string(),
-            request: CodexMcpElicitationExtRequest::Form {
-                meta: None,
-                message: "Pick account".to_string(),
-                requested_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "account": {
-                            "type": "string",
-                            "title": "Account",
-                            "enum": ["acct_123"],
-                            "enumNames": ["Work"]
-                        }
-                    },
-                    "required": ["account"],
-                    "additionalProperties": false
-                }),
-            },
-        })
-        .expect("schema should normalize");
-
-        let outcome = normalized
-            .pending
-            .accept(vec![McpElicitationSubmittedField {
-                field_id: "field_1".to_string(),
-                value: McpElicitationSubmittedValue::Option {
-                    option_id: "field_1_option_1".to_string(),
-                },
-            }])
-            .expect("submission should validate");
-
-        let McpElicitationOutcome::Accepted { content, .. } = outcome else {
-            panic!("expected accepted outcome");
-        };
-        assert_eq!(content, Some(json!({ "account": "acct_123" })));
-    }
-
-    #[test]
-    fn duplicate_multi_select_option_ids_are_rejected() {
-        let normalized = normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-            server_name: "google".to_string(),
-            request: CodexMcpElicitationExtRequest::Form {
-                meta: None,
-                message: "Pick accounts".to_string(),
-                requested_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "accounts": {
-                            "type": "array",
-                            "title": "Accounts",
-                            "items": {
-                                "type": "string",
-                                "enum": ["acct_123", "acct_456"],
-                                "enumNames": ["Work", "Personal"]
-                            },
-                            "minItems": 2
-                        }
-                    },
-                    "required": ["accounts"],
-                    "additionalProperties": false
-                }),
-            },
-        })
-        .expect("schema should normalize");
-
-        let error = normalized
-            .pending
-            .accept(vec![McpElicitationSubmittedField {
-                field_id: "field_1".to_string(),
-                value: McpElicitationSubmittedValue::OptionArray {
-                    option_ids: vec![
-                        "field_1_option_1".to_string(),
-                        "field_1_option_1".to_string(),
-                    ],
-                },
-            }])
-            .expect_err("duplicate option ids should be rejected");
-
-        assert_eq!(error, McpElicitationValidationError::InvalidValue);
-    }
-
-    #[test]
-    fn url_payload_and_debug_do_not_expose_full_url() {
-        let normalized = normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-            server_name: "oauth".to_string(),
-            request: CodexMcpElicitationExtRequest::Url {
-                meta: Some(json!({ "secret": "metadata-token" })),
-                message: "Authorize".to_string(),
-                url: "https://accounts.example.com/oauth?token=secret-token".to_string(),
-                elicitation_id: "original-request-id".to_string(),
-            },
-        })
-        .expect("url should normalize");
-
-        let public_json = serde_json::to_string(&normalized.payload).unwrap();
-        assert!(public_json.contains("https://accounts.example.com"));
-        assert!(!public_json.contains("secret-token"));
-        assert!(!public_json.contains("original-request-id"));
-        assert!(!public_json.contains("metadata-token"));
-
-        let debug = format!("{:?}", normalized.pending);
-        assert!(!debug.contains("secret-token"));
-        assert!(!debug.contains("original-request-id"));
-    }
-
-    #[test]
     fn normalizes_claude_elicitation_to_shared_payload() {
         let normalized = normalize_claude_mcp_elicitation(ClaudeMcpElicitationExtParams {
             server_name: "calendar".to_string(),
@@ -488,41 +293,4 @@ mod tests {
         assert!(!public_json.contains("cal_raw_1"));
     }
 
-    #[test]
-    fn accepted_outcome_debug_redacts_submitted_values() {
-        let normalized = normalize_codex_mcp_elicitation(CodexMcpElicitationExtParams {
-            server_name: "google".to_string(),
-            request: CodexMcpElicitationExtRequest::Form {
-                meta: None,
-                message: "Name account".to_string(),
-                requested_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "account": {
-                            "type": "string",
-                            "title": "Account"
-                        }
-                    },
-                    "required": ["account"],
-                    "additionalProperties": false
-                }),
-            },
-        })
-        .expect("schema should normalize");
-
-        let outcome = normalized
-            .pending
-            .accept(vec![McpElicitationSubmittedField {
-                field_id: "field_1".to_string(),
-                value: McpElicitationSubmittedValue::String {
-                    value: "submitted-secret".to_string(),
-                },
-            }])
-            .expect("submission should validate");
-
-        let debug = format!("{outcome:?}");
-        assert!(!debug.contains("submitted-secret"));
-        assert!(!debug.contains("account"));
-        assert!(debug.contains("field_1"));
-    }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation/ext_response.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/interactions/mcp_elicitation/ext_response.rs
@@ -1,37 +1,11 @@
+use std::collections::BTreeMap;
 use std::fmt;
 
+use agent_client_protocol as acp;
 use serde::Serialize;
 use serde_json::Value;
 
 use super::McpElicitationOutcome;
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CodexMcpElicitationExtResponse {
-    pub outcome: CodexMcpElicitationExtOutcome,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "_meta")]
-    pub meta: Option<Value>,
-}
-
-impl fmt::Debug for CodexMcpElicitationExtResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CodexMcpElicitationExtResponse")
-            .field("outcome", &self.outcome)
-            .field("content_present", &self.content.is_some())
-            .field("meta_present", &self.meta.is_some())
-            .finish()
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CodexMcpElicitationExtOutcome {
-    Accepted,
-    Declined,
-    Cancelled,
-}
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -58,26 +32,54 @@ pub enum ClaudeMcpElicitationExtAction {
     Cancel,
 }
 
-pub fn codex_ext_response_from_outcome(
+pub fn standard_elicitation_response_from_outcome(
     outcome: McpElicitationOutcome,
-) -> CodexMcpElicitationExtResponse {
+) -> acp::schema::CreateElicitationResponse {
+    use acp::schema::{
+        ElicitationAcceptAction, ElicitationAction, ElicitationContentValue,
+    };
+
     match outcome {
-        McpElicitationOutcome::Accepted { content, .. } => CodexMcpElicitationExtResponse {
-            outcome: CodexMcpElicitationExtOutcome::Accepted,
-            content,
-            meta: None,
-        },
-        McpElicitationOutcome::Declined => CodexMcpElicitationExtResponse {
-            outcome: CodexMcpElicitationExtOutcome::Declined,
-            content: None,
-            meta: None,
-        },
+        McpElicitationOutcome::Accepted { content, .. } => {
+            let acp_content = content.and_then(|value| {
+                value.as_object().map(|obj| {
+                    obj.iter()
+                        .filter_map(|(k, v)| {
+                            let elicitation_value = match v {
+                                Value::String(s) => {
+                                    Some(ElicitationContentValue::String(s.clone()))
+                                }
+                                Value::Number(n) => {
+                                    if let Some(i) = n.as_i64() {
+                                        Some(ElicitationContentValue::Integer(i))
+                                    } else {
+                                        n.as_f64().map(ElicitationContentValue::Number)
+                                    }
+                                }
+                                Value::Bool(b) => Some(ElicitationContentValue::Boolean(*b)),
+                                Value::Array(arr) => {
+                                    let strings: Vec<String> = arr
+                                        .iter()
+                                        .filter_map(|v| v.as_str().map(str::to_string))
+                                        .collect();
+                                    Some(ElicitationContentValue::StringArray(strings))
+                                }
+                                _ => None,
+                            };
+                            elicitation_value.map(|v| (k.clone(), v))
+                        })
+                        .collect::<BTreeMap<_, _>>()
+                })
+            });
+            acp::schema::CreateElicitationResponse::new(ElicitationAction::Accept(
+                ElicitationAcceptAction::new().content(acp_content),
+            ))
+        }
+        McpElicitationOutcome::Declined => {
+            acp::schema::CreateElicitationResponse::new(ElicitationAction::Decline)
+        }
         McpElicitationOutcome::Cancelled | McpElicitationOutcome::Dismissed => {
-            CodexMcpElicitationExtResponse {
-                outcome: CodexMcpElicitationExtOutcome::Cancelled,
-                content: None,
-                meta: None,
-            }
+            acp::schema::CreateElicitationResponse::new(ElicitationAction::Cancel)
         }
     }
 }

--- a/catalogs/agents/v1/catalog.json
+++ b/catalogs/agents/v1/catalog.json
@@ -33,7 +33,7 @@
         "agentProcess": {
           "install": {
             "kind": "managed_npm_package",
-            "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#906204b3cd798180df75502783a587bad19614ec",
+            "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#3ff484e671de5fe9275d2e7596d683df06b99e14",
             "packageSubdir": null,
             "sourceBuildBinaryName": null,
             "executableRelpath": "node_modules/.bin/claude-agent-acp"

--- a/catalogs/agents/v1/catalog.json
+++ b/catalogs/agents/v1/catalog.json
@@ -513,8 +513,8 @@
         "agentProcess": {
           "install": {
             "kind": "managed_npm_package",
-            "package": "@proliferateai/codex-acp@0.11.8",
-            "packageSubdir": null,
+            "package": "git+https://github.com/proliferate-ai/codex-acp.git#1fdb4661c2aef0815a6aab16be27ea70f4c2b94f",
+            "packageSubdir": "npm",
             "sourceBuildBinaryName": null,
             "executableRelpath": "node_modules/.bin/codex-acp"
           }


### PR DESCRIPTION
## Summary

- Rebases `proliferate-ai/codex-acp` fork onto upstream 0.16.0 (ACP 0.14, codex-core 0.137)
- Migrates `experimental/codex/mcpElicitation` ext method → standard `elicitation/create` ACP protocol
- Updates anyharness to handle standard elicitation inbound requests
- Repins registry to new fork branch

Stacks on #609 (ACP crate bump) — merge that first.

## Fork changes (`proliferate/v0.16-rebase`)

Ported from old fork onto upstream 0.16 base:

| Feature | Status |
|---|---|
| Proposed-plan markers | Ported |
| `requestUserInput` ext method | Ported |
| MCP elicitation | **Migrated** to standard `elicitation/create` |
| Transient status / hook events | Ported |
| GPT-5.5 / codex-core 0.137 | Free from upstream |

Fork SHA: `1fdb4661c2aef0815a6aab16be27ea70f4c2b94f`

## Anyharness changes

- **Added** `on_receive_request` handler for `CreateElicitationRequest` in `startup.rs` builder chain — routes through existing `interaction_broker.register_mcp_elicitation()` path unchanged
- **Added** `normalize_standard_mcp_elicitation` in `interactions/mcp_elicitation.rs`
- **Added** `standard_elicitation_response_from_outcome` in `ext_response.rs`  
- **Removed** `CODEX_MCP_ELICITATION_METHOD` ext dispatch + all codex-specific elicitation dead code
- **Removed** `should_advertise_codex_mcp_elicitation` and the `source=override` gate — standard elicitation needs no capability advertisement
- **Repinned** `catalog.json` codex adapter from `@proliferateai/codex-acp@0.11.8` to git SHA

`requestUserInput` and transient status events remain as ext methods — no standard equivalent in ACP 0.14.

## Test plan

- [x] `cargo test -p anyharness-lib` — 608 passed, 0 failed
- [ ] `anyharness install-agents --agent codex --reinstall`
- [ ] Live codex session: MCP OAuth flow (elicitation), requestUserInput, plan streaming, transient status events
- [ ] Run `catalog-probe` for codex auth context; diff snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)