### PR TITLE
feat(installer): plan-then-apply reconcile with drift detection (PR-3)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
@@ -1,0 +1,190 @@
+//! Pure plan-then-apply brain: (declared pins, install manifest, disk facts)
+//! -> per-artifact reinstall decisions. No IO — the service gathers facts and
+//! executes; this file only judges.
+//!
+//! Execution contract: the plan ESCALATES, never suppresses. An artifact the
+//! plan leaves alone still goes through its mechanism's own idempotent skip
+//! checks; a planned reinstall forces the mechanism to act. Pins come from the
+//! registry install specs today; catalog v2 pins take over in the consumption
+//! wave (PR-7b).
+
+use crate::domains::agents::model::{AgentDescriptor, AgentProcessInstallSpec, ArtifactRole};
+
+use super::managed_npm::npm_package_version;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReinstallReason {
+    /// Caller explicitly asked (the Reinstall button).
+    Requested,
+    /// The manifest's recorded version no longer matches the declared pin.
+    VersionDrift {
+        pinned: String,
+        recorded: String,
+    },
+    /// The artifact on disk no longer matches the manifest's recorded hash.
+    ChecksumMismatch,
+}
+
+impl std::fmt::Display for ReinstallReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Requested => write!(f, "requested"),
+            Self::VersionDrift { pinned, recorded } => {
+                write!(f, "version drift: pinned {pinned}, recorded {recorded}")
+            }
+            Self::ChecksumMismatch => write!(f, "checksum mismatch"),
+        }
+    }
+}
+
+/// The facts the service gathers per artifact role before planning.
+#[derive(Debug, Clone, Default)]
+pub struct ArtifactFacts {
+    pub pinned_version: Option<String>,
+    pub manifest_version: Option<String>,
+    /// None when the manifest has no hash or the file is gone (mechanisms
+    /// handle absence); Some(matches) when both sides were comparable.
+    pub checksum_matches: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedArtifact {
+    pub role: ArtifactRole,
+    pub reinstall: Option<ReinstallReason>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InstallPlan {
+    pub artifacts: Vec<PlannedArtifact>,
+}
+
+impl InstallPlan {
+    pub fn reinstall_for(&self, role: &ArtifactRole) -> Option<&ReinstallReason> {
+        self.artifacts
+            .iter()
+            .find(|artifact| &artifact.role == role)
+            .and_then(|artifact| artifact.reinstall.as_ref())
+    }
+
+    pub fn has_reinstalls(&self) -> bool {
+        self.artifacts
+            .iter()
+            .any(|artifact| artifact.reinstall.is_some())
+    }
+}
+
+/// Decide one artifact. Order: explicit request > version drift > corruption.
+pub fn plan_artifact(facts: &ArtifactFacts, reinstall_requested: bool) -> Option<ReinstallReason> {
+    if reinstall_requested {
+        return Some(ReinstallReason::Requested);
+    }
+    if let (Some(pinned), Some(recorded)) = (&facts.pinned_version, &facts.manifest_version) {
+        if pinned != recorded {
+            return Some(ReinstallReason::VersionDrift {
+                pinned: pinned.clone(),
+                recorded: recorded.clone(),
+            });
+        }
+    }
+    if facts.checksum_matches == Some(false) {
+        return Some(ReinstallReason::ChecksumMismatch);
+    }
+    None
+}
+
+/// The declared version pin for an agent-process install spec, when the spec
+/// carries one (registry npm package pins). Native CLIs are attested, not
+/// pinned, until the catalog supplies pins.
+pub fn agent_process_pinned_version(spec: &AgentProcessInstallSpec) -> Option<String> {
+    match spec {
+        AgentProcessInstallSpec::ManagedNpmPackage { package, .. } => npm_package_version(package),
+        AgentProcessInstallSpec::RegistryBacked { fallback, .. } => match fallback {
+            crate::domains::agents::model::AgentProcessFallback::NpmPackage {
+                package, ..
+            } => npm_package_version(package),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+pub fn pinned_version_for(descriptor: &AgentDescriptor, role: &ArtifactRole) -> Option<String> {
+    match role {
+        ArtifactRole::AgentProcess => {
+            agent_process_pinned_version(&descriptor.agent_process.install)
+        }
+        ArtifactRole::NativeCli => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(
+        pinned: Option<&str>,
+        recorded: Option<&str>,
+        checksum_matches: Option<bool>,
+    ) -> ArtifactFacts {
+        ArtifactFacts {
+            pinned_version: pinned.map(String::from),
+            manifest_version: recorded.map(String::from),
+            checksum_matches,
+        }
+    }
+
+    #[test]
+    fn matching_pin_and_manifest_keeps_the_artifact() {
+        assert_eq!(
+            plan_artifact(&facts(Some("0.24.2"), Some("0.24.2"), Some(true)), false),
+            None
+        );
+    }
+
+    #[test]
+    fn version_drift_forces_reinstall() {
+        assert_eq!(
+            plan_artifact(&facts(Some("0.25.0"), Some("0.24.2"), Some(true)), false),
+            Some(ReinstallReason::VersionDrift {
+                pinned: "0.25.0".into(),
+                recorded: "0.24.2".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn missing_manifest_or_pin_defers_to_the_mechanism() {
+        // No manifest yet (fresh target): mechanisms decide install-vs-skip.
+        assert_eq!(plan_artifact(&facts(Some("0.25.0"), None, None), false), None);
+        // No pin declared (unpinned native CLI): attested, never forced.
+        assert_eq!(plan_artifact(&facts(None, Some("1.2.3"), None), false), None);
+    }
+
+    #[test]
+    fn checksum_mismatch_forces_reinstall() {
+        assert_eq!(
+            plan_artifact(&facts(Some("1.0.0"), Some("1.0.0"), Some(false)), false),
+            Some(ReinstallReason::ChecksumMismatch)
+        );
+    }
+
+    #[test]
+    fn explicit_request_wins_over_everything() {
+        assert_eq!(
+            plan_artifact(&facts(Some("1.0.0"), Some("1.0.0"), Some(true)), true),
+            Some(ReinstallReason::Requested)
+        );
+    }
+
+    #[test]
+    fn extracts_registry_npm_pins() {
+        use crate::domains::agents::registry;
+        let claude = registry::descriptor("claude").expect("claude descriptor");
+        // The bundled claude agent-process spec pins a package version; the
+        // policy must surface it (exact value comes from the registry doc).
+        let pinned = pinned_version_for(&claude, &ArtifactRole::AgentProcess);
+        assert!(pinned.is_some(), "claude agent process should carry a pin");
+        // Native CLIs are attested, not pinned, in the registry era.
+        assert_eq!(pinned_version_for(&claude, &ArtifactRole::NativeCli), None);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/manifest.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/manifest.rs
@@ -135,7 +135,7 @@ fn write_manifest_atomic(
 
 /// Content hash for file artifacts; directories and unreadable paths read as
 /// None (the launcher/binary the result points at is what gets hashed).
-fn sha256_of_file(path: &Path) -> Option<String> {
+pub(super) fn sha256_of_file(path: &Path) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;
     let mut hasher = Sha256::new();
     hasher.update(&bytes);

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
@@ -1,5 +1,6 @@
 mod agent_process;
 mod downloads;
+pub mod install_policy;
 mod lock;
 pub mod manifest;
 pub(crate) mod managed_npm;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
@@ -60,6 +60,19 @@ pub fn install_agent(
     options: &InstallOptions,
 ) -> Result<Vec<InstalledArtifactResult>, InstallError> {
     let _install_lock = AgentInstallLock::acquire_agent(runtime_home, &descriptor.kind)?;
+    let plan = plan_for_descriptor(descriptor, runtime_home, options.reinstall);
+    if plan.has_reinstalls() {
+        for artifact in &plan.artifacts {
+            if let Some(reason) = &artifact.reinstall {
+                tracing::info!(
+                    agent = descriptor.kind.as_str(),
+                    role = super::manifest::role_name(&artifact.role),
+                    reason = %reason,
+                    "install plan forces reinstall"
+                );
+            }
+        }
+    }
     let mut installed = Vec::new();
     let mut has_installable = false;
 
@@ -75,9 +88,13 @@ pub fn install_agent(
     if let Some(native_spec) = &descriptor.native {
         if is_native_installable(&native_spec.install) {
             has_installable = true;
-            if let Some(result) =
-                install_native_artifact(native_spec, &descriptor.kind, runtime_home, options)?
-            {
+            let native_options = options_for_role(options, &plan, &ArtifactRole::NativeCli);
+            if let Some(result) = install_native_artifact(
+                native_spec,
+                &descriptor.kind,
+                runtime_home,
+                &native_options,
+            )? {
                 tracing::info!(
                     agent = descriptor.kind.as_str(),
                     role = "native_cli",
@@ -93,12 +110,13 @@ pub fn install_agent(
 
     if is_agent_process_installable(&descriptor.agent_process.install) {
         has_installable = true;
+        let process_options = options_for_role(options, &plan, &ArtifactRole::AgentProcess);
         if let Some(result) = install_agent_process_artifact(
             &descriptor.agent_process,
             &descriptor.kind,
             &descriptor.launch.default_args,
             runtime_home,
-            options,
+            &process_options,
         )? {
             tracing::info!(
                 agent = descriptor.kind.as_str(),
@@ -135,4 +153,60 @@ pub(crate) fn regenerate_seeded_agent_launchers(
     seeded_agents: &[String],
 ) -> Result<Vec<InstalledArtifactResult>, InstallError> {
     agent_process::regenerate_seeded_agent_launchers(runtime_home, seeded_agents)
+}
+
+/// Gather durable facts (manifest, pins, content hashes) and plan the agent's
+/// install. Pure judgment lives in install_policy; this gathers and executes.
+pub(crate) fn plan_for_descriptor(
+    descriptor: &AgentDescriptor,
+    runtime_home: &Path,
+    reinstall_requested: bool,
+) -> super::install_policy::InstallPlan {
+    use super::install_policy::{plan_artifact, pinned_version_for, ArtifactFacts, PlannedArtifact};
+
+    let manifest = super::manifest::read_manifest(runtime_home, descriptor.kind.as_str());
+    let mut roles = Vec::new();
+    if descriptor.native.is_some() {
+        roles.push(ArtifactRole::NativeCli);
+    }
+    roles.push(ArtifactRole::AgentProcess);
+
+    let artifacts = roles
+        .into_iter()
+        .map(|role| {
+            let entry = manifest.as_ref().and_then(|manifest| {
+                manifest
+                    .artifacts
+                    .iter()
+                    .find(|artifact| artifact.role == super::manifest::role_name(&role))
+            });
+            let checksum_matches = entry.and_then(|entry| {
+                let recorded = entry.sha256.as_ref()?;
+                let observed = super::manifest::sha256_of_file(Path::new(&entry.path))?;
+                Some(&observed == recorded)
+            });
+            let facts = ArtifactFacts {
+                pinned_version: pinned_version_for(descriptor, &role),
+                manifest_version: entry.and_then(|entry| entry.version.clone()),
+                checksum_matches,
+            };
+            PlannedArtifact {
+                reinstall: plan_artifact(&facts, reinstall_requested),
+                role,
+            }
+        })
+        .collect();
+    super::install_policy::InstallPlan { artifacts }
+}
+
+fn options_for_role(
+    options: &InstallOptions,
+    plan: &super::install_policy::InstallPlan,
+    role: &ArtifactRole,
+) -> InstallOptions {
+    InstallOptions {
+        reinstall: options.reinstall || plan.reinstall_for(role).is_some(),
+        native_version: options.native_version.clone(),
+        agent_process_version: options.agent_process_version.clone(),
+    }
 }


### PR DESCRIPTION
## Summary

PR-3 of the migration stack (`specs/tbd/agents-catalog-registry-migration.md` §5.2): the reconcile engine's **brain**.

- `installer/install_policy.rs` — pure: `(pins, manifest, hashes) → per-artifact ReinstallReason (Requested | VersionDrift | ChecksumMismatch)`; unit-tested on hand-built facts
- `install_agent` becomes plan-then-apply: gather facts → plan → execute, with forced-reinstall logging
- **Escalate-never-suppress contract**: mechanisms keep their internal idempotent skip checks (zero risk to fresh installs / PATH attestation); the plan only *forces* action on drift
- **The behavior change** (first in the stack): a pinned agent-process artifact whose manifest version drifts from the registry pin, or whose on-disk bytes stop matching the recorded sha256, now reinstalls on the next pass — killing silent CDN/registry drift. Native CLIs remain attested-not-pinned until catalog pins arrive (PR-7b swaps the pin source from registry specs to catalog v2).
- Reconcile inherits all of this through `install_agent` — the bulk loop is now plan-then-apply per agent.

## Verification
- 6 new policy unit tests (drift, checksum, request precedence, mechanism-deference, real registry pin extraction); 632 lib tests green; boundary + max-lines pass
- Stacked on #619 (manifests); base set accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)