### PR TITLE
fix(desktop): idle presentation for warming sessions + stable sidebar position for new workspaces

### DIFF
--- a/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx
+++ b/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx
@@ -20,10 +20,19 @@ const mocks = vi.hoisted(() => ({
   refreshCloudWorkspace: vi.fn(),
   selectWorkspace: vi.fn(),
   materializePendingWorkspaceSessions: vi.fn(),
+  trackWorkspaceInteraction: vi.fn(),
   workspaceCollections: {
     cloudWorkspaces: [] as CloudWorkspaceSummary[],
   },
 }));
+
+vi.mock("@/stores/preferences/workspace-ui-store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/stores/preferences/workspace-ui-store")>();
+  return {
+    ...actual,
+    trackWorkspaceInteraction: mocks.trackWorkspaceInteraction,
+  };
+});
 
 vi.mock("@/hooks/workspaces/cache/use-workspaces", () => ({
   useWorkspaces: () => ({
@@ -59,6 +68,7 @@ describe("useCloudWorkspacePolling", () => {
     mocks.refreshCloudWorkspace.mockReset();
     mocks.selectWorkspace.mockReset();
     mocks.materializePendingWorkspaceSessions.mockReset();
+    mocks.trackWorkspaceInteraction.mockReset();
     mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "pending" })];
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
@@ -118,6 +128,10 @@ describe("useCloudWorkspacePolling", () => {
       projectedSessionCount: 1,
       projectedSessionIds: [projectedSessionId],
     });
+    let pendingEntryAtInteraction: unknown = null;
+    mocks.trackWorkspaceInteraction.mockImplementation(() => {
+      pendingEntryAtInteraction = useSessionSelectionStore.getState().pendingWorkspaceEntry;
+    });
 
     renderHook(() => useCloudWorkspacePolling());
 
@@ -133,6 +147,14 @@ describe("useCloudWorkspacePolling", () => {
       workspaceId,
       { eventPrefix: "workspace.cloud_polling" },
     );
+    await waitFor(() => {
+      expect(mocks.trackWorkspaceInteraction).toHaveBeenCalledWith(
+        workspaceId,
+        expect.any(String),
+      );
+    });
+    expect(pendingEntryAtInteraction).toMatchObject({ attemptId: "attempt-1" });
+    expect(useSessionSelectionStore.getState().pendingWorkspaceEntry).toBeNull();
   });
 
   it("marks the current awaiting cloud workspace as failed when polling returns error", async () => {

--- a/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
+++ b/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
@@ -16,6 +16,7 @@ import {
   shouldShowCloudWorkspaceStatusScreen,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { trackWorkspaceInteraction } from "@/stores/preferences/workspace-ui-store";
 import {
   elapsedMs,
   elapsedSince,
@@ -189,6 +190,7 @@ export function useCloudWorkspacePolling() {
               selectedWorkspaceId,
               { eventPrefix: "workspace.cloud_polling" },
             );
+            trackWorkspaceInteraction(selectedWorkspaceId, new Date().toISOString());
             setPendingWorkspaceEntry(null);
             setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
               workspaceId: selectedWorkspaceId,

--- a/apps/desktop/src/hooks/cowork/workflows/cowork-thread-session-record.ts
+++ b/apps/desktop/src/hooks/cowork/workflows/cowork-thread-session-record.ts
@@ -49,6 +49,8 @@ function materializedCoworkSessionRecord(
       executionSummary: input.session.executionSummary ?? null,
       mcpBindingSummaries: input.session.mcpBindingSummaries ?? null,
       lastPromptAt: input.session.lastPromptAt ?? null,
+      hasAttemptedPrompt:
+        getSessionRecord(input.clientSessionId)?.hasAttemptedPrompt ?? false,
       optimisticPrompt: null,
       sessionRelationship: { kind: "root" },
     },

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getSessionRecord: vi.fn(),
   logLatency: vi.fn(),
   mutateAsync: vi.fn(),
+  patchSessionRecord: vi.fn(),
   promptAttachmentSnapshotsToBlocks: vi.fn(),
   rehydrateSessionSlotFromHistory: vi.fn(),
   sendCloudPromptCommand: vi.fn(),
@@ -51,6 +52,7 @@ vi.mock("@/hooks/sessions/workflows/session-materialization-deps", () => ({
 
 vi.mock("@/stores/sessions/session-records", () => ({
   getSessionRecord: mocks.getSessionRecord,
+  patchSessionRecord: mocks.patchSessionRecord,
 }));
 
 describe("dispatchPromptIntent", () => {

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
@@ -69,6 +69,30 @@ describe("dispatchPromptIntent", () => {
     mocks.waitForSessionMaterialization.mockResolvedValue("session-1");
   });
 
+  it("marks the prompt attempt on the session record before dispatching the request", async () => {
+    const entry = useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "client-session-1",
+      workspaceId: "workspace-1",
+      text: "Build please",
+      blocks: [{ type: "text", text: "Build please" }],
+    });
+    mocks.mutateAsync.mockResolvedValue({
+      session: { id: "session-1" },
+      status: "queued",
+      queuedSeq: 4,
+    });
+
+    await dispatchPromptIntent(entry, createDeps());
+
+    expect(mocks.patchSessionRecord).toHaveBeenCalledWith(
+      "client-session-1",
+      { hasAttemptedPrompt: true },
+    );
+    expect(mocks.patchSessionRecord.mock.invocationCallOrder[0]!)
+      .toBeLessThan(mocks.mutateAsync.mock.invocationCallOrder[0]!);
+  });
+
   it("does not overwrite a reconciled prompt when a late dispatch failure arrives", async () => {
     const entry = useSessionIntentStore.getState().enqueuePrompt({
       clientPromptId: "prompt-1",

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
@@ -31,6 +31,7 @@ import {
 } from "@/hooks/sessions/workflows/session-materialization-deps";
 import {
   getSessionRecord,
+  patchSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
 
@@ -68,6 +69,8 @@ export async function dispatchPromptIntent(
   if (!current || current.kind !== "send_prompt" || current.deliveryState !== "waiting_for_session") {
     return;
   }
+
+  patchSessionRecord(entry.clientSessionId, { hasAttemptedPrompt: true });
 
   let requestStarted = false;
   let requestHeaders: HeadersInit | null = null;

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -17,6 +17,7 @@ import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cl
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import {
   createEmptySessionRecord,
+  getSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
@@ -224,6 +225,7 @@ export async function materializeSessionCreation({
       executionSummary: launchedSession.executionSummary ?? null,
       mcpBindingSummaries: launchedSession.mcpBindingSummaries ?? null,
       lastPromptAt: launchedSession.lastPromptAt ?? null,
+      hasAttemptedPrompt: getSessionRecord(pendingSessionId)?.hasAttemptedPrompt ?? false,
       optimisticPrompt: null,
       pendingConfigChanges: {},
       sessionRelationship: { kind: "root" },
@@ -370,6 +372,7 @@ function materializedRecordFromExistingSession({
       executionSummary: session.executionSummary ?? null,
       mcpBindingSummaries: session.mcpBindingSummaries ?? null,
       lastPromptAt: session.lastPromptAt ?? null,
+      hasAttemptedPrompt: getSessionRecord(clientSessionId)?.hasAttemptedPrompt ?? false,
       optimisticPrompt: null,
       pendingConfigChanges,
       sessionRelationship: { kind: "root" },

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -182,6 +182,7 @@ export function useSessionCreationActions() {
         requestedModelId: options.modelId,
         modeId: resolvedModeId ?? null,
         title: existingProjectedRecord?.title ?? null,
+        hasAttemptedPrompt: existingProjectedRecord?.hasAttemptedPrompt ?? false,
         optimisticPrompt: null,
         pendingConfigChanges: {},
         sessionRelationship: { kind: "root" },

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
@@ -1,13 +1,4 @@
-import type { ContentPart, PromptInputBlock, ResolveInteractionRequest } from "@anyharness/sdk";
-import {
-  type McpElicitationUrlRevealResponse,
-  selectPendingApprovalInteraction,
-  selectPendingMcpElicitationInteraction,
-  selectPendingUserInputInteraction,
-  type McpElicitationSubmittedField,
-  type UserInputSubmittedAnswer,
-} from "@anyharness/sdk";
-import { useRevealMcpElicitationUrlMutation } from "@anyharness/sdk-react";
+import type { ContentPart, PromptInputBlock } from "@anyharness/sdk";
 import { useCallback } from "react";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { PROMPT_SUBMIT_MEASUREMENT_SURFACES } from "@/lib/domain/telemetry/debug-measurement-catalog";
@@ -19,7 +10,6 @@ import {
 } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
 import {
   promptIntentsForSession,
-  sessionIntentsForSession,
 } from "@proliferate/product-domain/sessions/intents/session-intent-state";
 import { finishLatencyFlow } from "@/lib/infra/measurement/latency-flow";
 import {
@@ -34,12 +24,9 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
 import type { SessionConfigOptionUpdateOptions } from "@/hooks/sessions/workflows/session-control-contract";
-import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
-import { getSessionClientAndWorkspace } from "@/lib/access/anyharness/session-runtime";
 import {
-  logInteractionDebug,
-  type InteractionAction,
-} from "@/hooks/sessions/workflows/session-interaction-debug";
+  useSessionInteractionResolutionActions,
+} from "@/hooks/sessions/workflows/use-session-interaction-resolution-actions";
 
 interface SendPromptInput {
   sessionId: string;
@@ -56,7 +43,12 @@ interface SendPromptInput {
 
 export function useSessionIntentActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
-  const revealMcpElicitationUrlMutation = useRevealMcpElicitationUrlMutation();
+  const {
+    resolvePermission,
+    resolveMcpElicitation,
+    resolveUserInput,
+    revealMcpElicitationUrl,
+  } = useSessionInteractionResolutionActions();
 
   const sendPrompt = useCallback(async ({
     sessionId,
@@ -181,213 +173,6 @@ export function useSessionIntentActions() {
       persistDefaultPreference: options?.persistDefaultPreference !== false,
     });
   }, [getWorkspaceRuntimeBlockReason]);
-
-  const enqueueResolveInteraction = useCallback((input: {
-    action: InteractionAction;
-    sessionId: string;
-    selectedWorkspaceId: string | null;
-    slot: SessionRuntimeRecord | null;
-    requestId: string;
-    request: ResolveInteractionRequest;
-    requestExtra?: Record<string, unknown>;
-  }) => {
-    const blockedReason = getWorkspaceRuntimeBlockReason(input.slot?.workspaceId ?? input.selectedWorkspaceId);
-    if (blockedReason) {
-      logInteractionDebug("resolve.blocked", {
-        ...input,
-        extra: { blockedReason },
-      });
-      throw new Error(blockedReason);
-    }
-    const existingIntent = sessionIntentsForSession(
-      useSessionIntentStore.getState(),
-      input.sessionId,
-    ).find((intent) =>
-      intent.kind === "resolve_interaction"
-      && intent.requestId === input.requestId
-      && (
-        intent.status === "queued"
-        || intent.status === "preparing"
-        || intent.status === "dispatching"
-        || intent.status === "accepted"
-      )
-    );
-    if (existingIntent) {
-      return;
-    }
-    useSessionIntentStore.getState().enqueueInteraction({
-      clientSessionId: input.sessionId,
-      materializedSessionId: input.slot?.materializedSessionId ?? null,
-      workspaceId: input.slot?.workspaceId ?? input.selectedWorkspaceId,
-      action: input.action,
-      requestId: input.requestId,
-      request: input.request,
-      requestExtra: input.requestExtra ?? null,
-    });
-    logInteractionDebug("resolve.enqueued", input);
-  }, [getWorkspaceRuntimeBlockReason]);
-
-  const resolvePermission = useCallback(async (
-    input: { decision?: "allow" | "deny"; optionId?: string },
-  ) => {
-    const state = useSessionSelectionStore.getState();
-    const sessionId = state.activeSessionId;
-    const slot = sessionId ? getSessionRecord(sessionId) : null;
-    const permission = slot?.transcript
-      ? selectPendingApprovalInteraction(slot.transcript)
-      : null;
-    if (!sessionId || !permission) {
-      logInteractionDebug("resolve.skipped_no_pending", {
-        action: "permission",
-        sessionId,
-        selectedWorkspaceId: state.selectedWorkspaceId,
-        slot,
-      });
-      return;
-    }
-
-    const request: ResolveInteractionRequest = input.optionId
-      ? { outcome: "selected", optionId: input.optionId }
-      : { outcome: "decision", decision: input.decision ?? "deny" };
-    enqueueResolveInteraction({
-      action: "permission",
-      sessionId,
-      selectedWorkspaceId: state.selectedWorkspaceId,
-      slot,
-      requestId: permission.requestId,
-      request,
-      requestExtra: {
-        outcome: input.optionId ? "selected" : "decision",
-        hasOptionId: Boolean(input.optionId),
-        decision: input.optionId ? null : input.decision ?? "deny",
-      },
-    });
-  }, [enqueueResolveInteraction]);
-
-  const resolveUserInput = useCallback(async (
-    input:
-      | { outcome: "submitted"; answers: UserInputSubmittedAnswer[] }
-      | { outcome: "cancelled" },
-  ) => {
-    const state = useSessionSelectionStore.getState();
-    const sessionId = state.activeSessionId;
-    const slot = sessionId ? getSessionRecord(sessionId) : null;
-    const userInput = slot?.transcript
-      ? selectPendingUserInputInteraction(slot.transcript)
-      : null;
-    if (!sessionId || !userInput) {
-      logInteractionDebug("resolve.skipped_no_pending", {
-        action: "user_input",
-        sessionId,
-        selectedWorkspaceId: state.selectedWorkspaceId,
-        slot,
-      });
-      return;
-    }
-
-    const request: ResolveInteractionRequest = input.outcome === "submitted"
-      ? { outcome: "submitted", answers: input.answers }
-      : { outcome: "cancelled" };
-    enqueueResolveInteraction({
-      action: "user_input",
-      sessionId,
-      selectedWorkspaceId: state.selectedWorkspaceId,
-      slot,
-      requestId: userInput.requestId,
-      request,
-      requestExtra: {
-        outcome: input.outcome,
-        answerCount: input.outcome === "submitted" ? input.answers.length : 0,
-      },
-    });
-  }, [enqueueResolveInteraction]);
-
-  const resolveMcpElicitation = useCallback(async (
-    input:
-      | { outcome: "accepted"; fields: McpElicitationSubmittedField[] }
-      | { outcome: "declined" }
-      | { outcome: "cancelled" },
-  ) => {
-    const state = useSessionSelectionStore.getState();
-    const sessionId = state.activeSessionId;
-    const slot = sessionId ? getSessionRecord(sessionId) : null;
-    const mcpElicitation = slot?.transcript
-      ? selectPendingMcpElicitationInteraction(slot.transcript)
-      : null;
-    if (!sessionId || !mcpElicitation) {
-      logInteractionDebug("resolve.skipped_no_pending", {
-        action: "mcp_elicitation",
-        sessionId,
-        selectedWorkspaceId: state.selectedWorkspaceId,
-        slot,
-      });
-      return;
-    }
-
-    const request: ResolveInteractionRequest = input.outcome === "accepted"
-      ? { outcome: "accepted", fields: input.fields }
-      : { outcome: input.outcome };
-    enqueueResolveInteraction({
-      action: "mcp_elicitation",
-      sessionId,
-      selectedWorkspaceId: state.selectedWorkspaceId,
-      slot,
-      requestId: mcpElicitation.requestId,
-      request,
-      requestExtra: {
-        outcome: input.outcome,
-        fieldCount: input.outcome === "accepted" ? input.fields.length : 0,
-      },
-    });
-  }, [enqueueResolveInteraction]);
-
-  const revealMcpElicitationUrl = useCallback(async (): Promise<McpElicitationUrlRevealResponse | null> => {
-    const state = useSessionSelectionStore.getState();
-    const sessionId = state.activeSessionId;
-    const slot = sessionId ? getSessionRecord(sessionId) : null;
-    const mcpElicitation = slot?.transcript
-      ? selectPendingMcpElicitationInteraction(slot.transcript)
-      : null;
-    if (!sessionId || !mcpElicitation) {
-      logInteractionDebug("reveal_url.skipped_no_pending", {
-        action: "mcp_elicitation",
-        sessionId,
-        selectedWorkspaceId: state.selectedWorkspaceId,
-        slot,
-      });
-      return null;
-    }
-    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
-    if (blockedReason) {
-      logInteractionDebug("reveal_url.blocked", {
-        action: "mcp_elicitation",
-        sessionId,
-        selectedWorkspaceId: state.selectedWorkspaceId,
-        slot,
-        requestId: mcpElicitation.requestId,
-        extra: { blockedReason },
-      });
-      throw new Error(blockedReason);
-    }
-    const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(sessionId);
-    const response = await revealMcpElicitationUrlMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
-      requestId: mcpElicitation.requestId,
-    });
-    logInteractionDebug("reveal_url.success", {
-      action: "mcp_elicitation",
-      sessionId,
-      selectedWorkspaceId: state.selectedWorkspaceId,
-      slot,
-      requestId: mcpElicitation.requestId,
-      extra: { hasUrl: Boolean(response.url) },
-    });
-    return response;
-  }, [
-    getWorkspaceRuntimeBlockReason,
-    revealMcpElicitationUrlMutation,
-  ]);
 
   return {
     promptSession: sendPrompt,

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
@@ -29,7 +29,7 @@ import {
 } from "@/lib/infra/measurement/debug-measurement";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
-import { getSessionRecord } from "@/stores/sessions/session-records";
+import { getSessionRecord, patchSessionRecord } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
@@ -112,6 +112,7 @@ export function useSessionIntentActions() {
       });
     };
     enqueuePrompt();
+    patchSessionRecord(sessionId, { hasAttemptedPrompt: true });
     logLatency("session.intent.prompt.enqueue", {
       clientPromptId,
       clientSessionId: sessionId,

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-interaction-resolution-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-interaction-resolution-actions.ts
@@ -1,0 +1,244 @@
+import type { ResolveInteractionRequest } from "@anyharness/sdk";
+import {
+  type McpElicitationUrlRevealResponse,
+  selectPendingApprovalInteraction,
+  selectPendingMcpElicitationInteraction,
+  selectPendingUserInputInteraction,
+  type McpElicitationSubmittedField,
+  type UserInputSubmittedAnswer,
+} from "@anyharness/sdk";
+import { useRevealMcpElicitationUrlMutation } from "@anyharness/sdk-react";
+import { useCallback } from "react";
+import {
+  sessionIntentsForSession,
+} from "@proliferate/product-domain/sessions/intents/session-intent-state";
+import { getSessionRecord } from "@/stores/sessions/session-records";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
+import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
+import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
+import { getSessionClientAndWorkspace } from "@/lib/access/anyharness/session-runtime";
+import {
+  logInteractionDebug,
+  type InteractionAction,
+} from "@/hooks/sessions/workflows/session-interaction-debug";
+
+// Resolves pending session interactions (permissions, user input, MCP elicitations).
+export function useSessionInteractionResolutionActions() {
+  const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
+  const revealMcpElicitationUrlMutation = useRevealMcpElicitationUrlMutation();
+
+  const enqueueResolveInteraction = useCallback((input: {
+    action: InteractionAction;
+    sessionId: string;
+    selectedWorkspaceId: string | null;
+    slot: SessionRuntimeRecord | null;
+    requestId: string;
+    request: ResolveInteractionRequest;
+    requestExtra?: Record<string, unknown>;
+  }) => {
+    const blockedReason = getWorkspaceRuntimeBlockReason(input.slot?.workspaceId ?? input.selectedWorkspaceId);
+    if (blockedReason) {
+      logInteractionDebug("resolve.blocked", {
+        ...input,
+        extra: { blockedReason },
+      });
+      throw new Error(blockedReason);
+    }
+    const existingIntent = sessionIntentsForSession(
+      useSessionIntentStore.getState(),
+      input.sessionId,
+    ).find((intent) =>
+      intent.kind === "resolve_interaction"
+      && intent.requestId === input.requestId
+      && (
+        intent.status === "queued"
+        || intent.status === "preparing"
+        || intent.status === "dispatching"
+        || intent.status === "accepted"
+      )
+    );
+    if (existingIntent) {
+      return;
+    }
+    useSessionIntentStore.getState().enqueueInteraction({
+      clientSessionId: input.sessionId,
+      materializedSessionId: input.slot?.materializedSessionId ?? null,
+      workspaceId: input.slot?.workspaceId ?? input.selectedWorkspaceId,
+      action: input.action,
+      requestId: input.requestId,
+      request: input.request,
+      requestExtra: input.requestExtra ?? null,
+    });
+    logInteractionDebug("resolve.enqueued", input);
+  }, [getWorkspaceRuntimeBlockReason]);
+
+  const resolvePermission = useCallback(async (
+    input: { decision?: "allow" | "deny"; optionId?: string },
+  ) => {
+    const state = useSessionSelectionStore.getState();
+    const sessionId = state.activeSessionId;
+    const slot = sessionId ? getSessionRecord(sessionId) : null;
+    const permission = slot?.transcript
+      ? selectPendingApprovalInteraction(slot.transcript)
+      : null;
+    if (!sessionId || !permission) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "permission",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
+      return;
+    }
+
+    const request: ResolveInteractionRequest = input.optionId
+      ? { outcome: "selected", optionId: input.optionId }
+      : { outcome: "decision", decision: input.decision ?? "deny" };
+    enqueueResolveInteraction({
+      action: "permission",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
+      requestId: permission.requestId,
+      request,
+      requestExtra: {
+        outcome: input.optionId ? "selected" : "decision",
+        hasOptionId: Boolean(input.optionId),
+        decision: input.optionId ? null : input.decision ?? "deny",
+      },
+    });
+  }, [enqueueResolveInteraction]);
+
+  const resolveUserInput = useCallback(async (
+    input:
+      | { outcome: "submitted"; answers: UserInputSubmittedAnswer[] }
+      | { outcome: "cancelled" },
+  ) => {
+    const state = useSessionSelectionStore.getState();
+    const sessionId = state.activeSessionId;
+    const slot = sessionId ? getSessionRecord(sessionId) : null;
+    const userInput = slot?.transcript
+      ? selectPendingUserInputInteraction(slot.transcript)
+      : null;
+    if (!sessionId || !userInput) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "user_input",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
+      return;
+    }
+
+    const request: ResolveInteractionRequest = input.outcome === "submitted"
+      ? { outcome: "submitted", answers: input.answers }
+      : { outcome: "cancelled" };
+    enqueueResolveInteraction({
+      action: "user_input",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
+      requestId: userInput.requestId,
+      request,
+      requestExtra: {
+        outcome: input.outcome,
+        answerCount: input.outcome === "submitted" ? input.answers.length : 0,
+      },
+    });
+  }, [enqueueResolveInteraction]);
+
+  const resolveMcpElicitation = useCallback(async (
+    input:
+      | { outcome: "accepted"; fields: McpElicitationSubmittedField[] }
+      | { outcome: "declined" }
+      | { outcome: "cancelled" },
+  ) => {
+    const state = useSessionSelectionStore.getState();
+    const sessionId = state.activeSessionId;
+    const slot = sessionId ? getSessionRecord(sessionId) : null;
+    const mcpElicitation = slot?.transcript
+      ? selectPendingMcpElicitationInteraction(slot.transcript)
+      : null;
+    if (!sessionId || !mcpElicitation) {
+      logInteractionDebug("resolve.skipped_no_pending", {
+        action: "mcp_elicitation",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
+      return;
+    }
+
+    const request: ResolveInteractionRequest = input.outcome === "accepted"
+      ? { outcome: "accepted", fields: input.fields }
+      : { outcome: input.outcome };
+    enqueueResolveInteraction({
+      action: "mcp_elicitation",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
+      requestId: mcpElicitation.requestId,
+      request,
+      requestExtra: {
+        outcome: input.outcome,
+        fieldCount: input.outcome === "accepted" ? input.fields.length : 0,
+      },
+    });
+  }, [enqueueResolveInteraction]);
+
+  const revealMcpElicitationUrl = useCallback(async (): Promise<McpElicitationUrlRevealResponse | null> => {
+    const state = useSessionSelectionStore.getState();
+    const sessionId = state.activeSessionId;
+    const slot = sessionId ? getSessionRecord(sessionId) : null;
+    const mcpElicitation = slot?.transcript
+      ? selectPendingMcpElicitationInteraction(slot.transcript)
+      : null;
+    if (!sessionId || !mcpElicitation) {
+      logInteractionDebug("reveal_url.skipped_no_pending", {
+        action: "mcp_elicitation",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+      });
+      return null;
+    }
+    const blockedReason = getWorkspaceRuntimeBlockReason(slot?.workspaceId ?? state.selectedWorkspaceId);
+    if (blockedReason) {
+      logInteractionDebug("reveal_url.blocked", {
+        action: "mcp_elicitation",
+        sessionId,
+        selectedWorkspaceId: state.selectedWorkspaceId,
+        slot,
+        requestId: mcpElicitation.requestId,
+        extra: { blockedReason },
+      });
+      throw new Error(blockedReason);
+    }
+    const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(sessionId);
+    const response = await revealMcpElicitationUrlMutation.mutateAsync({
+      workspaceId,
+      sessionId: materializedSessionId,
+      requestId: mcpElicitation.requestId,
+    });
+    logInteractionDebug("reveal_url.success", {
+      action: "mcp_elicitation",
+      sessionId,
+      selectedWorkspaceId: state.selectedWorkspaceId,
+      slot,
+      requestId: mcpElicitation.requestId,
+      extra: { hasUrl: Boolean(response.url) },
+    });
+    return response;
+  }, [
+    getWorkspaceRuntimeBlockReason,
+    revealMcpElicitationUrlMutation,
+  ]);
+
+  return {
+    resolvePermission,
+    resolveMcpElicitation,
+    resolveUserInput,
+    revealMcpElicitationUrl,
+  };
+}

--- a/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useWorkspaceSidebarActivityStates } from "./use-workspace-sidebar-activities";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+describe("useWorkspaceSidebarActivityStates", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("re-derives workspace activity when a starting session records a prompt attempt", () => {
+    act(() => {
+      useSessionDirectoryStore.getState().upsertEntry({
+        sessionId: "session-a",
+        workspaceId: "workspace-a",
+        agentKind: "codex",
+        status: "starting",
+      });
+    });
+
+    const { result } = renderHook(() => useWorkspaceSidebarActivityStates());
+    const neverPromptedStates = result.current;
+    expect(neverPromptedStates["workspace-a"]).toBe("idle");
+
+    act(() => {
+      useSessionDirectoryStore.getState().upsertEntry({
+        sessionId: "session-a",
+        workspaceId: "workspace-a",
+        agentKind: "codex",
+        status: "starting",
+        hasAttemptedPrompt: true,
+      });
+    });
+
+    expect(result.current).not.toBe(neverPromptedStates);
+    expect(result.current["workspace-a"]).toBe("iterating");
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
+++ b/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
@@ -82,6 +82,8 @@ function buildWorkspaceSidebarActivitySignature(
       entry.status ?? "",
       entry.executionSummary?.phase ?? "",
       pendingInteractionSignature(entry.executionSummary?.pendingInteractions),
+      entry.lastPromptAt ?? "",
+      entry.hasAttemptedPrompt ? "prompted" : "",
       entry.streamConnectionState,
       entry.activity.isStreaming ? "streaming" : "idle",
       pendingInteractionSignature(entry.activity.pendingInteractions),

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
@@ -232,6 +232,16 @@ describe("useWorkspaceEntryActions", () => {
       useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace[pendingWorkspaceUiKey],
     ).toBe(chatWorkspaceShellTabKey(projectedSessionId!));
 
+    let pendingEntryAtInteraction: unknown = null;
+    const unsubscribe = useWorkspaceUiStore.subscribe((state, previousState) => {
+      if (
+        state.workspaceLastInteracted["workspace-created"]
+        && !previousState.workspaceLastInteracted["workspace-created"]
+      ) {
+        pendingEntryAtInteraction = useSessionSelectionStore.getState().pendingWorkspaceEntry;
+      }
+    });
+
     finishCreate({
       workspace: worktreeWorkspace("workspace-created"),
       setupScript: null,
@@ -239,9 +249,14 @@ describe("useWorkspaceEntryActions", () => {
     await expect(actionPromise).resolves.toMatchObject({
       workspaceId: "workspace-created",
     });
+    unsubscribe();
     expect(useSessionSelectionStore.getState().pendingWorkspaceEntry).toBeNull();
     expect(useWorkspaceUiStore.getState().workspaceLastInteracted["workspace-created"])
       .toEqual(expect.any(String));
+    expect(pendingEntryAtInteraction).toMatchObject({
+      source: "worktree-created",
+      workspaceId: "workspace-created",
+    });
   });
 
   it("seeds a projected pending session from saved defaults when no initial session is passed", async () => {

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
@@ -145,6 +145,7 @@ describe("useWorkspaceEntryActions", () => {
       recentlyHiddenChatSessionIdsByWorkspace: {},
       collapsedChatGroupsByWorkspace: {},
       manualChatGroupsByWorkspace: {},
+      workspaceLastInteracted: {},
     });
   });
 
@@ -238,6 +239,9 @@ describe("useWorkspaceEntryActions", () => {
     await expect(actionPromise).resolves.toMatchObject({
       workspaceId: "workspace-created",
     });
+    expect(useSessionSelectionStore.getState().pendingWorkspaceEntry).toBeNull();
+    expect(useWorkspaceUiStore.getState().workspaceLastInteracted["workspace-created"])
+      .toEqual(expect.any(String));
   });
 
   it("seeds a projected pending session from saved defaults when no initial session is passed", async () => {

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
@@ -14,6 +14,7 @@ import {
 import { sidebarRepoGroupKeyForWorkspace } from "@/lib/domain/workspaces/sidebar/sidebar-group-key";
 import {
   ensureRepoGroupExpanded,
+  trackWorkspaceInteraction,
 } from "@/stores/preferences/workspace-ui-store";
 import { useWorkspaceActions } from "./use-workspace-actions";
 import { useWorkspaceEntryFlow } from "./use-workspace-entry-flow";
@@ -86,6 +87,7 @@ export function useWorkspaceEntryActions() {
     selectWorkspace,
     setPendingWorkspaceEntry,
     setWorkspaceArrivalEvent,
+    trackWorkspaceInteraction,
   }), [
     materializePendingWorkspaceSessions,
     selectWorkspace,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
@@ -87,7 +87,8 @@ export function useWorkspaceEntryActions() {
     selectWorkspace,
     setPendingWorkspaceEntry,
     setWorkspaceArrivalEvent,
-    trackWorkspaceInteraction,
+    trackWorkspaceInteraction: (workspaceId: string) =>
+      trackWorkspaceInteraction(workspaceId, new Date().toISOString()),
   }), [
     materializePendingWorkspaceSessions,
     selectWorkspace,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
@@ -12,13 +12,10 @@ import {
   type CreateWorktreeWorkspaceInput,
 } from "@/lib/domain/workspaces/creation/workspace-creation";
 import { sidebarRepoGroupKeyForWorkspace } from "@/lib/domain/workspaces/sidebar/sidebar-group-key";
-import {
-  ensureRepoGroupExpanded,
-  trackWorkspaceInteraction,
-} from "@/stores/preferences/workspace-ui-store";
+import { ensureRepoGroupExpanded } from "@/stores/preferences/workspace-ui-store";
 import { useWorkspaceActions } from "./use-workspace-actions";
 import { useWorkspaceEntryFlow } from "./use-workspace-entry-flow";
-import { useWorkspaceSelection } from "./selection/use-workspace-selection";
+import { useWorkspaceEntrySelectionDeps } from "./use-workspace-entry-selection-deps";
 import {
   elapsedMs,
   elapsedSince,
@@ -29,10 +26,6 @@ import {
   annotateLatencyFlow,
   failLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
-import {
-  usePendingWorkspaceSessionMaterialization,
-} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
-import { getSessionRecord } from "@/stores/sessions/session-records";
 import {
   buildMaterializedWorktreePendingEntry,
   normalizeWorktreeInput,
@@ -71,30 +64,7 @@ export function useWorkspaceEntryActions() {
     isCreatingWorktreeWorkspace,
   } = useWorkspaceActions();
   const { beginPendingWorkspace, selectWorkspaceWithArrival } = useWorkspaceEntryFlow();
-  const { selectWorkspace } = useWorkspaceSelection();
-  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
-  const setPendingWorkspaceEntry = useSessionSelectionStore(
-    (state) => state.setPendingWorkspaceEntry,
-  );
-  const setWorkspaceArrivalEvent = useSessionSelectionStore(
-    (state) => state.setWorkspaceArrivalEvent,
-  );
-  const entrySelectionDeps = useMemo(() => ({
-    expandRepoGroup: ensureRepoGroupExpanded,
-    getSelectionState: useSessionSelectionStore.getState,
-    getSessionRecord,
-    materializePendingWorkspaceSessions,
-    selectWorkspace,
-    setPendingWorkspaceEntry,
-    setWorkspaceArrivalEvent,
-    trackWorkspaceInteraction: (workspaceId: string) =>
-      trackWorkspaceInteraction(workspaceId, new Date().toISOString()),
-  }), [
-    materializePendingWorkspaceSessions,
-    selectWorkspace,
-    setPendingWorkspaceEntry,
-    setWorkspaceArrivalEvent,
-  ]);
+  const entrySelectionDeps = useWorkspaceEntrySelectionDeps();
 
   const finalizeSelection = useCallback(async (
     entry: PendingWorkspaceEntry,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-selection-deps.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-selection-deps.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import {
+  ensureRepoGroupExpanded,
+  trackWorkspaceInteraction,
+} from "@/stores/preferences/workspace-ui-store";
+import { getSessionRecord } from "@/stores/sessions/session-records";
+import {
+  usePendingWorkspaceSessionMaterialization,
+} from "@/hooks/workspaces/workflows/use-pending-workspace-session-materialization";
+import type {
+  WorkspaceEntrySelectionDeps,
+} from "@/hooks/workspaces/workflows/workspace-entry-finalization";
+import { useWorkspaceSelection } from "./selection/use-workspace-selection";
+
+// Stable dependency bundle consumed by the workspace-entry finalization workflows.
+export function useWorkspaceEntrySelectionDeps(): WorkspaceEntrySelectionDeps {
+  const { selectWorkspace } = useWorkspaceSelection();
+  const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
+  const setPendingWorkspaceEntry = useSessionSelectionStore(
+    (state) => state.setPendingWorkspaceEntry,
+  );
+  const setWorkspaceArrivalEvent = useSessionSelectionStore(
+    (state) => state.setWorkspaceArrivalEvent,
+  );
+
+  return useMemo(() => ({
+    expandRepoGroup: ensureRepoGroupExpanded,
+    getSelectionState: useSessionSelectionStore.getState,
+    getSessionRecord,
+    materializePendingWorkspaceSessions,
+    selectWorkspace,
+    setPendingWorkspaceEntry,
+    setWorkspaceArrivalEvent,
+    trackWorkspaceInteraction: (workspaceId: string) =>
+      trackWorkspaceInteraction(workspaceId, new Date().toISOString()),
+  }), [
+    materializePendingWorkspaceSessions,
+    selectWorkspace,
+    setPendingWorkspaceEntry,
+    setWorkspaceArrivalEvent,
+  ]);
+}

--- a/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
@@ -38,6 +38,7 @@ export interface WorkspaceEntrySelectionDeps {
   ) => Promise<void>;
   setPendingWorkspaceEntry: (entry: PendingWorkspaceEntry | null) => void;
   setWorkspaceArrivalEvent: (event: ReturnType<typeof buildWorkspaceArrivalEvent>) => void;
+  trackWorkspaceInteraction: (workspaceId: string, timestamp: string) => void;
 }
 
 export async function finalizePendingWorkspaceSelection(
@@ -104,6 +105,7 @@ export async function finalizePendingWorkspaceSelection(
     setupScript: input.entry.setupScript,
     baseBranchName: input.entry.baseBranchName,
   }));
+  deps.trackWorkspaceInteraction(input.workspaceId, new Date().toISOString());
   deps.setPendingWorkspaceEntry(null);
   logLatency("workspace.entry.selection.success", {
     attemptId: input.entry.attemptId,

--- a/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
@@ -38,7 +38,7 @@ export interface WorkspaceEntrySelectionDeps {
   ) => Promise<void>;
   setPendingWorkspaceEntry: (entry: PendingWorkspaceEntry | null) => void;
   setWorkspaceArrivalEvent: (event: ReturnType<typeof buildWorkspaceArrivalEvent>) => void;
-  trackWorkspaceInteraction: (workspaceId: string, timestamp: string) => void;
+  trackWorkspaceInteraction: (workspaceId: string) => void;
 }
 
 export async function finalizePendingWorkspaceSelection(
@@ -105,7 +105,7 @@ export async function finalizePendingWorkspaceSelection(
     setupScript: input.entry.setupScript,
     baseBranchName: input.entry.baseBranchName,
   }));
-  deps.trackWorkspaceInteraction(input.workspaceId, new Date().toISOString());
+  deps.trackWorkspaceInteraction(input.workspaceId);
   deps.setPendingWorkspaceEntry(null);
   logLatency("workspace.entry.selection.success", {
     attemptId: input.entry.attemptId,

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-activity.test.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-activity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isSessionSlotBusy } from "@proliferate/product-domain/sessions/activity";
+import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
+import { createDirectoryEntry } from "@/lib/domain/sessions/directory/directory-entry";
+
+describe("activity snapshot from directory entry", () => {
+  it("presents a never-prompted starting entry as not busy", () => {
+    const entry = createDirectoryEntry({
+      sessionId: "session-a",
+      agentKind: "proliferate",
+      status: "starting",
+    });
+
+    expect(isSessionSlotBusy(activitySnapshotFromDirectoryEntry(entry))).toBe(false);
+  });
+
+  it("keeps a starting entry busy once a prompt attempt is recorded", () => {
+    const entry = createDirectoryEntry({
+      sessionId: "session-a",
+      agentKind: "proliferate",
+      status: "starting",
+      hasAttemptedPrompt: true,
+    });
+
+    expect(isSessionSlotBusy(activitySnapshotFromDirectoryEntry(entry))).toBe(true);
+  });
+
+  it("keeps a starting entry busy once a prompt timestamp exists", () => {
+    const entry = createDirectoryEntry({
+      sessionId: "session-a",
+      agentKind: "proliferate",
+      status: "starting",
+      lastPromptAt: "2026-06-04T09:00:00Z",
+    });
+
+    expect(isSessionSlotBusy(activitySnapshotFromDirectoryEntry(entry))).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-activity.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-activity.ts
@@ -39,6 +39,7 @@ export function activitySnapshotFromDirectoryEntry(
       status: entry.status,
       executionSummary: entry.executionSummary,
       streamConnectionState: entry.streamConnectionState,
+      hasPromptActivity: entry.lastPromptAt !== null || entry.hasAttemptedPrompt,
       transcript: {
         isStreaming: entry.activity.isStreaming,
         pendingInteractions: entry.activity.pendingInteractions,

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-entry.test.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-entry.test.ts
@@ -63,6 +63,45 @@ describe("session directory entry model", () => {
     });
   });
 
+  it("keeps hasAttemptedPrompt sticky across upserts", () => {
+    const initial = createDirectoryEntry({
+      sessionId: "session-a",
+      agentKind: "proliferate",
+    });
+    expect(initial.hasAttemptedPrompt).toBe(false);
+
+    const prompted = normalizeDirectoryEntryInput(
+      {
+        sessionId: "session-a",
+        agentKind: "proliferate",
+        hasAttemptedPrompt: true,
+      },
+      initial,
+    );
+    expect(prompted.hasAttemptedPrompt).toBe(true);
+
+    expect(normalizeDirectoryEntryInput(
+      {
+        sessionId: "session-a",
+        agentKind: "proliferate",
+      },
+      prompted,
+    ).hasAttemptedPrompt).toBe(true);
+    expect(normalizeDirectoryEntryInput(
+      {
+        sessionId: "session-a",
+        agentKind: "proliferate",
+        hasAttemptedPrompt: false,
+      },
+      prompted,
+    ).hasAttemptedPrompt).toBe(true);
+
+    expect(directoryEntryEqual(prompted, {
+      ...prompted,
+      hasAttemptedPrompt: false,
+    })).toBe(false);
+  });
+
   it("merges activity patches and compares relationship values structurally", () => {
     const entry = createDirectoryEntry({
       sessionId: "session-a",

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-entry.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-entry.ts
@@ -45,6 +45,7 @@ export interface SessionDirectoryEntry {
   pendingConfigChanges: PendingSessionConfigChanges;
   status: SessionStatus | null;
   lastPromptAt: string | null;
+  hasAttemptedPrompt: boolean;
   streamConnectionState: SessionStreamConnectionState;
   transcriptHydrated: boolean;
   sessionRelationship: SessionRelationship;
@@ -67,6 +68,7 @@ export interface DirectoryEntryInput {
   pendingConfigChanges?: PendingSessionConfigChanges;
   status?: SessionStatus | null;
   lastPromptAt?: string | null;
+  hasAttemptedPrompt?: boolean;
   streamConnectionState?: SessionStreamConnectionState;
   transcriptHydrated?: boolean;
   sessionRelationship?: SessionRelationship;
@@ -123,6 +125,8 @@ export function normalizeDirectoryEntryInput(
     pendingConfigChanges: input.pendingConfigChanges ?? existing?.pendingConfigChanges ?? {},
     status: input.status ?? existing?.status ?? null,
     lastPromptAt: input.lastPromptAt ?? existing?.lastPromptAt ?? null,
+    hasAttemptedPrompt:
+      input.hasAttemptedPrompt === true || existing?.hasAttemptedPrompt === true,
     streamConnectionState:
       input.streamConnectionState
       ?? existing?.streamConnectionState
@@ -176,6 +180,7 @@ export function directoryEntryEqual(
     && a.pendingConfigChanges === b.pendingConfigChanges
     && a.status === b.status
     && a.lastPromptAt === b.lastPromptAt
+    && a.hasAttemptedPrompt === b.hasAttemptedPrompt
     && a.streamConnectionState === b.streamConnectionState
     && a.transcriptHydrated === b.transcriptHydrated
     && sessionRelationshipEqual(a.sessionRelationship, b.sessionRelationship)

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
@@ -154,6 +154,82 @@ describe("pending sidebar projection", () => {
     expect(groups.map((group) => group.name)).toEqual(["landing", "repo-a", "repo-b"]);
   });
 
+  it("keeps the group order stable across the pending-to-materialized handoff", () => {
+    const pendingWorkspaceEntry = {
+      ...buildSubmittingPendingWorkspaceEntry({
+        attemptId: "attempt-1",
+        selectedWorkspaceId: null,
+        source: "worktree-created",
+        displayName: "gulch",
+        repoLabel: "landing",
+        baseBranchName: "main",
+        request: {
+          kind: "worktree" as const,
+          input: {
+            repoRootId: "landing-root",
+            workspaceName: "gulch",
+            branchName: "gulch",
+            baseBranch: "main",
+            targetPath: "/tmp/landing/gulch",
+          },
+        },
+      }),
+      createdAt: Date.parse("2026-04-13T12:00:00.000Z"),
+    };
+    const otherLogicalWorkspaces = [
+      makeLocalLogicalWorkspace({
+        id: "repo-a-workspace",
+        repoKey: "/tmp/repo-a",
+        repoName: "repo-a",
+      }),
+      makeLocalLogicalWorkspace({
+        id: "repo-b-workspace",
+        repoKey: "/tmp/repo-b",
+        repoName: "repo-b",
+      }),
+    ];
+    const repoRoots = [
+      makeRepoRoot({
+        id: "landing-root",
+        repoName: "landing",
+        sourceRoot: "/tmp/landing",
+      }),
+    ];
+
+    const pendingGroups = buildGroups({
+      logicalWorkspaces: otherLogicalWorkspaces,
+      repoRoots,
+      pendingWorkspaceEntry,
+      workspaceLastInteracted: {
+        "repo-a-workspace": "2026-04-13T11:00:00.000Z",
+      },
+    });
+
+    const materializedGroups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "landing-gulch",
+          workspaceId: "workspace-gulch",
+          repoKey: "github:proliferate-ai:landing",
+          repoName: "landing",
+          kind: "worktree",
+          branch: "gulch",
+        }),
+        ...otherLogicalWorkspaces,
+      ],
+      repoRoots,
+      pendingWorkspaceEntry: null,
+      workspaceLastInteracted: {
+        "workspace-gulch": "2026-04-13T12:00:01.000Z",
+        "repo-a-workspace": "2026-04-13T11:00:00.000Z",
+      },
+    });
+
+    expect(pendingGroups.map((group) => group.name)).toEqual(["landing", "repo-a", "repo-b"]);
+    expect(materializedGroups.map((group) => group.name))
+      .toEqual(pendingGroups.map((group) => group.name));
+  });
+
   it("uses the real logical id for a pending worktree during materialization handoff", () => {
     const pendingWorkspaceEntry = {
       ...buildSubmittingPendingWorkspaceEntry({

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
@@ -3,6 +3,7 @@ import {
   buildPendingWorkspaceUiKey,
   buildSubmittingPendingWorkspaceEntry,
 } from "@/lib/domain/workspaces/creation/pending-entry";
+import { buildPendingSidebarProjection } from "./pending-sidebar-projection";
 import {
   buildGroups,
   makeCloudLogicalWorkspace,
@@ -57,6 +58,100 @@ describe("pending sidebar projection", () => {
       renameSupported: false,
       lastInteracted: new Date(pendingWorkspaceEntry.createdAt).toISOString(),
     });
+  });
+
+  it("counts pending creation as activity in the sort recency", () => {
+    const pendingWorkspaceEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-1",
+      selectedWorkspaceId: null,
+      source: "worktree-created",
+      displayName: "gulch",
+      repoLabel: "landing",
+      baseBranchName: "main",
+      request: {
+        kind: "worktree",
+        input: {
+          repoRootId: "landing-root",
+          workspaceName: "gulch",
+          branchName: "gulch",
+          baseBranch: "main",
+          targetPath: "/tmp/landing/gulch",
+        },
+      },
+    });
+    const repoRoot = makeRepoRoot({
+      id: "landing-root",
+      repoName: "landing",
+      sourceRoot: "/tmp/landing",
+    });
+
+    const projection = buildPendingSidebarProjection({
+      entry: pendingWorkspaceEntry,
+      repoRootsById: new Map([[repoRoot.id, repoRoot]]),
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: null,
+      activeSessionTitle: null,
+    });
+
+    const createdAt = new Date(pendingWorkspaceEntry.createdAt).toISOString();
+    expect(projection?.sortRecency).toEqual({
+      activityAt: createdAt,
+      recordUpdatedAt: createdAt,
+      sortAt: createdAt,
+      displayAt: null,
+    });
+  });
+
+  it("sorts a pending workspace in a new repo group above older-activity and no-activity groups", () => {
+    const pendingWorkspaceEntry = {
+      ...buildSubmittingPendingWorkspaceEntry({
+        attemptId: "attempt-1",
+        selectedWorkspaceId: null,
+        source: "worktree-created",
+        displayName: "gulch",
+        repoLabel: "landing",
+        baseBranchName: "main",
+        request: {
+          kind: "worktree" as const,
+          input: {
+            repoRootId: "landing-root",
+            workspaceName: "gulch",
+            branchName: "gulch",
+            baseBranch: "main",
+            targetPath: "/tmp/landing/gulch",
+          },
+        },
+      }),
+      createdAt: Date.parse("2026-04-13T12:00:00.000Z"),
+    };
+
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "repo-a-workspace",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "repo-b-workspace",
+          repoKey: "/tmp/repo-b",
+          repoName: "repo-b",
+        }),
+      ],
+      repoRoots: [
+        makeRepoRoot({
+          id: "landing-root",
+          repoName: "landing",
+          sourceRoot: "/tmp/landing",
+        }),
+      ],
+      pendingWorkspaceEntry,
+      workspaceLastInteracted: {
+        "repo-a-workspace": "2026-04-13T11:00:00.000Z",
+      },
+    });
+
+    expect(groups.map((group) => group.name)).toEqual(["landing", "repo-a", "repo-b"]);
   });
 
   it("uses the real logical id for a pending worktree during materialization handoff", () => {

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -93,7 +93,7 @@ export function buildPendingSidebarProjection(args: {
       branchName: null,
     },
     sortRecency: {
-      activityAt: null,
+      activityAt: createdAt,
       recordUpdatedAt: createdAt,
       sortAt: createdAt,
       displayAt: null,

--- a/apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.ts
+++ b/apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.ts
@@ -171,6 +171,7 @@ export function getKnownSessionViewState(known: KnownHeaderSession): SessionView
     status: known.session.status,
     executionSummary: known.session.executionSummary ?? null,
     streamConnectionState: "disconnected",
+    hasPromptActivity: known.session.lastPromptAt != null,
     transcript: { isStreaming: false, pendingInteractions: [] },
   });
 }

--- a/apps/desktop/src/stores/sessions/session-directory-store.test.ts
+++ b/apps/desktop/src/stores/sessions/session-directory-store.test.ts
@@ -141,6 +141,7 @@ describe("session directory store invariants", () => {
       status: null,
       executionSummary: null,
       streamConnectionState: "disconnected",
+      hasPromptActivity: false,
       transcript: {
         isStreaming: true,
         pendingInteractions,

--- a/apps/desktop/src/stores/sessions/session-records.test.ts
+++ b/apps/desktop/src/stores/sessions/session-records.test.ts
@@ -145,6 +145,18 @@ describe("session records facade invariants", () => {
     expect(record.sessionRelationship).toEqual({ kind: "pending" });
   });
 
+  it("defaults hasAttemptedPrompt to false and patches it through the directory", () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+    }));
+
+    expect(getSessionRecord("session-a")?.hasAttemptedPrompt).toBe(false);
+
+    patchSessionRecord("session-a", { hasAttemptedPrompt: true });
+
+    expect(getSessionRecord("session-a")?.hasAttemptedPrompt).toBe(true);
+  });
+
   it("applies and prunes relationship hints when records mount later", () => {
     useSessionDirectoryStore.getState().recordRelationshipHint("child-session", {
       kind: "subagent_child",

--- a/apps/desktop/src/stores/sessions/session-records.test.ts
+++ b/apps/desktop/src/stores/sessions/session-records.test.ts
@@ -157,6 +157,21 @@ describe("session records facade invariants", () => {
     expect(getSessionRecord("session-a")?.hasAttemptedPrompt).toBe(true);
   });
 
+  it("keeps hasAttemptedPrompt sticky when a rebuilt record replaces the entry", () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+      materializedSessionId: null,
+    }));
+    patchSessionRecord("session-a", { hasAttemptedPrompt: true });
+
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-a",
+      materializedSessionId: null,
+    }));
+
+    expect(getSessionRecord("session-a")?.hasAttemptedPrompt).toBe(true);
+  });
+
   it("applies and prunes relationship hints when records mount later", () => {
     useSessionDirectoryStore.getState().recordRelationshipHint("child-session", {
       kind: "subagent_child",

--- a/apps/desktop/src/stores/sessions/session-records.ts
+++ b/apps/desktop/src/stores/sessions/session-records.ts
@@ -134,7 +134,12 @@ export function createSessionRecordFromSummary(
 }
 
 export function putSessionRecord(record: SessionRuntimeRecord): void {
-  useSessionDirectoryStore.getState().putEntry(record);
+  const existingEntry = useSessionDirectoryStore.getState().entriesById[record.sessionId];
+  useSessionDirectoryStore.getState().putEntry({
+    ...record,
+    hasAttemptedPrompt:
+      record.hasAttemptedPrompt || (existingEntry?.hasAttemptedPrompt ?? false),
+  });
   useSessionTranscriptStore.getState().putEntry({
     sessionId: record.sessionId,
     events: record.events,

--- a/apps/desktop/src/stores/sessions/session-records.ts
+++ b/apps/desktop/src/stores/sessions/session-records.ts
@@ -42,6 +42,7 @@ export function createEmptySessionRecord(
     executionSummary?: SessionExecutionSummary | null;
     mcpBindingSummaries?: SessionMcpBindingSummary[] | null;
     lastPromptAt?: string | null;
+    hasAttemptedPrompt?: boolean;
     optimisticPrompt?: PendingPromptEntry | null;
     pendingConfigChanges?: PendingSessionConfigChanges;
     sessionRelationship?: SessionRelationship;
@@ -76,6 +77,7 @@ export function createEmptySessionRecord(
     mcpBindingSummaries: config?.mcpBindingSummaries ?? null,
     pendingConfigChanges: config?.pendingConfigChanges ?? {},
     lastPromptAt: config?.lastPromptAt ?? null,
+    hasAttemptedPrompt: config?.hasAttemptedPrompt ?? false,
     sessionRelationship: config?.sessionRelationship ?? { kind: "pending" },
     activity: activityFromTranscript(transcript),
   });
@@ -169,6 +171,9 @@ export function patchSessionRecord(
     }
     if ("status" in patch) directoryPatch.status = patch.status ?? null;
     if ("lastPromptAt" in patch) directoryPatch.lastPromptAt = patch.lastPromptAt ?? null;
+    if ("hasAttemptedPrompt" in patch && patch.hasAttemptedPrompt !== undefined) {
+      directoryPatch.hasAttemptedPrompt = patch.hasAttemptedPrompt;
+    }
     if ("streamConnectionState" in patch && patch.streamConnectionState) {
       directoryPatch.streamConnectionState = patch.streamConnectionState;
     }

--- a/apps/packages/product-domain/src/sessions/activity-status.ts
+++ b/apps/packages/product-domain/src/sessions/activity-status.ts
@@ -104,6 +104,9 @@ export function resolveSessionExecutionPhase(
   }
 
   if (slot.executionSummary?.phase) {
+    if (slot.executionSummary.phase === "starting" && slot.hasPromptActivity === false) {
+      return "idle";
+    }
     return slot.executionSummary.phase;
   }
 
@@ -117,7 +120,7 @@ export function resolveSessionExecutionPhase(
     return "awaiting_interaction";
   }
   if (slot.status === "starting") {
-    return "starting";
+    return slot.hasPromptActivity === false ? "idle" : "starting";
   }
   if (slot.status === "running" || isSessionEffectivelyStreaming(slot)) {
     return "running";

--- a/apps/packages/product-domain/src/sessions/activity-status.ts
+++ b/apps/packages/product-domain/src/sessions/activity-status.ts
@@ -104,7 +104,11 @@ export function resolveSessionExecutionPhase(
   }
 
   if (slot.executionSummary?.phase) {
-    if (slot.executionSummary.phase === "starting" && slot.hasPromptActivity === false) {
+    if (
+      slot.executionSummary.phase === "starting"
+      && slot.hasPromptActivity === false
+      && !isSessionEffectivelyStreaming(slot)
+    ) {
       return "idle";
     }
     return slot.executionSummary.phase;
@@ -120,7 +124,9 @@ export function resolveSessionExecutionPhase(
     return "awaiting_interaction";
   }
   if (slot.status === "starting") {
-    return slot.hasPromptActivity === false ? "idle" : "starting";
+    return slot.hasPromptActivity === false && !isSessionEffectivelyStreaming(slot)
+      ? "idle"
+      : "starting";
   }
   if (slot.status === "running" || isSessionEffectivelyStreaming(slot)) {
     return "running";

--- a/apps/packages/product-domain/src/sessions/activity-types.ts
+++ b/apps/packages/product-domain/src/sessions/activity-types.ts
@@ -24,6 +24,11 @@ export interface SessionActivitySnapshot {
   status: SessionStatus | null;
   executionSummary?: SessionExecutionSummary | null;
   streamConnectionState?: StreamConnectionState;
+  /**
+   * False when the session has never been prompted and no prompt is in
+   * flight; undefined preserves legacy behavior.
+   */
+  hasPromptActivity?: boolean;
   transcript: {
     isStreaming: boolean;
     pendingInteractions: PendingInteractionLike[];

--- a/apps/packages/product-domain/src/sessions/activity.test.ts
+++ b/apps/packages/product-domain/src/sessions/activity.test.ts
@@ -514,6 +514,50 @@ describe("session activity", () => {
         pendingInteractions: [],
       },
     })).toBe("starting");
+
+    expect(resolveSessionExecutionPhase({
+      status: null,
+      executionSummary: {
+        phase: "starting" as const,
+        hasLiveHandle: false,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "disconnected",
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    })).toBe("starting");
+  });
+
+  it("never presents a streaming session as idle without prompt activity", () => {
+    expect(resolveSessionExecutionPhase({
+      status: "starting",
+      executionSummary: null,
+      streamConnectionState: "open",
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+      },
+    })).toBe("starting");
+
+    expect(resolveSessionExecutionPhase({
+      status: "starting",
+      executionSummary: {
+        phase: "starting" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "open",
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+      },
+    })).toBe("starting");
   });
 
   it("does not suppress non-starting phases without prompt activity", () => {

--- a/apps/packages/product-domain/src/sessions/activity.test.ts
+++ b/apps/packages/product-domain/src/sessions/activity.test.ts
@@ -4,7 +4,9 @@ import {
   collectWorkspaceSidebarActivityStates,
   collectSessionActivityReconciliationIds,
   collectWorkspaceSessionViewStates,
+  isSessionSlotBusy,
   resolveSessionErrorAttentionKey,
+  resolveSessionExecutionPhase,
   resolveSessionSidebarActivityState,
   resolveSessionViewState,
   shouldSkipColdIdleSessionStream,
@@ -444,6 +446,124 @@ describe("session activity", () => {
       idleCount: 0,
       erroredCount: 0,
     })).toBe("needs_input");
+  });
+
+  it("presents never-prompted starting sessions as idle", () => {
+    const slot = {
+      status: "starting" as const,
+      executionSummary: null,
+      streamConnectionState: "disconnected" as const,
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("idle");
+    expect(resolveSessionViewState(slot)).toBe("idle");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("idle");
+    expect(isSessionSlotBusy(slot)).toBe(false);
+  });
+
+  it("keeps starting sessions busy when a prompt is in flight", () => {
+    const slot = {
+      status: "starting" as const,
+      executionSummary: null,
+      streamConnectionState: "disconnected" as const,
+      hasPromptActivity: true,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("starting");
+    expect(resolveSessionViewState(slot)).toBe("working");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("iterating");
+  });
+
+  it("gates the starting execution summary phase on prompt activity", () => {
+    const slot = (hasPromptActivity: boolean) => ({
+      status: null,
+      executionSummary: {
+        phase: "starting" as const,
+        hasLiveHandle: false,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "disconnected" as const,
+      hasPromptActivity,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    });
+
+    expect(resolveSessionExecutionPhase(slot(false))).toBe("idle");
+    expect(resolveSessionExecutionPhase(slot(true))).toBe("starting");
+  });
+
+  it("preserves legacy starting behavior when prompt activity is unknown", () => {
+    expect(resolveSessionExecutionPhase({
+      status: "starting",
+      executionSummary: null,
+      streamConnectionState: "disconnected",
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    })).toBe("starting");
+  });
+
+  it("does not suppress non-starting phases without prompt activity", () => {
+    expect(resolveSessionExecutionPhase({
+      status: "running",
+      executionSummary: null,
+      streamConnectionState: "open",
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    })).toBe("running");
+
+    expect(resolveSessionExecutionPhase({
+      status: "errored",
+      executionSummary: executionSummary("errored"),
+      streamConnectionState: "ended",
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+      },
+    })).toBe("errored");
+
+    const awaitingSlot = {
+      status: "running" as const,
+      executionSummary: {
+        phase: "awaiting_interaction" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [{
+          requestId: "request-1",
+          kind: "permission",
+          title: "Approve",
+          description: null,
+          source: { toolCallId: "tool-1", toolKind: "exec", toolStatus: null },
+          payload: { type: "permission", options: [] },
+        }],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "open" as const,
+      hasPromptActivity: false,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [{ requestId: "request-1" }],
+      },
+    };
+    expect(resolveSessionExecutionPhase(awaitingSlot)).toBe("awaiting_interaction");
+    expect(resolveSessionViewState(awaitingSlot)).toBe("needs_input");
+    expect(resolveSessionSidebarActivityState(awaitingSlot)).toBe("waiting_input");
   });
 
   it("skips the initial restore stream only for cold idle sessions", () => {

--- a/specs/codebase/features/pending-workspace-shell.md
+++ b/specs/codebase/features/pending-workspace-shell.md
@@ -342,7 +342,13 @@ When the real workspace id is known:
    Arrival panels use this event to show the final "new worktree/workspace"
    context and setup-script state.
 
-6. Clear pending workspace state after selection finalization.
+6. Stamp `workspaceLastInteracted` for the materialized workspace id
+   immediately before the pending entry is cleared. Both the finalization path
+   and the cloud-ready polling path do this, so the sidebar position holds
+   across the handoff instead of dropping when the pending projection's
+   creation-time activity disappears.
+
+7. Clear pending workspace state after selection finalization.
    Do not clear as soon as the real workspace appears in cache. That creates a
    visible gap between the pending projection and the real row.
 
@@ -398,6 +404,9 @@ projection path.
 ### Sidebar
 
 - Use `buildPendingSidebarProjection(entry)` for pending rows.
+- The pending projection counts the entry's creation time as activity
+  (`sortRecency.activityAt = createdAt`), so a new workspace sorts among
+  interacted workspaces from the first frame instead of below them.
 - Before materialization, the row id is `pending-workspace:<attemptId>`.
 - During materialization handoff, if the selected real logical workspace id is
   known and the selected workspace id matches the pending entry's workspace id,


### PR DESCRIPTION
## Summary

Two presentation fixes for freshly created chats and workspaces:

**1. New chats no longer show as loading.** A never-prompted session presented as busy (tab spinner, sidebar "iterating") for the entire create round-trip and agent boot, because both the optimistic record and the server execution summary report `starting`. The `starting` phase now resolves to `idle` unless the session has prompt activity — `lastPromptAt` from the server or a new sticky `hasAttemptedPrompt` directory-entry flag stamped at prompt enqueue/dispatch and carried across materialization. The gate is opt-in via a new optional `hasPromptActivity` field on `SessionActivitySnapshot`, populated only by the directory-entry adapter; stream pruning, hot-session policy, and playground snapshots keep legacy behavior so a booting session's stream is never pruned.

**2. New workspaces no longer jump bottom → top in the sidebar.** The sidebar's activity-first comparator ranked every previously-interacted group above a pending workspace (whose projection had `activityAt: null`), so a new workspace sat at the bottom until its first session summary stamped an interaction. The pending projection now counts its creation time as activity, and `workspaceLastInteracted` is stamped at both pending→materialized handoffs (entry finalization and cloud-ready polling), so the row holds its top position the instant the pending entry clears.

## Behavior notes

- A first prompt sent while the session is still booting keeps its spinner (the flag is stamped at enqueue, before dispatch waits for materialization).
- Dock running-agent count and the window activity indicator also stop counting never-prompted warming sessions as running (same presentation rule).

## Testing

- product-domain: 369 tests pass (5 new phase-gating cases).
- desktop: `tsc` clean; touched suites pass (directory entry stickiness, session records default/patch plumbing, prompt-dispatch mock, pending projection sort recency, sidebar group ordering, entry-actions + cloud-polling interaction stamping).
- Full desktop suite has 4 pre-existing failures that also fail on clean main (verified), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (multi-agent critique applied)

- **Real bug fixed:** `hasAttemptedPrompt` stickiness only guarded `upsertEntry` (no production callers); the pending-workspace handoff rebuilt the optimistic record via `putSessionRecord` and wiped the flag, dropping the spinner while the first prompt was in flight. The flag is now sticky at the store boundary, and the rebuild sites carry it explicitly.
- **Hardening:** the starting→idle gates also require the transcript not to be effectively streaming.
- **Accepted behavior change (deliberate):** stream reconnect, the activity reconciler, and the active-summary refresh no longer treat never-prompted booting sessions as busy. Worst case is a stale `starting` summary on an abandoned empty session, which can place the first prompt in the queue lane until the prompt response refreshes the summary — minor and self-healing.
- Spec `specs/codebase/features/pending-workspace-shell.md` §8/§9 updated in-PR; finalization workflow now takes the clock through its deps contract; seven test gaps closed (flag-write-before-dispatch, snapshot mapping, sticky-merge regression, legacy/streaming gates, sidebar memo signature, no-re-jump ordering, stamp-before-clear ordering).
