### PR TITLE
feat(installer): install manifests (PR-2 of catalog/registry stack)

### DIFF
--- a/anyharness/crates/anyharness-credential-discovery/src/aws.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/aws.rs
@@ -1,0 +1,194 @@
+//! AWS credential-chain detection: passive sources only (decisions ledger
+//! 12) — the env pair, a shared-credentials profile, or an SSO token cache.
+//! The exotic tail of the real AWS chain (IMDS, process credentials,
+//! container credentials) is deliberately NOT detected here: it is proven by
+//! launch/trial, never by detection — "menus lie, inference proves."
+//! No network access, ever.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::facts::fact_kinds;
+use crate::util::resolve_process_override_path;
+
+const AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
+const AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
+const AWS_SHARED_CREDENTIALS_FILE: &str = "AWS_SHARED_CREDENTIALS_FILE";
+
+/// Emits `aws-credential-chain` iff any passive chain source is present.
+/// `env_keys` is the caller-provided composed-launch-env presence set (this
+/// crate never reads credential env vars from the process env).
+pub(crate) fn discovery_fact_kinds(
+    home_dir: &Path,
+    env_keys: &BTreeSet<String>,
+) -> Vec<&'static str> {
+    let paths = AwsChainPaths::resolve(home_dir);
+    if chain_present(env_keys, &paths) {
+        vec![fact_kinds::AWS_CREDENTIAL_CHAIN]
+    } else {
+        Vec::new()
+    }
+}
+
+/// The filesystem sources of the passive chain. Separated from resolution so
+/// tests can inject temp paths directly.
+pub(crate) struct AwsChainPaths {
+    pub(crate) credentials_file: PathBuf,
+    pub(crate) sso_cache_dir: PathBuf,
+}
+
+impl AwsChainPaths {
+    /// `AWS_SHARED_CREDENTIALS_FILE` is a path override (not a credential),
+    /// honored only when `home_dir` is the process home — mirroring how the
+    /// `LocalAuthState` detectors treat `CODEX_HOME`/`GEMINI_CLI_HOME`.
+    pub(crate) fn resolve(home_dir: &Path) -> Self {
+        let default_credentials_file = home_dir.join(".aws").join("credentials");
+        Self {
+            credentials_file: resolve_process_override_path(
+                AWS_SHARED_CREDENTIALS_FILE,
+                home_dir,
+                default_credentials_file,
+            ),
+            sso_cache_dir: home_dir.join(".aws").join("sso").join("cache"),
+        }
+    }
+}
+
+pub(crate) fn chain_present(env_keys: &BTreeSet<String>, paths: &AwsChainPaths) -> bool {
+    env_pair_present(env_keys)
+        || credentials_file_has_profile(&paths.credentials_file)
+        || sso_cache_has_json(&paths.sso_cache_dir)
+}
+
+fn env_pair_present(env_keys: &BTreeSet<String>) -> bool {
+    env_keys.contains(AWS_ACCESS_KEY_ID) && env_keys.contains(AWS_SECRET_ACCESS_KEY)
+}
+
+/// At least one `[profile]` section header. Read failures (missing file,
+/// permissions) are facts of absence, never errors.
+fn credentials_file_has_profile(path: &Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    contents.lines().any(|line| {
+        let line = line.trim();
+        line.len() > 2 && line.starts_with('[') && line.ends_with(']')
+    })
+}
+
+fn sso_cache_has_json(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .path()
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn make_temp_home() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-aws-credential-discovery-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&path).expect("create temp home");
+        path
+    }
+
+    fn env_keys(keys: &[&str]) -> BTreeSet<String> {
+        keys.iter().map(|key| (*key).to_string()).collect()
+    }
+
+    #[test]
+    fn detects_env_pair_but_not_partial_pair() {
+        let home = make_temp_home();
+        let paths = AwsChainPaths::resolve(&home);
+
+        assert!(chain_present(
+            &env_keys(&["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]),
+            &paths
+        ));
+        assert!(!chain_present(&env_keys(&["AWS_ACCESS_KEY_ID"]), &paths));
+        assert!(!chain_present(&env_keys(&["AWS_SECRET_ACCESS_KEY"]), &paths));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn detects_shared_credentials_file_with_profile_section() {
+        let home = make_temp_home();
+        fs::create_dir_all(home.join(".aws")).expect("create aws dir");
+        fs::write(
+            home.join(".aws/credentials"),
+            "[default]\naws_access_key_id = AKIA\naws_secret_access_key = secret\n",
+        )
+        .expect("write credentials");
+
+        assert_eq!(
+            discovery_fact_kinds(&home, &BTreeSet::new()),
+            vec![fact_kinds::AWS_CREDENTIAL_CHAIN]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn ignores_credentials_file_without_profile_sections() {
+        let home = make_temp_home();
+        fs::create_dir_all(home.join(".aws")).expect("create aws dir");
+        fs::write(home.join(".aws/credentials"), "# empty\n\n").expect("write credentials");
+
+        assert!(discovery_fact_kinds(&home, &BTreeSet::new()).is_empty());
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn honors_injected_credentials_file_path() {
+        let home = make_temp_home();
+        let injected = home.join("custom-credentials");
+        fs::write(&injected, "[work]\naws_access_key_id = AKIA\n").expect("write credentials");
+
+        let paths = AwsChainPaths {
+            credentials_file: injected,
+            sso_cache_dir: home.join(".aws/sso/cache"),
+        };
+        assert!(chain_present(&BTreeSet::new(), &paths));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn detects_sso_cache_json_only() {
+        let home = make_temp_home();
+        let cache_dir = home.join(".aws/sso/cache");
+        fs::create_dir_all(&cache_dir).expect("create sso cache dir");
+        fs::write(cache_dir.join("notes.txt"), "not a token").expect("write non-json");
+
+        assert!(discovery_fact_kinds(&home, &BTreeSet::new()).is_empty());
+
+        fs::write(cache_dir.join("abc123.json"), r#"{"accessToken":"t"}"#)
+            .expect("write sso token");
+        assert_eq!(
+            discovery_fact_kinds(&home, &BTreeSet::new()),
+            vec![fact_kinds::AWS_CREDENTIAL_CHAIN]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn absent_when_no_passive_source_exists() {
+        let home = make_temp_home();
+        assert!(discovery_fact_kinds(&home, &BTreeSet::new()).is_empty());
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/anyharness/crates/anyharness-credential-discovery/src/claude.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/claude.rs
@@ -73,6 +73,56 @@ pub fn detect_local_auth_state(home_dir: &Path) -> Result<LocalAuthState, Discov
     Ok(LocalAuthState::Absent)
 }
 
+/// Kind-preserving fact detection: emits EVERY present claude credential
+/// kind (facts, never verdicts — unlike `detect_local_auth_state`, which is
+/// first-match). The kinds reuse exactly the checks above:
+/// `has_claude_api_key` → `claude-config-api-key`, `has_claude_oauth_payload`
+/// → `claude-oauth-creds`, the keychain lookup → `claude-keychain`, and
+/// `has_oauth_account_marker` → `claude-oauth-account`.
+pub(crate) fn discovery_fact_kinds(
+    home_dir: &Path,
+) -> Result<Vec<&'static str>, DiscoveryError> {
+    let mut kinds = Vec::new();
+
+    let api_config_paths = [
+        home_dir.join(CLAUDE_API_CONFIG_PATH),
+        home_dir.join(CLAUDE_CONFIG_PATH),
+    ];
+    for path in api_config_paths {
+        if let Some(data) = read_json_file(&path)? {
+            if has_claude_api_key(&data) {
+                kinds.push(crate::facts::fact_kinds::CLAUDE_CONFIG_API_KEY);
+                break;
+            }
+        }
+    }
+
+    let oauth_paths = [
+        home_dir.join(CLAUDE_CREDENTIALS_PATH),
+        home_dir.join(CLAUDE_OAUTH_CREDENTIALS_PATH),
+    ];
+    for path in oauth_paths {
+        if let Some(data) = read_json_file(&path)? {
+            if has_claude_oauth_payload(&data) {
+                kinds.push(crate::facts::fact_kinds::CLAUDE_OAUTH_CREDS);
+                break;
+            }
+        }
+    }
+
+    if read_keychain_claude_oauth(home_dir)?.is_some() {
+        kinds.push(crate::facts::fact_kinds::CLAUDE_KEYCHAIN);
+    }
+
+    if let Some(data) = read_json_file(&home_dir.join(CLAUDE_CONFIG_PATH))? {
+        if has_oauth_account_marker(&data) {
+            kinds.push(crate::facts::fact_kinds::CLAUDE_OAUTH_ACCOUNT);
+        }
+    }
+
+    Ok(kinds)
+}
+
 pub fn export_portable_auth(home_dir: &Path) -> Result<Option<PortableAuthExport>, DiscoveryError> {
     tracing::debug!(home_dir = %home_dir.display(), "Exporting portable Claude auth");
     let oauth_paths = [
@@ -338,6 +388,50 @@ mod tests {
                 ..
             })
         ));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fact_kinds_preserve_every_present_credential_kind() {
+        let home = make_temp_home();
+        fs::create_dir_all(home.join(".claude")).expect("create claude dir");
+        fs::write(
+            home.join(CLAUDE_CREDENTIALS_PATH),
+            r#"{"claudeAiOauth":{"accessToken":"token"}}"#,
+        )
+        .expect("write oauth creds");
+        fs::write(
+            home.join(CLAUDE_CONFIG_PATH),
+            r#"{"primaryApiKey":"sk-ant-123","oauthAccount":{"accountUuid":"acct-123"}}"#,
+        )
+        .expect("write claude config");
+
+        let kinds = discovery_fact_kinds(&home).expect("fact kinds");
+        assert_eq!(
+            kinds,
+            vec![
+                "claude-config-api-key",
+                "claude-oauth-creds",
+                "claude-oauth-account"
+            ]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fact_kinds_empty_when_nothing_present() {
+        let home = make_temp_home();
+        fs::write(
+            home.join(CLAUDE_CONFIG_PATH),
+            r#"{"hasCompletedOnboarding":true}"#,
+        )
+        .expect("write claude config");
+
+        assert!(discovery_fact_kinds(&home)
+            .expect("fact kinds")
+            .is_empty());
 
         let _ = fs::remove_dir_all(home);
     }

--- a/anyharness/crates/anyharness-credential-discovery/src/codex.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/codex.rs
@@ -98,15 +98,47 @@ fn read_json_file(path: &Path) -> Result<Option<Value>, DiscoveryError> {
 }
 
 fn has_codex_auth(data: &Value) -> bool {
+    has_codex_api_key(data) || has_codex_oauth_tokens(data)
+}
+
+fn has_codex_api_key(data: &Value) -> bool {
     data.get("OPENAI_API_KEY")
         .and_then(Value::as_str)
         .map(|value| !value.is_empty())
         .unwrap_or(false)
-        || data
-            .pointer("/tokens/access_token")
-            .and_then(Value::as_str)
-            .map(|value| !value.is_empty())
-            .unwrap_or(false)
+}
+
+fn has_codex_oauth_tokens(data: &Value) -> bool {
+    data.pointer("/tokens/access_token")
+        .and_then(Value::as_str)
+        .map(|value| !value.is_empty())
+        .unwrap_or(false)
+}
+
+/// Kind-preserving fact detection: emits EVERY present codex credential
+/// kind. auth.json content is split by what the existing parser can already
+/// distinguish — `OPENAI_API_KEY` → `codex-auth-json-api-key`,
+/// `tokens.access_token` → `codex-auth-json-oauth` (both may be present);
+/// a usable keychain entry → `codex-keychain`.
+pub(crate) fn discovery_fact_kinds(
+    home_dir: &Path,
+) -> Result<Vec<&'static str>, DiscoveryError> {
+    let mut kinds = Vec::new();
+
+    if let Some(data) = read_json_file(&local_codex_auth_path(home_dir))? {
+        if has_codex_api_key(&data) {
+            kinds.push(crate::facts::fact_kinds::CODEX_AUTH_JSON_API_KEY);
+        }
+        if has_codex_oauth_tokens(&data) {
+            kinds.push(crate::facts::fact_kinds::CODEX_AUTH_JSON_OAUTH);
+        }
+    }
+
+    if read_keychain_codex_auth(home_dir)?.is_some() {
+        kinds.push(crate::facts::fact_kinds::CODEX_KEYCHAIN);
+    }
+
+    Ok(kinds)
 }
 
 #[cfg(target_os = "macos")]
@@ -210,6 +242,36 @@ mod tests {
             state,
             LocalAuthState::Present(LocalAuthSource::File { .. })
         ));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fact_kinds_distinguish_api_key_from_oauth_tokens() {
+        let home = make_temp_home();
+        fs::write(
+            home.join(CODEX_AUTH_PATH),
+            r#"{"OPENAI_API_KEY":"sk-test","tokens":{"access_token":"token"}}"#,
+        )
+        .expect("write codex auth");
+
+        assert_eq!(
+            discovery_fact_kinds(&home).expect("fact kinds"),
+            vec!["codex-auth-json-api-key", "codex-auth-json-oauth"]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fact_kinds_empty_for_unusable_auth_file() {
+        let home = make_temp_home();
+        fs::write(home.join(CODEX_AUTH_PATH), r#"{"OPENAI_API_KEY":""}"#)
+            .expect("write codex auth");
+
+        assert!(discovery_fact_kinds(&home)
+            .expect("fact kinds")
+            .is_empty());
 
         let _ = fs::remove_dir_all(home);
     }

--- a/anyharness/crates/anyharness-credential-discovery/src/cursor.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/cursor.rs
@@ -1,0 +1,68 @@
+//! Cursor keychain detection: presence of the macOS keychain service
+//! `"Cursor Safe Storage"` (where the Cursor CLI stores its login state).
+//! Presence only — the secret value is never read into a fact. Non-macOS
+//! platforms are always absent.
+
+use std::path::Path;
+
+use crate::facts::fact_kinds;
+
+#[cfg(target_os = "macos")]
+const CURSOR_KEYCHAIN_SERVICE: &str = "Cursor Safe Storage";
+
+pub(crate) fn discovery_fact_kinds(home_dir: &Path) -> Vec<&'static str> {
+    if keychain_entry_present(home_dir) {
+        vec![fact_kinds::CURSOR_KEYCHAIN]
+    } else {
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn keychain_entry_present(home_dir: &Path) -> bool {
+    use crate::util::home_matches_process_home;
+
+    // Mirror the claude keychain guard: the keychain belongs to the process
+    // user, so probing it for a foreign home_dir would fabricate facts.
+    if !home_matches_process_home(home_dir) {
+        tracing::debug!(
+            home_dir = %home_dir.display(),
+            "Skipping Cursor keychain lookup because home_dir does not match process home"
+        );
+        return false;
+    }
+
+    let output = std::process::Command::new("security")
+        .args(["find-generic-password", "-s", CURSOR_KEYCHAIN_SERVICE])
+        .output();
+    match output {
+        Ok(output) => output.status.success(),
+        Err(err) => {
+            tracing::warn!(error = %err, "Cursor keychain lookup failed; treating as absent");
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn keychain_entry_present(_home_dir: &Path) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foreign_home_dir_is_always_absent() {
+        let home = std::env::temp_dir().join(format!(
+            "anyharness-cursor-credential-discovery-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+
+        assert!(discovery_fact_kinds(&home).is_empty());
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+}

--- a/anyharness/crates/anyharness-credential-discovery/src/facts.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/facts.rs
@@ -1,0 +1,235 @@
+//! Credential facts: the kind-preserving detection surface for auth-context
+//! classification (migration §5.4 layer 1).
+//!
+//! Facts, never verdicts — detectors report what exists, the pure classifier
+//! in `anyharness-lib` decides which auth contexts are active. Secrets rule:
+//! `Env` facts are presence-only (values are never read into a fact); values
+//! are readable only for `EnvFlag` facts, and the caller is responsible for
+//! passing values only for registry-declared flag vars.
+//!
+//! This module never reads credential material from the process env: the
+//! caller hands in env presence (`env_keys`) and flag values (`flag_values`)
+//! from the composed launch env. Non-credential *path override* env vars
+//! (`CODEX_HOME`, `GEMINI_CLI_HOME`, `XDG_DATA_HOME`,
+//! `AWS_SHARED_CREDENTIALS_FILE`) are honored only when `home_dir` matches
+//! the process home, mirroring the existing `LocalAuthState` detectors.
+//!
+//! Discovery kind vocabulary (the open id set; registry slot
+//! `discoveryKinds` and catalog v2 `discovery` signals reference these):
+//!
+//! | kind | meaning |
+//! | --- | --- |
+//! | `claude-config-api-key` | `sk-ant-` API key in `~/.claude.json(.api)` |
+//! | `claude-oauth-creds` | OAuth payload in `~/.claude/.credentials.json` (or legacy file) |
+//! | `claude-keychain` | macOS keychain `Claude Code(-credentials)` OAuth entry |
+//! | `claude-oauth-account` | `oauthAccount.accountUuid` marker in `~/.claude.json` |
+//! | `codex-auth-json-api-key` | `OPENAI_API_KEY` in `~/.codex/auth.json` |
+//! | `codex-auth-json-oauth` | `tokens.access_token` in `~/.codex/auth.json` |
+//! | `codex-keychain` | macOS keychain `Codex Auth` entry with usable auth |
+//! | `gemini-oauth-creds` | tokens in `~/.gemini/oauth_creds.json` |
+//! | `gemini-keychain` | macOS keychain `gemini-cli-oauth` entry |
+//! | `aws-credential-chain` | env pair, shared-credentials profile, or SSO cache (passive sources only — decisions ledger 12) |
+//! | `opencode-auth-json/<provider>` | usable provider entry in opencode's `auth.json` |
+//! | `cursor-keychain` | macOS keychain `Cursor Safe Storage` entry |
+//!
+//! Not emitted: `gemini-settings-api-key` — the existing gemini parser never
+//! reads API keys from `settings.json`, so the kind is not distinguishable
+//! from current detection and is deferred until a parser exists.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::{aws, claude, codex, cursor, gemini, opencode, DiscoveryError};
+
+/// The exact discovery-kind strings detectors emit. Open vocabulary: new
+/// detectors add new constants; consumers match on strings, never on a
+/// closed enum.
+pub mod fact_kinds {
+    pub const CLAUDE_CONFIG_API_KEY: &str = "claude-config-api-key";
+    pub const CLAUDE_OAUTH_CREDS: &str = "claude-oauth-creds";
+    pub const CLAUDE_KEYCHAIN: &str = "claude-keychain";
+    pub const CLAUDE_OAUTH_ACCOUNT: &str = "claude-oauth-account";
+    pub const CODEX_AUTH_JSON_API_KEY: &str = "codex-auth-json-api-key";
+    pub const CODEX_AUTH_JSON_OAUTH: &str = "codex-auth-json-oauth";
+    pub const CODEX_KEYCHAIN: &str = "codex-keychain";
+    pub const GEMINI_OAUTH_CREDS: &str = "gemini-oauth-creds";
+    pub const GEMINI_KEYCHAIN: &str = "gemini-keychain";
+    pub const AWS_CREDENTIAL_CHAIN: &str = "aws-credential-chain";
+    /// Per-provider facts are `opencode-auth-json/<provider>`.
+    pub const OPENCODE_AUTH_JSON_PREFIX: &str = "opencode-auth-json/";
+    pub const CURSOR_KEYCHAIN: &str = "cursor-keychain";
+}
+
+/// One observed credential fact. Presence only for secrets: `Env` carries no
+/// value, ever; `EnvFlag` values are readable because flag vars are
+/// registry-declared non-secrets.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CredentialFact {
+    /// Env var present in the composed launch env (presence only).
+    Env { var: String },
+    /// Flag env var present with this value (flag vars only).
+    EnvFlag { var: String, value: String },
+    /// A named local-discovery observation, e.g. `"claude-oauth-creds"`.
+    Discovery { kind: String },
+}
+
+/// Collect every credential fact observable for `home_dir` plus the
+/// caller-provided composed-launch-env view.
+///
+/// - `env_keys`: names of env vars present in the composed launch env
+///   (workspace env + auth overlay) — values are never passed for secrets.
+/// - `flag_values`: values of registry-declared *flag* vars only
+///   (e.g. `CLAUDE_CODE_USE_BEDROCK=1`). A var listed here emits an
+///   `EnvFlag` fact (not a duplicate `Env` fact).
+///
+/// Detector failures are tolerated per provider (logged, facts skipped):
+/// a broken credential file must never poison unrelated providers' facts.
+pub fn collect_facts(
+    home_dir: &Path,
+    env_keys: &BTreeSet<String>,
+    flag_values: &BTreeMap<String, String>,
+) -> Vec<CredentialFact> {
+    let mut facts = Vec::new();
+
+    for var in env_keys {
+        if flag_values.contains_key(var) {
+            continue;
+        }
+        facts.push(CredentialFact::Env { var: var.clone() });
+    }
+    for (var, value) in flag_values {
+        facts.push(CredentialFact::EnvFlag {
+            var: var.clone(),
+            value: value.clone(),
+        });
+    }
+    for kind in discovery_fact_kinds(home_dir, env_keys) {
+        facts.push(CredentialFact::Discovery { kind });
+    }
+
+    facts
+}
+
+fn discovery_fact_kinds(home_dir: &Path, env_keys: &BTreeSet<String>) -> Vec<String> {
+    let mut kinds: Vec<String> = Vec::new();
+    extend_tolerating(&mut kinds, "claude", claude::discovery_fact_kinds(home_dir));
+    extend_tolerating(&mut kinds, "codex", codex::discovery_fact_kinds(home_dir));
+    extend_tolerating(&mut kinds, "gemini", gemini::discovery_fact_kinds(home_dir));
+    kinds.extend(
+        aws::discovery_fact_kinds(home_dir, env_keys)
+            .into_iter()
+            .map(str::to_string),
+    );
+    kinds.extend(opencode::discovery_fact_kinds(home_dir));
+    kinds.extend(
+        cursor::discovery_fact_kinds(home_dir)
+            .into_iter()
+            .map(str::to_string),
+    );
+    kinds
+}
+
+fn extend_tolerating(
+    kinds: &mut Vec<String>,
+    provider: &str,
+    result: Result<Vec<&'static str>, DiscoveryError>,
+) {
+    match result {
+        Ok(provider_kinds) => kinds.extend(provider_kinds.into_iter().map(str::to_string)),
+        Err(err) => {
+            tracing::warn!(provider, error = %err, "Credential fact detection failed; skipping provider facts");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn make_temp_home() -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-credential-facts-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&path).expect("create temp home");
+        path
+    }
+
+    #[test]
+    fn collects_env_presence_and_flag_values() {
+        let home = make_temp_home();
+        let env_keys: BTreeSet<String> = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_BEDROCK"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let flag_values: BTreeMap<String, String> =
+            [("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string())]
+                .into_iter()
+                .collect();
+
+        let facts = collect_facts(&home, &env_keys, &flag_values);
+
+        assert_eq!(
+            facts,
+            vec![
+                CredentialFact::Env {
+                    var: "ANTHROPIC_API_KEY".to_string()
+                },
+                CredentialFact::EnvFlag {
+                    var: "CLAUDE_CODE_USE_BEDROCK".to_string(),
+                    value: "1".to_string()
+                },
+            ]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn collects_kind_preserving_discovery_facts() {
+        let home = make_temp_home();
+        fs::create_dir_all(home.join(".claude")).expect("create claude dir");
+        fs::write(
+            home.join(".claude/.credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"token"}}"#,
+        )
+        .expect("write oauth creds");
+        fs::write(home.join(".claude.json"), r#"{"primaryApiKey":"sk-ant-123"}"#)
+            .expect("write claude config");
+
+        let facts = collect_facts(&home, &BTreeSet::new(), &BTreeMap::new());
+
+        assert_eq!(
+            facts,
+            vec![
+                CredentialFact::Discovery {
+                    kind: fact_kinds::CLAUDE_CONFIG_API_KEY.to_string()
+                },
+                CredentialFact::Discovery {
+                    kind: fact_kinds::CLAUDE_OAUTH_CREDS.to_string()
+                },
+            ]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn aws_env_pair_surfaces_as_discovery_fact() {
+        let home = make_temp_home();
+        let env_keys: BTreeSet<String> = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+
+        let facts = collect_facts(&home, &env_keys, &BTreeMap::new());
+
+        assert!(facts.contains(&CredentialFact::Discovery {
+            kind: fact_kinds::AWS_CREDENTIAL_CHAIN.to_string()
+        }));
+
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/anyharness/crates/anyharness-credential-discovery/src/gemini.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/gemini.rs
@@ -44,6 +44,29 @@ pub fn detect_local_auth_state(home_dir: &Path) -> Result<LocalAuthState, Discov
     Ok(LocalAuthState::Absent)
 }
 
+/// Kind-preserving fact detection: `gemini-oauth-creds` for the OAuth cache
+/// file, `gemini-keychain` for the keychain entry (both may be present).
+/// `gemini-settings-api-key` is deliberately NOT emitted: the existing
+/// parser never reads API keys from settings.json, so the kind is not
+/// distinguishable today.
+pub(crate) fn discovery_fact_kinds(
+    home_dir: &Path,
+) -> Result<Vec<&'static str>, DiscoveryError> {
+    let mut kinds = Vec::new();
+
+    if let Some(data) = read_json_file(&local_gemini_oauth_path(home_dir))? {
+        if has_google_oauth_credentials(&data) {
+            kinds.push(crate::facts::fact_kinds::GEMINI_OAUTH_CREDS);
+        }
+    }
+
+    if read_keychain_gemini_oauth(home_dir)?.is_some() {
+        kinds.push(crate::facts::fact_kinds::GEMINI_KEYCHAIN);
+    }
+
+    Ok(kinds)
+}
+
 pub fn export_portable_auth(home_dir: &Path) -> Result<Option<PortableAuthExport>, DiscoveryError> {
     let oauth_path = local_gemini_oauth_path(home_dir);
     tracing::debug!(path = %oauth_path.display(), "Exporting portable Gemini auth");
@@ -245,6 +268,23 @@ mod tests {
             state,
             LocalAuthState::Present(LocalAuthSource::File { .. })
         ));
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fact_kinds_surface_oauth_creds_file() {
+        let home = make_temp_home();
+        fs::write(
+            home.join(GEMINI_OAUTH_FILE_PATH),
+            r#"{"refresh_token":"refresh-token"}"#,
+        )
+        .expect("write oauth creds");
+
+        assert_eq!(
+            discovery_fact_kinds(&home).expect("fact kinds"),
+            vec!["gemini-oauth-creds"]
+        );
 
         let _ = fs::remove_dir_all(home);
     }

--- a/anyharness/crates/anyharness-credential-discovery/src/lib.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/lib.rs
@@ -1,11 +1,16 @@
+mod aws;
 mod claude;
 mod codex;
+mod cursor;
+mod facts;
 mod gemini;
+mod opencode;
 mod types;
 mod util;
 
 use std::path::Path;
 
+pub use facts::{collect_facts, fact_kinds, CredentialFact};
 pub use types::{
     ConfigMarkerKind, LocalAuthSource, LocalAuthState, PortableAuthExport, PortableAuthFile,
     PortableRelativePath, ProviderId,

--- a/anyharness/crates/anyharness-credential-discovery/src/opencode.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/opencode.rs
@@ -1,0 +1,152 @@
+//! OpenCode auth.json detection: one fact per provider key with usable
+//! credential material (`opencode-auth-json/<provider>`), so a multi-slot
+//! opencode descriptor can classify each provider slot independently.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::facts::fact_kinds;
+use crate::util::resolve_process_override_path;
+
+/// Providers are emitted only when the entry carries usable credential
+/// material (mirrors the legacy opencode readiness rules): `type:"api"` with
+/// a non-empty `key`, `type:"oauth"` with non-empty `access`, or
+/// `type:"wellknown"` with non-empty `token`. Empty entries are absence.
+pub(crate) fn discovery_fact_kinds(home_dir: &Path) -> Vec<String> {
+    provider_fact_kinds(&auth_json_path(home_dir))
+}
+
+/// `XDG_DATA_HOME` is a path override (not a credential), honored only when
+/// `home_dir` is the process home — mirroring `CODEX_HOME`/`GEMINI_CLI_HOME`.
+fn auth_json_path(home_dir: &Path) -> PathBuf {
+    let default_data_home = home_dir.join(".local").join("share");
+    resolve_process_override_path("XDG_DATA_HOME", home_dir, default_data_home)
+        .join("opencode")
+        .join("auth.json")
+}
+
+pub(crate) fn provider_fact_kinds(path: &Path) -> Vec<String> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(data) = serde_json::from_str::<Value>(&contents) else {
+        tracing::warn!(path = %path.display(), "OpenCode auth file was not valid JSON");
+        return Vec::new();
+    };
+    let Some(providers) = data.as_object() else {
+        return Vec::new();
+    };
+
+    providers
+        .iter()
+        .filter(|(_, value)| entry_has_usable_credential(value))
+        .map(|(provider, _)| format!("{}{provider}", fact_kinds::OPENCODE_AUTH_JSON_PREFIX))
+        .collect()
+}
+
+fn entry_has_usable_credential(value: &Value) -> bool {
+    let Some(config) = value.as_object() else {
+        return false;
+    };
+    let credential_field = match config.get("type").and_then(Value::as_str) {
+        Some("api") => "key",
+        Some("oauth") => "access",
+        Some("wellknown") => "token",
+        _ => return false,
+    };
+    config
+        .get(credential_field)
+        .and_then(Value::as_str)
+        .is_some_and(|credential| !credential.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn make_temp_home() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-opencode-credential-discovery-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(path.join(".local/share/opencode")).expect("create opencode dir");
+        path
+    }
+
+    #[test]
+    fn emits_one_fact_per_usable_provider() {
+        let home = make_temp_home();
+        fs::write(
+            home.join(".local/share/opencode/auth.json"),
+            r#"{
+              "anthropic": {"type":"oauth","access":"access-token","refresh":"r","expires":1},
+              "openai": {"type":"api","key":"sk-test"},
+              "https://example.com": {"type":"wellknown","key":"CUSTOM_TOKEN","token":"token"}
+            }"#,
+        )
+        .expect("write auth json");
+
+        let mut kinds = discovery_fact_kinds(&home);
+        kinds.sort();
+        assert_eq!(
+            kinds,
+            vec![
+                "opencode-auth-json/anthropic",
+                "opencode-auth-json/https://example.com",
+                "opencode-auth-json/openai",
+            ]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn skips_empty_or_unknown_entries() {
+        let home = make_temp_home();
+        fs::write(
+            home.join(".local/share/opencode/auth.json"),
+            r#"{
+              "openai": {"type":"api","key":""},
+              "github-copilot": {"type":"oauth","access":""},
+              "custom": {"type":"wellknown","token":""},
+              "weird": {"type":"mystery","key":"value"},
+              "not-an-object": "nope"
+            }"#,
+        )
+        .expect("write auth json");
+
+        assert!(discovery_fact_kinds(&home).is_empty());
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn absent_when_file_missing_or_invalid() {
+        let home = make_temp_home();
+        assert!(discovery_fact_kinds(&home).is_empty());
+
+        fs::write(home.join(".local/share/opencode/auth.json"), "not json")
+            .expect("write auth json");
+        assert!(discovery_fact_kinds(&home).is_empty());
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn parses_injected_path_directly() {
+        let home = make_temp_home();
+        let injected = home.join("custom-auth.json");
+        fs::write(&injected, r#"{"openai":{"type":"api","key":"sk-test"}}"#)
+            .expect("write auth json");
+
+        assert_eq!(
+            provider_fact_kinds(&injected),
+            vec!["opencode-auth-json/openai"]
+        );
+
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/anyharness/crates/anyharness-credential-discovery/src/util.rs
+++ b/anyharness/crates/anyharness-credential-discovery/src/util.rs
@@ -5,6 +5,18 @@ pub(crate) fn resolve_process_override_dir(
     home_dir: &Path,
     default_path: PathBuf,
 ) -> PathBuf {
+    resolve_process_override_path(env_name, home_dir, default_path)
+}
+
+/// Resolve a filesystem location that an env var may relocate (a path
+/// override, never a credential). The override is honored only when
+/// `home_dir` is the process home: for foreign homes the process env says
+/// nothing about where that user keeps their files.
+pub(crate) fn resolve_process_override_path(
+    env_name: &str,
+    home_dir: &Path,
+    default_path: PathBuf,
+) -> PathBuf {
     if home_matches_process_home(home_dir) {
         if let Ok(value) = std::env::var(env_name) {
             if !value.is_empty() {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/context.rs
@@ -1,0 +1,209 @@
+//! Pure auth-context classification (migration §5.4 layer 4): credential
+//! facts × catalog v2 ordered signatures → `ActiveAuthContexts`.
+//!
+//! Rules (decisions ledger 7/8):
+//! - ONE winner per auth slot — the FIRST context in catalog order whose
+//!   signals match; list order IS the harness's own credential precedence
+//!   (probe-validated, e.g. an inherited API key masks an OAuth token).
+//! - UNION across slots (opencode-style multi-provider harnesses).
+//! - `"baseline"` is active iff no context matched any slot.
+//! - A context without signals NEVER matches: it is probe-only knowledge
+//!   (the probe injected its credentials; the runtime has no detection
+//!   signature for it yet).
+//! - Facts must come from the COMPOSED launch env (workspace env + auth
+//!   overlay), never the ambient process env — classifying ambient would
+//!   reproduce the probe env-leak bug in production. Secrets rule: values
+//!   are readable only for registry-declared flag vars (`EnvFlag` facts).
+//!
+//! Everything here is pure: no IO, no clock, no `&self` — call it anywhere.
+
+use anyharness_credential_discovery::CredentialFact;
+use serde::Serialize;
+
+use crate::domains::agents::catalog::schema_v2::{
+    AgentCatalogAuthSignal, AgentCatalogV2AuthContext,
+};
+use crate::domains::agents::model::{AgentDescriptor, AuthSpec, CredentialState};
+
+/// Reserved catalog context id meaning "no credentials at all".
+pub const BASELINE_CONTEXT_ID: &str = "baseline";
+
+/// The classified auth contexts for one agent, ordered by slot appearance in
+/// the catalog (each entry is its slot's first-match winner).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ActiveAuthContexts {
+    ids: Vec<String>,
+}
+
+impl ActiveAuthContexts {
+    pub fn ids(&self) -> &[String] {
+        &self.ids
+    }
+
+    pub fn is_active(&self, id: &str) -> bool {
+        self.ids.iter().any(|active| active == id)
+    }
+
+    /// True when classification fell through to `"baseline"` (no context
+    /// matched any slot).
+    pub fn is_baseline(&self) -> bool {
+        self.ids.len() == 1 && self.ids[0] == BASELINE_CONTEXT_ID
+    }
+
+    /// The cloud-sync projection: context IDS ONLY — no facts, no values.
+    /// TODO(PR-7b): serialize this on the worker registry-projection lane
+    /// (target → cloud) so menus render from last-classified contexts.
+    pub fn sync_summary(&self, agent_kind: &str) -> AuthContextSyncSummary {
+        AuthContextSyncSummary {
+            agent_kind: agent_kind.to_string(),
+            active_context_ids: self.ids.clone(),
+        }
+    }
+}
+
+/// What crosses the target → cloud boundary about classification: ids only.
+/// No credential fact, env var name, or value ever rides along (decisions
+/// ledger 8). TODO(PR-7b): wire the transport (worker/server).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthContextSyncSummary {
+    pub agent_kind: String,
+    pub active_context_ids: Vec<String>,
+}
+
+/// Classify which of `contexts` (the agent's catalog v2 `authContexts`, in
+/// document order) are active given the observed `facts`.
+///
+/// `descriptor` supplies the slot universe: a context referencing an auth
+/// slot the runtime descriptor does not declare is skipped (catalog/registry
+/// skew must never activate a slot the runtime cannot represent). Contexts
+/// with `auth_slot_id: None` other than `"baseline"` are invalid per
+/// validation and are likewise skipped here.
+pub fn classify(
+    descriptor: &AgentDescriptor,
+    contexts: &[AgentCatalogV2AuthContext],
+    facts: &[CredentialFact],
+) -> ActiveAuthContexts {
+    let mut winners: Vec<String> = Vec::new();
+    let mut decided_slots: Vec<&str> = Vec::new();
+
+    for context in contexts {
+        if context.id == BASELINE_CONTEXT_ID {
+            continue;
+        }
+        let Some(slot_id) = context.auth_slot_id.as_deref() else {
+            tracing::debug!(
+                agent_kind = descriptor.kind.as_str(),
+                context_id = %context.id,
+                "Skipping non-baseline auth context without auth slot id"
+            );
+            continue;
+        };
+        if descriptor.auth.slot(slot_id).is_none() {
+            tracing::debug!(
+                agent_kind = descriptor.kind.as_str(),
+                context_id = %context.id,
+                slot_id,
+                "Skipping auth context for slot unknown to the descriptor"
+            );
+            continue;
+        }
+        if decided_slots.contains(&slot_id) {
+            continue;
+        }
+        // No signals = probe-only context: never matches at runtime.
+        let Some(signals) = context.signals.as_ref() else {
+            continue;
+        };
+        if signal_matches(signals, facts) {
+            decided_slots.push(slot_id);
+            winners.push(context.id.clone());
+        }
+    }
+
+    if winners.is_empty() {
+        winners.push(BASELINE_CONTEXT_ID.to_string());
+    }
+    ActiveAuthContexts { ids: winners }
+}
+
+/// Signal evaluation over facts. `Env` matches presence — an `EnvFlag` fact
+/// also proves its var is present. `EnvFlag` signals (`"VAR=value"`) require
+/// an exact var+value `EnvFlag` fact; a malformed signal (no `=`) never
+/// matches. Empty combinators never match (validation rejects them; the
+/// conservative reading here means a broken document cannot unlock models).
+fn signal_matches(signal: &AgentCatalogAuthSignal, facts: &[CredentialFact]) -> bool {
+    match signal {
+        AgentCatalogAuthSignal::Env(var) => facts.iter().any(|fact| match fact {
+            CredentialFact::Env { var: fact_var } => fact_var == var,
+            CredentialFact::EnvFlag { var: fact_var, .. } => fact_var == var,
+            CredentialFact::Discovery { .. } => false,
+        }),
+        AgentCatalogAuthSignal::EnvFlag(spec) => {
+            let Some((var, value)) = spec.split_once('=') else {
+                tracing::debug!(signal = %spec, "Malformed envFlag signal never matches");
+                return false;
+            };
+            facts.iter().any(|fact| {
+                matches!(
+                    fact,
+                    CredentialFact::EnvFlag {
+                        var: fact_var,
+                        value: fact_value,
+                    } if fact_var == var && fact_value == value
+                )
+            })
+        }
+        AgentCatalogAuthSignal::Discovery(kind) => facts.iter().any(|fact| {
+            matches!(fact, CredentialFact::Discovery { kind: fact_kind } if fact_kind == kind)
+        }),
+        AgentCatalogAuthSignal::AnyOf(children) => children
+            .iter()
+            .any(|child| signal_matches(child, facts)),
+        AgentCatalogAuthSignal::AllOf(children) => {
+            !children.is_empty() && children.iter().all(|child| signal_matches(child, facts))
+        }
+    }
+}
+
+/// Layer-5 projection: today's `CredentialState` semantics derived from
+/// classified facts, for agents whose catalog declares v2 auth contexts.
+///
+/// Mirrors the slot-level ladder in `credentials.rs::detect_slot_credentials`
+/// exactly, in the same order:
+/// 1. any declared slot env var present in facts → `Ready` (env beats
+///    discovery, catalog or not — identical to today),
+/// 2. some non-baseline context active (i.e. discovery-matched) →
+///    `ReadyViaLocalAuth`,
+/// 3. nothing + login supported → `LoginRequired`, else `MissingEnv`.
+///
+/// The legacy env + `LocalAuthState` path in `credentials.rs` stays
+/// authoritative for the v1-catalog era; nothing is wired into readiness
+/// here. TODO(PR-7b): readiness consumes this projection and the parallel
+/// logic in `credentials.rs` is deleted, not duplicated.
+pub fn project_credential_state(
+    auth: &AuthSpec,
+    active: &ActiveAuthContexts,
+    facts: &[CredentialFact],
+) -> CredentialState {
+    let env_present = auth.expected_env_vars().iter().any(|var| {
+        facts.iter().any(|fact| match fact {
+            CredentialFact::Env { var: fact_var } => fact_var == var,
+            CredentialFact::EnvFlag { var: fact_var, .. } => fact_var == var,
+            CredentialFact::Discovery { .. } => false,
+        })
+    });
+    if env_present {
+        return CredentialState::Ready;
+    }
+
+    if !active.is_baseline() && !active.ids().is_empty() {
+        return CredentialState::ReadyViaLocalAuth;
+    }
+
+    if auth.supports_login() {
+        return CredentialState::LoginRequired;
+    }
+
+    CredentialState::MissingEnv
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs
@@ -1,0 +1,422 @@
+//! Classifier + projection tests: per-signature matching incl. precedence
+//! (catalog order = harness precedence), slot union, baseline fallback, and
+//! equivalence of the CredentialState projection with the legacy
+//! env + LocalAuthState path on the common cases.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use anyharness_credential_discovery::{collect_facts, CredentialFact};
+
+use super::context::{classify, project_credential_state, BASELINE_CONTEXT_ID};
+use super::credentials::detect_auth_slots_with_env;
+use crate::domains::agents::catalog::schema_v2::{
+    AgentCatalogAuthSignal, AgentCatalogV2AuthContext,
+};
+use crate::domains::agents::model::{
+    AgentDescriptor, AgentKind, AuthMaterializationSpec, AuthReadinessPolicy, AuthSlotSpec,
+    AuthSpec, CommandSpec, CredentialDiscoveryKind, CredentialState, LoginSpec,
+};
+use crate::domains::agents::registry::built_in_registry;
+
+// An env var name no real environment sets: keeps the legacy detector's
+// ambient `std::env::var` fallback inert during equivalence tests.
+const TEST_API_KEY_VAR: &str = "ANYHARNESS_CONTEXT_TEST_API_KEY";
+
+fn descriptor_with_auth(auth: AuthSpec) -> AgentDescriptor {
+    let mut descriptor = built_in_registry()
+        .into_iter()
+        .find(|descriptor| descriptor.kind == AgentKind::Claude)
+        .expect("claude descriptor");
+    descriptor.auth = auth;
+    descriptor
+}
+
+fn login_spec() -> LoginSpec {
+    LoginSpec {
+        label: "Log in".to_string(),
+        command: CommandSpec {
+            program: "claude".to_string(),
+            args: vec!["login".to_string()],
+        },
+        reuses_user_state: true,
+        message: None,
+    }
+}
+
+fn single_slot_auth(login: Option<LoginSpec>) -> AuthSpec {
+    AuthSpec::test_single_required_slot(
+        vec![TEST_API_KEY_VAR.to_string()],
+        login,
+        CredentialDiscoveryKind::Claude,
+    )
+}
+
+fn context(
+    id: &str,
+    slot_id: &str,
+    signals: Option<AgentCatalogAuthSignal>,
+) -> AgentCatalogV2AuthContext {
+    AgentCatalogV2AuthContext {
+        id: id.to_string(),
+        auth_slot_id: Some(slot_id.to_string()),
+        description: None,
+        signals,
+    }
+}
+
+fn env(var: &str) -> AgentCatalogAuthSignal {
+    AgentCatalogAuthSignal::Env(var.to_string())
+}
+
+fn discovery(kind: &str) -> AgentCatalogAuthSignal {
+    AgentCatalogAuthSignal::Discovery(kind.to_string())
+}
+
+fn env_fact(var: &str) -> CredentialFact {
+    CredentialFact::Env {
+        var: var.to_string(),
+    }
+}
+
+fn flag_fact(var: &str, value: &str) -> CredentialFact {
+    CredentialFact::EnvFlag {
+        var: var.to_string(),
+        value: value.to_string(),
+    }
+}
+
+fn discovery_fact(kind: &str) -> CredentialFact {
+    CredentialFact::Discovery {
+        kind: kind.to_string(),
+    }
+}
+
+fn claude_style_contexts() -> Vec<AgentCatalogV2AuthContext> {
+    vec![
+        context("anthropic-api", "default", Some(env(TEST_API_KEY_VAR))),
+        context(
+            "anthropic-oauth",
+            "default",
+            Some(AgentCatalogAuthSignal::AnyOf(vec![
+                env("CLAUDE_CODE_OAUTH_TOKEN"),
+                discovery("claude-oauth-creds"),
+            ])),
+        ),
+    ]
+}
+
+fn make_temp_home() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "anyharness-auth-context-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&path).expect("create temp home");
+    path
+}
+
+// ---------------------------------------------------------------------------
+// Classifier
+// ---------------------------------------------------------------------------
+
+#[test]
+fn api_key_masks_oauth_when_both_facts_present() {
+    // Mirrors the probe env-leak finding: contexts ordered [api, oauth]
+    // because the harness lets an inherited API key mask an OAuth token.
+    let descriptor = descriptor_with_auth(single_slot_auth(Some(login_spec())));
+    let facts = vec![
+        env_fact(TEST_API_KEY_VAR),
+        discovery_fact("claude-oauth-creds"),
+    ];
+
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+
+    assert_eq!(active.ids(), ["anthropic-api"]);
+    assert!(active.is_active("anthropic-api"));
+    assert!(!active.is_active("anthropic-oauth"));
+    assert!(!active.is_baseline());
+}
+
+#[test]
+fn oauth_wins_when_api_key_absent() {
+    let descriptor = descriptor_with_auth(single_slot_auth(Some(login_spec())));
+    let facts = vec![discovery_fact("claude-oauth-creds")];
+
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+
+    assert_eq!(active.ids(), ["anthropic-oauth"]);
+}
+
+#[test]
+fn bedrock_all_of_requires_flag_and_chain() {
+    let descriptor = descriptor_with_auth(single_slot_auth(Some(login_spec())));
+    let bedrock = context(
+        "anthropic-bedrock",
+        "default",
+        Some(AgentCatalogAuthSignal::AllOf(vec![
+            AgentCatalogAuthSignal::EnvFlag("CLAUDE_CODE_USE_BEDROCK=1".to_string()),
+            discovery("aws-credential-chain"),
+        ])),
+    );
+    let mut contexts = vec![bedrock];
+    contexts.extend(claude_style_contexts());
+
+    // Flag + chain + an API key fact: bedrock is first in catalog order.
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[
+            flag_fact("CLAUDE_CODE_USE_BEDROCK", "1"),
+            discovery_fact("aws-credential-chain"),
+            env_fact(TEST_API_KEY_VAR),
+        ],
+    );
+    assert_eq!(active.ids(), ["anthropic-bedrock"]);
+
+    // Flag without the chain: allOf fails, api wins instead.
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[
+            flag_fact("CLAUDE_CODE_USE_BEDROCK", "1"),
+            env_fact(TEST_API_KEY_VAR),
+        ],
+    );
+    assert_eq!(active.ids(), ["anthropic-api"]);
+
+    // Flag value mismatch never matches the envFlag leaf.
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[
+            flag_fact("CLAUDE_CODE_USE_BEDROCK", "0"),
+            discovery_fact("aws-credential-chain"),
+        ],
+    );
+    assert_eq!(active.ids(), [BASELINE_CONTEXT_ID]);
+}
+
+#[test]
+fn env_signal_is_satisfied_by_flag_fact_presence() {
+    let descriptor = descriptor_with_auth(single_slot_auth(None));
+    let contexts = vec![context(
+        "flag-presence",
+        "default",
+        Some(env("CLAUDE_CODE_USE_BEDROCK")),
+    )];
+
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[flag_fact("CLAUDE_CODE_USE_BEDROCK", "1")],
+    );
+
+    assert_eq!(active.ids(), ["flag-presence"]);
+}
+
+#[test]
+fn union_across_slots_for_multi_provider_descriptor() {
+    // OpenCode-style: independent provider slots, one winner each.
+    let auth = AuthSpec {
+        readiness_policy: AuthReadinessPolicy::ProviderManaged,
+        slots: vec![
+            AuthSlotSpec {
+                id: "anthropic".to_string(),
+                label: "Anthropic".to_string(),
+                credential_provider_ids: vec!["anthropic".to_string()],
+                required_for_readiness: false,
+                env_vars: vec!["ANTHROPIC_API_KEY".to_string()],
+                login: None,
+                discovery: CredentialDiscoveryKind::OpenCode,
+                materialization: AuthMaterializationSpec::default(),
+            },
+            AuthSlotSpec {
+                id: "openai".to_string(),
+                label: "OpenAI".to_string(),
+                credential_provider_ids: vec!["openai".to_string()],
+                required_for_readiness: false,
+                env_vars: vec!["OPENAI_API_KEY".to_string()],
+                login: None,
+                discovery: CredentialDiscoveryKind::OpenCode,
+                materialization: AuthMaterializationSpec::default(),
+            },
+        ],
+    };
+    let descriptor = descriptor_with_auth(auth);
+    let contexts = vec![
+        context(
+            "opencode-anthropic",
+            "anthropic",
+            Some(discovery("opencode-auth-json/anthropic")),
+        ),
+        context(
+            "opencode-anthropic-env",
+            "anthropic",
+            Some(env("ANTHROPIC_API_KEY")),
+        ),
+        context("opencode-openai", "openai", Some(env("OPENAI_API_KEY"))),
+    ];
+
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[
+            discovery_fact("opencode-auth-json/anthropic"),
+            env_fact("ANTHROPIC_API_KEY"),
+            env_fact("OPENAI_API_KEY"),
+        ],
+    );
+
+    // One winner per slot (first match), union across slots, catalog order.
+    assert_eq!(active.ids(), ["opencode-anthropic", "opencode-openai"]);
+}
+
+#[test]
+fn baseline_active_iff_nothing_matched() {
+    let descriptor = descriptor_with_auth(single_slot_auth(Some(login_spec())));
+
+    let active = classify(&descriptor, &claude_style_contexts(), &[]);
+
+    assert_eq!(active.ids(), [BASELINE_CONTEXT_ID]);
+    assert!(active.is_baseline());
+    assert!(active.is_active(BASELINE_CONTEXT_ID));
+}
+
+#[test]
+fn signal_less_context_never_matches() {
+    let descriptor = descriptor_with_auth(single_slot_auth(None));
+    let contexts = vec![context("anthropic-probe-only", "default", None)];
+
+    let active = classify(
+        &descriptor,
+        &contexts,
+        &[env_fact(TEST_API_KEY_VAR), discovery_fact("claude-oauth-creds")],
+    );
+
+    assert_eq!(active.ids(), [BASELINE_CONTEXT_ID]);
+}
+
+#[test]
+fn context_for_unknown_slot_is_skipped() {
+    let descriptor = descriptor_with_auth(single_slot_auth(None));
+    let contexts = vec![context(
+        "anthropic-vertex",
+        "no-such-slot",
+        Some(env(TEST_API_KEY_VAR)),
+    )];
+
+    let active = classify(&descriptor, &contexts, &[env_fact(TEST_API_KEY_VAR)]);
+
+    assert_eq!(active.ids(), [BASELINE_CONTEXT_ID]);
+}
+
+#[test]
+fn sync_summary_carries_context_ids_only() {
+    let descriptor = descriptor_with_auth(single_slot_auth(None));
+    let active = classify(
+        &descriptor,
+        &claude_style_contexts(),
+        &[env_fact(TEST_API_KEY_VAR)],
+    );
+
+    let summary = active.sync_summary(descriptor.kind.as_str());
+
+    assert_eq!(
+        serde_json::to_value(&summary).expect("serialize summary"),
+        serde_json::json!({
+            "agentKind": "claude",
+            "activeContextIds": ["anthropic-api"],
+        })
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CredentialState projection: equivalence with the legacy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn projection_env_var_present_is_ready_like_legacy() {
+    let home = make_temp_home();
+    let auth = single_slot_auth(Some(login_spec()));
+    let descriptor = descriptor_with_auth(auth.clone());
+
+    let env_keys: BTreeSet<String> = [TEST_API_KEY_VAR.to_string()].into_iter().collect();
+    let facts = collect_facts(&home, &env_keys, &BTreeMap::new());
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+    let projected = project_credential_state(&auth, &active, &facts);
+
+    let additional_env: BTreeMap<String, String> =
+        [(TEST_API_KEY_VAR.to_string(), "sk-test".to_string())]
+            .into_iter()
+            .collect();
+    let (_, slots) = detect_auth_slots_with_env(&auth, &home, &additional_env);
+
+    assert_eq!(active.ids(), ["anthropic-api"]);
+    assert_eq!(projected, CredentialState::Ready);
+    assert_eq!(slots[0].credential_state, projected);
+
+    let _ = std::fs::remove_dir_all(home);
+}
+
+#[test]
+fn projection_local_oauth_file_is_ready_via_local_auth_like_legacy() {
+    let home = make_temp_home();
+    std::fs::create_dir_all(home.join(".claude")).expect("create claude dir");
+    std::fs::write(
+        home.join(".claude/.credentials.json"),
+        r#"{"claudeAiOauth":{"accessToken":"token"}}"#,
+    )
+    .expect("write oauth creds");
+
+    let auth = single_slot_auth(Some(login_spec()));
+    let descriptor = descriptor_with_auth(auth.clone());
+
+    let facts = collect_facts(&home, &BTreeSet::new(), &BTreeMap::new());
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+    let projected = project_credential_state(&auth, &active, &facts);
+
+    let (_, slots) = detect_auth_slots_with_env(&auth, &home, &BTreeMap::new());
+
+    assert_eq!(active.ids(), ["anthropic-oauth"]);
+    assert_eq!(projected, CredentialState::ReadyViaLocalAuth);
+    assert_eq!(slots[0].credential_state, projected);
+
+    let _ = std::fs::remove_dir_all(home);
+}
+
+#[test]
+fn projection_nothing_with_login_is_login_required_like_legacy() {
+    let home = make_temp_home();
+    let auth = single_slot_auth(Some(login_spec()));
+    let descriptor = descriptor_with_auth(auth.clone());
+
+    let facts = collect_facts(&home, &BTreeSet::new(), &BTreeMap::new());
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+    let projected = project_credential_state(&auth, &active, &facts);
+
+    let (_, slots) = detect_auth_slots_with_env(&auth, &home, &BTreeMap::new());
+
+    assert!(active.is_baseline());
+    assert_eq!(projected, CredentialState::LoginRequired);
+    assert_eq!(slots[0].credential_state, projected);
+
+    let _ = std::fs::remove_dir_all(home);
+}
+
+#[test]
+fn projection_nothing_without_login_is_missing_env_like_legacy() {
+    let home = make_temp_home();
+    let auth = single_slot_auth(None);
+    let descriptor = descriptor_with_auth(auth.clone());
+
+    let facts = collect_facts(&home, &BTreeSet::new(), &BTreeMap::new());
+    let active = classify(&descriptor, &claude_style_contexts(), &facts);
+    let projected = project_credential_state(&auth, &active, &facts);
+
+    let (_, slots) = detect_auth_slots_with_env(&auth, &home, &BTreeMap::new());
+
+    assert_eq!(projected, CredentialState::MissingEnv);
+    assert_eq!(slots[0].credential_state, projected);
+
+    let _ = std::fs::remove_dir_all(home);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/mod.rs
@@ -1,7 +1,9 @@
-//! Agent auth: encrypted selection config, local credential detection, and
-//! interactive login. One concern, one service surface.
+//! Agent auth: encrypted selection config, local credential detection,
+//! pure auth-context classification, and interactive login. One concern,
+//! one service surface.
 
 mod codex_config;
+pub mod context;
 pub mod credentials;
 mod launch;
 pub mod login;
@@ -22,6 +24,9 @@ pub use store::AgentAuthConfigStore;
 
 #[cfg(test)]
 mod claude_tests;
+
+#[cfg(test)]
+mod context_tests;
 
 #[cfg(test)]
 mod scope_tests;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/loader.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/loader.rs
@@ -1,0 +1,109 @@
+//! Dual-read entry for agent catalog documents during the v1 -> v2
+//! transition. The bundled catalog stays on the v1 path (`bundled.rs` is
+//! untouched); this loader is for documents whose version is not known at
+//! compile time (sync fetches, build-pipeline drafts).
+//!
+//! DUAL-READ RULE: a document is read as v2 iff its top-level
+//! `schemaVersion` is a number >= 2, OR — for early drafts that predate the
+//! field — it lacks a numeric `schemaVersion` but carries a top-level
+//! `probedAgainst` key (the v2-only registry pairing). Everything else is
+//! read as v1. Both arms are validated before they are returned.
+
+use serde_json::Value;
+
+use super::schema::AgentCatalogDocument;
+use super::schema_v2::AgentCatalogV2Document;
+use super::validation::validate_agent_catalog_document;
+use super::validation_v2::validate_agent_catalog_v2_document;
+
+#[derive(Debug, Clone)]
+pub enum AgentCatalog {
+    V1(AgentCatalogDocument),
+    V2(AgentCatalogV2Document),
+}
+
+pub fn parse_agent_catalog_json(json: &str) -> anyhow::Result<AgentCatalog> {
+    let raw: Value = serde_json::from_str(json)?;
+    if is_v2_catalog_value(&raw) {
+        let catalog: AgentCatalogV2Document = serde_json::from_value(raw)?;
+        validate_agent_catalog_v2_document(&catalog)?;
+        Ok(AgentCatalog::V2(catalog))
+    } else {
+        let catalog: AgentCatalogDocument = serde_json::from_value(raw)?;
+        validate_agent_catalog_document(&catalog)?;
+        Ok(AgentCatalog::V1(catalog))
+    }
+}
+
+fn is_v2_catalog_value(raw: &Value) -> bool {
+    match raw.get("schemaVersion").and_then(Value::as_u64) {
+        Some(schema_version) => schema_version >= 2,
+        None => raw.get("probedAgainst").is_some(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::catalog::schema_v2::draft_catalog_v2_json;
+
+    const BUNDLED_V1_CATALOG: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../catalogs/agents/v1/catalog.json"
+    ));
+
+    #[test]
+    fn dual_read_picks_v2_for_the_draft_catalog() {
+        let catalog = parse_agent_catalog_json(draft_catalog_v2_json()).expect("draft must load");
+
+        match catalog {
+            AgentCatalog::V2(document) => {
+                assert_eq!(document.schema_version, 2);
+                assert_eq!(document.catalog_version, "2026-06-10.6");
+            }
+            AgentCatalog::V1(_) => panic!("draft catalog must be read as v2"),
+        }
+    }
+
+    #[test]
+    fn dual_read_picks_v1_for_the_bundled_catalog() {
+        let catalog = parse_agent_catalog_json(BUNDLED_V1_CATALOG).expect("bundled must load");
+
+        match catalog {
+            AgentCatalog::V1(document) => assert_eq!(document.schema_version, 1),
+            AgentCatalog::V2(_) => panic!("bundled catalog must be read as v1"),
+        }
+    }
+
+    #[test]
+    fn dual_read_treats_probed_against_without_schema_version_as_v2() {
+        let mut raw: serde_json::Value =
+            serde_json::from_str(draft_catalog_v2_json()).expect("draft must parse");
+        raw.as_object_mut()
+            .expect("draft is an object")
+            .remove("schemaVersion");
+        let json = serde_json::to_string(&raw).expect("serialize");
+
+        let catalog = parse_agent_catalog_json(&json).expect("must load via probedAgainst marker");
+
+        match catalog {
+            AgentCatalog::V2(document) => assert_eq!(document.schema_version, 2),
+            AgentCatalog::V1(_) => panic!("probedAgainst document must be read as v2"),
+        }
+    }
+
+    #[test]
+    fn dual_read_rejects_v2_document_that_fails_validation() {
+        let mut raw: serde_json::Value =
+            serde_json::from_str(draft_catalog_v2_json()).expect("draft must parse");
+        raw["catalogVersion"] = serde_json::Value::String(" ".to_string());
+        let json = serde_json::to_string(&raw).expect("serialize");
+
+        let error = parse_agent_catalog_json(&json).expect_err("blank catalogVersion must fail");
+
+        assert!(
+            error.to_string().contains("catalog version is empty"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
@@ -1,4 +1,8 @@
 pub mod bundled;
+pub mod loader;
 pub mod projection;
 pub mod schema;
+pub mod schema_v2;
 pub mod validation;
+pub mod validation_v2;
+pub mod validation_v2_pairing;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_v2.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_v2.rs
@@ -1,0 +1,407 @@
+//! Agent catalog schema v2: the probe-generated WHICH document — harness
+//! version pins, model rows, per-model option matrices, and ordered auth
+//! contexts with observed availability. Shapes mirror the build-catalog
+//! output (`scripts/agent-catalog/catalog.draft.json`); cross-field
+//! invariants live in `validation_v2.rs`, dual-read with v1 in `loader.rs`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::domains::agents::model::ModelCatalogStatus;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Document {
+    /// Early v2 drafts may omit the field; the dual-read loader then treats a
+    /// top-level `probedAgainst` key as the v2 marker (see `loader.rs`).
+    #[serde(default = "default_v2_schema_version")]
+    pub schema_version: u32,
+    pub catalog_version: String,
+    /// Pairing with the registry document the probe ran against. The
+    /// registry version is `None` while the probe pipeline does not yet pin
+    /// one; registry cross-checks are then deferred (see `validation_v2.rs`).
+    #[serde(default)]
+    pub probed_against: Option<AgentCatalogV2ProbedAgainst>,
+    pub generated_at: String,
+    #[serde(default)]
+    pub agents: Vec<AgentCatalogV2Agent>,
+}
+
+fn default_v2_schema_version() -> u32 {
+    2
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ProbedAgainst {
+    #[serde(default)]
+    pub registry_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Agent {
+    pub kind: String,
+    pub display_name: String,
+    pub harness: AgentCatalogV2HarnessPins,
+    /// Ordered: list position is harness credential precedence (first match
+    /// wins per auth slot when the runtime classifies credential facts).
+    #[serde(default)]
+    pub auth_contexts: Vec<AgentCatalogV2AuthContext>,
+    pub session: AgentCatalogV2Session,
+    pub provenance: AgentCatalogV2AgentProvenance,
+}
+
+/// The pin block: exact versions the probe validated and reconcile installs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2HarnessPins {
+    pub agent_process: AgentCatalogV2ArtifactPin,
+    #[serde(default)]
+    pub native: Option<AgentCatalogV2ArtifactPin>,
+    #[serde(default)]
+    pub data: Option<AgentCatalogV2DataPin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ArtifactPin {
+    pub version: String,
+    #[serde(default)]
+    pub sha256: Option<String>,
+}
+
+/// Pinned data dependency that gates model lists (e.g. opencode models.dev).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2DataPin {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub snapshot_path: Option<String>,
+    #[serde(default)]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2AuthContext {
+    /// Catalog-local id referenced by model availability. `"baseline"` is
+    /// reserved: it means "no credentials at all" and carries no auth slot.
+    pub id: String,
+    /// References a registry auth slot on the same agent kind; required for
+    /// every context except `"baseline"`.
+    #[serde(default)]
+    pub auth_slot_id: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Declarative detection signature evaluated over the composed launch
+    /// env + discovery facts. Absent on probe drafts that predate signals.
+    #[serde(default)]
+    pub signals: Option<AgentCatalogAuthSignal>,
+}
+
+/// The minimal probe-testable signal algebra: `env | envFlag | discovery |
+/// anyOf | allOf` — no NOT operator, nesting depth <= 2 (enforced in
+/// `validation_v2.rs`). Externally tagged so JSON reads as
+/// `{"env": "ANTHROPIC_API_KEY"}` / `{"allOf": [ ... ]}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AgentCatalogAuthSignal {
+    /// Env var present in the composed launch env (presence only — secret
+    /// values are never read).
+    Env(String),
+    /// `"VAR=value"`: env var present with this exact value; only valid for
+    /// registry vars tagged `flag` (values readable only for flags).
+    EnvFlag(String),
+    /// A named discovery fact kind, e.g. `"claude-oauth-creds"`.
+    Discovery(String),
+    AnyOf(Vec<AgentCatalogAuthSignal>),
+    AllOf(Vec<AgentCatalogAuthSignal>),
+}
+
+impl AgentCatalogAuthSignal {
+    /// Nesting depth: leaves are 1, combinators are 1 + deepest child.
+    pub fn depth(&self) -> usize {
+        match self {
+            Self::Env(_) | Self::EnvFlag(_) | Self::Discovery(_) => 1,
+            Self::AnyOf(children) | Self::AllOf(children) => {
+                1 + children.iter().map(Self::depth).max().unwrap_or(0)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Session {
+    /// The control universe: every key/value any model of this harness might
+    /// support. Per-model matrices are subsets of this.
+    #[serde(default)]
+    pub controls: Vec<AgentCatalogV2SessionControl>,
+    #[serde(default)]
+    pub models: Vec<AgentCatalogV2Model>,
+    /// Curation-owned default model per auth-context id.
+    #[serde(default)]
+    pub defaults: BTreeMap<String, String>,
+    /// Probe-owned: the model actually selected at session start per probed
+    /// auth context. Curation input only, never consumed by the runtime.
+    #[serde(default)]
+    pub observed_defaults: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2SessionControl {
+    pub key: String,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub values: Vec<String>,
+    #[serde(default)]
+    pub mapping: Option<AgentCatalogV2ControlMapping>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ControlMapping {
+    #[serde(default)]
+    pub create_field: Option<String>,
+    #[serde(default)]
+    pub live_config_id: Option<String>,
+    /// Model control only: `setSessionModel` | `configOption`, as observed
+    /// by the probe.
+    #[serde(default)]
+    pub switch_via: Option<String>,
+    /// e.g. `"slash-effort"` (codex) or `"bracket-params"` (cursor).
+    #[serde(default)]
+    pub variant_syntax: Option<String>,
+    #[serde(default)]
+    pub missing_live_config_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Model {
+    pub id: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    /// Display-only grouping tag; never used for resolution or fallback.
+    #[serde(default)]
+    pub family: Option<String>,
+    pub availability: AgentCatalogV2Availability,
+    #[serde(default)]
+    pub default_visible: bool,
+    /// The per-model option matrix: control key -> exactly the values this
+    /// model supports. A key absent here means the model lacks that control.
+    #[serde(default)]
+    pub controls: BTreeMap<String, AgentCatalogV2ModelControl>,
+    pub status: ModelCatalogStatus,
+    #[serde(default)]
+    pub provenance: Option<AgentCatalogV2ModelProvenance>,
+}
+
+/// Observed-set availability: exactly the auth contexts (incl. `"baseline"`)
+/// whose probe runs contained this model. No monotonicity inference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Availability {
+    pub any_of: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ModelControl {
+    pub values: Vec<String>,
+    /// Curation-owned product default.
+    #[serde(default)]
+    pub default: Option<String>,
+    /// Probe-owned session state captured after switching to this model.
+    #[serde(default)]
+    pub observed_value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ModelProvenance {
+    #[serde(default)]
+    pub observed_in: Vec<String>,
+    #[serde(default)]
+    pub observed_in_all_contexts: Option<bool>,
+    #[serde(default)]
+    pub via_trial_only: Option<bool>,
+    #[serde(default)]
+    pub variant_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2AgentProvenance {
+    pub probed_at: String,
+    /// `agent_info` from the ACP InitializeResponse during the probe; null
+    /// when the harness did not attest (e.g. cursor draft data).
+    #[serde(default)]
+    pub attestation: Option<AgentCatalogV2Attestation>,
+    #[serde(default)]
+    pub runs: Vec<AgentCatalogV2ProbeRun>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2Attestation {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogV2ProbeRun {
+    pub id: String,
+    #[serde(default)]
+    pub snapshot_path: Option<String>,
+}
+
+#[cfg(test)]
+pub(crate) fn draft_catalog_v2_json() -> &'static str {
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../scripts/agent-catalog/catalog.draft.json"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_draft() -> AgentCatalogV2Document {
+        serde_json::from_str(draft_catalog_v2_json()).expect("draft catalog must parse")
+    }
+
+    #[test]
+    fn draft_catalog_parses_with_expected_shape() {
+        let catalog = parse_draft();
+
+        assert_eq!(catalog.schema_version, 2);
+        assert_eq!(catalog.catalog_version, "2026-06-10.6");
+        let probed_against = catalog.probed_against.as_ref().expect("probedAgainst");
+        assert_eq!(probed_against.registry_version, None);
+        assert_eq!(catalog.agents.len(), 5);
+
+        let claude = &catalog.agents[0];
+        assert_eq!(claude.kind, "claude");
+        assert_eq!(claude.harness.agent_process.version, "0.29.0");
+        assert_eq!(
+            claude
+                .harness
+                .native
+                .as_ref()
+                .map(|pin| pin.version.as_str()),
+            Some("2.1.170 (Claude Code)")
+        );
+        assert_eq!(
+            claude
+                .auth_contexts
+                .iter()
+                .map(|context| context.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["anthropic-api", "anthropic-oauth"]
+        );
+        let sonnet = &claude.session.models[0];
+        assert_eq!(sonnet.id, "sonnet");
+        assert_eq!(sonnet.availability.any_of, vec!["anthropic-api"]);
+        assert!(sonnet.default_visible);
+        let effort = sonnet.controls.get("effort").expect("effort control");
+        assert_eq!(effort.values, vec!["low", "medium", "high"]);
+        assert_eq!(effort.observed_value.as_deref(), Some("high"));
+        assert_eq!(effort.default, None);
+
+        let codex = &catalog.agents[1];
+        let model_control = codex
+            .session
+            .controls
+            .iter()
+            .find(|control| control.key == "model")
+            .expect("model control");
+        let mapping = model_control.mapping.as_ref().expect("model mapping");
+        assert_eq!(mapping.switch_via.as_deref(), Some("setSessionModel"));
+        assert_eq!(mapping.variant_syntax.as_deref(), Some("slash-effort"));
+        let gpt = &codex.session.models[0];
+        let provenance = gpt.provenance.as_ref().expect("model provenance");
+        assert!(provenance
+            .variant_ids
+            .contains(&"gpt-5.5/xhigh".to_string()));
+
+        let cursor = &catalog.agents[2];
+        assert!(cursor.provenance.attestation.is_none());
+        assert!(cursor.harness.native.is_none());
+
+        let opencode = &catalog.agents[4];
+        assert!(opencode
+            .auth_contexts
+            .iter()
+            .any(|context| context.id == "baseline" && context.auth_slot_id.is_none()));
+        assert_eq!(
+            opencode
+                .session
+                .observed_defaults
+                .get("baseline")
+                .map(String::as_str),
+            Some("opencode/big-pickle")
+        );
+    }
+
+    #[test]
+    fn auth_signals_round_trip_bedrock_all_of_example() {
+        // The bedrock-style signature from the migration doc (§5.4).
+        let json = serde_json::json!({
+            "allOf": [
+                { "envFlag": "CLAUDE_CODE_USE_BEDROCK=1" },
+                { "discovery": "aws-credential-chain" }
+            ]
+        });
+
+        let signal: AgentCatalogAuthSignal =
+            serde_json::from_value(json.clone()).expect("bedrock signal must parse");
+
+        assert_eq!(
+            signal,
+            AgentCatalogAuthSignal::AllOf(vec![
+                AgentCatalogAuthSignal::EnvFlag("CLAUDE_CODE_USE_BEDROCK=1".to_string()),
+                AgentCatalogAuthSignal::Discovery("aws-credential-chain".to_string()),
+            ])
+        );
+        assert_eq!(signal.depth(), 2);
+        assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
+    }
+
+    #[test]
+    fn auth_signals_round_trip_any_of_and_leaves() {
+        let json = serde_json::json!({
+            "anyOf": [
+                { "env": "CLAUDE_CODE_OAUTH_TOKEN" },
+                { "discovery": "claude-oauth-creds" }
+            ]
+        });
+
+        let signal: AgentCatalogAuthSignal =
+            serde_json::from_value(json.clone()).expect("oauth signal must parse");
+
+        assert_eq!(signal.depth(), 2);
+        assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
+
+        let leaf: AgentCatalogAuthSignal =
+            serde_json::from_value(serde_json::json!({ "env": "ANTHROPIC_API_KEY" }))
+                .expect("leaf signal must parse");
+        assert_eq!(
+            leaf,
+            AgentCatalogAuthSignal::Env("ANTHROPIC_API_KEY".to_string())
+        );
+        assert_eq!(leaf.depth(), 1);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation_v2.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation_v2.rs
@@ -1,0 +1,376 @@
+//! Document-local invariants for the v2 agent catalog, always enforced (the
+//! loader runs [`validate_agent_catalog_v2_document`] on every v2 parse).
+//! Cross-document checks against the registry the catalog was probed
+//! against live in `validation_v2_pairing.rs`.
+
+use std::collections::HashSet;
+
+use chrono::DateTime;
+
+use super::schema_v2::{
+    AgentCatalogAuthSignal, AgentCatalogV2Agent, AgentCatalogV2AuthContext, AgentCatalogV2Document,
+    AgentCatalogV2Model,
+};
+use crate::domains::agents::model::AgentKind;
+
+/// Reserved auth-context id meaning "no credentials at all".
+pub const BASELINE_AUTH_CONTEXT_ID: &str = "baseline";
+
+/// Maximum signal nesting depth: one combinator over leaves, nothing deeper.
+const MAX_SIGNAL_DEPTH: usize = 2;
+
+pub fn validate_agent_catalog_v2_document(catalog: &AgentCatalogV2Document) -> anyhow::Result<()> {
+    if catalog.schema_version != 2 {
+        anyhow::bail!("agent catalog v2 schema version is not supported");
+    }
+    if catalog.catalog_version.trim().is_empty() {
+        anyhow::bail!("agent catalog version is empty");
+    }
+    DateTime::parse_from_rfc3339(&catalog.generated_at)?;
+    if catalog.agents.is_empty() {
+        anyhow::bail!("agent catalog has no agents");
+    }
+
+    let mut seen_agents = HashSet::new();
+    for agent in &catalog.agents {
+        validate_agent(agent, &mut seen_agents)?;
+    }
+    Ok(())
+}
+
+fn validate_agent(
+    agent: &AgentCatalogV2Agent,
+    seen_agents: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    if AgentKind::parse(agent.kind.as_str()).is_none() {
+        anyhow::bail!("agent catalog agent '{}' is not supported", agent.kind);
+    }
+    if !seen_agents.insert(agent.kind.clone()) {
+        anyhow::bail!("agent catalog agent '{}' is duplicated", agent.kind);
+    }
+    if agent.display_name.trim().is_empty() {
+        anyhow::bail!("agent catalog agent '{}' display name is empty", agent.kind);
+    }
+    if agent.harness.agent_process.version.trim().is_empty() {
+        anyhow::bail!(
+            "agent catalog agent '{}' agentProcess pin version is empty",
+            agent.kind
+        );
+    }
+    if let Some(native) = &agent.harness.native {
+        if native.version.trim().is_empty() {
+            anyhow::bail!(
+                "agent catalog agent '{}' native pin version is empty",
+                agent.kind
+            );
+        }
+    }
+
+    let mut context_ids = HashSet::new();
+    for context in &agent.auth_contexts {
+        validate_auth_context(&agent.kind, context, &mut context_ids)?;
+    }
+
+    if agent.session.models.is_empty() {
+        anyhow::bail!("agent catalog agent '{}' has no models", agent.kind);
+    }
+    let mut seen_models = HashSet::new();
+    for model in &agent.session.models {
+        validate_model(&agent.kind, model, &context_ids, &mut seen_models)?;
+    }
+    Ok(())
+}
+
+fn validate_auth_context(
+    agent_kind: &str,
+    context: &AgentCatalogV2AuthContext,
+    context_ids: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    if context.id.trim().is_empty() {
+        anyhow::bail!("agent catalog agent '{agent_kind}' has empty auth context id");
+    }
+    if !context_ids.insert(context.id.clone()) {
+        anyhow::bail!(
+            "agent catalog agent '{agent_kind}' auth context '{}' is duplicated",
+            context.id
+        );
+    }
+    if context.id == BASELINE_AUTH_CONTEXT_ID {
+        if context.auth_slot_id.is_some() {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' baseline auth context must not have authSlotId"
+            );
+        }
+        if context.signals.is_some() {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' baseline auth context must not have signals"
+            );
+        }
+        return Ok(());
+    }
+    match context.auth_slot_id.as_deref() {
+        Some(slot_id) if !slot_id.trim().is_empty() => {}
+        _ => anyhow::bail!(
+            "agent catalog agent '{agent_kind}' auth context '{}' is missing authSlotId",
+            context.id
+        ),
+    }
+    if let Some(signals) = &context.signals {
+        validate_signal(agent_kind, &context.id, signals)?;
+        if signals.depth() > MAX_SIGNAL_DEPTH {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' auth context '{}' signals exceed depth {MAX_SIGNAL_DEPTH}",
+                context.id
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_signal(
+    agent_kind: &str,
+    context_id: &str,
+    signal: &AgentCatalogAuthSignal,
+) -> anyhow::Result<()> {
+    match signal {
+        AgentCatalogAuthSignal::Env(var) => {
+            if var.trim().is_empty() {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' has empty env signal"
+                );
+            }
+        }
+        AgentCatalogAuthSignal::EnvFlag(flag) => {
+            let valid = flag
+                .split_once('=')
+                .is_some_and(|(var, value)| !var.trim().is_empty() && !value.trim().is_empty());
+            if !valid {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' envFlag signal '{flag}' is not 'VAR=value'"
+                );
+            }
+        }
+        AgentCatalogAuthSignal::Discovery(kind) => {
+            if kind.trim().is_empty() {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' has empty discovery signal"
+                );
+            }
+        }
+        AgentCatalogAuthSignal::AnyOf(children) | AgentCatalogAuthSignal::AllOf(children) => {
+            if children.is_empty() {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' has empty signal combinator"
+                );
+            }
+            for child in children {
+                validate_signal(agent_kind, context_id, child)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_model(
+    agent_kind: &str,
+    model: &AgentCatalogV2Model,
+    context_ids: &HashSet<String>,
+    seen_models: &mut HashSet<String>,
+) -> anyhow::Result<()> {
+    if model.id.trim().is_empty() {
+        anyhow::bail!("agent catalog agent '{agent_kind}' has empty model id");
+    }
+    if !seen_models.insert(model.id.clone()) {
+        anyhow::bail!(
+            "agent catalog agent '{agent_kind}' model '{}' is duplicated",
+            model.id
+        );
+    }
+    if model.display_name.trim().is_empty() {
+        anyhow::bail!(
+            "agent catalog agent '{agent_kind}' model '{}' display name is empty",
+            model.id
+        );
+    }
+    if model.availability.any_of.is_empty() {
+        anyhow::bail!(
+            "agent catalog agent '{agent_kind}' model '{}' has empty availability",
+            model.id
+        );
+    }
+    for context_id in &model.availability.any_of {
+        if context_id != BASELINE_AUTH_CONTEXT_ID && !context_ids.contains(context_id) {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' model '{}' availability references unknown auth context '{context_id}'",
+                model.id
+            );
+        }
+    }
+    for (control_key, control) in &model.controls {
+        if control.values.is_empty() {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' model '{}' control '{control_key}' has no values",
+                model.id
+            );
+        }
+        if let Some(default) = control.default.as_deref() {
+            if !control.values.iter().any(|value| value == default) {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' model '{}' control '{control_key}' default '{default}' is not a value",
+                    model.id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::catalog::schema_v2::draft_catalog_v2_json;
+
+    fn draft_catalog() -> AgentCatalogV2Document {
+        serde_json::from_str(draft_catalog_v2_json()).expect("draft catalog must parse")
+    }
+
+    fn signal(json: serde_json::Value) -> AgentCatalogAuthSignal {
+        serde_json::from_value(json).expect("signal must parse")
+    }
+
+    fn expect_invalid(catalog: &AgentCatalogV2Document, expected_fragment: &str) {
+        let error =
+            validate_agent_catalog_v2_document(catalog).expect_err("catalog must be invalid");
+        assert!(
+            error.to_string().contains(expected_fragment),
+            "expected '{expected_fragment}' in: {error}"
+        );
+    }
+
+    #[test]
+    fn draft_catalog_validates() {
+        validate_agent_catalog_v2_document(&draft_catalog()).expect("draft catalog must validate");
+    }
+
+    #[test]
+    fn rejects_empty_catalog_version() {
+        let mut catalog = draft_catalog();
+        catalog.catalog_version = "  ".to_string();
+        expect_invalid(&catalog, "catalog version is empty");
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_version() {
+        let mut catalog = draft_catalog();
+        catalog.schema_version = 3;
+        expect_invalid(&catalog, "schema version is not supported");
+    }
+
+    #[test]
+    fn rejects_duplicate_model_ids() {
+        let mut catalog = draft_catalog();
+        let claude = &mut catalog.agents[0];
+        let duplicate = claude.session.models[0].clone();
+        claude.session.models.push(duplicate);
+        expect_invalid(&catalog, "model 'sonnet' is duplicated");
+    }
+
+    #[test]
+    fn rejects_duplicate_auth_context_ids() {
+        let mut catalog = draft_catalog();
+        let claude = &mut catalog.agents[0];
+        let duplicate = claude.auth_contexts[0].clone();
+        claude.auth_contexts.push(duplicate);
+        expect_invalid(&catalog, "auth context 'anthropic-api' is duplicated");
+    }
+
+    #[test]
+    fn rejects_availability_referencing_unknown_auth_context() {
+        let mut catalog = draft_catalog();
+        let claude = &mut catalog.agents[0];
+        claude.session.models[0]
+            .availability
+            .any_of
+            .push("anthropic-vertex".to_string());
+        expect_invalid(
+            &catalog,
+            "availability references unknown auth context 'anthropic-vertex'",
+        );
+    }
+
+    #[test]
+    fn accepts_baseline_availability_without_declared_baseline_context() {
+        let mut catalog = draft_catalog();
+        let claude = &mut catalog.agents[0];
+        claude.session.models[0]
+            .availability
+            .any_of
+            .push(BASELINE_AUTH_CONTEXT_ID.to_string());
+        validate_agent_catalog_v2_document(&catalog).expect("baseline is always a known context");
+    }
+
+    #[test]
+    fn rejects_non_baseline_auth_context_without_slot_id() {
+        let mut catalog = draft_catalog();
+        catalog.agents[0].auth_contexts[0].auth_slot_id = None;
+        expect_invalid(
+            &catalog,
+            "auth context 'anthropic-api' is missing authSlotId",
+        );
+    }
+
+    #[test]
+    fn rejects_baseline_auth_context_with_slot_id_or_signals() {
+        let mut catalog = draft_catalog();
+        let baseline = catalog.agents[4]
+            .auth_contexts
+            .iter_mut()
+            .find(|context| context.id == BASELINE_AUTH_CONTEXT_ID)
+            .expect("opencode baseline context");
+        baseline.auth_slot_id = Some("anthropic".to_string());
+        expect_invalid(&catalog, "baseline auth context must not have authSlotId");
+
+        let mut catalog = draft_catalog();
+        let baseline = catalog.agents[4]
+            .auth_contexts
+            .iter_mut()
+            .find(|context| context.id == BASELINE_AUTH_CONTEXT_ID)
+            .expect("opencode baseline context");
+        baseline.signals = Some(signal(serde_json::json!({ "env": "ANTHROPIC_API_KEY" })));
+        expect_invalid(&catalog, "baseline auth context must not have signals");
+    }
+
+    #[test]
+    fn rejects_signals_deeper_than_two_levels() {
+        let mut catalog = draft_catalog();
+        catalog.agents[0].auth_contexts[0].signals = Some(signal(serde_json::json!({
+            "anyOf": [
+                { "allOf": [ { "env": "ANTHROPIC_API_KEY" } ] }
+            ]
+        })));
+        expect_invalid(&catalog, "signals exceed depth 2");
+    }
+
+    #[test]
+    fn rejects_empty_signal_combinator_and_malformed_env_flag() {
+        let mut catalog = draft_catalog();
+        catalog.agents[0].auth_contexts[0].signals =
+            Some(signal(serde_json::json!({ "anyOf": [] })));
+        expect_invalid(&catalog, "empty signal combinator");
+
+        let mut catalog = draft_catalog();
+        catalog.agents[0].auth_contexts[0].signals = Some(signal(
+            serde_json::json!({ "envFlag": "CLAUDE_CODE_USE_BEDROCK" }),
+        ));
+        expect_invalid(&catalog, "is not 'VAR=value'");
+    }
+
+    #[test]
+    fn rejects_model_control_default_outside_values() {
+        let mut catalog = draft_catalog();
+        let sonnet = &mut catalog.agents[0].session.models[0];
+        let effort = sonnet.controls.get_mut("effort").expect("effort control");
+        effort.default = Some("xhigh".to_string());
+        expect_invalid(&catalog, "default 'xhigh' is not a value");
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation_v2_pairing.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation_v2_pairing.rs
@@ -1,0 +1,281 @@
+//! Cross-document invariants pairing a v2 agent catalog with the registry
+//! it was probed against. Run wherever a registry pairing is in scope
+//! (build pipeline, sync validation); the current draft pins no registry
+//! (`probedAgainst.registryVersion: null`) and references slots a future
+//! registry revision will declare, so this is a separate entry rather than
+//! part of the loader path.
+
+use super::schema_v2::{AgentCatalogAuthSignal, AgentCatalogV2Document};
+use super::validation_v2::BASELINE_AUTH_CONTEXT_ID;
+use crate::domains::agents::registry::schema::{
+    AgentRegistryAuthSlot, AgentRegistryDocument, AgentRegistryEnvVarKind,
+};
+
+/// Cross-document invariants against the registry the catalog was probed
+/// against: every non-baseline `authSlotId` must name a registry auth slot
+/// on the same agent kind, and signal vocabulary must be a subset of what
+/// the slot declares (env vars with their secret|flag tags, discovery
+/// kinds). Slots that declare no vocabulary are validated structurally only.
+///
+/// TODO(PR-7a): once registry.json carries the source vocabulary (flag tags
+/// on CLAUDE_CODE_USE_BEDROCK-style vars, named discovery kinds), pair this
+/// check with the pinned registry in the build pipeline and sync path.
+pub fn validate_agent_catalog_v2_registry_pairing(
+    catalog: &AgentCatalogV2Document,
+    registry: &AgentRegistryDocument,
+) -> anyhow::Result<()> {
+    for agent in &catalog.agents {
+        let registry_agent = registry
+            .agents
+            .iter()
+            .find(|candidate| candidate.kind == agent.kind)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "agent catalog agent '{}' is not in the registry",
+                    agent.kind
+                )
+            })?;
+        for context in &agent.auth_contexts {
+            if context.id == BASELINE_AUTH_CONTEXT_ID {
+                continue;
+            }
+            let slot_id = context.auth_slot_id.as_deref().unwrap_or_default();
+            let slot = registry_agent
+                .auth
+                .slots
+                .iter()
+                .find(|slot| slot.id == slot_id)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "agent catalog agent '{}' auth context '{}' references unknown registry auth slot '{slot_id}'",
+                        agent.kind,
+                        context.id
+                    )
+                })?;
+            if let Some(signals) = &context.signals {
+                validate_signal_vocabulary(&agent.kind, &context.id, signals, slot)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_signal_vocabulary(
+    agent_kind: &str,
+    context_id: &str,
+    signal: &AgentCatalogAuthSignal,
+    slot: &AgentRegistryAuthSlot,
+) -> anyhow::Result<()> {
+    match signal {
+        AgentCatalogAuthSignal::Env(var) => {
+            if !slot.env_vars.is_empty() && declared_env_var_kind(slot, var).is_none() {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' env signal '{var}' is not in registry slot '{}' env vars",
+                    slot.id
+                );
+            }
+        }
+        AgentCatalogAuthSignal::EnvFlag(flag) => {
+            let var = flag.split_once('=').map(|(var, _)| var).unwrap_or(flag);
+            match declared_env_var_kind(slot, var) {
+                Some(AgentRegistryEnvVarKind::Flag) => {}
+                Some(AgentRegistryEnvVarKind::Secret) => anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' envFlag signal '{var}' is a secret env var in registry slot '{}'",
+                    slot.id
+                ),
+                None if !slot.env_vars.is_empty() => anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' envFlag signal '{var}' is not in registry slot '{}' env vars",
+                    slot.id
+                ),
+                None => {}
+            }
+        }
+        AgentCatalogAuthSignal::Discovery(kind) => {
+            if !slot.discovery_kinds.is_empty()
+                && !slot.discovery_kinds.iter().any(|declared| declared == kind)
+            {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' auth context '{context_id}' discovery signal '{kind}' is not in registry slot '{}' discovery kinds",
+                    slot.id
+                );
+            }
+        }
+        AgentCatalogAuthSignal::AnyOf(children) | AgentCatalogAuthSignal::AllOf(children) => {
+            for child in children {
+                validate_signal_vocabulary(agent_kind, context_id, child, slot)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn declared_env_var_kind(
+    slot: &AgentRegistryAuthSlot,
+    var: &str,
+) -> Option<AgentRegistryEnvVarKind> {
+    slot.env_vars
+        .iter()
+        .find(|env_var| env_var.name() == var)
+        .map(|env_var| env_var.kind())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::catalog::schema_v2::draft_catalog_v2_json;
+    use crate::domains::agents::catalog::validation_v2::validate_agent_catalog_v2_document;
+    use crate::domains::agents::registry::bundled::bundled_agent_registry_document;
+    use crate::domains::agents::registry::schema::AgentRegistryAuthSlotEnvVar;
+
+    fn draft_catalog() -> AgentCatalogV2Document {
+        serde_json::from_str(draft_catalog_v2_json()).expect("draft catalog must parse")
+    }
+
+    fn signal(json: serde_json::Value) -> AgentCatalogAuthSignal {
+        serde_json::from_value(json).expect("signal must parse")
+    }
+
+    /// Pairing fixture: the draft's auth contexts reference slots a future
+    /// registry revision will declare, so pairing tests use a hand-trimmed
+    /// catalog whose contexts resolve against the bundled registry.
+    fn pairing_catalog(signals: Option<serde_json::Value>) -> AgentCatalogV2Document {
+        let mut catalog = draft_catalog();
+        catalog.agents.truncate(1);
+        let claude = &mut catalog.agents[0];
+        claude.auth_contexts.truncate(1);
+        claude.auth_contexts[0].auth_slot_id = Some("anthropic".to_string());
+        claude.auth_contexts[0].signals = signals.map(signal);
+        claude.session.models.retain(|model| {
+            model
+                .availability
+                .any_of
+                .contains(&"anthropic-api".to_string())
+        });
+        for model in &mut claude.session.models {
+            model.availability.any_of.retain(|id| id == "anthropic-api");
+        }
+        validate_agent_catalog_v2_document(&catalog).expect("pairing fixture must validate");
+        catalog
+    }
+
+    #[test]
+    fn pairing_accepts_known_slot_and_declared_env_vars() {
+        let catalog = pairing_catalog(Some(serde_json::json!({ "env": "ANTHROPIC_API_KEY" })));
+        let registry = bundled_agent_registry_document();
+
+        validate_agent_catalog_v2_registry_pairing(&catalog, registry)
+            .expect("known slot + declared env var must pass");
+    }
+
+    #[test]
+    fn pairing_rejects_unknown_auth_slot() {
+        let mut catalog = pairing_catalog(None);
+        catalog.agents[0].auth_contexts[0].auth_slot_id = Some("anthropic-vertex".to_string());
+        let registry = bundled_agent_registry_document();
+
+        let error = validate_agent_catalog_v2_registry_pairing(&catalog, registry)
+            .expect_err("unknown slot must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown registry auth slot 'anthropic-vertex'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pairing_rejects_env_signal_outside_slot_vocabulary() {
+        let catalog = pairing_catalog(Some(serde_json::json!({ "env": "NOT_A_DECLARED_VAR" })));
+        let registry = bundled_agent_registry_document();
+
+        let error = validate_agent_catalog_v2_registry_pairing(&catalog, registry)
+            .expect_err("undeclared env var must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("env signal 'NOT_A_DECLARED_VAR' is not in registry slot 'anthropic'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pairing_rejects_env_flag_signal_on_secret_var() {
+        let catalog = pairing_catalog(Some(
+            serde_json::json!({ "envFlag": "ANTHROPIC_API_KEY=1" }),
+        ));
+        let registry = bundled_agent_registry_document();
+
+        let error = validate_agent_catalog_v2_registry_pairing(&catalog, registry)
+            .expect_err("envFlag on a secret var must fail");
+
+        assert!(
+            error.to_string().contains("is a secret env var"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pairing_accepts_flag_tagged_env_flag_and_declared_discovery_kind() {
+        let catalog = pairing_catalog(Some(serde_json::json!({
+            "allOf": [
+                { "envFlag": "CLAUDE_CODE_USE_BEDROCK=1" },
+                { "discovery": "aws-credential-chain" }
+            ]
+        })));
+        let mut registry = bundled_agent_registry_document().clone();
+        let slot = registry.agents[0]
+            .auth
+            .slots
+            .iter_mut()
+            .find(|slot| slot.id == "anthropic")
+            .expect("anthropic slot");
+        slot.env_vars.push(AgentRegistryAuthSlotEnvVar::Tagged {
+            name: "CLAUDE_CODE_USE_BEDROCK".to_string(),
+            kind: AgentRegistryEnvVarKind::Flag,
+        });
+        slot.discovery_kinds = vec!["aws-credential-chain".to_string()];
+
+        validate_agent_catalog_v2_registry_pairing(&catalog, &registry)
+            .expect("bedrock-style signature must pass against tagged vocabulary");
+    }
+
+    #[test]
+    fn pairing_rejects_discovery_signal_outside_declared_kinds() {
+        let catalog = pairing_catalog(Some(
+            serde_json::json!({ "discovery": "claude-oauth-creds" }),
+        ));
+        let mut registry = bundled_agent_registry_document().clone();
+        let slot = registry.agents[0]
+            .auth
+            .slots
+            .iter_mut()
+            .find(|slot| slot.id == "anthropic")
+            .expect("anthropic slot");
+        slot.discovery_kinds = vec!["aws-credential-chain".to_string()];
+
+        let error = validate_agent_catalog_v2_registry_pairing(&catalog, &registry)
+            .expect_err("undeclared discovery kind must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("discovery signal 'claude-oauth-creds' is not in registry slot"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pairing_waives_discovery_check_when_slot_declares_no_kinds() {
+        // registry.json has no discovery kinds yet (PR-7a vocabulary):
+        // structural validation only.
+        let catalog = pairing_catalog(Some(
+            serde_json::json!({ "discovery": "claude-oauth-creds" }),
+        ));
+        let registry = bundled_agent_registry_document();
+
+        validate_agent_catalog_v2_registry_pairing(&catalog, registry)
+            .expect("undeclared vocabulary must waive the subset check");
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/manifest.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/manifest.rs
@@ -1,0 +1,245 @@
+//! install-manifest.json: the durable proof of what the installer (or seed
+//! hydration) placed on disk — per agent, per artifact role: version, sha256,
+//! source, timestamp. The middle link of the attestation chain:
+//! catalog pin (declared) -> install manifest (on disk) -> agent_info (running).
+//!
+//! Writes are atomic (tmp + rename) and best-effort at call sites: a manifest
+//! failure never fails an install.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::InstalledArtifactResult;
+use crate::domains::agents::model::ArtifactRole;
+
+pub const INSTALL_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const MANIFEST_FILE_NAME: &str = "install-manifest.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallManifest {
+    pub schema_version: u32,
+    pub agent: String,
+    pub artifacts: Vec<ManifestArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestArtifact {
+    /// "native_cli" | "agent_process"
+    pub role: String,
+    pub version: Option<String>,
+    pub sha256: Option<String>,
+    /// Install mechanism that produced the artifact (e.g. "managed_npm",
+    /// "registry_binary", "binary_hint", "seed").
+    pub source: String,
+    pub installed_at: String,
+    pub path: String,
+}
+
+impl InstallManifest {
+    pub fn version_for(&self, role: &ArtifactRole) -> Option<String> {
+        let role = role_name(role);
+        self.artifacts
+            .iter()
+            .find(|artifact| artifact.role == role)
+            .and_then(|artifact| artifact.version.clone())
+    }
+}
+
+pub fn manifest_path(runtime_home: &Path, kind: &str) -> PathBuf {
+    runtime_home
+        .join("agents")
+        .join(kind)
+        .join(MANIFEST_FILE_NAME)
+}
+
+/// Read the manifest if present and parseable; any failure reads as absent.
+pub fn read_manifest(runtime_home: &Path, kind: &str) -> Option<InstallManifest> {
+    let text = std::fs::read_to_string(manifest_path(runtime_home, kind)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Merge newly installed artifacts into the manifest (one entry per role),
+/// atomically. Mints the timestamp — this is the effects layer.
+pub fn record_artifacts(
+    runtime_home: &Path,
+    kind: &str,
+    artifacts: &[InstalledArtifactResult],
+) -> std::io::Result<()> {
+    if artifacts.is_empty() {
+        return Ok(());
+    }
+    let installed_at = chrono::Utc::now().to_rfc3339();
+    let entries: Vec<ManifestArtifact> = artifacts
+        .iter()
+        .map(|artifact| ManifestArtifact {
+            role: role_name(&artifact.role).to_string(),
+            version: artifact.version.clone(),
+            sha256: sha256_of_file(&artifact.path),
+            source: artifact.source.clone(),
+            installed_at: installed_at.clone(),
+            path: artifact.path.display().to_string(),
+        })
+        .collect();
+    record_entries(runtime_home, kind, entries)
+}
+
+/// Merge pre-built entries (seed hydration path) into the manifest, atomically.
+pub fn record_entries(
+    runtime_home: &Path,
+    kind: &str,
+    entries: Vec<ManifestArtifact>,
+) -> std::io::Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let mut manifest = read_manifest(runtime_home, kind).unwrap_or_else(|| InstallManifest {
+        schema_version: INSTALL_MANIFEST_SCHEMA_VERSION,
+        agent: kind.to_string(),
+        artifacts: Vec::new(),
+    });
+    for entry in entries {
+        manifest
+            .artifacts
+            .retain(|existing| existing.role != entry.role);
+        manifest.artifacts.push(entry);
+    }
+    write_manifest_atomic(runtime_home, kind, &manifest)
+}
+
+pub fn role_name(role: &ArtifactRole) -> &'static str {
+    match role {
+        ArtifactRole::NativeCli => "native_cli",
+        ArtifactRole::AgentProcess => "agent_process",
+    }
+}
+
+fn write_manifest_atomic(
+    runtime_home: &Path,
+    kind: &str,
+    manifest: &InstallManifest,
+) -> std::io::Result<()> {
+    let path = manifest_path(runtime_home, kind);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &path)
+}
+
+/// Content hash for file artifacts; directories and unreadable paths read as
+/// None (the launcher/binary the result points at is what gets hashed).
+fn sha256_of_file(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_home(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("{name}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn result(role: ArtifactRole, path: PathBuf, version: Option<&str>) -> InstalledArtifactResult {
+        InstalledArtifactResult {
+            role,
+            path,
+            source: "managed_npm".into(),
+            version: version.map(String::from),
+        }
+    }
+
+    #[test]
+    fn records_and_reads_back_artifacts_with_hashes() {
+        let home = temp_home("manifest-roundtrip");
+        let artifact_path = home.join("launcher");
+        std::fs::write(&artifact_path, "#!/bin/sh\nexit 0\n").expect("write artifact");
+
+        record_artifacts(
+            &home,
+            "codex",
+            &[result(
+                ArtifactRole::AgentProcess,
+                artifact_path.clone(),
+                Some("0.12.0"),
+            )],
+        )
+        .expect("record");
+
+        let manifest = read_manifest(&home, "codex").expect("manifest");
+        assert_eq!(manifest.schema_version, INSTALL_MANIFEST_SCHEMA_VERSION);
+        assert_eq!(manifest.agent, "codex");
+        assert_eq!(manifest.artifacts.len(), 1);
+        let entry = &manifest.artifacts[0];
+        assert_eq!(entry.role, "agent_process");
+        assert_eq!(entry.version.as_deref(), Some("0.12.0"));
+        assert!(entry.sha256.as_deref().is_some_and(|h| h.len() == 64));
+        assert_eq!(
+            manifest.version_for(&ArtifactRole::AgentProcess).as_deref(),
+            Some("0.12.0")
+        );
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn rerecording_a_role_replaces_the_entry_and_keeps_others() {
+        let home = temp_home("manifest-merge");
+        let native = home.join("native");
+        let process = home.join("process");
+        std::fs::write(&native, "native-v1").expect("write");
+        std::fs::write(&process, "process-v1").expect("write");
+
+        record_artifacts(
+            &home,
+            "claude",
+            &[
+                result(ArtifactRole::NativeCli, native.clone(), Some("1.0.0")),
+                result(ArtifactRole::AgentProcess, process.clone(), Some("0.1.0")),
+            ],
+        )
+        .expect("record both");
+        record_artifacts(
+            &home,
+            "claude",
+            &[result(ArtifactRole::AgentProcess, process, Some("0.2.0"))],
+        )
+        .expect("re-record process");
+
+        let manifest = read_manifest(&home, "claude").expect("manifest");
+        assert_eq!(manifest.artifacts.len(), 2);
+        assert_eq!(
+            manifest.version_for(&ArtifactRole::NativeCli).as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            manifest.version_for(&ArtifactRole::AgentProcess).as_deref(),
+            Some("0.2.0")
+        );
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn unreadable_manifest_reads_as_absent() {
+        let home = temp_home("manifest-corrupt");
+        let path = manifest_path(&home, "gemini");
+        std::fs::create_dir_all(path.parent().unwrap()).expect("dirs");
+        std::fs::write(&path, "{not json").expect("write");
+        assert!(read_manifest(&home, "gemini").is_none());
+        let _ = std::fs::remove_dir_all(home);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
@@ -1,6 +1,7 @@
 mod agent_process;
 mod downloads;
 mod lock;
+pub mod manifest;
 pub(crate) mod managed_npm;
 mod native;
 mod npm;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/mod.rs
@@ -299,6 +299,9 @@ fn apply_seed_payload(
     let mut repaired = 0_u32;
     let mut skipped = 0_u32;
     let mut wrote = 0_u32;
+    let mut install_manifest_entries: HashMap<String, Vec<installer::manifest::ManifestArtifact>> =
+        HashMap::new();
+    let hydrated_at = chrono::Utc::now().to_rfc3339();
 
     for artifact in &manifest.artifacts {
         let rel_path = validate_relative_path(&artifact.path)?;
@@ -364,6 +367,16 @@ fn apply_seed_payload(
                 )));
             }
             wrote += 1;
+            install_manifest_entries.entry(artifact.kind.clone()).or_default().push(
+                installer::manifest::ManifestArtifact {
+                    role: artifact.role.clone(),
+                    version: Some(manifest.seed_version.clone()),
+                    sha256: Some(artifact.sha256.clone()),
+                    source: "seed".into(),
+                    installed_at: hydrated_at.clone(),
+                    path: dest.display().to_string(),
+                },
+            );
         }
 
         let observed = checksum_path(&dest).ok();
@@ -376,6 +389,16 @@ fn apply_seed_payload(
             seed_checksum: artifact.sha256.clone(),
             last_observed_checksum: observed,
         });
+    }
+
+    for (kind, entries) in install_manifest_entries {
+        if let Err(error) = installer::manifest::record_entries(runtime_home, &kind, entries) {
+            tracing::warn!(
+                agent = %kind,
+                error = %error,
+                "failed to write install manifest for seeded artifacts"
+            );
+        }
     }
 
     let launcher_agents = seed_owned_agent_process_agents(&manifest.seeded_agents, &next_records);

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
@@ -117,6 +117,15 @@ pub fn install_agent(
     }
 
     seed::mark_installed_artifacts_user_modified(runtime_home, &descriptor.kind, &installed);
+    if let Err(error) =
+        super::manifest::record_artifacts(runtime_home, descriptor.kind.as_str(), &installed)
+    {
+        tracing::warn!(
+            agent = descriptor.kind.as_str(),
+            error = %error,
+            "failed to write install manifest"
+        );
+    }
 
     Ok(installed)
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/mod.rs
@@ -5,3 +5,4 @@ mod overrides;
 pub(crate) mod paths;
 pub mod service;
 mod status;
+mod versions;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/service.rs
@@ -85,6 +85,18 @@ pub fn resolve_agent_with_env(
         compatibility_issue.as_ref(),
     );
 
+    let mut native = native;
+    let mut agent_process = agent_process;
+    super::versions::apply_manifest_versions(
+        crate::domains::agents::installer::manifest::read_manifest(
+            runtime_home,
+            descriptor.kind.as_str(),
+        )
+        .as_ref(),
+        &mut native,
+        &mut agent_process,
+    );
+
     ResolvedAgent {
         descriptor: descriptor.clone(),
         status,
@@ -95,6 +107,7 @@ pub fn resolve_agent_with_env(
         spawn,
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -540,4 +553,5 @@ mod tests {
 
         assert_eq!(status, ResolvedAgentStatus::InstallRequired);
     }
+
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/versions.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/versions.rs
@@ -1,0 +1,92 @@
+//! Surfacing durable install-manifest versions on resolved artifacts — the
+//! derived view reading the manifest link of the attestation chain.
+
+use crate::domains::agents::model::{ArtifactRole, ResolvedArtifact};
+
+/// Surface durable install-manifest versions on resolved artifacts that the
+/// path probes could not version. PATH-sourced artifacts are never claimed by
+/// the manifest (we attest what we don't own; we don't invent versions for it).
+pub(super) fn apply_manifest_versions(
+    manifest: Option<&crate::domains::agents::installer::manifest::InstallManifest>,
+    native: &mut Option<ResolvedArtifact>,
+    agent_process: &mut ResolvedArtifact,
+) {
+    let Some(manifest) = manifest else { return };
+    if let Some(native) = native.as_mut() {
+        if native.installed && native.version.is_none() && native.source.as_deref() != Some("path")
+        {
+            native.version = manifest.version_for(&ArtifactRole::NativeCli);
+        }
+    }
+    if agent_process.installed
+        && agent_process.version.is_none()
+        && agent_process.source.as_deref() != Some("path")
+    {
+        agent_process.version = manifest.version_for(&ArtifactRole::AgentProcess);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn manifest_versions_fill_managed_artifacts_but_never_path_sourced() {
+        use crate::domains::agents::installer::manifest::{
+            InstallManifest, ManifestArtifact, INSTALL_MANIFEST_SCHEMA_VERSION,
+        };
+        let manifest = InstallManifest {
+            schema_version: INSTALL_MANIFEST_SCHEMA_VERSION,
+            agent: "gemini".into(),
+            artifacts: vec![
+                ManifestArtifact {
+                    role: "agent_process".into(),
+                    version: Some("2.3.4".into()),
+                    sha256: None,
+                    source: "registry_npm".into(),
+                    installed_at: "2026-06-10T00:00:00Z".into(),
+                    path: "/managed/gemini".into(),
+                },
+                ManifestArtifact {
+                    role: "native_cli".into(),
+                    version: Some("9.9.9".into()),
+                    sha256: None,
+                    source: "managed".into(),
+                    installed_at: "2026-06-10T00:00:00Z".into(),
+                    path: "/managed/gemini-cli".into(),
+                },
+            ],
+        };
+        let managed = |role: ArtifactRole, source: &str| ResolvedArtifact {
+            role,
+            installed: true,
+            source: Some(source.into()),
+            version: None,
+            path: Some(PathBuf::from("/managed/x")),
+            message: None,
+        };
+
+        let mut native = Some(managed(ArtifactRole::NativeCli, "managed"));
+        let mut agent_process = managed(ArtifactRole::AgentProcess, "managed");
+        apply_manifest_versions(Some(&manifest), &mut native, &mut agent_process);
+        assert_eq!(native.unwrap().version.as_deref(), Some("9.9.9"));
+        assert_eq!(agent_process.version.as_deref(), Some("2.3.4"));
+
+        // PATH-sourced artifacts are never claimed by the manifest.
+        let mut native = Some(managed(ArtifactRole::NativeCli, "path"));
+        let mut agent_process = managed(ArtifactRole::AgentProcess, "path");
+        apply_manifest_versions(Some(&manifest), &mut native, &mut agent_process);
+        assert_eq!(native.unwrap().version, None);
+        assert_eq!(agent_process.version, None);
+
+        // Probe-provided versions are never overwritten.
+        let mut native = None;
+        let mut agent_process = ResolvedArtifact {
+            version: Some("probe-said-1.0".into()),
+            ..managed(ArtifactRole::AgentProcess, "managed")
+        };
+        apply_manifest_versions(Some(&manifest), &mut native, &mut agent_process);
+        assert_eq!(agent_process.version.as_deref(), Some("probe-said-1.0"));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/registry/projection.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/registry/projection.rs
@@ -62,7 +62,11 @@ fn agent_registry_agent_to_descriptor(
                         label: slot.label.clone(),
                         credential_provider_ids: slot.credential_provider_ids.clone(),
                         required_for_readiness: slot.required_for_readiness,
-                        env_vars: slot.env_vars.clone(),
+                        env_vars: slot
+                            .env_vars
+                            .iter()
+                            .map(|env_var| env_var.name().to_string())
+                            .collect(),
                         login: slot.login.as_ref().map(|login| LoginSpec {
                             label: login.label.clone(),
                             command: CommandSpec {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/registry/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/registry/schema.rs
@@ -155,12 +155,58 @@ pub struct AgentRegistryAuthSlot {
     pub credential_provider_ids: Vec<String>,
     pub required_for_readiness: bool,
     #[serde(default)]
-    pub env_vars: Vec<String>,
+    pub env_vars: Vec<AgentRegistryAuthSlotEnvVar>,
     pub discovery: String,
+    /// Named discovery fact kinds this slot's credentials may surface as
+    /// (e.g. `"claude-oauth-creds"`, `"aws-credential-chain"`). Optional
+    /// source vocabulary for catalog v2 auth-context signals; empty means
+    /// "not yet declared" and waives the subset check.
+    #[serde(default)]
+    pub discovery_kinds: Vec<String>,
     #[serde(default)]
     pub login: Option<AgentRegistryLogin>,
     #[serde(default)]
     pub materialization: AgentRegistryAuthMaterialization,
+}
+
+/// A credential env var declared by an auth slot. Backward compatible with
+/// the plain-string form in registry.json (`"ANTHROPIC_API_KEY"`, kind
+/// `secret`); the tagged form adds a `secret|flag` kind so catalog v2
+/// signals can be validated (flag values are readable, secrets are
+/// presence-only).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AgentRegistryAuthSlotEnvVar {
+    Name(String),
+    Tagged {
+        name: String,
+        #[serde(default)]
+        kind: AgentRegistryEnvVarKind,
+    },
+}
+
+impl AgentRegistryAuthSlotEnvVar {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Name(name) => name,
+            Self::Tagged { name, .. } => name,
+        }
+    }
+
+    pub fn kind(&self) -> AgentRegistryEnvVarKind {
+        match self {
+            Self::Name(_) => AgentRegistryEnvVarKind::default(),
+            Self::Tagged { kind, .. } => *kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRegistryEnvVarKind {
+    #[default]
+    Secret,
+    Flag,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -209,4 +255,61 @@ pub struct AgentRegistryCommand {
     pub program: String,
     #[serde(default)]
     pub args: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::registry::bundled::bundled_agent_registry_document;
+
+    #[test]
+    fn bundled_registry_parses_and_validates_with_env_var_vocabulary() {
+        let registry = bundled_agent_registry_document();
+
+        let anthropic_slot = registry
+            .agents
+            .iter()
+            .find(|agent| agent.kind == "claude")
+            .and_then(|agent| agent.auth.slots.iter().find(|slot| slot.id == "anthropic"))
+            .expect("claude anthropic slot");
+
+        // Plain-string entries keep working and default to secret.
+        assert_eq!(
+            anthropic_slot
+                .env_vars
+                .iter()
+                .map(|env_var| env_var.name())
+                .collect::<Vec<_>>(),
+            vec!["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]
+        );
+        assert!(anthropic_slot
+            .env_vars
+            .iter()
+            .all(|env_var| env_var.kind() == AgentRegistryEnvVarKind::Secret));
+        assert!(anthropic_slot.discovery_kinds.is_empty());
+    }
+
+    #[test]
+    fn auth_slot_env_vars_accept_plain_and_tagged_forms() {
+        let env_vars: Vec<AgentRegistryAuthSlotEnvVar> =
+            serde_json::from_value(serde_json::json!([
+                "ANTHROPIC_API_KEY",
+                { "name": "CLAUDE_CODE_USE_BEDROCK", "kind": "flag" },
+                { "name": "ANTHROPIC_AUTH_TOKEN" }
+            ]))
+            .expect("env vars must parse");
+
+        assert_eq!(env_vars[0].name(), "ANTHROPIC_API_KEY");
+        assert_eq!(env_vars[0].kind(), AgentRegistryEnvVarKind::Secret);
+        assert_eq!(env_vars[1].name(), "CLAUDE_CODE_USE_BEDROCK");
+        assert_eq!(env_vars[1].kind(), AgentRegistryEnvVarKind::Flag);
+        assert_eq!(env_vars[2].kind(), AgentRegistryEnvVarKind::Secret);
+
+        // Plain-string entries serialize back to plain strings (registry.json
+        // round-trips byte-compatibly).
+        assert_eq!(
+            serde_json::to_value(&env_vars[0]).expect("serialize"),
+            serde_json::json!("ANTHROPIC_API_KEY")
+        );
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/registry/validation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/registry/validation.rs
@@ -106,6 +106,42 @@ fn validate_auth(agent_kind: &str, auth: &AgentRegistryAuth) -> anyhow::Result<(
                 );
             }
         }
+        let mut seen_env_vars = HashSet::new();
+        for env_var in &slot.env_vars {
+            if env_var.name().trim().is_empty() {
+                anyhow::bail!(
+                    "agent registry agent '{}' auth slot '{}' has empty env var name",
+                    agent_kind,
+                    slot.id
+                );
+            }
+            if !seen_env_vars.insert(env_var.name().to_string()) {
+                anyhow::bail!(
+                    "agent registry agent '{}' auth slot '{}' env var '{}' is duplicated",
+                    agent_kind,
+                    slot.id,
+                    env_var.name()
+                );
+            }
+        }
+        let mut seen_discovery_kinds = HashSet::new();
+        for discovery_kind in &slot.discovery_kinds {
+            if discovery_kind.trim().is_empty() {
+                anyhow::bail!(
+                    "agent registry agent '{}' auth slot '{}' has empty discovery kind",
+                    agent_kind,
+                    slot.id
+                );
+            }
+            if !seen_discovery_kinds.insert(discovery_kind.clone()) {
+                anyhow::bail!(
+                    "agent registry agent '{}' auth slot '{}' discovery kind '{}' is duplicated",
+                    agent_kind,
+                    slot.id,
+                    discovery_kind
+                );
+            }
+        }
         if slot.required_for_readiness {
             required_count += 1;
         }
@@ -138,4 +174,46 @@ fn validate_auth(agent_kind: &str, auth: &AgentRegistryAuth) -> anyhow::Result<(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::registry::bundled::bundled_agent_registry_document;
+    use crate::domains::agents::registry::schema::AgentRegistryAuthSlotEnvVar;
+
+    #[test]
+    fn registry_rejects_duplicate_env_var_names() {
+        let mut registry = bundled_agent_registry_document().clone();
+        let slot = &mut registry.agents[0].auth.slots[0];
+        slot.env_vars.push(AgentRegistryAuthSlotEnvVar::Name(
+            "ANTHROPIC_API_KEY".to_string(),
+        ));
+
+        let error =
+            validate_agent_registry_document(&registry).expect_err("duplicate env var must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("env var 'ANTHROPIC_API_KEY' is duplicated"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn registry_rejects_empty_discovery_kind() {
+        let mut registry = bundled_agent_registry_document().clone();
+        registry.agents[0].auth.slots[0]
+            .discovery_kinds
+            .push("  ".to_string());
+
+        let error = validate_agent_registry_document(&registry)
+            .expect_err("empty discovery kind must fail");
+
+        assert!(
+            error.to_string().contains("has empty discovery kind"),
+            "unexpected error: {error}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

PR-2 of the migration stack (`specs/tbd/agents-catalog-registry-migration.md` §5.2): the **install manifest** — durable proof of what the installer placed on disk, per agent per artifact role.

- `installer/manifest.rs`: `install-manifest.json` at `agents/<kind>/` with `{role, version, sha256, source, installedAt, path}`; atomic writes (tmp+rename); merge-by-role semantics; corrupt manifests read as absent
- `install_agent` records artifacts after every install (best-effort — a manifest failure warns, never fails an install)
- **Seed hydration writes manifests too** (entries carry the seed version + seed sha256, source `"seed"`) — so a fresh E2B image's first reconcile won't misread seeded artifacts as unmanifested (the gap caught in design review)
- Readiness surfaces manifest versions on managed artifacts (`apply_manifest_versions`): PATH-sourced artifacts are never claimed (*pin what we own, attest what we don't*), probe-provided versions are never overwritten

No behavior change to installs themselves. Sets up PR-3 (plan-then-apply reconcile diffs manifest vs catalog pins).

## Verification
- 623 lib tests green (3 new manifest tests + 1 enrichment test); boundary + max-lines checkers pass
- Stacked on #618 (PR-1 regroup); base set accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)