### PR TITLE
fix(desktop): sidebar row shows blue dot for unseen session activity

### DIFF
--- a/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
+++ b/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
@@ -76,12 +76,16 @@ export function useWorkspaceSidebarState({
     archivedWorkspaceIds,
     hiddenRepoRootIds,
     lastViewedAt,
+    sessionLastInteracted,
+    sessionLastViewedAt,
     workspaceLastInteracted,
     workspaceTypes,
   } = useWorkspaceUiStore(useShallow((state) => ({
     archivedWorkspaceIds: state.archivedWorkspaceIds,
     hiddenRepoRootIds: state.hiddenRepoRootIds,
     lastViewedAt: state.lastViewedAt,
+    sessionLastInteracted: state.sessionLastInteracted,
+    sessionLastViewedAt: state.sessionLastViewedAt,
     workspaceLastInteracted: state.workspaceLastInteracted,
     workspaceTypes: state.workspaceTypes,
   })));
@@ -100,6 +104,13 @@ export function useWorkspaceSidebarState({
   const { data: gitStatus } = useWorkspaceMetadataSync();
   const computeTargets = useComputeTargetOptions();
 
+  const sessionWorkspaceIds = useSessionDirectoryStore(useShallow((state) => {
+    const ids: Record<string, string | null> = {};
+    for (const [sessionId, entry] of Object.entries(state.entriesById)) {
+      ids[sessionId] = entry.workspaceId;
+    }
+    return ids;
+  }));
   const archivedSet = useMemo(
     () => new Set(archivedWorkspaceIds),
     [archivedWorkspaceIds],
@@ -153,6 +164,9 @@ export function useWorkspaceSidebarState({
       activeSessionTitle,
       lastViewedAt,
       workspaceLastInteracted,
+      sessionWorkspaceIds,
+      sessionLastInteracted,
+      sessionLastViewedAt,
       targetAppearanceById: computeTargets.targetAppearanceById,
       suppressActiveNeedsReview: windowFocused,
     })), [
@@ -169,6 +183,9 @@ export function useWorkspaceSidebarState({
     workspaceTypes,
     selectedLogicalWorkspaceId,
     selectedWorkspaceId,
+    sessionLastInteracted,
+    sessionLastViewedAt,
+    sessionWorkspaceIds,
     showArchived,
     windowFocused,
     workspaceActivities,

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
@@ -86,6 +86,9 @@ export function buildSidebarGroupStates(args: {
   activeSessionTitle: string | null;
   lastViewedAt: Record<string, string>;
   workspaceLastInteracted: Record<string, string>;
+  sessionWorkspaceIds?: Record<string, string | null>;
+  sessionLastInteracted?: Record<string, string>;
+  sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
 }): SidebarGroupState[] {
@@ -154,6 +157,9 @@ export function buildSidebarGroupStates(args: {
         activeSessionTitle: args.activeSessionTitle,
         lastViewedAt: args.lastViewedAt,
         workspaceLastInteracted: args.workspaceLastInteracted,
+        sessionWorkspaceIds: args.sessionWorkspaceIds,
+        sessionLastInteracted: args.sessionLastInteracted,
+        sessionLastViewedAt: args.sessionLastViewedAt,
         targetAppearanceById: args.targetAppearanceById,
         suppressActiveNeedsReview: args.suppressActiveNeedsReview,
       });

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts
@@ -285,6 +285,9 @@ export function buildGroups(args: {
   pendingPromptCounts?: Record<string, number>;
   lastViewedAt?: Record<string, string>;
   workspaceLastInteracted?: Record<string, string>;
+  sessionWorkspaceIds?: Record<string, string | null>;
+  sessionLastInteracted?: Record<string, string>;
+  sessionLastViewedAt?: Record<string, string>;
   suppressActiveNeedsReview?: boolean;
 }) {
   return buildSidebarGroupStates({
@@ -303,6 +306,9 @@ export function buildGroups(args: {
     activeSessionTitle: null,
     lastViewedAt: args.lastViewedAt ?? {},
     workspaceLastInteracted: args.workspaceLastInteracted ?? {},
+    sessionWorkspaceIds: args.sessionWorkspaceIds,
+    sessionLastInteracted: args.sessionLastInteracted,
+    sessionLastViewedAt: args.sessionLastViewedAt,
     suppressActiveNeedsReview: args.suppressActiveNeedsReview,
   });
 }

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { detailIndicatorsForWorkspace } from "@/lib/domain/workspaces/sidebar/sidebar-detail-indicators";
 import { isWorkspaceNeedsReview } from "@/lib/domain/workspaces/sidebar/sidebar-review";
+import { logicalWorkspaceHasUnreadSessionActivity } from "@/lib/domain/workspaces/sidebar/workspace-activity-indicator";
 import { workspaceCopyMetadataForLogicalWorkspace } from "@/lib/domain/workspaces/workspace-copy-metadata";
 import { resolveLogicalWorkspaceRecency } from "@/lib/domain/workspaces/sidebar/recency";
 
@@ -41,6 +42,9 @@ export function buildSidebarWorkspaceItems(args: {
   activeSessionTitle: string | null;
   lastViewedAt: Record<string, string>;
   workspaceLastInteracted: Record<string, string>;
+  sessionWorkspaceIds?: Record<string, string | null>;
+  sessionLastInteracted?: Record<string, string>;
+  sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
 }): SidebarWorkspaceItemState[] {
@@ -80,6 +84,9 @@ function buildSidebarWorkspaceItem(
     activeSessionTitle: string | null;
     lastViewedAt: Record<string, string>;
     workspaceLastInteracted: Record<string, string>;
+    sessionWorkspaceIds?: Record<string, string | null>;
+    sessionLastInteracted?: Record<string, string>;
+    sessionLastViewedAt?: Record<string, string>;
     targetAppearanceById?: Record<string, ComputeTargetAppearance>;
     suppressActiveNeedsReview?: boolean;
   },
@@ -113,15 +120,24 @@ function buildSidebarWorkspaceItem(
         workspace: preferredCloudWorkspace,
       })
       : entry.displayName;
+  // The session tabs' blue dot and the sidebar row must agree: a related
+  // session with unseen activity marks the row even when the workspace is
+  // the active one (the user may be on a different tab).
+  const hasUnreadSessions = !archived
+    && logicalWorkspaceHasUnreadSessionActivity(
+      new Set(logicalWorkspaceRelatedIds(entry)),
+      args,
+    );
   // A workspace the user is actively viewing in a focused window has nothing
   // pending review, even when the viewed timestamp briefly trails the latest
   // interaction (e.g. right after a new session bootstraps).
-  const needsReview = !(active && args.suppressActiveNeedsReview)
-    && isWorkspaceNeedsReview({
-      isArchived: archived,
-      lastInteracted: activityLastInteracted,
-      lastViewedAt: latestLogicalWorkspaceTimestamp(args.lastViewedAt, entry),
-    });
+  const needsReview = hasUnreadSessions
+    || (!(active && args.suppressActiveNeedsReview)
+      && isWorkspaceNeedsReview({
+        isArchived: archived,
+        lastInteracted: activityLastInteracted,
+        lastViewedAt: latestLogicalWorkspaceTimestamp(args.lastViewedAt, entry),
+      }));
   const activity = activeWorkspaceActivity(entry, args.workspaceActivities);
   const copyMetadata = workspaceCopyMetadataForLogicalWorkspace(entry);
   const sshTargetId = variant === "ssh" ? logicalWorkspaceSshTargetId(entry) : null;

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts
@@ -350,6 +350,35 @@ describe("sidebar workspace filters", () => {
     ]);
   });
 
+  it("marks the row needs_review when a related session has unseen activity, even when active", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "ws-with-unseen-session",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+          updatedAt: "2026-04-13T12:00:00.000Z",
+        }),
+      ],
+      selectedLogicalWorkspaceId: "ws-with-unseen-session",
+      selectedWorkspaceId: "ws-with-unseen-session",
+      // The workspace itself was just viewed (active + focused window), so
+      // the workspace-recency rule alone would render nothing — but a
+      // related session finished unseen, which must mirror the session
+      // tab's blue dot on the sidebar row.
+      lastViewedAt: { "ws-with-unseen-session": "2026-04-13T12:05:00.000Z" },
+      workspaceLastInteracted: { "ws-with-unseen-session": "2026-04-13T12:04:00.000Z" },
+      sessionWorkspaceIds: { "session-1": "ws-with-unseen-session" },
+      sessionLastInteracted: { "session-1": "2026-04-13T12:04:00.000Z" },
+      sessionLastViewedAt: { "session-1": "2026-04-13T12:00:00.000Z" },
+      suppressActiveNeedsReview: true,
+    });
+
+    expect(groups[0]?.items[0]?.needsReview).toBe(true);
+    expect(groups[0]?.items[0]?.statusIndicator?.kind).toBe("needs_review");
+  });
+
   it("falls back to record recency when a workspace has no interaction timestamp", () => {
     const groups = buildGroups({
       logicalWorkspaces: [

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts
@@ -140,7 +140,7 @@ function logicalWorkspaceHasAttentionSessionActivity(
   return false;
 }
 
-function logicalWorkspaceHasUnreadSessionActivity(
+export function logicalWorkspaceHasUnreadSessionActivity(
   relatedIds: ReadonlySet<string>,
   args: Pick<
     BuildWorkspaceActivityIndicatorSnapshotArgs,


### PR DESCRIPTION
## What

The session tabs' blue (unseen) dot and the workspace sidebar row disagreed: a background session could finish — tab shows blue — while the sidebar row showed nothing. The row's `needs_review` only consulted workspace-level recency (and is suppressed for the active, focused workspace), while per-session unseen state only fed the app-level attention count, never the row indicator.

The row now mirrors the tabs: any related session with unseen activity (`sessionLastInteracted > sessionLastViewedAt`) marks the row `needs_review`, including on the active workspace (the user may be looking at a different tab). Session maps are threaded hook → groups → items; the existing unread rule from `workspace-activity-indicator` is reused, not duplicated.

## Test plan
- New regression test pins the active-workspace + unseen-session case.
- 99 sidebar-domain tests green; `tsc --noEmit`, frontend boundaries, max-lines all clean.
- Manual: let a background session finish — sidebar row shows the blue dot at the same time the session tab does; opening the session clears both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)