### PR TITLE
fix(web): explain when the local API is unreachable during first-run auth

### DIFF
--- a/apps/web/src/components/auth/screen/AuthScreen.tsx
+++ b/apps/web/src/components/auth/screen/AuthScreen.tsx
@@ -20,7 +20,7 @@ import { createWebCloudClient } from "../../../lib/access/cloud/client";
 import { useAuthToken } from "../../../providers/WebCloudProvider";
 
 export function AuthScreen() {
-  const { setToken, setSession } = useAuthToken();
+  const { setToken, setSession, bootstrapUnreachable } = useAuthToken();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [manualToken, setManualToken] = useState("");
@@ -98,7 +98,7 @@ export function AuthScreen() {
         onClick: () => void signIn(provider),
       }))}
       note={AUTH_SIGN_IN_COPY.note}
-      error={providerError}
+      error={providerError ?? (bootstrapUnreachable ? localApiUnreachableNotice() : null)}
       devAccess={webEnv.devAccessTokenLogin ? (
         <div className="mt-2 border-t border-border pt-4">
           {showDevAccess ? (
@@ -154,4 +154,14 @@ export function AuthScreen() {
 
 function providerIcon(provider: AuthProviderName) {
   return <ProviderBrandIcon provider={provider} />;
+}
+
+function localApiUnreachableNotice() {
+  return (
+    <>
+      Local API is not reachable at <code>{webEnv.apiBaseUrl}</code>. Start the
+      Proliferate API or set <code>VITE_PROLIFERATE_API_BASE_URL</code> before
+      signing in.
+    </>
+  );
 }

--- a/apps/web/src/lib/access/cloud/session-bootstrap-failure.test.ts
+++ b/apps/web/src/lib/access/cloud/session-bootstrap-failure.test.ts
@@ -1,0 +1,19 @@
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import { describe, expect, it } from "vitest";
+
+import { isApiUnreachableError } from "./session-bootstrap-failure";
+
+describe("session bootstrap failure", () => {
+  it("treats HTTP error responses as reachable", () => {
+    expect(isApiUnreachableError(new ProliferateClientError("Unauthorized", 401))).toBe(false);
+    expect(isApiUnreachableError(new ProliferateClientError("Session expired", 440, "session_expired"))).toBe(false);
+  });
+
+  it("treats connection failures as unreachable", () => {
+    expect(isApiUnreachableError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("treats timeout aborts as unreachable", () => {
+    expect(isApiUnreachableError(new DOMException("The operation was aborted.", "AbortError"))).toBe(true);
+  });
+});

--- a/apps/web/src/lib/access/cloud/session-bootstrap-failure.ts
+++ b/apps/web/src/lib/access/cloud/session-bootstrap-failure.ts
@@ -1,0 +1,7 @@
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+
+export function isApiUnreachableError(error: unknown): boolean {
+  // An HTTP error response proves the API answered; anything else — connection
+  // refused, DNS failure, timeout abort — means it never did.
+  return !(error instanceof ProliferateClientError);
+}

--- a/apps/web/src/providers/WebCloudProvider.tsx
+++ b/apps/web/src/providers/WebCloudProvider.tsx
@@ -23,11 +23,15 @@ import {
   readStoredAuthToken,
   writeStoredAuthToken,
 } from "../lib/access/cloud/auth-token-store";
+import { isApiUnreachableError } from "../lib/access/cloud/session-bootstrap-failure";
+
+const SESSION_BOOTSTRAP_TIMEOUT_MS = 5_000;
 
 interface AuthTokenContextValue {
   token: string | null;
   user: AuthUser | null;
   bootstrapping: boolean;
+  bootstrapUnreachable: boolean;
   setToken: (token: string) => void;
   setSession: (session: AuthSessionResponse) => void;
   clearToken: () => Promise<void>;
@@ -44,6 +48,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
   const [token, setTokenState] = useState<string | null>(initialTokenRef.current);
   const [user, setUserState] = useState<AuthUser | null>(null);
   const [bootstrapping, setBootstrapping] = useState(initialTokenRef.current === null);
+  const [bootstrapUnreachable, setBootstrapUnreachable] = useState(false);
   const authEpochRef = useRef(0);
   const client = useMemo(() => createWebCloudClient(webEnv.apiBaseUrl, token), [token]);
 
@@ -55,7 +60,14 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     const bootstrapEpoch = authEpochRef.current;
     const bootstrapClient = createWebCloudClient(webEnv.apiBaseUrl, null);
-    bootstrapWebSession(bootstrapClient)
+    const abortController = new AbortController();
+    // In dev, bound the wait so a missing local API surfaces an actionable
+    // notice instead of an indefinite loading screen. Production keeps the
+    // unbounded wait.
+    const timeoutId = import.meta.env.DEV
+      ? window.setTimeout(() => abortController.abort(), SESSION_BOOTSTRAP_TIMEOUT_MS)
+      : null;
+    bootstrapWebSession(bootstrapClient, { signal: abortController.signal })
       .then((session) => {
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
           queryClient.clear();
@@ -63,19 +75,24 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
           setUserState(session.user);
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
           setTokenState(null);
           setUserState(null);
+          setBootstrapUnreachable(import.meta.env.DEV && isApiUnreachableError(error));
         }
       })
       .finally(() => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
           setBootstrapping(false);
         }
       });
     return () => {
       cancelled = true;
+      abortController.abort();
     };
   }, []);
 
@@ -84,11 +101,13 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
       token,
       user,
       bootstrapping,
+      bootstrapUnreachable,
       setToken(nextToken) {
         authEpochRef.current += 1;
         queryClient.clear();
         writeStoredAuthToken(nextToken);
         setBootstrapping(false);
+        setBootstrapUnreachable(false);
         setTokenState(nextToken);
         setUserState(null);
       },
@@ -97,6 +116,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         queryClient.clear();
         clearStoredAuthToken();
         setBootstrapping(false);
+        setBootstrapUnreachable(false);
         setTokenState(session.accessToken);
         setUserState(session.user);
       },
@@ -118,7 +138,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         setUserState(null);
       },
     }),
-    [bootstrapping, token, user],
+    [bootstrapping, bootstrapUnreachable, token, user],
   );
 
   return (


### PR DESCRIPTION
## Summary

- Fixes #626: running the hosted web app locally without the Proliferate API left first-run stuck on "Loading account / Checking your cloud session." with no explanation.
- In dev, the session bootstrap in `WebCloudProvider` is now bounded by a 5s `AbortController` timeout, and connection-level failures (connection refused, DNS, abort) are classified separately from HTTP error responses via a new `isApiUnreachableError` helper in `lib/access/cloud`.
- When the bootstrap fails because the API never answered, the sign-in screen shows a dev-only notice: "Local API is not reachable at `<api base url>`. Start the Proliferate API or set `VITE_PROLIFERATE_API_BASE_URL` before signing in."
- Production behavior is unchanged: the timeout and the unreachable flag are both gated on `import.meta.env.DEV`, and HTTP error responses (e.g. 401) still land on the normal sign-in screen with no notice.

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label → `release:fix`
- Required: at least one `area:*` label → `area:product`

(I can't set labels as an outside contributor — would appreciate a maintainer adding `release:fix` + `area:product`.)

## Verification

- `pnpm --filter @proliferate/web test` — 23 passed, including 3 new tests for the failure classifier.
- `pnpm web:typecheck` — clean.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- Manually reproduced the issue: ran `vite` on `127.0.0.1:5173` with no API at `localhost:8000`. The loading screen shows briefly, then after ~5s the sign-in screen renders with the notice in the alert slot.


*Draft until a maintainer adds `release:fix` + `area:product` (outside contributors cannot set labels).*
