### PR TITLE
docs(specs): align anyharness structure specs with the live-sessions migration

### DIFF
--- a/specs/codebase/structures/anyharness/README.md
+++ b/specs/codebase/structures/anyharness/README.md
@@ -80,9 +80,9 @@ api/http/sessions
     -> live/sessions::LiveSessionManager
       -> LiveSessionHandle
         -> SessionActor
-          -> AcpClient
+          -> driver (ACP connection; InboundDoor for inbound traffic)
           -> SessionEventSink
-          -> InteractionBroker
+          -> InteractionRendezvous
 ```
 
 It owns these workflows:
@@ -103,9 +103,11 @@ Role boundaries:
 - `SessionStore` owns SQL for session data.
 - `LiveSessionManager` owns the live session registry and startup de-dupe.
 - `SessionActor` owns one running session command loop.
-- `AcpClient` owns low-level ACP request/notification I/O.
-- `SessionEventSink` owns ACP notification normalization and persistence.
-- `InteractionBroker` owns pending live interaction rendezvous.
+- The driver owns the ACP process/connection; its `InboundDoor` receives
+  agent-initiated requests and notifications.
+- `SessionEventSink` owns ACP notification normalization and persistence
+  (one ingestion entry: `sink.ingest`).
+- `InteractionRendezvous` owns pending live interaction rendezvous.
 
 ### Runtime Capabilities Around The Engine
 
@@ -171,7 +173,7 @@ domains/<feature>/mcp
 integrations/mcp
   shared JSON-RPC, tool formatting, and capability-token scaffolding
 
-live/sessions/interactions/mcp_elicitation
+live/sessions/rendezvous/mcp_elicitation
   live ACP interaction state
 
 api/http
@@ -223,7 +225,7 @@ Guides:
 - [guides/domains.md](guides/domains.md) for durable domains, the
   `model/store/service/runtime` shape, and product surface domains.
 - [guides/live-runtime.md](guides/live-runtime.md) for managers, handles,
-  actors, drivers, event sinks, interaction brokers, and long-lived
+  actors, drivers, event sinks, interaction rendezvous, and long-lived
   in-memory state.
 - [guides/adapters.md](guides/adapters.md) for files, git, hosting, and
   process capabilities.
@@ -244,8 +246,8 @@ verification for specific runtime flows.
 Specs:
 
 - [specs/session-engine.md](specs/session-engine.md) for the core session
-  engine: `SessionRuntime`, live session manager, actor, ACP client, event
-  sink, and interaction broker.
+  engine: `SessionRuntime`, live session manager, actor, driver, event
+  sink, and interaction rendezvous.
 - [specs/session-actor.md](specs/session-actor.md) for the target
   `live/sessions/actor` state-machine split, actor-owned state, command
   handling, turn loop, config, notifications, interactions, and shutdown.
@@ -396,7 +398,7 @@ focused guide that owns the layer.
 - `app/` wires dependencies. `AppState` is not a place for business logic.
 - `domains/` owns product concepts and durable business rules.
 - `live/` owns long-lived in-memory managers, handles, actors, drivers,
-  streams, subprocesses, and interaction brokers.
+  streams, subprocesses, and interaction rendezvous.
 - `adapters/` owns local workspace/machine capabilities such as file, git,
   hosting, and process operations.
 - `integrations/` owns external protocol/vendor mechanics such as MCP, ACP

--- a/specs/codebase/structures/anyharness/architecture.md
+++ b/specs/codebase/structures/anyharness/architecture.md
@@ -59,7 +59,7 @@ serve."
 api/            edges — HTTP/ACP surface. Translates wire ↔ runtime, nothing more.
 app/            composition root — wires deps, mounts SessionExtensions, registers product MCPs.
 domains/        DURABLE product meaning — sessions, agents, runtime_config, plugins, reviews, …
-live/           EPHEMERAL coordination — running sessions: the ACP actors, event sinks, interactions.
+live/           EPHEMERAL coordination — running sessions: the ACP actors, event sinks, rendezvous.
 adapters/       translate between a domain's types and an integration's types.
 integrations/   leaf I/O — talk to the outside (ACP processes, MCP protocol, filesystem).
 persistence/    durable storage substrate (SQLite) — how domains/ actually save.
@@ -78,7 +78,7 @@ The spine walks durable → live → external:
 ```text
 SessionRuntime → SessionService → SessionStore →          [DURABLE: domains/]
    LiveSessionManager → LiveSessionHandle → SessionActor → [LIVE: live/]
-      AcpClient / SessionEventSink / InteractionBroker      [EXTERNAL + ordering]
+      driver (ACP conn + InboundDoor) / SessionEventSink / InteractionRendezvous   [EXTERNAL + ordering]
 ```
 
 The handoff `SessionStore → LiveSessionManager` is exactly the durable/live
@@ -109,7 +109,7 @@ The one feature that cuts through every layer:
 domains/sessions/mcp_bindings    durable: which MCPs a session/workspace has + binding policy
 domains/<feature>/mcp            durable: a feature's product MCP tools (meaning)
 integrations/mcp                 leaf: protocol mechanics (JSON-RPC, capability tokens)
-live/.../interactions/mcp_elicitation   live: a pending elicitation rendezvous
+live/.../rendezvous/mcp_elicitation     live: a pending elicitation rendezvous
 api/http/product_mcp.rs          edge: the one HTTP route product MCPs are served on
 ```
 
@@ -159,17 +159,17 @@ launch: SessionExtensions resolve launch extras
 ```text
 handle.send_prompt → SessionCommand::Prompt → actor begins turn
   → sink.begin_turn (TurnStarted + User item) → conn.prompt(req)   [the long-lived ACP future]
-  → ACP streams session/update notifications → RuntimeClient → notification_rx
-  → normalize_notification → sink.* (ItemStarted/ItemDelta/ToolCall…), each seq'd + persisted + broadcast
+  → ACP streams session/update notifications → InboundDoor → actor channel
+  → sink.ingest normalizes (ItemStarted/ItemDelta/ToolCall…), each seq'd + persisted + broadcast
   → PromptResponse{stop_reason} → finish: sink.turn_ended → phase Idle → apply pending config → drain queue
 ```
 
 **Mid-turn interactions (one rendezvous, many askers):**
 ```text
 agent asks permission OR a product MCP tool elicits
-  → broker registers a parked oneshot + handle.add_pending_interaction + sink.interaction_requested
+  → rendezvous registers a parked oneshot + handle.add_pending_interaction + sink.interaction_requested
   → user answers → SessionCommand::ResolveInteraction (handled on the same actor)
-  → broker resolves the oneshot → the parked ACP callback returns → sink.interaction_resolved
+  → rendezvous resolves the oneshot → the parked ACP callback returns → sink.interaction_resolved
 ```
 
 **Config sync / reconcile (driven by the worker):**
@@ -220,7 +220,7 @@ SetConfigOption(model) → set_session_model on the existing native session (sam
   `sink` owns ordering. Outside `live/<resource>/`, only `manager` + `handle` +
   public types are visible.
 - Dependency rules: `live → domains/integrations/adapters/observability` OK; AVOID
-  `live → api/app`, `driver → domain services`, `event_sink → access-control`,
+  `live → api/app`, `driver → domain services`, `sink → access-control`,
   `integrations → live`.
 - The sink is the single source of event order: assign `seq`, persist, then
   broadcast — in that order.
@@ -247,8 +247,8 @@ files on disk; the manifest pins per session in `runtime_config_session_context`
 - Register once in `app/product_mcp.rs`: a **launch-catalog** entry (selector
   closure decides which sessions attach it + a token minter) and an
   **endpoint-registry** entry (slug → handler + mutating list).
-- Reuse the **interactions broker** for any mid-call user prompt (elicitation) —
-  do not invent a second rendezvous.
+- Reuse the **interaction rendezvous** for any mid-call user prompt (elicitation) —
+  do not invent a second one.
 
 **Synced config & auth notes**
 - Materialize secrets **once** at session create; fail loud (`MissingCredentials`)
@@ -266,7 +266,7 @@ files on disk; the manifest pins per session in `runtime_config_session_context`
 **AnyHarness is a single-sandbox session engine split by one axis — durable meaning
 (`domains/` + `persistence/`) vs the running instance (`live/`) — with edges
 (`api`/`app`) on top and leaves (`adapters`/`integrations`) underneath.** The role
-chain (`SessionRuntime → … → SessionActor → AcpClient/Sink/Broker`) walks that axis;
+chain (`SessionRuntime → … → SessionActor → driver/Sink/Rendezvous`) walks that axis;
 the live grammar (manager/handle/actor/driver/sink) governs the concurrency at the
 bottom; one event sink owns `seq`/turn/item order (persist-before-broadcast); MCP is
 the one vertical cutting through all layers; and two revision-pinned synced bundles

--- a/specs/codebase/structures/anyharness/guides/domains.md
+++ b/specs/codebase/structures/anyharness/guides/domains.md
@@ -69,6 +69,7 @@ sessions/
   model.rs
   runtime_event.rs
   extensions.rs
+  live_ports.rs
   store/
   service/
   runtime/
@@ -369,6 +370,37 @@ domains/sessions/workspace_naming/session_extension.rs
 `app/` wires implementations into the core. The core domain depends only on the
 trait.
 
+The same define-here/implement-there pattern runs in both directions. A domain
+implements ports defined elsewhere in a dedicated `*_ports.rs` /
+`*_observer.rs` file — pure trait impls, no new behavior homes:
+
+```text
+domains/plans/session_ports.rs
+  implements sessions-defined plan-reference/interaction-link resolver traits
+
+domains/sessions/live_ports.rs
+  implements live's durable-capability traits (EventPersist, QueueDurable,
+  BackgroundWorkDurable, SessionStateDurable, AttachmentSource from
+  live/sessions/model.rs) as 1:1 delegation over SessionStore and the
+  attachment storage
+```
+
+Product reactions to a live session use the live-defined hook ports the same
+way (see `guides/live-runtime.md` for the mechanism decision table):
+
+```text
+domains/plans/session_observer.rs     SessionEventObserver: plan sniffing
+domains/reviews/session_observer.rs   SessionEventObserver: candidate plans
+                                      (registered after the plans observer)
+domains/plans/permission_advisor.rs   PermissionAdvisor: plan-linked
+                                      permissions, predecided answers
+domains/plans/decision_op.rs          SessionDomainOp: approve/reject,
+                                      serialized through the actor mailbox
+```
+
+`app/sessions.rs` wires these into `ActorCapabilities`; the live layer depends
+only on its own traits.
+
 ## MCP Placement
 
 MCP crosses several owners. Do not put all MCP code in one folder.
@@ -491,10 +523,10 @@ violations.
 
 Migration exceptions (the rule is the law; this is the debt):
 `domains/runtime_config` persists contract types as rows and uses them as its
-model; `domains/agents/auth_config` uses contract auth structs end-to-end;
-`domains/sessions/runtime/contract.rs` builds contract responses inside the
-domain via a fetching mapper. Targets: domain twins minted at the API seam and
-a runtime-composed view model with a dep-less mapper.
+model; `domains/agents/auth_config` uses contract auth structs end-to-end.
+Target: domain twins minted at the API seam. (The sessions runtime's former
+fetching response mapper is resolved: `runtime/view.rs` composes `SessionView`
+and the API maps it dep-lessly.)
 
 ## Errors
 

--- a/specs/codebase/structures/anyharness/guides/integrations.md
+++ b/specs/codebase/structures/anyharness/guides/integrations.md
@@ -451,15 +451,16 @@ But session-stateful ACP code belongs under live session roles:
 ```text
 live/sessions/driver/
   process.rs
-  runtime_client.rs
-  start.rs
+  connection.rs
+  inbound/            # the InboundDoor (agent-initiated traffic)
+  session_lifecycle.rs
   native_session.rs
   shutdown.rs
 
-live/sessions/event_sink/
+live/sessions/sink/
   ACP notification -> AnyHarness event normalization
 
-live/sessions/interactions/
+live/sessions/rendezvous/
   permission/user-input/MCP elicitation rendezvous
 ```
 

--- a/specs/codebase/structures/anyharness/guides/live-runtime.md
+++ b/specs/codebase/structures/anyharness/guides/live-runtime.md
@@ -3,7 +3,7 @@
 Status: authoritative for long-lived in-memory runtime systems under
 `anyharness-lib/src/live/**`.
 
-Session manager, handle, actor, driver, event sink, interaction broker,
+Session manager, handle, actor, driver, sink, interaction rendezvous,
 background work, and replay live under `live/sessions/**`. Remaining `acp/**`
 files are shared permission, payload, and provider-error helpers, not
 live-session owners. Treat this guide as the grammar for new work and cleanup
@@ -72,21 +72,51 @@ Default target shape:
 ```text
 live/<resource>/
   mod.rs
+  model.rs          # the live vocabulary file (see below)
   manager.rs or manager/
   handle.rs
   actor/
   driver/
-  event_sink/       # or output_sink/ for terminal-style streams
-  interactions/
+  sink/             # or output_sink/ for terminal-style streams
+  rendezvous/
   background_work/
   snapshot/
   replay/
 ```
 
-Only `manager`, `handle`, and intentionally public live result/snapshot/event
-types should be visible outside `live/<resource>`. Actor commands, driver
-clients, sink internals, and interaction waiters are private implementation
-details.
+Only `model`, `manager`, `handle`, and intentionally public live
+result/snapshot/event types should be visible outside `live/<resource>`. Actor
+commands, driver clients, sink internals, and rendezvous waiters are private
+implementation details.
+
+## The Live Vocabulary File
+
+`live/<area>/model.rs` is the live layer's job-1 file: it declares every shape
+that crosses the live boundary, in live's own vocabulary. For sessions it
+holds:
+
+```text
+launch bundles      SessionLaunch, LaunchEnv (named env layers — never four
+                    adjacent maps), SystemPromptAppends, SessionStartupStrategy
+
+capability traits   the durable powers the actor needs, mirroring store
+                    signatures 1:1: EventPersist, QueueDurable,
+                    BackgroundWorkDurable, SessionStateDurable,
+                    AttachmentSource
+
+capability bundle   ActorCapabilities — the never-varies set (traits +
+                    observers + advisor), built once and owned by the manager
+
+per-call powers     SessionHooks (on_turn_finish, on_exit)
+
+product-hook ports  SessionEventObserver, PermissionAdvisor, SessionDomainOp
+                    (+ ObserverEffects, PermissionAdvice, SessionOpEmitter)
+```
+
+Live defines these traits; domains implement them
+(`domains/sessions/live_ports.rs` for the durable capabilities,
+`domains/plans/` and `domains/reviews/` for the product hooks); `app/` wires
+the implementations in. Live never imports domain services or stores.
 
 ## Manager
 
@@ -114,13 +144,21 @@ only to coordinate instances of this live resource. If a broker or service is
 used independently by other domains/resources, `app/` should compose it and
 pass it in as a dependency.
 
-Prefer explicit dependency bundles when a manager has many collaborators:
+The capability-wiring law: the wiring family (`app/sessions.rs`) builds the
+never-varies capability bundle exactly once; the manager owns it and hands it
+to every actor it starts.
 
 ```rust
-pub struct LiveSessionManagerDeps {
-    pub interaction_broker: Arc<InteractionBroker>,
-    pub actor_deps: Arc<LiveSessionActorDeps>,
-}
+// app/sessions.rs — composition only, no behavior
+let caps = ActorCapabilities { events, queue, background, state, attachments,
+                               observers, permission_advisor };
+let manager = LiveSessionManager::new(caps);
+```
+
+Per-call data rides the launch bundle; per-call powers ride beside it:
+
+```rust
+manager.start_session(launch /* SessionLaunch */, hooks /* SessionHooks */)
 ```
 
 ## Handle
@@ -148,9 +186,7 @@ private actor commands or send directly on the actor mailbox.
 Good boundary:
 
 ```rust
-handle
-    .send_prompt(LivePromptCommand { payload, prompt_id, latency })
-    .await?;
+handle.send_prompt(payload, prompt_id).await?;
 ```
 
 Bad boundary:
@@ -174,7 +210,7 @@ Actor responsibilities:
 - own authoritative live mutation for one instance
 - serialize commands, external notifications, timeouts, and shutdown
 - enforce live phase rules such as idle/busy/closing
-- decide ordering and delegate work to driver, sink, interactions, and
+- decide ordering and delegate work to driver, sink, rendezvous, and
   background-work helpers
 - update actor-owned snapshot state
 
@@ -192,7 +228,7 @@ The actor has gravity. Keep handlers thin:
 receive event
 validate current live phase
 update actor-owned state
-call driver/sink/interactions/background_work helper
+call driver/sink/rendezvous/background_work helper
 return accepted/queued/rejected outcome
 ```
 
@@ -236,11 +272,18 @@ protocol clients, browser drivers, and remote providers.
 A sink is the sequenced write path from external/runtime events into the
 internal live stream.
 
-For sessions, this is an event sink:
+For sessions, this is an event sink with one ingestion entry — `sink.ingest`
+takes one ACP `SessionNotification` and owns its whole transcript consequence:
 
 ```text
-ACP notifications -> normalized session events -> persist -> broadcast
+ACP notification -> sink.ingest -> normalize -> persist -> broadcast
+                                -> SinkObservations (for the observer pass)
+                                -> ActorBoundUpdate (arms only the actor may
+                                   finish: config/mode/session-info)
 ```
+
+The sink stays meaning-blind: it never touches durable session-row state or
+product reactors. What it cannot finish it parses and hands back to the actor.
 
 For terminals, this is more naturally an output sink:
 
@@ -271,12 +314,13 @@ actor decides when something happened
 sink decides how that becomes ordered output/events
 ```
 
-Avoid a generic `events/` folder. Use `event_sink/`, `output_sink/`,
+Avoid a generic `events/` folder. Use `sink/`, `output_sink/`,
 `projection/`, or a more specific name that says what the folder writes.
 
-## Interactions
+## Rendezvous
 
-`interactions/**` owns pending live rendezvous.
+`rendezvous/**` owns pending live rendezvous. For sessions the broker type is
+`InteractionRendezvous` (`live/sessions/rendezvous/broker.rs`).
 
 Examples:
 
@@ -324,7 +368,7 @@ Bad examples:
 - delayed UI notifications
 
 Those belong under the role they serve: `driver/retry.rs`,
-`actor/shutdown/cleanup.rs`, `event_sink/publish.rs`, or
+`actor/shutdown/cleanup.rs`, `sink/publish.rs`, or
 `manager/cleanup.rs`.
 
 ## Snapshots And Replay
@@ -349,7 +393,7 @@ Use `replay/**` when replay is more than a tiny helper:
 
 Do not call something `replay_actor` unless it truly has its own mailbox,
 serialized state, independent task, and lifecycle. Otherwise prefer
-`replay/stream.rs` or `event_sink/replay.rs`.
+`replay/stream.rs` or `sink/replay.rs`.
 
 ## Folder Composition
 
@@ -362,7 +406,7 @@ actor/
   mod.rs
   command.rs
   state.rs
-  event_loop.rs
+  run.rs
   spawn.rs
   startup.rs
 
@@ -386,10 +430,11 @@ command.rs
   private actor mailbox protocol
 
 state.rs
-  actor-owned mutable state and phase tracking
+  the actor struct: actor-owned mutable state and phase tracking
 
-event_loop.rs
-  select/receive loop and top-level dispatch
+run.rs
+  select/receive loop and top-level dispatch — `&mut self` methods on the
+  actor struct; receivers threaded as parameters, never stored on the struct
 
 spawn.rs/startup.rs
   task creation and initial live setup
@@ -458,12 +503,20 @@ files are:
 
 ```text
 driver/types.rs
-driver/start.rs
-driver/process.rs
-driver/native_session.rs
+driver/process.rs            # spawn and wire the agent process
+driver/connection.rs         # establish the ACP connection, register inbound handlers
+driver/session_lifecycle.rs  # initialize the connection
+driver/native_session.rs     # new/load/fork native session calls
+driver/inbound/              # InboundDoor — see below
 driver/stderr.rs
 driver/shutdown.rs
 ```
+
+`driver/inbound/` is the **inbound door**: everything the agent-initiated
+direction of the connection may touch. Handlers registered in `connection.rs`
+clone an `Arc<InboundDoor>`, which routes notifications to the actor's channel
+and inbound requests (permission, user input, MCP elicitation) through the
+rendezvous broker, rendering pending-interaction state via the shared sink.
 
 For terminals, target driver files would likely be:
 
@@ -475,14 +528,15 @@ live/terminals/driver/
   shutdown.rs
 ```
 
-### `event_sink/**` Or `output_sink/**`
+### `sink/**` Or `output_sink/**`
 
 Target event sink shape:
 
 ```text
-event_sink/
+sink/
   mod.rs
   state.rs
+  ingest.rs        # the one ingestion entry for ACP notifications
   publish.rs
   lifecycle.rs
   turns.rs
@@ -495,29 +549,29 @@ event_sink/
   pending_prompts.rs
   background_work.rs
   runtime_events.rs
+  metadata.rs
   normalization/
 ```
 
 Split by event/output family and sequencing responsibility. Keep the sink as
-the one ordered write path.
+the one ordered write path, with `ingest` as its one inbound entry.
 
-### `interactions/**`
+### `rendezvous/**`
 
 Target shape:
 
 ```text
-interactions/
+rendezvous/
   mod.rs
-  broker.rs
-  validation.rs
-  permission.rs
-  user_input.rs
-  cleanup.rs
+  broker.rs            # InteractionRendezvous
+  broker/validation.rs
   mcp_elicitation/
 ```
 
 Use subfolders when the rendezvous kind has several protocol or normalization
-steps.
+steps. The protocol-side creation of pending requests lives in
+`driver/inbound/` (permission, user input, MCP elicitation); the broker owns
+the waiters.
 
 ### `background_work/**`
 
@@ -535,75 +589,61 @@ Split provider-specific long-running work from generic registry/update logic.
 
 ## Live Sessions
 
-Target session shape:
+Current session shape:
 
 ```text
 live/sessions/
   mod.rs
-  manager.rs or manager/
+  model.rs           # the live vocabulary file
+  manager/           # surface, startup, replay, runtime-event injection
   handle.rs
+  probe.rs
 
   actor/
     command.rs
-    state.rs
-    event_loop.rs
+    state.rs         # struct SessionActor
+    run.rs
     spawn.rs
     startup.rs
     background_work.rs
     turn/
     config/
-    notifications/
+    notifications/   # dispatch, replay_filter, observations
     interactions/
     fork/
     shutdown/
+    tests/
 
   driver/
     types.rs
-    start.rs
     process.rs
+    connection.rs
+    session_lifecycle.rs
     native_session.rs
+    inbound/         # InboundDoor: permission, user_input, mcp_elicitation
     stderr.rs
     shutdown.rs
 
-  event_sink/
-  interactions/
+  sink/              # ingest.rs is the one ingestion entry
+  rendezvous/        # InteractionRendezvous broker + mcp_elicitation
   background_work/
   replay/
 ```
 
-Current mapping:
+Path mapping notes:
 
 ```text
-live/sessions/handle.rs
-  target handle
+live/sessions/rendezvous/**
+  permission, user-input, and MCP elicitation rendezvous (formerly
+  interactions/; the broker is InteractionRendezvous)
 
-live/sessions/actor/**
-  target actor
+live/sessions/sink/**
+  the session event sink (formerly event_sink/)
 
-live/sessions/driver/**
-  current and target session driver
-
-live/sessions/manager/**
-  current LiveSessionManager split by manager surface, startup, replay, and
-  runtime-event injection
-
-live/sessions/driver/runtime_client/**
-  current low-level ACP client name inside the driver role; reusable protocol
-  pieces belong under integrations/acp only when they are genuinely
-  protocol-neutral
-
-live/sessions/event_sink/**
-  current and target session event sink
-
-live/sessions/interactions/**
-  current and target permission, user-input, and MCP elicitation rendezvous
-
-live/sessions/background_work/**
-  current and target provider-reported long-running work registry
-
-live/sessions/replay/**
-  current replay actor support; target replay role unless it truly remains an
-  independent actor
+live/sessions/driver/inbound/**
+  the agent-initiated direction of the ACP connection (formerly the
+  runtime_client folder); reusable protocol pieces belong under
+  integrations/acp only when they are genuinely protocol-neutral
 
 acp/permission_context.rs
 acp/permission_payload.rs
@@ -616,11 +656,12 @@ The end-to-end session mental model:
 
 ```text
 SessionRuntime
-  loads durable session/workspace/agent state
-  prepares product-owned prompt/config/start data
-  calls LiveSessionManager
+  loads durable session/workspace/agent state (startup.rs resolves)
+  launch_policy (pure) decides strategy and assembles SessionLaunch
+  calls manager.start_session(launch, hooks)
 
 LiveSessionManager
+  owns ActorCapabilities (wired once in app/sessions.rs)
   starts or finds the live session
   returns LiveSessionHandle
 
@@ -631,15 +672,67 @@ LiveSessionHandle
 SessionActor
   serializes live mutation
   delegates external I/O to driver
-  delegates event persistence/broadcast to event_sink
-  delegates live rendezvous to interactions
+  delegates event persistence/broadcast to sink (sink.ingest)
+  delegates live rendezvous to the InteractionRendezvous broker
+  runs the observer dispatch pass and serialized domain ops
 
 Driver
-  owns ACP process/client lifecycle
+  owns ACP process/connection lifecycle; the InboundDoor receives
+  agent-initiated traffic
 
-EventSink
+Sink
   normalizes ACP notifications into durable/broadcast session events
 ```
+
+## Product Hooks
+
+Product domains react to a live session through four mechanisms, all declared
+in `live/sessions/model.rs` and wired in `app/`. The actor's pockets are
+empty: it never imports plan or review services.
+
+The mechanism decision table:
+
+| Mechanism | Timing | Task / thread | May emit events | May block |
+| --- | --- | --- | --- | --- |
+| `SessionExtension` | launch / turn-finish / session-close lifecycle | main tokio runtime (hooks may spawn) | no — use the runtime-event injection paths | no |
+| `SessionEventObserver` | each special observation in the dispatch pass | per-session thread, in-loop, sink lock held | yes — committed rows returned in `ObserverEffects` | sqlite tx only |
+| `PermissionAdvisor` | inbound permission arrival, before parking | inbound-door task, sink lock held by the caller | yes — committed rows returned in `Predecided` | sqlite tx only |
+| `SessionDomainOp` | product-initiated write needing command ordering | actor loop via the mailbox, sink lock per phase | yes — via `SessionOpEmitter::publish` | sqlite tx only (sync per phase) |
+
+Current implementors: `domains/plans/session_observer.rs` (plan sniffing),
+`domains/reviews/session_observer.rs` (candidate plans),
+`domains/plans/permission_advisor.rs` (plan-linked permissions),
+`domains/plans/decision_op.rs` (approve/reject via
+`SessionCommand::RunDomainOp`).
+
+## Event-Emission Serialization
+
+Session-event emission rests on two nested guarantees:
+
+1. **The per-session `current_thread` runtime** — nothing in one session is
+   ever parallel.
+2. **The sink lock** — every `next_seq` read, every domain tx persisting event
+   rows, and every publish happens while the sink mutex is held.
+
+The actor loop adds *ordering* on top: domain writes that must not interleave
+with `Cancel`/`Close`/other commands ride the mailbox as a `SessionDomainOp`
+(two locked phases, lock released only for an interaction resolution between
+them).
+
+Observers run **in-loop in a single ordered pass**, in registration order,
+under one sink lock hold. Observer `i`'s returned envelopes are published
+immediately and fed forward only to observers `j > i` — never backward, never
+a second pass. The partial-failure seq contract: a hook either fails WITHOUT
+committing event rows, or commits and returns EVERY committed envelope; the
+sink advances `next_seq` only by returned envelopes, so an unreturned row
+collides loudly (unique-seq violation), never a silent gap.
+
+The advisor runs on the **inbound-door task** with the sink lock held by the
+caller — exactly where the inline logic it replaced ran.
+
+Anything event-emitting is synchronous under the sink lock. Side effects that
+emit nothing may hand off to a main-runtime `Handle` captured at app wiring —
+the per-session runtime dies with the session; never spawn lasting work on it.
 
 ## Live Terminals
 
@@ -762,11 +855,11 @@ How product code hands work to a live resource, and what live may know back
   (multiple env maps) are a silent-swap hazard and must be named struct
   fields.
 
-Migration exceptions: `LiveSessionManager::start_session` takes 15+ positional
-parameters including four adjacent env maps, and receives concrete
-`SessionStore`/`PromptAttachmentStorage` per call; `SessionActorConfig` holds
-concrete domain stores/services. Target: a `SessionLaunch` bundle plus
-capability traits wired at construction.
+Sessions are the in-repo exemplar of this boundary:
+`manager.start_session(launch: SessionLaunch, hooks: SessionHooks)` is the
+whole per-call surface; the durable powers are the capability traits in
+`ActorCapabilities`, implemented by `domains/sessions/live_ports.rs` (pure
+1:1 delegation over `SessionStore`) and wired once in `app/sessions.rs`.
 
 ## Dependency Rules
 
@@ -785,7 +878,7 @@ Avoid:
 live -> api
 live -> app
 driver -> product domain services
-event_sink -> product access-control decisions
+sink -> product access-control decisions
 integrations -> live
 ```
 
@@ -793,13 +886,15 @@ Recommended module visibility:
 
 ```rust
 pub mod sessions {
+    pub mod model; // the boundary vocabulary is public
+
     pub use handle::LiveSessionHandle;
     pub use manager::LiveSessionManager;
 
     mod actor;
     mod driver;
-    mod event_sink;
-    mod interactions;
+    mod sink;
+    mod rendezvous;
     mod background_work;
 }
 ```

--- a/specs/codebase/structures/anyharness/guides/mental-model.md
+++ b/specs/codebase/structures/anyharness/guides/mental-model.md
@@ -298,19 +298,10 @@ textbook small domain   domains/repo_roots
 Known violations, named per the specs convention. The rule above is the law;
 these are the debt:
 
-- `LatencyRequestContext` threaded as a parameter through ~13 functions across
-  api -> domains -> live (sessions startup/prompt paths). Target: span
-  propagation.
-- `domains/sessions/runtime/contract.rs` is a fetching mapper (store reads +
-  live lookups inside `to_contract`), called per-record on list paths. Target:
-  a `SessionView` composed by the runtime + a dep-less mapper.
 - ~81 `anyharness_contract` import lines inside `domains/**`; worst:
   `runtime_config` persists wire types as rows, `agents/auth_config` uses
   contract structs as its domain model. Target: domain twins minted at the
   seams.
-- `live/sessions` receives concrete `SessionStore`/`PromptAttachmentStorage`
-  per call and `LiveSessionManager::start_session` takes 15+ positional params
-  including four adjacent env maps. Target: launch bundle + capability traits.
 - `api/http/agents.rs` carries a second error mechanism (`ProblemResponse`)
   alongside `ApiError`. Target: one mechanism.
 - `api/http/workspaces_lifecycle.rs` implements the retire state machine in
@@ -318,3 +309,17 @@ these are the debt:
   in `domains/workspaces`.
 - `WorkspaceService` and `WorkspaceRuntime` carry duplicated, diverged method
   bodies. Target: one entry surface.
+
+Resolved (the rule now holds; listed for traceability):
+
+- Latency context threading (a request-context struct through ~13 signatures
+  across api -> domains -> live) — resolved by the latency-to-spans migration;
+  flow context propagates through `#[tracing::instrument]` spans only.
+- The sessions runtime's fetching response mapper (store reads + live lookups
+  inside the domain-side contract builder) — resolved by
+  `domains/sessions/runtime/view.rs`: the runtime composes `SessionView`; the
+  API maps it with a dep-less mapper.
+- `live/sessions` receiving concrete stores per call and a 15+-positional-param
+  `start_session` — resolved by the `SessionLaunch`/`LaunchEnv` bundle,
+  `ActorCapabilities` (capability traits wired once at manager construction),
+  and per-call `SessionHooks`.

--- a/specs/codebase/structures/anyharness/guides/observability.md
+++ b/specs/codebase/structures/anyharness/guides/observability.md
@@ -43,19 +43,20 @@ How runtime code emits diagnostics, regardless of layer:
 - Phase timings are span events, not hand-rolled `Instant::now()` pairs with
   repeated field blocks.
 - **Observability context never appears in a function signature.** Request
-  latency/flow context is parsed from headers at the transport edge, attached
-  to the request span, and propagates through span context — never as a
-  `latency: Option<&LatencyRequestContext>` parameter or struct field.
+  latency/flow context is parsed from headers at the transport edge
+  (`FlowHeaders::from_headers` -> `.span()`), attached to the request span,
+  and propagates through span context — never as a `latency: Option<&...>`
+  parameter or struct field.
 - Hand-copying the same field cluster (`flow_id`/`flow_kind`/`flow_source`/
   `prompt_id`) across multiple `tracing::` calls in one file is the symptom
   that a span is missing. Copy-pasted clusters drift; spans cannot.
 - Log where an error is handled, not at every hop it passes through.
 
-Migration exception: the sessions startup/prompt paths currently thread
-`LatencyRequestContext` through ~13 signatures across api -> domains -> live
-and relay it via actor config/command fields, with the field cluster
-hand-copied in 10+ call sites. Target: one request span at the edge, child
-spans per use case, events for phases.
+This doctrine now holds on the sessions startup/prompt paths: the former
+`LatencyRequestContext` (once threaded through ~13 signatures across
+api -> domains -> live and relayed via actor config/command fields) is
+deleted. Spans are attached at the transport edges and the
+`[workspace-latency]` event names are unchanged.
 
 ## Dependency Rule
 

--- a/specs/codebase/structures/anyharness/guides/repo-shape.md
+++ b/specs/codebase/structures/anyharness/guides/repo-shape.md
@@ -15,7 +15,7 @@ Use these thresholds for Rust source under `anyharness/crates/**`:
 | `domains/**/runtime*.rs` | 500 | 900 | Split by workflow family. |
 | `live/**/actor/**/*.rs` | 500 | 900 | Split by command/startup/prompt/config/lifecycle concern. |
 | `live/**/driver/**/*.rs` | 500 | 900 | Split by external process/protocol/PTY lifecycle concern. |
-| `live/**/event_sink/**/*.rs` | 500 | 900 | Split by normalized event family. |
+| `live/**/sink/**/*.rs` | 500 | 900 | Split by normalized event family. |
 | `live/**/output_sink/**/*.rs` | 500 | 900 | Split by ordered output family. |
 | `adapters/**/*.rs` | 500 | 900 | Split by capability if the adapter grows. |
 | `integrations/**/*.rs` | 400 | 800 | Split by protocol concern. |
@@ -27,18 +27,18 @@ Current split shapes:
 - `domains/sessions/store/**` is the current split session store shape.
 - `domains/sessions/mcp_bindings/**` is the current split session MCP binding and
   launch assembly shape.
-- `live/sessions/event_sink/**` is the current split session event sink shape.
+- `live/sessions/sink/**` is the current split session event sink shape.
 - `domains/sessions/runtime/**` is the current split session runtime shape.
 - `live/sessions/manager/**`, `live/sessions/handle.rs`,
   `live/sessions/actor/**`, `live/sessions/driver/**`,
-  `live/sessions/event_sink/**`, `live/sessions/interactions/**`,
+  `live/sessions/sink/**`, `live/sessions/rendezvous/**`,
   `live/sessions/background_work/**`, and `live/sessions/replay/**` are the
-  current split live session shape. `RuntimeClient` is split under
-  `live/sessions/driver/runtime_client/**` as the current low-level ACP client
-  name inside the driver role.
+  current split live session shape. The `InboundDoor` is split under
+  `live/sessions/driver/inbound/**` as the agent-initiated inbound direction
+  inside the driver role.
 - Remaining `acp/**` files are shared ACP permission/payload/provider-error
-  helpers, not current owners for live session manager, event sink,
-  interactions, background work, or replay behavior.
+  helpers, not current owners for live session manager, sink, rendezvous,
+  background work, or replay behavior.
 
 ## Module Style
 
@@ -58,7 +58,7 @@ Split when a reader can name a real responsibility:
 store/events.rs
 runtime/prompt.rs
 actor/config.rs
-event_sink/tools.rs
+sink/tools.rs
 integrations/mcp/json_rpc.rs
 ```
 
@@ -71,7 +71,7 @@ files. The target is legibility by path at both levels:
 ```text
 domains/sessions/runtime/prompt.rs    # session workflow entrypoint
 live/sessions/actor/turn/active.rs    # active prompt turn loop
-live/sessions/event_sink/tools.rs     # transcript event normalization
+live/sessions/sink/tools.rs           # transcript event normalization
 ```
 
 Do not dump unrelated files into a newly-correct parent folder. A move into
@@ -86,7 +86,7 @@ owning spec or guide. For example:
 - app composition split by wiring family such as sessions, workspaces,
   product extensions, product MCP registration, and startup tasks.
 - live resources split by manager, handle, private actor, private driver,
-  sink, interactions, background work, snapshot, and replay roles.
+  sink, rendezvous, background work, snapshot, and replay roles.
 - live actors split by command surface, loop, startup, prompt turn, config,
   notifications, interactions, and shutdown.
 - event/output sinks split by normalized event or output family.

--- a/specs/codebase/structures/anyharness/guides/system-architecture.md
+++ b/specs/codebase/structures/anyharness/guides/system-architecture.md
@@ -458,9 +458,9 @@ live/<system>/
   handle.rs
   actor/              # optional, private serialized coordinator
   driver/             # optional, private external backing mechanism
-  event_sink/         # optional, sequenced event write path
+  sink/               # optional, sequenced event write path
   output_sink/        # optional terminal-style stream write path
-  interactions/       # optional pending live rendezvous
+  rendezvous/         # optional pending live rendezvous
   background_work/    # optional provider/runtime long-running work
   snapshot/           # optional read projection
   replay/             # optional replay/subscription mechanics
@@ -482,10 +482,10 @@ driver/
   external mechanism that makes the live resource real: ACP client,
   subprocess, PTY, browser driver, remote provider, or protocol client
 
-event_sink/ or output_sink/
+sink/ or output_sink/
   normalized, sequenced write path into durable/broadcast/live streams
 
-interactions/
+rendezvous/
   pending request-id to waiter/resolution state for live callbacks
 
 background_work/
@@ -503,8 +503,8 @@ mod.rs
 
 Only create a `live/<system>/` folder when there is a real long-lived runtime
 object: a manager, actor, handle, PTY, sidecar, watcher, stream registry, or
-pending interaction broker. A domain workflow that merely starts a session does
-not earn a `live/` folder.
+pending interaction rendezvous. A domain workflow that merely starts a session
+does not earn a `live/` folder.
 
 Not every live resource needs every role. The minimum shape is whatever keeps
 the live identity legible. A one-shot command runner may only need a handle
@@ -540,7 +540,7 @@ handle  = one live instance public port
 actor   = private serialized coordinator for one live instance
 driver  = private external backing mechanism
 sink    = sequenced event/output write path
-interactions = pending live rendezvous
+rendezvous = pending live interaction rendezvous
 snapshot = read projection published by the actor/handle
 ```
 
@@ -554,13 +554,14 @@ Target shape:
 ```text
 live/sessions/
   mod.rs
-  manager.rs
+  model.rs            # the live vocabulary (SessionLaunch, SessionHooks, …)
+  manager/
   handle.rs
 
   actor/
   driver/
-  event_sink/
-  interactions/
+  sink/
+  rendezvous/
   background_work/
   snapshot/
   replay/
@@ -569,7 +570,7 @@ live/sessions/
 Ownership:
 
 ```text
-manager.rs
+manager/
   live session registry and startup de-dupe
 
 handle.rs
@@ -580,14 +581,16 @@ actor/
   notification dispatch, shutdown decisions
 
 driver/
-  ACP process/session lifecycle: spawn, stdio, initialize, authenticate,
-  new/load/fork native session, stderr
+  ACP process/connection lifecycle: spawn, stdio, initialize, authenticate,
+  new/load/fork native session, stderr; the InboundDoor (driver/inbound/)
+  receives agent-initiated traffic
 
-event_sink/
+sink/
   event normalization, sequence assignment, persistence, broadcast
+  (one ingestion entry: sink.ingest)
 
-interactions/
-  permission/user-input/MCP pending request broker
+rendezvous/
+  permission/user-input/MCP pending request rendezvous
 
 background_work/
   long-running tool/background task tracking
@@ -597,8 +600,8 @@ The current tree uses `live/sessions/driver/**` for the driver role.
 
 The actor coordinates these collaborators, but it should not own all their
 implementation code. Actor handlers are thin: they decide ordering, validate
-the live phase, update actor-owned state, and delegate to driver/event sink/
-interaction/background-work helpers.
+the live phase, update actor-owned state, and delegate to driver/sink/
+rendezvous/background-work helpers.
 
 Use this boundary:
 
@@ -647,7 +650,7 @@ live/sessions/actor/
   mod.rs
   command.rs
   state.rs
-  event_loop.rs
+  run.rs
 
   turn/
     mod.rs
@@ -674,7 +677,7 @@ live/sessions/actor/
     handle.rs
     dispatch.rs
     replay_filter.rs
-    plans.rs
+    observations.rs
 
   shutdown/
     mod.rs
@@ -701,7 +704,7 @@ actor/ must not inline event normalization/persistence
 actor/ must not decide durable product policy
 actor/ must not expose its command enum outside the live resource
 driver/ must not import api/app or product stores/services
-event_sink/ must be the only sequenced event writer for that resource
+sink/ must be the only sequenced event writer for that resource
 ```
 
 ## Adapters

--- a/specs/codebase/structures/anyharness/specs/session-actor.md
+++ b/specs/codebase/structures/anyharness/specs/session-actor.md
@@ -1,13 +1,14 @@
 # Session Actor
 
-Status: authoritative for the split live session actor.
+Status: authoritative for the split live session actor. The migration this
+spec drove is complete; the shapes below are the current code.
 
 This spec is specific to the actor portion of the AnyHarness session engine. It
 assumes the broader architecture in
 [guides/system-architecture.md](../guides/system-architecture.md) and the
 session engine overview in [session-engine.md](session-engine.md).
 
-Current implementation:
+Implementation:
 
 ```text
 anyharness-lib/src/live/sessions/actor/
@@ -15,37 +16,25 @@ anyharness-lib/src/live/sessions/driver/
 anyharness-lib/src/live/sessions/handle.rs
 ```
 
-Target owner:
+## Scope
+
+The actor is not a giant `session_actor.rs` file with support modules around
+it. The split holds as:
 
 ```text
-anyharness-lib/src/live/sessions/actor/
-```
-
-## Full Cleanup Scope
-
-This is not a helper-extraction task. A completed actor migration means the
-actor implementation is no longer a giant `session_actor.rs` file with support
-modules around it.
-
-Done means:
-
-```text
-live/sessions/actor/ owns the actor command protocol, state, event loop, turn,
+live/sessions/actor/ owns the actor command protocol, state, run loop, turn,
 config, notification, interaction-command, fork policy, background-work update,
-and shutdown behavior.
+and shutdown behavior — as &mut-self methods on `struct SessionActor`.
 
-live/sessions/driver/ owns ACP process/native-session startup and shutdown
-mechanics currently embedded in actor startup paths.
+live/sessions/driver/ owns ACP process/connection/native-session startup and
+shutdown mechanics.
 
 live/sessions/handle.rs owns the public command/subscription port into one
 actor.
-
-acp/session_actor.rs is deleted. No top-level actor behavior remains there.
 ```
 
-Do not stop after moving types, small helpers, or diagnostics out of the old
-file. The top-level actor loop must be readable from
-`live/sessions/actor/event_loop.rs`.
+The old `acp/session_actor.rs` is gone. The top-level actor loop is readable
+from `live/sessions/actor/run.rs`.
 
 ## Purpose
 
@@ -72,8 +61,8 @@ domains/sessions/runtime
   -> live/sessions/handle
     -> live/sessions/actor
       -> live/sessions/driver
-      -> live/sessions/event_sink
-      -> live/sessions/interactions
+      -> live/sessions/sink
+      -> live/sessions/rendezvous
       -> live/sessions/background_work
 ```
 
@@ -107,27 +96,36 @@ live/sessions/handle
   public command/subscription port used by SessionRuntime and stream code
 
 live/sessions/driver
-  ACP process/session lifecycle: spawn, initialize, authenticate, load/new/fork,
-  stderr, graceful close
+  ACP process/connection/session lifecycle: spawn (process.rs), establish and
+  register handlers (connection.rs), initialize (session_lifecycle.rs),
+  load/new/fork (native_session.rs), stderr, graceful close; the InboundDoor
+  (driver/inbound/) receives agent-initiated requests and notifications
 
-live/sessions/acp_client
-  low-level ACP request/notification adapter
+live/sessions/sink
+  normalized event sequencing, persistence, and broadcast fanout; ingest.rs is
+  the one ingestion entry for ACP notifications
 
-live/sessions/event_sink
-  normalized event sequencing, persistence, and broadcast fanout
-
-live/sessions/interactions
+live/sessions/rendezvous
   pending permission, user-input, and MCP elicitation rendezvous
+  (InteractionRendezvous)
 
 live/sessions/background_work
   long-running tool/background work tracking
 
-domains/sessions/store
-  narrow durable operations the actor needs, such as raw notification append,
-  pending prompt queue mutation, and config queue mutation
+live/sessions/model.rs capability traits
+  the narrow durable operations the actor needs (EventPersist, QueueDurable,
+  BackgroundWorkDurable, SessionStateDurable, AttachmentSource), implemented
+  by domains/sessions/live_ports.rs and wired in app/sessions.rs as
+  ActorCapabilities — the actor never sees a concrete store
+
+live/sessions/model.rs product-hook ports
+  SessionEventObserver, PermissionAdvisor, SessionDomainOp — how plans and
+  reviews react without the actor importing their services
 
 domains/sessions/prompt
-  product prompt payload preparation before the actor receives a command
+  product prompt payload preparation before the actor receives a command;
+  prompt/render.rs is the pure ACP-block rendering the actor calls with
+  pre-loaded ResolvedParts
 
 domains/sessions/mcp_bindings
   product/user MCP launch assembly before actor startup
@@ -169,7 +167,7 @@ domain state or provider state.
 
 Actor commands are the only way product code mutates a live session.
 
-Target command categories:
+Command categories:
 
 ```text
 Prompt
@@ -180,6 +178,11 @@ SetConfigOption
 
 ResolveInteraction
   complete a pending permission/user-input/MCP elicitation
+
+RunDomainOp
+  execute a boxed SessionDomainOp (e.g. the plan approve/reject decision)
+  serialized through the mailbox; phases run under the sink lock, the boxed
+  Any reply downcasts at the submitter
 
 Fork
   allowed only when actor state and provider capability permit
@@ -283,7 +286,7 @@ Snapshot          -> return current snapshot
 This split should be explicit in code. Do not hide busy/idle behavior behind a
 single large command match.
 
-## Target Folder Shape
+## Folder Shape
 
 Top-level actor files:
 
@@ -292,10 +295,11 @@ live/sessions/actor/
   mod.rs
   command.rs
   state.rs
-  event_loop.rs
+  run.rs
   spawn.rs
   startup.rs
   background_work.rs
+  tests/
 ```
 
 Responsibilities:
@@ -308,20 +312,31 @@ command.rs
   command/result types accepted by the actor handle
 
 state.rs
-  actor-owned live state and phase types
+  `struct SessionActor` — identity from the launch, loop-owned conversation
+  state, wiring set at startup — plus SessionActorConfig (launch + caps +
+  hooks + broker + event channel) and phase types
 
-event_loop.rs
-  top-level select loop and dispatch only
+run.rs
+  top-level select loop and dispatch only: &mut-self methods
+  (run / run_idle / run_turn); every arm is one method call
 
 spawn.rs
   actor thread creation, readiness waiting, and handle construction
 
 startup.rs
-  ACP process/session startup orchestration after the actor thread is running
+  the SessionActor constructor: spawns the agent process
+  (driver/process.rs), establishes the connection (driver/connection.rs),
+  initializes it (driver/session_lifecycle.rs), starts the native session,
+  and runs the startup config-restore sequence
 
 background_work.rs
   actor-side background work update handling
 ```
+
+The three receivers (commands, notifications, background work) deliberately
+stay OUT of the struct: they are threaded through `run`/`run_idle`/`run_turn`
+as parameters so the inner selects can borrow them alongside `&mut self`.
+There are no per-flow context structs — handlers are methods on the actor.
 
 No actor-owned file should become the new god module. If one concern file grows
 past the repo-shape hard limit, split it by the concern grammar below before
@@ -368,7 +383,7 @@ diagnostics.rs # tracing/debug timeout logic
 
 ## Turn Folder
 
-Target:
+Shape:
 
 ```text
 actor/turn/
@@ -409,7 +424,7 @@ building remains in `domains/sessions/prompt`.
 
 ## Config Folder
 
-Target:
+Shape:
 
 ```text
 actor/config/
@@ -446,16 +461,15 @@ Config selection that is product-facing or launch-facing belongs in
 
 ## Notifications Folder
 
-Target:
+Shape:
 
 ```text
 actor/notifications/
   mod.rs
-  types.rs
   handle.rs
   dispatch.rs
   replay_filter.rs
-  plans.rs
+  observations.rs
 ```
 
 Responsibilities:
@@ -465,34 +479,39 @@ handle.rs
   ACP notification entrypoint
 
 dispatch.rs
-  route by notification kind: assistant, reasoning, tool, config, session info,
-  usage, permission/input/MCP request, lifecycle
+  persist the raw notification, hand it to sink.ingest, apply any returned
+  ActorBoundUpdate (config/mode/session-info arms only the actor may finish),
+  then run the observer pass over the collected observations
 
 replay_filter.rs
   suppress provider replay/startup notifications that should not become new
   product events
 
-plans.rs
-  actor-side plan extraction hooks only while this remains coupled to live
-  notification handling
+observations.rs
+  the observer dispatch pass: one sink lock hold, registration order,
+  feed-forward of earlier observers' envelopes (see live/sessions/model.rs)
 ```
 
-Notification handlers should persist the raw ACP notification before normalized
-event handling when the current invariant requires it.
+There is no actor-side plan code: plan sniffing lives in
+`domains/plans/session_observer.rs` (a `SessionEventObserver` wired in
+`app/sessions.rs`).
 
-Tool calls are not a separate actor subsystem unless they need one. They enter
-as ACP notifications, route through notification dispatch, and are normalized
-by `event_sink/tools.rs`.
+Notification handlers persist the raw ACP notification before normalized
+event handling.
+
+Tool calls are not a separate actor subsystem. They enter as ACP
+notifications, route through notification dispatch, and are normalized by
+`sink/tools.rs`.
 
 ## Interactions Folder
 
-Target:
+Shape:
 
 ```text
 actor/interactions/
   mod.rs
-  types.rs
   handle.rs
+  outcomes.rs
   cleanup.rs
 ```
 
@@ -502,23 +521,31 @@ Responsibilities:
 handle.rs
   ResolveInteraction command entrypoint
 
+outcomes.rs
+  resolution outcome handling
+
 cleanup.rs
   cancel/dismiss/shutdown cleanup for pending waits
 ```
 
+There are no plan files here. Plan approve/reject is
+`domains/plans/decision_op.rs`, a `SessionDomainOp` submitted via
+`SessionCommand::RunDomainOp` (through `handle.run_domain_op`), not a bespoke
+actor arm.
+
 The pending request broker itself belongs outside the actor:
 
 ```text
-live/sessions/interactions/
+live/sessions/rendezvous/
 ```
 
-Reason: `AcpClient` creates pending requests, API/runtime resolves them through
-commands, and the actor cleans them up. The broker is a collaborator, not an
-actor-internal module.
+Reason: the driver's `InboundDoor` creates pending requests, API/runtime
+resolves them through commands, and the actor cleans them up. The broker
+(`InteractionRendezvous`) is a collaborator, not an actor-internal module.
 
 ## Shutdown Folder
 
-Target:
+Shape:
 
 ```text
 actor/shutdown/
@@ -550,15 +577,17 @@ decide product retention/cleanup policy.
 
 ACP process startup does not belong inside `actor/` concern folders.
 
-Target:
+Shape:
 
 ```text
 live/sessions/driver/
   mod.rs
   types.rs
-  start.rs
   process.rs
+  connection.rs
+  session_lifecycle.rs
   native_session.rs
+  inbound/
   stderr.rs
   shutdown.rs
 ```
@@ -566,14 +595,25 @@ live/sessions/driver/
 Responsibilities:
 
 ```text
-start.rs
-  create an initialized ACP connection for this session launch
-
 process.rs
   spawn and wire the provider process/stdin/stdout/stderr
 
+connection.rs
+  establish the ACP client connection over the agent's stdio: register the
+  inbound handlers (via the InboundDoor), spawn the connect future on the
+  per-session LocalSet, return the ConnectionTo handle
+
+session_lifecycle.rs
+  initialize the established connection
+
 native_session.rs
   new/load/fork native ACP session decisions and calls
+
+inbound/
+  the InboundDoor: agent-initiated notifications and requests (permission,
+  user_input, mcp_elicitation) routed to the actor channel and the
+  rendezvous broker; the permission path consults the PermissionAdvisor
+  before parking
 
 stderr.rs
   stderr sanitization/classification
@@ -582,14 +622,12 @@ shutdown.rs
   provider/process close behavior that is not actor state-machine policy
 ```
 
-The actor calls driver code during startup and shutdown, but driver code
-owns the process/protocol resource mechanics.
-
-For a full actor cleanup, driver extraction is in scope when the code is
-currently embedded in `session_actor.rs`. The actor may keep policy decisions
-such as "start a new native session vs load an existing native session" only
-when that decision depends on actor phase or ordering. The process/protocol
-mechanics belong in `live/sessions/driver/`.
+The actor's constructor (`actor/startup.rs`) builds the actor by calling
+driver code in order — process spawn, `connection.rs`,
+`session_lifecycle.rs`, native session start — but driver code owns the
+process/protocol resource mechanics. The actor keeps policy decisions such as
+"start a new native session vs load an existing native session" only when
+that decision depends on actor phase or ordering.
 
 Reusable ACP protocol or provider mechanics should move lower:
 
@@ -603,12 +641,13 @@ integrations/agent_cli/
 The actor decides when something happened. The event sink decides how it becomes
 durable and streamable.
 
-Target:
+Shape:
 
 ```text
-live/sessions/event_sink/
+live/sessions/sink/
   mod.rs
   state.rs
+  ingest.rs
   publish.rs
   turns.rs
   assistant.rs
@@ -621,8 +660,15 @@ live/sessions/event_sink/
   background_work.rs
   lifecycle.rs
   runtime_events.rs
+  metadata.rs
   normalization/
+  tests/
 ```
+
+`ingest.rs` is the one ingestion entry: it takes one ACP notification, owns
+its transcript consequence, collects `SinkObservation`s for the observer pass,
+and returns `ActorBoundUpdate` for the arms it cannot finish (the sink is
+meaning-blind: no durable session-row state, no product reactors).
 
 Actor may call methods such as:
 
@@ -660,7 +706,7 @@ format API responses
 
 ## Required Invariants
 
-Actor rewrite must preserve these:
+These hold today; changes must preserve them:
 
 ```text
 one actor owns one live ACP native session
@@ -671,50 +717,23 @@ config applies immediately only when idle; otherwise it queues
 interaction cleanup runs on cancel, dismiss, close, and error
 shutdown emits terminal session state exactly once
 event sequence order is stable for SSE replay + live broadcast
+event-emitting hooks run synchronously under the sink lock (observer pass,
+  advisor, domain-op phases); the sink advances next_seq only by envelopes
+  returned/published back to it
 actor never decides product MCP selection
+actor never imports product-domain services — product reactions arrive as
+  observers, the advisor, and domain ops via ActorCapabilities
 actor never validates raw HTTP request shapes
 ```
 
-## Migration Plan
+## Shape Checklist
 
-This rewrite should be behavior-preserving and may be implemented in slices,
-but the final PR state must be the full target shape above. Partial helper
-extraction is not an acceptable endpoint.
-
-Recommended order:
+A change to the actor is in shape when all of these stay true:
 
 ```text
-1. Extract command/state/event-loop shell.
-2. Extract turn start/active/finish/queue code.
-3. Extract config apply/queue/persist code.
-4. Extract notification dispatch/replay filtering.
-5. Extract interaction resolution/cleanup commands.
-6. Extract shutdown finalization.
-7. Move process startup mechanics to live/sessions/driver.
-8. Rename remaining RuntimeClient types only after behavior-preserving
-   driver/client splits are stable.
-```
-
-Each slice should:
-
-```text
-preserve public command/result behavior
-preserve event ordering
-preserve existing tests or add focused characterization tests
-delete the old code path
-avoid unrelated topology moves
-```
-
-Do not combine actor behavior changes with broad `domains/` or `live/`
-renames. The actor is the core loop; keep the migration reviewable.
-
-## Acceptance Criteria
-
-A full actor migration is accepted only when all of these are true:
-
-```text
-1. Opening live/sessions/actor/event_loop.rs shows the session engine event loop
-   without reading prompt/config/notification/shutdown implementation details.
+1. live/sessions/actor/run.rs shows the session engine loop without
+   prompt/config/notification/shutdown implementation details — every select
+   arm is one &mut-self method call.
 
 2. Idle and busy command behavior are explicit and separated.
 
@@ -724,9 +743,11 @@ A full actor migration is accepted only when all of these are true:
 4. Config apply-vs-queue behavior lives under actor/config/.
 
 5. ACP notification dispatch lives under actor/notifications/ and delegates
-   normalization to event_sink.
+   normalization to sink.ingest; the observer pass runs from
+   actor/notifications/observations.rs.
 
-6. Actor-side interaction resolution and cleanup live under actor/interactions/.
+6. Actor-side interaction resolution and cleanup live under actor/interactions/;
+   product decisions arrive as SessionDomainOps, never bespoke actor arms.
 
 7. Fork readiness, fork command handling, and native child-session close policy
    live under actor/fork/.
@@ -736,18 +757,19 @@ A full actor migration is accepted only when all of these are true:
 
 9. Cancel/close/dismiss/error finalization lives under actor/shutdown/.
 
-10. ACP process/native-session startup mechanics no longer live in actor
-   concern files; they live under live/sessions/driver/.
+10. ACP process/connection/native-session startup mechanics live under
+    live/sessions/driver/, called by actor/startup.rs in order.
 
-11. Product prompt preparation remains in domains/sessions/prompt.
+11. Product prompt preparation remains in domains/sessions/prompt; rendering
+    is the pure domains/sessions/prompt/render.rs over AttachmentSource-loaded
+    parts.
 
 12. Product MCP selection/injection remains in domains/sessions/mcp_bindings.
 
 13. Event normalization, sequence assignment, persistence, and broadcast remain
-    in `live/sessions/event_sink/**`.
+    in `live/sessions/sink/**`.
 
-14. The old acp/session_actor.rs implementation is gone.
-
-15. Existing session behavior and event ordering are preserved by tests or
-    focused characterization coverage.
+14. The actor reaches durable state only through the capability traits in
+    ActorCapabilities; it is testable with vectors behind the traits
+    (see actor/tests/).
 ```

--- a/specs/codebase/structures/anyharness/specs/session-engine.md
+++ b/specs/codebase/structures/anyharness/specs/session-engine.md
@@ -8,35 +8,43 @@ Status: authoritative for the core AnyHarness session engine mental model.
 api/http/sessions
   -> SessionRuntime
     -> SessionService / SessionStore
-    -> LiveSessionManager
+    -> launch_policy (pure) -> SessionLaunch + SessionHooks
+    -> LiveSessionManager.start_session(launch, hooks)
       -> LiveSessionHandle
         -> SessionActor
-          -> AcpClient
-          -> SessionEventSink
-          -> InteractionBroker
+          -> driver (ACP connection; InboundDoor for inbound traffic)
+          -> SessionEventSink (sink.ingest)
+          -> InteractionRendezvous
 ```
 
 Current names:
 
 ```text
-SessionRuntime      anyharness-lib/src/domains/sessions/runtime/
-SessionService      anyharness-lib/src/domains/sessions/service/
-SessionStore        anyharness-lib/src/domains/sessions/store/**
-LiveSessionManager  live/sessions/manager/**
-LiveSessionHandle   live/sessions/handle.rs
-SessionActor        live/sessions/actor/**
-RuntimeClient       live/sessions/driver/runtime_client/**; current low-level ACP client name; target role: AcpClient
-SessionEventSink    live/sessions/event_sink/**
-InteractionBroker   live/sessions/interactions/broker.rs
+SessionRuntime         anyharness-lib/src/domains/sessions/runtime/
+SessionService         anyharness-lib/src/domains/sessions/service/
+SessionStore           anyharness-lib/src/domains/sessions/store/**
+SessionView            domains/sessions/runtime/view.rs
+SessionLaunch et al.   live/sessions/model.rs (the live vocabulary file)
+LiveSessionManager     live/sessions/manager/**
+LiveSessionHandle      live/sessions/handle.rs
+SessionActor           live/sessions/actor/** (struct in actor/state.rs)
+InboundDoor            live/sessions/driver/inbound/**
+SessionEventSink       live/sessions/sink/**
+InteractionRendezvous  live/sessions/rendezvous/broker.rs
 ```
 
-Implementation reality after the completed migration phases:
+Implementation reality:
 
 - session MCP assembly lives under `domains/sessions/mcp_bindings/**`.
 - `SessionStore` is split under `domains/sessions/store/**`.
 - `SessionService` is split under `domains/sessions/service/**`.
-- `SessionRuntime` is split under `domains/sessions/runtime/**`.
-- `SessionEventSink` is split under `live/sessions/event_sink/**`.
+- `SessionRuntime` is split under `domains/sessions/runtime/**`; pure launch
+  decisions are `runtime/launch_policy.rs`, read-side assembly is
+  `runtime/view.rs`.
+- The live capability traits the actor needs are implemented by
+  `domains/sessions/live_ports.rs` (pure 1:1 delegation over the store) and
+  wired once as `ActorCapabilities` in `app/sessions.rs`.
+- `SessionEventSink` is split under `live/sessions/sink/**`.
 - `SessionActor` is split under `live/sessions/actor/**`; driver mechanics are
   split under `live/sessions/driver/**`.
 
@@ -87,6 +95,17 @@ This is the bridge between durable sessions and live execution. The
 implementation is split under `domains/sessions/runtime/**` by API-facing operation
 family; callers should continue to use the public `SessionRuntime` type.
 
+Two files carry special roles:
+
+- `runtime/launch_policy.rs` — pure launch decisions: data-in/data-out, no
+  store, no clock, no `&self`. `startup.rs` resolves (record loads, link
+  lookups, env/MCP assembly) and feeds gathered facts in; the policy chooses
+  the startup strategy and assembles the final `SessionLaunch`.
+- `runtime/view.rs` — `SessionView`, the read-side aggregate (record +
+  live-config snapshot + execution summary + pending prompts) composed by the
+  runtime with batched queries. HTTP maps it via the dep-less
+  `SessionView::into_contract`; nothing fetches inside a mapper.
+
 ### LiveSessionManager
 
 Live registry:
@@ -94,9 +113,12 @@ Live registry:
 - session id to live handle map
 - startup de-dupe
 - pending startup waiters
-- shared interaction broker
+- owns the shared `InteractionRendezvous` broker
+- owns `ActorCapabilities` (wired once in `app/sessions.rs`) and hands it to
+  every actor it starts
 
-Current path: `live/sessions/manager/**`.
+Current path: `live/sessions/manager/**`. The whole per-call surface is
+`start_session(launch: SessionLaunch, hooks: SessionHooks)`.
 
 ### LiveSessionHandle
 
@@ -127,13 +149,18 @@ One running agent session state machine:
 The actor implementation is split under `live/sessions/actor/**`; the detailed
 folder contract is specified in `specs/session-actor.md`.
 
-### AcpClient
+### Driver / InboundDoor
 
-Low-level ACP client wrapper. Current name: `RuntimeClient`, under
-`live/sessions/driver/runtime_client/**`.
+`live/sessions/driver/**` owns the ACP process and connection mechanics:
+process spawn (`process.rs`), connection establishment (`connection.rs`),
+initialization (`session_lifecycle.rs`), and native new/load/fork calls
+(`native_session.rs`).
 
-It sends ACP requests to the subprocess and receives ACP notifications. It does
-not own session business rules.
+`driver/inbound/**` is the `InboundDoor` — the agent-initiated direction of
+the connection. It routes notifications to the actor's channel and inbound
+requests (permission, user input, MCP elicitation) through the rendezvous
+broker; the permission path consults the `PermissionAdvisor` before parking.
+The driver does not own session business rules.
 
 ### SessionEventSink
 
@@ -147,16 +174,17 @@ ACP notification to AnyHarness event normalizer:
 
 This is core runtime logic, not a helper.
 
-### InteractionBroker
+### InteractionRendezvous
 
-Pending interaction rendezvous:
+Pending interaction rendezvous (`live/sessions/rendezvous/broker.rs`):
 
 - permission decisions
 - user-input questions
 - MCP elicitation forms
 - MCP URL reveal
 
-The actor registers a pending request. The API later resolves it.
+The inbound door parks a pending request. The API later resolves it; the actor
+cleans up on shutdown.
 
 ### Prompt Preparation
 
@@ -169,6 +197,29 @@ Prompt preparation turns user intent into a protocol-safe prompt payload:
 - provenance
 - validation
 
+The pipeline is split pure/IO: `AttachmentSource::load` (the live capability,
+implemented over store + attachment storage) loads every referenced part;
+`domains/sessions/prompt/render.rs` is the pure half — `ResolvedParts` in,
+ACP content blocks out, no IO, base64 and UTF-8 validation only.
+
+### Plans And Reviews Hooks
+
+Plans and reviews never appear inside the actor. They hook in through the
+ports declared in `live/sessions/model.rs` and wired in `app/sessions.rs`:
+
+- `domains/plans/session_observer.rs` / `domains/reviews/session_observer.rs`
+  — `SessionEventObserver`s run in one ordered in-loop pass (plans before
+  reviews; reviews consumes the plan envelopes via feed-forward).
+- `domains/plans/permission_advisor.rs` — `PermissionAdvisor` consulted by the
+  inbound door before parking a permission request (plan linking, predecided
+  answers).
+- `domains/plans/decision_op.rs` — the approve/reject decision as a
+  `SessionDomainOp` serialized through the actor mailbox
+  (`SessionCommand::RunDomainOp`).
+
+See `guides/live-runtime.md` for the mechanism decision table and the
+serialization/seq contracts.
+
 ## Prompt Flow
 
 ```text
@@ -178,9 +229,10 @@ API handler
     -> prepare prompt payload
     -> ensure live handle exists
     -> send actor command
-    -> actor sends ACP prompt via AcpClient
-    -> ACP notifications return
-    -> SessionEventSink persists and broadcasts events
+    -> actor renders the payload (pure render.rs) and sends the ACP prompt
+       over the driver connection
+    -> ACP notifications return through the InboundDoor
+    -> sink.ingest persists and broadcasts events
 ```
 
 Prompt submission and transcript streaming are separate interfaces:
@@ -210,9 +262,10 @@ API handler
     -> WorkspaceRuntime resolves workspace path/env
     -> SessionExtension registry resolves launch extras
     -> user MCP bindings + internal MCP servers are combined
-    -> LiveSessionManager starts actor
-    -> actor starts ACP client/subprocess
-    -> SessionEventSink emits normalized events
+    -> launch_policy assembles SessionLaunch (pure); runtime builds SessionHooks
+    -> LiveSessionManager.start_session(launch, hooks) starts the actor
+    -> actor startup spawns the process and establishes the ACP connection
+    -> sink emits normalized events
 ```
 
 ## Session Actor Shape
@@ -225,20 +278,24 @@ The actor should not own prompt attachment validation, transcript rendering,
 MCP schemas, plan product semantics, raw SQL query families, or API
 request/response mapping. It should call the modules that own those concerns.
 
-High-level target actor files:
+High-level actor files:
 
 ```text
 live/sessions/actor/
   mod.rs
   command.rs
-  state.rs
-  event_loop.rs
+  state.rs          # struct SessionActor
+  run.rs            # &mut-self select loop; receivers threaded as parameters
+  spawn.rs
+  startup.rs        # constructor: driver/connection.rs + session_lifecycle.rs
+  background_work.rs
   turn/
   config/
   notifications/
   fork/
   interactions/
   shutdown/
+  tests/
 ```
 
 See `specs/session-actor.md` for the concern-folder grammar and migration
@@ -286,12 +343,13 @@ Core actor invariants:
 happened; the sink decides how that becomes durable `SessionEventEnvelope`
 records.
 
-Target sink files:
+Sink files:
 
 ```text
-live/sessions/event_sink/
+live/sessions/sink/
   mod.rs
   state.rs
+  ingest.rs         # the one ingestion entry for ACP notifications
   publish.rs
   turns.rs
   assistant.rs
@@ -304,36 +362,44 @@ live/sessions/event_sink/
   background_work.rs
   lifecycle.rs
   runtime_events.rs
+  metadata.rs
   normalization/
+  tests/
 ```
 
 The sink may assign sequence numbers, persist normalized events, and broadcast
 them. It should not decide actor lifecycle, prompt queueing, config timing, or
-pending interaction waits.
+pending interaction waits. The sink is meaning-blind: arms that need durable
+session-row state or product reactors are parsed in `ingest.rs` and returned
+to the actor as `ActorBoundUpdate`; special observations are collected for the
+actor's observer pass.
 
-## Target File Shape
+## File Shape
 
 ```text
 domains/sessions/
   model.rs
+  live_ports.rs     # implements live's capability traits over the store
   store/
   service/
-  runtime/
-  prompt/
-  events/
+  runtime/          # incl. launch_policy.rs (pure) and view.rs (SessionView)
+  prompt/           # incl. render.rs (pure)
   mcp_bindings/
-  extensions/
+  extensions.rs
+  live_config/
   links/
   subagents/
   workspace_naming/
 
 live/sessions/
-  manager.rs
+  model.rs          # launch bundles, capability traits, hook ports
+  manager/
   handle.rs
+  probe.rs
   actor/
-  driver/
-  event_sink/
-  interactions/
+  driver/           # incl. inbound/ (InboundDoor)
+  sink/
+  rendezvous/
   background_work/
   replay/
 ```

--- a/specs/codebase/structures/anyharness/src/acp.md
+++ b/specs/codebase/structures/anyharness/src/acp.md
@@ -6,7 +6,7 @@ mapping.
 
 Live ACP-backed session runtime now lives under `live/sessions/**`. This legacy
 subsystem doc maps the old "ACP runtime" concepts to current implementation
-paths: manager, handle, actor, connection, event sink, interactions, background
+paths: manager, handle, actor, driver, sink, rendezvous, background
 work, and replay are all under `live/sessions/**`.
 
 ## Core Concepts
@@ -34,7 +34,7 @@ installation.
 It owns:
 
 - the in-memory `session_id -> LiveSessionHandle` map
-- the shared `InteractionBroker`
+- the shared `InteractionRendezvous`
 - the start/inject sequencing critical section for session events
 
 Its main jobs are:
@@ -74,14 +74,16 @@ It includes:
 - workspace env
 - session launch env
 - session store
-- shared interaction broker
+- shared interaction rendezvous
 - resume metadata such as startup strategy and `last_seq`
 
 This is the handoff from durable orchestration into live execution.
 
-### `RuntimeClient` (`anyharness/crates/anyharness-lib/src/live/sessions/driver/runtime_client/**`)
+### `InboundDoor` (`anyharness/crates/anyharness-lib/src/live/sessions/driver/inbound/**`)
 
-`RuntimeClient` is the AnyHarness ACP client implementation.
+`InboundDoor` (formerly `RuntimeClient`) is the agent-initiated direction of
+the AnyHarness ACP client: the connection (`driver/connection.rs`) registers
+its handlers for inbound requests and notifications.
 
 It handles:
 
@@ -95,14 +97,14 @@ It handles:
 
 It does not own the actor loop. It translates ACP protocol callbacks into:
 
-- interaction broker requests
+- interaction rendezvous requests
 - internal notification messages
 - normalized runtime events through the event sink
 
-### `SessionEventSink` (`anyharness/crates/anyharness-lib/src/live/sessions/event_sink/**`)
+### `SessionEventSink` (`anyharness/crates/anyharness-lib/src/live/sessions/sink/**`)
 
 `SessionEventSink` is the canonical normalization layer from ACP updates into
-AnyHarness `SessionEventEnvelope`.
+AnyHarness `SessionEventEnvelope`, with one ingestion entry: `sink.ingest`.
 
 It owns:
 
@@ -112,10 +114,10 @@ It owns:
 - transcript item coalescing
 - plan, tool, usage, config, interaction, and session event emission
 
-### `InteractionBroker` (`anyharness/crates/anyharness-lib/src/live/sessions/interactions/broker.rs`)
+### `InteractionRendezvous` (`anyharness/crates/anyharness-lib/src/live/sessions/rendezvous/broker.rs`)
 
-`InteractionBroker` owns live pending interaction waits behind the normalized
-interaction contract.
+`InteractionRendezvous` owns live pending interaction waits behind the
+normalized interaction contract.
 
 It stores:
 
@@ -146,7 +148,8 @@ The live start flow is:
    needed.
 5. The actor launches the resolved agent-process executable with merged
    workspace and session env.
-6. The actor creates an ACP `ClientSideConnection` over child stdio.
+6. The actor establishes the ACP connection over child stdio
+   (`driver/connection.rs`), registering the `InboundDoor` handlers.
 7. The actor calls `initialize`.
 8. If the agent advertises auth methods, the actor attempts `authenticate`, but
    `new_session` or `load_session` is still the real startup gate.
@@ -229,14 +232,14 @@ The prompt flow is:
 
 The notification flow is:
 
-1. ACP sends `session_notification(...)` into `RuntimeClient`
-2. `RuntimeClient` forwards the notification into an internal channel
+1. ACP delivers `session_notification(...)` to the `InboundDoor`
+2. the `InboundDoor` forwards the notification into an internal channel
 3. the actor consumes notifications
 4. notification handlers in
    `anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/**`
    maps ACP updates into runtime behavior
 5. `SessionEventSink` converts ACP-native chunks and tool updates into
-   normalized transcript items and session events
+   normalized transcript items and session events (through `sink.ingest`)
 6. events are both:
    - appended durably through `SessionStore`
    - broadcast live through `tokio::broadcast`
@@ -259,13 +262,14 @@ Important normalization behaviors:
 The interaction flow is:
 
 1. ACP calls `request_permission(...)` or a supported extension method on
-   `RuntimeClient`
+   the `InboundDoor`
    - Codex extension methods use `experimental/codex/*`
    - Claude extension methods use `experimental/claude/*`
-2. `RuntimeClient` registers the broker wait before making the request visible
-3. `RuntimeClient` emits `interaction_requested` through the sink while
+2. the `InboundDoor` registers the rendezvous wait before making the request
+   visible
+3. the `InboundDoor` emits `interaction_requested` through the sink while
    publishing is locked against cleanup
-4. `InteractionBroker` stores the pending request and waits
+4. `InteractionRendezvous` stores the pending request and waits
 5. higher-level runtime resolves the request through the session actor by:
    - allow
    - deny
@@ -273,9 +277,9 @@ The interaction flow is:
    - submitted input
    - cancellation
    - dismissal
-6. the actor emits `interaction_resolved` exactly once and resumes the brokered
+6. the actor emits `interaction_resolved` exactly once and resumes the parked
    wait
-7. `RuntimeClient` converts that back into the ACP or extension-specific
+7. the `InboundDoor` converts that back into the ACP or extension-specific
    response
 
 ### Config Flow
@@ -314,7 +318,7 @@ Most of that logic lives in
 - live config application and queued config changes
 - notification handling
 - event normalization
-- interaction brokering
+- interaction rendezvous
 
 ### Live ACP Session Runtime Does Not Own
 


### PR DESCRIPTION
mental-model.md: three migration exceptions resolved (latency->spans,
contract.rs->view.rs, concrete-stores/15-params->launch+capabilities).
live-runtime.md: the live vocabulary file, the four product-hook
mechanisms + decision table, the event-emission serialization model,
renamed vocabulary (rendezvous/sink/inbound). session-actor.md and
session-engine.md rewritten present-tense against the real tree.
domains.md: bidirectional ports pattern (session_ports/live_ports +
hook implementors). Remaining specs swept for stale names; only
explicit '(formerly ...)' notes remain.

---
Part 10/10 of the live-sessions migration stack (see the stack overview in PR 1). Each PR is gated: full suite green, behavior-preserving except where the commit message states otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)