### PR TITLE
refactor(anyharness): cross the live boundary with a launch bundle and capability traits

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -256,6 +256,8 @@ impl AppState {
             plan_service.clone(),
         ));
         let acp_manager = sessions::wire_live_sessions(&sessions::LiveSessionsWiringDeps {
+            db: db.clone(),
+            runtime_home: runtime_home.clone(),
             plan_service: plan_service.clone(),
             review_service: review_service.clone(),
         });
@@ -270,7 +272,6 @@ impl AppState {
         let cowork_session_hooks = Arc::new(CoworkSessionHooks::new(
             cowork_delegation_service.clone(),
             acp_manager.clone(),
-            SessionStore::new(db.clone()),
         ));
         let subagent_service = Arc::new(SubagentService::new(
             SessionStore::new(db.clone()),
@@ -285,7 +286,6 @@ impl AppState {
         let subagent_session_hooks = Arc::new(SubagentSessionHooks::new(
             subagent_service.clone(),
             acp_manager.clone(),
-            SessionStore::new(db.clone()),
         ));
         let review_mcp_auth = Arc::new(ReviewMcpAuth::new(runtime_home.clone()));
         let review_session_hooks = Arc::new(ReviewSessionHooks::new(

--- a/anyharness/crates/anyharness-lib/src/app/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/app/sessions.rs
@@ -1,7 +1,9 @@
-//! Wiring family for the live-session manager: builds the product reactors
-//! (observers, permission advisor) and constructs the manager. Composition
-//! only — no behavior.
+//! Wiring family for the live-session manager: builds the durable
+//! capabilities (event/queue/background/state stores + attachment source) and
+//! the product reactors (observers, permission advisor), then constructs the
+//! manager. Composition only — no behavior.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::domains::plans::permission_advisor::PlanPermissionAdvisor;
@@ -9,10 +11,16 @@ use crate::domains::plans::service::PlanService;
 use crate::domains::plans::session_observer::PlanSessionObserver;
 use crate::domains::reviews::service::ReviewService;
 use crate::domains::reviews::session_observer::ReviewSessionObserver;
-use crate::live::sessions::model::{PermissionAdvisor, SessionEventObserver};
+use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::domains::sessions::live_ports::SessionAttachmentSource;
+use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::{ActorCapabilities, PermissionAdvisor, SessionEventObserver};
 use crate::live::sessions::LiveSessionManager;
+use crate::persistence::Db;
 
 pub(super) struct LiveSessionsWiringDeps {
+    pub db: Db,
+    pub runtime_home: PathBuf,
     pub plan_service: Arc<PlanService>,
     pub review_service: Arc<ReviewService>,
 }
@@ -31,5 +39,17 @@ pub(super) fn wire_live_sessions(deps: &LiveSessionsWiringDeps) -> LiveSessionMa
     let permission_advisor: Option<Arc<dyn PermissionAdvisor>> = Some(Arc::new(
         PlanPermissionAdvisor::new(deps.plan_service.clone()),
     ));
-    LiveSessionManager::new(observers, permission_advisor)
+
+    let store = SessionStore::new(deps.db.clone());
+    let attachment_storage = PromptAttachmentStorage::new(deps.runtime_home.clone());
+    let caps = ActorCapabilities {
+        events: Arc::new(store.clone()),
+        queue: Arc::new(store.clone()),
+        background: Arc::new(store.clone()),
+        state: Arc::new(store.clone()),
+        attachments: Arc::new(SessionAttachmentSource::new(store, attachment_storage)),
+        observers,
+        permission_advisor,
+    };
+    LiveSessionManager::new(caps)
 }

--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -1,8 +1,33 @@
 use std::ffi::OsString;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::domains::sessions::live_ports::SessionAttachmentSource;
 use crate::domains::sessions::mcp_bindings::crypto::DATA_KEY_ENV_VAR;
+use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::ActorCapabilities;
 use crate::persistence::Db;
+
+/// Store-backed [`ActorCapabilities`] for tests: the same wiring as
+/// `app/sessions.rs` (one `SessionStore` behind the four store traits plus a
+/// real `SessionAttachmentSource`), with no observers and no advisor.
+pub(crate) fn actor_capabilities_for_store(store: &SessionStore) -> ActorCapabilities {
+    let attachment_storage = PromptAttachmentStorage::new(
+        std::env::temp_dir().join(format!("anyharness-test-{}", uuid::Uuid::new_v4())),
+    );
+    ActorCapabilities {
+        events: Arc::new(store.clone()),
+        queue: Arc::new(store.clone()),
+        background: Arc::new(store.clone()),
+        state: Arc::new(store.clone()),
+        attachments: Arc::new(SessionAttachmentSource::new(
+            store.clone(),
+            attachment_storage,
+        )),
+        observers: Vec::new(),
+        permission_advisor: None,
+    }
+}
 
 pub(crate) static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
@@ -33,7 +33,6 @@ use crate::domains::sessions::runtime::{
 };
 use crate::domains::sessions::runtime_event::RuntimeInjectedSessionEvent;
 use crate::domains::sessions::service::SessionService;
-use crate::domains::sessions::store::SessionStore;
 use crate::domains::workspaces::creator_context::WorkspaceCreatorContext;
 use crate::domains::workspaces::model::{WorkspaceRecord, WorkspaceSurface};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
@@ -202,7 +201,6 @@ struct CodingWorkspaceNamePlan {
 pub struct CoworkSessionHooks {
     delegation_service: CoworkDelegationService,
     acp_manager: LiveSessionManager,
-    session_store: SessionStore,
     autosave_locks: Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
@@ -210,12 +208,10 @@ impl CoworkSessionHooks {
     pub fn new(
         delegation_service: CoworkDelegationService,
         acp_manager: LiveSessionManager,
-        session_store: SessionStore,
     ) -> Self {
         Self {
             delegation_service,
             acp_manager,
-            session_store,
             autosave_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -271,11 +267,8 @@ impl SessionExtension for CoworkSessionHooks {
         self.notify_turn_finished(&ctx.workspace, &ctx.session_id);
         let service = self.delegation_service.clone();
         let acp_manager = self.acp_manager.clone();
-        let session_store = self.session_store.clone();
         tokio::spawn(async move {
-            if let Err(error) =
-                deliver_cowork_coding_completion(service, acp_manager, session_store, ctx).await
-            {
+            if let Err(error) = deliver_cowork_coding_completion(service, acp_manager, ctx).await {
                 tracing::warn!(error = %error, "failed to process cowork coding completion");
             }
         });
@@ -285,7 +278,6 @@ impl SessionExtension for CoworkSessionHooks {
 async fn deliver_cowork_coding_completion(
     service: CoworkDelegationService,
     acp_manager: LiveSessionManager,
-    session_store: SessionStore,
     ctx: SessionTurnFinishedContext,
 ) -> anyhow::Result<()> {
     if ctx.turn_id.trim().is_empty() {
@@ -345,7 +337,6 @@ async fn deliver_cowork_coding_completion(
     match acp_manager
         .emit_runtime_event(
             &link.parent_session_id,
-            session_store.clone(),
             RuntimeInjectedSessionEvent::SessionLinkTurnCompleted(payload),
         )
         .await

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
@@ -1,0 +1,293 @@
+//! Domain-side implementations of live's durable-capability traits.
+//!
+//! Live declares the capability vocabulary in `live/sessions/model.rs`; the
+//! sessions domain implements it here over `SessionStore` (and the attachment
+//! storage); `app/` wires the implementations in. Every method is pure
+//! delegation — signatures mirror the store originals 1:1, no behavior.
+
+use agent_client_protocol as acp;
+use anyharness_contract::v1::{SessionEvent, SessionEventEnvelope};
+
+use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::domains::sessions::model::{
+    PendingConfigChangeRecord, PendingPromptRecord, PromptAttachmentRecord, PromptAttachmentState,
+    SessionBackgroundWorkRecord, SessionBackgroundWorkState, SessionEventRecord,
+    SessionLiveConfigSnapshotRecord,
+};
+use crate::domains::sessions::prompt::{PromptPayload, PromptValidationError};
+use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::{
+    AttachmentSource, BackgroundWorkDurable, EventPersist, QueueDurable, SessionStateDurable,
+};
+
+impl EventPersist for SessionStore {
+    fn append_event(&self, event: &SessionEventRecord) -> anyhow::Result<()> {
+        SessionStore::append_event(self, event)
+    }
+
+    fn append_event_and_touch_session(&self, event: &SessionEventRecord) -> anyhow::Result<()> {
+        SessionStore::append_event_and_touch_session(self, event)
+    }
+
+    fn append_event_with_next_seq(
+        &self,
+        session_id: &str,
+        event: SessionEvent,
+        touch_session_activity: bool,
+    ) -> anyhow::Result<SessionEventEnvelope> {
+        SessionStore::append_event_with_next_seq(self, session_id, event, touch_session_activity)
+    }
+
+    fn next_event_seq(&self, session_id: &str) -> anyhow::Result<i64> {
+        SessionStore::next_event_seq(self, session_id)
+    }
+
+    fn last_event_seq(&self, session_id: &str) -> anyhow::Result<i64> {
+        SessionStore::last_event_seq(self, session_id)
+    }
+
+    fn has_turn_started_event(&self, session_id: &str) -> anyhow::Result<bool> {
+        SessionStore::has_turn_started_event(self, session_id)
+    }
+
+    fn append_raw_notification(
+        &self,
+        session_id: &str,
+        notification_kind: &str,
+        timestamp: &str,
+        payload_json: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::append_raw_notification(
+            self,
+            session_id,
+            notification_kind,
+            timestamp,
+            payload_json,
+        )
+    }
+}
+
+impl QueueDurable for SessionStore {
+    fn insert_pending_prompt_payload(
+        &self,
+        session_id: &str,
+        payload: &PromptPayload,
+        prompt_id: Option<&str>,
+    ) -> anyhow::Result<PendingPromptRecord> {
+        SessionStore::insert_pending_prompt_payload(self, session_id, payload, prompt_id)
+    }
+
+    fn peek_head_pending_prompt(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<PendingPromptRecord>> {
+        SessionStore::peek_head_pending_prompt(self, session_id)
+    }
+
+    fn find_pending_prompt(
+        &self,
+        session_id: &str,
+        seq: i64,
+    ) -> anyhow::Result<Option<PendingPromptRecord>> {
+        SessionStore::find_pending_prompt(self, session_id, seq)
+    }
+
+    fn update_pending_prompt_payload(
+        &self,
+        session_id: &str,
+        seq: i64,
+        payload: &PromptPayload,
+    ) -> anyhow::Result<bool> {
+        SessionStore::update_pending_prompt_payload(self, session_id, seq, payload)
+    }
+
+    fn delete_pending_prompt(&self, session_id: &str, seq: i64) -> anyhow::Result<bool> {
+        SessionStore::delete_pending_prompt(self, session_id, seq)
+    }
+
+    fn delete_pending_prompt_record(
+        &self,
+        session_id: &str,
+        seq: i64,
+    ) -> anyhow::Result<Option<PendingPromptRecord>> {
+        SessionStore::delete_pending_prompt_record(self, session_id, seq)
+    }
+}
+
+impl BackgroundWorkDurable for SessionStore {
+    fn upsert_or_refresh_pending_background_work(
+        &self,
+        record: &SessionBackgroundWorkRecord,
+    ) -> anyhow::Result<bool> {
+        SessionStore::upsert_or_refresh_pending_background_work(self, record)
+    }
+
+    fn list_pending_background_work(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<SessionBackgroundWorkRecord>> {
+        SessionStore::list_pending_background_work(self, session_id)
+    }
+
+    fn touch_background_work_activity(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+        last_activity_at: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::touch_background_work_activity(self, session_id, tool_call_id, last_activity_at)
+    }
+
+    fn mark_background_work_terminal(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+        state: SessionBackgroundWorkState,
+        completed_at: &str,
+    ) -> anyhow::Result<bool> {
+        SessionStore::mark_background_work_terminal(self, session_id, tool_call_id, state, completed_at)
+    }
+}
+
+impl SessionStateDurable for SessionStore {
+    fn update_status(&self, id: &str, status: &str, now: &str) -> anyhow::Result<()> {
+        SessionStore::update_status(self, id, status, now)
+    }
+
+    fn update_title(&self, id: &str, title: &str, now: &str) -> anyhow::Result<()> {
+        SessionStore::update_title(self, id, title, now)
+    }
+
+    fn update_last_prompt_at(&self, id: &str, now: &str) -> anyhow::Result<()> {
+        SessionStore::update_last_prompt_at(self, id, now)
+    }
+
+    fn update_requested_configuration(
+        &self,
+        id: &str,
+        requested_model_id: Option<&str>,
+        requested_mode_id: Option<&str>,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::update_requested_configuration(
+            self,
+            id,
+            requested_model_id,
+            requested_mode_id,
+            now,
+        )
+    }
+
+    fn update_current_configuration(
+        &self,
+        id: &str,
+        current_model_id: Option<&str>,
+        current_mode_id: Option<&str>,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::update_current_configuration(self, id, current_model_id, current_mode_id, now)
+    }
+
+    fn update_action_capabilities_json(
+        &self,
+        id: &str,
+        action_capabilities_json: Option<String>,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::update_action_capabilities_json(self, id, action_capabilities_json, now)
+    }
+
+    fn upsert_live_config_snapshot(
+        &self,
+        record: &SessionLiveConfigSnapshotRecord,
+    ) -> anyhow::Result<()> {
+        SessionStore::upsert_live_config_snapshot(self, record)
+    }
+
+    fn find_live_config_snapshot(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<SessionLiveConfigSnapshotRecord>> {
+        SessionStore::find_live_config_snapshot(self, session_id)
+    }
+
+    fn upsert_pending_config_change(
+        &self,
+        record: &PendingConfigChangeRecord,
+    ) -> anyhow::Result<()> {
+        SessionStore::upsert_pending_config_change(self, record)
+    }
+
+    fn list_pending_config_changes(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<PendingConfigChangeRecord>> {
+        SessionStore::list_pending_config_changes(self, session_id)
+    }
+
+    fn delete_pending_config_change(
+        &self,
+        session_id: &str,
+        config_id: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::delete_pending_config_change(self, session_id, config_id)
+    }
+
+    fn repair_unclosed_turns(&self, session_id: &str) -> anyhow::Result<u32> {
+        SessionStore::repair_unclosed_turns(self, session_id)
+    }
+}
+
+/// [`AttachmentSource`] over the session store + attachment file storage.
+#[derive(Clone)]
+pub struct SessionAttachmentSource {
+    store: SessionStore,
+    storage: PromptAttachmentStorage,
+}
+
+impl SessionAttachmentSource {
+    pub fn new(store: SessionStore, storage: PromptAttachmentStorage) -> Self {
+        Self { store, storage }
+    }
+}
+
+impl AttachmentSource for SessionAttachmentSource {
+    fn resolve_prompt_blocks(
+        &self,
+        session_id: &str,
+        payload: &PromptPayload,
+    ) -> Result<Vec<acp::schema::ContentBlock>, PromptValidationError> {
+        payload.to_acp_blocks(&self.store, &self.storage, session_id)
+    }
+
+    fn mark_prompt_attachments_state(
+        &self,
+        session_id: &str,
+        attachment_ids: &[String],
+        state: PromptAttachmentState,
+    ) -> anyhow::Result<()> {
+        self.store
+            .mark_prompt_attachments_state(session_id, attachment_ids, state)
+    }
+
+    fn find_prompt_attachment(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+    ) -> anyhow::Result<Option<PromptAttachmentRecord>> {
+        self.store.find_prompt_attachment(session_id, attachment_id)
+    }
+
+    fn delete_prompt_attachments(
+        &self,
+        session_id: &str,
+        attachment_ids: &[&str],
+    ) -> anyhow::Result<()> {
+        self.store
+            .delete_prompt_attachments(session_id, attachment_ids)
+    }
+
+    fn delete_record(&self, record: &PromptAttachmentRecord) -> anyhow::Result<()> {
+        self.storage.delete_record(record)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
@@ -5,6 +5,7 @@ pub mod execution_summary;
 pub mod extensions;
 pub mod links;
 pub mod live_config;
+pub mod live_ports;
 pub mod mcp_bindings;
 pub mod model;
 pub mod plan_references;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
@@ -266,9 +266,7 @@ impl SessionRuntime {
         session_id: &str,
         event: RuntimeInjectedSessionEvent,
     ) -> RuntimeEventInjectionResult {
-        self.acp_manager
-            .emit_runtime_event(session_id, self.session_service.store().clone(), event)
-            .await
+        self.acp_manager.emit_runtime_event(session_id, event).await
     }
 
     pub(super) fn get_session_or_not_found(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/replay.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/replay.rs
@@ -109,7 +109,7 @@ impl SessionRuntime {
         let session_store = self.session_service.store().clone();
         let (_handle, ready) = self
             .acp_manager
-            .start_replay_session(record.clone(), events, speed, session_store, 0)
+            .start_replay_session(record.clone(), events, speed, 0)
             .await
             .map_err(ReplayError::Internal)?;
         self.persist_live_session_state(&record.id, &ready.native_session_id);

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -17,6 +17,7 @@ use crate::domains::sessions::mcp_bindings::summaries::{
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
 use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::handle::LiveSessionHandle;
+use crate::live::sessions::model::{LaunchEnv, SessionHooks, SessionLaunch, SystemPromptAppends};
 use crate::live::sessions::SessionStartupStrategy;
 use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
@@ -390,8 +391,6 @@ impl SessionRuntime {
             record.requested_model_id.as_deref(),
         )
         .map_err(StartSessionError::Internal)?;
-        let session_store = self.session_service.store().clone();
-        let attachment_storage = self.session_service.attachment_storage().clone();
         let mcp_launch = assemble_session_mcp_launch(
             self.session_data_cipher.as_ref(),
             &self.session_extensions,
@@ -408,41 +407,49 @@ impl SessionRuntime {
                 .map_err(StartSessionError::Internal)?;
         }
         let acp_start_started = Instant::now();
+        let launch = SessionLaunch {
+            session: record.clone(),
+            agent: resolved_agent,
+            workspace_path,
+            env: LaunchEnv {
+                workspace: workspace_env,
+                session: session_launch_env,
+                auth_support: agent_auth_overlay.support_env,
+                auth_protected: agent_auth_overlay.protected_env,
+            },
+            mcp_servers: mcp_launch.mcp_servers,
+            startup: startup_strategy,
+            prompts: SystemPromptAppends {
+                every_prompt: mcp_launch.system_prompt_append,
+                first_prompt: mcp_launch.first_prompt_system_prompt_append,
+            },
+            // Overwritten by the manager under the start/inject critical section.
+            last_seq: 0,
+        };
+        let hooks = SessionHooks {
+            on_turn_finish: Some(Arc::new({
+                let extensions = self.session_extensions.clone();
+                let workspace = workspace.clone();
+                move |result| {
+                    for extension in &extensions {
+                        extension.on_turn_finished(SessionTurnFinishedContext {
+                            workspace: workspace.clone(),
+                            session_id: result.session_id.clone(),
+                            turn_id: result.turn_id.clone(),
+                            outcome: result.outcome,
+                            stop_reason: result.stop_reason.clone(),
+                            last_event_seq: result.last_event_seq,
+                            error_details: result.error_details.clone(),
+                        });
+                    }
+                }
+            })),
+            on_exit: None,
+            latency: latency.cloned(),
+        };
         let (handle, ready) = self
             .acp_manager
-            .start_session(
-                record.clone(),
-                resolved_agent,
-                workspace_path,
-                workspace_env,
-                session_launch_env,
-                agent_auth_overlay.support_env,
-                agent_auth_overlay.protected_env,
-                session_store,
-                attachment_storage,
-                mcp_launch.mcp_servers,
-                startup_strategy,
-                mcp_launch.system_prompt_append,
-                mcp_launch.first_prompt_system_prompt_append,
-                Some(Arc::new({
-                    let extensions = self.session_extensions.clone();
-                    let workspace = workspace.clone();
-                    move |result| {
-                        for extension in &extensions {
-                            extension.on_turn_finished(SessionTurnFinishedContext {
-                                workspace: workspace.clone(),
-                                session_id: result.session_id.clone(),
-                                turn_id: result.turn_id.clone(),
-                                outcome: result.outcome,
-                                stop_reason: result.stop_reason.clone(),
-                                last_event_seq: result.last_event_seq,
-                                error_details: result.error_details.clone(),
-                            });
-                        }
-                    }
-                })),
-                latency.cloned(),
-            )
+            .start_session(launch, hooks)
             .await
             .map_err(StartSessionError::AcpStart)?;
         tracing::info!(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs
@@ -10,26 +10,19 @@ use crate::domains::sessions::extensions::{
 };
 use crate::domains::sessions::prompt::{provenance::PromptProvenance, PromptPayload};
 use crate::domains::sessions::runtime_event::RuntimeInjectedSessionEvent;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::LiveSessionManager;
 
 #[derive(Clone)]
 pub struct SubagentSessionHooks {
     service: Arc<SubagentService>,
     acp_manager: LiveSessionManager,
-    session_store: SessionStore,
 }
 
 impl SubagentSessionHooks {
-    pub fn new(
-        service: Arc<SubagentService>,
-        acp_manager: LiveSessionManager,
-        session_store: SessionStore,
-    ) -> Self {
+    pub fn new(service: Arc<SubagentService>, acp_manager: LiveSessionManager) -> Self {
         Self {
             service,
             acp_manager,
-            session_store,
         }
     }
 }
@@ -38,11 +31,8 @@ impl SessionExtension for SubagentSessionHooks {
     fn on_turn_finished(&self, ctx: SessionTurnFinishedContext) {
         let service = self.service.clone();
         let acp_manager = self.acp_manager.clone();
-        let session_store = self.session_store.clone();
         tokio::spawn(async move {
-            if let Err(error) =
-                deliver_subagent_completion(service, acp_manager, session_store, ctx).await
-            {
+            if let Err(error) = deliver_subagent_completion(service, acp_manager, ctx).await {
                 tracing::warn!(error = %error, "failed to process subagent completion");
             }
         });
@@ -52,7 +42,6 @@ impl SessionExtension for SubagentSessionHooks {
 async fn deliver_subagent_completion(
     service: Arc<SubagentService>,
     acp_manager: LiveSessionManager,
-    session_store: SessionStore,
     ctx: SessionTurnFinishedContext,
 ) -> anyhow::Result<()> {
     if ctx.turn_id.trim().is_empty() {
@@ -107,7 +96,6 @@ async fn deliver_subagent_completion(
     match acp_manager
         .emit_runtime_event(
             &link.parent_session_id,
-            session_store.clone(),
             RuntimeInjectedSessionEvent::SubagentTurnCompleted(payload),
         )
         .await

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/background_work.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/background_work.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::background_work::BackgroundWorkUpdate;
+use crate::live::sessions::model::BackgroundWorkDurable;
 use crate::live::sessions::sink::SessionEventSink;
 pub(in crate::live::sessions::actor) async fn handle_background_work_update(
     event_sink: &Arc<Mutex<SessionEventSink>>,
-    store: &SessionStore,
+    store: &dyn BackgroundWorkDurable,
     session_id: &str,
     update: BackgroundWorkUpdate,
 ) {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -4,7 +4,6 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::{ConfigApplyState, SessionLiveConfigSnapshot};
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::SetConfigOptionCommandError;
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, persist_requested_config_value_if_changed, persisted_control_values,
@@ -19,6 +18,7 @@ use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose, PersistedSessionConfigState,
 };
 use crate::live::sessions::actor::state::SessionStartupState;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 pub(in crate::live::sessions::actor) async fn try_apply_model_preference(
     conn: &acp::ConnectionTo<acp::Agent>,
@@ -139,7 +139,7 @@ pub(in crate::live::sessions::actor) async fn apply_specific_config_option(
     native_session_id: &str,
     source_agent_kind: &str,
     session_id: &str,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,
@@ -260,7 +260,7 @@ pub(in crate::live::sessions::actor) async fn restore_persisted_live_config_if_n
     native_session_id: &str,
     source_agent_kind: &str,
     session_id: &str,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -5,7 +5,6 @@ use anyharness_contract::v1::ConfigApplyState;
 use tokio::sync::Mutex;
 
 use crate::domains::sessions::model::SessionRecord;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::config::apply::{
     apply_mode_via_direct_setter_legacy, apply_specific_config_option, try_apply_config_option,
     try_apply_model_preference,
@@ -19,6 +18,7 @@ use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose, PersistedSessionConfigState,
 };
 use crate::live::sessions::actor::state::SessionStartupState;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 pub(in crate::live::sessions::actor) async fn apply_requested_session_preferences(
     conn: &acp::ConnectionTo<acp::Agent>,
@@ -102,7 +102,7 @@ pub(in crate::live::sessions::actor) async fn handle_idle_config_command(
     native_session_id: &str,
     source_agent_kind: &str,
     session_id: &str,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,
@@ -125,7 +125,7 @@ pub(in crate::live::sessions::actor) async fn handle_idle_config_command(
 }
 
 pub(in crate::live::sessions::actor) async fn handle_busy_config_command(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     persisted_config_state: &mut PersistedSessionConfigState,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/persist.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/persist.rs
@@ -11,12 +11,12 @@ use crate::domains::sessions::live_config::{
     build_live_config_snapshot, normalized_key_rank, snapshot_from_record, snapshot_to_record,
     NormalizedControlKind,
 };
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::config::types::{ConfigPurpose, PersistedSessionConfigState};
 use crate::live::sessions::actor::state::SessionStartupState;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 pub(in crate::live::sessions::actor) async fn persist_session_config_state_if_changed(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     state: &mut PersistedSessionConfigState,
@@ -58,7 +58,7 @@ pub(in crate::live::sessions::actor) async fn persist_session_config_state_if_ch
 }
 
 pub(in crate::live::sessions::actor) async fn persist_requested_config_value_if_changed(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     state: &mut PersistedSessionConfigState,
@@ -81,7 +81,7 @@ pub(in crate::live::sessions::actor) async fn persist_requested_config_value_if_
 }
 
 pub(in crate::live::sessions::actor) async fn persist_current_config_state_from_startup(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     state: &mut PersistedSessionConfigState,
@@ -99,7 +99,7 @@ pub(in crate::live::sessions::actor) async fn persist_current_config_state_from_
 pub(in crate::live::sessions::actor) async fn emit_live_config_update(
     source_agent_kind: &str,
     session_id: &str,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,
@@ -155,7 +155,7 @@ pub(in crate::live::sessions::actor) async fn emit_live_config_update(
 }
 
 pub(in crate::live::sessions::actor) fn load_startup_restore_snapshot(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     session_id: &str,
     source_agent_kind: &str,
     resumes_durable_history: bool,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/queue.rs
@@ -4,7 +4,6 @@ use agent_client_protocol as acp;
 use tokio::sync::Mutex;
 
 use crate::domains::sessions::model::PendingConfigChangeRecord;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::SetConfigOptionCommandError;
 use crate::live::sessions::actor::config::apply::{
     apply_specific_config_option, should_apply_model_via_direct_setter,
@@ -15,9 +14,10 @@ use crate::live::sessions::actor::config::selection::{
 };
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::state::SessionStartupState;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 pub(in crate::live::sessions::actor) fn queue_pending_config_change(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     session_id: &str,
     startup_state: &SessionStartupState,
     config_id: &str,
@@ -91,7 +91,7 @@ pub(in crate::live::sessions::actor) async fn apply_pending_config_changes_if_id
     native_session_id: &str,
     source_agent_kind: &str,
     session_id: &str,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/event_loop.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/event_loop.rs
@@ -28,9 +28,9 @@ pub(in crate::live::sessions::actor) async fn run_actor(
     ready_tx: std::sync::mpsc::Sender<anyhow::Result<String>>,
     handle: Arc<LiveSessionHandle>,
 ) -> anyhow::Result<()> {
-    let session_id = config.session.id.clone();
-    let source_agent_kind = config.session.agent_kind.clone();
-    let workspace_id = config.session.workspace_id.clone();
+    let session_id = config.launch.session.id.clone();
+    let source_agent_kind = config.launch.session.agent_kind.clone();
+    let workspace_id = config.launch.session.workspace_id.clone();
 
     let StartedActor {
         child,
@@ -47,9 +47,6 @@ pub(in crate::live::sessions::actor) async fn run_actor(
         mut resume_replay_filter,
         _acp_shutdown,
     } = start_actor(&config, ready_tx, &handle).await?;
-
-    let store = config.session_store.clone();
-    let attachment_storage = config.attachment_storage.clone();
 
     let mut exit_reason = ActorExitDisposition::Close;
     loop {
@@ -71,8 +68,6 @@ pub(in crate::live::sessions::actor) async fn run_actor(
                                 startup_state: &mut startup_state,
                                 resume_replay_filter: &mut resume_replay_filter,
                                 handle: &handle,
-                                store: &store,
-                                attachment_storage: &attachment_storage,
                             },
                             ActivePromptRequest {
                                 payload,
@@ -89,10 +84,10 @@ pub(in crate::live::sessions::actor) async fn run_actor(
                         }
                     }
                     Some(SessionCommand::EditPendingPrompt { seq, payload, respond_to }) => {
-                        let _ = respond_to.send(handle_edit_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq, payload).await);
+                        let _ = respond_to.send(handle_edit_pending_prompt(config.caps.queue.as_ref(), config.caps.attachments.as_ref(), &event_sink, &session_id, seq, payload).await);
                     }
                     Some(SessionCommand::DeletePendingPrompt { seq, respond_to }) => {
-                        let _ = respond_to.send(handle_delete_pending_prompt(&store, &attachment_storage, &event_sink, &session_id, seq).await);
+                        let _ = respond_to.send(handle_delete_pending_prompt(config.caps.queue.as_ref(), config.caps.attachments.as_ref(), &event_sink, &session_id, seq).await);
                     }
                     Some(SessionCommand::ResolveInteraction { request_id, resolution, respond_to }) => {
                         let result = handle_resolve_interaction(
@@ -133,7 +128,7 @@ pub(in crate::live::sessions::actor) async fn run_actor(
                             &native_session_id,
                             &source_agent_kind,
                             &session_id,
-                            &store,
+                            config.caps.state.as_ref(),
                             &event_sink,
                             &mut persisted_config_state,
                             &mut startup_state,
@@ -190,10 +185,10 @@ pub(in crate::live::sessions::actor) async fn run_actor(
                             command,
                             &conn,
                             &native_session_id,
-                            &config.workspace_path,
-                            &config.mcp_servers,
+                            &config.launch.workspace_path,
+                            &config.launch.mcp_servers,
                             &handle,
-                            &store,
+                            config.caps.queue.as_ref(),
                             &session_id,
                             action_capabilities,
                             supports_native_close,
@@ -210,11 +205,10 @@ pub(in crate::live::sessions::actor) async fn run_actor(
                         &mut resume_replay_filter,
                         &event_sink,
                         &mut background_work_registry,
-                        &store,
+                        &config.caps,
                         &session_id,
                         &workspace_id,
                         &source_agent_kind,
-                        &config.observers,
                         &mut persisted_config_state,
                         &mut startup_state,
                     ).await;
@@ -222,7 +216,7 @@ pub(in crate::live::sessions::actor) async fn run_actor(
             }
             background_update = background_work_rx.recv() => {
                 if let Some(update) = background_update {
-                    handle_background_work_update(&event_sink, &store, &session_id, update).await;
+                    handle_background_work_update(&event_sink, config.caps.background.as_ref(), &session_id, update).await;
                 }
             }
         }
@@ -232,7 +226,7 @@ pub(in crate::live::sessions::actor) async fn run_actor(
         &handle,
         &event_sink,
         &config.interaction_broker,
-        &store,
+        config.caps.state.as_ref(),
         &session_id,
         exit_reason,
     )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/fork/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/fork/handle.rs
@@ -6,19 +6,19 @@ use tokio::sync::oneshot;
 
 use crate::domains::sessions::mcp_bindings::acp::to_acp_servers;
 use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::{
     ForkSessionCommandError, ForkSessionCommandResult, SessionCommand,
 };
 use crate::live::sessions::driver::shutdown::close_native_session;
 use crate::live::sessions::handle::LiveSessionHandle;
+use crate::live::sessions::model::QueueDurable;
 pub(in crate::live::sessions::actor) async fn fork_native_session(
     conn: &acp::ConnectionTo<acp::Agent>,
     native_session_id: &str,
     workspace_path: &std::path::PathBuf,
     mcp_servers: &[SessionMcpServer],
     handle: &Arc<LiveSessionHandle>,
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     session_id: &str,
     action_capabilities: SessionActionCapabilities,
     supports_close: bool,
@@ -48,7 +48,7 @@ pub(in crate::live::sessions::actor) async fn handle_idle_fork_lifecycle_command
     workspace_path: &std::path::PathBuf,
     mcp_servers: &[SessionMcpServer],
     handle: &Arc<LiveSessionHandle>,
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     session_id: &str,
     action_capabilities: SessionActionCapabilities,
     supports_close: bool,
@@ -86,7 +86,7 @@ pub(in crate::live::sessions::actor) async fn handle_idle_fork_lifecycle_command
 
 pub(in crate::live::sessions::actor) async fn verify_fork_ready(
     handle: &Arc<LiveSessionHandle>,
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     session_id: &str,
     action_capabilities: SessionActionCapabilities,
 ) -> Result<(), ForkSessionCommandError> {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
@@ -10,7 +10,6 @@ use tokio::sync::Mutex;
 use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::config::apply::set_select_option_current_value_for_purpose;
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, persist_current_config_state_from_startup,
@@ -19,6 +18,7 @@ use crate::live::sessions::actor::config::types::{ConfigPurpose, PersistedSessio
 use crate::live::sessions::actor::notifications::observations::CollectedObservation;
 use crate::live::sessions::actor::state::SessionStartupState;
 use crate::live::sessions::background_work::BackgroundWorkRegistry;
+use crate::live::sessions::model::{EventPersist, SessionStateDurable};
 use crate::live::sessions::sink::{AcpChunkPayload, AcpToolPayload, SessionEventSink};
 use crate::live::sessions::handle::LiveSessionHandle;
 pub(in crate::live::sessions::actor) async fn inject_runtime_event(
@@ -43,7 +43,7 @@ pub(in crate::live::sessions::actor) async fn normalize_notification(
     notif: &acp::schema::SessionNotification,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     background_work_registry: &mut BackgroundWorkRegistry,
-    session_store: &SessionStore,
+    session_store: &dyn SessionStateDurable,
     session_id: &str,
     source_agent_kind: &str,
     persisted_config_state: &mut PersistedSessionConfigState,
@@ -305,13 +305,13 @@ fn is_non_transcript_chunk(meta: Option<&serde_json::Value>) -> bool {
 }
 
 pub(in crate::live::sessions::actor) fn persist_raw_notification(
-    session_store: &SessionStore,
+    events: &dyn EventPersist,
     session_id: &str,
     kind: &str,
     notif: &acp::schema::SessionNotification,
 ) -> anyhow::Result<()> {
     let payload_json = serde_json::to_string(notif)?;
-    session_store.append_raw_notification(
+    events.append_raw_notification(
         session_id,
         kind,
         &chrono::Utc::now().to_rfc3339(),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/handle.rs
@@ -4,13 +4,12 @@ use std::time::Instant;
 use agent_client_protocol as acp;
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::notifications::dispatch::{
     normalize_notification, persist_raw_notification,
 };
 use crate::live::sessions::actor::notifications::observations::dispatch_observations;
-use crate::live::sessions::model::SessionEventObserver;
+use crate::live::sessions::model::ActorCapabilities;
 use crate::live::sessions::actor::notifications::replay_filter::ResumeReplayFilter;
 use crate::live::sessions::actor::state::SessionStartupState;
 use crate::live::sessions::background_work::BackgroundWorkRegistry;
@@ -21,11 +20,10 @@ pub(in crate::live::sessions::actor) async fn handle_notification(
     notif: &acp::schema::SessionNotification,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     background_work_registry: &mut BackgroundWorkRegistry,
-    session_store: &SessionStore,
+    caps: &ActorCapabilities,
     session_id: &str,
     workspace_id: &str,
     source_agent_kind: &str,
-    observers: &[Arc<dyn SessionEventObserver>],
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,
 ) {
@@ -35,11 +33,10 @@ pub(in crate::live::sessions::actor) async fn handle_notification(
         &mut replay_filter,
         event_sink,
         background_work_registry,
-        session_store,
+        caps,
         session_id,
         workspace_id,
         source_agent_kind,
-        observers,
         persisted_config_state,
         startup_state,
     )
@@ -51,11 +48,10 @@ pub(in crate::live::sessions::actor) async fn handle_notification_with_resume_re
     replay_filter: &mut ResumeReplayFilter,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     background_work_registry: &mut BackgroundWorkRegistry,
-    session_store: &SessionStore,
+    caps: &ActorCapabilities,
     session_id: &str,
     workspace_id: &str,
     source_agent_kind: &str,
-    observers: &[Arc<dyn SessionEventObserver>],
     persisted_config_state: &mut PersistedSessionConfigState,
     startup_state: &mut SessionStartupState,
 ) {
@@ -66,7 +62,7 @@ pub(in crate::live::sessions::actor) async fn handle_notification_with_resume_re
         kind = kind,
         "handle_notification: received ACP notification"
     );
-    if let Err(error) = persist_raw_notification(session_store, session_id, kind, notif) {
+    if let Err(error) = persist_raw_notification(caps.events.as_ref(), session_id, kind, notif) {
         tracing::warn!(
             session_id = %session_id,
             kind = kind,
@@ -92,7 +88,7 @@ pub(in crate::live::sessions::actor) async fn handle_notification_with_resume_re
         notif,
         event_sink,
         background_work_registry,
-        session_store,
+        caps.state.as_ref(),
         session_id,
         source_agent_kind,
         persisted_config_state,
@@ -101,7 +97,7 @@ pub(in crate::live::sessions::actor) async fn handle_notification_with_resume_re
     .await;
     dispatch_observations(
         event_sink,
-        observers,
+        &caps.observers,
         session_id,
         workspace_id,
         source_agent_kind,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/shutdown/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/shutdown/handle.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::interactions::cleanup::resolve_pending_interactions;
 use crate::live::sessions::actor::shutdown::cleanup::interaction_resolution_for_exit;
 use crate::live::sessions::actor::shutdown::persist::persist_exit_disposition;
 use crate::live::sessions::actor::shutdown::types::ActorExitDisposition;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::rendezvous::broker::InteractionRendezvous;
@@ -14,7 +14,7 @@ pub(in crate::live::sessions::actor) async fn finalize_established_actor_exit(
     handle: &Arc<LiveSessionHandle>,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     interaction_broker: &Arc<InteractionRendezvous>,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     session_id: &str,
     disposition: ActorExitDisposition,
 ) {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/shutdown/persist.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/shutdown/persist.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 use anyharness_contract::v1::{SessionEndReason, SessionExecutionPhase};
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::shutdown::types::ActorExitDisposition;
+use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 use crate::live::sessions::handle::LiveSessionHandle;
 
 pub(in crate::live::sessions::actor) async fn persist_exit_disposition(
     handle: &Arc<LiveSessionHandle>,
     event_sink: &Arc<Mutex<SessionEventSink>>,
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     session_id: &str,
     disposition: ActorExitDisposition,
     now: &str,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
@@ -77,11 +77,11 @@ pub fn spawn_session_actor(
 pub fn spawn_session_actor_pending(
     mut config: SessionActorConfig,
 ) -> anyhow::Result<PendingSessionActor> {
-    let session_id = config.session.id.clone();
-    let workspace_id = config.session.workspace_id.clone();
-    let agent_kind = config.session.agent_kind.clone();
-    let startup_strategy = config.startup_strategy.as_str().to_string();
-    let actor_latency = config.latency.clone();
+    let session_id = config.launch.session.id.clone();
+    let workspace_id = config.launch.session.workspace_id.clone();
+    let agent_kind = config.launch.session.agent_kind.clone();
+    let startup_strategy = config.launch.startup.as_str().to_string();
+    let actor_latency = config.hooks.latency.clone();
     let actor_latency_fields = latency_trace_fields(actor_latency.as_ref());
     let started = Instant::now();
     tracing::info!(
@@ -114,7 +114,7 @@ pub fn spawn_session_actor_pending(
 
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<anyhow::Result<String>>();
 
-    let on_exit = config.on_exit.take();
+    let on_exit = config.hooks.on_exit.take();
 
     std::thread::Builder::new()
         .name(format!(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -8,7 +8,6 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::domains::sessions::model::serialize_action_capabilities;
 use crate::domains::sessions::prompt::capabilities::capabilities_from_acp;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::SessionCommand;
 use crate::live::sessions::actor::config::apply::restore_persisted_live_config_if_needed;
 use crate::live::sessions::actor::config::handle::apply_requested_session_preferences;
@@ -28,6 +27,7 @@ use crate::live::sessions::driver::process::spawn_agent_process;
 use crate::live::sessions::driver::inbound::RuntimeClient;
 use crate::live::sessions::driver::start::initialize_connection;
 use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
+use crate::live::sessions::model::{QueueDurable, SessionStateDurable};
 use crate::live::sessions::sink::SessionEventSink;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::observability::latency::latency_trace_fields;
@@ -55,22 +55,22 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     ready_tx: std::sync::mpsc::Sender<anyhow::Result<String>>,
     handle: &Arc<LiveSessionHandle>,
 ) -> anyhow::Result<StartedActor> {
-    let session_id = config.session.id.clone();
-    let source_agent_kind = config.session.agent_kind.clone();
-    let workspace_id = config.session.workspace_id.clone();
-    let startup_strategy = config.startup_strategy.clone();
+    let session_id = config.launch.session.id.clone();
+    let source_agent_kind = config.launch.session.agent_kind.clone();
+    let workspace_id = config.launch.session.workspace_id.clone();
+    let startup_strategy = config.launch.startup.clone();
     let startup_strategy_label = startup_strategy.as_str();
-    let actor_latency = config.latency.clone();
+    let actor_latency = config.hooks.latency.clone();
     let actor_latency_fields = latency_trace_fields(actor_latency.as_ref());
     let startup_started = Instant::now();
 
     let spawned = spawn_agent_process(
-        &config.agent,
-        &config.workspace_path,
-        &config.workspace_env,
-        &config.session_launch_env,
-        &config.agent_auth_env,
-        &config.protected_agent_auth_env,
+        &config.launch.agent,
+        &config.launch.workspace_path,
+        &config.launch.env.workspace,
+        &config.launch.env.session,
+        &config.launch.env.auth_support,
+        &config.launch.env.auth_protected,
         &session_id,
         &workspace_id,
         &source_agent_kind,
@@ -82,24 +82,23 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     let stdout = spawned.stdout;
 
     let (notification_tx, notification_rx) = mpsc::unbounded_channel::<acp::schema::SessionNotification>();
-    let store = config.session_store.clone();
 
     let event_sink = Arc::new(Mutex::new(if startup_strategy.resumes_durable_history() {
         SessionEventSink::resume_from_seq(
             session_id.clone(),
             source_agent_kind.clone(),
-            config.workspace_path.clone(),
-            config.last_seq,
+            config.launch.workspace_path.clone(),
+            config.launch.last_seq,
             config.event_tx.clone(),
-            config.session_store.clone(),
+            config.caps.events.clone(),
         )
     } else {
         SessionEventSink::new(
             session_id.clone(),
             source_agent_kind.clone(),
-            config.workspace_path.clone(),
+            config.launch.workspace_path.clone(),
             config.event_tx.clone(),
-            config.session_store.clone(),
+            config.caps.events.clone(),
         )
     }));
     let (background_work_tx, background_work_rx) =
@@ -107,7 +106,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     let mut background_work_registry = BackgroundWorkRegistry::new(
         session_id.clone(),
         source_agent_kind.clone(),
-        config.session_store.clone(),
+        config.caps.background.clone(),
         background_work_tx,
         BackgroundWorkOptions::default(),
     );
@@ -118,9 +117,9 @@ pub(in crate::live::sessions::actor) async fn start_actor(
         config.interaction_broker.clone(),
         event_sink.clone(),
         handle.clone(),
-        config.session.workspace_id.clone(),
-        config.session.agent_kind.clone(),
-        config.permission_advisor.clone(),
+        config.launch.session.workspace_id.clone(),
+        config.launch.session.agent_kind.clone(),
+        config.caps.permission_advisor.clone(),
     ));
 
     // Channel to extract ConnectionTo<Agent> from within the builder closure.
@@ -196,14 +195,18 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     let init_response = initialize_connection(
         &conn,
         &source_agent_kind,
-        &config.agent,
+        &config.launch.agent,
         &session_id,
         &workspace_id,
         &ready_tx,
     )
     .await?;
 
-    persist_session_action_capabilities(&store, &session_id, &init_response.agent_capabilities);
+    persist_session_action_capabilities(
+        config.caps.state.as_ref(),
+        &session_id,
+        &init_response.agent_capabilities,
+    );
     let action_capabilities = action_capabilities_from_acp(&init_response.agent_capabilities);
     let supports_native_close = init_response
         .agent_capabilities
@@ -213,9 +216,9 @@ pub(in crate::live::sessions::actor) async fn start_actor(
 
     let (native_session_id, native_startup_state, startup_disposition) = start_native_session(
         &conn,
-        &config.workspace_path,
-        &config.mcp_servers,
-        config.system_prompt_append.as_deref(),
+        &config.launch.workspace_path,
+        &config.launch.mcp_servers,
+        config.launch.prompts.every_prompt.as_deref(),
         &startup_strategy,
         action_capabilities,
         &session_id,
@@ -235,9 +238,10 @@ pub(in crate::live::sessions::actor) async fn start_actor(
         "ACP session established"
     );
 
-    let mut persisted_config_state = PersistedSessionConfigState::from_session(&config.session);
+    let mut persisted_config_state =
+        PersistedSessionConfigState::from_session(&config.launch.session);
     let startup_restore_snapshot = load_startup_restore_snapshot(
-        &store,
+        config.caps.state.as_ref(),
         &session_id,
         &source_agent_kind,
         startup_strategy.resumes_durable_history(),
@@ -255,7 +259,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     if let Err(error) = emit_live_config_update(
         &source_agent_kind,
         &session_id,
-        &store,
+        config.caps.state.as_ref(),
         &event_sink,
         &mut persisted_config_state,
         &mut startup_state,
@@ -284,7 +288,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     if let Err(error) = apply_requested_session_preferences(
         &conn,
         &native_session_id,
-        &config.session,
+        &config.launch.session,
         &mut startup_state,
     )
     .await
@@ -311,7 +315,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
         &native_session_id,
         &source_agent_kind,
         &session_id,
-        &store,
+        config.caps.state.as_ref(),
         &event_sink,
         &mut persisted_config_state,
         &mut startup_state,
@@ -339,7 +343,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     if let Err(error) = emit_live_config_update(
         &source_agent_kind,
         &session_id,
-        &store,
+        config.caps.state.as_ref(),
         &event_sink,
         &mut persisted_config_state,
         &mut startup_state,
@@ -385,10 +389,10 @@ pub(in crate::live::sessions::actor) async fn start_actor(
     let resume_replay_filter = ResumeReplayFilter::new(
         &source_agent_kind,
         startup_disposition,
-        &config.session.status,
+        &config.launch.session.status,
     );
 
-    dispatch_startup_drain(&store, &session_id, handle).await;
+    dispatch_startup_drain(config.caps.queue.as_ref(), &session_id, handle).await;
 
     Ok(StartedActor {
         child,
@@ -408,7 +412,7 @@ pub(in crate::live::sessions::actor) async fn start_actor(
 }
 
 async fn dispatch_startup_drain(
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     session_id: &str,
     handle: &Arc<LiveSessionHandle>,
 ) {
@@ -456,7 +460,7 @@ async fn dispatch_startup_drain(
     }
 }
 pub(in crate::live::sessions::actor) fn persist_session_action_capabilities(
-    store: &SessionStore,
+    store: &dyn SessionStateDurable,
     session_id: &str,
     agent_capabilities: &acp::schema::AgentCapabilities,
 ) {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
@@ -4,76 +4,22 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::SessionEventEnvelope;
 use tokio::sync::broadcast;
 
-use crate::domains::agents::model::ResolvedAgent;
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::live_config::SessionModelOption;
-use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
-use crate::domains::sessions::model::SessionRecord;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::config::selection::find_select_option_by_purpose;
 use crate::live::sessions::actor::config::types::ConfigPurpose;
-use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
 use crate::live::sessions::driver::types::NativeSessionStartupState;
-use crate::live::sessions::model::{PermissionAdvisor, SessionEventObserver};
+use crate::live::sessions::model::{ActorCapabilities, SessionHooks, SessionLaunch};
 use crate::live::sessions::rendezvous::broker::InteractionRendezvous;
-use crate::observability::latency::LatencyRequestContext;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SessionStartupStrategy {
-    Fresh,
-    ResumeSeqFreshNative,
-    LoadNative(String),
-    LoadNativeNoFallback(String),
-    ForkFromNative { parent_native_session_id: String },
-}
-
-impl SessionStartupStrategy {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Fresh => "fresh",
-            Self::ResumeSeqFreshNative => "resume_seq_fresh_native",
-            Self::LoadNative(_) => "load_native",
-            Self::LoadNativeNoFallback(_) => "load_native_no_fallback",
-            Self::ForkFromNative { .. } => "fork_from_native",
-        }
-    }
-
-    pub fn resumes_durable_history(&self) -> bool {
-        !matches!(self, Self::Fresh)
-    }
-
-    pub(in crate::live::sessions) fn allows_missing_load_fallback(&self) -> bool {
-        matches!(self, Self::LoadNative(_))
-    }
-}
 
 pub struct SessionActorConfig {
-    pub session: SessionRecord,
-    pub agent: ResolvedAgent,
-    pub workspace_path: std::path::PathBuf,
-    pub workspace_env: std::collections::BTreeMap<String, String>,
-    pub session_launch_env: std::collections::BTreeMap<String, String>,
-    pub agent_auth_env: std::collections::BTreeMap<String, String>,
-    pub protected_agent_auth_env: std::collections::BTreeMap<String, String>,
+    /// Everything describing THIS launch (session row, agent, env, startup).
+    pub launch: SessionLaunch,
+    /// The never-varies durable capabilities + product reactors.
+    pub caps: ActorCapabilities,
+    /// Per-call powers (turn-finish callback, exit callback, latency context).
+    pub hooks: SessionHooks,
     pub interaction_broker: Arc<InteractionRendezvous>,
-    /// Product reactors, registration order = dispatch order (plans before
-    /// reviews). See the dispatch contract in `live/sessions/model.rs`.
-    pub observers: Vec<Arc<dyn SessionEventObserver>>,
-    /// Consulted by the inbound permission door before parking.
-    pub permission_advisor: Option<Arc<dyn PermissionAdvisor>>,
     pub event_tx: broadcast::Sender<SessionEventEnvelope>,
-    pub session_store: SessionStore,
-    pub attachment_storage: PromptAttachmentStorage,
-    pub mcp_servers: Vec<SessionMcpServer>,
-    pub startup_strategy: SessionStartupStrategy,
-    pub last_seq: i64,
-    pub system_prompt_append: Option<String>,
-    pub first_prompt_system_prompt_append: Option<String>,
-    pub on_turn_finish: Option<Arc<dyn Fn(SessionTurnFinishResult) + Send + Sync + 'static>>,
-    pub latency: Option<LatencyRequestContext>,
-    /// Called after the actor loop exits (normal or error). The bool indicates
-    /// whether the actor exited with an error (true = errored).
-    pub on_exit: Option<Box<dyn FnOnce(bool) + Send + 'static>>,
 }
 
 #[derive(Debug, Clone)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/domain_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/domain_ops.rs
@@ -143,7 +143,7 @@ async fn live_plan_context(
         PathBuf::from("/tmp/workspace-1"),
         last_event_seq,
         event_tx,
-        session_store,
+        Arc::new(session_store),
     )));
     (event_sink, broker, handle, wait)
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -136,7 +136,7 @@ async fn actor_exit_test_context(
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         event_tx,
-        store.clone(),
+        Arc::new(store.clone()),
     )));
 
     (store, event_sink, interaction_broker, handle)
@@ -170,7 +170,7 @@ fn test_background_work_registry(store: &SessionStore) -> BackgroundWorkRegistry
     BackgroundWorkRegistry::new(
         "session-1".to_string(),
         "claude".to_string(),
-        store.clone(),
+        Arc::new(store.clone()),
         updates_tx,
         BackgroundWorkOptions::default(),
     )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/notifications.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/notifications.rs
@@ -45,7 +45,7 @@ async fn handle_notification_persists_raw_acp_notifications() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         event_tx,
-        store.clone(),
+        Arc::new(store.clone()),
     )));
     let mut startup_state = SessionStartupState {
         current_mode_id: None,
@@ -61,6 +61,7 @@ async fn handle_notification_persists_raw_acp_notifications() {
         requested_mode_id: None,
         current_mode_id: None,
     };
+    let caps = test_support::actor_capabilities_for_store(&store);
     let mut background_work_registry = test_background_work_registry(&store);
 
     let notif = acp::schema::SessionNotification::new(
@@ -72,11 +73,10 @@ async fn handle_notification_persists_raw_acp_notifications() {
         &notif,
         &event_sink,
         &mut background_work_registry,
-        &store,
+        &caps,
         "session-1",
         "workspace-1",
         "claude",
-        &[],
         &mut persisted_config_state,
         &mut startup_state,
     )
@@ -236,7 +236,7 @@ async fn replay_filter_keeps_raw_notifications_but_skips_normalized_transcript_e
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         event_tx,
-        store.clone(),
+        Arc::new(store.clone()),
     )));
     let mut startup_state = SessionStartupState {
         current_mode_id: None,
@@ -257,6 +257,7 @@ async fn replay_filter_keeps_raw_notifications_but_skips_normalized_transcript_e
         NativeSessionStartupDisposition::LoadedExisting,
         "idle",
     );
+    let caps = test_support::actor_capabilities_for_store(&store);
     let mut background_work_registry = test_background_work_registry(&store);
 
     let replay_user = acp::schema::SessionNotification::new(
@@ -268,11 +269,10 @@ async fn replay_filter_keeps_raw_notifications_but_skips_normalized_transcript_e
         &mut replay_filter,
         &event_sink,
         &mut background_work_registry,
-        &store,
+        &caps,
         "session-1",
         "workspace-1",
         "claude",
-        &[],
         &mut persisted_config_state,
         &mut startup_state,
     )
@@ -296,11 +296,10 @@ async fn replay_filter_keeps_raw_notifications_but_skips_normalized_transcript_e
         &mut replay_filter,
         &event_sink,
         &mut background_work_registry,
-        &store,
+        &caps,
         "session-1",
         "workspace-1",
         "claude",
-        &[],
         &mut persisted_config_state,
         &mut startup_state,
     )
@@ -327,11 +326,10 @@ async fn replay_filter_keeps_raw_notifications_but_skips_normalized_transcript_e
         &mut replay_filter,
         &event_sink,
         &mut background_work_registry,
-        &store,
+        &caps,
         "session-1",
         "workspace-1",
         "claude",
-        &[],
         &mut persisted_config_state,
         &mut startup_state,
     )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
@@ -5,9 +5,7 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::SessionExecutionPhase;
 use tokio::sync::{mpsc, oneshot, Mutex};
 
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::prompt::PromptPayload;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::background_work::handle_background_work_update;
 use crate::live::sessions::actor::command::{
     ForkSessionCommandError, Resolution, PromptAcceptError, PromptAcceptance,
@@ -56,8 +54,6 @@ pub(in crate::live::sessions::actor) struct ActivePromptContext<'a> {
     pub startup_state: &'a mut SessionStartupState,
     pub resume_replay_filter: &'a mut ResumeReplayFilter,
     pub handle: &'a Arc<LiveSessionHandle>,
-    pub store: &'a SessionStore,
-    pub attachment_storage: &'a PromptAttachmentStorage,
 }
 
 pub(in crate::live::sessions::actor) async fn handle_active_prompt(
@@ -77,13 +73,11 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
         startup_state,
         resume_replay_filter,
         handle,
-        store,
-        attachment_storage,
     } = context;
 
-    let session_id = config.session.id.as_str();
-    let workspace_id = config.session.workspace_id.as_str();
-    let source_agent_kind = config.session.agent_kind.as_str();
+    let session_id = config.launch.session.id.as_str();
+    let workspace_id = config.launch.session.workspace_id.as_str();
+    let source_agent_kind = config.launch.session.agent_kind.as_str();
 
     // Invariant 2: the actor is the sole writer of `busy`.
     handle.set_busy(true);
@@ -101,7 +95,6 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
             resume_replay_filter,
             event_sink,
             background_work_registry,
-            store,
             session_id,
             workspace_id,
             source_agent_kind,
@@ -126,8 +119,6 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
             turn_id,
         } = match begin_prompt_turn(
             config,
-            store,
-            attachment_storage,
             event_sink,
             session_id,
             source_agent_kind,
@@ -155,8 +146,8 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
         handle
             .set_execution_phase(SessionExecutionPhase::Running)
             .await;
-        let _ = store.update_status(session_id, "running", &now);
-        let _ = store.update_last_prompt_at(session_id, &now);
+        let _ = config.caps.state.update_status(session_id, "running", &now);
+        let _ = config.caps.state.update_last_prompt_at(session_id, &now);
         tracing::info!(
             session_id = %session_id,
             flow_id = latency_fields.flow_id,
@@ -233,11 +224,10 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                             resume_replay_filter,
                             event_sink,
                             background_work_registry,
-                            store,
+                            &config.caps,
                             session_id,
                             workspace_id,
                             source_agent_kind,
-                            &config.observers,
                             persisted_config_state,
                             startup_state,
                         ).await;
@@ -245,7 +235,13 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                 }
                 background_update = background_work_rx.recv() => {
                     if let Some(update) = background_update {
-                        handle_background_work_update(event_sink, store, session_id, update).await;
+                        handle_background_work_update(
+                            event_sink,
+                            config.caps.background.as_ref(),
+                            session_id,
+                            update,
+                        )
+                        .await;
                     }
                 }
                 cmd = command_rx.recv() => {
@@ -316,7 +312,7 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                         }
                         Some(SessionCommand::SetConfigOption { config_id, value, respond_to }) => {
                             let result = handle_busy_config_command(
-                                store,
+                                config.caps.state.as_ref(),
                                 event_sink,
                                 session_id,
                                 persisted_config_state,
@@ -341,7 +337,7 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                         }
                         Some(SessionCommand::Prompt { payload: queued_payload, prompt_id: queued_prompt_id, latency: _, from_queue_seq, respond_to }) => {
                             let result = handle_busy_prompt_queue(
-                                store,
+                                config.caps.queue.as_ref(),
                                 event_sink,
                                 session_id,
                                 queued_payload,
@@ -354,8 +350,8 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                         Some(SessionCommand::EditPendingPrompt { seq, payload, respond_to }) => {
                             let _ = respond_to.send(
                                 handle_edit_pending_prompt(
-                                    store,
-                                    attachment_storage,
+                                    config.caps.queue.as_ref(),
+                                    config.caps.attachments.as_ref(),
                                     event_sink,
                                     session_id,
                                     seq,
@@ -367,8 +363,8 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                         Some(SessionCommand::DeletePendingPrompt { seq, respond_to }) => {
                             let _ = respond_to.send(
                                 handle_delete_pending_prompt(
-                                    store,
-                                    attachment_storage,
+                                    config.caps.queue.as_ref(),
+                                    config.caps.attachments.as_ref(),
                                     event_sink,
                                     session_id,
                                     seq,
@@ -399,7 +395,6 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
                 startup_state,
                 resume_replay_filter,
                 handle,
-                store,
                 session_id,
                 workspace_id,
                 source_agent_kind,
@@ -423,7 +418,7 @@ pub(in crate::live::sessions::actor) async fn handle_active_prompt(
         // Invariant 2/3: peek the head of the queue BEFORE releasing `busy`.
         // If present, re-enter the prompt body with the new payload; begin_turn's
         // event emission is what durably hands off the queue row.
-        match next_pending_prompt_for_drain(store, session_id) {
+        match next_pending_prompt_for_drain(config.caps.queue.as_ref(), session_id) {
             Some((next_payload, next_prompt_id, next_seq)) => {
                 current_payload = next_payload;
                 current_prompt_id = next_prompt_id;
@@ -444,7 +439,6 @@ async fn drain_replay_notifications_before_prompt(
     resume_replay_filter: &mut ResumeReplayFilter,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     background_work_registry: &mut BackgroundWorkRegistry,
-    store: &SessionStore,
     session_id: &str,
     workspace_id: &str,
     source_agent_kind: &str,
@@ -458,11 +452,10 @@ async fn drain_replay_notifications_before_prompt(
             resume_replay_filter,
             event_sink,
             background_work_registry,
-            store,
+            &config.caps,
             session_id,
             workspace_id,
             source_agent_kind,
-            &config.observers,
             persisted_config_state,
             startup_state,
         )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
@@ -6,7 +6,6 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::acp::provider_errors::{classify_provider_rate_limit_error, PROVIDER_RATE_LIMIT_CODE};
 use crate::domains::sessions::extensions::SessionTurnOutcome;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::background_work::handle_background_work_update;
 use crate::live::sessions::actor::config::queue::apply_pending_config_changes_if_idle;
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
@@ -67,7 +66,6 @@ pub(in crate::live::sessions::actor) struct PromptFinishContext<'a> {
     pub startup_state: &'a mut SessionStartupState,
     pub resume_replay_filter: &'a mut ResumeReplayFilter,
     pub handle: &'a Arc<LiveSessionHandle>,
-    pub store: &'a SessionStore,
     pub session_id: &'a str,
     pub workspace_id: &'a str,
     pub source_agent_kind: &'a str,
@@ -91,7 +89,6 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
         startup_state,
         resume_replay_filter,
         handle,
-        store,
         session_id,
         workspace_id,
         source_agent_kind,
@@ -107,18 +104,23 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
                     resume_replay_filter,
                     event_sink,
                     background_work_registry,
-                    store,
+                    &config.caps,
                     session_id,
                     workspace_id,
                     source_agent_kind,
-                    &config.observers,
                     persisted_config_state,
                     startup_state,
                 )
                 .await;
             }
             while let Ok(update) = background_work_rx.try_recv() {
-                handle_background_work_update(event_sink, store, session_id, update).await;
+                handle_background_work_update(
+                    event_sink,
+                    config.caps.background.as_ref(),
+                    session_id,
+                    update,
+                )
+                .await;
             }
             let sink_snapshot_before_turn_end = {
                 let sink = event_sink.lock().await;
@@ -200,7 +202,7 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
             handle
                 .set_execution_phase(SessionExecutionPhase::Idle)
                 .await;
-            let _ = store.update_status(session_id, "idle", &now);
+            let _ = config.caps.state.update_status(session_id, "idle", &now);
             tracing::info!(
                 session_id = %session_id,
                 flow_id = latency_fields.flow_id,
@@ -211,7 +213,7 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
                 updated_at = %now,
                 "session.actor.prompt.status_idle_written"
             );
-            if let Some(callback) = config.on_turn_finish.as_ref() {
+            if let Some(callback) = config.hooks.on_turn_finish.as_ref() {
                 callback(SessionTurnFinishResult {
                     session_id: session_id.to_owned(),
                     turn_id: sink_snapshot_before_turn_end
@@ -229,7 +231,7 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
                 native_session_id,
                 source_agent_kind,
                 session_id,
-                store,
+                config.caps.state.as_ref(),
                 event_sink,
                 persisted_config_state,
                 startup_state,
@@ -280,8 +282,8 @@ pub(in crate::live::sessions::actor) async fn finish_prompt_result(
             handle
                 .set_execution_phase(SessionExecutionPhase::Errored)
                 .await;
-            let _ = store.update_status(session_id, "errored", &now);
-            if let Some(callback) = config.on_turn_finish.as_ref() {
+            let _ = config.caps.state.update_status(session_id, "errored", &now);
+            if let Some(callback) = config.hooks.on_turn_finish.as_ref() {
                 callback(SessionTurnFinishResult {
                     session_id: session_id.to_owned(),
                     turn_id: sink_snapshot_on_error

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/handle.rs
@@ -4,8 +4,6 @@ use agent_client_protocol as acp;
 use tokio::sync::{mpsc, Mutex};
 
 use crate::domains::agents::model::AgentKind;
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::SessionCommand;
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::notifications::replay_filter::ResumeReplayFilter;
@@ -31,8 +29,6 @@ pub(in crate::live::sessions::actor) struct IdlePromptContext<'a> {
     pub startup_state: &'a mut SessionStartupState,
     pub resume_replay_filter: &'a mut ResumeReplayFilter,
     pub handle: &'a Arc<LiveSessionHandle>,
-    pub store: &'a SessionStore,
-    pub attachment_storage: &'a PromptAttachmentStorage,
 }
 
 pub(in crate::live::sessions::actor) async fn handle_idle_prompt_command(
@@ -52,8 +48,6 @@ pub(in crate::live::sessions::actor) async fn handle_idle_prompt_command(
         startup_state,
         resume_replay_filter,
         handle,
-        store,
-        attachment_storage,
     } = context;
 
     handle_active_prompt(
@@ -70,8 +64,6 @@ pub(in crate::live::sessions::actor) async fn handle_idle_prompt_command(
             startup_state,
             resume_replay_filter,
             handle,
-            store,
-            attachment_storage,
         },
         request,
     )

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
@@ -6,17 +6,16 @@ use anyharness_contract::v1::{
 };
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::model::{PromptAttachmentRecord, PromptAttachmentState};
 use crate::domains::sessions::prompt::PromptPayload;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::{
     PromptAcceptError, PromptAcceptance, QueueMutationError,
 };
+use crate::live::sessions::model::{AttachmentSource, QueueDurable};
 use crate::live::sessions::sink::SessionEventSink;
 
 pub(in crate::live::sessions::actor) async fn handle_busy_prompt_queue(
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     payload: PromptPayload,
@@ -56,7 +55,7 @@ pub(in crate::live::sessions::actor) async fn handle_busy_prompt_queue(
 }
 
 pub(in crate::live::sessions::actor) async fn emit_prequeued_pending_prompt_added(
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     seq: i64,
@@ -86,7 +85,7 @@ pub(in crate::live::sessions::actor) async fn emit_prequeued_pending_prompt_adde
 }
 
 pub(in crate::live::sessions::actor) fn next_pending_prompt_for_drain(
-    store: &SessionStore,
+    store: &dyn QueueDurable,
     session_id: &str,
 ) -> Option<(PromptPayload, Option<String>, i64)> {
     match store.peek_head_pending_prompt(session_id) {
@@ -104,8 +103,8 @@ pub(in crate::live::sessions::actor) fn next_pending_prompt_for_drain(
 }
 
 pub(in crate::live::sessions::actor) async fn handle_edit_pending_prompt(
-    store: &SessionStore,
-    attachment_storage: &PromptAttachmentStorage,
+    store: &dyn QueueDurable,
+    attachments: &dyn AttachmentSource,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     seq: i64,
@@ -124,8 +123,8 @@ pub(in crate::live::sessions::actor) async fn handle_edit_pending_prompt(
                 .filter(|old_id| !new_attachment_ids.contains(old_id))
                 .map(String::as_str)
                 .collect::<Vec<_>>();
-            let removed_records = pending_attachment_records(store, session_id, &removed);
-            if let Err(error) = store.delete_prompt_attachments(session_id, &removed) {
+            let removed_records = pending_attachment_records(attachments, session_id, &removed);
+            if let Err(error) = attachments.delete_prompt_attachments(session_id, &removed) {
                 tracing::warn!(
                     session_id = %session_id,
                     seq,
@@ -133,7 +132,7 @@ pub(in crate::live::sessions::actor) async fn handle_edit_pending_prompt(
                     "failed to delete removed pending prompt attachments",
                 );
             }
-            delete_pending_attachment_files(attachment_storage, &removed_records);
+            delete_pending_attachment_files(attachments, &removed_records);
             let mut sink = event_sink.lock().await;
             let content_parts = payload.content_parts();
             sink.pending_prompt_updated(PendingPromptUpdatedPayload {
@@ -162,8 +161,8 @@ pub(in crate::live::sessions::actor) async fn handle_edit_pending_prompt(
 }
 
 pub(in crate::live::sessions::actor) async fn handle_delete_pending_prompt(
-    store: &SessionStore,
-    attachment_storage: &PromptAttachmentStorage,
+    store: &dyn QueueDurable,
+    attachments: &dyn AttachmentSource,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     seq: i64,
@@ -175,8 +174,9 @@ pub(in crate::live::sessions::actor) async fn handle_delete_pending_prompt(
                 .iter()
                 .map(String::as_str)
                 .collect::<Vec<_>>();
-            let removed_records = pending_attachment_records(store, session_id, &attachment_refs);
-            if let Err(error) = store.delete_prompt_attachments(session_id, &attachment_refs) {
+            let removed_records =
+                pending_attachment_records(attachments, session_id, &attachment_refs);
+            if let Err(error) = attachments.delete_prompt_attachments(session_id, &attachment_refs) {
                 tracing::warn!(
                     session_id = %session_id,
                     seq,
@@ -184,7 +184,7 @@ pub(in crate::live::sessions::actor) async fn handle_delete_pending_prompt(
                     "failed to delete pending prompt attachments",
                 );
             }
-            delete_pending_attachment_files(attachment_storage, &removed_records);
+            delete_pending_attachment_files(attachments, &removed_records);
             let mut sink = event_sink.lock().await;
             sink.pending_prompt_removed(PendingPromptRemovedPayload {
                 seq,
@@ -207,14 +207,14 @@ pub(in crate::live::sessions::actor) async fn handle_delete_pending_prompt(
 }
 
 pub(in crate::live::sessions::actor) fn pending_attachment_records(
-    store: &SessionStore,
+    attachments: &dyn AttachmentSource,
     session_id: &str,
     attachment_ids: &[&str],
 ) -> Vec<PromptAttachmentRecord> {
     attachment_ids
         .iter()
         .filter_map(|attachment_id| {
-            store
+            attachments
                 .find_prompt_attachment(session_id, attachment_id)
                 .ok()
                 .flatten()
@@ -224,11 +224,11 @@ pub(in crate::live::sessions::actor) fn pending_attachment_records(
 }
 
 pub(in crate::live::sessions::actor) fn delete_pending_attachment_files(
-    attachment_storage: &PromptAttachmentStorage,
+    attachments: &dyn AttachmentSource,
     records: &[PromptAttachmentRecord],
 ) {
     for record in records {
-        if let Err(error) = attachment_storage.delete_record(record) {
+        if let Err(error) = attachments.delete_record(record) {
             tracing::warn!(
                 session_id = %record.session_id,
                 attachment_id = %record.attachment_id,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/start.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/start.rs
@@ -4,10 +4,8 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::{PendingPromptRemovalReason, PendingPromptRemovedPayload};
 use tokio::sync::Mutex;
 
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::model::PromptAttachmentState;
 use crate::domains::sessions::prompt::PromptPayload;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::PromptAcceptError;
 use crate::live::sessions::actor::state::SessionActorConfig;
 use crate::live::sessions::actor::turn::handle::first_prompt_system_prompt_append_for_codex_prompt;
@@ -20,8 +18,6 @@ pub(in crate::live::sessions::actor) struct StartedPromptTurn {
 
 pub(in crate::live::sessions::actor) async fn begin_prompt_turn(
     config: &SessionActorConfig,
-    store: &SessionStore,
-    attachment_storage: &PromptAttachmentStorage,
     event_sink: &Arc<Mutex<SessionEventSink>>,
     session_id: &str,
     source_agent_kind: &str,
@@ -29,7 +25,11 @@ pub(in crate::live::sessions::actor) async fn begin_prompt_turn(
     prompt_id: Option<String>,
     queue_seq: Option<i64>,
 ) -> Result<StartedPromptTurn, PromptAcceptError> {
-    let mut acp_blocks = match payload.to_acp_blocks(store, attachment_storage, session_id) {
+    let mut acp_blocks = match config
+        .caps
+        .attachments
+        .resolve_prompt_blocks(session_id, payload)
+    {
         Ok(blocks) => blocks,
         Err(error) => {
             tracing::warn!(
@@ -42,11 +42,11 @@ pub(in crate::live::sessions::actor) async fn begin_prompt_turn(
         }
     };
 
-    match store.has_turn_started_event(session_id) {
+    match config.caps.events.has_turn_started_event(session_id) {
         Ok(has_turn_started) => {
             if let Some(append) = first_prompt_system_prompt_append_for_codex_prompt(
                 source_agent_kind,
-                config.first_prompt_system_prompt_append.as_deref(),
+                config.launch.prompts.first_prompt.as_deref(),
                 has_turn_started,
             ) {
                 prepend_system_prompt_append_to_acp_blocks(&mut acp_blocks, append);
@@ -71,7 +71,7 @@ pub(in crate::live::sessions::actor) async fn begin_prompt_turn(
             content_parts,
             payload.public_provenance(),
         );
-        if let Err(error) = store.mark_prompt_attachments_state(
+        if let Err(error) = config.caps.attachments.mark_prompt_attachments_state(
             session_id,
             &payload.attachment_ids(),
             PromptAttachmentState::Transcript,
@@ -85,7 +85,7 @@ pub(in crate::live::sessions::actor) async fn begin_prompt_turn(
         // Invariant: delete a drained queue row and emit Removed only after
         // begin_turn has durably persisted the replacement turn events.
         if let Some(seq) = queue_seq {
-            if let Err(error) = store.delete_pending_prompt(session_id, seq) {
+            if let Err(error) = config.caps.queue.delete_pending_prompt(session_id, seq) {
                 tracing::warn!(
                     session_id = %session_id,
                     seq,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/mod.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use super::{BackgroundWorkOptions, BackgroundWorkUpdate};
 use crate::domains::sessions::model::SessionBackgroundWorkRecord;
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::BackgroundWorkDurable;
 use crate::live::sessions::sink::AcpToolPayload;
 
 mod output;
@@ -27,7 +29,7 @@ pub fn detect_async_agent_registration(
 
 pub fn spawn_async_agent_tracker(
     record: SessionBackgroundWorkRecord,
-    store: SessionStore,
+    store: Arc<dyn BackgroundWorkDurable>,
     updates_tx: mpsc::UnboundedSender<BackgroundWorkUpdate>,
     options: BackgroundWorkOptions,
 ) -> JoinHandle<()> {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/tests.rs
@@ -106,7 +106,7 @@ async fn watch_async_agent_emits_completed_result_text() {
 
     watch_async_agent(
         record,
-        store,
+        std::sync::Arc::new(store),
         updates_tx,
         BackgroundWorkOptions {
             poll_interval: Duration::from_millis(5),
@@ -142,7 +142,7 @@ async fn watch_async_agent_uses_neutral_fallback_when_terminal_message_has_no_te
 
     watch_async_agent(
         record,
-        store,
+        std::sync::Arc::new(store),
         updates_tx,
         BackgroundWorkOptions {
             poll_interval: Duration::from_millis(5),
@@ -197,7 +197,7 @@ async fn watch_async_agent_ignores_tool_use_until_end_turn() {
 
     watch_async_agent(
         record,
-        store,
+        std::sync::Arc::new(store),
         updates_tx,
         BackgroundWorkOptions {
             poll_interval: Duration::from_millis(5),
@@ -226,7 +226,7 @@ async fn watch_async_agent_expires_when_the_output_file_stops_updating() {
 
     watch_async_agent(
         record,
-        store,
+        std::sync::Arc::new(store),
         updates_tx,
         BackgroundWorkOptions {
             poll_interval: Duration::from_millis(5),
@@ -266,7 +266,7 @@ async fn registry_rehydrates_pending_background_work_and_completes_it() {
             let mut registry = BackgroundWorkRegistry::new(
                 "session-1".to_string(),
                 "claude".to_string(),
-                store,
+                std::sync::Arc::new(store),
                 updates_tx,
                 BackgroundWorkOptions {
                     poll_interval: Duration::from_millis(5),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/watch.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/background_work/claude/watch.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -6,11 +7,11 @@ use tokio::task::JoinHandle;
 use super::output::{inspect_output_file, parse_timestamp, resolve_output_path};
 use super::{BackgroundWorkOptions, BackgroundWorkUpdate, BACKGROUND_WORK_FALLBACK_RESULT};
 use crate::domains::sessions::model::{SessionBackgroundWorkRecord, SessionBackgroundWorkState};
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::BackgroundWorkDurable;
 
 pub(super) fn spawn_async_agent_tracker(
     record: SessionBackgroundWorkRecord,
-    store: SessionStore,
+    store: Arc<dyn BackgroundWorkDurable>,
     updates_tx: mpsc::UnboundedSender<BackgroundWorkUpdate>,
     options: BackgroundWorkOptions,
 ) -> JoinHandle<()> {
@@ -21,7 +22,7 @@ pub(super) fn spawn_async_agent_tracker(
 
 pub(super) async fn watch_async_agent(
     record: SessionBackgroundWorkRecord,
-    store: SessionStore,
+    store: Arc<dyn BackgroundWorkDurable>,
     updates_tx: mpsc::UnboundedSender<BackgroundWorkUpdate>,
     options: BackgroundWorkOptions,
 ) {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/background_work/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/background_work/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -7,7 +8,7 @@ use tokio::task::JoinHandle;
 use crate::domains::sessions::model::{
     SessionBackgroundWorkRecord, SessionBackgroundWorkState, SessionBackgroundWorkTrackerKind,
 };
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::BackgroundWorkDurable;
 use crate::live::sessions::sink::AcpToolPayload;
 
 mod claude;
@@ -40,7 +41,7 @@ impl Default for BackgroundWorkOptions {
 pub struct BackgroundWorkRegistry {
     session_id: String,
     source_agent_kind: String,
-    store: SessionStore,
+    store: Arc<dyn BackgroundWorkDurable>,
     updates_tx: mpsc::UnboundedSender<BackgroundWorkUpdate>,
     options: BackgroundWorkOptions,
     trackers: HashMap<String, JoinHandle<()>>,
@@ -51,7 +52,7 @@ impl BackgroundWorkRegistry {
     pub fn new(
         session_id: String,
         source_agent_kind: String,
-        store: SessionStore,
+        store: Arc<dyn BackgroundWorkDurable>,
         updates_tx: mpsc::UnboundedSender<BackgroundWorkUpdate>,
         options: BackgroundWorkOptions,
     ) -> Self {
@@ -225,7 +226,7 @@ mod tests {
                 let mut registry = BackgroundWorkRegistry::new(
                     "session-1".to_string(),
                     "claude".to_string(),
-                    store.clone(),
+                    std::sync::Arc::new(store.clone()),
                     updates_tx,
                     BackgroundWorkOptions {
                         poll_interval: Duration::from_secs(60),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/native_session.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/native_session.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::live::sessions::actor::state::SessionStartupStrategy;
+use crate::live::sessions::model::SessionStartupStrategy;
 use crate::live::sessions::driver::start::start_new_session;
 use crate::live::sessions::driver::types::{
     NativeSessionStartupDisposition, NativeSessionStartupState,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
@@ -7,7 +7,7 @@ use super::rendezvous::broker::{
     InteractionRendezvous, ResolveInteractionError as BrokerResolveInteractionError,
 };
 use crate::live::sessions::handle::LiveSessionHandle;
-use crate::live::sessions::model::{PermissionAdvisor, SessionEventObserver};
+use crate::live::sessions::model::ActorCapabilities;
 
 mod replay;
 mod runtime_events;
@@ -22,9 +22,9 @@ pub struct LiveSessionManager {
     live_sessions: Arc<RwLock<HashMap<String, Arc<LiveSessionHandle>>>>,
     pending_startups: Arc<RwLock<HashMap<String, watch::Receiver<StartupReadinessState>>>>,
     interaction_broker: Arc<InteractionRendezvous>,
-    /// Product reactors; registration order = dispatch order.
-    observers: Vec<Arc<dyn SessionEventObserver>>,
-    permission_advisor: Option<Arc<dyn PermissionAdvisor>>,
+    /// The never-varies capability set every actor runs against; wired once
+    /// at construction.
+    caps: ActorCapabilities,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,17 +55,13 @@ impl From<BrokerResolveInteractionError> for RevealMcpElicitationUrlError {
 }
 
 impl LiveSessionManager {
-    pub fn new(
-        observers: Vec<Arc<dyn SessionEventObserver>>,
-        permission_advisor: Option<Arc<dyn PermissionAdvisor>>,
-    ) -> Self {
+    pub fn new(caps: ActorCapabilities) -> Self {
         let interaction_broker = Arc::new(InteractionRendezvous::new());
         Self {
             live_sessions: Arc::new(RwLock::new(HashMap::new())),
             pending_startups: Arc::new(RwLock::new(HashMap::new())),
             interaction_broker,
-            observers,
-            permission_advisor,
+            caps,
         }
     }
 
@@ -105,8 +101,7 @@ impl Clone for LiveSessionManager {
             live_sessions: self.live_sessions.clone(),
             pending_startups: self.pending_startups.clone(),
             interaction_broker: self.interaction_broker.clone(),
-            observers: self.observers.clone(),
-            permission_advisor: self.permission_advisor.clone(),
+            caps: self.caps.clone(),
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/replay.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/replay.rs
@@ -5,7 +5,6 @@ use tokio::sync::broadcast;
 
 use super::LiveSessionManager;
 use crate::domains::sessions::model::SessionRecord;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::spawn::ActorReadyResult;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::replay::{spawn_replay_actor, ReplayActorConfig};
@@ -16,7 +15,6 @@ impl LiveSessionManager {
         session: SessionRecord,
         events: Vec<SessionEventEnvelope>,
         speed: f32,
-        session_store: SessionStore,
         last_seq: i64,
     ) -> anyhow::Result<(Arc<LiveSessionHandle>, ActorReadyResult)> {
         let session_id = session.id.clone();
@@ -36,7 +34,7 @@ impl LiveSessionManager {
         let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4096);
         let live_sessions = self.live_sessions.clone();
         let exit_session_id = session_id.clone();
-        let exit_store = session_store.clone();
+        let exit_store = self.caps.state.clone();
         let on_exit: Box<dyn FnOnce(bool) + Send + 'static> = Box::new(move |errored| {
             live_sessions.blocking_write().remove(&exit_session_id);
             if errored {
@@ -50,7 +48,8 @@ impl LiveSessionManager {
             events,
             speed,
             event_tx,
-            session_store,
+            state: self.caps.state.clone(),
+            event_persist: self.caps.events.clone(),
             last_seq,
             on_exit: Some(on_exit),
         };

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/runtime_events.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/runtime_events.rs
@@ -4,10 +4,9 @@ use super::LiveSessionManager;
 use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionError, RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::EventPersist;
 
 impl LiveSessionManager {
-    #[cfg_attr(not(test), allow(dead_code))]
     /// Inject a runtime-owned event into a session.
     ///
     /// If the live actor dies between handle lookup and command delivery, this
@@ -18,7 +17,6 @@ impl LiveSessionManager {
     pub(crate) async fn emit_runtime_event(
         &self,
         session_id: &str,
-        session_store: SessionStore,
         event: RuntimeInjectedSessionEvent,
     ) -> RuntimeEventInjectionResult {
         loop {
@@ -27,7 +25,11 @@ impl LiveSessionManager {
                 if let Some(handle) = sessions.get(session_id) {
                     handle.clone()
                 } else {
-                    return append_offline_runtime_event(session_id, &session_store, event);
+                    return append_offline_runtime_event(
+                        session_id,
+                        self.caps.events.as_ref(),
+                        event,
+                    );
                 }
             };
 
@@ -39,10 +41,18 @@ impl LiveSessionManager {
                     match sessions.get(session_id) {
                         Some(current) if Arc::ptr_eq(current, &handle) => {
                             sessions.remove(session_id);
-                            return append_offline_runtime_event(session_id, &session_store, event);
+                            return append_offline_runtime_event(
+                                session_id,
+                                self.caps.events.as_ref(),
+                                event,
+                            );
                         }
                         None => {
-                            return append_offline_runtime_event(session_id, &session_store, event);
+                            return append_offline_runtime_event(
+                                session_id,
+                                self.caps.events.as_ref(),
+                                event,
+                            );
                         }
                         Some(_) => continue,
                     }
@@ -55,11 +65,11 @@ impl LiveSessionManager {
 
 fn append_offline_runtime_event(
     session_id: &str,
-    session_store: &SessionStore,
+    events: &dyn EventPersist,
     event: RuntimeInjectedSessionEvent,
 ) -> RuntimeEventInjectionResult {
     let touch_session_activity = event.updates_session_activity_at();
-    session_store
+    events
         .append_event_with_next_seq(
             session_id,
             event.into_session_event(),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -7,46 +6,29 @@ use anyharness_contract::v1::SessionEventEnvelope;
 use tokio::sync::{broadcast, watch, RwLock};
 
 use super::{LiveSessionManager, StartupReadinessState};
-use crate::domains::agents::model::ResolvedAgent;
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
-use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
-use crate::domains::sessions::model::SessionRecord;
-use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::spawn::{
     spawn_session_actor_pending, ActorReadyResult, PendingSessionActor,
 };
-use crate::live::sessions::actor::state::{SessionActorConfig, SessionStartupStrategy};
-use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
+use crate::live::sessions::actor::state::SessionActorConfig;
 use crate::live::sessions::handle::LiveSessionHandle;
+use crate::live::sessions::model::{SessionHooks, SessionLaunch};
 use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 impl LiveSessionManager {
+    #[tracing::instrument(skip_all, fields(session_id = %launch.session.id))]
     pub async fn start_session(
         &self,
-        session: SessionRecord,
-        agent: ResolvedAgent,
-        workspace_path: PathBuf,
-        workspace_env: std::collections::BTreeMap<String, String>,
-        session_launch_env: std::collections::BTreeMap<String, String>,
-        agent_auth_env: std::collections::BTreeMap<String, String>,
-        protected_agent_auth_env: std::collections::BTreeMap<String, String>,
-        session_store: SessionStore,
-        attachment_storage: PromptAttachmentStorage,
-        mcp_servers: Vec<SessionMcpServer>,
-        startup_strategy: SessionStartupStrategy,
-        system_prompt_append: Option<String>,
-        first_prompt_system_prompt_append: Option<String>,
-        on_turn_finish: Option<Arc<dyn Fn(SessionTurnFinishResult) + Send + Sync + 'static>>,
-        latency: Option<LatencyRequestContext>,
+        mut launch: SessionLaunch,
+        mut hooks: SessionHooks,
     ) -> anyhow::Result<(Arc<LiveSessionHandle>, ActorReadyResult)> {
-        let session_id = session.id.clone();
+        let session_id = launch.session.id.clone();
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency.as_ref());
-        let startup_strategy_label = startup_strategy.as_str();
+        let latency_fields = latency_trace_fields(hooks.latency.as_ref());
+        let startup_strategy_label = launch.startup.as_str();
         tracing::info!(
             session_id = %session_id,
-            workspace_id = %session.workspace_id,
-            agent_kind = %session.agent_kind,
+            workspace_id = %launch.session.workspace_id,
+            agent_kind = %launch.session.agent_kind,
             startup_strategy = startup_strategy_label,
             flow_id = latency_fields.flow_id,
             flow_kind = latency_fields.flow_kind,
@@ -79,7 +61,7 @@ impl LiveSessionManager {
                 return Ok((existing, ready));
             }
 
-            if let Some(native_session_id) = session.native_session_id {
+            if let Some(native_session_id) = launch.session.native_session_id {
                 return Ok((existing, ActorReadyResult { native_session_id }));
             }
 
@@ -88,13 +70,17 @@ impl LiveSessionManager {
             );
         }
 
-        let last_seq = session_store.last_event_seq(&session_id)?;
+        // The manager owns the last-seq read: it must happen under the
+        // live-sessions write lock (start/inject critical section), so any
+        // caller-provided value is overwritten here.
+        launch.last_seq = self.caps.events.last_event_seq(&session_id)?;
 
         let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4096);
 
         let live_sessions = self.live_sessions.clone();
         let exit_session_id = session_id.clone();
-        let exit_store = session_store.clone();
+        let exit_state = self.caps.state.clone();
+        let caller_on_exit = hooks.on_exit.take();
         let on_exit: Box<dyn FnOnce(bool) + Send + 'static> = Box::new(move |errored| {
             // Remove the dead handle from the live map so future callers do not
             // get a stale reference after the actor thread exits.
@@ -103,33 +89,21 @@ impl LiveSessionManager {
             live.blocking_write().remove(&sid);
             if errored {
                 let now = chrono::Utc::now().to_rfc3339();
-                let _ = exit_store.update_status(&sid, "errored", &now);
+                let _ = exit_state.update_status(&sid, "errored", &now);
+            }
+            if let Some(caller_on_exit) = caller_on_exit {
+                caller_on_exit(errored);
             }
         });
+        hooks.on_exit = Some(on_exit);
 
-        let actor_latency = latency.clone();
+        let actor_latency = hooks.latency.clone();
         let config = SessionActorConfig {
-            session,
-            agent,
-            workspace_path,
-            workspace_env,
-            session_launch_env,
-            agent_auth_env,
-            protected_agent_auth_env,
+            launch,
+            caps: self.caps.clone(),
+            hooks,
             interaction_broker: self.interaction_broker.clone(),
-            observers: self.observers.clone(),
-            permission_advisor: self.permission_advisor.clone(),
             event_tx,
-            session_store,
-            attachment_storage,
-            mcp_servers,
-            startup_strategy,
-            last_seq,
-            system_prompt_append,
-            first_prompt_system_prompt_append,
-            on_turn_finish,
-            latency,
-            on_exit: Some(on_exit),
         };
 
         // Make the live handle visible before waiting on ACP new_session so

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/tests.rs
@@ -14,13 +14,14 @@ use crate::domains::agents::model::{
     AgentKind, ArtifactRole, CredentialState, ResolvedAgent, ResolvedAgentStatus, ResolvedArtifact,
 };
 use crate::domains::agents::registry::built_in_registry;
-use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::model::{SessionEventRecord, SessionRecord};
 use crate::domains::sessions::runtime_event::RuntimeInjectedSessionEvent;
 use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::actor::command::SessionCommand;
-use crate::live::sessions::actor::state::SessionStartupStrategy;
 use crate::live::sessions::handle::LiveSessionHandle;
+use crate::live::sessions::model::{
+    LaunchEnv, SessionHooks, SessionLaunch, SessionStartupStrategy, SystemPromptAppends,
+};
 use crate::persistence::Db;
 
 fn resolved_agent(kind: AgentKind) -> ResolvedAgent {
@@ -93,10 +94,21 @@ fn seeded_session_store() -> SessionStore {
     store
 }
 
-fn test_attachment_storage() -> PromptAttachmentStorage {
-    PromptAttachmentStorage::new(
-        std::env::temp_dir().join(format!("anyharness-test-{}", uuid::Uuid::new_v4())),
-    )
+fn manager_for_store(store: &SessionStore) -> LiveSessionManager {
+    LiveSessionManager::new(test_support::actor_capabilities_for_store(store))
+}
+
+fn test_launch(startup: SessionStartupStrategy) -> SessionLaunch {
+    SessionLaunch {
+        session: session_record(),
+        agent: resolved_agent(AgentKind::Claude),
+        workspace_path: PathBuf::from("/tmp/workspace"),
+        env: LaunchEnv::default(),
+        mcp_servers: vec![],
+        startup,
+        prompts: SystemPromptAppends::default(),
+        last_seq: 0,
+    }
 }
 
 fn subagent_turn_completed_event() -> RuntimeInjectedSessionEvent {
@@ -114,7 +126,7 @@ fn subagent_turn_completed_event() -> RuntimeInjectedSessionEvent {
 
 #[tokio::test]
 async fn reused_live_handle_reports_the_live_native_session_id() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
+    let manager = manager_for_store(&SessionStore::new(Db::open_in_memory().expect("open db")));
     let (command_tx, _command_rx) = mpsc::channel(4);
     let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4);
     let handle = Arc::new(LiveSessionHandle::new_for_test(
@@ -132,21 +144,8 @@ async fn reused_live_handle_reports_the_live_native_session_id() {
 
     let (returned_handle, ready) = manager
         .start_session(
-            session_record(),
-            resolved_agent(AgentKind::Claude),
-            PathBuf::from("/tmp/workspace"),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            SessionStore::new(Db::open_in_memory().expect("open db")),
-            test_attachment_storage(),
-            vec![],
-            SessionStartupStrategy::ResumeSeqFreshNative,
-            None,
-            None,
-            None,
-            None,
+            test_launch(SessionStartupStrategy::ResumeSeqFreshNative),
+            SessionHooks::default(),
         )
         .await
         .expect("reuse existing handle");
@@ -157,7 +156,7 @@ async fn reused_live_handle_reports_the_live_native_session_id() {
 
 #[tokio::test]
 async fn reused_pending_live_handle_waits_for_shared_startup_readiness() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
+    let manager = manager_for_store(&SessionStore::new(Db::open_in_memory().expect("open db")));
     let (command_tx, _command_rx) = mpsc::channel(4);
     let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4);
     let handle = Arc::new(LiveSessionHandle::new_for_test(
@@ -183,21 +182,8 @@ async fn reused_pending_live_handle_waits_for_shared_startup_readiness() {
     let mut start = tokio::spawn(async move {
         manager_for_start
             .start_session(
-                session_record(),
-                resolved_agent(AgentKind::Claude),
-                PathBuf::from("/tmp/workspace"),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                SessionStore::new(Db::open_in_memory().expect("open db")),
-                test_attachment_storage(),
-                vec![],
-                SessionStartupStrategy::ResumeSeqFreshNative,
-                None,
-                None,
-                None,
-                None,
+                test_launch(SessionStartupStrategy::ResumeSeqFreshNative),
+                SessionHooks::default(),
             )
             .await
     });
@@ -221,7 +207,7 @@ async fn reused_pending_live_handle_waits_for_shared_startup_readiness() {
 
 #[tokio::test]
 async fn blocking_remove_discards_live_and_pending_handles() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
+    let manager = manager_for_store(&SessionStore::new(Db::open_in_memory().expect("open db")));
     let (command_tx, _command_rx) = mpsc::channel(4);
     let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4);
     let handle = Arc::new(LiveSessionHandle::new_for_test(
@@ -266,8 +252,8 @@ async fn blocking_remove_discards_live_and_pending_handles() {
 
 #[tokio::test]
 async fn offline_runtime_event_injection_appends_with_next_sequence() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
     let store = seeded_session_store();
+    let manager = manager_for_store(&store);
     store
         .append_event(&SessionEventRecord {
             id: 0,
@@ -284,7 +270,6 @@ async fn offline_runtime_event_injection_appends_with_next_sequence() {
     let envelope = manager
         .emit_runtime_event(
             "session-1",
-            store.clone(),
             RuntimeInjectedSessionEvent::SessionInfoUpdate {
                 title: Some("Renamed".to_string()),
                 updated_at: Some("2026-03-25T00:02:00Z".to_string()),
@@ -309,11 +294,11 @@ async fn offline_runtime_event_injection_appends_with_next_sequence() {
 
 #[tokio::test]
 async fn offline_runtime_activity_event_touches_session_updated_at() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
     let store = seeded_session_store();
+    let manager = manager_for_store(&store);
 
     let envelope = manager
-        .emit_runtime_event("session-1", store.clone(), subagent_turn_completed_event())
+        .emit_runtime_event("session-1", subagent_turn_completed_event())
         .await
         .expect("emit runtime event");
 
@@ -329,12 +314,11 @@ async fn offline_runtime_activity_event_touches_session_updated_at() {
 
 #[tokio::test]
 async fn offline_runtime_event_injection_serializes_concurrent_appends() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
     let store = seeded_session_store();
+    let manager = manager_for_store(&store);
 
     let first = manager.emit_runtime_event(
         "session-1",
-        store.clone(),
         RuntimeInjectedSessionEvent::SessionInfoUpdate {
             title: Some("First".to_string()),
             updated_at: None,
@@ -342,7 +326,6 @@ async fn offline_runtime_event_injection_serializes_concurrent_appends() {
     );
     let second = manager.emit_runtime_event(
         "session-1",
-        store.clone(),
         RuntimeInjectedSessionEvent::SessionInfoUpdate {
             title: Some("Second".to_string()),
             updated_at: None,
@@ -366,8 +349,8 @@ async fn offline_runtime_event_injection_serializes_concurrent_appends() {
 
 #[tokio::test]
 async fn runtime_event_injection_falls_back_when_live_handle_is_stale() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
     let store = seeded_session_store();
+    let manager = manager_for_store(&store);
     let (command_tx, command_rx) = mpsc::channel(1);
     drop(command_rx);
     let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4);
@@ -387,7 +370,6 @@ async fn runtime_event_injection_falls_back_when_live_handle_is_stale() {
     let envelope = manager
         .emit_runtime_event(
             "session-1",
-            store.clone(),
             RuntimeInjectedSessionEvent::SessionInfoUpdate {
                 title: Some("Renamed".to_string()),
                 updated_at: None,
@@ -410,8 +392,8 @@ async fn runtime_event_injection_falls_back_when_live_handle_is_stale() {
 
 #[tokio::test]
 async fn live_runtime_event_injection_routes_through_actor_command() {
-    let manager = LiveSessionManager::new(Vec::new(), None);
     let store = seeded_session_store();
+    let manager = manager_for_store(&store);
     let (command_tx, mut command_rx) = mpsc::channel(4);
     let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(4);
     let handle = Arc::new(LiveSessionHandle::new_for_test(
@@ -448,7 +430,6 @@ async fn live_runtime_event_injection_routes_through_actor_command() {
     let envelope = manager
         .emit_runtime_event(
             "session-1",
-            store,
             RuntimeInjectedSessionEvent::SessionInfoUpdate {
                 title: Some("Renamed".to_string()),
                 updated_at: None,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
@@ -10,7 +10,8 @@ pub mod probe;
 mod replay;
 
 pub use actor::spawn::ActorReadyResult;
-pub use actor::state::SessionStartupStrategy;
+pub use actor::turn::types::SessionTurnFinishResult;
+pub use model::SessionStartupStrategy;
 pub use handle::{
     ForkSessionCommandError, ForkSessionCommandResult, Resolution,
     LiveSessionCommandError, LiveSessionExecutionSnapshot, LiveSessionHandle, PromptAcceptError,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -32,15 +32,282 @@
 //! it.
 
 use std::any::Any;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use agent_client_protocol as acp;
-use anyharness_contract::v1::SessionEventEnvelope;
+use anyharness_contract::v1::{SessionEvent, SessionEventEnvelope};
 
+use crate::domains::agents::model::ResolvedAgent;
+use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
+use crate::domains::sessions::model::{
+    PendingConfigChangeRecord, PendingPromptRecord, PromptAttachmentRecord, PromptAttachmentState,
+    SessionBackgroundWorkRecord, SessionBackgroundWorkState, SessionEventRecord,
+    SessionLiveConfigSnapshotRecord, SessionRecord,
+};
+use crate::domains::sessions::prompt::{PromptPayload, PromptValidationError};
 use crate::live::sessions::actor::command::{Resolution, ResolveInteractionCommandError};
+use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
 use crate::live::sessions::sink::SessionEventSink;
+use crate::observability::latency::LatencyRequestContext;
 // Re-exported: the normalized-payload vocabulary observers consume. The sink
 // module itself stays private to live; these shapes are part of the doorstep.
 pub use crate::live::sessions::sink::{AcpChunkPayload, AcpToolPayload, CompletedAssistantMessage};
+
+/// How the actor should establish the native agent session at startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStartupStrategy {
+    Fresh,
+    ResumeSeqFreshNative,
+    LoadNative(String),
+    LoadNativeNoFallback(String),
+    ForkFromNative { parent_native_session_id: String },
+}
+
+impl SessionStartupStrategy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::ResumeSeqFreshNative => "resume_seq_fresh_native",
+            Self::LoadNative(_) => "load_native",
+            Self::LoadNativeNoFallback(_) => "load_native_no_fallback",
+            Self::ForkFromNative { .. } => "fork_from_native",
+        }
+    }
+
+    pub fn resumes_durable_history(&self) -> bool {
+        !matches!(self, Self::Fresh)
+    }
+
+    pub(in crate::live::sessions) fn allows_missing_load_fallback(&self) -> bool {
+        matches!(self, Self::LoadNative(_))
+    }
+}
+
+/// The named environment layers a session launch carries. Keeping the layers
+/// named (rather than four adjacent maps) removes the positional swap hazard.
+#[derive(Debug, Clone, Default)]
+pub struct LaunchEnv {
+    pub workspace: BTreeMap<String, String>,
+    pub session: BTreeMap<String, String>,
+    pub auth_support: BTreeMap<String, String>,
+    /// Secrets — never logged.
+    pub auth_protected: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SystemPromptAppends {
+    pub every_prompt: Option<String>,
+    pub first_prompt: Option<String>,
+}
+
+/// Everything that describes ONE session launch: the durable session row, the
+/// resolved agent binary, where and with what environment to run it, and how
+/// to establish the native session.
+pub struct SessionLaunch {
+    pub session: SessionRecord,
+    pub agent: ResolvedAgent,
+    pub workspace_path: PathBuf,
+    pub env: LaunchEnv,
+    pub mcp_servers: Vec<SessionMcpServer>,
+    pub startup: SessionStartupStrategy,
+    pub prompts: SystemPromptAppends,
+    /// Last persisted event seq. Owned by the manager: it re-reads this under
+    /// the start/inject critical section before spawning the actor; caller
+    /// values are overwritten.
+    pub last_seq: i64,
+}
+
+/// Durable event-ledger persistence as the live actor needs it.
+///
+/// Signatures mirror `SessionStore` 1:1 so the domain impl is pure delegation.
+pub trait EventPersist: Send + Sync {
+    fn append_event(&self, event: &SessionEventRecord) -> anyhow::Result<()>;
+    fn append_event_and_touch_session(&self, event: &SessionEventRecord) -> anyhow::Result<()>;
+    /// Offline injection path: seq assigned from the database under one tx.
+    ///
+    /// # Invariants
+    ///
+    /// Callers must hold the ACP start/inject critical section and must have
+    /// confirmed that no live actor owns event sequencing for this session.
+    fn append_event_with_next_seq(
+        &self,
+        session_id: &str,
+        event: SessionEvent,
+        touch_session_activity: bool,
+    ) -> anyhow::Result<SessionEventEnvelope>;
+    fn next_event_seq(&self, session_id: &str) -> anyhow::Result<i64>;
+    fn last_event_seq(&self, session_id: &str) -> anyhow::Result<i64>;
+    fn has_turn_started_event(&self, session_id: &str) -> anyhow::Result<bool>;
+    fn append_raw_notification(
+        &self,
+        session_id: &str,
+        notification_kind: &str,
+        timestamp: &str,
+        payload_json: &str,
+    ) -> anyhow::Result<()>;
+}
+
+/// Durable pending-prompt queue rows.
+pub trait QueueDurable: Send + Sync {
+    fn insert_pending_prompt_payload(
+        &self,
+        session_id: &str,
+        payload: &PromptPayload,
+        prompt_id: Option<&str>,
+    ) -> anyhow::Result<PendingPromptRecord>;
+    fn peek_head_pending_prompt(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<PendingPromptRecord>>;
+    fn find_pending_prompt(
+        &self,
+        session_id: &str,
+        seq: i64,
+    ) -> anyhow::Result<Option<PendingPromptRecord>>;
+    fn update_pending_prompt_payload(
+        &self,
+        session_id: &str,
+        seq: i64,
+        payload: &PromptPayload,
+    ) -> anyhow::Result<bool>;
+    fn delete_pending_prompt(&self, session_id: &str, seq: i64) -> anyhow::Result<bool>;
+    fn delete_pending_prompt_record(
+        &self,
+        session_id: &str,
+        seq: i64,
+    ) -> anyhow::Result<Option<PendingPromptRecord>>;
+}
+
+/// Durable background-work tracker rows.
+pub trait BackgroundWorkDurable: Send + Sync {
+    fn upsert_or_refresh_pending_background_work(
+        &self,
+        record: &SessionBackgroundWorkRecord,
+    ) -> anyhow::Result<bool>;
+    fn list_pending_background_work(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<SessionBackgroundWorkRecord>>;
+    fn touch_background_work_activity(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+        last_activity_at: &str,
+    ) -> anyhow::Result<()>;
+    fn mark_background_work_terminal(
+        &self,
+        session_id: &str,
+        tool_call_id: &str,
+        state: SessionBackgroundWorkState,
+        completed_at: &str,
+    ) -> anyhow::Result<bool>;
+}
+
+/// Durable session-row state: status/title/activity, config snapshots and the
+/// pending-config queue, capabilities, turn repair.
+pub trait SessionStateDurable: Send + Sync {
+    fn update_status(&self, id: &str, status: &str, now: &str) -> anyhow::Result<()>;
+    fn update_title(&self, id: &str, title: &str, now: &str) -> anyhow::Result<()>;
+    fn update_last_prompt_at(&self, id: &str, now: &str) -> anyhow::Result<()>;
+    fn update_requested_configuration(
+        &self,
+        id: &str,
+        requested_model_id: Option<&str>,
+        requested_mode_id: Option<&str>,
+        now: &str,
+    ) -> anyhow::Result<()>;
+    fn update_current_configuration(
+        &self,
+        id: &str,
+        current_model_id: Option<&str>,
+        current_mode_id: Option<&str>,
+        now: &str,
+    ) -> anyhow::Result<()>;
+    fn update_action_capabilities_json(
+        &self,
+        id: &str,
+        action_capabilities_json: Option<String>,
+        now: &str,
+    ) -> anyhow::Result<()>;
+    fn upsert_live_config_snapshot(
+        &self,
+        record: &SessionLiveConfigSnapshotRecord,
+    ) -> anyhow::Result<()>;
+    fn find_live_config_snapshot(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<SessionLiveConfigSnapshotRecord>>;
+    fn upsert_pending_config_change(
+        &self,
+        record: &PendingConfigChangeRecord,
+    ) -> anyhow::Result<()>;
+    fn list_pending_config_changes(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<PendingConfigChangeRecord>>;
+    fn delete_pending_config_change(&self, session_id: &str, config_id: &str)
+        -> anyhow::Result<()>;
+    fn repair_unclosed_turns(&self, session_id: &str) -> anyhow::Result<u32>;
+}
+
+/// Prompt-attachment resolution and hygiene as the actor's turn machinery
+/// needs it. v1 doorstep: `resolve_prompt_blocks` wraps the load+render path;
+/// PR-2b refines it into load + pure render.
+pub trait AttachmentSource: Send + Sync {
+    /// Resolve a stored prompt payload into the ACP content blocks to send.
+    fn resolve_prompt_blocks(
+        &self,
+        session_id: &str,
+        payload: &PromptPayload,
+    ) -> Result<Vec<acp::schema::ContentBlock>, PromptValidationError>;
+    fn mark_prompt_attachments_state(
+        &self,
+        session_id: &str,
+        attachment_ids: &[String],
+        state: PromptAttachmentState,
+    ) -> anyhow::Result<()>;
+    fn find_prompt_attachment(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+    ) -> anyhow::Result<Option<PromptAttachmentRecord>>;
+    fn delete_prompt_attachments(
+        &self,
+        session_id: &str,
+        attachment_ids: &[&str],
+    ) -> anyhow::Result<()>;
+    /// Delete the stored attachment file for a (pending) record.
+    fn delete_record(&self, record: &PromptAttachmentRecord) -> anyhow::Result<()>;
+}
+
+/// The never-varies capability set the actor runs against; wired once at
+/// manager construction and shared by every session the manager starts.
+#[derive(Clone)]
+pub struct ActorCapabilities {
+    pub events: Arc<dyn EventPersist>,
+    pub queue: Arc<dyn QueueDurable>,
+    pub background: Arc<dyn BackgroundWorkDurable>,
+    pub state: Arc<dyn SessionStateDurable>,
+    pub attachments: Arc<dyn AttachmentSource>,
+    /// Product reactors, registration order = dispatch order (plans before
+    /// reviews). See the dispatch contract on [`SessionEventObserver`].
+    pub observers: Vec<Arc<dyn SessionEventObserver>>,
+    /// Consulted by the inbound permission door before parking.
+    pub permission_advisor: Option<Arc<dyn PermissionAdvisor>>,
+}
+
+/// Per-call powers: hooks and context that vary per session start.
+#[derive(Default)]
+pub struct SessionHooks {
+    pub on_turn_finish: Option<Arc<dyn Fn(SessionTurnFinishResult) + Send + Sync>>,
+    /// Called after the actor loop exits (normal or error). The bool indicates
+    /// whether the actor exited with an error (true = errored).
+    pub on_exit: Option<Box<dyn FnOnce(bool) + Send>>,
+    /// Dies in PR-3b (latency → spans); carried here meanwhile.
+    pub latency: Option<LatencyRequestContext>,
+}
 
 /// Where in the session's event stream an observation (or op phase) is
 /// happening. A snapshot taken under the sink lock at this point in the

--- a/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
@@ -10,7 +10,7 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::runtime_event::RuntimeEventInjectionError;
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::{EventPersist, SessionStateDurable};
 use crate::live::sessions::actor::command::{
     ForkSessionCommandError, PromptAcceptError, QueueMutationError, ResolveInteractionCommandError,
     SessionCommand, SetConfigOptionCommandError,
@@ -26,7 +26,8 @@ pub struct ReplayActorConfig {
     pub events: Vec<SessionEventEnvelope>,
     pub speed: f32,
     pub event_tx: broadcast::Sender<SessionEventEnvelope>,
-    pub session_store: SessionStore,
+    pub state: std::sync::Arc<dyn SessionStateDurable>,
+    pub event_persist: std::sync::Arc<dyn EventPersist>,
     pub last_seq: i64,
     pub on_exit: Option<Box<dyn FnOnce(bool) + Send + 'static>>,
 }
@@ -105,7 +106,8 @@ async fn run_replay_actor(
     native_session_id: String,
 ) -> anyhow::Result<()> {
     let session_id = config.session.id.clone();
-    let store = config.session_store.clone();
+    let store = config.state.clone();
+    let event_persist = config.event_persist.clone();
     let mut next_seq = config.last_seq + 1;
     let mut first_turn_started = false;
     let mut previous_recorded_timestamp: Option<chrono::DateTime<chrono::FixedOffset>> = None;
@@ -165,7 +167,7 @@ async fn run_replay_actor(
             &session_id,
             &mut next_seq,
             &config.event_tx,
-            &store,
+            event_persist.as_ref(),
             event.clone(),
             recorded.turn_id,
             recorded.item_id,
@@ -234,7 +236,7 @@ async fn run_replay_actor(
             &session_id,
             &mut next_seq,
             &config.event_tx,
-            &store,
+            event_persist.as_ref(),
             SessionEvent::SessionEnded(SessionEndedEvent {
                 reason: SessionEndReason::Closed,
             }),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/mod.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
 use self::state::{PlanItemState, StreamingItemState, ToolItemState};
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::EventPersist;
 use crate::observability::transcript_phase::TranscriptPhaseDebugState;
 use anyharness_contract::v1::SessionEventEnvelope;
 
@@ -37,7 +38,7 @@ pub struct SessionEventSink {
     workspace_root: PathBuf,
     next_seq: i64,
     event_tx: broadcast::Sender<SessionEventEnvelope>,
-    store: SessionStore,
+    store: Arc<dyn EventPersist>,
 
     current_turn_id: Option<String>,
     open_assistant_item: Option<StreamingItemState>,
@@ -53,7 +54,7 @@ impl SessionEventSink {
         source_agent_kind: String,
         workspace_root: PathBuf,
         event_tx: broadcast::Sender<SessionEventEnvelope>,
-        store: SessionStore,
+        store: Arc<dyn EventPersist>,
     ) -> Self {
         Self {
             session_id,
@@ -77,7 +78,7 @@ impl SessionEventSink {
         workspace_root: PathBuf,
         last_seq: i64,
         event_tx: broadcast::Sender<SessionEventEnvelope>,
-        store: SessionStore,
+        store: Arc<dyn EventPersist>,
     ) -> Self {
         Self {
             session_id,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/publish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/publish.rs
@@ -3,7 +3,7 @@ use tokio::sync::broadcast;
 use super::SessionEventSink;
 use crate::domains::sessions::model::SessionEventRecord;
 use crate::domains::sessions::runtime_event::RuntimeEventInjectionError;
-use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::model::EventPersist;
 use crate::observability::transcript_phase::record_transcript_phase_event;
 use anyharness_contract::v1::{SessionEvent, SessionEventEnvelope};
 
@@ -18,7 +18,7 @@ impl SessionEventSink {
             &self.session_id,
             &mut self.next_seq,
             &self.event_tx,
-            &self.store,
+            self.store.as_ref(),
             event,
             turn_id,
             item_id,
@@ -31,7 +31,7 @@ pub(crate) fn publish_session_event(
     session_id: &str,
     next_seq: &mut i64,
     event_tx: &broadcast::Sender<SessionEventEnvelope>,
-    store: &SessionStore,
+    store: &dyn EventPersist,
     event: SessionEvent,
     turn_id: Option<String>,
     item_id: Option<String>,
@@ -80,7 +80,7 @@ pub(super) fn publish_session_event_strict(
     session_id: &str,
     next_seq: &mut i64,
     event_tx: &broadcast::Sender<SessionEventEnvelope>,
-    store: &SessionStore,
+    store: &dyn EventPersist,
     event: SessionEvent,
     turn_id: Option<String>,
     item_id: Option<String>,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/runtime_events.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/runtime_events.rs
@@ -16,7 +16,7 @@ impl SessionEventSink {
             &self.session_id,
             &mut self.next_seq,
             &self.event_tx,
-            &self.store,
+            self.store.as_ref(),
             event.into_session_event(),
             None,
             None,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde_json::json;
 use tokio::sync::broadcast;
@@ -26,7 +27,7 @@ fn assistant_chunking_emits_one_item_lifecycle_with_monotonic_seq() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store.clone(),
+        Arc::new(store.clone()),
     );
 
     sink.begin_turn("hello".to_string(), None, Vec::new(), None);
@@ -82,7 +83,7 @@ fn injected_runtime_event_persists_strictly_and_keeps_sequence() {
         PathBuf::from("/tmp/workspace"),
         5,
         tx,
-        store.clone(),
+        Arc::new(store.clone()),
     );
 
     let envelope = sink
@@ -110,7 +111,7 @@ fn injected_runtime_event_errors_when_persistence_fails() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store,
+        Arc::new(store),
     );
 
     let error = sink
@@ -140,7 +141,7 @@ fn assistant_completion_marker_closes_matching_open_message() {
         "codex".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store.clone(),
+        Arc::new(store.clone()),
     );
 
     sink.begin_turn("hello".to_string(), None, Vec::new(), None);
@@ -210,7 +211,7 @@ fn assistant_completion_marker_ignores_mismatched_message_id() {
         "codex".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store,
+        Arc::new(store),
     );
 
     sink.begin_turn("hello".to_string(), None, Vec::new(), None);
@@ -249,7 +250,7 @@ fn transient_status_marker_sets_transient_reasoning_and_replaces_text() {
         "codex".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store,
+        Arc::new(store),
     );
 
     sink.begin_turn("hello".to_string(), None, Vec::new(), None);
@@ -305,7 +306,7 @@ fn regular_thought_chunks_remain_non_transient_and_append() {
         "codex".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store,
+        Arc::new(store),
     );
 
     sink.begin_turn("hello".to_string(), None, Vec::new(), None);
@@ -343,7 +344,7 @@ fn plan_updates_reuse_the_same_plan_item_until_turn_end() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store.clone(),
+        Arc::new(store.clone()),
     );
 
     sink.begin_turn("plan this".to_string(), None, Vec::new(), None);
@@ -389,7 +390,7 @@ fn background_resolution_reuses_existing_tool_item_id() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store.clone(),
+        Arc::new(store.clone()),
     );
 
     sink.begin_turn("delegate".to_string(), None, Vec::new(), None);
@@ -485,7 +486,7 @@ fn async_launch_completion_preserves_background_metadata_on_completed_item() {
         "claude".to_string(),
         PathBuf::from("/tmp/workspace"),
         tx,
-        store,
+        Arc::new(store),
     );
 
     sink.begin_turn("delegate".to_string(), None, Vec::new(), None);


### PR DESCRIPTION
start_session(15 positional params) becomes start_session(launch:
SessionLaunch, hooks: SessionHooks). SessionLaunch is the complete
description (session record, resolved agent, workspace path, named
LaunchEnv layers - killing the four-adjacent-BTreeMap swap hazard - mcp
servers, startup strategy, prompt appends, resume seq); SessionHooks
carries the per-call powers (on_turn_finish, on_exit, latency).

Durable powers now cross as narrow capability traits defined in
live/sessions/model.rs and implemented by domains/sessions/live_ports.rs:
EventPersist, QueueDurable, BackgroundWorkDurable, SessionStateDurable,
AttachmentSource. ActorCapabilities bundles them with the PR-1 observers
and permission advisor, wired once at LiveSessionManager::new(caps) in
app/sessions.rs. SessionActorConfig shrinks to launch + caps + hooks +
channel wiring; the sink persists through Arc<dyn EventPersist>; the
replay actor takes state + event-persist capabilities instead of a
concrete store; emit_runtime_event keeps the two-writer offline-injection
lock discipline byte-for-byte, now against caps.events.

No concrete SessionStore/PromptAttachmentStorage usage remains in
live/sessions outside test code. Suite: 620 passed, 0 failed.

---
Part 4/10 of the live-sessions migration stack (see the stack overview in PR 1). Each PR is gated: full suite green, behavior-preserving except where the commit message states otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)