### PR TITLE
refactor(anyharness): replace latency threading with tracing spans

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/git.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/git.rs
@@ -23,7 +23,8 @@ use super::git_task::{run_git_task, GitTaskAccess};
 use crate::adapters::git::types::{CommitError, GitDiffScope as InternalGitDiffScope, PushError};
 use crate::adapters::git::GitService;
 use crate::app::AppState;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 // ---------------------------------------------------------------------------
 // Status
@@ -44,44 +45,37 @@ pub async fn get_git_status(
     headers: HeaderMap,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<GitStatusSnapshot>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    tracing::info!(
-        workspace_id = %workspace_id,
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] git.http.status.request_received"
-    );
-    let snapshot = run_git_task(
-        &state,
-        workspace_id.clone(),
-        GitTaskAccess::Read,
-        "git status",
-        |workspace_id, ws_path| {
-            GitService::status(&workspace_id, &ws_path)
-                .map(git_status_to_contract)
-                .map_err(|e| ApiError::bad_request(e.to_string(), "GIT_STATUS_FAILED"))
-        },
-    )
-    .await?;
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        tracing::info!(
+            workspace_id = %workspace_id,
+            "[anyharness-latency] git.http.status.request_received"
+        );
+        let snapshot = run_git_task(
+            &state,
+            workspace_id.clone(),
+            GitTaskAccess::Read,
+            "git status",
+            |workspace_id, ws_path| {
+                GitService::status(&workspace_id, &ws_path)
+                    .map(git_status_to_contract)
+                    .map_err(|e| ApiError::bad_request(e.to_string(), "GIT_STATUS_FAILED"))
+            },
+        )
+        .await?;
 
-    tracing::info!(
-        workspace_id = %workspace_id,
-        changed_files = snapshot.summary.changed_files,
-        included_files = snapshot.summary.included_files,
-        elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] git.http.status.response_ready"
-    );
-    Ok(Json(snapshot))
+        tracing::info!(
+            workspace_id = %workspace_id,
+            changed_files = snapshot.summary.changed_files,
+            included_files = snapshot.summary.included_files,
+            elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] git.http.status.response_ready"
+        );
+        Ok(Json(snapshot))
+    }
+    .instrument(span)
+    .await
 }
 
 // ---------------------------------------------------------------------------

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -24,7 +24,8 @@ use crate::domains::mobility::service::MobilityError;
 use crate::domains::workspaces::access_gate::WorkspaceAccessError;
 use crate::domains::workspaces::access_model::WorkspaceAccessMode;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 pub const MAX_MOBILITY_ARCHIVE_BODY_BYTES: usize =
     crate::domains::mobility::model::MAX_MOBILITY_ARCHIVE_BODY_BYTES;
@@ -44,43 +45,38 @@ pub async fn preflight_workspace_mobility(
     Path(workspace_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Json<WorkspaceMobilityPreflightResponse>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    tracing::info!(
-        session_id = tracing::field::Empty,
-        workspace_id = %workspace_id,
-        flow_id = ?latency_fields.flow_id,
-        flow_kind = ?latency_fields.flow_kind,
-        flow_source = ?latency_fields.flow_source,
-        prompt_id = ?latency_fields.prompt_id,
-        "[workspace-latency] mobility.http.preflight.request_received"
-    );
-    let _operation = state
-        .workspace_operation_gate
-        .acquire_shared(&workspace_id, WorkspaceOperationKind::MaterializationRead)
-        .await;
-    assert_workspace_not_retired(&state, &workspace_id)?;
-    let result = state
-        .mobility_service
-        .preflight_workspace(&workspace_id, &[])
-        .await
-        .map_err(map_mobility_error)?;
-    tracing::info!(
-        session_id = tracing::field::Empty,
-        workspace_id = %workspace_id,
-        can_move = result.can_move,
-        blocker_count = result.blockers.len(),
-        warning_count = result.warnings.len(),
-        archive_estimated_bytes = result.archive_estimated_bytes.unwrap_or_default(),
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        flow_id = ?latency_fields.flow_id,
-        flow_kind = ?latency_fields.flow_kind,
-        flow_source = ?latency_fields.flow_source,
-        prompt_id = ?latency_fields.prompt_id,
-        "[workspace-latency] mobility.http.preflight.completed"
-    );
-    Ok(Json(to_contract_preflight(result)))
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        tracing::info!(
+            session_id = tracing::field::Empty,
+            workspace_id = %workspace_id,
+            "[workspace-latency] mobility.http.preflight.request_received"
+        );
+        let _operation = state
+            .workspace_operation_gate
+            .acquire_shared(&workspace_id, WorkspaceOperationKind::MaterializationRead)
+            .await;
+        assert_workspace_not_retired(&state, &workspace_id)?;
+        let result = state
+            .mobility_service
+            .preflight_workspace(&workspace_id, &[])
+            .await
+            .map_err(map_mobility_error)?;
+        tracing::info!(
+            session_id = tracing::field::Empty,
+            workspace_id = %workspace_id,
+            can_move = result.can_move,
+            blocker_count = result.blockers.len(),
+            warning_count = result.warnings.len(),
+            archive_estimated_bytes = result.archive_estimated_bytes.unwrap_or_default(),
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "[workspace-latency] mobility.http.preflight.completed"
+        );
+        Ok(Json(to_contract_preflight(result)))
+    }
+    .instrument(span)
+    .await
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs
@@ -21,7 +21,8 @@ use crate::adapters::git::GitService;
 use crate::app::AppState;
 use crate::domains::repo_roots::model::RepoRootRecord;
 use crate::domains::workspaces::types::ResolveRepoRootError;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[utoipa::path(
     get,
@@ -33,52 +34,38 @@ pub async fn list_repo_roots(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<RepoRoot>>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    tracing::info!(
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] repo_root.http.list.request_received"
-    );
-    let repo_root_service = state.repo_root_service.clone();
-    let records_started = Instant::now();
-    let repo_roots = run_blocking("list repo roots", move || {
-        repo_root_service.list_repo_roots()
-    })
-    .await?
-    .map_err(|error| ApiError::internal(error.to_string()))?;
-    tracing::info!(
-        repo_root_count = repo_roots.len(),
-        elapsed_ms = records_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] repo_root.http.list.records_loaded"
-    );
-    let response_started = Instant::now();
-    let response = repo_roots
-        .into_iter()
-        .map(repo_root_to_contract)
-        .collect::<Vec<_>>();
-    tracing::info!(
-        repo_root_count = response.len(),
-        elapsed_ms = response_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] repo_root.http.list.response_built"
-    );
-    Ok(Json(response))
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        tracing::info!("[anyharness-latency] repo_root.http.list.request_received");
+        let repo_root_service = state.repo_root_service.clone();
+        let records_started = Instant::now();
+        let repo_roots = run_blocking("list repo roots", move || {
+            repo_root_service.list_repo_roots()
+        })
+        .await?
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+        tracing::info!(
+            repo_root_count = repo_roots.len(),
+            elapsed_ms = records_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] repo_root.http.list.records_loaded"
+        );
+        let response_started = Instant::now();
+        let response = repo_roots
+            .into_iter()
+            .map(repo_root_to_contract)
+            .collect::<Vec<_>>();
+        tracing::info!(
+            repo_root_count = response.len(),
+            elapsed_ms = response_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] repo_root.http.list.response_built"
+        );
+        Ok(Json(response))
+    }
+    .instrument(span)
+    .await
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions.rs
@@ -16,7 +16,8 @@ use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::sessions::mcp_bindings::summaries::validate_binding_summaries;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[derive(Debug, Deserialize)]
 pub struct ListSessionsQuery {
@@ -44,92 +45,86 @@ pub async fn create_session(
     headers: HeaderMap,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<Json<Session>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    let workspace_id = req.workspace_id.clone();
-    let agent_kind = req.agent_kind.clone();
-    let model_id = req.model_id.clone();
-    let mode_id = req.mode_id.clone();
-    let origin = request_origin_or_api_default(req.origin.clone(), "create_session");
-    assert_workspace_auth_scope(&auth, &workspace_id)?;
-    let runtime_inputs = if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
-        Some(
-            state
-                .runtime_config_service
-                .session_inputs_for_expected(expected)
-                .map_err(super::runtime_config::map_runtime_config_error)?,
-        )
-    } else {
-        None
-    };
-    let mcp_servers = runtime_inputs
-        .as_ref()
-        .map(|inputs| inputs.mcp_servers.clone())
-        .unwrap_or_default();
-    let mcp_binding_summaries = runtime_inputs
-        .as_ref()
-        .and_then(|inputs| inputs.mcp_binding_summaries.clone())
-        .filter(|summaries| !summaries.is_empty());
-    if let Some(summaries) = mcp_binding_summaries.as_deref() {
-        validate_binding_summaries(summaries)
-            .map_err(|error| ApiError::bad_request(error.to_string(), "INVALID_MCP_SUMMARY"))?;
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        let workspace_id = req.workspace_id.clone();
+        let agent_kind = req.agent_kind.clone();
+        let model_id = req.model_id.clone();
+        let mode_id = req.mode_id.clone();
+        let origin = request_origin_or_api_default(req.origin.clone(), "create_session");
+        assert_workspace_auth_scope(&auth, &workspace_id)?;
+        let runtime_inputs = if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
+            Some(
+                state
+                    .runtime_config_service
+                    .session_inputs_for_expected(expected)
+                    .map_err(super::runtime_config::map_runtime_config_error)?,
+            )
+        } else {
+            None
+        };
+        let mcp_servers = runtime_inputs
+            .as_ref()
+            .map(|inputs| inputs.mcp_servers.clone())
+            .unwrap_or_default();
+        let mcp_binding_summaries = runtime_inputs
+            .as_ref()
+            .and_then(|inputs| inputs.mcp_binding_summaries.clone())
+            .filter(|summaries| !summaries.is_empty());
+        if let Some(summaries) = mcp_binding_summaries.as_deref() {
+            validate_binding_summaries(summaries)
+                .map_err(|error| ApiError::bad_request(error.to_string(), "INVALID_MCP_SUMMARY"))?;
+        }
+        let system_prompt_append_count = req
+            .system_prompt_append
+            .as_ref()
+            .map(|entries| entries.len())
+            .unwrap_or(0);
+        let mcp_server_count = mcp_servers.len();
+        tracing::info!(
+            workspace_id = %workspace_id,
+            agent_kind = %agent_kind,
+            model_id = ?model_id,
+            mode_id = ?mode_id,
+            system_prompt_append_count,
+            mcp_server_count,
+            "[workspace-latency] session.http.create.request_received"
+        );
+        let _lease = state
+            .workspace_operation_gate
+            .acquire_shared(&workspace_id, WorkspaceOperationKind::SessionStart)
+            .await;
+        let record = state
+            .session_runtime
+            .create_and_start_session(
+                &workspace_id,
+                &agent_kind,
+                model_id.as_deref(),
+                mode_id.as_deref(),
+                req.system_prompt_append,
+                Vec::new(),
+                None,
+                req.expected_runtime_config_revision.clone(),
+                req.subagents_enabled.unwrap_or(true),
+                req.agent_auth_scope,
+                req.required_agent_auth_revision,
+                origin,
+            )
+            .await
+            .map_err(map_create_session_error)?;
+
+        tracing::info!(
+            workspace_id = %workspace_id,
+            session_id = %record.id,
+            elapsed_ms = started.elapsed().as_millis(),
+            "[workspace-latency] session.http.create.completed"
+        );
+
+        Ok(Json(session_to_contract(&state, &record).await?))
     }
-    let system_prompt_append_count = req
-        .system_prompt_append
-        .as_ref()
-        .map(|entries| entries.len())
-        .unwrap_or(0);
-    let mcp_server_count = mcp_servers.len();
-    tracing::info!(
-        workspace_id = %workspace_id,
-        agent_kind = %agent_kind,
-        model_id = ?model_id,
-        mode_id = ?mode_id,
-        system_prompt_append_count,
-        mcp_server_count,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.create.request_received"
-    );
-    let _lease = state
-        .workspace_operation_gate
-        .acquire_shared(&workspace_id, WorkspaceOperationKind::SessionStart)
-        .await;
-    let record = state
-        .session_runtime
-        .create_and_start_session(
-            &workspace_id,
-            &agent_kind,
-            model_id.as_deref(),
-            mode_id.as_deref(),
-            req.system_prompt_append,
-            Vec::new(),
-            None,
-            req.expected_runtime_config_revision.clone(),
-            req.subagents_enabled.unwrap_or(true),
-            req.agent_auth_scope,
-            req.required_agent_auth_revision,
-            origin,
-            latency.as_ref(),
-        )
-        .await
-        .map_err(map_create_session_error)?;
-
-    tracing::info!(
-        workspace_id = %workspace_id,
-        session_id = %record.id,
-        elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.create.completed"
-    );
-
-    Ok(Json(session_to_contract(&state, &record).await?))
+    .instrument(span)
+    .await
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_events.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_events.rs
@@ -12,7 +12,8 @@ use super::access::assert_session_auth_scope;
 use super::error::ApiError;
 use crate::api::auth::AuthContext;
 use crate::app::AppState;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[derive(Debug, Deserialize)]
 pub struct ListSessionEventsQuery {
@@ -49,99 +50,90 @@ pub async fn list_session_events(
     Query(query): Query<ListSessionEventsQuery>,
 ) -> Result<Json<Vec<SessionEventEnvelope>>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    let after_seq = query.after_seq.map(|seq| seq.max(0));
-    let before_seq = query.before_seq.map(|seq| seq.max(0));
-    let limit = query.limit.map(|limit| limit.clamp(1, 5_000));
-    let turn_limit = query.turn_limit.map(|turn_limit| turn_limit.clamp(1, 200));
-    let oldest_first = query.oldest_first.unwrap_or(false);
-    if is_unsupported_event_history_window(after_seq, before_seq, turn_limit) {
-        return Err(ApiError::bad_request(
-            "after_seq cannot be combined with before_seq or turn_limit",
-            "UNSUPPORTED_EVENT_HISTORY_WINDOW",
-        ));
-    }
-    tracing::debug!(
-        session_id = %session_id,
-        after_seq,
-        before_seq,
-        limit,
-        turn_limit,
-        oldest_first,
-        flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.events.start"
-    );
-    let event_records = state
-        .session_service
-        .list_session_event_records(
-            &session_id,
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        let after_seq = query.after_seq.map(|seq| seq.max(0));
+        let before_seq = query.before_seq.map(|seq| seq.max(0));
+        let limit = query.limit.map(|limit| limit.clamp(1, 5_000));
+        let turn_limit = query.turn_limit.map(|turn_limit| turn_limit.clamp(1, 200));
+        let oldest_first = query.oldest_first.unwrap_or(false);
+        if is_unsupported_event_history_window(after_seq, before_seq, turn_limit) {
+            return Err(ApiError::bad_request(
+                "after_seq cannot be combined with before_seq or turn_limit",
+                "UNSUPPORTED_EVENT_HISTORY_WINDOW",
+            ));
+        }
+        tracing::debug!(
+            session_id = %session_id,
             after_seq,
             before_seq,
             limit,
             turn_limit,
             oldest_first,
-        )
-        .map_err(|e| ApiError::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::not_found(
-                format!("Session not found: {session_id}"),
-                "SESSION_NOT_FOUND",
+            "[workspace-latency] session.http.events.start"
+        );
+        let event_records = state
+            .session_service
+            .list_session_event_records(
+                &session_id,
+                after_seq,
+                before_seq,
+                limit,
+                turn_limit,
+                oldest_first,
             )
-        })?;
+            .map_err(|e| ApiError::internal(e.to_string()))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    format!("Session not found: {session_id}"),
+                    "SESSION_NOT_FOUND",
+                )
+            })?;
 
-    let envelopes: Vec<SessionEventEnvelope> = event_records
-        .iter()
-        .filter_map(|r| {
-            let event = serde_json::from_str(&r.payload_json).ok()?;
-            Some(SessionEventEnvelope {
-                session_id: r.session_id.clone(),
-                seq: r.seq,
-                timestamp: r.timestamp.clone(),
-                turn_id: r.turn_id.clone(),
-                item_id: r.item_id.clone(),
-                event,
+        let envelopes: Vec<SessionEventEnvelope> = event_records
+            .iter()
+            .filter_map(|r| {
+                let event = serde_json::from_str(&r.payload_json).ok()?;
+                Some(SessionEventEnvelope {
+                    session_id: r.session_id.clone(),
+                    seq: r.seq,
+                    timestamp: r.timestamp.clone(),
+                    turn_id: r.turn_id.clone(),
+                    item_id: r.item_id.clone(),
+                    event,
+                })
             })
-        })
-        .collect();
+            .collect();
 
-    if envelopes.is_empty() {
-        tracing::debug!(
-            session_id = %session_id,
-            event_count = envelopes.len(),
-            after_seq,
-            before_seq,
-            limit,
-            turn_limit,
-            elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
-            "[workspace-latency] session.http.events.completed"
-        );
-    } else {
-        tracing::info!(
-            session_id = %session_id,
-            event_count = envelopes.len(),
-            after_seq,
-            before_seq,
-            limit,
-            turn_limit,
-            elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
-            "[workspace-latency] session.http.events.completed"
-        );
+        if envelopes.is_empty() {
+            tracing::debug!(
+                session_id = %session_id,
+                event_count = envelopes.len(),
+                after_seq,
+                before_seq,
+                limit,
+                turn_limit,
+                elapsed_ms = started.elapsed().as_millis(),
+                "[workspace-latency] session.http.events.completed"
+            );
+        } else {
+            tracing::info!(
+                session_id = %session_id,
+                event_count = envelopes.len(),
+                after_seq,
+                before_seq,
+                limit,
+                turn_limit,
+                elapsed_ms = started.elapsed().as_millis(),
+                "[workspace-latency] session.http.events.completed"
+            );
+        }
+
+        Ok(Json(envelopes))
     }
-
-    Ok(Json(envelopes))
+    .instrument(span)
+    .await
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_lifecycle.rs
@@ -14,7 +14,8 @@ use super::sessions_errors::map_session_lifecycle_error;
 use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[utoipa::path(
     post,
@@ -105,39 +106,34 @@ pub async fn restore_dismissed_session(
     Path(workspace_id): Path<String>,
 ) -> Result<Json<Option<Session>>, ApiError> {
     assert_workspace_auth_scope(&auth, &workspace_id)?;
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    tracing::info!(
-        workspace_id = %workspace_id,
-        flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.restore.request_received"
-    );
-    let _lease = state
-        .workspace_operation_gate
-        .acquire_shared(&workspace_id, WorkspaceOperationKind::SessionResume)
-        .await;
-    let restored = state
-        .session_runtime
-        .restore_dismissed_session(&workspace_id, latency.as_ref())
-        .await
-        .map_err(map_session_lifecycle_error)?;
-    tracing::info!(
-        workspace_id = %workspace_id,
-        restored = restored.is_some(),
-        elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] session.http.restore.completed"
-    );
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        tracing::info!(
+            workspace_id = %workspace_id,
+            "[workspace-latency] session.http.restore.request_received"
+        );
+        let _lease = state
+            .workspace_operation_gate
+            .acquire_shared(&workspace_id, WorkspaceOperationKind::SessionResume)
+            .await;
+        let restored = state
+            .session_runtime
+            .restore_dismissed_session(&workspace_id)
+            .await
+            .map_err(map_session_lifecycle_error)?;
+        tracing::info!(
+            workspace_id = %workspace_id,
+            restored = restored.is_some(),
+            elapsed_ms = started.elapsed().as_millis(),
+            "[workspace-latency] session.http.restore.completed"
+        );
 
-    match restored {
-        Some(record) => Ok(Json(Some(session_to_contract(&state, &record).await?))),
-        None => Ok(Json(None)),
+        match restored {
+            Some(record) => Ok(Json(Some(session_to_contract(&state, &record).await?))),
+            None => Ok(Json(None)),
+        }
     }
+    .instrument(span)
+    .await
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_prompt.rs
@@ -16,7 +16,8 @@ use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::sessions::runtime::SendPromptOutcome;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 const PROMPT_ID_MAX_BYTES: usize = 256;
 
@@ -39,64 +40,65 @@ pub async fn prompt_session(
     Json(req): Json<PromptSessionRequest>,
 ) -> Result<Json<PromptSessionResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let prompt_id = request_prompt_id(req.prompt_id.as_deref(), latency_fields.prompt_id)?;
-    let prompt_id_for_trace = prompt_id.clone();
-    let started = Instant::now();
-    tracing::info!(
-        session_id = %session_id,
-        block_count = req.blocks.len(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
+    let flow = FlowHeaders::from_headers(&headers);
+    let span = flow.span();
+    let prompt_id = request_prompt_id(req.prompt_id.as_deref(), flow.prompt_id.as_deref())?;
+    async move {
+        let prompt_id_for_trace = prompt_id.clone();
+        let started = Instant::now();
+        tracing::info!(
+            session_id = %session_id,
+            block_count = req.blocks.len(),
             prompt_id = prompt_id_for_trace.as_deref(),
-        "[workspace-latency] session.http.prompt.request_received"
-    );
+            "[workspace-latency] session.http.prompt.request_received"
+        );
 
-    let _lease =
-        acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
-            .await?;
-    if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
-        state
-            .runtime_config_service
-            .assert_session_context_matches(&session_id, expected)
-            .map_err(super::runtime_config::map_runtime_config_error)?;
+        let _lease = acquire_session_operation_lease(
+            &state,
+            &session_id,
+            WorkspaceOperationKind::SessionPrompt,
+        )
+        .await?;
+        if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
+            state
+                .runtime_config_service
+                .assert_session_context_matches(&session_id, expected)
+                .map_err(super::runtime_config::map_runtime_config_error)?;
+        }
+        let outcome = state
+            .session_runtime
+            .send_prompt(&session_id, req.blocks, prompt_id)
+            .await
+            .map_err(map_send_prompt_error)?;
+
+        tracing::info!(
+            session_id = %session_id,
+            elapsed_ms = started.elapsed().as_millis(),
+            prompt_id = prompt_id_for_trace.as_deref(),
+            "[workspace-latency] session.http.prompt.completed"
+        );
+
+        let (record, status, queued_seq) = match outcome {
+            SendPromptOutcome::Running { session, .. } => (
+                session,
+                anyharness_contract::v1::PromptSessionStatus::Running,
+                None,
+            ),
+            SendPromptOutcome::Queued { session, seq } => (
+                session,
+                anyharness_contract::v1::PromptSessionStatus::Queued,
+                Some(seq),
+            ),
+        };
+
+        Ok(Json(PromptSessionResponse {
+            session: session_to_contract(&state, &record).await?,
+            status,
+            queued_seq,
+        }))
     }
-    let outcome = state
-        .session_runtime
-        .send_prompt(&session_id, req.blocks, prompt_id, latency.as_ref())
-        .await
-        .map_err(map_send_prompt_error)?;
-
-    tracing::info!(
-        session_id = %session_id,
-        elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = prompt_id_for_trace.as_deref(),
-        "[workspace-latency] session.http.prompt.completed"
-    );
-
-    let (record, status, queued_seq) = match outcome {
-        SendPromptOutcome::Running { session, .. } => (
-            session,
-            anyharness_contract::v1::PromptSessionStatus::Running,
-            None,
-        ),
-        SendPromptOutcome::Queued { session, seq } => (
-            session,
-            anyharness_contract::v1::PromptSessionStatus::Queued,
-            Some(seq),
-        ),
-    };
-
-    Ok(Json(PromptSessionResponse {
-        session: session_to_contract(&state, &record).await?,
-        status,
-        queued_seq,
-    }))
+    .instrument(span)
+    .await
 }
 
 fn request_prompt_id(

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_resume.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_resume.rs
@@ -15,7 +15,8 @@ use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::sessions::runtime::SessionMcpRefresh;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
-use crate::observability::latency::LatencyRequestContext;
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[utoipa::path(
     post,
@@ -37,39 +38,46 @@ pub async fn resume_session(
     body: Bytes,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
-    let latency = LatencyRequestContext::from_headers(&headers);
+    let span = FlowHeaders::from_headers(&headers).span();
     let req = parse_optional_resume_request(body)?;
-    let has_live_session = state.session_runtime.has_live_session(&session_id).await;
-    if req.expected_runtime_config_revision.is_some() && has_live_session {
-        return Err(ApiError::conflict(
-            "runtime config changes require restarting the session",
-            "RUNTIME_CONFIG_RESUME_UNSUPPORTED",
-        ));
-    }
-    if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
-        state
-            .runtime_config_service
-            .assert_session_context_matches(&session_id, expected)
-            .map_err(super::runtime_config::map_runtime_config_error)?;
-    }
-    let mcp_refresh = if has_live_session {
-        None
-    } else {
-        Some(SessionMcpRefresh {
-            mcp_servers: Vec::new(),
-            mcp_binding_summaries: None,
-        })
-    };
-    let _lease =
-        acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionResume)
-            .await?;
-    let updated = state
-        .session_runtime
-        .ensure_live_session(&session_id, mcp_refresh, latency.as_ref())
-        .await
-        .map_err(map_ensure_live_session_error)?;
+    async move {
+        let has_live_session = state.session_runtime.has_live_session(&session_id).await;
+        if req.expected_runtime_config_revision.is_some() && has_live_session {
+            return Err(ApiError::conflict(
+                "runtime config changes require restarting the session",
+                "RUNTIME_CONFIG_RESUME_UNSUPPORTED",
+            ));
+        }
+        if let Some(expected) = req.expected_runtime_config_revision.as_ref() {
+            state
+                .runtime_config_service
+                .assert_session_context_matches(&session_id, expected)
+                .map_err(super::runtime_config::map_runtime_config_error)?;
+        }
+        let mcp_refresh = if has_live_session {
+            None
+        } else {
+            Some(SessionMcpRefresh {
+                mcp_servers: Vec::new(),
+                mcp_binding_summaries: None,
+            })
+        };
+        let _lease = acquire_session_operation_lease(
+            &state,
+            &session_id,
+            WorkspaceOperationKind::SessionResume,
+        )
+        .await?;
+        let updated = state
+            .session_runtime
+            .ensure_live_session(&session_id, mcp_refresh)
+            .await
+            .map_err(map_ensure_live_session_error)?;
 
-    Ok(Json(session_to_contract(&state, &updated).await?))
+        Ok(Json(session_to_contract(&state, &updated).await?))
+    }
+    .instrument(span)
+    .await
 }
 
 fn parse_optional_resume_request(body: Bytes) -> Result<ResumeSessionRequest, ApiError> {

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces.rs
@@ -22,7 +22,8 @@ use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::sessions::execution_summary::idle_workspace_execution_summary;
 use crate::domains::workspaces::creator_context::WorkspaceCreatorContext;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[utoipa::path(
     post,
@@ -105,85 +106,66 @@ pub async fn list_workspaces(
     Extension(auth): Extension<AuthContext>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<Workspace>>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    tracing::info!(
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] workspace.http.list.request_received"
-    );
-    let workspace_runtime = state.workspace_runtime.clone();
-    let records_started = Instant::now();
-    let records = run_blocking("list", move || workspace_runtime.list_workspaces())
-        .await?
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    tracing::info!(
-        workspace_count = records.len(),
-        elapsed_ms = records_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] workspace.http.list.records_loaded"
-    );
-    let summaries_started = Instant::now();
-    let summaries = state
-        .session_runtime
-        .workspace_execution_summaries()
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
-    tracing::info!(
-        summary_count = summaries.len(),
-        elapsed_ms = summaries_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] workspace.http.list.execution_summaries_loaded"
-    );
-    let response_started = Instant::now();
-    let scoped_workspace_id = match &auth {
-        AuthContext::UserClaim(claim) => Some(claim.anyharness_workspace_id.as_str()),
-        _ => None,
-    };
-    let response = records
-        .into_iter()
-        .filter(|record| {
-            scoped_workspace_id
-                .map(|workspace_id| record.id == workspace_id)
-                .unwrap_or(true)
-        })
-        .map(|record| {
-            let workspace_id = record.id.clone();
-            workspace_to_contract_with_summary(
-                record,
-                summaries
-                    .get(&workspace_id)
-                    .cloned()
-                    .unwrap_or_else(idle_workspace_execution_summary),
-            )
-        })
-        .collect::<Vec<_>>();
-    tracing::info!(
-        workspace_count = response.len(),
-        elapsed_ms = response_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] workspace.http.list.response_built"
-    );
-    Ok(Json(response))
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        tracing::info!("[anyharness-latency] workspace.http.list.request_received");
+        let workspace_runtime = state.workspace_runtime.clone();
+        let records_started = Instant::now();
+        let records = run_blocking("list", move || workspace_runtime.list_workspaces())
+            .await?
+            .map_err(|e| ApiError::internal(e.to_string()))?;
+        tracing::info!(
+            workspace_count = records.len(),
+            elapsed_ms = records_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] workspace.http.list.records_loaded"
+        );
+        let summaries_started = Instant::now();
+        let summaries = state
+            .session_runtime
+            .workspace_execution_summaries()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+        tracing::info!(
+            summary_count = summaries.len(),
+            elapsed_ms = summaries_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] workspace.http.list.execution_summaries_loaded"
+        );
+        let response_started = Instant::now();
+        let scoped_workspace_id = match &auth {
+            AuthContext::UserClaim(claim) => Some(claim.anyharness_workspace_id.as_str()),
+            _ => None,
+        };
+        let response = records
+            .into_iter()
+            .filter(|record| {
+                scoped_workspace_id
+                    .map(|workspace_id| record.id == workspace_id)
+                    .unwrap_or(true)
+            })
+            .map(|record| {
+                let workspace_id = record.id.clone();
+                workspace_to_contract_with_summary(
+                    record,
+                    summaries
+                        .get(&workspace_id)
+                        .cloned()
+                        .unwrap_or_else(idle_workspace_execution_summary),
+                )
+            })
+            .collect::<Vec<_>>();
+        tracing::info!(
+            workspace_count = response.len(),
+            elapsed_ms = response_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] workspace.http.list.response_built"
+        );
+        Ok(Json(response))
+    }
+    .instrument(span)
+    .await
 }
 
 #[utoipa::path(

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_worktrees.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_worktrees.rs
@@ -18,7 +18,8 @@ use crate::domains::workspaces::worktree_names::WorktreeNameConflictPolicy;
 use crate::domains::workspaces::worktree_runtime::{
     CreateWorktreeWorkflowError, CreateWorktreeWorkflowInput,
 };
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
+use tracing::Instrument;
 
 #[utoipa::path(
     post,
@@ -36,80 +37,75 @@ pub async fn create_worktree(
     headers: HeaderMap,
     Json(req): Json<CreateWorktreeWorkspaceRequest>,
 ) -> Result<Json<CreateWorktreeWorkspaceResponse>, ApiError> {
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    let repo_root_id = req.repo_root_id;
-    let target_path = req.target_path;
-    let new_branch_name = req.new_branch_name;
-    let checkout_mode = req
-        .checkout_mode
-        .map(worktree_checkout_mode_from_contract)
-        .unwrap_or_default();
-    let name_conflict_policy = req
-        .name_conflict_policy
-        .map(worktree_name_conflict_policy_from_contract)
-        .unwrap_or_default();
-    let base_branch = req.base_branch.clone();
-    let setup_script = req.setup_script;
-    let origin = request_origin_or_api_default(req.origin, "create_worktree");
-    let creator_context = req
-        .creator_context
-        .map(WorkspaceCreatorContext::from_contract);
-    let has_setup_script = setup_script
-        .as_deref()
-        .map(str::trim)
-        .map(|script| !script.is_empty())
-        .unwrap_or(false);
-    tracing::info!(
-        repo_root_id = %repo_root_id,
-        has_setup_script,
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] workspace.http.worktree.request_received"
-    );
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        let repo_root_id = req.repo_root_id;
+        let target_path = req.target_path;
+        let new_branch_name = req.new_branch_name;
+        let checkout_mode = req
+            .checkout_mode
+            .map(worktree_checkout_mode_from_contract)
+            .unwrap_or_default();
+        let name_conflict_policy = req
+            .name_conflict_policy
+            .map(worktree_name_conflict_policy_from_contract)
+            .unwrap_or_default();
+        let base_branch = req.base_branch.clone();
+        let setup_script = req.setup_script;
+        let origin = request_origin_or_api_default(req.origin, "create_worktree");
+        let creator_context = req
+            .creator_context
+            .map(WorkspaceCreatorContext::from_contract);
+        let has_setup_script = setup_script
+            .as_deref()
+            .map(str::trim)
+            .map(|script| !script.is_empty())
+            .unwrap_or(false);
+        tracing::info!(
+            repo_root_id = %repo_root_id,
+            has_setup_script,
+            "[workspace-latency] workspace.http.worktree.request_received"
+        );
 
-    state
-        .workspace_access_gate
-        .assert_can_mutate_for_repo_root(&repo_root_id)
-        .map_err(map_access_error)?;
+        state
+            .workspace_access_gate
+            .assert_can_mutate_for_repo_root(&repo_root_id)
+            .map_err(map_access_error)?;
 
-    let result = state
-        .workspace_worktree_runtime
-        .create_worktree(CreateWorktreeWorkflowInput {
-            repo_root_id: repo_root_id.clone(),
-            target_path,
-            new_branch_name,
-            base_branch: base_branch.clone(),
-            checkout_mode,
-            setup_script,
-            surface: "standard".to_string(),
-            name_conflict_policy,
-            origin,
-            creator_context,
-        })
-        .await
-        .map_err(map_create_worktree_error)?;
+        let result = state
+            .workspace_worktree_runtime
+            .create_worktree(CreateWorktreeWorkflowInput {
+                repo_root_id: repo_root_id.clone(),
+                target_path,
+                new_branch_name,
+                base_branch: base_branch.clone(),
+                checkout_mode,
+                setup_script,
+                surface: "standard".to_string(),
+                name_conflict_policy,
+                origin,
+                creator_context,
+            })
+            .await
+            .map_err(map_create_worktree_error)?;
 
-    tracing::info!(
-        workspace_id = %result.worktree.workspace.id,
-        repo_root_id = %repo_root_id,
-        has_setup_script,
-        setup_started = result.setup_started,
-        elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        "[workspace-latency] workspace.http.worktree.completed"
-    );
+        tracing::info!(
+            workspace_id = %result.worktree.workspace.id,
+            repo_root_id = %repo_root_id,
+            has_setup_script,
+            setup_started = result.setup_started,
+            elapsed_ms = started.elapsed().as_millis(),
+            "[workspace-latency] workspace.http.worktree.completed"
+        );
 
-    Ok(Json(CreateWorktreeWorkspaceResponse {
-        workspace: workspace_to_contract(&state, result.worktree.workspace).await?,
-        setup_script: None,
-    }))
+        Ok(Json(CreateWorktreeWorkspaceResponse {
+            workspace: workspace_to_contract(&state, result.worktree.workspace).await?,
+            setup_script: None,
+        }))
+    }
+    .instrument(span)
+    .await
 }
 
 fn worktree_checkout_mode_from_contract(

--- a/anyharness/crates/anyharness-lib/src/api/sse/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/sse/sessions.rs
@@ -15,8 +15,9 @@ use tokio_stream::wrappers::BroadcastStream;
 use crate::api::http::error::ApiError;
 use crate::api::{auth::AuthContext, http::access::assert_session_auth_scope};
 use crate::app::AppState;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
+use crate::observability::latency::FlowHeaders;
 use anyharness_contract::v1::{SessionEvent, SessionEventEnvelope};
+use tracing::Instrument;
 
 const LIVE_HANDLE_ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
 const LIVE_HANDLE_ATTACH_INTERVAL: Duration = Duration::from_millis(100);
@@ -44,184 +45,162 @@ pub async fn stream_session(
     Query(query): Query<StreamSessionQuery>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
-    let latency = LatencyRequestContext::from_headers(&headers);
-    let latency_fields = latency_trace_fields(latency.as_ref());
-    let started = Instant::now();
-    let after_seq = query.after_seq.unwrap_or(0).max(0);
-    tracing::info!(
-        session_id = %session_id,
-        after_seq,
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[workspace-latency] session.sse.request_received"
-    );
-    let session_record = state
-        .session_service
-        .get_session(&session_id)
-        .map_err(|e| ApiError::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::not_found(
-                format!("Session not found: {session_id}"),
-                "SESSION_NOT_FOUND",
-            )
-        })?;
-    let acp_manager = state.acp_manager.clone();
-    let live_handle_started = Instant::now();
-    let live_handle = acp_manager.get_handle(&session_id).await;
-    let live_rx = live_handle.as_ref().map(|handle| handle.subscribe());
-    tracing::info!(
-        session_id = %session_id,
-        has_live_handle = live_handle.is_some(),
-        elapsed_ms = live_handle_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] session.sse.live_handle_checked"
-    );
-
-    let backlog_query_started = Instant::now();
-    let backlog_records = state
-        .session_service
-        .list_session_event_records(&session_id, Some(after_seq), None, None, None, false)
-        .map_err(|e| ApiError::internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::not_found(
-                format!("Session not found: {session_id}"),
-                "SESSION_NOT_FOUND",
-            )
-        })?;
-    tracing::info!(
-        session_id = %session_id,
-        after_seq,
-        backlog_record_count = backlog_records.len(),
-        elapsed_ms = backlog_query_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] session.sse.backlog_records_loaded"
-    );
-
-    let backlog_map_started = Instant::now();
-    let backlog = backlog_records
-        .into_iter()
-        .filter_map(event_record_to_envelope)
-        .collect::<Vec<_>>();
-    tracing::info!(
-        session_id = %session_id,
-        after_seq,
-        backlog_count = backlog.len(),
-        elapsed_ms = backlog_map_started.elapsed().as_millis(),
-        total_elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[anyharness-latency] session.sse.backlog_mapped"
-    );
-    tracing::info!(
-        session_id = %session_id,
-        after_seq,
-        backlog_count = backlog.len(),
-        has_live_handle = live_handle.is_some(),
-        session_status = %session_record.status,
-        elapsed_ms = started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
-        measurement_operation_id = latency_fields.measurement_operation_id,
-        "[workspace-latency] session.sse.open"
-    );
-    let max_sent_seq = Arc::new(AtomicI64::new(
-        backlog.last().map(|env| env.seq).unwrap_or(after_seq),
-    ));
-    let backlog_stream = stream::iter(backlog.into_iter().filter_map(envelope_to_event));
-
-    let live_stream: BoxStream<'static, Result<Event, Infallible>> = if let Some(rx) = live_rx {
-        live_receiver_stream(rx, max_sent_seq.clone())
-    } else if should_wait_for_live_handle_attach(&session_record.status) {
-        let session_service = state.session_service.clone();
+    let span = FlowHeaders::from_headers(&headers).span();
+    async move {
+        let started = Instant::now();
+        let after_seq = query.after_seq.unwrap_or(0).max(0);
         tracing::info!(
             session_id = %session_id,
             after_seq,
-            session_status = %session_record.status,
-            timeout_ms = LIVE_HANDLE_ATTACH_TIMEOUT.as_millis(),
-            "[workspace-latency] session.sse.await_live_handle.start"
+            "[workspace-latency] session.sse.request_received"
         );
-        stream::once(wait_for_live_receiver(acp_manager, session_id.clone()))
-            .flat_map(move |rx| {
-                let Some(rx) = rx else {
-                    return stream::empty().boxed();
-                };
-                let after_seq = max_sent_seq.load(Ordering::Acquire);
-                let replay_started = Instant::now();
-                let replay = match session_service.list_session_event_records(
-                    &session_id,
-                    Some(after_seq),
-                    None,
-                    None,
-                    None,
-                    false,
-                ) {
-                    Ok(Some(records)) => records
-                        .into_iter()
-                        .filter_map(event_record_to_envelope)
-                        .collect::<Vec<_>>(),
-                    Ok(None) => Vec::new(),
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %error,
-                            "[workspace-latency] session.sse.await_live_handle.replay_failed"
-                        );
-                        Vec::new()
-                    }
-                };
-                tracing::info!(
-                    session_id = %session_id,
-                    after_seq,
-                    replay_count = replay.len(),
-                    elapsed_ms = replay_started.elapsed().as_millis(),
-                    "[workspace-latency] session.sse.await_live_handle.replay"
-                );
-                let replay_stream = stream::iter(replay.into_iter().filter_map({
-                    let max_sent_seq = max_sent_seq.clone();
-                    move |envelope| {
-                        let last_sent = max_sent_seq.load(Ordering::Acquire);
-                        if envelope.seq <= last_sent {
-                            return None;
+        let session_record = state
+            .session_service
+            .get_session(&session_id)
+            .map_err(|e| ApiError::internal(e.to_string()))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    format!("Session not found: {session_id}"),
+                    "SESSION_NOT_FOUND",
+                )
+            })?;
+        let acp_manager = state.acp_manager.clone();
+        let live_handle_started = Instant::now();
+        let live_handle = acp_manager.get_handle(&session_id).await;
+        let live_rx = live_handle.as_ref().map(|handle| handle.subscribe());
+        tracing::info!(
+            session_id = %session_id,
+            has_live_handle = live_handle.is_some(),
+            elapsed_ms = live_handle_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] session.sse.live_handle_checked"
+        );
+
+        let backlog_query_started = Instant::now();
+        let backlog_records = state
+            .session_service
+            .list_session_event_records(&session_id, Some(after_seq), None, None, None, false)
+            .map_err(|e| ApiError::internal(e.to_string()))?
+            .ok_or_else(|| {
+                ApiError::not_found(
+                    format!("Session not found: {session_id}"),
+                    "SESSION_NOT_FOUND",
+                )
+            })?;
+        tracing::info!(
+            session_id = %session_id,
+            after_seq,
+            backlog_record_count = backlog_records.len(),
+            elapsed_ms = backlog_query_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] session.sse.backlog_records_loaded"
+        );
+
+        let backlog_map_started = Instant::now();
+        let backlog = backlog_records
+            .into_iter()
+            .filter_map(event_record_to_envelope)
+            .collect::<Vec<_>>();
+        tracing::info!(
+            session_id = %session_id,
+            after_seq,
+            backlog_count = backlog.len(),
+            elapsed_ms = backlog_map_started.elapsed().as_millis(),
+            total_elapsed_ms = started.elapsed().as_millis(),
+            "[anyharness-latency] session.sse.backlog_mapped"
+        );
+        tracing::info!(
+            session_id = %session_id,
+            after_seq,
+            backlog_count = backlog.len(),
+            has_live_handle = live_handle.is_some(),
+            session_status = %session_record.status,
+            elapsed_ms = started.elapsed().as_millis(),
+            "[workspace-latency] session.sse.open"
+        );
+        let max_sent_seq = Arc::new(AtomicI64::new(
+            backlog.last().map(|env| env.seq).unwrap_or(after_seq),
+        ));
+        let backlog_stream = stream::iter(backlog.into_iter().filter_map(envelope_to_event));
+
+        let live_stream: BoxStream<'static, Result<Event, Infallible>> = if let Some(rx) = live_rx {
+            live_receiver_stream(rx, max_sent_seq.clone())
+        } else if should_wait_for_live_handle_attach(&session_record.status) {
+            let session_service = state.session_service.clone();
+            tracing::info!(
+                session_id = %session_id,
+                after_seq,
+                session_status = %session_record.status,
+                timeout_ms = LIVE_HANDLE_ATTACH_TIMEOUT.as_millis(),
+                "[workspace-latency] session.sse.await_live_handle.start"
+            );
+            stream::once(wait_for_live_receiver(acp_manager, session_id.clone()))
+                .flat_map(move |rx| {
+                    let Some(rx) = rx else {
+                        return stream::empty().boxed();
+                    };
+                    let after_seq = max_sent_seq.load(Ordering::Acquire);
+                    let replay_started = Instant::now();
+                    let replay = match session_service.list_session_event_records(
+                        &session_id,
+                        Some(after_seq),
+                        None,
+                        None,
+                        None,
+                        false,
+                    ) {
+                        Ok(Some(records)) => records
+                            .into_iter()
+                            .filter_map(event_record_to_envelope)
+                            .collect::<Vec<_>>(),
+                        Ok(None) => Vec::new(),
+                        Err(error) => {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %error,
+                                "[workspace-latency] session.sse.await_live_handle.replay_failed"
+                            );
+                            Vec::new()
                         }
-                        max_sent_seq.store(envelope.seq, Ordering::Release);
-                        envelope_to_event(envelope)
-                    }
-                }));
-                replay_stream
-                    .chain(live_receiver_stream(rx, max_sent_seq.clone()))
-                    .boxed()
-            })
-            .boxed()
-    } else {
-        tracing::info!(
-            session_id = %session_id,
-            after_seq,
-            session_status = %session_record.status,
-            "[workspace-latency] session.sse.await_live_handle.skipped"
-        );
-        stream::empty().boxed()
-    };
-    let stream = backlog_stream.chain(live_stream).boxed();
+                    };
+                    tracing::info!(
+                        session_id = %session_id,
+                        after_seq,
+                        replay_count = replay.len(),
+                        elapsed_ms = replay_started.elapsed().as_millis(),
+                        "[workspace-latency] session.sse.await_live_handle.replay"
+                    );
+                    let replay_stream = stream::iter(replay.into_iter().filter_map({
+                        let max_sent_seq = max_sent_seq.clone();
+                        move |envelope| {
+                            let last_sent = max_sent_seq.load(Ordering::Acquire);
+                            if envelope.seq <= last_sent {
+                                return None;
+                            }
+                            max_sent_seq.store(envelope.seq, Ordering::Release);
+                            envelope_to_event(envelope)
+                        }
+                    }));
+                    replay_stream
+                        .chain(live_receiver_stream(rx, max_sent_seq.clone()))
+                        .boxed()
+                })
+                .boxed()
+        } else {
+            tracing::info!(
+                session_id = %session_id,
+                after_seq,
+                session_status = %session_record.status,
+                "[workspace-latency] session.sse.await_live_handle.skipped"
+            );
+            stream::empty().boxed()
+        };
+        let stream = backlog_stream.chain(live_stream).boxed();
 
-    Ok(Sse::new(stream))
+        Ok(Sse::new(stream))
+    }
+    .instrument(span)
+    .await
 }
 
 async fn wait_for_live_receiver(

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
@@ -590,7 +590,7 @@ impl CoworkRuntime {
                 "[workspace-latency] cowork.runtime.create_thread.live_start.start"
             );
             match session_runtime
-                .start_persisted_session(&session_for_start, None)
+                .start_persisted_session(&session_for_start)
                 .await
             {
                 Ok(started) => {
@@ -912,11 +912,7 @@ impl CoworkRuntime {
                 }
             }
         }
-        let started = match self
-            .session_runtime
-            .start_persisted_session(&session, None)
-            .await
-        {
+        let started = match self.session_runtime.start_persisted_session(&session).await {
             Ok(started) => started,
             Err(error) => {
                 if input.wake_on_completion {

--- a/anyharness/crates/anyharness-lib/src/domains/plans/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plans/runtime.rs
@@ -187,7 +187,6 @@ impl PlanRuntime {
                     None,
                     None,
                     origin,
-                    None,
                 )
                 .await
                 .map_err(HandoffPlanError::CreateSession)?;
@@ -211,7 +210,6 @@ impl PlanRuntime {
             .send_prompt(
                 &target_session_id,
                 vec![PromptInputBlock::Text { text: prompt }],
-                None,
                 None,
             )
             .await

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs
@@ -156,11 +156,7 @@ impl ReviewRuntime {
                 return Err(error);
             }
         };
-        let started = match self
-            .session_runtime
-            .start_persisted_session(&child, None)
-            .await
-        {
+        let started = match self.session_runtime.start_persisted_session(&child).await {
             Ok(started) => started,
             Err(error) => {
                 let detail = format!("{error:?}");
@@ -269,7 +265,6 @@ impl ReviewRuntime {
                                 snapshot_hash: snapshot_hash.to_string(),
                             },
                         ],
-                        None,
                         None,
                     )
                     .await

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
@@ -41,7 +41,7 @@ impl SessionRuntime {
         // Config mutations go through the live ACP actor. If the actor is not
         // running yet, start or resume it and return its control handle.
         let handle = self
-            .ensure_live_session_handle(&record, None, None)
+            .ensure_live_session_handle(&record, None)
             .await
             .map_err(|error| match error {
                 StartSessionError::WorkspaceNotFound => SetSessionConfigOptionError::Internal(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
@@ -11,12 +11,12 @@ use crate::domains::sessions::mcp_bindings::summaries::{
     serialize_binding_summaries, SessionMcpSummaryError,
 };
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::origin::OriginContext;
 
 use super::{CreateAndStartSessionError, SessionRuntime};
 
 impl SessionRuntime {
+    #[tracing::instrument(skip_all, fields(workspace_id = %workspace_id, agent_kind = %agent_kind))]
     pub async fn create_and_start_session(
         &self,
         workspace_id: &str,
@@ -31,13 +31,11 @@ impl SessionRuntime {
         agent_auth_scope: Option<AgentAuthExternalScope>,
         required_agent_auth_revision: Option<i64>,
         origin: OriginContext,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<SessionRecord, CreateAndStartSessionError> {
         self.access_gate
             .assert_can_mutate_for_workspace(workspace_id)
             .map_err(|error| CreateAndStartSessionError::Invalid(error.to_string()))?;
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
         let system_prompt_append_count = system_prompt_append
             .as_ref()
             .map(|entries| entries.len())
@@ -48,10 +46,6 @@ impl SessionRuntime {
             model_id = ?model_id,
             mode_id = ?mode_id,
             system_prompt_append_count,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.create_and_start.start"
         );
         let durable_create_started = Instant::now();
@@ -78,22 +72,14 @@ impl SessionRuntime {
             workspace_id = %workspace_id,
             session_id = %record.id,
             elapsed_ms = durable_create_started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.durable_session_created"
         );
-        record = self.start_persisted_session(&record, latency).await?;
+        record = self.start_persisted_session(&record).await?;
         tracing::info!(
             workspace_id = %workspace_id,
             session_id = %record.id,
             native_session_id = %record.native_session_id.as_deref().unwrap_or_default(),
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.create_and_start.completed"
         );
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
@@ -41,7 +41,7 @@ impl SessionRuntime {
         validate_fork_parent(&parent, &self.session_link_service)?;
 
         let handle = self
-            .ensure_live_session_handle(&parent, None, None)
+            .ensure_live_session_handle(&parent, None)
             .await
             .map_err(map_start_error_to_fork)?;
         let parent = self
@@ -179,12 +179,7 @@ impl SessionRuntime {
         };
 
         match self
-            .start_live_session(
-                &child,
-                startup_strategy,
-                child.system_prompt_append.clone(),
-                None,
-            )
+            .start_live_session(&child, startup_strategy, child.system_prompt_append.clone())
             .await
         {
             Ok((_handle, native_session_id)) => {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
@@ -9,7 +9,6 @@ use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 use super::{SessionLifecycleError, SessionRuntime};
 
@@ -200,22 +199,17 @@ impl SessionRuntime {
             .ok_or_else(|| SessionLifecycleError::SessionNotFound(session_id.to_string()))
     }
 
+    #[tracing::instrument(skip_all, fields(workspace_id = %workspace_id))]
     pub async fn restore_dismissed_session(
         &self,
         workspace_id: &str,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<Option<SessionRecord>, SessionLifecycleError> {
         self.access_gate
             .assert_can_mutate_for_workspace(workspace_id)
             .map_err(|error| SessionLifecycleError::Internal(anyhow::anyhow!(error.to_string())))?;
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
         tracing::info!(
             workspace_id = %workspace_id,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.restore.start"
         );
         let now = chrono::Utc::now().to_rfc3339();
@@ -228,10 +222,6 @@ impl SessionRuntime {
             tracing::info!(
                 workspace_id = %workspace_id,
                 elapsed_ms = started.elapsed().as_millis(),
-                flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
                 "[workspace-latency] session.runtime.restore.empty"
             );
             return Ok(None);
@@ -241,20 +231,12 @@ impl SessionRuntime {
             session_id = %restored.id,
             workspace_id = %workspace_id,
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.restore.dismissed_cleared"
         );
         tracing::info!(
             session_id = %restored.id,
             workspace_id = %workspace_id,
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.restore.completed"
         );
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
@@ -31,7 +31,7 @@ impl SessionRuntime {
                 }
             })?;
         let handle = self
-            .ensure_live_session_handle(&record, None, None)
+            .ensure_live_session_handle(&record, None)
             .await
             .map_err(|error| {
                 PendingPromptMutationError::Internal(anyhow::anyhow!(
@@ -116,7 +116,7 @@ impl SessionRuntime {
                 }
             })?;
         let handle = self
-            .ensure_live_session_handle(&record, None, None)
+            .ensure_live_session_handle(&record, None)
             .await
             .map_err(|error| {
                 PendingPromptMutationError::Internal(anyhow::anyhow!(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -9,19 +9,18 @@ use crate::domains::sessions::prompt::prepare::prepare_prompt;
 use crate::domains::sessions::prompt::provenance::PromptProvenance;
 use crate::domains::sessions::prompt::PromptPrepareContext;
 use crate::live::sessions::{LiveSessionCommandError, PromptAcceptError, PromptAcceptance};
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 use super::{
     SendPromptError, SendPromptOutcome, SessionLifecycleError, SessionRuntime, StartSessionError,
 };
 
 impl SessionRuntime {
+    #[tracing::instrument(skip_all, fields(session_id = %session_id))]
     pub async fn send_prompt(
         &self,
         session_id: &str,
         blocks: Vec<PromptInputBlock>,
         prompt_id: Option<String>,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<SendPromptOutcome, SendPromptError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
@@ -30,14 +29,9 @@ impl SessionRuntime {
             return Err(SendPromptError::EmptyPrompt);
         }
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
-        let prompt_id = prompt_id.or_else(|| latency_fields.prompt_id.map(|s| s.to_string()));
         let prompt_id_for_trace = prompt_id.clone();
         tracing::info!(
             session_id = %session_id,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
             prompt_id = prompt_id_for_trace.as_deref(),
             "[workspace-latency] session.runtime.prompt.request_received"
         );
@@ -48,7 +42,7 @@ impl SessionRuntime {
 
         let ensure_started = Instant::now();
         let handle = self
-            .ensure_live_session_handle(&record, None, latency)
+            .ensure_live_session_handle(&record, None)
             .await
             .map_err(map_start_error_to_prompt)?;
         let live_config = self
@@ -78,9 +72,6 @@ impl SessionRuntime {
             session_id = %session_id,
             elapsed_ms = ensure_started.elapsed().as_millis(),
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
             prompt_id = prompt_id_for_trace.as_deref(),
             "[workspace-latency] session.runtime.prompt.live_handle_ready"
         );
@@ -89,7 +80,7 @@ impl SessionRuntime {
         // The runtime no longer precaptures `busy`; it just forwards the command
         // and awaits the actor's decision (Started vs Queued).
         let acceptance = handle
-            .send_prompt(prepared.payload.clone(), prompt_id, latency.cloned())
+            .send_prompt(prepared.payload.clone(), prompt_id)
             .await
             .map_err(|error| match error {
                 LiveSessionCommandError::ActorUnavailable => {
@@ -110,9 +101,6 @@ impl SessionRuntime {
         tracing::info!(
             session_id = %session_id,
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
             prompt_id = prompt_id_for_trace.as_deref(),
             "[workspace-latency] session.runtime.prompt.command_sent"
         );
@@ -120,9 +108,6 @@ impl SessionRuntime {
         tracing::info!(
             session_id = %session_id,
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
             prompt_id = prompt_id_for_trace.as_deref(),
             "[workspace-latency] session.runtime.prompt.actor_accepted"
         );
@@ -157,28 +142,25 @@ impl SessionRuntime {
             .get_session_or_not_found(session_id)
             .map_err(map_lifecycle_error_to_prompt)?;
         let handle = self
-            .ensure_live_session_handle(&record, None, None)
+            .ensure_live_session_handle(&record, None)
             .await
             .map_err(map_start_error_to_prompt)?;
         let payload =
             crate::domains::sessions::prompt::PromptPayload::text(text).with_provenance(provenance);
-        let acceptance =
-            handle
-                .send_prompt(payload, None, None)
-                .await
-                .map_err(|error| match error {
-                    LiveSessionCommandError::ActorUnavailable => {
-                        SendPromptError::Internal(anyhow::anyhow!("session actor channel closed"))
-                    }
-                    LiveSessionCommandError::ResponseDropped => {
-                        SendPromptError::Internal(anyhow::anyhow!("session actor dropped response"))
-                    }
-                    LiveSessionCommandError::Rejected(PromptAcceptError::EnqueueFailed(detail)) => {
-                        SendPromptError::Internal(anyhow::anyhow!(
-                            "failed to enqueue prompt: {detail}"
-                        ))
-                    }
-                })?;
+        let acceptance = handle
+            .send_prompt(payload, None)
+            .await
+            .map_err(|error| match error {
+                LiveSessionCommandError::ActorUnavailable => {
+                    SendPromptError::Internal(anyhow::anyhow!("session actor channel closed"))
+                }
+                LiveSessionCommandError::ResponseDropped => {
+                    SendPromptError::Internal(anyhow::anyhow!("session actor dropped response"))
+                }
+                LiveSessionCommandError::Rejected(PromptAcceptError::EnqueueFailed(detail)) => {
+                    SendPromptError::Internal(anyhow::anyhow!("failed to enqueue prompt: {detail}"))
+                }
+            })?;
         let session = self
             .session_service
             .get_session(session_id)

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -18,7 +18,6 @@ use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::SessionHooks;
 use crate::live::sessions::SessionStartupStrategy;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 use super::launch_policy::{
     assemble_session_launch, choose_startup_strategy, session_is_closed, SessionLaunchContext,
@@ -56,19 +55,17 @@ pub(super) fn choose_session_startup_strategy(
 }
 
 impl SessionRuntime {
+    #[tracing::instrument(skip_all, fields(session_id = %record.id))]
     pub async fn start_persisted_session(
         &self,
         record: &SessionRecord,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<SessionRecord, CreateAndStartSessionError> {
         let live_start_started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
         let (_handle, native_session_id) = match self
             .start_live_session(
                 record,
                 SessionStartupStrategy::Fresh,
                 record.system_prompt_append.clone(),
-                latency,
             )
             .await
         {
@@ -78,10 +75,6 @@ impl SessionRuntime {
                     session_id = %record.id,
                     native_session_id = %result.1,
                     elapsed_ms = live_start_started.elapsed().as_millis(),
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
-                    prompt_id = latency_fields.prompt_id,
                     "[workspace-latency] session.runtime.live_session_started"
                 );
                 result
@@ -93,10 +86,6 @@ impl SessionRuntime {
                     session_id = %record.id,
                     elapsed_ms = live_start_started.elapsed().as_millis(),
                     error = ?error,
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
-                    prompt_id = latency_fields.prompt_id,
                     "[workspace-latency] session.runtime.live_session_failed"
                 );
                 return Err(map_start_session_error_to_create(error));
@@ -120,20 +109,16 @@ impl SessionRuntime {
             session_id = %updated.id,
             native_session_id = %updated.native_session_id.as_deref().unwrap_or_default(),
             elapsed_ms = persist_started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.live_session_persisted"
         );
         Ok(updated)
     }
 
+    #[tracing::instrument(skip_all, fields(session_id = %session_id))]
     pub async fn ensure_live_session(
         &self,
         session_id: &str,
         mcp_refresh: Option<SessionMcpRefresh>,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<SessionRecord, EnsureLiveSessionError> {
         self.access_gate
             .assert_can_start_live_session(session_id)
@@ -149,7 +134,7 @@ impl SessionRuntime {
                 SessionLifecycleError::Internal(error) => EnsureLiveSessionError::Internal(error),
             })?;
 
-        self.ensure_live_session_handle(&record, mcp_refresh, latency)
+        self.ensure_live_session_handle(&record, mcp_refresh)
             .await
             .map_err(|error| match error {
                 StartSessionError::WorkspaceNotFound => EnsureLiveSessionError::Internal(
@@ -183,7 +168,6 @@ impl SessionRuntime {
         &self,
         record: &SessionRecord,
         mcp_refresh: Option<SessionMcpRefresh>,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<Arc<LiveSessionHandle>, StartSessionError> {
         self.access_gate
             .assert_can_start_live_session(&record.id)
@@ -192,16 +176,11 @@ impl SessionRuntime {
             return Err(StartSessionError::Closed);
         }
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
         if let Some(handle) = self.acp_manager.get_handle(&record.id).await {
             tracing::info!(
                 session_id = %record.id,
                 workspace_id = %record.workspace_id,
                 elapsed_ms = started.elapsed().as_millis(),
-                flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
                 "[workspace-latency] session.runtime.ensure_live_handle.reused"
             );
             return Ok(handle);
@@ -265,7 +244,6 @@ impl SessionRuntime {
                 &record,
                 startup_strategy,
                 record.system_prompt_append.clone(),
-                latency,
             )
             .await?;
 
@@ -275,10 +253,6 @@ impl SessionRuntime {
             workspace_id = %record.workspace_id,
             native_session_id = %native_session_id,
             elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.ensure_live_handle.live_started"
         );
         Ok(handle)
@@ -289,10 +263,8 @@ impl SessionRuntime {
         record: &SessionRecord,
         startup_strategy: SessionStartupStrategy,
         system_prompt_append: Option<String>,
-        latency: Option<&LatencyRequestContext>,
     ) -> Result<(Arc<LiveSessionHandle>, String), StartSessionError> {
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(latency);
         let startup_strategy_label = startup_strategy.as_str();
         tracing::info!(
             session_id = %record.id,
@@ -300,10 +272,6 @@ impl SessionRuntime {
             agent_kind = %record.agent_kind,
             startup_strategy = startup_strategy_label,
             has_system_prompt_append = system_prompt_append.is_some(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.start_live_session.start"
         );
 
@@ -317,10 +285,6 @@ impl SessionRuntime {
             session_id = %record.id,
             workspace_id = %record.workspace_id,
             elapsed_ms = workspace_lookup_started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.start_live_session.workspace_loaded"
         );
 
@@ -334,10 +298,6 @@ impl SessionRuntime {
             session_id = %record.id,
             agent_kind = %record.agent_kind,
             elapsed_ms = descriptor_lookup_started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.start_live_session.agent_descriptor_found"
         );
 
@@ -363,10 +323,6 @@ impl SessionRuntime {
             session_id = %record.id,
             agent_kind = %record.agent_kind,
             elapsed_ms = agent_resolution_started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.start_live_session.agent_resolved"
         );
         let session_launch_env = build_session_launch_env(
@@ -424,7 +380,6 @@ impl SessionRuntime {
                 }
             })),
             on_exit: None,
-            latency: latency.cloned(),
         };
         let (handle, ready) = self
             .acp_manager
@@ -438,10 +393,6 @@ impl SessionRuntime {
             startup_strategy = startup_strategy_label,
             elapsed_ms = acp_start_started.elapsed().as_millis(),
             total_elapsed_ms = started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.runtime.start_live_session.acp_started"
         );
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
@@ -285,7 +285,7 @@ async fn create_subagent(
         false
     };
 
-    let started = match session_runtime.start_persisted_session(&child, None).await {
+    let started = match session_runtime.start_persisted_session(&child).await {
         Ok(started) => started,
         Err(error) => {
             if args.wake_on_completion {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
@@ -12,7 +12,6 @@ use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
 use crate::live::sessions::rendezvous::broker::PermissionDecision;
-use crate::observability::latency::LatencyRequestContext;
 #[derive(Debug)]
 pub enum PromptAcceptError {
     EnqueueFailed(String),
@@ -122,7 +121,6 @@ pub(in crate::live::sessions) enum SessionCommand {
     Prompt {
         payload: PromptPayload,
         prompt_id: Option<String>,
-        latency: Option<LatencyRequestContext>,
         /// Set by the actor's own startup-drain path when self-dispatching a
         /// queue head. External callers pass `None` unless they have already
         /// durably inserted a queue row and only need the actor to drain it.

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
@@ -76,12 +76,11 @@ impl SessionActor {
         background_work_rx: &mut mpsc::UnboundedReceiver<BackgroundWorkUpdate>,
     ) -> Option<ActorExitDisposition> {
         match cmd {
-            SessionCommand::Prompt { payload, prompt_id, latency, from_queue_seq, respond_to } => {
+            SessionCommand::Prompt { payload, prompt_id, from_queue_seq, respond_to } => {
                 self.run_turn(
                     ActivePromptRequest {
                         payload,
                         prompt_id,
-                        latency,
                         from_queue_seq,
                         respond_to,
                     },

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
@@ -8,7 +8,6 @@ use tokio::sync::{mpsc, RwLock};
 use crate::live::sessions::actor::command::SessionCommand;
 use crate::live::sessions::actor::state::{SessionActor, SessionActorConfig};
 use crate::live::sessions::handle::{LiveSessionExecutionSnapshot, LiveSessionHandle};
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 pub struct ActorReadyResult {
     pub native_session_id: String,
@@ -21,7 +20,6 @@ pub struct PendingSessionActor {
     workspace_id: String,
     startup_strategy: String,
     started: Instant,
-    latency: Option<LatencyRequestContext>,
 }
 
 impl PendingSessionActor {
@@ -46,17 +44,12 @@ impl PendingSessionActor {
             .expect("native session id lock poisoned")
             .replace(native_session_id.clone());
 
-        let latency_fields = latency_trace_fields(self.latency.as_ref());
         tracing::info!(
             session_id = %self.session_id,
             workspace_id = %self.workspace_id,
             native_session_id = %native_session_id,
             startup_strategy = %self.startup_strategy,
             elapsed_ms = self.started.elapsed().as_millis(),
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.actor.spawn.ready"
         );
 
@@ -80,18 +73,12 @@ pub fn spawn_session_actor_pending(
     let workspace_id = config.launch.session.workspace_id.clone();
     let agent_kind = config.launch.session.agent_kind.clone();
     let startup_strategy = config.launch.startup.as_str().to_string();
-    let actor_latency = config.hooks.latency.clone();
-    let actor_latency_fields = latency_trace_fields(actor_latency.as_ref());
     let started = Instant::now();
     tracing::info!(
         session_id = %session_id,
         workspace_id = %workspace_id,
         agent_kind = %agent_kind,
         startup_strategy,
-        flow_id = actor_latency_fields.flow_id,
-        flow_kind = actor_latency_fields.flow_kind,
-        flow_source = actor_latency_fields.flow_source,
-        prompt_id = actor_latency_fields.prompt_id,
         "[workspace-latency] session.actor.spawn.start"
     );
     let (command_tx, command_rx) = mpsc::channel::<SessionCommand>(32);
@@ -155,6 +142,5 @@ pub fn spawn_session_actor_pending(
         workspace_id,
         startup_strategy,
         started,
-        latency: actor_latency,
     })
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -30,7 +30,6 @@ use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
 use crate::live::sessions::model::{QueueDurable, SessionStateDurable};
 use crate::live::sessions::sink::SessionEventSink;
 use crate::live::sessions::handle::LiveSessionHandle;
-use crate::observability::latency::latency_trace_fields;
 
 impl SessionActor {
     /// Spawns the agent process, establishes the ACP connection, starts the
@@ -53,8 +52,6 @@ impl SessionActor {
         let workspace_id = config.launch.session.workspace_id.clone();
         let startup_strategy = config.launch.startup.clone();
         let startup_strategy_label = startup_strategy.as_str();
-        let actor_latency = config.hooks.latency.clone();
-        let actor_latency_fields = latency_trace_fields(actor_latency.as_ref());
         let startup_started = Instant::now();
 
         let spawned = spawn_agent_process(
@@ -67,7 +64,6 @@ impl SessionActor {
             &session_id,
             &workspace_id,
             &source_agent_kind,
-            actor_latency.as_ref(),
             &ready_tx,
         )?;
         let child = spawned.child;
@@ -305,10 +301,6 @@ impl SessionActor {
             startup_strategy = startup_strategy_label,
             native_startup_disposition = startup_disposition.as_str(),
             total_elapsed_ms = startup_started.elapsed().as_millis(),
-            flow_id = actor_latency_fields.flow_id,
-            flow_kind = actor_latency_fields.flow_kind,
-            flow_source = actor_latency_fields.flow_source,
-            prompt_id = actor_latency_fields.prompt_id,
             "[workspace-latency] session.actor.startup_ready"
         );
         let resume_replay_filter = ResumeReplayFilter::new(
@@ -373,7 +365,6 @@ async fn dispatch_startup_drain(
                 .send(SessionCommand::Prompt {
                     payload: head.prompt_payload(),
                     prompt_id: head.prompt_id,
-                    latency: None,
                     from_queue_seq: Some(head.seq),
                     respond_to: drain_respond_tx,
                 })

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
@@ -24,7 +24,7 @@ pub struct SessionActorConfig {
     pub launch: SessionLaunch,
     /// The never-varies durable capabilities + product reactors.
     pub caps: ActorCapabilities,
-    /// Per-call powers (turn-finish callback, exit callback, latency context).
+    /// Per-call powers (turn-finish callback, exit callback).
     pub hooks: SessionHooks,
     pub interaction_broker: Arc<InteractionRendezvous>,
     pub event_tx: broadcast::Sender<SessionEventEnvelope>,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
@@ -15,12 +15,10 @@ use crate::live::sessions::actor::state::SessionActor;
 use crate::live::sessions::actor::turn::diagnostics::{age_ms, PromptDiagnostics};
 use crate::live::sessions::actor::turn::start::StartedPromptTurn;
 use crate::live::sessions::background_work::BackgroundWorkUpdate;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 pub(in crate::live::sessions::actor) struct ActivePromptRequest {
     pub payload: PromptPayload,
     pub prompt_id: Option<String>,
-    pub latency: Option<LatencyRequestContext>,
     pub from_queue_seq: Option<i64>,
     pub respond_to: oneshot::Sender<Result<PromptAcceptance, PromptAcceptError>>,
 }
@@ -40,7 +38,6 @@ impl SessionActor {
 
         let mut current_payload = request.payload;
         let mut current_prompt_id = request.prompt_id;
-        let mut current_latency = request.latency;
         let mut current_queue_seq = request.from_queue_seq;
         let mut current_respond_to = Some(request.respond_to);
         let mut exit_after_prompt: Option<ActorExitDisposition> = None;
@@ -50,13 +47,9 @@ impl SessionActor {
                 .await;
             self.resume_replay_filter.disable();
 
-            let latency_fields = latency_trace_fields(current_latency.as_ref());
             tracing::info!(
                 session_id = %self.session_id,
-                flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
+                prompt_id = current_prompt_id.as_deref(),
                 "[workspace-latency] session.actor.prompt.received"
             );
             let StartedPromptTurn {
@@ -98,10 +91,7 @@ impl SessionActor {
                 .update_last_prompt_at(&self.session_id, &now);
             tracing::info!(
                 session_id = %self.session_id,
-                flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
+                prompt_id = current_prompt_id.as_deref(),
                 "[workspace-latency] session.actor.prompt.accepted"
             );
 
@@ -111,10 +101,7 @@ impl SessionActor {
             let mut prompt_diagnostics = PromptDiagnostics::new(current_prompt_id.clone());
             tracing::info!(
                 session_id = %self.session_id,
-                flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
+                prompt_id = current_prompt_id.as_deref(),
                 "[workspace-latency] session.actor.prompt.dispatch_started"
             );
             // ConnectionTo is a cheap handle; the clone keeps the pinned
@@ -137,9 +124,6 @@ impl SessionActor {
                         let execution_snapshot = self.handle.execution_snapshot().await;
                         tracing::info!(
                             session_id = %self.session_id,
-                            flow_id = latency_fields.flow_id,
-                            flow_kind = latency_fields.flow_kind,
-                            flow_source = latency_fields.flow_source,
                             prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                             turn_id = ?sink_snapshot.current_turn_id,
                             pending_for_ms = prompt_diagnostics.prompt_started_at.elapsed().as_millis() as u64,
@@ -223,7 +207,7 @@ impl SessionActor {
                                 let _ = respond_to.send(Ok(()));
                                 exit_after_prompt = Some(ActorExitDisposition::Close);
                             }
-                            Some(SessionCommand::Prompt { payload: queued_payload, prompt_id: queued_prompt_id, latency: _, from_queue_seq, respond_to }) => {
+                            Some(SessionCommand::Prompt { payload: queued_payload, prompt_id: queued_prompt_id, from_queue_seq, respond_to }) => {
                                 let result = self.handle_busy_prompt_queue(
                                     queued_payload,
                                     queued_prompt_id,
@@ -255,7 +239,6 @@ impl SessionActor {
             let broken_session = self
                 .finish_prompt_result(
                     result,
-                    current_latency.as_ref(),
                     &mut prompt_diagnostics,
                     notification_rx,
                     background_work_rx,
@@ -263,10 +246,6 @@ impl SessionActor {
                 .await;
 
             self.resume_replay_filter.disable();
-
-            // Suppress reference-unused warnings on latency locals so the drain body
-            // behaves symmetrically across iterations.
-            let _ = current_prompt_id.take();
 
             if exit_after_prompt.is_some() || broken_session {
                 break 'drain;
@@ -279,7 +258,6 @@ impl SessionActor {
                 Some((next_payload, next_prompt_id, next_seq)) => {
                     current_payload = next_payload;
                     current_prompt_id = next_prompt_id;
-                    current_latency = None;
                     current_queue_seq = Some(next_seq);
                     continue 'drain;
                 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
@@ -10,7 +10,6 @@ use crate::live::sessions::actor::turn::diagnostics::{age_ms, PromptDiagnostics}
 use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
 use crate::live::sessions::background_work::BackgroundWorkUpdate;
 use crate::live::sessions::sink::SessionEventSinkDebugSnapshot;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 pub(in crate::live::sessions::actor) const EMPTY_TURN_ERROR_CODE: &str = "empty_turn";
 pub(in crate::live::sessions::actor) const EMPTY_TURN_ERROR_MESSAGE: &str = "The agent ended the turn without producing a response. The selected model or provider may need additional configuration or credentials.";
@@ -55,13 +54,10 @@ impl SessionActor {
     pub(in crate::live::sessions::actor) async fn finish_prompt_result(
         &mut self,
         result: acp::Result<acp::schema::PromptResponse>,
-        latency: Option<&LatencyRequestContext>,
         prompt_diagnostics: &mut PromptDiagnostics,
         notification_rx: &mut mpsc::UnboundedReceiver<acp::schema::SessionNotification>,
         background_work_rx: &mut mpsc::UnboundedReceiver<BackgroundWorkUpdate>,
     ) -> bool {
-        let latency_fields = latency_trace_fields(latency);
-
         match result {
             Ok(resp) => {
                 while let Ok(notif) = notification_rx.try_recv() {
@@ -77,9 +73,6 @@ impl SessionActor {
                 };
                 tracing::info!(
                     session_id = %self.session_id,
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
                     prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                     turn_id = ?sink_snapshot_before_turn_end.current_turn_id,
                     stop_reason = ?resp.stop_reason,
@@ -106,9 +99,6 @@ impl SessionActor {
                 if emit_empty_turn_error {
                     tracing::warn!(
                         session_id = %self.session_id,
-                        flow_id = latency_fields.flow_id,
-                        flow_kind = latency_fields.flow_kind,
-                        flow_source = latency_fields.flow_source,
                         prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                         turn_id = ?sink_snapshot_before_turn_end.current_turn_id,
                         stop_reason = ?resp.stop_reason,
@@ -140,9 +130,6 @@ impl SessionActor {
                 drop(sink);
                 tracing::info!(
                     session_id = %self.session_id,
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
                     prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                     turn_id = ?sink_snapshot_before_turn_end.current_turn_id,
                     "session.actor.prompt.turn_ended_emitted"
@@ -154,9 +141,6 @@ impl SessionActor {
                 let _ = self.caps.state.update_status(&self.session_id, "idle", &now);
                 tracing::info!(
                     session_id = %self.session_id,
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
                     prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                     turn_id = ?sink_snapshot_before_turn_end.current_turn_id,
                     updated_at = %now,
@@ -198,9 +182,6 @@ impl SessionActor {
                 };
                 tracing::warn!(
                     session_id = %self.session_id,
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
                     prompt_id = ?prompt_diagnostics.prompt_id.as_deref(),
                     turn_id = ?sink_snapshot_on_error.current_turn_id,
                     error = %e,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use super::*;
 use crate::live::sessions::driver::stderr::spawn_agent_stderr_logger;
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 use crate::process_env::remove_runtime_private_env;
 
 pub(in crate::live::sessions) struct SpawnedAgentProcess {
@@ -47,7 +46,6 @@ pub(in crate::live::sessions) fn spawn_agent_process(
     session_id: &str,
     workspace_id: &str,
     source_agent_kind: &str,
-    latency: Option<&LatencyRequestContext>,
     ready_tx: &std::sync::mpsc::Sender<anyhow::Result<String>>,
 ) -> anyhow::Result<SpawnedAgentProcess> {
     let resolved_path = agent
@@ -75,8 +73,6 @@ pub(in crate::live::sessions) fn spawn_agent_process(
         spawn_spec.map(|spec| &spec.env),
         protected_agent_auth_env,
     );
-    let latency_fields = latency_trace_fields(latency);
-
     if let Err(error) = validate_spawn_cwd(spawn_cwd, spawn_cwd_source) {
         tracing::warn!(
             session_id = %session_id,
@@ -87,10 +83,6 @@ pub(in crate::live::sessions) fn spawn_agent_process(
             spawn_cwd = %spawn_cwd.display(),
             spawn_cwd_source,
             error = %error,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.actor.process_spawn_cwd_invalid"
         );
         let _ = ready_tx.send(Err(anyhow::anyhow!(error.clone())));
@@ -119,10 +111,6 @@ pub(in crate::live::sessions) fn spawn_agent_process(
             spawn_cwd_source,
             elapsed_ms = process_spawn_started.elapsed().as_millis(),
             error = %e,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.actor.process_spawn_failed"
         );
         let _ = ready_tx.send(Err(anyhow::anyhow!("spawn failed: {e}")));
@@ -133,10 +121,6 @@ pub(in crate::live::sessions) fn spawn_agent_process(
         workspace_id = %workspace_id,
         agent_kind = %source_agent_kind,
         elapsed_ms = process_spawn_started.elapsed().as_millis(),
-        flow_id = latency_fields.flow_id,
-        flow_kind = latency_fields.flow_kind,
-        flow_source = latency_fields.flow_source,
-        prompt_id = latency_fields.prompt_id,
         "[workspace-latency] session.actor.process_spawned"
     );
 
@@ -237,7 +221,6 @@ mod tests {
             "session-1",
             "workspace-1",
             AgentKind::Codex.as_str(),
-            None,
             &ready_tx,
         );
         let error = match result {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
@@ -18,7 +18,6 @@ use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionError, RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
 use crate::live::sessions::actor::command::SessionCommand;
-use crate::observability::latency::LatencyRequestContext;
 
 #[derive(Debug)]
 pub enum LiveSessionCommandError<E> {
@@ -217,13 +216,11 @@ impl LiveSessionHandle {
         &self,
         payload: PromptPayload,
         prompt_id: Option<String>,
-        latency: Option<LatencyRequestContext>,
         from_queue_seq: Option<i64>,
     ) -> Result<PromptAcceptance, LiveSessionCommandError<PromptAcceptError>> {
         self.send_request(|respond_to| SessionCommand::Prompt {
             payload,
             prompt_id,
-            latency,
             from_queue_seq,
             respond_to,
         })
@@ -234,9 +231,8 @@ impl LiveSessionHandle {
         &self,
         payload: PromptPayload,
         prompt_id: Option<String>,
-        latency: Option<LatencyRequestContext>,
     ) -> Result<PromptAcceptance, LiveSessionCommandError<PromptAcceptError>> {
-        self.send_prompt_with_queue_marker(payload, prompt_id, latency, None)
+        self.send_prompt_with_queue_marker(payload, prompt_id, None)
             .await
     }
 
@@ -245,7 +241,7 @@ impl LiveSessionHandle {
         payload: PromptPayload,
         seq: i64,
     ) -> Result<PromptAcceptance, LiveSessionCommandError<PromptAcceptError>> {
-        self.send_prompt_with_queue_marker(payload, None, None, Some(seq))
+        self.send_prompt_with_queue_marker(payload, None, Some(seq))
             .await
     }
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
@@ -12,7 +12,6 @@ use crate::live::sessions::actor::spawn::{
 use crate::live::sessions::actor::state::SessionActorConfig;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::{SessionHooks, SessionLaunch};
-use crate::observability::latency::{latency_trace_fields, LatencyRequestContext};
 
 impl LiveSessionManager {
     #[tracing::instrument(skip_all, fields(session_id = %launch.session.id))]
@@ -23,17 +22,12 @@ impl LiveSessionManager {
     ) -> anyhow::Result<(Arc<LiveSessionHandle>, ActorReadyResult)> {
         let session_id = launch.session.id.clone();
         let started = Instant::now();
-        let latency_fields = latency_trace_fields(hooks.latency.as_ref());
         let startup_strategy_label = launch.startup.as_str();
         tracing::info!(
             session_id = %session_id,
             workspace_id = %launch.session.workspace_id,
             agent_kind = %launch.session.agent_kind,
             startup_strategy = startup_strategy_label,
-            flow_id = latency_fields.flow_id,
-            flow_kind = latency_fields.flow_kind,
-            flow_source = latency_fields.flow_source,
-            prompt_id = latency_fields.prompt_id,
             "[workspace-latency] session.acp_manager.start.start"
         );
 
@@ -45,10 +39,6 @@ impl LiveSessionManager {
             tracing::info!(
                 session_id = %session_id,
                 elapsed_ms = started.elapsed().as_millis(),
-                flow_id = latency_fields.flow_id,
-                flow_kind = latency_fields.flow_kind,
-                flow_source = latency_fields.flow_source,
-                prompt_id = latency_fields.prompt_id,
                 "[workspace-latency] session.acp_manager.start.reused_existing_handle"
             );
             if let Some(native_session_id) = ready_native_session_id {
@@ -97,7 +87,6 @@ impl LiveSessionManager {
         });
         hooks.on_exit = Some(on_exit);
 
-        let actor_latency = hooks.latency.clone();
         let config = SessionActorConfig {
             launch,
             caps: self.caps.clone(),
@@ -128,7 +117,6 @@ impl LiveSessionManager {
             startup_strategy_label.to_string(),
             actor_start_started,
             started,
-            actor_latency,
         )
         .await?;
 
@@ -145,7 +133,6 @@ async fn wait_for_new_startup_readiness(
     startup_strategy_label: String,
     actor_start_started: Instant,
     manager_started: Instant,
-    latency: Option<LatencyRequestContext>,
 ) -> anyhow::Result<ActorReadyResult> {
     let session_id = handle.session_id.clone();
     tokio::task::spawn_blocking(move || {
@@ -153,17 +140,12 @@ async fn wait_for_new_startup_readiness(
 
         match &ready_result {
             Ok(ready) => {
-                let latency_fields = latency_trace_fields(latency.as_ref());
                 tracing::info!(
                     session_id = %session_id,
                     native_session_id = %ready.native_session_id.as_str(),
                     startup_strategy = %startup_strategy_label,
                     elapsed_ms = actor_start_started.elapsed().as_millis(),
                     total_elapsed_ms = manager_started.elapsed().as_millis(),
-                    flow_id = latency_fields.flow_id,
-                    flow_kind = latency_fields.flow_kind,
-                    flow_source = latency_fields.flow_source,
-                    prompt_id = latency_fields.prompt_id,
                     "[workspace-latency] session.acp_manager.start.actor_ready"
                 );
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -50,7 +50,6 @@ use crate::domains::sessions::prompt::{PromptPayload, PromptValidationError, Res
 use crate::live::sessions::actor::command::{Resolution, ResolveInteractionCommandError};
 use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
 use crate::live::sessions::sink::SessionEventSink;
-use crate::observability::latency::LatencyRequestContext;
 // Re-exported: the normalized-payload vocabulary observers consume. The sink
 // module itself stays private to live; these shapes are part of the doorstep.
 pub use crate::live::sessions::sink::{AcpChunkPayload, AcpToolPayload, CompletedAssistantMessage};
@@ -307,8 +306,6 @@ pub struct SessionHooks {
     /// Called after the actor loop exits (normal or error). The bool indicates
     /// whether the actor exited with an error (true = errored).
     pub on_exit: Option<Box<dyn FnOnce(bool) + Send>>,
-    /// Dies in PR-3b (latency → spans); carried here meanwhile.
-    pub latency: Option<LatencyRequestContext>,
 }
 
 /// Where in the session's event stream an observation (or op phase) is

--- a/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
@@ -186,7 +186,6 @@ pub async fn probe_agent(options: ProbeOptions) -> anyhow::Result<ProbeSnapshot>
         PROBE_SESSION_ID,
         PROBE_WORKSPACE_ID,
         options.agent_kind.as_str(),
-        None,
         &ready_tx,
     )?;
     let mut child = spawned.child;

--- a/anyharness/crates/anyharness-lib/src/observability/latency.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/latency.rs
@@ -1,3 +1,16 @@
+//! Flow headers → tracing span, parsed once at the transport edge.
+//!
+//! Latency/flow context is observability data, not domain data: it never
+//! appears in a domain signature. Each HTTP/SSE handler that receives the
+//! `x-anyharness-flow-*` headers parses them into [`FlowHeaders`], opens the
+//! [`FlowHeaders::span`] and instruments its own future with it. Everything
+//! awaited inside the handler inherits the flow fields via span context.
+//!
+//! The session actor runs on its own thread/runtime, so the edge span does
+//! NOT cross the command channel. Actor-side log lines carry `session_id`
+//! (and `prompt_id` where it is real command data); operators correlate
+//! actor lines with edge lines via `session_id` + `prompt_id`.
+
 use axum::http::HeaderMap;
 
 const FLOW_ID_HEADER: &str = "x-anyharness-flow-id";
@@ -6,74 +19,39 @@ const FLOW_SOURCE_HEADER: &str = "x-anyharness-flow-source";
 const PROMPT_ID_HEADER: &str = "x-anyharness-prompt-id";
 const MEASUREMENT_OPERATION_ID_HEADER: &str = "x-proliferate-measurement-operation-id";
 
+/// The flow fields a client may attach to a request for latency tracing.
+/// Parsed at the transport edge and recorded once on a `session_flow` span.
 #[derive(Debug, Clone, Default)]
-pub struct LatencyRequestContext {
-    flow_id: Option<String>,
-    flow_kind: Option<String>,
-    flow_source: Option<String>,
-    prompt_id: Option<String>,
-    measurement_operation_id: Option<String>,
+pub struct FlowHeaders {
+    pub flow_id: Option<String>,
+    pub flow_kind: Option<String>,
+    pub flow_source: Option<String>,
+    pub prompt_id: Option<String>,
+    pub measurement_operation_id: Option<String>,
 }
 
-impl LatencyRequestContext {
-    pub fn from_headers(headers: &HeaderMap) -> Option<Self> {
-        let context = Self {
+impl FlowHeaders {
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        Self {
             flow_id: header_value(headers, FLOW_ID_HEADER),
             flow_kind: header_value(headers, FLOW_KIND_HEADER),
             flow_source: header_value(headers, FLOW_SOURCE_HEADER),
             prompt_id: header_value(headers, PROMPT_ID_HEADER),
             measurement_operation_id: header_value(headers, MEASUREMENT_OPERATION_ID_HEADER),
-        };
-
-        if context.flow_id.is_none()
-            && context.flow_kind.is_none()
-            && context.flow_source.is_none()
-            && context.prompt_id.is_none()
-            && context.measurement_operation_id.is_none()
-        {
-            return None;
         }
-
-        Some(context)
     }
 
-    pub fn flow_id(&self) -> Option<&str> {
-        self.flow_id.as_deref()
-    }
-
-    pub fn flow_kind(&self) -> Option<&str> {
-        self.flow_kind.as_deref()
-    }
-
-    pub fn flow_source(&self) -> Option<&str> {
-        self.flow_source.as_deref()
-    }
-
-    pub fn prompt_id(&self) -> Option<&str> {
-        self.prompt_id.as_deref()
-    }
-
-    pub fn measurement_operation_id(&self) -> Option<&str> {
-        self.measurement_operation_id.as_deref()
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct LatencyTraceFields<'a> {
-    pub flow_id: Option<&'a str>,
-    pub flow_kind: Option<&'a str>,
-    pub flow_source: Option<&'a str>,
-    pub prompt_id: Option<&'a str>,
-    pub measurement_operation_id: Option<&'a str>,
-}
-
-pub fn latency_trace_fields(latency: Option<&LatencyRequestContext>) -> LatencyTraceFields<'_> {
-    LatencyTraceFields {
-        flow_id: latency.and_then(LatencyRequestContext::flow_id),
-        flow_kind: latency.and_then(LatencyRequestContext::flow_kind),
-        flow_source: latency.and_then(LatencyRequestContext::flow_source),
-        prompt_id: latency.and_then(LatencyRequestContext::prompt_id),
-        measurement_operation_id: latency.and_then(LatencyRequestContext::measurement_operation_id),
+    /// The edge span carrying the flow fields. `Option::None` fields record
+    /// nothing, so requests without flow headers get a bare span.
+    pub fn span(&self) -> tracing::Span {
+        tracing::info_span!(
+            "session_flow",
+            flow_id = self.flow_id.as_deref(),
+            flow_kind = self.flow_kind.as_deref(),
+            flow_source = self.flow_source.as_deref(),
+            prompt_id = self.prompt_id.as_deref(),
+            measurement_operation_id = self.measurement_operation_id.as_deref(),
+        )
     }
 }
 
@@ -91,10 +69,10 @@ fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
 mod tests {
     use axum::http::{HeaderMap, HeaderValue};
 
-    use super::LatencyRequestContext;
+    use super::FlowHeaders;
 
     #[test]
-    fn parses_latency_request_headers() {
+    fn parses_flow_headers() {
         let mut headers = HeaderMap::new();
         headers.insert("x-anyharness-flow-id", HeaderValue::from_static("flow-123"));
         headers.insert(
@@ -114,21 +92,23 @@ mod tests {
             HeaderValue::from_static("mop_123"),
         );
 
-        let context = LatencyRequestContext::from_headers(&headers)
-            .expect("expected latency request context");
+        let flow = FlowHeaders::from_headers(&headers);
 
-        assert_eq!(context.flow_id(), Some("flow-123"));
-        assert_eq!(context.flow_kind(), Some("prompt_submit"));
-        assert_eq!(context.flow_source(), Some("composer_submit"));
-        assert_eq!(context.prompt_id(), Some("prompt-456"));
-        assert_eq!(context.measurement_operation_id(), Some("mop_123"));
+        assert_eq!(flow.flow_id.as_deref(), Some("flow-123"));
+        assert_eq!(flow.flow_kind.as_deref(), Some("prompt_submit"));
+        assert_eq!(flow.flow_source.as_deref(), Some("composer_submit"));
+        assert_eq!(flow.prompt_id.as_deref(), Some("prompt-456"));
+        assert_eq!(flow.measurement_operation_id.as_deref(), Some("mop_123"));
     }
 
     #[test]
-    fn ignores_empty_latency_headers() {
+    fn ignores_empty_flow_headers() {
         let mut headers = HeaderMap::new();
         headers.insert("x-anyharness-flow-id", HeaderValue::from_static("   "));
 
-        assert!(LatencyRequestContext::from_headers(&headers).is_none());
+        let flow = FlowHeaders::from_headers(&headers);
+
+        assert!(flow.flow_id.is_none());
+        assert!(flow.prompt_id.is_none());
     }
 }


### PR DESCRIPTION
LatencyRequestContext is deleted entirely: the flow fields parsed from
request headers now live on tracing spans created at the transport edges
(HTTP prompt/SSE/session handlers) and propagate via span context;
use-case entries gain #[instrument] spans. SessionHooks, SessionCommand,
handle.send_prompt, the runtime signatures, and the actor turn code lose
their threaded observability parameter - per the grammar law that
observability context never appears in a signature.

Actor-side [workspace-latency] lines keep session_id + prompt_id (real
data on the command) and drop flow_* fields rather than smuggling span
context across the per-session thread boundary; operators correlate via
prompt_id. Every [workspace-latency] event name is preserved exactly
(117 markers crate-wide, byte-identical to before).

Suite: 637 passed, 0 failed; workspace clean.

---
Part 7/10 of the live-sessions migration stack (see the stack overview in PR 1). Each PR is gated: full suite green, behavior-preserving except where the commit message states otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)