### PR TITLE
fix(catalog): codex back to npm delivery now that @proliferate-ai sidecars are published

### DIFF
--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -124,9 +124,9 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/codex-acp.git#1fdb4661c2aef0815a6aab16be27ea70f4c2b94f",
+          "package": "git+https://github.com/proliferate-ai/codex-acp.git#988bd156960d038104ae60e5bbbf5d190502a0f3",
           "packageSubdir": "npm",
-          "sourceBuildBinaryName": "codex-acp",
+          "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/codex-acp"
         }
       },


### PR DESCRIPTION
Completes the codex install fix from #646. The `@proliferate-ai/codex-acp` wrapper + platform sidecars are being published at `0.16.0-proliferate.1` (codex-acp release run 27402523834, dispatched with the new scoped NPM_TOKEN), and the pinned commit now includes the launcher scope fix (proliferate-ai/codex-acp#11) and bwrap packaging fix.

- Pin: `1fdb466` → `988bd15` (current codex-acp main)
- `sourceBuildBinaryName`: `"codex-acp"` → `null` — installs no longer require a Rust toolchain
- The pin/spec change deliberately invalidates the install source marker so existing installs refresh the stale wrapper

Merging ahead of the 09:00 UTC nightly train so v0.2.5 ships npm delivery instead of the source-build interim. Worst case if the npm publish run fails: codex installs are exactly as broken as v0.2.4 (wrapper-only), no regression — and the desktop updater publish is gated manually until npm is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)