### PR TITLE
fix(anyharness): preserve access-gate failures in session errors

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/access.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/access.rs
@@ -33,6 +33,9 @@ pub fn map_access_error(error: WorkspaceAccessError) -> ApiError {
             format!("workspace {workspace_id} is retired"),
             "WORKSPACE_RETIRED",
         ),
+        WorkspaceAccessError::Unexpected(error) => ApiError::internal(format!(
+            "workspace access state could not be verified: {error}"
+        )),
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -307,6 +307,9 @@ fn map_access_error(error: WorkspaceAccessError) -> ApiError {
             format!("workspace {workspace_id} is retired"),
             "WORKSPACE_RETIRED",
         ),
+        WorkspaceAccessError::Unexpected(error) => ApiError::internal(format!(
+            "workspace access state could not be verified: {error}"
+        )),
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -1,3 +1,4 @@
+use super::access::map_access_error;
 use super::error::ApiError;
 use crate::domains::sessions::mcp_bindings::crypto::SessionMcpBindingsError;
 use crate::domains::sessions::runtime::{
@@ -64,6 +65,7 @@ pub(super) fn map_resolve_interaction_error(error: ResolveInteractionError) -> A
             format!("Interaction request is not an MCP URL elicitation: {request_id}"),
             "INTERACTION_NOT_MCP_URL_ELICITATION",
         ),
+        ResolveInteractionError::Access(error) => map_access_error(error),
         ResolveInteractionError::Internal(error) => ApiError::internal(error.to_string()),
     }
 }
@@ -236,5 +238,24 @@ pub(super) fn map_session_lifecycle_error(error: SessionLifecycleError) -> ApiEr
             "SESSION_NOT_FOUND",
         ),
         SessionLifecycleError::Internal(error) => ApiError::internal(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use crate::domains::sessions::runtime::ResolveInteractionError;
+    use crate::domains::workspaces::access_gate::WorkspaceAccessError;
+
+    #[test]
+    fn interaction_access_store_failures_map_to_internal_error() {
+        let response = super::map_resolve_interaction_error(ResolveInteractionError::Access(
+            WorkspaceAccessError::Unexpected(anyhow::anyhow!("database unavailable")),
+        ))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/mobility/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/service.rs
@@ -1234,25 +1234,23 @@ fn validate_clean_repo_for_mobility(
 }
 
 fn map_access_error(error: WorkspaceAccessError) -> MobilityError {
+    use MobilityError::Invalid;
+
     match error {
         WorkspaceAccessError::WorkspaceNotFound(id) => MobilityError::WorkspaceNotFound(id),
-        WorkspaceAccessError::SessionNotFound(id) => MobilityError::Invalid(id),
-        WorkspaceAccessError::TerminalNotFound(id) => MobilityError::Invalid(id),
-        WorkspaceAccessError::MutationBlocked { workspace_id, mode } => {
-            MobilityError::Invalid(format!(
-                "workspace {workspace_id} is not writable while mode={}",
-                mode.as_str()
-            ))
+        WorkspaceAccessError::SessionNotFound(id) | WorkspaceAccessError::TerminalNotFound(id) => {
+            Invalid(id)
         }
-        WorkspaceAccessError::LiveSessionStartBlocked { workspace_id, mode } => {
-            MobilityError::Invalid(format!(
-                "workspace {workspace_id} cannot start live sessions while mode={}",
-                mode.as_str()
-            ))
-        }
-        WorkspaceAccessError::WorkspaceRetired(workspace_id) => {
-            MobilityError::Invalid(format!("workspace {workspace_id} is retired"))
-        }
+        WorkspaceAccessError::MutationBlocked { workspace_id, mode } => Invalid(format!(
+            "workspace {workspace_id} is not writable while mode={}",
+            mode.as_str()
+        )),
+        WorkspaceAccessError::LiveSessionStartBlocked { workspace_id, mode } => Invalid(format!(
+            "workspace {workspace_id} cannot start live sessions while mode={}",
+            mode.as_str()
+        )),
+        WorkspaceAccessError::WorkspaceRetired(id) => Invalid(format!("workspace {id} is retired")),
+        WorkspaceAccessError::Unexpected(error) => MobilityError::Internal(error),
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/interactions.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/interactions.rs
@@ -19,7 +19,7 @@ impl SessionRuntime {
     ) -> Result<(), ResolveInteractionError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| ResolveInteractionError::SessionNotLive(error.to_string()))?;
+            .map_err(ResolveInteractionError::Access)?;
 
         let handle = self
             .acp_manager
@@ -148,7 +148,7 @@ impl SessionRuntime {
     ) -> Result<McpElicitationUrlReveal, ResolveInteractionError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| ResolveInteractionError::SessionNotLive(error.to_string()))?;
+            .map_err(ResolveInteractionError::Access)?;
 
         let handle = self
             .acp_manager

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -17,7 +17,7 @@ use super::service::SessionService;
 use crate::domains::agents::auth::{AgentAuthSelectionRequired, AgentAuthService};
 use crate::domains::runtime_config::service::RuntimeConfigService;
 use crate::domains::sessions::extensions::SessionExtension;
-use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
+use crate::domains::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
 use crate::live::sessions::LiveSessionManager;
 
@@ -232,6 +232,7 @@ pub enum ResolveInteractionError {
     MissingMcpField(String),
     InvalidMcpFieldValue(String),
     NotMcpUrlElicitation(String),
+    Access(WorkspaceAccessError),
     Internal(anyhow::Error),
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs
@@ -27,6 +27,8 @@ pub enum WorkspaceAccessError {
     },
     #[error("workspace {0} is retired")]
     WorkspaceRetired(String),
+    #[error(transparent)]
+    Unexpected(#[from] anyhow::Error),
 }
 
 #[derive(Clone)]
@@ -59,12 +61,12 @@ impl WorkspaceAccessGate {
         let workspace = self
             .workspace_store
             .find_by_id(workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::WorkspaceNotFound(workspace_id.to_string()))?;
         Ok(self
             .access_store
             .find_by_workspace(workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .unwrap_or_else(|| WorkspaceAccessRecord::normal_for_workspace(&workspace)))
     }
 
@@ -77,7 +79,7 @@ impl WorkspaceAccessGate {
         let workspace = self
             .workspace_store
             .find_by_id(workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::WorkspaceNotFound(workspace_id.to_string()))?;
         let record = WorkspaceAccessRecord {
             workspace_id: workspace.id.clone(),
@@ -87,14 +89,14 @@ impl WorkspaceAccessGate {
         };
         self.access_store
             .upsert(&record)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?;
+            .map_err(WorkspaceAccessError::Unexpected)?;
         Ok(record)
     }
 
     pub fn clear_runtime_state(&self, workspace_id: &str) -> Result<(), WorkspaceAccessError> {
         self.access_store
             .delete(workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))
+            .map_err(WorkspaceAccessError::Unexpected)
     }
 
     pub fn assert_can_mutate_for_workspace(
@@ -104,7 +106,7 @@ impl WorkspaceAccessGate {
         let workspace = self
             .workspace_store
             .find_by_id(workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::WorkspaceNotFound(workspace_id.to_string()))?;
         if workspace.lifecycle_state == WorkspaceLifecycleState::Retired {
             return Err(WorkspaceAccessError::WorkspaceRetired(
@@ -128,7 +130,7 @@ impl WorkspaceAccessGate {
         let workspaces = self
             .workspace_store
             .list_active_by_repo_root_id(repo_root_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?;
+            .map_err(WorkspaceAccessError::Unexpected)?;
         for workspace in workspaces {
             self.assert_can_mutate_for_workspace(&workspace.id)?;
         }
@@ -142,7 +144,7 @@ impl WorkspaceAccessGate {
         let workspaces = self
             .workspace_store
             .list_active_by_repo_root_id(repo_root_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?;
+            .map_err(WorkspaceAccessError::Unexpected)?;
         for workspace in workspaces {
             let state = self.runtime_state(&workspace.id)?;
             if matches!(
@@ -165,7 +167,7 @@ impl WorkspaceAccessGate {
         let session = self
             .session_store
             .find_by_id(session_id)
-            .map_err(|error| WorkspaceAccessError::SessionNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::SessionNotFound(session_id.to_string()))?;
         self.assert_can_mutate_for_workspace(&session.workspace_id)
     }
@@ -193,13 +195,13 @@ impl WorkspaceAccessGate {
         let session = self
             .session_store
             .find_by_id(session_id)
-            .map_err(|error| WorkspaceAccessError::SessionNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::SessionNotFound(session_id.to_string()))?;
         let state = self.runtime_state(&session.workspace_id)?;
         let workspace = self
             .workspace_store
             .find_by_id(&session.workspace_id)
-            .map_err(|error| WorkspaceAccessError::WorkspaceNotFound(error.to_string()))?
+            .map_err(WorkspaceAccessError::Unexpected)?
             .ok_or_else(|| WorkspaceAccessError::WorkspaceNotFound(session.workspace_id.clone()))?;
         if workspace.lifecycle_state == WorkspaceLifecycleState::Retired {
             return Err(WorkspaceAccessError::WorkspaceRetired(session.workspace_id));
@@ -218,7 +220,7 @@ impl WorkspaceAccessGate {
 mod tests {
     use std::sync::Arc;
 
-    use super::WorkspaceAccessGate;
+    use super::{WorkspaceAccessError, WorkspaceAccessGate};
     use crate::domains::sessions::store::SessionStore;
     use crate::domains::terminals::store::TerminalStore;
     use crate::domains::workspaces::access_model::{WorkspaceAccessMode, WorkspaceAccessRecord};
@@ -263,7 +265,12 @@ mod tests {
         }
     }
 
-    fn build_gate() -> (WorkspaceAccessGate, WorkspaceStore, WorkspaceAccessStore) {
+    fn build_gate_with_db() -> (
+        WorkspaceAccessGate,
+        WorkspaceStore,
+        WorkspaceAccessStore,
+        Db,
+    ) {
         let db = Db::open_in_memory().expect("open db");
         db.with_conn(|conn| {
             conn.execute(
@@ -290,9 +297,54 @@ mod tests {
             workspace_store.clone(),
             session_store,
             access_store.clone(),
-            Arc::new(TerminalService::new(TerminalStore::new(db), runtime_home)),
+            Arc::new(TerminalService::new(
+                TerminalStore::new(db.clone()),
+                runtime_home,
+            )),
         );
+        (gate, workspace_store, access_store, db)
+    }
+
+    fn build_gate() -> (WorkspaceAccessGate, WorkspaceStore, WorkspaceAccessStore) {
+        let (gate, workspace_store, access_store, _) = build_gate_with_db();
         (gate, workspace_store, access_store)
+    }
+
+    #[test]
+    fn runtime_state_reports_missing_workspace_as_not_found() {
+        let (gate, _, _) = build_gate();
+
+        let error = gate
+            .runtime_state("missing-workspace")
+            .expect_err("missing workspace should be not found");
+
+        assert!(matches!(
+            error,
+            WorkspaceAccessError::WorkspaceNotFound(id) if id == "missing-workspace"
+        ));
+    }
+
+    #[test]
+    fn runtime_state_reports_access_store_failure_as_unexpected() {
+        let (gate, workspace_store, _, db) = build_gate_with_db();
+        workspace_store
+            .insert(&workspace_record(
+                "workspace-1",
+                "repo-root-1",
+                "/tmp/repo/one",
+            ))
+            .expect("insert workspace");
+        db.with_conn(|conn| {
+            conn.execute("DROP TABLE workspace_access_modes", [])?;
+            Ok(())
+        })
+        .expect("drop access table");
+
+        let error = gate
+            .runtime_state("workspace-1")
+            .expect_err("broken access store should not be not found");
+
+        assert!(matches!(error, WorkspaceAccessError::Unexpected(_)));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs
@@ -528,13 +528,8 @@ pub fn active_path_owner_retire_blocker(active: &WorkspaceRecord) -> WorkspaceRe
 
 pub fn workspace_access_retire_blocker(error: WorkspaceAccessError) -> WorkspaceRetireBlocker {
     let message = match error {
-        WorkspaceAccessError::MutationBlocked { mode, .. } => {
-            format!(
-                "Workspace cannot be marked done while access mode is {}.",
-                mode.as_str()
-            )
-        }
-        WorkspaceAccessError::LiveSessionStartBlocked { mode, .. } => {
+        WorkspaceAccessError::MutationBlocked { mode, .. }
+        | WorkspaceAccessError::LiveSessionStartBlocked { mode, .. } => {
             format!(
                 "Workspace cannot be marked done while access mode is {}.",
                 mode.as_str()
@@ -542,6 +537,7 @@ pub fn workspace_access_retire_blocker(error: WorkspaceAccessError) -> Workspace
         }
         WorkspaceAccessError::WorkspaceRetired(_) => "Workspace is already retired.".to_string(),
         WorkspaceAccessError::WorkspaceNotFound(_)
+        | WorkspaceAccessError::Unexpected(_)
         | WorkspaceAccessError::SessionNotFound(_)
         | WorkspaceAccessError::TerminalNotFound(_) => {
             "Workspace access state could not be verified.".to_string()

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -12,11 +12,11 @@ anyharness/crates/anyharness-contract/src/v1/sessions.rs 802 existing AnyHarness
 anyharness/crates/anyharness-lib/src/api/openapi.rs 845 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/api/router_tests.rs 1172 existing AnyHarness oversized test file
 anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1884 existing AnyHarness oversized file
-anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1524 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1522 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 1512 existing AnyHarness oversized test file
 anyharness/crates/anyharness-lib/src/domains/runtime_config/service.rs 1057 existing AnyHarness oversized file
-anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 617 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
 anyharness/crates/proliferate-worker/src/control/commands/executor.rs 1636 existing Proliferate worker oversized command executor
 anyharness/crates/proliferate-worker/src/control/commands/mapping.rs 979 existing Proliferate worker oversized command mapper


### PR DESCRIPTION
## Summary

- Preserve `WorkspaceAccessError` structure when access-gate store operations fail, instead of collapsing those failures into not-found variants.
- Route session interaction access failures through `ResolveInteractionError::Access` so they map through the access-error mapper instead of surfacing as `SESSION_NOT_LIVE`.
- Add focused regression coverage for missing workspace behavior, broken access-store behavior, and interaction error mapping.

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Labels requested: `release:fix`, `area:anyharness`

## Verification

- `pnpm install --frozen-lockfile`
- `cargo check -p anyharness-lib`
- `cargo test -p anyharness-lib access_gate`
- `cargo test -p anyharness-lib sessions_errors`
- `python scripts/check_max_lines.py`
- `python scripts/check_anyharness_boundaries.py`
- `python scripts/check_anyharness_old_paths.py`
- `python scripts/check_proliferate_worker_structure.py`
- `python scripts/check_frontend_boundaries.py`
- `python scripts/check_server_boundaries.py`
- `git diff --check`