### PR TITLE
feat(agents): bedrock + opencode-zen probe contexts, parallel matrix

### DIFF
--- a/anyharness/crates/anyharness/src/commands/catalog_probe.rs
+++ b/anyharness/crates/anyharness/src/commands/catalog_probe.rs
@@ -207,6 +207,20 @@ fn auth_env_for_context(
             env.insert("ANTHROPIC_API_KEY".to_string(), secrets.require("ANTHROPIC_API_KEY")?);
             Ok(env)
         }
+        // Claude against AWS Bedrock: same binary, server side is Bedrock's
+        // model namespace (us./global. inference profiles), so menus, defaults
+        // and model ids are a distinct surface from anthropic-api. Auth is a
+        // Bedrock API key (bearer token) — no SigV4 ceremony.
+        (AgentKind::Claude, "bedrock") => {
+            let mut env = isolation_env(auth_context, &[("CLAUDE_CONFIG_DIR", "claude-config")], isolation_dirs)?;
+            env.insert(
+                "AWS_BEARER_TOKEN_BEDROCK".to_string(),
+                secrets.require("AWS_BEARER_TOKEN_BEDROCK")?,
+            );
+            env.insert("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string());
+            env.insert("AWS_REGION".to_string(), probe_aws_region());
+            Ok(env)
+        }
         // Claude under subscription OAuth: requires a credentials file
         // produced by `claude setup-token` (or copied from a logged-in
         // ~/.claude/.credentials.json). We copy it into an isolated config
@@ -247,6 +261,13 @@ fn auth_env_for_context(
             env.insert("OPENAI_API_KEY".to_string(), secrets.require("OPENAI_API_KEY")?);
             Ok(env)
         }
+        // OpenCode Zen: opencode's own subscription gateway (provider id
+        // "opencode"), keyed by OPENCODE_API_KEY.
+        (AgentKind::OpenCode, "opencode-zen") => {
+            let mut env = opencode_isolation_env(auth_context, isolation_dirs)?;
+            env.insert("OPENCODE_API_KEY".to_string(), secrets.require("OPENCODE_API_KEY")?);
+            Ok(env)
+        }
         (AgentKind::OpenCode, "gemini-api") => {
             let key = secrets.require("GEMINI_API_KEY")?;
             let mut env = opencode_isolation_env(auth_context, isolation_dirs)?;
@@ -284,6 +305,33 @@ fn auth_env_for_context(
             let codex_home = env.get("CODEX_HOME").expect("codex isolation dir");
             std::fs::copy(&source, std::path::Path::new(codex_home).join("auth.json"))
                 .with_context(|| format!("failed to copy {source}"))?;
+            Ok(env)
+        }
+        // Codex against AWS Bedrock: codex has no native Bedrock support and
+        // only speaks the Responses API (wire_api "chat" was removed), so we
+        // point a custom model_provider at Bedrock's OpenAI-compatible
+        // "mantle" surface, which serves /v1/responses for OpenAI models.
+        // Mantle model ids are their own namespace (openai.gpt-oss-120b — no
+        // Bedrock -1:0 suffix); its Anthropic models do not support
+        // /v1/responses and are unreachable from codex.
+        (AgentKind::Codex, "bedrock") => {
+            let token = secrets.require("AWS_BEARER_TOKEN_BEDROCK")?;
+            let mut env = isolation_env(auth_context, &[("CODEX_HOME", "codex-home")], isolation_dirs)?;
+            let codex_home = env.get("CODEX_HOME").expect("codex isolation dir");
+            let config = format!(
+                r#"model = "openai.gpt-oss-120b"
+model_provider = "bedrock"
+
+[model_providers.bedrock]
+name = "Amazon Bedrock"
+base_url = "https://bedrock-mantle.{region}.api.aws/v1"
+env_key = "AWS_BEARER_TOKEN_BEDROCK"
+wire_api = "responses"
+"#,
+                region = probe_aws_region(),
+            );
+            std::fs::write(std::path::Path::new(codex_home).join("config.toml"), config)?;
+            env.insert("AWS_BEARER_TOKEN_BEDROCK".to_string(), token);
             Ok(env)
         }
         // Gemini stores state under $HOME/.gemini — isolate HOME and seed the
@@ -339,7 +387,22 @@ const CREDENTIAL_ENV_VARS: &[&str] = &[
     "GOOGLE_GENERATIVE_AI_API_KEY",
     "GOOGLE_API_KEY",
     "CURSOR_API_KEY",
+    "OPENCODE_API_KEY",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    // Ambient SigV4 credentials must not reach spawned agents either: some
+    // harnesses (e.g. opencode's amazon-bedrock provider) auto-detect them
+    // and would silently enable Bedrock in non-bedrock contexts.
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
 ];
+
+/// Region for bedrock auth contexts; model availability is region-dependent
+/// so the snapshot records it via the context env.
+fn probe_aws_region() -> String {
+    std::env::var("PROBE_AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string())
+}
 
 struct ProbeSecrets {
     values: BTreeMap<String, String>,

--- a/scripts/agent-catalog/.gitignore
+++ b/scripts/agent-catalog/.gitignore
@@ -1,3 +1,4 @@
 catalog.html
 generated-recheck/
 generated-experiments/
+generated/.probe-logs/

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-06-10.6",
+  "catalogVersion": "2026-06-10.7",
   "probedAgainst": {
     "registryVersion": null
   },
-  "generatedAt": "2026-06-10T02:19:36.860Z",
+  "generatedAt": "2026-06-10T04:20:35.597Z",
   "agents": [
     {
       "kind": "claude",
@@ -25,6 +25,10 @@
         {
           "id": "anthropic-oauth",
           "authSlotId": "anthropic-oauth"
+        },
+        {
+          "id": "bedrock",
+          "authSlotId": "bedrock"
         }
       ],
       "session": {
@@ -153,7 +157,8 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth"
+                "anthropic-oauth",
+                "bedrock"
               ]
             },
             "defaultVisible": true,
@@ -174,7 +179,8 @@
             "provenance": {
               "observedIn": [
                 "claude.anthropic-api",
-                "claude.anthropic-oauth"
+                "claude.anthropic-oauth",
+                "claude.bedrock"
               ],
               "observedInAllContexts": true,
               "viaTrialOnly": false
@@ -218,7 +224,7 @@
                 "claude.anthropic-api",
                 "claude.anthropic-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": true
             }
           },
@@ -267,7 +273,7 @@
                 "claude.anthropic-api",
                 "claude.anthropic-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": true
             }
           },
@@ -318,15 +324,453 @@
               "observedInAllContexts": false,
               "viaTrialOnly": false
             }
+          },
+          {
+            "id": "us.anthropic.claude-sonnet-4-6",
+            "displayName": "Sonnet 4.6",
+            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-sonnet-4-6[1m]",
+            "displayName": "Sonnet 4.6 (1M context)",
+            "description": "Sonnet 4.6 for long sessions",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-fable-5",
+            "displayName": "Fable 5",
+            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+            "displayName": "Opus 4.1",
+            "description": "Opus 4.1 · Legacy",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-8",
+            "displayName": "Opus 4.8",
+            "description": "Opus 4.8 · Best for everyday, complex tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-8[1m]",
+            "displayName": "Opus 4.8 (1M context)",
+            "description": "Opus 4.8 for long sessions",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-7",
+            "displayName": "Opus 4.7",
+            "description": "Opus 4.7 · Legacy",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-7[1m]",
+            "displayName": "Opus 4.7 (1M context)",
+            "description": "Opus 4.7 for long sessions",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-6-v1",
+            "displayName": "Opus 4.6",
+            "description": "Opus 4.6 · Legacy",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-6-v1[1m]",
+            "displayName": "Opus 4.6 (1M context)",
+            "description": "Opus 4.6 for long sessions",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "global.anthropic.claude-fable-5",
+            "displayName": "Fable 5",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": false,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "high"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": true
+            }
           }
         ],
         "observedDefaults": {
           "anthropic-api": "sonnet",
-          "anthropic-oauth": "opus"
+          "anthropic-oauth": "opus",
+          "bedrock": "us.anthropic.claude-sonnet-4-6"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-10T00:17:00.562127+00:00",
+        "probedAt": "2026-06-10T04:16:44.787695+00:00",
         "attestation": {
           "name": "@agentclientprotocol/claude-agent-acp",
           "version": "0.29.0",
@@ -340,6 +784,10 @@
           {
             "id": "claude.anthropic-oauth",
             "snapshotPath": "generated/claude.anthropic-oauth.probe.json"
+          },
+          {
+            "id": "claude.bedrock",
+            "snapshotPath": "generated/claude.bedrock.probe.json"
           }
         ]
       }
@@ -356,6 +804,10 @@
         }
       },
       "authContexts": [
+        {
+          "id": "bedrock",
+          "authSlotId": "bedrock"
+        },
         {
           "id": "openai-api",
           "authSlotId": "openai-api"
@@ -410,6 +862,227 @@
         ],
         "models": [
           {
+            "id": "openai.gpt-5.4-cmb/xhigh",
+            "displayName": "gpt-5.4 (xhigh)",
+            "description": "Strong model for everyday coding. Extra high reasoning depth for complex problems",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "plan",
+                  "default"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "xhigh"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.4-cmb",
+            "displayName": "gpt-5.4",
+            "description": "Strong model for everyday coding.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "plan",
+                  "default"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "openai.gpt-5.4-cmb/low",
+                "openai.gpt-5.4-cmb/medium",
+                "openai.gpt-5.4-cmb/high"
+              ]
+            }
+          },
+          {
+            "id": "openai.gpt-oss-120b",
+            "displayName": "GPT OSS 120B on Bedrock",
+            "description": "GPT OSS 120B on Bedrock Fast responses with lighter reasoning",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "plan",
+                  "default"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "openai.gpt-oss-120b/low",
+                "openai.gpt-oss-120b/medium",
+                "openai.gpt-oss-120b/high"
+              ]
+            }
+          },
+          {
+            "id": "openai.gpt-oss-20b",
+            "displayName": "GPT OSS 20B on Bedrock",
+            "description": "GPT OSS 20B on Bedrock Fast responses with lighter reasoning",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "plan",
+                  "default"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "openai.gpt-oss-20b/low",
+                "openai.gpt-oss-20b/medium",
+                "openai.gpt-oss-20b/high"
+              ]
+            }
+          },
+          {
             "id": "gpt-5.5",
             "displayName": "GPT-5.5",
             "description": "Frontier model for complex coding, research, and real-world work.",
@@ -459,7 +1132,7 @@
                 "codex.openai-api",
                 "codex.openai-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.5/low",
@@ -519,7 +1192,7 @@
                 "codex.openai-api",
                 "codex.openai-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.4/low",
@@ -579,7 +1252,7 @@
                 "codex.openai-api",
                 "codex.openai-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.4-mini/low",
@@ -639,7 +1312,7 @@
                 "codex.openai-api",
                 "codex.openai-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.3-codex/low",
@@ -699,7 +1372,7 @@
                 "codex.openai-api",
                 "codex.openai-oauth"
               ],
-              "observedInAllContexts": true,
+              "observedInAllContexts": false,
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.2/low",
@@ -769,18 +1442,23 @@
           }
         ],
         "observedDefaults": {
+          "bedrock": "openai.gpt-oss-120b/medium",
           "openai-api": "gpt-5.5/medium",
           "openai-oauth": "gpt-5.3-codex/medium"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-10T00:17:36.868072+00:00",
+        "probedAt": "2026-06-10T04:16:48.242571+00:00",
         "attestation": {
           "name": "codex-acp",
           "version": "0.11.8",
           "title": "Codex"
         },
         "runs": [
+          {
+            "id": "codex.bedrock",
+            "snapshotPath": "generated/codex.bedrock.probe.json"
+          },
           {
             "id": "codex.openai-api",
             "snapshotPath": "generated/codex.openai-api.probe.json"
@@ -1989,11 +2667,11 @@
           }
         ],
         "observedDefaults": {
-          "cursor-login": "claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]"
+          "cursor-login": "kimi-k2.5[]"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-10T00:26:29.701457+00:00",
+        "probedAt": "2026-06-10T04:19:51.541700+00:00",
         "attestation": null,
         "runs": [
           {
@@ -2236,7 +2914,7 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-10T00:19:20.487005+00:00",
+        "probedAt": "2026-06-10T04:17:09.648698+00:00",
         "attestation": {
           "name": "gemini-cli",
           "version": "0.45.3",
@@ -2277,6 +2955,10 @@
         {
           "id": "openai-api",
           "authSlotId": "openai-api"
+        },
+        {
+          "id": "opencode-zen",
+          "authSlotId": "opencode-zen"
         }
       ],
       "session": {
@@ -2290,6 +2972,13 @@
             }
           },
           {
+            "key": "mode",
+            "values": [
+              "build",
+              "plan"
+            ]
+          },
+          {
             "key": "effort",
             "values": [
               "high",
@@ -2300,50 +2989,9 @@
               "minimal",
               "none"
             ]
-          },
-          {
-            "key": "mode",
-            "values": [
-              "build",
-              "plan"
-            ]
           }
         ],
         "models": [
-          {
-            "id": "anthropic/claude-fable-5",
-            "displayName": "Anthropic/Claude Fable 5",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
           {
             "id": "anthropic/claude-3-5-haiku-latest",
             "displayName": "Anthropic/Claude Haiku 3.5 (latest)",
@@ -3048,7 +3696,8 @@
                 "anthropic-api",
                 "baseline",
                 "gemini-api",
-                "openai-api"
+                "openai-api",
+                "opencode-zen"
               ]
             },
             "defaultVisible": true,
@@ -3067,7 +3716,8 @@
                 "opencode.anthropic-api",
                 "opencode.baseline",
                 "opencode.gemini-api",
-                "opencode.openai-api"
+                "opencode.openai-api",
+                "opencode.opencode-zen"
               ],
               "observedInAllContexts": true,
               "viaTrialOnly": false
@@ -3081,7 +3731,8 @@
                 "anthropic-api",
                 "baseline",
                 "gemini-api",
-                "openai-api"
+                "openai-api",
+                "opencode-zen"
               ]
             },
             "defaultVisible": true,
@@ -3109,7 +3760,8 @@
                 "opencode.anthropic-api",
                 "opencode.baseline",
                 "opencode.gemini-api",
-                "opencode.openai-api"
+                "opencode.openai-api",
+                "opencode.opencode-zen"
               ],
               "observedInAllContexts": true,
               "viaTrialOnly": false
@@ -3123,7 +3775,8 @@
                 "anthropic-api",
                 "baseline",
                 "gemini-api",
-                "openai-api"
+                "openai-api",
+                "opencode-zen"
               ]
             },
             "defaultVisible": true,
@@ -3150,7 +3803,43 @@
                 "opencode.anthropic-api",
                 "opencode.baseline",
                 "opencode.gemini-api",
-                "opencode.openai-api"
+                "opencode.openai-api",
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/minimax-m3-free",
+            "displayName": "OpenCode Zen/MiniMax M3 Free",
+            "availability": {
+              "anyOf": [
+                "anthropic-api",
+                "baseline",
+                "gemini-api",
+                "openai-api",
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.anthropic-api",
+                "opencode.baseline",
+                "opencode.gemini-api",
+                "opencode.openai-api",
+                "opencode.opencode-zen"
               ],
               "observedInAllContexts": true,
               "viaTrialOnly": false
@@ -3164,7 +3853,8 @@
                 "anthropic-api",
                 "baseline",
                 "gemini-api",
-                "openai-api"
+                "openai-api",
+                "opencode-zen"
               ]
             },
             "defaultVisible": true,
@@ -3191,75 +3881,10 @@
                 "opencode.anthropic-api",
                 "opencode.baseline",
                 "opencode.gemini-api",
-                "opencode.openai-api"
+                "opencode.openai-api",
+                "opencode.opencode-zen"
               ],
               "observedInAllContexts": true,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode/north-mini-code-free",
-            "displayName": "OpenCode Zen/North Mini Code Free",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode/minimax-m3-free",
-            "displayName": "OpenCode Zen/MiniMax M3 Free",
-            "availability": {
-              "anyOf": [
-                "baseline",
-                "gemini-api",
-                "openai-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.baseline",
-                "opencode.gemini-api",
-                "opencode.openai-api"
-              ],
-              "observedInAllContexts": false,
               "viaTrialOnly": false
             }
           },
@@ -5571,17 +6196,1747 @@
               "observedInAllContexts": false,
               "viaTrialOnly": false
             }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-flash",
+            "displayName": "OpenCode Go/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-pro",
+            "displayName": "OpenCode Go/DeepSeek V4 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5",
+            "displayName": "OpenCode Go/GLM-5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5.1",
+            "displayName": "OpenCode Go/GLM-5.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.5",
+            "displayName": "OpenCode Go/Kimi K2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.6",
+            "displayName": "OpenCode Go/Kimi K2.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5",
+            "displayName": "OpenCode Go/MiMo V2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5-pro",
+            "displayName": "OpenCode Go/MiMo V2.5 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m2.5",
+            "displayName": "OpenCode Go/MiniMax M2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m2.7",
+            "displayName": "OpenCode Go/MiniMax M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m3",
+            "displayName": "OpenCode Go/MiniMax M3 3",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.6-plus",
+            "displayName": "OpenCode Go/Qwen3.6 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-max",
+            "displayName": "OpenCode Go/Qwen3.7 Max",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-plus",
+            "displayName": "OpenCode Go/Qwen3.7 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-haiku-4-5",
+            "displayName": "OpenCode Zen/Claude Haiku 4.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-opus-4-1",
+            "displayName": "OpenCode Zen/Claude Opus 4.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-opus-4-5",
+            "displayName": "OpenCode Zen/Claude Opus 4.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-opus-4-6",
+            "displayName": "OpenCode Zen/Claude Opus 4.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-opus-4-7",
+            "displayName": "OpenCode Zen/Claude Opus 4.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-opus-4-8",
+            "displayName": "OpenCode Zen/Claude Opus 4.8",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-sonnet-4",
+            "displayName": "OpenCode Zen/Claude Sonnet 4",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-sonnet-4-5",
+            "displayName": "OpenCode Zen/Claude Sonnet 4.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/claude-sonnet-4-6",
+            "displayName": "OpenCode Zen/Claude Sonnet 4.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/deepseek-v4-flash",
+            "displayName": "OpenCode Zen/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gemini-3-flash",
+            "displayName": "OpenCode Zen/Gemini 3 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "minimal"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gemini-3.1-pro",
+            "displayName": "OpenCode Zen/Gemini 3.1 Pro Preview",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gemini-3.5-flash",
+            "displayName": "OpenCode Zen/Gemini 3.5 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "minimal"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/glm-5",
+            "displayName": "OpenCode Zen/GLM-5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/glm-5.1",
+            "displayName": "OpenCode Zen/GLM-5.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5",
+            "displayName": "OpenCode Zen/GPT-5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "minimal"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5-codex",
+            "displayName": "OpenCode Zen/GPT-5 Codex",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5-nano",
+            "displayName": "OpenCode Zen/GPT-5 Nano",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "minimal"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.1",
+            "displayName": "OpenCode Zen/GPT-5.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.1-codex",
+            "displayName": "OpenCode Zen/GPT-5.1 Codex",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.1-codex-max",
+            "displayName": "OpenCode Zen/GPT-5.1 Codex Max",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.1-codex-mini",
+            "displayName": "OpenCode Zen/GPT-5.1 Codex Mini",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.2",
+            "displayName": "OpenCode Zen/GPT-5.2",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.2-codex",
+            "displayName": "OpenCode Zen/GPT-5.2 Codex",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.3-codex",
+            "displayName": "OpenCode Zen/GPT-5.3 Codex",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.3-codex-spark",
+            "displayName": "OpenCode Zen/GPT-5.3 Codex Spark",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.4",
+            "displayName": "OpenCode Zen/GPT-5.4",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.4-mini",
+            "displayName": "OpenCode Zen/GPT-5.4 Mini",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.4-nano",
+            "displayName": "OpenCode Zen/GPT-5.4 Nano",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.4-pro",
+            "displayName": "OpenCode Zen/GPT-5.4 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "medium"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.5",
+            "displayName": "OpenCode Zen/GPT-5.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.5-pro",
+            "displayName": "OpenCode Zen/GPT-5.5 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "medium"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/grok-build-0.1",
+            "displayName": "OpenCode Zen/Grok Build 0.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/kimi-k2.5",
+            "displayName": "OpenCode Zen/Kimi K2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/kimi-k2.6",
+            "displayName": "OpenCode Zen/Kimi K2.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/minimax-m2.5",
+            "displayName": "OpenCode Zen/MiniMax M2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/minimax-m2.7",
+            "displayName": "OpenCode Zen/MiniMax M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/qwen3.5-plus",
+            "displayName": "OpenCode Zen/Qwen3.5 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/qwen3.6-plus",
+            "displayName": "OpenCode Zen/Qwen3.6 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
           }
         ],
         "observedDefaults": {
           "anthropic-api": "opencode/big-pickle",
           "baseline": "opencode/big-pickle",
           "gemini-api": "opencode/big-pickle",
-          "openai-api": "opencode/big-pickle"
+          "openai-api": "opencode/big-pickle",
+          "opencode-zen": "opencode/big-pickle"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-10T00:17:38.139709+00:00",
+        "probedAt": "2026-06-10T04:20:28.761181+00:00",
         "attestation": {
           "name": "OpenCode",
           "version": "1.16.2",
@@ -5603,6 +7958,10 @@
           {
             "id": "opencode.openai-api",
             "snapshotPath": "generated/opencode.openai-api.probe.json"
+          },
+          {
+            "id": "opencode.opencode-zen",
+            "snapshotPath": "generated/opencode.opencode-zen.probe.json"
           }
         ]
       }

--- a/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-09T23:58:17.324567+00:00",
+  "probedAt": "2026-06-10T04:16:44.621939+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-api",
   "attestation": {
@@ -66,22 +66,22 @@
           "name": "Model",
           "options": [
             {
-              "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
               "name": "Fable",
               "value": "claude-fable-5"
             },
             {
-              "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks \u00b7 $3/$15 per Mtok",
+              "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
               "name": "Sonnet",
               "value": "sonnet"
             },
             {
-              "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+              "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
               "name": "Sonnet (1M context)",
               "value": "sonnet[1m]"
             },
             {
-              "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+              "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
               "name": "Haiku",
               "value": "haiku"
             }
@@ -169,17 +169,17 @@
           "name": "Model",
           "options": [
             {
-              "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks \u00b7 $3/$15 per Mtok",
+              "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
               "name": "Sonnet",
               "value": "sonnet"
             },
             {
-              "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+              "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
               "name": "Sonnet (1M context)",
               "value": "sonnet[1m]"
             },
             {
-              "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+              "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
               "name": "Haiku",
               "value": "haiku"
             },
@@ -324,17 +324,17 @@
       "name": "Model",
       "options": [
         {
-          "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks \u00b7 $3/$15 per Mtok",
+          "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
           "name": "Sonnet",
           "value": "sonnet"
         },
         {
-          "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+          "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
           "name": "Sonnet (1M context)",
           "value": "sonnet[1m]"
         },
         {
-          "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+          "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
           "name": "Haiku",
           "value": "haiku"
         }
@@ -368,7 +368,7 @@
     {
       "modelId": "sonnet",
       "name": "Sonnet",
-      "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks \u00b7 $3/$15 per Mtok",
+      "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
       "configOptions": [
         {
           "category": "mode",
@@ -447,7 +447,7 @@
     {
       "modelId": "sonnet[1m]",
       "name": "Sonnet (1M context)",
-      "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+      "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
       "configOptions": [
         {
           "category": "mode",
@@ -526,7 +526,7 @@
     {
       "modelId": "haiku",
       "name": "Haiku",
-      "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+      "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
       "configOptions": [
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:17:00.562127+00:00",
+  "probedAt": "2026-06-10T04:16:44.499656+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-oauth",
   "attestation": {
@@ -66,17 +66,17 @@
           "name": "Model",
           "options": [
             {
-              "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
               "name": "Fable",
               "value": "claude-fable-5"
             },
             {
-              "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+              "description": "Opus 4.8 · Best for everyday, complex tasks",
               "name": "Opus",
               "value": "opus"
             },
             {
-              "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+              "description": "Haiku 4.5 · Fastest for quick answers",
               "name": "Haiku",
               "value": "haiku"
             }
@@ -164,12 +164,12 @@
           "name": "Model",
           "options": [
             {
-              "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+              "description": "Opus 4.8 · Best for everyday, complex tasks",
               "name": "Opus",
               "value": "opus"
             },
             {
-              "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+              "description": "Haiku 4.5 · Fastest for quick answers",
               "name": "Haiku",
               "value": "haiku"
             },
@@ -314,12 +314,12 @@
       "name": "Model",
       "options": [
         {
-          "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+          "description": "Opus 4.8 · Best for everyday, complex tasks",
           "name": "Opus",
           "value": "opus"
         },
         {
-          "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+          "description": "Haiku 4.5 · Fastest for quick answers",
           "name": "Haiku",
           "value": "haiku"
         }
@@ -375,7 +375,7 @@
     {
       "modelId": "opus",
       "name": "Opus",
-      "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+      "description": "Opus 4.8 · Best for everyday, complex tasks",
       "configOptions": [
         {
           "category": "mode",
@@ -476,7 +476,7 @@
     {
       "modelId": "haiku",
       "name": "Haiku",
-      "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+      "description": "Haiku 4.5 · Fastest for quick answers",
       "configOptions": [
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/claude.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/claude.bedrock.probe.json
@@ -1,0 +1,1307 @@
+{
+  "probedAt": "2026-06-10T04:16:44.787695+00:00",
+  "agentKind": "claude",
+  "authContext": "bedrock",
+  "attestation": {
+    "name": "@agentclientprotocol/claude-agent-acp",
+    "version": "0.29.0",
+    "title": "Claude Agent"
+  },
+  "modelSource": "acpModels",
+  "nativeCli": {
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/claude/native/claude",
+    "version": "2.1.170 (Claude Code)"
+  },
+  "trials": [
+    {
+      "modelId": "global.anthropic.claude-fable-5",
+      "accepted": true,
+      "name": "Fable",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "global.anthropic.claude-fable-5",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [
+            {
+              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "name": "Sonnet",
+              "value": "us.anthropic.claude-sonnet-4-6"
+            },
+            {
+              "description": "Sonnet 4.6 for long sessions",
+              "name": "Sonnet (1M context)",
+              "value": "us.anthropic.claude-sonnet-4-6[1m]"
+            },
+            {
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+              "name": "Fable",
+              "value": "global.anthropic.claude-fable-5"
+            },
+            {
+              "description": "Opus 4.1 · Legacy",
+              "name": "Opus 4.1",
+              "value": "us.anthropic.claude-opus-4-1-20250805-v1:0"
+            },
+            {
+              "description": "Opus 4.8 · Best for everyday, complex tasks",
+              "name": "Opus",
+              "value": "us.anthropic.claude-opus-4-8"
+            },
+            {
+              "description": "Opus 4.8 for long sessions",
+              "name": "Opus (1M context)",
+              "value": "us.anthropic.claude-opus-4-8[1m]"
+            },
+            {
+              "description": "Opus 4.7 · Legacy",
+              "name": "Opus 4.7",
+              "value": "us.anthropic.claude-opus-4-7"
+            },
+            {
+              "description": "Opus 4.7 for long sessions",
+              "name": "Opus 4.7 (1M context)",
+              "value": "us.anthropic.claude-opus-4-7[1m]"
+            },
+            {
+              "description": "Opus 4.6 · Legacy",
+              "name": "Opus 4.6",
+              "value": "us.anthropic.claude-opus-4-6-v1"
+            },
+            {
+              "description": "Opus 4.6 for long sessions",
+              "name": "Opus 4.6 (1M context)",
+              "value": "us.anthropic.claude-opus-4-6-v1[1m]"
+            },
+            {
+              "description": "Haiku 4.5 · Fastest for quick answers",
+              "name": "Haiku",
+              "value": "haiku"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-8",
+      "accepted": true,
+      "name": "Opus",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-8",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [
+            {
+              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "name": "Sonnet",
+              "value": "us.anthropic.claude-sonnet-4-6"
+            },
+            {
+              "description": "Sonnet 4.6 for long sessions",
+              "name": "Sonnet (1M context)",
+              "value": "us.anthropic.claude-sonnet-4-6[1m]"
+            },
+            {
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+              "name": "Fable",
+              "value": "us.anthropic.claude-fable-5"
+            },
+            {
+              "description": "Opus 4.1 · Legacy",
+              "name": "Opus 4.1",
+              "value": "us.anthropic.claude-opus-4-1-20250805-v1:0"
+            },
+            {
+              "description": "Opus 4.8 · Best for everyday, complex tasks",
+              "name": "Opus",
+              "value": "us.anthropic.claude-opus-4-8"
+            },
+            {
+              "description": "Opus 4.8 for long sessions",
+              "name": "Opus (1M context)",
+              "value": "us.anthropic.claude-opus-4-8[1m]"
+            },
+            {
+              "description": "Opus 4.7 · Legacy",
+              "name": "Opus 4.7",
+              "value": "us.anthropic.claude-opus-4-7"
+            },
+            {
+              "description": "Opus 4.7 for long sessions",
+              "name": "Opus 4.7 (1M context)",
+              "value": "us.anthropic.claude-opus-4-7[1m]"
+            },
+            {
+              "description": "Opus 4.6 · Legacy",
+              "name": "Opus 4.6",
+              "value": "us.anthropic.claude-opus-4-6-v1"
+            },
+            {
+              "description": "Opus 4.6 for long sessions",
+              "name": "Opus 4.6 (1M context)",
+              "value": "us.anthropic.claude-opus-4-6-v1[1m]"
+            },
+            {
+              "description": "Haiku 4.5 · Fastest for quick answers",
+              "name": "Haiku",
+              "value": "haiku"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    }
+  ],
+  "currentModelId": "us.anthropic.claude-sonnet-4-6",
+  "currentModeId": "default",
+  "modes": {
+    "availableModes": [
+      {
+        "description": "Use a model classifier to approve/deny permission prompts.",
+        "id": "auto",
+        "name": "Auto"
+      },
+      {
+        "description": "Standard behavior, prompts for dangerous operations",
+        "id": "default",
+        "name": "Default"
+      },
+      {
+        "description": "Auto-accept file edit operations",
+        "id": "acceptEdits",
+        "name": "Accept Edits"
+      },
+      {
+        "description": "Planning mode, no actual tool execution",
+        "id": "plan",
+        "name": "Plan Mode"
+      },
+      {
+        "description": "Don't prompt for permissions, deny if not pre-approved",
+        "id": "dontAsk",
+        "name": "Don't Ask"
+      },
+      {
+        "description": "Bypass all permission checks",
+        "id": "bypassPermissions",
+        "name": "Bypass Permissions"
+      }
+    ],
+    "currentModeId": "default"
+  },
+  "baselineConfigOptions": [
+    {
+      "category": "mode",
+      "currentValue": "default",
+      "description": "Session permission mode",
+      "id": "mode",
+      "name": "Mode",
+      "options": [
+        {
+          "description": "Use a model classifier to approve/deny permission prompts.",
+          "name": "Auto",
+          "value": "auto"
+        },
+        {
+          "description": "Standard behavior, prompts for dangerous operations",
+          "name": "Default",
+          "value": "default"
+        },
+        {
+          "description": "Auto-accept file edit operations",
+          "name": "Accept Edits",
+          "value": "acceptEdits"
+        },
+        {
+          "description": "Planning mode, no actual tool execution",
+          "name": "Plan Mode",
+          "value": "plan"
+        },
+        {
+          "description": "Don't prompt for permissions, deny if not pre-approved",
+          "name": "Don't Ask",
+          "value": "dontAsk"
+        },
+        {
+          "description": "Bypass all permission checks",
+          "name": "Bypass Permissions",
+          "value": "bypassPermissions"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "model",
+      "currentValue": "us.anthropic.claude-sonnet-4-6",
+      "description": "AI model to use",
+      "id": "model",
+      "name": "Model",
+      "options": [
+        {
+          "description": "Sonnet 4.6 · Efficient for routine tasks",
+          "name": "Sonnet",
+          "value": "us.anthropic.claude-sonnet-4-6"
+        },
+        {
+          "description": "Sonnet 4.6 for long sessions",
+          "name": "Sonnet (1M context)",
+          "value": "us.anthropic.claude-sonnet-4-6[1m]"
+        },
+        {
+          "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+          "name": "Fable",
+          "value": "us.anthropic.claude-fable-5"
+        },
+        {
+          "description": "Opus 4.1 · Legacy",
+          "name": "Opus 4.1",
+          "value": "us.anthropic.claude-opus-4-1-20250805-v1:0"
+        },
+        {
+          "description": "Opus 4.8 · Best for everyday, complex tasks",
+          "name": "Opus",
+          "value": "us.anthropic.claude-opus-4-8"
+        },
+        {
+          "description": "Opus 4.8 for long sessions",
+          "name": "Opus (1M context)",
+          "value": "us.anthropic.claude-opus-4-8[1m]"
+        },
+        {
+          "description": "Opus 4.7 · Legacy",
+          "name": "Opus 4.7",
+          "value": "us.anthropic.claude-opus-4-7"
+        },
+        {
+          "description": "Opus 4.7 for long sessions",
+          "name": "Opus 4.7 (1M context)",
+          "value": "us.anthropic.claude-opus-4-7[1m]"
+        },
+        {
+          "description": "Opus 4.6 · Legacy",
+          "name": "Opus 4.6",
+          "value": "us.anthropic.claude-opus-4-6-v1"
+        },
+        {
+          "description": "Opus 4.6 for long sessions",
+          "name": "Opus 4.6 (1M context)",
+          "value": "us.anthropic.claude-opus-4-6-v1[1m]"
+        },
+        {
+          "description": "Haiku 4.5 · Fastest for quick answers",
+          "name": "Haiku",
+          "value": "haiku"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "thought_level",
+      "currentValue": "high",
+      "description": "Reasoning depth",
+      "id": "effort",
+      "name": "Effort",
+      "options": [
+        {
+          "name": "Low",
+          "value": "low"
+        },
+        {
+          "name": "Medium",
+          "value": "medium"
+        },
+        {
+          "name": "High",
+          "value": "high"
+        }
+      ],
+      "type": "select"
+    }
+  ],
+  "models": [
+    {
+      "modelId": "us.anthropic.claude-sonnet-4-6",
+      "name": "Sonnet",
+      "description": "Sonnet 4.6 · Efficient for routine tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-sonnet-4-6",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-sonnet-4-6[1m]",
+      "name": "Sonnet (1M context)",
+      "description": "Sonnet 4.6 for long sessions",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-sonnet-4-6[1m]",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-fable-5",
+      "name": "Fable",
+      "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-fable-5",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+      "name": "Opus 4.1",
+      "description": "Opus 4.1 · Legacy",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-8",
+      "name": "Opus",
+      "description": "Opus 4.8 · Best for everyday, complex tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-8",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-8[1m]",
+      "name": "Opus (1M context)",
+      "description": "Opus 4.8 for long sessions",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-8[1m]",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-7",
+      "name": "Opus 4.7",
+      "description": "Opus 4.7 · Legacy",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-7",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-7[1m]",
+      "name": "Opus 4.7 (1M context)",
+      "description": "Opus 4.7 for long sessions",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-7[1m]",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "X High",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-6-v1",
+      "name": "Opus 4.6",
+      "description": "Opus 4.6 · Legacy",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-6-v1",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-opus-4-6-v1[1m]",
+      "name": "Opus 4.6 (1M context)",
+      "description": "Opus 4.6 for long sessions",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-opus-4-6-v1[1m]",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Reasoning depth",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "haiku",
+      "name": "Haiku",
+      "description": "Haiku 4.5 · Fastest for quick answers",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts.",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "haiku",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    }
+  ],
+  "warnings": []
+}

--- a/scripts/agent-catalog/generated/codex.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/codex.bedrock.probe.json
@@ -1,0 +1,1248 @@
+{
+  "probedAt": "2026-06-10T04:16:47.726808+00:00",
+  "agentKind": "codex",
+  "authContext": "bedrock",
+  "attestation": {
+    "name": "codex-acp",
+    "version": "0.11.8",
+    "title": "Codex"
+  },
+  "modelSource": "acpModels",
+  "nativeCli": {
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
+    "version": "codex-cli 0.139.0"
+  },
+  "trials": [],
+  "currentModelId": "openai.gpt-oss-120b/medium",
+  "currentModeId": "read-only",
+  "modes": {
+    "availableModes": [
+      {
+        "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+        "id": "read-only",
+        "name": "Read Only"
+      },
+      {
+        "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+        "id": "auto",
+        "name": "Default"
+      },
+      {
+        "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+        "id": "full-access",
+        "name": "Full Access"
+      }
+    ],
+    "currentModeId": "read-only"
+  },
+  "baselineConfigOptions": [
+    {
+      "category": "mode",
+      "currentValue": "read-only",
+      "description": "Choose an approval and sandboxing preset for your session",
+      "id": "mode",
+      "name": "Approval Preset",
+      "options": [
+        {
+          "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+          "name": "Read Only",
+          "value": "read-only"
+        },
+        {
+          "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+          "name": "Default",
+          "value": "auto"
+        },
+        {
+          "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+          "name": "Full Access",
+          "value": "full-access"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "collaboration_mode",
+      "currentValue": "default",
+      "description": "Choose whether Codex should work in default or planning mode",
+      "id": "collaboration_mode",
+      "name": "Collaboration Mode",
+      "options": [
+        {
+          "description": "Switch to planning mode with Codex plan instructions",
+          "name": "Plan",
+          "value": "plan"
+        },
+        {
+          "description": "Switch to default execution mode with Codex default instructions",
+          "name": "Default",
+          "value": "default"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "model",
+      "currentValue": "openai.gpt-oss-120b",
+      "description": "Choose which model Codex should use",
+      "id": "model",
+      "name": "Model",
+      "options": [
+        {
+          "description": "Strong model for everyday coding.",
+          "name": "gpt-5.4",
+          "value": "openai.gpt-5.4-cmb"
+        },
+        {
+          "description": "GPT OSS 120B on Bedrock",
+          "name": "GPT OSS 120B on Bedrock",
+          "value": "openai.gpt-oss-120b"
+        },
+        {
+          "description": "GPT OSS 20B on Bedrock",
+          "name": "GPT OSS 20B on Bedrock",
+          "value": "openai.gpt-oss-20b"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "thought_level",
+      "currentValue": "medium",
+      "description": "Choose how much reasoning effort the model should use",
+      "id": "reasoning_effort",
+      "name": "Reasoning Effort",
+      "options": [
+        {
+          "description": "Fast responses with lighter reasoning",
+          "name": "Low",
+          "value": "low"
+        },
+        {
+          "description": "Balances speed and reasoning depth for everyday tasks",
+          "name": "Medium",
+          "value": "medium"
+        },
+        {
+          "description": "Greater reasoning depth for complex problems",
+          "name": "High",
+          "value": "high"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "fast_mode",
+      "currentValue": "off",
+      "description": "Choose whether Codex should use fast mode",
+      "id": "fast_mode",
+      "name": "Fast Mode",
+      "options": [
+        {
+          "description": "Use Codex's default service tier",
+          "name": "Off",
+          "value": "off"
+        },
+        {
+          "description": "Request the fast Codex service tier",
+          "name": "On",
+          "value": "on"
+        }
+      ],
+      "type": "select"
+    }
+  ],
+  "models": [
+    {
+      "modelId": "openai.gpt-5.4-cmb/low",
+      "name": "gpt-5.4 (low)",
+      "description": "Strong model for everyday coding. Fast responses with lighter reasoning",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.4-cmb",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.4-cmb/medium",
+      "name": "gpt-5.4 (medium)",
+      "description": "Strong model for everyday coding. Balances speed and reasoning depth for everyday tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.4-cmb",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.4-cmb/high",
+      "name": "gpt-5.4 (high)",
+      "description": "Strong model for everyday coding. Greater reasoning depth for complex problems",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.4-cmb",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.4-cmb/xhigh",
+      "name": "gpt-5.4 (xhigh)",
+      "description": "Strong model for everyday coding. Extra high reasoning depth for complex problems",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.4-cmb",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "xhigh",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-120b/low",
+      "name": "GPT OSS 120B on Bedrock (low)",
+      "description": "GPT OSS 120B on Bedrock Fast responses with lighter reasoning",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-120b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-120b/medium",
+      "name": "GPT OSS 120B on Bedrock (medium)",
+      "description": "GPT OSS 120B on Bedrock Balances speed and reasoning depth for everyday tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-120b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-120b/high",
+      "name": "GPT OSS 120B on Bedrock (high)",
+      "description": "GPT OSS 120B on Bedrock Greater reasoning depth for complex problems",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-120b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-20b/low",
+      "name": "GPT OSS 20B on Bedrock (low)",
+      "description": "GPT OSS 20B on Bedrock Fast responses with lighter reasoning",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-20b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-20b/medium",
+      "name": "GPT OSS 20B on Bedrock (medium)",
+      "description": "GPT OSS 20B on Bedrock Balances speed and reasoning depth for everyday tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-20b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-oss-20b/high",
+      "name": "GPT OSS 20B on Bedrock (high)",
+      "description": "GPT OSS 20B on Bedrock Greater reasoning depth for complex problems",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Switch to planning mode with Codex plan instructions",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Switch to default execution mode with Codex default instructions",
+              "name": "Default",
+              "value": "default"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-oss-20b",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use Codex's default service tier",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the fast Codex service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    }
+  ],
+  "warnings": []
+}

--- a/scripts/agent-catalog/generated/codex.openai-api.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:17:31.347128+00:00",
+  "probedAt": "2026-06-10T04:16:47.729834+00:00",
   "agentKind": "codex",
   "authContext": "openai-api",
   "attestation": {

--- a/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:17:36.868072+00:00",
+  "probedAt": "2026-06-10T04:16:48.242571+00:00",
   "agentKind": "codex",
   "authContext": "openai-oauth",
   "attestation": {

--- a/scripts/agent-catalog/generated/cursor.cursor-login.probe.json
+++ b/scripts/agent-catalog/generated/cursor.cursor-login.probe.json
@@ -1,12 +1,12 @@
 {
-  "probedAt": "2026-06-10T00:26:29.701457+00:00",
+  "probedAt": "2026-06-10T04:19:51.541700+00:00",
   "agentKind": "cursor",
   "authContext": "cursor-login",
   "attestation": null,
   "modelSource": "acpModels",
   "nativeCli": null,
   "trials": [],
-  "currentModelId": "claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]",
+  "currentModelId": "kimi-k2.5[]",
   "currentModeId": "agent",
   "modes": {
     "availableModes": [
@@ -56,7 +56,7 @@
     },
     {
       "category": "model",
-      "currentValue": "claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]",
+      "currentValue": "kimi-k2.5[]",
       "description": "Controls which model variant is used for responses",
       "id": "model",
       "name": "Model",

--- a/scripts/agent-catalog/generated/gemini.gemini-api.probe.json
+++ b/scripts/agent-catalog/generated/gemini.gemini-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:18:35.281128+00:00",
+  "probedAt": "2026-06-10T04:17:09.648698+00:00",
   "agentKind": "gemini",
   "authContext": "gemini-api",
   "attestation": {
@@ -77,11 +77,11 @@
     }
   ],
   "warnings": [
-    "no ConfigOptionUpdate within 6s after switching to auto",
-    "no ConfigOptionUpdate within 6s after switching to gemini-3-pro-preview",
-    "no ConfigOptionUpdate within 6s after switching to gemini-3-flash-preview",
-    "no ConfigOptionUpdate within 6s after switching to gemini-2.5-pro",
-    "no ConfigOptionUpdate within 6s after switching to gemini-2.5-flash",
-    "no ConfigOptionUpdate within 6s after switching to gemini-3.1-flash-lite"
+    "no ConfigOptionUpdate within 3s after switching to auto",
+    "no ConfigOptionUpdate within 3s after switching to gemini-3-pro-preview",
+    "no ConfigOptionUpdate within 3s after switching to gemini-3-flash-preview",
+    "no ConfigOptionUpdate within 3s after switching to gemini-2.5-pro",
+    "no ConfigOptionUpdate within 3s after switching to gemini-2.5-flash",
+    "no ConfigOptionUpdate within 3s after switching to gemini-3.1-flash-lite"
   ]
 }

--- a/scripts/agent-catalog/generated/gemini.google-oauth.probe.json
+++ b/scripts/agent-catalog/generated/gemini.google-oauth.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:19:20.487005+00:00",
+  "probedAt": "2026-06-10T04:17:05.851632+00:00",
   "agentKind": "gemini",
   "authContext": "google-oauth",
   "attestation": {

--- a/scripts/agent-catalog/generated/opencode.anthropic-api.probe.json
+++ b/scripts/agent-catalog/generated/opencode.anthropic-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-09T22:45:49.055258+00:00",
+  "probedAt": "2026-06-10T04:16:43.719600+00:00",
   "agentKind": "opencode",
   "authContext": "anthropic-api",
   "attestation": {
@@ -8,6 +8,8 @@
     "title": null
   },
   "modelSource": "modelConfigOption",
+  "nativeCli": null,
+  "trials": [],
   "currentModelId": null,
   "currentModeId": null,
   "modes": null,
@@ -18,10 +20,6 @@
       "id": "model",
       "name": "Model",
       "options": [
-        {
-          "name": "Anthropic/Claude Fable 5",
-          "value": "anthropic/claude-fable-5"
-        },
         {
           "name": "Anthropic/Claude Haiku 3.5 (latest)",
           "value": "anthropic/claude-3-5-haiku-latest"
@@ -115,12 +113,12 @@
           "value": "opencode/mimo-v2.5-free"
         },
         {
-          "name": "OpenCode Zen/Nemotron 3 Ultra Free",
-          "value": "opencode/nemotron-3-ultra-free"
+          "name": "OpenCode Zen/MiniMax M3 Free",
+          "value": "opencode/minimax-m3-free"
         },
         {
-          "name": "OpenCode Zen/North Mini Code Free",
-          "value": "opencode/north-mini-code-free"
+          "name": "OpenCode Zen/Nemotron 3 Ultra Free",
+          "value": "opencode/nemotron-3-ultra-free"
         }
       ],
       "type": "select"
@@ -146,59 +144,6 @@
     }
   ],
   "models": [
-    {
-      "modelId": "anthropic/claude-fable-5",
-      "name": "Anthropic/Claude Fable 5",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-fable-5",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
     {
       "modelId": "anthropic/claude-3-5-haiku-latest",
       "name": "Anthropic/Claude Haiku 3.5 (latest)",
@@ -1487,40 +1432,18 @@
       ]
     },
     {
-      "modelId": "opencode/nemotron-3-ultra-free",
-      "name": "OpenCode Zen/Nemotron 3 Ultra Free",
+      "modelId": "opencode/minimax-m3-free",
+      "name": "OpenCode Zen/MiniMax M3 Free",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "opencode/nemotron-3-ultra-free",
+          "currentValue": "opencode/minimax-m3-free",
           "id": "model",
           "name": "Model",
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",
@@ -1544,13 +1467,13 @@
       ]
     },
     {
-      "modelId": "opencode/north-mini-code-free",
-      "name": "OpenCode Zen/North Mini Code Free",
+      "modelId": "opencode/nemotron-3-ultra-free",
+      "name": "OpenCode Zen/Nemotron 3 Ultra Free",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "opencode/north-mini-code-free",
+          "currentValue": "opencode/nemotron-3-ultra-free",
           "id": "model",
           "name": "Model",
           "options": [],

--- a/scripts/agent-catalog/generated/opencode.baseline.probe.json
+++ b/scripts/agent-catalog/generated/opencode.baseline.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-09T22:45:37.753434+00:00",
+  "probedAt": "2026-06-10T04:16:43.697592+00:00",
   "agentKind": "opencode",
   "authContext": "baseline",
   "attestation": {
@@ -8,6 +8,8 @@
     "title": null
   },
   "modelSource": "modelConfigOption",
+  "nativeCli": null,
+  "trials": [],
   "currentModelId": null,
   "currentModeId": null,
   "modes": null,

--- a/scripts/agent-catalog/generated/opencode.gemini-api.probe.json
+++ b/scripts/agent-catalog/generated/opencode.gemini-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-10T00:17:38.139709+00:00",
+  "probedAt": "2026-06-10T04:16:43.714257+00:00",
   "agentKind": "opencode",
   "authContext": "gemini-api",
   "attestation": {

--- a/scripts/agent-catalog/generated/opencode.opencode-zen.probe.json
+++ b/scripts/agent-catalog/generated/opencode.opencode-zen.probe.json
@@ -1,7 +1,7 @@
 {
-  "probedAt": "2026-06-10T04:16:43.752536+00:00",
+  "probedAt": "2026-06-10T04:20:28.761181+00:00",
   "agentKind": "opencode",
-  "authContext": "openai-api",
+  "authContext": "opencode-zen",
   "attestation": {
     "name": "OpenCode",
     "version": "1.16.2",
@@ -21,224 +21,220 @@
       "name": "Model",
       "options": [
         {
-          "name": "OpenAI/chatgpt-image-latest",
-          "value": "openai/chatgpt-image-latest"
+          "name": "OpenCode Go/DeepSeek V4 Flash",
+          "value": "opencode-go/deepseek-v4-flash"
         },
         {
-          "name": "OpenAI/GPT-3.5-turbo",
-          "value": "openai/gpt-3.5-turbo"
+          "name": "OpenCode Go/DeepSeek V4 Pro",
+          "value": "opencode-go/deepseek-v4-pro"
         },
         {
-          "name": "OpenAI/GPT-4",
-          "value": "openai/gpt-4"
+          "name": "OpenCode Go/GLM-5",
+          "value": "opencode-go/glm-5"
         },
         {
-          "name": "OpenAI/GPT-4 Turbo",
-          "value": "openai/gpt-4-turbo"
+          "name": "OpenCode Go/GLM-5.1",
+          "value": "opencode-go/glm-5.1"
         },
         {
-          "name": "OpenAI/GPT-4.1",
-          "value": "openai/gpt-4.1"
+          "name": "OpenCode Go/Kimi K2.5",
+          "value": "opencode-go/kimi-k2.5"
         },
         {
-          "name": "OpenAI/GPT-4.1 mini",
-          "value": "openai/gpt-4.1-mini"
+          "name": "OpenCode Go/Kimi K2.6",
+          "value": "opencode-go/kimi-k2.6"
         },
         {
-          "name": "OpenAI/GPT-4.1 nano",
-          "value": "openai/gpt-4.1-nano"
+          "name": "OpenCode Go/MiMo V2.5",
+          "value": "opencode-go/mimo-v2.5"
         },
         {
-          "name": "OpenAI/GPT-4o",
-          "value": "openai/gpt-4o"
+          "name": "OpenCode Go/MiMo V2.5 Pro",
+          "value": "opencode-go/mimo-v2.5-pro"
         },
         {
-          "name": "OpenAI/GPT-4o (2024-05-13)",
-          "value": "openai/gpt-4o-2024-05-13"
+          "name": "OpenCode Go/MiniMax M2.5",
+          "value": "opencode-go/minimax-m2.5"
         },
         {
-          "name": "OpenAI/GPT-4o (2024-08-06)",
-          "value": "openai/gpt-4o-2024-08-06"
+          "name": "OpenCode Go/MiniMax M2.7",
+          "value": "opencode-go/minimax-m2.7"
         },
         {
-          "name": "OpenAI/GPT-4o (2024-11-20)",
-          "value": "openai/gpt-4o-2024-11-20"
+          "name": "OpenCode Go/MiniMax M3",
+          "value": "opencode-go/minimax-m3"
         },
         {
-          "name": "OpenAI/GPT-4o mini",
-          "value": "openai/gpt-4o-mini"
+          "name": "OpenCode Go/Qwen3.6 Plus",
+          "value": "opencode-go/qwen3.6-plus"
         },
         {
-          "name": "OpenAI/GPT-5",
-          "value": "openai/gpt-5"
+          "name": "OpenCode Go/Qwen3.7 Max",
+          "value": "opencode-go/qwen3.7-max"
         },
         {
-          "name": "OpenAI/GPT-5 Mini",
-          "value": "openai/gpt-5-mini"
-        },
-        {
-          "name": "OpenAI/GPT-5 Nano",
-          "value": "openai/gpt-5-nano"
-        },
-        {
-          "name": "OpenAI/GPT-5 Pro",
-          "value": "openai/gpt-5-pro"
-        },
-        {
-          "name": "OpenAI/GPT-5-Codex",
-          "value": "openai/gpt-5-codex"
-        },
-        {
-          "name": "OpenAI/GPT-5.1",
-          "value": "openai/gpt-5.1"
-        },
-        {
-          "name": "OpenAI/GPT-5.1 Chat",
-          "value": "openai/gpt-5.1-chat-latest"
-        },
-        {
-          "name": "OpenAI/GPT-5.1 Codex",
-          "value": "openai/gpt-5.1-codex"
-        },
-        {
-          "name": "OpenAI/GPT-5.1 Codex Max",
-          "value": "openai/gpt-5.1-codex-max"
-        },
-        {
-          "name": "OpenAI/GPT-5.1 Codex mini",
-          "value": "openai/gpt-5.1-codex-mini"
-        },
-        {
-          "name": "OpenAI/GPT-5.2",
-          "value": "openai/gpt-5.2"
-        },
-        {
-          "name": "OpenAI/GPT-5.2 Chat",
-          "value": "openai/gpt-5.2-chat-latest"
-        },
-        {
-          "name": "OpenAI/GPT-5.2 Codex",
-          "value": "openai/gpt-5.2-codex"
-        },
-        {
-          "name": "OpenAI/GPT-5.2 Pro",
-          "value": "openai/gpt-5.2-pro"
-        },
-        {
-          "name": "OpenAI/GPT-5.3 Chat (latest)",
-          "value": "openai/gpt-5.3-chat-latest"
-        },
-        {
-          "name": "OpenAI/GPT-5.3 Codex",
-          "value": "openai/gpt-5.3-codex"
-        },
-        {
-          "name": "OpenAI/GPT-5.3 Codex Spark",
-          "value": "openai/gpt-5.3-codex-spark"
-        },
-        {
-          "name": "OpenAI/GPT-5.4",
-          "value": "openai/gpt-5.4"
-        },
-        {
-          "name": "OpenAI/GPT-5.4 Fast",
-          "value": "openai/gpt-5.4-fast"
-        },
-        {
-          "name": "OpenAI/GPT-5.4 mini",
-          "value": "openai/gpt-5.4-mini"
-        },
-        {
-          "name": "OpenAI/GPT-5.4 mini Fast",
-          "value": "openai/gpt-5.4-mini-fast"
-        },
-        {
-          "name": "OpenAI/GPT-5.4 nano",
-          "value": "openai/gpt-5.4-nano"
-        },
-        {
-          "name": "OpenAI/GPT-5.4 Pro",
-          "value": "openai/gpt-5.4-pro"
-        },
-        {
-          "name": "OpenAI/GPT-5.5",
-          "value": "openai/gpt-5.5"
-        },
-        {
-          "name": "OpenAI/GPT-5.5 Fast",
-          "value": "openai/gpt-5.5-fast"
-        },
-        {
-          "name": "OpenAI/GPT-5.5 Pro",
-          "value": "openai/gpt-5.5-pro"
-        },
-        {
-          "name": "OpenAI/gpt-image-1",
-          "value": "openai/gpt-image-1"
-        },
-        {
-          "name": "OpenAI/gpt-image-1-mini",
-          "value": "openai/gpt-image-1-mini"
-        },
-        {
-          "name": "OpenAI/gpt-image-1.5",
-          "value": "openai/gpt-image-1.5"
-        },
-        {
-          "name": "OpenAI/o1",
-          "value": "openai/o1"
-        },
-        {
-          "name": "OpenAI/o1-pro",
-          "value": "openai/o1-pro"
-        },
-        {
-          "name": "OpenAI/o3",
-          "value": "openai/o3"
-        },
-        {
-          "name": "OpenAI/o3-deep-research",
-          "value": "openai/o3-deep-research"
-        },
-        {
-          "name": "OpenAI/o3-mini",
-          "value": "openai/o3-mini"
-        },
-        {
-          "name": "OpenAI/o3-pro",
-          "value": "openai/o3-pro"
-        },
-        {
-          "name": "OpenAI/o4-mini",
-          "value": "openai/o4-mini"
-        },
-        {
-          "name": "OpenAI/o4-mini-deep-research",
-          "value": "openai/o4-mini-deep-research"
-        },
-        {
-          "name": "OpenAI/text-embedding-3-large",
-          "value": "openai/text-embedding-3-large"
-        },
-        {
-          "name": "OpenAI/text-embedding-3-small",
-          "value": "openai/text-embedding-3-small"
-        },
-        {
-          "name": "OpenAI/text-embedding-ada-002",
-          "value": "openai/text-embedding-ada-002"
+          "name": "OpenCode Go/Qwen3.7 Plus",
+          "value": "opencode-go/qwen3.7-plus"
         },
         {
           "name": "OpenCode Zen/Big Pickle",
           "value": "opencode/big-pickle"
         },
         {
+          "name": "OpenCode Zen/Claude Haiku 4.5",
+          "value": "opencode/claude-haiku-4-5"
+        },
+        {
+          "name": "OpenCode Zen/Claude Opus 4.1",
+          "value": "opencode/claude-opus-4-1"
+        },
+        {
+          "name": "OpenCode Zen/Claude Opus 4.5",
+          "value": "opencode/claude-opus-4-5"
+        },
+        {
+          "name": "OpenCode Zen/Claude Opus 4.6",
+          "value": "opencode/claude-opus-4-6"
+        },
+        {
+          "name": "OpenCode Zen/Claude Opus 4.7",
+          "value": "opencode/claude-opus-4-7"
+        },
+        {
+          "name": "OpenCode Zen/Claude Opus 4.8",
+          "value": "opencode/claude-opus-4-8"
+        },
+        {
+          "name": "OpenCode Zen/Claude Sonnet 4",
+          "value": "opencode/claude-sonnet-4"
+        },
+        {
+          "name": "OpenCode Zen/Claude Sonnet 4.5",
+          "value": "opencode/claude-sonnet-4-5"
+        },
+        {
+          "name": "OpenCode Zen/Claude Sonnet 4.6",
+          "value": "opencode/claude-sonnet-4-6"
+        },
+        {
+          "name": "OpenCode Zen/DeepSeek V4 Flash",
+          "value": "opencode/deepseek-v4-flash"
+        },
+        {
           "name": "OpenCode Zen/DeepSeek V4 Flash Free",
           "value": "opencode/deepseek-v4-flash-free"
         },
         {
+          "name": "OpenCode Zen/Gemini 3 Flash",
+          "value": "opencode/gemini-3-flash"
+        },
+        {
+          "name": "OpenCode Zen/Gemini 3.1 Pro Preview",
+          "value": "opencode/gemini-3.1-pro"
+        },
+        {
+          "name": "OpenCode Zen/Gemini 3.5 Flash",
+          "value": "opencode/gemini-3.5-flash"
+        },
+        {
+          "name": "OpenCode Zen/GLM-5",
+          "value": "opencode/glm-5"
+        },
+        {
+          "name": "OpenCode Zen/GLM-5.1",
+          "value": "opencode/glm-5.1"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5",
+          "value": "opencode/gpt-5"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5 Codex",
+          "value": "opencode/gpt-5-codex"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5 Nano",
+          "value": "opencode/gpt-5-nano"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.1",
+          "value": "opencode/gpt-5.1"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.1 Codex",
+          "value": "opencode/gpt-5.1-codex"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.1 Codex Max",
+          "value": "opencode/gpt-5.1-codex-max"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.1 Codex Mini",
+          "value": "opencode/gpt-5.1-codex-mini"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.2",
+          "value": "opencode/gpt-5.2"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.2 Codex",
+          "value": "opencode/gpt-5.2-codex"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.3 Codex",
+          "value": "opencode/gpt-5.3-codex"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.3 Codex Spark",
+          "value": "opencode/gpt-5.3-codex-spark"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.4",
+          "value": "opencode/gpt-5.4"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.4 Mini",
+          "value": "opencode/gpt-5.4-mini"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.4 Nano",
+          "value": "opencode/gpt-5.4-nano"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.4 Pro",
+          "value": "opencode/gpt-5.4-pro"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.5",
+          "value": "opencode/gpt-5.5"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.5 Pro",
+          "value": "opencode/gpt-5.5-pro"
+        },
+        {
+          "name": "OpenCode Zen/Grok Build 0.1",
+          "value": "opencode/grok-build-0.1"
+        },
+        {
+          "name": "OpenCode Zen/Kimi K2.5",
+          "value": "opencode/kimi-k2.5"
+        },
+        {
+          "name": "OpenCode Zen/Kimi K2.6",
+          "value": "opencode/kimi-k2.6"
+        },
+        {
           "name": "OpenCode Zen/MiMo V2.5 Free",
           "value": "opencode/mimo-v2.5-free"
+        },
+        {
+          "name": "OpenCode Zen/MiniMax M2.5",
+          "value": "opencode/minimax-m2.5"
+        },
+        {
+          "name": "OpenCode Zen/MiniMax M2.7",
+          "value": "opencode/minimax-m2.7"
         },
         {
           "name": "OpenCode Zen/MiniMax M3 Free",
@@ -247,6 +243,14 @@
         {
           "name": "OpenCode Zen/Nemotron 3 Ultra Free",
           "value": "opencode/nemotron-3-ultra-free"
+        },
+        {
+          "name": "OpenCode Zen/Qwen3.5 Plus",
+          "value": "opencode/qwen3.5-plus"
+        },
+        {
+          "name": "OpenCode Zen/Qwen3.6 Plus",
+          "value": "opencode/qwen3.6-plus"
         }
       ],
       "type": "select"
@@ -273,433 +277,13 @@
   ],
   "models": [
     {
-      "modelId": "openai/chatgpt-image-latest",
-      "name": "OpenAI/chatgpt-image-latest",
+      "modelId": "opencode-go/deepseek-v4-flash",
+      "name": "OpenCode Go/DeepSeek V4 Flash",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/chatgpt-image-latest",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-3.5-turbo",
-      "name": "OpenAI/GPT-3.5-turbo",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-3.5-turbo",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4",
-      "name": "OpenAI/GPT-4",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4-turbo",
-      "name": "OpenAI/GPT-4 Turbo",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4-turbo",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4.1",
-      "name": "OpenAI/GPT-4.1",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4.1",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4.1-mini",
-      "name": "OpenAI/GPT-4.1 mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4.1-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4.1-nano",
-      "name": "OpenAI/GPT-4.1 nano",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4.1-nano",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4o",
-      "name": "OpenAI/GPT-4o",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4o",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4o-2024-05-13",
-      "name": "OpenAI/GPT-4o (2024-05-13)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4o-2024-05-13",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4o-2024-08-06",
-      "name": "OpenAI/GPT-4o (2024-08-06)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4o-2024-08-06",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4o-2024-11-20",
-      "name": "OpenAI/GPT-4o (2024-11-20)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4o-2024-11-20",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-4o-mini",
-      "name": "OpenAI/GPT-4o mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-4o-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5",
-      "name": "OpenAI/GPT-5",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5",
+          "currentValue": "opencode-go/deepseek-v4-flash",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -708,15 +292,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "minimal",
+          "currentValue": "low",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Minimal",
-              "value": "minimal"
-            },
             {
               "name": "Low",
               "value": "low"
@@ -728,6 +308,10 @@
             {
               "name": "High",
               "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
             }
           ],
           "type": "select"
@@ -754,13 +338,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5-mini",
-      "name": "OpenAI/GPT-5 Mini",
+      "modelId": "opencode-go/deepseek-v4-pro",
+      "name": "OpenCode Go/DeepSeek V4 Pro",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5-mini",
+          "currentValue": "opencode-go/deepseek-v4-pro",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -769,15 +353,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "minimal",
+          "currentValue": "low",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Minimal",
-              "value": "minimal"
-            },
             {
               "name": "Low",
               "value": "low"
@@ -789,6 +369,10 @@
             {
               "name": "High",
               "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
             }
           ],
           "type": "select"
@@ -815,13 +399,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5-nano",
-      "name": "OpenAI/GPT-5 Nano",
+      "modelId": "opencode-go/glm-5",
+      "name": "OpenCode Go/GLM-5",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5-nano",
+          "currentValue": "opencode-go/glm-5",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -829,32 +413,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "minimal",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Minimal",
-              "value": "minimal"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -876,13 +434,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5-pro",
-      "name": "OpenAI/GPT-5 Pro",
+      "modelId": "opencode-go/glm-5.1",
+      "name": "OpenCode Go/GLM-5.1",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5-pro",
+          "currentValue": "opencode-go/glm-5.1",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -890,18 +448,39 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
           "options": [
             {
-              "name": "High",
-              "value": "high"
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
             }
           ],
           "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/kimi-k2.5",
+      "name": "OpenCode Go/Kimi K2.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/kimi-k2.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -925,13 +504,48 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5-codex",
-      "name": "OpenAI/GPT-5-Codex",
+      "modelId": "opencode-go/kimi-k2.6",
+      "name": "OpenCode Go/Kimi K2.6",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5-codex",
+          "currentValue": "opencode-go/kimi-k2.6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/mimo-v2.5",
+      "name": "OpenCode Go/MiMo V2.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/mimo-v2.5",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -982,123 +596,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5.1",
-      "name": "OpenAI/GPT-5.1",
+      "modelId": "opencode-go/mimo-v2.5-pro",
+      "name": "OpenCode Go/MiMo V2.5 Pro",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5.1",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.1-chat-latest",
-      "name": "OpenAI/GPT-5.1 Chat",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.1-chat-latest",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.1-codex",
-      "name": "OpenAI/GPT-5.1 Codex",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.1-codex",
+          "currentValue": "opencode-go/mimo-v2.5-pro",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -1149,363 +653,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5.1-codex-max",
-      "name": "OpenAI/GPT-5.1 Codex Max",
+      "modelId": "opencode-go/minimax-m2.5",
+      "name": "OpenCode Go/MiniMax M2.5",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5.1-codex-max",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.1-codex-mini",
-      "name": "OpenAI/GPT-5.1 Codex mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.1-codex-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.2",
-      "name": "OpenAI/GPT-5.2",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.2",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.2-chat-latest",
-      "name": "OpenAI/GPT-5.2 Chat",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.2-chat-latest",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.2-codex",
-      "name": "OpenAI/GPT-5.2 Codex",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.2-codex",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.2-pro",
-      "name": "OpenAI/GPT-5.2 Pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.2-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.3-chat-latest",
-      "name": "OpenAI/GPT-5.3 Chat (latest)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.3-chat-latest",
+          "currentValue": "opencode-go/minimax-m2.5",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -1534,712 +688,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-5.3-codex",
-      "name": "OpenAI/GPT-5.3 Codex",
+      "modelId": "opencode-go/minimax-m2.7",
+      "name": "OpenCode Go/MiniMax M2.7",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-5.3-codex",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.3-codex-spark",
-      "name": "OpenAI/GPT-5.3 Codex Spark",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.3-codex-spark",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4",
-      "name": "OpenAI/GPT-5.4",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4-fast",
-      "name": "OpenAI/GPT-5.4 Fast",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4-fast",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4-mini",
-      "name": "OpenAI/GPT-5.4 mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4-mini-fast",
-      "name": "OpenAI/GPT-5.4 mini Fast",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4-mini-fast",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4-nano",
-      "name": "OpenAI/GPT-5.4 nano",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4-nano",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.4-pro",
-      "name": "OpenAI/GPT-5.4 Pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.4-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.5",
-      "name": "OpenAI/GPT-5.5",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.5",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.5-fast",
-      "name": "OpenAI/GPT-5.5 Fast",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.5-fast",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-5.5-pro",
-      "name": "OpenAI/GPT-5.5 Pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-5.5-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/gpt-image-1",
-      "name": "OpenAI/gpt-image-1",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/gpt-image-1",
+          "currentValue": "opencode-go/minimax-m2.7",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2268,13 +723,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-image-1-mini",
-      "name": "OpenAI/gpt-image-1-mini",
+      "modelId": "opencode-go/minimax-m3",
+      "name": "OpenCode Go/MiniMax M3",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-image-1-mini",
+          "currentValue": "opencode-go/minimax-m3",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2303,13 +758,13 @@
       ]
     },
     {
-      "modelId": "openai/gpt-image-1.5",
-      "name": "OpenAI/gpt-image-1.5",
+      "modelId": "opencode-go/qwen3.6-plus",
+      "name": "OpenCode Go/Qwen3.6 Plus",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/gpt-image-1.5",
+          "currentValue": "opencode-go/qwen3.6-plus",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2338,453 +793,13 @@
       ]
     },
     {
-      "modelId": "openai/o1",
-      "name": "OpenAI/o1",
+      "modelId": "opencode-go/qwen3.7-max",
+      "name": "OpenCode Go/Qwen3.7 Max",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/o1",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o1-pro",
-      "name": "OpenAI/o1-pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o1-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o3",
-      "name": "OpenAI/o3",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o3",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o3-deep-research",
-      "name": "OpenAI/o3-deep-research",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o3-deep-research",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o3-mini",
-      "name": "OpenAI/o3-mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o3-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o3-pro",
-      "name": "OpenAI/o3-pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o3-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o4-mini",
-      "name": "OpenAI/o4-mini",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o4-mini",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/o4-mini-deep-research",
-      "name": "OpenAI/o4-mini-deep-research",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/o4-mini-deep-research",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Medium",
-              "value": "medium"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/text-embedding-3-large",
-      "name": "OpenAI/text-embedding-3-large",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/text-embedding-3-large",
+          "currentValue": "opencode-go/qwen3.7-max",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2813,48 +828,13 @@
       ]
     },
     {
-      "modelId": "openai/text-embedding-3-small",
-      "name": "OpenAI/text-embedding-3-small",
+      "modelId": "opencode-go/qwen3.7-plus",
+      "name": "OpenCode Go/Qwen3.7 Plus",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "openai/text-embedding-3-small",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "openai/text-embedding-ada-002",
-      "name": "OpenAI/text-embedding-ada-002",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "openai/text-embedding-ada-002",
+          "currentValue": "opencode-go/qwen3.7-plus",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2895,6 +875,588 @@
           "options": [],
           "type": "select",
           "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-haiku-4-5",
+      "name": "OpenCode Zen/Claude Haiku 4.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-haiku-4-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-opus-4-1",
+      "name": "OpenCode Zen/Claude Opus 4.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-opus-4-1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-opus-4-5",
+      "name": "OpenCode Zen/Claude Opus 4.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-opus-4-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-opus-4-6",
+      "name": "OpenCode Zen/Claude Opus 4.6",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-opus-4-6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-opus-4-7",
+      "name": "OpenCode Zen/Claude Opus 4.7",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-opus-4-7",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-opus-4-8",
+      "name": "OpenCode Zen/Claude Opus 4.8",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-opus-4-8",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-sonnet-4",
+      "name": "OpenCode Zen/Claude Sonnet 4",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-sonnet-4",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-sonnet-4-5",
+      "name": "OpenCode Zen/Claude Sonnet 4.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-sonnet-4-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-sonnet-4-6",
+      "name": "OpenCode Zen/Claude Sonnet 4.6",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-sonnet-4-6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/deepseek-v4-flash",
+      "name": "OpenCode Zen/DeepSeek V4 Flash",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/deepseek-v4-flash",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
         },
         {
           "category": "mode",
@@ -2979,6 +1541,1405 @@
       ]
     },
     {
+      "modelId": "opencode/gemini-3-flash",
+      "name": "OpenCode Zen/Gemini 3 Flash",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gemini-3-flash",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "minimal",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gemini-3.1-pro",
+      "name": "OpenCode Zen/Gemini 3.1 Pro Preview",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gemini-3.1-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gemini-3.5-flash",
+      "name": "OpenCode Zen/Gemini 3.5 Flash",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gemini-3.5-flash",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "minimal",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/glm-5",
+      "name": "OpenCode Zen/GLM-5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/glm-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/glm-5.1",
+      "name": "OpenCode Zen/GLM-5.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/glm-5.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5",
+      "name": "OpenCode Zen/GPT-5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "minimal",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5-codex",
+      "name": "OpenCode Zen/GPT-5 Codex",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5-codex",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5-nano",
+      "name": "OpenCode Zen/GPT-5 Nano",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5-nano",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "minimal",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.1",
+      "name": "OpenCode Zen/GPT-5.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.1-codex",
+      "name": "OpenCode Zen/GPT-5.1 Codex",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.1-codex",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.1-codex-max",
+      "name": "OpenCode Zen/GPT-5.1 Codex Max",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.1-codex-max",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.1-codex-mini",
+      "name": "OpenCode Zen/GPT-5.1 Codex Mini",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.1-codex-mini",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.2",
+      "name": "OpenCode Zen/GPT-5.2",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.2",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.2-codex",
+      "name": "OpenCode Zen/GPT-5.2 Codex",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.2-codex",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.3-codex",
+      "name": "OpenCode Zen/GPT-5.3 Codex",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.3-codex",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.3-codex-spark",
+      "name": "OpenCode Zen/GPT-5.3 Codex Spark",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.3-codex-spark",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.4",
+      "name": "OpenCode Zen/GPT-5.4",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.4",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.4-mini",
+      "name": "OpenCode Zen/GPT-5.4 Mini",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.4-mini",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.4-nano",
+      "name": "OpenCode Zen/GPT-5.4 Nano",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.4-nano",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.4-pro",
+      "name": "OpenCode Zen/GPT-5.4 Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.4-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.5",
+      "name": "OpenCode Zen/GPT-5.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.5-pro",
+      "name": "OpenCode Zen/GPT-5.5 Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.5-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/grok-build-0.1",
+      "name": "OpenCode Zen/Grok Build 0.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/grok-build-0.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/kimi-k2.5",
+      "name": "OpenCode Zen/Kimi K2.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/kimi-k2.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/kimi-k2.6",
+      "name": "OpenCode Zen/Kimi K2.6",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/kimi-k2.6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "opencode/mimo-v2.5-free",
       "name": "OpenCode Zen/MiMo V2.5 Free",
       "description": null,
@@ -3013,6 +2974,76 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/minimax-m2.5",
+      "name": "OpenCode Zen/MiniMax M2.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/minimax-m2.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/minimax-m2.7",
+      "name": "OpenCode Zen/MiniMax M2.7",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/minimax-m2.7",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -3105,6 +3136,76 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/qwen3.5-plus",
+      "name": "OpenCode Zen/Qwen3.5 Plus",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/qwen3.5-plus",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/qwen3.6-plus",
+      "name": "OpenCode Zen/Qwen3.6 Plus",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/qwen3.6-plus",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/run-probes.sh
+++ b/scripts/agent-catalog/run-probes.sh
@@ -3,11 +3,19 @@
 # missing (with a warning) so partial runs are possible. Credentials come
 # from .probe-secrets.env at the repo root when present; the probe scrubs
 # them from spawned agents' environments, injecting only per-context.
+#
+# Probes fan out concurrently — one process per (agent, auth-context).
+# Each invocation is fully isolated (own config dirs, own env, own output
+# file) and shares only the read-only agent installs, so wall-clock is
+# roughly the slowest single probe. install-agents stays serial up front:
+# probes must all observe the same installed versions (collation enforces
+# version equality across a harness's runs).
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BIN="$ROOT/target/debug/anyharness"
 SECRETS="$ROOT/.probe-secrets.env"
+LOGS="$ROOT/scripts/agent-catalog/generated/.probe-logs"
 
 [ -f "$SECRETS" ] && source "$SECRETS"
 
@@ -17,16 +25,23 @@ echo "── building anyharness"
 echo "── reconciling harness installs"
 "$BIN" install-agents 2>/dev/null | grep -E "^agent=" || true
 
-failures=0
+mkdir -p "$LOGS"
+rm -f "$LOGS"/*.log
+
 skipped=0
+pids=()
+labels=()
+logs=()
 
 probe() { # probe <agent> <context> [extra args...]
   local agent="$1" context="$2"; shift 2
+  local log="$LOGS/$agent.$context.log"
   echo "── probe $agent × $context"
-  if RUST_LOG=warn "$BIN" catalog-probe --agent "$agent" --auth-context "$context" "$@"; then :; else
-    echo "✗ $agent × $context FAILED"
-    failures=$((failures + 1))
-  fi
+  RUST_LOG=warn "$BIN" catalog-probe --agent "$agent" --auth-context "$context" "$@" \
+    > "$log" 2>&1 &
+  pids+=($!)
+  labels+=("$agent × $context")
+  logs+=("$log")
 }
 
 skip() { echo "── skip $1 × $2 ($3)"; skipped=$((skipped + 1)); }
@@ -34,6 +49,7 @@ skip() { echo "── skip $1 × $2 ($3)"; skipped=$((skipped + 1)); }
 need_env() { [ -n "${!1:-}" ]; }
 
 CLAUDE_TRIALS=(--trial-model claude-fable-5 --trial-model claude-opus-4-8)
+BEDROCK_TRIALS=(--trial-model global.anthropic.claude-fable-5 --trial-model us.anthropic.claude-opus-4-8)
 
 if need_env ANTHROPIC_API_KEY; then
   probe claude anthropic-api "${CLAUDE_TRIALS[@]}"
@@ -43,6 +59,10 @@ if need_env CLAUDE_CODE_OAUTH_TOKEN; then
   probe claude anthropic-oauth "${CLAUDE_TRIALS[@]}"
 else skip claude anthropic-oauth "CLAUDE_CODE_OAUTH_TOKEN not set (run \`claude setup-token\`)"; fi
 
+if need_env AWS_BEARER_TOKEN_BEDROCK; then
+  probe claude bedrock "${BEDROCK_TRIALS[@]}"
+else skip claude bedrock "AWS_BEARER_TOKEN_BEDROCK not set (Bedrock API key)"; fi
+
 if need_env OPENAI_API_KEY; then
   probe codex openai-api
 else skip codex openai-api "OPENAI_API_KEY not set"; fi
@@ -50,6 +70,10 @@ else skip codex openai-api "OPENAI_API_KEY not set"; fi
 if [ -f "${PROBE_CODEX_OAUTH_AUTH_JSON:-$HOME/.codex/auth.json}" ]; then
   probe codex openai-oauth
 else skip codex openai-oauth "no codex auth.json (run \`codex login\`)"; fi
+
+if need_env AWS_BEARER_TOKEN_BEDROCK; then
+  probe codex bedrock
+else skip codex bedrock "AWS_BEARER_TOKEN_BEDROCK not set (Bedrock API key)"; fi
 
 probe opencode baseline --model-switch-timeout-secs 6
 if need_env ANTHROPIC_API_KEY; then
@@ -61,6 +85,9 @@ else skip opencode openai-api "OPENAI_API_KEY not set"; fi
 if need_env GEMINI_API_KEY; then
   probe opencode gemini-api --model-switch-timeout-secs 6
 else skip opencode gemini-api "GEMINI_API_KEY not set"; fi
+if need_env OPENCODE_API_KEY; then
+  probe opencode opencode-zen --model-switch-timeout-secs 6
+else skip opencode opencode-zen "OPENCODE_API_KEY not set (opencode zen subscription)"; fi
 
 if need_env GEMINI_API_KEY; then
   probe gemini gemini-api --model-switch-timeout-secs 3
@@ -71,6 +98,18 @@ else skip gemini google-oauth "no gemini oauth creds (run \`gemini\` and log in)
 
 # cursor: machine login (keychain); probe fails cleanly if not logged in
 probe cursor cursor-login --model-switch-timeout-secs 5
+
+echo "── waiting on ${#pids[@]} probes"
+failures=0
+for i in "${!pids[@]}"; do
+  if wait "${pids[$i]}"; then
+    echo "✓ ${labels[$i]}"
+  else
+    echo "✗ ${labels[$i]} FAILED — $(tail -1 "${logs[$i]}" 2>/dev/null | cut -c1-160)"
+    echo "  log: ${logs[$i]}"
+    failures=$((failures + 1))
+  fi
+done
 
 echo "── done: ${failures} failed, ${skipped} skipped"
 exit "$failures"


### PR DESCRIPTION
## Summary

Extends the catalog probe matrix with three new auth contexts and makes the full matrix run concurrently.

**claude × bedrock** — `CLAUDE_CODE_USE_BEDROCK=1` + Bedrock API key (bearer token) in an isolated `CLAUDE_CONFIG_DIR`. The menu is a fully distinct namespace (`us.`/`global.` inference-profile ids, 12 models incl. `[1m]` variants); `global.anthropic.claude-fable-5` and `us.anthropic.claude-opus-4-8` trials passed real inference turns. Notable menu≠available exhibit: the menu lists `us.anthropic.claude-fable-5`, but no `us.` profile exists for fable (raw Converse → model not found) — only `global.` works.

**codex × bedrock** — codex-core removed `wire_api = "chat"`, and Bedrock's classic OpenAI-compat endpoint only speaks Chat Completions. The context instead targets Bedrock's **mantle** surface (`bedrock-mantle.{region}.api.aws/v1`), which serves the Responses API; `openai.gpt-oss-120b/20b` verified. Mantle ids are their own namespace (no `-1:0` suffix); its Anthropic models reject `/v1/responses` and are unreachable from codex.

**opencode × opencode-zen** — the zen subscription gateway (`OPENCODE_API_KEY`): adds 53 models over baseline (`opencode/` frontier + `opencode-go/` open-weight namespaces), removes none of the 5 free baseline models.

**Credential hygiene** — the scrub list now covers `OPENCODE_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, and the ambient SigV4 family (`AWS_ACCESS_KEY_ID`/`SECRET`/`SESSION_TOKEN`/`PROFILE`): some harnesses (opencode's amazon-bedrock provider) auto-detect AWS creds and would silently enable Bedrock in non-bedrock contexts, corrupting auth attribution.

**Parallel matrix** — `run-probes.sh` fans out every (agent × context) probe concurrently after the serial build/install preamble; probes are process-isolated and share only read-only installs. Per-context logs under `generated/.probe-logs/`. Full 14-context matrix: ~7 minutes (was 25+ sequential).

All snapshots re-probed on current adapter versions (claude adapter 0.44.0) so collation's version-equality invariant holds; `catalog.draft.json` rebuilt: claude 17 / codex 10 / cursor 29 / gemini 6 / opencode 149 rows.

## Test plan

- [x] Raw inference verified per provider on Bedrock (Converse for Anthropic, mantle `/v1/responses` for OpenAI) before wiring contexts
- [x] `./scripts/agent-catalog/run-probes.sh` — 14/14 contexts green, concurrently
- [x] `node scripts/agent-catalog/build-catalog.mjs` — invariants hold (matrix equality, version consistency)
- [x] Viewer diff vs main shows only expected additions (bedrock + zen rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)