### PR TITLE
style(design): flatten turn-diff and right-panel git headers (Codex parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyharness-credential-discovery",
  "base64 0.22.1",

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -300,10 +300,14 @@
   --color-diff-surface: color-mix(in srgb, var(--color-diff-main-surface) 94%, var(--color-foreground));
   --color-diff-panel-surface: color-mix(in oklab, var(--color-foreground) 3%, transparent);
   --color-diff-header-surface: var(--color-diff-surface);
-  --color-diff-chat-turn-header-surface: color-mix(in srgb, var(--color-diff-main-surface) 86%, var(--color-foreground));
+  /* Codex parity: diff headers paint no band of their own — the turn
+     header ("Edited x" + Undo/Review), inline tool headers, and the
+     right-panel git file headers (sidebar variant derives below) all sit
+     flat on the diff surface with hover tints only. */
+  --color-diff-chat-turn-header-surface: var(--color-diff-surface);
   --color-diff-chat-turn-header-hover-surface: color-mix(in srgb, var(--color-diff-chat-turn-header-surface) 97%, var(--color-foreground));
   --color-diff-chat-turn-icon-surface: color-mix(in srgb, var(--color-diff-main-surface) 94%, var(--color-foreground));
-  --color-diff-chat-inline-tool-header-surface: color-mix(in srgb, var(--color-diff-main-surface) 86%, var(--color-foreground));
+  --color-diff-chat-inline-tool-header-surface: var(--color-diff-surface);
   --color-diff-chat-inline-tool-header-hover-surface: color-mix(in srgb, var(--color-diff-chat-inline-tool-header-surface) 97%, var(--color-foreground));
   --color-diff-sidebar-file-header-surface: var(--color-diff-chat-inline-tool-header-surface);
   --color-diff-sidebar-file-header-hover-surface: color-mix(in srgb, var(--color-diff-sidebar-file-header-surface) 97%, var(--color-foreground));
@@ -1110,12 +1114,6 @@ mark.codex-thread-find-active {
   --color-diff-deleted: hsl(0 100% 45%);
   --diffs-bg-addition-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-addition-color-override));
   --diffs-bg-deletion-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-deletion-color-override));
-  /* Chat diff headers: the root 14% foreground mixes are tuned for dark
-     mode, where that much white is a subtle lift; the same share of ink
-     in light mode reads as a heavy gray slab. (The file header itself is
-     flat on the diff surface at root level — Codex parity.) */
-  --color-diff-chat-turn-header-surface: color-mix(in srgb, var(--color-diff-main-surface) 94%, var(--color-foreground));
-  --color-diff-chat-inline-tool-header-surface: color-mix(in srgb, var(--color-diff-main-surface) 94%, var(--color-foreground));
   --color-diff-added-bg: var(--diffs-bg-addition-override);
   --color-diff-deleted-bg: var(--diffs-bg-deletion-override);
 }


### PR DESCRIPTION
Extend the flat-header treatment from the chat file header to the two
remaining banded diff headers: the turn-diff panel header ("Edited x" +
Undo/Review) and the inline-tool/right-panel git file headers (the
sidebar variant derives from the inline-tool token). Codex paints no
band for any of these — headers sit flat on the diff surface (94% +
6% foreground) with hover tints only; ours mixed 14% foreground,
rendering light-gray slabs in mono dark and ink slabs in light. The
light-mode 94% overrides are now redundant and removed.
