### PR TITLE
fix(desktop): markdown tables, sidebar menu polish, terminal creation grid

### DIFF
--- a/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
+++ b/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
@@ -151,15 +151,15 @@ export function MarkdownRenderer({
               <div className="overflow-x-auto">
                 {mdHtmlElement(
                   "table",
-                  "min-w-full w-max border-collapse text-chat leading-[var(--text-chat--line-height)]",
+                  "min-w-full w-max border-collapse text-chat leading-[var(--text-chat--line-height)] [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.02] [&_tbody_tr:last-child_td]:border-b-0",
                   props,
                 )}
               </div>
             </div>
           ),
           th: (props) =>
-            mdHtmlElement("th", "border-b border-border bg-foreground/5 p-1 text-left text-chat leading-[var(--text-chat--line-height)] font-semibold text-foreground", props),
-          td: (props) => mdHtmlElement("td", "border-b border-border p-1 text-chat leading-[var(--text-chat--line-height)]", props),
+            mdHtmlElement("th", "border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left text-chat leading-[var(--text-chat--line-height)] font-semibold text-foreground", props),
+          td: (props) => mdHtmlElement("td", "border-b border-border px-2.5 py-1.5 align-top text-chat leading-[var(--text-chat--line-height)]", props),
           code: ({
             className: codeClassName,
             children,

--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx
@@ -5,6 +5,7 @@ import { GitPanel } from "@/components/workspace/git/GitPanel";
 import { ScratchPadPanel } from "@/components/workspace/scratch/ScratchPadPanel";
 import { RightPanelPlaceholder } from "@/components/workspace/shell/right-panel/RightPanelPlaceholder";
 import { TerminalPanel } from "@/components/workspace/terminals/TerminalPanel";
+import { TERMINAL_GRID_PROBE_ATTRIBUTE } from "@/lib/infra/terminals/terminal-grid-probe";
 import type { TerminalRecord } from "@anyharness/sdk";
 import type {
   RightPanelActiveEntryKey,
@@ -76,6 +77,7 @@ export function RightPanelContent({
       data-panel="true"
       id="workspace-side-panel"
       className="relative min-h-0 flex-1 overflow-hidden"
+      {...(workspaceId ? { [TERMINAL_GRID_PROBE_ATTRIBUTE]: workspaceId } : {})}
     >
       {!shouldRenderContent ? (
         <RightPanelPlaceholder activeEntryKey={activeEntryKey} />

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -8,8 +8,8 @@ import {
   Archive,
   Folder,
   GitBranch,
-  GitMerge,
   Pencil,
+  Trash,
 } from "@proliferate/ui/icons";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
@@ -212,7 +212,7 @@ export function WorkspaceItem({
                 </div>
               </div>
               <PopoverMenuItem
-                icon={<GitMerge className="size-3.5 shrink-0 text-muted-foreground" />}
+                icon={<Trash className="size-3.5 shrink-0 text-muted-foreground" />}
                 label="Delete workspace"
                 variant="sidebar"
                 onClick={() => {
@@ -279,7 +279,7 @@ export function WorkspaceItem({
               )}
               {onMarkDone && (
                 <PopoverMenuItem
-                  icon={<GitMerge className="size-3.5 shrink-0 text-muted-foreground" />}
+                  icon={<Trash className="size-3.5 shrink-0 text-muted-foreground" />}
                   label="Delete workspace..."
                   variant="sidebar"
                   onClick={() => {

--- a/apps/desktop/src/components/workspace/terminals/TerminalPanel.tsx
+++ b/apps/desktop/src/components/workspace/terminals/TerminalPanel.tsx
@@ -5,6 +5,7 @@ import { TerminalCommandFloatingAction } from "@/components/workspace/terminals/
 import { TerminalErrorBoundary } from "@/components/workspace/terminals/TerminalErrorBoundary";
 import { TerminalTopBar } from "@/components/workspace/terminals/TerminalTopBar";
 import { TerminalViewport } from "@/components/workspace/terminals/TerminalViewport";
+import { TERMINAL_GRID_PROBE_ATTRIBUTE } from "@/lib/infra/terminals/terminal-grid-probe";
 
 interface TerminalPanelProps {
   workspaceId: string | null;
@@ -57,7 +58,10 @@ export function TerminalPanel({
           onNewTerminal={onNewTerminal}
         />
       )}
-      <div className="relative min-h-0 w-full flex-1 overflow-hidden bg-sidebar">
+      <div
+        className="relative min-h-0 w-full flex-1 overflow-hidden bg-sidebar"
+        {...(workspaceId ? { [TERMINAL_GRID_PROBE_ATTRIBUTE]: workspaceId } : {})}
+      >
         {isLoading ? (
           <TerminalEmptyState label="Loading terminals" />
         ) : errorMessage ? (

--- a/apps/desktop/src/hooks/terminals/lifecycle/use-xterm-surface.ts
+++ b/apps/desktop/src/hooks/terminals/lifecycle/use-xterm-surface.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getTerminalTheme, onThemeChange } from "@/config/theme";
 import { resolveReadableCodeFontScale } from "@/lib/domain/preferences/appearance";
+import { TERMINAL_FONT_FAMILY } from "@/lib/domain/terminals/terminal-grid";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 interface UseXtermSurfaceInput {
@@ -91,7 +92,7 @@ export function useXtermSurface({
           cursorBlink: true,
           fontSize: terminalFontSizeRef.current,
           ...(lineHeight === undefined ? {} : { lineHeight }),
-          fontFamily: "'Geist Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+          fontFamily: TERMINAL_FONT_FAMILY,
           theme: getTerminalTheme(),
           allowTransparency: true,
           scrollback,

--- a/apps/desktop/src/hooks/terminals/workflows/use-terminal-actions.ts
+++ b/apps/desktop/src/hooks/terminals/workflows/use-terminal-actions.ts
@@ -9,6 +9,13 @@ import {
 import {
   clearTerminal,
 } from "@/lib/infra/terminals/terminal-stream-registry";
+import { measureWorkspaceTerminalGrid } from "@/lib/infra/terminals/terminal-grid-probe";
+import {
+  DEFAULT_TERMINAL_GRID,
+  type TerminalGrid,
+} from "@/lib/domain/terminals/terminal-grid";
+import { resolveReadableCodeFontScale } from "@/lib/domain/preferences/appearance";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import {
   closeTerminal,
   createWorkspaceTerminal,
@@ -54,16 +61,27 @@ export function useTerminalActions() {
     setWorkspaceTerminalRecords,
   ]);
 
+  // The shell prints its first prompt at creation size; a grid that differs
+  // from the renderer leaves zsh's PROMPT_SP "%" mark visible. Measure the
+  // real pane and only fall back to the default grid when nothing is laid out.
+  const resolveCreateGrid = useCallback(async (
+    workspaceId: string,
+  ): Promise<TerminalGrid> => {
+    const { readableCodeFontSizeId } = useUserPreferencesStore.getState();
+    const fontSize = resolveReadableCodeFontScale(readableCodeFontSizeId).monacoFontSize;
+    const measured = await measureWorkspaceTerminalGrid(workspaceId, { fontSize });
+    return measured ?? DEFAULT_TERMINAL_GRID;
+  }, []);
+
   const createTabForWorkspace = useCallback(async (
     workspaceId: string,
-    cols: number,
-    rows: number,
     options?: { title?: string; purpose?: TerminalPurpose },
   ) => {
     const blockedReason = getWorkspaceRuntimeBlockReason(workspaceId);
     if (blockedReason) {
       throw new Error(blockedReason);
     }
+    const { cols, rows } = await resolveCreateGrid(workspaceId);
     const connection = await resolveTerminalWorkspaceConnection(workspaceId);
     const record = await createWorkspaceTerminal(connection, {
       cols,
@@ -76,20 +94,24 @@ export function useTerminalActions() {
   }, [
     getWorkspaceRuntimeBlockReason,
     invalidateWorkspaceTerminals,
+    resolveCreateGrid,
     resolveTerminalWorkspaceConnection,
   ]);
 
   const createRunTabForWorkspace = useCallback(async (
     workspaceId: string,
     command: string,
-    cols = 120,
-    rows = 40,
+    cols?: number,
+    rows?: number,
   ) => {
+    const grid = cols !== undefined && rows !== undefined
+      ? { cols, rows }
+      : await resolveCreateGrid(workspaceId);
     return createRunTerminalTabWorkflow({
       workspaceId,
       command,
-      cols,
-      rows,
+      cols: grid.cols,
+      rows: grid.rows,
     }, {
       getWorkspaceRuntimeBlockReason,
       resolveWorkspaceConnection: resolveTerminalWorkspaceConnection,
@@ -101,6 +123,7 @@ export function useTerminalActions() {
   }, [
     getWorkspaceRuntimeBlockReason,
     invalidateWorkspaceTerminals,
+    resolveCreateGrid,
     resolveTerminalWorkspaceConnection,
     setWorkspaceTerminalRecords,
   ]);

--- a/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
+++ b/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
@@ -99,7 +99,6 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       id: "copy-workspace-location",
       label: copyWorkspaceLocationLabel,
       accelerator: getShortcutNativeAccelerator(SHORTCUTS.copyWorkspacePath) ?? undefined,
-      icon: { kind: "native", name: "copy" },
       onSelect: onCopyWorkspaceLocation,
     });
   }
@@ -109,7 +108,6 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       id: "copy-branch-name",
       label: "Copy branch name",
       accelerator: getShortcutNativeAccelerator(SHORTCUTS.copyBranchName) ?? undefined,
-      icon: { kind: "native", name: "copy" },
       onSelect: onCopyBranchName,
     });
   }

--- a/apps/desktop/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
@@ -115,7 +115,7 @@ export function useRightPanelEntryActions({
     }
     const activate = options?.activate ?? true;
     try {
-      const terminalId = await createTab(workspaceId, 120, 40);
+      const terminalId = await createTab(workspaceId);
       const terminalKey = rightPanelTerminalHeaderKey(terminalId);
       updateState((previous) => ({
         ...previous,

--- a/apps/desktop/src/lib/domain/terminals/terminal-grid.ts
+++ b/apps/desktop/src/lib/domain/terminals/terminal-grid.ts
@@ -1,0 +1,14 @@
+export interface TerminalGrid {
+  cols: number;
+  rows: number;
+}
+
+// Fallback only: terminals created at a guessed grid render the first zsh
+// prompt at the wrong width, which leaves the PROMPT_SP "%" mark visible.
+// Prefer a measured grid from the terminal grid probe.
+export const DEFAULT_TERMINAL_GRID: TerminalGrid = { cols: 120, rows: 40 };
+
+// Single source for the terminal font stack. The grid probe must measure with
+// exactly the same renderer options as the live xterm surface.
+export const TERMINAL_FONT_FAMILY =
+  "'Geist Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";

--- a/apps/desktop/src/lib/infra/terminals/terminal-grid-probe.ts
+++ b/apps/desktop/src/lib/infra/terminals/terminal-grid-probe.ts
@@ -1,0 +1,91 @@
+import {
+  TERMINAL_FONT_FAMILY,
+  type TerminalGrid,
+} from "@/lib/domain/terminals/terminal-grid";
+
+// Elements that can host a terminal viewport advertise themselves with this
+// attribute (value = workspaceId) so terminal creation can measure the grid
+// the renderer will actually use.
+export const TERMINAL_GRID_PROBE_ATTRIBUTE = "data-terminal-grid-probe";
+
+export interface TerminalGridProbeOptions {
+  fontSize: number;
+  lineHeight?: number;
+}
+
+// The PTY must be created at the exact grid the xterm renderer will display.
+// zsh prints its first prompt immediately after spawn, prefixed by the
+// PROMPT_SP sequence ("%" + COLUMNS-1 spaces + CR); at a matching width the
+// prompt overwrites the "%", at any other width it survives as a stray line.
+// Measuring goes through a real offscreen xterm so cell metrics are identical
+// to the live surface.
+export async function measureWorkspaceTerminalGrid(
+  workspaceId: string,
+  options: TerminalGridProbeOptions,
+): Promise<TerminalGrid | null> {
+  const target = findProbeTargetSize(workspaceId);
+  if (!target) {
+    return null;
+  }
+
+  const host = document.createElement("div");
+  host.style.position = "fixed";
+  host.style.left = "-10000px";
+  host.style.top = "0";
+  host.style.width = `${target.width}px`;
+  host.style.height = `${target.height}px`;
+  host.style.visibility = "hidden";
+  host.style.pointerEvents = "none";
+  document.body.appendChild(host);
+
+  try {
+    const { Terminal } = await import("@xterm/xterm");
+    const { FitAddon } = await import("@xterm/addon-fit");
+    const term = new Terminal({
+      fontSize: options.fontSize,
+      ...(options.lineHeight === undefined ? {} : { lineHeight: options.lineHeight }),
+      fontFamily: TERMINAL_FONT_FAMILY,
+    });
+    try {
+      const fitAddon = new FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(host);
+      const proposed = fitAddon.proposeDimensions();
+      if (
+        !proposed
+        || !Number.isFinite(proposed.cols)
+        || !Number.isFinite(proposed.rows)
+        || proposed.cols < 2
+        || proposed.rows < 2
+      ) {
+        return null;
+      }
+      return { cols: proposed.cols, rows: proposed.rows };
+    } finally {
+      term.dispose();
+    }
+  } catch {
+    return null;
+  } finally {
+    host.remove();
+  }
+}
+
+function findProbeTargetSize(
+  workspaceId: string,
+): { width: number; height: number } | null {
+  const candidates = document.querySelectorAll(
+    `[${TERMINAL_GRID_PROBE_ATTRIBUTE}="${CSS.escape(workspaceId)}"]`,
+  );
+  // Prefer the innermost laid-out candidate: the panel content element is the
+  // exact viewport box when visible; the panel root is the fallback while the
+  // terminal pane is still hidden (first terminal in a pane).
+  let best: { width: number; height: number } | null = null;
+  for (const element of candidates) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width >= 1 && rect.height >= 1) {
+      best = { width: rect.width, height: rect.height };
+    }
+  }
+  return best;
+}

--- a/apps/desktop/src/lib/workflows/terminals/terminal-record-workflows.ts
+++ b/apps/desktop/src/lib/workflows/terminals/terminal-record-workflows.ts
@@ -3,6 +3,7 @@ import {
   findReusableRunTerminalId,
   RUN_TERMINAL_TITLE,
 } from "@/lib/domain/terminals/run-terminal";
+import { DEFAULT_TERMINAL_GRID } from "@/lib/domain/terminals/terminal-grid";
 
 export type CloseTerminalResult = "closed" | "missing" | "blocked" | "failed";
 
@@ -52,8 +53,8 @@ export async function createRunTerminalTabWorkflow<Connection>(
   }
 
   const record = await deps.createWorkspaceTerminal(connection, {
-    cols: input.cols ?? 120,
-    rows: input.rows ?? 40,
+    cols: input.cols ?? DEFAULT_TERMINAL_GRID.cols,
+    rows: input.rows ?? DEFAULT_TERMINAL_GRID.rows,
     title: RUN_TERMINAL_TITLE,
     purpose: "run",
     startupCommand: input.command,

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -2290,6 +2290,9 @@ body {
   --right-panel-tab-radius: 8px;
   --right-panel-tab-overlay-radius: 8px;
   --right-panel-tab-surface: transparent;
+  /* Matches the surface painted behind the header (workspace shell bg-sidebar)
+     so the sticky new-tab trigger masks tabs scrolling underneath it. */
+  --right-panel-tab-sticky-surface: color-mix(in srgb, var(--color-sidebar) 88%, transparent);
   --right-panel-tab-hover-bg: color-mix(
     in srgb,
     var(--color-sidebar-foreground) 4%,
@@ -2333,6 +2336,7 @@ body {
 
 :root[data-theme="mono"][data-mode="light"] .right-panel-tab-system {
   --right-panel-tab-surface: var(--color-surface);
+  --right-panel-tab-sticky-surface: color-mix(in srgb, var(--color-surface) 88%, transparent);
   --right-panel-tab-hover-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-active-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-text-secondary: color-mix(in oklab, var(--color-foreground) 65%, transparent);
@@ -2477,7 +2481,17 @@ body {
   align-items: center;
   height: 100%;
   flex-shrink: 0;
-  background-color: transparent;
+  background-color: var(--right-panel-tab-sticky-surface);
+}
+
+.right-panel-tab-system .ui-tab-system-new-tab-sticky::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  right: 100%;
+  width: 14px;
+  pointer-events: none;
+  background: linear-gradient(to left, var(--right-panel-tab-sticky-surface), transparent);
 }
 
 .right-panel-tab-system .right-panel-header-entry-shell {

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -106,16 +106,16 @@ const STATIC_MARKDOWN_COMPONENTS = {
       <div className="overflow-x-auto">
         {mdHtmlElement(
           "table",
-          "w-max min-w-full border-collapse text-chat leading-[var(--text-chat--line-height)]",
+          "w-max min-w-full border-collapse text-chat leading-[var(--text-chat--line-height)] [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.02] [&_tbody_tr:last-child_td]:border-b-0",
           props,
         )}
       </div>
     </div>
   ),
   th: (props: MdElementProps) =>
-    mdHtmlElement("th", "border-b border-border bg-foreground/5 p-1 text-left text-chat font-semibold leading-[var(--text-chat--line-height)] text-foreground", props),
+    mdHtmlElement("th", "border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left text-chat font-semibold leading-[var(--text-chat--line-height)] text-foreground", props),
   td: (props: MdElementProps) =>
-    mdHtmlElement("td", "border-b border-border p-1 text-chat leading-[var(--text-chat--line-height)]", props),
+    mdHtmlElement("td", "border-b border-border px-2.5 py-1.5 align-top text-chat leading-[var(--text-chat--line-height)]", props),
   pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;

--- a/specs/codebase/features/README.md
+++ b/specs/codebase/features/README.md
@@ -26,6 +26,7 @@ low-level runtime contracts.
 | Agent features / product MCPs | Product MCP server pattern and concrete agent-feature MCP definitions for reviews, workspace naming, subagents, artifacts, cowork, and prompt/skill policy. | [agent-features/servers.md](agent-features/servers.md), [agent-features/definitions/README.md](agent-features/definitions/README.md) |
 | Settings and admin IA | Settings/admin information architecture, billing/account/team/config surfaces, filtering, origins, and admin-facing state. | [settings-admin-ia.md](settings-admin-ia.md) |
 | Support reporting | Desktop support report uploads, sanitization, diagnostics, and support-submitted issue handoff. | [support-reporting.md](support-reporting.md) |
+| Terminals | Workspace terminal pane UX, terminal record actions, and the creation grid contract for new terminals. | [terminals.md](terminals.md) |
 | Workspace migration | Workspace migration flows, user attestation, durability, queue state, and completion/error semantics. | [workspace-migration.md](workspace-migration.md) |
 
 ## Outline Coverage
@@ -37,7 +38,7 @@ Use this map before creating a new spec:
 | --- | --- |
 | Onboarding | [onboarding.md](onboarding.md), with lower-level slices in [product-auth.md](product-auth.md), [../primitives/agent-auth-bifrost-byok.md](../primitives/agent-auth-bifrost-byok.md), [../primitives/billing.md](../primitives/billing.md), [../primitives/workspace-provisioning.md](../primitives/workspace-provisioning.md), and [settings-admin-ia.md](settings-admin-ia.md). |
 | Browsers | No dedicated browser feature spec yet. Product MCP ownership is in [agent-features/servers.md](agent-features/servers.md); runtime/domain ownership remains under [../structures/anyharness/README.md](../structures/anyharness/README.md). Create a browser feature spec before adding user-visible browser workflows. |
-| Terminals | No dedicated terminal feature spec yet. Runtime ownership remains under [../structures/anyharness/README.md](../structures/anyharness/README.md). Create a terminal feature spec before adding user-visible terminal workflows or terminal-specific QA gates. |
+| Terminals | [terminals.md](terminals.md) owns terminal pane UX and the creation grid contract. Runtime ownership remains under [../structures/anyharness/README.md](../structures/anyharness/README.md). |
 | Computer Use | No dedicated computer-use feature spec yet. Product MCP ownership is in [agent-features/servers.md](agent-features/servers.md); create a feature spec before adding user-visible Computer Use workflow, permissions, or QA behavior. |
 | Plugins | Runtime/config ownership lives in [../primitives/mcp-skills.md](../primitives/mcp-skills.md). Create a plugins feature spec only for user-facing catalog/install/manage workflows that exceed the primitive contract. |
 | Product MCP Structure | Covered by [agent-features/servers.md](agent-features/servers.md) and concrete definitions under [agent-features/definitions/](agent-features/definitions/). |

--- a/specs/codebase/features/terminals.md
+++ b/specs/codebase/features/terminals.md
@@ -1,0 +1,53 @@
+# Terminals
+
+Status: authoritative for user-facing workspace terminal behavior on Desktop.
+Runtime terminal internals (PTY lifecycle, output sinks, command runs) are
+owned by the AnyHarness structure specs under
+[../structures/anyharness/README.md](../structures/anyharness/README.md).
+
+## Surfaces
+
+- Right panel terminal pane: `apps/desktop/src/components/workspace/terminals/`
+  (`TerminalPanel`, `TerminalViewport`, `TerminalTopBar`), mounted from
+  `components/workspace/shell/right-panel/RightPanelContent.tsx`.
+- Record actions (create/close/rename/resize/run):
+  `hooks/terminals/workflows/use-terminal-actions.ts` and pure workflows in
+  `lib/workflows/terminals/terminal-record-workflows.ts`.
+- Rendering and stream lifecycle: `hooks/terminals/lifecycle/`
+  (`use-xterm-surface.ts`, `use-terminal-viewport.ts`) over
+  `lib/infra/terminals/terminal-stream-registry.ts`.
+
+## Creation Grid Contract
+
+A terminal PTY must be created with the exact cols/rows the xterm renderer
+will display. The shell prints its first prompt immediately after spawn; zsh
+prefixes every prompt with the PROMPT_SP sequence (`%` + COLUMNS−1 spaces +
+CR), which is invisible only when the emit width equals the render width. A
+mismatched creation grid shows a stray `%` line at the top of new terminals
+and mis-wraps anything printed before the first resize.
+
+Operating rules:
+
+- Elements that host a terminal viewport advertise the workspace they render
+  with the `data-terminal-grid-probe` attribute (value = workspaceId). Both
+  the right-panel content root and the terminal panel content box carry it so
+  a grid is measurable before the first terminal in a pane is visible.
+- Terminal creation resolves the grid via
+  `lib/infra/terminals/terminal-grid-probe.ts`, which measures an offscreen
+  xterm using the same renderer options as the live surface (font family from
+  `lib/domain/terminals/terminal-grid.ts`, font size from the readable-code
+  preference). Identical options are mandatory: cell metrics drive cols/rows.
+- `DEFAULT_TERMINAL_GRID` (120×40) is a fallback for when no probe target is
+  laid out (hidden shells, headless callers). Do not pass literal dimensions
+  from UI call sites.
+- The first fitted resize after attach still reconciles the PTY
+  (`use-terminal-viewport.ts` → `resizeTab`); the probe makes that resize a
+  no-op in the common case rather than a correction.
+
+## Acceptance
+
+- Opening the first terminal in a workspace pane shows a clean prompt: no
+  leading `%`, no leading blank line, prompt on row one.
+- Subsequent terminals and reopened terminals replay history without
+  re-wrapping artifacts at the top.
+- Terminals still open (at the default grid) when the pane is not measurable.

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -206,7 +206,7 @@ spec before end-to-end product work changes that surface.
 | --- | --- | --- |
 | **Onboarding** | `features/onboarding.md`; lower-level owners are `product-auth.md`, `agent-auth-bifrost-byok.md`, `billing.md`, `settings-admin-ia.md`, and workspace creation read path in `workspace-provisioning.md` | Covered for the current end-to-end read path; deepen the feature spec when onboarding UX grows. |
 | **Browsers** | AnyHarness runtime structure and future Product MCP pattern | Add a browser feature spec or Product MCP definition before adding user-visible browser workflows. |
-| **Terminals** | AnyHarness terminal internals and contract surfaces | Add `features/terminals.md` only for product UX/QA behavior; runtime-only work belongs in AnyHarness structure specs. |
+| **Terminals** | `features/terminals.md` for product UX (terminal pane, creation grid contract); AnyHarness structure specs for runtime internals | Covered for terminal pane UX; runtime-only work belongs in AnyHarness structure specs. |
 | **Computer Use** | Future Product MCP pattern | Add a computer-use feature spec or Product MCP definition before changing permissions, UX, or QA behavior. |
 | **Plugins** | `primitives/mcp-skills.md`, `settings-admin-ia.md` | Add `features/plugins.md` only when catalog/install/manage UX grows beyond the primitive contract. |
 | **Subagents** | `delegated-work.md`, `agent-features/definitions/subagents.md` | Covered for current UX and Product MCP semantics; split only if product-surface behavior outgrows those docs. |
@@ -374,7 +374,6 @@ until the operator-safe replacement flow and audit trail are implemented.
 | Gap | Action needed |
 | --- | --- |
 | Browsers feature | Write `features/browsers.md` |
-| Terminals feature | Write `features/terminals.md` |
 | Computer Use feature | Write `features/computer-use.md` |
 | Security spec | Write an authoritative security spec (no draft exists) |
 


### PR DESCRIPTION
## Summary
**Markdown + sidebar polish**
- Transcript and content markdown tables: comfortable cell padding (`px-2.5 py-1.5`), subtle zebra striping, top-aligned cells, no doubled border on the last row against the rounded frame. GFM column alignment already worked and is preserved.
- Sidebar workspace popover: "Delete workspace" used a `GitMerge` icon; now `Trash`, matching delete actions elsewhere.
- Sidebar workspace native context menu: removed the macOS `MultipleDocuments` icons from the two copy items (the only iconed rows; read as clutter).

**Terminal creation grid (in-tree work bundled per request)**
- New `terminal-grid` domain model + offscreen xterm grid probe so PTYs spawn with the exact cols/rows the renderer will display, eliminating the zsh PROMPT_SP first-prompt artifact.
- Right-panel sticky new-tab trigger gains a masking surface token in `desktop.css`.
- New authoritative `specs/codebase/features/terminals.md`, indexed from the features README and spec-catalog.

## Testing
- `tsc --noEmit` clean on `apps/desktop`
- `@proliferate/product-ui` builds
- 18/18 chat-input component tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)