### PR TITLE
fix(desktop): composer model picker search focus and submenu hover gap

### DIFF
--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ChangeEvent,
   type ClipboardEvent,
+  type MouseEvent,
 } from "react";
 import type { PromptInputBlock } from "@anyharness/sdk";
 import {
@@ -254,7 +255,13 @@ export function ChatInput({
     }
   }, [attachments, canAcceptPastedAttachments]);
 
-  const handleComposerSurfaceClick = useCallback(() => {
+  const handleComposerSurfaceClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    // Portal-rendered popovers (model picker, etc.) bubble clicks through the
+    // React tree even though their DOM lives outside the surface — those
+    // clicks must not pull focus back into the chat editor.
+    if (!event.currentTarget.contains(event.target as Node)) {
+      return;
+    }
     if (effectiveIsEditingQueuedPrompt) {
       textareaRef.current?.focus();
       return;

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigMenu.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigMenu.tsx
@@ -46,6 +46,7 @@ export function ComposerModelConfigMenu({
   submenuPosition,
   submenuRef,
   onAddProviderOpenChange,
+  onMenuMouseEnter,
   onMenuMouseLeave,
   onOpenSubmenu,
   onSearchChange,
@@ -67,6 +68,7 @@ export function ComposerModelConfigMenu({
   submenuPosition: ComposerSubmenuPosition | null;
   submenuRef: RefObject<HTMLDivElement | null>;
   onAddProviderOpenChange: Dispatch<SetStateAction<boolean>>;
+  onMenuMouseEnter: () => void;
   onMenuMouseLeave: () => void;
   onOpenSubmenu: (submenu: ComposerConfigSubmenu, anchorElement: HTMLElement) => void;
   onSearchChange: (search: string) => void;
@@ -84,6 +86,7 @@ export function ComposerModelConfigMenu({
     <div
       ref={menuRootRef}
       className="relative w-72 max-w-[calc(100vw-1rem)]"
+      onMouseEnter={onMenuMouseEnter}
       onMouseLeave={onMenuMouseLeave}
     >
       <ComposerPopoverSurface className="w-72 max-w-[calc(100vw-1rem)] p-1">

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
@@ -1,4 +1,6 @@
 import {
+  useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -32,6 +34,9 @@ interface ComposerModelConfigSelectorProps {
 
 const COMPOSER_SUBMENU_GAP_PX = 4;
 const COMPOSER_SUBMENU_VIEWPORT_MARGIN_PX = 8;
+// Crossing the gap between the menu and its submenu briefly leaves both
+// elements; closing must survive that traversal.
+const COMPOSER_SUBMENU_CLOSE_GRACE_MS = 150;
 
 export function ComposerModelConfigSelector({
   modelSelectorProps,
@@ -46,6 +51,25 @@ export function ComposerModelConfigSelector({
   const [submenuAnchorTop, setSubmenuAnchorTop] = useState<number | null>(null);
   const [submenuPosition, setSubmenuPosition] = useState<ComposerSubmenuPosition | null>(null);
   const [setupAgent, setSetupAgent] = useState<ModelSelectorProps["notReadyAgents"][number] | null>(null);
+  const submenuCloseTimerRef = useRef<number | null>(null);
+
+  const cancelPendingSubmenuClose = useCallback(() => {
+    if (submenuCloseTimerRef.current !== null) {
+      window.clearTimeout(submenuCloseTimerRef.current);
+      submenuCloseTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleSubmenuClose = useCallback(() => {
+    cancelPendingSubmenuClose();
+    submenuCloseTimerRef.current = window.setTimeout(() => {
+      submenuCloseTimerRef.current = null;
+      setActiveSubmenu(null);
+    }, COMPOSER_SUBMENU_CLOSE_GRACE_MS);
+  }, [cancelPendingSubmenuClose]);
+
+  useEffect(() => cancelPendingSubmenuClose, [cancelPendingSubmenuClose]);
+
   const {
     connectionState,
     currentModel,
@@ -182,6 +206,7 @@ export function ComposerModelConfigSelector({
         className="w-auto border-0 bg-transparent p-0 shadow-none"
         onOpenChange={(open) => {
           if (!open) {
+            cancelPendingSubmenuClose();
             resetMenuState({
               setActiveSubmenu,
               setAddProviderOpen,
@@ -209,8 +234,10 @@ export function ComposerModelConfigSelector({
             submenuRef={submenuRef}
             onAddProviderOpenChange={setAddProviderOpen}
             onClose={close}
-            onMenuMouseLeave={() => setActiveSubmenu(null)}
+            onMenuMouseEnter={cancelPendingSubmenuClose}
+            onMenuMouseLeave={scheduleSubmenuClose}
             onOpenSubmenu={(submenu, anchorElement) => {
+              cancelPendingSubmenuClose();
               setAddProviderOpen(false);
               setSubmenuPosition(null);
               setSubmenuAnchorTop(resolveSubmenuAnchorTop(menuRootRef.current, anchorElement));

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelPickerList.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelPickerList.tsx
@@ -31,6 +31,7 @@ export function ComposerModelPickerContent({
               value={search}
               onChange={(event) => onSearchChange(event.target.value)}
               placeholder={CHAT_MODEL_SELECTOR_LABELS.searchPlaceholder}
+              autoFocus
               className="h-auto min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus:ring-0"
             />
           </div>


### PR DESCRIPTION
## Summary
- Fix "Can't search through model list": clicks inside the portal-rendered model-config popover bubbled through the React tree to `ChatComposerSurface`'s `onClick`, which called `focusChatInput()` and stole focus from the picker's search field. The surface click handler now ignores clicks whose DOM target is outside the surface, and the search input autofocuses when the picker opens (parity with the old `ModelSelector`).
- Fix submenu auto-closing while hovering from a row (Agent / control) to the submenu: crossing the 4px gap fired the menu root's `mouseLeave` and unmounted the submenu before the pointer reached it. Closing now runs on a 150ms grace timer, cancelled on pointer re-enter, submenu open, popover close, and unmount.

## Testing
- `tsc --noEmit` clean
- `pnpm vitest run src/components/workspace/chat/input` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)