### PR TITLE
fix(web): explain unreachable API on first-run auth

### DIFF
--- a/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
+++ b/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
@@ -19,6 +19,7 @@ interface AuthStartPanelProps {
   footer: ReactNode;
   providers: AuthProviderActionView[];
   credentialForm?: ReactNode;
+  notice?: ReactNode;
   note?: ReactNode;
   error?: ReactNode;
   devAccess?: ReactNode;
@@ -31,12 +32,21 @@ export function AuthStartPanel({
   footer,
   providers,
   credentialForm,
+  notice,
   note,
   error,
   devAccess,
 }: AuthStartPanelProps) {
   return (
     <AuthLayout mark={mark} title={title} subtitle={subtitle} footer={footer}>
+      {notice ? (
+        <div
+          className="rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm leading-5 text-muted-foreground"
+          role="status"
+        >
+          {notice}
+        </div>
+      ) : null}
       {credentialForm}
       {credentialForm ? <AuthDivider /> : null}
       {providers.map((provider) => (

--- a/apps/web/src/components/auth/screen/AuthScreen.tsx
+++ b/apps/web/src/components/auth/screen/AuthScreen.tsx
@@ -20,7 +20,7 @@ import { createWebCloudClient } from "../../../lib/access/cloud/client";
 import { useAuthToken } from "../../../providers/WebCloudProvider";
 
 export function AuthScreen() {
-  const { setToken, setSession } = useAuthToken();
+  const { setToken, setSession, connectionFailed } = useAuthToken();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [manualToken, setManualToken] = useState("");
@@ -30,6 +30,10 @@ export function AuthScreen() {
   const [providerError, setProviderError] = useState<string | null>(null);
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const busy = Boolean(loadingProvider) || passwordSubmitting;
+  // In local development the API often isn't running yet. When the session
+  // bootstrap can't reach it, explain that instead of leaving a bare sign-in
+  // screen. Production builds never surface this developer hint.
+  const showApiUnreachableNotice = import.meta.env.DEV && connectionFailed;
 
   async function signIn(provider: AuthProviderName) {
     if (busy) {
@@ -76,6 +80,15 @@ export function AuthScreen() {
       title={AUTH_SIGN_IN_COPY.title}
       subtitle={AUTH_SIGN_IN_COPY.subtitle}
       footer={<span className="block text-faint">{AUTH_SIGN_IN_COPY.footer}</span>}
+      notice={showApiUnreachableNotice ? (
+        <span className="block">
+          Couldn&apos;t reach the Proliferate API at{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">{webEnv.apiBaseUrl}</code>.
+          Start the local API, or set{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">VITE_PROLIFERATE_API_BASE_URL</code>{" "}
+          to point at a running instance.
+        </span>
+      ) : null}
       credentialForm={(
         <PasswordCredentialForm
           email={email}

--- a/apps/web/src/providers/WebCloudProvider.tsx
+++ b/apps/web/src/providers/WebCloudProvider.tsx
@@ -28,6 +28,7 @@ interface AuthTokenContextValue {
   token: string | null;
   user: AuthUser | null;
   bootstrapping: boolean;
+  connectionFailed: boolean;
   setToken: (token: string) => void;
   setSession: (session: AuthSessionResponse) => void;
   clearToken: () => Promise<void>;
@@ -35,6 +36,10 @@ interface AuthTokenContextValue {
 
 const AuthTokenContext = createContext<AuthTokenContextValue | null>(null);
 const queryClient = new QueryClient();
+
+// Stop waiting on the bootstrap request if the API never answers, so the
+// sign-in screen can render (and, in development, explain why).
+const BOOTSTRAP_SESSION_TIMEOUT_MS = 8000;
 
 export function WebCloudProvider({ children }: { children: ReactNode }) {
   const initialTokenRef = useRef<string | null | undefined>(undefined);
@@ -44,6 +49,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
   const [token, setTokenState] = useState<string | null>(initialTokenRef.current);
   const [user, setUserState] = useState<AuthUser | null>(null);
   const [bootstrapping, setBootstrapping] = useState(initialTokenRef.current === null);
+  const [connectionFailed, setConnectionFailed] = useState(false);
   const authEpochRef = useRef(0);
   const client = useMemo(() => createWebCloudClient(webEnv.apiBaseUrl, token), [token]);
 
@@ -55,27 +61,34 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     const bootstrapEpoch = authEpochRef.current;
     const bootstrapClient = createWebCloudClient(webEnv.apiBaseUrl, null);
-    bootstrapWebSession(bootstrapClient)
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), BOOTSTRAP_SESSION_TIMEOUT_MS);
+    bootstrapWebSession(bootstrapClient, { signal: controller.signal })
       .then((session) => {
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
           queryClient.clear();
+          setConnectionFailed(false);
           setTokenState(session.accessToken);
           setUserState(session.user);
         }
       })
-      .catch(() => {
+      .catch((error) => {
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
+          setConnectionFailed(isApiUnreachableError(error));
           setTokenState(null);
           setUserState(null);
         }
       })
       .finally(() => {
+        window.clearTimeout(timeoutId);
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
           setBootstrapping(false);
         }
       });
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
+      controller.abort();
     };
   }, []);
 
@@ -84,6 +97,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
       token,
       user,
       bootstrapping,
+      connectionFailed,
       setToken(nextToken) {
         authEpochRef.current += 1;
         queryClient.clear();
@@ -118,7 +132,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         setUserState(null);
       },
     }),
-    [bootstrapping, token, user],
+    [bootstrapping, connectionFailed, token, user],
   );
 
   return (
@@ -138,6 +152,16 @@ export function useAuthToken() {
     throw new Error("useAuthToken must be used within WebCloudProvider.");
   }
   return value;
+}
+
+// Distinguishes "the API could not be reached" (request aborted by our timeout,
+// or fetch failing to connect at all) from genuine auth responses such as a 401.
+function isApiUnreachableError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+  // fetch() rejects with a TypeError when it cannot establish a connection.
+  return error instanceof TypeError;
 }
 
 function readCookie(name: string): string | null {


### PR DESCRIPTION
## What & why
The hosted web app showed an indefinite "Checking your cloud session" state
when the local Proliferate API wasn't running, leaving developers unsure
whether the app was loading, broken, or missing its backend.

## Changes
- Abort the session bootstrap after a bounded 8s timeout so the sign-in
  screen renders instead of hanging.
- Track whether the bootstrap failed because the API was unreachable
  (timeout / connection error) vs. a genuine auth response (e.g. 401).
- In development only, show a notice on the auth screen explaining the API
  could not be reached at `http://localhost:8000` and how to fix it (start
  the API or set `VITE_PROLIFERATE_API_BASE_URL`).
- Production behaviour is unchanged — the notice is gated behind `import.meta.env.DEV`.

## Testing
- `pnpm web:typecheck` ✅
- `pnpm shared:typecheck` ✅
- `pnpm --filter @proliferate/product-ui test` ✅ (42 passed)

Closes #626

> Note: I don't have permission to set labels. Please add `release:patch` and `area:web` (or the labels you prefer) so CI can proceed.