### PR TITLE
fix(desktop): runtime queries resolve materialized session ids (404 spam)

### DIFF
--- a/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts
+++ b/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts
@@ -1,5 +1,7 @@
 import type { CoworkManagedWorkspaceSummary } from "@anyharness/sdk";
 import { useCoworkManagedWorkspacesQuery } from "@anyharness/sdk-react";
+import { isPendingSessionId } from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 const EMPTY_MANAGED_WORKSPACES: CoworkManagedWorkspaceSummary[] = [];
 
@@ -7,8 +9,15 @@ export function useCoworkManagedWorkspaces(
   sessionId: string | null | undefined,
   enabled = true,
 ) {
-  const query = useCoworkManagedWorkspacesQuery(sessionId, {
-    enabled: enabled && !!sessionId,
+  // The runtime only knows materialized session ids; hot client-keyed
+  // sessions (client-session:<kind>:...) 404 forever (and react-query
+  // retries forever) if the raw id leaks into the request.
+  const materializedSessionId = useSessionDirectoryStore((state) =>
+    sessionId
+      ? state.entriesById[sessionId]?.materializedSessionId ?? sessionId
+      : null);
+  const query = useCoworkManagedWorkspacesQuery(materializedSessionId, {
+    enabled: enabled && !!materializedSessionId && !isPendingSessionId(materializedSessionId),
   });
 
   return {

--- a/apps/desktop/src/hooks/chat/facade/subagents/use-subagent-composer-strip.ts
+++ b/apps/desktop/src/hooks/chat/facade/subagents/use-subagent-composer-strip.ts
@@ -7,6 +7,8 @@ import {
 } from "@/hooks/chat/derived/use-active-session-identity";
 import { recordSubagentChildRelationshipHint } from "@/hooks/sessions/workflows/session-relationship-hints";
 import { useWorkspaceShellActivation } from "@/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
+import { isPendingSessionId } from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { formatSubagentLabel } from "@proliferate/product-domain/chats/subagents/provenance";
 import type {
   DelegatedAgentIdentity,
@@ -54,8 +56,14 @@ export function useSubagentComposerStrip(): SubagentComposerStripViewModel | nul
   const activeSessionId = useActiveSessionId();
   const activeWorkspaceId = useActiveSessionWorkspaceId();
   const { activateChatTab } = useWorkspaceShellActivation();
-  const subagentsQuery = useSessionSubagentsQuery(activeSessionId, {
-    enabled: !!activeSessionId,
+  // Hot client-keyed session ids never resolve on the runtime; query with
+  // the materialized id (404-retry loop otherwise).
+  const materializedSessionId = useSessionDirectoryStore((state) =>
+    activeSessionId
+      ? state.entriesById[activeSessionId]?.materializedSessionId ?? activeSessionId
+      : null);
+  const subagentsQuery = useSessionSubagentsQuery(materializedSessionId, {
+    enabled: !!materializedSessionId && !isPendingSessionId(materializedSessionId),
     workspaceId: activeWorkspaceId,
   });
   const parentSessionId = subagentsQuery.data?.parent?.parentSessionId ?? null;


### PR DESCRIPTION
## What

The cowork `managed-workspaces` and session `subagents` runtime queries sent the raw active session id. Hot sessions are keyed `client-session:<kind>:<ts>` on the desktop — an id the runtime never knows — so every poll 404'd and react-query retried indefinitely: dozens of `Failed to load resource: 404 (managed-workspaces)` console errors per minute whenever a hot session with cowork/subagent links was active.

Both hooks now resolve the materialized id through the session directory and stay disabled until the session materializes (`isPendingSessionId`).

## Test plan
- `tsc --noEmit` clean; touched-area vitest green; frontend boundaries clean.
- Manual: open a freshly created (hot) session with subagent/cowork links — console no longer streams 404s; the queries fire once with the UUID id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)