### PR TITLE
feat(worker): reconcile_agents cloud command — the trigger matrix (PR-6)

### DIFF
--- a/anyharness/crates/proliferate-worker/src/anyharness_client/agents.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/agents.rs
@@ -1,0 +1,24 @@
+use serde_json::json;
+
+use crate::error::WorkerError;
+
+use super::sessions::{parse_anyharness_response, AnyHarnessCommandResponse};
+use super::AnyHarnessClient;
+
+impl AnyHarnessClient {
+    /// Poke the runtime's one reconcile engine (plan-then-apply against pins).
+    pub async fn reconcile_agents(
+        &self,
+        reinstall: bool,
+    ) -> Result<AnyHarnessCommandResponse, WorkerError> {
+        let response = self
+            .authenticate(
+                self.http()
+                    .post(format!("{}/v1/agents/reconcile", self.base_url())),
+            )
+            .json(&json!({ "reinstall": reinstall }))
+            .send()
+            .await?;
+        parse_anyharness_response(response).await
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_client/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_auth;
+pub mod agents;
 pub mod auth;
 pub mod backfill;
 pub mod events;

--- a/anyharness/crates/proliferate-worker/src/control/commands/executor.rs
+++ b/anyharness/crates/proliferate-worker/src/control/commands/executor.rs
@@ -1268,6 +1268,9 @@ async fn dispatch_anyharness(
                 .await
         }
         AnyHarnessCommand::CancelTurn { session_id } => anyharness.cancel_turn(session_id).await,
+        AnyHarnessCommand::ReconcileAgents { reinstall } => {
+            anyharness.reconcile_agents(*reinstall).await
+        }
         AnyHarnessCommand::CloseSession { session_id } => {
             anyharness.close_session(session_id).await
         }
@@ -1473,7 +1476,8 @@ fn register_session_for_sync(
             .get("id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
-        AnyHarnessCommand::MaterializeWorkspace { .. } => None,
+        AnyHarnessCommand::MaterializeWorkspace { .. }
+        | AnyHarnessCommand::ReconcileAgents { .. } => None,
         AnyHarnessCommand::SendPrompt { session_id, .. }
         | AnyHarnessCommand::ResolveInteraction { session_id, .. }
         | AnyHarnessCommand::UpdateSessionConfig { session_id, .. }

--- a/anyharness/crates/proliferate-worker/src/control/commands/mapping.rs
+++ b/anyharness/crates/proliferate-worker/src/control/commands/mapping.rs
@@ -43,6 +43,9 @@ pub enum AnyHarnessCommand {
     CloseSession {
         session_id: String,
     },
+    ReconcileAgents {
+        reinstall: bool,
+    },
 }
 
 #[derive(Debug)]
@@ -116,6 +119,13 @@ pub fn map_cloud_command(
         }
         "cancel_turn" => Ok(AnyHarnessCommand::CancelTurn {
             session_id: require_session_id(command)?,
+        }),
+        "reconcile_agents" => Ok(AnyHarnessCommand::ReconcileAgents {
+            reinstall: command
+                .payload
+                .get("reinstall")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
         }),
         "close_session" => Ok(AnyHarnessCommand::CloseSession {
             session_id: require_session_id(command)?,
@@ -946,5 +956,24 @@ mod tests {
             lease_id: "lease-1".to_string(),
             lease_expires_at: "2026-05-14T00:00:00Z".to_string(),
         }
+    }
+
+    #[test]
+    fn maps_reconcile_agents_with_and_without_reinstall() {
+        let mut command = test_command(json!({ "reinstall": true }));
+        command.kind = "reconcile_agents".to_string();
+        let mapped = map_cloud_command(&command).expect("mapped");
+        let AnyHarnessCommand::ReconcileAgents { reinstall } = mapped else {
+            panic!("expected reconcile agents");
+        };
+        assert!(reinstall);
+
+        let mut command = test_command(json!({}));
+        command.kind = "reconcile_agents".to_string();
+        let mapped = map_cloud_command(&command).expect("mapped");
+        let AnyHarnessCommand::ReconcileAgents { reinstall } = mapped else {
+            panic!("expected reconcile agents");
+        };
+        assert!(!reinstall);
     }
 }

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -18,8 +18,8 @@ anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 15
 anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs 1057 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 617 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
-anyharness/crates/proliferate-worker/src/control/commands/executor.rs 1632 existing Proliferate worker oversized command executor
-anyharness/crates/proliferate-worker/src/control/commands/mapping.rs 950 existing Proliferate worker oversized command mapper
+anyharness/crates/proliferate-worker/src/control/commands/executor.rs 1636 existing Proliferate worker oversized command executor
+anyharness/crates/proliferate-worker/src/control/commands/mapping.rs 979 existing Proliferate worker oversized command mapper
 anyharness/sdk-react/src/hooks/sessions.ts 653 existing SDK React oversized file
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1880 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1575 existing SDK oversized file
@@ -29,10 +29,10 @@ apps/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx 733 
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 662 existing desktop oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 632 existing desktop oversized test file
 apps/desktop/src/lib/workflows/mcp/connector-persistence.test.ts 704 existing desktop oversized test file
-server/proliferate/server/cloud/commands/domain/payload.py 530 existing cloud command payload validator with workspace materialization policies
+server/proliferate/server/cloud/commands/domain/payload.py 549 existing cloud command payload validator with workspace materialization policies
 server/proliferate/server/cloud/agent_auth/models.py 535 existing cloud agent auth API schema module pending request/response split
 server/proliferate/server/cloud/agent_auth/runtime_keys.py 671 existing cloud agent auth runtime key service pending gateway/router split
-server/proliferate/constants/cloud.py 608 existing cloud constants module with command and target config enums
+server/proliferate/constants/cloud.py 610 existing cloud constants module with command and target config enums
 server/tests/integration/schema_migration_assertions.py 885 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -511,6 +511,7 @@ class CloudCommandKind(StrEnum):
     prune_workspace_worktree = "prune_workspace_worktree"
     materialize_environment = "materialize_environment"
     refresh_agent_auth_config = "refresh_agent_auth_config"
+    reconcile_agents = "reconcile_agents"
     send_prompt = "send_prompt"
     decide_plan = "decide_plan"
     resolve_interaction = "resolve_interaction"
@@ -558,6 +559,7 @@ ACTIVE_CLOUD_COMMAND_KINDS: tuple[str, ...] = (
     CloudCommandKind.prune_workspace_worktree.value,
     CloudCommandKind.materialize_environment.value,
     CloudCommandKind.refresh_agent_auth_config.value,
+    CloudCommandKind.reconcile_agents.value,
     CloudCommandKind.send_prompt.value,
     CloudCommandKind.decide_plan.value,
     CloudCommandKind.resolve_interaction.value,

--- a/server/proliferate/server/cloud/commands/domain/payload.py
+++ b/server/proliferate/server/cloud/commands/domain/payload.py
@@ -63,6 +63,9 @@ def validate_command_payload(*, kind: str, payload: dict[str, object]) -> None:
     if kind == CloudCommandKind.refresh_agent_auth_config.value:
         _validate_refresh_agent_auth_config_payload(payload)
         return
+    if kind == CloudCommandKind.reconcile_agents.value:
+        _validate_reconcile_agents_payload(payload)
+        return
     if kind in {
         CloudCommandKind.start_session.value,
         CloudCommandKind.send_prompt.value,
@@ -283,6 +286,22 @@ def _validate_refresh_agent_auth_config_payload(payload: dict[str, object]) -> N
         raise CloudApiError(
             "cloud_command_refresh_agent_auth_force_restart_required",
             "refresh_agent_auth_config payload must contain boolean forceRestart.",
+            status_code=400,
+        )
+
+
+def _validate_reconcile_agents_payload(payload: dict[str, object]) -> None:
+    _reject_unknown_fields(
+        payload,
+        frozenset({"reinstall"}),
+        code="cloud_command_reconcile_agents_payload_unknown",
+        message_prefix="reconcile_agents payload contains unsupported field(s): ",
+    )
+    value = payload.get("reinstall")
+    if value is not None and not isinstance(value, bool):
+        raise CloudApiError(
+            "cloud_command_reconcile_agents_reinstall_invalid",
+            "reconcile_agents reinstall must be a boolean when provided.",
             status_code=400,
         )
 

--- a/server/proliferate/server/cloud/commands/domain/rules.py
+++ b/server/proliferate/server/cloud/commands/domain/rules.py
@@ -59,6 +59,7 @@ def validate_command_shape(
         CloudCommandKind.ensure_repo_checkout.value,
         CloudCommandKind.materialize_environment.value,
         CloudCommandKind.refresh_agent_auth_config.value,
+        CloudCommandKind.reconcile_agents.value,
     } and (workspace_id or session_id):
         raise CloudApiError(
             "cloud_command_target_only",

--- a/server/proliferate/server/cloud/runtime/domain/wake.py
+++ b/server/proliferate/server/cloud/runtime/domain/wake.py
@@ -9,6 +9,7 @@ WAKE_REQUIRED_CLOUD_COMMAND_KINDS: frozenset[str] = frozenset(
         CloudCommandKind.materialize_workspace.value,
         CloudCommandKind.materialize_environment.value,
         CloudCommandKind.refresh_agent_auth_config.value,
+        CloudCommandKind.reconcile_agents.value,
         CloudCommandKind.start_session.value,
         CloudCommandKind.send_prompt.value,
         CloudCommandKind.decide_plan.value,


### PR DESCRIPTION
## Summary

PR-6 of the migration stack: every reconcile trigger now reaches **one engine** (`POST /v1/agents/reconcile`, serialized by the per-agent install lock).

| Trigger | Status |
|---|---|
| anyharness startup | pre-existing (`use-agent-auto-reconcile` from desktop) |
| desktop Settings | pre-existing (sdk-react `agents.reconcile()`) |
| **worker control command** | **this PR** — cloud → worker → runtime, desktop AND sandbox |
| fetched-newer catalog | PR-5 (sync poke, lands separately) |

Changes:
- **Worker**: `AnyHarnessCommand::ReconcileAgents { reinstall }`, mapped from envelope kind `reconcile_agents` (missing `reinstall` defaults false), executed via new `anyharness_client/agents.rs`; target-scoped (no session/workspace tail mapping)
- **Server**: `CloudCommandKind.reconcile_agents` — target-only scope rule, wake-required, payload validation (optional boolean `reinstall`, unknown fields rejected), externally creatable (unlike `refresh_agent_auth_config` which is internal-only)

## Verification
- Worker: 81 tests green incl. new mapping test (true/absent reinstall)
- Server: compileall + boundary checker + inline validation smoke (good / unknown-field / non-bool payloads)
- anyharness-lib untouched; workspace check clean; worker-structure + server-boundary checkers green

Stacked on #620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)