### PR TITLE
fix(desktop): single transcript spacing rhythm and resize-driven bottom pinning

### DIFF
--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptActivityBlock.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptActivityBlock.tsx
@@ -1,42 +1,19 @@
-import {
-  createContext,
-  useContext,
-  type ReactNode,
-} from "react";
+import type { ReactNode } from "react";
 
-export type TranscriptActivityDensity = "normal" | "compact";
-
-const TranscriptActivityDensityContext = createContext<TranscriptActivityDensity>("normal");
-
-export function TranscriptActivityDensityProvider({
-  children,
-  density,
-}: {
-  children: ReactNode;
-  density: TranscriptActivityDensity;
-}) {
-  return (
-    <TranscriptActivityDensityContext.Provider value={density}>
-      {children}
-    </TranscriptActivityDensityContext.Provider>
-  );
-}
-
+/**
+ * Marker wrapper for activity content (tool calls, thinking, collapsed
+ * actions). It carries no external vertical padding: sibling spacing comes
+ * solely from the parent turn container's gap.
+ */
 export function TranscriptActivityBlock({
   children,
-  density,
 }: {
   children: ReactNode;
-  density?: TranscriptActivityDensity;
 }) {
-  const inheritedDensity = useContext(TranscriptActivityDensityContext);
-  const resolvedDensity = density ?? inheritedDensity;
   return (
     <div
       data-transcript-activity-shell
       data-transcript-activity-block
-      data-transcript-activity-density={resolvedDensity}
-      className="pt-1 pb-2"
     >
       {children}
     </div>

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx
@@ -8,7 +8,6 @@ import {
   toolItem,
 } from "@proliferate/product-domain/chats/transcript/transcript-presentation-test-fixtures";
 import { ProposedPlanToolCallIdsProvider } from "./ProposedPlanToolCallIdsContext";
-import { TranscriptActivityDensityProvider } from "./TranscriptActivityBlock";
 import { TranscriptItemBlock } from "./TranscriptItemBlock";
 
 vi.mock("@/hooks/cowork/workflows/use-open-cowork-coding-session", () => ({
@@ -64,7 +63,7 @@ describe("TranscriptItemBlock", () => {
     expect(container.textContent).toContain("Fallback plan body");
   });
 
-  it("gives tool calls transcript activity spacing", () => {
+  it("renders tool calls in an activity block without external vertical padding", () => {
     const transcript = createTranscriptState("session-1");
     const item = genericToolCall();
     transcript.itemsById = { [item.itemId]: item };
@@ -82,11 +81,11 @@ describe("TranscriptItemBlock", () => {
 
     expect(container.innerHTML).toContain("data-transcript-activity-block");
     expect(container.innerHTML).toContain("data-transcript-activity-shell");
-    expect(container.innerHTML).toContain("pt-1 pb-2");
+    expect(activityBlockClassName(container)).toBe("");
     expect(container.textContent).toContain("Tool call");
   });
 
-  it("gives thinking blocks transcript activity spacing", () => {
+  it("renders thinking blocks in an activity block without external vertical padding", () => {
     const transcript = createTranscriptState("session-1");
     const item = genericThought();
     transcript.itemsById = { [item.itemId]: item };
@@ -104,33 +103,16 @@ describe("TranscriptItemBlock", () => {
 
     expect(container.innerHTML).toContain("data-transcript-activity-block");
     expect(container.innerHTML).toContain("data-transcript-activity-shell");
-    expect(container.innerHTML).toContain("pt-1 pb-2");
-    expect(container.textContent).toContain("Thinking");
-  });
-
-  it("keeps the same transcript activity spacing while the active turn is iterating", () => {
-    const transcript = createTranscriptState("session-1");
-    const item = genericThought();
-    transcript.itemsById = { [item.itemId]: item };
-
-    const { container } = render(
-      <ProposedPlanToolCallIdsProvider value={new Set()}>
-        <TranscriptActivityDensityProvider density="compact">
-          <TranscriptItemBlock
-            item={item}
-            transcript={transcript}
-            workspaceId={null}
-            onOpenArtifact={() => {}}
-          />
-        </TranscriptActivityDensityProvider>
-      </ProposedPlanToolCallIdsProvider>,
-    );
-
-    expect(container.innerHTML).toContain("data-transcript-activity-density=\"compact\"");
-    expect(container.innerHTML).toContain("pt-1 pb-2");
+    expect(activityBlockClassName(container)).toBe("");
     expect(container.textContent).toContain("Thinking");
   });
 });
+
+function activityBlockClassName(container: HTMLElement): string {
+  const block = container.querySelector("[data-transcript-activity-block]");
+  expect(block).toBeTruthy();
+  return block?.getAttribute("class") ?? "";
+}
 
 function claudeExitPlanFallback(): ToolCallItem {
   return {

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe("TurnShell", () => {
-  it("keeps normal completed rows roomy", () => {
+  it("uses one vertical rhythm for every row", () => {
     const { container } = render(
       <TurnShell>
         <div>row</div>
@@ -20,14 +20,14 @@ describe("TurnShell", () => {
     expect(container.innerHTML).toContain("pb-2");
   });
 
-  it("uses compact padding for active iteration rows", () => {
+  it("drops top padding on the first row only", () => {
     const { container } = render(
-      <TurnShell density="compact">
+      <TurnShell isFirst>
         <div>row</div>
       </TurnShell>,
     );
 
-    expect(container.innerHTML).toContain("pt-1");
-    expect(container.innerHTML).toContain("pb-1");
+    expect(container.innerHTML).toContain("pt-0");
+    expect(container.innerHTML).toContain("pb-2");
   });
 });

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
@@ -18,15 +18,11 @@ export const TRAILING_STATUS_MIN_HEIGHT =
 export function TurnShell({
   children,
   isFirst = false,
-  density = "normal",
 }: {
   children: ReactNode;
   isFirst?: boolean;
-  density?: "normal" | "compact";
 }) {
-  const verticalPadding = density === "compact"
-    ? `${isFirst ? "pt-0" : "pt-1"} pb-1`
-    : `${isFirst ? "pt-0" : "pt-2"} pb-2`;
+  const verticalPadding = `${isFirst ? "pt-0" : "pt-2"} pb-2`;
   return (
     <div className={`${TURN_HORIZONTAL_PADDING} w-full max-w-full ${verticalPadding}`}>
       {children}

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -7,10 +7,6 @@ import { useRevertGitPatchesMutation } from "@anyharness/sdk-react";
 import { TurnDiffPanel } from "./TurnDiffPanel";
 import { TranscriptPatchTurnDiffPanel } from "./TranscriptPatchTurnDiffPanel";
 import {
-  TranscriptActivityDensityProvider,
-  type TranscriptActivityDensity,
-} from "./TranscriptActivityBlock";
-import {
   TRAILING_STATUS_MIN_HEIGHT,
   TurnAssistantActionRow,
   TurnShell,
@@ -43,9 +39,6 @@ import type { SessionViewState } from "@proliferate/product-domain/sessions/acti
 import { useToastStore } from "@/stores/toast/toast-store";
 
 type PlanHandoffHandler = (plan: PromptPlanAttachmentDescriptor) => void;
-
-const ACTIVITY_ADJACENCY_CLASSNAME =
-  "[&>[data-transcript-activity-shell]+[data-transcript-activity-shell]]:pt-0 [&>[data-transcript-activity-shell]+[data-transcript-activity-shell]_[data-transcript-activity-block]]:pt-0";
 
 export function TranscriptTurnRow({
   row,
@@ -92,7 +85,6 @@ export function TranscriptTurnRow({
     hasFileBadges: turn.fileBadges.length > 0,
   });
   const isLatestCompletedTurnRow = diffPanelKind === "current";
-  const activityDensity: TranscriptActivityDensity = isLatestTurnInProgress ? "compact" : "normal";
   const presentation = row.presentation;
   const renderPresentation = row.renderPresentation;
   const liveExplorationBlock = isLatestTurn ? latestLiveExplorationBlock : null;
@@ -197,25 +189,20 @@ export function TranscriptTurnRow({
   ]);
 
   return (
-    <TurnShell
-      isFirst={rowIndex === 0}
-      density={activityDensity}
-    >
-      <div className={`flex flex-col ${isLatestTurnInProgress ? "gap-1" : "gap-2"} ${tailAssistantCopyContent ? "group/turn" : ""} ${ACTIVITY_ADJACENCY_CLASSNAME}`}>
-        <TranscriptActivityDensityProvider density={activityDensity}>
-          <TurnItemSequence
-            turn={turn}
-            transcript={transcript}
-            isTurnComplete={!!turn.completedAt}
-            presentation={renderPresentation}
-            autoFollowCollapsedActionBlockId={liveExplorationBlock?.blockId ?? null}
-            tailAssistantProseRootId={tailAssistantProseRootId}
-            showCompletedArtifactFallback={row.isLastTurnRow}
-            workspaceId={selectedWorkspaceId}
-            onOpenArtifact={onOpenArtifact}
-            onHandOffPlanToNewSession={onHandOffPlanToNewSession}
-          />
-        </TranscriptActivityDensityProvider>
+    <TurnShell isFirst={rowIndex === 0}>
+      <div className={`flex flex-col gap-2 ${tailAssistantCopyContent ? "group/turn" : ""}`}>
+        <TurnItemSequence
+          turn={turn}
+          transcript={transcript}
+          isTurnComplete={!!turn.completedAt}
+          presentation={renderPresentation}
+          autoFollowCollapsedActionBlockId={liveExplorationBlock?.blockId ?? null}
+          tailAssistantProseRootId={tailAssistantProseRootId}
+          showCompletedArtifactFallback={row.isLastTurnRow}
+          workspaceId={selectedWorkspaceId}
+          onOpenArtifact={onOpenArtifact}
+          onHandOffPlanToNewSession={onHandOffPlanToNewSession}
+        />
         {diffPanelKind === "current" ? (
           <TurnDiffPanel
             turn={turn}

--- a/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.test.tsx
@@ -57,7 +57,63 @@ describe("FullTranscriptRowList", () => {
     fireEvent.scroll(viewport, { target: { scrollTop: 0 } });
     expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
   });
+
+  it("re-sticks to the bottom when content resizes while pinned", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const { container } = render(
+      <FullTranscriptRowList {...makeProps(vi.fn(), 50)} />,
+    );
+    const viewport = getViewport(container);
+    Object.defineProperty(viewport, "scrollHeight", {
+      value: 500,
+      configurable: true,
+    });
+
+    notifyResize();
+
+    expect(viewport.scrollTop).toBe(500);
+  });
+
+  it("leaves the viewport alone on resize after scrolling away from the bottom", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const { container } = render(
+      <FullTranscriptRowList {...makeProps(vi.fn(), 50)} />,
+    );
+    const viewport = getViewport(container);
+    Object.defineProperty(viewport, "scrollHeight", {
+      value: 1000,
+      configurable: true,
+    });
+    fireEvent.scroll(viewport, { target: { scrollTop: 600 } });
+
+    notifyResize();
+
+    expect(viewport.scrollTop).toBe(600);
+  });
 });
+
+function stubCapturingResizeObserver(): () => void {
+  const callbacks: ResizeObserverCallback[] = [];
+  class CapturingResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      callbacks.push(callback);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", CapturingResizeObserver);
+  const observerStub = {
+    observe() {},
+    unobserve() {},
+    disconnect() {},
+  } as unknown as ResizeObserver;
+  return () => {
+    for (const callback of [...callbacks]) {
+      callback([], observerStub);
+    }
+  };
+}
 
 function makeProps(
   onLoadOlderHistory: () => void,

--- a/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
@@ -58,6 +58,7 @@ export function FullTranscriptRowList({
   virtualizationMode,
 }: FullTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const shouldStickToBottomRef = useRef(true);
   const pendingPrependAnchorRef = useRef<HistoryPrependScrollAnchor | null>(null);
   const lastOlderHistoryCursorRequestRef = useRef<number | null>(null);
@@ -233,6 +234,27 @@ export function FullTranscriptRowList({
     scrollToBottom,
   ]);
 
+  // Content can grow after the React commit (images decoding, async diff
+  // panels, code-highlight reflow). Re-stick on any content resize so a
+  // pinned viewport stays at the true bottom; the stickiness ref is the
+  // guard, so we always observe.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!shouldStickToBottomRef.current) {
+        return;
+      }
+      scrollToBottom();
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [scrollToBottom]);
+
   return (
     <div className="relative h-full">
       <AutoHideScrollArea
@@ -241,6 +263,7 @@ export function FullTranscriptRowList({
         onViewportScroll={handleViewportScroll}
       >
         <div
+          ref={contentRef}
           className={`${gutterClassName} min-h-full`}
           data-transcript-virtualization-mode="full"
           data-transcript-virtualization-setting={virtualizationMode}

--- a/specs/codebase/features/chat-transcript.md
+++ b/specs/codebase/features/chat-transcript.md
@@ -152,6 +152,21 @@ Some layout dimensions are load-bearing. They are tuned together so specific
 UI transitions stay visually smooth. Changing one without the others can
 reintroduce scroll/layout bumps.
 
+### Spacing Rhythm
+
+Sibling spacing inside a turn comes solely from the turn container's `gap-2`,
+and turn rows are separated by `TurnShell`'s `pt-2 pb-2` (`pt-0` for the first
+row). Blocks must not carry external vertical padding of their own
+(`TranscriptActivityBlock` is a zero-padding marker wrapper), and spacing must
+not vary with streaming state: a turn completing is a zero-delta layout change
+for everything already rendered.
+
+Bottom pinning in the non-virtualized list is resize-driven: a
+`ResizeObserver` on the scroll content re-sticks the viewport whenever content
+grows after the React commit (image decode, async diff panels, highlight
+reflow) while the user is pinned. The virtualized list gets the same guarantee
+from measured `totalContentHeight`.
+
 ### Streaming Handoff
 
 When an assistant turn transitions from streaming state to its first line of


### PR DESCRIPTION
## Summary

Two transcript layout fixes toward "perfectly even gaps, bottom always at the bottom":

**1. One spacing rhythm, no streaming flips.** The intra-turn gap (`gap-1` ↔ `gap-2`) and `TurnShell` padding (`pt-1 pb-1` ↔ `pt-2 pb-2`) changed with the latest turn's in-progress state, so the visible tail of the transcript reflowed (+4px everywhere) the moment a turn completed, and inter-turn gaps differed between streaming and completed turns. The activity ("thinking"/tool) block also carried its own asymmetric external `pt-1 pb-2`, patched only for the adjacent-activity case by a selector hack. Now: sibling spacing comes solely from the turn container's unconditional `gap-2` plus `TurnShell`'s `pt-2 pb-2`; `TranscriptActivityBlock` is a zero-padding marker wrapper; the adjacency hack and the dead density plumbing (context/provider had no remaining consumers) are deleted.

**2. Resize-driven bottom pinning in the full list.** `FullTranscriptRowList` only re-stuck to the bottom on React commits, so content growing after the commit (image decode, async diff panels, code-highlight reflow) left a pinned viewport short of the true bottom. A `ResizeObserver` on the scroll content now re-sticks while `shouldStickToBottom` holds — the same guarantee the virtualized list already gets from measured `totalContentHeight`.

Deliberately untouched: intra-block scales (`space-y-1` item internals, `space-y-1.5` tool-call groups) — nested-level rhythm, a separate design call — and the virtualized list's stick logic.

Spec: `specs/codebase/features/chat-transcript.md` gains a "Spacing Rhythm" layout invariant documenting both rules.

## Testing

- New `FullTranscriptRowList` tests: re-sticks on content resize while pinned; leaves the viewport alone after the user scrolls away.
- Updated tests that pinned the old compact padding / density attribute.
- `tsc` clean (desktop + product-ui), repo-shape check `TOTAL: 0`, transcript suites pass (desktop 38/38, product-ui 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)