### PR TITLE
fix(plans): fail rejected plans without native reject mapping

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/interactions/plan_decisions.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/interactions/plan_decisions.rs
@@ -180,9 +180,11 @@ pub(in crate::live::sessions::actor) fn plan_decision_native_resolution(
                         option_id: option_id.to_string(),
                     },
                 }),
-                None => Some(PlanNativeResolution::Resolve {
+                None => Some(PlanNativeResolution::FailAfterResolve {
                     request_id: link.request_id,
-                    resolution: InteractionResolution::Dismissed,
+                    resolution: InteractionResolution::Cancelled,
+                    error_message: "Rejected plan could not map to a native rejection option."
+                        .to_string(),
                 }),
             }
         }
@@ -400,6 +402,27 @@ mod tests {
                 resolution: InteractionResolution::Selected {
                     option_id: "reject-once".to_string(),
                 },
+            }),
+        );
+    }
+
+    #[test]
+    fn rejected_native_plan_fails_when_no_reject_mapping_exists() {
+        let (service, plan_id) = plan_service_with_link(json!({
+            "approve": "allow-once",
+        }));
+
+        assert_eq!(
+            plan_decision_native_resolution(
+                &service,
+                &plan_id,
+                &ProposedPlanDecisionState::Rejected,
+            ),
+            Some(PlanNativeResolution::FailAfterResolve {
+                request_id: "request-1".to_string(),
+                resolution: InteractionResolution::Cancelled,
+                error_message: "Rejected plan could not map to a native rejection option."
+                    .to_string(),
             }),
         );
     }


### PR DESCRIPTION
A rejected plan whose permission options lack a 'reject' mapping was silently resolved as Dismissed and recorded Finalized — the UI showed the rejection as delivered when the agent never learned of it. Mirror the approve arm: resolve Cancelled, record native_resolution_state = Failed with an error message. Pinned by test.

---
## The live-sessions migration stack (1/10)

Executes the approved migration plan: product knowledge out of `live/`, capability traits at the boundary, a real actor struct, spans instead of threaded latency context, grammar-true packaging, and restored model truth. Each PR is gated (full suite green; behavior-preserving unless the commit message states otherwise) and lands on the previous one:

1. #629 — reject fix (behavior change, test-pinned)
2. #630 — renames: `rendezvous/`, `sink/`, `driver/inbound/` (pure `git mv` + identifiers)
3. #631 — **keystone**: `SessionEventObserver` + `PermissionAdvisor` + `SessionDomainOp`; zero `domains::plans|reviews` imports in `live/`
4. #632 — `SessionLaunch` + 5 capability traits; `start_session` 15 params → `(launch, hooks)`; zero concrete stores in `live/`
5. #633 — pure `launch_policy.rs` + pure `prompt/render.rs`; `acp.rs` deleted
6. #634 — `struct SessionActor`, loop reads as dispatch; `driver/connection.rs` + `session_lifecycle.rs` extracted
7. #635 — `LatencyRequestContext` deleted → tracing spans; all `[workspace-latency]` event names preserved
8. #636 — `sink.ingest`, `InboundDoor`, background-work terminal ownership, `SessionView` (byte-for-byte wire proof)
9. #637 — live model truth from the `model` config option (post-ACP-0.14); catalog stack's registry migration consumes this as its live-truth dependency
10. #638 — specs aligned (migration exceptions resolved; mechanisms + decision table documented)

## End-to-end validation (tip of stack, `make dev` + real Claude session)

- session boot reports `model: sonnet` (PR 9 extraction live)
- full streaming turn over SSE, seqs strictly contiguous
- busy-queue: `pending_prompt_added` mid-turn, `removed{executed}` after the replacement turn started, both replies correct
- the plan bridge: plan mode → `ExitPlanMode` → observer-ingested plan record → approve via the decision-op → parked permission resolved (`interaction_requested` seq 98 → `interaction_resolved` seq 100) → agent unblocked and implemented the planned change on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)