### PR TITLE
ci(catalog): scheduled probe run with auto-PR (PR-8)

### DIFF
--- a/.github/workflows/catalog-probe.yml
+++ b/.github/workflows/catalog-probe.yml
@@ -1,0 +1,88 @@
+name: Catalog Probe
+
+# The measuring instrument on a schedule: run the harness x auth-context probe
+# matrix, rebuild the catalog draft, and open a PR with the diff. Contexts
+# whose credentials are missing are skipped (run-probes.sh), so partial runs
+# are useful. Follow-ups tracked in specs/tbd/agents-catalog-registry-
+# migration.md §8: bedrock/vertex contexts and deliberate precedence
+# experiments land once the probe binary grows those auth contexts.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, before the nightly release train picks up merged catalogs.
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CARGO_TERM_COLOR: always
+
+jobs:
+  probe:
+    name: Probe harnesses and draft catalog
+    if: github.repository == 'proliferate-ai/proliferate'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libcap-dev
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: anyharness
+
+      - name: Run probe matrix (skips missing credentials)
+        run: ./scripts/agent-catalog/run-probes.sh
+
+      - name: Rebuild catalog draft + viewer
+        working-directory: scripts/agent-catalog
+        run: |
+          node build-catalog.mjs
+          node render-catalog.mjs
+
+      - name: Upload viewer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: catalog-viewer
+          path: scripts/agent-catalog/catalog.html
+          if-no-files-found: ignore
+
+      - name: Open catalog PR when the draft changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git add scripts/agent-catalog/generated scripts/agent-catalog/catalog.draft.json
+          if git diff --cached --quiet; then
+            echo "No catalog changes."
+            exit 0
+          fi
+          branch="catalog-probe/$(date -u +%Y-%m-%d)-${GITHUB_RUN_ID}"
+          git checkout -b "$branch"
+          git -c user.name="catalog-probe[bot]" -c user.email="catalog-probe@proliferate.ai" \
+            commit -m "chore(catalog): probe run $(date -u +%Y-%m-%d)"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "chore(catalog): probe run $(date -u +%Y-%m-%d)" \
+            --label "release:internal-or-chore" --label "area:anyharness" \
+            --body "Automated catalog probe run. Review the per-context diffs in \`scripts/agent-catalog/generated/\` and the draft; download the catalog-viewer artifact from the workflow run for the rendered diff vs main. Skipped contexts (missing credentials) are listed in the run log."


### PR DESCRIPTION
## Summary

PR-8 of the migration stack: the probe pipeline rides CI.

- Daily schedule + `workflow_dispatch`; mirrors `agent-runtime-compat.yml` conventions (same secret names, ubuntu runner, rust+node toolchain, cargo cache)
- Runs `scripts/agent-catalog/run-probes.sh` — builds anyharness, reconciles harness installs, probes every context whose credentials exist as repo secrets, skips the rest with a logged reason
- Rebuilds the draft + viewer; uploads the rendered viewer as an artifact
- Opens a labeled PR (`release:internal-or-chore` + `area:anyharness`) only when the generated snapshots / draft actually changed

Independent of the rest of the stack (pure pipeline, base = main). Gate per the migration doc is a dry run: trigger `workflow_dispatch` after merge — with no secrets configured it exercises the skip path end-to-end and exits clean with "No catalog changes."

Follow-ups noted in-file: bedrock/vertex probe contexts + deliberate precedence experiments (need probe-binary auth contexts first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)