### PR TITLE
fix(sessions): fail ACP startup fast when the agent process exits + codex install fix

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/agent_process.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/agent_process.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::npm::install_managed_npm_package;
+use super::npm::{install_managed_npm_package, platform_binary_filename};
 use super::{InstallError, InstallOptions, InstalledArtifactResult};
 use crate::domains::agents::installer::seed;
 use crate::domains::agents::model::*;
@@ -54,24 +54,40 @@ fn regenerate_agent_process_launcher(
     let path_prefixes = launcher_path_prefixes(runtime_home, kind);
     let env = managed_launcher_env(kind);
 
-    let executable_relpath = match &descriptor.agent_process.install {
+    let (executable_relpath, source_build_binary_name) = match &descriptor.agent_process.install {
         AgentProcessInstallSpec::ManagedNpmPackage {
-            executable_relpath, ..
-        } => executable_relpath,
+            executable_relpath,
+            source_build_binary_name,
+            ..
+        } => (executable_relpath, source_build_binary_name),
         AgentProcessInstallSpec::RegistryBacked {
             fallback:
                 AgentProcessFallback::NpmPackage {
-                    executable_relpath, ..
+                    executable_relpath,
+                    source_build_binary_name,
+                    ..
                 },
             ..
-        } => executable_relpath,
+        } => (executable_relpath, source_build_binary_name),
         _ => return Ok(None),
     };
 
-    let exec_path = managed_dir.join(executable_relpath);
-    if !exec_path.exists() {
-        return Err(InstallError::MissingManagedArtifact(exec_path));
+    // Mirror install_managed_npm_package's exec-path resolution: source-built
+    // binaries live at the managed dir root, not under node_modules. Seed
+    // payloads built before an agent switched to source build only contain
+    // the node_modules layout, so fall back to it rather than failing the
+    // whole seed apply; the next install pass rebuilds and re-points the
+    // launcher.
+    let mut exec_candidates = Vec::new();
+    if let Some(binary_name) = source_build_binary_name {
+        exec_candidates.push(managed_dir.join(platform_binary_filename(binary_name)));
     }
+    exec_candidates.push(managed_dir.join(executable_relpath));
+    let Some(exec_path) = exec_candidates.iter().find(|path| path.exists()).cloned() else {
+        return Err(InstallError::MissingManagedArtifact(
+            exec_candidates.remove(0),
+        ));
+    };
 
     generate_launcher_script(&launcher_path, &exec_path, &[], &env, &path_prefixes)?;
     Ok(Some(InstalledArtifactResult {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/managed_npm.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/managed_npm.rs
@@ -109,6 +109,19 @@ fn recorded_source_spec(managed_dir: &Path) -> Option<String> {
     }
 }
 
+/// Staleness check for source-built artifacts: the managed dir has no npm
+/// metadata, so the source marker is the only record of which spec (and git
+/// ref) the installed binary was built from.
+pub(crate) fn source_build_install_issue(package: &str, managed_dir: &Path) -> Option<String> {
+    if recorded_source_spec(managed_dir).is_some_and(|recorded| recorded == package) {
+        return None;
+    }
+    Some(
+        "Managed agent source build is out of date. Reinstall this agent to rebuild the bundled ACP adapter."
+            .into(),
+    )
+}
+
 pub(crate) fn managed_npm_install_issue(package: &str, managed_dir: &Path) -> Option<String> {
     if is_npm_non_registry_spec(package) {
         if non_registry_install_matches(package, managed_dir) {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/npm.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/npm.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 
 use super::managed_npm::{
     apply_npm_version_override, installed_npm_package_version, managed_npm_install_issue,
-    npm_package_version, write_managed_npm_source_marker,
+    npm_package_version, source_build_install_issue, write_managed_npm_source_marker,
 };
 use super::{InstallError, InstalledArtifactResult};
 use crate::domains::agents::model::ArtifactRole;
@@ -36,7 +36,7 @@ pub(super) fn install_managed_npm_package(
     let package_issue = if source_build_binary_name.is_none() {
         managed_npm_install_issue(&versioned_package, managed_dir)
     } else {
-        None
+        source_build_install_issue(&versioned_package, managed_dir)
     };
 
     if force_reinstall || !exec_path.exists() || !launcher_path.exists() || package_issue.is_some()
@@ -160,7 +160,11 @@ fn install_managed_source_build_binary(
 ) -> Result<(), InstallError> {
     let staging = TempDirGuard::new("source-build")?;
     let source_root = materialize_npm_package_source(package, staging.path())?;
-    build_cargo_binary_from_source(&source_root, binary_name, managed_dir)
+    build_cargo_binary_from_source(&source_root, binary_name, managed_dir)?;
+    // Source builds leave no npm metadata behind, so the marker is the only
+    // way staleness checks can detect a later git-pin bump and rebuild.
+    write_managed_npm_source_marker(package, managed_dir)?;
+    Ok(())
 }
 
 fn materialize_npm_package_source(
@@ -385,7 +389,7 @@ fn install_npm_package_into_prefix(package: &str, managed_dir: &Path) -> Result<
     .map(|_| ())
 }
 
-fn platform_binary_filename(binary_name: &str) -> PathBuf {
+pub(super) fn platform_binary_filename(binary_name: &str) -> PathBuf {
     if cfg!(windows) {
         PathBuf::from(format!("{binary_name}.exe"))
     } else {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/artifacts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/artifacts.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use super::paths::{artifact_root, has_managed_registry_binary_for_names};
-use crate::domains::agents::installer::managed_npm::managed_npm_install_issue;
+use crate::domains::agents::installer::managed_npm::{
+    managed_npm_install_issue, source_build_install_issue,
+};
 use crate::domains::agents::model::*;
 use crate::integrations::agent_cli::executable::{
     find_in_path, find_real_binary_in_path, is_valid_executable,
@@ -96,17 +98,20 @@ pub(super) fn resolve_agent_process_artifact(
                 managed_launcher_candidates(&managed_dir, kind, Some(executable_relpath.as_path()));
             for path in &managed_candidates {
                 if path.exists() {
-                    if source_build_binary_name.is_none() {
-                        if let Some(message) = managed_npm_install_issue(package, &managed_dir) {
-                            return ResolvedArtifact {
-                                role: ArtifactRole::AgentProcess,
-                                installed: false,
-                                source: Some("managed".into()),
-                                version: None,
-                                path: Some(path.clone()),
-                                message: Some(message),
-                            };
-                        }
+                    let install_issue = if source_build_binary_name.is_none() {
+                        managed_npm_install_issue(package, &managed_dir)
+                    } else {
+                        source_build_install_issue(package, &managed_dir)
+                    };
+                    if let Some(message) = install_issue {
+                        return ResolvedArtifact {
+                            role: ArtifactRole::AgentProcess,
+                            installed: false,
+                            source: Some("managed".into()),
+                            version: None,
+                            path: Some(path.clone()),
+                            message: Some(message),
+                        };
                     }
                     return found_artifact(ArtifactRole::AgentProcess, path.clone(), "managed");
                 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/spawn.rs
@@ -29,6 +29,11 @@ impl PendingSessionActor {
             .recv_timeout(std::time::Duration::from_secs(60))
             .map_err(|e| match e {
                 std::sync::mpsc::RecvTimeoutError::Timeout => {
+                    // Agent-process exits during the handshake fail fast in
+                    // SessionActor::start, so this is reached only for an
+                    // agent that is alive but unresponsive (e.g. a genuine
+                    // auth wait). TODO: thread the AgentStderrTail up here so
+                    // the residual timeout cases are equally diagnosable.
                     anyhow::anyhow!(
                         "ACP session startup timed out after 60s. \
                          The agent may be waiting for authentication or is unresponsive."

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -24,6 +24,7 @@ use crate::live::sessions::driver::native_session::{
     has_anyharness_targeted_fork_extension, start_native_session,
 };
 use crate::live::sessions::driver::process::spawn_agent_process;
+use crate::live::sessions::driver::stderr::AgentStderrTail;
 use crate::live::sessions::driver::inbound::InboundDoor;
 use crate::live::sessions::driver::session_lifecycle::initialize_connection;
 use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
@@ -66,9 +67,11 @@ impl SessionActor {
             &source_agent_kind,
             &ready_tx,
         )?;
-        let child = spawned.child;
+        let mut child = spawned.child;
         let stdin = spawned.stdin;
         let stdout = spawned.stdout;
+        let stderr_tail = spawned.stderr_tail;
+        let mut stderr_done = spawned.stderr_done;
 
         let (notification_tx, notification_rx) =
             mpsc::unbounded_channel::<acp::schema::SessionNotification>();
@@ -113,40 +116,81 @@ impl SessionActor {
         ));
 
         let (conn, shutdown_tx) = establish_connection(client, stdin, stdout).await?;
-        let init_response = initialize_connection(
-            &conn,
-            &source_agent_kind,
-            &config.launch.agent,
-            &session_id,
-            &workspace_id,
-            &ready_tx,
-        )
-        .await?;
 
-        persist_session_action_capabilities(
-            config.caps.state.as_ref(),
-            &session_id,
-            &init_response.agent_capabilities,
-        );
-        let action_capabilities = action_capabilities_from_acp(&init_response.agent_capabilities);
+        // Race the initialize/new-session handshake against agent-process
+        // exit: an agent that dies before responding (bad install, crash on
+        // boot) should fail that phase immediately with its stderr instead of
+        // letting the caller burn the full ready timeout on a misleading
+        // "waiting for authentication" message.
+        let handshake = async {
+            let init_response = initialize_connection(
+                &conn,
+                &source_agent_kind,
+                &config.launch.agent,
+                &session_id,
+                &workspace_id,
+                &ready_tx,
+            )
+            .await?;
+
+            persist_session_action_capabilities(
+                config.caps.state.as_ref(),
+                &session_id,
+                &init_response.agent_capabilities,
+            );
+            let action_capabilities =
+                action_capabilities_from_acp(&init_response.agent_capabilities);
+
+            let native = start_native_session(
+                &conn,
+                &config.launch.workspace_path,
+                &config.launch.mcp_servers,
+                config.launch.prompts.every_prompt.as_deref(),
+                &startup_strategy,
+                action_capabilities,
+                &session_id,
+                &workspace_id,
+                &ready_tx,
+            )
+            .await?;
+            anyhow::Ok((init_response, action_capabilities, native))
+        };
+        let (init_response, action_capabilities, native_session) = tokio::select! {
+            // Biased so a handshake that completed on the same poll as the
+            // exit (agent answered and then died) is reported as the success
+            // it was; the exit arm only fires while it is genuinely pending.
+            biased;
+            result = handshake => result?,
+            exit_status = child.wait() => {
+                if let Some(reader_task) = stderr_done.take() {
+                    // The child held the only write end of the pipe, so EOF
+                    // arrives promptly after exit; give the reader a moment to
+                    // drain the final lines before snapshotting.
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_millis(250),
+                        reader_task,
+                    )
+                    .await;
+                }
+                let error = agent_exited_during_startup_error(exit_status, &stderr_tail);
+                tracing::warn!(
+                    session_id = %session_id,
+                    workspace_id = %workspace_id,
+                    agent_kind = %source_agent_kind,
+                    error = %error.to_string().replace('\n', " | "),
+                    elapsed_ms = startup_started.elapsed().as_millis(),
+                    "[workspace-latency] session.actor.process_exited_during_startup"
+                );
+                let _ = ready_tx.send(Err(anyhow::anyhow!("{error}")));
+                return Err(error);
+            }
+        };
         let supports_native_close = init_response
             .agent_capabilities
             .session_capabilities
             .close
             .is_some();
-
-        let (native_session_id, native_startup_state, startup_disposition) = start_native_session(
-            &conn,
-            &config.launch.workspace_path,
-            &config.launch.mcp_servers,
-            config.launch.prompts.every_prompt.as_deref(),
-            &startup_strategy,
-            action_capabilities,
-            &session_id,
-            &workspace_id,
-            &ready_tx,
-        )
-        .await?;
+        let (native_session_id, native_startup_state, startup_disposition) = native_session;
         let mut startup_state: SessionStartupState = native_startup_state.into();
         startup_state.prompt_capabilities =
             capabilities_from_acp(Some(&init_response.agent_capabilities.prompt_capabilities));
@@ -346,6 +390,25 @@ impl SessionActor {
     }
 }
 
+fn agent_exited_during_startup_error(
+    exit_status: std::io::Result<std::process::ExitStatus>,
+    stderr_tail: &AgentStderrTail,
+) -> anyhow::Error {
+    let status = match exit_status {
+        Ok(status) => status.to_string(),
+        Err(error) => format!("wait failed: {error}"),
+    };
+    let tail = stderr_tail.snapshot();
+    if tail.is_empty() {
+        anyhow::anyhow!("agent process exited during ACP startup ({status})")
+    } else {
+        anyhow::anyhow!(
+            "agent process exited during ACP startup ({status}). Agent stderr:\n{}",
+            tail.join("\n")
+        )
+    }
+}
+
 async fn dispatch_startup_drain(
     store: &dyn QueueDurable,
     session_id: &str,
@@ -434,5 +497,34 @@ pub(in crate::live::sessions::actor) fn action_capabilities_from_acp(
     SessionActionCapabilities {
         fork,
         targeted_fork: false,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt;
+
+    #[test]
+    fn agent_exit_error_reports_status_without_stderr() {
+        let tail = AgentStderrTail::default();
+        let exit_status = std::process::ExitStatus::from_raw(0x100); // exit code 1
+
+        let error = agent_exited_during_startup_error(Ok(exit_status), &tail);
+        let message = error.to_string();
+        assert!(message.contains("exited during ACP startup"));
+        assert!(!message.contains("Agent stderr"));
+    }
+
+    #[test]
+    fn agent_exit_error_includes_stderr_tail() {
+        let tail = AgentStderrTail::default();
+        tail.push("Failed to locate codex-acp binary");
+        let exit_status = std::process::ExitStatus::from_raw(0x100);
+
+        let error = agent_exited_during_startup_error(Ok(exit_status), &tail);
+        assert!(error
+            .to_string()
+            .contains("Failed to locate codex-acp binary"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
@@ -2,13 +2,16 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use super::*;
-use crate::live::sessions::driver::stderr::spawn_agent_stderr_logger;
+use crate::live::sessions::driver::stderr::{spawn_agent_stderr_logger, AgentStderrTail};
 use crate::process_env::remove_runtime_private_env;
 
 pub(in crate::live::sessions) struct SpawnedAgentProcess {
     pub child: tokio::process::Child,
     pub stdin: tokio::process::ChildStdin,
     pub stdout: tokio::process::ChildStdout,
+    pub stderr_tail: AgentStderrTail,
+    /// Completes when the stderr pipe reaches EOF (shortly after child exit).
+    pub stderr_done: Option<tokio::task::JoinHandle<()>>,
 }
 
 pub(in crate::live::sessions) fn merge_spawn_env(
@@ -132,14 +135,24 @@ pub(in crate::live::sessions) fn spawn_agent_process(
         .stdout
         .take()
         .ok_or_else(|| anyhow::anyhow!("no stdout"))?;
-    if let Some(stderr) = child.stderr.take() {
-        spawn_agent_stderr_logger(stderr, session_id.to_owned(), source_agent_kind.to_owned());
-    }
+    let (stderr_tail, stderr_done) = match child.stderr.take() {
+        Some(stderr) => {
+            let (tail, reader_task) = spawn_agent_stderr_logger(
+                stderr,
+                session_id.to_owned(),
+                source_agent_kind.to_owned(),
+            );
+            (tail, Some(reader_task))
+        }
+        None => (AgentStderrTail::default(), None),
+    };
 
     Ok(SpawnedAgentProcess {
         child,
         stdin,
         stdout,
+        stderr_tail,
+        stderr_done,
     })
 }
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
@@ -1,3 +1,6 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
 use tokio::process::ChildStderr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -5,6 +8,39 @@ pub(in crate::live::sessions) enum AgentStderrSeverity {
     Error,
     Warn,
     Debug,
+}
+
+/// Retains the most recent agent stderr lines so startup failures can surface
+/// what the process said before it died.
+#[derive(Debug, Clone, Default)]
+pub(in crate::live::sessions) struct AgentStderrTail {
+    lines: Arc<Mutex<VecDeque<String>>>,
+}
+
+impl AgentStderrTail {
+    /// Enough to capture a fatal error plus a few lines of context without
+    /// bloating the startup error string shown to the user.
+    const MAX_LINES: usize = 8;
+
+    pub(in crate::live::sessions) fn push(&self, line: &str) {
+        let mut lines = self.lock_lines();
+        while lines.len() >= Self::MAX_LINES {
+            lines.pop_front();
+        }
+        lines.push_back(line.to_string());
+    }
+
+    pub(in crate::live::sessions) fn snapshot(&self) -> Vec<String> {
+        self.lock_lines().iter().cloned().collect()
+    }
+
+    fn lock_lines(&self) -> std::sync::MutexGuard<'_, VecDeque<String>> {
+        // A poisoned tail must not panic the startup error path it exists to
+        // improve; the buffered lines stay usable regardless.
+        self.lines
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 pub(in crate::live::sessions) fn sanitize_agent_stderr_line(line: &str) -> String {
@@ -58,12 +94,16 @@ pub(in crate::live::sessions) fn strip_ansi_escape_codes(input: &str) -> String 
     cleaned
 }
 
+/// Returns the tail buffer plus the reader task's handle so callers can wait
+/// for the pipe to drain (EOF follows the child's exit) before snapshotting.
 pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
     stderr: ChildStderr,
     session_id: String,
     agent_kind: String,
-) {
-    tokio::task::spawn_local(async move {
+) -> (AgentStderrTail, tokio::task::JoinHandle<()>) {
+    let tail = AgentStderrTail::default();
+    let tail_writer = tail.clone();
+    let reader_task = tokio::task::spawn_local(async move {
         use tokio::io::AsyncBufReadExt;
         let reader = tokio::io::BufReader::new(stderr);
         let mut lines = reader.lines();
@@ -72,6 +112,7 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
             if line.is_empty() {
                 continue;
             }
+            tail_writer.push(&line);
 
             match classify_agent_stderr_line(&line) {
                 AgentStderrSeverity::Error => {
@@ -98,6 +139,7 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
             }
         }
     });
+    (tail, reader_task)
 }
 
 #[cfg(test)]
@@ -140,5 +182,20 @@ mod tests {
         let line = "fatal: failed to resolve workspace";
 
         assert_eq!(classify_agent_stderr_line(line), AgentStderrSeverity::Warn);
+    }
+
+    #[test]
+    fn agent_stderr_tail_keeps_only_the_most_recent_lines() {
+        let evicted = 3;
+        let total = AgentStderrTail::MAX_LINES + evicted;
+        let tail = AgentStderrTail::default();
+        for index in 0..total {
+            tail.push(&format!("line {index}"));
+        }
+
+        let snapshot = tail.snapshot();
+        assert_eq!(snapshot.len(), AgentStderrTail::MAX_LINES);
+        assert_eq!(snapshot.first(), Some(&format!("line {evicted}")));
+        assert_eq!(snapshot.last(), Some(&format!("line {}", total - 1)));
     }
 }

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -126,7 +126,7 @@
           "kind": "managed_npm_package",
           "package": "git+https://github.com/proliferate-ai/codex-acp.git#1fdb4661c2aef0815a6aab16be27ea70f4c2b94f",
           "packageSubdir": "npm",
-          "sourceBuildBinaryName": null,
+          "sourceBuildBinaryName": "codex-acp",
           "executableRelpath": "node_modules/.bin/codex-acp"
         }
       },

--- a/catalogs/agents/registry.schema.json
+++ b/catalogs/agents/registry.schema.json
@@ -259,6 +259,7 @@
               ]
             },
             "sourceBuildBinaryName": {
+              "description": "When set, the installer clones the package source and cargo-builds this binary instead of npm-installing the wrapper; packageSubdir and executableRelpath are ignored.",
               "type": [
                 "string",
                 "null"
@@ -340,6 +341,7 @@
               ]
             },
             "sourceBuildBinaryName": {
+              "description": "When set, the installer clones the package source and cargo-builds this binary instead of npm-installing the wrapper; packageSubdir and executableRelpath are ignored.",
               "type": [
                 "string",
                 "null"


### PR DESCRIPTION
## Problem

Creating a codex session timed out after 60s with `ACP session startup timed out after 60s. The agent may be waiting for authentication or is unresponsive.` — but the agent was not waiting for auth. The codex-acp npm install delivers only the JS launcher (the `@proliferate-ai/codex-acp-*` platform sidecars were never published to npm, and the launcher resolved the old `@zed-industries/` scope — fixed in proliferate-ai/codex-acp#11), so the agent process printed `Failed to locate ... binary` and exited within milliseconds. The harness never noticed the exit and burned the full 60s ready timeout with a misleading error.

## Changes

**fix(sessions): fail ACP startup fast when the agent process exits**
- Race the ACP initialize/new-session handshake against `child.wait()` in `SessionActor::start`
- Retain a tail (last 8 lines) of agent stderr via `AgentStderrTail`
- On exit-before-ready, fail immediately with the exit status + stderr tail instead of the 60s timeout; `/v1/sessions` now errors in ms with the real cause
- Applies to all agents, not just codex: any agent that crashes at boot now produces a self-diagnosing error

**fix(catalog): build codex-acp from source until @proliferate-ai npm sidecars exist**
- Sets `sourceBuildBinaryName: "codex-acp"` so installs produce a real binary via the installer's existing cargo source-build path
- Interim measure for dev machines; revert to npm delivery (null + pin bump) once the sidecars are published — see commit message

## Testing
- `cargo test -p anyharness-lib live::sessions` (100 tests), `stderr`, `startup_failure`, `registry`, `catalog` — all green
- New unit tests for the stderr tail cap and the exit-error formatting
- Manually reproduced the original failure and verified the fixed codex-acp launcher answers ACP `initialize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)